### PR TITLE
Upgrade to actions/checkouts v3.

### DIFF
--- a/.github/workflows/check-build-number.yml
+++ b/.github/workflows/check-build-number.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macOS-11
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.IOS_DEV_CI_PAT }}
       - name: Check Build Number

--- a/.github/workflows/non-drm-build.yml
+++ b/.github/workflows/non-drm-build.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Force Xcode 13.2
         run: sudo xcode-select -switch /Applications/Xcode_13.2.app
       - name: Checkout main repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up repo for nonDRM build
         run: exec ./scripts/setup-repo-nodrm.sh
         env:

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -11,12 +11,12 @@ jobs:
       - name: Force Xcode 13.2
         run: sudo xcode-select -switch /Applications/Xcode_13.2.app
       - name: Checkout main repo and submodules
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           submodules: true
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
       - name: Checkout Certificates
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           repository: ThePalaceProject/mobile-certificates
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,12 @@ jobs:
       - name: Force Xcode 13.2
         run: sudo xcode-select -switch /Applications/Xcode_13.2.app
       - name: Checkout main repo and submodules
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           submodules: true
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
       - name: Checkout Certificates
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           repository: ThePalaceProject/mobile-certificates
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -7,18 +7,18 @@ jobs:
       - name: Force Xcode 13.2
         run: sudo xcode-select -switch /Applications/Xcode_13.2.app
       - name: Checkout main repo and submodules
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           submodules: true
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
       - name: Checkout Certificates
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           repository: ThePalaceProject/mobile-certificates
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
           path: ./mobile-certificates
       - name: Checkout Adobe RMSDK
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           repository: ThePalaceProject/mobile-drm-adeptconnector
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/upload-on-merge.yml
+++ b/.github/workflows/upload-on-merge.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Force Xcode 13.2
         run: sudo xcode-select -switch /Applications/Xcode_13.2.app
       - name: Checkout main repo and submodules
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           submodules: true
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
@@ -30,24 +30,24 @@ jobs:
       - name: Force Xcode 13.2
         run: sudo xcode-select -switch /Applications/Xcode_13.2.app
       - name: Checkout main repo and submodules
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           submodules: true
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
       - name: Checkout Binaries
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           repository: ThePalaceProject/ios-binaries
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
           path: ./ios-binaries
       - name: Checkout Certificates
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           repository: ThePalaceProject/mobile-certificates
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
           path: ./mobile-certificates
       - name: Checkout Adobe RMSDK
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           repository: ThePalaceProject/mobile-drm-adeptconnector
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Force Xcode 13.2
         run: sudo xcode-select -switch /Applications/Xcode_13.2.app
       - name: Checkout main repo and submodules
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           submodules: true
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
@@ -26,24 +26,24 @@ jobs:
       - name: Force Xcode 13.2
         run: sudo xcode-select -switch /Applications/Xcode_13.2.app
       - name: Checkout main repo and submodules
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           submodules: true
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
       - name: Checkout Binaries
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           repository: ThePalaceProject/ios-binaries
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
           path: ./ios-binaries
       - name: Checkout Certificates
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           repository: ThePalaceProject/mobile-certificates
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
           path: ./mobile-certificates
       - name: Checkout Adobe RMSDK
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           repository: ThePalaceProject/mobile-drm-adeptconnector
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
**What's this do?**

Updates some GitHub actions to versions that: 
- Use the new`$GITHUB_STATE` and `$GITHUB_OUTPUT` environment files, instead of the deprecated `save-state` and `set-output` "commands", respectively.
- Have upgraded from Node.js 12.

**Why are we doing this? (w/ Notion link if applicable)**

To handle some GitHub actions deprecation warnings (that would eventually become errors):
- The `save-state` and `set-output` workflow commands have been deprecated. [[GitHub post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)] 
- All actions will begin running on Node.js 16, rather than 12. [[GitHub post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)]

[[Notion](https://www.notion.so/lyrasis/Use-new-GitHub-Actions-environment-files-816e94f3abfb4e73ad6bd75645f07249)] [[Notion](https://www.notion.so/lyrasis/Update-Github-workflow-actions-3e847d4db34a41d1b7b43516391f1c79)]

**How should this be tested? / Do these changes have associated tests?**

Review CI logs from the associated branch to verify that the `save-state`, `set-output`, and `Node.js 12`  deprecation errors no longer appear in the CI logs.

**Dependencies for merging? Releasing to production?**

No. This is a CI-only change.

**Does this include changes that require a new Palace build for QA?**

No. This is a CI-only change.

**Has the application documentation been updated for these changes?**

N/A

**Did someone actually run this code to verify it works?**

GitHub Actions will run this code as part of CI.