### PR TITLE
Reenable TPPButtonsView on state change and update the buttons state on return to detail view

### DIFF
--- a/Palace/Book/UI/TPPBookButtonsView.m
+++ b/Palace/Book/UI/TPPBookButtonsView.m
@@ -138,7 +138,8 @@
   static NSString *const TitleKey = @"title";
   static NSString *const HintKey = @"accessibilityHint";
   static NSString *const AddIndicatorKey = @"addIndicator";
-  
+  [self updateProcessingState:NO];
+
   NSString *fulfillmentId = [[TPPBookRegistry sharedRegistry] fulfillmentIdForIdentifier:self.book.identifier];
   
   switch(self.state) {
@@ -406,7 +407,7 @@
   self.activityIndicator.center = self.readButton.center;
   [self updateProcessingState:YES];
   [self.delegate didSelectReadForBook:self.book];
-  [[TPPRootTabBarController sharedController] dismissViewControllerAnimated:true completion:nil];
+  [[TPPRootTabBarController sharedController] dismissViewControllerAnimated:YES completion:nil];
 
 }
 

--- a/Palace/Book/UI/TPPBookDetailViewController.m
+++ b/Palace/Book/UI/TPPBookDetailViewController.m
@@ -97,6 +97,9 @@
   } else {
     self.navigationController.navigationBarHidden = NO;
   }
+  
+  [self.bookDetailView setState:[[TPPBookRegistry sharedRegistry]
+                                 stateForIdentifier:self.book.identifier]];
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/Palace/MyBooks/TPPMyBooksViewController.m
+++ b/Palace/MyBooks/TPPMyBooksViewController.m
@@ -145,6 +145,7 @@ typedef NS_ENUM(NSInteger, FacetSort) {
   self.instructionsLabel.text = NSLocalizedString(@"MyBooksGoToCatalog", nil);
   self.instructionsLabel.textAlignment = NSTextAlignmentCenter;
   self.instructionsLabel.textColor = [UIColor colorWithWhite:0.6667 alpha:1.0];
+  self.instructionsLabel.font = [UIFont palaceFontOfSize:18.0];
   self.instructionsLabel.numberOfLines = 0;
   [self.view addSubview:self.instructionsLabel];
   [self.instructionsLabel autoCenterInSuperview];


### PR DESCRIPTION

**What's this do?**
- Reenables detail view buttons when returning to the detail view
- Updates font on empty screen

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/Read-and-Delete-buttons-are-not-clickable-after-going-back-to-the-previous-screen-0e7b511f19cc4e2280553cb62e31f15d

**How should this be tested? / Do these changes have associated tests?**
Select read or listen from the detail book view, navigate back to detail view, attempt to select read or listen again.

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 