### PR TITLE
Fix navigation bar pushing book content down

### DIFF
--- a/Palace/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Palace/Reader2/ReaderPresentation/ReaderModule.swift
@@ -111,6 +111,7 @@ final class ReaderModule: ReaderModuleAPI {
       let backItem = UIBarButtonItem()
       backItem.title = NSLocalizedString("Back", comment: "Text for Back button")
       readerVC.navigationItem.backBarButtonItem = backItem
+      readerVC.extendedLayoutIncludesOpaqueBars = true
       readerVC.hidesBottomBarWhenPushed = true
       navigationController.pushViewController(readerVC, animated: true)
 


### PR DESCRIPTION
**What's this do?**
- Fixes navigation bar behaviour when it shows or hides, book content should now remain behind the bar.

**Why are we doing this? (w/ Notion link if applicable)**
Navigation bar was pushing reader content down, making the bottom part of the text disappear ([ticket](https://www.notion.so/lyrasis/The-low-part-of-the-text-is-invisible-when-you-open-the-navigation-bar-epub-e933d1c665ab45069a783b87250ef861)).

**How should this be tested? / Do these changes have associated tests?**
Open a book, tap on the centre of the screen to show/hide navigation bar. Book content should remain behind the bar.

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
No (preparing a new PR)

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 