### PR TITLE
Fix two latent bugs in governance scripts (gate-hook + grep counters)

### DIFF
--- a/scripts/forgeos-gate-hook.sh
+++ b/scripts/forgeos-gate-hook.sh
@@ -31,18 +31,26 @@ fi
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 
-# Find the most recent changeset for this branch
-CHANGESET_ID=$(curl -s \
+# Server's ?branch= query is currently ignored — paginate and filter client-side.
+# This was a real bug 2026-04-27 when this hook was resolving to whatever
+# changeset happened to be at the top of the unfiltered list (a stale
+# changeset on a different branch), letting the gate-check fail against the
+# wrong record.
+CHANGESET_ID=$(curl -s --max-time 5 \
   -H "X-ForgeOS-API-Key: $FORGEOS_API_KEY" \
-  "${API_URL}/api/projects/${PROJECT_ID}/changesets?branch=${BRANCH}&limit=1" 2>/dev/null | \
-  python3 -c "
-import sys, json
+  "${API_URL}/api/projects/${PROJECT_ID}/changesets?branch=${BRANCH}&limit=100" 2>/dev/null | \
+  BRANCH="$BRANCH" python3 -c "
+import sys, json, os
+target = os.environ.get('BRANCH', '')
 try:
     data = json.load(sys.stdin)
     items = data if isinstance(data, list) else data.get('items', data.get('changesets', []))
-    if items:
-        print(items[0]['id'])
-except:
+    matches = [i for i in items if i.get('branch') == target and i.get('status') != 'merged']
+    if not matches:
+        matches = [i for i in items if i.get('branch') == target]
+    if matches:
+        print(matches[0]['id'])
+except Exception:
     pass
 " 2>/dev/null)
 

--- a/scripts/forgeos-session.sh
+++ b/scripts/forgeos-session.sh
@@ -149,8 +149,12 @@ cmd_evidence() {
   echo "$test_output" | grep -q "BUILD SUCCEEDED\|TEST.*SUCCEEDED" && build_ok="true"
 
   local errors warnings
-  errors=$(echo "$test_output" | grep -c "error:" || echo "0")
-  warnings=$(echo "$test_output" | grep -c "warning:" || echo "0")
+  # `|| true` (not `|| echo "0"`): grep -c prints "0" on no match; the
+  # fallback was producing "0\n0" and breaking integer comparisons downstream.
+  errors=$(echo "$test_output" | grep -c "error:" || true)
+  warnings=$(echo "$test_output" | grep -c "warning:" || true)
+  errors=${errors:-0}
+  warnings=${warnings:-0}
 
   echo "Submitting unit_test evidence (pass: $pass_count, fail: $fail_count)..."
   api POST "/api/projects/${PROJECT_ID}/changesets/${cs_id}/evidence" "{
@@ -236,9 +240,9 @@ cmd_evidence() {
       [ -z "$ui_file" ] && continue
       [ ! -f "$ui_file" ] && continue
       local has_button has_a11y
-      has_button=$(grep -c 'UIButton\|Button(' "$ui_file" 2>/dev/null || echo "0")
-      has_a11y=$(grep -c 'accessibilityIdentifier\|accessibilityLabel\|isAccessibilityElement' "$ui_file" 2>/dev/null || echo "0")
-      if [ "$has_button" -gt 0 ] && [ "$has_a11y" -eq 0 ]; then
+      has_button=$(grep -c 'UIButton\|Button(' "$ui_file" 2>/dev/null || true)
+      has_a11y=$(grep -c 'accessibilityIdentifier\|accessibilityLabel\|isAccessibilityElement' "$ui_file" 2>/dev/null || true)
+      if [ "${has_button:-0}" -gt 0 ] && [ "${has_a11y:-0}" -eq 0 ]; then
         a11y_issues=$((a11y_issues + 1))
       fi
     done <<< "$changed_ui"

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -73,8 +73,10 @@ echo "--- Build ---"
 BUILD_OUTPUT=$(xcodebuild -project Palace.xcodeproj -scheme Palace \
   -destination "id=$SIM_ID" build 2>&1)
 if echo "$BUILD_OUTPUT" | grep -q "BUILD SUCCEEDED\|BUILD FAILED"; then
-  SWIFT_ERRORS=$(echo "$BUILD_OUTPUT" | grep -c "error:.*\.swift:" || echo "0")
-  if [ "$SWIFT_ERRORS" -eq 0 ]; then
+  # `|| true` (not `|| echo "0"`): grep -c already prints "0" on no match, so
+  # the fallback was producing "0\n0" and breaking the integer test below.
+  SWIFT_ERRORS=$(echo "$BUILD_OUTPUT" | grep -c "error:.*\.swift:" || true)
+  if [ "${SWIFT_ERRORS:-0}" -eq 0 ]; then
     record "build" "pass" "No Swift compilation errors"
   else
     record "build" "fail" "$SWIFT_ERRORS Swift compilation errors"
@@ -103,7 +105,7 @@ if [ -f scripts/lint-test-quality.py ]; then
   NEW_VIOLATIONS=0
   while IFS= read -r test_file; do
     [ -z "$test_file" ] && continue
-    FILE_VIOLATIONS=$(echo "$LINT_OUTPUT" | grep -c "$test_file" || echo "0")
+    FILE_VIOLATIONS=$(echo "$LINT_OUTPUT" | grep -c "$test_file" || true)
     NEW_VIOLATIONS=$((NEW_VIOLATIONS + FILE_VIOLATIONS))
   done <<< "$CHANGED_TEST_SWIFT"
   if [ "$NEW_VIOLATIONS" -eq 0 ]; then
@@ -187,9 +189,9 @@ if [ -n "$CHANGED_UI" ]; then
     [ -z "$ui_file" ] && continue
     [ ! -f "$ui_file" ] && continue
     # Check for Button/Image without accessibilityIdentifier or accessibilityLabel
-    HAS_BUTTON=$(grep -c 'UIButton\|Button(' "$ui_file" 2>/dev/null || echo "0")
-    HAS_A11Y=$(grep -c 'accessibilityIdentifier\|accessibilityLabel\|isAccessibilityElement' "$ui_file" 2>/dev/null || echo "0")
-    if [ "$HAS_BUTTON" -gt 0 ] && [ "$HAS_A11Y" -eq 0 ]; then
+    HAS_BUTTON=$(grep -c 'UIButton\|Button(' "$ui_file" 2>/dev/null || true)
+    HAS_A11Y=$(grep -c 'accessibilityIdentifier\|accessibilityLabel\|isAccessibilityElement' "$ui_file" 2>/dev/null || true)
+    if [ "${HAS_BUTTON:-0}" -gt 0 ] && [ "${HAS_A11Y:-0}" -eq 0 ]; then
       A11Y_ISSUES=$((A11Y_ISSUES + 1))
     fi
   done <<< "$CHANGED_UI"


### PR DESCRIPTION
## Summary

Two mechanical bugs in the governance tooling, surfaced while landing the Architectural Triad PRs (#866, #867). Tooling-only — no production Swift, no CI test surface change.

### 1. `scripts/forgeos-gate-hook.sh` — picked the wrong changeset

The API's `?branch=` query is currently ignored server-side, but the hook never client-side filtered the result. It was taking `items[0]` from the unfiltered list, which resolved to whatever changeset happened to be at the top — usually a stale changeset on a different branch. Reproduced live: phase-5 lookup was returning `cs_fee5cb8d` (a `fix/lru-eviction-registry-sync` changeset) instead of the actual phase-5 changeset.

The PreToolUse hook entry in `.claude/settings.json` swallows this hook's exit via `|| true`, so the wrong lookup didn't actually block PR creation, but the diagnostic was misleading and any future tightening would have started failing PRs erroneously.

Fix: port the harness's `pre-push-check.sh` client-side filter (the already-correct sibling), bump page size from 1 → 100, add curl `--max-time 5`.

### 2. `scripts/verify-pr.sh` + `scripts/forgeos-session.sh` — `grep -c "X" || echo "0"` produced "0\\n0"

8 places used the same buggy idiom. When `grep -c` finds 0 matches it prints `0` AND exits 1; the `||` fallback then APPENDS another `0`, producing the literal string `0\n0`. Subsequent integer tests like `[ "$VAR" -eq 0 ]` then bail with `[: 0\n0: integer expression expected`.

Symptom: `verify-pr.sh --quick` reports build `[FAIL]` with detail `0\n0 Swift compilation errors` even when xcodebuild succeeds — confirmed on the run that gated #866/#867. Build was actually green; only the bash counter was wrong.

Fix: replace `|| echo "0"` with `|| true`, add `${VAR:-0}` defaults at comparison sites so the variable is guaranteed numeric.

## Files

- `scripts/forgeos-gate-hook.sh` (+16 / −8)
- `scripts/verify-pr.sh` (+9 / −5)
- `scripts/forgeos-session.sh` (+8 / −6)

## Test plan

- [x] Manual: ran the fixed hook against `epic/arch-triad-phase-4` and `epic/arch-triad-phase-5` — both resolve to the correct changeset (`cs_8b37a0b7` and `cs_0a2d6c74` respectively).
- [x] Manual: `grep -c "X" || true` confirmed to output single `0` instead of `0\n0`.
- [ ] CI: no automated harness for bash scripts in this repo; future bash additions could benefit from a bats/shunit test suite.

## ForgeOS

Changeset `cs_9f8908a7` (initiative `init_e7603d4e`). All gates passed (review → testing → release). `forge_release_check: can_release: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)