### PR TITLE
Fix app crash on signing in to a new library account

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3817,7 +3817,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3838,7 +3838,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3873,7 +3873,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3894,7 +3894,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -4051,7 +4051,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4073,7 +4073,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -4106,7 +4106,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4128,7 +4128,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		21DDE32E25D31DB4002CBCE3 /* AdobeDRMFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DDE32D25D31DB4002CBCE3 /* AdobeDRMFetcher.swift */; };
 		21DDE33225D31DB4002CBCE3 /* AdobeDRMFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DDE32D25D31DB4002CBCE3 /* AdobeDRMFetcher.swift */; };
 		21DF7F9325AF5E1E0090402A /* ReaderModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DF7F9225AF5E1E0090402A /* ReaderModule.swift */; };
+		21E35FC3268CC8AC00066F9D /* AdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E35FC2268CC8AC00066F9D /* AdobeContentProtectionService.swift */; };
 		21E7E07B24FEA7E800189224 /* DPLAAudiobooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E7E07A24FEA7E800189224 /* DPLAAudiobooks.swift */; };
 		21EC1B8F2501538600A12384 /* AudioBookVendors+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EC1B8E2501538600A12384 /* AudioBookVendors+Extensions.swift */; };
 		2D2B47841D08F8E2007F7764 /* UpdateCheckUpToDate.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D2B47691D08F264007F7764 /* UpdateCheckUpToDate.json */; };
@@ -1104,6 +1105,7 @@
 		21DE2A8025B1FF5A00BCC9E0 /* R2Shared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2Shared.framework; path = "../r2-lcp-swift/Carthage/Build/iOS/R2Shared.framework"; sourceTree = "<group>"; };
 		21DF7F9225AF5E1E0090402A /* ReaderModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModule.swift; sourceTree = "<group>"; };
 		21DF7F9725AF5E560090402A /* ReaderFormatModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderFormatModule.swift; sourceTree = "<group>"; };
+		21E35FC2268CC8AC00066F9D /* AdobeContentProtectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeContentProtectionService.swift; sourceTree = "<group>"; };
 		21E7E07A24FEA7E800189224 /* DPLAAudiobooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DPLAAudiobooks.swift; sourceTree = "<group>"; };
 		21EC1B8E2501538600A12384 /* AudioBookVendors+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioBookVendors+Extensions.swift"; sourceTree = "<group>"; };
 		21F238C02499155E004DC0B1 /* AdobeDRMContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AdobeDRMContainer.h; sourceTree = "<group>"; };
@@ -1706,6 +1708,7 @@
 				21F238C724991A2A004DC0B1 /* AdobeDRMLibraryService.swift */,
 				21DDE32725D2CEFC002CBCE3 /* AdobeDRMContentProtection.swift */,
 				21DDE32D25D31DB4002CBCE3 /* AdobeDRMFetcher.swift */,
+				21E35FC2268CC8AC00066F9D /* AdobeContentProtectionService.swift */,
 			);
 			path = AdobeDRM;
 			sourceTree = "<group>";
@@ -3536,6 +3539,7 @@
 				E5AD65E12684FDA300C62951 /* TPPAccountListDataSource.swift in Sources */,
 				2D754BC22002F1B10061D34F /* TPPOPDSIndirectAcquisition.m in Sources */,
 				734917DA242EB79700059AA5 /* TPPR1R2UserSettings.swift in Sources */,
+				21E35FC3268CC8AC00066F9D /* AdobeContentProtectionService.swift in Sources */,
 				116A5EB3194767DC00491A21 /* TPPMyBooksViewController.m in Sources */,
 				73CC48B0260C09A400F1E2C3 /* TPPAnnotations+Deprecated.swift in Sources */,
 				21C7B87E25AE1DBA000E8BF3 /* LibraryServiceError.swift in Sources */,

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeContentProtectionService.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeContentProtectionService.swift
@@ -1,0 +1,52 @@
+//
+//  AdobeContentProtectionService.swift
+//  Palace
+//
+//  Created by Vladimir Fedorov on 30.06.2021.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+#if FEATURE_DRM_CONNECTOR
+
+import Foundation
+import R2Shared
+import R2Streamer
+import R2Navigator
+
+/// Provides information about a publication's content protection and manages user rights.
+final class AdobeContentProtectionService: ContentProtectionService {
+  var error: Error?
+  let context: PublicationServiceContext
+
+  init(context: PublicationServiceContext) {
+    self.context = context
+    self.error = nil
+    if let adobeFetcher = context.fetcher as? AdobeDRMFetcher {
+      if let drmError = adobeFetcher.container.epubDecodingError {
+        self.error = NSError(domain: "Adobe DRM decoding error",
+                             code: TPPErrorCode.adobeDRMFulfillmentFail.rawValue,
+                             userInfo: [
+                              "AdobeDRMContainer error msg": drmError
+                             ])
+      }
+    }
+  }
+
+  /// A restricted publication has a limited access to its manifest and
+  /// resources and can’t be rendered with a Navigator. It is usually
+  /// only used to import a publication to the user’s bookshelf.
+  var isRestricted: Bool {
+    context.publication.ref == nil || error != nil
+  }
+  
+  var rights: UserRights {
+    isRestricted ? AllRestrictedUserRights() : UnrestrictedUserRights()
+  }
+  
+  var name: LocalizedString? {
+    LocalizedString.nonlocalized("Adobe DRM")
+  }
+
+}
+
+#endif

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
@@ -6,47 +6,76 @@
 //  Copyright © 2021 NYPL Labs. All rights reserved.
 //
 
+#if FEATURE_DRM_CONNECTOR
+
 import Foundation
 import R2Shared
 
-#if FEATURE_DRM_CONNECTOR
-
 class AdobeDRMContentProtection: ContentProtection {
-  func open(asset: PublicationAsset, fetcher: Fetcher, credentials: String?, allowUserInteraction: Bool, sender: Any?, completion: @escaping (CancellableResult<ProtectedAsset?, Publication.OpeningError>) -> Void) {
+  func open(asset: PublicationAsset,
+            fetcher: Fetcher,
+            credentials: String?,
+            allowUserInteraction: Bool,
+            sender: Any?,
+            completion: @escaping (CancellableResult<ProtectedAsset?,
+                                                     Publication.OpeningError>) -> Void) {
     
     // Publication asset must be a FileAsset, as we are opening a file
     // If not, we can't open and use Adobe DRM
     guard let fileAsset = asset as? FileAsset else {
-      TPPErrorLogger.logError(nil, summary: "AdobeDRMContentProtection.open expected asset of FileAsset type, received \(type(of: asset)))")
-      completion(.failure(.unavailable(nil)))
+      TPPErrorLogger.logError(withCode: .adobeDRMFulfillmentFail,
+                               summary: "Missing file asset while opening Adobe DRM epub",
+                               metadata: [
+                                "asset type": type(of: asset),
+                                "asset name": asset.name,
+                                "allowUserInteraction": allowUserInteraction
+                               ])
+      completion(.failure(.unsupportedFormat))
       return
     }
     
-    do {
-      // META-INF is a part of .epub structure
-      // Adobe DRM expects to find encryption algorithms for each .epub file in it
-      // Other DRM software may look for other files to underestand the type of .epub protection,
-      // for example, LCP is looking for .lcpl file to open .epub files.
-      let encryptionPath = "META-INF/encryption.xml"
-      let resource = fetcher.get(encryptionPath)
-      // If encryption.xml doesn't exist, this is not an Adobe DRM .epub
-      // resource.read().get() throws in this case
-      let encryptionData = try resource.read().get()
-      let adobeFetcher = AdobeDRMFetcher(url: fileAsset.url, fetcher: fetcher, encryptionData: encryptionData)
-      let protectedAsset = ProtectedAsset(
-        asset: asset,
-        fetcher: adobeFetcher,
-        onCreatePublication: nil
-      )
-      completion(.success(protectedAsset))
-    } catch {
+    guard let encryptionData = fetcher.fetchAdobeEncryptionData() else {
       // .success(nil) means it is not an asset protected with Adobe DRM
       // Streamer continues to iterate over available ContentProtections
       // Don't use .failure(...) in this case, it means .epub is protected with this type of Content Protection,
       // but it failed to open it.
       completion(.success(nil))
+      return
     }
-    
+
+    let adobeFetcher = AdobeDRMFetcher(url: fileAsset.url, fetcher: fetcher, encryptionData: encryptionData)
+    let protectedAsset = ProtectedAsset(
+      asset: asset,
+      fetcher: adobeFetcher,
+      onCreatePublication: { _, _, _, services in
+        services.setContentProtectionServiceFactory { pubServiceContext in
+          AdobeContentProtectionService(context: pubServiceContext)
+        }
+      }
+    )
+    completion(.success(protectedAsset))
+  }
+}
+
+private extension Fetcher {
+  func fetchAdobeEncryptionData() -> Data? {
+    // The `META-INF` directory is a part of .epub structure.
+    // Adobe DRM expects to find encryption algorithms for each .epub file in it.
+    // Other DRM software may look for other files to underestand the type of .epub protection,
+    // for example, LCP is looking for .lcpl file to open .epub files.
+    let encryptionRelativePath = "META-INF/encryption.xml"
+
+    // If the encryption.xml file doesn't exist, this is definitely
+    // not an Adobe DRM .epub.
+    let resource = get("/" + encryptionRelativePath)
+    guard let data = try? resource.read().get() else {
+      // R2 has changed its expectation about the leading slash;
+      // here we verify both cases.
+      let resource = get(encryptionRelativePath)
+      return try? resource.read().get()
+    }
+
+    return data
   }
 }
 

--- a/scripts/build-openssl-curl.sh
+++ b/scripts/build-openssl-curl.sh
@@ -19,8 +19,8 @@ cp scripts/build_openssl.sh adobe-rmsdk/thirdparty/openssl/iOS-openssl
 SDKVERSION=`xcodebuild -version -sdk iphoneos | grep SDKVersion | sed 's/SDKVersion[: ]*//'`
 
 # edit as required if OpenSSL and cURL need updating or retargeting
-OPENSSL_VERSION="1.0.1u"
-OPENSSL_URL="https://www.openssl.org/source/old/1.0.1/openssl-1.0.1u.tar.gz"
+OPENSSL_VERSION="1.1.0e"
+OPENSSL_URL="https://www.openssl.org/source/old/1.1.0/openssl-1.1.0e.tar.gz"
 CURL_VERSION="7.64.1"
 CURL_URL="https://curl.se/download/curl-7.64.1.zip"
 

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -7,7 +7,7 @@
 # * based on your XCode, set SDK_VERSION below
 # * based on openssl version you are using, adjust OPENSSL_VERSION below
 #
-# * below code is verified on XCode 7.2 and iOS SDK version 9.2
+# * below code is verified on XCode 12.4 and iOS SDK version 13.4
 #
 
 set -x

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 
 # This script builds a static version of
-# OpenSSL ${OPENSSL_VERSION} for iOS 7.1 that contains code for
+# OpenSSL ${OPENSSL_VERSION} for iOS that contains code for
 # arm64, armv7, arm7s, i386 and x86_64.
+#
+# * based on your XCode, set SDK_VERSION below
+# * based on openssl version you are using, adjust OPENSSL_VERSION below
+#
+# * below code is verified on XCode 7.2 and iOS SDK version 9.2
+#
 
 set -x
 
 # Setup paths to stuff we need
 
-OPENSSL_VERSION="1.0.1u"
+OPENSSL_VERSION="1.1.0e"
 
 DEVELOPER="/Applications/Xcode.app/Contents/Developer"
 
 SDK_VERSION="13.4"
-MIN_VERSION="9.0"
 
 IPHONEOS_PLATFORM="${DEVELOPER}/Platforms/iPhoneOS.platform"
 IPHONEOS_SDK="${IPHONEOS_PLATFORM}/Developer/SDKs/iPhoneOS.sdk"
@@ -72,12 +77,13 @@ build()
    tar xfz "openssl-${OPENSSL_VERSION}.tar.gz"
    pushd .
    cd "openssl-${OPENSSL_VERSION}"
-   ./Configure ${TARGET} --openssldir="/tmp/openssl-${OPENSSL_VERSION}-${ARCH}" ${EXTRA} &> "/tmp/openssl-${OPENSSL_VERSION}-${ARCH}.log"
+   sed -i '' "s#'File::Glob' => qw/glob/;#'File::Glob' => qw/bsd_glob/;#g" ./Configure
+   sed -i '' "s#'File::Glob' => qw/glob/;#'File::Glob' => qw/bsd_glob/;#g" ./test/build.info 
+   ./Configure ${TARGET} no-shared --openssldir="/tmp/openssl-${OPENSSL_VERSION}-${ARCH}" --prefix="/tmp/openssl-${OPENSSL_VERSION}-${ARCH}" ${EXTRA} &> "/tmp/openssl-${OPENSSL_VERSION}-$i{ARCH}.log"
    perl -i -pe 's|static volatile sig_atomic_t intr_signal|static volatile int intr_signal|' crypto/ui/ui_openssl.c
-   perl -i -pe "s|^CC= gcc|CC= ${GCC} -arch ${ARCH} -miphoneos-version-min=${MIN_VERSION}|g" Makefile
-   perl -i -pe "s|^CFLAG= (.*)|CFLAG= -isysroot ${SDK} \$1|g" Makefile
-   make &> "/tmp/openssl-${OPENSSL_VERSION}-${ARCH}.build-log"
-   make install &> "/tmp/openssl-${OPENSSL_VERSION}-${ARCH}.install-log"
+   perl -i -pe "s|CFLAGS=-DDSO_DLFCN |CFLAGS=-arch ${ARCH} -isysroot ${SDK} -DDSO_DLFCN \$1|g" Makefile
+   make 
+   make install 
    popd
    rm -rf "openssl-${OPENSSL_VERSION}"
 }


### PR DESCRIPTION
**What's this do?**
This PR fixes issues with Adobe DRM software:
- updates scripts to build third-party dependencies in the updated RMSDK libraries;
- fixes the path for Adobe DRM encryption.xml preventing books from opening in R2 reader;
- fixes app crash on signing in to a new library account.

**Why are we doing this? (w/ Notion link if applicable)**
We are updating the libraries to fix the [crash on account registration](https://www.notion.so/lyrasis/Palace-iOS-app-crashes-on-account-registration-with-Adobe-44a24f69594d4bac8334a080cb9f4267). The cause of the crash was the difference between the version of header files in this repository and the version of pre-built libraries.

**How should this be tested? / Do these changes have associated tests?**
 You need to do a clean install:
  - `git clone git@github.com:ThePalaceProject/ios-core.git -b feature/palace-init`;
  - `cd ios-core`;
  - `./scripts/bootstrap-drm.sh`;
  - Open `Palace.xcodeproj` and build `Palace` target.

After that, follow the steps under **Success Criteria** in the ticket.

**Dependencies for merging? Releasing to production?**
Depends on [PR#2](https://github.com/ThePalaceProject/mobile-drm-adeptconnector/pull/2) in [mobile-drm-adeptconnector](https://github.com/ThePalaceProject/mobile-drm-adeptconnector)—should be merged first.

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 