### PR TITLE
Adopt new GH actions environment files.

### DIFF
--- a/scripts/ios-check-version.sh
+++ b/scripts/ios-check-version.sh
@@ -23,11 +23,11 @@ CURL_RESULT=`curl -I -s -o /dev/null -w "%{http_code}"  https://github.com/ThePa
 
 if [ "$CURL_RESULT" == 200 ]; then
   echo "Build for ${ARCHIVE_NAME} already exists in ios-binaries"
-  echo "::set-output name=version_changed::0"
+  echo "version_changed=0" >> $GITHUB_OUTPUT
 elif [ "$CURL_RESULT" != 404 ]; then
   echo "Obtained unexpected curl result for file named \"$UPLOAD_FILENAME\""
   exit 1
 else
   echo "Build for ${ARCHIVE_NAME} doesn't exist in ios-binaries"    
-  echo "::set-output name=version_changed::1"
+  echo "version_changed=1" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
**What's this do?**

Uses the new `$GITHUB_OUTPUT` environment file, instead of the deprecated `set-output`, for GH actions.

**Why are we doing this? (w/ Notion link if applicable)**

The `save-state` and `set-output` workflow commands have been deprecated. [[GitHub post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)] [[Notion](https://www.notion.so/lyrasis/Use-new-GitHub-Actions-environment-files-816e94f3abfb4e73ad6bd75645f07249)] [[Notion](https://www.notion.so/lyrasis/Update-Github-workflow-actions-3e847d4db34a41d1b7b43516391f1c79)]

**How should this be tested? / Do these changes have associated tests?**

Review CI logs from the associated branch to verify that the `set-output` deprecation error no longer appears in `Palace Build` > `check-version` > `Check Build Version`.

**Dependencies for merging? Releasing to production?**

No. This is a CI-only change.

**Does this include changes that require a new Palace build for QA?**

No. This is a CI-only change.

**Has the application documentation been updated for these changes?**

N/A

**Did someone actually run this code to verify it works?**

GitHub Actions will run this code as part of CI.
