### PR TITLE
palace_mutate.py: error on 0-test xcodebuild runs (handoff D3)

### DIFF
--- a/scripts/palace_mutate.py
+++ b/scripts/palace_mutate.py
@@ -157,10 +157,24 @@ def revert_file(file_path: str, original_content: str) -> None:
         f.write(original_content)
 
 
+def any_tests_ran(output: str) -> bool:
+    """
+    True if xcodebuild's output contains at least one `Executed N tests` line
+    with N >= 1. A misconfigured `--tests` arg (e.g. a directory instead of an
+    XCTestCase class name) silently matches no class and produces only zero-
+    count summaries, while still printing `** TEST SUCCEEDED **`. Without this
+    check the caller would grade every mutant as SURVIVED.
+    """
+    return bool(re.search(r"Executed [1-9]\d* test", output))
+
+
 def run_targeted_tests(test_class_paths: list[str], timeout: int = 600) -> tuple[bool, str]:
     """
     Run xcodebuild test scoped to the given test classes.
     Returns (all_passed, last_lines_of_output).
+    Returns (False, "ERROR: ...") if the configuration ran zero tests — that
+    is treated as a misconfiguration, not a passing run, so callers don't
+    grade mutants as SURVIVED against an empty test set.
     """
     only_testing_args: list[str] = []
     for path in test_class_paths:
@@ -184,6 +198,9 @@ def run_targeted_tests(test_class_paths: list[str], timeout: int = 600) -> tuple
         return (False, f"TIMEOUT after {timeout}s")
     output = result.stdout + result.stderr
     last = "\n".join(output.splitlines()[-15:])
+    if not any_tests_ran(output):
+        joined = ", ".join(test_class_paths)
+        return (False, f"ERROR: 0 tests executed for {joined} — likely a misconfigured --tests arg (directory instead of XCTestCase class name)")
     passed = result.returncode == 0 and "** TEST SUCCEEDED **" in output
     return (passed, last)
 

--- a/scripts/test_palace_mutate.py
+++ b/scripts/test_palace_mutate.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Unit tests for palace_mutate.py helpers.
+
+Run: python3 -m unittest scripts.test_palace_mutate
+  or: python3 scripts/test_palace_mutate.py
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from palace_mutate import any_tests_ran
+
+
+class AnyTestsRan(unittest.TestCase):
+
+    def test_zero_test_run_isDetected(self):
+        # xcodebuild output when -only-testing matches no class:
+        # the per-suite Executed lines are all 0, despite ** TEST SUCCEEDED **
+        output = """
+Test Suite 'Selected tests' started at 2026-04-27
+Test Suite 'PalaceTests.xctest' started at 2026-04-27
+Test Suite 'PalaceTests.xctest' passed at 2026-04-27
+\t Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
+Test Suite 'Selected tests' passed at 2026-04-27
+\t Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.002) seconds
+** TEST SUCCEEDED **
+"""
+        self.assertFalse(any_tests_ran(output),
+                         "0-test runs must be detected so callers don't grade SURVIVED against an empty suite")
+
+    def test_normal_run_isDetected(self):
+        output = """
+Test Suite 'TPPSignInBusinessLogicTests' started at 2026-04-27
+Test Case '-[PalaceTests.TPPSignInBusinessLogicTests testFoo]' started.
+Test Case '-[PalaceTests.TPPSignInBusinessLogicTests testFoo]' passed (0.123 seconds).
+Test Suite 'TPPSignInBusinessLogicTests' passed at 2026-04-27
+\t Executed 12 tests, with 0 failures (0 unexpected) in 0.812 (0.822) seconds
+** TEST SUCCEEDED **
+"""
+        self.assertTrue(any_tests_ran(output))
+
+    def test_partialFailure_isDetected(self):
+        # Even if a suite reported 0 (e.g. one bundle no-op'd), if ANY suite
+        # ran tests, we count as having executed tests — and the pass/fail
+        # signal flows through the ** TEST SUCCEEDED ** check separately.
+        output = """
+\t Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
+\t Executed 5 tests, with 1 failure (0 unexpected) in 0.500 (0.502) seconds
+** TEST FAILED **
+"""
+        self.assertTrue(any_tests_ran(output))
+
+    def test_emptyOutput_treatedAsZero(self):
+        self.assertFalse(any_tests_ran(""))
+
+    def test_singleTestRun(self):
+        # Boundary: exactly 1 test executed must be detected (regex must accept [1-9]\d*)
+        output = "\t Executed 1 test, with 0 failures"
+        self.assertTrue(any_tests_ran(output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A misconfigured \`--tests\` arg to \`scripts/palace_mutate.py\` (e.g. a directory \`PalaceTests/SignInLogic\` instead of an XCTestCase class name) silently matches no class. xcodebuild reports \`** TEST SUCCEEDED **\` with \`Executed 0 tests\`, and the runner used to grade every mutant as SURVIVED — making the report misleading. Caught the hard way during PR #867 verification (handoff item D3).

\`run_targeted_tests\` now scans the output for \`Executed [1-9]\d* test\` and surfaces a clear ERROR if no suite executed any tests. The baseline sanity check at the top of \`main()\` already exits 2 on baseline failure, so this propagates cleanly without per-mutation special-casing.

## Test plan

- [x] \`python3 scripts/test_palace_mutate.py\` — 5 unit tests cover the parser (zero-run, normal, partial-failure, empty, single-test boundary)
- [x] \`scripts/palace_mutate.py --dry-run\` smoke check on \`AuthReducer.swift\` — discovers mutation points correctly
- [x] Swift build still passes
- [ ] CI green on PR

ForgeOS: cs_82ef91a1 (all gates passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)