### PR TITLE
Return to book detail view following signin

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3997,7 +3997,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4022,7 +4022,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -4055,7 +4055,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4080,7 +4080,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App store";

--- a/Palace/Accounts/User/TPPUserAccount.swift
+++ b/Palace/Accounts/User/TPPUserAccount.swift
@@ -91,11 +91,11 @@ private enum StorageKey: String {
         let resolveFn = {
           TPPSettings.shared.accountMainFeedURL = mainFeed
           UIApplication.shared.delegate?.window??.tintColor = TPPConfiguration.mainColor()
-          
+
           if self.notifyAccountChange {
             NotificationCenter.default.post(name: NSNotification.Name.TPPCurrentAccountDidChange, object: nil)
           }
-          
+
           self.notifyAccountChange = true
 
         }
@@ -114,7 +114,7 @@ private enum StorageKey: String {
       }
 
       notifyAccountDidChange()
-      }
+    }
   }
 
   var credentials: TPPCredentials? {

--- a/Palace/Accounts/User/TPPUserAccount.swift
+++ b/Palace/Accounts/User/TPPUserAccount.swift
@@ -90,7 +90,13 @@ private enum StorageKey: String {
         let resolveFn = {
           TPPSettings.shared.accountMainFeedURL = mainFeed
           UIApplication.shared.delegate?.window??.tintColor = TPPConfiguration.mainColor()
-          NotificationCenter.default.post(name: NSNotification.Name.TPPCurrentAccountDidChange, object: nil)
+          
+          if self.notifyAccountChange {
+            NotificationCenter.default.post(name: NSNotification.Name.TPPCurrentAccountDidChange, object: nil)
+          }
+          
+          self.notifyAccountChange = true
+
         }
 
         if self.needsAgeCheck {
@@ -107,7 +113,14 @@ private enum StorageKey: String {
       }
 
       notifyAccountDidChange()
-    }
+      }
+  }
+  
+  private var notifyAccountChange: Bool = true
+  
+  func setAuthDefinitionWithoutUpdate(authDefinition: AccountDetails.Authentication?) {
+    notifyAccountChange = false
+    self.authDefinition = authDefinition
   }
 
   var credentials: TPPCredentials? {

--- a/Palace/Accounts/User/TPPUserAccount.swift
+++ b/Palace/Accounts/User/TPPUserAccount.swift
@@ -41,7 +41,8 @@ private enum StorageKey: String {
   static private let shared = TPPUserAccount()
   private let accountInfoLock = NSRecursiveLock()
   private lazy var keychainTransaction = TPPKeychainVariableTransaction(accountInfoLock: accountInfoLock)
-    
+  private var notifyAccountChange: Bool = true
+
   private var libraryUUID: String? {
     didSet {
       guard libraryUUID != oldValue else { return }
@@ -115,13 +116,6 @@ private enum StorageKey: String {
       notifyAccountDidChange()
       }
   }
-  
-  private var notifyAccountChange: Bool = true
-  
-  func setAuthDefinitionWithoutUpdate(authDefinition: AccountDetails.Authentication?) {
-    notifyAccountChange = false
-    self.authDefinition = authDefinition
-  }
 
   var credentials: TPPCredentials? {
     get {
@@ -189,6 +183,11 @@ private enum StorageKey: String {
     shared.libraryUUID = libraryUUID
 
     return shared
+  }
+
+  func setAuthDefinitionWithoutUpdate(authDefinition: AccountDetails.Authentication?) {
+    notifyAccountChange = false
+    self.authDefinition = authDefinition
   }
 
   private func notifyAccountDidChange() {

--- a/Palace/Book/UI/TPPBookButtonsView.m
+++ b/Palace/Book/UI/TPPBookButtonsView.m
@@ -264,8 +264,6 @@
   NSMutableArray *visibleButtons = [NSMutableArray array];
   
   BOOL fulfillmentIdRequired = NO;
-  TPPBookState state = [[TPPBookRegistry sharedRegistry] stateForIdentifier:self.book.identifier];
-  BOOL hasRevokeLink = (self.book.revokeURL && (state == TPPBookStateDownloadSuccessful || state == TPPBookStateUsed));
 
   #if defined(FEATURE_DRM_CONNECTOR)
   
@@ -276,6 +274,13 @@
   
   for (NSDictionary *buttonInfo in visibleButtonInfo) {
     TPPRoundedButton *button = buttonInfo[ButtonKey];
+    
+    if(button == self.deleteButton && (!fulfillmentId && fulfillmentIdRequired) && !self.book.revokeURL ) {
+      if(!self.book.defaultAcquisitionIfOpenAccess && TPPUserAccount.sharedAccount.authDefinition.needsAuth) {
+        continue;
+      }
+    }
+    
     button.hidden = NO;
     
     // Disable the animation for changing the title. This helps avoid visual issues with

--- a/Palace/Book/UI/TPPBookButtonsView.m
+++ b/Palace/Book/UI/TPPBookButtonsView.m
@@ -276,12 +276,6 @@
   
   for (NSDictionary *buttonInfo in visibleButtonInfo) {
     TPPRoundedButton *button = buttonInfo[ButtonKey];
-    if(button == self.deleteButton && (!fulfillmentId && fulfillmentIdRequired) && !hasRevokeLink) {
-      if(!self.book.defaultAcquisitionIfOpenAccess && TPPUserAccount.sharedAccount.authDefinition.needsAuth) {
-        continue;
-      }
-    }
-    
     button.hidden = NO;
     
     // Disable the animation for changing the title. This helps avoid visual issues with

--- a/Palace/Book/UI/TPPBookDetailViewController.m
+++ b/Palace/Book/UI/TPPBookDetailViewController.m
@@ -120,15 +120,6 @@
 
 #pragma mark NSObject
 
-- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion {
-  
-}
-
-- (void) viewWillDisappear:(BOOL)animated
-{
-  [super viewWillDisappear:animated];
-}
-
 - (void)dealloc
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/Palace/Book/UI/TPPBookDetailViewController.m
+++ b/Palace/Book/UI/TPPBookDetailViewController.m
@@ -120,6 +120,15 @@
 
 #pragma mark NSObject
 
+- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion {
+  
+}
+
+- (void) viewWillDisappear:(BOOL)animated
+{
+  [super viewWillDisappear:animated];
+}
+
 - (void)dealloc
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
@@ -487,7 +487,7 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
       setBarcode(barcode, pin: pin)
     }
 
-    userAccount.authDefinition = selectedAuthentication
+    userAccount.setAuthDefinitionWithoutUpdate(authDefinition: selectedAuthentication)
 
     if libraryAccountID == libraryAccountsProvider.currentAccountId {
       bookRegistry.syncResettingCache(false) { [weak bookRegistry] errorDict in

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -30,5 +30,4 @@ else
   CERTIFICATES_PATH="../mobile-certificates/Certificates"
 fi
 
-pip3 install requests > /dev/null
-python3 $CERTIFICATES_PATH/Palace/iOS/ReleaseNotes.py "$@"
+swift $CERTIFICATES_PATH/Palace/iOS/ReleaseNotes.swift "$@"


### PR DESCRIPTION
**What's this do?**
Returns user to the books detail view after signin

**Why are we doing this? (w/ Notion link if applicable)**
https://www.notion.so/lyrasis/iOS-Return-user-to-title-after-prompt-to-login-dce4c104a1c744cc99e1b6af37ac8043

**How should this be tested? / Do these changes have associated tests?**
Without logging in, attempt to checkout a book and follow prompts.

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 