### PR TITLE
Implements AppController and AccountManager

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -703,6 +703,14 @@
 		E5C49F14271E69D000C69A6F /* NetworkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C49F13271E69D000C69A6F /* NetworkManagerTests.swift */; };
 		E5C49F20271E7A1C00C69A6F /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C49F1F271E7A1C00C69A6F /* Publisher+Extensions.swift */; };
 		E5C49F24271E7F7900C69A6F /* lyrasis_reads_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = E5C49F23271E7F7900C69A6F /* lyrasis_reads_authentication_document.json */; };
+		E5C49F61271FB19400C69A6F /* AppContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C49F5E271FB19300C69A6F /* AppContextProvider.swift */; };
+		E5C49F62271FB19400C69A6F /* AppController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C49F5F271FB19400C69A6F /* AppController.swift */; };
+		E5C49F63271FB19400C69A6F /* WithContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C49F60271FB19400C69A6F /* WithContext.swift */; };
+		E5C49F69271FB6C100C69A6F /* AppController+EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C49F68271FB6C100C69A6F /* AppController+EventHandler.swift */; };
+		E5C49F6C271FB79500C69A6F /* AppEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C49F6B271FB79500C69A6F /* AppEvent.swift */; };
+		E5C49F6F271FBEC000C69A6F /* AppEventSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C49F6E271FBEC000C69A6F /* AppEventSubject.swift */; };
+		E5C49F722720FC8A00C69A6F /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C49F712720FC8A00C69A6F /* AccountManager.swift */; };
+		E5C49F762722693100C69A6F /* AccountManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C49F752722693100C69A6F /* AccountManagerTests.swift */; };
 		E5C8CAA1270B5653003F7BC0 /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C8CA9B270B5653003F7BC0 /* BundleExtension.swift */; };
 		E6202A021DD4E6F300C99553 /* TPPSettingsAccountDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E6202A011DD4E6F300C99553 /* TPPSettingsAccountDetailViewController.m */; };
 		E6207B652118973800864143 /* TPPAppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6207B642118973800864143 /* TPPAppTheme.swift */; };
@@ -1404,6 +1412,14 @@
 		E5C49F17271E6E0500C69A6F /* JSONMocker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONMocker.swift; sourceTree = "<group>"; };
 		E5C49F1F271E7A1C00C69A6F /* Publisher+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Extensions.swift"; sourceTree = "<group>"; };
 		E5C49F23271E7F7900C69A6F /* lyrasis_reads_authentication_document.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = lyrasis_reads_authentication_document.json; sourceTree = "<group>"; };
+		E5C49F5E271FB19300C69A6F /* AppContextProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppContextProvider.swift; sourceTree = "<group>"; };
+		E5C49F5F271FB19400C69A6F /* AppController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppController.swift; sourceTree = "<group>"; };
+		E5C49F60271FB19400C69A6F /* WithContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WithContext.swift; sourceTree = "<group>"; };
+		E5C49F68271FB6C100C69A6F /* AppController+EventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppController+EventHandler.swift"; sourceTree = "<group>"; };
+		E5C49F6B271FB79500C69A6F /* AppEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEvent.swift; sourceTree = "<group>"; };
+		E5C49F6E271FBEC000C69A6F /* AppEventSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEventSubject.swift; sourceTree = "<group>"; };
+		E5C49F712720FC8A00C69A6F /* AccountManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManager.swift; sourceTree = "<group>"; };
+		E5C49F752722693100C69A6F /* AccountManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManagerTests.swift; sourceTree = "<group>"; };
 		E5C8CA9B270B5653003F7BC0 /* BundleExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BundleExtension.swift; sourceTree = "<group>"; };
 		E61D7F631F6AC78B0091C781 /* SimplyE.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SimplyE.entitlements; sourceTree = "<group>"; };
 		E6202A001DD4E6F300C99553 /* TPPSettingsAccountDetailViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPSettingsAccountDetailViewController.h; sourceTree = "<group>"; };
@@ -1780,6 +1796,7 @@
 				730EDFFF251567820038DD9F /* TPPLibraryNavigationController.h */,
 				730EE000251567820038DD9F /* TPPLibraryNavigationController.m */,
 				52545184217A76FF00BBC1B4 /* TPPUserNotifications.swift */,
+				E5C49F65271FB19800C69A6F /* AppController */,
 			);
 			path = AppInfrastructure;
 			sourceTree = "<group>";
@@ -2346,6 +2363,7 @@
 				03F94CCE1DD627AA00CE8F4F /* Accounts.json */,
 				03F94CD01DD6288C00CE8F4F /* AccountsManager.swift */,
 				73DE53302525A386003E2C56 /* TPPLibraryAccountURLsProvider.swift */,
+				E5C49F712720FC8A00C69A6F /* AccountManager.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -2662,6 +2680,7 @@
 				17ADCF4E254BB84800D0A5FE /* TPPReaderBookmarksBusinessLogicTests.swift */,
 				17BE24D625F85D2300AE707F /* TPPAgeCheckTests.swift */,
 				E5C49F13271E69D000C69A6F /* NetworkManagerTests.swift */,
+				E5C49F752722693100C69A6F /* AccountManagerTests.swift */,
 			);
 			path = PalaceTests;
 			sourceTree = "<group>";
@@ -2736,6 +2755,19 @@
 				E5C49EF9271A0DBB00C69A6F /* NetworkManagerError.swift */,
 			);
 			path = NetworkManager;
+			sourceTree = "<group>";
+		};
+		E5C49F65271FB19800C69A6F /* AppController */ = {
+			isa = PBXGroup;
+			children = (
+				E5C49F5E271FB19300C69A6F /* AppContextProvider.swift */,
+				E5C49F60271FB19400C69A6F /* WithContext.swift */,
+				E5C49F5F271FB19400C69A6F /* AppController.swift */,
+				E5C49F68271FB6C100C69A6F /* AppController+EventHandler.swift */,
+				E5C49F6B271FB79500C69A6F /* AppEvent.swift */,
+				E5C49F6E271FBEC000C69A6F /* AppEventSubject.swift */,
+			);
+			path = AppController;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -3116,6 +3148,7 @@
 				7375AE5A25382AC900C85211 /* TPPUserAccountMock.swift in Sources */,
 				73C3CF5A25CB8D6100CA8166 /* NYPLNetworkExecutorMock.swift in Sources */,
 				735771AE2537687D00067CEA /* TPPURLSettingsProviderMock.swift in Sources */,
+				E5C49F762722693100C69A6F /* AccountManagerTests.swift in Sources */,
 				735771B12537691800067CEA /* TPPDRMAuthorizingMock.swift in Sources */,
 				E5C49F14271E69D000C69A6F /* NetworkManagerTests.swift in Sources */,
 				730EF263260955EF008E1DC3 /* TPPBookmarkSpecTests.swift in Sources */,
@@ -3445,6 +3478,7 @@
 				1139DA6519C7755D00A07810 /* TPPBookCoverRegistry.m in Sources */,
 				21D746E72718A4C000C0E1B4 /* AdobeDRMFetcherError.swift in Sources */,
 				73085E3525030D27008F6244 /* SEMigrations.swift in Sources */,
+				E5C49F62271FB19400C69A6F /* AppController.swift in Sources */,
 				11119742198827850014462F /* TPPBookDetailDownloadingView.m in Sources */,
 				730FC05B2512911E004D7C2D /* TPPWelcomeScreenViewController.swift in Sources */,
 				2DFAC8ED1CD8DDD1003D9EC0 /* TPPOPDSCategory.m in Sources */,
@@ -3463,6 +3497,7 @@
 				215C866D27064198005F9621 /* BundleExtension.swift in Sources */,
 				E699BA402166598B00A0736A /* TPPEntryPointView.swift in Sources */,
 				A46226271B39D4980063F549 /* TPPOPDSGroup.m in Sources */,
+				E5C49F69271FB6C100C69A6F /* AppController+EventHandler.swift in Sources */,
 				A93F9F9721CDACF700BD3B0C /* TPPAppReviewPrompt.swift in Sources */,
 				E5C49F20271E7A1C00C69A6F /* Publisher+Extensions.swift in Sources */,
 				E5C8CAA1270B5653003F7BC0 /* BundleExtension.swift in Sources */,
@@ -3519,6 +3554,7 @@
 				111E757D1A801A6F00718AD7 /* TPPSettingsPrimaryNavigationController.m in Sources */,
 				11A16E69195B2BD3004147F4 /* TPPCatalogUngroupedFeedViewController.m in Sources */,
 				E551B361267D402B0026FC1B /* TPPAccountList.swift in Sources */,
+				E5C49F6F271FBEC000C69A6F /* AppEventSubject.swift in Sources */,
 				D787E8441FB6B0290016D9D5 /* TPPSettingsAdvancedViewController.swift in Sources */,
 				5D60D3542297353C001080D0 /* TPPMigrationManager.swift in Sources */,
 				E5C49EEE271A03A400C69A6F /* NetworkManager.swift in Sources */,
@@ -3527,6 +3563,7 @@
 				086C45D624AE77CA00F5108E /* TPPBasicAuth.swift in Sources */,
 				B51C1E0422861C1A003B49A5 /* OPDS2AuthenticationDocument.swift in Sources */,
 				739ECB2B25102A2B00691A70 /* TPPCatalogs+SE.swift in Sources */,
+				E5C49F722720FC8A00C69A6F /* AccountManager.swift in Sources */,
 				112C694D197301FE00C48F95 /* TPPBookRegistryRecord.m in Sources */,
 				5DD5674522B303DF001F0C83 /* TPPDeveloperSettingsTableViewController.swift in Sources */,
 				E627B554216D4A9700A7D1D5 /* TPPBookContentType.m in Sources */,
@@ -3551,6 +3588,7 @@
 				219747FC26D9218400FA25DF /* TPPLCPClient.swift in Sources */,
 				21DDE32E25D31DB4002CBCE3 /* AdobeDRMFetcher.swift in Sources */,
 				11C5DCF21976D1E0005A9945 /* TPPHoldsNavigationController.m in Sources */,
+				E5C49F63271FB19400C69A6F /* WithContext.swift in Sources */,
 				73DB56CC25F7F739003788EE /* TPPLastReadPositionPoster.swift in Sources */,
 				A42E0DF11B3F5A490095EBAE /* TPPRemoteViewController.m in Sources */,
 				1798538B255A4092009F94D9 /* TPPBookLocation+Locator.swift in Sources */,
@@ -3573,6 +3611,7 @@
 				E6DA7EA01F2A718600CFBEC8 /* TPPBookAuthor.swift in Sources */,
 				739ECB2425101CCE00691A70 /* NSNotification+TPP.swift in Sources */,
 				734B789125659611006FB8AD /* URLResponse+TPPAuthentication.swift in Sources */,
+				E5C49F6C271FB79500C69A6F /* AppEvent.swift in Sources */,
 				E5C49EFA271A0DBB00C69A6F /* NetworkManagerError.swift in Sources */,
 				E5C2C422268BA5140046F415 /* TPPRegistryDebuggingCell.swift in Sources */,
 				118A0B1B19915BDF00792DDE /* TPPCatalogSearchViewController.m in Sources */,
@@ -3592,6 +3631,7 @@
 				E6B6E76F1F6859A4007EE361 /* TPPKeychainManager.swift in Sources */,
 				089E42C6249A823800310360 /* TPPCookiesWebViewController.swift in Sources */,
 				0826CD2924AA21B2000F4030 /* TPPSamlIDPCell.swift in Sources */,
+				E5C49F61271FB19400C69A6F /* AppContextProvider.swift in Sources */,
 				2126FE2E25C059250095C45C /* ReaderError.swift in Sources */,
 				5D7CF8B922C3FC06007CAA34 /* TPPErrorLogger.swift in Sources */,
 				0824D44E24B8DFE400C85A7E /* NSString+JSONParse.swift in Sources */,

--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -363,7 +363,7 @@ class OPDS2SamlIDP: NSObject, Codable {
   var details:AccountDetails?
   var homePageUrl: String?
   
-  let authenticationDocumentUrl:String?
+  var authenticationDocumentUrl:String?
   var authenticationDocument:OPDS2AuthenticationDocument? {
     didSet {
       guard let authenticationDocument = authenticationDocument else {
@@ -396,6 +396,7 @@ class OPDS2SamlIDP: NSObject, Codable {
     loadLogo()
   }
 
+  //TODO: Remove Authentication Document logic, now handled by AccountManager
   /// Load authentication documents from the network or cache.
   /// Providing the signedInStateProvider might lead to presentation of announcements
   /// - Parameter signedInStateProvider: The object providing user signed in state for presenting announcement. nil means no announcements will be present

--- a/Palace/Accounts/Library/AccountManager.swift
+++ b/Palace/Accounts/Library/AccountManager.swift
@@ -1,0 +1,184 @@
+//
+//  AccountManager.swift
+//  Palace
+//
+//  Created by Maurice Work on 10/20/21.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+import Combine
+
+protocol AccountManager {
+  var currentAccount: Account? { get set }
+  var accounts: [Account] { get }
+  var mainFeed: OPDS2CatalogsFeed? { get }
+  var catalogs: [OPDS2CatalogsFeed] { get }
+  var accountSet: String { get }
+  var ageCheck: TPPAgeCheckVerifying { get }
+  
+  var networkManager: NetworkManager { get }
+  
+  var currentAccountPublisher: AnyPublisher<Account?, Never> { get }
+  var accountsPublisher: AnyPublisher<[Account], Never> { get }
+  var mainFeedPublisher: AnyPublisher<OPDS2CatalogsFeed?, Never> { get }
+  var catalogPublisher: AnyPublisher<[OPDS2CatalogsFeed], Never> { get }
+
+  func updateAccountSet()
+  func clearCache()
+}
+
+class AppAccountManager: NSObject, AccountManager, TPPLibraryAccountsProvider {
+  
+  @Published var mainFeed: OPDS2CatalogsFeed?
+  @Published var catalogs: [OPDS2CatalogsFeed] = []
+  @Published var accounts: [Account] = []
+  @Published var currentAccount: Account? {
+    didSet {
+      guard let account = currentAccount else { return }
+      loadAuthDoc(account)
+    }
+  }
+  
+  private(set) var currentAccountId: String? {
+    get {
+      return UserDefaults.standard.string(forKey: currentAccountIdentifierKey)
+    }
+    set {
+
+      if let uuid = newValue {
+        currentAccount = account(uuid)
+      }
+
+      Log.debug(#file, "Setting currentAccountId to \(newValue ?? "N/A")>")
+      UserDefaults.standard.set(newValue,
+                                forKey: currentAccountIdentifierKey)
+    }
+  }
+
+  var accountSet: String
+  private var accountSets = [String: [Account]]()
+  var ageCheck: TPPAgeCheckVerifying
+  
+  var currentAccountPublisher: AnyPublisher<Account?, Never> { $currentAccount.eraseToAnyPublisher() }
+  var accountsPublisher: AnyPublisher<[Account], Never> { $accounts.eraseToAnyPublisher() }
+  var mainFeedPublisher: AnyPublisher<OPDS2CatalogsFeed?, Never> { $mainFeed.eraseToAnyPublisher() }
+  var catalogPublisher: AnyPublisher<[OPDS2CatalogsFeed], Never> { $catalogs.eraseToAnyPublisher() }
+  
+  var networkManager: NetworkManager
+  private var observers = Set<AnyCancellable>()
+
+  static let TPPAccountUUIDs = [
+    "urn:uuid:065c0c11-0d0f-42a3-82e4-277b18786949", //NYPL proper
+    "urn:uuid:edef2358-9f6a-4ce6-b64f-9b351ec68ac4", //Brooklyn
+    "urn:uuid:56906f26-2c9a-4ae9-bd02-552557720b99"  //Simplified Instant Classics
+  ]
+  
+  static let TPPNationalAccountUUIDs = [
+    "urn:uuid:6b849570-070f-43b4-9dcc-7ebb4bca292e", //DPLA
+    "urn:uuid:f60b644e-4955-4996-a4e5-a192feb4e7f8", //Internet Archive
+    "urn:uuid:5278562c-d642-4fda-ad7e-1613077cfb8d", //Open Textbook Library
+  ]
+  
+  let tppAccountUUID = AccountsManager.TPPAccountUUIDs[0]
+  
+  init(networkManager: NetworkManager) {
+    self.accountSet = TPPConfiguration.customUrlHash() ?? (TPPSettings.shared.useBetaLibraries ? TPPConfiguration.betaUrlHash : TPPConfiguration.prodUrlHash)
+
+    self.ageCheck = TPPAgeCheck(ageCheckChoiceStorage: TPPSettings.shared)
+    self.networkManager = networkManager
+    super.init()
+
+    self.loadCatalogs(
+      url: TPPConfiguration.customUrl() ??
+        (TPPSettings.shared.useBetaLibraries ? TPPConfiguration.betaUrl : TPPConfiguration.prodUrl)
+    )
+  }
+
+  func loadCatalogs(url: URL) {
+    Log.debug(#file, "Entering loadCatalog...")
+    
+    let hash = url.absoluteString.md5().base64EncodedStringUrlSafe()
+    
+    networkManager.fetchCatalog(url: url)
+      .sink { [weak self] result in
+        if case let .success(feed) = result {
+          self?.accountSets[hash] = feed?.catalogs.compactMap { Account(publication: $0) }
+        }
+      }
+      .store(in: &observers)
+  }
+  
+  func loadAuthDoc(_ account: Account) {
+    account.loadAuthenticationDocument(using: TPPUserAccount.sharedAccount()) { [weak self] success in
+      self?.setMainFeed(account)
+    }
+  }
+  
+  private func setMainFeed(_ account: Account) {
+    var mainFeed = URL(string: currentAccount?.catalogUrl ?? "")
+    
+    if currentAccount?.details?.needsAgeCheck ?? false {
+      ageCheck.verifyCurrentAccountAgeRequirement(userAccountProvider: TPPUserAccount.sharedAccount(), currentLibraryAccountProvider: self) { meetsAgeReq in
+        mainFeed = self.currentAccount?.details?.defaultAuth?.coppaURL(isOfAge: meetsAgeReq)
+        
+        Log.debug(#function, "mainFeedURL=\(String(describing: mainFeed))")
+        TPPSettings.shared.accountMainFeedURL = mainFeed
+        UIApplication.shared.delegate?.window??.tintColor = TPPConfiguration.mainColor()
+      }
+    }
+  }
+
+  func updateAccountSet() {
+    
+  }
+  
+  func account(_ uuid: String) -> Account? {
+    // get accountSets dictionary first for thread-safety
+    var accountSetsCopy = [String: [Account]]()
+    var accountSetKey = ""
+    
+    accountSetsCopy = self.accountSets
+    accountSetKey = self.accountSet
+    
+    // Check primary account set first
+    if let accounts = accountSetsCopy[accountSetKey],
+       let account = accounts.first(where: { $0.uuid == uuid }) {
+      return account
+    }
+    
+    // Check existing account lists
+    for accountEntry in accountSetsCopy where accountEntry.key != accountSetKey {
+      if let account = accountEntry.value.first(where: { $0.uuid == uuid }) {
+        return account
+      }
+    }
+    
+    return nil
+  }
+  
+  func clearCache() {
+    networkManager.clearCache()
+    do {
+      let applicationSupportUrl = try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+      let appSupportDirContents = try FileManager.default.contentsOfDirectory(at: applicationSupportUrl, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles, .skipsPackageDescendants, .skipsSubdirectoryDescendants])
+      let libraryListCaches = appSupportDirContents.filter { (url) -> Bool in
+        return url.lastPathComponent.starts(with: "library_list_") && url.pathExtension == "json"
+      }
+      let authDocCaches = appSupportDirContents.filter { (url) -> Bool in
+        return url.lastPathComponent.starts(with: "authentication_document_") && url.pathExtension == "json"
+      }
+      
+      let allCaches = libraryListCaches + authDocCaches
+      for cache in allCaches {
+        do {
+          try FileManager.default.removeItem(at: cache)
+        } catch {
+          Log.error("ClearCache", "Unable to clear cache for: \(cache)")
+        }
+      }
+    } catch {
+      Log.error("ClearCache", "Unable to clear cache")
+    }
+  }
+}
+

--- a/Palace/Accounts/Library/AccountManager.swift
+++ b/Palace/Accounts/Library/AccountManager.swift
@@ -2,7 +2,7 @@
 //  AccountManager.swift
 //  Palace
 //
-//  Created by Maurice Work on 10/20/21.
+//  Created by Maurice Carrier on 10/20/21.
 //  Copyright © 2021 The Palace Project. All rights reserved.
 //
 
@@ -56,7 +56,7 @@ class AppAccountManager: NSObject, AccountManager, TPPLibraryAccountsProvider {
   }
 
   var accountSet: String
-  private var accountSets = [String: [Account]]()
+  var accountSets = [String: [Account]]()
   var ageCheck: TPPAgeCheckVerifying
   
   var currentAccountPublisher: AnyPublisher<Account?, Never> { $currentAccount.eraseToAnyPublisher() }
@@ -115,9 +115,10 @@ class AppAccountManager: NSObject, AccountManager, TPPLibraryAccountsProvider {
   }
   
   private func setMainFeed(_ account: Account) {
-    var mainFeed = URL(string: currentAccount?.catalogUrl ?? "")
+    currentAccount = account
+    var mainFeed = URL(string: currentAccount!.catalogUrl ?? "")
     
-    if currentAccount?.details?.needsAgeCheck ?? false {
+    if currentAccount!.details?.needsAgeCheck ?? false {
       ageCheck.verifyCurrentAccountAgeRequirement(userAccountProvider: TPPUserAccount.sharedAccount(), currentLibraryAccountProvider: self) { meetsAgeReq in
         mainFeed = self.currentAccount?.details?.defaultAuth?.coppaURL(isOfAge: meetsAgeReq)
         
@@ -129,7 +130,11 @@ class AppAccountManager: NSObject, AccountManager, TPPLibraryAccountsProvider {
   }
 
   func updateAccountSet() {
+    accountSet = TPPConfiguration.customUrlHash() ?? (TPPSettings.shared.useBetaLibraries ? TPPConfiguration.betaUrlHash : TPPConfiguration.prodUrlHash)
     
+    if accounts.isEmpty || TPPConfiguration.customUrlHash() != nil, let url = URL(string: accountSet) {
+      loadCatalogs(url: url)
+    }
   }
   
   func account(_ uuid: String) -> Account? {

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -242,6 +242,8 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
     TPPNetworkExecutor.shared.GET(targetUrl) { result in
       switch result {
       case .success(let data, _):
+        
+        let string = try? JSONSerialization.jsonObject(with: data, options: [])
         self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { success in
           self.callAndClearLoadingCompletionHandlers(key: hash, success)
           NotificationCenter.default.post(name: NSNotification.Name.TPPCatalogDidLoad, object: nil)

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
 
@@ -58,6 +59,7 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
 
   private var loadingCompletionHandlers = [String: [(Bool) -> ()]]()
 
+  
   var currentAccount: Account? {
     get {
       guard let uuid = currentAccountId else {

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Combine
 
 let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
 
@@ -59,7 +58,6 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
 
   private var loadingCompletionHandlers = [String: [(Bool) -> ()]]()
 
-  
   var currentAccount: Account? {
     get {
       guard let uuid = currentAccountId else {
@@ -242,8 +240,6 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
     TPPNetworkExecutor.shared.GET(targetUrl) { result in
       switch result {
       case .success(let data, _):
-        
-        let string = try? JSONSerialization.jsonObject(with: data, options: [])
         self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { success in
           self.callAndClearLoadingCompletionHandlers(key: hash, success)
           NotificationCenter.default.post(name: NSNotification.Name.TPPCatalogDidLoad, object: nil)

--- a/Palace/AppInfrastructure/AppController/AppContextProvider.swift
+++ b/Palace/AppInfrastructure/AppController/AppContextProvider.swift
@@ -1,0 +1,25 @@
+//
+//  AppContext.swift
+//  Palace
+//
+//  Created by Maurice Carrier on 10/19/21.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+protocol AppContext {
+  var accountPublisher: AnyPublisher<Account?, Never> { get }
+  var catalogPublisher: AnyPublisher<OPDS2CatalogsFeed?, Never> { get }
+}
+
+class AppContextProvider {
+  @Published var currentAccount: Account?
+  @Published var currentCatalog: OPDS2CatalogsFeed?
+}
+
+extension AppContextProvider: AppContext {
+  var accountPublisher: AnyPublisher<Account?, Never> { $currentAccount.eraseToAnyPublisher() }
+  var catalogPublisher: AnyPublisher<OPDS2CatalogsFeed?, Never> { $currentCatalog.eraseToAnyPublisher() }
+}

--- a/Palace/AppInfrastructure/AppController/AppController+EventHandler.swift
+++ b/Palace/AppInfrastructure/AppController/AppController+EventHandler.swift
@@ -1,0 +1,38 @@
+//
+//  AppController+EventHandler.swift
+//  Palace
+//
+//  Created by Maurice Carrier on 10/19/21.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+import Combine
+
+extension AppController {
+  class AppEventHandler {
+    private let appContextProvider: AppContextProvider
+    private let networkManager: NetworkManager
+    private var accountManager: AccountManager
+    
+    init(
+      appContextProvider: AppContextProvider,
+      networkManager: NetworkManager,
+      accountManager: AccountManager
+    ) {
+      self.appContextProvider = appContextProvider
+      self.networkManager = networkManager
+      self.accountManager = accountManager
+    }
+    
+    func handle(_ event: AppEvent) {
+      switch event {
+      case let .setCurrentAccount(account):
+        accountManager.currentAccount = account
+      case .updateAccountSet:
+        accountManager.updateAccountSet()
+      case let .loadCatalog(catalog):
+        return
+      }
+    }
+  }
+}

--- a/Palace/AppInfrastructure/AppController/AppController.swift
+++ b/Palace/AppInfrastructure/AppController/AppController.swift
@@ -1,0 +1,64 @@
+//
+//  AppController.swift
+//  Palace
+//
+//  Created by Maurice Carrier on 10/19/21.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+class AppController: WithContext {
+
+  var context: AppContext { appContextProvider }
+  let eventInput: AppEventSubject = AppEventSubject()
+
+  private let appContextProvider: AppContextProvider
+  private let networkManager: NetworkManager
+  private let accountManager: AccountManager
+  private let eventHandler: AppEventHandler
+
+  private var observers = Set<AnyCancellable>()
+  private var dataObservers = Set<AnyCancellable>()
+
+  init(
+    appContextProvider: AppContextProvider,
+    networkManager: NetworkManager,
+    accountManager: AccountManager
+  ) {
+    self.appContextProvider = appContextProvider
+    self.networkManager = networkManager
+    self.accountManager = accountManager
+
+    self.eventHandler = AppEventHandler(
+      appContextProvider: self.appContextProvider,
+      networkManager: self.networkManager,
+      accountManager: self.accountManager
+    )
+
+    subscribeToAccountManager()
+    subscribeToEvents()
+  }
+
+  private func subscribeToAccountManager() {
+    accountManager.currentAccountPublisher
+      .assign(to: \.currentAccount, onWeak: appContextProvider)
+      .store(in: &observers)
+
+    accountManager.mainFeedPublisher
+      .assign(to: \.currentCatalog, onWeak: appContextProvider)
+      .store(in: &observers)
+  }
+
+  private func subscribeToEvents() {
+    eventInput
+      .sink { [weak self] event in
+        guard let self = self else { return }
+        
+        self.eventHandler.handle(event)
+      }
+      .store(in: &observers)
+  }
+}
+

--- a/Palace/AppInfrastructure/AppController/AppEvent.swift
+++ b/Palace/AppInfrastructure/AppController/AppEvent.swift
@@ -1,0 +1,17 @@
+//
+//  AppEvent.swift
+//  Palace
+//
+//  Created by Maurice Carrier on 10/19/21.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+typealias Completion = () -> Void
+
+enum AppEvent {
+  case setCurrentAccount(Account)
+  case updateAccountSet
+  case loadCatalog(OPDS2CatalogsFeed)
+}

--- a/Palace/AppInfrastructure/AppController/AppEventSubject.swift
+++ b/Palace/AppInfrastructure/AppController/AppEventSubject.swift
@@ -1,0 +1,11 @@
+//
+//  AppEventSubject.swift
+//  Palace
+//
+//  Created by Maurice Carrier on 10/19/21.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+import Combine
+
+typealias AppEventSubject = PassthroughSubject<AppEvent, Never>

--- a/Palace/AppInfrastructure/AppController/WithContext.swift
+++ b/Palace/AppInfrastructure/AppController/WithContext.swift
@@ -1,0 +1,13 @@
+//
+//  WithContext.swift
+//  Palace
+//
+//  Created by Maurice Carrier on 10/19/21.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+protocol WithContext {
+  var context: AppContext { get }
+}

--- a/Palace/Network/NetworkManager/NetworkManager.swift
+++ b/Palace/Network/NetworkManager/NetworkManager.swift
@@ -12,7 +12,37 @@ import Combine
 typealias NetworkManager = NetworkManagerAccount
 
 protocol NetworkManagerAccount {  
-  func fetchAuthenticationDocument(url: String) -> AnyPublisher<OPDS2AuthenticationDocument?, NetworkManagerError>
-  func fetchCatalog(url: String) -> AnyPublisher<OPDS2CatalogsFeed?, NetworkManagerError>
+  func fetchAuthenticationDocument(url: URL) -> AnyPublisher<OPDS2AuthenticationDocument?, NetworkManagerError>
+  func fetchCatalog(url: URL) -> AnyPublisher<OPDS2CatalogsFeed?, NetworkManagerError>
+  func clearCache()
 }
 
+extension NetworkManagerAccount {
+  func fetchAuthenticationDocument(url: String) -> AnyPublisher<OPDS2AuthenticationDocument?, NetworkManagerError> {
+    guard let targetUrl = URL(string: url) else {
+      TPPErrorLogger.logError(
+        withCode: .noURL,
+        summary: "Failed to load authentication document because its URL is invalid",
+        metadata: ["self.uuid": AccountsManager.shared.currentAccount?.uuid ?? "",
+                   "urlString": url])
+      
+      return Fail(error: .invalidURL).eraseToAnyPublisher()
+    }
+    
+    return fetchAuthenticationDocument(url: targetUrl)
+
+}
+  func fetchCatalog(url: String) -> AnyPublisher<OPDS2CatalogsFeed?, NetworkManagerError> {
+      guard let targetUrl = URL(string: url) else {
+        TPPErrorLogger.logError(
+          withCode: .noURL,
+          summary: "Failed to fetch catalogs because its URL is invalid",
+          metadata: ["self.uuid": AccountsManager.shared.currentAccount?.uuid ?? "",
+                     "urlString": url])
+
+        return Fail(error: .invalidURL).eraseToAnyPublisher()
+      }
+      
+      return fetchCatalog(url: targetUrl)
+  }
+}

--- a/Palace/Utilities/Publisher+Extensions.swift
+++ b/Palace/Utilities/Publisher+Extensions.swift
@@ -2,7 +2,7 @@
 //  Publisher+Extensions.swift
 //  Palace
 //
-//  Created by Maurice Work on 10/18/21.
+//  Created by Maurice Carrier on 10/18/21.
 //  Copyright © 2021 The Palace Project. All rights reserved.
 //
 
@@ -18,5 +18,16 @@ extension Publisher {
       case .finished: break
       }
     }) { receiveResult(.success($0)) }
+  }
+}
+
+extension Publisher where Failure == Never {
+  public func assign<Root: AnyObject>(
+    to keyPath: ReferenceWritableKeyPath<Root, Output>,
+    onWeak object: Root
+  ) -> AnyCancellable {
+    sink { [weak object] value in
+      object?[keyPath: keyPath] = value
+    }
   }
 }

--- a/PalaceTests/AccountManagerTests.swift
+++ b/PalaceTests/AccountManagerTests.swift
@@ -14,21 +14,26 @@ class AccountManagerTests: XCTestCase {
   
   private var cancellable: AnyCancellable?
   private let timeout: TimeInterval = 10
+  let testCatalogFeed = Bundle.init(for: OPDS2CatalogsFeedTests.self)
+    .url(forResource: "OPDS2CatalogsFeed", withExtension: "json")!
   
   let networkManager = AppNetworkManager(executor: MockNetworkExecutor())
   lazy var accountManager = AppAccountManager(networkManager: networkManager)
   
   func testLoadCatalogs() {
     let exp = expectation(description: "load catalog test succeeds")
-  
-    
+    accountManager.loadCatalogs(url: testCatalogFeed)
+    XCTAssertEqual(accountManager.accountSets.count, 2)
+    exp.fulfill()
     waitForExpectations(timeout: timeout)
   }
   
   func testLoadAuthDoc() {
     let exp = expectation(description: "network test succeeds")
-    
-
+    accountManager.loadCatalogs(url: testCatalogFeed)
+    accountManager.loadAuthDoc(accountManager.accountSets.first!.value.first!)
+    XCTAssertNotNil(accountManager.currentAccount?.authenticationDocument)
+    exp.fulfill()
     waitForExpectations(timeout: timeout)
   }
 }

--- a/PalaceTests/AccountManagerTests.swift
+++ b/PalaceTests/AccountManagerTests.swift
@@ -1,0 +1,55 @@
+//
+//  AccountManagerTests.swift
+//  PalaceTests
+//
+//  Created by Maurice Carrier on 10/21/21.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import Combine
+@testable import Palace
+
+class AccountManagerTests: XCTestCase {
+  
+  private var cancellable: AnyCancellable?
+  private let timeout: TimeInterval = 10
+  
+  let networkManager = AppNetworkManager(executor: MockNetworkExecutor())
+  lazy var accountManager = AppAccountManager(networkManager: networkManager)
+  
+  func testLoadCatalogs() {
+    let exp = expectation(description: "load catalog test succeeds")
+  
+    
+    waitForExpectations(timeout: timeout)
+  }
+  
+  func testLoadAuthDoc() {
+    let exp = expectation(description: "network test succeeds")
+    
+
+    waitForExpectations(timeout: timeout)
+  }
+}
+
+fileprivate struct TestError: TPPUserFriendlyError {
+  var userFriendlyTitle: String? = "Test Failed"
+  var userFriendlyMessage: String? = nil
+}
+
+fileprivate class MockNetworkExecutor: NetworkExecutor {
+  
+  func loadTestAuthDocument(url: URL) -> Data? {
+    try? Data(contentsOf: url)
+  }
+  
+  func GET(_ reqURL: URL, completion: @escaping (NYPLResult<Data>) -> Void) {
+    guard let data = loadTestAuthDocument(url: reqURL) else {
+      completion(.failure(TestError(), nil))
+      return
+    }
+    
+    completion(.success(data, nil))
+  }
+}

--- a/PalaceTests/NetworkManagerTests.swift
+++ b/PalaceTests/NetworkManagerTests.swift
@@ -2,7 +2,7 @@
 //  NetworkManagerTests.swift
 //  PalaceTests
 //
-//  Created by Maurice Work on 10/18/21.
+//  Created by Maurice Carrier on 10/18/21.
 //  Copyright © 2021 The Palace Project. All rights reserved.
 //
 


### PR DESCRIPTION
**What's this do?**
Implements `AppController` and related  publisher plumbing to manage app events and link service class functionality such as `AccountManager` and `NetworkManager` to the future view layer of the application.  `AccountManager` replaces `AccountsManager` and now manages the loading of the `AuthenticationDocument`

**Why are we doing this? (w/ Notion link if applicable)**
These changes are necessary infrastructure changes to support the Catalog redesign.

**How should this be tested? / Do these changes have associated tests?**
AccountManager functionality can be tested via the included unit tests. AppController will be unit tested in future stories.

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 


![Catalog - AppController](https://user-images.githubusercontent.com/6921353/138633041-41c759a3-5a34-409f-b665-eb140f78c555.png)

