### PR TITLE
Fix missing arm64 architecture TestFlight error

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -2,7 +2,6 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"
 github "ThePalaceProject/ios-audiobooktoolkit" "main"
 github "ThePalaceProject/ios-provider-pdf-renderer" "main"
-github "ThePalaceProject/ios-drm-audioengine" "main"
 github "PureLayout/PureLayout" ~> 3.1.2
 github "stephencelis/SQLite.swift" == 0.12.2
 github "zxingify/zxingify-objc" ~> 3.6

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -2,7 +2,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.j
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "8.2.0"
 github "PureLayout/PureLayout" "3.1.9"
 github "ThePalaceProject/ios-audiobooktoolkit" "d0280d85de025497bda186fc39189964b90d5ac5"
-github "ThePalaceProject/ios-drm-audioengine" "e5b53b70f8113a3326e345cd16f3643b59c1eb00"
+github "ThePalaceProject/ios-drm-audioengine" "7c1c7fa76e5a5767ebfa5d9fb2426f7a8f6ffca5"
 github "ThePalaceProject/ios-provider-pdf-renderer" "8ef188721398304dd19b93f83194b7492a827c48"
 github "cezheng/Fuzi" "3.1.3"
 github "dexman/Minizip" "1.4.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -2,7 +2,6 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.j
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "8.2.0"
 github "PureLayout/PureLayout" "3.1.9"
 github "ThePalaceProject/ios-audiobooktoolkit" "d0280d85de025497bda186fc39189964b90d5ac5"
-github "ThePalaceProject/ios-drm-audioengine" "7c1c7fa76e5a5767ebfa5d9fb2426f7a8f6ffca5"
 github "ThePalaceProject/ios-provider-pdf-renderer" "8ef188721398304dd19b93f83194b7492a827c48"
 github "cezheng/Fuzi" "3.1.3"
 github "dexman/Minizip" "1.4.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -2,7 +2,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.j
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "8.2.0"
 github "PureLayout/PureLayout" "3.1.9"
 github "ThePalaceProject/ios-audiobooktoolkit" "d0280d85de025497bda186fc39189964b90d5ac5"
-github "ThePalaceProject/ios-drm-audioengine" "495d3f1076fea87436e5b3ae53b09193a5800025"
+github "ThePalaceProject/ios-drm-audioengine" "40d56ed2eb4782c7c7ed9973b6e240763fc447b6"
 github "ThePalaceProject/ios-provider-pdf-renderer" "8ef188721398304dd19b93f83194b7492a827c48"
 github "cezheng/Fuzi" "3.1.3"
 github "dexman/Minizip" "1.4.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -2,7 +2,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.j
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "8.2.0"
 github "PureLayout/PureLayout" "3.1.9"
 github "ThePalaceProject/ios-audiobooktoolkit" "d0280d85de025497bda186fc39189964b90d5ac5"
-github "ThePalaceProject/ios-drm-audioengine" "40d56ed2eb4782c7c7ed9973b6e240763fc447b6"
+github "ThePalaceProject/ios-drm-audioengine" "e5b53b70f8113a3326e345cd16f3643b59c1eb00"
 github "ThePalaceProject/ios-provider-pdf-renderer" "8ef188721398304dd19b93f83194b7492a827c48"
 github "cezheng/Fuzi" "3.1.3"
 github "dexman/Minizip" "1.4.0"

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		21399900268F9F2500B4EB60 /* TPPAccountListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AD65DC2684FACA00C62951 /* TPPAccountListCell.swift */; };
 		21399902268F9F4C00B4EB60 /* TPPAccountListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AD65E02684FDA300C62951 /* TPPAccountListDataSource.swift */; };
 		2146872D2559A64B007B401A /* LCPLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2171ADA0251E38140003CABA /* LCPLibraryService.swift */; };
+		2178984D269F174500374A6B /* NYPLAEToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E585662526979AC100A5FBD5 /* NYPLAEToolkit.framework */; };
+		2178984E269F174500374A6B /* NYPLAEToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E585662526979AC100A5FBD5 /* NYPLAEToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		219868F7267E29830041369E /* CryptoSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 219868F6267E29830041369E /* CryptoSwift.xcframework */; };
 		219868F8267E29830041369E /* CryptoSwift.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 219868F6267E29830041369E /* CryptoSwift.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		219868FF267E29920041369E /* Fuzi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 219868FE267E29920041369E /* Fuzi.xcframework */; };
@@ -686,8 +688,6 @@
 		E551B363267D42A20026FC1B /* TPPAccountList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E551B360267D402B0026FC1B /* TPPAccountList.swift */; };
 		E551B365267D42AF0026FC1B /* TPPLoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E551B359267D396A0026FC1B /* TPPLoadingViewController.swift */; };
 		E58565CF269774C400A5FBD5 /* AudioEngine.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E58565CE269774C400A5FBD5 /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E585662826979EF100A5FBD5 /* NYPLAEToolkit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E585662726979EF100A5FBD5 /* NYPLAEToolkit.xcframework */; };
-		E585662C26979F1100A5FBD5 /* NYPLAEToolkit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E585662726979EF100A5FBD5 /* NYPLAEToolkit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E5AD65DD2684FACA00C62951 /* TPPAccountListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AD65DC2684FACA00C62951 /* TPPAccountListCell.swift */; };
 		E5AD65E12684FDA300C62951 /* TPPAccountListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AD65E02684FDA300C62951 /* TPPAccountListDataSource.swift */; };
 		E5C2C422268BA5140046F415 /* TPPRegistryDebuggingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C2C421268BA5140046F415 /* TPPRegistryDebuggingCell.swift */; };
@@ -773,9 +773,9 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				E585662C26979F1100A5FBD5 /* NYPLAEToolkit.xcframework in Embed Frameworks */,
 				E58565CF269774C400A5FBD5 /* AudioEngine.xcframework in Embed Frameworks */,
 				21986907267E299E0041369E /* GCDWebServer.xcframework in Embed Frameworks */,
+				2178984E269F174500374A6B /* NYPLAEToolkit.framework in Embed Frameworks */,
 				219868F8267E29830041369E /* CryptoSwift.xcframework in Embed Frameworks */,
 				2198693B267E2A030041369E /* SQLite.xcframework in Embed Frameworks */,
 				21986923267E29D70041369E /* PureLayout.xcframework in Embed Frameworks */,
@@ -1507,9 +1507,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E585662826979EF100A5FBD5 /* NYPLAEToolkit.xcframework in Frameworks */,
 				2198694D267E2A150041369E /* ZXingObjC.xcframework in Frameworks */,
 				03B092301E78871A00AD338D /* MediaPlayer.framework in Frameworks */,
+				2178984D269F174500374A6B /* NYPLAEToolkit.framework in Frameworks */,
 				03B092281E78859E00AD338D /* CoreMedia.framework in Frameworks */,
 				03B0922E1E7886ED00AD338D /* CoreVideo.framework in Frameworks */,
 				03B0922C1E7886C900AD338D /* AVFoundation.framework in Frameworks */,

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1401,7 +1401,7 @@
 		D787E8431FB6B0290016D9D5 /* TPPSettingsAdvancedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPSettingsAdvancedViewController.swift; sourceTree = "<group>"; };
 		E551B359267D396A0026FC1B /* TPPLoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPLoadingViewController.swift; sourceTree = "<group>"; };
 		E551B360267D402B0026FC1B /* TPPAccountList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAccountList.swift; sourceTree = "<group>"; };
-		E58565CE269774C400A5FBD5 /* AudioEngine.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AudioEngine.xcframework; path = Carthage/Build/iOS/AudioEngine.xcframework; sourceTree = "<group>"; };
+		E58565CE269774C400A5FBD5 /* AudioEngine.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AudioEngine.xcframework; path = Carthage/Build/AudioEngine.xcframework; sourceTree = "<group>"; };
 		E58565D2269774D900A5FBD5 /* NYPLAEToolkit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = NYPLAEToolkit.xcframework; sourceTree = "<group>"; };
 		E585662026979AC100A5FBD5 /* NYPLAEToolkit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = NYPLAEToolkit.xcodeproj; path = "ios-drm-audioengine/NYPLAEToolkit.xcodeproj"; sourceTree = "<group>"; };
 		E585662726979EF100A5FBD5 /* NYPLAEToolkit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = NYPLAEToolkit.xcframework; path = Carthage/Build/NYPLAEToolkit.xcframework; sourceTree = "<group>"; };
@@ -4062,6 +4062,7 @@
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -4117,6 +4118,7 @@
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;


### PR DESCRIPTION
**What's this do?**
This PR fixes TestFlight error message about missing arm64 architecture:
- fixes project build settings;
- removes `ios-drm-audioengine` from Cartfile, as we added it as a submodule.

**Why are we doing this? (w/ Notion link if applicable)**
TestFlight reporting missing arm64 architecture.

**How should this be tested? / Do these changes have associated tests?**
NA, the issue has no tests; uploaded Palace archive should appear in TestFlight.

**Dependencies for merging? Releasing to production?**
Depends on [PR#2](https://github.com/ThePalaceProject/ios-drm-audioengine/pull/2) in [ios-drm-audioengine](https://github.com/ThePalaceProject/ios-drm-audioengine).

**Does this include changes that require a new Palace build for QA?**
No (already uploaded)

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 