### PR TITLE
Update TPPBookButtonsView.m

### DIFF
--- a/Palace/Book/UI/TPPBookButtonsView.m
+++ b/Palace/Book/UI/TPPBookButtonsView.m
@@ -276,12 +276,6 @@
   
   for (NSDictionary *buttonInfo in visibleButtonInfo) {
     TPPRoundedButton *button = buttonInfo[ButtonKey];
-    if(button == self.deleteButton && (!fulfillmentId && fulfillmentIdRequired) && !hasRevokeLink) {
-      if(!self.book.defaultAcquisitionIfOpenAccess && TPPUserAccount.sharedAccount.authDefinition.needsAuth) {
-        continue;
-      }
-    }
-    
     button.hidden = NO;
     
     // Disable the animation for changing the title. This helps avoid visual issues with


### PR DESCRIPTION
**What's this do?**
Enables users to return un-downloaded books

**Why are we doing this? (w/ Notion link if applicable)**
https://www.notion.so/lyrasis/iOS-Add-ability-to-return-a-book-before-downloading-d2c8d96da11449bea0accfb1aeabb3e5

**How should this be tested? / Do these changes have associated tests?**
Checkout a book on a device,  log into the same account on another device and attempt to return the title without downloading it.

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new Palace build for QA?**
yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 