### PR TITLE
Fix empty catalog after announcement presentation

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3737,7 +3737,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3758,7 +3758,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3793,7 +3793,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3814,7 +3814,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";

--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -424,6 +424,10 @@ class OPDS2SamlIDP: NSObject, Codable {
       
       self.authenticationDocument = authenticationDocument
 
+      // Completion should be called before authentication,
+      // otherwise the code that presents alerts interferes with catalog presentation.
+      completion(true)
+
       if let provider = signedInStateProvider,
          provider.isSignedIn(),
          let announcements = self.authenticationDocument?.announcements {
@@ -431,8 +435,6 @@ class OPDS2SamlIDP: NSObject, Codable {
             TPPAnnouncementBusinessLogic.shared.presentAnnouncements(announcements)
           }
       }
-      
-      completion(true)
     }
   }
   

--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -424,7 +424,7 @@ class OPDS2SamlIDP: NSObject, Codable {
       
       self.authenticationDocument = authenticationDocument
 
-      // Completion should be called before authentication,
+      // Completion should be called before announcements,
       // otherwise the code that presents alerts interferes with catalog presentation.
       completion(true)
 


### PR DESCRIPTION
**What's this do?**
- Fixes empty catalog after announcement presentation.

**Why are we doing this? (w/ Notion link if applicable)**
The catalog is not displayed after announcements are dismissed ([Notion](https://www.notion.so/lyrasis/No-catalog-after-announcements-ac5f5c00e1754cf1bad43f8c2e834c9e))

**How should this be tested? / Do these changes have associated tests?**
Please follow the steps in the ticket.

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 