### PR TITLE
Fix accessibility issues in VoiceOver mode

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -4195,7 +4195,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -4217,7 +4217,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.25;
+				MARKETING_VERSION = 1.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -4253,7 +4253,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4274,7 +4274,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.25;
+				MARKETING_VERSION = 1.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -4434,7 +4434,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -4461,7 +4461,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.25;
+				MARKETING_VERSION = 1.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Ad hoc 2";
@@ -4495,7 +4495,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4521,7 +4521,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.25;
+				MARKETING_VERSION = 1.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "App Store 2";

--- a/Palace/Reader2/UI/TPPBaseReaderViewController.swift
+++ b/Palace/Reader2/UI/TPPBaseReaderViewController.swift
@@ -21,7 +21,7 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
   private static let bookmarkOffImageName = "BookmarkOff"
 
   // Side margins for long labels
-  private static let overlayLabelMargin: CGFloat = 20
+  static let overlayLabelMargin: CGFloat = 20
   
   // TODO: SIMPLY-2656 See if we still need this.
   weak var moduleDelegate: ModuleDelegate?
@@ -103,7 +103,7 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
     NSLayoutConstraint.activate([
       topConstraint,
       stackView.rightAnchor.constraint(equalTo: view.rightAnchor),
-      stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+      stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
       stackView.leftAnchor.constraint(equalTo: view.leftAnchor)
     ])
 
@@ -141,6 +141,8 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
       layoutConstraints.append(bookTitleLabel.topAnchor.constraint(equalTo: navigator.view.topAnchor, constant: TPPBaseReaderViewController.overlayLabelMargin))
     }
     NSLayoutConstraint.activate(layoutConstraints)
+    
+    updateViewsForVoiceOver(isRunning: UIAccessibility.isVoiceOverRunning)
   }
 
   override func willMove(toParent parent: UIViewController?) {
@@ -168,11 +170,12 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
                                       style: .plain,
                                       target: self,
                                       action: #selector(toggleBookmark))
-
     let tocButton = UIBarButtonItem(image: UIImage(named: "TOC"),
                                     style: .plain,
                                     target: self,
                                     action: #selector(presentPositionsVC))
+    tocButton.accessibilityLabel = NSLocalizedString("Table of contents and bookmarks", comment: "Table of contents and bookmarks")
+    
     buttons.append(bookmarkBtn)
     buttons.append(tocButton)
     tocBarButton = tocButton
@@ -315,29 +318,39 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
     }
 
     let toolbar = UIToolbar(frame: .zero)
+    let backButton = makeItem(.rewind, label: NSLocalizedString("Previous Chapter", comment: "Accessibility label to go backward in the publication"), action: #selector(goBackward))
+    let forwardButton = makeItem(.fastForward, label: NSLocalizedString("Next Chapter", comment: "Accessibility label to go forward in the publication"), action: #selector(goForward))
+        
     toolbar.items = [
       makeItem(.flexibleSpace),
-      makeItem(.rewind, label: NSLocalizedString("Previous Chapter", comment: "Accessibility label to go backward in the publication"), action: #selector(goBackward)),
+      backButton,
       makeItem(.flexibleSpace),
-      makeItem(.fastForward, label: NSLocalizedString("Next Chapter", comment: "Accessibility label to go forward in the publication"), action: #selector(goForward)),
+      forwardButton,
       makeItem(.flexibleSpace),
     ]
     toolbar.isHidden = !UIAccessibility.isVoiceOverRunning
     toolbar.tintColor = UIColor.black
+    toolbar.accessibilityElements = [forwardButton, backButton]
     return toolbar
   }()
 
   private var isVoiceOverRunning = UIAccessibility.isVoiceOverRunning
 
-  @objc private func voiceOverStatusDidChange() {
+  @objc func voiceOverStatusDidChange() {
     let isRunning = UIAccessibility.isVoiceOverRunning
     // Avoids excessive settings refresh when the status didn't change.
     guard isVoiceOverRunning != isRunning else {
       return
     }
+    updateViewsForVoiceOver(isRunning: isRunning)
+  }
+  
+  func updateViewsForVoiceOver(isRunning: Bool) {
     isVoiceOverRunning = isRunning
     accessibilityTopMargin.isActive = isRunning
     accessibilityToolbar.isHidden = !isRunning
+    positionLabel.isHidden = isRunning
+    bookTitleLabel.isHidden = isRunning
     updateNavigationBar()
   }
 

--- a/Palace/Reader2/UI/TPPBaseReaderViewController.swift
+++ b/Palace/Reader2/UI/TPPBaseReaderViewController.swift
@@ -323,14 +323,13 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
         
     toolbar.items = [
       makeItem(.flexibleSpace),
-      backButton,
-      makeItem(.flexibleSpace),
       forwardButton,
+      makeItem(.flexibleSpace),
+      backButton,
       makeItem(.flexibleSpace),
     ]
     toolbar.isHidden = !UIAccessibility.isVoiceOverRunning
     toolbar.tintColor = UIColor.black
-    toolbar.accessibilityElements = [forwardButton, backButton]
     return toolbar
   }()
 

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -16,21 +16,30 @@ import R2Navigator
 class TPPEPUBViewController: TPPBaseReaderViewController {
 
   var popoverUserconfigurationAnchor: UIBarButtonItem?
-  
+
   init(publication: Publication,
        book: TPPBook,
        initialLocation: Locator?,
        resourcesServer: ResourcesServer) {
+
+    let safeAreaInsets = UIApplication.shared.keyWindow?.safeAreaInsets ?? UIEdgeInsets()
+    let overlayLabelInset = TPPBaseReaderViewController.overlayLabelMargin * 2 // Vertical margin for labels
+    let contentInset: [UIUserInterfaceSizeClass: EPUBContentInsets] = [
+      .compact: (top: max(overlayLabelInset, safeAreaInsets.top), bottom: max(overlayLabelInset, safeAreaInsets.bottom)),
+      .regular: (top: max(overlayLabelInset, safeAreaInsets.top), bottom: max(overlayLabelInset, safeAreaInsets.bottom))
+    ]
 
     // this config was suggested by R2 engineers as a way to limit the possible
     // race conditions between restoring the initial location without
     // interfering with the web view layout timing
     // See: https://github.com/readium/r2-navigator-swift/issues/153
     var config = EPUBNavigatorViewController.Configuration()
-    config.preloadPreviousPositionCount = 0
-    config.preloadNextPositionCount = 0
-    config.debugState = true
+    config.preloadPreviousPositionCount = 2
+    config.preloadNextPositionCount = 2
+    config.debugState = false
+    config.decorationTemplates = HTMLDecorationTemplate.defaultTemplates()
     config.editingActions = [.lookup]
+    config.contentInset = contentInset
 
     let navigator = EPUBNavigatorViewController(publication: publication,
                                                 initialLocation: initialLocation,
@@ -104,6 +113,7 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
                                              style: .plain,
                                              target: self,
                                              action: #selector(presentUserSettings))
+    userSettingsButton.accessibilityLabel = NSLocalizedString("Reader settings", comment: "Reader settings")
     buttons.insert(userSettingsButton, at: 1)
     popoverUserconfigurationAnchor = userSettingsButton
 

--- a/Palace/en.lproj/Localizable.strings
+++ b/Palace/en.lproj/Localizable.strings
@@ -161,6 +161,10 @@
 "chapter" = "chapter";
 
 // ReaderViewController (R2)
+"Reader settings" = "Reader settings";
+"Table of contents and bookmarks" = "Table of contents and bookmarks";
+"Remove Bookmark" = "Remove Bookmark";
+"Add Bookmark" = "Add Bookmark";
 "Previous Chapter" = "Previous Chapter";
 "Next Chapter" = "Next Chapter";
 

--- a/PalaceConfig/Palace-Info.plist
+++ b/PalaceConfig/Palace-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSpokenName</key>
-	<string>Simply E</string>
+	<string>Palace</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
**What's this do?**
Fixes accessibility issues in VoiceOver mode:
- book title and page number overlap book content;
- some navigation buttons don't have accessibility labels;
- at the end of the chapter the app offers to go to previous chapter.

**Why are we doing this? (w/ Notion link if applicable)**
There are several accessibility issues in VoiceOver mode described in tickets:
- [iOS: The text of the books overlaps the title and page numbers when the VoiceOver is turned on](https://www.notion.so/lyrasis/iOS-The-text-of-the-books-overlaps-the-title-and-page-numbers-when-the-VoiceOver-is-turned-on-7e88182d1c7f486e90602bec33a4f9c4),
- [iOS: Investigate the buttons at the bottom of the screen for previous and next chapters after turning on the VoiceOver](https://www.notion.so/lyrasis/iOS-Investigate-the-buttons-at-the-bottom-of-the-screen-for-previous-and-next-chapters-after-turnin-f75153a3b217435494cc92ee547b0d01).

**How should this be tested? / Do these changes have associated tests?**
Open an ePub and turn VoiceOver on.

**Dependencies for merging? Releasing to production?**
NA

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
Yes, code documentation

**Did someone actually run this code to verify it works?**
@vladimirfedorov 


https://user-images.githubusercontent.com/941531/192036094-d4e08444-2f5a-4147-8f4e-aebb83e1a239.mov

