### PR TITLE
Update Log function to use Palace rather then Simplified

### DIFF
--- a/Palace/Logging/Log.swift
+++ b/Palace/Logging/Log.swift
@@ -68,7 +68,7 @@ final class Log: NSObject {
   }
 
   // Avoid including source paths related to the build machine/user such as
-  // "/Users/<username>/<local-path>/.../Simplified"
+  // "/Users/<username>/<local-path>/.../Palace"
   private class func trimTag(_ tag: String) -> String {
     guard tag.starts(with: "/") else {
       return tag
@@ -77,7 +77,7 @@ final class Log: NSObject {
     var components = tag.components(separatedBy: "/")
 
     // remove any local path components before the source root in repo
-    let sourcesRootIndex = (components.index(of: "Simplified") ?? 0) + 1
+    let sourcesRootIndex = (components.index(of: "Palace") ?? 0) + 1
 
     if sourcesRootIndex < components.count {
       components.removeFirst(sourcesRootIndex)


### PR DESCRIPTION
**What's this do?**

Makes the logs look a little nicer. 
```
Network/TPPNetworkResponder.swift
```

It looks like the logging function had some functionality to trim down the path, but it was broken when we renamed the project to Palace.

**Why are we doing this? (w/ Notion link if applicable)**

Noticed it when I was trying to figure out what logging function to use while working on https://github.com/ThePalaceProject/ios-core/pull/509.

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Does this include changes that require a new Palace build for QA?**
[Bump the Palace build number to generate a new build on ThePalaceProject/ios-binaries]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
