### PR TITLE
Add DRM support to Palace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ adobe-rmsdk
 **/APIKeys.swift
 Carthage*
 **/GoogleService-Info.plist
-**/NYPLSecrets.swift
+**/TPPSecrets.swift
 fastlane/report.xml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "readium-sdk"]
 	path = readium-sdk
-	url = https://github.com/NYPL-Simplified/readium-sdk.git
+	url = https://github.com/ThePalaceProject/mobile-readium-sdk
 [submodule "readium-shared-js"]
 	path = readium-shared-js
 	url = https://github.com/readium/readium-shared-js.git
@@ -9,10 +9,10 @@
 	url = https://github.com/NYPL/tenprintcover-ios.git
 [submodule "adept-ios"]
 	path = adept-ios
-	url = git@github.com:NYPL/DRM-iOS-Adobe.git
+	url = git@github.com:ThePalaceProject/ios-drm-adobe.git
 [submodule "adobe-content-filter"]
 	path = adobe-content-filter
-	url = git@github.com:NYPL/Adobe-Content-Filter.git
+	url = git@github.com:ThePalaceProject/mobile-adobe-content-filter.git
 [submodule "Simplified-Bookmarks-Spec"]
 	path = Simplified-Bookmarks-Spec
 	url = https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec.git

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -7,7 +7,7 @@ github "cezheng/Fuzi" "3.1.2"
 github "dexman/Minizip" "1.4.0"
 github "edrlab/GCDWebServer" "3.6.3"
 github "krzyzanowskim/CryptoSwift" "1.3.2"
-github "readium/r2-lcp-swift" "2.0.0-beta.1"
+
 github "readium/r2-shared-swift" "2.0.0-beta.1"
 github "readium/r2-streamer-swift" "2.0.0-beta.1"
 github "readium/r2-navigator-swift" "2.0.0-beta.1"

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -114,7 +114,6 @@
 		145DA48E215441A70055DB93 /* ZXingObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA48D215441A70055DB93 /* ZXingObjC.framework */; };
 		145DA4922154464F0055DB93 /* SQLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA4912154464F0055DB93 /* SQLite.framework */; };
 		145DA49621544A430055DB93 /* PureLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA49521544A420055DB93 /* PureLayout.framework */; };
-		148B1C2D21768EAA00FF64AB /* NYPLAEToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 148B1C1721710C6800FF64AB /* NYPLAEToolkit.framework */; };
 		148B1C2E21768EAA00FF64AB /* NYPLAudiobookToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 148B1C1C21710C6800FF64AB /* NYPLAudiobookToolkit.framework */; };
 		17071065242A923400E2648F /* TPPSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17071060242A923400E2648F /* TPPSecrets.swift */; };
 		170E5FBE25AFDD65007D6DE6 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 170E5FBD25AFDD64007D6DE6 /* ZIPFoundation.framework */; };
@@ -138,9 +137,6 @@
 		17BE24E725FABCDE00AE707F /* TPPUserAccountProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BE24E625FABCDE00AE707F /* TPPUserAccountProviderMock.swift */; };
 		17BE24ED25FB09F000AE707F /* TPPCurrentLibraryAccountProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BE24EC25FB09F000AE707F /* TPPCurrentLibraryAccountProviderMock.swift */; };
 		17BE24EF25FB114900AE707F /* simplye_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BE24EE25FB114900AE707F /* simplye_authentication_document.json */; };
-		17D08381248E938000092AA9 /* OverdriveProcessor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17D08378248E8EEB00092AA9 /* OverdriveProcessor.framework */; };
-		17DFC5ED251E7FBC003A19CC /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (Required, ); }; };
-		17DFC5F6251E84CF003A19CC /* AudioEngine.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		17E81F08261522B3001003C2 /* TPPRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* TPPRoundedButton.swift */; };
 		17E81F09261522B3001003C2 /* TPPRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* TPPRoundedButton.swift */; };
 		17E81F0B261522B3001003C2 /* TPPRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* TPPRoundedButton.swift */; };
@@ -316,8 +312,6 @@
 		736A54B8254B3C680031C3AA /* TPPSAMLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 730263AB2540DE4200A53891 /* TPPSAMLHelper.m */; };
 		736A54BD254B3C6D0031C3AA /* TPPSignInBusinessLogic+DRM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737F4A6A254A137900A3C34B /* TPPSignInBusinessLogic+DRM.swift */; };
 		736A54BE254B3C730031C3AA /* TPPSignInBusinessLogic+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A794A525477D8F00C59CC1 /* TPPSignInBusinessLogic+UI.swift */; };
-		736CF271252278AA0081D30A /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; };
-		736CF272252278AA0081D30A /* AudioEngine.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		7375AE5A25382AC900C85211 /* TPPUserAccountMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7375AE5925382AC900C85211 /* TPPUserAccountMock.swift */; };
 		737DCB8C245CCF2300A8F297 /* TPPReaderBookmarksBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737DCB8B245CCF2300A8F297 /* TPPReaderBookmarksBusinessLogic.swift */; };
 		737DCB8D245CCF2300A8F297 /* TPPReaderBookmarksBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737DCB8B245CCF2300A8F297 /* TPPReaderBookmarksBusinessLogic.swift */; };
@@ -587,8 +581,6 @@
 		73A794BD2548E36100C59CC1 /* TPPBookCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A794BC2548E36100C59CC1 /* TPPBookCreationTests.swift */; };
 		73A794C72549098700C59CC1 /* NYPLOPDSAcquisitionPathEntryMinimal.xml in Resources */ = {isa = PBXBuildFile; fileRef = 73A794C62549095700C59CC1 /* NYPLOPDSAcquisitionPathEntryMinimal.xml */; };
 		73A794CA25492C9800C59CC1 /* TPPFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A794C925492C9800C59CC1 /* TPPFake.swift */; };
-		73A7BA4C25A62FCF00C2906C /* ReadiumLCP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73A7BA4B25A62FCE00C2906C /* ReadiumLCP.framework */; };
-		73A7BA4E25A62FEA00C2906C /* R2LCPClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73A7BA4D25A62FE900C2906C /* R2LCPClient.framework */; };
 		73B501C524F48D4C00FBAD7D /* TPPUserAccountFrontEndValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B501C024F48D4B00FBAD7D /* TPPUserAccountFrontEndValidation.swift */; };
 		73B550F42511720E00D05B86 /* TPPConfiguration+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738CB2052509A87700891F31 /* TPPConfiguration+SE.swift */; };
 		73B550F92511721700D05B86 /* TPPRootTabBarController+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739ECB2D25108EE800691A70 /* TPPRootTabBarController+SE.swift */; };
@@ -1047,17 +1039,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		17DFC5F5251E84C5003A19CC /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				17DFC5F6251E84CF003A19CC /* AudioEngine.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		731B2B24244A2B6C00A7A649 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1068,7 +1049,6 @@
 				73BDB08325F1992B00556C35 /* R2Shared.framework in Embed Frameworks */,
 				73BDB08125F198F800556C35 /* R2Navigator.framework in Embed Frameworks */,
 				73BDB07A25F198D200556C35 /* R2Streamer.framework in Embed Frameworks */,
-				736CF272252278AA0081D30A /* AudioEngine.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1716,7 +1696,6 @@
 				739E6119244A0D8600D00301 /* PureLayout.framework in Frameworks */,
 				739E611A244A0D8600D00301 /* SQLite.framework in Frameworks */,
 				739E611B244A0D8600D00301 /* NYPLAEToolkit.framework in Frameworks */,
-				736CF271252278AA0081D30A /* AudioEngine.xcframework in Frameworks */,
 				739E611C244A0D8600D00301 /* NYPLAudiobookToolkit.framework in Frameworks */,
 				210715672592606A005F94AE /* R2LCPClient.framework in Frameworks */,
 				739E611E244A0D8600D00301 /* FirebaseCoreDiagnostics.framework in Frameworks */,
@@ -1797,7 +1776,6 @@
 				03B0922E1E7886ED00AD338D /* CoreVideo.framework in Frameworks */,
 				03B0922C1E7886C900AD338D /* AVFoundation.framework in Frameworks */,
 				03B0922A1E7885A600AD338D /* AudioToolbox.framework in Frameworks */,
-				73A7BA4C25A62FCF00C2906C /* ReadiumLCP.framework in Frameworks */,
 				03B092261E7883C400AD338D /* libiconv.tbd in Frameworks */,
 				A823D813192BABA400B55DE2 /* CoreGraphics.framework in Frameworks */,
 				03B092241E78839D00AD338D /* QuartzCore.framework in Frameworks */,
@@ -1817,16 +1795,12 @@
 				738574AE25A631B0001E615D /* Minizip.framework in Frameworks */,
 				1112A8431A3249B4002B8CC1 /* libTenPrintCover.a in Frameworks */,
 				73DED81A25A630AB00A4D63B /* SwiftSoup.framework in Frameworks */,
-				17DFC5ED251E7FBC003A19CC /* AudioEngine.xcframework in Frameworks */,
 				73CEF832252699DD006B2820 /* FirebaseCrashlytics.framework in Frameworks */,
-				73A7BA4E25A62FEA00C2906C /* R2LCPClient.framework in Frameworks */,
 				119503E91993F919009FB788 /* libz.dylib in Frameworks */,
 				119503E71993F914009FB788 /* libxml2.dylib in Frameworks */,
 				145DA48E215441A70055DB93 /* ZXingObjC.framework in Frameworks */,
 				145DA49621544A430055DB93 /* PureLayout.framework in Frameworks */,
-				17D08381248E938000092AA9 /* OverdriveProcessor.framework in Frameworks */,
 				145DA4922154464F0055DB93 /* SQLite.framework in Frameworks */,
-				148B1C2D21768EAA00FF64AB /* NYPLAEToolkit.framework in Frameworks */,
 				148B1C2E21768EAA00FF64AB /* NYPLAudiobookToolkit.framework in Frameworks */,
 				7326AB3424BD272000C3BA29 /* R2Streamer.framework in Frameworks */,
 				7326AB3624BD272200C3BA29 /* R2Navigator.framework in Frameworks */,
@@ -3062,7 +3036,6 @@
 				A823D80A192BABA400B55DE2 /* Frameworks */,
 				A823D80B192BABA400B55DE2 /* Resources */,
 				145DA48C215441260055DB93 /* Copy Frameworks (Carthage) */,
-				17DFC5F5251E84C5003A19CC /* Embed Frameworks */,
 				73DA43AD2404CA9500985482 /* Crashlytics */,
 			);
 			buildRules = (
@@ -3087,14 +3060,19 @@
 				TargetAttributes = {
 					2D2B47711D08F807007F7764 = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = 88CBA74T8K;
 						LastSwiftMigration = 1130;
+						ProvisioningStyle = Manual;
 						TestTargetID = 73EB0A6325821DF4006BC997;
 					};
 					739E6044244A0D8600D00301 = {
-						DevelopmentTeam = 7262U6ST2R;
+						DevelopmentTeam = 88CBA74T8K;
+					};
+					73EB0A6325821DF4006BC997 = {
+						DevelopmentTeam = 88CBA74T8K;
 					};
 					A823D80C192BABA400B55DE2 = {
-						DevelopmentTeam = 7262U6ST2R;
+						DevelopmentTeam = 88CBA74T8K;
 						LastSwiftMigration = 1130;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -3326,7 +3304,6 @@
 				"$(SRCROOT)/Carthage/Build/iOS/ZXingObjC.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SQLite.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/PureLayout.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/NYPLAEToolkit.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/NYPLAudiobookToolkit.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/PDFRendererProvider.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/R2Navigator.framework",
@@ -3337,9 +3314,6 @@
 				"$(SRCROOT)/Carthage/Build/iOS/GCDWebServer.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Minizip.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SwiftSoup.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/OverdriveProcessor.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/R2LCPClient.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/ReadiumLCP.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/ZIPFoundation.framework",
 			);
 			name = "Copy Frameworks (Carthage)";
@@ -3349,7 +3323,6 @@
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ZXingObjC.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SQLite.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/PureLayout.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/NYPLAEToolkit.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/NYPLAudiobookToolkit.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/PDFRendererProvider.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/R2Navigator.framework",
@@ -3360,8 +3333,6 @@
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/GCDWebServer.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Minizip.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SwiftSoup.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/R2LCPClient.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReadiumLCP.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ZIPFoundation.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4363,11 +4334,7 @@
 				);
 				INFOPLIST_FILE = PalaceTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.lyrasis.raybooks;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4416,11 +4383,7 @@
 				);
 				INFOPLIST_FILE = PalaceTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.lyrasis.raybooks;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4475,10 +4438,7 @@
 				);
 				INFOPLIST_FILE = "PalaceConfig/Palace-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
@@ -4535,10 +4495,7 @@
 				);
 				INFOPLIST_FILE = "PalaceConfig/Palace-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
@@ -4590,10 +4547,7 @@
 				);
 				INFOPLIST_FILE = "PalaceConfig/Palace-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
@@ -4645,10 +4599,7 @@
 				);
 				INFOPLIST_FILE = "PalaceConfig/Palace-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
@@ -4786,8 +4737,7 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -4818,21 +4768,16 @@
 					"DEBUG=1",
 					"FEATURE_DRM_CONNECTOR=1",
 					"FEATURE_CRASH_REPORTING=1",
-					"FEATURE_OVERDRIVE=1",
-					"LCP=1",
 				);
 				INFOPLIST_FILE = "PalaceConfig/Palace-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE LCP";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING";
 				SWIFT_OBJC_BRIDGING_HEADER = "Palace/AppInfrastructure/Palace-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -4875,21 +4820,16 @@
 					"DEBUG=0",
 					"FEATURE_DRM_CONNECTOR=1",
 					"FEATURE_CRASH_REPORTING=1",
-					"FEATURE_OVERDRIVE=1",
-					"LCP=1",
 				);
 				INFOPLIST_FILE = "PalaceConfig/Palace-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE LCP";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING";
 				SWIFT_OBJC_BRIDGING_HEADER = "Palace/AppInfrastructure/Palace-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.2;

--- a/Palace/AppInfrastructure/TPPLibraryNavigationController.m
+++ b/Palace/AppInfrastructure/TPPLibraryNavigationController.m
@@ -67,7 +67,7 @@
 
       BOOL workflowsInProgress;
 #if defined(FEATURE_DRM_CONNECTOR)
-      workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [NYPLBookRegistry sharedRegistry].syncing == YES);
+      workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [TPPBookRegistry sharedRegistry].syncing == YES);
 #else
       workflowsInProgress = ([TPPBookRegistry sharedRegistry].syncing == YES);
 #endif

--- a/Palace/OPDS/TPPOPDSAcquisitionPath.m
+++ b/Palace/OPDS/TPPOPDSAcquisitionPath.m
@@ -46,7 +46,9 @@ NSString * const _Nonnull ContentTypeAudiobookZip = @"application/audiobook+zip"
   if (!types) {
     types = [NSSet setWithArray:@[
       ContentTypeOPDSCatalog,
+#if FEATURE_DRM_CONNECTOR
       ContentTypeAdobeAdept,
+#endif
       ContentTypeBearerToken,
       ContentTypeEpubZip,
       ContentTypeFindaway,
@@ -55,7 +57,9 @@ NSString * const _Nonnull ContentTypeAudiobookZip = @"application/audiobook+zip"
       ContentTypeFeedbooksAudiobook,
       ContentTypeOverdriveAudiobook,
       ContentTypeOctetStream,
+#if LCP
       ContentTypeReadiumLCP,
+#endif
       ContentTypeAudiobookZip
     ]];
   }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
-[![SimplyE Build](https://github.com/NYPL-Simplified/Simplified-iOS/workflows/SimplyE%20Build/badge.svg)](https://github.com/NYPL-Simplified/Simplified-iOS/actions?query=workflow%3A%22SimplyE%20Build%22) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+# The Palace Project
 
-# SimplyE and Open eBooks
-
-This repo contains the client-side code for the New York Public Library's [SimplyE](https://www.nypl.org/books-music-movies/ebookcentral/simplye) and [Open eBooks](https://openebooks.net) apps.
-
-The 2 apps share most of the code base. App-specific source files will have a `SE` / `OE` prefix or suffix, while configuration files reside under the `SimplyE` and `OpenEbooks` directories at the root of the repo. 
-
-Consequently, [releases](https://github.com/NYPL-Simplified/Simplified-iOS/releases) in this repo track both apps. However, you won't see any Open eBooks versions before 1.9.0 because historically Open eBooks lived in a separate repo. Releases that lack an app specifier, i.e. any version before v3.6.2, are SimplyE releases.
+This repository contains the client-side code for The Palace Project [Palace](https://thepalaceproject.org) application.
 
 # System Requirements
 
@@ -16,8 +10,8 @@ Consequently, [releases](https://github.com/NYPL-Simplified/Simplified-iOS/relea
 # Building without Adobe DRM nor Private Repos
 
 ```bash
-git clone git@github.com:NYPL-Simplified/Simplified-iOS.git
-cd Simplified-iOS
+git clone git@github.com:ThePalaceProject/ios-core.git
+cd ios-core
 git checkout develop
 
 # one-time set-up
@@ -26,20 +20,20 @@ git checkout develop
 # idempotent script to rebuild all dependencies
 ./scripts/build-3rd-party-dependencies.sh --no-private
 ```
-Open `Simplified.xcodeproj` and build the `SimplyE-noDRM` target.
+Open `Palace.xcodeproj` and build the `Palace-noDRM` target.
 
 # Building With Adobe DRM
 
 ## Building the Application from Scratch
 
 01. Contact project lead and ensure you have access to all the required private repos.
-02. Then simply run:
+02. Then run:
 ```bash
-git clone git@github.com:NYPL-Simplified/Simplified-iOS.git
-cd Simplified-iOS
+git clone git@github.com:ThePalaceProject/ios-core.git
+cd ios-core
 ./scripts/bootstrap-drm.sh
 ```
-03. Open Simplified.xcodeproj and build the `SimplyE` or `Open eBooks` targets.
+03. Open Palace.xcodeproj and build the `Palace` target.
 
 ## Building Dependencies Individually
 
@@ -47,70 +41,17 @@ Unless the DRM dependencies change (which is very seldom) you shouldn't need to 
 
 Other 3rd party dependencies are managed via Carthage and a few git submodules. To rebuild them you can use the following idempotent script:
 ```bash
-cd Simplified-iOS #repo root
+cd ios-core
 ./scripts/build-3rd-party-dependencies.sh
 ```
-The `scripts` directory contains a number of other scripts to build dependencies more granularly and also to build/archive/test the app from the command line. These scripts are the same used by our CI system. All these scripts must be run from the root of the Simplified-iOS repo, not from the `scripts` directory.
-
-## Building for Readium 2 Integration
-
-Before working on R2 integration, make sure you can build the app without R2. Follow the steps listed above for building the app with DRM.
-
-For working on integrating R2 into SimplyE, first clone the following frameworks as siblings of `Simplified-iOS` on the file system:
-```bash
-cd Simplified-iOS/..
-git clone https://github.com/readium/r2-shared-swift
-git clone https://github.com/readium/r2-streamer-swift
-git clone https://github.com/NYPL-Simplified/r2-navigator-swift
-git clone https://github.com/readium/r2-lcp-swift
-```
-Then rebuild the dependencies:
-```bash
-cd Simplified-iOS
-./scripts/build-carthage-R2-integration.sh
-```
-Finally, open `SimplifiedR2.workspace` and use the `SimplyE-R2dev` target to build the app.
-
-# Building Secondary Targets
-
-The Xcode project contains 2 additional targets beside the ones referenced earlier:
-
-- **SimplyECardCreator**: This is a convenience target to use when making changes to the [CardCreator-iOS](https://github.com/NYPL-Simplified/CardCreator-iOS) framework. It takes the framework out of the normal Carthage build to instead build it directly via Xcode. Use this in conjunction with the `SimplifiedCardCreator` workspace. It requires DRM.
-- **Open eBooks**: This is an app primarily targeted toward the education space. It requires DRM.
-
-# Contributing
-
-This codebase follows Google's [Swift](https://google.github.io/swift/) and [Objective-C](https://google.github.io/styleguide/objcguide.xml) style guides, including the use of two-space indentation. More details are available in [our wiki](https://github.com/NYPL-Simplified/Simplified/wiki/Mobile-client-applications#code-style-1).
-
-Most of the code follows Apple's usual pattern of passive views,
-relatively passive models, and one-off controllers for integrating everything.
-Immutability is preferred wherever possible.
-
-Questions, suggestions, and general discussion occurs via Slack: Email
-`swans062@umn.edu` for access.
+The `scripts` directory contains a number of other scripts to build dependencies more granularly and also to build/archive/test the app from the command line. These scripts are the same used by our CI system. All these scripts must be run from the root of Palace `ios-core` repository, not from the `scripts` directory.
 
 ## Branching and CI
 
 `develop` is the main development branch.
 
-Release branch names follow the convention: `release/simplye/<version>` or `release/openebooks/<version>`. For example, `release/simplye/3.7.0`.
+Release branch names follow the convention: `release/palace/<version>`. For example, `release/palace/1.0.0`.
 
 Feature branch names (for features whose development is a month or more): `feature/<feature-name>`, e.g. `feature/my-new-screen`.
 
-Continuous integration is enabled on push events on `develop`, release and feature branches. SimplyE device builds are uploaded to [iOS-binaries](https://github.com/NYPL-Simplified/iOS-binaries). Commits on release branches also send the same build to TestFlight.
-
-# License
-
-Copyright © 2015-2021 The New York Public Library, Astor, Lenox, and Tilden Foundations
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Continuous integration is enabled on push events on `develop`, release and feature branches. Palace device builds are uploaded to [ios-binaries](https://github.com/ThePalaceProject/ios-binaries). Commits on release branches also send the same build to TestFlight.

--- a/scripts/bootstrap-drm.sh
+++ b/scripts/bootstrap-drm.sh
@@ -13,11 +13,10 @@
 
 cd ..
 git clone git@github.com:ThePalaceProject/mobile-certificates.git
-git clone git@github.com:ThePalaceProject/android-drm-adeptconnector.git
+git clone git@github.com:ThePalaceProject/mobile-drm-adeptconnector.git
 
 cd ios-core
-git checkout develop
 
 ./scripts/setup-repo-drm.sh
-
+./scripts/build-openssl-curl.sh
 ./scripts/build-3rd-party-dependencies.sh

--- a/scripts/bootstrap-drm.sh
+++ b/scripts/bootstrap-drm.sh
@@ -12,10 +12,10 @@
 #
 
 cd ..
-git clone git@github.com:NYPL-Simplified/Certificates.git
-git clone git@github.com:NYPL-Simplified/DRM-iOS-AdeptConnector.git
+git clone git@github.com:ThePalaceProject/mobile-certificates.git
+git clone git@github.com:ThePalaceProject/android-drm-adeptconnector.git
 
-cd Simplified-iOS
+cd ios-core
 git checkout develop
 
 ./scripts/setup-repo-drm.sh

--- a/scripts/build-openssl-curl.sh
+++ b/scripts/build-openssl-curl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Usage: run this script from the root of the Simplified-iOS repo.
+# Usage: run this script from the root of the Palace ios-core repository.
 #
 # Summary: this script rebuilds OpenSSL 1.0.1u and cURL 7.64.1 which are
 #              required by the Adobe RMSDK.
@@ -21,7 +21,7 @@ SDKVERSION=`xcodebuild -version -sdk iphoneos | grep SDKVersion | sed 's/SDKVers
 OPENSSL_VERSION="1.0.1u"
 OPENSSL_URL="https://www.openssl.org/source/old/1.0.1/openssl-1.0.1u.tar.gz"
 CURL_VERSION="7.64.1"
-CURL_URL="https://curl.haxx.se/download/curl-7.64.1.zip"
+CURL_URL="https://curl.se/download/curl-7.64.1.zip"
 
 echo "======================================="
 echo "Building OpenSSL..."

--- a/scripts/setup-repo-drm.sh
+++ b/scripts/setup-repo-drm.sh
@@ -22,12 +22,12 @@ fi
 git submodule update --init --recursive
 
 if [ "$BUILD_CONTEXT" == "ci" ]; then
-  ADOBE_SDK_PATH=./DRM-iOS-AdeptConnector
+  ADOBE_SDK_PATH=./mobile-drm-adeptconnector
 else
-  ADOBE_SDK_PATH=../DRM-iOS-AdeptConnector
+  ADOBE_SDK_PATH=../mobile-drm-adeptconnector
 fi
 
-ln -s $ADOBE_SDK_PATH adobe-rmsdk
+ln -s $ADOBE_SDK_PATH/uncompressed adobe-rmsdk
 
 cd $ADOBE_SDK_PATH
 ./uncompress.sh

--- a/scripts/update-certificates.sh
+++ b/scripts/update-certificates.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Usage: run this script from the root of Simplified-iOS repo.
+# Usage: run this script from the root of Palace ios-core repo.
 #
 #     ./scripts/update-certificates.sh
 #
-# Note: this script assumes you have the Certificates repo cloned as a sibling of Simplified-iOS.
+# Note: this script assumes you have the Certificates repo cloned as a sibling of ios-core.
 
 set -eo pipefail
 
@@ -15,24 +15,20 @@ else
 fi
 
 if [ "$BUILD_CONTEXT" == "ci" ]; then
-  CERTIFICATES_PATH="./Certificates"
+  CERTIFICATES_PATH="./mobile-certificates/Certificates"
 else
-  CERTIFICATES_PATH="../Certificates"
+  CERTIFICATES_PATH="../mobile-certificates/Certificates"
 fi
 
-cp $CERTIFICATES_PATH/SimplyE/iOS/APIKeys.swift Simplified/AppInfrastructure/
+cp Palace/AppInfrastructure/APIKeys.swift.example Palace/AppInfrastructure/APIKeys.swift
 
-# SimplyE-specific stuff
-cp $CERTIFICATES_PATH/SimplyE/iOS/GoogleService-Info.plist SimplyE/
-cp $CERTIFICATES_PATH/SimplyE/iOS/ReaderClientCertProduction.sig SimplyE/ReaderClientCert.sig
+# Copy configuration files
+cp $CERTIFICATES_PATH/Palace/iOS/GoogleService-Info.plist PalaceConfig/
+cp $CERTIFICATES_PATH/Palace/iOS/ReaderClientCert.sig PalaceConfig/
 
-# OpenEbooks-specific stuff
-cp $CERTIFICATES_PATH/OpenEbooks/iOS/ReaderClientCert.sig OpenEbooks/
-cp $CERTIFICATES_PATH/OpenEbooks/iOS/GoogleService-Info.plist OpenEbooks/
+git update-index --skip-worktree Palace/TPPSecrets.swift
 
-git update-index --skip-worktree Simplified/NYPLSecrets.swift
-
-echo "Obfuscating keys..."
-swift $CERTIFICATES_PATH/SimplyE/iOS/KeyObfuscator.swift "$CERTIFICATES_PATH/SimplyE/iOS/APIKeys.json"
+# echo "Obfuscating keys..."
+swift $CERTIFICATES_PATH/Palace/iOS/KeyObfuscator.swift "$CERTIFICATES_PATH/Palace/iOS/APIKeys.json"
 
 echo "update-certificates: finished"


### PR DESCRIPTION
**What's this do?**
This is a test PR to check CI scripts.

**Why are we doing this? (w/ Notion link if applicable)**
We are doing this as a part of app migration process [(Notion task)](https://www.notion.so/lyrasis/Plan-for-LYRASIS-Branded-iOS-App-ddf2322d16154b1eb2abd77a88ef3bb9)

**How should this be tested? / Do these changes have associated tests?**
Please follow the instructions in README.md, Xcode should build both `Palace-noDRM` and `Palace` targets without errors.

**Dependencies for merging? Releasing to production?**
Depends on `mobile-certificates` [PR #3](https://github.com/ThePalaceProject/mobile-certificates/pull/3)

**Does this include changes that require a new Palace build for QA?**
NA

**Has the application documentation been updated for these changes?**
Yes (README.md)

**Did someone actually run this code to verify it works?**
@vladimirfedorov 