### PR TITLE
Switch Palace library registry

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		21399900268F9F2500B4EB60 /* TPPAccountListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AD65DC2684FACA00C62951 /* TPPAccountListCell.swift */; };
 		21399902268F9F4C00B4EB60 /* TPPAccountListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AD65E02684FDA300C62951 /* TPPAccountListDataSource.swift */; };
 		2146872D2559A64B007B401A /* LCPLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2171ADA0251E38140003CABA /* LCPLibraryService.swift */; };
+		216FD1FC26DFE112003AF0D8 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E5506DE326C4688D009FA623 /* Colors.xcassets */; };
 		2178984D269F174500374A6B /* NYPLAEToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E585662526979AC100A5FBD5 /* NYPLAEToolkit.framework */; };
 		2178984E269F174500374A6B /* NYPLAEToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E585662526979AC100A5FBD5 /* NYPLAEToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		219747FC26D9218400FA25DF /* TPPLCPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219747F626D9218400FA25DF /* TPPLCPClient.swift */; };
@@ -2923,6 +2924,7 @@
 				73EB0B6225821DF4006BC997 /* reader.html in Resources */,
 				73EB0B6325821DF4006BC997 /* DetailSummaryTemplate.html in Resources */,
 				73EB0B6425821DF4006BC997 /* Localizable.strings in Resources */,
+				216FD1FC26DFE112003AF0D8 /* Colors.xcassets in Resources */,
 				73EB0B6525821DF4006BC997 /* Images.xcassets in Resources */,
 				73EB0B6625821DF4006BC997 /* sdk.css in Resources */,
 				E5BEF02A26BDAB3A00C2A50B /* OpenSans-SemiBold.ttf in Resources */,

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3743,7 +3743,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3764,7 +3764,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3799,7 +3799,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3820,7 +3820,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3979,7 +3979,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4004,7 +4004,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -4037,7 +4037,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4062,7 +4062,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App store";

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -237,11 +237,6 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
     let wasAlreadyLoading = addLoadingCompletionHandler(key: hash, completion)
     guard !wasAlreadyLoading else { return }
 
-    // Update current registry hash if registry changed
-    if TPPConfiguration.registryChanged {
-      TPPConfiguration.updateSavedeRegistryKey()
-    }
-
     TPPNetworkExecutor.shared.GET(targetUrl) { result in
       switch result {
       case .success(let data, _):

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -237,6 +237,11 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
     let wasAlreadyLoading = addLoadingCompletionHandler(key: hash, completion)
     guard !wasAlreadyLoading else { return }
 
+    // Update current registry hash if registry changed
+    if TPPConfiguration.registryChanged {
+      TPPConfiguration.updateSavedeRegistryKey()
+    }
+
     TPPNetworkExecutor.shared.GET(targetUrl) { result in
       switch result {
       case .success(let data, _):

--- a/Palace/AppInfrastructure/TPPConfiguration+SE.swift
+++ b/Palace/AppInfrastructure/TPPConfiguration+SE.swift
@@ -10,15 +10,28 @@ import Foundation
 
 extension TPPConfiguration {
   
-  static let betaUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries/qa")!
-  static let prodUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries")!
+  static let registryHashKey = "registryHashKey"
   
+  static let betaUrl = URL(string: "https://registry.palaceproject.io/libraries/qa")!
+  static let prodUrl = URL(string: "https://registry.palaceproject.io/libraries")!
+
   static let betaUrlHash = betaUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
   static let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
 
   static func customUrl() -> URL? {
     guard let server = TPPSettings.shared.customLibraryRegistryServer else { return nil }
     return URL(string: "https://\(server)/libraries/qa")
+  }
+  
+  /// Checks if registry changed
+  @objc
+  static var registryChanged: Bool {
+    (UserDefaults.standard.string(forKey: registryHashKey) ?? "") != prodUrlHash
+  }
+  
+  /// Updates registry key
+  static func updateSavedeRegistryKey() {
+    UserDefaults.standard.set(prodUrlHash, forKey: registryHashKey)
   }
   
   static func customUrlHash() -> String? {

--- a/Palace/AppInfrastructure/TPPConfiguration+SE.swift
+++ b/Palace/AppInfrastructure/TPPConfiguration+SE.swift
@@ -30,6 +30,7 @@ extension TPPConfiguration {
   }
   
   /// Updates registry key
+  @objc
   static func updateSavedeRegistryKey() {
     UserDefaults.standard.set(prodUrlHash, forKey: registryHashKey)
   }

--- a/Palace/Catalog/TPPCatalogNavigationController.m
+++ b/Palace/Catalog/TPPCatalogNavigationController.m
@@ -203,7 +203,7 @@
 #ifdef SIMPLYE
   TPPSettings *settings = [TPPSettings sharedSettings];
   
-  if (!settings.userHasSeenWelcomeScreen) {
+  if (!settings.userHasSeenWelcomeScreen  || TPPConfiguration.registryChanged) {
     Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
 
     __block NSURL *mainFeedUrl = [NSURL URLWithString:currentAccount.catalogUrl];

--- a/Palace/Catalog/TPPCatalogNavigationController.m
+++ b/Palace/Catalog/TPPCatalogNavigationController.m
@@ -221,6 +221,11 @@
         }
       }];
 
+      // Update current registry hash if registry changed
+      if (TPPConfiguration.registryChanged) {
+        [TPPConfiguration updateSavedeRegistryKey];
+      }
+
       UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:welcomeScreenVC];
 
       [navController setModalPresentationStyle:UIModalPresentationFullScreen];

--- a/Palace/Settings/TPPSettingsAccountsList.swift
+++ b/Palace/Settings/TPPSettingsAccountsList.swift
@@ -254,7 +254,11 @@
     if (indexPath.section == 0) {
       cell.configure(for: account)
     } else {
-      cell.configure(for: AccountsManager.shared.account(userAddedSecondaryAccounts[indexPath.row])!)
+      // The app crashes here when we switch registry accounts
+      if indexPath.row < userAddedSecondaryAccounts.count,
+         let account = AccountsManager.shared.account(userAddedSecondaryAccounts[indexPath.row]) {
+        cell.configure(for: account)
+      }
     }
     
     return cell


### PR DESCRIPTION
**What's this do?**
- Switches library registry to `registry.palaceproject.io`

**Why are we doing this? (w/ Notion link if applicable)**
We are switching to LYRASIS hosted library registry ([Notion](https://www.notion.so/lyrasis/Switch-to-LYRASIS-hosted-library-registry-iOS-042ed0e2e3714a20b7a1f9c7d3c50ca4))

**How should this be tested? / Do these changes have associated tests?**
Open the app, "Find Your Library" screen should appear once.

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
@vladimirfedorov 


https://user-images.githubusercontent.com/941531/132040961-7368468f-cfe0-4c80-812a-617c3e6cca1a.mov

