### PR TITLE
Restore Sync functionality

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3997,7 +3997,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4022,7 +4022,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.14;
+				MARKETING_VERSION = 1.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Palace App";
@@ -4055,7 +4055,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4080,7 +4080,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.14;
+				MARKETING_VERSION = 1.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App store";

--- a/Palace/Reader2/Bookmarks/TPPBookmarkFactory.swift
+++ b/Palace/Reader2/Bookmarks/TPPBookmarkFactory.swift
@@ -113,11 +113,7 @@ class TPPBookmarkFactory {
     guard
       let body = annotation[TPPBookmarkSpec.Body.key] as? [String: AnyObject],
       let device = body[TPPBookmarkSpec.Body.Device.key] as? String,
-      let time = body[TPPBookmarkSpec.Body.Time.key] as? String,
-
-      // TODO: SIMPLY-3655 update to R2 spec or remove
-      let progressWithinChapter = (body["http://librarysimplified.org/terms/progressWithinChapter"] as? NSNumber)?.floatValue,
-      let progressWithinBook = (body["http://librarysimplified.org/terms/progressWithinBook"] as? NSNumber)?.floatValue
+      let time = body[TPPBookmarkSpec.Body.Time.key] as? String
       else {
         Log.error(#file, "Error reading required bookmark key/values from body")
         return nil
@@ -144,6 +140,8 @@ class TPPBookmarkFactory {
 
     let serverCFI = selectorValueJSON[TPPBookmarkSpec.Target.Selector.Value.legacyLocatorCFIKey] as? String
     let chapter = body["http://librarysimplified.org/terms/chapter"] as? String
+    let progressWithinChapter = selectorValueJSON["progressWithinChapter"] as? Float
+    let progressWithinBook = Float(selectorValueJSON["progressWithinBook"] as? Double ?? 0.0)
 
     return TPPReadiumBookmark(annotationId: annotationID,
                                contentCFI: serverCFI,
@@ -151,7 +149,7 @@ class TPPBookmarkFactory {
                                chapter: chapter,
                                page: nil,
                                location: selectorValueEscJSON,
-                               progressWithinChapter: progressWithinChapter,
+                               progressWithinChapter: progressWithinChapter ?? 0.0,
                                progressWithinBook: progressWithinBook,
                                time:time,
                                device:device)

--- a/Palace/Reader2/BusinessLogic/TPPReaderBookmarksBusinessLogic.swift
+++ b/Palace/Reader2/BusinessLogic/TPPReaderBookmarksBusinessLogic.swift
@@ -201,7 +201,7 @@ class TPPReaderBookmarksBusinessLogic: NSObject {
           }
         }
         
-        TPPAnnotations.getServerBookmarks(forBook: self.book.identifier, atURL: self.book.annotationsURL) { serverBookmarks in
+        TPPAnnotations.getServerBookmarks(forBook: self.book.identifier, atURL: self.book.annotationsURL, motivation: .bookmark) { serverBookmarks in
 
           guard let serverBookmarks = serverBookmarks else {
             self.handleBookmarksSyncFail(message: "Ending sync without running completion. Returning original list of bookmarks.",


### PR DESCRIPTION
**What's this do?**
Updates sync functionality to support Readium 2 spec
https://github.com/NYPL-Simplified/Simplified/wiki/Annotations

**Why are we doing this? (w/ Notion link if applicable)**
https://www.notion.so/lyrasis/Palace-does-not-remember-place-in-book-or-audiobook-between-devices-on-iOS-4e408de1eb1e49d49da3853ca957e4f4

**How should this be tested? / Do these changes have associated tests?**
Set a reading position on a device, log into another device, the application should open to the new location.

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 


https://user-images.githubusercontent.com/6921353/143294910-3864bddf-6cf1-4be1-9d2d-91667902a2dd.mov


