### PR TITLE
Send changelog to TestFlight builds

### DIFF
--- a/.github/workflows/upload-on-merge.yml
+++ b/.github/workflows/upload-on-merge.yml
@@ -80,10 +80,14 @@ jobs:
           BUILD_CONTEXT: ci
       - name: Verify path and version
         run: |
-          echo "Path:    " $RELEASE_NOTES_PATH
-          echo "Version: " $VERSION_NUM
+          echo "Release notes path: " $RELEASE_NOTES_PATH
+          cat $RELEASE_NOTES_PATH
+          echo "Changelog path:     " $CHANGELOG_PATH
+          cat $CHANGELOG_PATH
+          echo "Version:            " $VERSION_NUM
         env:
           RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
+          CHANGELOG_PATH: ${{ env.CHANGELOG_PATH }}
           VERSION_NUM: ${{ env.VERSION_NUM }}
       - name: Create Release
         id: create_release
@@ -101,3 +105,4 @@ jobs:
         run: ./scripts/xcode-export-appstore.sh
         env:
           BUILD_CONTEXT: ci
+          CHANGELOG_PATH: ${{ env.CHANGELOG_PATH }}

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -77,7 +77,9 @@ jobs:
       - name: Verify path and version
         run: |
           echo "Release notes path: " $RELEASE_NOTES_PATH
+          cat $RELEASE_NOTES_PATH
           echo "Changelog path:     " $CHANGELOG_PATH
+          cat $CHANGELOG_PATH
           echo "Version:            " $VERSION_NUM
         env:
           RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -76,10 +76,12 @@ jobs:
           BUILD_CONTEXT: ci
       - name: Verify path and version
         run: |
-          echo "Path:    " $RELEASE_NOTES_PATH
-          echo "Version: " $VERSION_NUM
+          echo "Release notes path: " $RELEASE_NOTES_PATH
+          echo "Changelog path:     " $CHANGELOG_PATH
+          echo "Version:            " $VERSION_NUM
         env:
           RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
+          CHANGELOG_PATH: ${{ env.CHANGELOG_PATH }}
           VERSION_NUM: ${{ env.VERSION_NUM }}
       - name: Create Release
         id: create_release
@@ -94,6 +96,8 @@ jobs:
           body_path: ${{ env.RELEASE_NOTES_PATH }}
           draft: false
       - name: Export for App Store
+        env:
+          CHANGELOG_PATH: ${{ env.CHANGELOG_PATH }}
         run: ./scripts/xcode-export-appstore.sh
         env:
           BUILD_CONTEXT: ci

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -96,8 +96,7 @@ jobs:
           body_path: ${{ env.RELEASE_NOTES_PATH }}
           draft: false
       - name: Export for App Store
-        env:
-          CHANGELOG_PATH: ${{ env.CHANGELOG_PATH }}
         run: ./scripts/xcode-export-appstore.sh
         env:
           BUILD_CONTEXT: ci
+          CHANGELOG_PATH: ${{ env.CHANGELOG_PATH }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ platform :ios do
       }
     )
   end
-  lane :testflight do
+  lane :testflight do |options|
     build_app(
       project: "Palace.xcodeproj",
       scheme: "Palace",
@@ -40,7 +40,8 @@ platform :ios do
     )
     pilot(
       api_key_path: "fastlane/fastlane.json",
-      skip_submission: true
+      skip_submission: true,
+      changelog: options[:changelog]
     )
   end
 end

--- a/scripts/create-release-notes.sh
+++ b/scripts/create-release-notes.sh
@@ -8,7 +8,10 @@
 #
 #     ./scripts/create-release-notes.sh
 
+# Release notes for Github release
 RELEASE_NOTES_PATH="./fastlane/release-notes.md"
+# Changelog for TestFlight changelog
+CHANGELOG_PATH="./fastlane/changelog.txt"
 
 # Project version
 source ./scripts/xcode-settings.sh
@@ -18,11 +21,16 @@ echo "### Changelog:" > $RELEASE_NOTES_PATH
 echo "" >> $RELEASE_NOTES_PATH
 ./scripts/release-notes.sh -v 2 >> $RELEASE_NOTES_PATH
 
+# Create TestFlight changelog
+./scripts/release-notes.sh -v 3 >> $CHANGELOG_PATH
+
 if [ "$BUILD_CONTEXT" == "ci" ]; then
   # Save variables for further steps
   echo "RELEASE_NOTES_PATH=$RELEASE_NOTES_PATH" >> $GITHUB_ENV
+  echo "CHANGELOG_PATH=$CHANGELOG_PATH" >> $GITHUB_ENV
   echo "VERSION_NUM=$VERSION_NUM" >> $GITHUB_ENV
 else
   echo "Release notes path: " $RELEASE_NOTES_PATH
+  echo "Changelog path: " $CHANGELOG_PATH
   echo "Version: " $VERSION_NUM
 fi

--- a/scripts/xcode-export-appstore.sh
+++ b/scripts/xcode-export-appstore.sh
@@ -15,4 +15,5 @@
 # RESULTS
 #   The generated .ipa is uploaded to TestFlight.
 
-fastlane ios testflight
+CHANGELOG=$(<"$CHANGELOG_PATH")
+fastlane ios testflight changelog:"$CHANGELOG"


### PR DESCRIPTION
**What's this do?**
- Adds sending changelog to TestFlight

**Why are we doing this? (w/ Notion link if applicable)**
Currently changelog with release notes is published on Github only. This PR add steps to create a changelog for TestFlight builds.

**How should this be tested? / Do these changes have associated tests?**
You can test output running
```
gh workflow run upload.yml --ref fix/release-notes-test
```

**Dependencies for merging? Releasing to production?**
NA

**Does this include changes that require a new Palace build for QA?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 