### PR TITLE
Wire AuthReducer into TPPSignInBusinessLogic (Phase 5b)

### DIFF
--- a/Palace/SignInLogic/TPPSignInBusinessLogic+OAuth.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+OAuth.swift
@@ -187,7 +187,7 @@ extension TPPSignInBusinessLogic {
             Log.info(#file, "🔐 [REDIRECT]   Patron name: \(patronName)")
         }
 
-        self.authToken = authToken
+        self.dispatch(.bearerTokenReceived(token: authToken, expiration: nil))
         self.patron = parsedPatron
         Log.info(#file, "🔐 [REDIRECT] Stored authToken and patron in businessLogic")
         Log.info(#file, "🔐 [REDIRECT] Calling validateCredentials()...")

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+OIDC.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+OIDC.swift
@@ -301,7 +301,7 @@ extension TPPSignInBusinessLogic {
             return
         }
 
-        self.authToken = authToken
+        self.dispatch(.bearerTokenReceived(token: authToken, expiration: nil))
         self.patron = parsedPatron
         validateCredentials()
     }

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
@@ -221,6 +221,7 @@ extension TPPSignInBusinessLogic {
         userAccount.removeAll()
         selectedIDP = nil
         samlHelper.clearState()
+        dispatch(.signOutCompleted)
 
         TPPNetworkExecutor.shared.clearCache()
         URLCache.shared.removeAllCachedResponses()

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+UI.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+UI.swift
@@ -37,11 +37,6 @@ extension TPPSignInBusinessLogic {
             let barcode = self.capturedBarcode ?? self.uiDelegate?.username
             let pin = self.capturedPin ?? self.uiDelegate?.pin
 
-            // Clear captured credentials immediately after reading — they're now
-            // in local variables and will be written to the keychain below.
-            self.capturedBarcode = nil
-            self.capturedPin = nil
-
             self.updateUserAccount(forDRMAuthorization: drmSuccess,
                                    withBarcode: barcode,
                                    pin: pin,
@@ -63,8 +58,8 @@ extension TPPSignInBusinessLogic {
             }
             #endif
 
-            self.ignoreSignedInState = false
-            // Phase 4: Restore auth state after successful credential refresh
+            // ignoreSignedInState is cleared by `.userAccountUpdated` dispatch
+            // inside `updateUserAccount`. Restore the persisted auth state too.
             self.userAccount.markLoggedIn()
 
             let completionHandler = self.refreshAuthCompletion

--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
@@ -103,8 +103,26 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
         return uiDelegate?.context ?? "Unknown"
     }
 
+    // MARK: - Auth state machine
+
+    /// In-flight auth state managed by `AuthReducer`. The legacy `@objc`
+    /// properties below are computed from this state — `authState` is the
+    /// single source of truth.
+    /// Internal so tests under `@testable import Palace` can assert against
+    /// it directly when the public delegate API isn't expressive enough.
+    var authState = AuthState()
+
+    /// Run an `AuthAction` through `AuthReducer`. Effects are currently all
+    /// `.none`, so we discard the return value.
+    func dispatch(_ action: AuthAction) {
+        _ = AuthReducer.reduce(&authState, action)
+    }
+
     /// This flag should be set if the instance is used to register new users.
-    @objc var isLoggingInAfterSignUp: Bool = false
+    @objc var isLoggingInAfterSignUp: Bool {
+        get { authState.isLoggingInAfterSignUp }
+        set { dispatch(.loggingInAfterSignUpFlagSet(newValue)) }
+    }
 
     /// A closure that will be invoked at the end of the sign-in process when
     /// refreshing authentication.
@@ -113,17 +131,19 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
     // MARK: - OAuth / SAML / Clever Info
 
     /// The current OAuth token if available.
-    var authToken: String?
+    var authToken: String? { authState.authToken }
 
-    var authTokenExpiration: Date?
+    var authTokenExpiration: Date? { authState.authTokenExpiration }
 
     /// Barcode/PIN captured at sign-in time so that `finalizeSignIn` does not
     /// need to re-read them from the ViewModel, which may have been cleared by
     /// an intermediate `accountDidChange` notification.
-    var capturedBarcode: String?
-    var capturedPin: String?
+    var capturedBarcode: String? { authState.capturedBarcode }
+    var capturedPin: String? { authState.capturedPin }
 
-    /// The current patron info if available.
+    /// The current patron info if available. Excluded from `AuthState` by
+    /// design — opaque dictionary that's not Equatable and is set/cleared
+    /// imperatively via `updateUserAccount`.
     var patron: [String: Any]?
 
     /// Settings used by OAuth sign-in flows.
@@ -155,10 +175,8 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
     /// This overrides the sign-in state logic to behave as if the user isn't
     /// authenticated. This is useful if we already have credentials, but
     /// the session expired (e.g. SAML flow).
-    /// TODO: Remove once credentialsStale state machine is proven in production.
-    /// isSignedIn() now checks both this flag AND userAccount.authState == .credentialsStale.
-    /// Both are set/reset in tandem (refreshAuth sets both, updateUserAccount resets both).
-    var ignoreSignedInState: Bool = false
+    /// isSignedIn() checks both this flag AND userAccount.authState == .credentialsStale.
+    var ignoreSignedInState: Bool { authState.ignoreSignedInState }
 
     /// This is `true` during the process of validating credentials.
     ///
@@ -167,7 +185,7 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
     /// typing them in, or the redirection to 3rd party website for OAuth;
     /// see `logIn`), and *before* doing DRM authorization (see
     /// `drmAuthorizeUserData`).
-    @objc var isValidatingCredentials = false
+    @objc var isValidatingCredentials: Bool { authState.isValidatingCredentials }
 
     // MARK: - Library Accounts Info
 
@@ -302,7 +320,7 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
     /// Clever and SAML), validate said credentials against the Circulation
     /// Manager servers and call back to the UI once that's concluded.
     func validateCredentials() {
-        isValidatingCredentials = true
+        dispatch(.credentialsValidationStarted)
 
         guard let req = makeRequest(for: .signIn, context: uiContext) else {
             let error = NSError(domain: TPPErrorLogger.clientDomain,
@@ -319,8 +337,6 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
         networker.executeRequest(req, enableTokenRefresh: false) { [weak self] result in
             guard let self = self else { return }
 
-            self.isValidatingCredentials = false
-
             let loggingContext: [String: Any] = [
                 "Request": req.loggableString,
                 "Attempted Barcode": self.uiDelegate?.username?.md5hex() ?? "N/A",
@@ -328,6 +344,7 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
 
             switch result {
             case .success(let responseData, _):
+                self.dispatch(.credentialsValidationSucceeded)
                 // Notify delegate that credentials were received and DRM processing is about to begin
                 // This allows the UI to show a loading indicator after WebView dismisses
                 TPPMainThreadRun.asyncIfNeeded {
@@ -359,8 +376,8 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
 
             switch result {
             case .success(let tokenResponse):
-                self?.authToken = tokenResponse.accessToken
-                self?.authTokenExpiration = tokenResponse.expirationDate
+                self?.dispatch(.bearerTokenReceived(token: tokenResponse.accessToken,
+                                                   expiration: tokenResponse.expirationDate))
                 self?.validateCredentials()
             case .failure(let error):
                 self?.handleNetworkError(error as NSError, loggingContext: ["Context": self?.uiContext as Any])
@@ -385,6 +402,7 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
                                      metadata: loggingContext)
 
         let (title, message) = Self.userFacingSignInError(for: error, problemDocument: problemDoc)
+        dispatch(.credentialsValidationFailed(title: title, message: message))
 
         TPPMainThreadRun.asyncIfNeeded {
             self.uiDelegate?.businessLogic(self,
@@ -446,8 +464,7 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
 
         NotificationCenter.default.post(name: .TPPIsSigningIn, object: true)
 
-        capturedBarcode = uiDelegate?.username
-        capturedPin = uiDelegate?.pin
+        dispatch(.credentialCaptureStarted(barcode: uiDelegate?.username, pin: uiDelegate?.pin))
 
         TPPMainThreadRun.asyncIfNeeded {
             self.uiDelegate?.businessLogicWillSignIn(self)
@@ -477,7 +494,7 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
         }
     }
 
-    @objc var isAuthenticationDocumentLoading: Bool = false
+    @objc var isAuthenticationDocumentLoading: Bool { authState.isAuthenticationDocumentLoading }
 
     /// Makes sure we have the `libraryAccount` `details` loading the
     /// authentication document if needed.
@@ -496,9 +513,9 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
             return
         }
 
-        isAuthenticationDocumentLoading = true
+        dispatch(.authDocumentLoadStarted)
         libraryAccount.loadAuthenticationDocument(using: self) { success in
-            self.isAuthenticationDocumentLoading = false
+            self.dispatch(.authDocumentLoadCompleted)
             completion(success)
         }
     }
@@ -529,15 +546,16 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
 
         refreshAuthCompletion = completion
 
+        if let methodType = authDef.asAuthMethodType {
+            dispatch(.refreshAuthStarted(authType: methodType,
+                                         usingExistingCredentials: usingExistingCredentials))
+        }
+
         // reset authentication if needed
         if authDef.isSaml || authDef.isOauth || authDef.isOidc {
             if !usingExistingCredentials {
-                // if current authentication is SAML and we don't want to use current
-                // credentials, we need to force log in process. this is for the case
-                // when we were logged in, but IDP expired our session and if this
-                // happens, we want the user to pick the idp to begin reauthentication
-                ignoreSignedInState = true
-                // Phase 4: Also mark credentials stale via state machine
+                // when the IdP session expired, force the user to pick the
+                // IdP again instead of reusing stale cookies/tokens
                 userAccount.markCredentialsStale()
                 if authDef.isSaml {
                     selectedAuthentication = nil
@@ -643,6 +661,10 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
         if libraryAccountID == libraryAccountsProvider.currentAccountId {
             bookRegistry.sync()
         }
+
+        // Canonical credential store is now TPPUserAccount — clear all
+        // in-flight reducer state (token, captured creds, ignoreSignedIn).
+        dispatch(.userAccountUpdated)
 
         NotificationCenter.default.post(name: .TPPIsSigningIn, object: false)
     }
@@ -754,5 +776,22 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
 
         Log.info(#file, "Stale credentials with valid Adobe authorization - will skip activation")
         return true
+    }
+}
+
+private extension AccountDetails.Authentication {
+    /// Map the persisted auth-method enum onto the reducer's narrower
+    /// `AuthMethodType`. Returns nil for `.coppa`, `.anonymous`, `.none` —
+    /// callers that gate on `isBasic || isOauth || isSaml || isOidc || isToken`
+    /// will never see those.
+    var asAuthMethodType: AuthMethodType? {
+        switch authType {
+        case .basic: return .basic
+        case .oauthIntermediary: return .oauthIntermediary
+        case .saml: return .saml
+        case .oidc: return .oidc
+        case .token: return .token
+        case .coppa, .anonymous, .none: return nil
+        }
     }
 }

--- a/PalaceTests/SignInLogic/TPPSignInAdobeSkipTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInAdobeSkipTests.swift
@@ -180,8 +180,9 @@ final class TPPSignInAdobeSkipTests: XCTestCase {
         )
         XCTAssertTrue(businessLogic.isSignedIn())
 
-        // Set ignoreSignedInState
-        businessLogic.ignoreSignedInState = true
+        // Force ignoreSignedInState via the same reducer action production uses
+        // when refreshAuth fires for a SAML browser flow without cached creds.
+        businessLogic.dispatch(.refreshAuthStarted(authType: .saml, usingExistingCredentials: false))
         XCTAssertFalse(businessLogic.isSignedIn(),
                        "isSignedIn should return false when ignoreSignedInState is true")
     }
@@ -244,8 +245,7 @@ final class TPPSignInAdobeSkipTests: XCTestCase {
 
     func testMakeRequest_withOAuthButNoToken_logsError() {
         businessLogic.selectedAuthentication = libraryAccountMock.oauthAuthentication
-        businessLogic.authToken = nil
-        // userAccount also has no authToken by default
+        // AuthState starts with authToken == nil; userAccount also has no token by default
 
         let request = businessLogic.makeRequest(for: .signIn, context: "test")
 
@@ -256,24 +256,22 @@ final class TPPSignInAdobeSkipTests: XCTestCase {
     }
 
     func testMakeRequest_prefersBusinessLogicToken_overUserAccountToken() {
+        // Production path during sign-in: OAuth handler dispatches the fresh
+        // token via `.bearerTokenReceived` before `updateUserAccount` has
+        // written it to the keychain. `makeRequest` must surface this fresh
+        // token (in-flight) — falling back to a stale `userAccount.authToken`
+        // would attach the previous session's bearer token to the new request.
         businessLogic.selectedAuthentication = libraryAccountMock.oauthAuthentication
-        businessLogic.authToken = "fresh-token"
 
-        // Set up user account with a different token
-        businessLogic.updateUserAccount(
-            forDRMAuthorization: true,
-            withBarcode: nil,
-            pin: nil,
-            authToken: "old-token",
-            expirationDate: nil,
-            patron: nil,
-            cookies: nil
-        )
+        // Seed userAccount directly (no updateUserAccount, which would dispatch
+        // .userAccountUpdated and clear the in-flight reducer state).
+        businessLogic.userAccount.setAuthToken("old-token", barcode: nil, pin: nil, expirationDate: nil)
+        businessLogic.dispatch(.bearerTokenReceived(token: "fresh-token", expiration: nil))
 
         let request = businessLogic.makeRequest(for: .signIn, context: "test")
         let authHeader = request?.value(forHTTPHeaderField: "Authorization")
 
         XCTAssertEqual(authHeader, "Bearer fresh-token",
-                       "Should prefer business logic authToken over user account token")
+                       "Should prefer in-flight authToken over the previously persisted userAccount token")
     }
 }

--- a/PalaceTests/SignInLogic/TPPSignInBusinessLogicExtendedTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInBusinessLogicExtendedTests.swift
@@ -186,7 +186,7 @@ final class TPPSignInBusinessLogicExtendedTests: XCTestCase {
             cookies: nil
         )
 
-        businessLogic.ignoreSignedInState = true
+        businessLogic.dispatch(.refreshAuthStarted(authType: .saml, usingExistingCredentials: false))
         XCTAssertFalse(businessLogic.isSignedIn())
     }
 
@@ -245,7 +245,7 @@ final class TPPSignInBusinessLogicExtendedTests: XCTestCase {
 
     func testMakeRequest_forOAuth_hasBearerToken() {
         businessLogic.selectedAuthentication = libraryAccountMock.oauthAuthentication
-        businessLogic.authToken = "test-token"
+        businessLogic.dispatch(.bearerTokenReceived(token: "test-token", expiration: nil))
 
         let request = businessLogic.makeRequest(for: .signIn, context: "test")
 
@@ -256,7 +256,7 @@ final class TPPSignInBusinessLogicExtendedTests: XCTestCase {
 
     func testMakeRequest_forSAML_hasBearerToken() {
         businessLogic.selectedAuthentication = libraryAccountMock.samlAuthentication
-        businessLogic.authToken = "saml-token"
+        businessLogic.dispatch(.bearerTokenReceived(token: "saml-token", expiration: nil))
 
         let request = businessLogic.makeRequest(for: .signIn, context: "test")
 
@@ -641,6 +641,101 @@ final class TPPSignInBusinessLogicExtendedTests: XCTestCase {
 
         XCTAssertEqual(result, expectedResult,
                        "shouldShowSyncButton() should return \(expectedResult) based on library configuration")
+    }
+
+    // MARK: - AuthReducer integration: behaviors introduced by the wiring
+
+    func testUpdateUserAccount_clearsInFlightAuthToken() {
+        // .userAccountUpdated dispatched at the end of updateUserAccount must
+        // clear the in-flight authToken — the persisted store on userAccount
+        // is now the only source of truth.
+        businessLogic.selectedAuthentication = libraryAccountMock.oauthAuthentication
+        businessLogic.dispatch(.bearerTokenReceived(token: "in-flight-token", expiration: Date()))
+        XCTAssertEqual(businessLogic.authToken, "in-flight-token", "precondition")
+
+        businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                        withBarcode: nil, pin: nil,
+                                        authToken: "persisted-token",
+                                        expirationDate: nil,
+                                        patron: nil,
+                                        cookies: nil)
+
+        XCTAssertNil(businessLogic.authToken,
+                     "In-flight authToken must be cleared once the canonical store is updated")
+        XCTAssertNil(businessLogic.authTokenExpiration,
+                     "In-flight expiration must be cleared alongside the token")
+        XCTAssertEqual(businessLogic.userAccount.authToken, "persisted-token",
+                       "Persisted token on userAccount must reflect what was passed in")
+    }
+
+    func testUpdateUserAccount_clearsCapturedCredentials() {
+        // capturedBarcode/Pin are set by .credentialCaptureStarted at logIn;
+        // .userAccountUpdated must clear them so a re-auth doesn't reuse stale
+        // input from a previous sign-in attempt.
+        businessLogic.selectedAuthentication = libraryAccountMock.barcodeAuthentication
+        businessLogic.dispatch(.credentialCaptureStarted(barcode: "old-barcode", pin: "old-pin"))
+        XCTAssertEqual(businessLogic.capturedBarcode, "old-barcode")
+        XCTAssertEqual(businessLogic.capturedPin, "old-pin")
+
+        businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                        withBarcode: "new-barcode", pin: "new-pin",
+                                        authToken: nil, expirationDate: nil,
+                                        patron: nil, cookies: nil)
+
+        XCTAssertNil(businessLogic.capturedBarcode)
+        XCTAssertNil(businessLogic.capturedPin)
+    }
+
+    func testUpdateUserAccount_clearsIgnoreSignedInState() {
+        // Browser-flow refresh arms ignoreSignedInState; once new credentials
+        // are persisted, the bypass must be lifted automatically.
+        businessLogic.dispatch(.refreshAuthStarted(authType: .saml, usingExistingCredentials: false))
+        XCTAssertTrue(businessLogic.ignoreSignedInState, "precondition")
+
+        businessLogic.selectedAuthentication = libraryAccountMock.barcodeAuthentication
+        businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                        withBarcode: "b", pin: "p",
+                                        authToken: nil, expirationDate: nil,
+                                        patron: nil, cookies: nil)
+
+        XCTAssertFalse(businessLogic.ignoreSignedInState,
+                       ".userAccountUpdated must lift the ignoreSignedInState bypass")
+    }
+
+    func testValidateCredentials_setsValidatingFlag() {
+        // The original `isValidatingCredentials = true` write at the entry of
+        // validateCredentials() is now mediated by the reducer; the observable
+        // effect must remain the same.
+        businessLogic.selectedAuthentication = libraryAccountMock.barcodeAuthentication
+        XCTAssertFalse(businessLogic.isValidatingCredentials, "precondition")
+
+        businessLogic.validateCredentials()
+
+        XCTAssertTrue(businessLogic.isValidatingCredentials,
+                      "validateCredentials() must enter the validating state synchronously")
+    }
+
+    func testEnsureAuthDoc_setsAndClearsLoadingFlag() {
+        // The auth-doc loading toggles bracket the network call. They must
+        // round-trip through the reducer the same way the legacy boolean did.
+        XCTAssertFalse(businessLogic.isAuthenticationDocumentLoading, "precondition")
+
+        businessLogic.dispatch(.authDocumentLoadStarted)
+        XCTAssertTrue(businessLogic.isAuthenticationDocumentLoading)
+
+        businessLogic.dispatch(.authDocumentLoadCompleted)
+        XCTAssertFalse(businessLogic.isAuthenticationDocumentLoading)
+    }
+
+    func testIsLoggingInAfterSignUp_setterRoutesThroughReducer() {
+        // The @objc setter forwards into .loggingInAfterSignUpFlagSet so any
+        // external caller that still pokes the property in the legacy way
+        // ends up in the same reducer-managed state.
+        XCTAssertFalse(businessLogic.isLoggingInAfterSignUp, "precondition")
+        businessLogic.isLoggingInAfterSignUp = true
+        XCTAssertTrue(businessLogic.isLoggingInAfterSignUp)
+        XCTAssertTrue(businessLogic.authState.isLoggingInAfterSignUp,
+                      "Setter must reach the reducer state, not just a stored mirror")
     }
 }
 

--- a/PalaceTests/SignInLogic/TPPSignInOIDCTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInOIDCTests.swift
@@ -240,7 +240,7 @@ final class OIDCMakeRequestTests: XCTestCase {
 
     func testMakeRequest_forOIDC_addsBearerTokenHeader() {
         businessLogic.selectedAuthentication = libraryMock.oidcAuthentication
-        businessLogic.authToken = "oidc-test-access-token"
+        businessLogic.dispatch(.bearerTokenReceived(token: "oidc-test-access-token", expiration: nil))
 
         let request = businessLogic.makeRequest(for: .signIn, context: "test")
 
@@ -253,7 +253,7 @@ final class OIDCMakeRequestTests: XCTestCase {
 
     func testMakeRequest_forOIDC_withoutToken_stillCreatesRequest() {
         businessLogic.selectedAuthentication = libraryMock.oidcAuthentication
-        businessLogic.authToken = nil
+        businessLogic.dispatch(.signOutCompleted)
 
         let request = businessLogic.makeRequest(for: .signIn, context: "test")
 
@@ -262,7 +262,7 @@ final class OIDCMakeRequestTests: XCTestCase {
 
     func testMakeRequest_forOIDCSignOut_usesUserProfileURL() {
         businessLogic.selectedAuthentication = libraryMock.oidcAuthentication
-        businessLogic.authToken = "oidc-token"
+        businessLogic.dispatch(.bearerTokenReceived(token: "oidc-token", expiration: nil))
 
         let request = businessLogic.makeRequest(for: .signOut, context: "test")
 
@@ -714,7 +714,7 @@ final class OIDCRegressionTests: XCTestCase {
         defer { businessLogic.userAccount.removeAll() }
 
         businessLogic.selectedAuthentication = libraryMock.oauthAuthentication
-        businessLogic.authToken = "oauth-regression-token"
+        businessLogic.dispatch(.bearerTokenReceived(token: "oauth-regression-token", expiration: nil))
 
         let request = businessLogic.makeRequest(for: .signIn, context: "regression-test")
         XCTAssertEqual(request?.value(forHTTPHeaderField: "Authorization"), "Bearer oauth-regression-token")
@@ -736,7 +736,7 @@ final class OIDCRegressionTests: XCTestCase {
         defer { businessLogic.userAccount.removeAll() }
 
         businessLogic.selectedAuthentication = libraryMock.samlAuthentication
-        businessLogic.authToken = "saml-regression-token"
+        businessLogic.dispatch(.bearerTokenReceived(token: "saml-regression-token", expiration: nil))
 
         let request = businessLogic.makeRequest(for: .signIn, context: "regression-test")
         XCTAssertEqual(request?.value(forHTTPHeaderField: "Authorization"), "Bearer saml-regression-token")
@@ -976,7 +976,7 @@ final class OIDCCallbackEdgeCaseTests: XCTestCase {
 
     func testHandleOIDCCallback_doesNotAffectPriorOAuthState() {
         businessLogic.selectedAuthentication = libraryMock.oauthAuthentication
-        businessLogic.authToken = "existing-oauth-token"
+        businessLogic.dispatch(.bearerTokenReceived(token: "existing-oauth-token", expiration: nil))
 
         businessLogic.selectedAuthentication = libraryMock.oidcAuthentication
         let url = URL(string: "palace-oidc-callback://org.thepalaceproject.oidc/callback")!
@@ -1367,6 +1367,38 @@ final class OIDCSignOutRegressionTests: XCTestCase {
         XCTAssertNil(businessLogic.userAccount.authToken,
                      "SAML sign-out must still clear tokens after OIDC changes")
     }
+
+    func testSignOut_resetsInFlightAuthState() {
+        // performLogOut now dispatches .signOutCompleted after userAccount.removeAll().
+        // Verifies the in-flight reducer state (authToken, capturedBarcode, ignoreSignedInState,
+        // isLoggingInAfterSignUp) is fully reset — the next sign-in starts from a clean slate.
+        businessLogic.selectedAuthentication = libraryMock.oidcAuthentication
+        businessLogic.dispatch(.bearerTokenReceived(token: "stale", expiration: Date()))
+        businessLogic.dispatch(.credentialCaptureStarted(barcode: "u", pin: "p"))
+        businessLogic.dispatch(.refreshAuthStarted(authType: .oidc, usingExistingCredentials: false))
+        businessLogic.isLoggingInAfterSignUp = true
+        businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                        withBarcode: nil, pin: nil,
+                                        authToken: "current",
+                                        expirationDate: nil,
+                                        patron: nil, cookies: nil)
+        // After updateUserAccount, .userAccountUpdated already cleared most fields.
+        // Re-arm a couple to verify .signOutCompleted clears them too.
+        businessLogic.dispatch(.bearerTokenReceived(token: "post-update-token", expiration: nil))
+        businessLogic.isLoggingInAfterSignUp = true
+
+        let exp = expectation(description: "Sign-out completes")
+        uiDelegate.didFinishDeauthorizingHandler = { exp.fulfill() }
+        businessLogic.performLogOut()
+        waitForExpectations(timeout: 5.0)
+
+        XCTAssertNil(businessLogic.authToken, "signOut must clear in-flight authToken")
+        XCTAssertNil(businessLogic.capturedBarcode)
+        XCTAssertNil(businessLogic.capturedPin)
+        XCTAssertFalse(businessLogic.ignoreSignedInState)
+        XCTAssertFalse(businessLogic.isLoggingInAfterSignUp,
+                       "signOut must clear the after-signup flag (.signOutCompleted resets the whole AuthState)")
+    }
 }
 
 // MARK: - Regression Tests: Token Refresh Logic
@@ -1577,12 +1609,12 @@ final class OIDCIsolationRegressionTests: XCTestCase {
 
         let oauthBL = makeBusinessLogic()
         oauthBL.selectedAuthentication = libraryMock.oauthAuthentication
-        oauthBL.authToken = "oauth-tok"
+        oauthBL.dispatch(.bearerTokenReceived(token: "oauth-tok", expiration: nil))
         let oauthReq = oauthBL.makeRequest(for: .signIn, context: "test")
 
         let oidcBL = makeBusinessLogic()
         oidcBL.selectedAuthentication = libraryMock.oidcAuthentication
-        oidcBL.authToken = "oidc-tok"
+        oidcBL.dispatch(.bearerTokenReceived(token: "oidc-tok", expiration: nil))
         let oidcReq = oidcBL.makeRequest(for: .signIn, context: "test")
 
         XCTAssertEqual(oauthReq?.value(forHTTPHeaderField: "Authorization"), "Bearer oauth-tok")

--- a/PalaceTests/TPPSignInBusinessLogicTests.swift
+++ b/PalaceTests/TPPSignInBusinessLogicTests.swift
@@ -147,7 +147,7 @@ class TPPSignInBusinessLogicTests: XCTestCase {
         XCTAssertFalse(barcodeHeaderValue?.starts(with: "Bearer") ?? false)
 
         // prerequisite for both OAuth and SAML
-        businessLogic.authToken = "tekken"
+        businessLogic.dispatch(.bearerTokenReceived(token: "tekken", expiration: nil))
 
         // test sign-in request for oauth auth
         businessLogic.selectedAuthentication = libraryAccountMock.oauthAuthentication


### PR DESCRIPTION
## Summary

- 8 in-flight auth-state properties on `TPPSignInBusinessLogic` (`authToken`, `authTokenExpiration`, `capturedBarcode`, `capturedPin`, `isValidatingCredentials`, `isAuthenticationDocumentLoading`, `ignoreSignedInState`, `isLoggingInAfterSignUp`) are now computed from a single `AuthState` value driven by `AuthReducer`. The 13 production mutation sites across `TPPSignInBusinessLogic.swift` and its OAuth / OIDC / UI / SignOut extensions route through `dispatch(_:)` instead of writing the legacy stored vars directly.
- Skipped the `Store` wrapper from the Phase 5 plan — `Store` is `@MainActor` and the auth flow runs across UI / network-completion / DRM-completion contexts that aren't all main-bound. Calling the reducer function directly preserves the architectural goal (single source of truth, pure transitions) without forcing a `@MainActor` cascade. We can wrap in `Store` later if Combine binding is ever needed.

## Behaviour change

`updateUserAccount` now dispatches `.userAccountUpdated` which clears the in-flight reducer state once the canonical store (TPPUserAccount keychain) is written. Legacy code kept the in-flight mirror alive indefinitely; one test (`testMakeRequest_prefersBusinessLogicToken_overUserAccountToken`) exercised that artifact and was rewritten to seed userAccount directly via `setAuthToken` instead of going through `updateUserAccount`.

## Stacked on

This PR is stacked on **#873** (UserAccountValidationTests CI skip + AppContainer MainActor crash). It will auto-retarget to `develop` once #873 merges.

## Test plan

- [x] 180/180 sign-in tests pass (TPPSignInBusinessLogic + Extended + AuthReducer + OIDC + SAML + Adobe-skip + Credentials + Reauthenticator + CrossLibrarySignOut + DeferredAdobeActivation + IdleSignOutRegression)
- [x] 152/152 consumer-VM regression (AccountDetailViewModelTests, BookDetailViewModelTests, AccountsManagerTests, TPPBookRegistryTests)
- [x] **Mutation testing: 40.0% kill rate** on `TPPSignInBusinessLogic.swift` (8/20 mutants), up from 30% baseline. Hits Phase 3 exit criteria.
- [x] Full suite: 16998/16998 tests pass via ForgeOS evidence run
- [ ] CI green on PR

## New transition tests

Added 7 tests covering transitions that were previously implicit:
- `testUpdateUserAccount_clearsInFlightAuthToken` (the new clearing behaviour)
- `testUpdateUserAccount_clearsCapturedCredentials`
- `testUpdateUserAccount_clearsIgnoreSignedInState`
- `testValidateCredentials_setsValidatingFlag`
- `testEnsureAuthDoc_setsAndClearsLoadingFlag`
- `testIsLoggingInAfterSignUp_setterRoutesThroughReducer`
- `testSignOut_resetsInFlightAuthState` (in OIDCSignOutRegressionTests)

ForgeOS: cs_505d4e73 (all gates passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)