### PR TITLE
PP-4115/4116/4117 + preview regression + search race (build 463)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -7385,7 +7385,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 462;
+				CURRENT_PROJECT_VERSION = 463;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7442,7 +7442,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 462;
+				CURRENT_PROJECT_VERSION = 463;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7628,8 +7628,9 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 462;
-				DEVELOPMENT_TEAM = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 463;
+				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -7688,7 +7689,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 462;
+				CURRENT_PROJECT_VERSION = 463;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -7628,9 +7628,8 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 463;
-				DEVELOPMENT_TEAM = 88CBA74T8K;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Palace/Book/UI/BookDetail/BookActionHandler.swift
+++ b/Palace/Book/UI/BookDetail/BookActionHandler.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import UIKit
+import SafariServices
 import PalaceAudiobookToolkit
 
 /// Encapsulates book action handling (download, return, read, reserve, etc.)
@@ -285,14 +286,22 @@ final class BookActionHandler {
 
     private func presentWebView(_ url: URL?) {
         guard let url = url else { return }
-        let webController = BundledHTMLViewController(
-            fileURL: url,
+        guard let top = (UIApplication.shared.delegate as? TPPAppDelegate)?.topViewController() else { return }
+        let controller = Self.previewController(
+            for: url,
             title: AccountsManager.shared.currentAccount?.name ?? ""
         )
+        top.present(controller, animated: true)
+    }
 
-        if let top = (UIApplication.shared.delegate as? TPPAppDelegate)?.topViewController() {
-            top.present(webController, animated: true)
+    // Remote URLs require SFSafariViewController — third-party preview readers
+    // depend on Web APIs our embedded WKWebView doesn't expose. Local file://
+    // previews stay in BundledHTMLViewController.
+    static func previewController(for url: URL, title: String) -> UIViewController {
+        if url.scheme == "http" || url.scheme == "https" {
+            return SFSafariViewController(url: url)
         }
+        return BundledHTMLViewController(fileURL: url, title: title)
     }
 
     func presentUnsupportedItemError() {

--- a/Palace/CatalogDomain/API/CatalogAPI.swift
+++ b/Palace/CatalogDomain/API/CatalogAPI.swift
@@ -12,6 +12,7 @@ public protocol CatalogAPI {
 public final class DefaultCatalogAPI: CatalogAPI {
     public let client: NetworkClient
     public let parser: OPDSParser
+    private let inflight = InflightFeedFetches()
 
     public init(client: NetworkClient, parser: OPDSParser) {
         self.client = client
@@ -19,6 +20,15 @@ public final class DefaultCatalogAPI: CatalogAPI {
     }
 
     public func fetchFeed(at url: URL) async throws -> CatalogFeed? {
+        // Concurrent callers for the same URL share one network request.
+        // Prevents N-way fan-out when search fires while the initial catalog
+        // is still loading (each keystroke used to re-fetch /groups/).
+        try await inflight.run(url: url) { [self] in
+            try await self.fetchFeedFromNetwork(at: url)
+        }
+    }
+
+    private func fetchFeedFromNetwork(at url: URL) async throws -> CatalogFeed? {
         let acceptHeader = RemoteFeatureFlags.shared.isOPDS2Enabled
             ? "application/opds+json, application/atom+xml;q=0.9, */*;q=0.1"
             : "application/atom+xml, */*;q=0.1"
@@ -184,5 +194,26 @@ public final class DefaultCatalogAPI: CatalogAPI {
             }
         }
         return entries
+    }
+}
+
+/// Deduplicates concurrent feed fetches keyed by URL. Callers arriving while
+/// a fetch is in flight share the existing task. The creator clears the
+/// entry inline after the task resolves, so a subsequent sequential caller
+/// always fires a fresh request (no fire-and-forget cleanup race).
+actor InflightFeedFetches {
+    private var tasks: [URL: Task<CatalogFeed?, Error>] = [:]
+
+    func run(
+        url: URL,
+        _ work: @Sendable @escaping () async throws -> CatalogFeed?
+    ) async throws -> CatalogFeed? {
+        if let existing = tasks[url] {
+            return try await existing.value
+        }
+        let task = Task<CatalogFeed?, Error> { try await work() }
+        tasks[url] = task
+        defer { tasks.removeValue(forKey: url) }
+        return try await task.value
     }
 }

--- a/Palace/CatalogUI/ViewModels/CatalogSearchViewModel.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogSearchViewModel.swift
@@ -50,7 +50,7 @@ class CatalogSearchViewModel: ObservableObject {
     init(
         repository: CatalogRepositoryProtocol,
         baseURL: @escaping () -> URL?,
-        debounceInterval: TimeInterval = 0.1,
+        debounceInterval: TimeInterval = 0.4,
         announcements: TPPAccessibilityAnnouncementCenter = TPPAccessibilityAnnouncementCenter(),
         bookRegistry: TPPBookRegistry = .shared,
         bookCellModelCache: BookCellModelCache = .shared

--- a/Palace/CatalogUI/Views/CatalogSearchView.swift
+++ b/Palace/CatalogUI/Views/CatalogSearchView.swift
@@ -58,6 +58,10 @@ struct CatalogSearchView: View {
         .onAppear {
             viewModel.updateBooks(books)
             viewModel.loadFormatEntryPoints()
+            // PP-4115: when returning from book detail, registry state may have
+            // changed (cancel hold, return, etc.) while a throttled notification
+            // was in flight or the view was off-screen. Force a full reconcile.
+            viewModel.applyRegistryUpdates(changedIdentifier: nil)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 isSearchFieldFocused = true
             }

--- a/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
+++ b/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Combine
 import SwiftUI
+import SafariServices
 import PalaceAudiobookToolkit
 
 enum BookCellState {
@@ -51,6 +52,12 @@ class BookCellModel: ObservableObject {
             statePublisher.send(isLoading)
         }
     }
+
+    // Debounce guard for the Read/Listen button. Rapid taps used to stack two
+    // reader presentations (PP-4116) because isLoading flips back to false
+    // synchronously after the presentation trigger.
+    @Published private(set) var isPresentingReader: Bool = false
+    private static let readerPresentationLockWindow: TimeInterval = 0.5
 
     @Published private var currentBookIdentifier: String?
 
@@ -437,6 +444,10 @@ extension BookCellModel {
     }
 
     func didSelectRead() {
+        guard acquireReaderPresentationLock() else {
+            Log.debug(#file, "didSelectRead ignored — reader presentation already in flight")
+            return
+        }
         isLoading = true
         switch book.defaultBookContentType {
         case .epub:
@@ -457,6 +468,19 @@ extension BookCellModel {
         default:
             self.isLoading = false
         }
+    }
+
+    /// Returns `true` if the caller may proceed with reader presentation.
+    /// Returns `false` if a presentation is already in flight (rapid repeat tap).
+    /// The lock auto-releases after `readerPresentationLockWindow` so the button
+    /// stays usable for legitimate re-entry.
+    func acquireReaderPresentationLock() -> Bool {
+        guard !isPresentingReader else { return false }
+        isPresentingReader = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.readerPresentationLockWindow) { [weak self] in
+            self?.isPresentingReader = false
+        }
+        return true
     }
 
     private func openAudiobookFromCell() {
@@ -566,14 +590,10 @@ extension BookCellModel {
         if book.defaultBookContentType == .audiobook {
             if book.sampleAcquisition?.type == "text/html" {
                 SamplePreviewManager.shared.close()
-                if let url = book.sampleAcquisition?.hrefURL {
-                    let webController = BundledHTMLViewController(
-                        fileURL: url,
-                        title: accountsManager.currentAccount?.name ?? ""
-                    )
-                    if let top = (UIApplication.shared.delegate as? TPPAppDelegate)?.topViewController() {
-                        top.present(webController, animated: true)
-                    }
+                if let url = book.sampleAcquisition?.hrefURL,
+                   let top = (UIApplication.shared.delegate as? TPPAppDelegate)?.topViewController() {
+                    let safari = SFSafariViewController(url: url)
+                    top.present(safari, animated: true)
                 }
             } else {
                 SamplePreviewManager.shared.toggle(for: book)
@@ -589,9 +609,9 @@ extension BookCellModel {
                 return
             }
             if let sampleWebURL = sampleURL as? EpubSampleWebURL {
-                let web = BundledHTMLViewController(fileURL: sampleWebURL.url, title: self.book.title)
                 if let appDelegate = UIApplication.shared.delegate as? TPPAppDelegate, let top = appDelegate.topViewController() {
-                    top.present(web, animated: true)
+                    let safari = SFSafariViewController(url: sampleWebURL.url)
+                    top.present(safari, animated: true)
                 }
                 return
             }

--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
@@ -384,20 +384,52 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
                                      problemDocument: problemDoc,
                                      metadata: loggingContext)
 
-        let title, message: String?
-        if let problemDoc = problemDoc {
-            title = problemDoc.title
-            message = problemDoc.detail
-        } else {
-            title = Strings.Error.invalidCredentialsErrorTitle
-            message = Strings.Error.invalidCredentialsErrorMessage
-        }
+        let (title, message) = Self.userFacingSignInError(for: error, problemDocument: problemDoc)
 
         TPPMainThreadRun.asyncIfNeeded {
             self.uiDelegate?.businessLogic(self,
                                            didEncounterValidationError: error,
                                            userFriendlyErrorTitle: title,
                                            andMessage: message)
+        }
+    }
+
+    /// Classifies a sign-in failure into a user-facing (title, message) pair.
+    /// Precedence: server-supplied problem document > network-connectivity
+    /// error > default "invalid credentials". Without the connectivity check,
+    /// a dropped Wi-Fi or LTE during sign-in was misreported as bad creds.
+    static func userFacingSignInError(
+        for error: NSError,
+        problemDocument: TPPProblemDocument?
+    ) -> (title: String?, message: String?) {
+        if let problemDocument {
+            return (problemDocument.title, problemDocument.detail)
+        }
+        if isNetworkConnectivityError(error) {
+            return (Strings.Error.networkUnavailableErrorTitle,
+                    Strings.Error.networkUnavailableErrorMessage)
+        }
+        return (Strings.Error.invalidCredentialsErrorTitle,
+                Strings.Error.invalidCredentialsErrorMessage)
+    }
+
+    /// True when the error is from URLSession indicating the request never
+    /// reached the server (lost connection, DNS failure, TLS handshake, etc).
+    static func isNetworkConnectivityError(_ error: NSError) -> Bool {
+        guard error.domain == NSURLErrorDomain else { return false }
+        switch error.code {
+        case NSURLErrorNotConnectedToInternet,
+             NSURLErrorTimedOut,
+             NSURLErrorNetworkConnectionLost,
+             NSURLErrorCannotFindHost,
+             NSURLErrorCannotConnectToHost,
+             NSURLErrorDNSLookupFailed,
+             NSURLErrorDataNotAllowed,
+             NSURLErrorInternationalRoamingOff,
+             NSURLErrorSecureConnectionFailed:
+            return true
+        default:
+            return false
         }
     }
 

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -34,6 +34,8 @@ struct Strings {
         static let loadFailedError = NSLocalizedString("The page could not load due to a conection error.", comment: "")
         static let invalidCredentialsErrorTitle = NSLocalizedString("Invalid Credentials", comment: "")
         static let invalidCredentialsErrorMessage = NSLocalizedString("Please check your username and password and try again.", comment: "")
+        static let networkUnavailableErrorTitle = NSLocalizedString("No Internet Connection", comment: "Title shown when sign-in fails because the device lost connectivity")
+        static let networkUnavailableErrorMessage = NSLocalizedString("Check your connection and try again.", comment: "Message shown when sign-in fails because the device lost connectivity")
         static let sessionExpiredTitle = NSLocalizedString("Session Expired", comment: "Title for session expired alert")
         static let sessionExpiredMessage = NSLocalizedString("Your session has expired. Please sign in again to continue.", comment: "Message explaining that the user's session has expired")
         static let unknownRequestError = NSLocalizedString("An unknown error occurred. Please check your connection or try again later.", comment: "A generic error message for when a network request fails")

--- a/PalaceTests/Book/BookDetailViewModelTests.swift
+++ b/PalaceTests/Book/BookDetailViewModelTests.swift
@@ -9,6 +9,7 @@
 
 import XCTest
 import Combine
+import SafariServices
 @testable import Palace
 
 @MainActor
@@ -771,6 +772,48 @@ final class BookDetailViewModelUnitTests: XCTestCase {
 
     // Assert - Should end up in final state
     XCTAssertEqual(viewModel.bookState, .downloadSuccessful)
+  }
+}
+
+// MARK: - Preview Routing (PP-2979 regression pin)
+//
+// PP-2979 (commit 384b6aef9) added SFSafariViewController routing because
+// third-party preview readers (e.g. Cantook) need Web APIs that the embedded
+// WKWebView doesn't expose. The routing was dropped when BookActionHandler
+// was extracted from BookDetailViewModel — these tests pin the invariant so
+// the next refactor can't silently regress it.
+
+@MainActor
+final class BookActionHandlerPreviewRoutingTests: XCTestCase {
+
+  func testPreviewController_ForHTTPSURL_ReturnsSafariViewController() {
+    let url = URL(string: "https://marketplace.example.com/preview/abc")!
+
+    let controller = BookActionHandler.previewController(for: url, title: "Lib")
+
+    XCTAssertTrue(
+      controller is SFSafariViewController,
+      "Remote https previews must use SFSafariViewController — third-party readers rely on full Safari Web APIs."
+    )
+  }
+
+  func testPreviewController_ForHTTPURL_ReturnsSafariViewController() {
+    let url = URL(string: "http://marketplace.example.com/preview/abc")!
+
+    let controller = BookActionHandler.previewController(for: url, title: "Lib")
+
+    XCTAssertTrue(controller is SFSafariViewController)
+  }
+
+  func testPreviewController_ForFileURL_ReturnsBundledHTMLViewController() {
+    let url = URL(fileURLWithPath: "/tmp/sample.html")
+
+    let controller = BookActionHandler.previewController(for: url, title: "Lib")
+
+    XCTAssertTrue(
+      controller is BundledHTMLViewController,
+      "Local file:// previews must stay in BundledHTMLViewController — SFSafariViewController cannot load file URLs."
+    )
   }
 }
 

--- a/PalaceTests/BookStateManagement/BookCellModelActionTests.swift
+++ b/PalaceTests/BookStateManagement/BookCellModelActionTests.swift
@@ -213,4 +213,45 @@ final class BookCellModelActionTests: XCTestCase {
         XCTAssertNil(model.showAlert,
             "Remove (local delete) should not show a confirmation alert")
     }
+
+    // MARK: - Reader presentation debounce (PP-4116)
+    //
+    // Rapidly tapping Read used to stack two reader presentations because
+    // didSelectRead set isLoading=true then cleared it synchronously, leaving
+    // no window for the second tap to detect an in-progress presentation.
+
+    func testAcquireReaderPresentationLock_FirstCall_Succeeds() {
+        let model = makeModel()
+
+        XCTAssertTrue(model.acquireReaderPresentationLock(),
+            "First acquisition must succeed — no presentation in flight yet")
+        XCTAssertTrue(model.isPresentingReader,
+            "Lock must flip isPresentingReader on successful acquisition")
+    }
+
+    func testAcquireReaderPresentationLock_SecondRapidCall_IsBlocked() {
+        let model = makeModel()
+
+        _ = model.acquireReaderPresentationLock()
+        let secondResult = model.acquireReaderPresentationLock()
+
+        XCTAssertFalse(secondResult,
+            "Second rapid acquisition must be blocked while the first is still in flight")
+    }
+
+    func testAcquireReaderPresentationLock_ReleasesAfterDelay() {
+        let model = makeModel()
+        _ = model.acquireReaderPresentationLock()
+        XCTAssertTrue(model.isPresentingReader)
+
+        let released = expectation(description: "Lock releases after debounce window")
+        // 0.5s lock window + 0.3s buffer — the async dispatch must clear the flag.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+            if !model.isPresentingReader { released.fulfill() }
+        }
+        wait(for: [released], timeout: 2.0)
+
+        XCTAssertTrue(model.acquireReaderPresentationLock(),
+            "After the debounce window expires, a fresh tap must be able to re-acquire")
+    }
 }

--- a/PalaceTests/CatalogDomain/CatalogRepositoryTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogRepositoryTests.swift
@@ -405,3 +405,78 @@ extension CatalogRepositoryTests {
         }
     }
 }
+
+// MARK: - In-flight fetch deduplication
+//
+// Regression guard: search-before-load used to fan out to 5 concurrent /groups/
+// requests because every keystroke-triggered search needed the base feed to
+// resolve the OPDS2 search URL. These tests pin the invariant that concurrent
+// callers share one network fetch.
+
+final class CatalogAPIDedupeTests: XCTestCase {
+
+    private var networkClient: NetworkClientMock!
+    private var api: DefaultCatalogAPI!
+    private let feedURL = URL(string: "https://library.example.com/groups/")!
+    private let otherURL = URL(string: "https://library.example.com/other/")!
+
+    override func setUp() {
+        super.setUp()
+        networkClient = NetworkClientMock()
+        api = DefaultCatalogAPI(client: networkClient, parser: OPDSParser())
+        networkClient.stubOPDSResponse(
+            for: feedURL,
+            xml: NetworkClientMock.makeOPDSFeedXML(title: "Base")
+        )
+        networkClient.stubOPDSResponse(
+            for: otherURL,
+            xml: NetworkClientMock.makeOPDSFeedXML(title: "Other")
+        )
+        // Hold the first in-flight request long enough for concurrent callers
+        // to arrive and observe the in-flight task rather than starting their own.
+        networkClient.simulatedDelay = 0.1
+    }
+
+    override func tearDown() {
+        networkClient = nil
+        api = nil
+        super.tearDown()
+    }
+
+    func testFetchFeed_ConcurrentCallersForSameURL_ShareOneNetworkRequest() async throws {
+        async let a = api.fetchFeed(at: feedURL)
+        async let b = api.fetchFeed(at: feedURL)
+        async let c = api.fetchFeed(at: feedURL)
+        async let d = api.fetchFeed(at: feedURL)
+        async let e = api.fetchFeed(at: feedURL)
+
+        _ = try await (a, b, c, d, e)
+
+        XCTAssertEqual(
+            networkClient.sendCallCount, 1,
+            "Five concurrent fetchFeed calls for the same URL must collapse to a single network request."
+        )
+    }
+
+    func testFetchFeed_ConcurrentCallersForDifferentURLs_DoNotDedupe() async throws {
+        async let a = api.fetchFeed(at: feedURL)
+        async let b = api.fetchFeed(at: otherURL)
+
+        _ = try await (a, b)
+
+        XCTAssertEqual(
+            networkClient.sendCallCount, 2,
+            "Fetches for different URLs must NOT be deduped — each URL gets its own request."
+        )
+    }
+
+    func testFetchFeed_SequentialCallsAfterCompletion_FireFreshRequests() async throws {
+        _ = try await api.fetchFeed(at: feedURL)
+        _ = try await api.fetchFeed(at: feedURL)
+
+        XCTAssertEqual(
+            networkClient.sendCallCount, 2,
+            "Once the first fetch completes the in-flight slot must clear so a later caller fires a fresh request."
+        )
+    }
+}

--- a/PalaceTests/TPPSignInBusinessLogicTests.swift
+++ b/PalaceTests/TPPSignInBusinessLogicTests.swift
@@ -182,4 +182,79 @@ class TPPSignInBusinessLogicTests: XCTestCase {
         XCTAssertNotNil(user)
         XCTAssertNotNil(drmAuthorizer)
     }
+
+    // MARK: - Network-vs-credentials error classification (PP-4117)
+    //
+    // Network loss during sign-in used to render as "Invalid Credentials"
+    // because the fallback path ran unconditionally when no problem document
+    // was attached. These tests pin the precedence:
+    //   1. problem document > 2. network connectivity > 3. invalid credentials.
+
+    private func urlError(_ code: Int) -> NSError {
+        NSError(domain: NSURLErrorDomain, code: code)
+    }
+
+    func testUserFacingSignInError_NoInternet_ReturnsNetworkMessage() {
+        let error = urlError(NSURLErrorNotConnectedToInternet)
+
+        let (title, message) = TPPSignInBusinessLogic.userFacingSignInError(for: error, problemDocument: nil)
+
+        XCTAssertEqual(title, Strings.Error.networkUnavailableErrorTitle)
+        XCTAssertEqual(message, Strings.Error.networkUnavailableErrorMessage)
+        XCTAssertNotEqual(title, Strings.Error.invalidCredentialsErrorTitle,
+                          "Connectivity error must not surface as invalid credentials.")
+    }
+
+    func testUserFacingSignInError_Timeout_ReturnsNetworkMessage() {
+        let error = urlError(NSURLErrorTimedOut)
+
+        let (title, _) = TPPSignInBusinessLogic.userFacingSignInError(for: error, problemDocument: nil)
+
+        XCTAssertEqual(title, Strings.Error.networkUnavailableErrorTitle)
+    }
+
+    func testUserFacingSignInError_ConnectionLost_ReturnsNetworkMessage() {
+        let error = urlError(NSURLErrorNetworkConnectionLost)
+
+        let (title, _) = TPPSignInBusinessLogic.userFacingSignInError(for: error, problemDocument: nil)
+
+        XCTAssertEqual(title, Strings.Error.networkUnavailableErrorTitle)
+    }
+
+    func testUserFacingSignInError_NonURLErrorDomain_ReturnsInvalidCredentials() {
+        // Server returned 401 with no problem doc — not URLErrorDomain, so
+        // the fallback (invalid credentials) is the correct message here.
+        let error = NSError(domain: "TPPErrorDomain", code: 401)
+
+        let (title, message) = TPPSignInBusinessLogic.userFacingSignInError(for: error, problemDocument: nil)
+
+        XCTAssertEqual(title, Strings.Error.invalidCredentialsErrorTitle)
+        XCTAssertEqual(message, Strings.Error.invalidCredentialsErrorMessage)
+    }
+
+    func testUserFacingSignInError_ProblemDocument_TakesPrecedenceOverNetworkError() throws {
+        // If the server did respond with a problem document, its message wins
+        // even if the underlying NSError code happens to match a network code.
+        let error = urlError(NSURLErrorTimedOut)
+        let json = #"{"type":"about:blank","title":"Account Locked","detail":"Too many attempts."}"#
+        let problemDoc = try TPPProblemDocument.fromData(Data(json.utf8))
+
+        let (title, message) = TPPSignInBusinessLogic.userFacingSignInError(for: error, problemDocument: problemDoc)
+
+        XCTAssertEqual(title, "Account Locked")
+        XCTAssertEqual(message, "Too many attempts.")
+    }
+
+    func testIsNetworkConnectivityError_OnlyRecognizesURLErrorDomain() {
+        XCTAssertTrue(TPPSignInBusinessLogic.isNetworkConnectivityError(urlError(NSURLErrorNotConnectedToInternet)))
+        XCTAssertTrue(TPPSignInBusinessLogic.isNetworkConnectivityError(urlError(NSURLErrorCannotFindHost)))
+        XCTAssertTrue(TPPSignInBusinessLogic.isNetworkConnectivityError(urlError(NSURLErrorSecureConnectionFailed)))
+
+        XCTAssertFalse(TPPSignInBusinessLogic.isNetworkConnectivityError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorUserAuthenticationRequired)),
+            "HTTP auth failures surfaced as URLErrors must NOT be classified as connectivity errors.")
+        XCTAssertFalse(TPPSignInBusinessLogic.isNetworkConnectivityError(
+            NSError(domain: "TPPErrorDomain", code: NSURLErrorNotConnectedToInternet)),
+            "Same code under a different domain is not a URLSession connectivity error.")
+    }
 }


### PR DESCRIPTION
## Summary
Batch of five fixes covering three PP-4020 regression tickets plus two proactive stability fixes. Governance via ForgeOS changeset `cs_46e42943` — all gates passed, release_check ok.

### Fixes

1. **PDF preview regression** — restore `SFSafariViewController` scheme routing at `BookActionHandler.presentWebView` + the two `BookCellModel.didSelectSample` remote-URL sites. The Mar-13 PP-2979 fix was dropped during the BookActionHandler extraction in `69a6a9b39`; remote previews were opening in the embedded `BundledHTMLViewController` and Cantook/third-party readers were reporting "browser doesn't support essential features required by reader" because of missing Web APIs.

2. **Search-race dedup** — new `InflightFeedFetches` actor makes `DefaultCatalogAPI.fetchFeed` dedupe concurrent callers for the same URL. The five concurrent `/groups/` fetches seen when a user started typing before the initial catalog loaded now collapse to one. Cleanup is inline (defer-based) so sequential callers still get fresh requests. Search debounce bumped `0.1s → 0.4s`.

3. **PP-4116 (F-062)** — debounce the Read/Listen button on `BookCellModel.didSelectRead` via a 0.5s reader-presentation lock so rapid taps no longer stack two reader presentations. Detail-screen path was already guarded; the list-cell path was the remaining gap.

4. **PP-4115 (F-065)** — call `applyRegistryUpdates(changedIdentifier: nil)` in `CatalogSearchView.onAppear` so a hold cancelled from the detail screen reconciles deterministically on return to search, without relying on throttled-notification timing.

5. **PP-4117 (F-067)** — classify sign-in errors by `NSURLErrorDomain` connectivity codes (`notConnectedToInternet`, `timedOut`, `networkConnectionLost`, etc.) before falling through to "Invalid Credentials". Airplane-Mode sign-in now surfaces "No Internet Connection" instead of misleading the user about their credentials.

### Tests
- **15 new pin tests**, all mutation-style (flipping the guarded condition makes them fail):
  - `BookActionHandlerPreviewRoutingTests` — 3 tests for `http/https/file://` routing
  - `CatalogAPIDedupeTests` — 3 tests: concurrent-same-URL shares 1 request, different URLs don't dedupe, sequential after completion fires fresh
  - `BookCellModelActionTests` — 3 tests: first acquire succeeds, second rapid call blocked, release after debounce window
  - `TPPSignInBusinessLogicTests` — 6 tests: each connectivity code + problem-doc precedence + non-URLErrorDomain fallback + URLErrorUserAuthenticationRequired isolation
- **Full suite: ~5,600 tests, 0 regressions.** 6 pre-existing `TPPBookRegistry{Bookmark,Location}Tests` flakes confirmed identical on pre-change baseline via `git stash` — unrelated to this PR.
- **Initial dedup design regressed 2 existing `DefaultCatalogAPITests`** via a cleanup race; refactored the actor to inline defer-based cleanup, both now green.

> **Note on `scripts/verify-pr.sh`:** the script reports an inflated test count (12,363 in today's run) because it sums every `Executed N tests` line from xcodebuild, which emits those at per-class, per-suite, and per-target levels. The real count is the largest single `Executed` line (~5,600). Should be fixed in a follow-up PR — out of scope here.

### Build
- `CURRENT_PROJECT_VERSION` bumped `462 → 463`.

## Test plan
- [ ] `xcodebuild build` on iPhone 16 Pro sim — BUILD SUCCEEDED
- [ ] Targeted test runs (all passing): `BookActionHandlerPreviewRoutingTests`, `CatalogAPIDedupeTests`, `BookCellModelActionTests`, `TPPSignInBusinessLogicTests`, `DefaultCatalogAPITests`, `CatalogRepositoryTests`, `CatalogSearchViewModelTests`
- [ ] **Manual smoke on simulator**:
  - [ ] Palace Marketplace PDF preview (Cantook reader): open book detail → Preview → Safari VC loads, no sandbox errors in console
  - [ ] PP-4115: search for a book → detail → reserve → cancel hold → back → search list cell shows "Reserve" button (not stale "Cancel Hold")
  - [ ] PP-4116: rapid-tap Read on a downloaded book in My Books list → single reader presentation, not stacked
  - [ ] PP-4117: enable Airplane Mode → attempt sign-in → alert says "No Internet Connection" (not "Invalid Credentials")
  - [ ] Search race: search immediately after app launch → only one `/groups/` request in logs, subsequent keystrokes only fire `/search/` requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)