### PR TITLE
Uncheck Run script: For install builds only

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -3630,7 +3630,7 @@
 		};
 		73DA43AD2404CA9500985482 /* Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 8;
+			buildActionMask = 12;
 			files = (
 			);
 			inputFileListPaths = (
@@ -3647,7 +3647,7 @@
 			);
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 1;
+			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
 		};


### PR DESCRIPTION
**What's this do?**
Unchecks Run script: For install builds only in Palace target - Build Phase - Crashlytics script.

**Why are we doing this? (w/ Notion link if applicable)**
We got another missing dSYM message; committing this because this is the only difference between our script and one created from scratch.

**How should this be tested? / Do these changes have associated tests?**
No associated tests; fatal crash adds a crash record in Crashlytics as expected.

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new Palace build for QA?**
No (project configuration only)

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@vladimirfedorov 