### PR TITLE
Resolve epub crash 

### DIFF
--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContainer.mm
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContainer.mm
@@ -66,6 +66,12 @@ static id acsdrm_lock = nil;
     dp::Data encryptionXMLData (encryptionContent, encryptionLen);
     dp::ref<dputils::EncryptionMetadata> encryptionMetadata = dputils::EncryptionMetadata::createFromXMLData(encryptionXMLData);
     uft::String itemPath (path.UTF8String);
+
+    if (!encryptionMetadata) {
+      self.epubDecodingError = @"Missing EncryptionMetadata";
+      return data;
+    }
+
     dp::ref<dputils::EncryptionItemInfo> itemInfo = encryptionMetadata->getItemForURI(itemPath);
 
     if (!itemInfo) {


### PR DESCRIPTION
**What's this do?**
Resolves a crash caused by attempting to extract info from an epub that does not have encryption metadata

**Why are we doing this? (w/ Notion link if applicable)**
Resolves: https://www.notion.so/lyrasis/iOS-app-is-crashed-after-opening-NonEmbeddedJStyle_tag-epub-aaa5feb951b3462dab7d2dcf146174a2

**How should this be tested? / Do these changes have associated tests?**
Attempt to access title "Korean_FallBackFont_nonembed_tag.epub" from Lyrasis library

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new Palace build for QA?**
Yes
**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 


https://user-images.githubusercontent.com/6921353/131891144-41225d40-143d-4a47-a739-cfe35c7460eb.mov

