### PR TITLE
Fix upload workflow: download iOS SDK and propagate build failures

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -69,6 +69,10 @@ jobs:
         with:
           xcode-version: '26'
 
+      - name: Download iOS platform SDK
+        run: xcodebuild -downloadPlatform iOS
+        timeout-minutes: 15
+
       - name: 📋 Log Xcode & Swift Info
         run: |
           echo "## 🔧 Toolchain Versions" >> $GITHUB_STEP_SUMMARY
@@ -162,6 +166,7 @@ jobs:
 
       - name: Export to binaries (Ad Hoc)
         id: export-adhoc
+        shell: bash -eo pipefail {0}
         run: |
           echo "## 📱 Ad Hoc Export" >> $GITHUB_STEP_SUMMARY
           ./scripts/xcode-export-adhoc.sh 2>&1 | tee adhoc-export.log
@@ -203,6 +208,7 @@ jobs:
 
       - name: Export for App Store
         id: export-appstore
+        shell: bash -eo pipefail {0}
         run: |
           echo "## 🚀 App Store Export" >> $GITHUB_STEP_SUMMARY
           ./scripts/xcode-export-appstore.sh 2>&1 | tee appstore-export.log


### PR DESCRIPTION
## Summary

The Palace Manual Build workflow was silently producing no artifact and reporting success. Two independent bugs caused this:

**Bug 1 — iOS 26.4 platform not installed on runner**
The `macos-26` runner has `Xcode_26.4_Release_Candidate.app` but the iOS 26.4 platform component (device support / SDK) is not pre-downloaded inside it. Every `xcodebuild archive` call fails immediately with `iOS 26.4 is not installed`. Fix: add an explicit `xcodebuild -downloadPlatform iOS` step after Xcode is selected.

**Bug 2 — `| tee` swallowed build script exit codes**
`./scripts/xcode-export-adhoc.sh 2>&1 | tee adhoc-export.log` exits with `tee`'s exit code (always 0), not the script's. A completely failed build appeared green, downstream steps ran against no artifact, and the job reported overall success. Fix: add `shell: bash -eo pipefail {0}` to both build steps so a non-zero exit from the script fails the step correctly.

## Test plan
- [ ] Trigger Palace Manual Build — confirm the "Download iOS platform SDK" step completes cleanly
- [ ] Confirm the ad hoc and App Store export steps fail loudly if xcodebuild fails (rather than silently passing)
- [ ] Confirm a successful run produces a build in TestFlight

Made with [Cursor](https://cursor.com)