### PR TITLE
Unblock HoldsSyncFailureTests after hasCredentials-guard landing

### DIFF
--- a/PalaceTests/ViewModels/HoldsViewModelTests.swift
+++ b/PalaceTests/ViewModels/HoldsViewModelTests.swift
@@ -441,10 +441,20 @@ final class HoldsSyncFailureTests: XCTestCase {
         super.tearDown()
     }
 
+    /// All tests in this suite exercise the sign-in-required error-banner
+    /// path, which `HoldsViewModel.handleSyncFailure(_:)` guards behind
+    /// `hasCredentials()`. The default closure reads from
+    /// `AccountsManager.shared.currentUserAccount`, which is not populated
+    /// in the test harness, so inject `hasCredentials: { true }` to exercise
+    /// the authenticated-user branch under test.
+    private func makeSignedInViewModel() -> HoldsViewModel {
+        HoldsViewModel(bookRegistry: mockRegistry, hasCredentials: { true })
+    }
+
     // MARK: - Error State Tests
 
     func testSyncFailure_SetsSyncError() async {
-        let viewModel = HoldsViewModel(bookRegistry: mockRegistry)
+        let viewModel = makeSignedInViewModel()
         XCTAssertNil(viewModel.syncError, "No error initially")
 
         let errorExpectation = XCTestExpectation(description: "syncError is set")
@@ -462,7 +472,7 @@ final class HoldsSyncFailureTests: XCTestCase {
     }
 
     func testSyncFailure_WithProblemDocument_ShowsServerMessage() async {
-        let viewModel = HoldsViewModel(bookRegistry: mockRegistry)
+        let viewModel = makeSignedInViewModel()
 
         let errorExpectation = XCTestExpectation(description: "syncError is set with server detail")
         viewModel.$syncError
@@ -491,7 +501,7 @@ final class HoldsSyncFailureTests: XCTestCase {
     }
 
     func testSyncFailure_WithoutProblemDocument_ShowsGenericMessage() async {
-        let viewModel = HoldsViewModel(bookRegistry: mockRegistry)
+        let viewModel = makeSignedInViewModel()
 
         let errorExpectation = XCTestExpectation(description: "syncError is set")
         viewModel.$syncError
@@ -511,7 +521,7 @@ final class HoldsSyncFailureTests: XCTestCase {
     }
 
     func testSyncFailure_StopsLoading() async {
-        let viewModel = HoldsViewModel(bookRegistry: mockRegistry)
+        let viewModel = makeSignedInViewModel()
         viewModel.isLoading = true
 
         let errorExpectation = XCTestExpectation(description: "syncError is set")
@@ -530,7 +540,7 @@ final class HoldsSyncFailureTests: XCTestCase {
     // MARK: - Error Dismissal & Retry Tests
 
     func testSyncBegan_ClearsPreviousSyncError() async {
-        let viewModel = HoldsViewModel(bookRegistry: mockRegistry)
+        let viewModel = makeSignedInViewModel()
 
         // First, set an error
         let errorSet = XCTestExpectation(description: "Error set")
@@ -629,7 +639,7 @@ final class HoldsSyncFailureTests: XCTestCase {
     }
 
     func testSyncFailure_WithTitleOnly_UsesTitle() async {
-        let viewModel = HoldsViewModel(bookRegistry: mockRegistry)
+        let viewModel = makeSignedInViewModel()
 
         let errorExpectation = XCTestExpectation(description: "syncError uses title")
         viewModel.$syncError


### PR DESCRIPTION
## Summary

On `modernize/whole-shot` HEAD (`cc2b8d995`), 5 tests in `HoldsSyncFailureTests` are red:

- `testSyncFailure_SetsSyncError`
- `testSyncFailure_WithProblemDocument_ShowsServerMessage`
- `testSyncFailure_WithoutProblemDocument_ShowsGenericMessage`
- `testSyncFailure_StopsLoading`
- `testSyncBegan_ClearsPreviousSyncError`
- `testSyncFailure_WithTitleOnly_UsesTitle`

They went red when commit `cc2b8d9950` added `guard hasCredentials() else { return }` to `HoldsViewModel.handleSyncFailure(_:)`. The production change is correct (anonymous users shouldn't see an error banner — the empty-state text already covers them), but the tests were written before the guard and rely on the test harness happening to return true for `AccountsManager.shared.currentUserAccount.hasCredentials()`, which it doesn't.

## Fix

Add a `makeSignedInViewModel()` helper that injects `hasCredentials: { true }` so the authenticated-user error-banner path is actually exercised. No production change.

The two tests that explicitly assert suppression (`testSyncFailure_AnonymousUser_SuppressesErrorBanner`, `testSyncFailure_StaleDataPersists_ErrorSuppressedWhenCachedDataExists`) already configure their guards correctly and are left untouched.

## Why this matters

`scripts/verify-pr.sh` was refusing to pass any PR from whole-shot HEAD because of the 5 reds above. This unblocks the 3.0.0 gate and any stacked hotfix work.

## Test results

- `HoldsSyncFailureTests`: **10/10 pass** (was 5 failing on HEAD).
- Broader SignIn + Holds + SAML + CrossLibrarySignOut + Extended business-logic run on the feature branch: **104 passed, 0 failed**.

## What this PR is NOT

Earlier revision of this branch also contained a "race fix" in `TPPSignInBusinessLogic.completeLogOutProcess()` (main-queue hop before the stale-sign-out guard). Code review (`NYPLADEPTWorkflowTask.m:26-32`) confirmed the real Adobe RMSDK wrapper **already dispatches its completion to `dispatch_get_main_queue()`**, so the race the fix targeted is not observable in production. That change + its supporting test hooks have been dropped; this PR now contains only the test-setup change described above.

## Context

Discovered during the PP-WHOLESHOT regression run (finding WS-017). ForgeOS changeset `cs_98344f77` — all gates passed.

## Test plan

- [ ] `xcodebuild test -only-testing:PalaceTests/HoldsSyncFailureTests` → expect 10/10 pass.
- [ ] Sanity: verify that the two suppression tests (`testSyncFailure_AnonymousUser_SuppressesErrorBanner`, `testSyncFailure_StaleDataPersists_ErrorSuppressedWhenCachedDataExists`) still pass — they should, nothing changed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)