### PR TITLE
Show placeholder logo while downloading account logos

### DIFF
--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -387,7 +387,7 @@ class OPDS2SamlIDP: NSObject, Codable {
     supportEmail = publication.links.first(where: { $0.rel == "help" })?.href.replacingOccurrences(of: "mailto:", with: "")
     
     authenticationDocumentUrl = publication.links.first(where: { $0.type == "application/vnd.opds.authentication.v1.0+json" })?.href
-    logo = UIImage.init(named: "LibraryLogoMagic")!
+    logo = UIImage(named: "LibraryLogoMagic")!
 
     super.init()
     loadLogo()
@@ -488,7 +488,7 @@ class OPDS2SamlIDP: NSObject, Codable {
          let logoData = Data.init(base64Encoded: modString),
          let logoImage = UIImage(data: logoData) {
         self.logo = logoImage
-      } 
+      }
     }
   }
 }

--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -387,8 +387,8 @@ class OPDS2SamlIDP: NSObject, Codable {
     supportEmail = publication.links.first(where: { $0.rel == "help" })?.href.replacingOccurrences(of: "mailto:", with: "")
     
     authenticationDocumentUrl = publication.links.first(where: { $0.type == "application/vnd.opds.authentication.v1.0+json" })?.href
-    logo = UIImage()
-    
+    logo = UIImage.init(named: "LibraryLogoMagic")!
+
     super.init()
     loadLogo()
   }
@@ -488,9 +488,7 @@ class OPDS2SamlIDP: NSObject, Codable {
          let logoData = Data.init(base64Encoded: modString),
          let logoImage = UIImage(data: logoData) {
         self.logo = logoImage
-      } else {
-        self.logo = UIImage.init(named: "LibraryLogoMagic")!
-      }
+      } 
     }
   }
 }


### PR DESCRIPTION
**What's this do?**
Sets placeholder logo before attempting to download account logo so that all accounts have an image on first launch.

**Why are we doing this? (w/ JIRA link if applicable)**
On application first launch, if user quickly enters the onboarding screen some accounts will not have yet an image loaded

**How should this be tested? / Do these changes have associated tests?**
Delete and reinstall the app, view library onboarding screen

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 