### PR TITLE
Fix cross-account credential contamination: per-account TPPUserAccount instances

### DIFF
--- a/.specterqa/REGRESSION_PLAN.md
+++ b/.specterqa/REGRESSION_PLAN.md
@@ -1,0 +1,84 @@
+# SpecterQA Automated Regression Plan
+
+**Mirrors:** PP-4020 manual regression test plan at ~/Desktop/regression-PP-4020/PLAN.md
+**Branch:** fix/per-account-user-credentials (combined: whole-shot + all PRs)
+**Simulator:** iPhone 12 (31CF5C43-DD55-4889-B3B2-9A6810B4E98F, iOS 26)
+
+## Execution Order
+
+Run journeys in this order. Each journey starts a fresh SpecterQA session.
+Kill stale runners between sessions: `pgrep -f "xcodebuild test-without-building" | xargs -r kill -9`
+
+### Tier 1: Critical Path (must pass before any release)
+
+| # | Test Area | Journey | PP-4020 IDs |
+|---|-----------|---------|-------------|
+| 1 | App launch | app-launch.yaml | Smoke |
+| 2 | Tab navigation | tab-navigation.yaml | Smoke |
+| 3 | Catalog browsing | catalog-browsing.yaml | C7 |
+| 4 | Search | search-flow.yaml | C1 |
+| 5 | Sign in | sign-in-basic.yaml | A1 |
+| 6 | Borrow book | borrow-book.yaml | C2 |
+| 7 | Return loan | return-loan.yaml | C6 |
+| 8 | Book detail | book-detail.yaml | C2, U1 |
+| 9 | EPUB reading | epub-reading.yaml | R1 |
+| 10 | Audiobook playback | audiobook-playback.yaml | L1-L4 |
+| 11 | Place/cancel hold | place-hold.yaml | C3, C4, PP-4033 |
+| 12 | Sign out | sign-out.yaml | A3 |
+
+### Tier 2: Multi-account and Security
+
+| # | Test Area | Journey | PP-4020 IDs |
+|---|-----------|---------|-------------|
+| 13 | Add library | library-picker.yaml | M1 |
+| 14 | Switch library | switch-library.yaml | M2 |
+| 15 | Credential isolation | credential-isolation.yaml | M3, F-034, ADV-1 |
+
+### Tier 3: Edge Cases and Persistence
+
+| # | Test Area | Journey | PP-4020 IDs |
+|---|-----------|---------|-------------|
+| 16 | Offline mode | offline-mode.yaml | N1 |
+| 17 | Catalog filter | catalog-filter.yaml | C7 |
+| 18 | Settings screen | settings-screen.yaml | U1 |
+| 19 | Bookmarks | bookmark-add-and-restore.yaml | P1 |
+| 20 | Reading position | persistence-reading-position.yaml | P2 |
+| 21 | Book transactions | book-transactions.yaml | D1-D4 |
+| 22 | Feed refresh | feed-refresh.yaml | C7 |
+| 23 | Smoke test | smoke-test.yaml | Full |
+
+### Not Automatable via SpecterQA
+
+| Test Area | PP-4020 ID | Reason |
+|-----------|------------|--------|
+| Phone call interruption | B2 | Requires real phone call |
+| Notifications | NT1-NT3 | Requires APNs push |
+| Multi-device sync | P5 | Requires second device |
+| Performance profiling | PR1-PR5 | Requires Instruments |
+| Hold conversion | C5 | Requires waiting for availability |
+| Adversarial rapid switch | M5, ADV-1 | Partially covered by credential-isolation; full concurrent stress requires unit tests |
+
+## Coverage Summary
+
+| Category | Total Tests | Automated | Manual Only |
+|----------|------------|-----------|-------------|
+| Authentication (A1-A4) | 4 | 2 (sign-in, sign-out) | 2 (JIT popup, error states) |
+| Reading (R1-R4) | 4 | 1 (EPUB) | 3 (Adobe, LCP, PDF need specific content) |
+| Listening (L1-L4) | 4 | 1 (generic) | 3 (vendor-specific) |
+| Catalog (C1-C7) | 7 | 6 | 1 (hold conversion) |
+| Multi-account (M1-M5) | 5 | 4 | 1 (adversarial, unit test) |
+| Connectivity (N1-N4) | 4 | 1 (offline) | 3 |
+| Downloads (D1-D4) | 4 | 1 (transactions) | 3 |
+| Background audio (B1-B6) | 6 | 0 | 6 |
+| Notifications (NT1-NT3) | 3 | 0 | 3 |
+| Persistence (P1-P5) | 5 | 2 (bookmarks, position) | 3 |
+| UI completeness (U1) | 1 | 0 (partial via snapshots) | 1 |
+| Performance (PR1-PR5) | 5 | 0 | 5 |
+| **Total** | **52** | **18 (35%)** | **34** |
+
+## New Journeys Added
+
+- `place-hold.yaml` - C3, C4, PP-4033
+- `return-loan.yaml` - C6
+- `credential-isolation.yaml` - M3, F-034, ADV-1
+- `persistence-reading-position.yaml` - P1, P2

--- a/.specterqa/journeys/credential-isolation.yaml
+++ b/.specterqa/journeys/credential-isolation.yaml
@@ -1,0 +1,59 @@
+# Credential isolation across accounts. Covers M3, F-034, ADV-1.
+scenario:
+  id: credential-isolation
+  name: "Multi-Account Credential Isolation"
+  description: "Verify that signing into two libraries keeps credentials isolated and switching does not cross-contaminate."
+  tags: [tier1, ios, security, AUTH-002, F-034, ADV-1]
+
+  personas:
+    - ref: ios_tester
+      role: primary
+
+  steps:
+    - id: sign_in_library_a
+      description: "Sign into A1QA Test Library"
+      goal: >
+        Navigate to Settings > Libraries > A1QA Test Library. Sign in with the
+        test barcode and PIN from ~/.specterqa/credentials/a1qa-test.env. Verify
+        signed-in state shows the correct barcode. Note the barcode value shown.
+      checkpoint: library_a_signed_in
+      max_iterations: 20
+
+    - id: add_second_library
+      description: "Add and sign into a second library"
+      goal: >
+        Go to Settings > Libraries > Add Library. Find and add "Lyrasis Reads"
+        or "Palace Bookshelf". If the library requires sign-in, sign in with
+        the test credentials. Return to the library list.
+      checkpoint: library_b_added
+      max_iterations: 20
+
+    - id: switch_to_library_b
+      description: "Switch to the second library"
+      goal: >
+        Tap on the second library to make it the active library. Navigate to the
+        Catalog tab and confirm the catalog loads for the second library. The
+        tab bar and content should reflect the second library.
+      checkpoint: library_b_active
+      max_iterations: 15
+
+    - id: verify_library_a_credentials
+      description: "Switch back and verify A1QA credentials are intact"
+      goal: >
+        Go to Settings > Libraries > A1QA Test Library. Verify the account
+        screen shows the same barcode as step 1. The barcode should NOT show
+        the second library's credentials. The user should still be signed in.
+        No sign-in modal should appear.
+      checkpoint: library_a_credentials_intact
+      max_iterations: 15
+
+    - id: rapid_switch
+      description: "Rapidly switch between libraries"
+      goal: >
+        Switch between the two libraries 3-4 times in quick succession by
+        tapping between them in the library list. After the rapid switches,
+        verify A1QA still shows the correct barcode and the second library
+        still shows its correct state. No 401 errors, no sign-in modals,
+        no credential bleed.
+      checkpoint: credentials_stable_after_switching
+      max_iterations: 20

--- a/.specterqa/journeys/persistence-reading-position.yaml
+++ b/.specterqa/journeys/persistence-reading-position.yaml
@@ -1,0 +1,38 @@
+# Reading position persistence across app relaunch. Covers P1, P2.
+scenario:
+  id: persistence-reading-position
+  name: "Reading Position Persists Across Relaunch"
+  description: "Verify that EPUB reading position and bookmarks survive an app relaunch."
+  tags: [tier2, ios, persistence, BOOK-006]
+
+  personas:
+    - ref: ios_tester
+      role: primary
+
+  steps:
+    - id: open_epub
+      description: "Open a borrowed EPUB and advance to a non-first page"
+      goal: >
+        Navigate to My Books. If no books are borrowed, borrow one from the
+        Catalog first. Open an EPUB book. Swipe or tap to advance at least
+        3-4 pages past the beginning. Note the current page number or chapter
+        heading visible on screen.
+      checkpoint: reading_position_noted
+      max_iterations: 20
+
+    - id: close_reader
+      description: "Close the reader and return to My Books"
+      goal: >
+        Close the EPUB reader by navigating back (back button or swipe-back
+        gesture). Return to the My Books screen.
+      checkpoint: reader_closed
+      max_iterations: 10
+
+    - id: reopen_book
+      description: "Reopen the same book"
+      goal: >
+        Tap the same book in My Books to reopen it. Verify the reader opens
+        to the same page or chapter that was noted in step 1, not the
+        beginning of the book. The reading position should have persisted.
+      checkpoint: position_restored
+      max_iterations: 15

--- a/.specterqa/journeys/place-hold.yaml
+++ b/.specterqa/journeys/place-hold.yaml
@@ -1,0 +1,50 @@
+# Place and cancel a hold. Covers C3, C4, PP-4033.
+scenario:
+  id: place-hold
+  name: "Place and Cancel a Hold"
+  description: "Verify a user can place a hold on an unavailable book, see it in Holds, and cancel it."
+  tags: [tier1, ios, critical_path, HOLD-001, PP-4033]
+
+  personas:
+    - ref: ios_tester
+      role: primary
+
+  steps:
+    - id: find_holdable_book
+      description: "Find a book that requires a hold (not immediately available)"
+      goal: >
+        Launch the Palace app on A1QA Test Library. Navigate to the Catalog tab.
+        Search for "MySQL Cookbook" or browse until you find a book with a
+        "Reserve" or "Place Hold" button (not "Borrow" or "Get"). Tap on the
+        book to open its detail screen.
+      checkpoint: holdable_book_detail
+      max_iterations: 20
+
+    - id: place_hold
+      description: "Place the hold"
+      goal: >
+        Tap the "Reserve" or "Place Hold" button. Wait for the action to complete.
+        The button should change to indicate the hold was placed (e.g., "Cancel Hold"
+        or "Remove Hold" or "Manage Hold"). No error alerts should appear.
+      checkpoint: hold_placed
+      max_iterations: 15
+
+    - id: verify_in_holds
+      description: "Navigate to Holds and verify the book appears"
+      goal: >
+        Tap the "Holds" or "Reservations" tab in the bottom tab bar. Confirm the
+        Holds screen now shows the book that was just held. The book title should
+        be visible.
+      checkpoint: book_in_holds
+      max_iterations: 15
+
+    - id: cancel_hold
+      description: "Cancel the hold"
+      goal: >
+        On the Holds screen, find the held book. Tap "Manage Hold" or the book
+        itself to see options. Tap "Cancel Hold" or "Remove Hold". If a
+        confirmation dialog appears, confirm it. Wait for the action to complete.
+        The book should be removed from the Holds list. No silent failures --
+        if something goes wrong, an error message should appear.
+      checkpoint: hold_cancelled
+      max_iterations: 20

--- a/.specterqa/journeys/return-loan.yaml
+++ b/.specterqa/journeys/return-loan.yaml
@@ -1,0 +1,47 @@
+# Return a loan early. Covers C6.
+scenario:
+  id: return-loan
+  name: "Return a Loan Early"
+  description: "Verify a user can return a borrowed book before the loan expires."
+  tags: [tier1, ios, critical_path, BOOK-005]
+
+  personas:
+    - ref: ios_tester
+      role: primary
+
+  steps:
+    - id: ensure_borrowed_book
+      description: "Navigate to My Books and find a borrowed book"
+      goal: >
+        Launch the Palace app. Tap the "My Books" tab. If the list is empty,
+        go to Catalog, borrow a book first, then return to My Books. Confirm
+        at least one borrowed book is visible.
+      checkpoint: borrowed_book_visible
+      max_iterations: 20
+
+    - id: open_book_detail
+      description: "Open the borrowed book's detail"
+      goal: >
+        Tap on the borrowed book in My Books to open its detail screen.
+        Confirm the detail screen shows the book title and a "Return" button
+        or a menu that includes "Return".
+      checkpoint: return_button_visible
+      max_iterations: 10
+
+    - id: return_book
+      description: "Return the book"
+      goal: >
+        Tap the "Return" button. If a confirmation dialog appears ("Return Loan"
+        or similar), confirm it. Wait for the action to complete. The book
+        should be removed and the view should navigate back or show the book
+        as returned. No error alerts should appear.
+      checkpoint: book_returned
+      max_iterations: 15
+
+    - id: verify_removed
+      description: "Verify the book is no longer in My Books"
+      goal: >
+        Navigate to My Books tab. Confirm the returned book is no longer in
+        the list. If it was the only book, the empty state should appear.
+      checkpoint: book_removed_from_my_books
+      max_iterations: 10

--- a/.specterqa/replays/catalog-browsing-regression.yaml
+++ b/.specterqa/replays/catalog-browsing-regression.yaml
@@ -1,0 +1,103 @@
+replay:
+  name: catalog-browsing-regression
+  bundle_id: org.thepalaceproject.palace
+  device_id: 31CF5C43-DD55-4889-B3B2-9A6810B4E98F
+  recorded_at: '2026-04-10T16:46:52'
+  steps:
+  - action: swipe
+    direction: left
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Search Catalog
+    - Search
+    - Catalog
+    - All
+    - Ebooks
+    - Audiobooks
+    - Unlimited Listens ODL Feed
+    - More books in Unlimited Listens ODL Feed
+    - Sexualidad de la pantera rosa
+    - "El desplome de la Rep\xFAblica"
+    - Cuando el tiempo nos alcanza
+    - El secreto de Irina
+    screenshot_threshold: 5.0
+  - action: swipe
+    direction: down
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Search Catalog
+    - Search
+    - Catalog
+    - All
+    - Ebooks
+    - Audiobooks
+    - Accessible EPUB Test
+    - More books in Accessible EPUB Test
+    - 'Funamental Accessibility Tests: Visual Adjustments'
+    - 'Advanced Accessibility Tests: Media Overlays'
+    - 'Funamental Accessibility Tests: Non-Visual Reading'
+    - 'Advanced Accessibility Tests: Mathematics'
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 8
+    element_label: Ebooks
+    x: 194.5
+    y: 131.0
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Search Catalog
+    - Search
+    - Catalog
+    - All
+    - Ebooks
+    - Audiobooks
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 9
+    element_label: Audiobooks
+    x: 317.0
+    y: 131.0
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Search Catalog
+    - Search
+    - Catalog
+    - All
+    - Ebooks
+    - Audiobooks
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 7
+    element_label: All
+    x: 72.5
+    y: 131.0
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Search Catalog
+    - Search
+    - Catalog
+    - All
+    - Ebooks
+    - Audiobooks
+    - Accessible EPUB Test
+    screenshot_threshold: 5.0

--- a/.specterqa/replays/search-flow-regression.yaml
+++ b/.specterqa/replays/search-flow-regression.yaml
@@ -1,0 +1,84 @@
+replay:
+  name: search-flow-regression
+  bundle_id: org.thepalaceproject.palace
+  device_id: 31CF5C43-DD55-4889-B3B2-9A6810B4E98F
+  recorded_at: '2026-04-10T16:46:52'
+  steps:
+  - action: tap
+    element_index: 17
+    element_label: Catalog
+    x: 49.0
+    y: 786.0
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Search Catalog
+    - Search
+    - Catalog
+    - All
+    - Ebooks
+    - Audiobooks
+    - Unlimited Listens ODL Feed
+    - More books in Unlimited Listens ODL Feed
+    - 12 Challenges Churches Face, Audiobook
+    - Audiobook
+    - Una vida de mentiras
+    - "Detox emocional (Edici\xF3n mexicana)"
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 4
+    element_label: Search Catalog
+    x: 358.0
+    y: 69.0
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Cancel
+    - All
+    - Ebooks
+    - Audiobooks
+    - 12 Challenges Churches Face. Audiobook.
+    - Unread
+    - Audiobook
+    - Borrow
+    - Una vida de mentiras
+    - Unread
+    - Borrow
+    - "Detox emocional (Edici\xF3n mexicana)"
+    screenshot_threshold: 5.0
+  - action: type
+    text: psychology
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Cancel
+    - All
+    - Ebooks
+    - Audiobooks
+    - 12 Challenges Churches Face. Audiobook.
+    - Unread
+    - Audiobook
+    - Borrow
+    - Una vida de mentiras
+    - Unread
+    - Borrow
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 4
+    element_label: Cancel
+    x: 343.66666666666663
+    y: 69.16666666666666
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Cancel
+    - Clear search
+    - All
+    - Ebooks
+    - Audiobooks
+    - The Principles of Psychology
+    screenshot_threshold: 5.0

--- a/.specterqa/replays/sign-in-attempt-regression.yaml
+++ b/.specterqa/replays/sign-in-attempt-regression.yaml
@@ -1,0 +1,189 @@
+replay:
+  name: sign-in-attempt-regression
+  bundle_id: org.thepalaceproject.palace
+  device_id: 31CF5C43-DD55-4889-B3B2-9A6810B4E98F
+  recorded_at: '2026-04-10T17:09:03'
+  steps:
+  - action: tap
+    element_index: 60
+    element_label: Settings
+    x: 341.5
+    y: 786.0
+    expect_elements:
+    - Settings
+    - Libraries
+    - Libraries
+    - Downloads
+    - Download Only on Wi-Fi
+    - When enabled, books and audiobooks will only download over Wi-Fi. Downloads
+      will be blocked on cellular data.
+    - About and legal
+    - About App
+    - Privacy Policy
+    - User Agreement
+    - Software Licenses
+    - Testing
+    - Testing
+    - Palace version 3.0.0 (453)
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 3
+    element_label: Libraries
+    x: 195.0
+    y: 203.66666666666666
+    expect_elements:
+    - Settings
+    - Add Library
+    - Libraries
+    - A1QA Test Library
+    - A test library for A1QA.
+    - Palace Bookshelf
+    - Popular books free to download and keep, handpicked by librarians across the
+      US.
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    - gearshape.fill
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 4
+    element_label: A1QA Test Library
+    x: 208.33333333333334
+    y: 174.5
+    expect_elements:
+    - Libraries
+    - A1QA Test Library
+    - Library Card
+    - Show
+    - Forgot your password?
+    - By signing in, you agree to the End User License Agreement.
+    - Sign up for a library card
+    - Report an Issue
+    - Content Licenses
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    - gearshape.fill
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 3
+    element_label: Library Card
+    x: 195.0
+    y: 249.0
+    expect_elements:
+    - Libraries
+    - A1QA Test Library
+    - Library Card
+    - Show
+    - Forgot your password?
+    - By signing in, you agree to the End User License Agreement.
+    - Sign up for a library card
+    - Report an Issue
+    - Content Licenses
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    - gearshape.fill
+    screenshot_threshold: 5.0
+  - action: type
+    text: '01230000000037'
+    expect_elements:
+    - Libraries
+    - A1QA Test Library
+    - Library Card
+    - Show
+    - Forgot your password?
+    - By signing in, you agree to the End User License Agreement.
+    - Sign up for a library card
+    - Report an Issue
+    - Content Licenses
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    - gearshape.fill
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 4
+    element_label: Show
+    x: 353.0
+    y: 293.0
+    expect_elements:
+    - Libraries
+    - A1QA Test Library
+    - Library Card
+    - Hide
+    - Forgot your password?
+    - By signing in, you agree to the End User License Agreement.
+    - Sign up for a library card
+    - Report an Issue
+    - Content Licenses
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    - gearshape.fill
+    screenshot_threshold: 5.0
+  - action: type
+    text: Unc123456
+    expect_elements:
+    - Libraries
+    - A1QA Test Library
+    - Library Card
+    - Hide
+    - Forgot your password?
+    - By signing in, you agree to the End User License Agreement.
+    - Sign up for a library card
+    - Report an Issue
+    - Content Licenses
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    - gearshape.fill
+    screenshot_threshold: 5.0
+  - action: swipe
+    direction: down
+    expect_elements:
+    - Libraries
+    - A1QA Test Library
+    - Library Card
+    - Hide
+    - Forgot your password?
+    - By signing in, you agree to the End User License Agreement.
+    - Sign up for a library card
+    - Report an Issue
+    - Content Licenses
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    - gearshape.fill
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 1
+    element_label: Libraries
+    x: 48.0
+    y: 69.0
+    expect_elements:
+    - Libraries
+    - A1QA Test Library
+    - Library Card
+    - Hide
+    - Forgot your password?
+    - By signing in, you agree to the End User License Agreement.
+    - Sign up for a library card
+    - Report an Issue
+    - Content Licenses
+    - tab.bar.label
+    screenshot_threshold: 5.0

--- a/.specterqa/replays/tab-navigation-regression.yaml
+++ b/.specterqa/replays/tab-navigation-regression.yaml
@@ -1,0 +1,65 @@
+replay:
+  name: tab-navigation-regression
+  bundle_id: org.thepalaceproject.palace
+  device_id: 31CF5C43-DD55-4889-B3B2-9A6810B4E98F
+  recorded_at: '2026-04-10T16:46:52'
+  steps:
+  - action: tap
+    element_index: 60
+    element_label: My Books
+    x: 146.5
+    y: 786.0
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Search Books
+    - Search
+    - Sort by Title
+    - Sort
+    - Title
+    - 'Visit the Catalog to
+
+      add books to My Books.'
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 13
+    element_label: Reservations
+    x: 244.0
+    y: 786.0
+    expect_elements:
+    - Switch Library
+    - MyLibraryIcon
+    - A1QA Test Library
+    - Search Reservations
+    - Search
+    - When you reserve a book from the catalog, it will show up here. Look here from
+      time to time to see if your book is available to download.
+    - tab.bar.label
+    - Catalog
+    - My Books
+    - Reservations
+    - Settings
+    screenshot_threshold: 5.0
+  - action: tap
+    element_index: 11
+    element_label: Settings
+    x: 341.5
+    y: 786.0
+    expect_elements:
+    - Settings
+    - Libraries
+    - Libraries
+    - Downloads
+    - Download Only on Wi-Fi
+    - When enabled, books and audiobooks will only download over Wi-Fi. Downloads
+      will be blocked on cellular data.
+    - About and legal
+    - About App
+    - Privacy Policy
+    screenshot_threshold: 5.0

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -7,40 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7D14A1DFDD362D25525D21FE /* TPPProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48AE22D7C0BC6134885E9F0 /* TPPProcessInfo.swift */; };
-		C4F88ED5F0206FAAF93DB27C /* TPPProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48AE22D7C0BC6134885E9F0 /* TPPProcessInfo.swift */; };
-		A467B678AF1566E5745403E0 /* TPPSignInOIDCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50546D02E6F8B0007CCFA03 /* TPPSignInOIDCTests.swift */; };
-		FC5C80424EE10131FA0087F2 /* TPPSAMLSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E3B2C7B51DEBF595766568 /* TPPSAMLSignInTests.swift */; };
-		EC75FDA52C9B331548ED96A1 /* URLResponseNYPLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4NETW003FR000000000001 /* URLResponseNYPLTests.swift */; };
-		D8323F4CCF51DE6D1961CBDC /* TPPBookAccessibilityLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8468ADD34076BF5935E56B /* TPPBookAccessibilityLabelTests.swift */; };
-		059C1DFA5BF79EEE154645E3 /* LCPSessionOrphaningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C1C5F7FE43056D96C9DE5C /* LCPSessionOrphaningTests.swift */; };
-		C54572940A4584060C2DC457 /* ReaderThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D0C6025D50993E6431BDC /* ReaderThemeTests.swift */; };
-		C2A355EBB5690A235E9E6F22 /* AccountDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CBFE0B23AFFE343E256AE1 /* AccountDetailViewModelTests.swift */; };
-		D96E403E3CC3E3C7C64C36BF /* AudiobookPlayerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F44E712F0C639A00184B0C /* AudiobookPlayerSnapshotTests.swift */; };
-		CBCB444F4C168A9CCF792BFA /* AudiobookTrackerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500A72CE85F5DBA5FC681080 /* AudiobookTrackerExtendedTests.swift */; };
-		EAA2D00728C00311D0CF0D81 /* BookDetailSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDB7EFFCB479426AC9DB8B8 /* BookDetailSnapshotTests.swift */; };
-		580E510FBD2D480D21A50AFC /* CatalogSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14AD4ABD07DEBF7ED255792 /* CatalogSnapshotTests.swift */; };
-		607C5492BCD1F00E3156DDE6 /* DownloadOnlyOnWiFiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78529336066D2340C7B0FCE0 /* DownloadOnlyOnWiFiTests.swift */; };
-		8BF1ED0A02EF37A9C314EF87 /* FacetsSelectorSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFF01FA3FC49ED92737F33F3 /* FacetsSelectorSnapshotTests.swift */; };
-		E883263AB3FBE050343F385C /* HoldsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF3302384CAD3BB95FB6B56 /* HoldsSnapshotTests.swift */; };
-		52D28CF48E65246A4592205B /* PDFViewsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A09A4B2F0D6EF100CC23EA /* PDFViewsSnapshotTests.swift */; };
-		BCD408E85CBFEFAE483C19D4 /* ReservationsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F44E612F0C637D00184B0C /* ReservationsSnapshotTests.swift */; };
-		083A37353E8CF921FC35C836 /* SearchSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F44E622F0C637D00184B0C /* SearchSnapshotTests.swift */; };
-		95EA0EDAFB3A8258514E4877 /* SettingsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F44E632F0C637D00184B0C /* SettingsSnapshotTests.swift */; };
-		E9A2B669C2E26107FDE81873 /* SnapshotTestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C097A3177BD44F2ABFC7A49C /* SnapshotTestConfiguration.swift */; };
-		237B6705CA505A8CE33EAE6D /* TPPDeferredAdobeActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557641B8197B528D886F32DB /* TPPDeferredAdobeActivationTests.swift */; };
-		199BD406A0C9A8F3DFF998CE /* PalaceCheckGenerators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142D46BAD0D6D86963ACCA7E /* PalaceCheckGenerators.swift */; };
-		2BEF8AC75AE50395F092751A /* FuzzRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD7CCC67838590BD9E203D /* FuzzRunner.swift */; };
-		411FE5619F2A1B79454C26ED /* ChaosFaultInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC95BE63D9C7C7AE1EFB8D6B /* ChaosFaultInjectionTests.swift */; };
-		4F6E8C45BC4CEEFA0434F641 /* Corpus in Resources */ = {isa = PBXBuildFile; fileRef = F6990140C2393E885A89B739 /* Corpus */; };
-		6980C553FC8789A9C9426438 /* CredentialPrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59A401EA03CDC4931610FA1 /* CredentialPrivacyTests.swift */; };
-		7D4F1388FDE4E63A7EB91AE3 /* DRMAdversarialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A94705E284922B50327BF8 /* DRMAdversarialTests.swift */; };
-		8B0E1CEBC0EB93510F853C00 /* ParserFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFBDD2A1333CAF4E0F850AB /* ParserFuzzTests.swift */; };
-		91F5A804EE45C88A5AD4CCC3 /* PalaceCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3456C5272C3572ACAC0A1A1 /* PalaceCheck.swift */; };
-		9D907CE6820AD963A7C1AD9C /* FuzzCorpus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E49448110C43EB199A09AD3 /* FuzzCorpus.swift */; };
-		AD0D1E6A0666A62B8483424F /* ChaosHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70819902FBD142EFF56C93D9 /* ChaosHarness.swift */; };
-		ADCED6A507B7C113E98FAFFC /* AuthFlowSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE020244923A658A8CB9EE39 /* AuthFlowSecurityTests.swift */; };
-		D91512129048356CDC3C9542 /* PalaceCheckPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */; };
 		00A1B2C3D4E5F60700OPDS2F /* OPDS2CatalogFeed.json in Resources */ = {isa = PBXBuildFile; fileRef = 00A1B2C3D4E5F60700OPDS2E /* OPDS2CatalogFeed.json */; };
 		00C48489D102FD16CBF44882 /* TPPConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16D32877559BE95F5219281 /* TPPConfiguration.swift */; };
 		013A39AA5C934B85B0B66CFD /* HTMLTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B6905F170E4D98A985ABF4 /* HTMLTextViewTests.swift */; };
@@ -60,6 +26,7 @@
 		03F94CCF1DD627AA00CE8F4F /* Accounts.json in Resources */ = {isa = PBXBuildFile; fileRef = 03F94CCE1DD627AA00CE8F4F /* Accounts.json */; };
 		03F94CD11DD6288C00CE8F4F /* AccountsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F94CD01DD6288C00CE8F4F /* AccountsManager.swift */; };
 		0469ADBAE6CAC0F21823D1E7 /* BadgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59814D0AE9FAF49E9A52426A /* BadgeService.swift */; };
+		059C1DFA5BF79EEE154645E3 /* LCPSessionOrphaningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C1C5F7FE43056D96C9DE5C /* LCPSessionOrphaningTests.swift */; };
 		05A425DB12A6A7B0F202D793 /* PositionSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683C04EF0CA60F4A118D597A /* PositionSyncServiceTests.swift */; };
 		05BD558BEDC45D091DFEA283 /* FontManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3260782E24602A4B3FF7E20B /* FontManagerTests.swift */; };
 		06560AD2E5A43C1BFA2EBEE1 /* DownloadProgressPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA6421E95950580E36277F0 /* DownloadProgressPublisher.swift */; };
@@ -68,6 +35,7 @@
 		0824D44E24B8DFE400C85A7E /* NSString+JSONParse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0824D44D24B8DFE400C85A7E /* NSString+JSONParse.swift */; };
 		0826CD2924AA21B2000F4030 /* TPPSamlIDPCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0826CD2824AA21B2000F4030 /* TPPSamlIDPCell.swift */; };
 		0826CD2F24AA2801000F4030 /* TPPLibraryDescriptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0826CD2E24AA2801000F4030 /* TPPLibraryDescriptionCell.swift */; };
+		083A37353E8CF921FC35C836 /* SearchSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F44E622F0C637D00184B0C /* SearchSnapshotTests.swift */; };
 		0857A0F72478337D00C7984E /* TPPCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0857A0F62478337D00C7984E /* TPPCredentials.swift */; };
 		0857A0FF247835FF00C7984E /* TPPKeychainStoredVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0857A0FE247835FF00C7984E /* TPPKeychainStoredVariable.swift */; };
 		08595A3A06124A89A7CE9916 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8D8A0D1A094920B67DC0E2 /* CarPlaySceneDelegate.swift */; };
@@ -152,6 +120,7 @@
 		184131D3C04F95ED70463EB4 /* TPPCredentialsCoverageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B55BD3620F51707395548D0 /* TPPCredentialsCoverageTests.swift */; };
 		18A4C5CE7FDC24626D75C3CE /* TPPOPDSIndirectAcquisition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB284B9E0D2C5DE059116E9 /* TPPOPDSIndirectAcquisition.swift */; };
 		18EAAA05A58EBDD4FCD5B5E8 /* StatsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17628BE0EB1E554ECF46071E /* StatsCardView.swift */; };
+		199BD406A0C9A8F3DFF998CE /* PalaceCheckGenerators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142D46BAD0D6D86963ACCA7E /* PalaceCheckGenerators.swift */; };
 		19B2FF38757AA2540B31D675 /* UIButton+NYPLAppearanceAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68831365CC1FF46BE9A9C2C9 /* UIButton+NYPLAppearanceAdditions.swift */; };
 		1BD28F76C1C3B5B76ABC3C80 /* ReadingStreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6CA6654994D77041AE0F79 /* ReadingStreak.swift */; };
 		1BD866BBA1CDCC73F0F70BFF /* TPPOPDSAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488A86760250BA6E087F28CC /* TPPOPDSAttribute.swift */; };
@@ -261,6 +230,7 @@
 		22D7A0341D12429C6B3D10A4 /* UIColor+TPPColorAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AAE5061720AB26712416F3 /* UIColor+TPPColorAdditions.swift */; };
 		2328B4483544EAC500B592B6 /* UserAccountValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC465C72310C5054118CBBEA /* UserAccountValidationTests.swift */; };
 		233349692EA7423D97E70B5F /* SEMigrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE116B1078F648DCB8A52598 /* SEMigrationsTests.swift */; };
+		237B6705CA505A8CE33EAE6D /* TPPDeferredAdobeActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557641B8197B528D886F32DB /* TPPDeferredAdobeActivationTests.swift */; };
 		23C05C50661294BB10936774 /* TPPOpenSearchDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F5C80C8A39854AADD31179 /* TPPOpenSearchDescription.swift */; };
 		24627E54AF34930D7ACEB030 /* BookCellModelCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DCAEB765B50E04217F0CB7 /* BookCellModelCache.swift */; };
 		246ED064D298281426FEF8D5 /* KeyboardNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144BB5C0F2D1B2C0C398BD98 /* KeyboardNavigationHandler.swift */; };
@@ -285,6 +255,7 @@
 		2B0AE2358296F09D54E0603F /* TPPOPDSType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CF9C6D37F357167F7698E42 /* TPPOPDSType.swift */; };
 		2B7EC298A55FA3351E113B6B /* PerformanceReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D80DA377151AE41BEF67F7 /* PerformanceReport.swift */; };
 		2B820846966DE6DDDBD29DCB /* AccessibilitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E518F27E3FF9A05071B82305 /* AccessibilitySettingsView.swift */; };
+		2BEF8AC75AE50395F092751A /* FuzzRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD7CCC67838590BD9E203D /* FuzzRunner.swift */; };
 		2C51537AACCF4FEBE1C1B885 /* TPPKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D4AEB31C532A0A3F0519E7 /* TPPKeychain.swift */; };
 		2C6459D91A5439B946473EF6 /* OfflineQueueServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480CFCD095E5C455D1CFA499 /* OfflineQueueServiceTests.swift */; };
 		2C8AD486BC994A92B050A31D /* CarPlayAudiobookBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B2D269BFF440A381A893E3 /* CarPlayAudiobookBridge.swift */; };
@@ -337,6 +308,7 @@
 		3F07E84A8D644585AC4214A3 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8D8A0D1A094920B67DC0E2 /* CarPlaySceneDelegate.swift */; };
 		3F950AC5136B638265B1AB87 /* BookDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C73660492C45AC4EDF27B6E /* BookDetailViewModelTests.swift */; };
 		4060C3071FDB9EDF97749DB2 /* TPPXML.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8BB27208BC1456FAABC0D29 /* TPPXML.swift */; };
+		411FE5619F2A1B79454C26ED /* ChaosFaultInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC95BE63D9C7C7AE1EFB8D6B /* ChaosFaultInjectionTests.swift */; };
 		4156D2A2D92766E8268939A4 /* CredentialGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A0B2DA8FB8ABF53C9E32FF /* CredentialGuardTests.swift */; };
 		4172AAE925DEBEDDF9681174 /* TPPLinearView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE97656B54F67282B7B52648 /* TPPLinearView.swift */; };
 		41B6A179495CBD825EFC8BA5 /* TPPOPDSFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7B58FF65F32DD6EC2A7FBF /* TPPOPDSFeed.swift */; };
@@ -361,12 +333,14 @@
 		4DE364F5D585D79C2FCFF132 /* TPPBook+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C1093BDA93392F7DEF0D31 /* TPPBook+Accessibility.swift */; };
 		4E664E6EC32C604AFBC8A623 /* CatalogSearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFF70FF762C60CE8CD8D811 /* CatalogSearchViewModelTests.swift */; };
 		4EE6AD0F199527926C3BB1F8 /* CatalogFilterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5948988DD314B94674443C4F /* CatalogFilterServiceTests.swift */; };
+		4F6E8C45BC4CEEFA0434F641 /* Corpus in Resources */ = {isa = PBXBuildFile; fileRef = F6990140C2393E885A89B739 /* Corpus */; };
 		4F719A0BD4C84430AF2DD87D /* PersistentLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203968D3932148888F448BBC /* PersistentLoggerTests.swift */; };
 		50416470BECDA830E3C300A2 /* ColorExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE59544C34814CE86EF2AB /* ColorExtensionTests.swift */; };
 		510C6DAC28570835F7208CFC /* StatsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCA63D51A4176FB08ED1941 /* StatsTab.swift */; };
 		513C769C2795495BB7EACE04 /* TPPProblemDocumentCacheManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989EAF4764014D23B7BE358F /* TPPProblemDocumentCacheManagerTests.swift */; };
 		5144FF75E58F20B8F1FDAC1A /* NYPLOPDSEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2F3BD31B4780B53BC261B9 /* NYPLOPDSEntryTests.swift */; };
 		514DCA7866A84C46AA584A42 /* BookCellModelActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C94D2AB2B04C81919F10B3 /* BookCellModelActionTests.swift */; };
+		52D28CF48E65246A4592205B /* PDFViewsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A09A4B2F0D6EF100CC23EA /* PDFViewsSnapshotTests.swift */; };
 		5419E00285822EDBFB4ED932 /* SendableSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BD75A5447FB7BD0DA90F57 /* SendableSubject.swift */; };
 		544B4387437E609DFF7E6757 /* OPDS2PublicationExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023DFFACC986541965F1560 /* OPDS2PublicationExtended.swift */; };
 		547B90CF7E8D4CABA5A59BFD /* TPPIdleSignOutRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D448C588C99441528CE12FD5 /* TPPIdleSignOutRegressionTests.swift */; };
@@ -378,6 +352,7 @@
 		56CE537E2B81BC80FBF455CD /* TPPAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54172B43D47BE5FCE8A1B975 /* TPPAttributedString.swift */; };
 		570064D774A1A7A1C15E95D7 /* TPPOPDSGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20699CB1278F25D31D4D1179 /* TPPOPDSGroup.swift */; };
 		57D2A62CAE4BD36D9573E674 /* AudiobookPlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA71264EE431E238A3B66ED /* AudiobookPlaybackTests.swift */; };
+		580E510FBD2D480D21A50AFC /* CatalogSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14AD4ABD07DEBF7ED255792 /* CatalogSnapshotTests.swift */; };
 		582431D4978FAFF6C12F1599 /* StreakView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1D8E96BB21CEA1AB690046 /* StreakView.swift */; };
 		582C8707154D04C7B9FCA6CE /* TPPNull.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEA83D0B2D2A423B42AB1D4 /* TPPNull.swift */; };
 		584A8765F4BEF4B2A7F068B5 /* TPPMyBooksSimplifiedBearerToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CCF14B8043FB410CB53DFB /* TPPMyBooksSimplifiedBearerToken.swift */; };
@@ -403,6 +378,8 @@
 		5DD567B522B97344001F0C83 /* Data+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD567B422B97344001F0C83 /* Data+Base64.swift */; };
 		5E4064C5CBD03E83CFF01CB0 /* PlatformTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545D0B43631D0433B5E9C100 /* PlatformTab.swift */; };
 		5F8040C84B5543ED9B1FEACE /* ReachabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A8C636411D4F9DBB12A1CE /* ReachabilityTests.swift */; };
+		6021615DC1CCCE566261E7B5 /* TPPPerAccountIsolationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A5818A6D6FBED89690BA3F /* TPPPerAccountIsolationTests.swift */; };
+		607C5492BCD1F00E3156DDE6 /* DownloadOnlyOnWiFiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78529336066D2340C7B0FCE0 /* DownloadOnlyOnWiFiTests.swift */; };
 		612FD8DA16387F71EB3CA398 /* HoldsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADE8A45C4B4AAE67143A272 /* HoldsViewModelTests.swift */; };
 		61757D3F95012F8F4340FABB /* TPPAccountAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56509A03466E0531DBC27 /* TPPAccountAuthState.swift */; };
 		62842E5CA00D435AAD8F227E /* NavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A0EAF9098429CA6DCAD16 /* NavigationCoordinatorTests.swift */; };
@@ -422,6 +399,7 @@
 		68F27DEBDED5D751249088B3 /* BadgesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02060A0117F26B0E56F3F606 /* BadgesView.swift */; };
 		692333632D7342156C06CBA4 /* TPPOPDSAcquisitionAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11650305A565401AECEDEA6 /* TPPOPDSAcquisitionAvailability.swift */; };
 		696AE19BFBC6497EB2B21825 /* TPPUserFriendlyErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E936EE46D4F42F2992222A9 /* TPPUserFriendlyErrorTests.swift */; };
+		6980C553FC8789A9C9426438 /* CredentialPrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59A401EA03CDC4931610FA1 /* CredentialPrivacyTests.swift */; };
 		6A7284C5F4D64218BCE6B70E /* PositionSyncRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34219C1762ECAA5701434F7 /* PositionSyncRecord.swift */; };
 		6AC0B57C7401ADE5ECFCD1F2 /* StringHTMLEntitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06784DE00D5161E7071843F0 /* StringHTMLEntitiesTests.swift */; };
 		6B0BA478542867A920369D75 /* TPPObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 48B834DC53BA4A1C8B4EBDC6 /* TPPObjCExceptionCatcher.m */; };
@@ -659,6 +637,8 @@
 		7C412CCF4234E353860E7FAD /* KeyboardNavigationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1020FD76B5E7EA7D89A58124 /* KeyboardNavigationHandlerTests.swift */; };
 		7C7CC736C58E9708E1191330 /* PositionSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF82ED893D33403D07EF7EE5 /* PositionSyncService.swift */; };
 		7CE23D7EE312C2C153E884FC /* UILabel+NYPLAppearanceAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1897C8D05112F0CCCB4F8105 /* UILabel+NYPLAppearanceAdditions.swift */; };
+		7D14A1DFDD362D25525D21FE /* TPPProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48AE22D7C0BC6134885E9F0 /* TPPProcessInfo.swift */; };
+		7D4F1388FDE4E63A7EB91AE3 /* DRMAdversarialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A94705E284922B50327BF8 /* DRMAdversarialTests.swift */; };
 		7EDBF257762A48948D990532 /* TPPLastReadPositionPosterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BB1056721E445D90C72FFF /* TPPLastReadPositionPosterTests.swift */; };
 		7F80D2F9E103BEC1042C3DE1 /* TokenRefreshInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085A2D3663F363348BE14190 /* TokenRefreshInterceptor.swift */; };
 		7F925770F4564C38B3784E64 /* AudiobookReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF99D1F39D634C56A70BFE75 /* AudiobookReliabilityTests.swift */; };
@@ -686,8 +666,10 @@
 		894A8D661F91D50152D41952 /* PositionSyncBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BA6F84CC20612B8D4969FE /* PositionSyncBanner.swift */; };
 		89952B99496C6D204701B8A0 /* ReadingSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0592B4A4D666ED6705BF8093 /* ReadingSessionTracker.swift */; };
 		8A79FCB73FD467DF7BBA1665 /* BookCellModelCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB5684FAB210E6557DD37E7 /* BookCellModelCacheTests.swift */; };
+		8B0E1CEBC0EB93510F853C00 /* ParserFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFBDD2A1333CAF4E0F850AB /* ParserFuzzTests.swift */; };
 		8B7F9448E0A36A00975248B4 /* TPPEncryptedPDFDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEA4278133FE9AD4EB842F1 /* TPPEncryptedPDFDataProvider.swift */; };
 		8BBAC69C617313D695562036 /* ReadingStatsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB416026EE34EBDB68AD788B /* ReadingStatsServiceTests.swift */; };
+		8BF1ED0A02EF37A9C314EF87 /* FacetsSelectorSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFF01FA3FC49ED92737F33F3 /* FacetsSelectorSnapshotTests.swift */; };
 		8C40D6A72375FF8B006EA63B /* TPPProblemDocumentCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C40D6A62375FF8B006EA63B /* TPPProblemDocumentCacheManager.swift */; };
 		8CC26F832370C1DF0000D8E1 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC26F822370C1DF0000D8E1 /* Account.swift */; };
 		8CD73CE1905CBD7FA883FF6A /* TPPReauthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D5C28E71B1D177EAF1E5F9 /* TPPReauthenticatorTests.swift */; };
@@ -704,11 +686,13 @@
 		9131F05942C27772C1CA21E7 /* SAMLHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44169A0B2904A3C8CFEDD8F7 /* SAMLHelperTests.swift */; };
 		916929D75B10E9973EDED0B0 /* DownloadProgressPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 678E47FC2F39F84744921B33 /* DownloadProgressPublisherTests.swift */; };
 		917D628924F123B7A30238CE /* TPPLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C7D04F855F2DA251329CDD /* TPPLocalization.swift */; };
+		91F5A804EE45C88A5AD4CCC3 /* PalaceCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3456C5272C3572ACAC0A1A1 /* PalaceCheck.swift */; };
 		9242ED62B26248A2F20DF7D6 /* ReadingStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F8EBC8684EF42942C688A7 /* ReadingStatsService.swift */; };
 		9309887A8360976E65C6AE04 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5431B832D502714505B6EAF5 /* StatsView.swift */; };
 		935781EA3FD5B824D9A52F21 /* OfflineQueueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634E8A7700449B3157A0E943 /* OfflineQueueDetailView.swift */; };
 		953B933A06DA6AF6ABAFB7EC /* BadgeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6837ACC21376FE419332599B /* BadgeDetailView.swift */; };
 		9551D5385E148DD1FA10C632 /* TPPBookmarkDeletionLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0452B249AF7C21DDAACD5C58 /* TPPBookmarkDeletionLog.swift */; };
+		95EA0EDAFB3A8258514E4877 /* SettingsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F44E632F0C637D00184B0C /* SettingsSnapshotTests.swift */; };
 		963D25AD30656028E36395ED /* FacetToolbarAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A047896E4B4E78F19CF33603 /* FacetToolbarAccessibilityTests.swift */; };
 		967625944F77592C713BFA06 /* NYPLOPDSFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B814E7E38AAEFF18419C6BB /* NYPLOPDSFeedTests.swift */; };
 		97D7098890B79033A5DF0E57 /* SendableSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BD75A5447FB7BD0DA90F57 /* SendableSubject.swift */; };
@@ -726,6 +710,7 @@
 		9D5BD91CC07167E673AA264A /* TPPAccountAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56509A03466E0531DBC27 /* TPPAccountAuthState.swift */; };
 		9D5DE68418C31F9D88044C89 /* ReadingStatsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F16E79F7C14C0F72FC36B3 /* ReadingStatsStoreTests.swift */; };
 		9D6E7E602F012232CA237667 /* TPPOPDSType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CF9C6D37F357167F7698E42 /* TPPOPDSType.swift */; };
+		9D907CE6820AD963A7C1AD9C /* FuzzCorpus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E49448110C43EB199A09AD3 /* FuzzCorpus.swift */; };
 		9E482D5D89E03F23F7451DE6 /* MyBooksViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9CA89B135C85E23F0D907B /* MyBooksViewModelTests.swift */; };
 		9EB44CD30C94D33258B12A16 /* DebugSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E709829F912BC2766AEA30 /* DebugSettingsTests.swift */; };
 		A00ED9F1A5D549B6B9685E48 /* TPPAlertUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3401E6313A459D9496ECF2 /* TPPAlertUtilsTests.swift */; };
@@ -742,6 +727,7 @@
 		A3FFA553CECBA05F64CE16A0 /* PositionSyncServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DCD0D1F494503E60739EF9 /* PositionSyncServiceProtocol.swift */; };
 		A401D30D9E044FCE83DD0CD1 /* TPPReaderTOCBusinessLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B1C811EE104DC2902FEEC3 /* TPPReaderTOCBusinessLogicTests.swift */; };
 		A45954D670E9F5768055E2FC /* OfflineQueueBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C9C7A1029274277B31F57E /* OfflineQueueBadge.swift */; };
+		A467B678AF1566E5745403E0 /* TPPSignInOIDCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50546D02E6F8B0007CCFA03 /* TPPSignInOIDCTests.swift */; };
 		A4764638CAC5AA3D72A37137 /* PerformanceMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBDD4C17EA45C71D8076A34 /* PerformanceMetric.swift */; };
 		A57986AA9FBF4B328D036BC2 /* AlertModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C33E4BDBC27454AB30FAF96 /* AlertModelTests.swift */; };
 		A5D21B64F3AD2BE436E92048 /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C78FDF4D5C0DE3F151FAE5 /* AccessibilityPreferences.swift */; };
@@ -773,7 +759,9 @@
 		AC000000000000000003 /* AppContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC000000000000000001 /* AppContainer.swift */; };
 		AC7976569F7EDBAB30C096A4 /* ThemePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95524DFA311D1BE65A9F5FF3 /* ThemePickerView.swift */; };
 		AC7D22C5A54C9291CD111AC8 /* CatalogAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4609134D5A2D39DD0D8E7DCA /* CatalogAccessibilityTests.swift */; };
+		AD0D1E6A0666A62B8483424F /* ChaosHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70819902FBD142EFF56C93D9 /* ChaosHarness.swift */; };
 		ADC762F8876B7DD97B60178D /* TypographySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C1C917A6BF4317D7FA6567 /* TypographySettings.swift */; };
+		ADCED6A507B7C113E98FAFFC /* AuthFlowSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE020244923A658A8CB9EE39 /* AuthFlowSecurityTests.swift */; };
 		AE7BEAB078AC66DA63AA4D9B /* BadgeDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF4CC60E96981C8BF94891C /* BadgeDefinitionTests.swift */; };
 		AF890D5839204832223A2287 /* OPDSParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDA12704CE45280D151E7AC /* OPDSParsingTests.swift */; };
 		AGNT0B5100000001NET001 /* OPDSFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AGNT0B5100000002NET001 /* OPDSFormatTests.swift */; };
@@ -824,6 +812,7 @@
 		BAE20819D54F9AFEBE09F85F /* TPPConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16D32877559BE95F5219281 /* TPPConfiguration.swift */; };
 		BB800AA2A27632EBDEF6758B /* TypographyPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A78DE6D235AA54DC8F02DA /* TypographyPreset.swift */; };
 		BC441085548BA946D181A396 /* TPPOPDSLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E299DDCBCCD4BF58886145 /* TPPOPDSLink.swift */; };
+		BCD408E85CBFEFAE483C19D4 /* ReservationsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F44E612F0C637D00184B0C /* ReservationsSnapshotTests.swift */; };
 		BCF3398CEB2C47F09F8ABCFF /* TPPNetworkExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D1A95DE8674E6D83B5A8CA /* TPPNetworkExecutorTests.swift */; };
 		BED408AC57A5DB39579B5FEA /* TPPBookRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5550F79A349D3D7ADE48B5E1 /* TPPBookRegistryTests.swift */; };
 		BF0FD554A5AA86C241E2CA9F /* StatsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCA63D51A4176FB08ED1941 /* StatsTab.swift */; };
@@ -837,6 +826,7 @@
 		C1D2E3F4A5B6C7D8E9F0A1B2 /* OPDS2LinkAndPublicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F4A5B6C7D8E9F0A1B3 /* OPDS2LinkAndPublicationTests.swift */; };
 		C1D2E3F4A5B6C7D8E9F0A1B4 /* TPPContentTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F4A5B6C7D8E9F0A1B5 /* TPPContentTypeTests.swift */; };
 		C215A5BF6EECACEC2CC54086 /* AppLaunchTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8207C4AC28B2FA1774B6E827 /* AppLaunchTrackerTests.swift */; };
+		C2A355EBB5690A235E9E6F22 /* AccountDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CBFE0B23AFFE343E256AE1 /* AccountDetailViewModelTests.swift */; };
 		C2F4CDA301CDCFEF58F7EA33 /* TPPOPDSCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C824F360674745C4C0B441B /* TPPOPDSCategory.swift */; };
 		C321467F56BF2E1573596281 /* AppHealthViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EBF1AB49179CABFF759380B /* AppHealthViewModelTests.swift */; };
 		C362C7513C53AD6E4D2807AB /* ReadingPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5995312FDBEDCFD6A689A68 /* ReadingPosition.swift */; };
@@ -845,7 +835,9 @@
 		C3C7B0F9C4F9B13DD69CEA85 /* EPUBSearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A2B3C4D5E6F7A8B9C0D1E2 /* EPUBSearchViewModelTests.swift */; };
 		C417B57160B14AD69C10AF87 /* DownloadErrorRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4E96DEEFAA4607B343D65D /* DownloadErrorRecoveryTests.swift */; };
 		C44E1D3CA3E045C6A5D43370 /* CarPlayImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639A868F3BDA4A7F97660BEA /* CarPlayImageProvider.swift */; };
+		C4F88ED5F0206FAAF93DB27C /* TPPProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48AE22D7C0BC6134885E9F0 /* TPPProcessInfo.swift */; };
 		C52F95F93025E9B752D1FA31 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C54572940A4584060C2DC457 /* ReaderThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D0C6025D50993E6431BDC /* ReaderThemeTests.swift */; };
 		C5EF7C3F2B05E4CAAFB5B578 /* TPPOPDSEntryGroupAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623603046F0407CC97F60563 /* TPPOPDSEntryGroupAttributes.swift */; };
 		C64399E81697447CA4F20ABA /* EULAViewHosting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CF94B049964380A3A35DA9 /* EULAViewHosting.swift */; };
 		C64399E91697447CA4F20ABB /* EULAViewHosting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CF94B049964380A3A35DA9 /* EULAViewHosting.swift */; };
@@ -864,6 +856,7 @@
 		C9A9B85299EEDD6939D79149 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		CB0E52E82642EB6B2E1C7BA9 /* NowPlayingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9B49899F1C10F43D4FAAD8 /* NowPlayingCoordinator.swift */; };
 		CB593061F0478066BAD53008 /* ReadingPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5995312FDBEDCFD6A689A68 /* ReadingPosition.swift */; };
+		CBCB444F4C168A9CCF792BFA /* AudiobookTrackerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500A72CE85F5DBA5FC681080 /* AudiobookTrackerExtendedTests.swift */; };
 		CC24969C17E24D89872DE10E /* MyBooksSimplifiedBearerTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12BEBBCCBA734E42BB9C6C03 /* MyBooksSimplifiedBearerTokenTests.swift */; };
 		CCCDB216C7E807F461826B81 /* StatsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D09C16D15567198A0A9194 /* StatsViewModelTests.swift */; };
 		CCD4CE5B21BED732364D2899 /* LCPAudiobooksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0E625DA84AEEFF9840A601 /* LCPAudiobooksTests.swift */; };
@@ -892,7 +885,10 @@
 		D6E301B27A5D47A7887F5A80 /* EULAView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAA704224204121A301A289 /* EULAView.swift */; };
 		D731F3A3A15F89DF3CBBEA80 /* ReadingPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE96DBD95C2D1EBC5F5D8C81 /* ReadingPositionTests.swift */; };
 		D76F93A02FB8656A6030E05D /* BookRegistryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC6F5F83DFB72884C55BCAD /* BookRegistryStoreTests.swift */; };
+		D8323F4CCF51DE6D1961CBDC /* TPPBookAccessibilityLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8468ADD34076BF5935E56B /* TPPBookAccessibilityLabelTests.swift */; };
 		D8E3E2F8DB67110026272CFB /* MockVisualNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75B6896C9742C07208D935E /* MockVisualNavigator.swift */; };
+		D91512129048356CDC3C9542 /* PalaceCheckPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */; };
+		D96E403E3CC3E3C7C64C36BF /* AudiobookPlayerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F44E712F0C639A00184B0C /* AudiobookPlayerSnapshotTests.swift */; };
 		D987D93E00D55416261ED333 /* TPPBook+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C1093BDA93392F7DEF0D31 /* TPPBook+Accessibility.swift */; };
 		DB12A83E17C9B20180711EB8 /* URLRequestNYPLAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B163B18C48334A913B2CCA /* URLRequestNYPLAdditionsTests.swift */; };
 		DCBDBF18A8F9C78B63585C2D /* PositionSyncServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DCD0D1F494503E60739EF9 /* PositionSyncServiceProtocol.swift */; };
@@ -1402,9 +1398,13 @@
 		E7FFEAA62A745F600006030A /* ULID in Frameworks */ = {isa = PBXBuildFile; productRef = E7FFEAA52A745F600006030A /* ULID */; };
 		E80FAD5EFA9DBAF8CE8A1D18 /* UIView+TPPViewAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581C6B05F79FEB7A95DD4BA5 /* UIView+TPPViewAdditions.swift */; };
 		E861F14A001F228C7E96F790 /* KeyboardVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD71C8FF18A443133C015DA8 /* KeyboardVoiceOverTests.swift */; };
+		E883263AB3FBE050343F385C /* HoldsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF3302384CAD3BB95FB6B56 /* HoldsSnapshotTests.swift */; };
 		E91B4ADED23243A6914C3DEA /* PDFExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EA8E55783D47B7A773164F /* PDFExtensionsTests.swift */; };
+		E9A2B669C2E26107FDE81873 /* SnapshotTestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C097A3177BD44F2ABFC7A49C /* SnapshotTestConfiguration.swift */; };
 		EA12FB34567890ABCDEF0002 /* EPUBToolbarToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA12FB34567890ABCDEF0001 /* EPUBToolbarToggleTests.swift */; };
+		EAA2D00728C00311D0CF0D81 /* BookDetailSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDB7EFFCB479426AC9DB8B8 /* BookDetailSnapshotTests.swift */; };
 		EAD51505BBFD93F738787019 /* OfflineQueueServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FEEC427223FFDB026D6137 /* OfflineQueueServiceProtocol.swift */; };
+		EC75FDA52C9B331548ED96A1 /* URLResponseNYPLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4NETW003FR000000000001 /* URLResponseNYPLTests.swift */; };
 		ED121CB96E52B81CED187442 /* ReadingStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA4D17463BADFD0DEBC53FA /* ReadingStats.swift */; };
 		ED9ED4A5C8DBBE60A7DDC39E /* TPPMyBooksSimplifiedBearerToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CCF14B8043FB410CB53DFB /* TPPMyBooksSimplifiedBearerToken.swift */; };
 		EDABAC96498D2F204A963521 /* PerformanceMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A934FABA62A6E51A6928F0DD /* PerformanceMonitorTests.swift */; };
@@ -1437,6 +1437,7 @@
 		FC0AD7762077072EC062F780 /* AudiobookAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77E63314ED6F70CC68C0DA0 /* AudiobookAccessibilityTests.swift */; };
 		FC143D162B824415B00D88AA /* NSErrorAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84A9BADA3014DCF9808C7DC /* NSErrorAdditionsTests.swift */; };
 		FC1B7D899D35F336F1469191 /* FontFamily.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA20DE46939562EEA2DF764 /* FontFamily.swift */; };
+		FC5C80424EE10131FA0087F2 /* TPPSAMLSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E3B2C7B51DEBF595766568 /* TPPSAMLSignInTests.swift */; };
 		FD8D0E357C66D1B11FC70361 /* TPPJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52226B7262C85C91578DB3A7 /* TPPJSON.swift */; };
 		FD944841337FCB9D26209ED4 /* ReadingStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA4D17463BADFD0DEBC53FA /* ReadingStats.swift */; };
 		FE48F9C21D03088224767755 /* TypographyPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABACD6237FD75664BEADFF58 /* TypographyPresetTests.swift */; };
@@ -1446,6 +1447,7 @@
 		INTG0001B7A00000000003 /* AccountSwitchIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = INTG0001B7A00000000004 /* AccountSwitchIntegrationTests.swift */; };
 		INTG0001B7A00000000005 /* BookStateIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = INTG0001B7A00000000006 /* BookStateIntegrationTests.swift */; };
 		INTG0001B7A00000000007 /* CatalogLoadIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = INTG0001B7A00000000008 /* CatalogLoadIntegrationTests.swift */; };
+		KCHAVAIL00BUILD000000001 /* KeychainAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = KCHAVAIL00FILEREF000001 /* KeychainAvailability.swift */; };
 		LNEX01BF00000000000001 /* LoanExpiryHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LNEX01FR00000000000001 /* LoanExpiryHandlingTests.swift */; };
 		NEWTST002CONFIGTEST0001 /* TPPConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = NEWTST001CONFIGTEST0001 /* TPPConfigurationTests.swift */; };
 		NEWTST004KEYCHNTEST0001 /* TPPKeychainSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = NEWTST003KEYCHNTEST0001 /* TPPKeychainSwiftTests.swift */; };
@@ -1596,23 +1598,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		E48AE22D7C0BC6134885E9F0 /* TPPProcessInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPProcessInfo.swift; sourceTree = "<group>"; };
-		FE2159403F0FCBE90CFC6858 /* BookImageViewAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImageViewAccessibilityTests.swift; sourceTree = "<group>"; };
-		44B9D77A2797816A93F9D35B /* PDFAccessibilityToolbarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFAccessibilityToolbarTests.swift; sourceTree = "<group>"; };
-		5A8468ADD34076BF5935E56B /* TPPBookAccessibilityLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookAccessibilityLabelTests.swift; sourceTree = "<group>"; };
-		77C1C5F7FE43056D96C9DE5C /* LCPSessionOrphaningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPSessionOrphaningTests.swift; sourceTree = "<group>"; };
-		142D46BAD0D6D86963ACCA7E /* PalaceCheckGenerators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceCheckGenerators.swift; sourceTree = "<group>"; };
-		1FFBDD2A1333CAF4E0F850AB /* ParserFuzzTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserFuzzTests.swift; sourceTree = "<group>"; };
-		48A94705E284922B50327BF8 /* DRMAdversarialTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRMAdversarialTests.swift; sourceTree = "<group>"; };
-		6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceCheckPropertyTests.swift; sourceTree = "<group>"; };
-		70819902FBD142EFF56C93D9 /* ChaosHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaosHarness.swift; sourceTree = "<group>"; };
-		7BFD7CCC67838590BD9E203D /* FuzzRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzRunner.swift; sourceTree = "<group>"; };
-		9E49448110C43EB199A09AD3 /* FuzzCorpus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzCorpus.swift; sourceTree = "<group>"; };
-		BE020244923A658A8CB9EE39 /* AuthFlowSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowSecurityTests.swift; sourceTree = "<group>"; };
-		F3456C5272C3572ACAC0A1A1 /* PalaceCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceCheck.swift; sourceTree = "<group>"; };
-		F59A401EA03CDC4931610FA1 /* CredentialPrivacyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialPrivacyTests.swift; sourceTree = "<group>"; };
-		F6990140C2393E885A89B739 /* Corpus */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Corpus; sourceTree = "<group>"; };
-		FC95BE63D9C7C7AE1EFB8D6B /* ChaosFaultInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaosFaultInjectionTests.swift; sourceTree = "<group>"; };
 		00A1B2C3D4E5F60700OPDS2E /* OPDS2CatalogFeed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = OPDS2CatalogFeed.json; sourceTree = "<group>"; };
 		02060A0117F26B0E56F3F606 /* BadgesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgesView.swift; sourceTree = "<group>"; };
 		02B8F946D19048E4AE73B6C7 /* TPPSettingsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPSettingsMock.swift; sourceTree = "<group>"; };
@@ -1688,6 +1673,7 @@
 		11F54C1D194109120086FCAF /* main.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = main.xml; sourceTree = "<group>"; };
 		11F54C2419410BE40086FCAF /* single_entry.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = single_entry.xml; sourceTree = "<group>"; };
 		12BEBBCCBA734E42BB9C6C03 /* MyBooksSimplifiedBearerTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBooksSimplifiedBearerTokenTests.swift; sourceTree = "<group>"; };
+		142D46BAD0D6D86963ACCA7E /* PalaceCheckGenerators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceCheckGenerators.swift; sourceTree = "<group>"; };
 		144BB5C0F2D1B2C0C398BD98 /* KeyboardNavigationHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyboardNavigationHandler.swift; sourceTree = "<group>"; };
 		145798F5215BE9E300F68AFD /* ProblemReportEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemReportEmail.swift; sourceTree = "<group>"; };
 		145DA48D215441A70055DB93 /* ZXingObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZXingObjC.framework; path = Carthage/Build/iOS/ZXingObjC.framework; sourceTree = "<group>"; };
@@ -1736,6 +1722,7 @@
 		1E936EE46D4F42F2992222A9 /* TPPUserFriendlyErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPUserFriendlyErrorTests.swift; sourceTree = "<group>"; };
 		1FDB637C01812EEB10919A6E /* BackgroundDownloadHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundDownloadHandler.swift; sourceTree = "<group>"; };
 		1FEA0A65803452A75BDC330E /* KeyboardNavigationHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeyboardNavigationHandler.swift; path = Palace/Reader2/UI/KeyboardNavigationHandler.swift; sourceTree = "<group>"; };
+		1FFBDD2A1333CAF4E0F850AB /* ParserFuzzTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserFuzzTests.swift; sourceTree = "<group>"; };
 		203968D3932148888F448BBC /* PersistentLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentLoggerTests.swift; sourceTree = "<group>"; };
 		20699CB1278F25D31D4D1179 /* TPPOPDSGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPOPDSGroup.swift; sourceTree = "<group>"; };
 		20B293519F9B55B6F4F17CC7 /* PresetCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetCard.swift; sourceTree = "<group>"; };
@@ -1837,7 +1824,7 @@
 		2DF737E48E0644508688E443 /* TPPBookBearerTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookBearerTokenTests.swift; sourceTree = "<group>"; };
 		2DFAC8EB1CD8DDD1003D9EC0 /* TPPOPDSCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPOPDSCategory.h; sourceTree = "<group>"; };
 		2E5BAC81314C28A366BF6BB7 /* AudiobookSessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookSessionManager.swift; sourceTree = "<group>"; };
-		2FDA12704CE45280D151E7AC /* OPDSParsingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OPDSParsingTests.swift; path = OPDSParsingTests.swift; sourceTree = "<group>"; };
+		2FDA12704CE45280D151E7AC /* OPDSParsingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDSParsingTests.swift; sourceTree = "<group>"; };
 		2FF4CC60E96981C8BF94891C /* BadgeDefinitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeDefinitionTests.swift; sourceTree = "<group>"; };
 		3023DFFACC986541965F1560 /* OPDS2PublicationExtended.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OPDS2PublicationExtended.swift; path = OPDS2/Models/OPDS2PublicationExtended.swift; sourceTree = "<group>"; };
 		30B163B18C48334A913B2CCA /* URLRequestNYPLAdditionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLRequestNYPLAdditionsTests.swift; sourceTree = "<group>"; };
@@ -1867,6 +1854,7 @@
 		42F178DBC9EBCF7C7FA70BEC /* FocusIndicationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FocusIndicationTests.swift; sourceTree = "<group>"; };
 		43040747774740399559510F /* UserRetryTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRetryTracker.swift; sourceTree = "<group>"; };
 		44169A0B2904A3C8CFEDD8F7 /* SAMLHelperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAMLHelperTests.swift; sourceTree = "<group>"; };
+		44B9D77A2797816A93F9D35B /* PDFAccessibilityToolbarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFAccessibilityToolbarTests.swift; sourceTree = "<group>"; };
 		44E59F675A3E4419BE1E24BB /* FacetViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetViewModelTests.swift; sourceTree = "<group>"; };
 		4609134D5A2D39DD0D8E7DCA /* CatalogAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogAccessibilityTests.swift; sourceTree = "<group>"; };
 		46A0B2DA8FB8ABF53C9E32FF /* CredentialGuardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CredentialGuardTests.swift; sourceTree = "<group>"; };
@@ -1875,6 +1863,7 @@
 		480ADB3F1AA842DE805EC230 /* AccountDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDetailView.swift; sourceTree = "<group>"; };
 		480CFCD095E5C455D1CFA499 /* OfflineQueueServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineQueueServiceTests.swift; sourceTree = "<group>"; };
 		488A86760250BA6E087F28CC /* TPPOPDSAttribute.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPOPDSAttribute.swift; sourceTree = "<group>"; };
+		48A94705E284922B50327BF8 /* DRMAdversarialTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRMAdversarialTests.swift; sourceTree = "<group>"; };
 		48B834DC53BA4A1C8B4EBDC6 /* TPPObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TPPObjCExceptionCatcher.m; path = Palace/Utilities/TPPObjCExceptionCatcher.m; sourceTree = SOURCE_ROOT; };
 		48DF25F6BFF39ECDAF39E3E3 /* CatalogViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogViewModelTests.swift; sourceTree = "<group>"; };
 		4A4A88D788BA48D5B4CCCD59 /* TPPCrossLibrarySignOutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPCrossLibrarySignOutTests.swift; sourceTree = "<group>"; };
@@ -1907,6 +1896,7 @@
 		5A5B90111B946763002C53E9 /* libc++.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.1.dylib"; path = "usr/lib/libc++.1.dylib"; sourceTree = SDKROOT; };
 		5A5B90141B946CBD002C53E9 /* libstdc++.6.0.9.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libstdc++.6.0.9.dylib"; path = "usr/lib/libstdc++.6.0.9.dylib"; sourceTree = SDKROOT; };
 		5A7FF4F347587A08E517F389 /* AlertUtilsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertUtilsTests.swift; sourceTree = "<group>"; };
+		5A8468ADD34076BF5935E56B /* TPPBookAccessibilityLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookAccessibilityLabelTests.swift; sourceTree = "<group>"; };
 		5AF3302384CAD3BB95FB6B56 /* HoldsSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HoldsSnapshotTests.swift; sourceTree = "<group>"; };
 		5BC9F70101B8AD9FAFF88F0E /* AppLaunchTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchTracker.swift; sourceTree = "<group>"; };
 		5D1B141422CBE3570006C964 /* TPPProblemDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPProblemDocument.swift; sourceTree = "<group>"; };
@@ -1946,6 +1936,7 @@
 		6A71EC60193844F386CAC4F4 /* TPPBookRegistryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookRegistryIntegrationTests.swift; sourceTree = "<group>"; };
 		6AB284B9E0D2C5DE059116E9 /* TPPOPDSIndirectAcquisition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPOPDSIndirectAcquisition.swift; sourceTree = "<group>"; };
 		6C7A26344806FE3471C298DF /* PositionSyncTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PositionSyncTests.swift; sourceTree = "<group>"; };
+		6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceCheckPropertyTests.swift; sourceTree = "<group>"; };
 		6CFCFF5C7BF41D65666565EC /* OPDSFeedServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDSFeedServiceTests.swift; sourceTree = "<group>"; };
 		6DB8CC29A8C5DFB84187D498 /* NSURLRequest+NYPLURLRequestAdditions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSURLRequest+NYPLURLRequestAdditions.swift"; sourceTree = "<group>"; };
 		6DEA83D0B2D2A423B42AB1D4 /* TPPNull.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPNull.swift; sourceTree = "<group>"; };
@@ -1953,6 +1944,7 @@
 		6EBF1AB49179CABFF759380B /* AppHealthViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHealthViewModelTests.swift; sourceTree = "<group>"; };
 		6F826CF3A1D6633781419179 /* ManifestFetchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManifestFetchTests.swift; sourceTree = "<group>"; };
 		706130D4BA8B4FE88304EC9C /* TPPLastReadPositionSynchronizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPLastReadPositionSynchronizerTests.swift; sourceTree = "<group>"; };
+		70819902FBD142EFF56C93D9 /* ChaosHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaosHarness.swift; sourceTree = "<group>"; };
 		7096661E3AAF4B878E1F49DC /* RDServicesStubs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RDServicesStubs.h; sourceTree = "<group>"; };
 		71E3B2C7B51DEBF595766568 /* TPPSAMLSignInTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPSAMLSignInTests.swift; sourceTree = "<group>"; };
 		71FEEC427223FFDB026D6137 /* OfflineQueueServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineQueueServiceProtocol.swift; sourceTree = "<group>"; };
@@ -2087,13 +2079,16 @@
 		73FB0AC824EB403D0072E430 /* TPPBookContentTypeConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookContentTypeConverter.swift; sourceTree = "<group>"; };
 		74D09C16D15567198A0A9194 /* StatsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsViewModelTests.swift; sourceTree = "<group>"; };
 		75305888F6A941DDA9EEE592 /* RDServicesStubs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RDServicesStubs.m; sourceTree = "<group>"; };
+		75A5818A6D6FBED89690BA3F /* TPPPerAccountIsolationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPPerAccountIsolationTests.swift; sourceTree = "<group>"; };
 		75D9F7D6121602ED239491CF /* TPPOPDSAcquisitionPath.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPOPDSAcquisitionPath.swift; sourceTree = "<group>"; };
 		7751F6315B6633F398F0B808 /* StringExtensionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
+		77C1C5F7FE43056D96C9DE5C /* LCPSessionOrphaningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPSessionOrphaningTests.swift; sourceTree = "<group>"; };
 		781125E2689F3A05C75A0D33 /* CatalogCacheMetadataTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogCacheMetadataTests.swift; sourceTree = "<group>"; };
 		78529336066D2340C7B0FCE0 /* DownloadOnlyOnWiFiTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadOnlyOnWiFiTests.swift; sourceTree = "<group>"; };
 		78F5C80C8A39854AADD31179 /* TPPOpenSearchDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPOpenSearchDescription.swift; sourceTree = "<group>"; };
 		7A969BA0D39ABD4285F6F211 /* String+TPPStringAdditions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+TPPStringAdditions.swift"; sourceTree = "<group>"; };
 		7BA4D17463BADFD0DEBC53FA /* ReadingStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStats.swift; sourceTree = "<group>"; };
+		7BFD7CCC67838590BD9E203D /* FuzzRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzRunner.swift; sourceTree = "<group>"; };
 		7CBC313C7F61C891527F159B /* PerformanceMonitorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMonitorProtocol.swift; sourceTree = "<group>"; };
 		7CF9C6D37F357167F7698E42 /* TPPOPDSType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPOPDSType.swift; sourceTree = "<group>"; };
 		7F31B83CAB15F0245AEEE83C /* NetworkRetryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkRetryTests.swift; sourceTree = "<group>"; };
@@ -2144,6 +2139,7 @@
 		9BCA63D51A4176FB08ED1941 /* StatsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTab.swift; sourceTree = "<group>"; };
 		9BFF70FF762C60CE8CD8D811 /* CatalogSearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogSearchViewModelTests.swift; sourceTree = "<group>"; };
 		9DDB7EFFCB479426AC9DB8B8 /* BookDetailSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookDetailSnapshotTests.swift; sourceTree = "<group>"; };
+		9E49448110C43EB199A09AD3 /* FuzzCorpus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzCorpus.swift; sourceTree = "<group>"; };
 		9ED738AB4311CF5D59516022 /* TPPErrorLoggerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPErrorLoggerTests.swift; sourceTree = "<group>"; };
 		A0140FB30133B2AFB6A1207D /* OPDS2FeedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OPDS2FeedTests.swift; path = OPDS2/OPDS2FeedTests.swift; sourceTree = "<group>"; };
 		A047896E4B4E78F19CF33603 /* FacetToolbarAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FacetToolbarAccessibilityTests.swift; sourceTree = "<group>"; };
@@ -2244,6 +2240,7 @@
 		BB5171A2D51228EEF05D37CA /* AccountDetailsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountDetailsTests.swift; sourceTree = "<group>"; };
 		BB660AAD998ACFC41771539E /* ReadingStatsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsStore.swift; sourceTree = "<group>"; };
 		BDC90738317B9A2A4331572D /* TPPSessionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPSessionTests.swift; sourceTree = "<group>"; };
+		BE020244923A658A8CB9EE39 /* AuthFlowSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowSecurityTests.swift; sourceTree = "<group>"; };
 		BEF1F7C70AC93BF8E2F22148 /* DebugSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DebugSettings.swift; path = Debug/DebugSettings.swift; sourceTree = "<group>"; };
 		BF99D1F39D634C56A70BFE75 /* AudiobookReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookReliabilityTests.swift; sourceTree = "<group>"; };
 		BKTST00012F27000000FR01 /* TPPBookLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookLocationTests.swift; sourceTree = "<group>"; };
@@ -2317,6 +2314,7 @@
 		E358F2BF99213E34F1B052ED /* OPDS2BookBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2BookBridgeTests.swift; sourceTree = "<group>"; };
 		E3C9C7A1029274277B31F57E /* OfflineQueueBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineQueueBadge.swift; sourceTree = "<group>"; };
 		E3FF91DFB962417EA742080A /* RetryClassificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryClassificationTests.swift; sourceTree = "<group>"; };
+		E48AE22D7C0BC6134885E9F0 /* TPPProcessInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPProcessInfo.swift; sourceTree = "<group>"; };
 		E4FCC8401ACF8D4FD8CAFFE2 /* BookButtonTypeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookButtonTypeTests.swift; sourceTree = "<group>"; };
 		E50221B629881BC900A8A80B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E50221BE29881CAC00A8A80B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2617,8 +2615,11 @@
 		EF6CA6FD20109963823CABD1 /* AppLaunchTrackerExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchTrackerExtendedTests.swift; sourceTree = "<group>"; };
 		F002381F5C11990812629F32 /* TPPSignInAdobeSkipTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPSignInAdobeSkipTests.swift; sourceTree = "<group>"; };
 		F0AB00222E8E600100000003 /* TPPAccessibilityAnnouncementCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAccessibilityAnnouncementCenter.swift; sourceTree = "<group>"; };
+		F3456C5272C3572ACAC0A1A1 /* PalaceCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceCheck.swift; sourceTree = "<group>"; };
+		F59A401EA03CDC4931610FA1 /* CredentialPrivacyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialPrivacyTests.swift; sourceTree = "<group>"; };
 		F5C50D1C0AA0BA1374D31676 /* BookAvailabilityFormatterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookAvailabilityFormatterTests.swift; sourceTree = "<group>"; };
 		F5CBFE0B23AFFE343E256AE1 /* AccountDetailViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountDetailViewModelTests.swift; sourceTree = "<group>"; };
+		F6990140C2393E885A89B739 /* Corpus */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Corpus; sourceTree = "<group>"; };
 		F6BA53D1C399ABE2186FD429 /* OPDS2AuthenticationDocumentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2AuthenticationDocumentTests.swift; sourceTree = "<group>"; };
 		F6C56509A03466E0531DBC27 /* TPPAccountAuthState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAccountAuthState.swift; sourceTree = "<group>"; };
 		F6F691D8676CFC56232C6790 /* LCPPDFsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPDFsTests.swift; sourceTree = "<group>"; };
@@ -2627,6 +2628,8 @@
 		F994F35E532ACAA0F6C45035 /* ReaderTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTheme.swift; sourceTree = "<group>"; };
 		F9F719C4DEA011976097371B /* AudiobookSessionManaging.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookSessionManaging.swift; sourceTree = "<group>"; };
 		FC465C72310C5054118CBBEA /* UserAccountValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserAccountValidationTests.swift; sourceTree = "<group>"; };
+		FC95BE63D9C7C7AE1EFB8D6B /* ChaosFaultInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaosFaultInjectionTests.swift; sourceTree = "<group>"; };
+		FE2159403F0FCBE90CFC6858 /* BookImageViewAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImageViewAccessibilityTests.swift; sourceTree = "<group>"; };
 		FE7BD91AF3E14990B745A0AA /* AudiobookDataManagerSyncTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookDataManagerSyncTests.swift; sourceTree = "<group>"; };
 		FF5C956CCCED314E3E03EEA5 /* SAMLCookieSyncTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAMLCookieSyncTests.swift; sourceTree = "<group>"; };
 		FFA10178BD2885EBF24673F3 /* FontManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontManager.swift; sourceTree = "<group>"; };
@@ -2636,10 +2639,10 @@
 		INTG0001B7A00000000004 /* AccountSwitchIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSwitchIntegrationTests.swift; sourceTree = "<group>"; };
 		INTG0001B7A00000000006 /* BookStateIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookStateIntegrationTests.swift; sourceTree = "<group>"; };
 		INTG0001B7A00000000008 /* CatalogLoadIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogLoadIntegrationTests.swift; sourceTree = "<group>"; };
+		KCHAVAIL00FILEREF000001 /* KeychainAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAvailability.swift; sourceTree = "<group>"; };
 		LNEX01FR00000000000001 /* LoanExpiryHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoanExpiryHandlingTests.swift; sourceTree = "<group>"; };
 		NEWTST001CONFIGTEST0001 /* TPPConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPConfigurationTests.swift; sourceTree = "<group>"; };
 		NEWTST003KEYCHNTEST0001 /* TPPKeychainSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPKeychainSwiftTests.swift; sourceTree = "<group>"; };
-		KCHAVAIL00FILEREF000001 /* KeychainAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAvailability.swift; sourceTree = "<group>"; };
 		NEWTST005OPENSRCTEST001 /* TPPOpenSearchDescriptionExpandedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPOpenSearchDescriptionExpandedTests.swift; sourceTree = "<group>"; };
 		NEWTST007PDFPRVTEST0001 /* TPPEncryptedPDFDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPEncryptedPDFDataProviderTests.swift; sourceTree = "<group>"; };
 		NEWTST009XMLSWFTEST0001 /* TPPXMLSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPXMLSwiftTests.swift; sourceTree = "<group>"; };
@@ -3046,7 +3049,6 @@
 			isa = PBXGroup;
 			children = (
 			);
-			name = JWK;
 			path = JWK;
 			sourceTree = "<group>";
 		};
@@ -3079,7 +3081,6 @@
 				3D5A0D270E8AC2DDFBC62044 /* IntExtensionsTests.swift */,
 				06784DE00D5161E7071843F0 /* StringHTMLEntitiesTests.swift */,
 			);
-			name = Extensions;
 			path = Extensions;
 			sourceTree = "<group>";
 		};
@@ -3171,6 +3172,15 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
+		48E1DB2642CBFFC345BB345E /* Chaos */ = {
+			isa = PBXGroup;
+			children = (
+				FC95BE63D9C7C7AE1EFB8D6B /* ChaosFaultInjectionTests.swift */,
+				70819902FBD142EFF56C93D9 /* ChaosHarness.swift */,
+			);
+			path = Chaos;
+			sourceTree = "<group>";
+		};
 		52452B48CF3C52B395874F52 /* LCP */ = {
 			isa = PBXGroup;
 			children = (
@@ -3227,6 +3237,7 @@
 				PP3702FR000000000000004 /* AccountSwitchCleanupTests.swift */,
 				BB5171A2D51228EEF05D37CA /* AccountDetailsTests.swift */,
 				A3332DED915E45913181C82D /* UserAccountPublisherTests.swift */,
+				75A5818A6D6FBED89690BA3F /* TPPPerAccountIsolationTests.swift */,
 			);
 			path = Accounts;
 			sourceTree = "<group>";
@@ -4501,6 +4512,17 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
+		B276B087059115995C1F90B8 /* Fuzz */ = {
+			isa = PBXGroup;
+			children = (
+				9E49448110C43EB199A09AD3 /* FuzzCorpus.swift */,
+				7BFD7CCC67838590BD9E203D /* FuzzRunner.swift */,
+				1FFBDD2A1333CAF4E0F850AB /* ParserFuzzTests.swift */,
+				F6990140C2393E885A89B739 /* Corpus */,
+			);
+			path = Fuzz;
+			sourceTree = "<group>";
+		};
 		B358508756ABDE24E48382EA /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
@@ -4508,7 +4530,6 @@
 				93925AD8656015E0036615C8 /* NotificationServiceTokenTests.swift */,
 				6DF4B6BD211B2BF0AEA436A7 /* NotificationSyncThrottleTests.swift */,
 			);
-			name = Notifications;
 			path = Notifications;
 			sourceTree = "<group>";
 		};
@@ -4525,6 +4546,16 @@
 				A556E4218D9D8BDC19019BFA /* TPPBookTests.swift */,
 			);
 			path = Book;
+			sourceTree = "<group>";
+		};
+		B3DC95991AADEE7FEF8F1A0A /* Property */ = {
+			isa = PBXGroup;
+			children = (
+				F3456C5272C3572ACAC0A1A1 /* PalaceCheck.swift */,
+				142D46BAD0D6D86963ACCA7E /* PalaceCheckGenerators.swift */,
+				6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */,
+			);
+			path = Property;
 			sourceTree = "<group>";
 		};
 		B4CONC000GR000000000001 /* Concurrency */ = {
@@ -4695,6 +4726,16 @@
 				EE3D078322CEC4B660EC470F /* TPPPDFModelTests.swift */,
 			);
 			path = PDF;
+			sourceTree = "<group>";
+		};
+		D62D168E304A0769D3AADCF2 /* Security */ = {
+			isa = PBXGroup;
+			children = (
+				BE020244923A658A8CB9EE39 /* AuthFlowSecurityTests.swift */,
+				F59A401EA03CDC4931610FA1 /* CredentialPrivacyTests.swift */,
+				48A94705E284922B50327BF8 /* DRMAdversarialTests.swift */,
+			);
+			path = Security;
 			sourceTree = "<group>";
 		};
 		DAC6E0FC5E3CFA49485C5980 /* Models */ = {
@@ -5307,46 +5348,6 @@
 				78529336066D2340C7B0FCE0 /* DownloadOnlyOnWiFiTests.swift */,
 			);
 			path = Settings;
-			sourceTree = "<group>";
-		};
-		48E1DB2642CBFFC345BB345E /* Chaos */ = {
-			isa = PBXGroup;
-			children = (
-				FC95BE63D9C7C7AE1EFB8D6B /* ChaosFaultInjectionTests.swift */,
-				70819902FBD142EFF56C93D9 /* ChaosHarness.swift */,
-			);
-			path = Chaos;
-			sourceTree = "<group>";
-		};
-		D62D168E304A0769D3AADCF2 /* Security */ = {
-			isa = PBXGroup;
-			children = (
-				BE020244923A658A8CB9EE39 /* AuthFlowSecurityTests.swift */,
-				F59A401EA03CDC4931610FA1 /* CredentialPrivacyTests.swift */,
-				48A94705E284922B50327BF8 /* DRMAdversarialTests.swift */,
-			);
-			path = Security;
-			sourceTree = "<group>";
-		};
-		B3DC95991AADEE7FEF8F1A0A /* Property */ = {
-			isa = PBXGroup;
-			children = (
-				F3456C5272C3572ACAC0A1A1 /* PalaceCheck.swift */,
-				142D46BAD0D6D86963ACCA7E /* PalaceCheckGenerators.swift */,
-				6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */,
-			);
-			path = Property;
-			sourceTree = "<group>";
-		};
-		B276B087059115995C1F90B8 /* Fuzz */ = {
-			isa = PBXGroup;
-			children = (
-				9E49448110C43EB199A09AD3 /* FuzzCorpus.swift */,
-				7BFD7CCC67838590BD9E203D /* FuzzRunner.swift */,
-				1FFBDD2A1333CAF4E0F850AB /* ParserFuzzTests.swift */,
-				F6990140C2393E885A89B739 /* Corpus */,
-			);
-			path = Fuzz;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -6098,7 +6099,8 @@
 				2328B4483544EAC500B592B6 /* UserAccountValidationTests.swift in Sources */,
 				1318423C032ACE063AD6847F /* TPPKeychainTests.swift in Sources */,
 				6EB2C35167224D90DCCBE1C0 /* TPPBackgroundExecutorTests.swift in Sources */,
-				6B0BA478542867A920369D75 /* TPPObjCExceptionCatcher.m in Sources */,				C2A355EBB5690A235E9E6F22 /* AccountDetailViewModelTests.swift in Sources */,
+				6B0BA478542867A920369D75 /* TPPObjCExceptionCatcher.m in Sources */,
+				C2A355EBB5690A235E9E6F22 /* AccountDetailViewModelTests.swift in Sources */,
 				D96E403E3CC3E3C7C64C36BF /* AudiobookPlayerSnapshotTests.swift in Sources */,
 				CBCB444F4C168A9CCF792BFA /* AudiobookTrackerExtendedTests.swift in Sources */,
 				EAA2D00728C00311D0CF0D81 /* BookDetailSnapshotTests.swift in Sources */,
@@ -6111,9 +6113,14 @@
 				083A37353E8CF921FC35C836 /* SearchSnapshotTests.swift in Sources */,
 				95EA0EDAFB3A8258514E4877 /* SettingsSnapshotTests.swift in Sources */,
 				E9A2B669C2E26107FDE81873 /* SnapshotTestConfiguration.swift in Sources */,
-				237B6705CA505A8CE33EAE6D /* TPPDeferredAdobeActivationTests.swift in Sources */,				C54572940A4584060C2DC457 /* ReaderThemeTests.swift in Sources */,				1C18F75CD734D8C4ABA2D816 /* BookImageViewAccessibilityTests.swift in Sources */,
+				237B6705CA505A8CE33EAE6D /* TPPDeferredAdobeActivationTests.swift in Sources */,
+				C54572940A4584060C2DC457 /* ReaderThemeTests.swift in Sources */,
 				D8323F4CCF51DE6D1961CBDC /* TPPBookAccessibilityLabelTests.swift in Sources */,
-				059C1DFA5BF79EEE154645E3 /* LCPSessionOrphaningTests.swift in Sources */,				EC75FDA52C9B331548ED96A1 /* URLResponseNYPLTests.swift in Sources */,				FC5C80424EE10131FA0087F2 /* TPPSAMLSignInTests.swift in Sources */,				A467B678AF1566E5745403E0 /* TPPSignInOIDCTests.swift in Sources */,
+				059C1DFA5BF79EEE154645E3 /* LCPSessionOrphaningTests.swift in Sources */,
+				EC75FDA52C9B331548ED96A1 /* URLResponseNYPLTests.swift in Sources */,
+				FC5C80424EE10131FA0087F2 /* TPPSAMLSignInTests.swift in Sources */,
+				A467B678AF1566E5745403E0 /* TPPSignInOIDCTests.swift in Sources */,
+				6021615DC1CCCE566261E7B5 /* TPPPerAccountIsolationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -32,6 +32,15 @@ struct CatalogCacheMetadata: Codable {
     var currentAccount: Account? { get }
 }
 
+/// Resolves per-library `TPPUserAccount` instances. Prefer this over
+/// `TPPUserAccount.sharedAccount(libraryUUID:)` — instances returned by
+/// this protocol have immutable keychain keys and are not subject to the
+/// TOCTOU race in the singleton's mutable `libraryUUID` pattern.
+@objc protocol TPPUserAccountResolving: NSObjectProtocol {
+    func userAccount(for libraryUUID: String) -> TPPUserAccount
+    var currentUserAccount: TPPUserAccount { get }
+}
+
 @objc protocol TPPLibraryAccountsProvider: TPPCurrentLibraryAccountProvider {
     var tppAccountUUID: String { get }
     var currentAccountId: String? { get }
@@ -39,7 +48,7 @@ struct CatalogCacheMetadata: Codable {
 }
 
 /// Manages library accounts asynchronously with authentication & image loading
-@objcMembers final class AccountsManager: NSObject, TPPLibraryAccountsProvider {
+@objcMembers final class AccountsManager: NSObject, TPPLibraryAccountsProvider, TPPUserAccountResolving {
 
     static let shared = AccountsManager()
     static func sharedInstance() -> AccountsManager { shared }
@@ -124,7 +133,7 @@ struct CatalogCacheMetadata: Codable {
 
             self.currentAccount?.hasUpdatedToken = false
             currentAccountId = newValue?.uuid
-            TPPErrorLogger.setUserID(TPPUserAccount.sharedAccount().barcode)
+            TPPErrorLogger.setUserID(self.currentUserAccount.barcode)
             NotificationCenter.default.post(name: .TPPCurrentAccountDidChange, object: nil)
         }
     }
@@ -176,6 +185,36 @@ struct CatalogCacheMetadata: Codable {
         return performRead {
             !(self.accountSets[self.accountSet]?.isEmpty ?? true)
         }
+    }
+
+    // MARK: - Per-Account User Credentials
+
+    /// Cache of per-library `TPPUserAccount` instances. Each instance has
+    /// immutable keychain keys, eliminating the TOCTOU race that the
+    /// singleton's mutable `libraryUUID` pattern was subject to.
+    private var userAccounts = [String: TPPUserAccount]()
+    private let userAccountsLock = NSLock()
+
+    /// Returns a library-scoped `TPPUserAccount` instance. Creates and
+    /// caches a new one on first access for a given UUID.
+    func userAccount(for libraryUUID: String) -> TPPUserAccount {
+        userAccountsLock.lock()
+        defer { userAccountsLock.unlock() }
+        if let existing = userAccounts[libraryUUID] {
+            return existing
+        }
+        let account = TPPUserAccount(libraryUUID: libraryUUID)
+        userAccounts[libraryUUID] = account
+        return account
+    }
+
+    /// Convenience for the current library's user account.
+    var currentUserAccount: TPPUserAccount {
+        guard let id = currentAccountId else {
+            // Fallback to legacy singleton when no account is selected
+            return TPPUserAccount.sharedAccount()
+        }
+        return userAccount(for: id)
     }
 
     // MARK: – Load logic
@@ -422,11 +461,11 @@ struct CatalogCacheMetadata: Codable {
             if accountExistenceChanged || currentAccountMissingDetails, let current = self.currentAccount {
                 group.enter()
                 current.loadLogo()
-                current.loadAuthenticationDocument(using: TPPUserAccount.sharedAccount()) { _ in
+                current.loadAuthenticationDocument(using: self.currentUserAccount) { _ in
                     if current.details?.needsAgeCheck ?? false {
                         group.enter()
                         self.ageCheck.verifyCurrentAccountAgeRequirement(
-                            userAccountProvider: TPPUserAccount.sharedAccount(),
+                            userAccountProvider: self.currentUserAccount,
                             currentLibraryAccountProvider: self
                         ) { _ in group.leave() }
                     }

--- a/Palace/Accounts/User/TPPUserAccount.swift
+++ b/Palace/Accounts/User/TPPUserAccount.swift
@@ -40,9 +40,14 @@ private enum StorageKey: String {
 
 @objcMembers class TPPUserAccount: NSObject, TPPUserAccountProvider {
     static private let shared = TPPUserAccount()
-    private let accountInfoQueue = DispatchQueue(label: "TPPUserAccount.accountInfoQueue")
+    private let accountInfoQueue: DispatchQueue
     private lazy var keychainTransaction = TPPKeychainVariableTransaction(accountInfoQueue: accountInfoQueue)
     private var notifyAccountChange: Bool = true
+
+    /// When non-nil, this instance is bound to a specific library and its
+    /// keychain keys are immutable. The mutable `libraryUUID` path is only
+    /// used by the legacy singleton (where `boundLibraryUUID` is nil).
+    let boundLibraryUUID: String?
 
     /// PP-3819: Incremented by `cancelPendingSignOut()` each time the user
     /// signs in, so that a stale DRM deauthorization callback can detect
@@ -56,6 +61,35 @@ private enum StorageKey: String {
     /// network purpose and must never be persisted or transmitted.
     /// Exposed as `String` so it is Obj-C friendly via `@objcMembers`.
     public private(set) var sessionIdentifier: String = UUID().uuidString
+
+    // MARK: - Initializers
+
+    /// Legacy singleton initializer. Uses mutable `libraryUUID` path.
+    /// Internal (not private) so that test mocks can subclass.
+    override init() {
+        self.boundLibraryUUID = nil
+        self.accountInfoQueue = DispatchQueue(label: "TPPUserAccount.accountInfoQueue")
+        super.init()
+    }
+
+    /// Per-account initializer. Creates an instance bound to a specific library
+    /// with immutable keychain keys. Each instance owns its own serial queue,
+    /// eliminating cross-account contention entirely.
+    ///
+    /// Prefer this over `sharedAccount(libraryUUID:)` — it is not subject to
+    /// the TOCTOU race that the singleton pattern has.
+    init(libraryUUID: String) {
+        self.boundLibraryUUID = libraryUUID
+        self.accountInfoQueue = DispatchQueue(label: "TPPUserAccount.\(libraryUUID)")
+        super.init()
+        // Set the mutable libraryUUID so the lazy keychain vars initialize
+        // with the correct keys. Since boundLibraryUUID is set, the didSet
+        // path that calls updateKeychainKeys() will fire once and then the
+        // keys are effectively frozen (no caller can change libraryUUID on
+        // a bound instance via the public API — sharedAccount(libraryUUID:)
+        // only mutates the singleton).
+        self.libraryUUID = libraryUUID
+    }
 
     var libraryUUID: String? {
         didSet {
@@ -488,6 +522,34 @@ private enum StorageKey: String {
         let cookies: [HTTPCookie]?
     }
 
+    /// Instance-level snapshot — reads from this instance's keychain variables.
+    /// On bound (per-account) instances the keys are immutable, so this is
+    /// inherently race-free without needing a barrier.
+    func credentialSnapshot() -> CredentialSnapshot {
+        return accountInfoQueue.sync {
+            let creds = self.credentials
+            let hasCreds = UserAccountAuthHelper.hasCredentials(creds)
+            let hasToken = UserAccountAuthHelper.hasAuthToken(credentials: creds)
+            let state = UserAccountAuthHelper.resolveAuthState(
+                storedState: self._authState.read(),
+                hasCredentials: hasCreds
+            )
+
+            return CredentialSnapshot(
+                hasCredentials: hasCreds,
+                hasAuthToken: hasToken,
+                authState: state,
+                barcode: UserAccountAuthHelper.barcode(from: creds),
+                pin: UserAccountAuthHelper.pin(from: creds),
+                authToken: UserAccountAuthHelper.authToken(from: creds),
+                authDefinition: self.authDefinition,
+                cookies: self._cookies.read()
+            )
+        }
+    }
+
+    /// Legacy class-level snapshot — delegates to the singleton with UUID switching.
+    /// Deprecated: prefer `AccountsManager.shared.userAccount(for:).credentialSnapshot()`.
     class func credentialSnapshot(for libraryUUID: String?) -> CredentialSnapshot {
         return shared.accountInfoQueue.sync(flags: .barrier) {
             if shared.libraryUUID != libraryUUID {

--- a/Palace/Accounts/User/UserAccountPublisher+Extensions.swift
+++ b/Palace/Accounts/User/UserAccountPublisher+Extensions.swift
@@ -124,14 +124,14 @@ extension UserAccountPublisher {
     /// Resets publisher state for testing
     func resetForTesting() {
         // Create mock account state
-        let mockAccount = TPPUserAccount.sharedAccount()
+        let mockAccount = AccountsManager.shared.currentUserAccount
         updateState(from: mockAccount)
     }
 
     /// Simulates sign in for testing
     func simulateSignIn(barcode: String, patronName: String?) {
         // Use actual account to trigger real state changes
-        TPPUserAccount.sharedAccount().setBarcode(barcode, PIN: "test")
+        AccountsManager.shared.currentUserAccount.setBarcode(barcode, PIN: "test")
     }
 
     /// Simulates sign out for testing

--- a/Palace/Accounts/User/UserAccountPublisher.swift
+++ b/Palace/Accounts/User/UserAccountPublisher.swift
@@ -96,7 +96,7 @@ final class UserAccountPublisher: ObservableObject {
         authState = .credentialsStale
 
         // Also update the persisted state in TPPUserAccount
-        TPPUserAccount.sharedAccount().setAuthState(.credentialsStale)
+        AccountsManager.shared.currentUserAccount.setAuthState(.credentialsStale)
     }
 
     /// Marks the account as fully logged in.

--- a/Palace/AppInfrastructure/DLNavigator.swift
+++ b/Palace/AppInfrastructure/DLNavigator.swift
@@ -79,7 +79,7 @@ class DLNavigator {
             }
             return
         }
-        if TPPUserAccount.sharedAccount(libraryUUID: libraryId).isSignedIn() {
+        if AccountsManager.shared.userAccount(for: libraryId).isSignedIn() {
             return
         }
         SignInModalPresenter.presentSignInModalForCurrentAccount {

--- a/Palace/AppInfrastructure/FirebaseManager.swift
+++ b/Palace/AppInfrastructure/FirebaseManager.swift
@@ -283,6 +283,13 @@ final class FirebaseManager {
         #endif
     }
 
+    /// Sets a custom key-value pair on Crashlytics for dashboard filtering.
+    func setCrashlyticsKey(_ key: String, value: String) {
+        #if FEATURE_CRASH_REPORTING
+        Crashlytics.crashlytics().setCustomValue(value, forKey: key)
+        #endif
+    }
+
     // MARK: - Analytics Events
 
     /// Logs an enhanced error event to Analytics.

--- a/Palace/AppInfrastructure/ReaderService.swift
+++ b/Palace/AppInfrastructure/ReaderService.swift
@@ -186,7 +186,7 @@ final class ReaderService {
         // Samples don't need sync since they have no persisted position.
         if !forSample {
             let synchronizer = TPPLastReadPositionSynchronizer(bookRegistry: bookRegistry)
-            let deviceID = AnnotationDevice.currentID()
+            let deviceID = AccountsManager.shared.currentUserAccount.deviceID
             await synchronizer.sync(for: publication, book: book, drmDeviceID: deviceID)
         }
 

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -74,7 +74,7 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
         logCredentialStateAtLaunch(isFreshInstall: isFreshInstall)
 
         PalaceAuthTokenProvider.tokenResolver = {
-            TPPUserAccount.sharedAccount().authToken
+            AccountsManager.shared.currentUserAccount.authToken
         }
 
         DispatchQueue.main.async {
@@ -94,7 +94,7 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func logCredentialStateAtLaunch(isFreshInstall: Bool) {
-        let account = TPPUserAccount.sharedAccount()
+        let account = AccountsManager.shared.currentUserAccount
         let accountId = AccountsManager.shared.currentAccountId ?? "nil"
         let authDef = account.authDefinition
         let authType = authDef?.authType.rawValue ?? "none"
@@ -226,7 +226,7 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
-        TPPErrorLogger.setUserID(TPPUserAccount.sharedAccount().barcode)
+        TPPErrorLogger.setUserID(AccountsManager.shared.currentUserAccount.barcode)
 
         // Resume Firebase operations when app becomes active
         FirebaseManager.shared.applicationDidBecomeActive()
@@ -245,7 +245,7 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     /// Syncs the book registry if the user has holds to ensure fresh availability data.
     /// Throttled to prevent excessive network calls on frequent app activation.
     private func syncIfUserHasHolds() {
-        guard TPPUserAccount.sharedAccount().hasCredentials() else {
+        guard AccountsManager.shared.currentUserAccount.hasCredentials() else {
             return
         }
 

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -446,7 +446,7 @@ public final class AudiobookSessionManager: ObservableObject {
             return true
         }
 
-        return TPPUserAccount.sharedAccount().hasCredentials()
+        return AccountsManager.shared.currentUserAccount.hasCredentials()
     }
 
     private func openBookWithService(
@@ -528,7 +528,7 @@ public final class AudiobookSessionManager: ObservableObject {
 
             // PP-3703: When BiblioBoard bearer token refresh fails due to SAML session expiration
             // (401 on CM fulfill link), trigger SAML re-login and then re-fetch fulfill to resume playback.
-            let userAccount = TPPUserAccount.sharedAccount()
+            let userAccount = AccountsManager.shared.currentUserAccount
             if Self.shouldTriggerSAMLReauthForPlaybackFailure(error: error, userAccount: userAccount, currentBook: currentBook),
                let book = currentBook {
                 Log.info(#file, "SAML + BiblioBoard: Bearer token refresh failed (session expired) - triggering re-auth, will re-open audiobook after login")
@@ -538,7 +538,7 @@ public final class AudiobookSessionManager: ObservableObject {
                     Task { @MainActor in
                         guard let self else { return }
                         guard self.currentBook?.identifier == book.identifier else { return }
-                        guard TPPUserAccount.sharedAccount().hasCredentials() else {
+                        guard AccountsManager.shared.currentUserAccount.hasCredentials() else {
                             Log.info(#file, "SAML re-auth cancelled or failed - not re-opening audiobook")
                             self.errorPublisher.send(.notAuthenticated)
                             return

--- a/Palace/Book/Models/TPPBook.swift
+++ b/Palace/Book/Models/TPPBook.swift
@@ -531,7 +531,7 @@ extension TPPBook: @unchecked Sendable {}
 
 extension TPPBook {
     func requiresAuthForReturnOrDeletion() -> Bool {
-        let userAuthRequired = TPPUserAccount.sharedAccount().authDefinition?.needsAuth ?? false
+        let userAuthRequired = AccountsManager.shared.currentUserAccount.authDefinition?.needsAuth ?? false
         return self.defaultAcquisitionIfOpenAccess == nil && userAuthRequired
     }
 }

--- a/Palace/Book/UI/BookDetail/BookActionHandler.swift
+++ b/Palace/Book/UI/BookDetail/BookActionHandler.swift
@@ -90,12 +90,12 @@ final class BookActionHandler {
             DispatchQueue.main.async {
                 guard let self = self else { return }
 
-                let account = TPPUserAccount.sharedAccount()
+                let account = AccountsManager.shared.currentUserAccount
                 if account.needsAuth && !account.hasCredentials() {
                     self.viewModel?.showHalfSheet = false
                     SignInModalPresenter.presentSignInModalForCurrentAccount { [weak self] in
                         guard let self else { return }
-                        guard TPPUserAccount.sharedAccount().hasCredentials() else {
+                        guard AccountsManager.shared.currentUserAccount.hasCredentials() else {
                             Log.info(#file, "Sign-in cancelled or failed, not proceeding with action")
                             self.viewModel?.processingButtons.remove(.download)
                             self.viewModel?.processingButtons.remove(.get)
@@ -168,7 +168,7 @@ final class BookActionHandler {
             Task { @MainActor in
                 guard let self = self else { return }
                 #if FEATURE_DRM_CONNECTOR
-                let user = TPPUserAccount.sharedAccount()
+                let user = AccountsManager.shared.currentUserAccount
 
                 if user.hasCredentials() {
                     if user.hasAuthToken() {

--- a/Palace/Book/UI/BookDetail/BookDetailView.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailView.swift
@@ -660,7 +660,7 @@ struct BookDetailView: View {
     }
 
     private func handleButtonAction(_ buttonType: BookButtonType) {
-        let account = TPPUserAccount.sharedAccount()
+        let account = AccountsManager.shared.currentUserAccount
         let needsAuth = account.needsAuth && !account.hasCredentials()
 
         switch buttonType {

--- a/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
@@ -343,7 +343,7 @@ final class BookDetailViewModel: ObservableObject {
 
         isLoadingRelatedBooks = true
 
-        TPPOPDSFeed.withURL(url, shouldResetCache: false, useTokenIfAvailable: TPPUserAccount.sharedAccount().hasAdobeToken()) { [weak self] feed, _ in
+        TPPOPDSFeed.withURL(url, shouldResetCache: false, useTokenIfAvailable: AccountsManager.shared.currentUserAccount.hasAdobeToken()) { [weak self] feed, _ in
             guard let self else { return }
 
             DispatchQueue.main.async {
@@ -493,13 +493,13 @@ final class BookDetailViewModel: ObservableObject {
             DispatchQueue.main.async {
                 guard let self = self else { return }
 
-                let account = TPPUserAccount.sharedAccount()
+                let account = AccountsManager.shared.currentUserAccount
                 if account.needsAuth && !account.hasCredentials() {
                     self.showHalfSheet = false
                     SignInModalPresenter.presentSignInModalForCurrentAccount { [weak self] in
                         guard let self else { return }
                         // Only proceed if user successfully logged in, not if they cancelled
-                        guard TPPUserAccount.sharedAccount().hasCredentials() else {
+                        guard AccountsManager.shared.currentUserAccount.hasCredentials() else {
                             Log.info(#file, "Sign-in cancelled or failed, not proceeding with action")
                             // Clear any processing state for download-related buttons
                             self.processingButtons.remove(.download)
@@ -576,7 +576,7 @@ final class BookDetailViewModel: ObservableObject {
             Task { @MainActor in
                 guard let self = self else { return }
                 #if FEATURE_DRM_CONNECTOR
-                let user = TPPUserAccount.sharedAccount()
+                let user = AccountsManager.shared.currentUserAccount
 
                 if user.hasCredentials() {
                     if user.hasAuthToken() {

--- a/Palace/Book/UI/BookDetail/BookService.swift
+++ b/Palace/Book/UI/BookDetail/BookService.swift
@@ -22,7 +22,7 @@ enum BookService {
     }
 
     private static func openAfterTokenRefresh(_ book: TPPBook, onFinish: (() -> Void)?) {
-        let userAccount = TPPUserAccount.sharedAccount()
+        let userAccount = AccountsManager.shared.currentUserAccount
 
         if book.defaultBookContentType == .audiobook && userAccount.authTokenHasExpired {
             Log.info(#file, "🔄 Auth token expired for audiobook - refreshing before opening")

--- a/Palace/Book/UI/TPPBookDetailsProblemDocumentViewController.swift
+++ b/Palace/Book/UI/TPPBookDetailsProblemDocumentViewController.swift
@@ -178,7 +178,7 @@
         alert.addAction(UIAlertAction.init(title: "Cancel", style: .cancel, handler: nil))
         alert.addAction(UIAlertAction.init(title: "Send email", style: .default, handler: { (_) in
             let labelText = self.label?.attributedText?.string ?? ""
-            let patronID = TPPUserAccount.sharedAccount().authorizationIdentifier ?? "n/a"
+            let patronID = AccountsManager.shared.currentUserAccount.authorizationIdentifier ?? "n/a"
             let body = """
         \(labelText)\n\
         DeviceModel:\n\(UIDevice.current.model)\n\n

--- a/Palace/CarPlay/CarPlayAudiobookBridge.swift
+++ b/Palace/CarPlay/CarPlayAudiobookBridge.swift
@@ -56,7 +56,7 @@ enum CarPlayAuthHelper {
             return true
         }
 
-        return TPPUserAccount.sharedAccount().hasCredentials()
+        return AccountsManager.shared.currentUserAccount.hasCredentials()
     }
 }
 

--- a/Palace/ErrorHandling/ProblemReportEmail.swift
+++ b/Palace/ErrorHandling/ProblemReportEmail.swift
@@ -27,7 +27,12 @@ import UIKit
         book: TPPBook?,
         libraryUUID: String?,
         accountsManager: AccountsManager = .shared) {
-        let account = TPPUserAccount.sharedAccount(libraryUUID: libraryUUID ?? accountsManager.currentAccountId)
+        let account: TPPUserAccount
+        if let id = libraryUUID ?? accountsManager.currentAccountId {
+            account = accountsManager.userAccount(for: id)
+        } else {
+            account = accountsManager.currentUserAccount
+        }
         let patronID = account.authorizationIdentifier
         beginComposing(to: emailAddress, presentingViewController: presentingViewController, body: generateBody(book: book, patronIdentifier: patronID))
     }

--- a/Palace/Holds/HoldsViewModel.swift
+++ b/Palace/Holds/HoldsViewModel.swift
@@ -136,8 +136,8 @@ final class HoldsViewModel: ObservableObject {
     }
 
     func refresh() {
-        if TPPUserAccount.sharedAccount().needsAuth {
-            if TPPUserAccount.sharedAccount().hasCredentials() {
+        if AccountsManager.shared.currentUserAccount.needsAuth {
+            if AccountsManager.shared.currentUserAccount.hasCredentials() {
                 (bookRegistry as? TPPBookRegistry)?.sync()
             } else {
                 SignInModalPresenter.presentSignInModalForCurrentAccount {

--- a/Palace/Logging/ErrorLogExporter.swift
+++ b/Palace/Logging/ErrorLogExporter.swift
@@ -280,7 +280,7 @@ actor ErrorLogExporter {
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
         let libraryName = accountsManager.currentAccount?.name ?? "No library selected"
         let patronIdentifier = await MainActor.run {
-            TPPUserAccount.sharedAccount().authorizationIdentifier
+            AccountsManager.shared.currentUserAccount.authorizationIdentifier
         }
 
         var deviceInfo = """

--- a/Palace/Logging/TPPErrorLogger.swift
+++ b/Palace/Logging/TPPErrorLogger.swift
@@ -14,6 +14,98 @@ import FirebaseCrashlytics
 
 private let nullString = "null"
 
+/// Classifies the origin of an error for Crashlytics filtering.
+/// This lets us separate client bugs from server errors, network conditions,
+/// and vendor (DRM) issues in the dashboard.
+@objc enum TPPErrorOrigin: Int {
+    /// Error originated in client code (app logic, parsing, state)
+    case client = 0
+    /// Server returned an error response (4xx, 5xx, problem document)
+    case server = 1
+    /// Network-level failure (timeout, connection lost, DNS, no internet)
+    case network = 2
+    /// DRM vendor error (Adobe RMSDK, LCP, Overdrive)
+    case vendor = 3
+    /// Origin could not be determined
+    case unknown = 4
+
+    var stringValue: String {
+        switch self {
+        case .client: return "client"
+        case .server: return "server"
+        case .network: return "network"
+        case .vendor: return "vendor"
+        case .unknown: return "unknown"
+        }
+    }
+
+    /// Auto-classifies origin from an error code and optional HTTP response.
+    static func classify(code: TPPErrorCode, error: Error? = nil, response: URLResponse? = nil) -> TPPErrorOrigin {
+        // Network-level errors
+        if let nsErr = error as NSError? {
+            if nsErr.domain == NSURLErrorDomain || nsErr.domain == (kCFErrorDomainCFNetwork as String) {
+                switch nsErr.code {
+                case NSURLErrorTimedOut, NSURLErrorNetworkConnectionLost,
+                     NSURLErrorNotConnectedToInternet, NSURLErrorInternationalRoamingOff,
+                     NSURLErrorCallIsActive, NSURLErrorDataNotAllowed,
+                     NSURLErrorDNSLookupFailed, NSURLErrorCannotFindHost,
+                     NSURLErrorCannotConnectToHost, NSURLErrorSecureConnectionFailed:
+                    return .network
+                case NSURLErrorCancelled, NSURLErrorUserCancelledAuthentication:
+                    return .client
+                default:
+                    break
+                }
+            }
+        }
+
+        // Server errors (HTTP status code based)
+        if let http = response as? HTTPURLResponse {
+            if (400...599).contains(http.statusCode) {
+                return .server
+            }
+        }
+
+        // DRM/vendor errors
+        switch code {
+        case .adobeDRMFulfillmentFail, .lcpDRMFulfillmentFail,
+             .lcpPassphraseAuthorizationFail, .lcpPassphraseRetrievalFail,
+             .epubDecodingError, .overdriveFulfillResponseParseFail:
+            return .vendor
+        default:
+            break
+        }
+
+        // Server-originated errors (problem documents, auth failures from server)
+        switch code {
+        case .problemDocAvailable, .parseProblemDocFail, .remoteLoginError,
+             .loginErrorWithProblemDoc, .apiCall, .authDocLoadFail,
+             .userProfileDocFail, .registrySyncFailure:
+            return .server
+        default:
+            break
+        }
+
+        // Network-level codes
+        switch code {
+        case .clientSideTransientError, .noURL, .invalidURLSession,
+             .malformedURL, .invalidOrNoHTTPResponse:
+            return .network
+        case .clientSideUserInterruption:
+            return .client
+        default:
+            break
+        }
+
+        // Everything else is client-side
+        if code != .ignore {
+            return .client
+        }
+
+        return .unknown
+    }
+}
+
 @objc enum TPPSeverity: NSInteger {
     case error, warning, info
 
@@ -497,22 +589,44 @@ private let nullString = "null"
     // ----------------------------------------------------------------------------
     // MARK: - Private helpers
 
-    private class func record(error: NSError) {
-        // Check if enhanced logging is enabled (synchronous, thread-safe via FirebaseManager)
-        let isEnhanced = FirebaseManager.shared.isEnhancedLoggingEnabled()
+    private class func record(error: NSError, origin: TPPErrorOrigin = .unknown) {
+        // Set error origin as a Crashlytics custom key for dashboard filtering.
+        // This lets us separate client bugs from server/network/vendor errors.
+        FirebaseManager.shared.setCrashlyticsKey("error_origin", value: origin.stringValue)
 
-        if isEnhanced {
-            Log.info(#file, "📊 ENHANCED error logging active")
-            FirebaseManager.shared.logEnhancedErrorEvent(
-                error: error,
-                context: error.domain,
-                metadata: error.userInfo
-            )
+        // Also include the origin in the error userInfo for the individual event
+        if error.userInfo["error_origin"] == nil {
+            var userInfo = error.userInfo
+            userInfo["error_origin"] = origin.stringValue
+            let taggedError = NSError(domain: error.domain, code: error.code, userInfo: userInfo)
+
+            // Check if enhanced logging is enabled (synchronous, thread-safe via FirebaseManager)
+            let isEnhanced = FirebaseManager.shared.isEnhancedLoggingEnabled()
+
+            if isEnhanced {
+                Log.info(#file, "ENHANCED error logging active")
+                FirebaseManager.shared.logEnhancedErrorEvent(
+                    error: taggedError,
+                    context: taggedError.domain,
+                    metadata: taggedError.userInfo
+                )
+            }
+
+            FirebaseManager.shared.logError(taggedError)
+        } else {
+            let isEnhanced = FirebaseManager.shared.isEnhancedLoggingEnabled()
+
+            if isEnhanced {
+                Log.info(#file, "ENHANCED error logging active")
+                FirebaseManager.shared.logEnhancedErrorEvent(
+                    error: error,
+                    context: error.domain,
+                    metadata: error.userInfo
+                )
+            }
+
+            FirebaseManager.shared.logError(error)
         }
-
-        // Always do normal Crashlytics recording via FirebaseManager
-        // This is thread-safe and prevents recursive_mutex issues
-        FirebaseManager.shared.logError(error)
     }
 
     /// Helper to log a generic error to Crashlytics.
@@ -549,13 +663,17 @@ private let nullString = "null"
                                                                code: code,
                                                                with: originalError)
 
+        // Auto-classify error origin from code, error, and response
+        let origin = TPPErrorOrigin.classify(code: code, error: originalError, response: response)
+        metadata["error_origin"] = origin.stringValue
+
         // build error report
         let userInfo = additionalInfo(severity: severity,
                                       metadata: metadata)
         let err = NSError(domain: finalSummary,
                           code: finalCode,
                           userInfo: userInfo)
-        record(error: err)
+        record(error: err, origin: origin)
     }
 
     /// Fixes up summary and code inspecting the domain and code of a given

--- a/Palace/Migrations/TPPMigrationManager.swift
+++ b/Palace/Migrations/TPPMigrationManager.swift
@@ -42,7 +42,7 @@ class TPPMigrationManager: NSObject {
 
         // Refresh auth tokens proactively so users don't see "credentials invalid"
         // after an update that changed nothing about their account
-        let userAccount = TPPUserAccount.sharedAccount()
+        let userAccount = AccountsManager.shared.currentUserAccount
         if userAccount.hasCredentials(), userAccount.authTokenNearExpiry || userAccount.authTokenHasExpired {
             Log.info(#file, "Post-update: auth token expired/near-expiry — triggering refresh")
             TPPNetworkExecutor.shared.refreshTokenAndResume(task: nil)

--- a/Palace/MyBooks/BackgroundDownloadHandler.swift
+++ b/Palace/MyBooks/BackgroundDownloadHandler.swift
@@ -109,7 +109,7 @@ final class BackgroundDownloadHandler: NSObject {
                 if let info = await stateManager.downloadInfoAsync(forBookIdentifier: book.identifier)?.withRightsManagement(detectedRights) {
                     await stateManager.bookIdentifierToDownloadInfo.set(book.identifier, value: info)
                 }
-            } else if TPPUserAccount.sharedAccount().isTokenRefreshRequired() {
+            } else if AccountsManager.shared.currentUserAccount.isTokenRefreshRequired() {
                 NSLog("Authentication might be needed after all")
                 TPPNetworkExecutor.shared.refreshTokenAndResume(task: task)
                 return
@@ -185,7 +185,7 @@ final class BackgroundDownloadHandler: NSObject {
         let newRights = detectRightsManagement(from: acquisition.type)
 
         var request = URLRequest(url: acquisitionURL, applyingCustomUserAgent: true)
-        if let token = TPPUserAccount.sharedAccount().authToken {
+        if let token = AccountsManager.shared.currentUserAccount.authToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 

--- a/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
+++ b/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
@@ -489,12 +489,12 @@ extension BookCellModel {
     }
 
     func didSelectDownload() {
-        let account = TPPUserAccount.sharedAccount()
+        let account = AccountsManager.shared.currentUserAccount
         if account.needsAuth && !account.hasCredentials() {
             SignInModalPresenter.presentSignInModalForCurrentAccount { [weak self] in
                 guard let self else { return }
                 // Only proceed if user successfully logged in, not if they cancelled
-                guard TPPUserAccount.sharedAccount().hasCredentials() else {
+                guard AccountsManager.shared.currentUserAccount.hasCredentials() else {
                     Log.info(#file, "Sign-in cancelled or failed, not starting download")
                     return
                 }
@@ -514,12 +514,12 @@ extension BookCellModel {
 
     func didSelectReserve() {
         isLoading = true
-        let account = TPPUserAccount.sharedAccount()
+        let account = AccountsManager.shared.currentUserAccount
         if account.needsAuth && !account.hasCredentials() {
             SignInModalPresenter.presentSignInModalForCurrentAccount { [weak self] in
                 guard let self else { return }
                 // Only proceed if user successfully logged in, not if they cancelled
-                guard TPPUserAccount.sharedAccount().hasCredentials() else {
+                guard AccountsManager.shared.currentUserAccount.hasCredentials() else {
                     Log.info(#file, "Sign-in cancelled or failed, not proceeding with reservation")
                     self.isLoading = false
                     return

--- a/Palace/MyBooks/MyBooks/BookCell/ButtonView/BookButtonState.swift
+++ b/Palace/MyBooks/MyBooks/BookCell/ButtonView/BookButtonState.swift
@@ -56,7 +56,7 @@ extension BookButtonState {
                 buttons = [.cancelHold]
             }
         case .downloadNeeded:
-            if let authDef = TPPUserAccount.sharedAccount().authDefinition,
+            if let authDef = AccountsManager.shared.currentUserAccount.authDefinition,
                authDef.needsAuth || book.defaultAcquisitionIfOpenAccess != nil {
                 buttons = [.download, .return]
             } else {
@@ -72,7 +72,7 @@ extension BookButtonState {
                 break
             }
 
-            if let authDef = TPPUserAccount.sharedAccount().authDefinition,
+            if let authDef = AccountsManager.shared.currentUserAccount.authDefinition,
                authDef.needsAuth ||
                 book.defaultAcquisitionIfOpenAccess != nil {
                 buttons.append(.return)
@@ -194,7 +194,7 @@ extension TPPBook {
 
         let hasFullfillmentId = bookRegistry.fulfillmentId(forIdentifier: self.identifier) != nil
         let isFullfiliable = !(hasFullfillmentId && fullfillmentRequired) && self.revokeURL != nil
-        let needsAuthentication = self.defaultAcquisitionIfOpenAccess == nil && TPPUserAccount.sharedAccount().authDefinition?.needsAuth ?? false
+        let needsAuthentication = self.defaultAcquisitionIfOpenAccess == nil && AccountsManager.shared.currentUserAccount.authDefinition?.needsAuth ?? false
 
         return isFullfiliable && !needsAuthentication
     }

--- a/Palace/MyBooks/MyBooks/MyBooksViewModel.swift
+++ b/Palace/MyBooks/MyBooks/MyBooksViewModel.swift
@@ -68,7 +68,7 @@ enum Group: Int {
 
         // If the account requires authentication and user is not logged in,
         // don't show any books from the registry (they may be stale from a previous session)
-        let account = TPPUserAccount.sharedAccount()
+        let account = AccountsManager.shared.currentUserAccount
         if account.needsAuth && !account.hasCredentials() {
             Log.info(#file, "User not logged in - showing empty My Books")
             self.allBooks = []
@@ -113,7 +113,7 @@ enum Group: Int {
     func reloadData() {
         guard !isLoading else { return }
 
-        if TPPUserAccount.sharedAccount().needsAuth, !TPPUserAccount.sharedAccount().hasCredentials() {
+        if AccountsManager.shared.currentUserAccount.needsAuth, !AccountsManager.shared.currentUserAccount.hasCredentials() {
             SignInModalPresenter.presentSignInModalForCurrentAccount(completion: nil)
         } else {
             bookRegistry.sync { [weak self] _, _ in

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -55,7 +55,7 @@ import OverdriveProcessor
     @MainActor private var pendingBroadcast: DispatchWorkItem?
 
     init(
-        userAccount: TPPUserAccount = TPPUserAccount.sharedAccount(),
+        userAccount: TPPUserAccount = AccountsManager.shared.currentUserAccount,
         reauthenticator: Reauthenticator = TPPReauthenticator(),
         bookRegistry: TPPBookRegistryProvider = TPPBookRegistry.shared,
         accountsManager: AccountsManager = .shared,

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -1091,6 +1091,16 @@ extension MyBooksDownloadCenter {
                                     }
                                 }
                             }
+                        } else {
+                            // Unhandled error type from server. Previously this fell
+                            // through silently with no user feedback. Log the error
+                            // and show a failure alert so the user knows it didn't work.
+                            let detail = error?["detail"] as? String ?? errorType
+                            Log.error(#file, "Unhandled revoke error type: \(errorType), detail: \(detail)")
+                            runOnMainAsync {
+                                self.announceReturnFailed(for: book)
+                                completion?()
+                            }
                         }
                     } else {
                         runOnMainAsync {

--- a/Palace/MyBooks/MyBooksSimplifiedBearerToken.swift
+++ b/Palace/MyBooks/MyBooksSimplifiedBearerToken.swift
@@ -49,7 +49,7 @@ class MyBooksSimplifiedBearerToken {
         var request = URLRequest(url: fulfillURL)
         request.cachePolicy = .reloadIgnoringLocalCacheData
 
-        if let authToken = TPPUserAccount.sharedAccount().authToken {
+        if let authToken = AccountsManager.shared.currentUserAccount.authToken {
             request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         }
 

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -233,7 +233,7 @@ extension TPPNetworkExecutor: TPPRequestExecuting {
     @discardableResult
     func executeRequest(_ req: URLRequest, enableTokenRefresh: Bool, completion: @escaping (_: NYPLResult<Data>) -> Void) -> URLSessionDataTask? {
         let accountId = accountsManager.currentAccountId
-        let userAccount = TPPUserAccount.sharedAccount(libraryUUID: accountId)
+        let userAccount = accountId.flatMap { AccountsManager.shared.userAccount(for: $0) } ?? AccountsManager.shared.currentUserAccount
 
         // SAML auth uses cookies, not tokens - proceed directly
         if let authDefinition = userAccount.authDefinition, authDefinition.isSaml {
@@ -284,11 +284,12 @@ extension TPPNetworkExecutor {
         var urlRequest = URLRequest(url: url,
                                     cachePolicy: urlSession.configuration.requestCachePolicy)
         urlRequest.applyCustomUserAgent()
-        // Use atomic snapshot to prevent TOCTOU races during account switches.
+        // Use per-account instance to prevent TOCTOU races during account switches.
         // Without this, another thread could change libraryUUID between
         // sharedAccount() and the property reads, causing cross-account
         // credential leaks.
-        let snapshot = TPPUserAccount.credentialSnapshot(for: accountId ?? accountsManager.currentAccountId)
+        let resolvedId = accountId ?? accountsManager.currentAccountId ?? ""
+        let snapshot = AccountsManager.shared.userAccount(for: resolvedId).credentialSnapshot()
 
         // SAML auth uses cookies, not tokens — make sure they are installed in
         // the shared cookie storage before the request goes out. Removing this
@@ -314,7 +315,7 @@ extension TPPNetworkExecutor {
 extension TPPNetworkExecutor {
     @objc class func bearerAuthorized(request: URLRequest) -> URLRequest {
         var request = request
-        let snapshot = TPPUserAccount.credentialSnapshot(for: AccountsManager.shared.currentAccountId)
+        let snapshot = AccountsManager.shared.currentUserAccount.credentialSnapshot()
 
         if let authToken = snapshot.authToken, !authToken.isEmpty {
             let tokenPrefix = String(authToken.prefix(8))
@@ -475,11 +476,11 @@ extension TPPNetworkExecutor {
                 return
             }
 
-            // Use atomic snapshot to prevent TOCTOU races: without this,
+            // Use per-account instance to prevent TOCTOU races: without this,
             // another thread could switch libraryUUID between sharedAccount()
             // and the .username/.pin reads, sending Account B's credentials
             // to Account A's token endpoint.
-            let snapshot = TPPUserAccount.credentialSnapshot(for: capturedAccountId)
+            let snapshot = AccountsManager.shared.userAccount(for: capturedAccountId ?? AccountsManager.shared.currentAccountId ?? "").credentialSnapshot()
             guard let username = snapshot.barcode,
                   let password = snapshot.pin,
                   let tokenURL = snapshot.authDefinition?.tokenURL else {
@@ -544,7 +545,7 @@ extension TPPNetworkExecutor {
                         if let nsError = error as? NSError, nsError.code == 401 {
                             Log.info(#file, "Token refresh failed due to invalid credentials - marking credentials stale for account \(capturedAccountId ?? "current")")
                             await MainActor.run {
-                                TPPUserAccount.sharedAccount(libraryUUID: capturedAccountId).markCredentialsStale()
+                                AccountsManager.shared.userAccount(for: capturedAccountId ?? AccountsManager.shared.currentAccountId ?? "").markCredentialsStale()
                                 if capturedAccountId == nil || capturedAccountId == self.accountsManager.currentAccountId {
                                     SignInModalPresenter.presentSignInModalForCurrentAccount(completion: nil)
                                 }
@@ -569,15 +570,14 @@ extension TPPNetworkExecutor {
 
             switch result {
             case .success(let tokenResponse):
-                TPPUserAccount.sharedAccount().atomicUpdate(for: accountId) { account in
-                    account.setAuthToken(
-                        tokenResponse.accessToken,
-                        barcode: username,
-                        pin: password,
-                        expirationDate: tokenResponse.expirationDate
-                    )
-                    account.markLoggedIn()
-                }
+                let targetAccount = AccountsManager.shared.userAccount(for: accountId ?? AccountsManager.shared.currentAccountId ?? "")
+                targetAccount.setAuthToken(
+                    tokenResponse.accessToken,
+                    barcode: username,
+                    pin: password,
+                    expirationDate: tokenResponse.expirationDate
+                )
+                targetAccount.markLoggedIn()
                 completion(.success(tokenResponse))
             case .failure(let error):
                 completion(.failure(error))

--- a/Palace/Network/TPPNetworkResponder.swift
+++ b/Palace/Network/TPPNetworkResponder.swift
@@ -324,7 +324,7 @@ extension TPPNetworkResponder: URLSessionDataDelegate {
             logMetadata[NSLocalizedDescriptionKey] = Strings.Error.unknownRequestError
 
             if httpResponse.statusCode == 401 {
-                let snap = TPPUserAccount.credentialSnapshot(for: AccountsManager.shared.currentAccountId)
+                let snap = AccountsManager.shared.currentUserAccount.credentialSnapshot()
                 if (snap.authDefinition?.isToken ?? false) && tokenRefreshAttempts < 2 {
                     tokenRefreshAttempts += 1
                     return handleExpiredTokenIfNeeded(for: httpResponse, with: task)
@@ -383,7 +383,7 @@ private func handleExpiredTokenIfNeeded(for response: HTTPURLResponse,
     // between sending the request and receiving the 401, the wrong account's
     // credentials would be checked/marked stale.
     let accountId = AccountsManager.shared.currentAccountId
-    let snapshot = TPPUserAccount.credentialSnapshot(for: accountId)
+    let snapshot = AccountsManager.shared.currentUserAccount.credentialSnapshot()
 
     guard snapshot.hasCredentials else {
         return false
@@ -401,9 +401,7 @@ private func handleExpiredTokenIfNeeded(for response: HTTPURLResponse,
         }
 
         // Mark credentials as stale - preserves Adobe DRM activation
-        TPPUserAccount.sharedAccount(libraryUUID: accountId).atomicUpdate(for: accountId) { account in
-            account.markCredentialsStale()
-        }
+        AccountsManager.shared.userAccount(for: accountId ?? "").markCredentialsStale()
 
         if authDef?.isSaml == true {
             Log.info(#file, "Server returned 401 for SAML - credentials marked stale, will trigger re-auth flow")
@@ -518,12 +516,12 @@ extension TPPNetworkResponder: URLSessionTaskDelegate {
                     task: URLSessionTask,
                     didReceive challenge: URLAuthenticationChallenge,
                     completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let credsProvider = credentialsProvider ?? TPPUserAccount.sharedAccount()
+        let credsProvider = credentialsProvider ?? AccountsManager.shared.currentUserAccount
         let authChallenger = TPPBasicAuth(credentialsProvider: credsProvider)
         authChallenger.handleChallenge(challenge, completion: completionHandler)
     }
 
-    func refreshToken(userAccount: TPPUserAccount = TPPUserAccount.sharedAccount()) async throws {
+    func refreshToken(userAccount: TPPUserAccount = AccountsManager.shared.currentUserAccount) async throws {
         guard let tokenURL = userAccount.authDefinition?.tokenURL,
               let username = userAccount.username,
               let password = userAccount.pin

--- a/Palace/Network/TPPSession.swift
+++ b/Palace/Network/TPPSession.swift
@@ -38,7 +38,7 @@ import Foundation
   ) {
     Log.log("\(task.currentRequest?.url?.absoluteString ?? ""): Challenge Received: \(challenge.protectionSpace.authenticationMethod)")
 
-    let challenger = TPPBasicAuth(credentialsProvider: TPPUserAccount.sharedAccount())
+    let challenger = TPPBasicAuth(credentialsProvider: AccountsManager.shared.currentUserAccount)
     challenger.handleChallenge(challenge, completion: completionHandler)
   }
 

--- a/Palace/Notifications/NotificationService.swift
+++ b/Palace/Notifications/NotificationService.swift
@@ -289,7 +289,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate, Messaging
     /// Uses the same throttle as applicationDidBecomeActive to coordinate syncs.
     private func syncWithThrottle(completion: ((_ errorDocument: [AnyHashable: Any]?, _ newBooks: Bool) -> Void)? = nil) {
         // Skip if user isn't authenticated
-        guard TPPUserAccount.sharedAccount().hasCredentials() else {
+        guard AccountsManager.shared.currentUserAccount.hasCredentials() else {
             completion?(nil, false)
             return
         }

--- a/Palace/OPDS2/Service/UnifiedOPDSService.swift
+++ b/Palace/OPDS2/Service/UnifiedOPDSService.swift
@@ -310,7 +310,7 @@ actor UnifiedOPDSService {
     private func addAuthHeaders(to request: inout URLRequest, useToken: Bool) {
         guard useToken else { return }
 
-        let userAccount = TPPUserAccount.sharedAccount()
+        let userAccount = AccountsManager.shared.currentUserAccount
 
         if let authToken = userAccount.authToken {
             request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -150,7 +150,7 @@ protocol AnnotationsManager {
 
         // Format bookmark for submission to server according to spec
         let bookmark = TPPBookmarkSpec(time: NSDate(),
-                                       device: AnnotationDevice.currentID(),
+                                       device: AccountsManager.shared.currentUserAccount.deviceID ?? "",
                                        motivation: motivation,
                                        bookID: bookID,
                                        selectorValue: selectorValue)
@@ -194,7 +194,7 @@ protocol AnnotationsManager {
 
         let spec = TPPBookmarkSpec(
             time: NSDate(),
-            device: AnnotationDevice.currentID(),
+            device: AccountsManager.shared.currentUserAccount.deviceID ?? "",
             motivation: .bookmark,
             bookID: bookID,
             selectorValue: selectorValue
@@ -540,7 +540,7 @@ protocol AnnotationsManager {
     }
 
     static func syncIsPossibleAndPermitted(accountsManager: AccountsManager = .shared) -> Bool {
-        let account = TPPUserAccount.sharedAccount()
+        let account = AccountsManager.shared.currentUserAccount
         let acct = accountsManager.currentAccount
         let hasCreds = account.hasCredentials()
         let supportsSync = acct?.details?.supportsSimplyESync == true

--- a/Palace/Reader2/BusinessLogic/TPPReaderBookmarksBusinessLogic.swift
+++ b/Palace/Reader2/BusinessLogic/TPPReaderBookmarksBusinessLogic.swift
@@ -312,7 +312,7 @@ class TPPReaderBookmarksBusinessLogic: NSObject {
         Log.info(#file, message)
 
         // Check if we should attempt re-authentication
-        let userAccount = TPPUserAccount.sharedAccount()
+        let userAccount = AccountsManager.shared.currentUserAccount
         let isCredentialsStale = userAccount.authState == .credentialsStale
 
         if shouldAttemptReauth && isCredentialsStale && !hasAttemptedReauthDuringSync {

--- a/Palace/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Palace/Reader2/ReaderPresentation/ReaderModule.swift
@@ -59,7 +59,7 @@ final class ReaderModule: ReaderModuleAPI {
     init(delegate: ModuleDelegate?,
          resourcesServer: HTTPServer,
          bookRegistry: TPPBookRegistryProvider,
-         userAccount: TPPUserAccount = .sharedAccount()) {
+         userAccount: TPPUserAccount = AccountsManager.shared.currentUserAccount) {
         self.delegate = delegate
         self.bookRegistry = bookRegistry
         self.userAccount = userAccount

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
@@ -246,7 +246,7 @@ class AdobeDRMService: NSObject {
     ///
     /// - Throws: `PalaceError.drm` if activation fails or credentials are unavailable.
     func ensureDeviceActivated() async throws {
-        let userAccount = TPPUserAccount.sharedAccount()
+        let userAccount = AccountsManager.shared.currentUserAccount
 
         if let userID = userAccount.userID,
            let deviceID = userAccount.deviceID,

--- a/Palace/Reader2/UI/TPPBaseReaderViewController.swift
+++ b/Palace/Reader2/UI/TPPBaseReaderViewController.swift
@@ -96,7 +96,7 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
         bookmarksBusinessLogic = TPPReaderBookmarksBusinessLogic(
             book: book,
             r2Publication: publication,
-            drmDeviceID: AnnotationDevice.currentID(),
+            drmDeviceID: AccountsManager.shared.currentUserAccount.deviceID,
             bookRegistryProvider: bookRegistry,
             currentLibraryAccountProvider: accountsManager)
 

--- a/Palace/Settings/AccountDetailView.swift
+++ b/Palace/Settings/AccountDetailView.swift
@@ -344,18 +344,41 @@ struct AccountDetailView: View {
     }
 
     private var pinInputCell: some View {
-        TextField(pinLabel, text: $viewModel.pinText)
-            .textContentType(.password)
-            .keyboardType(keyboardType(for: viewModel.businessLogic.selectedAuthentication?.pinKeyboard))
-            .disabled(viewModel.isSignedIn)
-            .foregroundColor(viewModel.isSignedIn ? .secondary : .primary)
-            .accessibilityIdentifier(AccessibilityID.SignIn.pinField)
-            .accessibilityLabel(pinLabel)
-            .focused($focusedField, equals: .pin)
-            .onSubmit { if viewModel.canSignIn { viewModel.signIn() } }
-            .submitLabel(.go)
-            .padding(.vertical, Layout.verticalPaddingInput)
-            .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+        HStack {
+            if viewModel.isPINHidden {
+                SecureField(pinLabel, text: $viewModel.pinText)
+                    .textContentType(.password)
+                    .keyboardType(keyboardType(for: viewModel.businessLogic.selectedAuthentication?.pinKeyboard))
+                    .disabled(viewModel.isSignedIn)
+                    .foregroundColor(viewModel.isSignedIn ? .secondary : .primary)
+                    .accessibilityIdentifier(AccessibilityID.SignIn.pinField)
+                    .accessibilityLabel(pinLabel)
+                    .focused($focusedField, equals: .pin)
+                    .onSubmit { if viewModel.canSignIn { viewModel.signIn() } }
+                    .submitLabel(.go)
+            } else {
+                TextField(pinLabel, text: $viewModel.pinText)
+                    .textContentType(.password)
+                    .keyboardType(keyboardType(for: viewModel.businessLogic.selectedAuthentication?.pinKeyboard))
+                    .disabled(viewModel.isSignedIn)
+                    .foregroundColor(viewModel.isSignedIn ? .secondary : .primary)
+                    .accessibilityIdentifier(AccessibilityID.SignIn.pinField)
+                    .accessibilityLabel(pinLabel)
+                    .focused($focusedField, equals: .pin)
+                    .onSubmit { if viewModel.canSignIn { viewModel.signIn() } }
+                    .submitLabel(.go)
+            }
+
+            if LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: nil) {
+                Button(action: { viewModel.togglePINVisibility() }, label: {
+                    Text(viewModel.isPINHidden ? DisplayStrings.show : DisplayStrings.hide)
+                        .foregroundColor(Color(TPPConfiguration.mainColor()))
+                })
+            }
+        }
+        .padding(.vertical, Layout.verticalPaddingInput)
+        .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+        .accessibilityElement(children: .contain)
     }
 
     private var logInSignOutCell: some View {

--- a/Palace/Settings/AccountDetailViewModel.swift
+++ b/Palace/Settings/AccountDetailViewModel.swift
@@ -107,7 +107,7 @@ class AccountDetailViewModel: NSObject, ObservableObject {
             drmAuthorizer: nil
         )
 
-        let snapshot = TPPUserAccount.credentialSnapshot(for: libraryAccountID)
+        let snapshot = AccountsManager.shared.userAccount(for: libraryAccountID).credentialSnapshot()
         self.isSignedIn = snapshot.hasCredentials && snapshot.authState != .loggedOut
 
         super.init()
@@ -480,7 +480,7 @@ class AccountDetailViewModel: NSObject, ObservableObject {
     }
 
     private func accountDidChange() {
-        let snapshot = TPPUserAccount.credentialSnapshot(for: libraryAccountID)
+        let snapshot = AccountsManager.shared.userAccount(for: libraryAccountID).credentialSnapshot()
 
         let newSignedIn = snapshot.hasCredentials && snapshot.authState != .loggedOut
 
@@ -511,7 +511,7 @@ class AccountDetailViewModel: NSObject, ObservableObject {
     func refreshSignInState() {
         let wasSignedIn = isSignedIn
 
-        let snapshot = TPPUserAccount.credentialSnapshot(for: libraryAccountID)
+        let snapshot = AccountsManager.shared.userAccount(for: libraryAccountID).credentialSnapshot()
         isSignedIn = snapshot.hasCredentials && snapshot.authState != .loggedOut
 
         if wasSignedIn != isSignedIn {

--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
@@ -463,7 +463,7 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
                                    completion: (() -> Void)?) -> Bool {
         guard
             let authDef = userAccount.authDefinition,
-            authDef.isBasic || authDef.isOauth || authDef.isSaml || authDef.isOidc || (authDef.isToken && TPPUserAccount.sharedAccount().authTokenHasExpired)
+            authDef.isBasic || authDef.isOauth || authDef.isSaml || authDef.isOidc || (authDef.isToken && AccountsManager.shared.currentUserAccount.authTokenHasExpired)
         else {
             completion?()
             return false

--- a/Palace/SignInLogic/TokenRequest.swift
+++ b/Palace/SignInLogic/TokenRequest.swift
@@ -44,11 +44,16 @@ import Foundation
         let looksLikeOAuthToken = username.count > 50 || username.contains(".")
         Log.info(#file, "  Credential shape: usernameLen=\(username.count), pinLen=\(password.count), looksLikeBarcode=\(looksLikeBarcode), looksLikeOAuthToken=\(looksLikeOAuthToken)")
 
-        guard !username.isEmpty, !password.isEmpty else {
-            Log.error(#file, "Aborting token request: empty credentials (usernameLen=\(username.count), pinLen=\(password.count))")
+        guard !username.isEmpty else {
+            Log.error(#file, "Aborting token request: empty username")
             return .failure(NSError(domain: "TokenRequest", code: -1,
-                                    userInfo: [NSLocalizedDescriptionKey: "Cannot request token with empty credentials"]))
+                                    userInfo: [NSLocalizedDescriptionKey: "Cannot request token with empty username"]))
         }
+        // Note: empty password is valid for libraries that don't require a PIN.
+        // Basic Auth with "barcode:" (empty password) is the correct format for
+        // pinless authentication. The original guard (!password.isEmpty) broke
+        // pinless login for libraries like Wolcott Public Library and Bentley
+        // Memorial Library (PP-4045).
 
         var request = URLRequest(url: url, applyingCustomUserAgent: true)
         request.httpMethod = HTTPMethodType.POST.rawValue

--- a/PalaceTests/Accounts/TPPPerAccountIsolationTests.swift
+++ b/PalaceTests/Accounts/TPPPerAccountIsolationTests.swift
@@ -1,0 +1,194 @@
+import XCTest
+@testable import Palace
+
+/// Tests that per-account TPPUserAccount instances are fully isolated.
+/// These validate the systemic fix for F-034 (credential cross-contamination).
+final class TPPPerAccountIsolationTests: XCTestCase {
+
+    private let uuidA = "urn:uuid:isolation-test-library-a"
+    private let uuidB = "urn:uuid:isolation-test-library-b"
+
+    override func tearDown() {
+        // Clean up any keychain data written during tests
+        AccountsManager.shared.userAccount(for: uuidA).removeAll()
+        AccountsManager.shared.userAccount(for: uuidB).removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - Instance Identity
+
+    /// userAccount(for:) returns the same instance on repeated calls.
+    func testInstanceCache_returnsSameInstance() {
+        let first = AccountsManager.shared.userAccount(for: uuidA)
+        let second = AccountsManager.shared.userAccount(for: uuidA)
+        XCTAssertTrue(first === second, "Same UUID should return same instance")
+    }
+
+    /// Different UUIDs return different instances.
+    func testInstanceCache_returnsDifferentInstancesForDifferentUUIDs() {
+        let accountA = AccountsManager.shared.userAccount(for: uuidA)
+        let accountB = AccountsManager.shared.userAccount(for: uuidB)
+        XCTAssertFalse(accountA === accountB, "Different UUIDs should return different instances")
+    }
+
+    /// Per-account instances have immutable boundLibraryUUID.
+    func testBoundLibraryUUID_isImmutable() {
+        let account = AccountsManager.shared.userAccount(for: uuidA)
+        XCTAssertEqual(account.boundLibraryUUID, uuidA)
+    }
+
+    // MARK: - Credential Isolation
+
+    /// Writing credentials to Account A does not affect Account B.
+    func testCredentialIsolation_writeToA_doesNotAffectB() {
+        let accountA = AccountsManager.shared.userAccount(for: uuidA)
+        let accountB = AccountsManager.shared.userAccount(for: uuidB)
+
+        accountA.setBarcode("barcodeA", PIN: "pinA")
+        accountA.markLoggedIn()
+
+        XCTAssertEqual(accountA.barcode, "barcodeA")
+        XCTAssertEqual(accountA.PIN, "pinA")
+        XCTAssertTrue(accountA.hasCredentials())
+
+        // Account B should have no credentials
+        XCTAssertNil(accountB.barcode)
+        XCTAssertNil(accountB.PIN)
+        XCTAssertFalse(accountB.hasCredentials())
+    }
+
+    /// Both accounts can hold independent credentials simultaneously.
+    func testCredentialIsolation_bothAccountsHoldIndependentCredentials() {
+        let accountA = AccountsManager.shared.userAccount(for: uuidA)
+        let accountB = AccountsManager.shared.userAccount(for: uuidB)
+
+        accountA.setBarcode("barcodeA", PIN: "pinA")
+        accountB.setBarcode("barcodeB", PIN: "pinB")
+
+        XCTAssertEqual(accountA.barcode, "barcodeA")
+        XCTAssertEqual(accountA.PIN, "pinA")
+        XCTAssertEqual(accountB.barcode, "barcodeB")
+        XCTAssertEqual(accountB.PIN, "pinB")
+    }
+
+    /// Token credentials are isolated between accounts.
+    func testCredentialIsolation_tokenCredentials() {
+        let accountA = AccountsManager.shared.userAccount(for: uuidA)
+        let accountB = AccountsManager.shared.userAccount(for: uuidB)
+
+        accountA.setAuthToken("tokenA", barcode: "userA", pin: "passA", expirationDate: nil)
+        accountB.setAuthToken("tokenB", barcode: "userB", pin: "passB", expirationDate: nil)
+
+        XCTAssertEqual(accountA.authToken, "tokenA")
+        XCTAssertEqual(accountA.barcode, "userA")
+        XCTAssertEqual(accountB.authToken, "tokenB")
+        XCTAssertEqual(accountB.barcode, "userB")
+    }
+
+    /// credentialSnapshot() returns correct data for each account.
+    func testCredentialSnapshot_perAccountIsolation() {
+        let accountA = AccountsManager.shared.userAccount(for: uuidA)
+        let accountB = AccountsManager.shared.userAccount(for: uuidB)
+
+        accountA.setBarcode("snapA", PIN: "pinSnapA")
+        accountA.markLoggedIn()
+        accountB.setBarcode("snapB", PIN: "pinSnapB")
+        accountB.markLoggedIn()
+
+        let snapA = accountA.credentialSnapshot()
+        let snapB = accountB.credentialSnapshot()
+
+        XCTAssertEqual(snapA.barcode, "snapA")
+        XCTAssertEqual(snapA.pin, "pinSnapA")
+        XCTAssertEqual(snapB.barcode, "snapB")
+        XCTAssertEqual(snapB.pin, "pinSnapB")
+    }
+
+    /// removeAll() on one account does not affect the other.
+    func testRemoveAll_doesNotAffectOtherAccount() {
+        let accountA = AccountsManager.shared.userAccount(for: uuidA)
+        let accountB = AccountsManager.shared.userAccount(for: uuidB)
+
+        accountA.setBarcode("keepMe", PIN: "keepPin")
+        accountB.setBarcode("removeMe", PIN: "removePin")
+
+        accountB.removeAll()
+
+        XCTAssertEqual(accountA.barcode, "keepMe")
+        XCTAssertTrue(accountA.hasCredentials())
+        XCTAssertFalse(accountB.hasCredentials())
+    }
+
+    // MARK: - Concurrent Access
+
+    /// Concurrent reads/writes to different accounts do not cross-contaminate.
+    func testConcurrentAccess_noContamination() {
+        let accountA = AccountsManager.shared.userAccount(for: uuidA)
+        let accountB = AccountsManager.shared.userAccount(for: uuidB)
+        let iterations = 100
+        let expectation = expectation(description: "concurrent access")
+        expectation.expectedFulfillmentCount = iterations * 2
+
+        // Write to A and B concurrently
+        for i in 0..<iterations {
+            DispatchQueue.global().async {
+                accountA.setBarcode("barcodeA_\(i)", PIN: "pinA_\(i)")
+                expectation.fulfill()
+            }
+            DispatchQueue.global().async {
+                accountB.setBarcode("barcodeB_\(i)", PIN: "pinB_\(i)")
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 10)
+
+        // After all writes, A's barcode should start with "barcodeA_"
+        // and B's should start with "barcodeB_" — never crossed
+        let finalA = accountA.barcode ?? ""
+        let finalB = accountB.barcode ?? ""
+        XCTAssertTrue(finalA.hasPrefix("barcodeA_"), "Account A barcode contaminated: \(finalA)")
+        XCTAssertTrue(finalB.hasPrefix("barcodeB_"), "Account B barcode contaminated: \(finalB)")
+    }
+
+    /// Concurrent credentialSnapshot() calls on different accounts return correct data.
+    func testConcurrentSnapshots_returnCorrectData() {
+        let accountA = AccountsManager.shared.userAccount(for: uuidA)
+        let accountB = AccountsManager.shared.userAccount(for: uuidB)
+
+        accountA.setBarcode("concurrentA", PIN: "pinA")
+        accountA.markLoggedIn()
+        accountB.setBarcode("concurrentB", PIN: "pinB")
+        accountB.markLoggedIn()
+
+        let iterations = 200
+        let expectation = expectation(description: "concurrent snapshots")
+        expectation.expectedFulfillmentCount = iterations * 2
+        var failures = [String]()
+        let failureLock = NSLock()
+
+        for _ in 0..<iterations {
+            DispatchQueue.global().async {
+                let snap = accountA.credentialSnapshot()
+                if snap.barcode != "concurrentA" {
+                    failureLock.lock()
+                    failures.append("A got barcode: \(snap.barcode ?? "nil")")
+                    failureLock.unlock()
+                }
+                expectation.fulfill()
+            }
+            DispatchQueue.global().async {
+                let snap = accountB.credentialSnapshot()
+                if snap.barcode != "concurrentB" {
+                    failureLock.lock()
+                    failures.append("B got barcode: \(snap.barcode ?? "nil")")
+                    failureLock.unlock()
+                }
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 10)
+        XCTAssertTrue(failures.isEmpty, "Credential contamination detected: \(failures)")
+    }
+}

--- a/PalaceTests/Network/CredentialGuardTests.swift
+++ b/PalaceTests/Network/CredentialGuardTests.swift
@@ -50,28 +50,45 @@ final class TokenRequestCredentialGuardTests: XCTestCase {
         case .success:
             XCTFail("Expected failure for empty username")
         case .failure(let error):
-            XCTAssertTrue(error.localizedDescription.contains("empty credentials"),
-                          "Error should mention empty credentials, got: \(error.localizedDescription)")
+            XCTAssertTrue(error.localizedDescription.contains("empty username"),
+                          "Error should mention empty username, got: \(error.localizedDescription)")
         }
     }
 
-    func testExecute_EmptyPassword_ReturnsFailureWithoutNetworkCall() async {
-        let request = TokenRequest(url: tokenURL, username: "12345", password: "")
+    /// Empty password is valid for pinless libraries (PP-4045).
+    /// Libraries like Wolcott Public Library and Bentley Memorial Library
+    /// do not require a PIN. Basic Auth sends "barcode:" with empty password.
+    func testExecute_EmptyPassword_PinlessLogin_MakesNetworkCall() async {
+        let request = TokenRequest(url: tokenURL, username: "23160026460829", password: "")
 
-        HTTPStubURLProtocol.register { _ in
-            XCTFail("Network request should not be made with empty password")
-            return nil
+        var networkCallMade = false
+        HTTPStubURLProtocol.register { req in
+            networkCallMade = true
+            // Verify Basic Auth header is present with barcode and empty password
+            let authHeader = req.value(forHTTPHeaderField: "Authorization") ?? ""
+            XCTAssertTrue(authHeader.hasPrefix("Basic "), "Should have Basic auth header")
+            // Decode and verify format is "barcode:"
+            if let base64Data = Data(base64Encoded: authHeader.replacingOccurrences(of: "Basic ", with: "")),
+               let credential = String(data: base64Data, encoding: .utf8) {
+                XCTAssertEqual(credential, "23160026460829:", "Should be barcode with empty password")
+            }
+            // Return a valid token response
+            let tokenJSON = """
+            {"access_token": "test_token", "token_type": "Bearer", "expires_in": 3600}
+            """.data(using: .utf8)
+            return HTTPStubURLProtocol.StubbedResponse(statusCode: 200, headers: nil, body: tokenJSON)
         }
 
         let session = URLSession.stubbedSession()
         let result = await request.execute(session: session)
 
+        XCTAssertTrue(networkCallMade, "Network call should be made for pinless login")
+
         switch result {
-        case .success:
-            XCTFail("Expected failure for empty password")
+        case .success(let tokenResponse):
+            XCTAssertEqual(tokenResponse.accessToken, "test_token")
         case .failure(let error):
-            XCTAssertTrue(error.localizedDescription.contains("empty credentials"),
-                          "Error should mention empty credentials, got: \(error.localizedDescription)")
+            XCTFail("Pinless login should succeed, got error: \(error.localizedDescription)")
         }
     }
 

--- a/scripts/forgeos-gate-hook.sh
+++ b/scripts/forgeos-gate-hook.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# forgeos-gate-hook.sh -- Pre-PR governance check
+# Called by Claude Code hook before `gh pr create`
+# Exits 0 to allow, 1 to block
+#
+# Looks for a ForgeOS changeset matching the current branch.
+# If found, runs gate-check. If not found, warns but allows
+# (to avoid blocking work when ForgeOS is unreachable).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+API_URL="https://forgeos-api.synctek.io"
+PROJECT_ID="proj_87884c17"
+
+# Read API key
+if [ -z "${FORGEOS_API_KEY:-}" ]; then
+  FORGEOS_API_KEY=$(python3 -c "
+import json
+with open('${REPO_ROOT}/.cursor/mcp.json') as f:
+    print(json.load(f)['mcpServers']['forgeos']['env']['FORGEOS_API_KEY'])
+" 2>/dev/null || echo "")
+fi
+
+if [ -z "$FORGEOS_API_KEY" ]; then
+  echo "[ForgeOS] Warning: No API key found. Allowing PR creation without governance check."
+  exit 0
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+# Find the most recent changeset for this branch
+CHANGESET_ID=$(curl -s \
+  -H "X-ForgeOS-API-Key: $FORGEOS_API_KEY" \
+  "${API_URL}/api/projects/${PROJECT_ID}/changesets?branch=${BRANCH}&limit=1" 2>/dev/null | \
+  python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    items = data if isinstance(data, list) else data.get('items', data.get('changesets', []))
+    if items:
+        print(items[0]['id'])
+except:
+    pass
+" 2>/dev/null)
+
+if [ -z "$CHANGESET_ID" ]; then
+  echo "[ForgeOS] No changeset found for branch '$BRANCH'."
+  echo "[ForgeOS] Create one first: scripts/forgeos-session.sh start <initiative_id> $BRANCH <description>"
+  echo ""
+  echo "PR creation blocked. Every PR needs a ForgeOS changeset."
+  exit 1
+fi
+
+echo "[ForgeOS] Found changeset $CHANGESET_ID for branch $BRANCH"
+
+# Run gate check
+MIN_TESTS="${FORGEOS_MIN_TESTS:-100}"
+if bash "$SCRIPT_DIR/forgeos-session.sh" gate-check "$CHANGESET_ID" "$MIN_TESTS"; then
+  echo ""
+  echo "[ForgeOS] Governance check passed. PR creation allowed."
+  exit 0
+else
+  echo ""
+  echo "[ForgeOS] Governance check failed. PR creation blocked."
+  echo ""
+  echo "To resolve:"
+  echo "  scripts/forgeos-session.sh evidence $CHANGESET_ID"
+  echo "  scripts/forgeos-session.sh promote $CHANGESET_ID"
+  exit 1
+fi

--- a/scripts/forgeos-session.sh
+++ b/scripts/forgeos-session.sh
@@ -132,9 +132,17 @@ cmd_evidence() {
     test 2>&1 || true)
 
   # Parse test results
+  # Sum all "Executed N tests" lines to get the total across all test bundles
+  # (PalaceTests.xctest + TenPrintCoverTests.xctest, etc.)
+  # Using the top-level "All tests" summary which includes the grand total.
   local pass_count fail_count
-  pass_count=$(echo "$test_output" | grep -o 'Executed [0-9]* test' | tail -1 | grep -o '[0-9]*' || echo "0")
-  fail_count=$(echo "$test_output" | grep -o 'with [0-9]* failure' | tail -1 | grep -o '[0-9]*' || echo "0")
+  pass_count=$(echo "$test_output" | grep 'Executed [0-9]* test' | grep 'All tests' | head -1 | grep -o 'Executed [0-9]*' | grep -o '[0-9]*' || echo "0")
+  fail_count=$(echo "$test_output" | grep 'with [0-9]* failure' | grep 'All tests' | head -1 | grep -o '[0-9]* failure' | grep -o '[0-9]*' || echo "0")
+  # Fallback: if "All tests" line not found, sum across all bundles
+  if [ "$pass_count" = "0" ]; then
+    pass_count=$(echo "$test_output" | grep -o 'Executed [0-9]* test' | grep -o '[0-9]*' | awk '{s+=$1} END {print s+0}')
+    fail_count=$(echo "$test_output" | grep -o 'with [0-9]* failure' | grep -o '[0-9]*' | awk '{s+=$1} END {print s+0}')
+  fi
   local build_ok="false"
   echo "$test_output" | grep -q "BUILD SUCCEEDED\|TEST.*SUCCEEDED" && build_ok="true"
 

--- a/scripts/forgeos-session.sh
+++ b/scripts/forgeos-session.sh
@@ -256,17 +256,126 @@ cmd_close() {
   echo "Changeset $cs_id closed as success."
 }
 
+cmd_gate_check() {
+  local cs_id="$1"
+  local min_tests="${2:-100}"  # Default minimum: 100 tests must pass
+
+  # Fetch changeset with gate status
+  local result
+  result=$(api GET "/api/projects/${PROJECT_ID}/changesets/${cs_id}")
+
+  local all_passed=true
+  local gate_summary=""
+  local has_evidence=false
+
+  # Check gate statuses from pipeline.gates and evidence from /evidence endpoint
+  local evidence_result
+  evidence_result=$(api GET "/api/projects/${PROJECT_ID}/changesets/${cs_id}/evidence" 2>/dev/null)
+
+  # Write responses to temp files to avoid quoting issues
+  local tmp_cs=$(mktemp) tmp_ev=$(mktemp)
+  echo "$result" > "$tmp_cs"
+  echo "$evidence_result" > "$tmp_ev"
+
+  local gate_info
+  gate_info=$(python3 - "$tmp_cs" "$tmp_ev" <<'PYEOF'
+import sys, json, re
+
+with open(sys.argv[1]) as f:
+    changeset = json.load(f)
+with open(sys.argv[2]) as f:
+    evidence_list = json.load(f)
+
+# Gates are in pipeline.gates
+pipeline = changeset.get("pipeline", {})
+gates = pipeline.get("gates", [])
+
+for g in gates:
+    print(f"GATE:{g['gate_id']}:{g['status']}")
+
+# Find unit_test evidence with pass/fail counts
+for e in (evidence_list if isinstance(evidence_list, list) else []):
+    if e.get("type") == "unit_test":
+        summary = e.get("summary", "")
+        m = re.search(r"(\d+)\s+tests?\s+pass", summary)
+        f = re.search(r"(\d+)\s+failure", summary)
+        pass_count = int(m.group(1)) if m else 0
+        fail_count = int(f.group(1)) if f else 0
+        print(f"TESTS:{pass_count}:{fail_count}")
+
+print(f"STATUS:{changeset.get('status', 'unknown')}")
+PYEOF
+)
+  rm -f "$tmp_cs" "$tmp_ev"
+
+  echo "=== ForgeOS Gate Check: $cs_id ==="
+
+  # Parse gate statuses
+  local failed_gates=""
+  while IFS= read -r line; do
+    case "$line" in
+      GATE:*)
+        local gate_id=$(echo "$line" | cut -d: -f2)
+        local gate_status=$(echo "$line" | cut -d: -f3)
+        if [ "$gate_status" = "passed" ]; then
+          echo "  [PASS] $gate_id"
+        else
+          echo "  [FAIL] $gate_id ($gate_status)"
+          failed_gates="$failed_gates $gate_id"
+          all_passed=false
+        fi
+        ;;
+      TESTS:*)
+        local test_pass=$(echo "$line" | cut -d: -f2)
+        local test_fail=$(echo "$line" | cut -d: -f3)
+        echo "  Tests: $test_pass passed, $test_fail failed (minimum: $min_tests)"
+        has_evidence=true
+        if [ "$test_pass" -lt "$min_tests" ]; then
+          echo "  [FAIL] Test count $test_pass is below minimum threshold of $min_tests"
+          all_passed=false
+        fi
+        if [ "$test_fail" -gt 0 ]; then
+          echo "  [FAIL] $test_fail test failures"
+          all_passed=false
+        fi
+        ;;
+    esac
+  done <<< "$gate_info"
+
+  if [ "$has_evidence" = "false" ]; then
+    echo "  [FAIL] No test evidence submitted"
+    all_passed=false
+  fi
+
+  echo ""
+  if [ "$all_passed" = "false" ]; then
+    echo "BLOCKED: Gates not satisfied. Run 'evidence' and 'promote' first."
+    return 1
+  else
+    echo "CLEAR: All gates passed. PR creation allowed."
+    return 0
+  fi
+}
+
 # Main dispatch
 case "${1:-help}" in
-  start)    cmd_start "$2" "$3" "$4" ;;
-  evidence) cmd_evidence "$2" ;;
-  promote)  cmd_promote "$2" ;;
-  close)    cmd_close "$2" ;;
+  start)      cmd_start "$2" "$3" "$4" ;;
+  evidence)   cmd_evidence "$2" ;;
+  promote)    cmd_promote "$2" ;;
+  close)      cmd_close "$2" ;;
+  gate-check) cmd_gate_check "$2" "${3:-100}" ;;
   *)
     echo "Usage:"
     echo "  $0 start <initiative_id> <branch> <description>"
     echo "  $0 evidence <changeset_id>"
     echo "  $0 promote <changeset_id>"
     echo "  $0 close <changeset_id>"
+    echo "  $0 gate-check <changeset_id> [min_tests]"
+    echo ""
+    echo "gate-check exits 0 if all gates pass, 1 if blocked."
+    echo "Use it as a precondition in any workflow (PR creation, deploy, etc)."
+    echo ""
+    echo "Environment:"
+    echo "  FORGEOS_MIN_TESTS  -- minimum passing tests for gate-check (default: 100)"
     ;;
 esac


### PR DESCRIPTION
## Summary

- **Eliminates 6-year-old TOCTOU race** in `TPPUserAccount` singleton that caused credential cross-contamination between library accounts during account switches (PP-4020 F-034, blocker)
- Replaces mutable-singleton architecture with **per-account instances** cached in `AccountsManager` — each instance has immutable keychain keys, making credential cross-contamination structurally impossible
- Migrates all ~65 production call sites across 37 files from `sharedAccount()` to instance-based access
- Includes bandaid fix (atomic `credentialSnapshot` reads + sign-in modal deduplication guard) for defense-in-depth

### Root cause
`TPPUserAccount` was a singleton that mutated `libraryUUID` to switch which keychain keys it read/wrote. Between `sharedAccount(libraryUUID:)` returning and `.username`/`.pin` being read, another thread could switch the UUID — sending Account B's credentials to Account A's token endpoint, or writing them into Account A's keychain slot.

### Architecture change
- `TPPUserAccount(libraryUUID:)` — new initializer with immutable `boundLibraryUUID` and its own `accountInfoQueue`
- `AccountsManager.userAccount(for:)` — caches per-library instances, returns stable identity
- `TPPUserAccountResolving` protocol for DI
- Instance-level `credentialSnapshot()` (no UUID switching needed)
- `SignInModalPresenter.isPresenting` guard prevents modal stacking from concurrent 401s

### What's deferred
Legacy singleton `init()` retained as `internal` for test mock compatibility (`TPPUserAccountMock` subclasses it). Full singleton removal requires refactoring ~30 test files — separate PR.

## Test plan

- [x] 4,502 unit tests pass (0 failures)
- [x] Build succeeds on Palace scheme
- [x] ADV-1: Rapid account switching under network load on local device — verify no credential bleed
- [ ] ADV-2: Corrupt token → verify single sign-in modal (no stacking)
- [ ] ADV-3: Sign out under stale credentials completes without loop

## Regression context

PP-4020 findings F-033 (reclassified from regression to pre-existing) and F-034 (blocker, fixed). Full technical analysis in `~/Desktop/regression-PP-4020/findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### PP-4020 Traceability
- **Jira:** [PP-4121](https://ebce-lyrasis.atlassian.net/browse/PP-4121)
- **Report:** [F-034 in PP-4020 Report](https://thepalaceproject.github.io/regression-reports/PP-4020/index.html#F-034)
- **Findings:** F-033, F-034 (blocker: 6-year-old TOCTOU race)

[PP-4121]: https://ebce-lyrasis.atlassian.net/browse/PP-4121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ