### PR TITLE
Filter out Overdrive Audiobooks

### DIFF
--- a/Palace/OPDS/TPPOPDSAcquisitionPath.m
+++ b/Palace/OPDS/TPPOPDSAcquisitionPath.m
@@ -55,7 +55,9 @@ NSString * const _Nonnull ContentTypeAudiobookZip = @"application/audiobook+zip"
       ContentTypeOpenAccessAudiobook,
       ContentTypeOpenAccessPDF,
       ContentTypeFeedbooksAudiobook,
-      ContentTypeOverdriveAudiobook,
+// Temporarily removed,
+// https://www.notion.so/lyrasis/Filter-out-Overdrive-Audiobooks-iOS-e413e07cd8e541cfb4f5761e6bb467bb
+//      ContentTypeOverdriveAudiobook,
       ContentTypeOctetStream,
 #if LCP
       ContentTypeReadiumLCP,
@@ -96,7 +98,9 @@ NSString * const _Nonnull ContentTypeAudiobookZip = @"application/audiobook+zip"
         ContentTypeOpenAccessPDF,
         ContentTypeOpenAccessAudiobook,
         ContentTypeFeedbooksAudiobook,
-        ContentTypeOverdriveAudiobook,
+// Temporarily removed,
+// https://www.notion.so/lyrasis/Filter-out-Overdrive-Audiobooks-iOS-e413e07cd8e541cfb4f5761e6bb467bb
+//        ContentTypeOverdriveAudiobook,
         ContentTypeOctetStream,
         ContentTypeReadiumLCP,
         ContentTypeAudiobookZip
@@ -123,7 +127,9 @@ NSString * const _Nonnull ContentTypeAudiobookZip = @"application/audiobook+zip"
   return [NSSet setWithArray:@[ContentTypeFindaway,
                                ContentTypeOpenAccessAudiobook,
                                ContentTypeFeedbooksAudiobook,
-                               ContentTypeOverdriveAudiobook,
+// Temporarily removed,
+// https://www.notion.so/lyrasis/Filter-out-Overdrive-Audiobooks-iOS-e413e07cd8e541cfb4f5761e6bb467bb
+//                               ContentTypeOverdriveAudiobook,
                                ContentTypeAudiobookZip ]];
 }
 


### PR DESCRIPTION
**What's this do?**
Removes support for Overdrive Audiobooks content type

**Why are we doing this? (w/ Notion link if applicable)**
[Notion](https://www.notion.so/lyrasis/Filter-out-Overdrive-Audiobooks-iOS-e413e07cd8e541cfb4f5761e6bb467bb)

**How should this be tested? / Do these changes have associated tests?**
Open a library with Overdrive audiobooks (e.g., Carnegie Library of Pittsburgh), audiobooks should not be visible.

**Dependencies for merging? Releasing to production?**
NA

**Does this include changes that require a new Palace build for QA?**
No

**Has the application documentation been updated for these changes?**
Yes, added the link to the ticket in Notion.

**Did someone actually run this code to verify it works?**
@vladimirfedorov 