### PR TITLE
Update logo initialization order for faster loading

### DIFF
--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -397,7 +397,8 @@ protocol AccountLogoDelegate: AnyObject {
       details = AccountDetails(authenticationDocument: authenticationDocument, uuid: uuid)
     }
   }
-  
+  var logoUrl: URL? = nil
+
 
   var loansUrl: URL? {
     return details?.loansUrl
@@ -423,12 +424,9 @@ protocol AccountLogoDelegate: AnyObject {
     logo = UIImage(named: "LibraryLogoMagic")!
     
     homePageUrl = publication.links.first(where: { $0.rel == "alternate" })?.href
+    logoUrl = publication.thumbnailURL
 
     super.init()
-    
-    DispatchQueue.main.async {
-      self.loadLogo(imageURL: publication.thumbnailURL)
-    }
   }
 
   /// Load authentication documents from the network or cache.
@@ -515,8 +513,8 @@ protocol AccountLogoDelegate: AnyObject {
     }
   }
   
-  private func loadLogo(imageURL: URL?) {
-    guard let url = imageURL else { return }
+  func loadLogo() {
+    guard let url = self.logoUrl else { return }
 
       self.fetchImage(from: url, completion: {
         guard let image = $0 else { return }

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -191,6 +191,7 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
       // changing the `accountsSets` dictionary will also change `currentAccount`
       Log.debug(#function, "hadAccount=\(hadAccount) currentAccountID=\(currentAccountId ?? "N/A") currentAcct=\(String(describing: currentAccount))")
       if hadAccount != (self.currentAccount != nil) {
+        self.currentAccount?.loadLogo()
         self.currentAccount?.loadAuthenticationDocument(using: TPPUserAccount.sharedAccount(), completion: { success in
           DispatchQueue.main.async {
             var mainFeed = URL(string: self.currentAccount?.catalogUrl ?? "")
@@ -224,6 +225,9 @@ let currentAccountIdentifierKey  = "TPPCurrentAccountIdentifier"
         // we pass `true` because at this point we know the catalogs loaded
         // successfully
         completion(true)
+      }
+      for account in accountSet {
+        account.loadLogo()
       }
     } catch (let error) {
       TPPErrorLogger.logError(error,


### PR DESCRIPTION
**What's this do?**

I've wondered for awhile why the app seems so slow to load the main catalog screen sometimes. Looking at the requests, it seems like its because we are adding all the library logos to the network queue, before adding the libraries authentication document. 

When the cache is stale this means that we need to fetch all ~600 library logos before displaying the main catalog view. I addressed this by not adding the task to get the library logo when the `Account` class is initialized, but providing a method to do so, then calling this method after the libraries authentication document is added to the queue.

I'm not sure this is the cleanest approach, and I don't really understand the order things are expected to be initialized in here, so feel free to give this a tough code review. It does help the user experience a lot when the cache is empty, I see a 10 - 15 second reduction in the time it takes to display the main catalog page.

**Why are we doing this? (w/ Notion link if applicable)**

Honestly because the long load time has been driving me crazy for some time.

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Does this include changes that require a new Palace build for QA?**
[Bump the Palace build number to generate a new build on ThePalaceProject/ios-binaries]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
