### PR TITLE
Don't add libraries that already are on the list

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3727,7 +3727,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3748,7 +3748,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3783,7 +3783,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3804,7 +3804,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3963,7 +3963,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3986,7 +3986,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -4019,7 +4019,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4042,7 +4042,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App store";

--- a/Palace/Settings/TPPSettingsAccountsList.swift
+++ b/Palace/Settings/TPPSettingsAccountsList.swift
@@ -176,7 +176,6 @@
     }
     updateSettingsAccountList()
     // Return from search screen to the list of libraries
-    updateNavBar()
     tableView.reloadData()
     navigationController?.popViewController(animated: false)
     // Switch to the selected library

--- a/Palace/Settings/TPPSettingsAccountsList.swift
+++ b/Palace/Settings/TPPSettingsAccountsList.swift
@@ -176,7 +176,6 @@
     }
     updateSettingsAccountList()
     // Return from search screen to the list of libraries
-    tableView.reloadData()
     navigationController?.popViewController(animated: false)
     // Switch to the selected library
     AccountsManager.shared.currentAccount = account

--- a/Palace/Settings/TPPSettingsAccountsList.swift
+++ b/Palace/Settings/TPPSettingsAccountsList.swift
@@ -171,7 +171,9 @@
   }
   
   private func updateList(withAccount uuid: String) {
-    userAddedSecondaryAccounts.append(uuid)
+    if !userAddedSecondaryAccounts.contains(uuid) {
+      userAddedSecondaryAccounts.append(uuid)
+    }
     updateSettingsAccountList()
     updateNavBar()
     tableView.reloadData()


### PR DESCRIPTION
**What's this do?**
- Checks if selected library already is on the list of libraries

**Why are we doing this? (w/ Notion link if applicable)**
It is possible to add libraries that are already on the list ([notion](https://www.notion.so/lyrasis/There-is-a-possibility-to-add-multiple-count-of-DPLA-libraries-5fdb618d71694403989850dec03750d7))

**How should this be tested? / Do these changes have associated tests?**
Please follow "Steps to reproduce" in the ticket.

**Dependencies for merging? Releasing to production?**
NA

**Does this include changes that require a new palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
@vladimirfedorov 