### PR TITLE
Make sure binaries are deleted when returing an book (PP-1024)

### DIFF
--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -468,8 +468,10 @@ extension MyBooksDownloadCenter {
     let isLcpAudiobook = false
 #endif
 
-    // LCP Audiobooks are a single binary file, without an easily loaded manifest. So they skip this logic
-    // that deleted the local audio files, used by other audiobook types.
+    // LCP Audiobooks are a single binary file, without an easily loaded manifest.
+    // So they skip this logic that deleted the local audio files, used by other
+    // audiobook types.
+    // TODO: Update LCP so we don't have to special case it here.
     if (!isLcpAudiobook) {
       let manifestData = try Data(contentsOf: bookURL)
       let manifest = try Manifest.customDecoder().decode(Manifest.self, from: manifestData)


### PR DESCRIPTION
**What's this do?**

Updates `MyBooksDownloadCenter` so that both books and audiobooks are correctly deleted from the device when the item is returned.

**Why are we doing this? (w/ Notion link if applicable)**

See: PP-1024

**How should this be tested? / Do these changes have associated tests?**

Checking out various content sources and make sure the item is deleted.

**Dependencies for merging? Releasing to production?**

This relies on the PR to the audiobook toolkit: 
https://github.com/ThePalaceProject/ios-audiobooktoolkit/pull/119

**Does this include changes that require a new Palace build for QA?**
[Bump the Palace build number to generate a new build on ThePalaceProject/ios-binaries]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**

I tested it against:
Audiobooks:
- Findaway
- Open access
- Marketplace LCP
- Marketplace non-LCP
Books:
- Adobe

And I saw the space being released in all those cases.
