### PR TITLE
Disable copy and paste in app

### DIFF
--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -32,6 +32,7 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
     config.preloadPreviousPositionCount = 0
     config.preloadNextPositionCount = 0
     config.debugState = true
+    config.editingActions = [.lookup]
 
     let navigator = EPUBNavigatorViewController(publication: publication,
                                                 initialLocation: initialLocation,
@@ -150,3 +151,4 @@ extension TPPEPUBViewController: UIPopoverPresentationControllerDelegate {
     return .none
   }
 }
+

--- a/Palace/TPPReaderReadiumView.m
+++ b/Palace/TPPReaderReadiumView.m
@@ -35,11 +35,10 @@
 -(BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   // Note: this does not work on iOS <= 10.
-  // Also Note: _share is in fact a declared selector
-  if (action == @selector(copy:) || action == @selector(_share:)) {
-    return NO;
+  if (action == @selector(lookup:) || action == @selector(_share:)) {
+    return [super canPerformAction:action withSender:sender];
   }
-  return [super canPerformAction:action withSender:sender];
+  return NO;
 }
 
 @end

--- a/Palace/TPPReaderReadiumView.m
+++ b/Palace/TPPReaderReadiumView.m
@@ -35,7 +35,7 @@
 -(BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   // Note: this does not work on iOS <= 10.
-  if action == @selector(lookup:) {
+  if (action == @selector(lookup:)) {
     return [super canPerformAction:action withSender:sender];
   }
   return NO;

--- a/Palace/TPPReaderReadiumView.m
+++ b/Palace/TPPReaderReadiumView.m
@@ -35,7 +35,7 @@
 -(BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   // Note: this does not work on iOS <= 10.
-  if (action == @selector(lookup:) || action == @selector(_share:)) {
+  if action == @selector(lookup:) {
     return [super canPerformAction:action withSender:sender];
   }
   return NO;

--- a/Palace/TPPReaderReadiumView.m
+++ b/Palace/TPPReaderReadiumView.m
@@ -34,9 +34,9 @@
 
 -(BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
-  // Note: this does not work on iOS <= 10: the callback is never called for
-  // the copy: action. It is on iOS 11+.
-  if (action == @selector(copy:)) {
+  // Note: this does not work on iOS <= 10.
+  // Also Note: _share is in fact a declared selector
+  if (action == @selector(copy:) || action == @selector(_share:)) {
     return NO;
   }
   return [super canPerformAction:action withSender:sender];

--- a/Palace/TPPReaderReadiumView.m
+++ b/Palace/TPPReaderReadiumView.m
@@ -32,8 +32,6 @@
 
 @implementation TPPWebView
 
-// On Open eBooks we have a requirement to not allow copying of book text
-#ifdef OPENEBOOKS
 -(BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   // Note: this does not work on iOS <= 10: the callback is never called for
@@ -43,7 +41,6 @@
   }
   return [super canPerformAction:action withSender:sender];
 }
-#endif
 
 @end
 

--- a/Palace/TPPReaderReadiumView.m
+++ b/Palace/TPPReaderReadiumView.m
@@ -35,10 +35,11 @@
 -(BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   // Note: this does not work on iOS <= 10.
-  if (action == @selector(lookup:)) {
-    return [super canPerformAction:action withSender:sender];
+  // Also Note: _share is in fact a declared selector
+  if (action == @selector(copy:) || action == @selector(_share:)) {
+    return NO;
   }
-  return NO;
+  return [super canPerformAction:action withSender:sender];
 }
 
 @end


### PR DESCRIPTION
**What's this do?**
Disables copy and paste for iOS 11 and above

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/Disable-Copy-Paste-in-iOS-App-33f4256072f742e59221d8f0591647ad

**How should this be tested? / Do these changes have associated tests?**
Attempt to copy and paste text from an e-book

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A 

**Did someone actually run this code to verify it works?**
@mauricecarrier7 