### PR TITLE
(CI) Remove create_release step from Github build workflows

### DIFF
--- a/.github/workflows/upload-on-merge.yml
+++ b/.github/workflows/upload-on-merge.yml
@@ -90,18 +90,6 @@ jobs:
           RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
           CHANGELOG_PATH: ${{ env.CHANGELOG_PATH }}
           VERSION_NUM: ${{ env.VERSION_NUM }}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
-          VERSION_NUM: ${{ env.VERSION_NUM }}
-        with:
-          tag_name: ${{ env.VERSION_NUM }}
-          release_name: ${{ env.VERSION_NUM }}
-          body_path: ${{ env.RELEASE_NOTES_PATH }}
-          draft: false
       - name: Export for App Store
         run: ./scripts/xcode-export-appstore.sh
         env:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -86,18 +86,6 @@ jobs:
           RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
           CHANGELOG_PATH: ${{ env.CHANGELOG_PATH }}
           VERSION_NUM: ${{ env.VERSION_NUM }}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
-          VERSION_NUM: ${{ env.VERSION_NUM }}
-        with:
-          tag_name: ${{ env.VERSION_NUM }}
-          release_name: ${{ env.VERSION_NUM }}
-          body_path: ${{ env.RELEASE_NOTES_PATH }}
-          draft: false
       - name: Export for App Store
         run: ./scripts/xcode-export-appstore.sh
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,7 +24,6 @@ The script performs several steps:
 
 - checks the project build version - if the version remains the same, the action stops; it helps to avoid unnecessary builds when updates are not related to the project itself, for example, changes in a CI script should not result in a new binary on Test Flight;
 - generates release notes for a new release on Github and Test Flight "What to Test" description;
-- creates a new release on Github;
 - uploads a new build to Test Flight.
 
 ### Palace Manual Build


### PR DESCRIPTION
**What's this do?**
- Removes create_release step from build workflows - we don't create releases every time we merge to `develop` now.

**Why are we doing this? (w/ Notion link if applicable)**
This step fails if we already have a release on Github with the same name. As we don't change version number for every build in `develop` branch now, the step fails. A better place for it is a separate workflow for merging to `main`. It also remains available as a separate workflow, `create-release.yml`.

**How should this be tested? / Do these changes have associated tests?**
This can be run manually as
```
gh workflow run upload.yml --ref <branch>
```

**Dependencies for merging? Releasing to production?**
NA

**Does this include changes that require a new Palace build for QA?**
NA

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
@vladimirfedorov ([Successful action run](https://github.com/ThePalaceProject/ios-core/actions/runs/1548509317))