### PR TITLE
Add custom library registry debugging functionality

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -703,6 +703,7 @@
 		E551B365267D42AF0026FC1B /* TPPLoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E551B359267D396A0026FC1B /* TPPLoadingViewController.swift */; };
 		E5AD65DD2684FACA00C62951 /* TPPAccountListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AD65DC2684FACA00C62951 /* TPPAccountListCell.swift */; };
 		E5AD65E12684FDA300C62951 /* TPPAccountListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AD65E02684FDA300C62951 /* TPPAccountListDataSource.swift */; };
+		E5C2C422268BA5140046F415 /* TPPRegistryDebuggingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C2C421268BA5140046F415 /* TPPRegistryDebuggingCell.swift */; };
 		E6202A021DD4E6F300C99553 /* TPPSettingsAccountDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E6202A011DD4E6F300C99553 /* TPPSettingsAccountDetailViewController.m */; };
 		E6207B652118973800864143 /* TPPAppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6207B642118973800864143 /* TPPAppTheme.swift */; };
 		E627B554216D4A9700A7D1D5 /* TPPBookContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = E627B553216D4A9700A7D1D5 /* TPPBookContentType.m */; };
@@ -1426,6 +1427,7 @@
 		E551B360267D402B0026FC1B /* TPPAccountList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAccountList.swift; sourceTree = "<group>"; };
 		E5AD65DC2684FACA00C62951 /* TPPAccountListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAccountListCell.swift; sourceTree = "<group>"; };
 		E5AD65E02684FDA300C62951 /* TPPAccountListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAccountListDataSource.swift; sourceTree = "<group>"; };
+		E5C2C421268BA5140046F415 /* TPPRegistryDebuggingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPRegistryDebuggingCell.swift; sourceTree = "<group>"; };
 		E61D7F631F6AC78B0091C781 /* SimplyE.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SimplyE.entitlements; sourceTree = "<group>"; };
 		E6202A001DD4E6F300C99553 /* TPPSettingsAccountDetailViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPSettingsAccountDetailViewController.h; sourceTree = "<group>"; };
 		E6202A011DD4E6F300C99553 /* TPPSettingsAccountDetailViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPSettingsAccountDetailViewController.m; sourceTree = "<group>"; };
@@ -1750,7 +1752,7 @@
 			children = (
 				732940BF251D0B790065E362 /* BarcodeScanning */,
 				732940BE251D05E30065E362 /* SettingsCells */,
-				5DD5674422B303DF001F0C83 /* TPPDeveloperSettingsTableViewController.swift */,
+				E5C2C41B268BA4E00046F415 /* DeveloperSettings */,
 				5DD5677122B7ECE3001F0C83 /* TPPSettings.swift */,
 				730FC04F25127FA2004D7C2D /* TPPSettings+OE.swift */,
 				7347312825142FE200BE3D2C /* TPPSettings+SE.swift */,
@@ -2757,6 +2759,15 @@
 			path = AccountList;
 			sourceTree = "<group>";
 		};
+		E5C2C41B268BA4E00046F415 /* DeveloperSettings */ = {
+			isa = PBXGroup;
+			children = (
+				5DD5674422B303DF001F0C83 /* TPPDeveloperSettingsTableViewController.swift */,
+				E5C2C421268BA5140046F415 /* TPPRegistryDebuggingCell.swift */,
+			);
+			path = DeveloperSettings;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -3574,6 +3585,7 @@
 				E6DA7EA01F2A718600CFBEC8 /* TPPBookAuthor.swift in Sources */,
 				739ECB2425101CCE00691A70 /* NSNotification+TPP.swift in Sources */,
 				734B789125659611006FB8AD /* URLResponse+TPPAuthentication.swift in Sources */,
+				E5C2C422268BA5140046F415 /* TPPRegistryDebuggingCell.swift in Sources */,
 				118A0B1B19915BDF00792DDE /* TPPCatalogSearchViewController.m in Sources */,
 				737DCB8C245CCF2300A8F297 /* TPPReaderBookmarksBusinessLogic.swift in Sources */,
 				179699D124131BA500EC309F /* UIColor+LabelColor.swift in Sources */,

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -331,6 +331,8 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
 
     if self.accounts().isEmpty {
       loadCatalogs(completion: completion)
+    } else {
+      completion?(false)
     }
   }
 

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -106,7 +106,7 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
   #endif
 
   private override init() {
-    self.accountSet = TPPSettings.shared.useBetaLibraries ? TPPConfiguration.betaUrlHash : TPPConfiguration.prodUrlHash
+    self.accountSet = TPPConfiguration.customUrlHash() ?? (TPPSettings.shared.useBetaLibraries ? TPPConfiguration.betaUrlHash : TPPConfiguration.prodUrlHash)
     self.ageCheck = TPPAgeCheck(ageCheckChoiceStorage: TPPSettings.shared)
     
     super.init()
@@ -257,7 +257,7 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
   /// thread or not.
   func loadCatalogs(completion: ((Bool) -> ())?) {
     Log.debug(#file, "Entering loadCatalog...")
-    let targetUrl = TPPSettings.shared.useBetaLibraries ? TPPConfiguration.betaUrl : TPPConfiguration.prodUrl
+    let targetUrl = TPPConfiguration.customUrl() ?? (TPPSettings.shared.useBetaLibraries ? TPPConfiguration.betaUrl : TPPConfiguration.prodUrl)
     let hash = targetUrl.absoluteString.md5().base64EncodedStringUrlSafe()
       .trimmingCharacters(in: ["="])
 
@@ -326,7 +326,7 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
 
   func updateAccountSet(completion: ((Bool) -> ())?) {
     accountSetsWorkQueue.sync(flags: .barrier) {
-      self.accountSet = TPPSettings.shared.useBetaLibraries ? TPPConfiguration.betaUrlHash : TPPConfiguration.prodUrlHash
+      self.accountSet = TPPConfiguration.customUrlHash() ?? (TPPSettings.shared.useBetaLibraries ? TPPConfiguration.betaUrlHash : TPPConfiguration.prodUrlHash)
     }
 
     if self.accounts().isEmpty {

--- a/Palace/AppInfrastructure/TPPConfiguration+SE.swift
+++ b/Palace/AppInfrastructure/TPPConfiguration+SE.swift
@@ -9,13 +9,22 @@
 import Foundation
 
 extension TPPConfiguration {
-
+  
   static let betaUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries/qa")!
   static let prodUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries")!
-
+  
   static let betaUrlHash = betaUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
   static let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
 
+  static func customUrl() -> URL? {
+    guard let server = TPPSettings.shared.customLibraryRegistryServer else { return nil }
+    return URL(string: "https://\(server)/libraries/qa")
+  }
+  
+  static func customUrlHash() -> String? {
+    customUrl()?.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  }
+  
   @objc static func mainColor() -> UIColor {
     let libAccount = AccountsManager.sharedInstance().currentAccount
     if let mainColor = libAccount?.details?.mainColor {

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -61,10 +61,7 @@ import Foundation
     switch indexPath.section {
     case 0: return cellForBetaLibraries()
     case 1: return cellForR2Toggle()
-    case 2:
-      let cell = TPPRegistryDebuggingCell()
-      cell.delegate = self
-      return cell
+    case 2: return cellForCustomRegsitry()
     default: return cellForClearCache()
     }
   }
@@ -106,6 +103,11 @@ import Foundation
     return cell
   }
   
+  private func cellForCustomRegsitry() -> UITableViewCell {
+    let cell = TPPRegistryDebuggingCell()
+    cell.delegate = self
+    return cell
+  }
   
   private func cellForClearCache() -> UITableViewCell {
     let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "clearCacheCell")

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -4,7 +4,8 @@ import Foundation
 /// can then log in and adjust settings after selecting Accounts.
 @objcMembers class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
   weak var tableView: UITableView!
-  
+  var loadingView: UIView?
+
   required init() {
     super.init(nibName: nil, bundle: nil)
   }
@@ -60,7 +61,10 @@ import Foundation
     switch indexPath.section {
     case 0: return cellForBetaLibraries()
     case 1: return cellForR2Toggle()
-    case 2: return TPPRegistryDebuggingCell()
+    case 2:
+      let cell = TPPRegistryDebuggingCell()
+      cell.delegate = self
+      return cell
     default: return cellForClearCache()
     }
   }
@@ -134,3 +138,5 @@ import Foundation
     return false
   }
 }
+
+extension TPPDeveloperSettingsTableViewController: TPPRegistryDebugger {}

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -53,13 +53,14 @@ import Foundation
   }
   
   func numberOfSections(in tableView: UITableView) -> Int {
-    return 3
+    return 4
   }
   
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     switch indexPath.section {
     case 0: return cellForBetaLibraries()
     case 1: return cellForR2Toggle()
+    case 2: return TPPRegistryDebuggingCell()
     default: return cellForClearCache()
     }
   }
@@ -70,6 +71,8 @@ import Foundation
       return "Library Settings"
     case 1:
       return "eReader Settings"
+    case 2:
+      return "Library Registry Debugging"
     default:
       return "Data Management"
     }
@@ -99,6 +102,7 @@ import Foundation
     return cell
   }
   
+  
   private func cellForClearCache() -> UITableViewCell {
     let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "clearCacheCell")
     cell.selectionStyle = .none
@@ -111,7 +115,7 @@ import Foundation
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     self.tableView.deselectRow(at: indexPath, animated: true)
     
-    if indexPath.section == 2 {
+    if indexPath.section == 3 {
       AccountsManager.shared.clearCache()
       let alert = TPPAlertUtils.alert(title: "Data Management", message: "Cache Cleared")
       self.present(alert, animated: true, completion: nil)

--- a/Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift
+++ b/Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift
@@ -1,0 +1,147 @@
+import UIKit
+
+class TPPRegistryDebuggingCell: UITableViewCell {
+  
+  private var inputField = UITextField()
+  
+  lazy var horizontalStackView: UIStackView = {
+    let stack = UIStackView()
+    stack.axis = .horizontal
+    stack.distribution = .fillProportionally
+    stack.spacing = 5
+    stack.alignment = .center
+    return stack
+  }()
+  
+  lazy var prefixLabel: UILabel = {
+    let label = UILabel()
+    label.text = "https://"
+    label.adjustsFontSizeToFitWidth = true
+    label.textColor = .gray
+    label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    return label
+  }()
+  
+  lazy var postfixLabel: UILabel = {
+    let label = UILabel()
+    label.text = "/libraries/qa"
+    label.adjustsFontSizeToFitWidth = true
+    label.textColor = .gray
+    label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    return label
+  }()
+  
+  lazy var inputStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    
+    inputField.placeholder = "Input custom server"
+    inputField.text = TPPSettings.shared.customLibraryRegistryServer
+    stackView.addArrangedSubview(inputField)
+    inputField.autoSetDimension(.width, toSize: 200, relation: .greaterThanOrEqual)
+    
+    let underline = UIView()
+    underline.backgroundColor = .gray
+    stackView.addArrangedSubview(underline)
+    underline.autoSetDimension(.height, toSize: 1)
+    return stackView
+  }()
+  
+  lazy var buttonStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.spacing = 30
+    stackView.distribution = .equalSpacing
+    
+    let clearButton = UIButton()
+    clearButton.layer.cornerRadius = 5
+    clearButton.layer.borderWidth = 1
+    clearButton.layer.borderColor = UIColor.black.cgColor
+    
+    clearButton.setTitle("Clear", for: .normal)
+    clearButton.setTitleColor(UIColor.black, for: .normal)
+
+    clearButton.addTarget(self, action: #selector(clear), for: .touchUpInside)
+    
+    clearButton.autoSetDimension(.width, toSize: 125)
+    stackView.addArrangedSubview(clearButton)
+    
+    let setButton = UIButton()
+    setButton.layer.cornerRadius = 5
+    setButton.layer.borderWidth = 1
+    setButton.layer.borderColor = UIColor.black.cgColor
+    setButton.autoSetDimension(.width, toSize: 125)
+
+    setButton.setTitle("Set", for: .normal)
+    setButton.setTitleColor(UIColor.black, for: .normal)
+
+    setButton.addTarget(self, action: #selector(set), for: .touchUpInside)
+    stackView.addArrangedSubview(setButton)
+    return stackView
+  }()
+  
+  init() {
+    super.init(style: .default, reuseIdentifier: "CustomRegistryCell")
+    configure()
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+  
+  private func configure() {
+    selectionStyle = .none
+    
+    let containerStack = UIStackView()
+    containerStack.axis = .vertical
+    containerStack.spacing = 10
+    
+    horizontalStackView.addArrangedSubview(prefixLabel)
+    horizontalStackView.addArrangedSubview(inputStackView)
+    horizontalStackView.addArrangedSubview(postfixLabel)
+    containerStack.addArrangedSubview(horizontalStackView)
+    containerStack.addArrangedSubview(buttonStackView)
+    contentView.addSubview(containerStack)
+    
+    containerStack.autoSetDimension(.height, toSize: 100, relation: .greaterThanOrEqual)
+    containerStack.autoPinEdgesToSuperviewMargins()
+  }
+  
+  @objc private func clear() {
+    inputField.text = nil
+    TPPSettings.shared.customLibraryRegistryServer = nil
+    showAlert(title: "Configuration Updated", message: "Custom server has been reset to default")
+    reloadRegistry()
+  }
+  
+  @objc private func set() {
+    TPPSettings.shared.customLibraryRegistryServer = inputField.text
+    let message = String(format: "Custom server: %@", inputField.text ?? "")
+    showAlert(title: "Configuration Updated", message: message)
+    reloadRegistry()
+  }
+  
+  private func reloadRegistry() {
+    AccountsManager.shared.clearCache()
+    AccountsManager.shared.updateAccountSet(completion: nil)
+  }
+  
+  private func showAlert(title: String, message: String) {
+    let alert = TPPAlertUtils.alert(title: title, message: message)
+    UIApplication.shared.keyWindow?.rootViewController?.present(alert, animated: true, completion: nil)
+  }
+}
+
+ extension UIButton {
+  open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    super.touchesBegan(touches, with: event)
+    
+    alpha = 0.5
+  }
+  
+  open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    super.touchesEnded(touches, with: event)
+    
+    alpha = 1.0
+  }
+}

--- a/Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift
+++ b/Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift
@@ -162,17 +162,3 @@ class TPPRegistryDebuggingCell: UITableViewCell {
     }
   }
 }
-
- extension UIButton {
-  open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-    super.touchesBegan(touches, with: event)
-    
-    alpha = 0.5
-  }
-  
-  open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-    super.touchesEnded(touches, with: event)
-    
-    alpha = 1.0
-  }
-}

--- a/Palace/Settings/TPPSettings.swift
+++ b/Palace/Settings/TPPSettings.swift
@@ -31,6 +31,7 @@ import Foundation
   static private let useR2Key = "NYPLUseR2Key"
   static let settingsLibraryAccountsKey = "NYPLSettingsLibraryAccountsKey"
   static private let versionKey = "NYPLSettingsVersionKey"
+  static private let customLibraryRegistryKey = "TPPSettingsCustomLibraryRegistryKey"
   
   // Set to nil (the default) if no custom feed should be used.
   var customMainFeedURL: URL? {
@@ -130,6 +131,16 @@ import Foundation
     }
     set(versionString) {
       UserDefaults.standard.set(versionString, forKey: TPPSettings.versionKey)
+      UserDefaults.standard.synchronize()
+    }
+  }
+  
+  var customLibraryRegistryServer: String? {
+    get {
+      return UserDefaults.standard.string(forKey: TPPSettings.customLibraryRegistryKey)
+    }
+    set(customServer) {
+      UserDefaults.standard.set(customServer, forKey: TPPSettings.customLibraryRegistryKey)
       UserDefaults.standard.synchronize()
     }
   }

--- a/Palace/Utilities/UI/TPPLoadingViewController.swift
+++ b/Palace/Utilities/UI/TPPLoadingViewController.swift
@@ -21,22 +21,19 @@ extension TPPLoadingViewController {
     guard loadingView == nil else { return }
     
     let loadingOverlay = loadingOverlayView()
-    if !Thread.isMainThread {
       DispatchQueue.main.async {
         UIApplication.shared.keyWindow?.addSubview(loadingOverlay)
         loadingOverlay.autoPinEdgesToSuperviewEdges()
       }
-    } else {
-      UIApplication.shared.keyWindow?.addSubview(loadingOverlay)
-      loadingOverlay.autoPinEdgesToSuperviewEdges()
-    }
     
     loadingView = loadingOverlay
   }
   
   func stopLoading() {
-    loadingView?.removeFromSuperview()
-    loadingView = nil
+    DispatchQueue.main.async {
+      self.loadingView?.removeFromSuperview()
+      self.loadingView = nil
+    }
   }
 }
 


### PR DESCRIPTION
**What's this do?**
Implements functionality enabling tests to input custom library registry servers

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/Add-ability-in-Palace-iOS-app-to-configure-library-registry-libraries-URL-304cf93efb1448f597887739d84c421c

**How should this be tested? / Do these changes have associated tests?**
- Enter debug menu
- Input a valid test server
- Cache should will be cleared and new configuration will be loaded

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 

![Simulator Screen Shot - iPhone 12 Pro - 2021-06-30 at 11 18 19](https://user-images.githubusercontent.com/6921353/123987126-f09adc00-d994-11eb-8cfb-de2c3e773b91.png)
