### PR TITLE
Removes automatic inclusion of SimplyE collection during onboarding

### DIFF
--- a/Palace/WelcomeScreen/TPPWelcomeScreenViewController.swift
+++ b/Palace/WelcomeScreen/TPPWelcomeScreenViewController.swift
@@ -127,11 +127,8 @@ import PureLayout
                 self.showLoadingFailureAlert()
                 return
               }
-              if account.uuid != AccountsManager.TPPAccountUUIDs[2] {
-                TPPSettings.shared.settingsAccountsList = [account.uuid, AccountsManager.TPPAccountUUIDs[2]]
-              } else {
-                TPPSettings.shared.settingsAccountsList = [AccountsManager.TPPAccountUUIDs[2]]
-              }
+                
+              TPPSettings.shared.settingsAccountsList = [account.uuid]
               self.completion?(account)
             }
           }


### PR DESCRIPTION

**What's this do?**
Removes functionality that auto-adds SimplyE collection when onboarding

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/Palace-iOS-automatically-adds-the-SimplyE-collection-to-accounts-e34e74d5acaa4c8aba7232839c7854ee

**How should this be tested? / Do these changes have associated tests?**
Delete and reinstall application, complete onboarding

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 

https://user-images.githubusercontent.com/6921353/124174475-6b89f280-da7a-11eb-9e6e-3f878fedd3a9.mov

