### PR TITLE
release-rc: fix stale-tag baseline + empty version output that broke 3.0.0 jira-sync

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -5,7 +5,7 @@ jobs:
   create-rc:
     runs-on: macos-26
     outputs:
-      version: ${{ steps.notes.outputs.version }}
+      version: ${{ steps.ver.outputs.version }}
     steps:
       - name: Guard branch
         run: |
@@ -31,11 +31,26 @@ jobs:
           repository: ThePalaceProject/mobile-certificates
           token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
           path: ./mobile-certificates
-      - name: Create release notes
-        id: notes
+      - name: Resolve version and clear stale prerelease
+        id: ver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./scripts/create-release-notes.sh
+          source ./scripts/xcode-settings.sh
+          echo "VERSION_NUM=$VERSION_NUM" >> "$GITHUB_ENV"
           echo "version=$VERSION_NUM" >> "$GITHUB_OUTPUT"
+          if gh release view "$VERSION_NUM" > /dev/null 2>&1; then
+            IS_PRERELEASE=$(gh release view "$VERSION_NUM" --json isPrerelease --jq .isPrerelease)
+            if [ "$IS_PRERELEASE" != "true" ]; then
+              echo "::error::Release $VERSION_NUM already exists and is NOT a prerelease. Bump VERSION_NUM on this branch before re-running."
+              exit 1
+            fi
+            echo "Deleting existing prerelease $VERSION_NUM (remote release + remote tag)"
+            gh release delete "$VERSION_NUM" --yes --cleanup-tag
+            git tag -d "$VERSION_NUM" 2>/dev/null || true
+          fi
+      - name: Create release notes
+        run: ./scripts/create-release-notes.sh
         env:
           BUILD_CONTEXT: ci
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
@@ -44,25 +59,6 @@ jobs:
           echo "Release notes path: $RELEASE_NOTES_PATH"
           cat "$RELEASE_NOTES_PATH"
           echo "Version: $VERSION_NUM"
-      - name: Guard against clobbering shipped release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh release view "$VERSION_NUM" > /dev/null 2>&1; then
-            IS_PRERELEASE=$(gh release view "$VERSION_NUM" --json isPrerelease --jq .isPrerelease)
-            if [ "$IS_PRERELEASE" != "true" ]; then
-              echo "::error::Release $VERSION_NUM already exists and is NOT a prerelease. Bump VERSION_NUM on this branch before re-running."
-              exit 1
-            fi
-          fi
-      - name: Delete existing prerelease (if any)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh release view "$VERSION_NUM" > /dev/null 2>&1; then
-            echo "Deleting existing prerelease $VERSION_NUM (and its tag)"
-            gh release delete "$VERSION_NUM" --yes --cleanup-tag
-          fi
       - name: Create prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes two bugs in `release-rc.yml` that combined to publish 3.0.0 with a 2-line release body (out of 25 PP-* tickets in the actual diff) and zero `fixVersion` updates in JIRA.

## Bugs

**Bug 1 — stale prerelease tag poisons the script baseline.**
The first run on Apr 23 created tag `3.0.0` at HEAD-of-the-day. The Apr 24 re-run found that tag still in place at checkout time. `ReleaseNotes.py`'s `baseline_tag()` walks `git tag --sort=-creatordate --merged HEAD` and picked the stale `3.0.0` tag, so it walked a 24-commit diff (2 tickets) instead of the `2.2.5..HEAD` diff (~73 commits, 19 tickets). The "Delete existing prerelease" step ran *after* the notes step, too late to help.

**Bug 2 — `version` step output was always empty.**
`scripts/create-release-notes.sh` writes `VERSION_NUM` to `$GITHUB_ENV` (which propagates to *subsequent* steps, not the calling shell). The same step then ran `echo "version=$VERSION_NUM" >> $GITHUB_OUTPUT` in the calling shell, where `VERSION_NUM` was unset. Chained `jira-release-sync` workflow received `tag=""` and exited with `No tag provided` — both Apr 23 and Apr 24 runs hit this.

## Fix

Folds both into a single early step before `Create release notes`:
- Source `xcode-settings.sh` inline to resolve `VERSION_NUM`, then write to **both** `$GITHUB_ENV` (for downstream steps) and `$GITHUB_OUTPUT` (for the chained jira-sync).
- Delete stale prerelease + remote tag + local tag *before* running the notes script, so `baseline_tag()` falls through to the previous shipped tag.
- Keep the "Guard against clobbering shipped (non-prerelease) release" check, hoisted into the same step.

## Test plan

- [ ] Manual dispatch of `release-rc.yml` from a `release/*` branch — verify the new `Resolve version and clear stale prerelease` step runs first, that the chained `jira-sync` job receives a non-empty tag, and that release notes contain the full diff since the previous tag.
- [ ] Re-run on the same branch with no commits — verify the stale prerelease + tag get cleaned and the second run produces an identical release.

## Related

Companion script-side improvements in `mobile-certificates` (subject-mention scoring + multi-key prefix cleanup) live in a separate PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)