### PR TITLE
Show library picker view from action sheet

### DIFF
--- a/Palace/AppInfrastructure/TPPLibraryNavigationController.m
+++ b/Palace/AppInfrastructure/TPPLibraryNavigationController.m
@@ -84,9 +84,16 @@
   }
 
   [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Add Library", nil) style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
-    TPPSettingsAccountsTableViewController *tableVC = [[TPPSettingsAccountsTableViewController alloc] initWithAccounts: TPPSettings.shared.settingsAccountsList];
-    tableVC.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"AddAccount", nil) style:UIBarButtonItemStylePlain target:tableVC action:@selector(addAccount)];
-    [self pushViewController:tableVC animated:YES];
+    TPPAccountList *listVC = [[TPPAccountList alloc] initWithCompletion:^(Account * _Nonnull account) {
+      [account loadAuthenticationDocumentUsingSignedInStateProvider:nil completion:^(BOOL success) {
+        if (success) {
+          TPPSettings.shared.settingsAccountsList = [TPPSettings.shared.settingsAccountsList arrayByAddingObject:account.uuid];
+          AccountsManager.shared.currentAccount = account;
+          [self popToRootViewControllerAnimated:YES];
+        }
+      }];
+    }];
+    [self pushViewController:listVC animated:YES];
   }]];
 
   [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil) style:(UIAlertActionStyleCancel) handler:nil]];

--- a/Palace/AppInfrastructure/TPPLibraryNavigationController.m
+++ b/Palace/AppInfrastructure/TPPLibraryNavigationController.m
@@ -87,7 +87,11 @@
     TPPAccountList *listVC = [[TPPAccountList alloc] initWithCompletion:^(Account * _Nonnull account) {
       [account loadAuthenticationDocumentUsingSignedInStateProvider:nil completion:^(BOOL success) {
         if (success) {
-          TPPSettings.shared.settingsAccountsList = [TPPSettings.shared.settingsAccountsList arrayByAddingObject:account.uuid];
+          
+          if (![TPPSettings.shared.settingsAccountsList containsObject:account.uuid]) {
+            TPPSettings.shared.settingsAccountsList = [TPPSettings.shared.settingsAccountsList arrayByAddingObject:account.uuid];
+          }
+          
           AccountsManager.shared.currentAccount = account;
           [self popToRootViewControllerAnimated:YES];
         }

--- a/Palace/Settings/AccountList/TPPAccountList.swift
+++ b/Palace/Settings/AccountList/TPPAccountList.swift
@@ -16,7 +16,7 @@ final class TPPAccountList: UIViewController {
   private var estimatedRowHeight: CGFloat = 100
   private var sectionHeaderSize: CGFloat = 20
   
-  required init(completion: @escaping (Account) -> ()) {
+  @objc required init(completion: @escaping (Account) -> ()) {
     self.completion = completion
     super.init(nibName:nil, bundle:nil)
   }


### PR DESCRIPTION
**What's this do?**
Shows the library picker view when a user selects to add a library from the action sheet menu

**Why are we doing this? (w/ Notion link if applicable)**
https://www.notion.so/lyrasis/Send-user-to-Add-Library-screen-when-Add-Library-is-tapped-19e292407c2943a2b5e28b724ec32d3c

**How should this be tested? / Do these changes have associated tests?**
Attempt to add a library from the action sheet menu 

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 

https://user-images.githubusercontent.com/6921353/145462391-43e8f184-df2f-4d37-bf1d-fe770e4e702c.mov
