### PR TITLE
docs: reframe public CLAUDE.md + TESTING_POSTURE.md (ForgeOS as internal tooling)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,60 +2,32 @@
 
 Library reading app supporting EPUB, PDF, and audiobooks with multiple DRM systems.
 
-## Mandatory Verification — READ FIRST
+## Contributing & Development Workflow
 
-Every session that produces code changes MUST follow this workflow. No exceptions.
+**Outside contributors:** standard GitHub flow — fork the repo, branch from `develop` (never `main`), open a PR back to `develop` when ready. Tests are mandatory for production changes (see [TDD & Test Quality](#tdd--test-quality--mandatory) below).
 
-### 1. ForgeOS governance (every session)
-```bash
-# Session start — initialize project
-forge_init  # project: proj_87884c17
-forge_propose_changeset  # BEFORE coding — read required evidence to shape implementation
+**Internal Synctek contributors** additionally run through ForgeOS governance gates (changeset → evidence → review → promote). That tooling is in `scripts/forgeos-*.sh` and is exercised via the local-only `.claude/settings.json` PreToolUse hooks. Outside contributors can ignore those scripts; they no-op gracefully without an API key.
 
-# During work — collect evidence as milestones hit
-scripts/forgeos-session.sh evidence <changeset_id>
+**Pre-PR self-check (anyone):** `scripts/verify-pr.sh --quick` runs the full battery — build, tests, lint, coverage, accessibility — against the iPhone 16 Pro simulator. JSON report optional: `--report /tmp/v.json`.
 
-# Before PR — ALL gates must be promoted
-scripts/forgeos-session.sh promote <changeset_id>
-forge_release_check  # must return can_release: true
-```
-
-### 2. Pre-PR verification (every PR)
-```bash
-# Full verification battery — build, tests, lint, coverage, mutation, a11y
-scripts/verify-pr.sh                     # All checks
-scripts/verify-pr.sh --quick             # Skip mutation (faster)
-scripts/verify-pr.sh --report /tmp/v.json  # JSON report for tracking
-```
-
-### 3. Enforcement hooks (automatic — you WILL be blocked)
-- **git commit**: blocked unless ForgeOS changeset exists for current branch
-- **git push**: blocked unless ForgeOS gates pass
-- **gh pr create**: blocked unless ForgeOS gates pass
-
-### 4. Testing posture
-Full testing capabilities, confidence matrix, and gaps documented in:
-**`docs/Testing/TESTING_POSTURE.md`** — read before writing tests for unfamiliar areas.
-
-### 5. Before every PR
-- Run mutation testing: `python3 scripts/palace_mutate.py --file <changed>.swift --tests PalaceTests/`
-- ForgeOS gate-check passes
-- Target branch: `develop` (never `main` directly)
+**Architecture decisions:** see [`docs/architecture/`](./docs/architecture/) for the rationale behind major refactors (the post-modernization triad work, the parallel-agent rebase pattern, post-PR retros).
 
 ## Build & Test
 
 ```bash
-# Build (use xcodeproj, NOT workspace — workspace hits Firebase SPM issues)
+# Build (use xcodeproj, NOT workspace — workspace hits Firebase SPM issues).
+# Replace SIM_ID with your iPhone simulator UDID:
+#   xcrun simctl list devices iPhone | grep Booted
 xcodebuild -project Palace.xcodeproj -scheme Palace \
-  -destination 'platform=iOS Simulator,id=DF4A2A27-9888-429D-A749-2E157A049A37' build
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build
 
 # Run all tests
 xcodebuild -project Palace.xcodeproj -scheme Palace \
-  -destination 'platform=iOS Simulator,id=DF4A2A27-9888-429D-A749-2E157A049A37' test
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' test
 
 # Run a single test class
 xcodebuild -project Palace.xcodeproj -scheme Palace \
-  -destination 'platform=iOS Simulator,id=DF4A2A27-9888-429D-A749-2E157A049A37' \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
   -only-testing:PalaceTests/MyTestClass test
 ```
 
@@ -67,7 +39,7 @@ xcodebuild -project Palace.xcodeproj -scheme Palace \
 
 ```
 Palace/
-  AppInfrastructure/   # App launch, Firebase, navigation
+  AppInfrastructure/   # App launch, Firebase, navigation, AppContainer DI root
   Accounts/            # Library account management
   Book/                # Book models and detail views
   MyBooks/             # Downloaded books management
@@ -79,30 +51,36 @@ Palace/
   Reader3/             # PDF reader
   OPDS/                # OPDS 1.x parsing (Objective-C)
   OPDS2/               # OPDS 2.0 parsing and services
-  SignInLogic/         # Authentication flows (OAuth, SAML, basic)
+  SignInLogic/         # Authentication flows (OAuth, SAML, basic, OIDC)
   Network/             # HTTP networking layer
   Keychain/            # Secure credential storage
+  Holds/               # Reservations / holds flows + HoldsReducer
   Utilities/           # Extensions, helpers, concurrency
   Migrations/          # App upgrade migrations
 
 PalaceTests/
   Mocks/               # 21 shared mock implementations
-  ViewModels/          # ViewModel unit tests
+  ViewModels/          # ViewModel + reducer unit tests
   Network/             # Network layer tests
   Snapshots/           # UI snapshot tests
   (organized by feature area)
 
 PalaceConfig/          # Assets, certs, plists
 scripts/               # Build, test, release automation
+docs/                  # Architecture decisions + testing posture
 ```
 
 ## Architecture
 
-- **MVVM + Services** — ViewModels are `@MainActor ObservableObject` with `@Published` properties
+- **MVVM + Services + Reducers** — ViewModels are `@MainActor ObservableObject` with `@Published` properties; critical-path state machines extracted into pure `Reducer.reduce(state, action) -> Effect` functions
+- **`AppContainer`** — single composition root in `Palace/AppInfrastructure/AppContainer.swift`. Use `AppContainer.production()` for the live graph; pass an explicit `AppContainer` for tests/previews. Avoid `.shared` reads in new code.
+- **`Store<State, Action, Environment>`** — closure-based reducer + Effect type (~70 LOC) in `Palace/AppInfrastructure/Store.swift`. Not TCA — minimal ceremony.
 - **SwiftUI** for new UI, **UIKit** for legacy screens
 - **Combine** for reactive state management
 - **Manual DI** via protocols — no framework, inject through constructors
 - Mixed **Swift/Objective-C** (legacy OPDS parsing)
+
+See [`docs/architecture/architectural-triad.md`](./docs/architecture/architectural-triad.md) for the design rationale and decision log.
 
 ## Dependencies
 
@@ -131,7 +109,7 @@ scripts/               # Build, test, release automation
 **Test quality rules — every test must:**
 - **Test behavior, not implementation.** Assert what the code DOES, not how it's structured. `XCTAssertEqual(cart.total, 15.99)` is good. `XCTAssertTrue(viewModel.showSearchSheet)` after just setting it is fluff.
 - **Have meaningful setup.** If the test body is just `let x = Foo(); XCTAssertNotNil(x)`, it's not a test. Tests need Arrange → Act → Assert with a real Act step.
-- **Use mocks/stubs for dependencies.** Never hit real singletons (.shared), network, keychain, or UserDefaults. Inject via protocol.
+- **Use mocks/stubs for dependencies.** Never hit real singletons (`.shared`), network, keychain, or `UserDefaults`. Inject via protocol.
 - **Test edge cases, not happy paths only.** Empty arrays, nil values, concurrent access, error responses, expired tokens, malformed data.
 - **Name tests as behavior specs.** `testBorrow_WhenNotSignedIn_ShowsAuthPrompt` not `testBorrowButton`.
 
@@ -149,9 +127,19 @@ scripts/               # Build, test, release automation
 
 If the answer is no, the test is fluff regardless of assertion count. Run mutation testing on changed files:
 ```bash
-python3 scripts/palace_mutate.py --file Palace/Path/ChangedFile.swift --tests PalaceTests/Path/ --dry-run
-# Then without --dry-run to verify tests catch the mutants
+# Discover mutation surface (no test runs):
+python3 scripts/palace_mutate.py \
+  --file Palace/Path/ChangedFile.swift \
+  --tests PalaceTests/ChangedFileTests \
+  --dry-run
+
+# Verify tests catch the mutants:
+python3 scripts/palace_mutate.py \
+  --file Palace/Path/ChangedFile.swift \
+  --tests PalaceTests/ChangedFileTests
 ```
+
+The `--tests` arg is an XCTest **class** name (not a directory) — `-only-testing` matches `<TestBundle>/<XCTestCase subclass>`. A run that says "0 tests executed" is a misconfiguration, not a clean pass.
 
 A test that doesn't kill any mutants should be rewritten to test the actual behavior path, not just surface properties.
 
@@ -180,7 +168,7 @@ Never commit: `APIKeys.swift`, `GoogleService-Info.plist`, `TPPSecrets.swift`, `
 
 Recording coverage is reported as `<journeys-with-matching-replay> / <total-journeys>` (see `.github/workflows/unit-testing.yml`). Do NOT divide total replay files by total journeys — that ratio is meaningless and was the bug behind the "46/25 passing" mislabel.
 
-MCP server: `specterqa-ios==7.0.0`. Preferred sim: iPhone 12 (`31CF5C43-DD55-4889-B3B2-9A6810B4E98F`, iOS 26).
+MCP server: `specterqa-ios==7.0.0`.
 
 ### MCP Tool Rules — MANDATORY
 
@@ -201,11 +189,11 @@ MCP server: `specterqa-ios==7.0.0`. Preferred sim: iPhone 12 (`31CF5C43-DD55-488
 ### Simulator Setup
 
 ```bash
-# Kill stale runners, boot sim, enable dev settings
+# Kill stale runners; replace SIM_UDID with your iPhone simulator UDID:
 pgrep -f "xcodebuild test-without-building" | xargs -r kill -9
-xcrun simctl boot 31CF5C43-DD55-4889-B3B2-9A6810B4E98F 2>/dev/null || true
-xcrun simctl spawn 31CF5C43-DD55-4889-B3B2-9A6810B4E98F defaults write org.thepalaceproject.palace showDeveloperSettings -bool true
-xcrun simctl spawn 31CF5C43-DD55-4889-B3B2-9A6810B4E98F defaults write org.thepalaceproject.palace NYPLUseBetaLibrariesKey -bool true
+SIM_UDID=$(xcrun simctl list devices iPhone | awk '/Booted/ {print $NF; exit}' | tr -d '()')
+xcrun simctl spawn "$SIM_UDID" defaults write org.thepalaceproject.palace showDeveloperSettings -bool true
+xcrun simctl spawn "$SIM_UDID" defaults write org.thepalaceproject.palace NYPLUseBetaLibrariesKey -bool true
 ```
 
-Two libraries configured: A1QA Test Library (signed in) + Lyrasis Reads. Credentials at `~/.specterqa/credentials/a1qa-test.env`.
+Test library credentials live in your local environment (e.g. `~/.specterqa/credentials/`) and are never committed to the repo.

--- a/docs/Testing/TESTING_POSTURE.md
+++ b/docs/Testing/TESTING_POSTURE.md
@@ -88,30 +88,20 @@ Last updated: 2026-04-16
 - `ui-testing.yml` — E2E test runner (manual trigger)
 - `ledger.yml` — Ledger + QAAtlas + AccessLint (non-blocking)
 
-## Governance Pipeline
+## Pre-PR Verification
 
-Every code change follows this pipeline (enforced by hooks):
+Anyone can self-check their work before opening a PR:
 
-```
-forge_init ─→ forge_propose_changeset ─→ evidence collection ─→ gate promotion ─→ PR
-                                              │
-                    ┌─────────────────────────┴───────────────────────────┐
-                    │ unit_test: XCTest pass/fail counts                  │
-                    │ lint: build errors + test-quality violations         │
-                    │ coverage: line coverage % vs floors                  │
-                    │ mutation: kill rate on changed files (threshold 50%) │
-                    │ a11y_audit: accessibility annotations on UI files    │
-                    └─────────────────────────────────────────────────────┘
+```bash
+scripts/verify-pr.sh --quick    # build + tests + lint + coverage + a11y
+scripts/verify-pr.sh            # adds mutation testing on changed files
 ```
 
-**Enforcement hooks** (`.claude/settings.json`):
-- `git commit` blocked without ForgeOS changeset
-- `git push` blocked without passing gates
-- `gh pr create` blocked without passing gates
+Each check is recorded against the changed files only — pass/fail summary at the end. JSON report optional via `--report /tmp/v.json` for CI consumption.
 
-**Evidence collection**: `scripts/forgeos-session.sh evidence <cs_id>` runs the full battery automatically.
+The mutation pass invokes `python3 scripts/palace_mutate.py` per changed Swift file, looking for ≥50% mutant kill rate (or ≥40% on legacy code with no characterization tests). Critical-path files (sign-in, borrow, download, DRM) require 100% kill rate.
 
-**Pre-PR verification**: `scripts/verify-pr.sh` runs build + tests + lint + coverage + mutation + a11y and produces a JSON report.
+Internal Synctek contributors additionally run through ForgeOS governance gates that hook into `git commit` / `git push` / `gh pr create` — that pipeline is local-only and outside contributors don't need it.
 
 ## Confidence Matrix
 
@@ -196,32 +186,13 @@ Use this for releases and for areas where automation gaps exist:
 
 ## Process Integration
 
-### Every Session
-```bash
-# 1. Init governance
-forge_init  # project: proj_87884c17
-
-# 2. Propose changeset BEFORE coding (read required evidence)
-forge_propose_changeset  # with planned files + modules
-
-# 3. Implement with TDD (tests first, then production code)
-
-# 4. Collect evidence
-scripts/forgeos-session.sh evidence <changeset_id>
-# Collects: unit_test, lint, coverage, mutation, a11y
-
-# 5. Promote gates
-scripts/forgeos-session.sh promote <changeset_id>
-
-# 6. Verify
-scripts/verify-pr.sh --report /tmp/verify.json
-
-# 7. Release check
-forge_release_check  # must return can_release: true
-
-# 8. Create PR (hooks enforce governance)
-gh pr create --base develop
-```
+### Per-change cycle
+1. **Plan tests first.** What edge cases, what error paths, what state transitions need to be pinned?
+2. **Write the failing test.** TDD — never write production code without a failing test driving it.
+3. **Make it pass.** Minimum production code, then refactor both sides.
+4. **Verify with `scripts/verify-pr.sh --quick`.** Build, tests, lint, coverage, accessibility — all green before pushing.
+5. **For critical-path changes** (sign-in, borrow, download, DRM, payment): also run `scripts/palace_mutate.py` against changed files and confirm 100% kill rate.
+6. **Open the PR against `develop`** (never `main`). Hooks enforce additional internal governance for Synctek contributors; outside contributors follow standard GitHub PR flow.
 
 ### Every Release
 ```bash


### PR DESCRIPTION
## Summary

The public `CLAUDE.md` and `docs/Testing/TESTING_POSTURE.md` previously presented ForgeOS governance as mandatory for all contributors, embedded the internal project ID, hardcoded sim UDIDs, and included Maurice-specific local paths. Outside contributors saw a workflow they couldn't follow (no API key) and would-be contributors saw "you WILL be blocked" language for hooks that gracefully no-op anyway.

This PR reframes both files so:

- **Outside contributors** get a clear "Contributing & Development Workflow" section: fork, branch from `develop`, open PR. Tests are mandatory. `scripts/verify-pr.sh --quick` available for self-checking.
- **Internal Synctek contributors** are pointed at the additional ForgeOS gates as a one-paragraph footnote — visible-but-optional rather than mandatory-but-hidden.

## Changes

### `CLAUDE.md`

- Removed mandatory "Mandatory Verification — READ FIRST" preamble (lines 5–46) that hardcoded `proj_87884c17` and `forge_*` commands.
- Added "Contributing & Development Workflow" section that branches by contributor type.
- Added pointer to `docs/architecture/` for design rationale (lands separately in #869).
- Replaced hardcoded `id=DF4A2A27-9888-429D-A749-2E157A049A37` simulator UDIDs in build commands with generic `name=iPhone 16 Pro` lookups.
- Removed hardcoded preferred-sim UDID from SpecterQA section.
- Removed credentials path (`~/.specterqa/credentials/a1qa-test.env`) — replaced with generic "your local environment" pointer.
- Added small note clarifying that `palace_mutate.py`'s `--tests` arg is an XCTest **class** name, not a directory (this caught a real misconfiguration during PR #867 verification).

### `docs/Testing/TESTING_POSTURE.md`

- Removed "Governance Pipeline" section that hardcoded ForgeOS commands and project ID.
- Replaced with "Pre-PR Verification" section focused on `scripts/verify-pr.sh` (which IS useful for any contributor).
- Removed 8-step "Process Integration / Every Session" workflow that was ForgeOS-specific.
- Replaced with generic 6-step per-change cycle (plan tests → write failing test → make pass → verify-pr → mutation for critical-path → open PR).

## Preserved

Everything that benefits *every* contributor stays:

- TDD rules (test-first, test behavior not implementation)
- Test quality checklist (banned patterns, fluff replacement, mutation verification)
- Critical-path-air-tight rule (sign-in, borrow, download, DRM tests must kill mutants)
- SpecterQA MCP tool rules
- Build instructions
- Project structure / architecture / dependencies

## Net diff

`+55 / -96`. CLAUDE.md ends up cleaner-and-shorter than before; TESTING_POSTURE.md drops the ForgeOS-specific sections without losing anything generic.

## Test plan

- [x] `proj_87884c17` no longer appears in either file
- [x] No hardcoded sim UDIDs in build commands
- [x] No Maurice-specific paths
- [x] All preserved sections render correctly in GitHub markdown preview
- [x] No Swift / test code changed; CI suite unaffected

## Strategic context

This is the "Layer 2" half of a planned three-layer strategic move (Layer 1 = parameterize the scripts, Layer 2 = reframe the docs, Layer 3 = publish architectural decisions). Layer 3 ships in #869. Layer 1 is a future decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)