### PR TITLE
Remove the build command for OpenSSL and curl

### DIFF
--- a/scripts/bootstrap-drm.sh
+++ b/scripts/bootstrap-drm.sh
@@ -18,5 +18,4 @@ git clone git@github.com:ThePalaceProject/mobile-drm-adeptconnector.git
 cd ios-core
 
 ./scripts/setup-repo-drm.sh
-./scripts/build-openssl-curl.sh
 ./scripts/build-3rd-party-dependencies.sh


### PR DESCRIPTION
**What's this do?**
Removes the command that builds OpenSSL and curl libraries. Prebuilt libraries are included in mobile-drm-adeptconnector repository.

**Why are we doing this? (w/ Notion link if applicable)**
Building this libraries takes enormous time.

**How should this be tested? / Do these changes have associated tests?**
In an empty folder, run:
```
git clone git@github.com:ThePalaceProject/ios-core.git -b feature/prebuilt-libs
cd ios-core
./scripts/bootstrap-drm.sh
```
The build process should end in *less then an hour*.

**Dependencies for merging? Releasing to production?**
Should be tested after [mobile-drm-adeptconnector PR#3](https://github.com/ThePalaceProject/mobile-drm-adeptconnector/pull/3) is merged.

**Does this include changes that require a new Palace build for QA?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 