### PR TITLE
Add LCP passphrase retrieval

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -137,6 +137,8 @@
 		2146872D2559A64B007B401A /* LCPLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2171ADA0251E38140003CABA /* LCPLibraryService.swift */; };
 		215C866D27064198005F9621 /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C866C27064198005F9621 /* BundleExtension.swift */; };
 		215C866E27064198005F9621 /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C866C27064198005F9621 /* BundleExtension.swift */; };
+		216D2E39274286D200472538 /* TPPLCPLicense.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216D2E38274286D200472538 /* TPPLCPLicense.swift */; };
+		216D2E3A274286D200472538 /* TPPLCPLicense.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216D2E38274286D200472538 /* TPPLCPLicense.swift */; };
 		216FD1FC26DFE112003AF0D8 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E5506DE326C4688D009FA623 /* Colors.xcassets */; };
 		2178984D269F174500374A6B /* NYPLAEToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E585662526979AC100A5FBD5 /* NYPLAEToolkit.framework */; };
 		2178984E269F174500374A6B /* NYPLAEToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E585662526979AC100A5FBD5 /* NYPLAEToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1031,6 +1033,7 @@
 		2156B54425B200EA003AD8EC /* R2LCPClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2LCPClient.framework; path = Carthage/Build/iOS/R2LCPClient.framework; sourceTree = "<group>"; };
 		2156B54625B200F6003AD8EC /* ReadiumLCP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReadiumLCP.framework; path = Carthage/Build/iOS/ReadiumLCP.framework; sourceTree = "<group>"; };
 		215C866C27064198005F9621 /* BundleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtension.swift; sourceTree = "<group>"; };
+		216D2E38274286D200472538 /* TPPLCPLicense.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPLCPLicense.swift; sourceTree = "<group>"; };
 		2171ADA0251E38140003CABA /* LCPLibraryService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LCPLibraryService.swift; sourceTree = "<group>"; };
 		2171ADA6251E38560003CABA /* ReadiumLCP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ReadiumLCP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		219747F626D9218400FA25DF /* TPPLCPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPLCPClient.swift; sourceTree = "<group>"; };
@@ -1590,6 +1593,7 @@
 				2171ADA0251E38140003CABA /* LCPLibraryService.swift */,
 				17A5AB4E25D201BD005DFF05 /* LCPPassphraseAuthenticationService.swift */,
 				219747F626D9218400FA25DF /* TPPLCPClient.swift */,
+				216D2E38274286D200472538 /* TPPLCPLicense.swift */,
 			);
 			path = LCP;
 			sourceTree = "<group>";
@@ -3160,6 +3164,7 @@
 				73EB0A8925821DF4006BC997 /* TPPProblemDocument.swift in Sources */,
 				73EB0A8A25821DF4006BC997 /* TPPReturnPromptHelper.swift in Sources */,
 				73EB0A8C25821DF4006BC997 /* TPPOpenSearchDescription.m in Sources */,
+				216D2E3A274286D200472538 /* TPPLCPLicense.swift in Sources */,
 				73EB0A8E25821DF4006BC997 /* TPPSignInBusinessLogic+UI.swift in Sources */,
 				73D8D27825A68D3B00DF5F69 /* TPPUserSettingsVC.swift in Sources */,
 				73EB0A9025821DF4006BC997 /* OPDS2CatalogsFeed.swift in Sources */,
@@ -3366,6 +3371,7 @@
 				11616E11196B0531003D60D9 /* TPPBookRegistry.m in Sources */,
 				081387571BC574DA003DEA6A /* UILabel+NYPLAppearanceAdditions.m in Sources */,
 				21F4BF3A26BC62D4000CF592 /* AdobeCertificate.swift in Sources */,
+				216D2E39274286D200472538 /* TPPLCPLicense.swift in Sources */,
 				21D746FC2719B00E00C0E1B4 /* PublicationOpeningError.swift in Sources */,
 				734917D1242D77D800059AA5 /* TPPUserSettingsVC.swift in Sources */,
 				21DDE31F25D2CEAF002CBCE3 /* AdobeDRMContainer.mm in Sources */,

--- a/Palace/Logging/TPPErrorLogger.swift
+++ b/Palace/Logging/TPPErrorLogger.swift
@@ -107,6 +107,7 @@ fileprivate let nullString = "null"
   case adobeDRMFulfillmentFail = 1001
   case lcpDRMFulfillmentFail = 1002
   case lcpPassphraseAuthorizationFail = 1003
+  case lcpPassphraseRetrievalFail = 1004
 
   // wrong content
   case unknownRightsManagement = 1100

--- a/Palace/MyBooks/TPPMyBooksDownloadCenter.m
+++ b/Palace/MyBooks/TPPMyBooksDownloadCenter.m
@@ -1509,6 +1509,11 @@ didFinishDownload:(BOOL)didFinishDownload
                      forDownloadTask:downloadTask];
     if (!success) {
       [self failDownloadWithAlertForBook:book];
+    } else {
+      // Store license ID
+      TPPLCPLicense *license = [[TPPLCPLicense alloc] initWithUrl: licenseUrl];
+      [[TPPBookRegistry sharedRegistry] setFulfillmentId:license.identifier forIdentifier:book.identifier];
+      [[TPPBookRegistry sharedRegistry] save];
     }
   }];
   #endif

--- a/Palace/Reader2/ReaderStackConfiguration/LCP/LCPPassphraseAuthenticationService.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LCP/LCPPassphraseAuthenticationService.swift
@@ -16,6 +16,78 @@ import ReadiumLCP
  */
 class LCPPassphraseAuthenticationService: LCPAuthenticating {
   func retrievePassphrase(for license: LCPAuthenticatedLicense, reason: LCPAuthenticationReason, allowUserInteraction: Bool, sender: Any?, completion: @escaping (String?) -> Void) {
+    retrievePassphraseFromLoan(for: license, reason: reason, allowUserInteraction: allowUserInteraction, sender: sender, completion: completion)
+  }
+
+  /// Retrieves LCP passphrase from loans
+  private func retrievePassphraseFromLoan(for license: LCPAuthenticatedLicense, reason: LCPAuthenticationReason, allowUserInteraction: Bool, sender: Any?, completion: @escaping (String?) -> Void) {
+    let licenseId = license.document.id
+    let registry = TPPBookRegistry.shared()
+    guard let loansUrl = AccountsManager.shared.currentAccount?.loansUrl else {
+      completion(nil)
+      return
+    }
+    guard let books = registry.myBooks as? [TPPBook],
+          let book = books.filter({ registry.fulfillmentId(forIdentifier: $0.identifier) == licenseId }).first else {
+            Log.error(#file, "LCP passphrase retrieval failed, no book with fulfillment id=\(licenseId) found")
+            completion(nil)
+            return
+    }
+    TPPNetworkExecutor.shared.GET(loansUrl) { result in
+      switch result {
+      case .success(let data, _):
+        let responseBody = String(data: data, encoding: .utf8)
+        guard let xml = TPPXML(data: data),
+              let entries = xml.children(withName: "entry") as? [TPPXML] else {
+          TPPErrorLogger.logError(
+            withCode: .lcpPassphraseRetrievalFail,
+            summary: "LCP Passphrase Retrieval error: loans XML parsing failed",
+            metadata: [
+              "loansUrl": loansUrl,
+              "responseBody": responseBody ?? "N/A"
+            ]
+          )
+          completion(nil)
+          return
+        }
+        for entry in entries {
+          if let entryId = entry.firstChild(withName: "id")?.value, entryId == book.identifier {
+            guard let links = (entry.children as? [TPPXML])?.filter({ $0.name == "link" }) else {
+              continue
+            }
+            for link in links {
+              if let passphrase = link.firstChild(withName: "hashed_passphrase")?.value {
+                completion(passphrase)
+                return
+              }
+            }
+          }
+        }
+        // Passphrase was not found
+        TPPErrorLogger.logError(
+          withCode: .lcpPassphraseRetrievalFail,
+          summary: "LCP Passphrase Retrieval error: passphrase not found for \(book.identifier)",
+          metadata: [
+            "loansUrl": loansUrl,
+            "responseBody": responseBody ?? "N/A"
+          ]
+        )
+      case .failure(let error, _):
+        TPPErrorLogger.logError(
+          withCode: .lcpPassphraseRetrievalFail,
+          summary: "LCP Passphrase Retrieval Error",
+          metadata: [
+            "loansUrl": loansUrl,
+            NSUnderlyingErrorKey: error
+          ]
+        )
+        completion(nil)
+      }
+    }
+    
+  }
+  /// Retrieves LCP passphrase from hint URL in the license
+  private func retrievePassphraseFromHint(for license: LCPAuthenticatedLicense, reason: LCPAuthenticationReason, allowUserInteraction: Bool, sender: Any?, completion: @escaping (String?) -> Void) {
     guard let hintLink = license.hintLink,
       let hintURL = URL(string: hintLink.href) else {
       Log.error(#file, "LCP Authenticated License does not contain valid hint link")

--- a/Palace/Reader2/ReaderStackConfiguration/LCP/TPPLCPLicense.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LCP/TPPLCPLicense.swift
@@ -1,0 +1,37 @@
+//
+//  TPPLCPLicense.swift
+//  Palace
+//
+//  Created by Vladimir Fedorov on 01.11.2021.
+//  Copyright © 2021 The Palace Project. All rights reserved.
+//
+
+#if LCP
+
+import Foundation
+
+// TODO: Convert to Codable struct once TPPMyBookDownloadCenter is rewritten with Swift.
+
+/// LCP License representation.
+/// This class is used to get license identifier to use after fulfillment is done.
+@objc class TPPLCPLicense: NSObject, Codable {
+  /// License ID
+  private var id: String
+  
+  /// Objective-C visible identifier
+  @objc var identifier: String {
+    id
+  }
+  
+  /// Initializes with license URL
+  @objc init?(url: URL) {
+    if let data = try? Data(contentsOf: url),
+       let license = try? JSONDecoder().decode(TPPLCPLicense.self, from: data) {
+      self.id = license.id
+    } else {
+      return nil
+    }
+  }
+}
+
+#endif


### PR DESCRIPTION
**What's this do?**
- Replaces LCP passphrase retrieval from license hint link with passphrase retrieval from loans.

**Why are we doing this? (w/ Notion link if applicable)**
[Notion](https://www.notion.so/lyrasis/Support-LCP-Automatic-Key-Retreval-iOS-d8345515af014850a59274fe4c533fa5)

**How should this be tested? / Do these changes have associated tests?**
Open a book from "LYRASIS Reads" - "DPLA Titles", the book should open without an error message.

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
@vladimirfedorov 
