### PR TITLE
Fix the app losing audiobook position

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3761,7 +3761,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3782,7 +3782,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3817,7 +3817,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3838,7 +3838,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3997,7 +3997,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4022,7 +4022,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -4055,7 +4055,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4080,7 +4080,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App store";

--- a/Palace/Book/UI/TPPBookCellDelegate.m
+++ b/Palace/Book/UI/TPPBookCellDelegate.m
@@ -26,6 +26,9 @@
 #endif
 
 @interface TPPBookCellDelegate () <RefreshDelegate>
+{
+  @private NSTimeInterval previousPlayheadOffset;
+}
 
 @property (nonatomic) NSTimer *timer;
 @property (nonatomic) TPPBook *book;
@@ -344,6 +347,13 @@
   [[TPPBookRegistry sharedRegistry]
    setLocation:[[TPPBookLocation alloc] initWithLocationString:string renderer:@"NYPLAudiobookToolkit"]
    forIdentifier:self.book.identifier];
+  
+  // Save updated playhead position in audiobook chapter
+  NSTimeInterval playheadOffset = self.manager.audiobook.player.currentChapterLocation.playheadOffset;
+  if (previousPlayheadOffset != playheadOffset) {
+    previousPlayheadOffset = playheadOffset;
+    [[TPPBookRegistry sharedRegistry] save];
+  }
 }
 
 - (void)presentDRMKeyError:(NSError *) error {

--- a/Palace/MyBooks/TPPMyBooksDownloadCenter.m
+++ b/Palace/MyBooks/TPPMyBooksDownloadCenter.m
@@ -762,9 +762,11 @@ didCompleteWithError:(NSError *)error
 /// @param book The book that failed to download.
 - (void)failDownloadWithAlertForBook:(TPPBook *const)book
 {
+  TPPBookLocation *location = [[TPPBookRegistry sharedRegistry] locationForIdentifier:book.identifier];
+  
   [[TPPBookRegistry sharedRegistry]
    addBook:book
-   location:nil
+   location:location
    state:TPPBookStateDownloadFailed
    fulfillmentId:nil
    readiumBookmarks:nil
@@ -839,9 +841,11 @@ didCompleteWithError:(NSError *)error
       return;
     }
 
+    TPPBookLocation *location = [[TPPBookRegistry sharedRegistry] locationForIdentifier:book.identifier];
+    
     [[TPPBookRegistry sharedRegistry]
      addBook:book
-     location:nil
+     location:location
      state:TPPBookStateDownloadNeeded
      fulfillmentId:nil
      readiumBookmarks:nil
@@ -881,6 +885,8 @@ didCompleteWithError:(NSError *)error
   TPPBookState state = [[TPPBookRegistry sharedRegistry]
                          stateForIdentifier:book.identifier];
 
+  TPPBookLocation *location = [[TPPBookRegistry sharedRegistry] locationForIdentifier:book.identifier];
+  
   BOOL loginRequired = TPPUserAccount.sharedAccount.authDefinition.needsAuth;
 
   switch(state) {
@@ -890,7 +896,7 @@ didCompleteWithError:(NSError *)error
 
         [[TPPBookRegistry sharedRegistry]
          addBook:book
-         location:nil
+         location:location
          state:TPPBookStateDownloadNeeded
          fulfillmentId:nil
          readiumBookmarks:nil
@@ -1121,9 +1127,11 @@ didCompleteWithError:(NSError *)error
   
   [task resume];
   
+  TPPBookLocation *location = [[TPPBookRegistry sharedRegistry] locationForIdentifier:book.identifier];
+  
   [[TPPBookRegistry sharedRegistry]
    addBook:book
-   location:nil
+   location:location
    state:TPPBookStateDownloading
    fulfillmentId:nil
    readiumBookmarks:nil


### PR DESCRIPTION
**What's this do?**
- Stores audiobook position

**Why are we doing this? (w/ Notion link if applicable)**
There are cases when audiobook player loses playhead position: [Notion](https://www.notion.so/lyrasis/iOS-losing-audiobook-position-ca493cb945fd42c1911fecda9895ca4e)

**How should this be tested? / Do these changes have associated tests?**
Please follow **Description** section in the ticket.

An easier way is to return a book and download it again - in this case the app should remember position in the book

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 