### PR TITLE
Prevent infinite loop

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3921,7 +3921,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3944,7 +3944,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.8;
+				MARKETING_VERSION = 0.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -3977,7 +3977,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4000,7 +4000,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.8;
+				MARKETING_VERSION = 0.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App store";

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -304,9 +304,7 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
 
     if self.accounts().isEmpty || TPPConfiguration.customUrlHash() != nil {
       loadCatalogs(completion: completion)
-    } else {
-      completion?(true) //Called when resetting a custom registry
-    }
+    } 
   }
 
   func clearCache() {

--- a/Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift
+++ b/Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift
@@ -46,6 +46,9 @@ class TPPRegistryDebuggingCell: UITableViewCell {
     
     inputField.placeholder = "Input custom server"
     inputField.text = TPPSettings.shared.customLibraryRegistryServer
+    inputField.autocapitalizationType = .none
+    inputField.autocorrectionType = .no
+    
     stackView.addArrangedSubview(inputField)
     inputField.autoSetDimension(.width, toSize: 200, relation: .greaterThanOrEqual)
     
@@ -104,6 +107,7 @@ class TPPRegistryDebuggingCell: UITableViewCell {
     let containerStack = UIStackView()
     containerStack.axis = .vertical
     containerStack.spacing = 10
+    inputField.delegate = self
     
     horizontalStackView.addArrangedSubview(prefixLabel)
     horizontalStackView.addArrangedSubview(inputStackView)
@@ -119,12 +123,8 @@ class TPPRegistryDebuggingCell: UITableViewCell {
   @objc private func clear() {
     inputField.text = nil
     TPPSettings.shared.customLibraryRegistryServer = nil
-    
-    reloadRegistry { isSuccess in
-      if isSuccess {
-        self.showAlert(title: "Configuration Updated", message: "Registry has been reset to default")
-      }
-    }
+    AccountsManager.shared.clearCache()
+    self.showAlert(title: "Configuration Updated", message: "Registry has been reset to default")
   }
   
   @objc private func set() {
@@ -162,5 +162,11 @@ class TPPRegistryDebuggingCell: UITableViewCell {
     DispatchQueue.main.async {
       UIApplication.shared.keyWindow?.rootViewController?.present(alert, animated: true, completion: nil)
     }
+  }
+}
+
+extension TPPRegistryDebuggingCell: UITextFieldDelegate {
+  func textFieldDidChangeSelection(_ textField: UITextField) {
+    textField.text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 }


### PR DESCRIPTION

**What's this do?**
Modifies custom registry reset functionality to prevent attempt to reset account after cache is cleared. Adds restrictions to registry input field.

**Why are we doing this? (w/ JIRA link if applicable)**
The logic path that initally supported custom registry reset caused an infinite loop when calling `updateAccountSetFromNotification`
 
**How should this be tested? / Do these changes have associated tests?**
Run the app attached to the debugger and see if extraneous network calls are made.

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 
