### PR TITLE
Fix Crashlytics module name

### DIFF
--- a/Palace/Logging/Log.swift
+++ b/Palace/Logging/Log.swift
@@ -1,6 +1,6 @@
 import os
 import Foundation
-import FirebaseCore
+import FirebaseCrashlytics
 
 final class Log: NSObject {
   static var dateFormatter: DateFormatter = {


### PR DESCRIPTION
**What's this do?**
Fixes Firebase Crashlytics module name.

**Why are we doing this? (w/ Notion link if applicable)**
We have a part of code that builds for real devices only; wrong Firebase module caused the build to fail during CI build.

**How should this be tested? / Do these changes have associated tests?**
Open the project in Xcode and try to run Product - Archive. Archiving should not fail.

**Dependencies for merging? Releasing to production?**
NA

**Does this include changes that require a new Palace build for QA?**
Yes (should trigger the build on merge)

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 