### PR TITLE
Update adobe build scripts (PP-2494)

### DIFF
--- a/scripts/build-openssl-curl.sh
+++ b/scripts/build-openssl-curl.sh
@@ -20,29 +20,36 @@ SDKVERSION=`xcodebuild -version -sdk iphoneos | grep SDKVersion | sed 's/SDKVers
 
 # edit as required if OpenSSL and cURL need updating or retargeting
 OPENSSL_VERSION="1.1.0e"
-OPENSSL_URL="https://www.openssl.org/source/old/1.1.0/openssl-1.1.0e.tar.gz"
+OPENSSL_URL="https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_0e/openssl-1.1.0e.tar.gz"
 CURL_VERSION="7.64.1"
 CURL_URL="https://curl.se/download/curl-7.64.1.zip"
 
 echo "======================================="
 echo "Building OpenSSL..."
-cd adobe-rmsdk/thirdparty/openssl
-mkdir -p public
-[ -d "iOS-openssl" ] && [ ! -d "public/ios" ] && mv iOS-openssl public/ios
-cd public/ios
-curl -O $OPENSSL_URL
+pushd adobe-rmsdk/thirdparty/openssl
+rm -Rf public
+cd iOS-openssl
+curl -OL $OPENSSL_URL
 sed -i '' "s/OPENSSL_VERSION=\".*\"/OPENSSL_VERSION=\"$OPENSSL_VERSION\"/" build_openssl.sh
 sed -i '' "s/SDK_VERSION=\".*\"/SDK_VERSION=\"$SDKVERSION\"/" build_openssl.sh
 sed -i '' 's/MIN_VERSION=".*"/MIN_VERSION="9.0"/' build_openssl.sh
 bash ./build_openssl.sh  #this will take a while
+rm "openssl-${OPENSSL_VERSION}.tar.gz"
+rm build_openssl.sh
+popd
 
 echo "======================================="
 echo "Building cURL..."
-cd ../../../curl/iOS-libcurl
-curl -O $CURL_URL
+pushd adobe-rmsdk/thirdparty/curl
+rm -Rf public
+cd iOS-libcurl
+curl -OL $CURL_URL
 sed -i '' "s/CURL_VERSION=\".*\"/CURL_VERSION=\"$CURL_VERSION\"/" build_curl.sh
 sed -i '' "s/SDK_VERSION=\".*\"/SDK_VERSION=\"$SDKVERSION\"/" build_curl.sh
 sed -i '' 's/MIN_VERSION=".*"/MIN_VERSION="9.0"/' build_curl.sh
 bash ./build_curl.sh  #this will take a while
+rm "curl-${CURL_VERSION}.zip"
+rm build_curl.sh
+popd
 
 echo "Finished building OpenSSL and cURL."

--- a/scripts/build_curl.sh
+++ b/scripts/build_curl.sh
@@ -85,8 +85,6 @@ build()
     rm -rf "curl-${CURL_VERSION}"
 }
 
-build "armv7-apple-darwin"  "armv7"  "${IPHONEOS_SDK}" ""
-build "armv7s-apple-darwin" "armv7s" "${IPHONEOS_SDK}" ""
 build "arm-apple-darwin"    "arm64"  "${IPHONEOS_SDK}" ""
 build "i386-apple-darwin"   "i386"   "${IPHONESIMULATOR_SDK}" "-D__IPHONE_OS_VERSION_MIN_REQUIRED=${IPHONEOS_DEPLOYMENT_TARGET%%.*}0000"
 build "x86_64-apple-darwin" "x86_64" "${IPHONESIMULATOR_SDK}" "-D__IPHONE_OS_VERSION_MIN_REQUIRED=${IPHONEOS_DEPLOYMENT_TARGET%%.*}0000"
@@ -95,8 +93,6 @@ mkdir -p ../public/ios/lib ../public/ios/include-32 ../public/ios/include-64
 cp -r /tmp/curl-${CURL_VERSION}-i386/include/curl ../public/ios/include-32/
 cp -r /tmp/curl-${CURL_VERSION}-x86_64/include/curl ../public/ios/include-64/
 lipo \
-"/tmp/curl-${CURL_VERSION}-armv7/lib/libcurl.a" \
-"/tmp/curl-${CURL_VERSION}-armv7s/lib/libcurl.a" \
 "/tmp/curl-${CURL_VERSION}-arm64/lib/libcurl.a" \
 "/tmp/curl-${CURL_VERSION}-i386/lib/libcurl.a" \
 "/tmp/curl-${CURL_VERSION}-x86_64/lib/libcurl.a" \

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -74,7 +74,7 @@ build()
    SDK=$4
    EXTRA=$5
    rm -rf "openssl-${OPENSSL_VERSION}"
-   tar xfz "openssl-${OPENSSL_VERSION}.tar.gz"
+   tar xvfz "openssl-${OPENSSL_VERSION}.tar.gz"
    pushd .
    cd "openssl-${OPENSSL_VERSION}"
    sed -i '' "s#'File::Glob' => qw/glob/;#'File::Glob' => qw/bsd_glob/;#g" ./Configure
@@ -96,24 +96,24 @@ build "BSD-generic64" "x86_64" "${IPHONESIMULATOR_GCC}" "${IPHONESIMULATOR_SDK}"
 
 #
 
-mkdir include
-cp -r /tmp/openssl-${OPENSSL_VERSION}-i386/include/openssl include/
+mkdir -p ../public/ios/include
+cp -r /tmp/openssl-${OPENSSL_VERSION}-i386/include/openssl ../public/ios/include/
 
-mkdir lib
+mkdir -p ../public/ios/lib
 lipo \
 	"/tmp/openssl-${OPENSSL_VERSION}-armv7/lib/libcrypto.a" \
 	"/tmp/openssl-${OPENSSL_VERSION}-armv7s/lib/libcrypto.a" \
 	"/tmp/openssl-${OPENSSL_VERSION}-arm64/lib/libcrypto.a" \
 	"/tmp/openssl-${OPENSSL_VERSION}-i386/lib/libcrypto.a" \
 	"/tmp/openssl-${OPENSSL_VERSION}-x86_64/lib/libcrypto.a" \
-	-create -output lib/libcrypto.a
+	-create -output ../public/ios/lib/libcrypto.a
 lipo \
 	"/tmp/openssl-${OPENSSL_VERSION}-armv7/lib/libssl.a" \
 	"/tmp/openssl-${OPENSSL_VERSION}-armv7s/lib/libssl.a" \
 	"/tmp/openssl-${OPENSSL_VERSION}-arm64/lib/libssl.a" \
 	"/tmp/openssl-${OPENSSL_VERSION}-i386/lib/libssl.a" \
 	"/tmp/openssl-${OPENSSL_VERSION}-x86_64/lib/libssl.a" \
-	-create -output lib/libssl.a
+	-create -output ../public/ios/lib/libssl.a
 
 rm -rf "/tmp/openssl-${OPENSSL_VERSION}-*"
 rm -rf "/tmp/openssl-${OPENSSL_VERSION}-*.*-log"


### PR DESCRIPTION
**What's this do?**

Update the adobe build scripts, these are the scripts that were used to produce:
https://github.com/ThePalaceProject/mobile-drm-adeptconnector/pull/5

**Why are we doing this? (w/ Notion link if applicable)**

JIRA: PP-2494

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Does this include changes that require a new Palace build for QA?**
[Bump the Palace build number to generate a new build on ThePalaceProject/ios-binaries]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
