### PR TITLE
Fix pinless login (PP-4045), hold cancel (PP-4033), error origin tagging

### DIFF
--- a/Palace/AppInfrastructure/FirebaseManager.swift
+++ b/Palace/AppInfrastructure/FirebaseManager.swift
@@ -283,6 +283,13 @@ final class FirebaseManager {
         #endif
     }
 
+    /// Sets a custom key-value pair on Crashlytics for dashboard filtering.
+    func setCrashlyticsKey(_ key: String, value: String) {
+        #if FEATURE_CRASH_REPORTING
+        Crashlytics.crashlytics().setCustomValue(value, forKey: key)
+        #endif
+    }
+
     // MARK: - Analytics Events
 
     /// Logs an enhanced error event to Analytics.

--- a/Palace/Logging/TPPErrorLogger.swift
+++ b/Palace/Logging/TPPErrorLogger.swift
@@ -14,6 +14,98 @@ import FirebaseCrashlytics
 
 private let nullString = "null"
 
+/// Classifies the origin of an error for Crashlytics filtering.
+/// This lets us separate client bugs from server errors, network conditions,
+/// and vendor (DRM) issues in the dashboard.
+@objc enum TPPErrorOrigin: Int {
+    /// Error originated in client code (app logic, parsing, state)
+    case client = 0
+    /// Server returned an error response (4xx, 5xx, problem document)
+    case server = 1
+    /// Network-level failure (timeout, connection lost, DNS, no internet)
+    case network = 2
+    /// DRM vendor error (Adobe RMSDK, LCP, Overdrive)
+    case vendor = 3
+    /// Origin could not be determined
+    case unknown = 4
+
+    var stringValue: String {
+        switch self {
+        case .client: return "client"
+        case .server: return "server"
+        case .network: return "network"
+        case .vendor: return "vendor"
+        case .unknown: return "unknown"
+        }
+    }
+
+    /// Auto-classifies origin from an error code and optional HTTP response.
+    static func classify(code: TPPErrorCode, error: Error? = nil, response: URLResponse? = nil) -> TPPErrorOrigin {
+        // Network-level errors
+        if let nsErr = error as NSError? {
+            if nsErr.domain == NSURLErrorDomain || nsErr.domain == (kCFErrorDomainCFNetwork as String) {
+                switch nsErr.code {
+                case NSURLErrorTimedOut, NSURLErrorNetworkConnectionLost,
+                     NSURLErrorNotConnectedToInternet, NSURLErrorInternationalRoamingOff,
+                     NSURLErrorCallIsActive, NSURLErrorDataNotAllowed,
+                     NSURLErrorDNSLookupFailed, NSURLErrorCannotFindHost,
+                     NSURLErrorCannotConnectToHost, NSURLErrorSecureConnectionFailed:
+                    return .network
+                case NSURLErrorCancelled, NSURLErrorUserCancelledAuthentication:
+                    return .client
+                default:
+                    break
+                }
+            }
+        }
+
+        // Server errors (HTTP status code based)
+        if let http = response as? HTTPURLResponse {
+            if (400...599).contains(http.statusCode) {
+                return .server
+            }
+        }
+
+        // DRM/vendor errors
+        switch code {
+        case .adobeDRMFulfillmentFail, .lcpDRMFulfillmentFail,
+             .lcpPassphraseAuthorizationFail, .lcpPassphraseRetrievalFail,
+             .epubDecodingError, .overdriveFulfillResponseParseFail:
+            return .vendor
+        default:
+            break
+        }
+
+        // Server-originated errors (problem documents, auth failures from server)
+        switch code {
+        case .problemDocAvailable, .parseProblemDocFail, .remoteLoginError,
+             .loginErrorWithProblemDoc, .apiCall, .authDocLoadFail,
+             .userProfileDocFail, .registrySyncFailure:
+            return .server
+        default:
+            break
+        }
+
+        // Network-level codes
+        switch code {
+        case .clientSideTransientError, .noURL, .invalidURLSession,
+             .malformedURL, .invalidOrNoHTTPResponse:
+            return .network
+        case .clientSideUserInterruption:
+            return .client
+        default:
+            break
+        }
+
+        // Everything else is client-side
+        if code != .ignore {
+            return .client
+        }
+
+        return .unknown
+    }
+}
+
 @objc enum TPPSeverity: NSInteger {
     case error, warning, info
 
@@ -497,22 +589,44 @@ private let nullString = "null"
     // ----------------------------------------------------------------------------
     // MARK: - Private helpers
 
-    private class func record(error: NSError) {
-        // Check if enhanced logging is enabled (synchronous, thread-safe via FirebaseManager)
-        let isEnhanced = FirebaseManager.shared.isEnhancedLoggingEnabled()
+    private class func record(error: NSError, origin: TPPErrorOrigin = .unknown) {
+        // Set error origin as a Crashlytics custom key for dashboard filtering.
+        // This lets us separate client bugs from server/network/vendor errors.
+        FirebaseManager.shared.setCrashlyticsKey("error_origin", value: origin.stringValue)
 
-        if isEnhanced {
-            Log.info(#file, "📊 ENHANCED error logging active")
-            FirebaseManager.shared.logEnhancedErrorEvent(
-                error: error,
-                context: error.domain,
-                metadata: error.userInfo
-            )
+        // Also include the origin in the error userInfo for the individual event
+        if error.userInfo["error_origin"] == nil {
+            var userInfo = error.userInfo
+            userInfo["error_origin"] = origin.stringValue
+            let taggedError = NSError(domain: error.domain, code: error.code, userInfo: userInfo)
+
+            // Check if enhanced logging is enabled (synchronous, thread-safe via FirebaseManager)
+            let isEnhanced = FirebaseManager.shared.isEnhancedLoggingEnabled()
+
+            if isEnhanced {
+                Log.info(#file, "ENHANCED error logging active")
+                FirebaseManager.shared.logEnhancedErrorEvent(
+                    error: taggedError,
+                    context: taggedError.domain,
+                    metadata: taggedError.userInfo
+                )
+            }
+
+            FirebaseManager.shared.logError(taggedError)
+        } else {
+            let isEnhanced = FirebaseManager.shared.isEnhancedLoggingEnabled()
+
+            if isEnhanced {
+                Log.info(#file, "ENHANCED error logging active")
+                FirebaseManager.shared.logEnhancedErrorEvent(
+                    error: error,
+                    context: error.domain,
+                    metadata: error.userInfo
+                )
+            }
+
+            FirebaseManager.shared.logError(error)
         }
-
-        // Always do normal Crashlytics recording via FirebaseManager
-        // This is thread-safe and prevents recursive_mutex issues
-        FirebaseManager.shared.logError(error)
     }
 
     /// Helper to log a generic error to Crashlytics.
@@ -549,13 +663,17 @@ private let nullString = "null"
                                                                code: code,
                                                                with: originalError)
 
+        // Auto-classify error origin from code, error, and response
+        let origin = TPPErrorOrigin.classify(code: code, error: originalError, response: response)
+        metadata["error_origin"] = origin.stringValue
+
         // build error report
         let userInfo = additionalInfo(severity: severity,
                                       metadata: metadata)
         let err = NSError(domain: finalSummary,
                           code: finalCode,
                           userInfo: userInfo)
-        record(error: err)
+        record(error: err, origin: origin)
     }
 
     /// Fixes up summary and code inspecting the domain and code of a given

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -1091,6 +1091,16 @@ extension MyBooksDownloadCenter {
                                     }
                                 }
                             }
+                        } else {
+                            // Unhandled error type from server. Previously this fell
+                            // through silently with no user feedback. Log the error
+                            // and show a failure alert so the user knows it didn't work.
+                            let detail = error?["detail"] as? String ?? errorType
+                            Log.error(#file, "Unhandled revoke error type: \(errorType), detail: \(detail)")
+                            runOnMainAsync {
+                                self.announceReturnFailed(for: book)
+                                completion?()
+                            }
                         }
                     } else {
                         runOnMainAsync {

--- a/Palace/SignInLogic/TokenRequest.swift
+++ b/Palace/SignInLogic/TokenRequest.swift
@@ -44,11 +44,16 @@ import Foundation
         let looksLikeOAuthToken = username.count > 50 || username.contains(".")
         Log.info(#file, "  Credential shape: usernameLen=\(username.count), pinLen=\(password.count), looksLikeBarcode=\(looksLikeBarcode), looksLikeOAuthToken=\(looksLikeOAuthToken)")
 
-        guard !username.isEmpty, !password.isEmpty else {
-            Log.error(#file, "Aborting token request: empty credentials (usernameLen=\(username.count), pinLen=\(password.count))")
+        guard !username.isEmpty else {
+            Log.error(#file, "Aborting token request: empty username")
             return .failure(NSError(domain: "TokenRequest", code: -1,
-                                    userInfo: [NSLocalizedDescriptionKey: "Cannot request token with empty credentials"]))
+                                    userInfo: [NSLocalizedDescriptionKey: "Cannot request token with empty username"]))
         }
+        // Note: empty password is valid for libraries that don't require a PIN.
+        // Basic Auth with "barcode:" (empty password) is the correct format for
+        // pinless authentication. The original guard (!password.isEmpty) broke
+        // pinless login for libraries like Wolcott Public Library and Bentley
+        // Memorial Library (PP-4045).
 
         var request = URLRequest(url: url, applyingCustomUserAgent: true)
         request.httpMethod = HTTPMethodType.POST.rawValue

--- a/PalaceTests/Network/CredentialGuardTests.swift
+++ b/PalaceTests/Network/CredentialGuardTests.swift
@@ -50,28 +50,45 @@ final class TokenRequestCredentialGuardTests: XCTestCase {
         case .success:
             XCTFail("Expected failure for empty username")
         case .failure(let error):
-            XCTAssertTrue(error.localizedDescription.contains("empty credentials"),
-                          "Error should mention empty credentials, got: \(error.localizedDescription)")
+            XCTAssertTrue(error.localizedDescription.contains("empty username"),
+                          "Error should mention empty username, got: \(error.localizedDescription)")
         }
     }
 
-    func testExecute_EmptyPassword_ReturnsFailureWithoutNetworkCall() async {
-        let request = TokenRequest(url: tokenURL, username: "12345", password: "")
+    /// Empty password is valid for pinless libraries (PP-4045).
+    /// Libraries like Wolcott Public Library and Bentley Memorial Library
+    /// do not require a PIN. Basic Auth sends "barcode:" with empty password.
+    func testExecute_EmptyPassword_PinlessLogin_MakesNetworkCall() async {
+        let request = TokenRequest(url: tokenURL, username: "23160026460829", password: "")
 
-        HTTPStubURLProtocol.register { _ in
-            XCTFail("Network request should not be made with empty password")
-            return nil
+        var networkCallMade = false
+        HTTPStubURLProtocol.register { req in
+            networkCallMade = true
+            // Verify Basic Auth header is present with barcode and empty password
+            let authHeader = req.value(forHTTPHeaderField: "Authorization") ?? ""
+            XCTAssertTrue(authHeader.hasPrefix("Basic "), "Should have Basic auth header")
+            // Decode and verify format is "barcode:"
+            if let base64Data = Data(base64Encoded: authHeader.replacingOccurrences(of: "Basic ", with: "")),
+               let credential = String(data: base64Data, encoding: .utf8) {
+                XCTAssertEqual(credential, "23160026460829:", "Should be barcode with empty password")
+            }
+            // Return a valid token response
+            let tokenJSON = """
+            {"access_token": "test_token", "token_type": "Bearer", "expires_in": 3600}
+            """.data(using: .utf8)
+            return HTTPStubURLProtocol.StubbedResponse(statusCode: 200, headers: nil, body: tokenJSON)
         }
 
         let session = URLSession.stubbedSession()
         let result = await request.execute(session: session)
 
+        XCTAssertTrue(networkCallMade, "Network call should be made for pinless login")
+
         switch result {
-        case .success:
-            XCTFail("Expected failure for empty password")
+        case .success(let tokenResponse):
+            XCTAssertEqual(tokenResponse.accessToken, "test_token")
         case .failure(let error):
-            XCTAssertTrue(error.localizedDescription.contains("empty credentials"),
-                          "Error should mention empty credentials, got: \(error.localizedDescription)")
+            XCTFail("Pinless login should succeed, got error: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary

Three fixes cherry-picked from release/2.2.5 into modernize/whole-shot:

**PP-4045 (BLOCKER):** Libraries that don't require a PIN (e.g. Wolcott Public Library, Bentley Memorial Library) got "Invalid Credentials" on sign-in. The `TokenRequest` guard added in March (`77c5af2e5`) rejected empty passwords, but empty password is valid Basic Auth for pinless libraries per RFC 7617. Fix: only guard against empty username.

**PP-4033:** Cancel Hold button did nothing. The revoke endpoint error handler only handled `TypeNoActiveLoan` and `TypeInvalidCredentials`. Any other server error type fell through silently with no user feedback. Fix: catch-all else branch that calls `announceReturnFailed()`.

**Error origin tagging (F-META-1):** Every non-fatal error logged to Crashlytics now includes `error_origin` (client/server/network/vendor) as a custom key. Auto-classified from error codes, HTTP status codes, and URL error domains. Enables filtering the Crashlytics dashboard to separate client bugs from server/network/vendor issues.

## Test plan

- [x] 13 credential guard tests pass (0 failures)
- [x] New pinless login test verifies Basic Auth "barcode:" format with empty password
- [x] Build succeeds on Palace scheme
- [ ] Manual: sign into Wolcott Public Library or Bentley Memorial Library with barcode only (no PIN)
- [ ] Manual: place and cancel a hold on A1QA Test Library

🤖 Generated with [Claude Code](https://claude.com/claude-code)