### PR TITLE
[PP-1924] Resolves crashlytics crashes

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -5599,7 +5599,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 310;
+				CURRENT_PROJECT_VERSION = 311;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -5621,7 +5621,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -5658,7 +5658,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 310;
+				CURRENT_PROJECT_VERSION = 311;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -5680,7 +5680,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -5843,7 +5843,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 310;
+				CURRENT_PROJECT_VERSION = 311;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -5870,7 +5870,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "Ad Hoc 2";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Ad Hoc 2";
@@ -5904,7 +5904,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 310;
+				CURRENT_PROJECT_VERSION = 311;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -5931,7 +5931,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "App Store";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "App Store 2";
@@ -5966,7 +5966,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 310;
+				CURRENT_PROJECT_VERSION = 311;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -5992,7 +5992,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_NAME = Palace;
 				PROVISIONING_PROFILE_SPECIFIER = "Ad Hoc 2";
@@ -6027,7 +6027,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 310;
+				CURRENT_PROJECT_VERSION = 311;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -6053,7 +6053,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_NAME = Palace;
 				PROVISIONING_PROFILE_SPECIFIER = "App Store";

--- a/Palace/Accounts/AgeCheck/TPPAgeCheck.swift
+++ b/Palace/Accounts/AgeCheck/TPPAgeCheck.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol TPPAgeCheckValidationDelegate: class {
+protocol TPPAgeCheckValidationDelegate: AnyObject {
   var minYear : Int { get }
   var currentYear : Int { get }
   var birthYearList : [Int] { get }

--- a/Palace/Announcements/TPPAnnouncementBusinessLogic.swift
+++ b/Palace/Announcements/TPPAnnouncementBusinessLogic.swift
@@ -63,7 +63,7 @@ class TPPAnnouncementBusinessLogic {
     }
     
     do {
-      let codedData = NSKeyedArchiver.archivedData(withRootObject: presentedAnnouncements)
+      let codedData = try NSKeyedArchiver.archivedData(withRootObject: presentedAnnouncements, requiringSecureCoding: false)
       try codedData.write(to: filePathURL)
     } catch {
       TPPErrorLogger.logError(error,

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -103,7 +103,7 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
     if let url = userActivity.webpageURL {
-      return DynamicLinks.dynamicLinks().handleUniversalLink(url) { [weak self] dynamicLink, error in
+      return DynamicLinks.dynamicLinks().handleUniversalLink(url) { dynamicLink, error in
         if let error = error {
           Log.error(error.localizedDescription, "Dynamic Link error")
           return

--- a/Palace/AppInfrastructure/TPPUserNotifications.swift
+++ b/Palace/AppInfrastructure/TPPUserNotifications.swift
@@ -4,7 +4,6 @@ let HoldNotificationCategoryIdentifier = "NYPLHoldToReserveNotificationCategory"
 let CheckOutActionIdentifier = "NYPLCheckOutNotificationAction"
 let DefaultActionIdentifier = "UNNotificationDefaultActionIdentifier"
 
-@available (iOS 10.0, *)
 @objcMembers class TPPUserNotifications: NSObject
 {
   typealias DisplayStrings = Strings.UserNotifications

--- a/Palace/Book/Models/TPPBook.swift
+++ b/Palace/Book/Models/TPPBook.swift
@@ -415,3 +415,5 @@ extension TPPBook: Comparable {
     lhs.identifier < rhs.identifier
   }
 }
+
+extension TPPBook: @unchecked Sendable {}

--- a/Palace/Book/UI/AudiobookSampleToolbar.swift
+++ b/Palace/Book/UI/AudiobookSampleToolbar.swift
@@ -124,11 +124,12 @@ struct AudiobookSampleToolbar: View {
   }
 
   @ViewBuilder private var loadingView: some View {
+    withAnimation {
       ProgressView()
         .progressViewStyle(CircularProgressViewStyle())
         .scaleEffect(1.25)
         .transition(.opacity)
-        .animation(.easeInOut)
+    }
   }
 }
 

--- a/Palace/Book/UI/TPPBookCellDelegate.m
+++ b/Palace/Book/UI/TPPBookCellDelegate.m
@@ -150,14 +150,36 @@
         [TPPAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:nil animated:YES completion:nil];
         return;
       }
+
+      if (!encryptedUrl) {
+        NSError *urlError = [NSError errorWithDomain:@"com.Palace.pdf" code:1001 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid encrypted URL", nil)}];
+        NSString *errorMessage = NSLocalizedString(@"Error extracting encrypted PDF file", nil);
+        [TPPErrorLogger logError:urlError
+                         summary:errorMessage
+                        metadata:@{ @"error": urlError }];
+        UIAlertController *alert = [TPPAlertUtils alertWithTitle:errorMessage error:urlError];
+        [TPPAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:nil animated:YES completion:nil];
+        return;
+      }
+
       NSData *encryptedData = [[NSData alloc] initWithContentsOfURL:encryptedUrl options:NSDataReadingMappedAlways error:nil];
+      if (!encryptedData) {
+        NSError *dataError = [NSError errorWithDomain:@"com.Palace.pdf" code:1002 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to load encrypted PDF data", nil)}];
+        NSString *errorMessage = NSLocalizedString(@"Error extracting encrypted PDF file", nil);
+        [TPPErrorLogger logError:dataError
+                         summary:errorMessage
+                        metadata:@{ @"error": dataError }];
+        UIAlertController *alert = [TPPAlertUtils alertWithTitle:errorMessage error:dataError];
+        [TPPAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:nil animated:YES completion:nil];
+        return;
+      }
 
       TPPPDFDocumentMetadata *metadata = [[TPPPDFDocumentMetadata alloc] initWith:book];
 
       TPPPDFDocument *document = [[TPPPDFDocument alloc] initWithEncryptedData:encryptedData decryptor:^NSData * _Nonnull(NSData *data, NSUInteger start, NSUInteger end) {
         return [decryptor decryptDataWithData:data start:start end:end];
       }];
-      
+
       UIViewController *vc = [TPPPDFViewController createWithDocument:document metadata:metadata];
       [[TPPRootTabBarController sharedController] pushViewController:vc animated:YES];
     }];

--- a/Palace/MyBooks/MyBooks/MyBooksView.swift
+++ b/Palace/MyBooks/MyBooks/MyBooksView.swift
@@ -75,7 +75,11 @@ struct MyBooksView: View {
     HStack {
       TextField(DisplayStrings.searchBooks, text: $model.searchQuery)
         .searchBarStyle()
-        .onChange(of: model.searchQuery, perform: model.filterBooks)
+        .onChange(of: model.searchQuery) { query in
+          Task {
+            await model.filterBooks(query: query)
+          }
+        }
       Button(action: clearSearch, label: {
         Image(systemName: "xmark.circle.fill")
           .foregroundColor(.gray)
@@ -110,8 +114,10 @@ struct MyBooksView: View {
   }
 
   private func clearSearch() {
-    model.searchQuery = ""
-    model.filterBooks(query: "")
+    Task {
+      model.searchQuery = ""
+      await model.filterBooks(query: "")
+    }
   }
 
   private var loadingOverlay: some View {

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -854,7 +854,9 @@ extension MyBooksDownloadCenter: URLSessionTaskDelegate {
                          readiumBookmarks: nil,
                          genericBookmarks: nil)
 
-    NotificationCenter.default.post(name: .TPPMyBooksDownloadCenterDidChange, object: self)
+    DispatchQueue.main.async {
+      NotificationCenter.default.post(name: .TPPMyBooksDownloadCenterDidChange, object: self)
+    }
   }
 }
 

--- a/Palace/Network/TPPRequestExecuting.swift
+++ b/Palace/Network/TPPRequestExecuting.swift
@@ -35,7 +35,8 @@ extension TPPRequestExecuting {
   static var defaultRequestTimeout: TimeInterval {
     return TPPDefaultRequestTimeout
   }
-  
+
+  @discardableResult
   func executeRequest(_ req: URLRequest,
                       useTokenIfAvailable: Bool = true,
                       completion: @escaping (_: NYPLResult<Data>) -> Void) -> URLSessionDataTask {

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -52,7 +52,12 @@ protocol AnnotationsManager {
     }
 
     let bookmarks = await withCheckedContinuation { continuation in
+      var didResume = false
+
       getServerBookmarks(forBook: book, atURL: url, motivation: .readingProgress) { bookmarks in
+        guard !didResume else { return }
+        didResume = true
+
         continuation.resume(returning: bookmarks)
       }
     }
@@ -229,7 +234,7 @@ protocol AnnotationsManager {
       Log.error(#file, "No Annotation ID saved: No data received from server.")
       return nil
     }
-    guard let json = try? JSONSerialization.jsonObject(with: data, options: []) as! [String:Any] else {
+    guard let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String:Any] else {
       Log.error(#file, "No Annotation ID saved: JSON could not be created from data.")
       return nil
     }
@@ -246,7 +251,7 @@ protocol AnnotationsManager {
       Log.error(#file, "No Annotation ID saved: No data received from server.")
       return nil
     }
-    guard let json = try? JSONSerialization.jsonObject(with: data, options: []) as! [String:Any] else {
+    guard let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String:Any] else {
       Log.error(#file, "No Annotation ID saved: JSON could not be created from data.")
       return nil
     }

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
@@ -47,14 +47,16 @@ extension AdobeCertificate {
   }
     
   /// Default certificate for Palace app.
-  @objc static var defaultCertificate: AdobeCertificate? {
-    guard let adobeCertUrl = Bundle.main.url(forResource: "ReaderClientCert", withExtension: "sig"),
-          let adobeCertData = try? Data(contentsOf: adobeCertUrl) else {
+  @objc static var defaultCertificate: AdobeCertificate? = {
+    let bundle: Bundle = (ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil) ? Bundle(for: TPPAppDelegate.self) : Bundle.main
+    guard let adobeCertUrl = bundle.url(forResource: "ReaderClientCert", withExtension: "sig"),
+          let adobeCertData = try? Data(contentsOf: adobeCertUrl),
+          !adobeCertData.isEmpty else {
       return nil
     }
     return AdobeCertificate(data: adobeCertData)
-  }
-  
+  }()
+
   /// Initialise with Adobe DRM certificate data.
   /// - Parameter data: `ReaderClientCert.sig` data.
   @objc convenience init?(data: Data) {

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
@@ -139,7 +139,7 @@ extension AdobeDRMContainer: Container {
   }
 
   private func readDataFromArchive(at path: String) -> Data? {
-    guard let fileURL, let archive = try? Archive(url: fileURL, accessMode: .read, pathEncoding: nil) else {
+    guard let fileURL, let archive = Archive(url: fileURL, accessMode: .read) else {
       return nil
     }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,8 @@ default_platform(:ios)
 
 platform :ios do
   lane :test do
+    ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "60"
+    ENV["FASTLANE_XCODEBUILD_SETTINGS_RETRIES"] = "4"
     run_tests(
       project: "Palace.xcodeproj",
       devices: ["iPhone SE (3rd generation)"],


### PR DESCRIPTION
**What's this do?**
- Resolves MyBooksViewModel.loadData crash
- Resolves TPPAnnotations.syncReadingPosition crash
- Resolves TPPBookRegistry concurrency issues
- Cleans up TPPBookCellDelegate openPDF crash
- Cleans up several compiler warnings

**Why are we doing this? (w/ Notion link if applicable)**
https://ebce-lyrasis.atlassian.net/browse/PP-1924

**How should this be tested? / Do these changes have associated tests?**
Watch crashlytics to observe release

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new Palace build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@mauricecarrier7 