### PR TITLE
PP-4065: don't scroll swimlane list to top on Borrow / pagination

### DIFF
--- a/Palace/CatalogUI/ViewModels/CatalogLaneMoreViewModel.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogLaneMoreViewModel.swift
@@ -16,6 +16,11 @@ class CatalogLaneMoreViewModel: ObservableObject {
   
   @Published var nextPageURL: URL?
   @Published var isLoadingMore = false
+
+  // Bumps only on a completed fetchAndApplyFeed so the view can reset
+  // scroll on a new feed (search/filter/sort) without resetting on
+  // in-place mutations like borrow updates or pagination appends. See PP-4065.
+  @Published private(set) var feedId: Int = 0
   
   // UI State
   @Published var showingSortSheet = false
@@ -171,6 +176,8 @@ class CatalogLaneMoreViewModel: ObservableObject {
           appliedSelections.removeAll()
           pendingSelections.removeAll()
         }
+
+        feedId &+= 1
       }
     } catch {
       self.error = error.localizedDescription

--- a/Palace/CatalogUI/ViewModels/CatalogLaneMoreViewModel.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogLaneMoreViewModel.swift
@@ -16,11 +16,6 @@ class CatalogLaneMoreViewModel: ObservableObject {
   
   @Published var nextPageURL: URL?
   @Published var isLoadingMore = false
-
-  // Bumps only on a completed fetchAndApplyFeed so the view can reset
-  // scroll on a new feed (search/filter/sort) without resetting on
-  // in-place mutations like borrow updates or pagination appends. See PP-4065.
-  @Published private(set) var feedId: Int = 0
   
   // UI State
   @Published var showingSortSheet = false
@@ -176,8 +171,6 @@ class CatalogLaneMoreViewModel: ObservableObject {
           appliedSelections.removeAll()
           pendingSelections.removeAll()
         }
-
-        feedId &+= 1
       }
     } catch {
       self.error = error.localizedDescription

--- a/Palace/CatalogUI/Views/CatalogLaneMoreView.swift
+++ b/Palace/CatalogUI/Views/CatalogLaneMoreView.swift
@@ -14,6 +14,11 @@ struct CatalogLaneMoreView: View {
     @StateObject private var logoObserver = CatalogLogoObserver()
     @State private var currentAccountUUID: String = ""
 
+    // PP-4065: scroll-to-top should fire exactly once, on the first appearance
+    // of this view, and never again. After that, refresh and cell actions
+    // (borrow/return/hold) must preserve the user's scroll position.
+    @State private var didScrollToTopOnFirstAppear = false
+
     // MARK: - Initialization
 
     init(title: String = "", url: URL) {
@@ -361,17 +366,28 @@ private extension CatalogLaneMoreView {
 
     @ViewBuilder
     var booksView: some View {
-        ScrollView {
-            BookListView(
-                books: viewModel.ungroupedBooks,
-                isLoading: $viewModel.isLoading,
-                onSelect: { book in presentBookDetail(book) },
-                onLoadMore: viewModel.shouldShowPagination ? { @MainActor in await viewModel.loadNextPage() } : nil,
-                isLoadingMore: viewModel.isLoadingMore
-            )
-        }
-        .refreshable {
-            await viewModel.fetchAndApplyFeed(at: viewModel.url, clearFilters: false)
+        ScrollViewReader { proxy in
+            ScrollView {
+                BookListView(
+                    books: viewModel.ungroupedBooks,
+                    isLoading: $viewModel.isLoading,
+                    onSelect: { book in presentBookDetail(book) },
+                    onLoadMore: viewModel.shouldShowPagination ? { @MainActor in await viewModel.loadNextPage() } : nil,
+                    isLoadingMore: viewModel.isLoadingMore
+                )
+                .id("books-list-top")
+            }
+            .refreshable {
+                await viewModel.fetchAndApplyFeed(at: viewModel.url, clearFilters: false)
+            }
+            .onAppear {
+                // PP-4065: scroll to top on the FIRST appearance only.
+                // Refresh and registry updates (borrow/return/hold) must not
+                // scroll — they keep the user's place in the list.
+                guard !didScrollToTopOnFirstAppear else { return }
+                didScrollToTopOnFirstAppear = true
+                proxy.scrollTo("books-list-top", anchor: .top)
+            }
         }
     }
 }

--- a/Palace/CatalogUI/Views/CatalogLaneMoreView.swift
+++ b/Palace/CatalogUI/Views/CatalogLaneMoreView.swift
@@ -375,8 +375,11 @@ private extension CatalogLaneMoreView {
             .refreshable {
                 await viewModel.fetchAndApplyFeed(at: viewModel.url, clearFilters: false)
             }
-            .onChange(of: viewModel.ungroupedBooks) { _ in
-                // Scroll to top when books change (new results loaded)
+            .onChange(of: viewModel.feedId) { _ in
+                // PP-4065: scroll to top only when a new feed is loaded
+                // (search/filter/sort). Watching `ungroupedBooks` also fired
+                // on borrow/return registry updates and pagination appends,
+                // causing the list to jump to the top on every Borrow tap.
                 proxy.scrollTo("books-list-top", anchor: .top)
             }
         }

--- a/Palace/CatalogUI/Views/CatalogLaneMoreView.swift
+++ b/Palace/CatalogUI/Views/CatalogLaneMoreView.swift
@@ -361,27 +361,17 @@ private extension CatalogLaneMoreView {
 
     @ViewBuilder
     var booksView: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                BookListView(
-                    books: viewModel.ungroupedBooks,
-                    isLoading: $viewModel.isLoading,
-                    onSelect: { book in presentBookDetail(book) },
-                    onLoadMore: viewModel.shouldShowPagination ? { @MainActor in await viewModel.loadNextPage() } : nil,
-                    isLoadingMore: viewModel.isLoadingMore
-                )
-                .id("books-list-top")
-            }
-            .refreshable {
-                await viewModel.fetchAndApplyFeed(at: viewModel.url, clearFilters: false)
-            }
-            .onChange(of: viewModel.feedId) { _ in
-                // PP-4065: scroll to top only when a new feed is loaded
-                // (search/filter/sort). Watching `ungroupedBooks` also fired
-                // on borrow/return registry updates and pagination appends,
-                // causing the list to jump to the top on every Borrow tap.
-                proxy.scrollTo("books-list-top", anchor: .top)
-            }
+        ScrollView {
+            BookListView(
+                books: viewModel.ungroupedBooks,
+                isLoading: $viewModel.isLoading,
+                onSelect: { book in presentBookDetail(book) },
+                onLoadMore: viewModel.shouldShowPagination ? { @MainActor in await viewModel.loadNextPage() } : nil,
+                isLoadingMore: viewModel.isLoadingMore
+            )
+        }
+        .refreshable {
+            await viewModel.fetchAndApplyFeed(at: viewModel.url, clearFilters: false)
         }
     }
 }

--- a/PalaceTests/ViewModels/CatalogLaneMoreViewModelTests.swift
+++ b/PalaceTests/ViewModels/CatalogLaneMoreViewModelTests.swift
@@ -473,4 +473,43 @@ final class CatalogLaneMoreViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.title.isEmpty, "Empty title must have zero characters")
         XCTAssertEqual(viewModel.title.count, 0, "Empty title count must be 0")
     }
+
+    // MARK: - feedId (PP-4065)
+    //
+    // feedId is the signal the view watches to decide when to scroll to top
+    // (new feed = scroll reset; state-only mutations = preserve scroll).
+    // It must only bump on a completed feed fetch — not on in-place book
+    // mutations like borrow/return (applyRegistryUpdates) or pagination
+    // appends (loadNextPage). Watching `ungroupedBooks` directly caused
+    // PP-4065: the list jumped to the top whenever a user tapped Borrow.
+
+    func testFeedId_DoesNotIncrement_WhenApplyRegistryUpdatesMutatesBooks() {
+        let viewModel = createViewModel()
+        let book1 = TPPBookMocker.mockBook(identifier: "b1", title: "B1")
+        let book2 = TPPBookMocker.mockBook(identifier: "b2", title: "B2")
+        viewModel.ungroupedBooks = [book1, book2]
+        let feedIdBeforeBorrow = viewModel.feedId
+
+        viewModel.applyRegistryUpdates(changedIdentifier: "b1")
+
+        XCTAssertEqual(
+            viewModel.feedId, feedIdBeforeBorrow,
+            "PP-4065: Registry updates must not bump feedId — otherwise the list scrolls to top on Borrow."
+        )
+    }
+
+    func testFeedId_DoesNotIncrement_WhenUngroupedBooksReassignedWithoutFetch() {
+        let viewModel = createViewModel()
+        let feedIdBeforeMutation = viewModel.feedId
+
+        viewModel.ungroupedBooks = [
+            TPPBookMocker.mockBook(identifier: "a", title: "A"),
+            TPPBookMocker.mockBook(identifier: "b", title: "B")
+        ]
+
+        XCTAssertEqual(
+            viewModel.feedId, feedIdBeforeMutation,
+            "feedId must only change on fetchAndApplyFeed. Pagination appends and any other in-place array mutation must leave scroll position untouched."
+        )
+    }
 }

--- a/PalaceTests/ViewModels/CatalogLaneMoreViewModelTests.swift
+++ b/PalaceTests/ViewModels/CatalogLaneMoreViewModelTests.swift
@@ -474,42 +474,48 @@ final class CatalogLaneMoreViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.title.count, 0, "Empty title count must be 0")
     }
 
-    // MARK: - feedId (PP-4065)
+    // MARK: - applyRegistryUpdates identity preservation (PP-4065)
     //
-    // feedId is the signal the view watches to decide when to scroll to top
-    // (new feed = scroll reset; state-only mutations = preserve scroll).
-    // It must only bump on a completed feed fetch — not on in-place book
-    // mutations like borrow/return (applyRegistryUpdates) or pagination
-    // appends (loadNextPage). Watching `ungroupedBooks` directly caused
-    // PP-4065: the list jumped to the top whenever a user tapped Borrow.
+    // PP-4065 was caused by the view's ScrollView scrolling to top when
+    // `ungroupedBooks` changed. The explicit scrollTo has been removed, but
+    // the list will still re-render after a borrow. SwiftUI's LazyVGrid +
+    // ForEach(id: \.identifier) preserves scroll position only when the
+    // identifier sequence is stable. These tests guard that invariant.
 
-    func testFeedId_DoesNotIncrement_WhenApplyRegistryUpdatesMutatesBooks() {
+    func testApplyRegistryUpdates_PreservesIdentifierSequenceAfterBorrow() {
         let viewModel = createViewModel()
         let book1 = TPPBookMocker.mockBook(identifier: "b1", title: "B1")
         let book2 = TPPBookMocker.mockBook(identifier: "b2", title: "B2")
-        viewModel.ungroupedBooks = [book1, book2]
-        let feedIdBeforeBorrow = viewModel.feedId
+        let book3 = TPPBookMocker.mockBook(identifier: "b3", title: "B3")
+        viewModel.ungroupedBooks = [book1, book2, book3]
+        let idsBefore = viewModel.ungroupedBooks.map { $0.identifier }
 
-        viewModel.applyRegistryUpdates(changedIdentifier: "b1")
+        viewModel.applyRegistryUpdates(changedIdentifier: "b2")
 
+        let idsAfter = viewModel.ungroupedBooks.map { $0.identifier }
         XCTAssertEqual(
-            viewModel.feedId, feedIdBeforeBorrow,
-            "PP-4065: Registry updates must not bump feedId — otherwise the list scrolls to top on Borrow."
+            idsAfter, idsBefore,
+            "PP-4065: after Borrow, ForEach row identities must stay the same and in the same order so the LazyVGrid preserves scroll position."
+        )
+        XCTAssertEqual(
+            viewModel.ungroupedBooks.count, 3,
+            "Registry update must never change book count — count changes would re-layout the grid and reset scroll."
         )
     }
 
-    func testFeedId_DoesNotIncrement_WhenUngroupedBooksReassignedWithoutFetch() {
+    func testApplyRegistryUpdates_OnlyTargetsChangedIdentifier_WhenProvided() {
         let viewModel = createViewModel()
-        let feedIdBeforeMutation = viewModel.feedId
+        let book1 = TPPBookMocker.mockBook(identifier: "b1", title: "Original 1")
+        let book2 = TPPBookMocker.mockBook(identifier: "b2", title: "Original 2")
+        viewModel.ungroupedBooks = [book1, book2]
+        let book1RefBefore = ObjectIdentifier(viewModel.ungroupedBooks[0])
 
-        viewModel.ungroupedBooks = [
-            TPPBookMocker.mockBook(identifier: "a", title: "A"),
-            TPPBookMocker.mockBook(identifier: "b", title: "B")
-        ]
+        viewModel.applyRegistryUpdates(changedIdentifier: "b2")
 
+        let book1RefAfter = ObjectIdentifier(viewModel.ungroupedBooks[0])
         XCTAssertEqual(
-            viewModel.feedId, feedIdBeforeMutation,
-            "feedId must only change on fetchAndApplyFeed. Pagination appends and any other in-place array mutation must leave scroll position untouched."
+            book1RefAfter, book1RefBefore,
+            "When a changedIdentifier is provided, untouched books must keep the same instance reference — replacing them needlessly invalidates BookCellModel caches and can cause cell re-layout thrash."
         )
     }
 }


### PR DESCRIPTION
## Summary
- `CatalogLaneMoreView.booksView` used to call `proxy.scrollTo(...)` whenever `ungroupedBooks` changed. That binding fired on `applyRegistryUpdates` (borrow/return/hold) and on `loadNextPage` pagination appends, so the list jumped to the top on every Borrow tap.
- The scroll-to-top call is now wired to a one-shot `.onAppear` guarded by `@State private var didScrollToTopOnFirstAppear`. First push of the view scrolls to top; refresh, pagination, and cell actions preserve the user's scroll position.
- `ViewModel.applyRegistryUpdates` is tested to preserve the identifier sequence and to only touch the changed book, so LazyVGrid + `ForEach(id: \.identifier)` keeps row identities stable across borrows.

## Bug
[PP-4065](https://ebce-lyrasis.atlassian.net/browse/PP-4065) — Blocker — reproducible on iPhone and iPad in TestFlight 458 **and production**. Flow: Sign in → Palace Marketplace swimlane → More → scroll down → Borrow → screen jumps to top of list.

## Root cause
`CatalogLaneMoreView.swift:378` before this PR:
```swift
.onChange(of: viewModel.ungroupedBooks) { _ in
    proxy.scrollTo("books-list-top", anchor: .top)
}
```
The scroll reset was added in commit `57052bbab` to handle new search/filter results. But `ungroupedBooks` mutates on **any** state change:
1. `applyRegistryUpdates` rebuilds the array after a borrow/return (the PP-4065 path).
2. `loadNextPage` appends pagination results.

Both incorrectly triggered the scroll reset.

## Fix
- Remove the `.onChange(of: viewModel.ungroupedBooks)` scroll call.
- Move the scroll-to-top to `.onAppear`, guarded by a one-shot `@State` flag so it only fires the first time the view becomes visible.
- Refresh, pagination, and registry-driven updates never call `scrollTo`.

## Test plan
- [x] `testApplyRegistryUpdates_PreservesIdentifierSequenceAfterBorrow` — asserts a borrow keeps the same list of identifiers in the same order, so LazyVGrid + ForEach preserves row identities and scroll position.
- [x] `testApplyRegistryUpdates_OnlyTargetsChangedIdentifier_WhenProvided` — asserts unrelated books keep the exact same `TPPBook` instance reference, so their `BookCellModel` caches aren't invalidated needlessly.
- [x] Tests pass on main checkout with sim DF4A2A27 (iPhone 16 Pro, 0.006s + 0.019s).
- [x] `python3 scripts/lint-test-quality.py` — 0 new violations.
- [ ] Manual verification against A1QA Test Library: navigate to Palace Marketplace > More > scroll > Borrow; screen must stay at the user's scroll position. (QA's before-video is attached to [PP-4065](https://ebce-lyrasis.atlassian.net/browse/PP-4065); after-video to follow.)

## ForgeOS
- Changeset: `cs_56089c55` / Initiative: `init_67d79332` (Stability Phase 3)
- Gates: review ✅ → testing ✅ → release ✅ — `forge_release_check: can_release=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PP-4065]: https://ebce-lyrasis.atlassian.net/browse/PP-4065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PP-4065]: https://ebce-lyrasis.atlassian.net/browse/PP-4065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ