### PR TITLE
Mock Backend Service: scenario-based URL interception for testing

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -429,6 +429,10 @@
 		65C9C378EE67A7B2D1D12B08 /* MyBooksDownloadCenterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420E95312BFA6C62C6CA835D /* MyBooksDownloadCenterProtocol.swift */; };
 		66AE9D42FA4F53E26C31747C /* ReadingStreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6CA6654994D77041AE0F79 /* ReadingStreak.swift */; };
 		676F638471BA390A373B329B /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF1F7C70AC93BF8E2F22148 /* DebugSettings.swift */; };
+		MOCKBK01BL001 /* MockScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR001 /* MockScenario.swift */; };
+		MOCKBK01BL002 /* MockBackendURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR002 /* MockBackendURLProtocol.swift */; };
+		MOCKBK01BL003 /* MockBackendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR003 /* MockBackendService.swift */; };
+		MOCKBK01BL004 /* MockBackendPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR004 /* MockBackendPickerView.swift */; };
 		681FBB4C5C3E2B2A10DAD273 /* CatalogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DF25F6BFF39ECDAF39E3E3 /* CatalogViewModelTests.swift */; };
 		68AE152553DC4596F31D8842 /* NYPLXMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151A1BCD2A3E9E836B277A8C /* NYPLXMLTests.swift */; };
 		68B4EB5D20D6EDBEA0D18156 /* AppInfrastructureCoverageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262879F496344EE8F262446A /* AppInfrastructureCoverageTests.swift */; };
@@ -2303,6 +2307,10 @@
 		BDC90738317B9A2A4331572D /* TPPSessionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPSessionTests.swift; sourceTree = "<group>"; };
 		BE020244923A658A8CB9EE39 /* AuthFlowSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowSecurityTests.swift; sourceTree = "<group>"; };
 		BEF1F7C70AC93BF8E2F22148 /* DebugSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DebugSettings.swift; path = Debug/DebugSettings.swift; sourceTree = "<group>"; };
+		MOCKBK01FR001 /* MockScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockScenario.swift; path = Debug/MockBackend/MockScenario.swift; sourceTree = "<group>"; };
+		MOCKBK01FR002 /* MockBackendURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockBackendURLProtocol.swift; path = Debug/MockBackend/MockBackendURLProtocol.swift; sourceTree = "<group>"; };
+		MOCKBK01FR003 /* MockBackendService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockBackendService.swift; path = Debug/MockBackend/MockBackendService.swift; sourceTree = "<group>"; };
+		MOCKBK01FR004 /* MockBackendPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockBackendPickerView.swift; path = Debug/MockBackend/MockBackendPickerView.swift; sourceTree = "<group>"; };
 		BF99D1F39D634C56A70BFE75 /* AudiobookReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookReliabilityTests.swift; sourceTree = "<group>"; };
 		BKTST00012F27000000FR01 /* TPPBookLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookLocationTests.swift; sourceTree = "<group>"; };
 		BKTST00012F27000000FR02 /* TPPBookContentTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookContentTypeTests.swift; sourceTree = "<group>"; };
@@ -4057,6 +4065,10 @@
 			isa = PBXGroup;
 			children = (
 				BEF1F7C70AC93BF8E2F22148 /* DebugSettings.swift */,
+				MOCKBK01FR001 /* MockScenario.swift */,
+				MOCKBK01FR002 /* MockBackendURLProtocol.swift */,
+				MOCKBK01FR003 /* MockBackendService.swift */,
+				MOCKBK01FR004 /* MockBackendPickerView.swift */,
 			);
 			name = Debug;
 			sourceTree = "<group>";
@@ -6896,6 +6908,10 @@
 				E7E89399284A1EB800C7A4F3 /* TPPPDFPreviewBar.swift in Sources */,
 				5DD5674522B303DF001F0C83 /* TPPDeveloperSettingsTableViewController.swift in Sources */,
 				676F638471BA390A373B329B /* DebugSettings.swift in Sources */,
+				MOCKBK01BL001 /* MockScenario.swift in Sources */,
+				MOCKBK01BL002 /* MockBackendURLProtocol.swift in Sources */,
+				MOCKBK01BL003 /* MockBackendService.swift in Sources */,
+				MOCKBK01BL004 /* MockBackendPickerView.swift in Sources */,
 				E512240C2DDFC41D00D034A4 /* UIViewController+Extensions.swift in Sources */,
 				E5FD62162BFD30F600DD4B94 /* LoadingViewController.swift in Sources */,
 				E50543892E5F98B9007CCFAB /* CatalogLoadingViewController.swift in Sources */,

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -433,6 +433,8 @@
 		MOCKBK01BL002 /* MockBackendURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR002 /* MockBackendURLProtocol.swift */; };
 		MOCKBK01BL003 /* MockBackendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR003 /* MockBackendService.swift */; };
 		MOCKBK01BL004 /* MockBackendPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR004 /* MockBackendPickerView.swift */; };
+		MOCKBK01BL005 /* EmbeddedScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR005 /* EmbeddedScenarios.swift */; };
+		MOCKBK01BL006 /* EmbeddedFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR006 /* EmbeddedFixtures.swift */; };
 		681FBB4C5C3E2B2A10DAD273 /* CatalogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DF25F6BFF39ECDAF39E3E3 /* CatalogViewModelTests.swift */; };
 		68AE152553DC4596F31D8842 /* NYPLXMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151A1BCD2A3E9E836B277A8C /* NYPLXMLTests.swift */; };
 		68B4EB5D20D6EDBEA0D18156 /* AppInfrastructureCoverageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262879F496344EE8F262446A /* AppInfrastructureCoverageTests.swift */; };
@@ -2313,6 +2315,8 @@
 		MOCKBK01FR002 /* MockBackendURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockBackendURLProtocol.swift; path = Debug/MockBackend/MockBackendURLProtocol.swift; sourceTree = "<group>"; };
 		MOCKBK01FR003 /* MockBackendService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockBackendService.swift; path = Debug/MockBackend/MockBackendService.swift; sourceTree = "<group>"; };
 		MOCKBK01FR004 /* MockBackendPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockBackendPickerView.swift; path = Debug/MockBackend/MockBackendPickerView.swift; sourceTree = "<group>"; };
+		MOCKBK01FR005 /* EmbeddedScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EmbeddedScenarios.swift; path = Debug/MockBackend/EmbeddedScenarios.swift; sourceTree = "<group>"; };
+		MOCKBK01FR006 /* EmbeddedFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EmbeddedFixtures.swift; path = Debug/MockBackend/EmbeddedFixtures.swift; sourceTree = "<group>"; };
 		BF99D1F39D634C56A70BFE75 /* AudiobookReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookReliabilityTests.swift; sourceTree = "<group>"; };
 		BKTST00012F27000000FR01 /* TPPBookLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookLocationTests.swift; sourceTree = "<group>"; };
 		BKTST00012F27000000FR02 /* TPPBookContentTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookContentTypeTests.swift; sourceTree = "<group>"; };
@@ -4073,6 +4077,8 @@
 				MOCKBK01FR002 /* MockBackendURLProtocol.swift */,
 				MOCKBK01FR003 /* MockBackendService.swift */,
 				MOCKBK01FR004 /* MockBackendPickerView.swift */,
+				MOCKBK01FR005 /* EmbeddedScenarios.swift */,
+				MOCKBK01FR006 /* EmbeddedFixtures.swift */,
 			);
 			name = Debug;
 			sourceTree = "<group>";
@@ -6920,6 +6926,8 @@
 				MOCKBK01BL002 /* MockBackendURLProtocol.swift in Sources */,
 				MOCKBK01BL003 /* MockBackendService.swift in Sources */,
 				MOCKBK01BL004 /* MockBackendPickerView.swift in Sources */,
+				MOCKBK01BL005 /* EmbeddedScenarios.swift in Sources */,
+				MOCKBK01BL006 /* EmbeddedFixtures.swift in Sources */,
 				E512240C2DDFC41D00D034A4 /* UIViewController+Extensions.swift in Sources */,
 				E5FD62162BFD30F600DD4B94 /* LoadingViewController.swift in Sources */,
 				E50543892E5F98B9007CCFAB /* CatalogLoadingViewController.swift in Sources */,

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1488,6 +1488,8 @@
 		FFF27FB1D19EC2A0B2827B32 /* TPPOPDSGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23421B886CD7122945915B93 /* TPPOPDSGroupTests.swift */; };
 		INTG0001B7A00000000001 /* SearchFlowIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = INTG0001B7A00000000002 /* SearchFlowIntegrationTests.swift */; };
 		INTG0001B7A00000000003 /* AccountSwitchIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = INTG0001B7A00000000004 /* AccountSwitchIntegrationTests.swift */; };
+		MOCKINTG01BLD00000001 /* MockBackendIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKINTG01FREF0000001 /* MockBackendIntegrationTests.swift */; };
+		MOCKINTG01BLD00000002 /* MockBackendTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKINTG01FREF0000002 /* MockBackendTestHelper.swift */; };
 		INTG0001B7A00000000005 /* BookStateIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = INTG0001B7A00000000006 /* BookStateIntegrationTests.swift */; };
 		INTG0001B7A00000000007 /* CatalogLoadIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = INTG0001B7A00000000008 /* CatalogLoadIntegrationTests.swift */; };
 		KCHAVAIL00BUILD000000001 /* KeychainAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = KCHAVAIL00FILEREF000001 /* KeychainAvailability.swift */; };
@@ -2706,6 +2708,8 @@
 		FFFD104EE843356CD66327E6 /* CrossFormatMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrossFormatMappingTests.swift; sourceTree = "<group>"; };
 		INTG0001B7A00000000002 /* SearchFlowIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFlowIntegrationTests.swift; sourceTree = "<group>"; };
 		INTG0001B7A00000000004 /* AccountSwitchIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSwitchIntegrationTests.swift; sourceTree = "<group>"; };
+		MOCKINTG01FREF0000001 /* MockBackendIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendIntegrationTests.swift; sourceTree = "<group>"; };
+		MOCKINTG01FREF0000002 /* MockBackendTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendTestHelper.swift; sourceTree = "<group>"; };
 		INTG0001B7A00000000006 /* BookStateIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookStateIntegrationTests.swift; sourceTree = "<group>"; };
 		INTG0001B7A00000000008 /* CatalogLoadIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogLoadIntegrationTests.swift; sourceTree = "<group>"; };
 		KCHAVAIL00FILEREF000001 /* KeychainAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAvailability.swift; sourceTree = "<group>"; };
@@ -5323,6 +5327,8 @@
 			children = (
 				INTG0001B7A00000000002 /* SearchFlowIntegrationTests.swift */,
 				INTG0001B7A00000000004 /* AccountSwitchIntegrationTests.swift */,
+				MOCKINTG01FREF0000001 /* MockBackendIntegrationTests.swift */,
+				MOCKINTG01FREF0000002 /* MockBackendTestHelper.swift */,
 				INTG0001B7A00000000006 /* BookStateIntegrationTests.swift */,
 				INTG0001B7A00000000008 /* CatalogLoadIntegrationTests.swift */,
 			);
@@ -6035,6 +6041,8 @@
 				E18A0DC8C00A41B8841DBBE7 /* TPPBookRegistryIntegrationTests.swift in Sources */,
 				INTG0001B7A00000000001 /* SearchFlowIntegrationTests.swift in Sources */,
 				INTG0001B7A00000000003 /* AccountSwitchIntegrationTests.swift in Sources */,
+				MOCKINTG01BLD00000001 /* MockBackendIntegrationTests.swift in Sources */,
+				MOCKINTG01BLD00000002 /* MockBackendTestHelper.swift in Sources */,
 				INTG0001B7A00000000005 /* BookStateIntegrationTests.swift in Sources */,
 				INTG0001B7A00000000007 /* CatalogLoadIntegrationTests.swift in Sources */,
 				7C412CCF4234E353860E7FAD /* KeyboardNavigationHandlerTests.swift in Sources */,

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -435,6 +435,7 @@
 		MOCKBK01BL004 /* MockBackendPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR004 /* MockBackendPickerView.swift */; };
 		MOCKBK01BL005 /* EmbeddedScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR005 /* EmbeddedScenarios.swift */; };
 		MOCKBK01BL006 /* EmbeddedFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR006 /* EmbeddedFixtures.swift */; };
+		MOCKBK01BL007 /* URLSessionConfiguration+MockBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR007 /* URLSessionConfiguration+MockBackend.swift */; };
 		681FBB4C5C3E2B2A10DAD273 /* CatalogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DF25F6BFF39ECDAF39E3E3 /* CatalogViewModelTests.swift */; };
 		68AE152553DC4596F31D8842 /* NYPLXMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151A1BCD2A3E9E836B277A8C /* NYPLXMLTests.swift */; };
 		68B4EB5D20D6EDBEA0D18156 /* AppInfrastructureCoverageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262879F496344EE8F262446A /* AppInfrastructureCoverageTests.swift */; };
@@ -2317,6 +2318,7 @@
 		MOCKBK01FR004 /* MockBackendPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockBackendPickerView.swift; path = Debug/MockBackend/MockBackendPickerView.swift; sourceTree = "<group>"; };
 		MOCKBK01FR005 /* EmbeddedScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EmbeddedScenarios.swift; path = Debug/MockBackend/EmbeddedScenarios.swift; sourceTree = "<group>"; };
 		MOCKBK01FR006 /* EmbeddedFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EmbeddedFixtures.swift; path = Debug/MockBackend/EmbeddedFixtures.swift; sourceTree = "<group>"; };
+		MOCKBK01FR007 /* URLSessionConfiguration+MockBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "URLSessionConfiguration+MockBackend.swift"; path = "Debug/MockBackend/URLSessionConfiguration+MockBackend.swift"; sourceTree = "<group>"; };
 		BF99D1F39D634C56A70BFE75 /* AudiobookReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookReliabilityTests.swift; sourceTree = "<group>"; };
 		BKTST00012F27000000FR01 /* TPPBookLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookLocationTests.swift; sourceTree = "<group>"; };
 		BKTST00012F27000000FR02 /* TPPBookContentTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookContentTypeTests.swift; sourceTree = "<group>"; };
@@ -4079,6 +4081,7 @@
 				MOCKBK01FR004 /* MockBackendPickerView.swift */,
 				MOCKBK01FR005 /* EmbeddedScenarios.swift */,
 				MOCKBK01FR006 /* EmbeddedFixtures.swift */,
+				MOCKBK01FR007 /* URLSessionConfiguration+MockBackend.swift */,
 			);
 			name = Debug;
 			sourceTree = "<group>";
@@ -6928,6 +6931,7 @@
 				MOCKBK01BL004 /* MockBackendPickerView.swift in Sources */,
 				MOCKBK01BL005 /* EmbeddedScenarios.swift in Sources */,
 				MOCKBK01BL006 /* EmbeddedFixtures.swift in Sources */,
+				MOCKBK01BL007 /* URLSessionConfiguration+MockBackend.swift in Sources */,
 				E512240C2DDFC41D00D034A4 /* UIViewController+Extensions.swift in Sources */,
 				E5FD62162BFD30F600DD4B94 /* LoadingViewController.swift in Sources */,
 				E50543892E5F98B9007CCFAB /* CatalogLoadingViewController.swift in Sources */,

--- a/Palace/Book/Models/TPPBook+Presentation.swift
+++ b/Palace/Book/Models/TPPBook+Presentation.swift
@@ -34,7 +34,7 @@ extension TPPBook {
         // the generic keys risks returning a small thumbnail that was cached from a list/lane
         // view, which would appear pixelated at larger display sizes.
         let sizeKey: String? = displayHeight.map { "\(identifier)_\(Int($0))pt" }
-        let lookupKeys: [String] = sizeKey != nil ? [sizeKey!] : [simpleKey, coverKey]
+        let lookupKeys: [String] = if let sizeKey { [sizeKey] } else { [simpleKey, coverKey] }
 
         if let img = lookupKeys.lazy.compactMap({ [weak self] in
           self?.imageCache.get(for: $0) }).first {

--- a/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
@@ -244,8 +244,22 @@ final class BookDetailViewModel: ObservableObject {
 
         // Subscribe to download errors so we can present them via SwiftUI .alert
         // instead of UIKit (which can fail when a SwiftUI sheet is topmost).
+        // Filter by error kind so borrow errors only show when the user initiated
+        // a borrow (Get), and download errors only show for downloads/retries.
         downloadCenter.downloadErrorPublisher
             .filter { [weak self] in $0.bookId == self?.book.identifier }
+            .filter { [weak self] errorInfo in
+                guard let self else { return true }
+                switch errorInfo.kind {
+                case .borrow:
+                    return self.processingButtons.contains(.get) || self.bookState == .unregistered
+                case .download:
+                    return self.processingButtons.contains(.download) || self.processingButtons.contains(.retry)
+                        || self.bookState == .downloading || self.bookState == .downloadFailed || self.bookState == .downloadNeeded
+                case .general:
+                    return true
+                }
+            }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] errorInfo in
                 if let retryAction = errorInfo.retryAction {

--- a/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
+++ b/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
@@ -241,9 +241,23 @@ class BookCellModel: ObservableObject {
             }
             .store(in: &cancellables)
 
-        // Subscribe to download errors so the half sheet can present them via SwiftUI .alert
+        // Subscribe to download errors so the half sheet can present them via SwiftUI .alert.
+        // Filter by error kind: borrow errors only show for unregistered books (user tapped Get),
+        // download errors only for books in download-related states.
         downloadCenter.downloadErrorPublisher
             .filter { [weak self] in $0.bookId == self?.book.identifier }
+            .filter { [weak self] errorInfo in
+                guard let self else { return true }
+                switch errorInfo.kind {
+                case .borrow:
+                    return self.registryState == .unregistered || self.registryState == .holding
+                case .download:
+                    return self.registryState == .downloading || self.registryState == .downloadFailed
+                        || self.registryState == .downloadNeeded
+                case .general:
+                    return true
+                }
+            }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] errorInfo in
                 guard let self else { return }

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -275,7 +275,7 @@ import OverdriveProcessor
         case TPPProblemDocument.TypeLoanAlreadyExists:
             let alertMessage = DisplayStrings.loanAlreadyExistsAlertMessage
             runOnMainAsync {
-                self.publishAndAnnounceError(DownloadErrorInfo(bookId: book.identifier, title: alertTitle, message: alertMessage))
+                self.publishAndAnnounceError(DownloadErrorInfo(bookId: book.identifier, title: alertTitle, message: alertMessage, kind: .borrow))
             }
 
         case TPPProblemDocument.TypeInvalidCredentials:
@@ -346,7 +346,7 @@ import OverdriveProcessor
         }()
 
         runOnMainAsync {
-            self.publishAndAnnounceError(DownloadErrorInfo(bookId: book.identifier, title: alertTitle, message: alertMessage, retryAction: retryAction))
+            self.publishAndAnnounceError(DownloadErrorInfo(bookId: book.identifier, title: alertTitle, message: alertMessage, kind: .borrow, retryAction: retryAction))
         }
     }
 
@@ -363,7 +363,7 @@ import OverdriveProcessor
         }()
 
         runOnMainAsync {
-            self.publishAndAnnounceError(DownloadErrorInfo(bookId: book.identifier, title: DisplayStrings.borrowFailed, message: formattedMessage, retryAction: retryAction))
+            self.publishAndAnnounceError(DownloadErrorInfo(bookId: book.identifier, title: DisplayStrings.borrowFailed, message: formattedMessage, kind: .borrow, retryAction: retryAction))
         }
     }
 
@@ -2384,7 +2384,7 @@ extension MyBooksDownloadCenter {
 
         // Publish error and announce via VoiceOver (PP-3673)
         runOnMainAsync {
-            self.publishAndAnnounceError(DownloadErrorInfo(bookId: book.identifier, title: DisplayStrings.downloadFailed, message: finalMessage, retryAction: retryAction))
+            self.publishAndAnnounceError(DownloadErrorInfo(bookId: book.identifier, title: DisplayStrings.downloadFailed, message: finalMessage, kind: .download, retryAction: retryAction))
         }
 
         broadcastUpdate()
@@ -2421,7 +2421,7 @@ extension MyBooksDownloadCenter {
 
         // Publish error and announce via VoiceOver (PP-3673)
         runOnMainAsync {
-            self.publishAndAnnounceError(DownloadErrorInfo(bookId: book.identifier, title: DisplayStrings.downloadFailed, message: finalMessage, retryAction: retryAction))
+            self.publishAndAnnounceError(DownloadErrorInfo(bookId: book.identifier, title: DisplayStrings.downloadFailed, message: finalMessage, kind: .download, retryAction: retryAction))
         }
     }
 

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -109,6 +109,22 @@ import OverdriveProcessor
         if let injected = urlSession {
             self.session = injected
         } else {
+            #if DEBUG
+            // When mock backend is active, use a default (non-background) session
+            // so MockBackendURLProtocol can intercept download requests.
+            // Background sessions don't support custom URLProtocol classes.
+            if MockBackendURLProtocol.activeScenario != nil {
+                let configuration = URLSessionConfiguration.default
+                self.session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
+            } else {
+                let backgroundIdentifier = (Bundle.main.bundleIdentifier ?? "") + ".downloadCenterBackgroundIdentifier"
+                let configuration = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
+                configuration.isDiscretionary = false
+                configuration.waitsForConnectivity = false
+                configuration.allowsConstrainedNetworkAccess = true
+                self.session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
+            }
+            #else
             let backgroundIdentifier = (Bundle.main.bundleIdentifier ?? "") + ".downloadCenterBackgroundIdentifier"
             let configuration = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
             configuration.isDiscretionary = false
@@ -117,11 +133,34 @@ import OverdriveProcessor
                 configuration.allowsConstrainedNetworkAccess = true
             }
             self.session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
+            #endif
         }
 
         // Setup intelligent download management
         setupNetworkMonitoring()
     }
+
+    #if DEBUG
+    /// Recreate the download session to pick up mock backend protocol changes.
+    /// Background sessions don't support URLProtocol, so when the mock is active
+    /// we use a default session instead.
+    func recreateSessionForMockBackend() {
+        session.invalidateAndCancel()
+        if MockBackendURLProtocol.activeScenario != nil {
+            let configuration = URLSessionConfiguration.default
+            session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
+            Log.info(#file, "MyBooksDownloadCenter: switched to default session for mock backend")
+        } else {
+            let backgroundIdentifier = (Bundle.main.bundleIdentifier ?? "") + ".downloadCenterBackgroundIdentifier"
+            let configuration = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
+            configuration.isDiscretionary = false
+            configuration.waitsForConnectivity = false
+            configuration.allowsConstrainedNetworkAccess = true
+            session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
+            Log.info(#file, "MyBooksDownloadCenter: restored background session")
+        }
+    }
+    #endif
 
     deinit {
         session?.invalidateAndCancel()

--- a/Palace/MyBooks/MyBooksDownloadErrorInfo.swift
+++ b/Palace/MyBooks/MyBooksDownloadErrorInfo.swift
@@ -14,24 +14,39 @@ import Foundation
 /// Info published when a download or borrow error occurs.
 /// Includes retry support so SwiftUI views can offer a "Retry" button.
 struct DownloadErrorInfo {
+
+  /// Distinguishes the operation that produced the error so subscribers
+  /// can filter out errors that don't apply to their current context.
+  enum ErrorKind {
+    /// Error occurred during the borrow (loan acquisition) phase.
+    case borrow
+    /// Error occurred during the file download phase.
+    case download
+    /// General error not tied to a specific phase (e.g. Wi-Fi restriction).
+    case general
+  }
+
   let bookId: String
   let title: String
   let message: String
+  let kind: ErrorKind
   let retryAction: (() -> Void)?
 
   /// Convenience for non-retryable errors.
-  init(bookId: String, title: String, message: String) {
+  init(bookId: String, title: String, message: String, kind: ErrorKind = .general) {
     self.bookId = bookId
     self.title = title
     self.message = message
+    self.kind = kind
     self.retryAction = nil
   }
 
   /// Full initializer with optional retry action.
-  init(bookId: String, title: String, message: String, retryAction: (() -> Void)?) {
+  init(bookId: String, title: String, message: String, kind: ErrorKind = .general, retryAction: (() -> Void)?) {
     self.bookId = bookId
     self.title = title
     self.message = message
+    self.kind = kind
     self.retryAction = retryAction
   }
 }

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -184,7 +184,11 @@ private final class ActiveTasksStore {
         urlSession.finishTasksAndInvalidate()
     }
 
+    #if DEBUG
+    @objc static var shared = TPPNetworkExecutor(cachingStrategy: .fallback)
+    #else
     @objc static let shared = TPPNetworkExecutor(cachingStrategy: .fallback)
+    #endif
 
     /// Number of underlying token-refresh attempts that have taken the
     /// single-flight slot since process start (or last reset). Concurrent

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -122,7 +122,11 @@ private final class ActiveTasksStore {
 }
 
 @objc class TPPNetworkExecutor: NSObject {
+    #if DEBUG
+    private var urlSession: URLSession
+    #else
     private let urlSession: URLSession
+    #endif
     private let tokenCoordinator = TokenRefreshCoordinator()
     private let activeTasksStore = ActiveTasksStore()
 
@@ -183,6 +187,22 @@ private final class ActiveTasksStore {
     deinit {
         urlSession.finishTasksAndInvalidate()
     }
+
+    #if DEBUG
+    /// Recreate the internal URLSession so it picks up any newly registered
+    /// URLProtocol classes (e.g., MockBackendURLProtocol). Called by
+    /// MockBackendService when activating/deactivating the mock backend.
+    func recreateSession() {
+        urlSession.finishTasksAndInvalidate()
+        let config = TPPCaching.makeURLSessionConfiguration(
+            caching: .fallback,
+            requestTimeout: TPPNetworkExecutor.defaultRequestTimeout)
+        urlSession = URLSession(configuration: config,
+                                delegate: responder,
+                                delegateQueue: nil)
+        Log.info(#file, "TPPNetworkExecutor: session recreated for mock backend")
+    }
+    #endif
 
     @objc static let shared = TPPNetworkExecutor(cachingStrategy: .fallback)
 

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -184,11 +184,7 @@ private final class ActiveTasksStore {
         urlSession.finishTasksAndInvalidate()
     }
 
-    #if DEBUG
-    @objc static var shared = TPPNetworkExecutor(cachingStrategy: .fallback)
-    #else
     @objc static let shared = TPPNetworkExecutor(cachingStrategy: .fallback)
-    #endif
 
     /// Number of underlying token-refresh attempts that have taken the
     /// single-flight slot since process start (or last reset). Concurrent

--- a/Palace/OPDS2/Models/OPDS2PublicationExtended.swift
+++ b/Palace/OPDS2/Models/OPDS2PublicationExtended.swift
@@ -317,12 +317,12 @@ struct OPDS2FullPublication: Codable, Equatable, Sendable, Identifiable {
 
     public var thumbnailURL: URL? {
         images?.first { $0.rel?.contains("thumbnail") == true }?.hrefURL ??
-            images?.first { $0.width != nil && $0.width! < 200 }?.hrefURL
+            images?.first { ($0.width ?? 0) < 200 && $0.width != nil }?.hrefURL
     }
 
     public var coverURL: URL? {
         images?.first { $0.rel?.contains("cover") == true }?.hrefURL ??
-            images?.first { $0.width != nil && $0.width! >= 200 }?.hrefURL
+            images?.first { ($0.width ?? 0) >= 200 }?.hrefURL
     }
 
     // MARK: - Acquisition Links

--- a/Palace/Settings/Debug/MockBackend/EmbeddedFixtures.swift
+++ b/Palace/Settings/Debug/MockBackend/EmbeddedFixtures.swift
@@ -1,0 +1,43 @@
+//
+//  EmbeddedFixtures.swift
+//  Palace
+//
+//  Fixture data embedded as Swift string literals.
+//  These are the same JSON files from PalaceTests/Fixtures/API/,
+//  compiled directly into the binary so no bundle resources needed.
+//
+
+#if DEBUG
+
+import Foundation
+
+enum EmbeddedFixtures {
+
+    static func data(for name: String) -> Data? {
+        switch name {
+        case "opds2_feed": return opds2Feed.data(using: .utf8)
+        case "auth_document": return authDocument.data(using: .utf8)
+        case "problem_documents": return problemDocuments.data(using: .utf8)
+        case "annotations": return annotations.data(using: .utf8)
+        default: return nil
+        }
+    }
+
+    static let opds2Feed = """
+    {"metadata":{"title":"A1QA Test Library","itemsPerPage":50},"links":[{"rel":"self","href":"https://gorgon.staging.palaceproject.io/a1qa-test/","type":"application/opds+json"},{"rel":"search","href":"https://gorgon.staging.palaceproject.io/a1qa-test/search{?query}","type":"application/opds+json","templated":true}],"publications":[{"metadata":{"identifier":"urn:uuid:b309a3a0-1234","title":"Agnes Grey","author":[{"name":"Anne Bront\\u00eb"}],"published":"2020-01-15","language":["en"],"description":"A heroine who is honest, perceptive and charming."},"images":[{"href":"https://example.com/cover.jpg","type":"image/jpeg"}],"links":[{"rel":"http://opds-spec.org/acquisition/borrow","href":"https://gorgon.staging.palaceproject.io/a1qa-test/works/b309a3a0/borrow","type":"application/atom+xml;type=entry;profile=opds-catalog","properties":{"availability":{"state":"available"},"copies":{"total":9999,"available":9999}}}]},{"metadata":{"identifier":"urn:uuid:audio-1234","type":"http://schema.org/Audiobook","title":"Animal Farm","author":[{"name":"George Orwell"}],"published":"2019-06-01","language":["en"],"duration":10800},"images":[{"href":"https://example.com/animal-farm.jpg","type":"image/jpeg"}],"links":[{"rel":"http://opds-spec.org/acquisition/borrow","href":"https://gorgon.staging.palaceproject.io/a1qa-test/works/audio-1234/borrow","type":"application/atom+xml;type=entry;profile=opds-catalog","properties":{"availability":{"state":"available"},"copies":{"total":5,"available":3}}}]}],"groups":[{"metadata":{"title":"Unlimited Listens ODL Feed"},"links":[{"rel":"self","href":"https://gorgon.staging.palaceproject.io/a1qa-test/groups/unlimited-listens","type":"application/opds+json"}],"publications":[]}],"facets":[{"metadata":{"title":"Format"},"links":[{"rel":"http://opds-spec.org/facet","href":"https://gorgon.staging.palaceproject.io/a1qa-test/?entrypoint=All","title":"All","properties":{"activeFacet":true}},{"rel":"http://opds-spec.org/facet","href":"https://gorgon.staging.palaceproject.io/a1qa-test/?entrypoint=eBooks","title":"eBooks"},{"rel":"http://opds-spec.org/facet","href":"https://gorgon.staging.palaceproject.io/a1qa-test/?entrypoint=Audiobooks","title":"Audiobooks"}]}]}
+    """
+
+    static let authDocument = """
+    {"title":"A1QA Test Library","service_description":"A test library for QA.","id":"https://gorgon.staging.palaceproject.io/a1qa-test/authentication_document","authentication":[{"type":"http://palaceproject.io/authtype/Basic","description":"Library Card","labels":{"login":"Barcode","password":"PIN"},"inputs":{"login":{"keyboard":"DEFAULT","maximum_length":14},"password":{"keyboard":"NUMBER_PAD"}}}],"links":[{"rel":"start","href":"https://gorgon.staging.palaceproject.io/a1qa-test/","type":"application/atom+xml;profile=opds-catalog"},{"rel":"help","href":"mailto:support@example.com"},{"rel":"terms-of-service","href":"https://thepalaceproject.org/terms/"},{"rel":"privacy-policy","href":"https://thepalaceproject.org/privacy/"}],"features":{"enabled":["reservations"],"disabled":[]},"announcements":[]}
+    """
+
+    static let problemDocuments = """
+    {"invalid_credentials":{"type":"http://librarysimplified.org/terms/problem/invalid-credentials","status":401,"title":"Invalid Credentials","detail":"A valid library card barcode number and PIN are required."},"expired_credentials":{"type":"http://librarysimplified.org/terms/problem/expired-credentials","status":403,"title":"Expired Credentials","detail":"Library card has expired."},"loan_limit_reached":{"type":"http://librarysimplified.org/terms/problem/loan-limit-reached","status":403,"title":"Loan Limit Reached","detail":"You have reached your loan limit. Please return books before borrowing more."},"hold_limit_reached":{"type":"http://librarysimplified.org/terms/problem/hold-limit-reached","status":403,"title":"Hold Limit Reached","detail":"You have reached your hold limit."},"no_licenses":{"type":"http://librarysimplified.org/terms/problem/no-licenses","status":404,"title":"No Licenses","detail":"The library currently has no licenses for this book."},"no_available_license":{"type":"http://librarysimplified.org/terms/problem/no-available-license","status":403,"title":"No Available License","detail":"All licenses for this book are loaned out."},"already_checked_out":{"type":"http://librarysimplified.org/terms/problem/already-checked-out","status":400,"title":"Already Checked Out","detail":"You have already checked out this book."},"remote_integration_failed":{"type":"http://librarysimplified.org/terms/problem/remote-integration-failed","status":502,"title":"Remote Integration Failed","detail":"A third-party service has failed."}}
+    """
+
+    static let annotations = """
+    {"@context":"http://www.w3.org/ns/anno.jsonld","id":"https://example.com/annotations/","type":["BasicContainer","AnnotationCollection"],"total":2,"first":{"id":"https://example.com/annotations/page/1","type":"AnnotationPage","items":[{"id":"https://example.com/annotations/abc123","type":"Annotation","motivation":"http://www.w3.org/ns/oa#idling","body":{"http://librarysimplified.org/terms/time":"2026-04-10T14:30:00Z","http://librarysimplified.org/terms/device":"urn:uuid:device-1234","http://librarysimplified.org/terms/chapter":"Chapter 3"},"target":{"source":"urn:uuid:b309a3a0-1234","selector":{"type":"oa:FragmentSelector","value":"{\\"idref\\":\\"chapter3\\",\\"contentCFI\\":\\"/4/2/10\\",\\"progressWithinChapter\\":0.45,\\"progressWithinBook\\":0.23}"}}},{"id":"https://example.com/annotations/def456","type":"Annotation","motivation":"http://www.w3.org/ns/oa#bookmarking","body":{"http://librarysimplified.org/terms/time":"2026-04-09T08:15:00Z"},"target":{"source":"urn:uuid:b309a3a0-1234","selector":{"type":"oa:FragmentSelector","value":"{\\"idref\\":\\"chapter1\\",\\"contentCFI\\":\\"/4/2/4\\",\\"progressWithinChapter\\":0.10,\\"progressWithinBook\\":0.05}"}}}]}}
+    """
+}
+
+#endif

--- a/Palace/Settings/Debug/MockBackend/EmbeddedScenarios.swift
+++ b/Palace/Settings/Debug/MockBackend/EmbeddedScenarios.swift
@@ -1,0 +1,86 @@
+//
+//  EmbeddedScenarios.swift
+//  Palace
+//
+//  Pre-built scenarios embedded as Swift string literals.
+//  No bundle resource management needed — they compile directly in.
+//
+
+#if DEBUG
+
+import Foundation
+
+extension MockScenario {
+
+    static let embeddedScenarios: [MockScenario] = [
+        happyPath,
+        expiredCredentials,
+        loanLimit,
+        serverDown,
+        slowNetwork,
+    ]
+
+    static let happyPath = MockScenario(
+        id: "happy_path",
+        displayName: "Happy Path",
+        description: "All endpoints return successful responses with test library data.",
+        routes: [
+            MockRoute(pathPattern: ".*/libraries.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
+            MockRoute(pathPattern: ".*/authentication_document", fixtureName: "auth_document", statusCode: 200, contentType: "application/vnd.opds.authentication+json"),
+            MockRoute(pathPattern: ".*/search.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
+            MockRoute(pathPattern: ".*/annotations.*", fixtureName: "annotations", statusCode: 200, contentType: "application/ld+json"),
+            MockRoute(pathPattern: ".*/loans.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
+            MockRoute(method: "POST", pathPattern: ".*/borrow", fixtureName: "opds2_feed", statusCode: 201, contentType: "application/opds+json"),
+            MockRoute(method: "PUT", pathPattern: ".*/revoke", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
+            MockRoute(pathPattern: ".*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/json"),
+        ]
+    )
+
+    static let expiredCredentials = MockScenario(
+        id: "expired_credentials",
+        displayName: "Expired Credentials",
+        description: "Library card has expired. Catalog loads but authenticated requests return 403.",
+        routes: [
+            MockRoute(pathPattern: ".*/libraries.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
+            MockRoute(pathPattern: ".*/authentication_document", fixtureName: "auth_document", statusCode: 200, contentType: "application/vnd.opds.authentication+json"),
+            MockRoute(pathPattern: ".*/loans.*", fixtureName: "problem_documents", fixtureKey: "expired_credentials", statusCode: 403, contentType: "application/problem+json"),
+            MockRoute(method: "POST", pathPattern: ".*/borrow", fixtureName: "problem_documents", fixtureKey: "expired_credentials", statusCode: 403, contentType: "application/problem+json"),
+            MockRoute(pathPattern: ".*/annotations.*", fixtureName: "problem_documents", fixtureKey: "expired_credentials", statusCode: 403, contentType: "application/problem+json"),
+            MockRoute(pathPattern: ".*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/json"),
+        ]
+    )
+
+    static let loanLimit = MockScenario(
+        id: "loan_limit",
+        displayName: "Loan Limit Reached",
+        description: "User has too many active loans. Browsing works but borrowing returns 403.",
+        routes: [
+            MockRoute(pathPattern: ".*/libraries.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
+            MockRoute(pathPattern: ".*/authentication_document", fixtureName: "auth_document", statusCode: 200, contentType: "application/vnd.opds.authentication+json"),
+            MockRoute(method: "POST", pathPattern: ".*/borrow", fixtureName: "problem_documents", fixtureKey: "loan_limit_reached", statusCode: 403, contentType: "application/problem+json"),
+            MockRoute(pathPattern: ".*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
+        ]
+    )
+
+    static let serverDown = MockScenario(
+        id: "server_down",
+        displayName: "Server Down (502)",
+        description: "All backend endpoints return 502 Bad Gateway.",
+        routes: [
+            MockRoute(pathPattern: ".*", fixtureName: "problem_documents", fixtureKey: "remote_integration_failed", statusCode: 502, contentType: "application/problem+json"),
+        ]
+    )
+
+    static let slowNetwork = MockScenario(
+        id: "slow_network",
+        displayName: "Slow Network (3s delay)",
+        description: "All endpoints respond successfully but with a 3-second delay.",
+        routes: [
+            MockRoute(pathPattern: ".*/libraries.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json", delayMs: 3000),
+            MockRoute(pathPattern: ".*/authentication_document", fixtureName: "auth_document", statusCode: 200, contentType: "application/vnd.opds.authentication+json", delayMs: 3000),
+            MockRoute(pathPattern: ".*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json", delayMs: 3000),
+        ]
+    )
+}
+
+#endif

--- a/Palace/Settings/Debug/MockBackend/EmbeddedScenarios.swift
+++ b/Palace/Settings/Debug/MockBackend/EmbeddedScenarios.swift
@@ -29,10 +29,9 @@ extension MockScenario {
             MockRoute(pathPattern: ".*/authentication_document", fixtureName: "auth_document", statusCode: 200, contentType: "application/vnd.opds.authentication+json"),
             MockRoute(pathPattern: ".*/search.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
             MockRoute(pathPattern: ".*/annotations.*", fixtureName: "annotations", statusCode: 200, contentType: "application/ld+json"),
-            MockRoute(pathPattern: ".*/loans.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
-            MockRoute(method: "POST", pathPattern: ".*/borrow", fixtureName: "opds2_feed", statusCode: 201, contentType: "application/opds+json"),
+            MockRoute(pathPattern: ".*/loans($|[/?].*)", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
+            MockRoute(pathPattern: ".*/borrow($|[/?])", fixtureName: "opds2_feed", statusCode: 201, contentType: "application/opds+json"),
             MockRoute(method: "PUT", pathPattern: ".*/revoke", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
-            MockRoute(pathPattern: ".*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/json"),
         ]
     )
 
@@ -41,12 +40,10 @@ extension MockScenario {
         displayName: "Expired Credentials",
         description: "Library card has expired. Catalog loads but authenticated requests return 403.",
         routes: [
-            MockRoute(pathPattern: ".*/libraries.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
             MockRoute(pathPattern: ".*/authentication_document", fixtureName: "auth_document", statusCode: 200, contentType: "application/vnd.opds.authentication+json"),
-            MockRoute(pathPattern: ".*/loans.*", fixtureName: "problem_documents", fixtureKey: "expired_credentials", statusCode: 403, contentType: "application/problem+json"),
-            MockRoute(method: "POST", pathPattern: ".*/borrow", fixtureName: "problem_documents", fixtureKey: "expired_credentials", statusCode: 403, contentType: "application/problem+json"),
+            MockRoute(pathPattern: ".*/loans($|[/?].*)", fixtureName: "problem_documents", fixtureKey: "expired_credentials", statusCode: 403, contentType: "application/problem+json"),
+            MockRoute(pathPattern: ".*/borrow($|[/?])", fixtureName: "problem_documents", fixtureKey: "expired_credentials", statusCode: 403, contentType: "application/problem+json"),
             MockRoute(pathPattern: ".*/annotations.*", fixtureName: "problem_documents", fixtureKey: "expired_credentials", statusCode: 403, contentType: "application/problem+json"),
-            MockRoute(pathPattern: ".*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/json"),
         ]
     )
 
@@ -55,30 +52,33 @@ extension MockScenario {
         displayName: "Loan Limit Reached",
         description: "User has too many active loans. Browsing works but borrowing returns 403.",
         routes: [
-            MockRoute(pathPattern: ".*/libraries.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
             MockRoute(pathPattern: ".*/authentication_document", fixtureName: "auth_document", statusCode: 200, contentType: "application/vnd.opds.authentication+json"),
-            MockRoute(method: "POST", pathPattern: ".*/borrow", fixtureName: "problem_documents", fixtureKey: "loan_limit_reached", statusCode: 403, contentType: "application/problem+json"),
-            MockRoute(pathPattern: ".*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json"),
+            MockRoute(pathPattern: ".*/borrow($|[/?])", fixtureName: "problem_documents", fixtureKey: "loan_limit_reached", statusCode: 403, contentType: "application/problem+json"),
         ]
     )
 
     static let serverDown = MockScenario(
         id: "server_down",
         displayName: "Server Down (502)",
-        description: "All backend endpoints return 502 Bad Gateway.",
+        description: "API endpoints return 502 Bad Gateway. Catalog still loads from real server.",
         routes: [
-            MockRoute(pathPattern: ".*", fixtureName: "problem_documents", fixtureKey: "remote_integration_failed", statusCode: 502, contentType: "application/problem+json"),
+            MockRoute(pathPattern: ".*/authentication_document", fixtureName: "problem_documents", fixtureKey: "remote_integration_failed", statusCode: 502, contentType: "application/problem+json"),
+            MockRoute(pathPattern: ".*/loans($|[/?].*)", fixtureName: "problem_documents", fixtureKey: "remote_integration_failed", statusCode: 502, contentType: "application/problem+json"),
+            MockRoute(pathPattern: ".*/borrow($|[/?])", fixtureName: "problem_documents", fixtureKey: "remote_integration_failed", statusCode: 502, contentType: "application/problem+json"),
+            MockRoute(pathPattern: ".*/annotations.*", fixtureName: "problem_documents", fixtureKey: "remote_integration_failed", statusCode: 502, contentType: "application/problem+json"),
+            MockRoute(pathPattern: ".*/search.*", fixtureName: "problem_documents", fixtureKey: "remote_integration_failed", statusCode: 502, contentType: "application/problem+json"),
         ]
     )
 
     static let slowNetwork = MockScenario(
         id: "slow_network",
         displayName: "Slow Network (3s delay)",
-        description: "All endpoints respond successfully but with a 3-second delay.",
+        description: "Authenticated endpoints respond with a 3-second delay.",
         routes: [
-            MockRoute(pathPattern: ".*/libraries.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json", delayMs: 3000),
             MockRoute(pathPattern: ".*/authentication_document", fixtureName: "auth_document", statusCode: 200, contentType: "application/vnd.opds.authentication+json", delayMs: 3000),
-            MockRoute(pathPattern: ".*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json", delayMs: 3000),
+            MockRoute(pathPattern: ".*/loans($|[/?].*)", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/opds+json", delayMs: 3000),
+            MockRoute(pathPattern: ".*/borrow($|[/?])", fixtureName: "opds2_feed", statusCode: 201, contentType: "application/opds+json", delayMs: 3000),
+            MockRoute(pathPattern: ".*/annotations.*", fixtureName: "annotations", statusCode: 200, contentType: "application/ld+json", delayMs: 3000),
         ]
     )
 }

--- a/Palace/Settings/Debug/MockBackend/MockBackendPickerView.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendPickerView.swift
@@ -1,0 +1,96 @@
+//
+//  MockBackendPickerView.swift
+//  Palace
+//
+//  Debug menu UI for activating/deactivating the mock backend
+//  and selecting test scenarios.
+//
+
+#if DEBUG
+
+import SwiftUI
+
+struct MockBackendPickerView: View {
+    @ObservedObject var service = MockBackendService.shared
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("Mock Backend", isOn: Binding(
+                    get: { service.isActive },
+                    set: { newValue in
+                        if newValue {
+                            if let first = service.availableScenarios.first {
+                                service.activate(scenario: first)
+                            }
+                        } else {
+                            service.deactivate()
+                        }
+                    }
+                ))
+
+                if service.isActive, let current = service.currentScenario {
+                    HStack {
+                        Text("Active Scenario")
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        Text(current.displayName)
+                            .foregroundColor(.primary)
+                    }
+                }
+            } header: {
+                Text("Mock Backend")
+            } footer: {
+                Text("When enabled, ALL network requests are intercepted and served from local fixture files. No real server traffic.")
+            }
+
+            if service.isActive {
+                Section("Scenarios") {
+                    ForEach(service.availableScenarios) { scenario in
+                        Button {
+                            service.activate(scenario: scenario)
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(scenario.displayName)
+                                        .foregroundColor(.primary)
+                                    Text(scenario.description)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(2)
+                                }
+
+                                Spacer()
+
+                                if service.currentScenario?.id == scenario.id {
+                                    Image(systemName: "checkmark")
+                                        .foregroundColor(.accentColor)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Section("Diagnostics") {
+                    HStack {
+                        Text("Routes")
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        Text("\(service.currentScenario?.routes.count ?? 0)")
+                    }
+
+                    HStack {
+                        Text("Fixture Bundle")
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        Text(MockBackendURLProtocol.fixtureBundle == .main ? "Main" : "Test")
+                            .font(.caption)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Mock Backend")
+    }
+}
+
+#endif

--- a/Palace/Settings/Debug/MockBackend/MockBackendService.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendService.swift
@@ -71,10 +71,9 @@ final class MockBackendService: ObservableObject {
         // Swizzle URLSessionConfiguration so new sessions get the protocol
         URLSessionConfiguration.mockBackend_swizzleProtocolClasses()
 
-        // Recreate TPPNetworkExecutor's internal session so it picks up
-        // the swizzled protocol classes. This is the only way to intercept
-        // requests from an already-created URLSession.
+        // Recreate sessions so they pick up the mock protocol
         TPPNetworkExecutor.shared.recreateSession()
+        MyBooksDownloadCenter.shared.recreateSessionForMockBackend()
 
         currentScenario = scenario
         isActive = true
@@ -91,8 +90,9 @@ final class MockBackendService: ObservableObject {
         URLProtocol.unregisterClass(MockBackendURLProtocol.self)
         URLSessionConfiguration.mockBackend_unswizzleProtocolClasses()
 
-        // Recreate session to remove the mock protocol
+        // Recreate sessions to remove the mock protocol
         TPPNetworkExecutor.shared.recreateSession()
+        MyBooksDownloadCenter.shared.recreateSessionForMockBackend()
 
         currentScenario = nil
         isActive = false

--- a/Palace/Settings/Debug/MockBackend/MockBackendService.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendService.swift
@@ -65,11 +65,14 @@ final class MockBackendService: ObservableObject {
         MockBackendURLProtocol.activeScenario = scenario
         MockBackendURLProtocol.fixtureBundle = fixtureBundle()
 
-        // Register the protocol globally — this intercepts URLSession.shared
-        // and any session using .default configuration. For sessions with
-        // custom configurations (like TPPNetworkExecutor), the protocol is
-        // also registered via URLSessionConfiguration.default.protocolClasses.
+        // Register globally for URLSession.shared
         URLProtocol.registerClass(MockBackendURLProtocol.self)
+
+        // Swizzle URLSessionConfiguration to inject the protocol into ALL
+        // sessions — including TPPNetworkExecutor's custom session that was
+        // created before activation. This is the same approach used by
+        // OHHTTPStubs and other HTTP mocking frameworks.
+        URLSessionConfiguration.mockBackend_swizzleProtocolClasses()
 
         currentScenario = scenario
         isActive = true
@@ -84,6 +87,7 @@ final class MockBackendService: ObservableObject {
 
         MockBackendURLProtocol.activeScenario = nil
         URLProtocol.unregisterClass(MockBackendURLProtocol.self)
+        URLSessionConfiguration.mockBackend_unswizzleProtocolClasses()
 
         currentScenario = nil
         isActive = false

--- a/Palace/Settings/Debug/MockBackend/MockBackendService.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendService.swift
@@ -62,11 +62,11 @@ final class MockBackendService: ObservableObject {
         MockBackendURLProtocol.activeScenario = scenario
         MockBackendURLProtocol.fixtureBundle = fixtureBundle()
 
-        // Register the protocol globally
+        // Register the protocol globally — this intercepts URLSession.shared
+        // and any session using .default configuration. For sessions with
+        // custom configurations (like TPPNetworkExecutor), the protocol is
+        // also registered via URLSessionConfiguration.default.protocolClasses.
         URLProtocol.registerClass(MockBackendURLProtocol.self)
-
-        // Rebuild TPPNetworkExecutor.shared with the protocol injected
-        injectIntoNetworkExecutor()
 
         currentScenario = scenario
         isActive = true
@@ -82,31 +82,11 @@ final class MockBackendService: ObservableObject {
         MockBackendURLProtocol.activeScenario = nil
         URLProtocol.unregisterClass(MockBackendURLProtocol.self)
 
-        // Restore the default network executor
-        restoreNetworkExecutor()
-
         currentScenario = nil
         isActive = false
 
         UserDefaults.standard.set(false, forKey: Self.enabledKey)
         UserDefaults.standard.removeObject(forKey: Self.scenarioKey)
-    }
-
-    // MARK: - Network Executor Injection
-
-    private func injectIntoNetworkExecutor() {
-        let config = URLSessionConfiguration.default
-        config.protocolClasses = [MockBackendURLProtocol.self] + (config.protocolClasses ?? [])
-
-        // TPPNetworkExecutor.shared is reassignable under #if DEBUG
-        TPPNetworkExecutor.shared = TPPNetworkExecutor(
-            cachingStrategy: .fallback,
-            sessionConfiguration: config
-        )
-    }
-
-    private func restoreNetworkExecutor() {
-        TPPNetworkExecutor.shared = TPPNetworkExecutor(cachingStrategy: .fallback)
     }
 
     // MARK: - State Restoration

--- a/Palace/Settings/Debug/MockBackend/MockBackendService.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendService.swift
@@ -43,12 +43,15 @@ final class MockBackendService: ObservableObject {
     // MARK: - Scenario Management
 
     func loadScenarios(from bundle: Bundle = .main) {
-        availableScenarios = MockScenario.loadAll(from: bundle)
+        // Use embedded Swift scenarios (always available, no bundle required)
+        availableScenarios = MockScenario.embeddedScenarios
 
-        // If no bundle-embedded scenarios found, try loading from file system
-        // (useful during development before fixtures are bundled)
-        if availableScenarios.isEmpty {
-            availableScenarios = loadScenariosFromDisk()
+        // Also try loading from bundle/disk for custom scenarios
+        let bundleScenarios = MockScenario.loadAll(from: bundle)
+        if !bundleScenarios.isEmpty {
+            let embeddedIds = Set(availableScenarios.map(\.id))
+            let custom = bundleScenarios.filter { !embeddedIds.contains($0.id) }
+            availableScenarios.append(contentsOf: custom)
         }
 
         Log.info(#file, "MockBackend: loaded \(availableScenarios.count) scenarios")

--- a/Palace/Settings/Debug/MockBackend/MockBackendService.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendService.swift
@@ -65,6 +65,14 @@ final class MockBackendService: ObservableObject {
         MockBackendURLProtocol.activeScenario = scenario
         MockBackendURLProtocol.fixtureBundle = fixtureBundle()
 
+        // Scope mock interception to the current library's host so other
+        // libraries aren't affected when the user switches accounts.
+        if let catalogUrlString = AccountsManager.shared.currentAccount?.catalogUrl,
+           let catalogURL = URL(string: catalogUrlString) {
+            MockBackendURLProtocol.scopedHost = catalogURL.host
+            Log.info(#file, "MockBackend: scoped to host '\(catalogURL.host ?? "unknown")'")
+        }
+
         // Register globally for URLSession.shared
         URLProtocol.registerClass(MockBackendURLProtocol.self)
 
@@ -87,6 +95,7 @@ final class MockBackendService: ObservableObject {
         Log.info(#file, "MockBackend: deactivating")
 
         MockBackendURLProtocol.activeScenario = nil
+        MockBackendURLProtocol.scopedHost = nil
         URLProtocol.unregisterClass(MockBackendURLProtocol.self)
         URLSessionConfiguration.mockBackend_unswizzleProtocolClasses()
 

--- a/Palace/Settings/Debug/MockBackend/MockBackendService.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendService.swift
@@ -1,0 +1,158 @@
+//
+//  MockBackendService.swift
+//  Palace
+//
+//  Manager for the mock backend. Activates/deactivates URL interception,
+//  loads scenarios, and persists the current selection.
+//
+//  Used by both the debug menu (runtime) and XCTest (test-time).
+//
+
+#if DEBUG
+
+import Foundation
+import Combine
+
+final class MockBackendService: ObservableObject {
+
+    static let shared = MockBackendService()
+
+    // MARK: - Published State
+
+    @Published private(set) var isActive: Bool = false
+    @Published private(set) var currentScenario: MockScenario?
+    @Published private(set) var availableScenarios: [MockScenario] = []
+
+    // MARK: - UserDefaults Keys
+
+    private static let enabledKey = "debug.mockBackendEnabled"
+    private static let scenarioKey = "debug.mockBackendScenario"
+
+    // MARK: - Init
+
+    private init() {
+        loadScenarios()
+        restoreState()
+    }
+
+    /// Test-friendly initializer — does not auto-restore state.
+    init(scenarios: [MockScenario]) {
+        self.availableScenarios = scenarios
+    }
+
+    // MARK: - Scenario Management
+
+    func loadScenarios(from bundle: Bundle = .main) {
+        availableScenarios = MockScenario.loadAll(from: bundle)
+
+        // If no bundle-embedded scenarios found, try loading from file system
+        // (useful during development before fixtures are bundled)
+        if availableScenarios.isEmpty {
+            availableScenarios = loadScenariosFromDisk()
+        }
+
+        Log.info(#file, "MockBackend: loaded \(availableScenarios.count) scenarios")
+    }
+
+    // MARK: - Activation
+
+    func activate(scenario: MockScenario) {
+        Log.info(#file, "MockBackend: activating scenario '\(scenario.displayName)'")
+
+        MockBackendURLProtocol.activeScenario = scenario
+        MockBackendURLProtocol.fixtureBundle = fixtureBundle()
+
+        // Register the protocol globally
+        URLProtocol.registerClass(MockBackendURLProtocol.self)
+
+        // Rebuild TPPNetworkExecutor.shared with the protocol injected
+        injectIntoNetworkExecutor()
+
+        currentScenario = scenario
+        isActive = true
+
+        // Persist selection
+        UserDefaults.standard.set(true, forKey: Self.enabledKey)
+        UserDefaults.standard.set(scenario.id, forKey: Self.scenarioKey)
+    }
+
+    func deactivate() {
+        Log.info(#file, "MockBackend: deactivating")
+
+        MockBackendURLProtocol.activeScenario = nil
+        URLProtocol.unregisterClass(MockBackendURLProtocol.self)
+
+        // Restore the default network executor
+        restoreNetworkExecutor()
+
+        currentScenario = nil
+        isActive = false
+
+        UserDefaults.standard.set(false, forKey: Self.enabledKey)
+        UserDefaults.standard.removeObject(forKey: Self.scenarioKey)
+    }
+
+    // MARK: - Network Executor Injection
+
+    private func injectIntoNetworkExecutor() {
+        let config = URLSessionConfiguration.default
+        config.protocolClasses = [MockBackendURLProtocol.self] + (config.protocolClasses ?? [])
+
+        // TPPNetworkExecutor.shared is reassignable under #if DEBUG
+        TPPNetworkExecutor.shared = TPPNetworkExecutor(
+            cachingStrategy: .fallback,
+            sessionConfiguration: config
+        )
+    }
+
+    private func restoreNetworkExecutor() {
+        TPPNetworkExecutor.shared = TPPNetworkExecutor(cachingStrategy: .fallback)
+    }
+
+    // MARK: - State Restoration
+
+    private func restoreState() {
+        let wasEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey)
+        guard wasEnabled else { return }
+
+        let scenarioId = UserDefaults.standard.string(forKey: Self.scenarioKey)
+        if let id = scenarioId,
+           let scenario = availableScenarios.first(where: { $0.id == id }) {
+            activate(scenario: scenario)
+        }
+    }
+
+    // MARK: - Bundle Resolution
+
+    private func fixtureBundle() -> Bundle {
+        // In the app, fixtures are in the main bundle (DEBUG builds only)
+        // In tests, they're in the test bundle
+        return .main
+    }
+
+    // MARK: - Disk Loading (Development Fallback)
+
+    private func loadScenariosFromDisk() -> [MockScenario] {
+        // Try to find scenarios relative to the project root
+        // This works during development when fixtures aren't bundled yet
+        let possiblePaths = [
+            "PalaceTests/Fixtures/API/Scenarios",
+            "../PalaceTests/Fixtures/API/Scenarios",
+        ]
+
+        for path in possiblePaths {
+            let url = URL(fileURLWithPath: path)
+            guard let files = try? FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+                .filter({ $0.pathExtension == "json" }) else { continue }
+
+            return files.compactMap { fileURL in
+                guard let data = try? Data(contentsOf: fileURL) else { return nil }
+                return try? JSONDecoder().decode(MockScenario.self, from: data)
+            }.sorted { $0.displayName < $1.displayName }
+        }
+
+        return []
+    }
+}
+
+#endif

--- a/Palace/Settings/Debug/MockBackend/MockBackendService.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendService.swift
@@ -68,11 +68,13 @@ final class MockBackendService: ObservableObject {
         // Register globally for URLSession.shared
         URLProtocol.registerClass(MockBackendURLProtocol.self)
 
-        // Swizzle URLSessionConfiguration to inject the protocol into ALL
-        // sessions — including TPPNetworkExecutor's custom session that was
-        // created before activation. This is the same approach used by
-        // OHHTTPStubs and other HTTP mocking frameworks.
+        // Swizzle URLSessionConfiguration so new sessions get the protocol
         URLSessionConfiguration.mockBackend_swizzleProtocolClasses()
+
+        // Recreate TPPNetworkExecutor's internal session so it picks up
+        // the swizzled protocol classes. This is the only way to intercept
+        // requests from an already-created URLSession.
+        TPPNetworkExecutor.shared.recreateSession()
 
         currentScenario = scenario
         isActive = true
@@ -88,6 +90,9 @@ final class MockBackendService: ObservableObject {
         MockBackendURLProtocol.activeScenario = nil
         URLProtocol.unregisterClass(MockBackendURLProtocol.self)
         URLSessionConfiguration.mockBackend_unswizzleProtocolClasses()
+
+        // Recreate session to remove the mock protocol
+        TPPNetworkExecutor.shared.recreateSession()
 
         currentScenario = nil
         isActive = false

--- a/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
@@ -1,0 +1,188 @@
+//
+//  MockBackendURLProtocol.swift
+//  Palace
+//
+//  URLProtocol subclass that intercepts ALL network requests when active.
+//  Routes requests to fixture files based on the active MockScenario.
+//  Covers both legacy TPPNetworkExecutor and modern NetworkClient layers.
+//
+
+#if DEBUG
+
+import Foundation
+
+final class MockBackendURLProtocol: URLProtocol {
+
+    // MARK: - Static Configuration
+
+    /// The active scenario. When nil, this protocol does not intercept.
+    static var activeScenario: MockScenario?
+
+    /// Bundle containing fixture files. Override for test bundles.
+    static var fixtureBundle: Bundle = .main
+
+    /// Request counter for diagnostics.
+    private static var requestCount = 0
+
+    // MARK: - URLProtocol Overrides
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        // Only intercept when a scenario is active
+        guard activeScenario != nil else { return false }
+        // Don't intercept our own marked requests (prevent infinite recursion)
+        guard URLProtocol.property(forKey: "MockBackendHandled", in: request) == nil else {
+            return false
+        }
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        Self.requestCount += 1
+        let requestNum = Self.requestCount
+
+        guard let scenario = Self.activeScenario,
+              let url = request.url else {
+            deliverError(NSError(domain: "MockBackend", code: -1,
+                                 userInfo: [NSLocalizedDescriptionKey: "No active scenario or URL"]))
+            return
+        }
+
+        let method = request.httpMethod ?? "GET"
+        Log.info(#file, "MockBackend [\(requestNum)] \(method) \(url.absoluteString)")
+
+        // Find matching route
+        guard let route = scenario.routes.first(where: { $0.matches(request) }) else {
+            Log.warn(#file, "MockBackend [\(requestNum)] No route matched, returning 404")
+            deliverResponse(statusCode: 404,
+                           contentType: "application/problem+json",
+                           data: makeProblemDocument(title: "Not Found",
+                                                     detail: "MockBackend: no route matched \(url.path)",
+                                                     status: 404))
+            return
+        }
+
+        Log.info(#file, "MockBackend [\(requestNum)] Matched route: \(route.fixtureName) → \(route.statusCode)")
+
+        // Load fixture data
+        guard let fixtureData = loadFixture(route: route) else {
+            deliverError(NSError(domain: "MockBackend", code: -2,
+                                 userInfo: [NSLocalizedDescriptionKey: "Fixture \(route.fixtureName) not found"]))
+            return
+        }
+
+        // Deliver with optional delay
+        let delay = route.delayMs.map { Double($0) / 1000.0 } ?? 0
+
+        if delay > 0 {
+            DispatchQueue.global().asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.deliverResponse(statusCode: route.statusCode,
+                                      contentType: route.contentType,
+                                      data: fixtureData,
+                                      additionalHeaders: route.headers)
+            }
+        } else {
+            deliverResponse(statusCode: route.statusCode,
+                           contentType: route.contentType,
+                           data: fixtureData,
+                           additionalHeaders: route.headers)
+        }
+    }
+
+    override func stopLoading() {
+        // Nothing to cancel — responses are delivered synchronously or via short delay
+    }
+
+    // MARK: - Fixture Loading
+
+    private func loadFixture(route: MockRoute) -> Data? {
+        let bundle = Self.fixtureBundle
+
+        // Try multiple locations for the fixture file
+        let name = route.fixtureName
+        let possibleExtensions = ["json", "xml", "atom"]
+
+        var data: Data?
+
+        for ext in possibleExtensions {
+            if let url = bundle.url(forResource: name, withExtension: ext, subdirectory: "Fixtures/API") ??
+                         bundle.url(forResource: name, withExtension: ext) {
+                data = try? Data(contentsOf: url)
+                if data != nil { break }
+            }
+        }
+
+        // Fallback: try loading from file system path relative to bundle
+        if data == nil {
+            let basePath = bundle.bundlePath
+            for ext in possibleExtensions {
+                let path = "\(basePath)/Fixtures/API/\(name).\(ext)"
+                if let d = FileManager.default.contents(atPath: path) {
+                    data = d
+                    break
+                }
+            }
+        }
+
+        guard var fixtureData = data else {
+            Log.error(#file, "MockBackend: fixture '\(name)' not found in bundle")
+            return nil
+        }
+
+        // If fixtureKey is set, extract a sub-object from a dictionary fixture
+        if let key = route.fixtureKey {
+            if let dict = try? JSONSerialization.jsonObject(with: fixtureData) as? [String: Any],
+               let subObject = dict[key] {
+                fixtureData = (try? JSONSerialization.data(withJSONObject: subObject)) ?? fixtureData
+            }
+        }
+
+        return fixtureData
+    }
+
+    // MARK: - Response Delivery
+
+    private func deliverResponse(statusCode: Int,
+                                  contentType: String,
+                                  data: Data,
+                                  additionalHeaders: [String: String]? = nil) {
+        guard let url = request.url else { return }
+
+        var headers: [String: String] = [
+            "Content-Type": contentType,
+            "Content-Length": "\(data.count)",
+            "X-Mock-Backend": "true"
+        ]
+        additionalHeaders?.forEach { headers[$0.key] = $0.value }
+
+        guard let response = HTTPURLResponse(url: url,
+                                              statusCode: statusCode,
+                                              httpVersion: "HTTP/1.1",
+                                              headerFields: headers) else {
+            return
+        }
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    private func deliverError(_ error: Error) {
+        client?.urlProtocol(self, didFailWithError: error)
+    }
+
+    private func makeProblemDocument(title: String, detail: String, status: Int) -> Data {
+        let doc: [String: Any] = [
+            "type": "http://librarysimplified.org/terms/problem/mock-backend",
+            "title": title,
+            "detail": detail,
+            "status": status
+        ]
+        return (try? JSONSerialization.data(withJSONObject: doc)) ?? Data()
+    }
+}
+
+#endif

--- a/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
@@ -18,6 +18,11 @@ final class MockBackendURLProtocol: URLProtocol {
     /// The active scenario. When nil, this protocol does not intercept.
     static var activeScenario: MockScenario?
 
+    /// Host to scope interception to. When set, only requests to this host
+    /// are considered for mocking — requests to other hosts pass through.
+    /// Set automatically from the current library's catalog URL on activation.
+    static var scopedHost: String?
+
     /// Bundle containing fixture files. Override for test bundles.
     static var fixtureBundle: Bundle = .main
 
@@ -32,12 +37,25 @@ final class MockBackendURLProtocol: URLProtocol {
 
     override class func canInit(with request: URLRequest) -> Bool {
         // Only intercept when a scenario is active
-        guard activeScenario != nil else { return false }
+        guard let scenario = activeScenario else { return false }
         // Don't intercept our own marked requests (prevent infinite recursion)
         guard URLProtocol.property(forKey: "MockBackendHandled", in: request) == nil else {
             return false
         }
-        return true
+        // Only intercept requests to the scoped library host (if set).
+        // This prevents the mock from interfering with other libraries
+        // when the user switches accounts.
+        if let host = scopedHost, request.url?.host != host {
+            return false
+        }
+        // Only intercept requests that match an explicit route.
+        // Unmatched requests pass through to the real server so the
+        // catalog, cover images, and other non-mocked endpoints work normally.
+        let matched = scenario.routes.contains { $0.matches(request) }
+        if !matched, let url = request.url?.absoluteString {
+            Log.debug(#file, "MockBackend: pass-through (no route matched) \(request.httpMethod ?? "?") \(url)")
+        }
+        return matched
     }
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {

--- a/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
@@ -183,9 +183,16 @@ final class MockBackendURLProtocol: URLProtocol {
             return
         }
 
+        // Deliver response and data synchronously, then finish on next runloop
+        // tick. This ensures the URLSession delegate processes didReceive(data:)
+        // before didCompleteWithError: fires — otherwise TPPNetworkResponder's
+        // progressData may be empty when it tries to parse the problem document.
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: data)
-        client?.urlProtocolDidFinishLoading(self)
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.client?.urlProtocolDidFinishLoading(self)
+        }
     }
 
     private func deliverError(_ error: Error) {

--- a/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
@@ -21,6 +21,10 @@ final class MockBackendURLProtocol: URLProtocol {
     /// Bundle containing fixture files. Override for test bundles.
     static var fixtureBundle: Bundle = .main
 
+    /// Direct file system path to fixtures directory. When set, bypasses bundle lookup.
+    /// Set this in tests where fixtures aren't bundled.
+    static var fixtureDirectoryPath: String?
+
     /// Request counter for diagnostics.
     private static var requestCount = 0
 
@@ -99,25 +103,36 @@ final class MockBackendURLProtocol: URLProtocol {
     // MARK: - Fixture Loading
 
     private func loadFixture(route: MockRoute) -> Data? {
-        let bundle = Self.fixtureBundle
-
-        // Try multiple locations for the fixture file
         let name = route.fixtureName
         let possibleExtensions = ["json", "xml", "atom"]
-
         var data: Data?
 
-        for ext in possibleExtensions {
-            if let url = bundle.url(forResource: name, withExtension: ext, subdirectory: "Fixtures/API") ??
-                         bundle.url(forResource: name, withExtension: ext) {
-                data = try? Data(contentsOf: url)
-                if data != nil { break }
+        // Priority 1: direct file system path (set by tests)
+        if let dirPath = Self.fixtureDirectoryPath {
+            for ext in possibleExtensions {
+                let path = "\(dirPath)/\(name).\(ext)"
+                if let d = FileManager.default.contents(atPath: path) {
+                    data = d
+                    break
+                }
             }
         }
 
-        // Fallback: try loading from file system path relative to bundle
+        // Priority 2: bundle resource lookup (runtime debug menu)
         if data == nil {
-            let basePath = bundle.bundlePath
+            let bundle = Self.fixtureBundle
+            for ext in possibleExtensions {
+                if let url = bundle.url(forResource: name, withExtension: ext, subdirectory: "Fixtures/API") ??
+                             bundle.url(forResource: name, withExtension: ext) {
+                    data = try? Data(contentsOf: url)
+                    if data != nil { break }
+                }
+            }
+        }
+
+        // Priority 3: fallback to bundle base path
+        if data == nil {
+            let basePath = Self.fixtureBundle.bundlePath
             for ext in possibleExtensions {
                 let path = "\(basePath)/Fixtures/API/\(name).\(ext)"
                 if let d = FileManager.default.contents(atPath: path) {

--- a/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
@@ -107,6 +107,9 @@ final class MockBackendURLProtocol: URLProtocol {
         let possibleExtensions = ["json", "xml", "atom"]
         var data: Data?
 
+        // Priority 0: embedded fixtures (always available, no bundle needed)
+        data = EmbeddedFixtures.data(for: name)
+
         // Priority 1: direct file system path (set by tests)
         if let dirPath = Self.fixtureDirectoryPath {
             for ext in possibleExtensions {

--- a/Palace/Settings/Debug/MockBackend/MockScenario.swift
+++ b/Palace/Settings/Debug/MockBackend/MockScenario.swift
@@ -1,0 +1,126 @@
+//
+//  MockScenario.swift
+//  Palace
+//
+//  Declarative scenario model for the mock backend service.
+//  Each scenario maps URL patterns to fixture responses, enabling
+//  QA to test any backend state from the debug menu.
+//
+
+#if DEBUG
+
+import Foundation
+
+/// A test scenario that defines how the mock backend responds to each URL pattern.
+struct MockScenario: Codable, Identifiable {
+    let id: String
+    let displayName: String
+    let description: String
+    let routes: [MockRoute]
+
+    /// Load a scenario from a JSON file in the given bundle.
+    static func load(_ name: String, from bundle: Bundle) -> MockScenario? {
+        guard let url = bundle.url(forResource: name, withExtension: "json", subdirectory: "Scenarios") ??
+                        bundle.url(forResource: name, withExtension: "json") else {
+            Log.warn(#file, "MockScenario: fixture \(name).json not found in bundle")
+            return nil
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(MockScenario.self, from: data)
+        } catch {
+            Log.error(#file, "MockScenario: failed to decode \(name).json: \(error)")
+            return nil
+        }
+    }
+
+    /// Load all scenarios from a bundle's Scenarios/ directory.
+    static func loadAll(from bundle: Bundle) -> [MockScenario] {
+        guard let scenariosURL = bundle.url(forResource: "Scenarios", withExtension: nil) ??
+                                  bundle.resourceURL?.appendingPathComponent("Scenarios") else {
+            return []
+        }
+
+        let fileManager = FileManager.default
+        guard let files = try? fileManager.contentsOfDirectory(at: scenariosURL,
+                                                                includingPropertiesForKeys: nil)
+            .filter({ $0.pathExtension == "json" }) else {
+            return []
+        }
+
+        return files.compactMap { url in
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            return try? JSONDecoder().decode(MockScenario.self, from: data)
+        }.sorted { $0.displayName < $1.displayName }
+    }
+}
+
+/// A single route in a mock scenario — maps a URL pattern to a fixture response.
+struct MockRoute: Codable {
+    /// HTTP method to match (nil matches any method).
+    let method: String?
+
+    /// Regex pattern matched against the full request URL.
+    let pathPattern: String
+
+    /// Name of the fixture file (without extension) in the Fixtures/API/ directory.
+    let fixtureName: String
+
+    /// Optional key within a fixture file (for dictionaries like problem_documents.json).
+    let fixtureKey: String?
+
+    /// HTTP status code to return.
+    let statusCode: Int
+
+    /// Content-Type header value.
+    let contentType: String
+
+    /// Optional simulated network delay in milliseconds.
+    let delayMs: Int?
+
+    /// Optional additional response headers.
+    let headers: [String: String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case method, pathPattern, fixtureName, fixtureKey
+        case statusCode, contentType, delayMs, headers
+    }
+
+    init(
+        method: String? = nil,
+        pathPattern: String,
+        fixtureName: String,
+        fixtureKey: String? = nil,
+        statusCode: Int = 200,
+        contentType: String = "application/json",
+        delayMs: Int? = nil,
+        headers: [String: String]? = nil
+    ) {
+        self.method = method
+        self.pathPattern = pathPattern
+        self.fixtureName = fixtureName
+        self.fixtureKey = fixtureKey
+        self.statusCode = statusCode
+        self.contentType = contentType
+        self.delayMs = delayMs
+        self.headers = headers
+    }
+
+    /// Check if this route matches a given URLRequest.
+    func matches(_ request: URLRequest) -> Bool {
+        if let method = method, method.uppercased() != request.httpMethod?.uppercased() {
+            return false
+        }
+
+        guard let urlString = request.url?.absoluteString else { return false }
+
+        guard let regex = try? NSRegularExpression(pattern: pathPattern, options: .caseInsensitive) else {
+            return false
+        }
+
+        let range = NSRange(urlString.startIndex..., in: urlString)
+        return regex.firstMatch(in: urlString, range: range) != nil
+    }
+}
+
+#endif

--- a/Palace/Settings/Debug/MockBackend/URLSessionConfiguration+MockBackend.swift
+++ b/Palace/Settings/Debug/MockBackend/URLSessionConfiguration+MockBackend.swift
@@ -1,0 +1,74 @@
+//
+//  URLSessionConfiguration+MockBackend.swift
+//  Palace
+//
+//  Swizzles URLSessionConfiguration.protocolClasses to inject
+//  MockBackendURLProtocol into ALL URLSession instances, including
+//  those already created with custom configurations.
+//
+//  This is the standard approach used by HTTP mocking frameworks
+//  (OHHTTPStubs, Mocker, etc.) because URLProtocol.registerClass()
+//  only affects URLSession.shared and .default configs, not custom ones.
+//
+
+#if DEBUG
+
+import Foundation
+
+extension URLSessionConfiguration {
+
+    private static var isSwizzled = false
+
+    /// Swizzle the `protocolClasses` getter to prepend MockBackendURLProtocol.
+    static func mockBackend_swizzleProtocolClasses() {
+        guard !isSwizzled else { return }
+
+        let originalSelector = #selector(getter: protocolClasses)
+        let swizzledSelector = #selector(getter: mockBackend_protocolClasses)
+
+        guard let originalMethod = class_getInstanceMethod(self, originalSelector),
+              let swizzledMethod = class_getInstanceMethod(self, swizzledSelector) else {
+            Log.error(#file, "MockBackend: failed to swizzle URLSessionConfiguration.protocolClasses")
+            return
+        }
+
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+        isSwizzled = true
+        Log.info(#file, "MockBackend: swizzled URLSessionConfiguration.protocolClasses")
+    }
+
+    /// Undo the swizzle.
+    static func mockBackend_unswizzleProtocolClasses() {
+        guard isSwizzled else { return }
+
+        let originalSelector = #selector(getter: protocolClasses)
+        let swizzledSelector = #selector(getter: mockBackend_protocolClasses)
+
+        guard let originalMethod = class_getInstanceMethod(self, originalSelector),
+              let swizzledMethod = class_getInstanceMethod(self, swizzledSelector) else {
+            return
+        }
+
+        // Swapping again restores the original
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+        isSwizzled = false
+        Log.info(#file, "MockBackend: unswizzled URLSessionConfiguration.protocolClasses")
+    }
+
+    /// Swizzled getter that prepends MockBackendURLProtocol.
+    @objc private var mockBackend_protocolClasses: [AnyClass]? {
+        // This calls the ORIGINAL implementation (because we swapped them)
+        var classes = self.mockBackend_protocolClasses ?? []
+
+        // Only inject if the mock backend is active
+        if MockBackendURLProtocol.activeScenario != nil {
+            if !classes.contains(where: { $0 == MockBackendURLProtocol.self }) {
+                classes.insert(MockBackendURLProtocol.self, at: 0)
+            }
+        }
+
+        return classes
+    }
+}
+
+#endif

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -1,4 +1,5 @@
 import MessageUI
+import SwiftUI
 
 @objcMembers
 class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, MFMailComposeViewControllerDelegate {
@@ -14,6 +15,9 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         case featurePreviews
         case badgeTesting
         case errorSimulation
+        #if DEBUG
+        case mockBackend
+        #endif
     }
 
     private let fcmTokenCellIdentifier = "fcmTokenCell"
@@ -92,6 +96,9 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             #else
             return 2  // Simulate Borrow Error + Simulate Sync Failure (available in TestFlight for QA)
             #endif
+        #if DEBUG
+        case .mockBackend: return 1
+        #endif
         default: return 1
         }
     }
@@ -142,6 +149,10 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
                 return UITableViewCell()
                 #endif
             }
+        #if DEBUG
+        case .mockBackend:
+            return cellForMockBackend()
+        #endif
         }
     }
 
@@ -167,6 +178,10 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             #endif
         case .errorSimulation:
             return "Error Simulation (Testing)"
+        #if DEBUG
+        case .mockBackend:
+            return "Mock Backend"
+        #endif
         }
     }
 
@@ -497,6 +512,25 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
     }
 
     #if DEBUG
+    private func cellForMockBackend() -> UITableViewCell {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "mockBackendCell")
+        cell.selectionStyle = .default
+        cell.accessoryType = .disclosureIndicator
+
+        let service = MockBackendService.shared
+        if service.isActive, let scenario = service.currentScenario {
+            cell.textLabel?.text = "Mock Backend: \(scenario.displayName)"
+            cell.textLabel?.textColor = .systemGreen
+            cell.detailTextLabel?.text = "Active — \(scenario.routes.count) routes"
+        } else {
+            cell.textLabel?.text = "Mock Backend"
+            cell.textLabel?.textColor = .label
+            cell.detailTextLabel?.text = "Tap to configure"
+        }
+        cell.detailTextLabel?.textColor = .secondaryLabel
+        return cell
+    }
+
     private func cellForPreviewErrorDetails() -> UITableViewCell {
         let cell = UITableViewCell(style: .default, reuseIdentifier: "previewErrorDetailsCell")
         cell.selectionStyle = .default
@@ -597,10 +631,23 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
                 #endif
             }
 
+        #if DEBUG
+        case .mockBackend:
+            showMockBackendPicker()
+        #endif
+
         default:
             break
         }
     }
+
+    #if DEBUG
+    private func showMockBackendPicker() {
+        let hostingController = UIHostingController(rootView: MockBackendPickerView())
+        hostingController.title = "Mock Backend"
+        navigationController?.pushViewController(hostingController, animated: true)
+    }
+    #endif
 
     #if DEBUG
     private func showTestHoldsPicker() {

--- a/PalaceTests/Fixtures/API/Scenarios/expired_credentials.json
+++ b/PalaceTests/Fixtures/API/Scenarios/expired_credentials.json
@@ -1,0 +1,52 @@
+{
+  "id": "expired_credentials",
+  "displayName": "Expired Credentials",
+  "description": "Library card has expired. Catalog loads normally but any authenticated request returns 403.",
+  "routes": [
+    {
+      "pathPattern": ".*/libraries.*",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json"
+    },
+    {
+      "pathPattern": ".*/authentication_document",
+      "fixtureName": "auth_document",
+      "statusCode": 200,
+      "contentType": "application/vnd.opds.authentication+json"
+    },
+    {
+      "pathPattern": ".*/a1qa-test/?$",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json"
+    },
+    {
+      "pathPattern": ".*/loans.*",
+      "fixtureName": "problem_documents",
+      "fixtureKey": "expired_credentials",
+      "statusCode": 403,
+      "contentType": "application/problem+json"
+    },
+    {
+      "pathPattern": ".*/borrow",
+      "fixtureName": "problem_documents",
+      "fixtureKey": "expired_credentials",
+      "statusCode": 403,
+      "contentType": "application/problem+json"
+    },
+    {
+      "pathPattern": ".*/annotations.*",
+      "fixtureName": "problem_documents",
+      "fixtureKey": "expired_credentials",
+      "statusCode": 403,
+      "contentType": "application/problem+json"
+    },
+    {
+      "pathPattern": ".*",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/json"
+    }
+  ]
+}

--- a/PalaceTests/Fixtures/API/Scenarios/happy_path.json
+++ b/PalaceTests/Fixtures/API/Scenarios/happy_path.json
@@ -1,0 +1,63 @@
+{
+  "id": "happy_path",
+  "displayName": "Happy Path",
+  "description": "All endpoints return successful responses. Catalog loads, auth works, borrow succeeds.",
+  "routes": [
+    {
+      "pathPattern": ".*/libraries.*",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json"
+    },
+    {
+      "pathPattern": ".*/authentication_document",
+      "fixtureName": "auth_document",
+      "statusCode": 200,
+      "contentType": "application/vnd.opds.authentication+json"
+    },
+    {
+      "pathPattern": ".*/a1qa-test/?$",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json"
+    },
+    {
+      "pathPattern": ".*/search.*",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json"
+    },
+    {
+      "pathPattern": ".*/annotations.*",
+      "fixtureName": "annotations",
+      "statusCode": 200,
+      "contentType": "application/ld+json"
+    },
+    {
+      "pathPattern": ".*/loans.*",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json"
+    },
+    {
+      "pathPattern": ".*/borrow",
+      "method": "POST",
+      "fixtureName": "opds2_feed",
+      "statusCode": 201,
+      "contentType": "application/opds+json"
+    },
+    {
+      "pathPattern": ".*/revoke",
+      "method": "PUT",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json"
+    },
+    {
+      "pathPattern": ".*",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/json"
+    }
+  ]
+}

--- a/PalaceTests/Fixtures/API/Scenarios/loan_limit.json
+++ b/PalaceTests/Fixtures/API/Scenarios/loan_limit.json
@@ -1,0 +1,33 @@
+{
+  "id": "loan_limit",
+  "displayName": "Loan Limit Reached",
+  "description": "User has too many active loans. Browsing works but borrowing returns 403.",
+  "routes": [
+    {
+      "pathPattern": ".*/libraries.*",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json"
+    },
+    {
+      "pathPattern": ".*/authentication_document",
+      "fixtureName": "auth_document",
+      "statusCode": 200,
+      "contentType": "application/vnd.opds.authentication+json"
+    },
+    {
+      "pathPattern": ".*/borrow",
+      "method": "POST",
+      "fixtureName": "problem_documents",
+      "fixtureKey": "loan_limit_reached",
+      "statusCode": 403,
+      "contentType": "application/problem+json"
+    },
+    {
+      "pathPattern": ".*",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json"
+    }
+  ]
+}

--- a/PalaceTests/Fixtures/API/Scenarios/server_down.json
+++ b/PalaceTests/Fixtures/API/Scenarios/server_down.json
@@ -1,0 +1,14 @@
+{
+  "id": "server_down",
+  "displayName": "Server Down (502)",
+  "description": "All backend endpoints return 502 Bad Gateway. Tests offline/error handling.",
+  "routes": [
+    {
+      "pathPattern": ".*",
+      "fixtureName": "problem_documents",
+      "fixtureKey": "remote_integration_failed",
+      "statusCode": 502,
+      "contentType": "application/problem+json"
+    }
+  ]
+}

--- a/PalaceTests/Fixtures/API/Scenarios/slow_network.json
+++ b/PalaceTests/Fixtures/API/Scenarios/slow_network.json
@@ -1,0 +1,28 @@
+{
+  "id": "slow_network",
+  "displayName": "Slow Network (3s delay)",
+  "description": "All endpoints respond successfully but with a 3-second delay. Tests loading states and timeouts.",
+  "routes": [
+    {
+      "pathPattern": ".*/libraries.*",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json",
+      "delayMs": 3000
+    },
+    {
+      "pathPattern": ".*/authentication_document",
+      "fixtureName": "auth_document",
+      "statusCode": 200,
+      "contentType": "application/vnd.opds.authentication+json",
+      "delayMs": 3000
+    },
+    {
+      "pathPattern": ".*",
+      "fixtureName": "opds2_feed",
+      "statusCode": 200,
+      "contentType": "application/opds+json",
+      "delayMs": 3000
+    }
+  ]
+}

--- a/PalaceTests/Integration/MockBackendIntegrationTests.swift
+++ b/PalaceTests/Integration/MockBackendIntegrationTests.swift
@@ -1,0 +1,207 @@
+//
+//  MockBackendIntegrationTests.swift
+//  PalaceTests
+//
+//  Integration tests that exercise real app code against the mock backend.
+//  Uses MockBackendTestHelper for clean one-line setup.
+//
+
+import XCTest
+@testable import Palace
+
+// MARK: - Happy Path
+
+final class MockBackendIntegrationTests: XCTestCase {
+
+    private var env: MockBackendEnvironment!
+    private let baseURL = URL(string: "https://gorgon.staging.palaceproject.io/a1qa-test/")!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        env = try MockBackendTestHelper.activate(scenario: "happy_path")
+    }
+
+    override func tearDown() {
+        MockBackendTestHelper.deactivate()
+        env = nil
+        super.tearDown()
+    }
+
+    func testFetchCatalog_ReturnsParsedFeed() async throws {
+        let feed = try await env.fetchFeed(at: baseURL)
+        XCTAssertEqual(feed.title, "A1QA Test Library")
+        // OPDS2 feeds may have entries from publications OR groups
+        XCTAssertNotNil(feed.opds2Feed, "Feed must have OPDS2 source data")
+        let hasContent = !feed.entries.isEmpty ||
+                         !(feed.opds2Feed?.publications?.isEmpty ?? true) ||
+                         !(feed.opds2Feed?.groups?.isEmpty ?? true)
+        XCTAssertTrue(hasContent, "Feed must have entries, publications, or groups")
+    }
+
+    func testFetchAnnotations_ReturnsAnnotations() async throws {
+        let url = baseURL.appendingPathComponent("annotations")
+        let json = try await env.fetchJSON(at: url)
+        XCTAssertEqual(json["total"] as? Int, 2)
+    }
+
+    func testFetchAuthDocument_ParsesCorrectly() async throws {
+        let url = baseURL.appendingPathComponent("authentication_document")
+        let json = try await env.fetchJSON(at: url)
+        XCTAssertEqual(json["title"] as? String, "A1QA Test Library")
+        let methods = json["authentication"] as? [[String: Any]]
+        XCTAssertGreaterThanOrEqual(methods?.count ?? 0, 1)
+    }
+
+    func testBorrow_Returns201() async throws {
+        let url = URL(string: "https://gorgon.staging.palaceproject.io/a1qa-test/works/book-123/borrow")!
+        let (_, status) = try await env.fetchWithStatus(url, method: "POST")
+        XCTAssertEqual(status, 201)
+    }
+}
+
+// MARK: - Expired Credentials
+
+final class MockBackendExpiredCredentialsTests: XCTestCase {
+
+    private var env: MockBackendEnvironment!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        env = try MockBackendTestHelper.activate(scenario: "expired_credentials")
+    }
+
+    override func tearDown() {
+        MockBackendTestHelper.deactivate()
+        env = nil
+        super.tearDown()
+    }
+
+    func testCatalog_StillReturns200() async throws {
+        let url = URL(string: "https://gorgon.staging.palaceproject.io/a1qa-test/")!
+        let (_, status) = try await env.fetchWithStatus(url)
+        XCTAssertEqual(status, 200)
+    }
+
+    func testLoans_Returns403WithProblemDocument() async throws {
+        let url = URL(string: "https://gorgon.staging.palaceproject.io/a1qa-test/loans")!
+        let (data, status) = try await env.fetchWithStatus(url)
+
+        XCTAssertEqual(status, 403)
+        let doc = try JSONDecoder().decode(TPPProblemDocument.self, from: data)
+        XCTAssertTrue(doc.type?.contains("expired") ?? false)
+    }
+
+    func testBorrow_Returns403() async throws {
+        let url = URL(string: "https://gorgon.staging.palaceproject.io/a1qa-test/works/book-123/borrow")!
+        let (_, status) = try await env.fetchWithStatus(url, method: "POST")
+        XCTAssertEqual(status, 403)
+    }
+}
+
+// MARK: - Loan Limit
+
+final class MockBackendLoanLimitTests: XCTestCase {
+
+    private var env: MockBackendEnvironment!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        env = try MockBackendTestHelper.activate(scenario: "loan_limit")
+    }
+
+    override func tearDown() {
+        MockBackendTestHelper.deactivate()
+        env = nil
+        super.tearDown()
+    }
+
+    func testBorrow_Returns403WithLoanLimitProblem() async throws {
+        let url = URL(string: "https://gorgon.staging.palaceproject.io/a1qa-test/works/book-123/borrow")!
+        let (data, status) = try await env.fetchWithStatus(url, method: "POST")
+
+        XCTAssertEqual(status, 403)
+        let doc = try JSONDecoder().decode(TPPProblemDocument.self, from: data)
+        XCTAssertTrue(doc.type?.contains("loan-limit") ?? false)
+        XCTAssertTrue(doc.detail?.lowercased().contains("return") ?? false)
+    }
+
+    func testCatalogBrowsing_StillWorks() async throws {
+        let url = URL(string: "https://gorgon.staging.palaceproject.io/a1qa-test/")!
+        let feed = try await env.fetchFeed(at: url)
+        XCTAssertEqual(feed.title, "A1QA Test Library")
+    }
+}
+
+// MARK: - Server Down
+
+final class MockBackendServerDownTests: XCTestCase {
+
+    private var env: MockBackendEnvironment!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        env = try MockBackendTestHelper.activate(scenario: "server_down")
+    }
+
+    override func tearDown() {
+        MockBackendTestHelper.deactivate()
+        env = nil
+        super.tearDown()
+    }
+
+    func testAllEndpoints_Return502() async throws {
+        let urls = [
+            URL(string: "https://gorgon.staging.palaceproject.io/a1qa-test/")!,
+            URL(string: "https://gorgon.staging.palaceproject.io/a1qa-test/loans")!,
+            URL(string: "https://gorgon.staging.palaceproject.io/a1qa-test/annotations")!,
+        ]
+
+        for url in urls {
+            let (data, status) = try await env.fetchWithStatus(url)
+            XCTAssertEqual(status, 502, "\(url.path) should return 502")
+
+            let doc = try JSONDecoder().decode(TPPProblemDocument.self, from: data)
+            XCTAssertTrue(doc.type?.contains("remote-integration-failed") ?? false)
+        }
+    }
+}
+
+// MARK: - Route Matching Unit Tests
+
+final class MockBackendRouteMatchingTests: XCTestCase {
+
+    func testRouteMatching_ExactPath() {
+        let route = MockRoute(pathPattern: ".*/loans.*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/json")
+
+        var request = URLRequest(url: URL(string: "https://example.com/a1qa-test/loans")!)
+        XCTAssertTrue(route.matches(request))
+
+        request = URLRequest(url: URL(string: "https://example.com/a1qa-test/catalog")!)
+        XCTAssertFalse(route.matches(request))
+    }
+
+    func testRouteMatching_MethodFilter() {
+        let postRoute = MockRoute(method: "POST", pathPattern: ".*/borrow", fixtureName: "opds2_feed", statusCode: 201, contentType: "application/json")
+
+        var request = URLRequest(url: URL(string: "https://example.com/borrow")!)
+        request.httpMethod = "POST"
+        XCTAssertTrue(postRoute.matches(request))
+
+        request.httpMethod = "GET"
+        XCTAssertFalse(postRoute.matches(request))
+    }
+
+    func testRouteMatching_CatchAll() {
+        let catchAll = MockRoute(pathPattern: ".*", fixtureName: "opds2_feed", statusCode: 200, contentType: "application/json")
+        let request = URLRequest(url: URL(string: "https://anything.com/any/path")!)
+        XCTAssertTrue(catchAll.matches(request))
+    }
+
+    func testScenarioLoading() throws {
+        let env = try MockBackendTestHelper.activate(scenario: "happy_path")
+        defer { MockBackendTestHelper.deactivate() }
+
+        XCTAssertEqual(env.scenario.id, "happy_path")
+        XCTAssertGreaterThanOrEqual(env.scenario.routes.count, 5)
+    }
+}

--- a/PalaceTests/Integration/MockBackendTestHelper.swift
+++ b/PalaceTests/Integration/MockBackendTestHelper.swift
@@ -1,0 +1,126 @@
+//
+//  MockBackendTestHelper.swift
+//  PalaceTests
+//
+//  Clean, reusable helper for setting up mock backend scenarios in tests.
+//  Any test can activate a scenario in one line and get a fully-configured
+//  network executor that exercises real app code against fixture data.
+//
+//  Usage:
+//    let env = try MockBackendTestHelper.activate(scenario: "happy_path")
+//    let data = try await env.fetch(url)
+//    let feed = try env.parser.parseFeed(from: data)
+//
+
+
+
+import XCTest
+@testable import Palace
+
+/// A test environment with a mock-backed network stack.
+/// All real app code runs — only the HTTP layer is intercepted.
+struct MockBackendEnvironment {
+    let session: URLSession
+    let executor: TPPNetworkExecutor
+    let parser: OPDSParser
+    let scenario: MockScenario
+
+    /// Fetch a URL and return the data + HTTP response.
+    func fetch(_ url: URL, method: String = "GET") async throws -> Data {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        let (data, _) = try await session.data(for: request)
+        return data
+    }
+
+    /// Fetch and return both data and HTTP status code.
+    func fetchWithStatus(_ url: URL, method: String = "GET") async throws -> (Data, Int) {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        let (data, response) = try await session.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        return (data, statusCode)
+    }
+
+    /// Convenience: fetch and parse an OPDS feed.
+    func fetchFeed(at url: URL) async throws -> CatalogFeed {
+        let data = try await fetch(url)
+        return try parser.parseFeed(from: data)
+    }
+
+    /// Convenience: fetch and parse a problem document.
+    func fetchProblemDocument(at url: URL, method: String = "GET") async throws -> TPPProblemDocument {
+        let data = try await fetch(url, method: method)
+        return try JSONDecoder().decode(TPPProblemDocument.self, from: data)
+    }
+
+    /// Convenience: fetch and parse JSON.
+    func fetchJSON(at url: URL) async throws -> [String: Any] {
+        let data = try await fetch(url)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NSError(domain: "MockBackend", code: -1, userInfo: [NSLocalizedDescriptionKey: "Not a JSON object"])
+        }
+        return json
+    }
+}
+
+/// Helper for activating mock backend scenarios in tests.
+enum MockBackendTestHelper {
+
+    /// Activate a named scenario and return a fully-configured test environment.
+    ///
+    /// The returned environment has a real `TPPNetworkExecutor` with the mock
+    /// URLProtocol injected, plus a real `OPDSParser`. All app code paths
+    /// execute normally — only HTTP responses are mocked.
+    ///
+    /// Call `deactivate()` in tearDown to clean up.
+    static func activate(scenario name: String) throws -> MockBackendEnvironment {
+        let scenarioPath = fixturesURL().appendingPathComponent("Scenarios/\(name).json")
+        let data = try Data(contentsOf: scenarioPath)
+        let scenario = try JSONDecoder().decode(MockScenario.self, from: data)
+
+        // Configure the protocol — set direct path for test fixtures
+        MockBackendURLProtocol.activeScenario = scenario
+        MockBackendURLProtocol.fixtureDirectoryPath = fixturesURL().path
+        MockBackendURLProtocol.fixtureBundle = testBundle()
+
+        // Create executor with mock-injected session
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockBackendURLProtocol.self]
+
+        let session = URLSession(configuration: config)
+        let executor = TPPNetworkExecutor(
+            cachingStrategy: .ephemeral,
+            sessionConfiguration: config
+        )
+
+        return MockBackendEnvironment(
+            session: session,
+            executor: executor,
+            parser: OPDSParser(),
+            scenario: scenario
+        )
+    }
+
+    /// Deactivate the mock backend. Call in tearDown.
+    static func deactivate() {
+        MockBackendURLProtocol.activeScenario = nil
+        MockBackendURLProtocol.fixtureDirectoryPath = nil
+    }
+
+    // MARK: - Private
+
+    private static func fixturesURL() -> URL {
+        // Resolve relative to this source file
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/API")
+    }
+
+    private static func testBundle() -> Bundle {
+        Bundle(for: MockBackendIntegrationTests.self)
+    }
+}
+
+


### PR DESCRIPTION
## Summary

- Adds a mock backend service that intercepts ALL network requests at the URLProtocol level
- Serves fixture data based on declarative JSON scenarios — same fixtures used by API contract tests
- Debug menu picker lets QA switch between scenarios at runtime (Happy Path, Expired Credentials, Loan Limit, Server Down, Slow Network)
- Covers both legacy TPPNetworkExecutor and modern NetworkClient in one interception layer
- All code gated behind `#if DEBUG` — never compiles into release builds

## Architecture

```
MockBackendURLProtocol  →  intercepts URLSession requests
        ↓
MockScenario.routes[]   →  regex match URL → fixture file
        ↓
fixture.json            →  serve with configured status/content-type
```

## Test plan

- [ ] Build with DEBUG flag, verify mock backend compiles
- [ ] Open Developer Settings → Mock Backend → select "Happy Path"
- [ ] Verify catalog loads from fixture data (no real network)
- [ ] Switch to "Expired Credentials" → verify borrow shows error
- [ ] Switch to "Server Down" → verify error handling throughout
- [ ] Deactivate → verify real network resumes
- [ ] Run existing contract tests → verify fixtures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### PP-4020 Traceability
- **Jira:** [PP-4119](https://ebce-lyrasis.atlassian.net/browse/PP-4119)
- **Report:** [Methodology](https://thepalaceproject.github.io/regression-reports/PP-4020/index.html#methodology)
- **Findings:** Test infrastructure for network-dependent flows

[PP-4119]: https://ebce-lyrasis.atlassian.net/browse/PP-4119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ