### PR TITLE
Fix the "Borrowing failed" error

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3143,7 +3143,6 @@
 						DevelopmentTeam = 88CBA74T8K;
 					};
 					A823D80C192BABA400B55DE2 = {
-						DevelopmentTeam = 88CBA74T8K;
 						LastSwiftMigration = 1130;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -4530,9 +4529,11 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 123;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 124;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4561,6 +4562,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Ad hoc 2";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING LCP FEATURE_OVERDRIVE";
 				SWIFT_OBJC_BRIDGING_HEADER = "Palace/AppInfrastructure/Palace-Bridging-Header.h";
@@ -4591,7 +4593,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 123;
+				CURRENT_PROJECT_VERSION = 124;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Palace/Book/Models/TPPBookRegistry.swift
+++ b/Palace/Book/Models/TPPBookRegistry.swift
@@ -317,6 +317,7 @@ class TPPBookRegistry: NSObject {
       return
     }
     coverRegistry.removePinnedThumbnailImageForBookIdentifier(book.identifier)
+    registry[book.identifier]?.book = book
     registry[book.identifier]?.state = .Unregistered
     save()
   }


### PR DESCRIPTION
**What's this do?**
Restores `book` object from OPDS feed after the book is returned.

**Why are we doing this? (w/ Notion link if applicable)**
It is impossible to borrow a book immediately after it was retuned ([Ticket](https://www.notion.so/lyrasis/iOS-There-is-an-alert-Borrowing-Failed-when-trying-to-get-the-finished-audiobook-immediately-afte-36177030433f407aa8f6d235b637923e)).

**How should this be tested? / Do these changes have associated tests?**
Follow the steps in "Steps to reproduce" in the [ticket](https://www.notion.so/lyrasis/iOS-There-is-an-alert-Borrowing-Failed-when-trying-to-get-the-finished-audiobook-immediately-afte-36177030433f407aa8f6d235b637923e).

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 


https://user-images.githubusercontent.com/941531/208083091-8b3a088a-3ee9-49cc-b178-daa3b74d7827.mov

