### PR TITLE
[CI] Fix indefinitely running release notes step

### DIFF
--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -30,4 +30,5 @@ else
   CERTIFICATES_PATH="../mobile-certificates/Certificates"
 fi
 
+pip3 install requests > /dev/null
 python3 $CERTIFICATES_PATH/Palace/iOS/ReleaseNotes.py "$@"


### PR DESCRIPTION
**What's this do?**
- Replaces the script that creates release notes.

**Why are we doing this? (w/ Notion link if applicable)**
Last build action failed due to the script that 1) failed due to weird segmentation fault, 2) was running indefinitely.

**How should this be tested? / Do these changes have associated tests?**
```
gh workflow run create-release.yml --ref fix/release-notes-test
```
Should create a draft release with a changelog from 1.0.8 (we don't have changes at the moment to run from current version)

**Dependencies for merging? Releasing to production?**
Depends on [PR#12](https://github.com/ThePalaceProject/mobile-certificates/pull/12) in `mobile-certificates`

**Does this include changes that require a new Palace build for QA?**
No

**Has the application documentation been updated for these changes?**
Yes, script

**Did someone actually run this code to verify it works?**
@vladimirfedorov 