### PR TITLE
Fix reservations screen refresh progress

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -4409,7 +4409,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 140;
+				CURRENT_PROJECT_VERSION = 141;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4430,7 +4430,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.26;
+				MARKETING_VERSION = 1.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -4465,7 +4465,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 140;
+				CURRENT_PROJECT_VERSION = 141;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4486,7 +4486,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.26;
+				MARKETING_VERSION = 1.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -4646,7 +4646,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 140;
+				CURRENT_PROJECT_VERSION = 141;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -4673,7 +4673,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.26;
+				MARKETING_VERSION = 1.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Ad hoc 2";
@@ -4707,7 +4707,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 140;
+				CURRENT_PROJECT_VERSION = 141;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4733,7 +4733,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.26;
+				MARKETING_VERSION = 1.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "App Store 2";
 				RUN_CLANG_STATIC_ANALYZER = YES;

--- a/Palace/Holds/TPPHoldsViewController.m
+++ b/Palace/Holds/TPPHoldsViewController.m
@@ -296,7 +296,7 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
 ///
 /// `refreshControl` remains on screen when multiple views are animated at the same time,
 /// e.g., modal view controllers, or scrollView is being scrolled.
-/// Starting and stopping `refreshControl` animatin guarantees to stop it.
+/// Starting and stopping `refreshControl` animation guarantees to stop it.
 - (void)endRefreshing
 {
   dispatch_time_t stopTime = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC);

--- a/Palace/Holds/TPPHoldsViewController.m
+++ b/Palace/Holds/TPPHoldsViewController.m
@@ -153,10 +153,7 @@
     BOOL isSyncing = [TPPBookRegistry shared].isSyncing;
     if(!isSyncing) {
       [self.refreshControl endRefreshing];
-      if (self.collectionView.numberOfSections == 0) {
-        self.collectionView.contentOffset = CGPointMake(0, -self.collectionView.contentInset.top);
-      }
-      [[NSNotificationCenter defaultCenter] postNotificationName:NSNotification.TPPSyncEnded object:nil];\
+      [[NSNotificationCenter defaultCenter] postNotificationName:NSNotification.TPPSyncEnded object:nil];
     } else {
       self.navigationItem.leftBarButtonItem.enabled = NO;
     }

--- a/Palace/Holds/TPPHoldsViewController.m
+++ b/Palace/Holds/TPPHoldsViewController.m
@@ -42,14 +42,6 @@
   self.title = NSLocalizedString(@"Reservations", nil);
   self.navigationItem.title = NSLocalizedString(@"Reservations", nil);
 
-  [self willReloadCollectionViewData];
-  
-  [[NSNotificationCenter defaultCenter]
-   addObserver:self
-   selector:@selector(bookRegistryDidChange)
-   name:NSNotification.TPPBookRegistryDidChange
-   object:nil];
-  
   [[NSNotificationCenter defaultCenter]
    addObserver:self
    selector:@selector(syncEnded)
@@ -87,7 +79,7 @@
   self.collectionView.alwaysBounceVertical = YES;
   self.refreshControl = [[UIRefreshControl alloc] init];
   [self.refreshControl addTarget:self action:@selector(didPullToRefresh) forControlEvents:UIControlEventValueChanged];
-  [self.collectionView addSubview:self.refreshControl];
+  [self.collectionView setRefreshControl:self.refreshControl];
   
   // We know that super sets it to a flow layout.
   UICollectionViewFlowLayout *layout = (UICollectionViewFlowLayout *)self.collectionView.collectionViewLayout;
@@ -152,8 +144,7 @@
   [[NSOperationQueue mainQueue] addOperationWithBlock:^{
     BOOL isSyncing = [TPPBookRegistry shared].isSyncing;
     if(!isSyncing) {
-      [self.refreshControl endRefreshing];
-      [[NSNotificationCenter defaultCenter] postNotificationName:NSNotification.TPPSyncEnded object:nil];
+      [self endRefreshing];
     } else {
       self.navigationItem.leftBarButtonItem.enabled = NO;
     }
@@ -265,6 +256,7 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
   self.heldBooks = held;
   self.reservedBooks = reserved;
   [self updateBadge];
+  [self endRefreshing];
 }
 
 #pragma mark -
@@ -283,24 +275,12 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
     if([[TPPUserAccount sharedAccount] hasCredentials]) {
       [[TPPBookRegistry shared] sync];
     } else {
+      [self endRefreshing];
       [TPPAccountSignInViewController requestCredentialsWithCompletion:nil];
-      [self.refreshControl endRefreshing];
-      [[NSNotificationCenter defaultCenter] postNotificationName:NSNotification.TPPSyncEnded object:nil];
     }
   } else {
     [[TPPBookRegistry shared] loadWithAccount:nil];
-    [[NSNotificationCenter defaultCenter] postNotificationName:NSNotification.TPPSyncEnded object:nil];
   }
-}
-
-- (void)bookRegistryDidChange
-{
-  [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-    if([TPPBookRegistry shared].isSyncing == NO) {
-      [self.refreshControl endRefreshing];
-      [self willReloadCollectionViewData];
-    }
-  }];
 }
 
 - (void)didSelectSearch
@@ -310,6 +290,22 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
   [self.navigationController
    pushViewController:[[TPPCatalogSearchViewController alloc] initWithOpenSearchDescription:searchDescription]
    animated:YES];
+}
+
+/// Makes sure `refreshControl` animation ends
+///
+/// `refreshControl` remains on screen when multiple views are animated at the same time,
+/// e.g., modal view controllers, or scrollView is being scrolled.
+/// Starting and stopping `refreshControl` animatin guarantees to stop it.
+- (void)endRefreshing
+{
+  dispatch_time_t stopTime = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC);
+  dispatch_after(stopTime, dispatch_get_main_queue(), ^{
+    if (!self.collectionView.refreshControl.isRefreshing) {
+      [self.collectionView.refreshControl beginRefreshing];
+    }
+    [self.collectionView.refreshControl endRefreshing];
+  });
 }
 
 - (void)syncBegan


### PR DESCRIPTION
**What's this do?**
Refactors reservations screen code to fix refresh progress behaviour.

**Why are we doing this? (w/ Notion link if applicable)**
Refresh animation doesn't stop, books are not available after refresh [Ticket](https://www.notion.so/lyrasis/iOS-Reservations-screen-is-not-refreshed-622f7708be944479a21e7a6922c2f82b).

**How should this be tested? / Do these changes have associated tests?**
Follow the steps under "Steps to reproduce" in the [ticket](https://www.notion.so/lyrasis/iOS-Reservations-screen-is-not-refreshed-622f7708be944479a21e7a6922c2f82b).

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
Yes, code documentation.

**Did someone actually run this code to verify it works?**
@vladimirfedorov 

<details>
<summary>Demo</summary>

https://user-images.githubusercontent.com/941531/220367375-1c74cd77-5aea-471e-b5da-c9cec8b8b512.mov

</details>
