### PR TITLE
Dismiss book detail view

### DIFF
--- a/Palace/Book/UI/TPPBookButtonsView.m
+++ b/Palace/Book/UI/TPPBookButtonsView.m
@@ -406,6 +406,8 @@
   self.activityIndicator.center = self.readButton.center;
   [self updateProcessingState:YES];
   [self.delegate didSelectReadForBook:self.book];
+  [[TPPRootTabBarController sharedController] dismissViewControllerAnimated:true completion:nil];
+
 }
 
 - (void)didSelectDownload


### PR DESCRIPTION
**What's this do?**
Dismisses book detail view on iPad when user taps read

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/iPad-BookDetails-View-does-not-disappear-after-clicking-Read-button-14423f80e88249a982a27854a2372252

**How should this be tested? / Do these changes have associated tests?**
On ipad, download and select to read a book. detail view should be dismissed

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 