### PR TITLE
(CI) Add Github token to workflow scripts

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,13 +21,18 @@ jobs:
         run: ./scripts/create-release-notes.sh
         env:
           BUILD_CONTEXT: ci
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
       - name: Verify path and version
         run: |
-          echo "Path:    " $RELEASE_NOTES_PATH
-          echo "Version: " $VERSION_NUM
+          echo "Release notes path: " $RELEASE_NOTES_PATH
+          cat $RELEASE_NOTES_PATH
+          echo "Changelog path:     " $CHANGELOG_PATH
+          cat $CHANGELOG_PATH
+          echo "Version:            " $VERSION_NUM
         env:
           RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
-          VERSION_NUM: ${{ env.VERSION_NUM }}
+          CHANGELOG_PATH: ${{ env.CHANGELOG_PATH }}
+          VERSION_NUM: ${{ env.VERSION_NUM }}          
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/upload-on-merge.yml
+++ b/.github/workflows/upload-on-merge.yml
@@ -78,6 +78,7 @@ jobs:
         run: ./scripts/create-release-notes.sh
         env:
           BUILD_CONTEXT: ci
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
       - name: Verify path and version
         run: |
           echo "Release notes path: " $RELEASE_NOTES_PATH

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -74,6 +74,7 @@ jobs:
         run: ./scripts/create-release-notes.sh
         env:
           BUILD_CONTEXT: ci
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
       - name: Verify path and version
         run: |
           echo "Release notes path: " $RELEASE_NOTES_PATH

--- a/scripts/create-release-notes.sh
+++ b/scripts/create-release-notes.sh
@@ -19,10 +19,10 @@ source ./scripts/xcode-settings.sh
 # Create release notes
 echo "### Changelog:" > $RELEASE_NOTES_PATH
 echo "" >> $RELEASE_NOTES_PATH
-./scripts/release-notes.sh -v 2 >> $RELEASE_NOTES_PATH
+./scripts/release-notes.sh -v 2 --token "$GITHUB_TOKEN" >> $RELEASE_NOTES_PATH
 
 # Create TestFlight changelog
-./scripts/release-notes.sh -v 3 >> $CHANGELOG_PATH
+./scripts/release-notes.sh -v 3 --token "$GITHUB_TOKEN" >> $CHANGELOG_PATH
 
 if [ "$BUILD_CONTEXT" == "ci" ]; then
   # Save variables for further steps


### PR DESCRIPTION
**What's this do?**
- Updates workflows and scripts to use Github workflow token;
- Passes Github token to `release-notes.sh` script.

**Why are we doing this? (w/ Notion link if applicable)**
The script was updated to pass User-Agent and Authentication headers to Github API, to avoid Github 403 error. ([Notion](https://www.notion.so/lyrasis/Capture-Release-Notes-3670a190ba224dc1bd69d01b2e5f8a58))

**How should this be tested? / Do these changes have associated tests?**
Run
```
gh workflow run create-release.yml --ref fix/release-notes-test
```
and see the result on Actions tab. `fix/release-notes-test` is prepared to generate change log from release 1.0.1.

**Dependencies for merging? Releasing to production?**
No (CI-related only)

**Does this include changes that require a new Palace build for QA?**
NA

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 