### PR TITLE
Feature/launch catalog after adding account

### DIFF
--- a/Palace/Settings/TPPSettingsAccountsList.swift
+++ b/Palace/Settings/TPPSettingsAccountsList.swift
@@ -170,21 +170,23 @@
     self.navigationItem.rightBarButtonItem?.isEnabled = enable
   }
   
-  private func updateList(withAccount uuid: String) {
-    userAddedSecondaryAccounts.append(uuid)
+  private func updateList(withAccount account: Account) {
+    userAddedSecondaryAccounts.append(account.uuid)
     updateSettingsAccountList()
-    updateNavBar()
-    tableView.reloadData()
-    navigationController?.popViewController(animated: true)
+    AccountsManager.shared.currentAccount = account
+    let catalog = TPPRootTabBarController.shared()?.viewControllers?.first as? TPPCatalogNavigationController
+    catalog?.updateFeedAndRegistryOnAccountChange()
+    self.tabBarController?.selectedIndex = 0
+    (navigationController?.parent as? UINavigationController)?.popToRootViewController(animated: false)
   }
   
   @objc private func addAccount() {
     let listVC = TPPAccountList { [weak self] account in
       if account.details != nil {
-        self?.updateList(withAccount: account.uuid)
+        self?.updateList(withAccount: account)
       } else {
         self?.authenticateAccount(account) {
-          self?.updateList(withAccount: account.uuid)
+          self?.updateList(withAccount: account)
         }
         self?.libraryAccounts = AccountsManager.shared.accounts()
       }


### PR DESCRIPTION
**What's this do?**
Returns the user back to the catalog view after a new account is added.

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/Switch-library-catalog-when-adding-new-library-1a69ffceed66446c9d32ecc4e38dfbd2

**How should this be tested? / Do these changes have associated tests?**
Launch app, add a secondary new account

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 



https://user-images.githubusercontent.com/6921353/130246644-01acd84c-626b-43c5-b8fc-aeaab9089c79.mov

