### PR TITLE
Custom library registry fails to load

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3921,7 +3921,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3944,7 +3944,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.9;
+				MARKETING_VERSION = 0.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -3977,7 +3977,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4000,7 +4000,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.9;
+				MARKETING_VERSION = 0.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App store";

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3921,7 +3921,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3944,7 +3944,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.8;
+				MARKETING_VERSION = 0.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -3977,7 +3977,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4000,7 +4000,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.8;
+				MARKETING_VERSION = 0.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App store";

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -302,10 +302,10 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
       self.accountSet = TPPConfiguration.customUrlHash() ?? (TPPSettings.shared.useBetaLibraries ? TPPConfiguration.betaUrlHash : TPPConfiguration.prodUrlHash)
     }
 
-    if self.accounts().isEmpty {
+    if self.accounts().isEmpty || TPPConfiguration.customUrlHash() != nil {
       loadCatalogs(completion: completion)
     } else {
-      completion?(false)
+      completion?(true) //Called when resetting a custom registry
     }
   }
 

--- a/Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift
+++ b/Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift
@@ -128,13 +128,15 @@ class TPPRegistryDebuggingCell: UITableViewCell {
   }
   
   @objc private func set() {
+    AccountsManager.shared.clearCache()
+
     guard let text = inputField.text, !text.isEmpty else {
       self.showAlert(title: "Configuration Update Failed", message: "Please enter a valid server URL")
       return
     }
     
-    TPPSettings.shared.customLibraryRegistryServer = inputField.text
-    let message = String(format: "Registry server: %@", inputField.text ?? "")
+    TPPSettings.shared.customLibraryRegistryServer = text
+    let message = String(format: "Registry server: %@", text)
     reloadRegistry { isSuccess in
       if isSuccess {
         self.showAlert(title: "Configuration Updated", message: message)

--- a/Palace/Settings/TPPSettingsAccountsList.swift
+++ b/Palace/Settings/TPPSettingsAccountsList.swift
@@ -161,7 +161,12 @@
   }
   
   private func updateNavBar() {
-    let enable = self.userAddedSecondaryAccounts.count + 1 < self.libraryAccounts.count
+    var enable = self.userAddedSecondaryAccounts.count + 1 < self.libraryAccounts.count
+    
+    if TPPSettings.shared.customLibraryRegistryServer != nil {
+      enable = self.userAddedSecondaryAccounts.count < self.libraryAccounts.count
+    }
+    
     self.navigationItem.rightBarButtonItem?.isEnabled = enable
   }
   


### PR DESCRIPTION
**What's this do?**
Ensures that catalog is loaded when a custom registry is added. Enable the ability to add multiple custom libraries

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/Unable-to-configure-alternate-library-registry-in-iOS-app-8873852fdc824e148ef3c2c2bbfbdd1d

**How should this be tested? / Do these changes have associated tests?**
Go to developer settings, add custom registry attempt to add library from registry

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 