### PR TITLE
Fix unsupported OD holds appearing in my books (PP-2154)

### DIFF
--- a/Palace/Book/Models/TPPBookRegistryRecord.swift
+++ b/Palace/Book/Models/TPPBookRegistryRecord.swift
@@ -28,8 +28,7 @@ class TPPBookRegistryRecord: NSObject {
     self.genericBookmarks = genericBookmarks
     
     super.init()
-    
-    var actuallyOnHold = false
+
     if let defaultAcquisition = book.defaultAcquisition {
       defaultAcquisition.availability.matchUnavailable { _ in
         
@@ -39,10 +38,8 @@ class TPPBookRegistryRecord: NSObject {
         
       } reserved: { [weak self] _ in
         self?.state = .holding
-        actuallyOnHold = true
       } ready: { [weak self] _ in
         self?.state = .holding
-        actuallyOnHold = true
       }
 
     } else {
@@ -55,15 +52,6 @@ class TPPBookRegistryRecord: NSObject {
       // using another app.
       self.state = .unsupported
     }
-    
-    if !actuallyOnHold {
-      if self.state == .holding || self.state == .unsupported {
-        // Since we're not in some download-related state and we're not unregistered,
-        // we must need to be downloaded.
-        self.state = .downloadNeeded
-      }
-    }
-    
   }
   
   init?(record: TPPBookRegistryData) {


### PR DESCRIPTION
**What's this do?**

If you take out a hold on Overdrive content that isn't supported in the Libby app, its showing up in Palace as downloadable. This updates that logic to make sure that it doesn't end up in that state.

Note: I tried to sort out exactly why the code I pulled out was here, but I don't understand what we were checking for with the `actuallyOnHold` flag, which makes me a bit nervous. Let me know if this looks like it will cause any problems to you.

**Why are we doing this? (w/ Notion link if applicable)**

See JIRA: [PP-2154](https://ebce-lyrasis.atlassian.net/browse/PP-2154)

**How should this be tested? / Do these changes have associated tests?**

I've got a barcode where this is currently happening I can share. Holds that are currently showing up in the my books screen should not be shown at all.

**Dependencies for merging? Releasing to production?**

None.

**Does this include changes that require a new Palace build for QA?**

Might be good to have this go out in a new build so Courtney / Carissa can verify it.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**

I did against the barcode i mentioned earlier.


[PP-2154]: https://ebce-lyrasis.atlassian.net/browse/PP-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ