### PR TITLE
Add library button to Reservations tab

### DIFF
--- a/Palace/Holds/TPPHoldsViewController.m
+++ b/Palace/Holds/TPPHoldsViewController.m
@@ -16,7 +16,7 @@
 #import "Palace-Swift.h"
 
 @interface TPPHoldsViewController ()
-<UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout>
+<UICollectionViewDataSource, UICollectionViewDelegate, TPPFacetBarViewDelegate, UICollectionViewDelegateFlowLayout>
 
 // FIXME: It's unclear how "reserved" is different from "held" in this class. These
 // two terms are used interchangably in both OPDS and elsewhere in this application.
@@ -27,6 +27,7 @@
 @property (nonatomic) UILabel *instructionsLabel;
 @property (nonatomic) UIRefreshControl *refreshControl;
 @property (nonatomic) UIBarButtonItem *searchButton;
+@property (nonatomic) TPPFacetBarView *facetBarView;
 
 @end
 
@@ -118,6 +119,31 @@
                                            initWithTitle:NSLocalizedString(@"Back", @"Back button text")
                                            style:UIBarButtonItemStylePlain
                                            target:nil action:nil];
+
+  self.facetBarView = [[TPPFacetBarView alloc] initWithOrigin:CGPointZero width:self.view.bounds.size.width];
+  self.facetBarView.delegate = self;
+  
+  [self.view addSubview:self.facetBarView];
+  
+  [self.facetBarView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
+  [self.facetBarView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
+  [self.facetBarView autoPinToTopLayoutGuideOfViewController:self withInset:0.0];
+
+}
+
+- (void)didMoveToParentViewController:(UIViewController *)parent
+{
+  [super didMoveToParentViewController:parent];
+  
+  if (parent) {
+    CGFloat facetBarHeight = self.facetBarView.frame.size.height;
+    UIEdgeInsets insets = self.collectionView.contentInset;
+    insets.top += facetBarHeight;
+    if (@available(iOS 11.0, *)) {
+      insets.top += parent.additionalSafeAreaInsets.top;
+    }
+    [self.collectionView setContentInset:insets];
+  }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -303,6 +329,18 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
 - (void)viewWillTransitionToSize:(CGSize)__unused size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)__unused coordinator
 {
   [self.collectionView reloadData];
+}
+
+#pragma mark TPPFacetBarViewDelegate
+
+- (void)present:(UIViewController *)viewController
+{
+  [self.navigationController pushViewController:viewController animated:YES];
+}
+
+- (NSArray<TPPCatalogFacet *> *)facetsForEntryPointView
+{
+  return @[];
 }
 
 @end


### PR DESCRIPTION
**What's this do?**
- Adds library button to Reservation tab.

**Why are we doing this? (w/ Notion link if applicable)**
Library button is missing on Reservations tab ([Notion](https://www.notion.so/lyrasis/Android-Update-Title-menu-Bar-label-to-for-view-names-vs-library-names-and-catalog-breadcrumbs-cfdfbdb03614475984eef1b70a937f3a))

**How should this be tested? / Do these changes have associated tests?**
Open the app, switch to "Reservations" tab. Library button should be visible on top of the collection of reserved books.

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 

https://user-images.githubusercontent.com/941531/140181426-c7dea35e-50b2-4c61-9b16-e4edb74086e4.mov


