### PR TITLE
Decode HTML entities in book titles

### DIFF
--- a/Palace/Utilities/Strings/TPPAttributedString.m
+++ b/Palace/Utilities/Strings/TPPAttributedString.m
@@ -25,15 +25,16 @@ NSAttributedString *TPPAttributedStringForTitleFromString(NSString *string)
   NSData *stringData = [string dataUsingEncoding:NSUTF8StringEncoding];
   if (!stringData) return nil;
   
+  // Decode HTML entities using NSAttributedString
   NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *options = @{
     NSDocumentTypeDocumentAttribute : NSHTMLTextDocumentType,
     NSCharacterEncodingDocumentAttribute :@(NSUTF8StringEncoding)
   };
   
   NSError *error;
-  NSAttributedString *decodedAttibutedString = [[NSAttributedString alloc] initWithData:stringData options:options documentAttributes:nil error:&error];
+  NSAttributedString *decodedAttributedString = [[NSAttributedString alloc] initWithData:stringData options:options documentAttributes:nil error:&error];
   if (!error) {
-    decodedString = decodedAttibutedString.string;
+    decodedString = decodedAttributedString.string;
   }
 
   NSMutableParagraphStyle *const paragraphStyle = [[NSMutableParagraphStyle alloc] init];


### PR DESCRIPTION
**What's this do?**
- Decodes HTML entities in book title label

**Why are we doing this? (w/ Notion link if applicable)**
Apostrophe not appearing correctly in book title ([Notion](https://www.notion.so/lyrasis/Apostrophe-not-appearing-correctly-in-book-title-on-iOS-and-Android-cf09e549d7374d83aa3c620c75b221d9))

**How should this be tested? / Do these changes have associated tests?**
In LYRASIS library, search for book "Ada's Ideas", the title should be displayed with apostrophe symbol.

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 