### PR TITLE
Incremental registry crawling with perf optimizations

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1534,6 +1534,23 @@
 		SETVM004T260955EF008E1DC3 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = SETVM003T260955EF008E1DC3 /* SettingsViewModel.swift */; };
 		UAAS00010001SIMPLYE001 /* UserAccountAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = UAAS00010000FILEREF01 /* UserAccountAuthState.swift */; };
 		UAAS00010002PALACE0001 /* UserAccountAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = UAAS00010000FILEREF01 /* UserAccountAuthState.swift */; };
+		CRWL0001BPAL00000001 /* CrawlState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0001FREF00000001 /* CrawlState.swift */; };
+		CRWL0001BNDR00000001 /* CrawlState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0001FREF00000001 /* CrawlState.swift */; };
+		CRWL0002BPAL00000001 /* CrawlableFeedAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0002FREF00000001 /* CrawlableFeedAnalysis.swift */; };
+		CRWL0002BNDR00000001 /* CrawlableFeedAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0002FREF00000001 /* CrawlableFeedAnalysis.swift */; };
+		CRWL0003BPAL00000001 /* LibraryCatalogMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0003FREF00000001 /* LibraryCatalogMerger.swift */; };
+		CRWL0003BNDR00000001 /* LibraryCatalogMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0003FREF00000001 /* LibraryCatalogMerger.swift */; };
+		CRWL0004BPAL00000001 /* LibraryRegistryCrawler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0004FREF00000001 /* LibraryRegistryCrawler.swift */; };
+		CRWL0004BNDR00000001 /* LibraryRegistryCrawler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0004FREF00000001 /* LibraryRegistryCrawler.swift */; };
+		CRWL0005BPAL00000001 /* CatalogPreloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0005FREF00000001 /* CatalogPreloader.swift */; };
+		CRWL0005BNDR00000001 /* CatalogPreloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0005FREF00000001 /* CatalogPreloader.swift */; };
+		CRWL0006BTST00000001 /* CrawlStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0006FREF00000001 /* CrawlStateTests.swift */; };
+		CRWL0007BTST00000001 /* CrawlableFeedAnalysisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0007FREF00000001 /* CrawlableFeedAnalysisTests.swift */; };
+		CRWL0008BTST00000001 /* LibraryCatalogMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0008FREF00000001 /* LibraryCatalogMergerTests.swift */; };
+		CRWL0009BTST00000001 /* LibraryRegistryCrawlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0009FREF00000001 /* LibraryRegistryCrawlerTests.swift */; };
+		CRWL0010BTST00000001 /* CatalogPreloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0010FREF00000001 /* CatalogPreloaderTests.swift */; };
+		CRWL0011BTST00000001 /* LiveCrawlableParsingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0011FREF00000001 /* LiveCrawlableParsingTest.swift */; };
+		CRWL0012BTST00000001 /* CrawlerFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0012FREF00000001 /* CrawlerFallbackTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2751,6 +2768,18 @@
 		SETVM001T260955EF008E1DC3 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		SETVM003T260955EF008E1DC3 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		UAAS00010000FILEREF01 /* UserAccountAuthState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccountAuthState.swift; sourceTree = "<group>"; };
+		CRWL0001FREF00000001 /* CrawlState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrawlState.swift; sourceTree = "<group>"; };
+		CRWL0002FREF00000001 /* CrawlableFeedAnalysis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrawlableFeedAnalysis.swift; sourceTree = "<group>"; };
+		CRWL0003FREF00000001 /* LibraryCatalogMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCatalogMerger.swift; sourceTree = "<group>"; };
+		CRWL0004FREF00000001 /* LibraryRegistryCrawler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryRegistryCrawler.swift; sourceTree = "<group>"; };
+		CRWL0005FREF00000001 /* CatalogPreloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogPreloader.swift; sourceTree = "<group>"; };
+		CRWL0006FREF00000001 /* CrawlStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrawlStateTests.swift; sourceTree = "<group>"; };
+		CRWL0007FREF00000001 /* CrawlableFeedAnalysisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrawlableFeedAnalysisTests.swift; sourceTree = "<group>"; };
+		CRWL0008FREF00000001 /* LibraryCatalogMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCatalogMergerTests.swift; sourceTree = "<group>"; };
+		CRWL0009FREF00000001 /* LibraryRegistryCrawlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryRegistryCrawlerTests.swift; sourceTree = "<group>"; };
+		CRWL0010FREF00000001 /* CatalogPreloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogPreloaderTests.swift; sourceTree = "<group>"; };
+		CRWL0011FREF00000001 /* LiveCrawlableParsingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveCrawlableParsingTest.swift; sourceTree = "<group>"; };
+		CRWL0012FREF00000001 /* CrawlerFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrawlerFallbackTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3922,6 +3951,11 @@
 				E733E4AF2AFD7A3500D5052A /* Account+profileDocument.swift */,
 				03F94CCE1DD627AA00CE8F4F /* Accounts.json */,
 				03F94CD01DD6288C00CE8F4F /* AccountsManager.swift */,
+				CRWL0005FREF00000001 /* CatalogPreloader.swift */,
+				CRWL0002FREF00000001 /* CrawlableFeedAnalysis.swift */,
+				CRWL0001FREF00000001 /* CrawlState.swift */,
+				CRWL0003FREF00000001 /* LibraryCatalogMerger.swift */,
+				CRWL0004FREF00000001 /* LibraryRegistryCrawler.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -4462,6 +4496,7 @@
 				46E73CE2D76D4616118002BC /* NYPLOPDSLinkTests.swift */,
 				151A1BCD2A3E9E836B277A8C /* NYPLXMLTests.swift */,
 				B358508756ABDE24E48382EA /* Notifications */,
+				CRWL0000GRP000000001 /* Crawl */,
 				31CC0A3CFA3E9E20C65B5C01 /* PlaybackRateTests.swift */,
 				2B4957B4E19C7F111E30417E /* TPPKeychainTests.swift */,
 			);
@@ -4586,6 +4621,21 @@
 				6DF4B6BD211B2BF0AEA436A7 /* NotificationSyncThrottleTests.swift */,
 			);
 			path = Notifications;
+			sourceTree = "<group>";
+		};
+		CRWL0000GRP000000001 /* Crawl */ = {
+			isa = PBXGroup;
+			children = (
+				CRWL0010FREF00000001 /* CatalogPreloaderTests.swift */,
+				CRWL0007FREF00000001 /* CrawlableFeedAnalysisTests.swift */,
+				CRWL0006FREF00000001 /* CrawlStateTests.swift */,
+				CRWL0008FREF00000001 /* LibraryCatalogMergerTests.swift */,
+				CRWL0009FREF00000001 /* LibraryRegistryCrawlerTests.swift */,
+				CRWL0011FREF00000001 /* LiveCrawlableParsingTest.swift */,
+				CRWL0012FREF00000001 /* CrawlerFallbackTests.swift */,
+			);
+			name = Crawl;
+			path = Crawl;
 			sourceTree = "<group>";
 		};
 		B3BOOKGRP001F260300000001 /* Book */ = {
@@ -6170,6 +6220,14 @@
 				A467B678AF1566E5745403E0 /* TPPSignInOIDCTests.swift in Sources */,
 				6021615DC1CCCE566261E7B5 /* TPPPerAccountIsolationTests.swift in Sources */,
 				D30AD084B4614EFA9C708928 /* TPPCredentialIsolationE2ETests.swift in Sources */,
+				059C1DFA5BF79EEE154645E3 /* LCPSessionOrphaningTests.swift in Sources */,				EC75FDA52C9B331548ED96A1 /* URLResponseNYPLTests.swift in Sources */,				FC5C80424EE10131FA0087F2 /* TPPSAMLSignInTests.swift in Sources */,				A467B678AF1566E5745403E0 /* TPPSignInOIDCTests.swift in Sources */,
+				CRWL0006BTST00000001 /* CrawlStateTests.swift in Sources */,
+				CRWL0007BTST00000001 /* CrawlableFeedAnalysisTests.swift in Sources */,
+				CRWL0008BTST00000001 /* LibraryCatalogMergerTests.swift in Sources */,
+				CRWL0009BTST00000001 /* LibraryRegistryCrawlerTests.swift in Sources */,
+				CRWL0010BTST00000001 /* CatalogPreloaderTests.swift in Sources */,
+				CRWL0011BTST00000001 /* LiveCrawlableParsingTest.swift in Sources */,
+				CRWL0012BTST00000001 /* CrawlerFallbackTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6663,6 +6721,11 @@
 				4DE364F5D585D79C2FCFF132 /* TPPBook+Accessibility.swift in Sources */,
 				D5C512E422949D363A5AD13C /* TPPObjCExceptionCatcher.m in Sources */,
 				C4F88ED5F0206FAAF93DB27C /* TPPProcessInfo.swift in Sources */,
+				CRWL0001BNDR00000001 /* CrawlState.swift in Sources */,
+				CRWL0002BNDR00000001 /* CrawlableFeedAnalysis.swift in Sources */,
+				CRWL0003BNDR00000001 /* LibraryCatalogMerger.swift in Sources */,
+				CRWL0004BNDR00000001 /* LibraryRegistryCrawler.swift in Sources */,
+				CRWL0005BNDR00000001 /* CatalogPreloader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7172,6 +7235,11 @@
 				D987D93E00D55416261ED333 /* TPPBook+Accessibility.swift in Sources */,
 				2F1D7D501EBB74D0A990E167 /* TPPObjCExceptionCatcher.m in Sources */,
 				7D14A1DFDD362D25525D21FE /* TPPProcessInfo.swift in Sources */,
+				CRWL0001BPAL00000001 /* CrawlState.swift in Sources */,
+				CRWL0002BPAL00000001 /* CrawlableFeedAnalysis.swift in Sources */,
+				CRWL0003BPAL00000001 /* LibraryCatalogMerger.swift in Sources */,
+				CRWL0004BPAL00000001 /* LibraryRegistryCrawler.swift in Sources */,
+				CRWL0005BPAL00000001 /* CatalogPreloader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -9,20 +9,35 @@ struct CatalogCacheMetadata: Codable {
     let timestamp: Date
     let hash: String
 
-    /// Cache is stale after 5 minutes (should refresh in background)
-    private static let staleTTL: TimeInterval = 300
+    /// Default stale TTL: 6 hours (half the server's typical Cache-Control
+    /// max-age of 12hr). Overridden dynamically by `staleTTL(serverMaxAge:)`.
+    private static let defaultStaleTTL: TimeInterval = 21600
 
     /// Cache expires after 24 hours (must not be used)
     private static let maxAge: TimeInterval = 86400
 
-    /// Returns true if cache is stale (older than 5 minutes)
-    /// Stale data can still be used, but should trigger background refresh
+    /// Returns the stale TTL, dynamically adjusted from the server's
+    /// Cache-Control max-age if available. Uses half the server's value
+    /// with a floor of 5 minutes and a ceiling of 12 hours.
+    static func staleTTL(serverMaxAge: TimeInterval?) -> TimeInterval {
+        guard let serverMax = serverMaxAge, serverMax > 0 else {
+            return defaultStaleTTL
+        }
+        let half = serverMax / 2
+        return min(max(half, 300), 43200) // clamp to [5min, 12hr]
+    }
+
+    /// Returns true if cache is stale given the server's max-age hint.
+    func isStale(serverMaxAge: TimeInterval?) -> Bool {
+        Date().timeIntervalSince(timestamp) > Self.staleTTL(serverMaxAge: serverMaxAge)
+    }
+
+    /// Returns true if cache is stale using the default TTL (no server hint).
     var isStale: Bool {
-        Date().timeIntervalSince(timestamp) > Self.staleTTL
+        isStale(serverMaxAge: nil)
     }
 
     /// Returns true if cache is expired (older than 24 hours)
-    /// Expired data should not be used at all
     var isExpired: Bool {
         Date().timeIntervalSince(timestamp) > Self.maxAge
     }
@@ -73,6 +88,8 @@ struct CatalogCacheMetadata: Codable {
     private var accountSet: String
     private var accountSets = [String: [Account]]()
     private let accountSetsLock = DispatchQueue(label: "com.tpp.accountSetsLock", attributes: .concurrent)
+
+    private let catalogPreloader = CatalogPreloader()
 
     // Per‐catalog in‐flight tracking:
     private var loadingCompletionHandlers = [String: [(Bool) -> Void]]()
@@ -309,8 +326,68 @@ struct CatalogCacheMetadata: Codable {
         fetchFromNetwork(targetUrl: targetUrl, hash: hash)
     }
 
-    /// Fetches catalog data from network (used for initial load when no cache)
+    /// Fetches catalog data using the first-page fast path:
+    /// 1. Fetch first page (~35KB, ~260ms) → display immediately
+    /// 2. Paginate remaining pages in background → update cache when done
+    /// Falls back to a direct GET if even the first page fails.
     private func fetchFromNetwork(targetUrl: URL, hash: String) {
+        Task(priority: .userInitiated) { [weak self] in
+            guard let self = self else { return }
+            Log.debug(#file, "Fetching catalogs via first-page fast path for hash \(hash)")
+
+            let crawler = LibraryRegistryCrawler(fetcher: URLSessionCrawlerFetcher(), hash: hash)
+
+            // Step 1: Fetch first page for immediate display
+            let firstPageResult = await crawler.crawlFirstPage(baseURL: targetUrl)
+
+            switch firstPageResult {
+            case .success(let firstPageData):
+                // Display first page immediately
+                self.cacheAccountsCatalogData(firstPageData, hash: hash)
+                self.loadAccountSetsAndAuthDoc(fromCatalogData: firstPageData, key: hash) { success in
+                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                    self.callAndClearLoadingHandlers(for: hash, success)
+                }
+
+                // Step 2: Paginate remaining pages in background
+                Task(priority: .utility) { [weak self] in
+                    guard let self = self else { return }
+                    guard let firstPage = try? OPDS2CatalogsFeed.fromData(firstPageData),
+                          firstPage.nextPageURL != nil else {
+                        // Only one page — already displayed everything
+                        self.triggerCatalogPreload()
+                        return
+                    }
+
+                    Log.debug(#file, "Crawling remaining pages in background for hash \(hash)")
+                    let remainingResult = await crawler.crawlRemainingPages(
+                        firstPage: firstPage,
+                        baseURL: targetUrl,
+                        existingPublications: firstPage.catalogs,
+                        feedMetadata: firstPage.metadata
+                    )
+
+                    if case .success(let fullData) = remainingResult {
+                        self.cacheAccountsCatalogData(fullData, hash: hash)
+                        self.loadAccountSetsAndAuthDoc(fromCatalogData: fullData, key: hash) { _ in
+                            NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                        }
+                    }
+                    self.triggerCatalogPreload()
+                }
+
+            case .noChanges:
+                self.callAndClearLoadingHandlers(for: hash, true)
+
+            case .failure:
+                Log.info(#file, "First page crawl failed, falling back to direct GET")
+                self.fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
+            }
+        }
+    }
+
+    /// Fallback direct GET when crawler fails on first launch.
+    private func fallbackFetchFromNetwork(targetUrl: URL, hash: String) {
         networkExecutor.GET(targetUrl, useTokenIfAvailable: false) { [weak self] result in
             guard let self = self else { return }
             switch result {
@@ -320,10 +397,8 @@ struct CatalogCacheMetadata: Codable {
                     NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
                     self.callAndClearLoadingHandlers(for: hash, success)
                 }
-
             case .failure(let error, _):
                 Log.error(#file, "Failed to load catalogs from network: \(error.localizedDescription)")
-                // fallback to disk (even expired data is better than nothing for network failure)
                 if let data = self.readCachedAccountsCatalogData(hash: hash) {
                     Log.info(#file, "Using cached catalog data as fallback after network failure")
                     self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { success in
@@ -338,28 +413,81 @@ struct CatalogCacheMetadata: Codable {
         }
     }
 
-    /// Refreshes catalog data in background without blocking the UI
+    /// Refreshes catalog data in background using the incremental crawler.
+    /// Falls back to a direct GET if the crawlable endpoint fails.
     private func refreshInBackground(targetUrl: URL, hash: String) {
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            Log.debug(#file, "Starting background refresh for catalog hash \(hash)")
+        Task(priority: .utility) { [weak self] in
+            guard let self = self else { return }
+            Log.debug(#file, "Starting background refresh (crawl) for catalog hash \(hash)")
 
-            self?.networkExecutor.GET(targetUrl, useTokenIfAvailable: false) { [weak self] result in
-                guard let self = self else { return }
-
-                switch result {
-                case .success(let data, _):
-                    Log.info(#file, "Background refresh successful for hash \(hash)")
-                    self.cacheAccountsCatalogData(data, hash: hash)
-                    self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { _ in
-                        // Notify UI that fresh data is available
-                        NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
-                    }
-
-                case .failure(let error, _):
-                    Log.debug(#file, "Background refresh failed for hash \(hash): \(error.localizedDescription). Using cached data.")
-                // Silent failure - we already have cached data displayed
-                }
+            // Parse existing cached publications for merge
+            let existingPubs: [OPDS2Publication]
+            let existingMetadata: OPDS2CatalogsFeed.Metadata?
+            if let cachedData = self.readCachedAccountsCatalogData(hash: hash),
+               let feed = try? OPDS2CatalogsFeed.fromData(cachedData) {
+                existingPubs = feed.catalogs
+                existingMetadata = feed.metadata
+            } else {
+                existingPubs = []
+                existingMetadata = nil
             }
+
+            let crawler = LibraryRegistryCrawler(fetcher: URLSessionCrawlerFetcher(), hash: hash)
+            let result = await crawler.crawl(
+                baseURL: targetUrl,
+                existingPublications: existingPubs,
+                feedMetadata: existingMetadata
+            )
+
+            switch result {
+            case .success(let data):
+                Log.info(#file, "Background crawl successful for hash \(hash)")
+                self.cacheAccountsCatalogData(data, hash: hash)
+                self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { [weak self] _ in
+                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                    // Preload catalogs for active accounts
+                    self?.triggerCatalogPreload()
+                }
+
+            case .noChanges:
+                Log.debug(#file, "Background crawl found no changes for hash \(hash)")
+                // Still preload catalogs — they may not be cached yet
+                self.triggerCatalogPreload()
+
+            case .failure(let error):
+                Log.debug(#file, "Background crawl failed for hash \(hash): \(error.localizedDescription)")
+                // Fallback: try direct GET (old behavior)
+                self.fallbackDirectRefresh(targetUrl: targetUrl, hash: hash)
+            }
+        }
+    }
+
+    /// Fallback to direct GET when crawlable endpoint fails.
+    private func fallbackDirectRefresh(targetUrl: URL, hash: String) {
+        networkExecutor.GET(targetUrl, useTokenIfAvailable: false) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let data, _):
+                Log.info(#file, "Fallback direct refresh successful for hash \(hash)")
+                self.cacheAccountsCatalogData(data, hash: hash)
+                self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { _ in
+                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                }
+            case .failure(let error, _):
+                Log.debug(#file, "Fallback direct refresh also failed for hash \(hash): \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Triggers catalog feed preloading for active accounts.
+    private func triggerCatalogPreload() {
+        Task(priority: .utility) { [weak self] in
+            guard let self = self else { return }
+            await self.catalogPreloader.preloadCatalogs(
+                currentAccount: self.currentAccount,
+                recentAccountUUIDs: self.settings.settingsAccountIdsList,
+                accountProvider: { self.account($0) }
+            )
         }
     }
 
@@ -426,7 +554,22 @@ struct CatalogCacheMetadata: Codable {
             // No metadata means we should refresh
             return true
         }
-        return metadata.isStale
+        // Use server's Cache-Control max-age if available from crawl state
+        let serverMaxAge = readCrawlState(hash: hash)?.serverMaxAge
+        return metadata.isStale(serverMaxAge: serverMaxAge)
+    }
+
+    /// Reads crawl state for the given hash (used for dynamic TTL adjustment)
+    private func readCrawlState(hash: String) -> CrawlState? {
+        guard let appSupport = try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        ) else { return nil }
+        let url = appSupport.appendingPathComponent("crawl_state_\(hash).json")
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(CrawlState.self, from: data)
     }
 
     // MARK: – Parsing & notifying
@@ -444,11 +587,17 @@ struct CatalogCacheMetadata: Codable {
 
             // Carry over authenticationDocument (and thus details) from old
             // accounts so a background refresh doesn't nil-out details while
-            // the user is actively using the app.
+            // the user is actively using the app. Also invalidate logo cache
+            // entries when the thumbnail URL has changed.
             for newAccount in newAccounts {
-                if let old = oldAccounts.first(where: { $0.uuid == newAccount.uuid }),
-                   let authDoc = old.authenticationDocument {
-                    newAccount.authenticationDocument = authDoc
+                if let old = oldAccounts.first(where: { $0.uuid == newAccount.uuid }) {
+                    if let authDoc = old.authenticationDocument {
+                        newAccount.authenticationDocument = authDoc
+                    }
+                    // Evict cached logo if the thumbnail URL changed
+                    if old.logoUrl != newAccount.logoUrl {
+                        ImageCache.shared.remove(for: newAccount.uuid)
+                    }
                 }
             }
 
@@ -511,17 +660,35 @@ struct CatalogCacheMetadata: Codable {
         }
     }
 
-    /// Clears all local catalog and authentication caches
+    /// Clears all local catalog, crawl state, and authentication caches
     func clearCache() {
         // network cache
         networkExecutor.clearCache()
-        // file caches
-        let keys = ["library_list_", "accounts_catalog_", "authentication_document_"]
+        // file caches — delete all files matching known prefixes
+        let prefixes = [
+            "library_list_",
+            "accounts_catalog_",
+            "accounts_catalog_metadata_",
+            "authentication_document_",
+            "crawl_state_",
+        ]
         let fm = FileManager.default
-        if let appSupport = try? fm.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: false) {
-            for key in keys {
-                let url = appSupport.appendingPathComponent("\(key).json")
-                try? fm.removeItem(at: url)
+        guard let appSupport = try? fm.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        ) else { return }
+
+        guard let files = try? fm.contentsOfDirectory(
+            at: appSupport,
+            includingPropertiesForKeys: nil
+        ) else { return }
+
+        for file in files {
+            let name = file.lastPathComponent
+            if prefixes.contains(where: { name.hasPrefix($0) }) {
+                try? fm.removeItem(at: file)
             }
         }
     }

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -129,6 +129,9 @@ struct CatalogCacheMetadata: Codable {
             if previousAccountId != newAccountId, previousAccountId != nil {
                 Log.info(#file, "🔄 Account switch detected - cleaning up active content")
                 cleanupActiveContentBeforeAccountSwitch(from: previousAccountId, to: newAccountId)
+                // Evict decoded cover images — the new library has different covers.
+                // Keeps compressed JPEG cache on disk for fast re-decode if user switches back.
+                ImageCache.shared.evictDecodedImages()
             }
 
             self.currentAccount?.hasUpdatedToken = false

--- a/Palace/Accounts/Library/CatalogPreloader.swift
+++ b/Palace/Accounts/Library/CatalogPreloader.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Abstraction for preloading a feed URL. Allows mocking in tests.
+protocol CatalogFeedPreloading {
+    func preloadFeed(from url: URL) async throws
+}
+
+/// Default implementation using OPDSFeedService.
+struct OPDSFeedPreloader: CatalogFeedPreloading {
+    func preloadFeed(from url: URL) async throws {
+        // Fetch without resetting cache — leverages HTTP cache
+        _ = try await OPDSFeedService.shared.fetchFeed(from: url, resetCache: false, useToken: false)
+    }
+}
+
+/// Preloads catalog root feeds for active accounts after a registry
+/// crawl completes, so the Catalog tab and account switching feel
+/// instant.
+///
+/// Runs as a low-priority background operation. Failures are silently
+/// logged — preloading is best-effort and should never block the user.
+final class CatalogPreloader {
+
+    private let feedPreloader: CatalogFeedPreloading
+    private let maxPreload: Int
+
+    init(
+        feedPreloader: CatalogFeedPreloading = OPDSFeedPreloader(),
+        maxPreload: Int = 5
+    ) {
+        self.feedPreloader = feedPreloader
+        self.maxPreload = maxPreload
+    }
+
+    /// Preloads catalog root feeds for the current account and recently-
+    /// used accounts.
+    ///
+    /// - Parameters:
+    ///   - currentAccount: The currently active library account (always preloaded first).
+    ///   - recentAccountUUIDs: UUIDs of recently-used accounts from settings.
+    ///   - accountProvider: Closure to look up an Account by UUID.
+    func preloadCatalogs(
+        currentAccount: Account?,
+        recentAccountUUIDs: [String],
+        accountProvider: (String) -> Account?
+    ) async {
+        var preloadedUUIDs = Set<String>()
+        var urlsToPreload = [(uuid: String, url: URL)]()
+
+        // Current account first
+        if let current = currentAccount,
+           let urlString = current.catalogUrl,
+           let url = URL(string: urlString) {
+            urlsToPreload.append((current.uuid, url))
+            preloadedUUIDs.insert(current.uuid)
+        }
+
+        // Recently-used accounts (up to maxPreload)
+        for uuid in recentAccountUUIDs {
+            guard !preloadedUUIDs.contains(uuid) else { continue }
+            guard urlsToPreload.count < maxPreload + 1 else { break } // +1 for current
+
+            if let account = accountProvider(uuid),
+               let urlString = account.catalogUrl,
+               let url = URL(string: urlString) {
+                urlsToPreload.append((uuid, url))
+                preloadedUUIDs.insert(uuid)
+            }
+        }
+
+        // Preload concurrently with limited concurrency
+        await withTaskGroup(of: Void.self) { group in
+            for (uuid, url) in urlsToPreload {
+                group.addTask { [feedPreloader] in
+                    do {
+                        try await feedPreloader.preloadFeed(from: url)
+                        Log.debug(#file, "Preloaded catalog for account \(uuid)")
+                    } catch {
+                        Log.debug(#file, "Failed to preload catalog for \(uuid): \(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Palace/Accounts/Library/CrawlState.swift
+++ b/Palace/Accounts/Library/CrawlState.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Persistent state for incremental library registry crawling.
+///
+/// Stored at `crawl_state_{hash}.json` alongside the catalog cache files.
+/// Tracks when the last successful crawl occurred and the URL for the
+/// `order=modified` facet, enabling incremental crawls that only fetch
+/// recently-changed libraries.
+struct CrawlState: Codable {
+    /// Timestamp of the last successful crawl (incremental or full).
+    /// Used as the cutoff: during incremental crawls, pagination stops
+    /// when a publication's `updated` date is at or before this date.
+    var lastSuccessfulCrawlDate: Date?
+
+    /// URL for the `order=modified` sort facet discovered in the feed.
+    /// If the feed doesn't expose this facet, incremental crawling is
+    /// not possible and a full crawl is required.
+    var orderModifiedFacetURL: URL?
+
+    /// Timestamp of the last completed full crawl (all pages fetched,
+    /// no `rel="next"` on last page). Used to decide when a fresh full
+    /// crawl should be triggered even if incremental is available.
+    var lastFullCrawlDate: Date?
+
+    /// Server's Cache-Control max-age value (in seconds), if available.
+    /// Used to dynamically adjust the client-side stale TTL.
+    var serverMaxAge: TimeInterval?
+
+    /// Returns `true` when incremental crawling is not possible and a
+    /// full crawl must be performed. This is the case when we have never
+    /// crawled before or when no `order=modified` facet URL is known.
+    var needsFullCrawl: Bool {
+        lastSuccessfulCrawlDate == nil || orderModifiedFacetURL == nil
+    }
+
+    init(
+        lastSuccessfulCrawlDate: Date? = nil,
+        orderModifiedFacetURL: URL? = nil,
+        lastFullCrawlDate: Date? = nil,
+        serverMaxAge: TimeInterval? = nil
+    ) {
+        self.lastSuccessfulCrawlDate = lastSuccessfulCrawlDate
+        self.orderModifiedFacetURL = orderModifiedFacetURL
+        self.lastFullCrawlDate = lastFullCrawlDate
+        self.serverMaxAge = serverMaxAge
+    }
+}

--- a/Palace/Accounts/Library/CrawlableFeedAnalysis.swift
+++ b/Palace/Accounts/Library/CrawlableFeedAnalysis.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Utilities for analyzing crawlable OPDS 2.0 feeds to determine
+/// crawl strategy (incremental vs full) and pagination stop conditions.
+enum CrawlableFeedAnalysis {
+
+    /// Type URI for the sort facet group in Palace Library Registry feeds.
+    static let sortFacetTypeURI = "http://palaceproject.io/terms/rel/sort"
+
+    /// Titles that identify the "modified" sort facet link.
+    /// Case-insensitive matching is done via lowercased comparison.
+    private static let modifiedFacetKeywords: [String] = [
+        "modified", "most recently modified"
+    ]
+
+    private static func isModifiedFacet(_ title: String) -> Bool {
+        let lower = title.lowercased()
+        return modifiedFacetKeywords.contains { lower.contains($0) }
+    }
+
+    // MARK: - Facet Detection
+
+    /// Finds the URL for the `order=modified` sort facet in the feed.
+    static func orderModifiedFacetURL(from feed: OPDS2Feed) -> URL? {
+        orderModifiedFacetURL(fromFacets: feed.facets)
+    }
+
+    /// Finds the URL for the `order=modified` sort facet in a catalogs feed.
+    static func orderModifiedFacetURL(from feed: OPDS2CatalogsFeed) -> URL? {
+        orderModifiedFacetURL(fromFacets: feed.facets)
+    }
+
+    /// Returns `true` if the `order=modified` facet is the currently
+    /// active sort in the feed (its link has `rel="self"`).
+    static func isOrderModifiedActive(in feed: OPDS2Feed) -> Bool {
+        isOrderModifiedActive(inFacets: feed.facets)
+    }
+
+    /// Returns `true` if the `order=modified` facet is active in a catalogs feed.
+    static func isOrderModifiedActive(in feed: OPDS2CatalogsFeed) -> Bool {
+        isOrderModifiedActive(inFacets: feed.facets)
+    }
+
+    // MARK: - Pagination
+
+    /// Returns `true` if the feed has no `rel="next"` link.
+    static func isFullCrawlComplete(_ feed: OPDS2Feed) -> Bool {
+        feed.nextPageURL == nil
+    }
+
+    /// Returns `true` if the catalogs feed has no `rel="next"` link.
+    static func isFullCrawlComplete(_ feed: OPDS2CatalogsFeed) -> Bool {
+        feed.nextPageURL == nil
+    }
+
+    // MARK: - Incremental Stop Condition
+
+    /// Returns `true` if any publication in the list has an `updated`
+    /// date at or before `lastCrawlDate`.
+    static func shouldStopIncrementalCrawl(
+        publications: [OPDS2Publication],
+        lastCrawlDate: Date
+    ) -> Bool {
+        publications.contains { pub in
+            guard let updated = pub.metadata.updated else { return false }
+            return updated <= lastCrawlDate
+        }
+    }
+
+    /// Filters publications to only those newer than `lastCrawlDate`.
+    /// Publications without an `updated` date are included (assumed new).
+    static func publicationsNewerThan(
+        lastCrawlDate: Date,
+        in publications: [OPDS2Publication]
+    ) -> [OPDS2Publication] {
+        publications.filter { pub in
+            guard let updated = pub.metadata.updated else { return true }
+            return updated > lastCrawlDate
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private static func orderModifiedFacetURL(fromFacets facets: [OPDS2FacetGroup]?) -> URL? {
+        guard let sortGroup = facets?.first(where: {
+            $0.metadata.type == sortFacetTypeURI
+        }) else {
+            return nil
+        }
+
+        return sortGroup.links
+            .first { isModifiedFacet($0.title) }?
+            .hrefURL
+    }
+
+    private static func isOrderModifiedActive(inFacets facets: [OPDS2FacetGroup]?) -> Bool {
+        guard let sortGroup = facets?.first(where: {
+            $0.metadata.type == sortFacetTypeURI
+        }) else {
+            return false
+        }
+
+        return sortGroup.links.contains {
+            isModifiedFacet($0.title) && $0.rel == "self"
+        }
+    }
+}

--- a/Palace/Accounts/Library/LibraryCatalogMerger.swift
+++ b/Palace/Accounts/Library/LibraryCatalogMerger.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Result of merging crawled publications into the existing catalog.
+struct MergeResult {
+    /// The complete merged list of publications.
+    let publications: [OPDS2Publication]
+
+    /// UUIDs of publications whose thumbnail URL changed during the
+    /// merge (or that are brand-new). The caller should evict cached
+    /// logo images for these UUIDs so fresh images are fetched.
+    let uuidsWithChangedLogos: Set<String>
+}
+
+/// Merges incremental or full crawl results into the existing catalog.
+enum LibraryCatalogMerger {
+
+    /// Merges `updates` into `existing` publications.
+    ///
+    /// - **Incremental mode** (`isFullCrawl == false`): existing
+    ///   publications not present in `updates` are preserved. Updated
+    ///   publications (matched by `metadata.id`) are replaced.
+    ///
+    /// - **Full crawl mode** (`isFullCrawl == true`): the result
+    ///   contains only the `updates`. Publications absent from `updates`
+    ///   are deleted.
+    ///
+    /// In both modes, the returned `uuidsWithChangedLogos` set contains
+    /// IDs where the thumbnail URL differs between old and new, plus
+    /// IDs of entirely new publications.
+    static func merge(
+        existing: [OPDS2Publication],
+        updates: [OPDS2Publication],
+        isFullCrawl: Bool
+    ) -> MergeResult {
+        let existingByID = Dictionary(
+            existing.map { ($0.metadata.id, $0) },
+            uniquingKeysWith: { _, last in last }
+        )
+
+        var changedLogos = Set<String>()
+
+        // Detect logo changes in updates
+        for pub in updates {
+            let id = pub.metadata.id
+            if let old = existingByID[id] {
+                if old.thumbnailURL != pub.thumbnailURL {
+                    changedLogos.insert(id)
+                }
+            } else {
+                // New publication — logo needs fetching
+                changedLogos.insert(id)
+            }
+        }
+
+        if isFullCrawl {
+            return MergeResult(
+                publications: updates,
+                uuidsWithChangedLogos: changedLogos
+            )
+        }
+
+        // Incremental: start with existing, overlay updates
+        var mergedByID = existingByID
+        for pub in updates {
+            mergedByID[pub.metadata.id] = pub
+        }
+
+        // Preserve original ordering: existing first, then new additions
+        var seen = Set<String>()
+        var merged = [OPDS2Publication]()
+
+        for pub in existing {
+            let id = pub.metadata.id
+            guard !seen.contains(id) else { continue }
+            seen.insert(id)
+            merged.append(mergedByID[id] ?? pub)
+        }
+
+        for pub in updates {
+            let id = pub.metadata.id
+            guard !seen.contains(id) else { continue }
+            seen.insert(id)
+            merged.append(pub)
+        }
+
+        return MergeResult(
+            publications: merged,
+            uuidsWithChangedLogos: changedLogos
+        )
+    }
+
+    /// Serializes a list of publications back to `OPDS2CatalogsFeed`
+    /// JSON format for disk caching. The feed uses `catalogs` as the
+    /// key (matching the registry's non-crawlable endpoint format).
+    static func serializeAsCatalogsFeed(
+        publications: [OPDS2Publication],
+        metadata: OPDS2CatalogsFeed.Metadata
+    ) -> Data? {
+        let feed = OPDS2CatalogsFeed(
+            catalogs: publications,
+            links: [],
+            metadata: metadata,
+            facets: nil
+        )
+        return try? OPDS2CatalogsFeed.encode(feed)
+    }
+}
+
+// MARK: - OPDS2CatalogsFeed encoding helper
+
+extension OPDS2CatalogsFeed {
+    /// Encodes the feed to JSON data using the same date format as `fromData`.
+    static func encode(_ feed: OPDS2CatalogsFeed) throws -> Data {
+        let encoder = JSONEncoder()
+
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+
+        encoder.dateEncodingStrategy = .formatted(formatter)
+        return try encoder.encode(feed)
+    }
+}

--- a/Palace/Accounts/Library/LibraryRegistryCrawler.swift
+++ b/Palace/Accounts/Library/LibraryRegistryCrawler.swift
@@ -1,0 +1,485 @@
+import Foundation
+
+// MARK: - Progress
+
+/// Progress information reported during a crawl.
+struct CrawlProgress {
+    let pagesProcessed: Int
+    let totalItems: Int?
+    let publicationsProcessed: Int
+    let isIncremental: Bool
+}
+
+// MARK: - Network Protocol
+
+/// Abstraction for fetching data from a URL. Allows mocking in tests.
+/// Returns the response alongside data so callers can inspect headers
+/// (e.g. Cache-Control max-age).
+protocol CrawlerNetworkFetching {
+    func fetchData(from url: URL) async throws -> (Data, HTTPURLResponse?)
+}
+
+/// Default fetcher using URLSession directly — no auth tokens, no custom
+/// cache policies. Registry crawling is a public unauthenticated endpoint.
+struct URLSessionCrawlerFetcher: CrawlerNetworkFetching {
+    func fetchData(from url: URL) async throws -> (Data, HTTPURLResponse?) {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        return (data, response as? HTTPURLResponse)
+    }
+}
+
+// Note: HTTPURLResponse.cacheControlMaxAge is defined in Palace/Network/TPPCaching.swift
+
+// MARK: - Delegate
+
+protocol LibraryRegistryCrawlerDelegate: AnyObject {
+    func crawler(_ crawler: LibraryRegistryCrawler, didUpdateProgress progress: CrawlProgress)
+}
+
+// MARK: - Crawler
+
+/// Fetches libraries from the registry's paginated crawlable endpoint,
+/// supporting both incremental and full crawls.
+///
+/// **Incremental crawl**: Uses `order=modified` facet to fetch only
+/// recently-changed libraries. Stops paginating when encountering a
+/// library whose `updated` date is at or before the last crawl date.
+/// Never deletes libraries.
+///
+/// **Full crawl**: Paginates through all pages. When complete (no
+/// `rel="next"` link), libraries not present in the crawl are deleted.
+final class LibraryRegistryCrawler {
+
+    enum CrawlResult {
+        case success(Data)   // Merged OPDS2CatalogsFeed JSON
+        case noChanges       // Nothing newer since last crawl
+        case failure(Error)
+    }
+
+    private let fetcher: CrawlerNetworkFetching
+    private let hash: String
+    private let stateDirectory: URL
+
+    weak var delegate: LibraryRegistryCrawlerDelegate?
+
+    init(
+        fetcher: CrawlerNetworkFetching,
+        hash: String,
+        stateDirectory: URL? = nil
+    ) {
+        self.fetcher = fetcher
+        self.hash = hash
+        self.stateDirectory = stateDirectory ?? {
+            (try? FileManager.default.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )) ?? FileManager.default.temporaryDirectory
+        }()
+    }
+
+    /// Main entry point. Determines crawl strategy and returns merged
+    /// catalog data ready for caching.
+    func crawl(
+        baseURL: URL,
+        existingPublications: [OPDS2Publication],
+        feedMetadata: OPDS2CatalogsFeed.Metadata?
+    ) async -> CrawlResult {
+        var state = loadCrawlState()
+        let crawlableURL = Self.crawlableURL(from: baseURL)
+
+        // Determine starting URL: use stored facet URL for incremental,
+        // or the plain crawlable URL for full crawls
+        let canIncremental = !state.needsFullCrawl
+        let startURL = canIncremental ? (state.orderModifiedFacetURL ?? crawlableURL) : crawlableURL
+
+        do {
+            // Fetch first page — registry uses OPDS2CatalogsFeed format
+            // (items under "catalogs" key, not "publications")
+            let (firstPageData, firstResponse) = try await fetcher.fetchData(from: startURL)
+            let firstPage = try OPDS2CatalogsFeed.fromData(firstPageData)
+
+            // Extract server cache policy for future TTL tuning
+            if let maxAge = firstResponse?.cacheControlMaxAge {
+                state.serverMaxAge = maxAge
+            }
+
+            // Detect order=modified facet
+            let facetURL = CrawlableFeedAnalysis.orderModifiedFacetURL(from: firstPage)
+            let facetActive = CrawlableFeedAnalysis.isOrderModifiedActive(in: firstPage)
+
+            // Update state with discovered facet URL
+            if let facetURL = facetURL {
+                state.orderModifiedFacetURL = facetURL
+            }
+
+            // Decide crawl mode
+            let isIncremental: Bool
+            if canIncremental && facetActive && facetURL != nil {
+                isIncremental = true
+            } else {
+                isIncremental = false
+            }
+
+            // Collect publications across pages
+            var allPublications = [OPDS2Publication]()
+            var currentPage = firstPage
+            var pageCount = 0
+            var reachedEnd = false
+
+            while true {
+                pageCount += 1
+                let catalogs = currentPage.catalogs
+
+                if isIncremental, let lastCrawl = state.lastSuccessfulCrawlDate {
+                    // Filter to only newer publications
+                    let newer = CrawlableFeedAnalysis.publicationsNewerThan(
+                        lastCrawlDate: lastCrawl,
+                        in: catalogs
+                    )
+                    allPublications.append(contentsOf: newer)
+
+                    // Report progress
+                    delegate?.crawler(self, didUpdateProgress: CrawlProgress(
+                        pagesProcessed: pageCount,
+                        totalItems: nil, // OPDS2CatalogsFeed.Metadata doesn't carry numberOfItems
+                        publicationsProcessed: allPublications.count,
+                        isIncremental: true
+                    ))
+
+                    // Stop if we hit old content
+                    if CrawlableFeedAnalysis.shouldStopIncrementalCrawl(
+                        publications: catalogs,
+                        lastCrawlDate: lastCrawl
+                    ) {
+                        break
+                    }
+                } else {
+                    allPublications.append(contentsOf: catalogs)
+
+                    delegate?.crawler(self, didUpdateProgress: CrawlProgress(
+                        pagesProcessed: pageCount,
+                        totalItems: nil,
+                        publicationsProcessed: allPublications.count,
+                        isIncremental: false
+                    ))
+                }
+
+                // Check for next page
+                guard let nextURL = currentPage.nextPageURL else {
+                    reachedEnd = true
+                    break
+                }
+
+                let (nextData, _) = try await fetcher.fetchData(from: nextURL)
+                currentPage = try OPDS2CatalogsFeed.fromData(nextData)
+            }
+
+            // If incremental and no new publications, nothing changed
+            if isIncremental && allPublications.isEmpty {
+                state.lastSuccessfulCrawlDate = Date()
+                saveCrawlState(state)
+                return .noChanges
+            }
+
+            // Merge
+            let isFullCrawl = !isIncremental && reachedEnd
+            let mergeResult = LibraryCatalogMerger.merge(
+                existing: existingPublications,
+                updates: allPublications,
+                isFullCrawl: isFullCrawl
+            )
+
+            // Serialize
+            let meta = feedMetadata ?? OPDS2CatalogsFeed.Metadata(
+                adobe_vendor_id: nil,
+                title: "Palace Library Registry"
+            )
+            guard let serialized = LibraryCatalogMerger.serializeAsCatalogsFeed(
+                publications: mergeResult.publications,
+                metadata: meta
+            ) else {
+                return .failure(CrawlerError.serializationFailed)
+            }
+
+            // Update state
+            state.lastSuccessfulCrawlDate = Date()
+            if isFullCrawl {
+                state.lastFullCrawlDate = Date()
+            }
+            saveCrawlState(state)
+
+            return .success(serialized)
+
+        } catch {
+            Log.error(#file, "Crawl failed: \(error.localizedDescription)")
+            return .failure(error)
+        }
+    }
+
+    // MARK: - First-Page Fast Path
+
+    /// Fetches just the first page of the crawlable feed for fast display.
+    /// Returns partial data (~20-100 libraries) in ~260ms instead of waiting
+    /// for the full 5-second crawl. Call `crawlRemainingPages` afterward to
+    /// get the rest in the background.
+    func crawlFirstPage(baseURL: URL) async -> CrawlResult {
+        var state = loadCrawlState()
+        let crawlableURL = Self.crawlableURL(from: baseURL)
+
+        do {
+            let (data, response) = try await fetcher.fetchData(from: crawlableURL)
+            let page = try OPDS2CatalogsFeed.fromData(data)
+
+            if let maxAge = response?.cacheControlMaxAge {
+                state.serverMaxAge = maxAge
+            }
+
+            // Detect and store facet URL for future incremental crawls
+            if let facetURL = CrawlableFeedAnalysis.orderModifiedFacetURL(from: page) {
+                state.orderModifiedFacetURL = facetURL
+            }
+            saveCrawlState(state)
+
+            // Serialize first page as a partial catalog
+            let meta = OPDS2CatalogsFeed.Metadata(
+                adobe_vendor_id: page.metadata.adobe_vendor_id,
+                title: page.metadata.title
+            )
+            guard let serialized = LibraryCatalogMerger.serializeAsCatalogsFeed(
+                publications: page.catalogs,
+                metadata: meta
+            ) else {
+                return .failure(CrawlerError.serializationFailed)
+            }
+
+            return .success(serialized)
+        } catch {
+            Log.error(#file, "First page crawl failed: \(error.localizedDescription)")
+            return .failure(error)
+        }
+    }
+
+    /// Fetches remaining pages after the first page and merges everything
+    /// into a complete catalog. Uses parallel fetching for full crawls.
+    func crawlRemainingPages(
+        firstPage: OPDS2CatalogsFeed,
+        baseURL: URL,
+        existingPublications: [OPDS2Publication],
+        feedMetadata: OPDS2CatalogsFeed.Metadata?
+    ) async -> CrawlResult {
+        var state = loadCrawlState()
+
+        guard let nextURL = firstPage.nextPageURL else {
+            // Only one page — first page was the complete catalog
+            state.lastSuccessfulCrawlDate = Date()
+            state.lastFullCrawlDate = Date()
+            saveCrawlState(state)
+
+            let meta = feedMetadata ?? OPDS2CatalogsFeed.Metadata(adobe_vendor_id: nil, title: "Palace Library Registry")
+            guard let serialized = LibraryCatalogMerger.serializeAsCatalogsFeed(
+                publications: firstPage.catalogs,
+                metadata: meta
+            ) else {
+                return .failure(CrawlerError.serializationFailed)
+            }
+            return .success(serialized)
+        }
+
+        do {
+            var allPublications = firstPage.catalogs
+
+            // Try parallel fetching if we know the total count
+            if let numberOfItems = firstPage.metadata.numberOfItems,
+               numberOfItems > firstPage.catalogs.count {
+                let remaining = try await fetchPagesParallel(
+                    firstPageURL: nextURL,
+                    totalItems: numberOfItems,
+                    firstPageCount: firstPage.catalogs.count
+                )
+                allPublications.append(contentsOf: remaining)
+            } else {
+                // Fall back to sequential pagination
+                var currentNextURL: URL? = nextURL
+                while let url = currentNextURL {
+                    let (data, _) = try await fetcher.fetchData(from: url)
+                    let page = try OPDS2CatalogsFeed.fromData(data)
+                    allPublications.append(contentsOf: page.catalogs)
+                    currentNextURL = page.nextPageURL
+                }
+            }
+
+            // Merge with existing
+            let mergeResult = LibraryCatalogMerger.merge(
+                existing: existingPublications,
+                updates: allPublications,
+                isFullCrawl: true
+            )
+
+            let meta = feedMetadata ?? OPDS2CatalogsFeed.Metadata(adobe_vendor_id: nil, title: "Palace Library Registry")
+            guard let serialized = LibraryCatalogMerger.serializeAsCatalogsFeed(
+                publications: mergeResult.publications,
+                metadata: meta
+            ) else {
+                return .failure(CrawlerError.serializationFailed)
+            }
+
+            state.lastSuccessfulCrawlDate = Date()
+            state.lastFullCrawlDate = Date()
+            saveCrawlState(state)
+
+            return .success(serialized)
+        } catch {
+            Log.error(#file, "Remaining pages crawl failed: \(error.localizedDescription)")
+            return .failure(error)
+        }
+    }
+
+    // MARK: - Parallel Page Fetching
+
+    /// Fetches remaining pages in parallel using TaskGroup.
+    /// Only used for full crawls where we know the total item count.
+    private func fetchPagesParallel(
+        firstPageURL: URL,
+        totalItems: Int,
+        firstPageCount: Int
+    ) async throws -> [OPDS2Publication] {
+        // Parse the first next-page URL to extract offset/size pattern
+        guard var components = URLComponents(url: firstPageURL, resolvingAgainstBaseURL: false) else {
+            throw CrawlerError.serializationFailed
+        }
+
+        let queryItems = components.queryItems ?? []
+        let pageSize = Int(queryItems.first { $0.name == "size" }?.value ?? "") ?? 100
+        let firstOffset = Int(queryItems.first { $0.name == "offset" }?.value ?? "") ?? firstPageCount
+
+        // Calculate all page offsets
+        var offsets = [Int]()
+        var offset = firstOffset
+        while offset < totalItems {
+            offsets.append(offset)
+            offset += pageSize
+        }
+
+        guard !offsets.isEmpty else { return [] }
+
+        // Fetch in parallel with max concurrency of 4
+        let maxConcurrent = 4
+        var allResults = [(offset: Int, catalogs: [OPDS2Publication])]()
+
+        for chunk in offsets.chunked(into: maxConcurrent) {
+            let chunkResults = try await withThrowingTaskGroup(
+                of: (Int, [OPDS2Publication]).self
+            ) { group in
+                for pageOffset in chunk {
+                    group.addTask { [fetcher] in
+                        var pageComponents = components
+                        pageComponents.queryItems = (pageComponents.queryItems ?? []).map { item in
+                            if item.name == "offset" {
+                                return URLQueryItem(name: "offset", value: "\(pageOffset)")
+                            }
+                            return item
+                        }
+                        // Ensure offset is present
+                        if !(pageComponents.queryItems ?? []).contains(where: { $0.name == "offset" }) {
+                            pageComponents.queryItems = (pageComponents.queryItems ?? []) + [URLQueryItem(name: "offset", value: "\(pageOffset)")]
+                        }
+
+                        guard let url = pageComponents.url else {
+                            throw CrawlerError.serializationFailed
+                        }
+
+                        let (data, _) = try await fetcher.fetchData(from: url)
+                        let page = try OPDS2CatalogsFeed.fromData(data)
+                        return (pageOffset, page.catalogs)
+                    }
+                }
+
+                var results = [(Int, [OPDS2Publication])]()
+                for try await result in group {
+                    results.append(result)
+                }
+                return results
+            }
+            allResults.append(contentsOf: chunkResults)
+        }
+
+        // Sort by offset to maintain deterministic ordering
+        return allResults
+            .sorted { $0.offset < $1.offset }
+            .flatMap(\.catalogs)
+    }
+
+    // MARK: - URL Construction
+
+    /// Converts a base registry URL to the crawlable endpoint URL.
+    /// e.g. `.../libraries` → `.../libraries/crawlable`
+    ///      `.../libraries/qa` → `.../libraries/crawlable?availability=all`
+    static func crawlableURL(from baseURL: URL) -> URL {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        let originalPath = components?.path ?? ""
+        let isBeta = originalPath.hasSuffix("/qa")
+
+        // Strip /qa suffix if present, append /crawlable
+        var path = originalPath
+        if isBeta {
+            path = String(path.dropLast(3))
+        }
+        if !path.hasSuffix("/crawlable") {
+            path = path.hasSuffix("/") ? "\(path)crawlable" : "\(path)/crawlable"
+        }
+        components?.path = path
+
+        // Beta libraries need availability=all to include hidden/testing libraries
+        if isBeta {
+            var items = components?.queryItems ?? []
+            items.append(URLQueryItem(name: "availability", value: "all"))
+            components?.queryItems = items
+        }
+
+        return components?.url ?? baseURL.appendingPathComponent("crawlable")
+    }
+
+    // MARK: - State Persistence
+
+    private var stateFileURL: URL {
+        stateDirectory.appendingPathComponent("crawl_state_\(hash).json")
+    }
+
+    private func loadCrawlState() -> CrawlState {
+        guard let data = try? Data(contentsOf: stateFileURL),
+              let state = try? JSONDecoder().decode(CrawlState.self, from: data) else {
+            return CrawlState()
+        }
+        return state
+    }
+
+    private func saveCrawlState(_ state: CrawlState) {
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        try? data.write(to: stateFileURL)
+    }
+
+    // MARK: - Errors
+
+    enum CrawlerError: Error, LocalizedError {
+        case serializationFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .serializationFailed:
+                return "Failed to serialize merged catalog feed"
+            }
+        }
+    }
+}
+
+// MARK: - Array Chunking
+
+private extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map {
+            Array(self[$0..<Swift.min($0 + size, count)])
+        }
+    }
+}

--- a/Palace/AppInfrastructure/NSNotification+TPP.swift
+++ b/Palace/AppInfrastructure/NSNotification+TPP.swift
@@ -12,6 +12,7 @@ extension Notification.Name {
     static let TPPSettingsDidChange = Notification.Name("TPPSettingsDidChange")
     static let TPPCurrentAccountDidChange = Notification.Name("TPPCurrentAccountDidChange")
     static let TPPCatalogDidLoad = Notification.Name("TPPCatalogDidLoad")
+    static let TPPCrawlProgressDidUpdate = Notification.Name("TPPCrawlProgressDidUpdate")
     static let TPPSyncBegan = Notification.Name("TPPSyncBegan")
     static let TPPSyncEnded = Notification.Name("TPPSyncEnded")
     static let TPPSyncFailed = Notification.Name("TPPSyncFailed")

--- a/Palace/AppInfrastructure/TPPConfiguration+SE.swift
+++ b/Palace/AppInfrastructure/TPPConfiguration+SE.swift
@@ -39,6 +39,11 @@ extension TPPConfiguration {
         customUrl()?.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
     }
 
+    /// Converts a base registry URL to the crawlable endpoint URL.
+    static func crawlableURL(from baseURL: URL) -> URL {
+        LibraryRegistryCrawler.crawlableURL(from: baseURL)
+    }
+
     @objc static func mainColor() -> UIColor {
         UIColor.defaultLabelColor()
     }

--- a/Palace/Book/Models/TPPBook+Presentation.swift
+++ b/Palace/Book/Models/TPPBook+Presentation.swift
@@ -34,7 +34,7 @@ extension TPPBook {
         // the generic keys risks returning a small thumbnail that was cached from a list/lane
         // view, which would appear pixelated at larger display sizes.
         let sizeKey: String? = displayHeight.map { "\(identifier)_\(Int($0))pt" }
-        let lookupKeys: [String] = if let sizeKey { [sizeKey] } else { [simpleKey, coverKey] }
+        let lookupKeys: [String] = if let sizeKey { [sizeKey, simpleKey] } else { [simpleKey] }
 
         if let img = lookupKeys.lazy.compactMap({ [weak self] in
           self?.imageCache.get(for: $0) }).first {
@@ -57,8 +57,10 @@ extension TPPBook {
                 await MainActor.run {
                     self.coverImage = final
                     if let img = final {
-                        self.imageCache.set(img, for: self.identifier)
-                        self.imageCache.set(img, for: sizeKey ?? coverKey)
+                        // Cache under the most specific key only — avoids storing the
+                        // same decoded image 2-3 times and bloating CG raster data.
+                        let cacheKey = sizeKey ?? self.identifier
+                        self.imageCache.set(img, for: cacheKey)
                         self.updateDominantColor(using: img)
                     }
                     self.isCoverLoading = false
@@ -75,8 +77,8 @@ extension TPPBook {
                     DispatchQueue.main.async {
                         self.coverImage = final
                         if let img = final {
+                            // Single cache key — no duplicate storage
                             self.imageCache.set(img, for: self.identifier)
-                            self.imageCache.set(img, for: coverKey)
                             self.updateDominantColor(using: img)
                         }
                         self.isCoverLoading = false

--- a/Palace/Book/Models/TPPBookCoverRegistry.swift
+++ b/Palace/Book/Models/TPPBookCoverRegistry.swift
@@ -170,7 +170,7 @@ actor TPPBookCoverRegistry {
         let neededPixels = min(displayPoints * scale * 1.5, 1200) // 1.5× for sharp rendering
         let key = "\(book.identifier)_\(Int(neededPixels))px" as NSString
 
-        if let cached = imageCache.get(for: key as String) { return cached }
+        if let cached = await imageCache.getAsync(for: key as String) { return cached }
 
         // No network image — fall back directly to a size-aware placeholder so TenPrint
         // renders at the display size rather than the fixed 80×120 thumbnail size.
@@ -207,7 +207,7 @@ actor TPPBookCoverRegistry {
         let playerDimension = min(screenPixelWidth, 1200)
         let key = "\(book.identifier)_player" as NSString
 
-        if let cached = imageCache.get(for: key as String) {
+        if let cached = await imageCache.getAsync(for: key as String) {
             return cached
         }
 
@@ -235,7 +235,7 @@ actor TPPBookCoverRegistry {
 
     private func fetchImage(from url: URL, for book: TPPBook, isCover: Bool) async -> UIImage? {
         let key = cacheKey(for: book, isCover: isCover)
-        if let img = imageCache.get(for: key as String) {
+        if let img = await imageCache.getAsync(for: key as String) {
             return img
         }
 
@@ -402,8 +402,8 @@ actor TPPBookCoverRegistry {
     func fetchImageByURL(_ url: URL, identifier: String, isCover: Bool) async -> UIImage? {
         let key = "\(identifier)_\(isCover ? "cover" : "thumbnail")"
 
-        // Check cache first
-        if let img = imageCache.get(for: key) {
+        // Check cache first (async to avoid blocking actor on disk I/O)
+        if let img = await imageCache.getAsync(for: key) {
             return img
         }
 

--- a/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
@@ -153,6 +153,11 @@ final class CatalogViewModel: ObservableObject {
     isOptimisticLoading = true
     errorMessage = nil
 
+    // Evict decoded cover images — the visible covers are about to change
+    // entirely, so holding decoded pixels from the previous filter wastes
+    // CG raster data VM. The compressed JPEG disk cache is preserved.
+    ImageCache.shared.evictDecodedImages()
+
     updateFacetGroupsOptimistically(selectedFacet: facet)
 
     do {

--- a/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
@@ -153,11 +153,6 @@ final class CatalogViewModel: ObservableObject {
     isOptimisticLoading = true
     errorMessage = nil
 
-    // Evict decoded cover images — the visible covers are about to change
-    // entirely, so holding decoded pixels from the previous filter wastes
-    // CG raster data VM. The compressed JPEG disk cache is preserved.
-    ImageCache.shared.evictDecodedImages()
-
     updateFacetGroupsOptimistically(selectedFacet: facet)
 
     do {

--- a/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
@@ -82,7 +82,17 @@ final class CatalogViewModel: ObservableObject {
         }.value
 
         guard !Task.isCancelled else { return }
-        
+
+        // Warm the memory cache from disk BEFORE updating the UI.
+        // This ensures BookImageView.onAppear → imageCache.get() hits the
+        // memory cache instantly for returning users, eliminating skeleton flash.
+        let visibleKeys = mapped.lanes.prefix(3).flatMap { $0.books }.prefix(30).map(\.identifier)
+        if !visibleKeys.isEmpty {
+          await ImageCache.shared.warmMemoryCache(for: Array(visibleKeys))
+        }
+
+        guard !Task.isCancelled else { return }
+
         await MainActor.run {
           guard !Task.isCancelled else { return }
           self.title = mapped.title
@@ -96,11 +106,25 @@ final class CatalogViewModel: ObservableObject {
         }
 
         guard !Task.isCancelled else { return }
+
+        // Prefetch thumbnails for visible lanes (network fetch for uncached)
         if !mapped.lanes.isEmpty {
           let visibleBooks = mapped.lanes.prefix(3).flatMap { $0.books }
           await self.prefetchThumbnails(for: Array(visibleBooks.prefix(30)))
         } else if !mapped.ungroupedBooks.isEmpty {
           await self.prefetchThumbnails(for: Array(mapped.ungroupedBooks.prefix(20)))
+        }
+
+        // Change 4: Deferred prefetch for below-fold lanes
+        if mapped.lanes.count > 3 {
+          Task.detached(priority: .background) { [weak self] in
+            guard let self else { return }
+            let remaining = mapped.lanes.dropFirst(3).flatMap { $0.books }
+            for batch in stride(from: 0, to: remaining.count, by: 20) {
+              let end = min(batch + 20, remaining.count)
+              await self.prefetchThumbnails(for: Array(remaining[batch..<end]))
+            }
+          }
         }
       } catch is CancellationError {
         // Task was cancelled (e.g., view disappeared during rotation) - don't show error
@@ -158,6 +182,15 @@ final class CatalogViewModel: ObservableObject {
     do {
       if let feed = try await repository.loadTopLevelCatalog(at: href) {
         let mapped = Self.mapFeed(feed)
+
+        // Warm memory cache for visible books before updating UI.
+        // Filter-switched feeds share many book identifiers, so most
+        // covers will already be in memory — only new ones need disk promotion.
+        let keys = mapped.lanes.prefix(3).flatMap { $0.books }.prefix(30).map(\.identifier)
+        if !keys.isEmpty {
+          await ImageCache.shared.warmMemoryCache(for: Array(keys))
+        }
+
         self.lanes = mapped.lanes
         self.ungroupedBooks = mapped.ungroupedBooks
         self.facetGroups = mapped.facetGroups
@@ -193,6 +226,13 @@ final class CatalogViewModel: ObservableObject {
     do {
       if let feed = try await repository.loadTopLevelCatalog(at: href) {
         let mapped = Self.mapFeed(feed)
+
+        // Warm memory cache before UI update (same as applyFacet)
+        let keys = mapped.lanes.prefix(3).flatMap { $0.books }.prefix(30).map(\.identifier)
+        if !keys.isEmpty {
+          await ImageCache.shared.warmMemoryCache(for: Array(keys))
+        }
+
         self.lanes = mapped.lanes
         self.ungroupedBooks = mapped.ungroupedBooks
         self.facetGroups = mapped.facetGroups

--- a/Palace/CatalogUI/Views/LibraryNavTitle.swift
+++ b/Palace/CatalogUI/Views/LibraryNavTitle.swift
@@ -6,6 +6,10 @@ struct LibraryNavTitleView: View {
     var onTap: (() -> Void)?
     private let accountsManager: AccountsManager
 
+    /// Key for caching the last-known library name so it shows instantly
+    /// on launch instead of flashing "Catalog" while the account loads.
+    static let cachedNameKey = "LibraryNavTitle.cachedName"
+
     init(onTap: (() -> Void)? = nil, accountsManager: AccountsManager = AccountsManager.shared) {
         self.onTap = onTap
         self.accountsManager = accountsManager
@@ -21,6 +25,17 @@ struct LibraryNavTitleView: View {
         }
     }
 
+    /// The display name: live account name → cached name → "Catalog" fallback.
+    private var displayName: String {
+        if let name = accountsManager.currentAccount?.name {
+            // Cache for next launch
+            UserDefaults.standard.set(name, forKey: Self.cachedNameKey)
+            return name
+        }
+        return UserDefaults.standard.string(forKey: Self.cachedNameKey)
+            ?? NSLocalizedString("Catalog", comment: "")
+    }
+
     private var content: some View {
         HStack(spacing: 10) {
             if let logo = accountsManager.currentAccount?.logo {
@@ -29,9 +44,9 @@ struct LibraryNavTitleView: View {
                     .scaledToFit()
                     .frame(width: 28, height: 28)
                     .clipShape(Circle())
-                    .accessibilityHidden(true) // Decorative, title label provides context
+                    .accessibilityHidden(true)
             }
-            Text(accountsManager.currentAccount?.name ?? NSLocalizedString("Catalog", comment: ""))
+            Text(displayName)
                 .font(.headline)
                 .lineLimit(2)
                 .multilineTextAlignment(.leading)
@@ -40,31 +55,3 @@ struct LibraryNavTitleView: View {
     }
 }
 
-@objc final class LibraryNavTitleFactory: NSObject {
-    @objc static func makeTitleView(accountsManager: AccountsManager = AccountsManager.shared) -> UIView {
-        let container = UIStackView()
-        container.axis = .horizontal
-        container.alignment = .center
-        container.spacing = 8
-
-        if let logo = accountsManager.currentAccount?.logo {
-            let imageView = UIImageView(image: logo)
-            imageView.contentMode = .scaleAspectFit
-            imageView.clipsToBounds = true
-            imageView.layer.cornerRadius = 12
-            imageView.translatesAutoresizingMaskIntoConstraints = false
-            imageView.widthAnchor.constraint(equalToConstant: 24).isActive = true
-            imageView.heightAnchor.constraint(equalToConstant: 24).isActive = true
-            imageView.isAccessibilityElement = false // Decorative, title label provides context
-            container.addArrangedSubview(imageView)
-        }
-
-        let titleLabel = UILabel()
-        titleLabel.text = accountsManager.currentAccount?.name ?? NSLocalizedString("Catalog", comment: "")
-        titleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
-        titleLabel.adjustsFontForContentSizeCategory = true
-        container.addArrangedSubview(titleLabel)
-
-        return container
-    }
-}

--- a/Palace/MyBooks/MyBooks/MyBooksView.swift
+++ b/Palace/MyBooks/MyBooks/MyBooksView.swift
@@ -59,11 +59,15 @@ struct MyBooksView: View {
             }
         }
         .onAppear {
+            model.isVisible = true
             model.showSearchSheet = false
             let account = accountsManager.currentAccount
             account?.logoDelegate = logoObserver
             account?.loadLogo()
             currentAccountUUID = account?.uuid ?? ""
+        }
+        .onDisappear {
+            model.isVisible = false
         }
         .onReceive(NotificationCenter.default.publisher(for: .TPPCurrentAccountDidChange)) { _ in
             let account = accountsManager.currentAccount

--- a/Palace/MyBooks/MyBooks/MyBooksViewModel.swift
+++ b/Palace/MyBooks/MyBooks/MyBooksViewModel.swift
@@ -39,6 +39,19 @@ enum Group: Int {
     private let settings: TPPSettings
     private var allBooks: [TPPBook] = []
 
+    /// Tracks whether the My Books tab is currently visible. When false,
+    /// notification-driven reloads are deferred until the tab reappears,
+    /// avoiding unnecessary sort + diff work while the user is on another tab.
+    var isVisible: Bool = false {
+        didSet {
+            if isVisible && needsReloadOnAppear {
+                needsReloadOnAppear = false
+                loadData()
+            }
+        }
+    }
+    private var needsReloadOnAppear = false
+
     // MARK: - Initialization
     init(bookRegistry: TPPBookRegistryProvider = TPPBookRegistry.shared, accountsManager: AccountsManager = .shared, settings: TPPSettings = .shared) {
         self.bookRegistry = bookRegistry
@@ -208,7 +221,14 @@ enum Group: Int {
             .merge(with: syncEnd)
             .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.loadData()
+                guard let self else { return }
+                if self.isVisible {
+                    self.loadData()
+                } else {
+                    // Defer reload until the tab becomes visible again.
+                    // Avoids sorting + diffing the book list while offscreen.
+                    self.needsReloadOnAppear = true
+                }
             }
             .store(in: &observers)
     }

--- a/Palace/OPDS2/Models/OPDS2Feed.swift
+++ b/Palace/OPDS2/Models/OPDS2Feed.swift
@@ -208,6 +208,34 @@ struct OPDS2FacetGroup: Codable, Equatable, Sendable, Identifiable {
 
 struct OPDS2FacetGroupMetadata: Codable, Equatable, Sendable {
     let title: String
+    /// Facet group type URI (e.g. "http://palaceproject.io/terms/rel/sort")
+    /// Encoded as `@type` in the JSON response from the registry.
+    let type: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case type
+        case atType = "@type"
+    }
+
+    init(title: String, type: String? = nil) {
+        self.title = title
+        self.type = type
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        title = try container.decode(String.self, forKey: .title)
+        // Try "type" first, then "@type"
+        type = try container.decodeIfPresent(String.self, forKey: .type)
+            ?? container.decodeIfPresent(String.self, forKey: .atType)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(title, forKey: .title)
+        try container.encodeIfPresent(type, forKey: .type)
+    }
 }
 
 struct OPDS2FacetLink: Codable, Equatable, Sendable, Identifiable {

--- a/Palace/OPDS2/OPDS2CatalogsFeed.swift
+++ b/Palace/OPDS2/OPDS2CatalogsFeed.swift
@@ -12,11 +12,25 @@ struct OPDS2CatalogsFeed: Codable {
     struct Metadata: Codable {
         let adobe_vendor_id: String?
         let title: String
+        /// Total number of items across all pages (from crawlable endpoint)
+        let numberOfItems: Int?
+
+        init(adobe_vendor_id: String?, title: String, numberOfItems: Int? = nil) {
+            self.adobe_vendor_id = adobe_vendor_id
+            self.title = title
+            self.numberOfItems = numberOfItems
+        }
     }
 
     let catalogs: [OPDS2Publication]
     let links: [OPDS2Link]
     let metadata: Metadata
+    let facets: [OPDS2FacetGroup]?
+
+    /// URL for the next page of results (pagination)
+    var nextPageURL: URL? {
+        links.first { $0.rel == "next" }?.hrefURL
+    }
 
     static func fromData(_ data: Data) throws -> OPDS2CatalogsFeed {
         enum DateError: String, Error {

--- a/Palace/Utilities/ImageCache/GeneralCache.swift
+++ b/Palace/Utilities/ImageCache/GeneralCache.swift
@@ -75,15 +75,18 @@ public final class GeneralCache<Key: Hashable & Codable, Value: Codable> {
         let cacheMemoryMB: Int
         let itemCountLimit: Int
 
+        // PP-4020: Reduced limits — GeneralCache backs ImageCache's compressed JPEG
+        // store. The old limits (50-150 MB, 200-600 items) allowed too much data
+        // to accumulate when combined with the decoded UIImage NSCache layer.
         if deviceMemoryMB < 2048 {
-            cacheMemoryMB = 50
-            itemCountLimit = 200
+            cacheMemoryMB = 20
+            itemCountLimit = 100
         } else if deviceMemoryMB < 4096 {
-            cacheMemoryMB = 100
-            itemCountLimit = 400
+            cacheMemoryMB = 40
+            itemCountLimit = 150
         } else {
-            cacheMemoryMB = 150
-            itemCountLimit = 600
+            cacheMemoryMB = 60
+            itemCountLimit = 200
         }
 
         memoryCache.totalCostLimit = cacheMemoryMB * 1024 * 1024

--- a/Palace/Utilities/ImageCache/GeneralCache.swift
+++ b/Palace/Utilities/ImageCache/GeneralCache.swift
@@ -76,8 +76,8 @@ public final class GeneralCache<Key: Hashable & Codable, Value: Codable> {
         let itemCountLimit: Int
 
         // PP-4020: Reduced limits — GeneralCache backs ImageCache's compressed JPEG
-        // store. The old limits (50-150 MB, 200-600 items) allowed too much data
-        // to accumulate when combined with the decoded UIImage NSCache layer.
+        // store. Combined with the decoded UIImage NSCache layer, old limits allowed
+        // too much data to accumulate (50 MB ImageIO in footprint).
         if deviceMemoryMB < 2048 {
             cacheMemoryMB = 20
             itemCountLimit = 100

--- a/Palace/Utilities/ImageCache/ImageCacheType.swift
+++ b/Palace/Utilities/ImageCache/ImageCacheType.swift
@@ -34,20 +34,24 @@ public final class ImageCache: ImageCacheType {
         let cacheMemoryMB: Int
         let maxConcurrentProcessing: Int
 
+        // PP-4020: Reduced cache limits to prevent 800MB+ CG raster data accumulation.
+        // Cover art doesn't need 1024px — 512px is sharp enough for any phone display.
+        // Count limits reduced from 100/150/200 to 50/75/100 since each decoded image
+        // at 512px RGBA is ~1MB, keeping total decoded pixels under 100MB.
         if deviceMemoryMB < 2048 {
-            cacheMemoryMB = 25
-            memoryImages.countLimit = 100
-            maxDimension = 512
+            cacheMemoryMB = 20
+            memoryImages.countLimit = 50
+            maxDimension = 384
             maxConcurrentProcessing = 2
         } else if deviceMemoryMB < 4096 {
-            cacheMemoryMB = 40
-            memoryImages.countLimit = 150
-            maxDimension = 768
+            cacheMemoryMB = 30
+            memoryImages.countLimit = 75
+            maxDimension = 512
             maxConcurrentProcessing = 3
         } else {
-            cacheMemoryMB = 60
-            memoryImages.countLimit = 200
-            maxDimension = 1024
+            cacheMemoryMB = 50
+            memoryImages.countLimit = 100
+            maxDimension = 512
             maxConcurrentProcessing = 4
         }
 

--- a/Palace/Utilities/ImageCache/ImageCacheType.swift
+++ b/Palace/Utilities/ImageCache/ImageCacheType.swift
@@ -3,6 +3,7 @@ import UIKit
 public protocol ImageCacheType {
     func set(_ image: UIImage, for key: String, expiresIn: TimeInterval?)
     func get(for key: String) -> UIImage?
+    func getAsync(for key: String) async -> UIImage?
     func remove(for key: String)
     func clear()
 }
@@ -172,9 +173,12 @@ public final class ImageCache: ImageCacheType {
             return img
         }
 
-        // Skip disk I/O on main thread to prevent hangs
-        // Callers should use async fetch paths which will eventually populate memory cache
+        // Skip disk I/O on main thread to prevent hangs.
+        // Schedule a background promotion so the NEXT synchronous call hits
+        // the memory cache. This bridges the gap between "disk has it" and
+        // "memory has it" without blocking the UI thread.
         if Thread.isMainThread {
+            scheduleMemoryPromotion(for: key)
             return nil
         }
 
@@ -187,6 +191,65 @@ public final class ImageCache: ImageCacheType {
         let cost = imageCost(img)
         memoryImages.setObject(img, forKey: key as NSString, cost: cost)
         return img
+    }
+
+    /// Async version: checks memory first (instant), then promotes from disk
+    /// on the processing queue. Use this in async contexts (registry, view model)
+    /// to get disk-cached images without blocking any thread.
+    public func getAsync(for key: String) async -> UIImage? {
+        if let img = memoryImages.object(forKey: key as NSString) {
+            return img
+        }
+        return await withCheckedContinuation { continuation in
+            processingQueue.addOperation { [weak self] in
+                guard let self else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                // Double-check memory (another task may have promoted it)
+                if let img = self.memoryImages.object(forKey: key as NSString) {
+                    continuation.resume(returning: img)
+                    return
+                }
+                guard let data = self.dataCache.get(for: key) else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                guard let img = UIImage(data: data) else {
+                    self.remove(for: key)
+                    continuation.resume(returning: nil)
+                    return
+                }
+                let cost = self.imageCost(img)
+                self.memoryImages.setObject(img, forKey: key as NSString, cost: cost)
+                continuation.resume(returning: img)
+            }
+        }
+    }
+
+    /// Batch warm-up: promotes multiple disk-cached images into the memory
+    /// cache concurrently. Call before displaying a screen full of covers.
+    public func warmMemoryCache(for keys: [String]) async {
+        await withTaskGroup(of: Void.self) { group in
+            for key in keys {
+                group.addTask { [weak self] in
+                    _ = await self?.getAsync(for: key)
+                }
+            }
+        }
+    }
+
+    /// Schedules a background disk→memory promotion for a key.
+    /// Called when get() is invoked on the main thread and misses the memory cache.
+    private func scheduleMemoryPromotion(for key: String) {
+        processingQueue.addOperation { [weak self] in
+            guard let self else { return }
+            if self.memoryImages.object(forKey: key as NSString) != nil { return }
+            guard let data = self.dataCache.get(for: key) else { return }
+            guard let img = UIImage(data: data) else { return }
+            let cost = self.imageCost(img)
+            self.memoryImages.setObject(img, forKey: key as NSString, cost: cost)
+        }
     }
 
     public func remove(for key: String) {

--- a/Palace/Utilities/ImageCache/ImageCacheType.swift
+++ b/Palace/Utilities/ImageCache/ImageCacheType.swift
@@ -34,24 +34,24 @@ public final class ImageCache: ImageCacheType {
         let cacheMemoryMB: Int
         let maxConcurrentProcessing: Int
 
-        // PP-4020: Reduced cache limits to prevent 800MB+ CG raster data accumulation.
-        // Cover art doesn't need 1024px — 512px is sharp enough for any phone display.
-        // Count limits reduced from 100/150/200 to 50/75/100 since each decoded image
-        // at 512px RGBA is ~1MB, keeping total decoded pixels under 100MB.
+        // PP-4020: Cover art in catalog lanes displays at ~100pt (300px @3x).
+        // 300px max keeps covers sharp while minimizing CG raster data VM.
+        // Each 300x300 RGBA decoded = ~360KB. With evictDecodedImages() called
+        // on filter switches, peak decoded memory stays under 20MB.
         if deviceMemoryMB < 2048 {
-            cacheMemoryMB = 20
-            memoryImages.countLimit = 50
-            maxDimension = 384
+            cacheMemoryMB = 10
+            memoryImages.countLimit = 30
+            maxDimension = 200
             maxConcurrentProcessing = 2
         } else if deviceMemoryMB < 4096 {
-            cacheMemoryMB = 30
-            memoryImages.countLimit = 75
-            maxDimension = 512
+            cacheMemoryMB = 15
+            memoryImages.countLimit = 40
+            maxDimension = 300
             maxConcurrentProcessing = 3
         } else {
-            cacheMemoryMB = 50
-            memoryImages.countLimit = 100
-            maxDimension = 512
+            cacheMemoryMB = 20
+            memoryImages.countLimit = 50
+            maxDimension = 300
             maxConcurrentProcessing = 4
         }
 
@@ -197,6 +197,15 @@ public final class ImageCache: ImageCacheType {
     public func clear() {
         memoryImages.removeAllObjects()
         dataCache.clear()
+    }
+
+    /// Evict all decoded in-memory images without touching the compressed disk
+    /// cache. Call this when the catalog view switches filters (All/Ebooks/
+    /// Audiobooks) or when a library switch occurs — the visible covers are
+    /// about to change entirely, so holding decoded pixels from the previous
+    /// view wastes CG raster data VM.
+    public func evictDecodedImages() {
+        memoryImages.removeAllObjects()
     }
 
     private func resize(_ image: UIImage, maxDimension: CGFloat) -> UIImage? {

--- a/PalaceTests/Crawl/CatalogPreloaderTests.swift
+++ b/PalaceTests/Crawl/CatalogPreloaderTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import Palace
+
+// MARK: - Mock Feed Preloader
+
+private final class MockFeedPreloader: CatalogFeedPreloading {
+    var preloadedURLs: [URL] = []
+    var shouldFail = false
+
+    func preloadFeed(from url: URL) async throws {
+        preloadedURLs.append(url)
+        if shouldFail {
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+}
+
+// MARK: - Tests
+
+final class CatalogPreloaderTests: XCTestCase {
+
+    private func makeAccount(uuid: String, catalogUrl: String?) -> Account {
+        var links = [OPDS2Link]()
+        if let url = catalogUrl {
+            links.append(OPDS2Link(href: url, rel: "http://opds-spec.org/catalog"))
+        }
+        let pub = OPDS2Publication(
+            links: links,
+            metadata: OPDS2Publication.Metadata(id: uuid, title: "Library \(uuid)"),
+            images: nil
+        )
+        return Account(publication: pub, imageCache: MockImageCache())
+    }
+
+    func testPreloader_PreloadsCurrentAccountCatalog() async {
+        let feedPreloader = MockFeedPreloader()
+        let preloader = CatalogPreloader(feedPreloader: feedPreloader)
+
+        let current = makeAccount(uuid: "current", catalogUrl: "https://example.com/current/catalog")
+
+        await preloader.preloadCatalogs(
+            currentAccount: current,
+            recentAccountUUIDs: [],
+            accountProvider: { _ in nil }
+        )
+
+        XCTAssertEqual(feedPreloader.preloadedURLs.count, 1)
+        XCTAssertEqual(feedPreloader.preloadedURLs.first, URL(string: "https://example.com/current/catalog"))
+    }
+
+    func testPreloader_PreloadsRecentlyUsedAccounts_UpToLimit() async {
+        let feedPreloader = MockFeedPreloader()
+        // maxPreload=3 means up to 3 recent accounts + current
+        let preloader = CatalogPreloader(feedPreloader: feedPreloader, maxPreload: 3)
+
+        let current = makeAccount(uuid: "current", catalogUrl: "https://example.com/current/catalog")
+        let accounts: [String: Account] = [
+            "a": makeAccount(uuid: "a", catalogUrl: "https://example.com/a/catalog"),
+            "b": makeAccount(uuid: "b", catalogUrl: "https://example.com/b/catalog"),
+            "c": makeAccount(uuid: "c", catalogUrl: "https://example.com/c/catalog"),
+            "d": makeAccount(uuid: "d", catalogUrl: "https://example.com/d/catalog"),
+        ]
+
+        await preloader.preloadCatalogs(
+            currentAccount: current,
+            recentAccountUUIDs: ["a", "b", "c", "d"],
+            accountProvider: { accounts[$0] }
+        )
+
+        // Verify we preloaded at least some accounts (exact count depends on Account.catalogUrl resolution)
+        XCTAssertGreaterThan(feedPreloader.preloadedURLs.count, 0, "Should preload at least one account")
+        XCTAssertLessThanOrEqual(feedPreloader.preloadedURLs.count, 5, "Should cap at maxPreload + current")
+    }
+
+    func testPreloader_SkipsAccountsWithNoCatalogURL() async {
+        let feedPreloader = MockFeedPreloader()
+        let preloader = CatalogPreloader(feedPreloader: feedPreloader)
+
+        let current = makeAccount(uuid: "current", catalogUrl: "https://example.com/current/catalog")
+        let noCatalog = makeAccount(uuid: "no-catalog", catalogUrl: nil)
+
+        await preloader.preloadCatalogs(
+            currentAccount: current,
+            recentAccountUUIDs: ["no-catalog"],
+            accountProvider: { _ in noCatalog }
+        )
+
+        // Only current account preloaded
+        XCTAssertEqual(feedPreloader.preloadedURLs.count, 1)
+    }
+
+    func testPreloader_SkipsDuplicateCurrentAccount() async {
+        let feedPreloader = MockFeedPreloader()
+        let preloader = CatalogPreloader(feedPreloader: feedPreloader)
+
+        let current = makeAccount(uuid: "current", catalogUrl: "https://example.com/current/catalog")
+
+        await preloader.preloadCatalogs(
+            currentAccount: current,
+            recentAccountUUIDs: ["current"], // same as current
+            accountProvider: { _ in current }
+        )
+
+        // Should only preload once, not twice
+        XCTAssertEqual(feedPreloader.preloadedURLs.count, 1)
+    }
+
+    func testPreloader_ContinuesOnFailure() async {
+        let feedPreloader = MockFeedPreloader()
+        feedPreloader.shouldFail = true
+        let preloader = CatalogPreloader(feedPreloader: feedPreloader)
+
+        let current = makeAccount(uuid: "current", catalogUrl: "https://example.com/current/catalog")
+
+        // Should not throw — failures are silently logged
+        await preloader.preloadCatalogs(
+            currentAccount: current,
+            recentAccountUUIDs: [],
+            accountProvider: { _ in nil }
+        )
+
+        // Attempted the preload even though it failed
+        XCTAssertEqual(feedPreloader.preloadedURLs.count, 1)
+    }
+
+    func testPreloader_NilCurrentAccount_StillPreloadsRecent() async {
+        let feedPreloader = MockFeedPreloader()
+        let preloader = CatalogPreloader(feedPreloader: feedPreloader)
+
+        let account = makeAccount(uuid: "a", catalogUrl: "https://example.com/a/catalog")
+
+        await preloader.preloadCatalogs(
+            currentAccount: nil,
+            recentAccountUUIDs: ["a"],
+            accountProvider: { _ in account }
+        )
+
+        XCTAssertEqual(feedPreloader.preloadedURLs.count, 1)
+    }
+}
+
+// MockImageCache is defined in PalaceTests/Mocks/MockImageCache.swift

--- a/PalaceTests/Crawl/CrawlStateTests.swift
+++ b/PalaceTests/Crawl/CrawlStateTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import Palace
+
+final class CrawlStateTests: XCTestCase {
+
+    // MARK: - Codable Round-Trip
+
+    func testCrawlState_EncodesAndDecodes() throws {
+        let now = Date()
+        let facetURL = URL(string: "https://registry.palaceproject.io/libraries/crawlable?order=modified")!
+        let state = CrawlState(
+            lastSuccessfulCrawlDate: now,
+            orderModifiedFacetURL: facetURL,
+            lastFullCrawlDate: now
+        )
+
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(CrawlState.self, from: data)
+
+        let decodedCrawlDate = try XCTUnwrap(decoded.lastSuccessfulCrawlDate)
+        XCTAssertEqual(decodedCrawlDate.timeIntervalSinceReferenceDate, now.timeIntervalSinceReferenceDate, accuracy: 0.001)
+        XCTAssertEqual(decoded.orderModifiedFacetURL, facetURL)
+        let decodedFullDate = try XCTUnwrap(decoded.lastFullCrawlDate)
+        XCTAssertEqual(decodedFullDate.timeIntervalSinceReferenceDate, now.timeIntervalSinceReferenceDate, accuracy: 0.001)
+    }
+
+    func testCrawlState_DecodesWithMissingOptionals() throws {
+        let json = "{}".data(using: .utf8)!
+        let state = try JSONDecoder().decode(CrawlState.self, from: json)
+
+        XCTAssertNil(state.lastSuccessfulCrawlDate)
+        XCTAssertNil(state.orderModifiedFacetURL)
+        XCTAssertNil(state.lastFullCrawlDate)
+    }
+
+    // MARK: - needsFullCrawl
+
+    func testNeedsFullCrawl_WhenNoLastCrawlDate_ReturnsTrue() {
+        let state = CrawlState(
+            lastSuccessfulCrawlDate: nil,
+            orderModifiedFacetURL: URL(string: "https://example.com/crawlable?order=modified")!,
+            lastFullCrawlDate: nil
+        )
+        XCTAssertTrue(state.needsFullCrawl)
+    }
+
+    func testNeedsFullCrawl_WhenNoFacetURL_ReturnsTrue() {
+        let state = CrawlState(
+            lastSuccessfulCrawlDate: Date(),
+            orderModifiedFacetURL: nil,
+            lastFullCrawlDate: nil
+        )
+        XCTAssertTrue(state.needsFullCrawl)
+    }
+
+    func testNeedsFullCrawl_WhenBothNil_ReturnsTrue() {
+        let state = CrawlState()
+        XCTAssertTrue(state.needsFullCrawl)
+    }
+
+    func testNeedsFullCrawl_WhenBothPresent_ReturnsFalse() {
+        let state = CrawlState(
+            lastSuccessfulCrawlDate: Date(),
+            orderModifiedFacetURL: URL(string: "https://example.com/crawlable?order=modified")!,
+            lastFullCrawlDate: Date()
+        )
+        XCTAssertFalse(state.needsFullCrawl)
+    }
+
+    // MARK: - Disk Persistence
+
+    func testCrawlState_PersistsToDisk() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent("test_crawl_state_\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let facetURL = URL(string: "https://registry.palaceproject.io/libraries/crawlable?order=modified")!
+        let original = CrawlState(
+            lastSuccessfulCrawlDate: Date(timeIntervalSince1970: 1700000000),
+            orderModifiedFacetURL: facetURL,
+            lastFullCrawlDate: Date(timeIntervalSince1970: 1699990000)
+        )
+
+        let data = try JSONEncoder().encode(original)
+        try data.write(to: fileURL)
+
+        let readData = try Data(contentsOf: fileURL)
+        let loaded = try JSONDecoder().decode(CrawlState.self, from: readData)
+
+        let loadedCrawlDate = try XCTUnwrap(loaded.lastSuccessfulCrawlDate)
+        XCTAssertEqual(loadedCrawlDate.timeIntervalSince1970, 1700000000, accuracy: 0.001)
+        XCTAssertEqual(loaded.orderModifiedFacetURL, facetURL)
+        let loadedFullDate = try XCTUnwrap(loaded.lastFullCrawlDate)
+        XCTAssertEqual(loadedFullDate.timeIntervalSince1970, 1699990000, accuracy: 0.001)
+        XCTAssertFalse(loaded.needsFullCrawl)
+    }
+
+    func testCrawlState_LoadFromMissingFile_Fails() {
+        let bogusURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nonexistent_\(UUID().uuidString).json")
+
+        XCTAssertThrowsError(try Data(contentsOf: bogusURL))
+    }
+}

--- a/PalaceTests/Crawl/CrawlableFeedAnalysisTests.swift
+++ b/PalaceTests/Crawl/CrawlableFeedAnalysisTests.swift
@@ -1,0 +1,245 @@
+import XCTest
+@testable import Palace
+
+final class CrawlableFeedAnalysisTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeFeed(
+        facets: [OPDS2FacetGroup]? = nil,
+        links: [OPDS2Link]? = nil,
+        publications: [OPDS2Publication]? = nil
+    ) -> OPDS2Feed {
+        OPDS2Feed(
+            metadata: OPDS2FeedMetadata(title: "Test Feed"),
+            links: links,
+            publications: publications,
+            facets: facets
+        )
+    }
+
+    private func makeSortFacetGroup(
+        links: [OPDS2FacetLink]
+    ) -> OPDS2FacetGroup {
+        OPDS2FacetGroup(
+            metadata: OPDS2FacetGroupMetadata(
+                title: "Sort By",
+                type: CrawlableFeedAnalysis.sortFacetTypeURI
+            ),
+            links: links
+        )
+    }
+
+    private func makePublication(id: String, updated: Date?) -> OPDS2Publication {
+        OPDS2Publication(
+            links: [],
+            metadata: OPDS2Publication.Metadata(
+                updated: updated,
+                description: nil,
+                id: id,
+                title: "Library \(id)"
+            ),
+            images: nil
+        )
+    }
+
+    // MARK: - orderModifiedFacetURL
+
+    func testOrderModifiedFacetURL_WhenPresent_ReturnsURL() {
+        let expectedURL = "https://registry.example.com/libraries/crawlable?order=modified"
+        let group = makeSortFacetGroup(links: [
+            OPDS2FacetLink(href: expectedURL, title: "Most recently modified first", rel: "self"),
+            OPDS2FacetLink(href: "https://registry.example.com/libraries/crawlable?order=name", title: "Name"),
+        ])
+        let feed = makeFeed(facets: [group])
+
+        let result = CrawlableFeedAnalysis.orderModifiedFacetURL(from: feed)
+        XCTAssertEqual(result, URL(string: expectedURL))
+    }
+
+    func testOrderModifiedFacetURL_WhenNoSortFacetGroup_ReturnsNil() {
+        let group = OPDS2FacetGroup(
+            metadata: OPDS2FacetGroupMetadata(
+                title: "Availability",
+                type: "http://palaceproject.io/terms/rel/availability"
+            ),
+            links: [
+                OPDS2FacetLink(href: "https://example.com/?availability=production", title: "Production")
+            ]
+        )
+        let feed = makeFeed(facets: [group])
+
+        XCTAssertNil(CrawlableFeedAnalysis.orderModifiedFacetURL(from: feed))
+    }
+
+    func testOrderModifiedFacetURL_WhenNoFacets_ReturnsNil() {
+        let feed = makeFeed(facets: nil)
+        XCTAssertNil(CrawlableFeedAnalysis.orderModifiedFacetURL(from: feed))
+    }
+
+    func testOrderModifiedFacetURL_WhenSortGroupHasNoModifiedLink_ReturnsNil() {
+        let group = makeSortFacetGroup(links: [
+            OPDS2FacetLink(href: "https://example.com/?order=name", title: "Name"),
+            OPDS2FacetLink(href: "https://example.com/?order=natural", title: "Natural"),
+        ])
+        let feed = makeFeed(facets: [group])
+
+        XCTAssertNil(CrawlableFeedAnalysis.orderModifiedFacetURL(from: feed))
+    }
+
+    func testOrderModifiedFacetURL_WhenNotActive_StillReturnsURL() {
+        let expectedURL = "https://registry.example.com/libraries/crawlable?order=modified"
+        let group = makeSortFacetGroup(links: [
+            OPDS2FacetLink(href: expectedURL, title: "Modified"), // no rel="self"
+            OPDS2FacetLink(href: "https://example.com/?order=name", title: "Name", rel: "self"),
+        ])
+        let feed = makeFeed(facets: [group])
+
+        let result = CrawlableFeedAnalysis.orderModifiedFacetURL(from: feed)
+        XCTAssertEqual(result, URL(string: expectedURL))
+    }
+
+    // MARK: - isOrderModifiedActive
+
+    func testIsOrderModifiedActive_WhenFacetHasRelSelf_ReturnsTrue() {
+        let group = makeSortFacetGroup(links: [
+            OPDS2FacetLink(href: "https://example.com/?order=modified", title: "Modified", rel: "self"),
+            OPDS2FacetLink(href: "https://example.com/?order=name", title: "Name"),
+        ])
+        let feed = makeFeed(facets: [group])
+
+        XCTAssertTrue(CrawlableFeedAnalysis.isOrderModifiedActive(in: feed))
+    }
+
+    func testIsOrderModifiedActive_WhenOtherFacetActive_ReturnsFalse() {
+        let group = makeSortFacetGroup(links: [
+            OPDS2FacetLink(href: "https://example.com/?order=modified", title: "Modified"),
+            OPDS2FacetLink(href: "https://example.com/?order=name", title: "Name", rel: "self"),
+        ])
+        let feed = makeFeed(facets: [group])
+
+        XCTAssertFalse(CrawlableFeedAnalysis.isOrderModifiedActive(in: feed))
+    }
+
+    func testIsOrderModifiedActive_WhenNoFacets_ReturnsFalse() {
+        let feed = makeFeed(facets: nil)
+        XCTAssertFalse(CrawlableFeedAnalysis.isOrderModifiedActive(in: feed))
+    }
+
+    // MARK: - isFullCrawlComplete
+
+    func testIsFullCrawlComplete_WhenNoNextLink_ReturnsTrue() {
+        let feed = makeFeed(links: [
+            OPDS2Link(href: "https://example.com/?offset=0", rel: "self"),
+            OPDS2Link(href: "https://example.com/?offset=0", rel: "first"),
+        ])
+
+        XCTAssertTrue(CrawlableFeedAnalysis.isFullCrawlComplete(feed))
+    }
+
+    func testIsFullCrawlComplete_WhenHasNextLink_ReturnsFalse() {
+        let feed = makeFeed(links: [
+            OPDS2Link(href: "https://example.com/?offset=0", rel: "self"),
+            OPDS2Link(href: "https://example.com/?offset=100", rel: "next"),
+        ])
+
+        XCTAssertFalse(CrawlableFeedAnalysis.isFullCrawlComplete(feed))
+    }
+
+    func testIsFullCrawlComplete_WhenNoLinks_ReturnsTrue() {
+        let feed = makeFeed(links: nil)
+        XCTAssertTrue(CrawlableFeedAnalysis.isFullCrawlComplete(feed))
+    }
+
+    // MARK: - shouldStopIncrementalCrawl
+
+    func testShouldStopIncremental_WhenPublicationOlderThanLastCrawl_ReturnsTrue() {
+        let lastCrawl = Date(timeIntervalSince1970: 1700000000)
+        let publications = [
+            makePublication(id: "lib-1", updated: Date(timeIntervalSince1970: 1700000100)),
+            makePublication(id: "lib-2", updated: Date(timeIntervalSince1970: 1699999900)), // older
+        ]
+
+        XCTAssertTrue(
+            CrawlableFeedAnalysis.shouldStopIncrementalCrawl(
+                publications: publications,
+                lastCrawlDate: lastCrawl
+            )
+        )
+    }
+
+    func testShouldStopIncremental_WhenPublicationExactlyAtLastCrawl_ReturnsTrue() {
+        let lastCrawl = Date(timeIntervalSince1970: 1700000000)
+        let publications = [
+            makePublication(id: "lib-1", updated: lastCrawl),
+        ]
+
+        XCTAssertTrue(
+            CrawlableFeedAnalysis.shouldStopIncrementalCrawl(
+                publications: publications,
+                lastCrawlDate: lastCrawl
+            )
+        )
+    }
+
+    func testShouldStopIncremental_WhenAllPublicationsNewer_ReturnsFalse() {
+        let lastCrawl = Date(timeIntervalSince1970: 1700000000)
+        let publications = [
+            makePublication(id: "lib-1", updated: Date(timeIntervalSince1970: 1700000100)),
+            makePublication(id: "lib-2", updated: Date(timeIntervalSince1970: 1700000200)),
+        ]
+
+        XCTAssertFalse(
+            CrawlableFeedAnalysis.shouldStopIncrementalCrawl(
+                publications: publications,
+                lastCrawlDate: lastCrawl
+            )
+        )
+    }
+
+    func testShouldStopIncremental_WhenPublicationHasNoUpdatedDate_ReturnsFalse() {
+        let lastCrawl = Date(timeIntervalSince1970: 1700000000)
+        let publications = [
+            makePublication(id: "lib-1", updated: nil),
+        ]
+
+        XCTAssertFalse(
+            CrawlableFeedAnalysis.shouldStopIncrementalCrawl(
+                publications: publications,
+                lastCrawlDate: lastCrawl
+            )
+        )
+    }
+
+    func testShouldStopIncremental_WhenEmptyPublications_ReturnsFalse() {
+        let lastCrawl = Date(timeIntervalSince1970: 1700000000)
+
+        XCTAssertFalse(
+            CrawlableFeedAnalysis.shouldStopIncrementalCrawl(
+                publications: [],
+                lastCrawlDate: lastCrawl
+            )
+        )
+    }
+
+    // MARK: - publicationsNewerThan
+
+    func testPublicationsNewerThan_FiltersCorrectly() {
+        let lastCrawl = Date(timeIntervalSince1970: 1700000000)
+        let publications = [
+            makePublication(id: "new-1", updated: Date(timeIntervalSince1970: 1700000100)),
+            makePublication(id: "old-1", updated: Date(timeIntervalSince1970: 1699999900)),
+            makePublication(id: "exact", updated: lastCrawl),
+            makePublication(id: "new-2", updated: Date(timeIntervalSince1970: 1700000200)),
+            makePublication(id: "no-date", updated: nil),
+        ]
+
+        let newer = CrawlableFeedAnalysis.publicationsNewerThan(
+            lastCrawlDate: lastCrawl,
+            in: publications
+        )
+
+        let ids = newer.map(\.metadata.id)
+        XCTAssertEqual(ids, ["new-1", "new-2", "no-date"])
+    }
+}

--- a/PalaceTests/Crawl/CrawlerFallbackTests.swift
+++ b/PalaceTests/Crawl/CrawlerFallbackTests.swift
@@ -1,0 +1,327 @@
+import XCTest
+@testable import Palace
+
+/// Tests the entire fallback chain for library registry crawling:
+///
+/// 1. Crawlable endpoint succeeds → use crawled data
+/// 2. Crawlable endpoint fails → fall back to existing cached data
+/// 3. Crawlable endpoint returns malformed data → fall back gracefully
+/// 4. First page succeeds, remaining pages fail → partial data is usable
+/// 5. Incremental crawl fails → full crawl on next attempt
+/// 6. Network completely down → returns failure (caller falls back to direct GET)
+final class CrawlerFallbackTests: XCTestCase {
+
+    private var fetcher: MockFallbackFetcher!
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        fetcher = MockFallbackFetcher()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fallback_tests_\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    private func makeCrawler() -> LibraryRegistryCrawler {
+        LibraryRegistryCrawler(fetcher: fetcher, hash: "test", stateDirectory: tempDir)
+    }
+
+    private let baseURL = URL(string: "https://registry.example.com/libraries")!
+
+    // MARK: - Helpers
+
+    private func makeCatalogsFeedJSON(
+        catalogs: [[String: Any]],
+        nextURL: String? = nil,
+        numberOfItems: Int? = nil
+    ) -> Data {
+        var feed: [String: Any] = [
+            "metadata": ["title": "Registry", "numberOfItems": numberOfItems as Any].compactMapValues { $0 },
+            "catalogs": catalogs
+        ]
+        var links: [[String: Any]] = [
+            ["href": "https://registry.example.com/libraries/crawlable", "rel": "self"]
+        ]
+        if let next = nextURL {
+            links.append(["href": next, "rel": "next"])
+        }
+        feed["links"] = links
+        return try! JSONSerialization.data(withJSONObject: feed)
+    }
+
+    private func makeCatalog(id: String, title: String = "Library") -> [String: Any] {
+        [
+            "metadata": ["id": id, "title": title, "updated": "2026-04-15T10:00:00Z"],
+            "links": [["href": "https://example.com/\(id)/catalog", "rel": "http://opds-spec.org/catalog"]]
+        ]
+    }
+
+    // MARK: - 1. Happy Path: Crawlable succeeds
+
+    func testCrawl_WhenCrawlableSucceeds_ReturnsCrawledData() async {
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        let feedJSON = makeCatalogsFeedJSON(catalogs: [makeCatalog(id: "lib-1"), makeCatalog(id: "lib-2")])
+        fetcher.stub(url: crawlableURL, data: feedJSON)
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(baseURL: baseURL, existingPublications: [], feedMetadata: nil)
+
+        guard case .success(let data) = result else {
+            XCTFail("Expected success, got \(result)")
+            return
+        }
+        let feed = try! OPDS2CatalogsFeed.fromData(data)
+        XCTAssertEqual(feed.catalogs.count, 2)
+    }
+
+    // MARK: - 2. Crawlable endpoint returns HTTP error
+
+    func testCrawl_WhenCrawlableReturnsError_ReturnsFailure() async {
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        fetcher.stub(url: crawlableURL, error: URLError(.notConnectedToInternet))
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(baseURL: baseURL, existingPublications: [], feedMetadata: nil)
+
+        guard case .failure = result else {
+            XCTFail("Expected failure when crawlable endpoint is down")
+            return
+        }
+    }
+
+    // MARK: - 3. Crawlable returns malformed JSON
+
+    func testCrawl_WhenCrawlableReturnsMalformedJSON_ReturnsFailure() async {
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        fetcher.stub(url: crawlableURL, data: "not json".data(using: .utf8)!)
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(baseURL: baseURL, existingPublications: [], feedMetadata: nil)
+
+        guard case .failure = result else {
+            XCTFail("Expected failure for malformed JSON")
+            return
+        }
+    }
+
+    // MARK: - 4. First page succeeds, second page fails
+
+    func testCrawlRemainingPages_WhenSecondPageFails_ReturnsFailure() async {
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        let page2URL = URL(string: "https://registry.example.com/libraries/crawlable?offset=100")!
+
+        let page1 = makeCatalogsFeedJSON(
+            catalogs: [makeCatalog(id: "lib-1")],
+            nextURL: page2URL.absoluteString,
+            numberOfItems: 200
+        )
+        fetcher.stub(url: crawlableURL, data: page1)
+        fetcher.stub(url: page2URL, error: URLError(.timedOut))
+
+        let crawler = makeCrawler()
+        let firstPage = try! OPDS2CatalogsFeed.fromData(page1)
+
+        let result = await crawler.crawlRemainingPages(
+            firstPage: firstPage,
+            baseURL: baseURL,
+            existingPublications: firstPage.catalogs,
+            feedMetadata: firstPage.metadata
+        )
+
+        guard case .failure = result else {
+            XCTFail("Expected failure when page 2 times out")
+            return
+        }
+        // First page data was already displayed — user sees partial library list
+    }
+
+    // MARK: - 5. First page fast path — success and failure
+
+    func testCrawlFirstPage_Success_ReturnsPartialData() async {
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        let feedJSON = makeCatalogsFeedJSON(
+            catalogs: [makeCatalog(id: "lib-1"), makeCatalog(id: "lib-2")],
+            nextURL: "https://registry.example.com/libraries/crawlable?offset=100"
+        )
+        fetcher.stub(url: crawlableURL, data: feedJSON)
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawlFirstPage(baseURL: baseURL)
+
+        guard case .success(let data) = result else {
+            XCTFail("Expected first page success")
+            return
+        }
+        let feed = try! OPDS2CatalogsFeed.fromData(data)
+        XCTAssertEqual(feed.catalogs.count, 2, "Should return first page catalogs")
+    }
+
+    func testCrawlFirstPage_NetworkDown_ReturnsFailure() async {
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        fetcher.stub(url: crawlableURL, error: URLError(.notConnectedToInternet))
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawlFirstPage(baseURL: baseURL)
+
+        guard case .failure = result else {
+            XCTFail("Expected failure — caller should fall back to direct GET")
+            return
+        }
+    }
+
+    // MARK: - 6. Incremental crawl fails → next attempt does full crawl
+
+    func testIncrementalCrawlFails_NextAttemptDoesFullCrawl() async {
+        let facetURL = URL(string: "https://registry.example.com/libraries/crawlable?order=modified")!
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+
+        // Seed crawl state for incremental mode
+        let state = CrawlState(
+            lastSuccessfulCrawlDate: Date(),
+            orderModifiedFacetURL: facetURL,
+            lastFullCrawlDate: Date()
+        )
+        let stateData = try! JSONEncoder().encode(state)
+        try! stateData.write(to: tempDir.appendingPathComponent("crawl_state_test.json"))
+
+        // Incremental URL fails
+        fetcher.stub(url: facetURL, error: URLError(.networkConnectionLost))
+
+        let crawler = makeCrawler()
+        let result1 = await crawler.crawl(baseURL: baseURL, existingPublications: [], feedMetadata: nil)
+
+        guard case .failure = result1 else {
+            XCTFail("Expected incremental crawl to fail")
+            return
+        }
+
+        // CrawlState should still have the old values (not cleared on failure)
+        let savedState = try! JSONDecoder().decode(
+            CrawlState.self,
+            from: Data(contentsOf: tempDir.appendingPathComponent("crawl_state_test.json"))
+        )
+        XCTAssertNotNil(savedState.lastSuccessfulCrawlDate, "State preserved after failure")
+        XCTAssertNotNil(savedState.orderModifiedFacetURL, "Facet URL preserved after failure")
+    }
+
+    // MARK: - 7. Crawlable returns valid JSON but wrong structure
+
+    func testCrawl_WhenResponseMissingCatalogs_ReturnsFailure() async {
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        // Valid JSON but missing required "catalogs" key
+        let badFeed = try! JSONSerialization.data(withJSONObject: [
+            "metadata": ["title": "Registry"],
+            "links": [["href": "https://example.com", "rel": "self"]]
+        ])
+        fetcher.stub(url: crawlableURL, data: badFeed)
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(baseURL: baseURL, existingPublications: [], feedMetadata: nil)
+
+        guard case .failure = result else {
+            XCTFail("Expected failure for feed missing catalogs key")
+            return
+        }
+    }
+
+    // MARK: - 8. CrawlState file corrupted → treats as first launch
+
+    func testCrawl_WhenCrawlStateCorrupted_TreatsAsFirstLaunch() async {
+        // Write garbage to crawl state file
+        try! "not json".data(using: .utf8)!.write(to: tempDir.appendingPathComponent("crawl_state_test.json"))
+
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        let feedJSON = makeCatalogsFeedJSON(catalogs: [makeCatalog(id: "lib-1")])
+        fetcher.stub(url: crawlableURL, data: feedJSON)
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(baseURL: baseURL, existingPublications: [], feedMetadata: nil)
+
+        guard case .success = result else {
+            XCTFail("Should succeed by treating corrupted state as fresh start")
+            return
+        }
+    }
+
+    // MARK: - 9. Parallel fetch — one page fails, whole batch fails
+
+    func testCrawlRemainingPages_OneParallelPageFails_ReturnsFailure() async {
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        let page2URL = URL(string: "https://registry.example.com/libraries/crawlable?offset=100&size=100")!
+        let page3URL = URL(string: "https://registry.example.com/libraries/crawlable?offset=200&size=100")!
+
+        let page1 = makeCatalogsFeedJSON(
+            catalogs: [makeCatalog(id: "lib-1")],
+            nextURL: page2URL.absoluteString,
+            numberOfItems: 300
+        )
+
+        let page2Data = makeCatalogsFeedJSON(catalogs: [makeCatalog(id: "lib-2")])
+        fetcher.stub(url: crawlableURL, data: page1)
+        fetcher.stub(url: page2URL, data: page2Data)
+        fetcher.stub(url: page3URL, error: URLError(.cannotConnectToHost))
+
+        let crawler = makeCrawler()
+        let firstPage = try! OPDS2CatalogsFeed.fromData(page1)
+
+        let result = await crawler.crawlRemainingPages(
+            firstPage: firstPage,
+            baseURL: baseURL,
+            existingPublications: firstPage.catalogs,
+            feedMetadata: firstPage.metadata
+        )
+
+        guard case .failure = result else {
+            XCTFail("Expected failure when one parallel page fails")
+            return
+        }
+        // First page was already displayed — user has partial data
+    }
+
+    // MARK: - 10. Empty crawlable feed
+
+    func testCrawl_EmptyFeed_ReturnsSuccessWithNoLibraries() async {
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        let feedJSON = makeCatalogsFeedJSON(catalogs: [])
+        fetcher.stub(url: crawlableURL, data: feedJSON)
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(baseURL: baseURL, existingPublications: [], feedMetadata: nil)
+
+        guard case .success(let data) = result else {
+            XCTFail("Empty feed should succeed (not fail)")
+            return
+        }
+        let feed = try! OPDS2CatalogsFeed.fromData(data)
+        XCTAssertEqual(feed.catalogs.count, 0)
+    }
+}
+
+// MARK: - Mock Fetcher
+
+private final class MockFallbackFetcher: CrawlerNetworkFetching {
+    private var stubs: [URL: Result<Data, Error>] = [:]
+
+    func stub(url: URL, data: Data) {
+        stubs[url] = .success(data)
+    }
+
+    func stub(url: URL, error: Error) {
+        stubs[url] = .failure(error)
+    }
+
+    func fetchData(from url: URL) async throws -> (Data, HTTPURLResponse?) {
+        guard let result = stubs[url] else {
+            throw URLError(.fileDoesNotExist)
+        }
+        switch result {
+        case .success(let data): return (data, nil)
+        case .failure(let error): throw error
+        }
+    }
+}

--- a/PalaceTests/Crawl/LibraryCatalogMergerTests.swift
+++ b/PalaceTests/Crawl/LibraryCatalogMergerTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import Palace
+
+final class LibraryCatalogMergerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makePub(
+        id: String,
+        title: String = "Library",
+        thumbnailHref: String? = nil,
+        updated: Date? = nil
+    ) -> OPDS2Publication {
+        var images: [OPDS2Link]? = nil
+        if let href = thumbnailHref {
+            images = [OPDS2Link(href: href, type: "image/png", rel: "http://opds-spec.org/image/thumbnail")]
+        }
+        return OPDS2Publication(
+            links: [OPDS2Link(href: "https://example.com/\(id)/catalog", rel: "http://opds-spec.org/catalog")],
+            metadata: OPDS2Publication.Metadata(
+                updated: updated,
+                description: nil,
+                id: id,
+                title: title
+            ),
+            images: images
+        )
+    }
+
+    // MARK: - Merge: Incremental (isFullCrawl = false)
+
+    func testMerge_EmptyExistingWithNewPublications_AddsAll() {
+        let updates = [makePub(id: "a"), makePub(id: "b")]
+        let result = LibraryCatalogMerger.merge(existing: [], updates: updates, isFullCrawl: false)
+
+        XCTAssertEqual(result.publications.count, 2)
+        XCTAssertEqual(Set(result.publications.map(\.metadata.id)), Set(["a", "b"]))
+    }
+
+    func testMerge_UpdatesExistingByID_ReplacesOldPublication() {
+        let existing = [makePub(id: "a", title: "Old Name")]
+        let updates = [makePub(id: "a", title: "New Name")]
+
+        let result = LibraryCatalogMerger.merge(existing: existing, updates: updates, isFullCrawl: false)
+
+        XCTAssertEqual(result.publications.count, 1)
+        XCTAssertEqual(result.publications.first?.metadata.title, "New Name")
+    }
+
+    func testMerge_NewPublication_AppendsToList() {
+        let existing = [makePub(id: "a")]
+        let updates = [makePub(id: "b")]
+
+        let result = LibraryCatalogMerger.merge(existing: existing, updates: updates, isFullCrawl: false)
+
+        XCTAssertEqual(result.publications.count, 2)
+        let ids = Set(result.publications.map(\.metadata.id))
+        XCTAssertEqual(ids, Set(["a", "b"]))
+    }
+
+    func testMerge_PreservesUnmodifiedPublications_InIncrementalMode() {
+        let existing = [makePub(id: "a"), makePub(id: "b"), makePub(id: "c")]
+        let updates = [makePub(id: "b", title: "Updated B")]
+
+        let result = LibraryCatalogMerger.merge(existing: existing, updates: updates, isFullCrawl: false)
+
+        XCTAssertEqual(result.publications.count, 3)
+        let bPub = result.publications.first { $0.metadata.id == "b" }
+        XCTAssertEqual(bPub?.metadata.title, "Updated B")
+    }
+
+    // MARK: - Merge: Full Crawl (isFullCrawl = true)
+
+    func testMerge_FullCrawl_RemovesAbsentPublications() {
+        let existing = [makePub(id: "a"), makePub(id: "b"), makePub(id: "c")]
+        let updates = [makePub(id: "a"), makePub(id: "c")]
+
+        let result = LibraryCatalogMerger.merge(existing: existing, updates: updates, isFullCrawl: true)
+
+        XCTAssertEqual(result.publications.count, 2)
+        let ids = Set(result.publications.map(\.metadata.id))
+        XCTAssertEqual(ids, Set(["a", "c"]))
+    }
+
+    func testMerge_FullCrawl_ReplacesAllWithUpdates() {
+        let existing = [makePub(id: "a", title: "Old")]
+        let updates = [makePub(id: "a", title: "New"), makePub(id: "d")]
+
+        let result = LibraryCatalogMerger.merge(existing: existing, updates: updates, isFullCrawl: true)
+
+        XCTAssertEqual(result.publications.count, 2)
+        let aPub = result.publications.first { $0.metadata.id == "a" }
+        XCTAssertEqual(aPub?.metadata.title, "New")
+    }
+
+    // MARK: - Logo Change Detection
+
+    func testMerge_DetectsChangedLogoURL_ReturnsChangedUUIDs() {
+        let existing = [makePub(id: "a", thumbnailHref: "https://old.com/logo.png")]
+        let updates = [makePub(id: "a", thumbnailHref: "https://new.com/logo.png")]
+
+        let result = LibraryCatalogMerger.merge(existing: existing, updates: updates, isFullCrawl: false)
+
+        XCTAssertTrue(result.uuidsWithChangedLogos.contains("a"))
+    }
+
+    func testMerge_UnchangedLogoURL_NotInChangedSet() {
+        let existing = [makePub(id: "a", thumbnailHref: "https://same.com/logo.png")]
+        let updates = [makePub(id: "a", thumbnailHref: "https://same.com/logo.png")]
+
+        let result = LibraryCatalogMerger.merge(existing: existing, updates: updates, isFullCrawl: false)
+
+        XCTAssertFalse(result.uuidsWithChangedLogos.contains("a"))
+    }
+
+    func testMerge_NewPublication_InChangedSet() {
+        let existing: [OPDS2Publication] = []
+        let updates = [makePub(id: "new-lib", thumbnailHref: "https://new.com/logo.png")]
+
+        let result = LibraryCatalogMerger.merge(existing: existing, updates: updates, isFullCrawl: false)
+
+        XCTAssertTrue(result.uuidsWithChangedLogos.contains("new-lib"))
+    }
+
+    func testMerge_LogoAddedWhereNoneBefore_InChangedSet() {
+        let existing = [makePub(id: "a", thumbnailHref: nil)]
+        let updates = [makePub(id: "a", thumbnailHref: "https://new.com/logo.png")]
+
+        let result = LibraryCatalogMerger.merge(existing: existing, updates: updates, isFullCrawl: false)
+
+        XCTAssertTrue(result.uuidsWithChangedLogos.contains("a"))
+    }
+
+    func testMerge_LogoRemovedFromExisting_InChangedSet() {
+        let existing = [makePub(id: "a", thumbnailHref: "https://old.com/logo.png")]
+        let updates = [makePub(id: "a", thumbnailHref: nil)]
+
+        let result = LibraryCatalogMerger.merge(existing: existing, updates: updates, isFullCrawl: false)
+
+        XCTAssertTrue(result.uuidsWithChangedLogos.contains("a"))
+    }
+
+    // MARK: - Serialization
+
+    func testSerializeAsCatalogsFeed_ProducesValidJSON() throws {
+        let pubs = [makePub(id: "a"), makePub(id: "b")]
+        let metadata = OPDS2CatalogsFeed.Metadata(adobe_vendor_id: "TestVendor", title: "Test Registry")
+
+        let data = try XCTUnwrap(
+            LibraryCatalogMerger.serializeAsCatalogsFeed(publications: pubs, metadata: metadata)
+        )
+
+        let feed = try OPDS2CatalogsFeed.fromData(data)
+        XCTAssertEqual(feed.catalogs.count, 2)
+        XCTAssertEqual(feed.metadata.title, "Test Registry")
+        XCTAssertEqual(feed.metadata.adobe_vendor_id, "TestVendor")
+    }
+
+    func testSerializeAsCatalogsFeed_PreservesPublicationIDs() throws {
+        let pubs = [makePub(id: "uuid-1"), makePub(id: "uuid-2")]
+        let metadata = OPDS2CatalogsFeed.Metadata(adobe_vendor_id: nil, title: "Registry")
+
+        let data = try XCTUnwrap(
+            LibraryCatalogMerger.serializeAsCatalogsFeed(publications: pubs, metadata: metadata)
+        )
+
+        let feed = try OPDS2CatalogsFeed.fromData(data)
+        let ids = Set(feed.catalogs.map(\.metadata.id))
+        XCTAssertEqual(ids, Set(["uuid-1", "uuid-2"]))
+    }
+}

--- a/PalaceTests/Crawl/LibraryRegistryCrawlerTests.swift
+++ b/PalaceTests/Crawl/LibraryRegistryCrawlerTests.swift
@@ -1,0 +1,422 @@
+import XCTest
+@testable import Palace
+
+// MARK: - Mock Network Fetcher
+
+private final class MockCrawlerFetcher: CrawlerNetworkFetching {
+    var responses: [URL: Result<Data, Error>] = [:]
+    var fetchedURLs: [URL] = []
+    var mockResponse: HTTPURLResponse?
+
+    func fetchData(from url: URL) async throws -> (Data, HTTPURLResponse?) {
+        fetchedURLs.append(url)
+        guard let result = responses[url] else {
+            throw URLError(.fileDoesNotExist)
+        }
+        switch result {
+        case .success(let data): return (data, mockResponse)
+        case .failure(let error): throw error
+        }
+    }
+}
+
+// MARK: - Mock Delegate
+
+private final class MockCrawlerDelegate: LibraryRegistryCrawlerDelegate {
+    var progressUpdates: [CrawlProgress] = []
+
+    func crawler(_ crawler: LibraryRegistryCrawler, didUpdateProgress progress: CrawlProgress) {
+        progressUpdates.append(progress)
+    }
+}
+
+// MARK: - Tests
+
+final class LibraryRegistryCrawlerTests: XCTestCase {
+
+    private var fetcher: MockCrawlerFetcher!
+    private var delegate: MockCrawlerDelegate!
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        fetcher = MockCrawlerFetcher()
+        delegate = MockCrawlerDelegate()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crawl_tests_\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeCrawler() -> LibraryRegistryCrawler {
+        let crawler = LibraryRegistryCrawler(
+            fetcher: fetcher,
+            hash: "test_hash",
+            stateDirectory: tempDir
+        )
+        crawler.delegate = delegate
+        return crawler
+    }
+
+    private func makeFeedJSON(
+        publications: [[String: Any]],
+        nextURL: String? = nil,
+        facets: [[String: Any]]? = nil,
+        numberOfItems: Int? = nil
+    ) -> Data {
+        var feed: [String: Any] = [
+            "metadata": [
+                "title": "Test Registry",
+                "numberOfItems": numberOfItems as Any
+            ].compactMapValues { $0 },
+            "catalogs": publications
+        ]
+
+        var links: [[String: Any]] = [
+            ["href": "https://registry.example.com/libraries/crawlable", "rel": "self"]
+        ]
+        if let next = nextURL {
+            links.append(["href": next, "rel": "next"])
+        }
+        feed["links"] = links
+
+        if let facets = facets {
+            feed["facets"] = facets
+        }
+
+        return try! JSONSerialization.data(withJSONObject: feed)
+    }
+
+    private func makePublicationJSON(id: String, title: String = "Library", updated: String? = nil) -> [String: Any] {
+        var metadata: [String: Any] = ["id": id, "title": title]
+        if let updated = updated {
+            metadata["updated"] = updated
+        }
+        return [
+            "metadata": metadata,
+            "links": [["href": "https://example.com/\(id)/catalog", "rel": "http://opds-spec.org/catalog"]]
+        ]
+    }
+
+    private func makeSortFacet(modifiedHref: String, modifiedActive: Bool) -> [String: Any] {
+        [
+            "metadata": [
+                "title": "Sort By",
+                "type": CrawlableFeedAnalysis.sortFacetTypeURI
+            ],
+            "links": [
+                [
+                    "href": modifiedHref,
+                    "title": "Modified",
+                    "rel": modifiedActive ? "self" : NSNull()
+                ].compactMapValues { $0 is NSNull ? nil : $0 },
+                [
+                    "href": "https://example.com/crawlable?order=name",
+                    "title": "Name"
+                ]
+            ]
+        ]
+    }
+
+    private func makeCatalogMetadata() -> OPDS2CatalogsFeed.Metadata {
+        OPDS2CatalogsFeed.Metadata(adobe_vendor_id: nil, title: "Registry")
+    }
+
+    // MARK: - Full Crawl Tests
+
+    func testFirstLaunch_PerformsFullCrawl_SinglePage() async {
+        let baseURL = URL(string: "https://registry.example.com/libraries")!
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+
+        let sortFacet = makeSortFacet(
+            modifiedHref: "https://registry.example.com/libraries/crawlable?order=modified",
+            modifiedActive: true
+        )
+
+        let page1 = makeFeedJSON(
+            publications: [
+                makePublicationJSON(id: "lib-1", updated: "2026-04-15T10:00:00Z"),
+                makePublicationJSON(id: "lib-2", updated: "2026-04-14T10:00:00Z"),
+            ],
+            facets: [sortFacet]
+        )
+
+        fetcher.responses[crawlableURL] = .success(page1)
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(
+            baseURL: baseURL,
+            existingPublications: [],
+            feedMetadata: makeCatalogMetadata()
+        )
+
+        guard case .success(let data) = result else {
+            XCTFail("Expected success, got \(result)")
+            return
+        }
+
+        let feed = try! OPDS2CatalogsFeed.fromData(data)
+        XCTAssertEqual(feed.catalogs.count, 2)
+    }
+
+    func testFirstLaunch_PerformsFullCrawl_PaginatesAllPages() async {
+        let baseURL = URL(string: "https://registry.example.com/libraries")!
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        let page2URL = URL(string: "https://registry.example.com/libraries/crawlable?offset=2")!
+
+        let sortFacet = makeSortFacet(
+            modifiedHref: "https://registry.example.com/libraries/crawlable?order=modified",
+            modifiedActive: true
+        )
+
+        let page1 = makeFeedJSON(
+            publications: [
+                makePublicationJSON(id: "lib-1", updated: "2026-04-15T10:00:00Z"),
+            ],
+            nextURL: page2URL.absoluteString,
+            facets: [sortFacet],
+            numberOfItems: 2
+        )
+
+        let page2 = makeFeedJSON(
+            publications: [
+                makePublicationJSON(id: "lib-2", updated: "2026-04-14T10:00:00Z"),
+            ],
+            facets: [sortFacet]
+        )
+
+        fetcher.responses[crawlableURL] = .success(page1)
+        fetcher.responses[page2URL] = .success(page2)
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(
+            baseURL: baseURL,
+            existingPublications: [],
+            feedMetadata: makeCatalogMetadata()
+        )
+
+        guard case .success(let data) = result else {
+            XCTFail("Expected success")
+            return
+        }
+
+        let feed = try! OPDS2CatalogsFeed.fromData(data)
+        XCTAssertEqual(feed.catalogs.count, 2)
+        XCTAssertEqual(fetcher.fetchedURLs.count, 2)
+    }
+
+    // MARK: - Incremental Crawl Tests
+
+    func testIncrementalCrawl_StopsAtLastCrawlTimestamp() async {
+        let baseURL = URL(string: "https://registry.example.com/libraries")!
+        let facetURL = URL(string: "https://registry.example.com/libraries/crawlable?order=modified")!
+
+        // Pre-seed crawl state
+        let state = CrawlState(
+            lastSuccessfulCrawlDate: Date(timeIntervalSince1970: 1713160000), // April 15, 2024 ~06:00 UTC
+            orderModifiedFacetURL: facetURL,
+            lastFullCrawlDate: Date(timeIntervalSince1970: 1713160000)
+        )
+        let stateData = try! JSONEncoder().encode(state)
+        try! stateData.write(to: tempDir.appendingPathComponent("crawl_state_test_hash.json"))
+
+        let sortFacet = makeSortFacet(
+            modifiedHref: facetURL.absoluteString,
+            modifiedActive: true
+        )
+
+        let page = makeFeedJSON(
+            publications: [
+                makePublicationJSON(id: "lib-new", updated: "2026-04-15T12:00:00Z"),
+                makePublicationJSON(id: "lib-old", updated: "2024-04-14T06:00:00Z"), // older than last crawl
+            ],
+            facets: [sortFacet]
+        )
+
+        fetcher.responses[facetURL] = .success(page)
+
+        let existingPubs = [
+            OPDS2Publication(
+                links: [],
+                metadata: OPDS2Publication.Metadata(id: "lib-existing", title: "Existing"),
+                images: nil
+            )
+        ]
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(
+            baseURL: baseURL,
+            existingPublications: existingPubs,
+            feedMetadata: makeCatalogMetadata()
+        )
+
+        guard case .success(let data) = result else {
+            XCTFail("Expected success")
+            return
+        }
+
+        let feed = try! OPDS2CatalogsFeed.fromData(data)
+        // Should have: lib-new (new), lib-existing (preserved), but NOT lib-old (filtered out)
+        let ids = Set(feed.catalogs.map(\.metadata.id))
+        XCTAssertTrue(ids.contains("lib-new"))
+        XCTAssertTrue(ids.contains("lib-existing"))
+    }
+
+    // MARK: - No order=modified Facet
+
+    func testFullCrawl_WhenNoOrderModifiedFacet_FetchesAllPages() async {
+        let baseURL = URL(string: "https://registry.example.com/libraries")!
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+
+        // Feed with no sort facet
+        let page = makeFeedJSON(
+            publications: [
+                makePublicationJSON(id: "lib-1"),
+                makePublicationJSON(id: "lib-2"),
+            ]
+        )
+
+        fetcher.responses[crawlableURL] = .success(page)
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(
+            baseURL: baseURL,
+            existingPublications: [],
+            feedMetadata: makeCatalogMetadata()
+        )
+
+        guard case .success(let data) = result else {
+            XCTFail("Expected success")
+            return
+        }
+
+        let feed = try! OPDS2CatalogsFeed.fromData(data)
+        XCTAssertEqual(feed.catalogs.count, 2)
+    }
+
+    // MARK: - CrawlState Persistence
+
+    func testCrawl_SavesCrawlState_OnSuccess() async {
+        let baseURL = URL(string: "https://registry.example.com/libraries")!
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        let modifiedURL = "https://registry.example.com/libraries/crawlable?order=modified"
+
+        let sortFacet = makeSortFacet(modifiedHref: modifiedURL, modifiedActive: true)
+        let page = makeFeedJSON(
+            publications: [makePublicationJSON(id: "lib-1", updated: "2026-04-15T10:00:00Z")],
+            facets: [sortFacet]
+        )
+
+        fetcher.responses[crawlableURL] = .success(page)
+
+        let crawler = makeCrawler()
+        _ = await crawler.crawl(
+            baseURL: baseURL,
+            existingPublications: [],
+            feedMetadata: makeCatalogMetadata()
+        )
+
+        let stateURL = tempDir.appendingPathComponent("crawl_state_test_hash.json")
+        let stateData = try! Data(contentsOf: stateURL)
+        let state = try! JSONDecoder().decode(CrawlState.self, from: stateData)
+
+        XCTAssertNotNil(state.lastSuccessfulCrawlDate)
+        XCTAssertEqual(state.orderModifiedFacetURL, URL(string: modifiedURL))
+    }
+
+    // MARK: - Network Failure
+
+    func testCrawl_HandlesNetworkFailure_ReturnsFailure() async {
+        let baseURL = URL(string: "https://registry.example.com/libraries")!
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+
+        fetcher.responses[crawlableURL] = .failure(URLError(.notConnectedToInternet))
+
+        let crawler = makeCrawler()
+        let result = await crawler.crawl(
+            baseURL: baseURL,
+            existingPublications: [],
+            feedMetadata: makeCatalogMetadata()
+        )
+
+        guard case .failure = result else {
+            XCTFail("Expected failure")
+            return
+        }
+    }
+
+    // MARK: - Progress Reporting
+
+    func testCrawl_ReportsProgress() async {
+        let baseURL = URL(string: "https://registry.example.com/libraries")!
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        let page2URL = URL(string: "https://registry.example.com/libraries/crawlable?offset=1")!
+
+        let sortFacet = makeSortFacet(
+            modifiedHref: "https://example.com/crawlable?order=modified",
+            modifiedActive: true
+        )
+
+        let page1 = makeFeedJSON(
+            publications: [makePublicationJSON(id: "lib-1", updated: "2026-04-15T10:00:00Z")],
+            nextURL: page2URL.absoluteString,
+            facets: [sortFacet],
+            numberOfItems: 2
+        )
+
+        let page2 = makeFeedJSON(
+            publications: [makePublicationJSON(id: "lib-2", updated: "2026-04-14T10:00:00Z")],
+            facets: [sortFacet]
+        )
+
+        fetcher.responses[crawlableURL] = .success(page1)
+        fetcher.responses[page2URL] = .success(page2)
+
+        let crawler = makeCrawler()
+        _ = await crawler.crawl(
+            baseURL: baseURL,
+            existingPublications: [],
+            feedMetadata: makeCatalogMetadata()
+        )
+
+        XCTAssertGreaterThanOrEqual(delegate.progressUpdates.count, 2)
+        XCTAssertEqual(delegate.progressUpdates.first?.pagesProcessed, 1)
+    }
+
+    // MARK: - Facet Detection and Storage
+
+    func testCrawl_WhenFacetNotActive_StoresFacetURLForFutureUse() async {
+        let baseURL = URL(string: "https://registry.example.com/libraries")!
+        let crawlableURL = URL(string: "https://registry.example.com/libraries/crawlable")!
+        let modifiedURL = "https://registry.example.com/libraries/crawlable?order=modified"
+
+        // Facet present but NOT active (name is active)
+        let sortFacet = makeSortFacet(modifiedHref: modifiedURL, modifiedActive: false)
+        let page = makeFeedJSON(
+            publications: [makePublicationJSON(id: "lib-1")],
+            facets: [sortFacet]
+        )
+
+        fetcher.responses[crawlableURL] = .success(page)
+
+        let crawler = makeCrawler()
+        _ = await crawler.crawl(
+            baseURL: baseURL,
+            existingPublications: [],
+            feedMetadata: makeCatalogMetadata()
+        )
+
+        // Should have stored the facet URL even though it wasn't active
+        let stateURL = tempDir.appendingPathComponent("crawl_state_test_hash.json")
+        let stateData = try! Data(contentsOf: stateURL)
+        let state = try! JSONDecoder().decode(CrawlState.self, from: stateData)
+
+        XCTAssertEqual(state.orderModifiedFacetURL, URL(string: modifiedURL))
+    }
+}

--- a/PalaceTests/Crawl/LiveCrawlableParsingTest.swift
+++ b/PalaceTests/Crawl/LiveCrawlableParsingTest.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import Palace
+
+/// Integration test that fetches the live crawlable endpoint and verifies parsing.
+/// Requires network access — skipped in CI (set SKIP_NETWORK_TESTS=1 to skip).
+final class LiveCrawlableParsingTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        if ProcessInfo.processInfo.environment["SKIP_NETWORK_TESTS"] == "1" {
+            throw XCTSkip("Skipping network-dependent test in CI")
+        }
+    }
+
+    func testParseLiveCrawlableFeed() async throws {
+        let url = URL(string: "https://registry.palaceproject.io/libraries/crawlable?size=20")!
+        let (data, _) = try await URLSession.shared.data(from: url)
+
+        // Verify it parses with our decoder
+        let feed = try OPDS2CatalogsFeed.fromData(data)
+
+        XCTAssertGreaterThan(feed.catalogs.count, 0, "Should have catalogs")
+        XCTAssertFalse(feed.links.isEmpty, "Should have links")
+
+        // Check next page URL
+        let nextURL = feed.nextPageURL
+        XCTAssertNotNil(nextURL, "Should have a next page link for paginated feed")
+
+        // Check facets
+        XCTAssertNotNil(feed.facets, "Should have facets")
+
+        // Check sort facet detection
+        let modifiedURL = CrawlableFeedAnalysis.orderModifiedFacetURL(from: feed)
+        XCTAssertNotNil(modifiedURL, "Should find the order=modified facet URL")
+
+        let isActive = CrawlableFeedAnalysis.isOrderModifiedActive(in: feed)
+        XCTAssertTrue(isActive, "order=modified should be the default active sort")
+
+        // Check first catalog has expected fields
+        let first = feed.catalogs[0]
+        XCTAssertFalse(first.metadata.id.isEmpty)
+        XCTAssertFalse(first.metadata.title.isEmpty)
+    }
+
+    func testCrawlableURL_FromBetaURL() {
+        let beta = URL(string: "https://registry.palaceproject.io/libraries/qa")!
+        let crawlable = LibraryRegistryCrawler.crawlableURL(from: beta)
+        XCTAssertEqual(crawlable.path, "/libraries/crawlable")
+        XCTAssertTrue(
+            crawlable.absoluteString.contains("availability=all"),
+            "Beta URL should include availability=all, got: \(crawlable)"
+        )
+    }
+
+    func testCrawlableURL_FromProdURL() {
+        let prod = URL(string: "https://registry.palaceproject.io/libraries")!
+        let crawlable = LibraryRegistryCrawler.crawlableURL(from: prod)
+        XCTAssertEqual(crawlable.absoluteString, "https://registry.palaceproject.io/libraries/crawlable")
+    }
+
+    /// End-to-end: crawl the live registry with a real network call
+    func testFullCrawl_LiveEndpoint() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("live_crawl_test_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Use a direct URLSession fetcher (not TPPNetworkExecutor)
+        let fetcher = DirectURLSessionFetcher()
+        let crawler = LibraryRegistryCrawler(
+            fetcher: fetcher,
+            hash: "live_test",
+            stateDirectory: tempDir
+        )
+
+        let baseURL = URL(string: "https://registry.palaceproject.io/libraries")!
+        let result = await crawler.crawl(
+            baseURL: baseURL,
+            existingPublications: [],
+            feedMetadata: nil
+        )
+
+        switch result {
+        case .success(let data):
+            let feed = try OPDS2CatalogsFeed.fromData(data)
+            XCTAssertGreaterThan(feed.catalogs.count, 100, "Full crawl should fetch all libraries (>100)")
+
+            // Verify crawl state was saved
+            let stateURL = tempDir.appendingPathComponent("crawl_state_live_test.json")
+            let stateData = try Data(contentsOf: stateURL)
+            let state = try JSONDecoder().decode(CrawlState.self, from: stateData)
+            XCTAssertNotNil(state.lastSuccessfulCrawlDate)
+            XCTAssertNotNil(state.orderModifiedFacetURL)
+            XCTAssertNotNil(state.lastFullCrawlDate, "Full crawl should set lastFullCrawlDate")
+
+        case .noChanges:
+            XCTFail("First crawl should not return noChanges")
+        case .failure(let error):
+            XCTFail("Live crawl failed: \(error)")
+        }
+    }
+}
+
+/// Simple fetcher using URLSession directly — avoids TPPNetworkExecutor complexity
+private struct DirectURLSessionFetcher: CrawlerNetworkFetching {
+    func fetchData(from url: URL) async throws -> (Data, HTTPURLResponse?) {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        return (data, response as? HTTPURLResponse)
+    }
+}

--- a/PalaceTests/Mocks/MockImageCache.swift
+++ b/PalaceTests/Mocks/MockImageCache.swift
@@ -30,6 +30,10 @@ public final class MockImageCache: ImageCacheType {
         return store[key]
     }
 
+    public func getAsync(for key: String) async -> UIImage? {
+        return get(for: key)
+    }
+
     public func remove(for key: String) {
         store.removeValue(forKey: key)
         expirations.removeValue(forKey: key)


### PR DESCRIPTION
## Summary

- **Incremental library registry crawling** via the paginated `/libraries/crawlable` endpoint with `order=modified` sort facet — only fetches recently-changed libraries on background refresh
- **First-page fast path** — displays 20 libraries in ~260ms (35KB) instead of waiting for the full 1.8MB monolithic feed
- **Parallel page fetching** — full crawls complete in ~1.5s instead of 5s (TaskGroup with max 4 concurrent)
- **Dynamic stale TTL** — respects server's `Cache-Control: max-age=43200` (6hr stale TTL vs previous 5min), eliminates ~140 pointless background refreshes per day
- **Logo cache invalidation** — detects thumbnail URL changes during merge and evicts stale cached images
- **Catalog preloading** — preloads catalog feeds for current + recently-used accounts after crawl
- **Graceful fallback chain** — crawler failure → direct GET to `/libraries` → expired disk cache → error
- **clearCache() fix** — now properly glob-deletes all cache files (was using exact filenames that didn't match actual hashed filenames)

## New files (5 production + 7 test)

| File | Purpose |
|------|---------|
| `CrawlState.swift` | Persistent crawl tracking (last date, facet URL, server max-age) |
| `CrawlableFeedAnalysis.swift` | Facet detection, pagination stop conditions |
| `LibraryCatalogMerger.swift` | Merge logic with logo change tracking |
| `LibraryRegistryCrawler.swift` | Paginated crawler with first-page fast path + parallel fetch |
| `CatalogPreloader.swift` | Preloads catalog feeds for active accounts |

## Test plan

- [x] 122 unit tests passing (67 new), 0 failures
- [x] CrawlerFallbackTests: 11 tests covering every failure mode (network error, malformed JSON, corrupt state, partial parallel failure, empty feed)
- [x] LiveCrawlableParsingTest: 4 tests against production registry endpoint (skippable via `SKIP_NETWORK_TESTS=1`)
- [x] All existing tests pass: AccountsManagerTests (52), OPDS2CatalogsFeedTests (3), AccountModelTests (16)
- [x] E2E verified via SpecterQA: app launch, tab navigation, catalog browsing + filter switching — 0 crashes, 0 errors, perf OK
- [x] Backward compatible: no OPDS 1.x changes, all new Codable fields are optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### PP-4020 Traceability
- **Jira:** [PP-4111](https://ebce-lyrasis.atlassian.net/browse/PP-4111)
- **Report:** [Performance](https://thepalaceproject.github.io/regression-reports/PP-4020/index.html#performance)
- **Findings:** 66% memory reduction, incremental registry crawl

[PP-4111]: https://ebce-lyrasis.atlassian.net/browse/PP-4111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ