### PR TITLE
Add some additional logging to network calls

### DIFF
--- a/Palace/Network/TPPNetworkResponder.swift
+++ b/Palace/Network/TPPNetworkResponder.swift
@@ -188,7 +188,7 @@ extension TPPNetworkResponder: URLSessionDataDelegate {
   private func logTaskCompletion(taskID: Int, startDate: Date, metadata: inout [String: Any]) {
     let elapsed = Date().timeIntervalSince(startDate)
     metadata["elapsedTime"] = elapsed
-    Log.info(#file, "Task \(taskID) completed, elapsed time: \(elapsed) sec")
+    Log.info(#file, "Task \(taskID) completed (\(metadata["currentRequest"] ?? "nil")), elapsed time: \(elapsed) sec")
   }
 
   


### PR DESCRIPTION
**What's this do?**

Adds the request URL to `TPPNetworkResponder` task completion log.  I found this helpful when I was troubleshooting, otherwise its hard to tell exactly what URL has been fetched by a task. 

Thought it might be useful to have in general, but feel free to just close this if it doesn't make sense or isn't helpful.

**Why are we doing this? (w/ Notion link if applicable)**
[Quick blurb about why the code is needed and Notion link goes here / Do these changes meet the business requirements of the story?]

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Does this include changes that require a new Palace build for QA?**
[Bump the Palace build number to generate a new build on ThePalaceProject/ios-binaries]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
