### PR TITLE
Modify tabbar/navbar background color

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3997,7 +3997,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4022,7 +4022,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.11;
+				MARKETING_VERSION = 1.0.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -4055,7 +4055,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4080,7 +4080,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.11;
+				MARKETING_VERSION = 1.0.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App store";

--- a/Palace/AppInfrastructure/TPPAppDelegate.m
+++ b/Palace/AppInfrastructure/TPPAppDelegate.m
@@ -68,9 +68,11 @@ didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOpti
   
   [[UITabBar appearance] setTintColor: [TPPConfiguration iconColor]];
   [[UITabBar appearance] setBackgroundColor:[TPPConfiguration backgroundColor]];
+  [[UITabBar appearance] setTranslucent:NO];
   [[UITabBarItem appearance] setTitleTextAttributes:@{NSFontAttributeName: [UIFont palaceFontOfSize:12.0]} forState:UIControlStateNormal];
 
   [[UINavigationBar appearance] setTintColor: [TPPConfiguration iconColor]];
+  [[UINavigationBar appearance] setTranslucent:NO];
   [[UINavigationBar appearance] setBackgroundColor:[TPPConfiguration backgroundColor]];
   [[UINavigationBar appearance] setTitleTextAttributes:@{NSFontAttributeName: [UIFont semiBoldPalaceFontOfSize:18.0]}];
   


### PR DESCRIPTION
**What's this do?**
Updates tabbar and navbar to have opaque backgrounds

**Why are we doing this? (w/ Notion link if applicable)**
https://www.notion.so/lyrasis/Update-Android-UI-to-match-iOS-and-implement-new-icon-and-Brand-design-f504c6b7f5fe40c6a66c40a6e1c3438b#d36a89e20c8e498c8f7ea4c29c1303c1

**How should this be tested? / Do these changes have associated tests?**
View application 

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 