### PR TITLE
Check Adobe DRM certificate expiration date to prompt for update

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -234,6 +234,8 @@
 		21E35FC3268CC8AC00066F9D /* AdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E35FC2268CC8AC00066F9D /* AdobeContentProtectionService.swift */; };
 		21E7E07B24FEA7E800189224 /* DPLAAudiobooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E7E07A24FEA7E800189224 /* DPLAAudiobooks.swift */; };
 		21EC1B8F2501538600A12384 /* AudioBookVendors+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EC1B8E2501538600A12384 /* AudioBookVendors+Extensions.swift */; };
+		21F4BF3A26BC62D4000CF592 /* AdobeCertificate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F4BF3926BC62D4000CF592 /* AdobeCertificate.swift */; };
+		21F4BF3B26BC62D4000CF592 /* AdobeCertificate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F4BF3926BC62D4000CF592 /* AdobeCertificate.swift */; };
 		2D2B47841D08F8E2007F7764 /* UpdateCheckUpToDate.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D2B47691D08F264007F7764 /* UpdateCheckUpToDate.json */; };
 		2D2B478E1D08FDF5007F7764 /* UpdateCheckNeedsUpdate.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D2B478A1D08FC78007F7764 /* UpdateCheckNeedsUpdate.json */; };
 		2D2B478F1D08FDF5007F7764 /* UpdateCheckUnknown.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D2B47891D08FC78007F7764 /* UpdateCheckUnknown.json */; };
@@ -1051,6 +1053,7 @@
 		21F238C02499155E004DC0B1 /* AdobeDRMContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AdobeDRMContainer.h; sourceTree = "<group>"; };
 		21F238C12499155E004DC0B1 /* AdobeDRMContainer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AdobeDRMContainer.mm; sourceTree = "<group>"; };
 		21F238C724991A2A004DC0B1 /* AdobeDRMLibraryService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdobeDRMLibraryService.swift; sourceTree = "<group>"; };
+		21F4BF3926BC62D4000CF592 /* AdobeCertificate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeCertificate.swift; sourceTree = "<group>"; };
 		2D2B47621D08F1ED007F7764 /* PalaceTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PalaceTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		2D2B47691D08F264007F7764 /* UpdateCheckUpToDate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UpdateCheckUpToDate.json; sourceTree = "<group>"; };
 		2D2B47721D08F807007F7764 /* PalaceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PalaceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1605,6 +1608,7 @@
 				21DDE32725D2CEFC002CBCE3 /* AdobeDRMContentProtection.swift */,
 				21DDE32D25D31DB4002CBCE3 /* AdobeDRMFetcher.swift */,
 				21E35FC2268CC8AC00066F9D /* AdobeContentProtectionService.swift */,
+				21F4BF3926BC62D4000CF592 /* AdobeCertificate.swift */,
 			);
 			path = AdobeDRM;
 			sourceTree = "<group>";
@@ -3050,6 +3054,7 @@
 				73D8D26825A68C6500DF5F69 /* TPPR2Owner.swift in Sources */,
 				73EB0A6525821DF4006BC997 /* TPPLibraryDescriptionCell.swift in Sources */,
 				73D8D28125A68D4F00DF5F69 /* EPUBModule.swift in Sources */,
+				21F4BF3B26BC62D4000CF592 /* AdobeCertificate.swift in Sources */,
 				73EB0A6725821DF4006BC997 /* TPPCirculationAnalytics.swift in Sources */,
 				73EB0A6825821DF4006BC997 /* TPPBookState.swift in Sources */,
 				73EB0A6925821DF4006BC997 /* APIKeys.swift in Sources */,
@@ -3296,6 +3301,7 @@
 				2D382BD71D08BA99002C423D /* Log.swift in Sources */,
 				11616E11196B0531003D60D9 /* TPPBookRegistry.m in Sources */,
 				081387571BC574DA003DEA6A /* UILabel+NYPLAppearanceAdditions.m in Sources */,
+				21F4BF3A26BC62D4000CF592 /* AdobeCertificate.swift in Sources */,
 				734917D1242D77D800059AA5 /* TPPUserSettingsVC.swift in Sources */,
 				21DDE31F25D2CEAF002CBCE3 /* AdobeDRMContainer.mm in Sources */,
 				734731232514235900BE3D2C /* TPPAppDelegate+SE.swift in Sources */,

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3691,7 +3691,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3712,7 +3712,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.7;
+				MARKETING_VERSION = 0.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3747,7 +3747,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3768,7 +3768,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.7;
+				MARKETING_VERSION = 0.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";

--- a/Palace/AppInfrastructure/TPPAppDelegate.m
+++ b/Palace/AppInfrastructure/TPPAppDelegate.m
@@ -166,6 +166,16 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundF
 {
   [TPPErrorLogger setUserID:[[TPPUserAccount sharedAccount] barcode]];
   [self completeBecomingActive];
+  
+#if FEATURE_DRM_CONNECTOR
+  if ([AdobeCertificate.defaultCertificate hasExpired] == YES && AdobeCertificate.shouldNotifyAboutExpiration) {
+    UIAlertController *alert = [TPPAlertUtils
+                                alertWithTitle:NSLocalizedString(@"Something went wrong with the Adobe DRM system", @"Expired DRM certificate title")
+                                message:NSLocalizedString(@"Some books will be unavailable in this version. Please try updating to the latest version of the application.", @"Expired DRM certificate message")
+                                ];
+    [TPPAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:nil animated:YES completion:nil];
+  }
+#endif
 }
 
 - (void)applicationWillResignActive:(__attribute__((unused)) UIApplication *)application

--- a/Palace/AppInfrastructure/TPPLibraryNavigationController.m
+++ b/Palace/AppInfrastructure/TPPLibraryNavigationController.m
@@ -67,7 +67,11 @@
 
       BOOL workflowsInProgress;
 #if defined(FEATURE_DRM_CONNECTOR)
-      workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [TPPBookRegistry sharedRegistry].syncing == YES);
+      if ([AdobeCertificate.defaultCertificate hasExpired] == NO) {
+        workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [TPPBookRegistry sharedRegistry].syncing == YES);
+      } else {
+        workflowsInProgress = ([TPPBookRegistry sharedRegistry].syncing == YES);
+      }
 #else
       workflowsInProgress = ([TPPBookRegistry sharedRegistry].syncing == YES);
 #endif

--- a/Palace/Book/UI/TPPBookCellDelegate.m
+++ b/Palace/Book/UI/TPPBookCellDelegate.m
@@ -85,6 +85,7 @@
 
   TPPUserAccount *user = [TPPUserAccount sharedAccount];
   if ([user hasCredentials]
+      && [AdobeCertificate.defaultCertificate hasExpired] == NO
       && ![[NYPLADEPT sharedInstance] isUserAuthorized:[user userID]
                                             withDevice:[user deviceID]]) {
     // NOTE: This was cut and pasted while refactoring preexisting work:

--- a/Palace/MyBooks/TPPMyBooksDownloadCenter.m
+++ b/Palace/MyBooks/TPPMyBooksDownloadCenter.m
@@ -1080,10 +1080,19 @@ didCompleteWithError:(NSError *)error
       }
     }
   } else {
-    [TPPAccountSignInViewController
-     requestCredentialsWithCompletion:^{
-       [[TPPMyBooksDownloadCenter sharedDownloadCenter] startDownloadForBook:book];
-     }];
+    if ([AdobeCertificate.defaultCertificate hasExpired] == YES) {
+      // ADEPT crashes the app with expired certificate.
+      UIAlertController *alert = [TPPAlertUtils
+                                  alertWithTitle:NSLocalizedString(@"Something went wrong with the Adobe DRM system", @"Expired DRM certificate title")
+                                  message:NSLocalizedString(@"Some books will be unavailable in this version. Please try updating to the latest version of the application.", @"Expired DRM certificate message")
+                                  ];
+      [TPPAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:nil animated:YES completion:nil];
+    } else {
+      [TPPAccountSignInViewController
+       requestCredentialsWithCompletion:^{
+         [[TPPMyBooksDownloadCenter sharedDownloadCenter] startDownloadForBook:book];
+       }];
+    }
   }
 }
 

--- a/Palace/MyBooks/TPPMyBooksDownloadCenter.m
+++ b/Palace/MyBooks/TPPMyBooksDownloadCenter.m
@@ -75,7 +75,11 @@
   if(!self) return nil;
   
 #if defined(FEATURE_DRM_CONNECTOR)
-  [NYPLADEPT sharedInstance].delegate = self;
+  // If Adobe certificate is expired, but we still are trying to download an Adobe DRM-protected book,
+  // the app will crash
+  if (!AdobeCertificate.defaultCertificate.hasExpired) {
+    [NYPLADEPT sharedInstance].delegate = self;
+  }
 #endif
   
   NSURLSessionConfiguration *const configuration =

--- a/Palace/MyBooks/TPPMyBooksDownloadCenter.m
+++ b/Palace/MyBooks/TPPMyBooksDownloadCenter.m
@@ -1080,6 +1080,7 @@ didCompleteWithError:(NSError *)error
       }
     }
   } else {
+#if FEATURE_DRM_CONNECTOR
     if ([AdobeCertificate.defaultCertificate hasExpired] == YES) {
       // ADEPT crashes the app with expired certificate.
       UIAlertController *alert = [TPPAlertUtils
@@ -1093,6 +1094,12 @@ didCompleteWithError:(NSError *)error
          [[TPPMyBooksDownloadCenter sharedDownloadCenter] startDownloadForBook:book];
        }];
     }
+#else
+    [TPPAccountSignInViewController
+     requestCredentialsWithCompletion:^{
+       [[TPPMyBooksDownloadCenter sharedDownloadCenter] startDownloadForBook:book];
+     }];
+#endif
   }
 }
 

--- a/Palace/OPDS/TPPOPDSAcquisitionPath.m
+++ b/Palace/OPDS/TPPOPDSAcquisitionPath.m
@@ -41,13 +41,16 @@ NSString * const _Nonnull ContentTypeAudiobookZip = @"application/audiobook+zip"
 
 + (NSSet<NSString *> *_Nonnull)supportedTypes
 {
-  static NSMutableSet<NSString *> *types = nil;
+  static NSSet<NSString *> *types = nil;
 
   if (!types) {
-    types = [NSMutableSet setWithArray:@[
+    types = [NSSet setWithArray:@[
       ContentTypeOPDSCatalog,
       ContentTypeBearerToken,
       ContentTypeEpubZip,
+#if FEATURE_DRM_CONNECTOR
+      ContentTypeAdobeAdept,
+#endif
       ContentTypeFindaway,
       ContentTypeOpenAccessAudiobook,
       ContentTypeOpenAccessPDF,
@@ -62,12 +65,14 @@ NSString * const _Nonnull ContentTypeAudiobookZip = @"application/audiobook+zip"
   }
 
 #if FEATURE_DRM_CONNECTOR
-  // Adobe DRM crashes the app when certificate expired.
-  if (!AdobeCertificate.defaultCertificate.hasExpired) {
-    [types addObject:ContentTypeAdobeAdept];
+  // Adobe DRM crashes the app when certificate is expired.
+  if ([AdobeCertificate.defaultCertificate hasExpired] == YES) {
+    NSMutableSet<NSString *> *mutableTypes = [types mutableCopy];
+    [mutableTypes removeObject:ContentTypeAdobeAdept];
+    return [mutableTypes copy];
   }
 #endif
-  return [types copy];
+  return types;
 }
   
 + (NSSet<NSString *> *_Nonnull)supportedSubtypesForType:(NSString *)type

--- a/Palace/OPDS/TPPOPDSAcquisitionPath.m
+++ b/Palace/OPDS/TPPOPDSAcquisitionPath.m
@@ -1,6 +1,6 @@
 #import "TPPOPDSIndirectAcquisition.h"
-
 #import "TPPOPDSAcquisitionPath.h"
+#import "Palace-Swift.h"
 
 NSString * const _Nonnull ContentTypeOPDSCatalog = @"application/atom+xml;type=entry;profile=opds-catalog";
 NSString * const _Nonnull ContentTypeAdobeAdept = @"application/vnd.adobe.adept+xml";
@@ -41,14 +41,11 @@ NSString * const _Nonnull ContentTypeAudiobookZip = @"application/audiobook+zip"
 
 + (NSSet<NSString *> *_Nonnull)supportedTypes
 {
-  static NSSet<NSString *> *types = nil;
+  static NSMutableSet<NSString *> *types = nil;
 
   if (!types) {
-    types = [NSSet setWithArray:@[
+    types = [NSMutableSet setWithArray:@[
       ContentTypeOPDSCatalog,
-#if FEATURE_DRM_CONNECTOR
-      ContentTypeAdobeAdept,
-#endif
       ContentTypeBearerToken,
       ContentTypeEpubZip,
       ContentTypeFindaway,
@@ -64,7 +61,13 @@ NSString * const _Nonnull ContentTypeAudiobookZip = @"application/audiobook+zip"
     ]];
   }
 
-  return types;
+#if FEATURE_DRM_CONNECTOR
+  // Adobe DRM crashes the app when certificate expired.
+  if (!AdobeCertificate.defaultCertificate.hasExpired) {
+    [types addObject:ContentTypeAdobeAdept];
+  }
+#endif
+  return [types copy];
 }
   
 + (NSSet<NSString *> *_Nonnull)supportedSubtypesForType:(NSString *)type

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
@@ -47,7 +47,6 @@ extension AdobeCertificate {
   }
     
   /// Default certificate for Palace app.
-  
   @objc static var defaultCertificate: AdobeCertificate? {
     guard let adobeCertUrl = Bundle.main.url(forResource: "ReaderClientCert", withExtension: "sig"),
           let adobeCertData = try? Data(contentsOf: adobeCertUrl) else {
@@ -65,6 +64,25 @@ extension AdobeCertificate {
       return nil
     }
   }
+  
+  /// Period of notification for expired Adobe DRM certificate
+  fileprivate static let notificationPeriod: TimeInterval = 10 //60 * 60
+  
+  /// Last expired DRM certificate notification date
+  fileprivate static var notificationDate: Date?
+
+  /// Returns true every `notificationPeriod` time interval.
+  ///
+  /// Used to avoid showing expiration message every time the user opens the app with expired certificate.
+  @objc static var shouldNotifyAboutExpiration: Bool {
+    if let notificationDate = notificationDate, -notificationDate.timeIntervalSinceNow < notificationPeriod {
+      return false
+    } else {
+      notificationDate = Date()
+      return true
+    }
+  }
+  
 }
 
 #endif

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
@@ -1,0 +1,70 @@
+//
+//  AdobeCertificate.swift
+//  Palace
+//
+//  Created by Vladimir Fedorov on 04.08.2021.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+#if FEATURE_DRM_CONNECTOR
+
+import Foundation
+
+/// Adobe DRM Certificate structure.
+///
+/// Includes only fields Palace checks to verify the certificate is not expired.
+@objc class AdobeCertificate: NSObject, Codable {
+  
+  /// Certificate expiration date, seconds since UNIX epoch.
+  ///
+  /// This field is not present in production certificates.
+  let expireson: UInt?
+  
+  /// Initializes certificate data
+  init(expireson: UInt?) {
+    self.expireson = expireson
+  }
+}
+
+extension AdobeCertificate {
+  
+  /// Certificate expiration date.
+  @objc var expirationDate: Date? {
+    guard let expireson = expireson else {
+      return nil
+    }
+    return Date(timeIntervalSince1970: Double(expireson))
+  }
+  
+  /// Returns `true` if certificate has already expired.
+  ///
+  /// If expiration date is not present in certificate data, returns `false`
+  @objc var hasExpired: Bool {
+    guard let expirationDate = expirationDate else {
+      return false
+    }
+    return expirationDate.timeIntervalSinceNow <= 0
+  }
+    
+  /// Default certificate for Palace app.
+  
+  @objc static var defaultCertificate: AdobeCertificate? {
+    guard let adobeCertUrl = Bundle.main.url(forResource: "ReaderClientCert", withExtension: "sig"),
+          let adobeCertData = try? Data(contentsOf: adobeCertUrl) else {
+      return nil
+    }
+    return AdobeCertificate(data: adobeCertData)
+  }
+  
+  /// Initialise with Adobe DRM certificate data.
+  /// - Parameter data: `ReaderClientCert.sig` data.
+  @objc convenience init?(data: Data) {
+    if let cert = try? JSONDecoder().decode(AdobeCertificate.self, from: data) {
+      self.init(expireson: cert.expireson)
+    } else {
+      return nil
+    }
+  }
+}
+
+#endif

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
@@ -66,7 +66,7 @@ extension AdobeCertificate {
   }
   
   /// Period of notification for expired Adobe DRM certificate
-  fileprivate static let notificationPeriod: TimeInterval = 10 //60 * 60
+  fileprivate static let notificationPeriod: TimeInterval = 60 * 60
   
   /// Last expired DRM certificate notification date
   fileprivate static var notificationDate: Date?

--- a/Palace/Settings/TPPSettingsAccountDetailViewController.m
+++ b/Palace/Settings/TPPSettingsAccountDetailViewController.m
@@ -149,7 +149,9 @@ Authenticating with any of those barcodes should work.
 
   id<TPPDRMAuthorizing> drmAuthorizer = nil;
 #if defined(FEATURE_DRM_CONNECTOR)
-  drmAuthorizer = [NYPLADEPT sharedInstance];
+  if ([AdobeCertificate.defaultCertificate hasExpired] == NO) {
+    drmAuthorizer = [NYPLADEPT sharedInstance];
+  }
 #endif
 
   self.businessLogic = [[TPPSignInBusinessLogic alloc]

--- a/Palace/SignInLogic/TPPAccountSignInViewController.m
+++ b/Palace/SignInLogic/TPPAccountSignInViewController.m
@@ -90,11 +90,11 @@ CGFloat const marginPadding = 2.0;
   if(!self) return nil;
 
   NYPLADEPT *adeptInstance = nil;
-//#if FEATURE_DRM_CONNECTOR
-//  if ([AdobeCertificate.defaultCertificate hasExpired] == NO) {
+#if FEATURE_DRM_CONNECTOR
+  if ([AdobeCertificate.defaultCertificate hasExpired] == NO) {
     adeptInstance = [NYPLADEPT sharedInstance];
-//  }
-//#endif
+  }
+#endif
   
   self.businessLogic = [[TPPSignInBusinessLogic alloc]
                         initWithLibraryAccountID:AccountsManager.shared.currentAccountId
@@ -104,12 +104,7 @@ CGFloat const marginPadding = 2.0;
                         bookDownloadsCenter:[TPPMyBooksDownloadCenter sharedDownloadCenter]
                         userAccountProvider:[TPPUserAccount class]
                         uiDelegate:self
-                        drmAuthorizer:
-#if FEATURE_DRM_CONNECTOR
-                        adeptInstance
-#else
-                        nil
-#endif
+                        drmAuthorizer:adeptInstance
                         ];
 
   self.title = NSLocalizedString(@"Sign In", nil);

--- a/Palace/SignInLogic/TPPAccountSignInViewController.m
+++ b/Palace/SignInLogic/TPPAccountSignInViewController.m
@@ -89,8 +89,8 @@ CGFloat const marginPadding = 2.0;
   self = [super initWithStyle:UITableViewStyleGrouped];
   if(!self) return nil;
 
-  NYPLADEPT *adeptInstance = nil;
 #if FEATURE_DRM_CONNECTOR
+  NYPLADEPT *adeptInstance = nil;
   if ([AdobeCertificate.defaultCertificate hasExpired] == NO) {
     adeptInstance = [NYPLADEPT sharedInstance];
   }
@@ -104,7 +104,12 @@ CGFloat const marginPadding = 2.0;
                         bookDownloadsCenter:[TPPMyBooksDownloadCenter sharedDownloadCenter]
                         userAccountProvider:[TPPUserAccount class]
                         uiDelegate:self
-                        drmAuthorizer:adeptInstance
+                        drmAuthorizer:
+#if FEATURE_DRM_CONNECTOR
+                        adeptInstance
+#else
+                        nil
+#endif
                         ];
 
   self.title = NSLocalizedString(@"Sign In", nil);

--- a/Palace/SignInLogic/TPPAccountSignInViewController.m
+++ b/Palace/SignInLogic/TPPAccountSignInViewController.m
@@ -89,6 +89,13 @@ CGFloat const marginPadding = 2.0;
   self = [super initWithStyle:UITableViewStyleGrouped];
   if(!self) return nil;
 
+  NYPLADEPT *adeptInstance = nil;
+//#if FEATURE_DRM_CONNECTOR
+//  if ([AdobeCertificate.defaultCertificate hasExpired] == NO) {
+    adeptInstance = [NYPLADEPT sharedInstance];
+//  }
+//#endif
+  
   self.businessLogic = [[TPPSignInBusinessLogic alloc]
                         initWithLibraryAccountID:AccountsManager.shared.currentAccountId
                         libraryAccountsProvider:AccountsManager.shared
@@ -99,7 +106,7 @@ CGFloat const marginPadding = 2.0;
                         uiDelegate:self
                         drmAuthorizer:
 #if FEATURE_DRM_CONNECTOR
-                        [NYPLADEPT sharedInstance]
+                        adeptInstance
 #else
                         nil
 #endif

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
@@ -157,27 +157,31 @@ extension TPPSignInBusinessLogic {
     AdobeDeviceID: \(adobeDeviceID ?? "N/A")
     """)
 
-    drmAuthorizer?.deauthorize(
-      withUsername: tokenUsername,
-      password: tokenPassword,
-      userID: adobeUserID,
-      deviceID: adobeDeviceID) { [weak self] success, error in
-        if success {
-          Log.info(#file, "*** Successful DRM Deactivation ***")
-        } else {
-          // Even though we failed, let the user continue to log out.
-          // The most likely reason is a user changing their PIN.
-          TPPErrorLogger.logError(error,
-                                   summary: "User lost an activation on signout: ADEPT error",
-                                   metadata: [
-                                    "AdobeUserID": adobeUserID ?? "N/A",
-                                    "DeviceID": adobeDeviceID ?? "N/A",
-                                    "Licensor": licensor,
-                                    "AdobeTokenUsername": tokenUsername ?? "N/A",
-                                    "AdobeTokenPassword": tokenPassword ?? "N/A"])
-        }
+    if let drmAuthorizer = drmAuthorizer {
+      drmAuthorizer.deauthorize(
+        withUsername: tokenUsername,
+        password: tokenPassword,
+        userID: adobeUserID,
+        deviceID: adobeDeviceID) { [weak self] success, error in
+          if success {
+            Log.info(#file, "*** Successful DRM Deactivation ***")
+          } else {
+            // Even though we failed, let the user continue to log out.
+            // The most likely reason is a user changing their PIN.
+            TPPErrorLogger.logError(error,
+                                     summary: "User lost an activation on signout: ADEPT error",
+                                     metadata: [
+                                      "AdobeUserID": adobeUserID ?? "N/A",
+                                      "DeviceID": adobeDeviceID ?? "N/A",
+                                      "Licensor": licensor,
+                                      "AdobeTokenUsername": tokenUsername ?? "N/A",
+                                      "AdobeTokenPassword": tokenPassword ?? "N/A"])
+          }
 
-        self?.completeLogOutProcess()
+          self?.completeLogOutProcess()
+      }
+    } else {
+      self.completeLogOutProcess()
     }
   }
   #endif

--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
@@ -278,7 +278,11 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
       switch result {
       case .success(let responseData, _):
         #if FEATURE_DRM_CONNECTOR
-        self.drmAuthorizeUserData(responseData, loggingContext: loggingContext)
+        if (AdobeCertificate.defaultCertificate?.hasExpired == true) {
+          self.finalizeSignIn(forDRMAuthorization: true)
+        } else {
+          self.drmAuthorizeUserData(responseData, loggingContext: loggingContext)
+        }
         #else
         self.finalizeSignIn(forDRMAuthorization: true)
         #endif

--- a/Palace/en.lproj/Localizable.strings
+++ b/Palace/en.lproj/Localizable.strings
@@ -265,3 +265,7 @@
 "week_suffix_short" = "%d w";
 "day_suffix_short" = "%d d";
 "hour_suffix_short" = "%d h";
+
+// Adobe DRM Expired certificate title and message
+"Something went wrong with the Adobe DRM system" = "Something went wrong with the Adobe DRM system";
+"Some books will be unavailable in this version. Please try updating to the latest version of the application." = "Some books will be unavailable in this version. Please try updating to the latest version of the application.";


### PR DESCRIPTION
**What's this do?**
Checks expiration date of development certificate; if DRM certificate expired, prompts for the app update.

**Why are we doing this? (w/ Notion link if applicable)**
This check will prompt early adopters to update the app once the certificate expires. It also makes sure the app doesn't crash when this happens.

**How should this be tested? / Do these changes have associated tests?**
1. Build and run the app, open LYRASIS library, see all books are available.
2. Replace `ios-core/PalaceConfig/ReaderClientCert.sig` with the [previous version](https://github.com/ThePalaceProject/mobile-certificates/blob/7ba7de92a6deda8eaae707dd89286368cf8a4445/Certificates/Palace/iOS/ReaderClientCert.sig) from `mobile-certificates`.
3. Run the app again, only books without DRM protection should be visible. The app shows a message to update the app.

![Simulator Screen Shot - iPod touch (7th generation) - 2021-08-06 at 21 51 57](https://user-images.githubusercontent.com/941531/128545400-c674fc2a-9e3d-4b0e-a49e-1e10d78fa8a5.png)

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
@vladimirfedorov 