### PR TITLE
Prevent language based filtering during search

### DIFF
--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -98,7 +98,8 @@ extension TPPNetworkExecutor {
 
       headers.forEach { urlRequest.setValue($0.value, forHTTPHeaderField: $0.key) }
     }
-
+    
+    urlRequest.setValue("", forHTTPHeaderField: "Accept-Language")
     return urlRequest
   }
 

--- a/Palace/WelcomeScreen/TPPWelcomeScreenViewController.swift
+++ b/Palace/WelcomeScreen/TPPWelcomeScreenViewController.swift
@@ -127,11 +127,8 @@ import PureLayout
                 self.showLoadingFailureAlert()
                 return
               }
-              if account.uuid != AccountsManager.TPPAccountUUIDs[2] {
-                TPPSettings.shared.settingsAccountsList = [account.uuid, AccountsManager.TPPAccountUUIDs[2]]
-              } else {
-                TPPSettings.shared.settingsAccountsList = [AccountsManager.TPPAccountUUIDs[2]]
-              }
+              
+              TPPSettings.shared.settingsAccountsList = [account.uuid]
               self.completion?(account)
             }
           }

--- a/Palace/WelcomeScreen/TPPWelcomeScreenViewController.swift
+++ b/Palace/WelcomeScreen/TPPWelcomeScreenViewController.swift
@@ -127,8 +127,11 @@ import PureLayout
                 self.showLoadingFailureAlert()
                 return
               }
-              
-              TPPSettings.shared.settingsAccountsList = [account.uuid]
+              if account.uuid != AccountsManager.TPPAccountUUIDs[2] {
+                TPPSettings.shared.settingsAccountsList = [account.uuid, AccountsManager.TPPAccountUUIDs[2]]
+              } else {
+                TPPSettings.shared.settingsAccountsList = [AccountsManager.TPPAccountUUIDs[2]]
+              }
               self.completion?(account)
             }
           }


### PR DESCRIPTION
**What's this do?**
Removes default `Accpet-Language` values to prevent search filtering based on device localization settings

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/iOS-Filters-Language-based-on-localization-of-app-d6c4b7a4029b48628e13f71cbbfa3bc6

**How should this be tested? / Do these changes have associated tests?**
Set iPhone language to english and attempt to search for a non english title

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 


https://user-images.githubusercontent.com/6921353/124171355-75115b80-da76-11eb-8eaf-7d77101823a4.mov


