### PR TITLE
Default to Readium 2

### DIFF
--- a/Palace/Book/UI/TPPBookCellDelegate.m
+++ b/Palace/Book/UI/TPPBookCellDelegate.m
@@ -130,20 +130,20 @@
 
 - (void)openEPUB:(TPPBook *)book
 {
-  if (TPPSettings.shared.useR2) {
+  if (TPPSettings.shared.useR1) {
+    // R1
+    TPPReaderViewController *readerVC = [[TPPReaderViewController alloc] initWithBookIdentifier:book.identifier];
+    [[TPPRootTabBarController sharedController] pushViewController:readerVC animated:YES];
+  } else {
     // R2
     [[TPPRootTabBarController sharedController] presentBook:book];
-
+    
     [TPPAnnotations requestServerSyncStatusForAccount:[TPPUserAccount sharedAccount] completion:^(BOOL enableSync) {
       if (enableSync == YES) {
         Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
         currentAccount.details.syncPermissionGranted = enableSync;
       }
     }];
-  } else {
-    // R1
-    TPPReaderViewController *readerVC = [[TPPReaderViewController alloc] initWithBookIdentifier:book.identifier];
-    [[TPPRootTabBarController sharedController] pushViewController:readerVC animated:YES];
   }
 }
 

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -31,8 +31,8 @@ import Foundation
     TPPSettings.shared.useBetaLibraries = sender.isOn
   }
 
-  func r2SwitchDidChange(sender: UISwitch!) {
-    TPPSettings.shared.useR2 = sender.isOn
+  func r1SwitchDidChange(sender: UISwitch!) {
+    TPPSettings.shared.useR1 = sender.isOn
   }
 
   // MARK:- UIViewController
@@ -60,7 +60,7 @@ import Foundation
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     switch indexPath.section {
     case 0: return cellForBetaLibraries()
-    case 1: return cellForR2Toggle()
+    case 1: return cellForR1Toggle()
     case 2: return cellForCustomRegsitry()
     default: return cellForClearCache()
     }
@@ -90,16 +90,16 @@ import Foundation
     return cell
   }
 
-  private func cellForR2Toggle() -> UITableViewCell {
+  private func cellForR1Toggle() -> UITableViewCell {
     let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "R2ToggleCell")
     cell.selectionStyle = .none
-    cell.textLabel?.text = "Enable Readium 2"
-    let r2Switch = UISwitch()
-    r2Switch.setOn(TPPSettings.shared.useR2, animated: false)
-    r2Switch.addTarget(self,
-                       action:#selector(r2SwitchDidChange),
+    cell.textLabel?.text = "Enable Readium 1"
+    let r1Switch = UISwitch()
+    r1Switch.setOn(TPPSettings.shared.useR1, animated: false)
+    r1Switch.addTarget(self,
+                       action:#selector(r1SwitchDidChange),
                        for:.valueChanged)
-    cell.accessoryView = r2Switch
+    cell.accessoryView = r1Switch
     return cell
   }
   

--- a/Palace/Settings/TPPSettings.swift
+++ b/Palace/Settings/TPPSettings.swift
@@ -29,7 +29,7 @@ import Foundation
   static let userHasAcceptedEULAKey = "NYPLSettingsUserAcceptedEULA"
   static private let userSeenFirstTimeSyncMessageKey = "userSeenFirstTimeSyncMessageKey"
   static private let useBetaLibrariesKey = "NYPLUseBetaLibrariesKey"
-  static private let useR2Key = "NYPLUseR2Key"
+  static private let useR1Key = "NYPLUseR1Key"
   static let settingsLibraryAccountsKey = "NYPLSettingsLibraryAccountsKey"
   static private let versionKey = "NYPLSettingsVersionKey"
   static private let customLibraryRegistryKey = "TPPSettingsCustomLibraryRegistryKey"
@@ -116,12 +116,12 @@ import Foundation
     }
   }
 
-  var useR2: Bool {
+  var useR1: Bool {
     get {
-      return UserDefaults.standard.bool(forKey: TPPSettings.useR2Key)
+      return UserDefaults.standard.bool(forKey: TPPSettings.useR1Key)
     }
     set(b) {
-      UserDefaults.standard.set(b, forKey: TPPSettings.useR2Key)
+      UserDefaults.standard.set(b, forKey: TPPSettings.useR1Key)
       UserDefaults.standard.synchronize()
     }
   }


### PR DESCRIPTION
What's this do?
Defaults application to use Readium 2 and allows R1 to be enabled from the developer settings menu

Why are we doing this? (w/ JIRA link if applicable)
Readium 1 is being deprecated

How should this be tested? / Do these changes have associated tests?
View an ebook, observe default reader is R2. Go to settings and toggle on R1, view an ebook, observe reader is R1.

Dependencies for merging? Releasing to production?
N/A

Has the application documentation been updated for these changes?
N/A

Did someone actually run this code to verify it works?
@mauricecarrier7 