### PR TITLE
Enable testing settings in App Store apps

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3761,7 +3761,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3782,7 +3782,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.10;
+				MARKETING_VERSION = 1.0.13;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3817,7 +3817,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3838,7 +3838,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.10;
+				MARKETING_VERSION = 1.0.13;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -3997,7 +3997,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4022,7 +4022,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.12;
+				MARKETING_VERSION = 1.0.13;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -4055,7 +4055,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4080,7 +4080,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.12;
+				MARKETING_VERSION = 1.0.13;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App store";

--- a/Palace/Settings/TPPSettingsPrimaryTableViewController.m
+++ b/Palace/Settings/TPPSettingsPrimaryTableViewController.m
@@ -133,13 +133,10 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       self.infoLabel.textAlignment = NSTextAlignmentCenter;
       [self.infoLabel sizeToFit];
 
-      // Disable debug features in production environment
-      if (NSBundle.mainBundle.applicationEnvironment != TPPEnvironmentProduction) {
-        UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(revealDeveloperSettings)];
-        tap.numberOfTapsRequired = 7;
-        [self.infoLabel setUserInteractionEnabled:YES];
-        [self.infoLabel addGestureRecognizer:tap];
-      }
+      UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(revealDeveloperSettings)];
+      tap.numberOfTapsRequired = 7;
+      [self.infoLabel setUserInteractionEnabled:YES];
+      [self.infoLabel addGestureRecognizer:tap];
     }
     return self.infoLabel;
   }


### PR DESCRIPTION
**What's this do?**
- Re-enables seven-tap gesture that opens debug menu for App Store builds.

**Why are we doing this? (w/ Notion link if applicable)**
[Notion ticket](https://www.notion.so/lyrasis/re-Enable-seven-click-test-library-access-on-Palace-iOS-app-store-release-256891fe1c5642dda2b4d75caffb8891); (previously was disabled by [this ticket](https://www.notion.so/lyrasis/iOS-Pre-Aplause-PRH-security-validation-for-DRM-8fc1fd54268345aaa17de90024a990fb))

**How should this be tested? / Do these changes have associated tests?**
The app downloaded from App Store should open debug setting after the user taps seven times on the version label.

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
No (reverting one of previous updates)

**Did someone actually run this code to verify it works?**
@vladimirfedorov 