### PR TITLE
Reuse object to reduce memory pressure

### DIFF
--- a/Palace/MyBooks/TPPMyBooksDownloadCenter.m
+++ b/Palace/MyBooks/TPPMyBooksDownloadCenter.m
@@ -555,7 +555,8 @@ didCompleteWithError:(NSError *)error
   if (!data) {
     return;
   }
-  id const json = TPPJSONObjectFromData([NSData dataWithContentsOfURL:bookURL]);
+
+  id const json = TPPJSONObjectFromData(data);
   
   NSMutableDictionary *dict = nil;
   


### PR DESCRIPTION
**What's this do?**
Updates local content deletion logic to use existing data object in order to reduce memory pressure that was causing the app to crash on large books. 

**Why are we doing this? (w/ Notion link if applicable)**
https://www.notion.so/lyrasis/Returning-Anna-Karenina-audiobook-causes-crash-on-iOS-6f0da86f0c0944b4b5297ddc5ced9428

**How should this be tested? / Do these changes have associated tests?**
Download one of the titles listed in the ticket and attempt to return/delete it. The app should not crash.

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 