### PR TITLE
Use existing github action for doing jira release sync

### DIFF
--- a/.github/workflows/jira-release-sync.yml
+++ b/.github/workflows/jira-release-sync.yml
@@ -2,110 +2,20 @@ name: Jira Release Sync
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag to sync (e.g. 2.2.2)'
-        required: true
 jobs:
   sync-to-jira:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Resolve release info
-        id: release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-          EVENT_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          TAG="${INPUT_TAG:-$EVENT_TAG}"
-          RELEASE_JSON=$(gh release view "$TAG" --json tagName,url,body)
-          echo "tag=$(echo "$RELEASE_JSON" | jq -r .tagName)" >> "$GITHUB_OUTPUT"
-          echo "url=$(echo "$RELEASE_JSON" | jq -r .url)" >> "$GITHUB_OUTPUT"
-          {
-            echo "body<<EOFBODY"
-            echo "$RELEASE_JSON" | jq -r .body
-            echo "EOFBODY"
-          } >> "$GITHUB_OUTPUT"
+      - name: Sync release to Jira
+        uses: ./.github/actions/jira-release-sync
+        with:
+          jira-base-url: ${{ secrets.JIRA_BASE_URL }}
+          jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}
+          jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
 
-      - name: Create Jira version
-        id: create-version
-        env:
-          JIRA_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-          RELEASE_NAME: "iOS ${{ steps.release.outputs.tag }}"
-        run: |
-          echo "Creating Jira version: $RELEASE_NAME"
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
-            --url "${JIRA_URL}/rest/api/3/version" \
-            --user "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
-            --header 'Accept: application/json' \
-            --header 'Content-Type: application/json' \
-            --data "$(jq -n --arg name "$RELEASE_NAME" '{
-              name: $name,
-              description: "Release created from GitHub build.",
-              project: "PP",
-              released: false
-            }')")
-          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "HTTP status: $HTTP_CODE"
-          echo "Response: $BODY"
-          if [ "$HTTP_CODE" -ge 400 ]; then
-            echo "::error::Jira API returned HTTP $HTTP_CODE"
-            exit 1
-          fi
-
-      - name: Link GitHub release to Jira version
-        env:
-          JIRA_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-          RELEASE_NAME: "iOS ${{ steps.release.outputs.tag }}"
-          RELEASE_URL: ${{ steps.release.outputs.url }}
-        run: |
-          VERSION_ID=$(curl -s \
-            --user "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
-            --url "${JIRA_URL}/rest/api/3/project/PP/versions" \
-            | jq -r ".[] | select(.name == \"$RELEASE_NAME\") | .id")
-          echo "Version ID: $VERSION_ID"
-          curl -s --fail -X POST \
-            --url "${JIRA_URL}/rest/api/3/version/$VERSION_ID/relatedwork" \
-            --user "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
-            --header 'Accept: application/json' \
-            --header 'Content-Type: application/json' \
-            --data "$(jq -n --arg title "GitHub Release Notes" --arg url "$RELEASE_URL" '{
-              title: $title,
-              url: $url,
-              category: "release notes"
-            }')"
-
-      - name: Update fixVersions on linked tickets
-        env:
-          JIRA_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-          RELEASE_NAME: "iOS ${{ steps.release.outputs.tag }}"
-          RELEASE_BODY: ${{ steps.release.outputs.body }}
-        run: |
-          KEYS=$((echo "$RELEASE_BODY" | grep -oE "PP-[0-9]+" | sort -u) || echo "")
-          if [ -z "$KEYS" ]; then
-            echo "No Jira keys found in release body."
-            exit 0
-          fi
-          echo "Found tickets: $KEYS"
-          for KEY in $KEYS; do
-            echo "Updating fixVersion on $KEY..."
-            curl -s --fail -X PUT \
-              --url "${JIRA_URL}/rest/api/3/issue/$KEY" \
-              --user "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
-              --header 'Accept: application/json' \
-              --header 'Content-Type: application/json' \
-              --data "$(jq -n --arg name "$RELEASE_NAME" '{
-                update: { fixVersions: [{ add: { name: $name } }] }
-              }')" || echo "Warning: failed to update $KEY"
-          done
+          release-name: "CM ${{ github.event.release.tag_name }}"
+          release-url: ${{ github.event.release.html_url }}
+          release-body: ${{ github.event.release.body }}


### PR DESCRIPTION
**Use existing github action for doing jira release sync**
---

**What's this do?**
Replaces the existing jira release sync workflow contents with a reference to the plugin in ThePalaceProject/circulation.

**Why are we doing this? (w/ Notion link if applicable)**
Trying to reduce code duplication.

**How should this be tested? / Do these changes have associated tests?**
It should just work next time we do a release.
**Dependencies for merging? Releasing to production?**
N/A
**Does this include changes that require a new Palace build for QA?**
No
**Has the application documentation been updated for these changes?**
N/A
**Did someone actually run this code to verify it works?**
The action is being used by other repositories (such circulation-admin)