### PR TITLE
Fix navigation bar color issues switching from different reading color modes

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		219C769A27629B8F00483647 /* TPPPagerDotsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F0992627629AC000CD85E2 /* TPPPagerDotsView.swift */; };
 		219E4D8F25C34A8500588588 /* DRMLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733DEC8B24108D8D008C74BC /* DRMLibraryService.swift */; };
 		219E4D9325C34A8800588588 /* DRMLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733DEC8B24108D8D008C74BC /* DRMLibraryService.swift */; };
+		21C184DC27B12347008CC4F8 /* UINavigationBar+appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C184DB27B12347008CC4F8 /* UINavigationBar+appearance.swift */; };
+		21C184DD27B12347008CC4F8 /* UINavigationBar+appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C184DB27B12347008CC4F8 /* UINavigationBar+appearance.swift */; };
 		21C7B87E25AE1DBA000E8BF3 /* LibraryServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7B87D25AE1DB9000E8BF3 /* LibraryServiceError.swift */; };
 		21D746E72718A4C000C0E1B4 /* AdobeDRMFetcherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D746E62718A4C000C0E1B4 /* AdobeDRMFetcherError.swift */; };
 		21D746E82718A4C000C0E1B4 /* AdobeDRMFetcherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D746E62718A4C000C0E1B4 /* AdobeDRMFetcherError.swift */; };
@@ -1100,6 +1102,7 @@
 		219901F924FD2E56001BC727 /* jwk_public */ = {isa = PBXFileReference; lastKnownFileType = text; path = jwk_public; sourceTree = "<group>"; };
 		2199020524FD3334001BC727 /* TPPJWKConversionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPJWKConversionTest.swift; sourceTree = "<group>"; };
 		2199020724FD35DC001BC727 /* JWKResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWKResponse.swift; sourceTree = "<group>"; };
+		21C184DB27B12347008CC4F8 /* UINavigationBar+appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationBar+appearance.swift"; sourceTree = "<group>"; };
 		21C7B87D25AE1DB9000E8BF3 /* LibraryServiceError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LibraryServiceError.swift; sourceTree = "<group>"; };
 		21D746E62718A4C000C0E1B4 /* AdobeDRMFetcherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeDRMFetcherError.swift; sourceTree = "<group>"; };
 		21D746FB2719B00E00C0E1B4 /* PublicationOpeningError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationOpeningError.swift; sourceTree = "<group>"; };
@@ -2243,6 +2246,7 @@
 				1107835C19816E3D0071AB1E /* UIView+TPPViewAdditions.h */,
 				1107835D19816E3D0071AB1E /* UIView+TPPViewAdditions.m */,
 				E551B359267D396A0026FC1B /* TPPLoadingViewController.swift */,
+				21C184DB27B12347008CC4F8 /* UINavigationBar+appearance.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -3431,6 +3435,7 @@
 				73EB0B0F25821DF4006BC997 /* NSString+JSONParse.swift in Sources */,
 				73EB0B1025821DF4006BC997 /* TPPOPDSEntryGroupAttributes.m in Sources */,
 				73D8D28225A68D5600DF5F69 /* Publication+NYPLAdditions.swift in Sources */,
+				21C184DD27B12347008CC4F8 /* UINavigationBar+appearance.swift in Sources */,
 				73EB0B1125821DF4006BC997 /* TPPMyBooksDownloadCenter.m in Sources */,
 				73EB0B1225821DF4006BC997 /* TPPProblemDocumentCacheManager.swift in Sources */,
 				73EB0B1325821DF4006BC997 /* TPPBookButtonsView.m in Sources */,
@@ -3656,6 +3661,7 @@
 				21045C552761092C00D2D407 /* TPPOnboardingViewController.swift in Sources */,
 				739ECB2425101CCE00691A70 /* NSNotification+TPP.swift in Sources */,
 				734B789125659611006FB8AD /* URLResponse+TPPAuthentication.swift in Sources */,
+				21C184DC27B12347008CC4F8 /* UINavigationBar+appearance.swift in Sources */,
 				E5C2C422268BA5140046F415 /* TPPRegistryDebuggingCell.swift in Sources */,
 				118A0B1B19915BDF00792DDE /* TPPCatalogSearchViewController.m in Sources */,
 				737DCB8C245CCF2300A8F297 /* TPPReaderBookmarksBusinessLogic.swift in Sources */,

--- a/Palace/AppInfrastructure/TPPAppDelegate.m
+++ b/Palace/AppInfrastructure/TPPAppDelegate.m
@@ -71,9 +71,12 @@ didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOpti
   [[UITabBarItem appearance] setTitleTextAttributes:@{NSFontAttributeName: [UIFont palaceFontOfSize:12.0]} forState:UIControlStateNormal];
 
   [[UINavigationBar appearance] setTintColor: [TPPConfiguration iconColor]];
-  [[UINavigationBar appearance] setTranslucent:NO];
-  [[UINavigationBar appearance] setBackgroundColor:[TPPConfiguration backgroundColor]];
-  [[UINavigationBar appearance] setTitleTextAttributes:@{NSFontAttributeName: [UIFont semiBoldPalaceFontOfSize:18.0]}];
+  [[UINavigationBar appearance] setStandardAppearance:[TPPConfiguration defaultAppearance]];
+  [[UINavigationBar appearance] setScrollEdgeAppearance:[TPPConfiguration defaultAppearance]];
+  [[UINavigationBar appearance] setCompactAppearance:[TPPConfiguration defaultAppearance]];
+  if (@available(iOS 15.0, *)) {
+    [[UINavigationBar appearance] setCompactScrollEdgeAppearance:[TPPConfiguration defaultAppearance]];
+  }
   
   [self setUpRootVC];
 

--- a/Palace/AppInfrastructure/TPPConfiguration.h
+++ b/Palace/AppInfrastructure/TPPConfiguration.h
@@ -40,4 +40,11 @@
 
 + (CGFloat)defaultBookmarkRowHeight;
 
+/// Default navigation bar appearance with proper status bar background color
++ (UINavigationBarAppearance *)defaultAppearance;
+
+/// Navigation bar appearance with a specified background color
+/// @param backgroundColor Navigation bar background color
++ (UINavigationBarAppearance *)appearanceWithBackgroundColor:(UIColor *)backgroundColor;
+
 @end

--- a/Palace/AppInfrastructure/TPPConfiguration.m
+++ b/Palace/AppInfrastructure/TPPConfiguration.m
@@ -104,4 +104,18 @@
   return 100;
 }
 
++ (UINavigationBarAppearance *)defaultAppearance
+{
+  return [TPPConfiguration appearanceWithBackgroundColor:[TPPConfiguration backgroundColor]];
+}
+
++ (UINavigationBarAppearance *)appearanceWithBackgroundColor:(UIColor *)backgroundColor
+{
+  UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
+  [appearance configureWithOpaqueBackground];
+  [appearance setBackgroundColor: backgroundColor];
+  [appearance setTitleTextAttributes:@{NSFontAttributeName: [UIFont semiBoldPalaceFontOfSize:18.0]}];
+  return appearance;
+}
+
 @end

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -70,6 +70,7 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
 
   override open func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
+    self.navigationController?.navigationBar.setAppearance(TPPConfiguration.defaultAppearance())
     self.navigationController?.navigationBar.tintColor = TPPConfiguration.iconColor()
     self.tabBarController?.tabBar.tintColor = TPPConfiguration.iconColor()
     userSettings.save()
@@ -115,7 +116,7 @@ extension TPPEPUBViewController: TPPUserSettingsReaderDelegate {
         self.navigator.view.backgroundColor = colors.backgroundColor
         self.view.backgroundColor = colors.backgroundColor
         self.view.tintColor = colors.textColor
-        self.navigationController?.navigationBar.barTintColor = colors.backgroundColor
+        self.navigationController?.navigationBar.setAppearance(TPPConfiguration.appearance(withBackgroundColor: colors.backgroundColor))
         self.navigationController?.navigationBar.tintColor = colors.navigationColor
         self.tabBarController?.tabBar.tintColor = colors.navigationColor
       }

--- a/Palace/Utilities/UI/UINavigationBar+appearance.swift
+++ b/Palace/Utilities/UI/UINavigationBar+appearance.swift
@@ -1,0 +1,22 @@
+//
+//  UINavigationBar+appearance.swift
+//  Palace
+//
+//  Created by Vladimir Fedorov on 03.02.2022.
+//  Copyright © 2022 The Palace Project. All rights reserved.
+//
+
+import UIKit
+
+extension UINavigationBar {
+  /// Sets navigation bar appearance to all appearance properties
+  /// - Parameter appearance: Navigation bar appearance
+  func setAppearance(_ appearance: UINavigationBarAppearance) {
+    standardAppearance = appearance
+    scrollEdgeAppearance = appearance
+    compactAppearance = appearance
+    if #available(iOS 15.0, *) {
+      compactScrollEdgeAppearance = appearance
+    }
+  }
+}


### PR DESCRIPTION
**What's this do?**
- Fixes navigation bar color issues when closing a book with dark content in light mode. This also fixes similar issues in iOS dark mode.

**Why are we doing this? (w/ Notion link if applicable)**
Navigation bar was keeping the color from book reading settings after the book was closed ([ticket](https://www.notion.so/lyrasis/Navigation-bar-has-a-wrong-color-after-the-closing-a-book-7d4ddfbda65542c5a85d3c9b7c279b61)).

**How should this be tested? / Do these changes have associated tests?**
Please follow the steps in the ticket.

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
No (several PRs in queue)

**Has the application documentation been updated for these changes?**
Yes, code documentation.

**Did someone actually run this code to verify it works?**
@vladimirfedorov 

https://user-images.githubusercontent.com/941531/152804822-4990637b-9c61-489b-bedc-d15ae7ac2a7c.mov


