### PR TITLE
Disable analytics on non production builds

### DIFF
--- a/Palace/Logging/TPPErrorLogger.swift
+++ b/Palace/Logging/TPPErrorLogger.swift
@@ -136,6 +136,9 @@ fileprivate let nullString = "null"
   // MARK:- Configuration
 
   class func configureCrashAnalytics() {
+    // Only enable Crashlytics on Production builds
+    guard Bundle.main.applicationEnvironment == .production else { return }
+    
     #if FEATURE_CRASH_REPORTING
     FirebaseApp.configure()
 
@@ -146,6 +149,8 @@ fileprivate let nullString = "null"
   }
 
   class func setUserID(_ userID: String?) {
+    // Only enable Crashlytics on Production builds
+
     #if FEATURE_CRASH_REPORTING
     if let userIDmd5 = userID?.md5hex() {
       Crashlytics.crashlytics().setUserID(userIDmd5)
@@ -430,6 +435,9 @@ fileprivate let nullString = "null"
   // MARK:- Private helpers
 
   private class func record(error: NSError) {
+    // Only enable Crashlytics on Production builds
+    guard Bundle.main.applicationEnvironment == .production else { return }
+
     #if FEATURE_CRASH_REPORTING
     Crashlytics.crashlytics().record(error: error)
     #else

--- a/Palace/Settings/BundleExtensions.swift
+++ b/Palace/Settings/BundleExtensions.swift
@@ -1,0 +1,37 @@
+//
+//  BundleExtension.swift
+//  Palace
+//
+//  Created by Vladimir Fedorov on 30.09.2021.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+import Foundation
+
+@objc
+enum TPPEnvironment: NSInteger {
+  case debug, testFlight, production
+}
+
+/**
+ This solution is based on this discussion:
+ https://stackoverflow.com/questions/26081543/how-to-tell-at-runtime-whether-an-ios-app-is-running-through-a-testflight-beta-i
+ */
+extension Bundle {
+  
+  @objc
+  var applicationEnvironment: TPPEnvironment {
+    #if DEBUG
+    return .debug
+    #else
+    guard let path = self.appStoreReceiptURL?.path else {
+      return .production
+    }
+    // Sandbox receipt means the app is in TestFlight environment.
+    if path.contains("sandboxReceipt") {
+      return .testFlight
+    } else {
+      return .production
+    }
+    #endif
+  }
+}


### PR DESCRIPTION
**What's this do?**
Disables Analytics for non-production builds

**Why are we doing this? (w/ Notion link if applicable)**
https://www.notion.so/lyrasis/Automated-tests-are-causing-usage-statistics-in-firebase-to-be-incorrect-iOS-1762b8f79d12492289b326d20cb943f7

**How should this be tested? / Do these changes have associated tests?**
Use TestFlight, Adhoc or Debug build and check if interactions are reported to Crashlytics

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7  verified that the fix works locally, will need to be uploaded to BrowserStack using the current process to verify that workflow as well.