### PR TITLE
[CI] Update CI workflows to macOS 12 and Xcode 14.2

### DIFF
--- a/.github/workflows/check-build-number.yml
+++ b/.github/workflows/check-build-number.yml
@@ -7,7 +7,7 @@ on:
       - feature/**
 jobs:
   check-binaries:
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
       - name: Checkout main repo
         uses: actions/checkout@v3

--- a/.github/workflows/non-drm-build.yml
+++ b/.github/workflows/non-drm-build.yml
@@ -2,10 +2,10 @@ name: NonDRM Build
 on: workflow_dispatch
 jobs:
   build:
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
-      - name: Force Xcode 13.2
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
+      - name: Force Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Checkout main repo
         uses: actions/checkout@v3
       - name: Set up repo for nonDRM build

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -6,10 +6,10 @@ on:
     types: [closed]
 jobs:
   create-release:
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
-      - name: Force Xcode 13.2
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
+      - name: Force Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Checkout main repo and submodules
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,10 @@ name: Palace Manual Release
 on: workflow_dispatch
 jobs:
   create-release:
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
-      - name: Force Xcode 13.2
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
+      - name: Force Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Checkout main repo and submodules
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -2,10 +2,10 @@ name: Unit Tests
 on: [ pull_request, workflow_dispatch ]
 jobs:
   build-and-test:
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
-      - name: Force Xcode 13.2
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
+      - name: Force Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Checkout main repo and submodules
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/upload-on-merge.yml
+++ b/.github/workflows/upload-on-merge.yml
@@ -6,10 +6,10 @@ on:
     types: [closed]
 jobs:
   check-version:
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
-      - name: Force Xcode 13.2
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
+      - name: Force Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Checkout main repo and submodules
         uses: actions/checkout@v3
         with:
@@ -23,12 +23,12 @@ jobs:
     outputs:
       should_upload: ${{ steps.checkVersion.outputs.version_changed }}
   upload-build:
-    runs-on: macOS-11
+    runs-on: macOS-12
     needs: check-version
     if: github.event.pull_request.merged == true && needs.check-version.outputs.should_upload == '1'
     steps:
-      - name: Force Xcode 13.2
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
+      - name: Force Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Checkout main repo and submodules
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -2,10 +2,10 @@ name: Palace Manual Build
 on: workflow_dispatch
 jobs:
   check-version:
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
-      - name: Force Xcode 13.2
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
+      - name: Force Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Checkout main repo and submodules
         uses: actions/checkout@v3
         with:
@@ -19,12 +19,12 @@ jobs:
     outputs:
       should_upload: ${{ steps.checkVersion.outputs.version_changed }}
   upload-build:
-    runs-on: macOS-11
+    runs-on: macOS-12
     needs: check-version
     if: needs.check-version.outputs.should_upload == '1'
     steps:
-      - name: Force Xcode 13.2
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
+      - name: Force Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Checkout main repo and submodules
         uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the client-side code for The Palace Project [Palace](ht
 
 # System Requirements
 
-- Install Xcode 13.2 in `/Applications`, open it and make sure to install additional components if it asks you.
+- Install Xcode 14.2 in `/Applications`, open it and make sure to install additional components if it asks you.
 - Install [Carthage](https://github.com/Carthage/Carthage) if you haven't already. Using `brew` is recommended.
 
 If you run this project **with DRM support** on a Mac computer with Apple Silicon, make sure to check **[x]&nbsp;Open&nbsp;using&nbsp;Rosetta** in Xcode.app application info. This is required to build with Adobe DRM support. 


### PR DESCRIPTION
**What's this do?**
Updates CI workflows environment to macOS 12 and Xcode 14.2

**Why are we doing this? (w/ Notion link if applicable)**
Upload scripts fail with an error [Ticket](https://www.notion.so/lyrasis/Update-AppStore-API-Requests-Token-6aea97e7499041c5824ce27cb1e92f3c?d=cb811cacdd3043be8857735a5fde678a)

**How should this be tested? / Do these changes have associated tests?**
Has been tested during the [recent build and upload](https://github.com/ThePalaceProject/ios-core/actions/runs/4246129245).

**Dependencies for merging? Releasing to production?**
NA

**Does this include changes that require a new Palace build for QA?**
NA

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 