### PR TITLE
Use a single library selection screen for welcome and settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Carthage*
 **/GoogleService-Info.plist
 **/NYPLSecrets.swift
 fastlane/report.xml
+curl-7.64.1.zip
+openssl-1.0.1u.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ Carthage*
 **/GoogleService-Info.plist
 **/NYPLSecrets.swift
 fastlane/report.xml
-curl-7.64.1.zip
-openssl-1.0.1u.tar.gz

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1663,6 +1663,10 @@
 		B51C1E19229456E2003B49A5 /* nypl_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = B51C1E15229456E2003B49A5 /* nypl_authentication_document.json */; };
 		B51C1E1A229456E2003B49A5 /* dpl_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = B51C1E16229456E2003B49A5 /* dpl_authentication_document.json */; };
 		D787E8441FB6B0290016D9D5 /* NYPLSettingsAdvancedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D787E8431FB6B0290016D9D5 /* NYPLSettingsAdvancedViewController.swift */; };
+		E55B433A267153C000953BB5 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B4339267153C000953BB5 /* LoadingViewController.swift */; };
+		E55B433E2671579700953BB5 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B4339267153C000953BB5 /* LoadingViewController.swift */; };
+		E55B433F2671579800953BB5 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B4339267153C000953BB5 /* LoadingViewController.swift */; };
+		E55B43402671579800953BB5 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B4339267153C000953BB5 /* LoadingViewController.swift */; };
 		E6202A021DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E6202A011DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m */; };
 		E6207B652118973800864143 /* NYPLAppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6207B642118973800864143 /* NYPLAppTheme.swift */; };
 		E627B554216D4A9700A7D1D5 /* NYPLBookContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = E627B553216D4A9700A7D1D5 /* NYPLBookContentType.m */; };
@@ -2349,6 +2353,7 @@
 		B51C1E16229456E2003B49A5 /* dpl_authentication_document.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = dpl_authentication_document.json; sourceTree = "<group>"; };
 		CAE35BBA1B86289500BF9BC5 /* Simplified.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Simplified.xcconfig; path = ../Simplified.xcconfig; sourceTree = "<group>"; };
 		D787E8431FB6B0290016D9D5 /* NYPLSettingsAdvancedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSettingsAdvancedViewController.swift; sourceTree = "<group>"; };
+		E55B4339267153C000953BB5 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
 		E61D7F631F6AC78B0091C781 /* SimplyE.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SimplyE.entitlements; sourceTree = "<group>"; };
 		E6202A001DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsAccountDetailViewController.h; sourceTree = "<group>"; };
 		E6202A011DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLSettingsAccountDetailViewController.m; sourceTree = "<group>"; };
@@ -3375,6 +3380,7 @@
 				081387561BC574DA003DEA6A /* UILabel+NYPLAppearanceAdditions.m */,
 				1107835C19816E3D0071AB1E /* UIView+NYPLViewAdditions.h */,
 				1107835D19816E3D0071AB1E /* UIView+NYPLViewAdditions.m */,
+				E55B4339267153C000953BB5 /* LoadingViewController.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -4868,6 +4874,7 @@
 				7347F071245A4DE200558D7F /* main.m in Sources */,
 				7347F072245A4DE200558D7F /* NYPLCaching.swift in Sources */,
 				73B5DFDE26052A1800225C12 /* NYPLBookButtonsState.m in Sources */,
+				E55B433F2671579800953BB5 /* LoadingViewController.swift in Sources */,
 				7347F073245A4DE200558D7F /* UIView+NYPLViewAdditions.m in Sources */,
 				7347F074245A4DE200558D7F /* NYPLSettingsPrimaryTableViewController.m in Sources */,
 				7347F075245A4DE200558D7F /* UIFont+NYPLSystemFontOverride.m in Sources */,
@@ -5110,6 +5117,7 @@
 				73F11E10251945E500FCD22B /* NYPLPresentationUtils.swift in Sources */,
 				739E608D244A0D8600D00301 /* NYPLReadiumBookmark.swift in Sources */,
 				73B5DFDD26052A1800225C12 /* NYPLBookButtonsState.m in Sources */,
+				E55B433E2671579700953BB5 /* LoadingViewController.swift in Sources */,
 				73DEB54F2486FDFC00B5FF0A /* NYPLBookmarkR2Location.swift in Sources */,
 				739E608E244A0D8600D00301 /* NYPLFacetViewDefaultDataSource.swift in Sources */,
 				739E608F244A0D8600D00301 /* NYPLAppTheme.swift in Sources */,
@@ -5462,6 +5470,7 @@
 				73EB0B0D25821DF4006BC997 /* NYPLSamlIDPCell.swift in Sources */,
 				73EB0B0E25821DF4006BC997 /* NYPLErrorLogger.swift in Sources */,
 				73EB0B0F25821DF4006BC997 /* NSString+JSONParse.swift in Sources */,
+				E55B43402671579800953BB5 /* LoadingViewController.swift in Sources */,
 				73EB0B1025821DF4006BC997 /* NYPLOPDSEntryGroupAttributes.m in Sources */,
 				73D8D28225A68D5600DF5F69 /* Publication+NYPLAdditions.swift in Sources */,
 				73EB0B1125821DF4006BC997 /* NYPLMyBooksDownloadCenter.m in Sources */,
@@ -5801,6 +5810,7 @@
 				21DDE32825D2CEFC002CBCE3 /* AdobeDRMContentProtection.swift in Sources */,
 				73B80BAB25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */,
 				73B5DFFE2605679800225C12 /* NYPLBook+Additions.swift in Sources */,
+				E55B433A267153C000953BB5 /* LoadingViewController.swift in Sources */,
 				21DDE31325D2CE9A002CBCE3 /* AdobeDRMLibraryService.swift in Sources */,
 				0813875A1BC5767F003DEA6A /* UIButton+NYPLAppearanceAdditions.m in Sources */,
 				1139DA6519C7755D00A07810 /* NYPLBookCoverRegistry.m in Sources */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1667,6 +1667,10 @@
 		E55B433E2671579700953BB5 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B4339267153C000953BB5 /* LoadingViewController.swift */; };
 		E55B433F2671579800953BB5 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B4339267153C000953BB5 /* LoadingViewController.swift */; };
 		E55B43402671579800953BB5 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B4339267153C000953BB5 /* LoadingViewController.swift */; };
+		E55B43502672711600953BB5 /* AccountList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B434F2672711600953BB5 /* AccountList.swift */; };
+		E55B4351267271D200953BB5 /* AccountList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B434F2672711600953BB5 /* AccountList.swift */; };
+		E55B4352267271D300953BB5 /* AccountList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B434F2672711600953BB5 /* AccountList.swift */; };
+		E55B4353267271D300953BB5 /* AccountList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55B434F2672711600953BB5 /* AccountList.swift */; };
 		E6202A021DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E6202A011DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m */; };
 		E6207B652118973800864143 /* NYPLAppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6207B642118973800864143 /* NYPLAppTheme.swift */; };
 		E627B554216D4A9700A7D1D5 /* NYPLBookContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = E627B553216D4A9700A7D1D5 /* NYPLBookContentType.m */; };
@@ -2354,6 +2358,7 @@
 		CAE35BBA1B86289500BF9BC5 /* Simplified.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Simplified.xcconfig; path = ../Simplified.xcconfig; sourceTree = "<group>"; };
 		D787E8431FB6B0290016D9D5 /* NYPLSettingsAdvancedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSettingsAdvancedViewController.swift; sourceTree = "<group>"; };
 		E55B4339267153C000953BB5 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
+		E55B434F2672711600953BB5 /* AccountList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountList.swift; sourceTree = "<group>"; };
 		E61D7F631F6AC78B0091C781 /* SimplyE.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SimplyE.entitlements; sourceTree = "<group>"; };
 		E6202A001DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsAccountDetailViewController.h; sourceTree = "<group>"; };
 		E6202A011DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLSettingsAccountDetailViewController.m; sourceTree = "<group>"; };
@@ -3381,6 +3386,7 @@
 				1107835C19816E3D0071AB1E /* UIView+NYPLViewAdditions.h */,
 				1107835D19816E3D0071AB1E /* UIView+NYPLViewAdditions.m */,
 				E55B4339267153C000953BB5 /* LoadingViewController.swift */,
+				E55B434F2672711600953BB5 /* AccountList.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -4809,6 +4815,7 @@
 				7347F049245A4DE200558D7F /* NYPLNetworkQueue.swift in Sources */,
 				7347F04A245A4DE200558D7F /* NYPLMyBooksNavigationController.m in Sources */,
 				7347F04B245A4DE200558D7F /* NYPLBookCellCollectionViewController.m in Sources */,
+				E55B4352267271D300953BB5 /* AccountList.swift in Sources */,
 				73B551092511748900D05B86 /* NYPLLoginCellTypes.swift in Sources */,
 				7342703324DCB30B00A4F605 /* Publication+NYPLAdditions.swift in Sources */,
 				730FC05225128225004D7C2D /* NYPLSettings.swift in Sources */,
@@ -5052,6 +5059,7 @@
 				739E605A244A0D8600D00301 /* OPDS2Publication.swift in Sources */,
 				739E605B244A0D8600D00301 /* String+MD5.swift in Sources */,
 				739E605C244A0D8600D00301 /* NYPLNetworkQueue.swift in Sources */,
+				E55B4351267271D200953BB5 /* AccountList.swift in Sources */,
 				73B551022511738A00D05B86 /* NYPLBasicAuth.swift in Sources */,
 				739E605D244A0D8600D00301 /* NYPLMyBooksNavigationController.m in Sources */,
 				739E605E244A0D8600D00301 /* NYPLBookCellCollectionViewController.m in Sources */,
@@ -5384,6 +5392,7 @@
 				73EB0AC425821DF4006BC997 /* URLResponse+NYPL.swift in Sources */,
 				73EB0AC525821DF4006BC997 /* NYPLSettings+SE.swift in Sources */,
 				73EB0AC625821DF4006BC997 /* NYPLSettingsAccountDetailViewController.m in Sources */,
+				E55B4353267271D300953BB5 /* AccountList.swift in Sources */,
 				73EB0AC725821DF4006BC997 /* AudioBookVendorsHelper.swift in Sources */,
 				73EB0AC825821DF4006BC997 /* NYPLReaderReadiumView.m in Sources */,
 				73D8D28025A68D4300DF5F69 /* NYPLBookLocation+Locator.swift in Sources */,
@@ -5781,6 +5790,7 @@
 				5DD567AF22B95A30001F0C83 /* String+MD5.swift in Sources */,
 				E671FF7D1E3A7068002AB13F /* NYPLNetworkQueue.swift in Sources */,
 				116A5EAF194767B200491A21 /* NYPLMyBooksNavigationController.m in Sources */,
+				E55B43502672711600953BB5 /* AccountList.swift in Sources */,
 				739062D225358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift in Sources */,
 				1120749319D20BF9008203A4 /* NYPLBookCellCollectionViewController.m in Sources */,
 				0857A0FF247835FF00C7984E /* NYPLKeychainStoredVariable.swift in Sources */,

--- a/Simplified/Settings/NYPLSettingsAccountsList.swift
+++ b/Simplified/Settings/NYPLSettingsAccountsList.swift
@@ -173,7 +173,7 @@
   }
   
   @objc private func addAccount() {
-    let listVC = NYPLWelcomeScreenAccountList { [weak self] account in
+    let listVC = AccountList { [weak self] account in
       if account.details != nil {
         self?.updateList(withAccount: account.uuid)
       } else {

--- a/Simplified/Settings/NYPLSettingsAccountsList.swift
+++ b/Simplified/Settings/NYPLSettingsAccountsList.swift
@@ -7,7 +7,7 @@
     case failure
     case success
   }
-  
+
   weak var tableView: UITableView!
   var reloadView: NYPLReloadView!
   var spinner: UIActivityIndicatorView!

--- a/Simplified/Utilities/UI/AccountList.swift
+++ b/Simplified/Utilities/UI/AccountList.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+final class AccountList: UIViewController, UITableViewDelegate, UITableViewDataSource {
+  
+  var accounts: [Account]!
+  var nyplAccounts: [Account]!
+  let completion: (Account) -> ()
+  weak var tableView : UITableView!
+  
+  required init(completion: @escaping (Account) -> ()) {
+    self.completion = completion
+    super.init(nibName:nil, bundle:nil)
+  }
+  
+  @available(*, unavailable)
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func viewDidLoad() {
+    self.view = UITableView(frame: .zero, style: .grouped)
+    self.tableView = self.view as? UITableView
+    self.tableView.delegate = self
+    self.tableView.dataSource = self
+    
+    self.accounts = AccountsManager.shared.accounts()
+    
+    //FIXME Replace with SettingsAccounts improvements to library selection VC
+    //once that gets finalized and merged in.
+    self.accounts.sort { $0.name < $1.name }
+    self.nyplAccounts = self.accounts.filter { AccountsManager.NYPLAccountUUIDs.contains($0.uuid) }
+    self.accounts = self.accounts.filter { !AccountsManager.NYPLAccountUUIDs.contains($0.uuid) }
+    
+    self.title = NSLocalizedString("Pick Your Library", comment: "Title that also informs the user that they should choose a library from the list.")
+    self.view.backgroundColor = NYPLConfiguration.backgroundColor()
+  }
+  
+  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    return 100
+  }
+  
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    if indexPath.section == 0 {
+      completion(nyplAccounts[indexPath.row])
+    } else {
+      completion(accounts[indexPath.row])
+    }
+  }
+  
+  func numberOfSections(in tableView: UITableView) -> Int {
+    return 2
+  }
+  
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    if section == 0 {
+      return self.nyplAccounts.count
+    } else {
+      return self.accounts.count
+    }
+  }
+  
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    if indexPath.section == 0 {
+      return cellForLibrary(self.nyplAccounts[indexPath.row])
+    } else {
+      return cellForLibrary(self.accounts[indexPath.row])
+    }
+  }
+  
+  func cellForLibrary(_ account: Account) -> UITableViewCell {
+    let cell = UITableViewCell.init(style: .subtitle, reuseIdentifier: "")
+    
+    let container = UIView()
+    let textContainer = UIView()
+    
+    cell.accessoryType = .disclosureIndicator
+    let imageView = UIImageView(image: account.logo)
+    imageView.contentMode = .scaleAspectFit
+    
+    let textLabel = UILabel()
+    textLabel.font = UIFont.systemFont(ofSize: 16)
+    textLabel.text = account.name
+    textLabel.numberOfLines = 0
+    
+    let detailLabel = UILabel()
+    detailLabel.font = UIFont(name: "AvenirNext-Regular", size: 12)
+    detailLabel.numberOfLines = 0
+    detailLabel.text = account.subtitle
+    
+    textContainer.addSubview(textLabel)
+    textContainer.addSubview(detailLabel)
+    
+    container.addSubview(imageView)
+    container.addSubview(textContainer)
+    cell.contentView.addSubview(container)
+    
+    imageView.autoAlignAxis(toSuperviewAxis: .horizontal)
+    imageView.autoPinEdge(toSuperviewEdge: .left)
+    imageView.autoSetDimensions(to: CGSize(width: 45, height: 45))
+    
+    textContainer.autoPinEdge(.left, to: .right, of: imageView, withOffset: cell.contentView.layoutMargins.left * 2)
+    textContainer.autoPinEdge(toSuperviewMargin: .right)
+    textContainer.autoAlignAxis(toSuperviewAxis: .horizontal)
+    
+    NSLayoutConstraint.autoSetPriority(UILayoutPriority.defaultLow) {
+      textContainer.autoPinEdge(toSuperviewEdge: .top, withInset: 0, relation: .greaterThanOrEqual)
+      textContainer.autoPinEdge(toSuperviewEdge: .bottom, withInset: 0, relation: .greaterThanOrEqual)
+    }
+    
+    textLabel.autoPinEdgesToSuperviewEdges(with: .zero, excludingEdge: .bottom)
+    
+    detailLabel.autoPinEdge(.top, to: .bottom, of: textLabel)
+    detailLabel.autoPinEdgesToSuperviewEdges(with: .zero, excludingEdge: .top)
+    
+    container.autoPinEdgesToSuperviewMargins()
+    container.autoSetDimension(.height, toSize: 55, relation: .greaterThanOrEqual)
+    
+    return cell
+  }
+}

--- a/Simplified/Utilities/UI/LoadingViewController.swift
+++ b/Simplified/Utilities/UI/LoadingViewController.swift
@@ -1,0 +1,49 @@
+//
+//  UIViewController+Loading.swift
+//  SimplyE
+//
+//  Created by Maurice Work on 6/9/21.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import UIKit
+
+protocol LoadingViewController: UIViewController {
+  var loadingView: UIView? { get set }
+}
+
+extension LoadingViewController {
+  
+  private func loadingOverlayView() -> UIView {
+    let overlayView = UIView()
+    overlayView.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+    let activityView = UIActivityIndicatorView(style: .whiteLarge)
+    overlayView.addSubview(activityView)
+    activityView.autoCenterInSuperviewMargins()
+    overlayView.translatesAutoresizingMaskIntoConstraints = false
+    activityView.startAnimating()
+    return overlayView
+  }
+  
+  func startLoading() {
+    guard loadingView == nil else { return }
+    
+    let loadingOverlay = loadingOverlayView()
+    if !Thread.isMainThread {
+      DispatchQueue.main.async {
+        UIApplication.shared.keyWindow?.addSubview(loadingOverlay)
+        loadingOverlay.autoPinEdgesToSuperviewEdges()
+      }
+    } else {
+      UIApplication.shared.keyWindow?.addSubview(loadingOverlay)
+      loadingOverlay.autoPinEdgesToSuperviewEdges()
+    }
+    
+    loadingView = loadingOverlay
+  }
+  
+  func stopLoading() {
+    loadingView?.removeFromSuperview()
+    loadingView = nil
+  }
+}

--- a/Simplified/Utilities/UI/LoadingViewController.swift
+++ b/Simplified/Utilities/UI/LoadingViewController.swift
@@ -1,11 +1,3 @@
-//
-//  UIViewController+Loading.swift
-//  SimplyE
-//
-//  Created by Maurice Work on 6/9/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
-//
-
 import UIKit
 
 protocol LoadingViewController: UIViewController {

--- a/Simplified/WelcomeScreen/NYPLWelcomeScreenViewController.swift
+++ b/Simplified/WelcomeScreen/NYPLWelcomeScreenViewController.swift
@@ -157,7 +157,7 @@ import PureLayout
     }
     
     let pickLibrary = {
-      let listVC = NYPLWelcomeScreenAccountList { account in
+      let listVC = AccountList { account in
         if account.details != nil {
           self.completion?(account)
         } else {
@@ -245,127 +245,5 @@ import PureLayout
         }
       }
     }
-  }
-}
-
-
-/// List of available Libraries/Accounts to select as patron's primary
-/// when going through Welcome Screen flow.
-final class NYPLWelcomeScreenAccountList: UIViewController, UITableViewDelegate, UITableViewDataSource {
-  
-  var accounts: [Account]!
-  var nyplAccounts: [Account]!
-  let completion: (Account) -> ()
-  weak var tableView : UITableView!
-  
-  required init(completion: @escaping (Account) -> ()) {
-    self.completion = completion
-    super.init(nibName:nil, bundle:nil)
-  }
-  
-  @available(*, unavailable)
-  required init?(coder aDecoder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-  
-  override func viewDidLoad() {
-    self.view = UITableView(frame: .zero, style: .grouped)
-    self.tableView = self.view as? UITableView
-    self.tableView.delegate = self
-    self.tableView.dataSource = self
-    
-    self.accounts = AccountsManager.shared.accounts()
-
-    //FIXME Replace with SettingsAccounts improvements to library selection VC
-    //once that gets finalized and merged in.
-    self.accounts.sort { $0.name < $1.name }
-    self.nyplAccounts = self.accounts.filter { AccountsManager.NYPLAccountUUIDs.contains($0.uuid) }
-    self.accounts = self.accounts.filter { !AccountsManager.NYPLAccountUUIDs.contains($0.uuid) }
-
-    self.title = NSLocalizedString("Pick Your Library", comment: "Title that also informs the user that they should choose a library from the list.")
-    self.view.backgroundColor = NYPLConfiguration.backgroundColor()
-  }
-  
-  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-    return 100
-  }
-  
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    if indexPath.section == 0 {
-      completion(nyplAccounts[indexPath.row])
-    } else {
-      completion(accounts[indexPath.row])
-    }
-  }
-
-  func numberOfSections(in tableView: UITableView) -> Int {
-    return 2
-  }
-  
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    if section == 0 {
-      return self.nyplAccounts.count
-    } else {
-      return self.accounts.count
-    }
-  }
-  
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    if indexPath.section == 0 {
-      return cellForLibrary(self.nyplAccounts[indexPath.row])
-    } else {
-      return cellForLibrary(self.accounts[indexPath.row])
-    }
-  }
-  
-  func cellForLibrary(_ account: Account) -> UITableViewCell {
-    let cell = UITableViewCell.init(style: .subtitle, reuseIdentifier: "")
-    
-    let container = UIView()
-    let textContainer = UIView()
-
-    cell.accessoryType = .disclosureIndicator
-    let imageView = UIImageView(image: account.logo)
-    imageView.contentMode = .scaleAspectFit
-
-    let textLabel = UILabel()
-    textLabel.font = UIFont.systemFont(ofSize: 16)
-    textLabel.text = account.name
-    textLabel.numberOfLines = 0
-
-    let detailLabel = UILabel()
-    detailLabel.font = UIFont(name: "AvenirNext-Regular", size: 12)
-    detailLabel.numberOfLines = 0
-    detailLabel.text = account.subtitle
-
-    textContainer.addSubview(textLabel)
-    textContainer.addSubview(detailLabel)
-
-    container.addSubview(imageView)
-    container.addSubview(textContainer)
-    cell.contentView.addSubview(container)
-
-    imageView.autoAlignAxis(toSuperviewAxis: .horizontal)
-    imageView.autoPinEdge(toSuperviewEdge: .left)
-    imageView.autoSetDimensions(to: CGSize(width: 45, height: 45))
-
-    textContainer.autoPinEdge(.left, to: .right, of: imageView, withOffset: cell.contentView.layoutMargins.left * 2)
-    textContainer.autoPinEdge(toSuperviewMargin: .right)
-    textContainer.autoAlignAxis(toSuperviewAxis: .horizontal)
-
-    NSLayoutConstraint.autoSetPriority(UILayoutPriority.defaultLow) {
-      textContainer.autoPinEdge(toSuperviewEdge: .top, withInset: 0, relation: .greaterThanOrEqual)
-      textContainer.autoPinEdge(toSuperviewEdge: .bottom, withInset: 0, relation: .greaterThanOrEqual)
-    }
-
-    textLabel.autoPinEdgesToSuperviewEdges(with: .zero, excludingEdge: .bottom)
-
-    detailLabel.autoPinEdge(.top, to: .bottom, of: textLabel)
-    detailLabel.autoPinEdgesToSuperviewEdges(with: .zero, excludingEdge: .top)
-
-    container.autoPinEdgesToSuperviewMargins()
-    container.autoSetDimension(.height, toSize: 55, relation: .greaterThanOrEqual)
-
-    return cell
   }
 }

--- a/Simplified/WelcomeScreen/NYPLWelcomeScreenViewController.swift
+++ b/Simplified/WelcomeScreen/NYPLWelcomeScreenViewController.swift
@@ -212,7 +212,7 @@ import PureLayout
         }
         return
       }
-      // If we didn't add the loading overlay to load the library list, we need to add it now to load the auth document
+      //Show indicator while loading the auth document
       self.startLoading()
       
       // Load the auth document for the classics library


### PR DESCRIPTION
** HOLD MERGE until https://github.com/ThePalaceProject/ios-core/pull/2/files is merged into develop **

This change: 

- replaces the library selection UI of the settings screen with `AccountList`, formerly `NYPLWelcomeScreenAccountList`
- implements a loading protocol to handle `LoadingOverlayViewController` presentation and conforms `NYPLSettingsAccountsTableViewController` and `NYPLWelcomeScreenViewController`