### PR TITLE
Load unencrypted PDFs via URL to stop OOM on large files

### DIFF
--- a/Palace/Book/UI/BookDetail/BookService.swift
+++ b/Palace/Book/UI/BookDetail/BookService.swift
@@ -63,9 +63,8 @@ enum BookService {
 
     @MainActor private static func presentPDF(_ book: TPPBook, completion: (() -> Void)? = nil) {
         guard let url = MyBooksDownloadCenter.shared.fileUrl(for: book.identifier) else { completion?(); return }
-        let data = try? Data(contentsOf: url)
         let metadata = TPPPDFDocumentMetadata(with: book)
-        let document = TPPPDFDocument(data: data ?? Data())
+        let document = TPPPDFDocument(url: url)
         if let coordinator = NavigationCoordinatorHub.shared.coordinator {
             coordinator.storePDF(document: document, metadata: metadata, forBookId: book.identifier)
             coordinator.push(.pdf(BookRoute(id: book.identifier)))

--- a/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
+++ b/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
@@ -455,9 +455,8 @@ extension BookCellModel {
             self.isLoading = false
         case .pdf:
             guard let url = downloadCenter.fileUrl(for: book.identifier) else { self.isLoading = false; return }
-            let data = try? Data(contentsOf: url)
             let metadata = TPPPDFDocumentMetadata(with: book)
-            let document = TPPPDFDocument(data: data ?? Data())
+            let document = TPPPDFDocument(url: url)
             if let coordinator = NavigationCoordinatorHub.shared.coordinator {
                 coordinator.storePDF(document: document, metadata: metadata, forBookId: book.identifier)
                 coordinator.push(.pdf(BookRoute(id: book.identifier)))

--- a/Palace/PDF/Model/TPPPDFDocument.swift
+++ b/Palace/PDF/Model/TPPPDFDocument.swift
@@ -17,6 +17,7 @@ protocol TPPPDFDocumentDelegate {
 /// Wrapper class for PDF docuument in general
 @objcMembers class TPPPDFDocument: NSObject {
     let data: Data
+    let fileURL: URL?
     let decryptor: ((_ data: Data, _ start: UInt, _ end: UInt) -> Data)?
     let isEncrypted: Bool
 
@@ -26,6 +27,18 @@ protocol TPPPDFDocumentDelegate {
     /// - Parameter data: PDF document data
     init(data: Data) {
         self.data = data
+        self.fileURL = nil
+        self.decryptor = nil
+        self.isEncrypted = false
+    }
+
+    /// Initialize with a non-encrypted PDF file on disk. `PDFDocument(url:)` mmaps
+    /// the file and pages in on demand, so opening a 500 MB textbook doesn't
+    /// pin the whole buffer in RAM or block the main thread on a synchronous
+    /// read — both of which `Data(contentsOf:)` + `init(data:)` does.
+    init(url: URL) {
+        self.data = Data()
+        self.fileURL = url
         self.decryptor = nil
         self.isEncrypted = false
     }
@@ -36,6 +49,7 @@ protocol TPPPDFDocumentDelegate {
     ///   - decryptor: Decryptor function
     init(encryptedData: Data, decryptor: @escaping (_ data: Data, _ start: UInt, _ end: UInt) -> Data) {
         self.data = encryptedData
+        self.fileURL = nil
         self.decryptor = decryptor
         self.isEncrypted = true
     }
@@ -52,6 +66,9 @@ protocol TPPPDFDocumentDelegate {
     lazy var document: PDFDocument? = {
         guard !isEncrypted else {
             return nil
+        }
+        if let fileURL {
+            return PDFDocument(url: fileURL)
         }
         return PDFDocument(data: data)
     }()


### PR DESCRIPTION
## Summary

User reported **"some PDFs are too large to open"** — specifically a 200+ MB textbook at `urn:isbn:9781637152874` that silently fails to open with a `CoreGraphics PDF has logged an error` line in the log and no user-visible alert.

### Root cause

Two call sites load unencrypted PDFs into RAM synchronously on the main thread before handing the buffer to `TPPPDFDocument(data:)`:

- `Palace/Book/UI/BookDetail/BookService.swift:66` (BookDetail → Open)
- `Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift:458` (My Books cell → Open)

```swift
let data = try? Data(contentsOf: url)
let document = TPPPDFDocument(data: data ?? Data())
```

For a large textbook this (a) reads the whole file off disk on main, (b) pins the buffer in RAM for the document's lifetime, (c) under memory pressure surfaces as a truncated/partial read — which is exactly the state that triggers CoreGraphics's generic "PDF has logged an error" line right before the reader fails to render.

The team already knows PDF size is a problem: `TPPPDFViewController.swift:13` hardcodes a 200 MB cap for **encrypted** PDFs. Unencrypted PDFs had no size gate at all, which matches the reported symptom.

### Fix

Added `TPPPDFDocument.init(url:)` that stores the file URL and makes the `document` lazy property use `PDFDocument(url:)`. PDFKit mmaps the file and pages in on demand — no up-front RAM cost, no synchronous main-thread disk read of the whole file. Switched both call sites to the URL init.

Encrypted path is unchanged — byte-range decryption genuinely needs the data in memory, and the existing `supportedEncryptedDataSize` guard already covers that case.

### What this doesn't fix

A genuinely malformed PDF will still fail, but the failure will be scoped to that document rather than also risking OOM/jetsam for the whole app. If a specific PDF keeps erroring after this ships, set the `CG_PDF_VERBOSE` environment variable to get CoreGraphics to log specifics.

## Test plan

- [x] `xcodebuild -project Palace.xcodeproj -scheme Palace -destination 'platform=iOS Simulator,id=DF4A2A27-9888-429D-A749-2E157A049A37' build` passes cleanly.
- [x] ForgeOS: `cs_55cae8b2` on initiative `init_67d79332`, all gates promoted (review, testing, release), `forge_release_check` returns `can_release: true`.
- [ ] Manual repro: open the previously-failing 200+ MB PDF (`urn:isbn:9781637152874`) from BookDetail → confirms it now opens and pages work.
- [ ] Manual repro: open the same PDF from My Books cell → same outcome.
- [ ] Regression check: open a small PDF (<5 MB) → no behavior change, still opens instantly.
- [ ] Regression check: open an encrypted/LCP PDF → encrypted path unchanged, still routes through byte-range decryption with the existing 200 MB cap.

ForgeOS: cs_55cae8b2 (init_67d79332).

🤖 Generated with [Claude Code](https://claude.com/claude-code)