### PR TITLE
Enable unit testing on pull requests

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -1,58 +1,39 @@
 name: Unit Tests
-on:
+on: 
   pull_request:
 jobs:
   build-and-test:
     runs-on: macOS-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Force Xcode 11.5
-        run: sudo xcode-select -switch /Applications/Xcode_11.5.app
+      - name: Force Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       - name: Checkout main repo and submodules
         uses: actions/checkout@v2.3.4
         with:
           submodules: true
-          token: ${{ secrets.IOS_DEV_CI_PAT }}
-      - name: Checkout Adobe RMSDK
-        uses: actions/checkout@v2.3.4
-        with:
-          repository: NYPL-Simplified/DRM-iOS-AdeptConnector
-          token: ${{ secrets.IOS_DEV_CI_PAT }}
-          path: ./DRM-iOS-AdeptConnector
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
       - name: Checkout Certificates
         uses: actions/checkout@v2.3.4
         with:
-          repository: NYPL-Simplified/Certificates
-          token: ${{ secrets.IOS_DEV_CI_PAT }}
-          path: ./Certificates
-      - name: Checkout NYPLAEToolkit
+          repository: ThePalaceProject/mobile-certificates
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
+          path: ./mobile-certificates
+      - name: Checkout Adobe RMSDK
         uses: actions/checkout@v2.3.4
         with:
-          repository: NYPL-Simplified/NYPLAEToolkit
-          token: ${{ secrets.IOS_DEV_CI_PAT }}
-          path: ./NYPLAEToolkit
-      - name: Fetch AudioEngine
-        run: ./NYPLAEToolkit/scripts/fetch-audioengine.sh
-      - name: Set up repo for DRM build
-        run: exec ./scripts/setup-repo-drm.sh
+          repository: ThePalaceProject/mobile-drm-adeptconnector
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
+          path: ./mobile-drm-adeptconnector
+      - name: Uncompress Adobe RMSDK
+        run: ./scripts/setup-repo-drm.sh
         env:
           BUILD_CONTEXT: ci
       - name: Build non-Carthage 3rd party dependencies
         run: ./scripts/build-3rd-party-dependencies.sh
         env:
           BUILD_CONTEXT: ci
-      - name: Carthage Bootstrap
-        uses: devbotsxyz/carthage-bootstrap@v1
-        with:
-          github-token: ${{ secrets.IOS_DEV_CI_PAT }}
-          platform: iOS
-          cache: false
-          verbose: true
-      - name: Run SimplyE tests
-        run: ./scripts/xcode-test.sh simplye
-        env:
-          BUILD_CONTEXT: ci
-      - name: Run Open eBooks tests
-        run: ./scripts/xcode-test.sh openebooks
+      - name: Run Palace unit tests
+        run: ./scripts/xcode-test.sh
         env:
           BUILD_CONTEXT: ci

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -3,4 +3,4 @@
 # For more information about the Appfile, see:
 #     https://docs.fastlane.tools/advanced/#appfile
 
-team_id "7262U6ST2R"
+team_id "88CBA74T8K"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,20 +1,45 @@
 default_platform(:ios)
 
 platform :ios do
-  lane :fetch_install_certs do
-    cert(
-      keychain_path: ENV['KEYCHAIN_PATH'],
-      generate_apple_certs: "false"
+  lane :test do
+    run_tests(
+      project: "Palace.xcodeproj",
+      devices: ["iPhone 12 Pro"],
+      scheme: "Palace"
     )
   end
-
-  lane :fetch_install_provisioning do
-    sigh(
-      app_identifier: ENV['APP_BUNDLE_ID']
+  lane :beta do |options|
+    build_app(
+      project: "Palace.xcodeproj",
+      scheme: "Palace",
+      include_symbols: true,
+      include_bitcode: false,
+      silent: true,
+      output_name: options[:output_name],
+      output_directory: options[:export_path],
+      export_options: {
+        method: "development",
+        provisioningProfiles: { 
+          "org.thepalaceproject.palace" => "Palace App"
+        }
+      }
     )
-    sigh(
-      app_identifier: ENV['APP_BUNDLE_ID'],
-      adhoc: "true"
+  end
+  lane :testflight do
+    build_app(
+      project: "Palace.xcodeproj",
+      scheme: "Palace",
+      include_symbols: true,
+      include_bitcode: false,
+      export_options: {
+        method: "app-store",
+        provisioningProfiles: { 
+          "org.thepalaceproject.palace" => "App store"
+        }
+      }
+    )
+    pilot(
+      skip_submission: true
     )
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -16,14 +16,19 @@ or alternatively using `brew install fastlane`
 
 # Available Actions
 ## iOS
-### ios fetch_install_certs
+### ios test
 ```
-fastlane ios fetch_install_certs
+fastlane ios test
 ```
 
-### ios fetch_install_provisioning
+### ios beta
 ```
-fastlane ios fetch_install_provisioning
+fastlane ios beta
+```
+
+### ios testflight
+```
+fastlane ios testflight
 ```
 
 

--- a/scripts/bootstrap-drm.sh
+++ b/scripts/bootstrap-drm.sh
@@ -12,12 +12,10 @@
 #
 
 cd ..
-git clone git@github.com:NYPL-Simplified/Certificates.git
-git clone git@github.com:NYPL-Simplified/DRM-iOS-AdeptConnector.git
+git clone git@github.com:ThePalaceProject/mobile-certificates.git
+git clone git@github.com:ThePalaceProject/mobile-drm-adeptconnector.git
 
-cd Simplified-iOS
-git checkout develop
+cd ios-core
 
 ./scripts/setup-repo-drm.sh
-
 ./scripts/build-3rd-party-dependencies.sh

--- a/scripts/build-3rd-party-dependencies.sh
+++ b/scripts/build-3rd-party-dependencies.sh
@@ -6,7 +6,7 @@
 #   dependencies.
 #
 # USAGE
-#   Run this script from the root of Simplified-iOS repo:
+#   Run this script from the root of ios-core repo:
 #
 #     ./scripts/build-3rd-party-dependencies.sh [--no-private]
 #

--- a/scripts/build-carthage.sh
+++ b/scripts/build-carthage.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # SUMMARY
-#   Sets up and build dependencies for the SimplyE, SimplyE-noDRM and
-#   Open eBooks targets.
+#   Sets up and build dependencies for the Palace and Palace-noDRM targets
 #
 # SYNOPSIS
 #     ./scripts/build-carthage.sh [--no-private ]
@@ -12,7 +11,7 @@
 #
 # USAGE
 #   Make sure to run this script from a clean checkout and from the root
-#   of Simplified-iOS, e.g.:
+#   of ios-core, e.g.:
 #
 #     git checkout Cartfile
 #     git checkout Cartfile.resolved
@@ -33,27 +32,8 @@ fi
 # deep clean to avoid any caching issues
 rm -rf ~/Library/Caches/org.carthage.CarthageKit
 
-if [ "$1" != "--no-private" ]; then
-  if [ "$BUILD_CONTEXT" == "ci" ]; then
-    # in a CI context we cannot have siblings repos, so we check them out nested
-    CERTIFICATES_PATH_PREFIX="."
-  else
-    CERTIFICATES_PATH_PREFIX=".."
+./ios-drm-audioengine/scripts/fetch-audioengine.sh
 
-    # checkout NYPLAEToolkit to use the private script to fetch AudioEngine.
-    # We can only do it from outside of a GitHub Actions CI context, because
-    # git authentication is not passed correctly to Carthage there.
-    echo "Checking out NYPLAEToolkit to fetch AudioEngine binary before carthage bootstrap..."
-    carthage checkout NYPLAEToolkit
-    ./Carthage/Checkouts/NYPLAEToolkit/scripts/fetch-audioengine.sh
-  fi
+echo "Carthage build..."
+carthage bootstrap --use-xcframeworks --platform ios
 
-  # r2-lcp requires a private client library, available via Certificates repo
-  echo "Fixing up the Cartfile for LCP..."
-  swift $CERTIFICATES_PATH_PREFIX/Certificates/SimplyE/iOS/LCPLib.swift
-fi
-
-if [ "$BUILD_CONTEXT" != "ci" ] || [ "$1" == "--no-private" ]; then
-  echo "Carthage build..."
-  carthage bootstrap --platform ios
-fi

--- a/scripts/build-openssl-curl.sh
+++ b/scripts/build-openssl-curl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Usage: run this script from the root of the Simplified-iOS repo.
+# Usage: run this script from the root of the Palace ios-core repository.
 #
 # Summary: this script rebuilds OpenSSL 1.0.1u and cURL 7.64.1 which are
 #              required by the Adobe RMSDK.
@@ -15,13 +15,14 @@
 # at the top of both the build.sh / build_curl.sh scripts below.
 
 cp scripts/build_curl.sh adobe-rmsdk/thirdparty/curl/iOS-libcurl/
+cp scripts/build_openssl.sh adobe-rmsdk/thirdparty/openssl/iOS-openssl
 SDKVERSION=`xcodebuild -version -sdk iphoneos | grep SDKVersion | sed 's/SDKVersion[: ]*//'`
 
 # edit as required if OpenSSL and cURL need updating or retargeting
-OPENSSL_VERSION="1.0.1u"
-OPENSSL_URL="https://www.openssl.org/source/old/1.0.1/openssl-1.0.1u.tar.gz"
+OPENSSL_VERSION="1.1.0e"
+OPENSSL_URL="https://www.openssl.org/source/old/1.1.0/openssl-1.1.0e.tar.gz"
 CURL_VERSION="7.64.1"
-CURL_URL="https://curl.haxx.se/download/curl-7.64.1.zip"
+CURL_URL="https://curl.se/download/curl-7.64.1.zip"
 
 echo "======================================="
 echo "Building OpenSSL..."
@@ -30,10 +31,10 @@ mkdir -p public
 [ -d "iOS-openssl" ] && [ ! -d "public/ios" ] && mv iOS-openssl public/ios
 cd public/ios
 curl -O $OPENSSL_URL
-sed -i '' "s/OPENSSL_VERSION=\".*\"/OPENSSL_VERSION=\"$OPENSSL_VERSION\"/" build.sh
-sed -i '' "s/SDK_VERSION=\".*\"/SDK_VERSION=\"$SDKVERSION\"/" build.sh
-sed -i '' 's/MIN_VERSION=".*"/MIN_VERSION="9.0"/' build.sh
-bash ./build.sh  #this will take a while
+sed -i '' "s/OPENSSL_VERSION=\".*\"/OPENSSL_VERSION=\"$OPENSSL_VERSION\"/" build_openssl.sh
+sed -i '' "s/SDK_VERSION=\".*\"/SDK_VERSION=\"$SDKVERSION\"/" build_openssl.sh
+sed -i '' 's/MIN_VERSION=".*"/MIN_VERSION="9.0"/' build_openssl.sh
+bash ./build_openssl.sh  #this will take a while
 
 echo "======================================="
 echo "Building cURL..."

--- a/scripts/build_curl.sh
+++ b/scripts/build_curl.sh
@@ -19,11 +19,11 @@ SDK_VERSION="12.2"
 MIN_VERSION="9.0"
 
 IPHONEOS_PLATFORM="${DEVELOPER}/Platforms/iPhoneOS.platform"
-IPHONEOS_SDK="${IPHONEOS_PLATFORM}/Developer/SDKs/iPhoneOS${SDK_VERSION}.sdk"
+IPHONEOS_SDK="${IPHONEOS_PLATFORM}/Developer/SDKs/iPhoneOS.sdk"
 IPHONEOS_GCC="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
 
 IPHONESIMULATOR_PLATFORM="${DEVELOPER}/Platforms/iPhoneSimulator.platform"
-IPHONESIMULATOR_SDK="${IPHONESIMULATOR_PLATFORM}/Developer/SDKs/iPhoneSimulator${SDK_VERSION}.sdk"
+IPHONESIMULATOR_SDK="${IPHONESIMULATOR_PLATFORM}/Developer/SDKs/iPhoneSimulator.sdk"
 IPHONESIMULATOR_GCC="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
 
 # Make sure things actually exist

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# This script builds a static version of
+# OpenSSL ${OPENSSL_VERSION} for iOS that contains code for
+# arm64, armv7, arm7s, i386 and x86_64.
+#
+# * based on your XCode, set SDK_VERSION below
+# * based on openssl version you are using, adjust OPENSSL_VERSION below
+#
+# * below code is verified on XCode 12.4 and iOS SDK version 13.4
+#
+
+set -x
+
+# Setup paths to stuff we need
+
+OPENSSL_VERSION="1.1.0e"
+
+DEVELOPER="/Applications/Xcode.app/Contents/Developer"
+
+SDK_VERSION="13.4"
+
+IPHONEOS_PLATFORM="${DEVELOPER}/Platforms/iPhoneOS.platform"
+IPHONEOS_SDK="${IPHONEOS_PLATFORM}/Developer/SDKs/iPhoneOS.sdk"
+IPHONEOS_GCC="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+
+IPHONESIMULATOR_PLATFORM="${DEVELOPER}/Platforms/iPhoneSimulator.platform"
+IPHONESIMULATOR_SDK="${IPHONESIMULATOR_PLATFORM}/Developer/SDKs/iPhoneSimulator.sdk"
+IPHONESIMULATOR_GCC="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+
+# Make sure things actually exist
+
+if [ ! -d "$IPHONEOS_PLATFORM" ]; then
+  echo "Cannot find $IPHONEOS_PLATFORM"
+  exit 1
+fi
+
+if [ ! -d "$IPHONEOS_SDK" ]; then
+  echo "Cannot find $IPHONEOS_SDK"
+  exit 1
+fi
+
+if [ ! -x "$IPHONEOS_GCC" ]; then
+  echo "Cannot find $IPHONEOS_GCC"
+  exit 1
+fi
+
+if [ ! -d "$IPHONESIMULATOR_PLATFORM" ]; then
+  echo "Cannot find $IPHONESIMULATOR_PLATFORM"
+  exit 1
+fi
+
+if [ ! -d "$IPHONESIMULATOR_SDK" ]; then
+  echo "Cannot find $IPHONESIMULATOR_SDK"
+  exit 1
+fi
+
+if [ ! -x "$IPHONESIMULATOR_GCC" ]; then
+  echo "Cannot find $IPHONESIMULATOR_GCC"
+  exit 1
+fi
+
+# Clean up whatever was left from our previous build
+
+rm -rf include lib
+rm -rf /tmp/openssl-${OPENSSL_VERSION}-*
+rm -rf /tmp/openssl-${OPENSSL_VERSION}-*.*-log
+
+build()
+{
+   TARGET=$1
+   ARCH=$2
+   GCC=$3
+   SDK=$4
+   EXTRA=$5
+   rm -rf "openssl-${OPENSSL_VERSION}"
+   tar xfz "openssl-${OPENSSL_VERSION}.tar.gz"
+   pushd .
+   cd "openssl-${OPENSSL_VERSION}"
+   sed -i '' "s#'File::Glob' => qw/glob/;#'File::Glob' => qw/bsd_glob/;#g" ./Configure
+   sed -i '' "s#'File::Glob' => qw/glob/;#'File::Glob' => qw/bsd_glob/;#g" ./test/build.info 
+   ./Configure ${TARGET} no-shared --openssldir="/tmp/openssl-${OPENSSL_VERSION}-${ARCH}" --prefix="/tmp/openssl-${OPENSSL_VERSION}-${ARCH}" ${EXTRA} &> "/tmp/openssl-${OPENSSL_VERSION}-$i{ARCH}.log"
+   perl -i -pe 's|static volatile sig_atomic_t intr_signal|static volatile int intr_signal|' crypto/ui/ui_openssl.c
+   perl -i -pe "s|CFLAGS=-DDSO_DLFCN |CFLAGS=-arch ${ARCH} -isysroot ${SDK} -DDSO_DLFCN \$1|g" Makefile
+   make 
+   make install 
+   popd
+   rm -rf "openssl-${OPENSSL_VERSION}"
+}
+
+build "BSD-generic32" "armv7" "${IPHONEOS_GCC}" "${IPHONEOS_SDK}" ""
+build "BSD-generic32" "armv7s" "${IPHONEOS_GCC}" "${IPHONEOS_SDK}" ""
+build "BSD-generic64" "arm64" "${IPHONEOS_GCC}" "${IPHONEOS_SDK}" ""
+build "BSD-generic32" "i386" "${IPHONESIMULATOR_GCC}" "${IPHONESIMULATOR_SDK}" ""
+build "BSD-generic64" "x86_64" "${IPHONESIMULATOR_GCC}" "${IPHONESIMULATOR_SDK}" "-DOPENSSL_NO_ASM"
+
+#
+
+mkdir include
+cp -r /tmp/openssl-${OPENSSL_VERSION}-i386/include/openssl include/
+
+mkdir lib
+lipo \
+	"/tmp/openssl-${OPENSSL_VERSION}-armv7/lib/libcrypto.a" \
+	"/tmp/openssl-${OPENSSL_VERSION}-armv7s/lib/libcrypto.a" \
+	"/tmp/openssl-${OPENSSL_VERSION}-arm64/lib/libcrypto.a" \
+	"/tmp/openssl-${OPENSSL_VERSION}-i386/lib/libcrypto.a" \
+	"/tmp/openssl-${OPENSSL_VERSION}-x86_64/lib/libcrypto.a" \
+	-create -output lib/libcrypto.a
+lipo \
+	"/tmp/openssl-${OPENSSL_VERSION}-armv7/lib/libssl.a" \
+	"/tmp/openssl-${OPENSSL_VERSION}-armv7s/lib/libssl.a" \
+	"/tmp/openssl-${OPENSSL_VERSION}-arm64/lib/libssl.a" \
+	"/tmp/openssl-${OPENSSL_VERSION}-i386/lib/libssl.a" \
+	"/tmp/openssl-${OPENSSL_VERSION}-x86_64/lib/libssl.a" \
+	-create -output lib/libssl.a
+
+rm -rf "/tmp/openssl-${OPENSSL_VERSION}-*"
+rm -rf "/tmp/openssl-${OPENSSL_VERSION}-*.*-log"

--- a/scripts/ios-binaries-upload.sh
+++ b/scripts/ios-binaries-upload.sh
@@ -1,42 +1,35 @@
 #!/bin/bash
 
 # SUMMARY
-#   Uploads an exported .ipa for SimplyE or Open eBooks to the
-#   https://github.com/NYPL-Simplified/iOS-binaries repo.
+#   Uploads an exported .ipa for The Palace Project to the
+#   https://github.com/ThePalaceProject/ios-binaries repo.
 #
 # SYNOPSIS
-#   ios-binaries-upload.sh <app_name>
-#
-# PARAMETERS
-#   See xcode-settings.sh for possible parameters.
+#   ios-binaries-upload.sh
 #
 # USAGE
-#   Run this script from the root of Simplified-iOS repo, e.g.:
+#   Run this script from the root of ios-core repo, e.g.:
 #
-#     ./scripts/ios-binaries-upload simplye
+#     ./scripts/ios-binaries-upload
 
 source "$(dirname $0)/xcode-settings.sh"
 
 echo "Uploading $ARCHIVE_NAME to 'ios-binaries' repo..."
 
-SIMPLIFIED_DIR=$PWD
+PALACE_DIR=$PWD
 
 # In a GitHub Actions CI context we can't clone a repo as a sibling
 if [ "$BUILD_CONTEXT" != "ci" ]; then
   cd ..
 fi
 
-if [[ -d "iOS-binaries" ]]; then
-  echo "iOS-binaries repo appears to be cloned already..."
-  IOS_BINARIES_DIR_NAME=iOS-binaries
-elif [[ -d "NYPL-iOS-binaries" ]]; then
-  echo "iOS-binaries repo appears to be cloned already..."
-  IOS_BINARIES_DIR_NAME=NYPL-iOS-binaries
+if [[ -d "ios-binaries" ]]; then
+  echo "ios-binaries repo appears to be cloned already..."
 else
-  IOS_BINARIES_DIR_NAME=iOS-binaries
-  git clone https://${GITHUB_TOKEN}@github.com/NYPL-Simplified/iOS-binaries.git
+  git clone git@github.com:ThePalaceProject/ios-binaries.git
 fi
 
+IOS_BINARIES_DIR_NAME=ios-binaries
 IOS_BINARIES_DIR_PATH="$PWD/$IOS_BINARIES_DIR_NAME"
 
  # check we didn't already upload this build
@@ -46,24 +39,16 @@ if [[ -f "$ZIP_FULLPATH" ]]; then
   exit 1
 fi
 
-# put .ipa with rest of files to be uploaded
-cd "$SIMPLIFIED_DIR"
-IPA_NAME="${ARCHIVE_NAME}.ipa"
-cp "$ADHOC_EXPORT_PATH/$APP_NAME.ipa" "$PAYLOAD_PATH/$IPA_NAME"
-
 # zip .ipa with dSYMs
-cd "$PAYLOAD_PATH/.."
-zip -r "$ZIP_FULLPATH" "$PAYLOAD_DIR_NAME"
+cd $PALACE_DIR
+cd "$ARCHIVE_DIR"
+echo "Creating $ZIP_FULLPATH"
+zip -r "$ZIP_FULLPATH" .
 
 # upload to iOS-binaries repo
 cd "$IOS_BINARIES_DIR_PATH"
 git add "$ZIP_FULLPATH"
 git status
-
-if [ "$BUILD_CONTEXT" == "ci" ]; then
-  git config --global user.email "librarysimplifiedci@nypl.org"
-  git config --global user.name "Library Simplified CI"
-fi
 
 COMMIT_MSG="Add ${ARCHIVE_NAME} build"
 git commit -m "$COMMIT_MSG"

--- a/scripts/setup-repo-drm.sh
+++ b/scripts/setup-repo-drm.sh
@@ -19,15 +19,17 @@ else
   echo "Setting up repo for building with DRM support for [$BUILD_CONTEXT]..."
 fi
 
-git submodule update --init --recursive
-
-if [ "$BUILD_CONTEXT" == "ci" ]; then
-  ADOBE_SDK_PATH=./DRM-iOS-AdeptConnector
-else
-  ADOBE_SDK_PATH=../DRM-iOS-AdeptConnector
+if [ "$BUILD_CONTEXT" != "ci" ]; then
+  git submodule update --init --recursive
 fi
 
-ln -s $ADOBE_SDK_PATH adobe-rmsdk
+if [ "$BUILD_CONTEXT" == "ci" ]; then
+  ADOBE_SDK_PATH=./mobile-drm-adeptconnector
+else
+  ADOBE_SDK_PATH=../mobile-drm-adeptconnector
+fi
+
+ln -s $ADOBE_SDK_PATH/uncompressed adobe-rmsdk
 
 cd $ADOBE_SDK_PATH
 ./uncompress.sh

--- a/scripts/setup-repo-nodrm.sh
+++ b/scripts/setup-repo-nodrm.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
 # SUMMARY
-#   Sets up the Simplified-iOS repo for running SimplyE without DRM support.
+#   Sets up the ios-core repo for running Palace without DRM support.
 #
 # USAGE
 #   You only have to run this script once after checking out the related repos.
-#   Run it from the root of Simplified-iOS, e.g.:
+#   Run it from the root of ios-core, e.g.:
 #
 #     ./scripts/setup-repo-nodrm.sh
 #
 # NOTES
-#   1. Building Open eBooks without DRM is not supported.
-#   2. On a fresh checkout this script will produce some errors while trying
+#   1. On a fresh checkout this script will produce some errors while trying
 #      to deinit the adobe repos. This is expected and does not affect the
 #      build process.
 
@@ -19,29 +18,27 @@ set -eo pipefail
 
 echo "Setting up repo for non-DRM build"
 
-git submodule foreach --quiet 'git submodule deinit adept-ios'
+git submodule deinit adept-ios
 git rm -rf adept-ios
-git submodule foreach --quiet 'git submodule deinit adobe-content-filter'
+git submodule deinit adobe-content-filter
 git rm -rf adobe-content-filter
+git submodule deinit ios-drm-audioengine
+git rm -rf ios-drm-audioengine
 
 git submodule update --init --recursive
 
 # Remove private repos from Cartfile and Cartfile.resolved.
-sed -i '' "s#.*NYPL-Simplified/NYPLAEToolkit.*##" Cartfile
-sed -i '' "s#.*NYPL-Simplified/NYPLAEToolkit.*##" Cartfile.resolved
-sed -i '' "s#.*NYPL-Simplified/audiobook-ios-overdrive.*##" Cartfile
-sed -i '' "s#.*NYPL-Simplified/audiobook-ios-overdrive.*##" Cartfile.resolved
 sed -i '' "s#.*lcp.*##" Cartfile
 sed -i '' "s#.*lcp.*##" Cartfile.resolved
 
 if [ ! -f "APIKeys.swift" ]; then
-  cp Simplified/AppInfrastructure/APIKeys.swift.example Simplified/AppInfrastructure/APIKeys.swift
+  cp Palace/AppInfrastructure/APIKeys.swift.example Palace/AppInfrastructure/APIKeys.swift
 fi
 
 # These will need to be filled in with real values
-if [ ! -f "SimplyE/GoogleService-Info.plist" ]; then
-  cp SimplyE/GoogleService-Info.plist.example SimplyE/GoogleService-Info.plist
+if [ ! -f "PalaceConfig/GoogleService-Info.plist" ]; then
+  cp PalaceConfig/GoogleService-Info.plist.example PalaceConfig/GoogleService-Info.plist
 fi
-if [ ! -f "SimplyE/ReaderClientCert.sig" ]; then
-  cp SimplyE/ReaderClientCert.sig.example SimplyE/ReaderClientCert.sig
+if [ ! -f "PalaceConfig/ReaderClientCert.sig" ]; then
+  cp PalaceConfig/ReaderClientCert.sig.example PalaceConfig/ReaderClientCert.sig
 fi

--- a/scripts/update-certificates.sh
+++ b/scripts/update-certificates.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Usage: run this script from the root of Simplified-iOS repo.
+# Usage: run this script from the root of Palace ios-core repo.
 #
 #     ./scripts/update-certificates.sh
 #
-# Note: this script assumes you have the Certificates repo cloned as a sibling of Simplified-iOS.
+# Note: this script assumes you have the Certificates repo cloned as a sibling of ios-core.
 
 set -eo pipefail
 
@@ -15,24 +15,20 @@ else
 fi
 
 if [ "$BUILD_CONTEXT" == "ci" ]; then
-  CERTIFICATES_PATH="./Certificates"
+  CERTIFICATES_PATH="./mobile-certificates/Certificates"
 else
-  CERTIFICATES_PATH="../Certificates"
+  CERTIFICATES_PATH="../mobile-certificates/Certificates"
 fi
 
-cp $CERTIFICATES_PATH/SimplyE/iOS/APIKeys.swift Simplified/AppInfrastructure/
+cp Palace/AppInfrastructure/APIKeys.swift.example Palace/AppInfrastructure/APIKeys.swift
 
-# SimplyE-specific stuff
-cp $CERTIFICATES_PATH/SimplyE/iOS/GoogleService-Info.plist SimplyE/
-cp $CERTIFICATES_PATH/SimplyE/iOS/ReaderClientCertProduction.sig SimplyE/ReaderClientCert.sig
+# Copy configuration files
+cp $CERTIFICATES_PATH/Palace/iOS/GoogleService-Info.plist PalaceConfig/
+cp $CERTIFICATES_PATH/Palace/iOS/ReaderClientCert.sig PalaceConfig/
 
-# OpenEbooks-specific stuff
-cp $CERTIFICATES_PATH/OpenEbooks/iOS/ReaderClientCert.sig OpenEbooks/
-cp $CERTIFICATES_PATH/OpenEbooks/iOS/GoogleService-Info.plist OpenEbooks/
+git update-index --skip-worktree Palace/TPPSecrets.swift
 
-git update-index --skip-worktree Simplified/NYPLSecrets.swift
-
-echo "Obfuscating keys..."
-swift $CERTIFICATES_PATH/SimplyE/iOS/KeyObfuscator.swift "$CERTIFICATES_PATH/SimplyE/iOS/APIKeys.json"
+# echo "Obfuscating keys..."
+swift $CERTIFICATES_PATH/Palace/iOS/KeyObfuscator.swift "$CERTIFICATES_PATH/Palace/iOS/APIKeys.json"
 
 echo "update-certificates: finished"

--- a/scripts/xcode-build-nodrm.sh
+++ b/scripts/xcode-build-nodrm.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 
 # SUMMARY
-#   Builds SimplyE without DRM support.
+#   Builds Palace without DRM support.
 #
 # SYNOPSIS
 #   xcode-build-nodrm.sh
 #
 # USAGE
-#   Run this script from the root of Simplified-iOS repo, e.g.:
+#   Run this script from the root of Palace ios-core repo, e.g.:
 #
 #     ./scripts/xcode-build-nodrm.sh
 
 set -eo pipefail
 
-echo "Building SimplyE without DRM support..."
+echo "Building Palace without DRM support..."
 
-xcodebuild -project Simplified.xcodeproj \
-           -scheme SimplyE-noDRM \
-           -destination platform=iOS\ Simulator,OS=13.5,name=iPhone\ 11\ Pro\
+xcodebuild -project Palace.xcodeproj \
+           -scheme Palace-noDRM \
+           -destination platform=iOS\ Simulator,OS=14.4,name=iPhone\ 12\ Pro\
            clean build | \
            if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi

--- a/scripts/xcode-export-adhoc.sh
+++ b/scripts/xcode-export-adhoc.sh
@@ -1,32 +1,27 @@
 #!/bin/bash
 
 # SUMMARY
-#   Exports an archive for SimplyE / Open eBooks generating the related ipa.
+#   Exports an archive for The Palace Project generating the related ipa.
 #
 # SYNOPSIS
-#   xcode-export-adhoc.sh <app_name>
+#   xcode-export-adhoc.sh
 #
 # PARAMETERS
 #   See xcode-settings.sh for possible parameters.
 #
 # USAGE
-#   Run this script from the root of Simplified-iOS repo, e.g.:
+#   Run this script from the root of `ios-core` repo, e.g.:
 #
-#     ./scripts/xcode-export-adhoc.sh simplye
+#     ./scripts/xcode-export-adhoc.sh
 #
 # RESULTS
 #   The generated .ipa is placed in its own directory inside
-#   `./Build/exports-adhoc`.
+#   `./Build/Palace-<version>` folder.
 
 source "$(dirname $0)/xcode-settings.sh"
 
 echo "Exporting $ARCHIVE_NAME for Ad-Hoc distribution..."
 
-mkdir -p "$ADHOC_EXPORT_PATH"
+fastlane ios beta output_name:$ARCHIVE_NAME.ipa export_path:$ARCHIVE_DIR
 
-xcodebuild -archivePath "$ARCHIVE_PATH" \
-            -exportOptionsPlist "$APP_NAME_FOLDER/exportOptions-adhoc.plist" \
-            -exportPath "$ADHOC_EXPORT_PATH" \
-            -allowProvisioningUpdates \
-            -exportArchive | \
-            if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
+./scripts/ios-binaries-upload.sh

--- a/scripts/xcode-export-appstore.sh
+++ b/scripts/xcode-export-appstore.sh
@@ -1,33 +1,18 @@
 #!/bin/bash
 
 # SUMMARY
-#   Exports an SimplyE / Open eBooks archive for App Store distribution
+#   Exports The Palace Projects archive for App Store distribution
 #   generating the related ipa.
 #
 # SYNOPSIS
-#   xcode-export-appstore.sh <app_name>
-#
-# PARAMETERS
-#   See xcode-settings.sh for possible parameters.
+#   xcode-export-appstore.sh
 #
 # USAGE
-#   Run this script from the root of Simplified-iOS repo, e.g.:
+#   Run this script from the root of `ios-core` repo, e.g.:
 #
-#     ./scripts/xcode-export-appstore.sh simplye
+#     ./scripts/xcode-export-appstore.sh
 #
 # RESULTS
-#   The generated .ipa is placed in its own directory inside
-#   `./Build/exports-appstore`.
+#   The generated .ipa is uploaded to TestFlight.
 
-source "$(dirname $0)/xcode-settings.sh"
-
-echo "Exporting $ARCHIVE_NAME for AppStore distribution..."
-
-mkdir -p "$APPSTORE_EXPORT_PATH"
-
-xcodebuild -archivePath "$ARCHIVE_PATH" \
-            -exportOptionsPlist "$APP_NAME_FOLDER/exportOptions-appstore.plist" \
-            -exportPath "$APPSTORE_EXPORT_PATH" \
-            -allowProvisioningUpdates \
-            -exportArchive | \
-            if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
+fastlane ios testflight

--- a/scripts/xcode-settings.sh
+++ b/scripts/xcode-settings.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SUMMARY
-#   Configures common environment variables for building Simplified apps.
+#   Configures common environment variables for building Palace app.
 #
 # USAGE
 #   Source this script from other scripts (e.g. xcode-archive.sh)
@@ -11,14 +11,7 @@
 #     ...
 #
 #   invocation:
-#     xcode-archive.sh <app_name>
-#
-#   The assumption here is that the app name (visible to the end-user)
-#   coincides with the Xcode target and scheme names.
-#
-# PARAMETERS
-#     <app_name> : Which app to build. Mandatory. Possible values:
-#         [ simplye | SE | openebooks | OE ]
+#     xcode-archive.sh
 
 set -eo pipefail
 
@@ -29,27 +22,13 @@ fatal()
 }
 
 # determine which app we're going to work on
-APPNAME_PARAM=`echo "$1" | tr '[:upper:]' '[:lower:]'`
-case "$APPNAME_PARAM" in
-  se | simplye)
-    APP_NAME=SimplyE
-    APP_NAME_FOLDER=SimplyE
-    ;;
-  oe | openebooks | open_ebooks)
-    APP_NAME="Open eBooks"
-    APP_NAME_FOLDER=OpenEbooks
-    ;;
-  *)
-    echo "xcode-settings: please specify a valid app. Possible values: simplye | openebooks"
-    exit 1
-    ;;
-esac
-TARGET_NAME=$APP_NAME
-SCHEME=$APP_NAME
+TARGET_NAME=Palace
+SCHEME=Palace
 
 # app-agnostic settings
+APP_NAME="Palace"
 PROV_PROFILES_DIR_PATH="$HOME/Library/MobileDevice/Provisioning Profiles"
-PROJECT_NAME=Simplified.xcodeproj
+PROJECT_NAME=Palace.xcodeproj
 BUILD_PATH="./Build"
 BUILD_SETTINGS="`xcodebuild -project $PROJECT_NAME -showBuildSettings -target \"$TARGET_NAME\"`"
 VERSION_NUM=`echo "$BUILD_SETTINGS" | grep "MARKETING_VERSION" | sed 's/[ ]*MARKETING_VERSION = //'`

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -1,25 +1,16 @@
 #!/bin/bash
 
 # SUMMARY
-#   Runs the unit tests for SimplyE / Open eBooks.
+#   Runs the unit tests for Palace.
 #
 # SYNOPSIS
-#   xcode-test.sh <app_name>
-#
-# PARAMETERS
-#   See xcode-settings.sh for possible parameters.
+#   xcode-test.sh
 #
 # USAGE
-#   Run this script from the root of Simplified-iOS repo, e.g.:
+#   Run this script from the root of Palace ios-core repo, e.g.:
 #
-#     ./scripts/xcode-test.sh simplye
+#     ./scripts/xcode-test.sh
 
-source "$(dirname $0)/xcode-settings.sh"
+echo "Running unit tests for Palace..."
 
-echo "Running unit tests for $APP_NAME..."
-
-xcodebuild -project "$PROJECT_NAME" \
-           -scheme "$SCHEME" \
-           -destination platform=iOS\ Simulator,OS=13.5,name=iPhone\ 11 \
-           clean test | \
-           if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
+fastlane ios test


### PR DESCRIPTION
**What's this do?**
This PR:
- updates scripts and fastlane configuration in `main` for CI, they are copies of scripts and fastlane configuration in `feature/ci-unit-testing` branch;
- enables unit testing workflow on pull requests.

Current workflows should fail, this is expected.

**Why are we doing this? (w/ Notion link if applicable)**
We are doing it as a part of CI update process.

**How should this be tested? / Do these changes have associated tests?**
Unit testing should be tested on `feature/ci-unit-testing` branch, branched off of `feature/palace-init`.
You need GitHub CLI for testing.

Run
```
gh workflow run unit-testing.yml --ref feature/ci-unit-testing
```

After that, please check [Actions](https://github.com/ThePalaceProject/ios-core/actions) tab in `ios-core` repository, you should see "Unit Tests" action running.

**Dependencies for merging? Releasing to production?**
NA

**Does this include changes that require a new SimplyE build for QA?**
NA

**Has the application documentation been updated for these changes?**
Yes, script files.

**Did someone actually run this code to verify it works?**
@vladimirfedorov 