### PR TITLE
PP-473 Disable push notifications

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -4637,7 +4637,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 197;
+				CURRENT_PROJECT_VERSION = 198;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -4694,7 +4694,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 197;
+				CURRENT_PROJECT_VERSION = 198;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -4876,7 +4876,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 197;
+				CURRENT_PROJECT_VERSION = 198;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -4936,7 +4936,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 197;
+				CURRENT_PROJECT_VERSION = 198;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -70,7 +70,9 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     _ = TPPBookRegistry.shared
     
     // Push Notificatoins
-    NotificationService.shared.setupPushNotifications()
+    // TODO: Enable push notifications once they are fully tested here
+    // Disabling because of PP-473
+//    NotificationService.shared.setupPushNotifications()
   }
   
   // TODO: This method is deprecated, we should migrate to BGAppRefreshTask in the BackgroundTasks framework instead

--- a/Palace/Notifications/NotificationService.swift
+++ b/Palace/Notifications/NotificationService.swift
@@ -50,7 +50,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate, Messaging
   
   @objc
   /// Runs configuration function, registers the app for remote notifications.
-  func setupPushNotifications() {
+  func setupPushNotifications(completion: ((_ granted: Bool) -> Void)? = nil) {
     notificationCenter.delegate = self
     notificationCenter.requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
       if granted {
@@ -58,8 +58,18 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate, Messaging
           UIApplication.shared.registerForRemoteNotifications()
         }
       }
+      completion?(granted)
     }
     Messaging.messaging().delegate = self
+  }
+  
+  func getNotificationStatus(completion: @escaping (_ areEnabled: Bool) -> Void) {
+    notificationCenter.getNotificationSettings { notificationSettings in
+      switch notificationSettings.authorizationStatus {
+      case .authorized, .provisional: completion(true)
+      default: completion(false)
+      }
+    }
   }
   
   /// Check if token exists on the server


### PR DESCRIPTION
**What's this do?**
Disables push notifications authorisation on the start of the app + adds a settings option to enable them

**Why are we doing this? (w/ Notion link if applicable)**
Testing the feature [PP-473](https://ebce-lyrasis.atlassian.net/browse/PP-473).

**How should this be tested? / Do these changes have associated tests?**
Remove the app, install it back again. The app should show push notification authorization dialog only when Settings - Testing - Enable Push Notification switch is switched on the first time.

**Dependencies for merging? Releasing to production?**
NA

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
Yes, code documentation

**Did someone actually run this code to verify it works?**
@vladimirfedorov 

[PP-473]: https://ebce-lyrasis.atlassian.net/browse/PP-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ