### PR TITLE
Create release when code is merged to main

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,5 +1,9 @@
-name: Create Release Test
-on: workflow_dispatch
+name: Palace Release
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
 jobs:
   create-release:
     runs-on: macOS-latest

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -48,4 +48,4 @@ jobs:
           tag_name: ${{ env.VERSION_NUM }}
           release_name: ${{ env.VERSION_NUM }}
           body_path: ${{ env.RELEASE_NOTES_PATH }}
-          draft: true
+          draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Palace Manual Release
+on: workflow_dispatch
+jobs:
+  create-release:
+    runs-on: macOS-latest
+    steps:
+      - name: Force Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Checkout main repo and submodules
+        uses: actions/checkout@v2.3.4
+        with:
+          submodules: true
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
+      - name: Checkout Certificates
+        uses: actions/checkout@v2.3.4
+        with:
+          repository: ThePalaceProject/mobile-certificates
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
+          path: ./mobile-certificates
+      - name: Create release notes
+        run: ./scripts/create-release-notes.sh
+        env:
+          BUILD_CONTEXT: ci
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
+      - name: Verify path and version
+        run: |
+          echo "Release notes path: " $RELEASE_NOTES_PATH
+          cat $RELEASE_NOTES_PATH
+          echo "Changelog path:     " $CHANGELOG_PATH
+          cat $CHANGELOG_PATH
+          echo "Version:            " $VERSION_NUM
+        env:
+          RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
+          CHANGELOG_PATH: ${{ env.CHANGELOG_PATH }}
+          VERSION_NUM: ${{ env.VERSION_NUM }}          
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
+          VERSION_NUM: ${{ env.VERSION_NUM }}
+        with:
+          tag_name: ${{ env.VERSION_NUM }}
+          release_name: ${{ env.VERSION_NUM }}
+          body_path: ${{ env.RELEASE_NOTES_PATH }}
+          draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,4 @@ jobs:
           tag_name: ${{ env.VERSION_NUM }}
           release_name: ${{ env.VERSION_NUM }}
           body_path: ${{ env.RELEASE_NOTES_PATH }}
-          draft: true
+          draft: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@ Starts on merge to `develop` branch.
 The script performs several steps:
 
 - checks the project build version - if the version remains the same, the action stops; it helps to avoid unnecessary builds when updates are not related to the project itself, for example, changes in a CI script should not result in a new binary on Test Flight;
-- generates release notes for a new release on Github and Test Flight "What to Test" description;
+- generates release notes for Test Flight "What to Test" description;
 - uploads a new build to Test Flight.
 
 ### Palace Manual Build
@@ -31,6 +31,23 @@ The script performs several steps:
 Location: [.github/workflows/upload.yml](https://github.com/ThePalaceProject/ios-core/blob/main/.github/workflows/upload.yml)
 
 This script is similar to "Palace Build", but can be started manually. Performs the same set of steps.
+
+### Palace Release
+
+Location:  [.github/workflows/upload-on-merge.yml](https://github.com/ThePalaceProject/ios-core/blob/main/.github/workflows/release-on-merge.yml)
+
+Starts on merge to `main` branch.
+
+The script performs several steps:
+
+- generates release notes for a new release on Github;
+- creates a new release on Github.
+
+### Palace Manual Release
+
+Location:  [.github/workflows/upload-on-merge.yml](https://github.com/ThePalaceProject/ios-core/blob/main/.github/workflows/release.yml)
+
+This script is similar to "Palace Release", but can be started manually. Performs the same set of steps.
 
 ### Unit Tests
 


### PR DESCRIPTION
**What's this do?**
- Adds workflows to create Github release when code is merged to main

**Why are we doing this? (w/ Notion link if applicable)**
Previously this step was removed from `build-on-merge.yml` because we stopped increasing version number for every merge to `develop` branch - the step is moved to these workflows now. 

**How should this be tested? / Do these changes have associated tests?**
First, you need to rename current release on Github, or the step will fail. Then run:
```
gh workflow run release.yml --ref feature/release-on-merge
```

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
NA

**Has the application documentation been updated for these changes?**
Yes, updated RELEASING.md

**Did someone actually run this code to verify it works?**
@vladimirfedorov 