### PR TITLE
Fix four pre-existing test-suite failures

### DIFF
--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
@@ -439,6 +439,12 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
 
     /// Initiates process of signing in with the server.
     @objc func logIn(with tokenURL: URL? = nil) {
+        // Bail out BEFORE posting TPPIsSigningIn. Without a selected auth
+        // method we have nothing to actually send; firing the notification
+        // would leave observers (UI progress indicators, tests) in a
+        // sign-in-in-progress state that never resolves.
+        guard selectedAuthentication != nil else { return }
+
         NotificationCenter.default.post(name: .TPPIsSigningIn, object: true)
 
         capturedBarcode = uiDelegate?.username

--- a/PalaceTests/Audiobook/AudiobookDataManagerSyncTests.swift
+++ b/PalaceTests/Audiobook/AudiobookDataManagerSyncTests.swift
@@ -113,6 +113,15 @@ class MockNetworkExecutorForSync: TPPNetworkExecutor {
 
 // MARK: - Network Sync Tests
 
+// Test methods must run on the main thread: setUp schedules a drain block
+// via `DispatchQueue.main.asyncAfter` and then calls `wait(for:)` to pump
+// until the block fires. Without `@MainActor` XCTest is free to hop the
+// method onto a background queue; the asyncAfter block never fires because
+// nothing is pumping the main runloop, and the wait times out at 3s —
+// producing the unrelated-looking "drain initial sync" failure in
+// testAudiobookDataManager_Sync_InitializesCorrectly and
+// testSyncValues_withSuccessfulResponse_removesEntriesFromQueue.
+@MainActor
 final class AudiobookDataManagerNetworkSyncTests: XCTestCase {
 
     private var mockNetworkExecutor: MockNetworkExecutorForSync!

--- a/PalaceTests/BookStateManagement/BookCellModelActionTests.swift
+++ b/PalaceTests/BookStateManagement/BookCellModelActionTests.swift
@@ -244,11 +244,21 @@ final class BookCellModelActionTests: XCTestCase {
         _ = model.acquireReaderPresentationLock()
         XCTAssertTrue(model.isPresentingReader)
 
-        let released = expectation(description: "Lock releases after debounce window")
-        // 0.5s lock window + 0.3s buffer — the async dispatch must clear the flag.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-            if !model.isPresentingReader { released.fulfill() }
-        }
+        // Observe `isPresentingReader` via its @Published publisher instead
+        // of sleeping a fixed duration. The previous implementation used a
+        // 0.3s cushion (0.5s production timer + 0.8s test check), which was
+        // too tight under full-suite load — the test would time out when
+        // the main queue's scheduled block slipped by more than 300ms.
+        // Observing the publisher fulfills the moment the flag flips,
+        // regardless of dispatch jitter.
+        let released = expectation(description: "isPresentingReader flips to false")
+        model.$isPresentingReader
+            .dropFirst()
+            .filter { $0 == false }
+            .first()
+            .sink { _ in released.fulfill() }
+            .store(in: &cancellables)
+
         wait(for: [released], timeout: 2.0)
 
         XCTAssertTrue(model.acquireReaderPresentationLock(),


### PR DESCRIPTION
Four test failures that were red on `release/3.0.0` / `develop` before PR #860 was cut, surfaced by the full-suite run after the Firebase Analytics disable fix (PR #860) removed the earlier simulator wedge that was masking them.

## Failures and root causes

### 1. `TPPSignInAdobeSkipTests.testLogIn_withNoSelectedAuth_doesNotCrash`

**Assertion:** \`XCTAssertFalse(signInNotificationPosted, "logIn without a selected auth must not post TPPIsSigningIn")\`.

**Bug:** production. \`TPPSignInBusinessLogic.logIn(with:)\` posted \`TPPIsSigningIn\` unconditionally at line 442 *before* the switch that early-returned on \`.none\`. Observers (UI progress indicators, tests) landed in a sign-in-in-progress state that never resolved.

**Fix:** added \`guard selectedAuthentication != nil else { return }\` at the top of \`logIn(with:)\` so the notification only fires when there's an actual sign-in to observe.

### 2. `BookCellModelActionTests.testAcquireReaderPresentationLock_ReleasesAfterDelay`

**Assertion:** \`wait(for: [released], timeout: 2.0)\` timed out.

**Bug:** test-side fragility. Used a fixed 0.3s cushion between the production code's 0.5s release timer and the test's 0.8s check. Under full-suite load the main queue slipped by more than 300ms, and the 2s wait timed out waiting for a flag flip that had happened 300ms later.

**Fix:** replaced the timer-based check with a Combine observer on \`model.\$isPresentingReader\` that fulfills the moment the flag flips to \`false\`. Robust to dispatch jitter.

### 3 & 4. `AudiobookDataManagerNetworkSyncTests.setUp` drain timeout

Both \`testAudiobookDataManager_Sync_InitializesCorrectly\` and \`testSyncValues_withSuccessfulResponse_removesEntriesFromQueue\` failed at \`setUp\`'s \`wait(for: [drain], timeout: 3.0)\`. The second one had also been hanging for 933s *after* the drain timeout — same root cause, same fix.

**Bug:** test-side threading mismatch. setUp schedules a drain block via \`DispatchQueue.main.asyncAfter\` and then calls \`wait(for:)\` to pump until it fires. Without \`@MainActor\` on the class, XCTest was free to hop the setUp method onto a background queue; the asyncAfter block landed on main with no one pumping the runloop, and the drain timed out.

**Fix:** marked the class \`@MainActor\` so setUp runs on main, where \`wait(for:)\` pumps the main runloop as expected.

## Verification

| suite | before | after |
|---|---|---|
| \`TPPSignInAdobeSkipTests\` | 13 pass / 1 fail | 14 pass / 0 fail |
| \`BookCellModelActionTests\` | 17 pass / 1 fail | 18 pass / 0 fail |
| \`AudiobookDataManagerNetworkSyncTests\` | 3 pass / 2 fail | 5 pass / 0 fail |

All four tests now pass deterministically.

## Test plan

- [x] Each fixed suite passes in isolation
- [ ] Full suite run on develop with this branch merged — confirm no regressions introduced, no new hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)