### PR TITLE
Check project version before uploading a new build

### DIFF
--- a/.github/workflows/upload-on-merge.yml
+++ b/.github/workflows/upload-on-merge.yml
@@ -5,9 +5,27 @@ on:
       - develop
     types: [closed]
 jobs:
+  check-version:
+    runs-on: macOS-latest
+    steps:
+      - name: Force Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Checkout main repo and submodules
+        uses: actions/checkout@v2.3.4
+        with:
+          submodules: true
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
+      - id: checkVersion
+        name: Check Build Version
+        run: ./scripts/ios-check-version.sh
+        env:
+          BUILD_CONTEXT: ci
+    outputs:
+      should_upload: ${{ steps.checkVersion.outputs.version_changed }}
   upload-build:
     runs-on: macOS-latest
-    if: github.event.pull_request.merged == true
+    needs: check-version
+    if: github.event.pull_request.merged == true && needs.check-version.outputs.should_upload == '1'
     steps:
       - name: Force Xcode 12.4
         run: sudo xcode-select -switch /Applications/Xcode_12.4.app

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,7 +1,7 @@
 name: Palace Manual Build
 on: workflow_dispatch
 jobs:
-  upload-build:
+  check-version:
     runs-on: macOS-latest
     steps:
       - name: Force Xcode 12.4
@@ -11,6 +11,18 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
+      - id: checkVersion
+        name: Check Build Version
+        run: ./scripts/ios-check-version.sh
+        env:
+          BUILD_CONTEXT: ci
+    outputs:
+      should_upload: ${{ steps.checkVersion.outputs.version_changed }}
+  upload-build:
+    runs-on: macOS-latest
+    needs: check-version
+    if: needs.check-version.outputs.should_upload == '1'
+    steps:
       - name: Checkout Binaries
         uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -23,6 +23,13 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.should_upload == '1'
     steps:
+      - name: Force Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Checkout main repo and submodules
+        uses: actions/checkout@v2.3.4
+        with:
+          submodules: true
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
       - name: Checkout Binaries
         uses: actions/checkout@v2.3.4
         with:

--- a/scripts/ios-check-version.sh
+++ b/scripts/ios-check-version.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# SUMMARY
+#   Checks if a binary with the current build number already exists on the
+#   https://github.com/ThePalaceProject/ios-binaries repo.
+#
+# SYNOPSIS
+#   ios-check-version.sh
+#
+# PARAMETERS
+#   See xcode-settings.sh for possible parameters.
+#
+# USAGE
+#   Run this script from the root of ios-core repo, e.g.:
+#
+#     ./scripts/ios-binaries-check
+
+set -eo pipefail
+
+source "$(dirname $0)/xcode-settings.sh"
+
+CURL_RESULT=`curl -I -s -o /dev/null -w "%{http_code}"  https://github.com/ThePalaceProject/ios-binaries/blob/master/$UPLOAD_FILENAME`
+
+if [ "$CURL_RESULT" == 200 ]; then
+  echo "Build for ${ARCHIVE_NAME} already exists in ios-binaries"
+  echo "::set-output name=version_changed::0"
+elif [ "$CURL_RESULT" != 404 ]; then
+  echo "Obtained unexpected curl result for file named \"$UPLOAD_FILENAME\""
+  exit 1
+else
+  echo "Build for ${ARCHIVE_NAME} doesn't exist in ios-binaries"    
+  echo "::set-output name=version_changed::1"
+fi


### PR DESCRIPTION
**What's this do?**
Checks project version before uploading a new build.

**Why are we doing this? (w/ Notion link if applicable)**
The upload script fails when a binary with current project version already is in `ios-binaries` ([notion](https://www.notion.so/lyrasis/CI-Palace-Build-fails-when-a-binary-with-the-same-project-build-number-already-exists-in-the-reposi-04447abaa80c49f2afb9e687e4e344ae)).

**How should this be tested? / Do these changes have associated tests?**
You can branch off `task/check-version` and run upload.yml workflow; if Palace version already is in the repository, the workflow should stop before trying to upload a new one.
```
git clone git@github.com:ThePalaceProject/ios-core.git -b task/check-version
git checkout -b <branch_name>
git push origin <branch_name>
gh workflow run upload.yml --ref <branch_name>
```

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
No

**Has the application documentation been updated for these changes?**
Yes, script documentation

**Did someone actually run this code to verify it works?**
@vladimirfedorov 