### PR TITLE
Add release-rc workflow to cut prereleases from release/* branches

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,68 @@
+name: Palace Release Candidate
+on:
+  workflow_dispatch:
+jobs:
+  create-rc:
+    runs-on: macos-26
+    steps:
+      - name: Guard branch
+        run: |
+          if [[ "${GITHUB_REF_NAME}" != release/* ]]; then
+            echo "::error::release-rc must be dispatched from a release/* branch (got ${GITHUB_REF_NAME})"
+            exit 1
+          fi
+      - name: Set up Xcode 26
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26'
+      - name: Verify Xcode Version
+        run: xcodebuild -version
+      - name: Checkout release branch and submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
+      - name: Checkout Certificates
+        uses: actions/checkout@v3
+        with:
+          repository: ThePalaceProject/mobile-certificates
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
+          path: ./mobile-certificates
+      - name: Create release notes
+        run: ./scripts/create-release-notes.sh
+        env:
+          BUILD_CONTEXT: ci
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
+      - name: Verify path and version
+        run: |
+          echo "Release notes path: $RELEASE_NOTES_PATH"
+          cat "$RELEASE_NOTES_PATH"
+          echo "Version: $VERSION_NUM"
+      - name: Guard against clobbering shipped release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$VERSION_NUM" > /dev/null 2>&1; then
+            IS_PRERELEASE=$(gh release view "$VERSION_NUM" --json isPrerelease --jq .isPrerelease)
+            if [ "$IS_PRERELEASE" != "true" ]; then
+              echo "::error::Release $VERSION_NUM already exists and is NOT a prerelease. Bump VERSION_NUM on this branch before re-running."
+              exit 1
+            fi
+          fi
+      - name: Create or update prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$VERSION_NUM" > /dev/null 2>&1; then
+            gh release edit "$VERSION_NUM" \
+              --prerelease \
+              --target "$GITHUB_REF_NAME" \
+              --title "$VERSION_NUM (RC)" \
+              --notes-file "$RELEASE_NOTES_PATH"
+          else
+            gh release create "$VERSION_NUM" \
+              --prerelease \
+              --target "$GITHUB_REF_NAME" \
+              --title "$VERSION_NUM (RC)" \
+              --notes-file "$RELEASE_NOTES_PATH"
+          fi


### PR DESCRIPTION
## Summary
Adds `.github/workflows/release-rc.yml`, a `workflow_dispatch`-only workflow that cuts a **GitHub prerelease** from a `release/*` branch using the existing `scripts/create-release-notes.sh` machinery.

This unlocks the backend/Android release pattern for iOS:
1. Cut `release/x.y.z` from develop
2. Dispatch `release-rc.yml` against the release branch → prerelease `x.y.z` is created
3. Existing `jira-release-sync.yml` fires on the `release: published` event and auto-tags every `PP-####` ticket in the notes with `fixVersions = iOS x.y.z` — **QA now knows exactly what to validate, automatically**
4. Bugfix on the release branch → bump Info.plist to `x.y.z.1` → re-dispatch → new prerelease, Jira sync picks up the delta
5. When viable, merge `release/x.y.z` → main as today; existing `release-on-merge.yml` cuts the final (non-prerelease) version

## Why this PR exists
`workflow_dispatch` workflows must exist on the **default branch** before GitHub will accept a dispatch from any branch. This PR is the one-time bootstrap. After merge, future RC cuts need no further changes to main.

## Safety notes
- Trigger is `workflow_dispatch` only — nothing fires on push/PR
- Hard-guarded to `release/*` branches (fails fast otherwise)
- Refuses to clobber an existing non-prerelease tag with the same `VERSION_NUM`
- Inert on `main` — only does work when explicitly dispatched against a release branch
- No changes to `create-release-notes.sh`, `release-notes.sh`, or `jira-release-sync.yml`

## Test plan
- [ ] Merge to main
- [ ] `gh workflow run release-rc.yml --ref release/2.2.5`
- [ ] Verify prerelease `2.2.5` created on the release branch's HEAD
- [ ] Verify `jira-release-sync.yml` fires and tags PP tickets with `iOS 2.2.5`