### PR TITLE
Fix empty device ID breaking cross-device bookmark sync

### DIFF
--- a/Palace/AppInfrastructure/ReaderService.swift
+++ b/Palace/AppInfrastructure/ReaderService.swift
@@ -186,8 +186,8 @@ final class ReaderService {
         // Samples don't need sync since they have no persisted position.
         if !forSample {
             let synchronizer = TPPLastReadPositionSynchronizer(bookRegistry: bookRegistry)
-            let drmDeviceID = TPPUserAccount.sharedAccount().deviceID
-            await synchronizer.sync(for: publication, book: book, drmDeviceID: drmDeviceID)
+            let deviceID = AnnotationDevice.currentID()
+            await synchronizer.sync(for: publication, book: book, drmDeviceID: deviceID)
         }
 
         // Re-read location after sync — it may have been updated if user chose "Move"

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -6,6 +6,25 @@ public struct AnnotationResponse {
     var timeStamp: String?
 }
 
+/// Provides a stable device identifier for annotation sync.
+///
+/// Prefers the Adobe DRM device ID (set during device activation) for
+/// backwards compatibility with existing annotations. Falls back to the
+/// Firebase-managed device ID (persisted in UserDefaults) so that
+/// non-DRM users still get working cross-device sync detection.
+///
+/// - Important: Prior to this fix, non-Adobe-DRM users sent an empty
+///   string, which made cross-device sync prompts impossible because
+///   both devices appeared to be the same device.
+enum AnnotationDevice {
+    static func currentID() -> String {
+        if let adobeID = TPPUserAccount.sharedAccount().deviceID, !adobeID.isEmpty {
+            return adobeID
+        }
+        return "urn:uuid:\(FirebaseManager.shared.deviceID)"
+    }
+}
+
 protocol AnnotationsManager {
     var syncIsPossibleAndPermitted: Bool { get }
     func postListeningPosition(forBook bookID: String, selectorValue: String, completion: ((_ response: AnnotationResponse?) -> Void)?)
@@ -131,7 +150,7 @@ protocol AnnotationsManager {
 
         // Format bookmark for submission to server according to spec
         let bookmark = TPPBookmarkSpec(time: NSDate(),
-                                       device: TPPUserAccount.sharedAccount().deviceID ?? "",
+                                       device: AnnotationDevice.currentID(),
                                        motivation: motivation,
                                        bookID: bookID,
                                        selectorValue: selectorValue)
@@ -175,7 +194,7 @@ protocol AnnotationsManager {
 
         let spec = TPPBookmarkSpec(
             time: NSDate(),
-            device: TPPUserAccount.sharedAccount().deviceID ?? "",
+            device: AnnotationDevice.currentID(),
             motivation: .bookmark,
             bookID: bookID,
             selectorValue: selectorValue

--- a/Palace/Reader2/UI/TPPBaseReaderViewController.swift
+++ b/Palace/Reader2/UI/TPPBaseReaderViewController.swift
@@ -96,7 +96,7 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
         bookmarksBusinessLogic = TPPReaderBookmarksBusinessLogic(
             book: book,
             r2Publication: publication,
-            drmDeviceID: TPPUserAccount.sharedAccount().deviceID,
+            drmDeviceID: AnnotationDevice.currentID(),
             bookRegistryProvider: bookRegistry,
             currentLibraryAccountProvider: accountsManager)
 

--- a/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
+++ b/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
@@ -1397,3 +1397,48 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         XCTAssertEqual(url.lastPathComponent, "annotations")
     }
 }
+
+// MARK: - AnnotationDevice.currentID() Tests
+
+/// Tests for F-079 fix: annotation device ID must never be empty.
+/// Prior to this fix, non-Adobe-DRM users sent device="" which broke
+/// cross-device sync detection (the "sync to furthest position?" prompt).
+///
+/// Discovery: PP-4020 regression sprint — API-level sync test revealed
+/// 23 annotations on the server with empty device IDs, all from non-DRM
+/// devices. Cross-referenced TPPAnnotations.swift and found the fallback
+/// to TPPUserAccount.deviceID (Adobe-only) with ?? "" default.
+class AnnotationDeviceIDTests: XCTestCase {
+
+    func testAnnotationDeviceID_WhenNoAdobeDRM_ReturnsFirebaseDeviceID() {
+        // Non-Adobe-DRM users have nil deviceID on TPPUserAccount.
+        // The function must still return a non-empty urn:uuid: identifier
+        // from FirebaseManager so cross-device sync detection works.
+        let deviceID = AnnotationDevice.currentID()
+
+        XCTAssertFalse(deviceID.isEmpty,
+                       "Device ID must never be empty — empty strings break cross-device sync detection")
+        XCTAssertTrue(deviceID.hasPrefix("urn:uuid:"),
+                      "Device ID must use urn:uuid: format to match W3C Annotation convention. Got: \(deviceID)")
+    }
+
+    func testAnnotationDeviceID_IsStableAcrossCalls() {
+        // The device ID must be the same value every time — if it changed
+        // between calls, the sync comparison would never match "same device"
+        let first = AnnotationDevice.currentID()
+        let second = AnnotationDevice.currentID()
+
+        XCTAssertEqual(first, second,
+                       "Device ID must be stable across calls — unstable IDs break same-device detection")
+    }
+
+    func testAnnotationDeviceID_MatchesFirebaseManagerFormat() {
+        // Verify the returned ID contains the FirebaseManager UUID
+        // (since we're in a test environment without Adobe DRM)
+        let deviceID = AnnotationDevice.currentID()
+        let firebaseID = FirebaseManager.shared.deviceID
+
+        XCTAssertTrue(deviceID.contains(firebaseID),
+                      "Without Adobe DRM, annotation device ID should contain the Firebase device UUID")
+    }
+}


### PR DESCRIPTION
## Summary

- Non-Adobe-DRM users (LCP, Findaway, open-access) had annotation device field set to empty string, breaking cross-device sync detection
- The "sync to furthest position?" prompt never triggered for these users because both devices appeared identical
- Adds `AnnotationDevice.currentID()` which falls back to `FirebaseManager.shared.deviceID` when Adobe DRM ID is unavailable

## How this was found

During PP-4020 regression testing (session 8, 2026-04-15), we built an automated API-level sync test (`scripts/test-sync.sh`) to verify cross-device bookmark and reading position sync for the P1-P5 test area. The script POST/GET/DELETE annotations against the A1QA staging server (`gorgon.staging.palaceproject.io/a1qa-test/annotations/`).

The 17 API tests all passed — proving the server-side sync works. But when we verified the real data on the server (at the user's request, to check whether 1.2.8 position sync was actually working), we found:

- **255 total annotations** on the A1QA account across 25 device IDs
- **23 annotations with `device=""`** (empty string) — all from non-DRM test sessions (April 2-13)
- **232 annotations with proper `urn:uuid:` device IDs** — only from devices with Adobe DRM activated

Tracing the empty device IDs to `TPPAnnotations.swift:134`:
```swift
device: TPPUserAccount.sharedAccount().deviceID ?? ""
```
`TPPUserAccount.deviceID` is only populated during Adobe RMSDK device activation (`TPPSignInBusinessLogic+DRM.swift:162`). For LCP, Findaway, and open-access content — which is most of the modern A1QA library — it's always `nil`.

The empty device ID breaks `TPPLastReadPositionSynchronizer.swift:85`:
```swift
if (deviceID == drmDeviceID && localLocation != nil)
```
When both sides are empty strings, every server annotation appears to come from "this device," so the sync prompt never shows.

**Both 1.2.8 and 2.2.5 have this bug** — the code is identical. The reason some 2.2.5 devices appeared to work is that those specific devices happened to have Adobe DRM activated from earlier testing.

## Changes

| File | Change |
|------|--------|
| `TPPAnnotations.swift` | Add `AnnotationDevice.currentID()` — prefers Adobe DRM ID, falls back to `urn:uuid:{FirebaseManager.deviceID}` |
| `TPPAnnotations.swift` | Replace `TPPUserAccount.sharedAccount().deviceID ?? ""` with `AnnotationDevice.currentID()` (2 call sites) |
| `ReaderService.swift` | Use `AnnotationDevice.currentID()` for sync comparison (was `TPPUserAccount.deviceID`) |
| `TPPBaseReaderViewController.swift` | Use `AnnotationDevice.currentID()` for bookmark business logic (was `TPPUserAccount.deviceID`) |
| `TPPAnnotationsTests.swift` | 3 new tests: non-empty guarantee, stability, format validation |

## Test plan

- [x] `AnnotationDeviceIDTests` — 3 tests pass (non-empty, stable, urn:uuid: format)
- [ ] Manual: Open EPUB on Sim A → read to 40% → open same book on Sim B → verify "sync to furthest position?" prompt appears
- [ ] Manual: Create bookmark on Sim A → open same book on Sim B → verify bookmark appears in list
- [ ] Verify Adobe DRM users still get their existing device ID (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### PP-4020 Traceability
- **Jira:** [PP-4110](https://ebce-lyrasis.atlassian.net/browse/PP-4110)
- **Report:** [F-079 in PP-4020 Report](https://thepalaceproject.github.io/regression-reports/PP-4020/index.html#F-079)
- **Findings:** F-079 (empty device ID breaks bookmark sync)

[PP-4110]: https://ebce-lyrasis.atlassian.net/browse/PP-4110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ