### PR TITLE
Fix 3 PP-4020 regressions: nav title, sign-up context, login prompt

### DIFF
--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -82,6 +82,10 @@ struct CatalogCacheMetadata: Codable {
 
     let tppAccountUUID = AccountsManager.TPPAccountUUIDs[0]
 
+    /// True during an account switch — suppresses sign-in modal presentation
+    /// to prevent the intermittent login prompt (F-032).
+    private(set) var isAccountSwitching = false
+
     let ageCheck: TPPAgeCheckVerifying
     private let settings: TPPSettings
     private let networkExecutor: TPPNetworkExecutor
@@ -145,6 +149,7 @@ struct CatalogCacheMetadata: Codable {
 
             if previousAccountId != newAccountId, previousAccountId != nil {
                 Log.info(#file, "🔄 Account switch detected - cleaning up active content")
+                isAccountSwitching = true
                 cleanupActiveContentBeforeAccountSwitch(from: previousAccountId, to: newAccountId)
                 // Evict decoded cover images — the new library has different covers.
                 // Keeps compressed JPEG cache on disk for fast re-decode if user switches back.
@@ -154,6 +159,7 @@ struct CatalogCacheMetadata: Codable {
             self.currentAccount?.hasUpdatedToken = false
             currentAccountId = newValue?.uuid
             TPPErrorLogger.setUserID(self.currentUserAccount.barcode)
+            isAccountSwitching = false
             NotificationCenter.default.post(name: .TPPCurrentAccountDidChange, object: nil)
         }
     }

--- a/Palace/Settings/AccountDetailView.swift
+++ b/Palace/Settings/AccountDetailView.swift
@@ -32,6 +32,7 @@ struct AccountDetailView: View {
 
     var body: some View {
         contentView
+            .navigationTitle(DisplayStrings.account)
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.visible, for: .tabBar)
             .toolbarBackground(Color(UIColor.systemBackground), for: .tabBar)
@@ -82,6 +83,7 @@ struct AccountDetailView: View {
             signInMessageSection
             SectionSeparator()
             signInButtonSection
+            registrationLinkIfAvailable
             reportIssueLinkIfAvailable
             Spacer()
         }

--- a/Palace/SignInLogic/SignInModalView.swift
+++ b/Palace/SignInLogic/SignInModalView.swift
@@ -64,6 +64,10 @@ class SignInModalPresenter: NSObject {
             Log.debug(#file, "Sign-in modal already presented — suppressing duplicate")
             return
         }
+        guard !AccountsManager.shared.isAccountSwitching else {
+            Log.debug(#file, "Account switch in progress — suppressing sign-in modal (F-032)")
+            return
+        }
         isPresenting = true
 
         let view = SignInModalView(


### PR DESCRIPTION
## Summary

Fixes the 3 remaining regressions found during PP-4020 side-by-side regression testing (1.2.8 vs 2.2.5).

- **F-001** (minor): Restore "Account" navigation title on the account detail screen
- **F-002** (major): Restore the "Sign up for a library card" registration link in the sign-in prompt
- **F-032** (minor): Suppress sign-in modal during account switch to prevent intermittent login prompt

## Changes

| File | Change |
|------|--------|
| `AccountDetailView.swift` | Add `.navigationTitle(DisplayStrings.account)` — was dropped during SwiftUI migration |
| `AccountDetailView.swift` | Add `registrationLinkIfAvailable` to `signInPromptView` VStack — view was defined but never rendered |
| `AccountsManager.swift` | Add `isAccountSwitching` flag, set during account switch lifecycle |
| `SignInModalView.swift` | Guard `presentSignInModal` against `isAccountSwitching` to suppress spurious login prompts |

## How these were found

PP-4020 regression sprint (8 sessions, April 8-15 2026). Manual side-by-side comparison on physical devices (iPhone 13 Pro Max running 1.2.8 vs iPhone 17 Pro Max running 2.2.5). Full report: 73 findings across 40+ test areas.

## Test plan

- [ ] Account screen shows "Account" in the nav bar when navigating to a library (F-001)
- [ ] Signed-out account screen shows "Sign up for a library card" button below sign-in form for libraries that support registration (F-002)
- [ ] Switching between libraries does not flash a sign-in modal (F-032)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### PP-4020 Traceability
- **Jira:** [PP-4105](https://ebce-lyrasis.atlassian.net/browse/PP-4105), [PP-4106](https://ebce-lyrasis.atlassian.net/browse/PP-4106), [PP-4107](https://ebce-lyrasis.atlassian.net/browse/PP-4107)
- **Report:** [Regressions](https://thepalaceproject.github.io/regression-reports/PP-4020/index.html#regressions)
- **Findings:** F-001 (nav title), F-002 (sign-up context), F-032 (login prompt)

[PP-4105]: https://ebce-lyrasis.atlassian.net/browse/PP-4105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ