### PR TITLE
Promote regression skill to tracked tooling (PP-4164 dogfood)

### DIFF
--- a/.claude/skills/regression/QA_QUICKSTART.md
+++ b/.claude/skills/regression/QA_QUICKSTART.md
@@ -1,0 +1,84 @@
+# QA Quick Start — Regression Testing with Claude Code
+
+## Prerequisites
+
+1. **Claude Code** installed (CLI, desktop app, or IDE extension)
+2. **ios-core repo** cloned and on the branch you're testing
+3. **Two devices or simulators** — one with baseline build, one with candidate build
+4. **Test library credentials** — A1QA: `01230000000237 / Lyrtest123`
+
+## Running a Regression
+
+Open Claude Code in the ios-core directory and type:
+
+```
+/regression PP-XXXX --baseline-version 2.2.5 --candidate-version 3.0.0
+```
+
+Replace `PP-XXXX` with your Jira ticket number.
+
+Claude will:
+1. **Set up your workspace** at `~/Desktop/regression-PP-XXXX/`
+2. **Run automated tests** (sync, push notifications, mutation testing)
+3. **Walk you through manual testing** — area by area, asking what you see
+4. **Help you log findings** to the CSV with proper classification and severity
+5. **Generate an HTML report** with screenshots and evidence
+6. **Create Jira tickets** for regressions and pre-existing bugs (with your approval)
+
+## What You'll Need to Do
+
+- **Test on device.** Claude guides you, but you're the one tapping buttons and comparing screens.
+- **Capture screenshots.** When you find something, take a screenshot pair (baseline + candidate).
+- **Verify findings.** Claude will ask you to confirm each finding is real before including it in the report.
+
+## Manual Alternative (without Claude Code)
+
+If you prefer to run the process manually:
+
+```bash
+# 1. Setup workspace
+scripts/regression-report.sh setup --ticket PP-XXXX --output-dir ~/Desktop/regression-PP-XXXX
+
+# 2. Run automated tools
+scripts/regression-report.sh auto --output-dir ~/Desktop/regression-PP-XXXX
+
+# 3. Test manually using TEST_MATRIX.md as your checklist
+# 4. Log findings to findings.csv (use any spreadsheet app)
+
+# 5. Generate report
+scripts/regression-report.sh report --output-dir ~/Desktop/regression-PP-XXXX \
+  --baseline-version 2.2.5 --candidate-version 3.0.0 --strict
+
+# 6. Generate Jira tickets (dry-run first!)
+scripts/regression-report.sh tickets --output-dir ~/Desktop/regression-PP-XXXX \
+  --ticket PP-XXXX --dry-run
+```
+
+## CSV Format
+
+When logging findings to `findings.csv`, use these columns:
+
+| Column | Example | Required |
+|--------|---------|----------|
+| ID | F-001 | Yes |
+| Title | Account screen lost nav title | Yes |
+| Area | A1 | Yes (from TEST_MATRIX.md) |
+| Test ID | A1-01 | Optional |
+| Classification | regression | Yes |
+| Severity | major | Yes |
+| Verified | true | Yes (default: false) |
+| Baseline Behavior | Shows "Account" as nav title | Yes |
+| Candidate Behavior | Nav title missing | Yes |
+| Steps | Settings > Libraries > A1QA | Yes |
+| Screenshot Baseline | F-001-baseline-account.png | Recommended |
+| Screenshot Candidate | F-001-candidate-account.png | Recommended |
+| Notes | VoiceOver impact | Optional |
+| PR | 834 | If fixed |
+| Jira Ticket | | Filled by ticket generator |
+
+## Tips
+
+- **Don't skip P0 areas.** These are the critical paths — auth, borrow, download, DRM.
+- **Pre-existing bugs are valuable too.** If something is broken in both versions, log it. PP-4020 found a 6-year-old blocker this way.
+- **Compress screenshots.** 800px wide is plenty. Videos at 720p. Large files block report publishing.
+- **Verify before reporting.** The `verified` column prevents false positives. PP-4020 had a 9.6% false positive rate before adding this check.

--- a/.claude/skills/regression/SKILL.md
+++ b/.claude/skills/regression/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: regression
+description: Run a full release regression test — sets up workspace, runs automated tools, guides manual testing, generates report and Jira tickets. Use for release gates and QA cycles.
+argument-hint: <ticket> [--baseline-version X.X.X] [--candidate-version X.X.X]
+allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, Agent
+---
+
+# Palace iOS Release Regression
+
+You are guiding a QA tester through a full release regression test. This is a structured, multi-phase workflow. Follow each phase in order. Be conversational — explain what you're doing and why, ask for confirmation at key checkpoints.
+
+## Arguments
+
+The user provides:
+- `<ticket>` — the Jira ticket for this regression (e.g., PP-4200)
+- `--baseline-version` — the version being compared against (e.g., 2.2.5). Defaults to "develop"
+- `--candidate-version` — the version being tested (e.g., 3.0.0). Defaults to "candidate"
+
+Parse these from `$ARGUMENTS`. If no ticket is provided, ask the user for one.
+
+## Phase 1: Setup
+
+Run the workspace setup:
+
+```bash
+scripts/regression-report.sh setup \
+  --ticket <TICKET> \
+  --output-dir ~/Desktop/regression-<TICKET>
+```
+
+Tell the user what was created:
+- `findings.csv` — where all findings go (CSV is the single source of truth)
+- `TEST_MATRIX.md` — the test checklist (40+ areas across P0/P1/P2 tiers)
+- `ENVIRONMENT.md` — fill in with build details
+- `screenshots/` — evidence goes here (800px max width for images, 720p for video)
+
+Ask the user to fill in ENVIRONMENT.md with their build details, devices, and credentials. Read the file back and confirm it looks correct.
+
+## Phase 2: Automated Sweep
+
+Run automated tools:
+
+```bash
+scripts/regression-report.sh auto \
+  --output-dir ~/Desktop/regression-<TICKET> \
+  --baseline-ref <BASELINE_REF> \
+  --candidate-branch <CANDIDATE_BRANCH> \
+  --run-sync-tests \
+  [--mutation-run]
+```
+
+Notes on flags:
+- `--baseline-ref` accepts any git ref (tag OR branch). `--baseline-tag` still works as an alias.
+- `--mutation-run` triggers REAL mutation execution (otherwise dry-run enumeration).
+  The script auto-derives the right XCTest class for each source file via filename
+  matching; override per-file with `--mutation-test-class CLASSNAME`.
+- `--mutation-files file1,file2,...` lets you target a specific list (overrides the
+  changed-files derivation from baseline...candidate). Use this when you want to
+  scope mutation to high-risk files instead of running over the full delta.
+- `--mutation-limit N` caps the file count; `--mutation-max-per-file N` caps mutations
+  per file (default 8).
+- For long real-mutation runs (>30 min estimated), the script aborts unless you pass
+  `--yes-long-mutation`. Tighten the caps or split the run.
+- `--sim-id UDID` overrides the simulator. Default is read from `~/harness/projects/palace-ios.yml`
+  if present, else falls back to a sane default.
+
+Report results from each tool:
+- Annotation sync tests (pass/fail)
+- Push notification tests (pass/fail) — skipped automatically if no Firebase service
+  account at `~/.palace/firebase-service-account.json`
+- Mutation testing — dry-run gives a top-N-by-surface histogram; real execution
+  gives kill/survive rates per file. Always check `automated/mutation/summary.txt`.
+
+Any automated failures should be logged as findings. Help the user add them to the CSV:
+- `Verified` = `false` until they confirm on device
+- `Classification` = `regression` or `pre-existing` as appropriate
+
+**Watch out for**: a mutation kill rate <50% on a critical-path file is itself a
+finding worth filing as `pre-existing major` even if it isn't a regression — the
+test suite has insufficient discriminating power. PP-4164 found `AccountsManager.swift`
+at 0% kill rate this way.
+
+## Phase 3: Manual Side-by-Side Testing
+
+This is the highest-value phase. Read `TEST_MATRIX.md` and walk through each priority tier.
+
+### Driving the sim: `simdrive` (MCP)
+
+`simdrive` replaces the specterqa-ios pipeline from prior cycles. It's an MCP server
+with real CoreSimulator HID input — taps actually focus UITextFields and accept
+keyboard input on iOS 26+ (the v15/v16 cliclick path didn't).
+
+**One-time install**:
+```bash
+gh release download simdrive-v0.1.0a1 -R SyncTek-LLC/specterqa-ios \
+  -p "simdrive-0.1.0a1-py3-none-any.whl" -O /tmp/simdrive.whl --clobber
+python3 -m pip install /tmp/simdrive.whl
+```
+
+(The pip-direct URL hits a 404 because GitHub release assets need authenticated
+download — `gh release download` uses your gh auth.)
+
+**Wire into Claude Code** — add to `~/.claude.json` under `mcpServers`:
+```json
+{ "mcpServers": { "simdrive": { "type": "stdio", "command": "simdrive", "args": [] } } }
+```
+
+Restart Claude Code (or `/mcp` reload) so the simdrive tools become available.
+
+**Tool surface** (all `mcp__simdrive__*`):
+- `session_start` / `session_end` / `session_status` — boot/find sim, optionally launch app
+- `observe` — screenshot + numbered annotated copy + OCR'd text marks
+- `tap` — by `{x,y}` (pixel), `{mark: N}` (numbered region from observe), or `{text: "..."}` (text match)
+- `swipe`, `type_text`, `press_key` (home, lock, return, tab, escape, arrow keys)
+- `record_start` / `record_stop` / `replay` — capture flows, replay with drift-aware halting
+- `logs` — tail simulator logs (NSPredicate-filterable)
+
+### Per-area workflow (use this for each P0/P1 area)
+
+### P0 — Critical Path (mandatory)
+
+Walk through each P0 area one at a time:
+
+1. **Tell the user what to test.** Read the test area description from the matrix.
+2. **Ask what they see.** After they test, ask: "Any differences between baseline and candidate?"
+3. **If they find something:**
+   - Ask them to capture a screenshot pair (baseline + candidate)
+   - Ask for naming: `F-NNN-baseline-description.png` / `F-NNN-candidate-description.png`
+   - Help them write the CSV row. Set `Verified=false` initially.
+   - Ask: "Can you verify this on the actual device right now?" If yes, set `Verified=true`.
+4. **If no differences:** Mark the area as tested and move on.
+5. **Track progress.** After each area, show how many P0 areas remain.
+
+### P1 — Core Experience (mandatory)
+
+Same process as P0. These cover reading, playback, sync, and catalog.
+
+### P2 — Polish & Edge Cases (sample)
+
+Ask the user: "Which P2 areas are relevant to the changes in this release?" Only test the areas they select.
+
+## Phase 4: Finding Review
+
+After all testing is complete:
+
+1. Read the CSV and show a summary table:
+   - Total findings by classification (regression, pre-existing, fixed, behavior-change)
+   - How many are verified vs unverified
+   - How many have severity blocker or major
+
+2. For any unverified findings, ask: "Can you verify these now, or should we exclude them from the report?"
+
+3. Ask: "Are there any findings you want to reclassify or remove?"
+
+## Phase 5: Report Generation
+
+Generate the HTML report:
+
+```bash
+scripts/regression-report.sh report \
+  --output-dir ~/Desktop/regression-<TICKET> \
+  --baseline-version <BASELINE> \
+  --candidate-version <CANDIDATE> \
+  --strict
+```
+
+If `--strict` fails (unverified findings), show which findings are unverified and ask the user what to do:
+- Verify them now
+- Remove them from the CSV
+- Run without `--strict` (will include warning badges)
+
+Open the report for review:
+```bash
+open ~/Desktop/regression-<TICKET>/report/index.html
+```
+
+Ask: "Does the report look correct? Any findings to adjust?"
+
+## Phase 6: Jira Tickets
+
+Generate Jira tickets from findings:
+
+```bash
+# Dry run first
+scripts/regression-report.sh tickets \
+  --output-dir ~/Desktop/regression-<TICKET> \
+  --ticket <TICKET> \
+  --dry-run
+```
+
+Show the dry-run output and ask: "These tickets will be created. Proceed?"
+
+If confirmed:
+```bash
+scripts/regression-report.sh tickets \
+  --output-dir ~/Desktop/regression-<TICKET> \
+  --ticket <TICKET>
+```
+
+## Phase 7: Publishing
+
+Ask the user where to publish the report:
+1. GitHub Pages (push to `mauricecarrier7/pp-regression-reports`)
+2. Local only (just the HTML file)
+3. Confluence (provide instructions)
+
+If GitHub Pages:
+- Compress assets (video to 720p, PNGs to 800px) using ffmpeg and sips
+- Push to the regression-reports repo
+- Enable Pages if needed
+- Provide the URL
+
+Add the report URL as a comment on the parent Jira ticket.
+
+## Rules
+
+- **CSV is the contract.** All findings go into findings.csv. Report and tickets are generated from it.
+- **Verified column matters.** Don't let unverified findings into the final report without flagging them.
+- **Screenshot evidence for every finding.** If a finding doesn't have screenshots, ask the tester to capture them.
+- **Compress media on capture.** 800px max width for screenshots, 720p for video.
+- **Never create Jira tickets without showing dry-run first.**
+- **Be encouraging.** Regression testing is tedious. Acknowledge progress and celebrate when blockers are found — that's the whole point.
+
+## Quick Reference
+
+| Classification | Jira Type | When to Use |
+|---------------|-----------|-------------|
+| `regression` | Bug | Worked in baseline, broken in candidate |
+| `pre-existing` | Bug | Broken in both versions |
+| `fixed` | N/A | Broken in baseline, fixed in candidate |
+| `behavior-change` | N/A | Intentional change |
+| `new-feature` | N/A | Only in candidate |
+| `superseded` | N/A | Found to be incorrect |
+
+| Severity | Jira Priority | Criteria |
+|----------|--------------|----------|
+| `blocker` | Blocker | Data loss, credential leak, unrecoverable |
+| `major` | High | Core flow broken, painful workaround |
+| `minor` | Normal | Noticeable but low impact |
+| `cosmetic` | Low | Visual only |

--- a/scripts/generate-jira-tickets.py
+++ b/scripts/generate-jira-tickets.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""
+Create Jira tickets from a regression findings CSV via the Jira REST API.
+
+Pure stdlib — no external dependencies required.
+
+Usage:
+    # Dry run (preview what would be created)
+    python3 scripts/generate-jira-tickets.py \\
+        --csv findings.csv \\
+        --parent PP-4020 \\
+        --jira-url https://ebce-lyrasis.atlassian.net \\
+        --component iOS \\
+        --dry-run
+
+    # Create tickets and update the CSV with ticket keys
+    python3 scripts/generate-jira-tickets.py \\
+        --csv findings.csv \\
+        --parent PP-4020 \\
+        --jira-url https://ebce-lyrasis.atlassian.net \\
+        --component iOS \\
+        --update-csv
+
+Environment variables:
+    JIRA_EMAIL       Jira account email
+    JIRA_API_TOKEN   Jira API token
+
+Fallback: reads from .jira-config at repo root (KEY=VALUE format, one per line).
+
+Only creates tickets for findings where:
+    - Verified = true
+    - Jira Ticket column is empty
+    - Classification is 'regression' or 'pre-existing'
+"""
+import argparse
+import base64
+import csv
+import json
+import os
+import shutil
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Priority mapping (Jira-valid names only)
+# ---------------------------------------------------------------------------
+PRIORITY_MAP = {
+    "blocker": "Blocker",
+    "major": "High",
+    "minor": "Normal",
+    "cosmetic": "Low",
+}
+DEFAULT_PRIORITY = "Normal"
+
+# Classifications eligible for ticket creation
+TICKETABLE_CLASSIFICATIONS = {"regression", "pre-existing"}
+
+# Jira constants
+ISSUE_TYPE_BUG_ID = "10014"
+COMPONENT_ID = "10000"
+LABEL = "pp-4020"
+
+
+# ---------------------------------------------------------------------------
+# Credential helpers
+# ---------------------------------------------------------------------------
+
+def _repo_root() -> str:
+    """Walk up from this script to find the repo root (contains .git)."""
+    d = os.path.dirname(os.path.abspath(__file__))
+    while d != os.path.dirname(d):
+        if os.path.isdir(os.path.join(d, ".git")):
+            return d
+        d = os.path.dirname(d)
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_jira_config() -> Dict[str, str]:
+    """Read .jira-config from repo root as KEY=VALUE pairs."""
+    config_path = os.path.join(_repo_root(), ".jira-config")
+    cfg: Dict[str, str] = {}
+    if not os.path.isfile(config_path):
+        return cfg
+    with open(config_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, _, value = line.partition("=")
+                cfg[key.strip()] = value.strip()
+    return cfg
+
+
+def get_credentials() -> Tuple[str, str]:
+    """Return (email, api_token) from env vars or .jira-config fallback."""
+    email = os.environ.get("JIRA_EMAIL", "")
+    token = os.environ.get("JIRA_API_TOKEN", "")
+    if email and token:
+        return email, token
+
+    cfg = _load_jira_config()
+    email = email or cfg.get("JIRA_EMAIL", "")
+    token = token or cfg.get("JIRA_API_TOKEN", "")
+    if not email or not token:
+        print("Error: JIRA_EMAIL and JIRA_API_TOKEN must be set "
+              "(environment variables or .jira-config).", file=sys.stderr)
+        sys.exit(1)
+    return email, token
+
+
+def make_auth_header(email: str, token: str) -> str:
+    """Build Basic auth header value."""
+    raw = f"{email}:{token}".encode("utf-8")
+    return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# ADF (Atlassian Document Format) helpers
+# ---------------------------------------------------------------------------
+
+def text_to_adf(text: str) -> Dict[str, Any]:
+    """Convert plain text to ADF document. Double-newlines split paragraphs."""
+    paragraphs = text.split("\n\n")
+    content = []
+    for para in paragraphs:
+        para = para.strip()
+        if not para:
+            continue
+        content.append({
+            "type": "paragraph",
+            "content": [{"type": "text", "text": para}],
+        })
+    if not content:
+        content.append({
+            "type": "paragraph",
+            "content": [{"type": "text", "text": "(no description)"}],
+        })
+    return {"type": "doc", "version": 1, "content": content}
+
+
+# ---------------------------------------------------------------------------
+# Description builder
+# ---------------------------------------------------------------------------
+
+def build_description(finding: Dict[str, str]) -> str:
+    """Build plain-text description from a finding row."""
+    classification = finding.get("Classification", "").strip()
+    baseline = finding.get("Baseline Behavior", "").strip()
+    candidate = finding.get("Candidate Behavior", "").strip()
+    steps = finding.get("Steps", "").strip()
+    notes = finding.get("Notes", "").strip()
+    pr = finding.get("PR", "").strip()
+
+    parts = [
+        f"{classification} found during regression testing.",
+        "",
+        baseline,
+        "",
+        "vs candidate:",
+        "",
+        candidate,
+        "",
+        f"Steps: {steps}",
+        "",
+        notes,
+    ]
+
+    if pr:
+        parts.extend([
+            "",
+            f"Fixed in PR #{pr}: https://github.com/ThePalaceProject/ios-core/pull/{pr}",
+        ])
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Jira REST API helpers
+# ---------------------------------------------------------------------------
+
+def jira_request(url: str, auth: str, method: str = "GET",
+                 data: Optional[Dict] = None) -> Tuple[int, Any]:
+    """Make a Jira REST API request. Returns (status_code, parsed_json)."""
+    body = json.dumps(data).encode("utf-8") if data else None
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Authorization", auth)
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            resp_body = resp.read().decode("utf-8")
+            return resp.status, json.loads(resp_body) if resp_body else {}
+    except urllib.error.HTTPError as e:
+        resp_body = e.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(resp_body)
+        except (json.JSONDecodeError, ValueError):
+            parsed = {"raw": resp_body}
+        return e.code, parsed
+
+
+def create_issue(base_url: str, auth: str, project_key: str,
+                 summary: str, description_adf: Dict,
+                 priority_name: str, component_id: str,
+                 label: str) -> Tuple[Optional[str], Optional[str]]:
+    """Create a Jira issue. Returns (key, error_message)."""
+    url = f"{base_url}/rest/api/3/issue"
+    payload = {
+        "fields": {
+            "project": {"key": project_key},
+            "issuetype": {"id": ISSUE_TYPE_BUG_ID},
+            "summary": summary,
+            "description": description_adf,
+            "priority": {"name": priority_name},
+            "components": [{"id": component_id}],
+            "labels": [label],
+        }
+    }
+    status, body = jira_request(url, auth, method="POST", data=payload)
+    if 200 <= status < 300:
+        return body.get("key"), None
+    errors = body.get("errors", body.get("errorMessages", body))
+    return None, f"HTTP {status}: {json.dumps(errors)}"
+
+
+def link_issues(base_url: str, auth: str,
+                inward_key: str, outward_key: str) -> Optional[str]:
+    """Create a 'Relates' link between two issues. Returns error or None."""
+    url = f"{base_url}/rest/api/3/issueLink"
+    payload = {
+        "type": {"name": "Relates"},
+        "inwardIssue": {"key": inward_key},
+        "outwardIssue": {"key": outward_key},
+    }
+    status, body = jira_request(url, auth, method="POST", data=payload)
+    if 200 <= status < 300:
+        return None
+    return f"HTTP {status}: {json.dumps(body)}"
+
+
+def transition_to_done(base_url: str, auth: str, issue_key: str) -> Optional[str]:
+    """Transition an issue to Done. Returns error or None."""
+    url = f"{base_url}/rest/api/3/issue/{issue_key}/transitions"
+    status, body = jira_request(url, auth)
+    if status != 200:
+        return f"Failed to get transitions: HTTP {status}"
+
+    transitions = body.get("transitions", [])
+    done_transition = None
+    for t in transitions:
+        if t.get("name", "").lower() == "done":
+            done_transition = t
+            break
+
+    if not done_transition:
+        names = [t.get("name", "?") for t in transitions]
+        return f"No 'Done' transition found. Available: {names}"
+
+    payload = {"transition": {"id": done_transition["id"]}}
+    status, body = jira_request(url, auth, method="POST", data=payload)
+    if 200 <= status < 300:
+        return None
+    return f"Transition failed: HTTP {status}: {json.dumps(body)}"
+
+
+# ---------------------------------------------------------------------------
+# CSV helpers
+# ---------------------------------------------------------------------------
+
+def load_csv(path: str) -> Tuple[List[str], List[Dict[str, str]]]:
+    """Load CSV, return (fieldnames, rows)."""
+    with open(path, "r", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+    return fieldnames, rows
+
+
+def save_csv(path: str, fieldnames: List[str], rows: List[Dict[str, str]]) -> None:
+    """Write rows back to CSV."""
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def backup_csv(path: str) -> str:
+    """Backup CSV to path.{timestamp}.bak. Returns backup path."""
+    ts = time.strftime("%Y%m%d%H%M%S")
+    bak = f"{path}.{ts}.bak"
+    shutil.copy2(path, bak)
+    return bak
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+def is_eligible(row: Dict[str, str]) -> bool:
+    """Return True if this finding should get a Jira ticket."""
+    verified = row.get("Verified", "").strip().lower()
+    if verified != "true":
+        return False
+    jira_ticket = row.get("Jira Ticket", "").strip()
+    if jira_ticket:
+        return False
+    classification = row.get("Classification", "").strip().lower()
+    if classification not in TICKETABLE_CLASSIFICATIONS:
+        return False
+    return True
+
+
+def should_transition_done(row: Dict[str, str]) -> bool:
+    """Return True if this finding's ticket should be transitioned to Done."""
+    classification = row.get("Classification", "").strip().lower()
+    pr = row.get("PR", "").strip()
+    return classification in TICKETABLE_CLASSIFICATIONS and bool(pr)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run display
+# ---------------------------------------------------------------------------
+
+def print_dry_run_table(eligible: List[Dict[str, str]]) -> None:
+    """Print a formatted table of what would be created."""
+    if not eligible:
+        print("No eligible findings found. Nothing to create.")
+        return
+
+    headers = ["ID", "Summary", "Priority", "Classification", "Has PR"]
+    rows = []
+    for row in eligible:
+        fid = row.get("ID", "").strip()
+        title = row.get("Title", "").strip()
+        severity = row.get("Severity", "").strip().lower()
+        classification = row.get("Classification", "").strip()
+        pr = row.get("PR", "").strip()
+        priority = PRIORITY_MAP.get(severity, DEFAULT_PRIORITY)
+        summary = f"iOS: {fid}: {title}"
+        rows.append([fid, summary, priority, classification, "Yes" if pr else "No"])
+
+    # Compute column widths
+    widths = [len(h) for h in headers]
+    for r in rows:
+        for i, cell in enumerate(r):
+            widths[i] = max(widths[i], len(cell))
+
+    def fmt_row(cells: List[str]) -> str:
+        return "  ".join(c.ljust(widths[i]) for i, c in enumerate(cells))
+
+    print(fmt_row(headers))
+    print("  ".join("-" * w for w in widths))
+    for r in rows:
+        print(fmt_row(r))
+
+    print(f"\nTotal: {len(rows)} ticket(s) would be created.")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create Jira tickets from a regression findings CSV via the REST API.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Preview what would be created
+  python3 scripts/generate-jira-tickets.py \\
+      --csv findings.csv --parent PP-4020 \\
+      --jira-url https://ebce-lyrasis.atlassian.net \\
+      --component iOS --dry-run
+
+  # Create tickets and update the CSV
+  python3 scripts/generate-jira-tickets.py \\
+      --csv findings.csv --parent PP-4020 \\
+      --jira-url https://ebce-lyrasis.atlassian.net \\
+      --component iOS --update-csv
+
+Environment:
+  JIRA_EMAIL        Jira account email
+  JIRA_API_TOKEN    Jira API token
+  Fallback: .jira-config at repo root (KEY=VALUE, one per line)
+""",
+    )
+    parser.add_argument("--csv", required=True,
+                        help="Path to findings CSV")
+    parser.add_argument("--parent", required=True,
+                        help="Parent Jira ticket to link new issues to (e.g. PP-4020)")
+    parser.add_argument("--jira-url", required=True,
+                        help="Jira instance base URL (e.g. https://ebce-lyrasis.atlassian.net)")
+    parser.add_argument("--component", default="iOS",
+                        help="Component name for display (default: iOS)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print what would be created without making API calls")
+    parser.add_argument("--update-csv", action="store_true",
+                        help="Write Jira ticket keys back to the CSV (backs up first)")
+
+    args = parser.parse_args()
+
+    # Strip trailing slash from URL
+    base_url = args.jira_url.rstrip("/")
+
+    # Load CSV
+    if not os.path.isfile(args.csv):
+        print(f"Error: CSV file not found: {args.csv}", file=sys.stderr)
+        sys.exit(1)
+
+    fieldnames, rows = load_csv(args.csv)
+    print(f"Loaded {len(rows)} findings from {args.csv}", file=sys.stderr)
+
+    # Ensure Jira Ticket column exists
+    if "Jira Ticket" not in fieldnames:
+        fieldnames.append("Jira Ticket")
+        for row in rows:
+            row.setdefault("Jira Ticket", "")
+
+    # Filter eligible
+    eligible_indices = [i for i, row in enumerate(rows) if is_eligible(row)]
+    eligible = [rows[i] for i in eligible_indices]
+
+    print(f"Found {len(eligible)} eligible findings "
+          f"(verified=true, no existing ticket, regression/pre-existing)",
+          file=sys.stderr)
+
+    # Dry run
+    if args.dry_run:
+        print_dry_run_table(eligible)
+        return
+
+    if not eligible:
+        print("No eligible findings. Nothing to do.")
+        return
+
+    # Get credentials
+    email, token = get_credentials()
+    auth = make_auth_header(email, token)
+
+    # Extract project key from parent ticket
+    project_key = args.parent.rsplit("-", 1)[0] if "-" in args.parent else "PP"
+
+    # Process each eligible finding
+    results: List[Dict[str, str]] = []
+    created_count = 0
+    error_count = 0
+
+    for idx in eligible_indices:
+        row = rows[idx]
+        fid = row.get("ID", "").strip()
+        title = row.get("Title", "").strip()
+        severity = row.get("Severity", "").strip().lower()
+        priority = PRIORITY_MAP.get(severity, DEFAULT_PRIORITY)
+        summary = f"iOS: {fid}: {title}"
+        description_text = build_description(row)
+        description_adf = text_to_adf(description_text)
+
+        print(f"\nCreating: {summary} ...", file=sys.stderr)
+
+        # 1. Create the issue
+        issue_key, err = create_issue(
+            base_url, auth, project_key, summary, description_adf,
+            priority, COMPONENT_ID, LABEL,
+        )
+        if err:
+            print(f"  FAILED: {err}", file=sys.stderr)
+            results.append({"id": fid, "summary": summary, "status": "FAILED", "error": err})
+            error_count += 1
+            continue
+
+        print(f"  Created: {issue_key}", file=sys.stderr)
+        created_count += 1
+
+        # Update the row
+        rows[idx]["Jira Ticket"] = issue_key
+
+        result_entry = {"id": fid, "summary": summary, "key": issue_key, "status": "CREATED"}
+
+        # 2. Link to parent
+        link_err = link_issues(base_url, auth, issue_key, args.parent)
+        if link_err:
+            print(f"  Link to {args.parent} failed: {link_err}", file=sys.stderr)
+            result_entry["link_error"] = link_err
+        else:
+            print(f"  Linked to {args.parent}", file=sys.stderr)
+
+        # 3. Transition to Done if PR exists and classification qualifies
+        if should_transition_done(row):
+            trans_err = transition_to_done(base_url, auth, issue_key)
+            if trans_err:
+                print(f"  Transition to Done failed: {trans_err}", file=sys.stderr)
+                result_entry["transition_error"] = trans_err
+            else:
+                print(f"  Transitioned to Done", file=sys.stderr)
+                result_entry["status"] = "CREATED+DONE"
+
+        results.append(result_entry)
+
+    # Summary
+    print(f"\n{'='*60}", file=sys.stderr)
+    print(f"Created: {created_count}  Errors: {error_count}  "
+          f"Total eligible: {len(eligible)}", file=sys.stderr)
+
+    # Save results file alongside the CSV
+    csv_dir = os.path.dirname(os.path.abspath(args.csv))
+    results_path = os.path.join(csv_dir, "created-tickets.txt")
+    with open(results_path, "w") as f:
+        f.write(f"Jira Ticket Creation Results\n")
+        f.write(f"{'='*60}\n")
+        f.write(f"CSV: {args.csv}\n")
+        f.write(f"Parent: {args.parent}\n")
+        f.write(f"Created: {created_count}  Errors: {error_count}\n")
+        f.write(f"{'='*60}\n\n")
+        for r in results:
+            key = r.get("key", "N/A")
+            f.write(f"{r['id']}  {key}  {r['status']}  {r['summary']}\n")
+            if r.get("error"):
+                f.write(f"    Error: {r['error']}\n")
+            if r.get("link_error"):
+                f.write(f"    Link error: {r['link_error']}\n")
+            if r.get("transition_error"):
+                f.write(f"    Transition error: {r['transition_error']}\n")
+    print(f"Results saved to {results_path}", file=sys.stderr)
+
+    # Update CSV if requested
+    if args.update_csv:
+        bak = backup_csv(args.csv)
+        print(f"CSV backed up to {bak}", file=sys.stderr)
+        save_csv(args.csv, fieldnames, rows)
+        print(f"CSV updated with ticket keys.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-regression-report.py
+++ b/scripts/generate-regression-report.py
@@ -1,0 +1,829 @@
+#!/usr/bin/env python3
+"""Generate an interactive HTML regression report from a findings CSV.
+
+Pure stdlib — no external dependencies required.
+
+Usage:
+    python3 scripts/generate-regression-report.py \\
+        --csv findings.csv \\
+        --screenshots ./screenshots/ \\
+        --output report/index.html \\
+        --baseline-version 1.2.8 \\
+        --candidate-version 2.2.5
+
+    python3 scripts/generate-regression-report.py --csv findings.csv --validate --screenshots ./screenshots/
+    python3 scripts/generate-regression-report.py --csv findings.csv --strict --output report.html
+
+CSV columns:
+    ID, Title, Area, Test ID, Classification, Severity, Verified,
+    Baseline Behavior, Candidate Behavior, Steps,
+    Screenshot Baseline, Screenshot Candidate, Notes, PR, Jira Ticket
+"""
+import argparse
+import csv
+import html
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SEVERITY_COLORS: Dict[str, str] = {
+    "blocker": "#dc2626",
+    "major": "#ea580c",
+    "minor": "#ca8a04",
+    "cosmetic": "#6b7280",
+}
+
+CLASSIFICATION_COLORS: Dict[str, str] = {
+    "regression": "#dc2626",
+    "pre-existing": "#ea580c",
+    "fixed": "#16a34a",
+    "behavior-change": "#7c3aed",
+    "new-feature": "#3b82f6",
+    "superseded": "#6b7280",
+}
+
+CLASSIFICATION_LABELS: Dict[str, str] = {
+    "regression": "Regression",
+    "pre-existing": "Pre-existing",
+    "fixed": "Fixed",
+    "behavior-change": "Behavior Change",
+    "new-feature": "New Feature",
+    "superseded": "Superseded",
+}
+
+TOC_TAGS: Dict[str, str] = {
+    "regression": "REG",
+    "pre-existing": "PRE",
+    "fixed": "FIX",
+    "behavior-change": "CHG",
+    "new-feature": "NEW",
+    "superseded": "SUP",
+}
+
+TOC_TAG_COLORS: Dict[str, str] = {
+    "REG": "#dc2626",
+    "PRE": "#ea580c",
+    "FIX": "#16a34a",
+    "CHG": "#7c3aed",
+    "NEW": "#3b82f6",
+    "SUP": "#6b7280",
+}
+
+# Sections displayed in the main body (excludes superseded).
+MAIN_SECTIONS = [
+    ("regressions", "Regressions", "regression",
+     "Functionality that regressed between the baseline and candidate versions."),
+    ("pre-existing", "Pre-existing Bugs", "pre-existing",
+     "Bugs present in both versions — not introduced by the candidate."),
+    ("fixed", "Fixed", "fixed",
+     "Issues present in the baseline that are resolved in the candidate."),
+    ("improvements", "Improvements", None,  # special: behavior-change + new-feature
+     "Behavior changes and new features in the candidate version."),
+]
+
+DEFAULT_JIRA_URL = "https://ebce-lyrasis.atlassian.net/browse"
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def load_findings(csv_path: Path) -> List[Dict[str, str]]:
+    """Read findings CSV and return a list of row dicts."""
+    with csv_path.open("r", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        return list(reader)
+
+
+def classify_findings(findings: List[Dict[str, str]]) -> Dict[str, List[Dict[str, str]]]:
+    """Group findings by their Classification value (lowercased)."""
+    groups: Dict[str, List[Dict[str, str]]] = {}
+    for row in findings:
+        val = row.get("Classification")
+        cls = val.strip().lower() if val else ""
+        groups.setdefault(cls, []).append(row)
+    return groups
+
+
+def _unique_prs(findings: List[Dict[str, str]]) -> int:
+    """Count unique non-empty PR numbers across all findings."""
+    prs = set()
+    for row in findings:
+        val = row.get("PR")
+        pr = val.strip() if val else ""
+        if pr:
+            prs.add(pr)
+    return len(prs)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def validate_findings(
+    findings: List[Dict[str, str]],
+    screenshots_dir: Optional[Path],
+    strict: bool,
+) -> List[str]:
+    """Return a list of error strings. Empty means valid."""
+    errors: List[str] = []
+
+    # Screenshot reference check (only when --validate is active).
+    if screenshots_dir is not None:
+        for row in findings:
+            for col in ("Screenshot Baseline", "Screenshot Candidate"):
+                ref = _cell(row, col)
+                if not ref:
+                    continue
+                full = screenshots_dir / ref
+                if not full.exists():
+                    errors.append(
+                        f"{row.get('ID', '?')}: referenced screenshot "
+                        f"'{ref}' not found in {screenshots_dir}"
+                    )
+
+    # Strict: every finding must be verified.
+    if strict:
+        unverified: List[str] = []
+        for row in findings:
+            val = row.get("Verified")
+            v = val.strip().lower() if val else ""
+            if v not in ("true", "yes", "1"):
+                fid_val = row.get("ID")
+                unverified.append(fid_val.strip() if fid_val else "?")
+        if unverified:
+            errors.append(
+                f"Unverified findings (--strict mode): {', '.join(unverified)}"
+            )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# HTML helpers
+# ---------------------------------------------------------------------------
+
+def esc(text: str) -> str:
+    """HTML-escape a string, handling None/empty gracefully."""
+    return html.escape(str(text)) if text else ""
+
+
+_COLUMN_ALIASES: Dict[str, List[str]] = {
+    "Baseline Behavior": ["Baseline Behavior", "1.2.8 Behavior"],
+    "Candidate Behavior": ["Candidate Behavior", "2.2.5 Behavior"],
+    "Screenshot Baseline": ["Screenshot Baseline", "Screenshot 1.2.8"],
+    "Screenshot Candidate": ["Screenshot Candidate", "Screenshot 2.2.5"],
+}
+
+
+def _cell(row: Dict[str, str], key: str) -> str:
+    """Safely retrieve a CSV cell, trying column aliases for backward compat."""
+    val = row.get(key)
+    if val is None:
+        for alias in _COLUMN_ALIASES.get(key, []):
+            val = row.get(alias)
+            if val is not None:
+                break
+    return val.strip() if val else ""
+
+
+def _is_image(filename: str) -> bool:
+    return filename.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".webp"))
+
+
+def _is_video(filename: str) -> bool:
+    return filename.lower().endswith((".mp4", ".mov", ".m4v", ".webm"))
+
+
+# ---------------------------------------------------------------------------
+# CSS
+# ---------------------------------------------------------------------------
+
+def _css() -> str:
+    return """\
+:root {
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border: #334155;
+  --accent: #3b82f6;
+}
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: -apple-system, system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+.container { max-width: 1200px; margin: 0 auto; padding: 0 24px; }
+
+/* Header */
+header {
+  background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+  border-bottom: 1px solid var(--border);
+  padding: 40px 0;
+}
+header h1 { font-size: 2rem; font-weight: 700; margin-bottom: 4px; }
+header .subtitle { color: var(--text-muted); font-size: 1.1rem; }
+
+/* Stats grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+  margin: 32px 0 0;
+}
+.stat-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  text-align: center;
+}
+.stat-number { font-size: 2rem; font-weight: 700; }
+.stat-label {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Sticky nav */
+nav {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+nav .container { display: flex; gap: 0; overflow-x: auto; }
+nav a {
+  color: var(--text-muted);
+  text-decoration: none;
+  padding: 14px 18px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s;
+}
+nav a:hover { color: var(--text); border-bottom-color: var(--accent); }
+
+/* Sections */
+.section-wrap { padding: 48px 0; border-bottom: 1px solid var(--border); }
+.section-collapse summary { cursor: pointer; list-style: none; }
+.section-collapse summary::-webkit-details-marker { display: none; }
+.section-collapse summary h2 { font-size: 1.5rem; margin-bottom: 8px; display: inline; }
+.section-desc { color: var(--text-muted); margin-bottom: 24px; font-size: 0.95rem; }
+
+/* Finding cards */
+.finding-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 16px;
+}
+.finding-card:hover { border-color: #475569; }
+.finding-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.finding-id {
+  font-family: ui-monospace, 'SF Mono', monospace;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--accent);
+}
+.badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: white;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.jira-link {
+  color: #f59e0b;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+.jira-link:hover { text-decoration: underline; }
+.pr-link {
+  color: #06b6d4;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+.pr-link:hover { text-decoration: underline; }
+.finding-card h3 { font-size: 1.05rem; font-weight: 600; margin-bottom: 12px; line-height: 1.4; }
+
+/* Comparison columns */
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin: 16px 0;
+}
+.version {
+  background: var(--bg);
+  padding: 16px;
+  border-radius: 8px;
+}
+.version.old { border-left: 3px solid #475569; }
+.version.new { border-left: 3px solid var(--accent); }
+.version strong {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.version p { font-size: 0.9rem; line-height: 1.5; }
+
+/* Meta (steps / notes) */
+.meta {
+  margin: 8px 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* Evidence grid */
+.evidence {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.evidence-item {
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--bg);
+}
+.evidence-item img {
+  width: 100%;
+  display: block;
+  max-height: 400px;
+  object-fit: contain;
+  background: #000;
+}
+.evidence-item video {
+  width: 100%;
+  display: block;
+  max-height: 400px;
+}
+.screenshot-label {
+  padding: 6px 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: rgba(0,0,0,0.3);
+}
+
+/* Hero video */
+.hero-video {
+  margin: 24px 0;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: #000;
+  max-width: 900px;
+}
+.hero-video video { width: 100%; display: block; }
+
+/* All-findings TOC */
+.toc { columns: 2; column-gap: 32px; }
+.toc a {
+  display: block;
+  color: var(--text-muted);
+  text-decoration: none;
+  padding: 3px 0;
+  font-size: 0.85rem;
+  font-family: ui-monospace, 'SF Mono', monospace;
+}
+.toc a:hover { color: var(--text); }
+.toc-tag {
+  font-family: -apple-system, system-ui, sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+/* Footer */
+footer {
+  padding: 48px 0;
+  text-align: center;
+  color: #475569;
+  font-size: 0.8rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .comparison, .evidence { grid-template-columns: 1fr; }
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .toc { columns: 1; }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+def _render_stats(groups: Dict[str, List], pr_count: int) -> str:
+    """Render the header stats grid."""
+    n_reg = len(groups.get("regression", []))
+    n_fix = len(groups.get("fixed", []))
+    n_pre = len(groups.get("pre-existing", []))
+    n_imp = len(groups.get("behavior-change", [])) + len(groups.get("new-feature", []))
+
+    def _card(number: int, label: str, color: str) -> str:
+        return (
+            f'<div class="stat-card">'
+            f'<div class="stat-number" style="color:{color}">{number}</div>'
+            f'<div class="stat-label">{esc(label)}</div></div>'
+        )
+
+    return (
+        '<div class="stats-grid">'
+        + _card(n_reg, "Regressions", "#ef4444")
+        + _card(n_fix, "Fixed", "#22c55e")
+        + _card(n_pre, "Pre-existing", "#f97316")
+        + _card(n_imp, "Improvements", "#a78bfa")
+        + _card(pr_count, "PRs", "#06b6d4")
+        + "</div>"
+    )
+
+
+def _render_evidence_item(label: str, filename: str, screenshots_rel: str) -> str:
+    """Render a single evidence item (image or video)."""
+    path = f"{screenshots_rel}/{esc(filename)}"
+    if _is_video(filename):
+        media = (
+            f'<video controls preload="metadata">'
+            f'<source src="{path}"></video>'
+        )
+    else:
+        media = f'<img src="{path}" loading="lazy" alt="{esc(label)}">'
+    return (
+        f'<div class="evidence-item">'
+        f'<div class="screenshot-label">{esc(label)}</div>'
+        f'{media}</div>'
+    )
+
+
+def _render_finding(
+    row: Dict[str, str],
+    baseline_ver: str,
+    candidate_ver: str,
+    jira_url: str,
+    screenshots_rel: str,
+) -> str:
+    """Render a single finding card."""
+    fid = _cell(row, "ID")
+    title = _cell(row, "Title")
+    severity = _cell(row, "Severity").lower()
+    classification = _cell(row, "Classification").lower()
+    jira = _cell(row, "Jira Ticket")
+    pr = _cell(row, "PR")
+
+    sev_color = SEVERITY_COLORS.get(severity, "#6b7280")
+    cls_color = CLASSIFICATION_COLORS.get(classification, "#6b7280")
+    cls_label = CLASSIFICATION_LABELS.get(classification, classification.title())
+
+    # Header line: ID, optional Jira, severity badge, classification badge, optional PR.
+    parts = [f'<span class="finding-id">{esc(fid)}</span>']
+    if jira:
+        parts.append(
+            f'<a class="jira-link" href="{esc(jira_url)}/{esc(jira)}" '
+            f'target="_blank">{esc(jira)}</a>'
+        )
+    if severity:
+        parts.append(f'<span class="badge" style="background:{sev_color}">{esc(severity)}</span>')
+    parts.append(f'<span class="badge" style="background:{cls_color}">{esc(cls_label)}</span>')
+    if pr:
+        parts.append(
+            f'<a class="pr-link" href="https://github.com/ThePalaceProject/ios-core/pull/{esc(pr)}" '
+            f'target="_blank">PR #{esc(pr)}</a>'
+        )
+
+    header = f'<div class="finding-header">{"".join(parts)}</div>'
+
+    # Title
+    title_html = f"<h3>{esc(title)}</h3>"
+
+    # Comparison columns
+    old_b = _cell(row, "Baseline Behavior")
+    new_b = _cell(row, "Candidate Behavior")
+    comparison = ""
+    if old_b or new_b:
+        comparison = (
+            '<div class="comparison">'
+            f'<div class="version old"><strong>{esc(baseline_ver)}</strong><p>{esc(old_b)}</p></div>'
+            f'<div class="version new"><strong>{esc(candidate_ver)}</strong><p>{esc(new_b)}</p></div>'
+            "</div>"
+        )
+
+    # Steps and notes
+    steps = _cell(row, "Steps")
+    notes = _cell(row, "Notes")
+    meta = ""
+    if steps:
+        meta += f'<div class="meta"><strong>Steps:</strong> {esc(steps)}</div>'
+    if notes:
+        meta += f'<div class="meta"><strong>Notes:</strong> {esc(notes)}</div>'
+
+    # Evidence
+    ss_base = _cell(row, "Screenshot Baseline")
+    ss_cand = _cell(row, "Screenshot Candidate")
+    evidence = ""
+    if ss_base or ss_cand:
+        items = ""
+        if ss_base:
+            items += _render_evidence_item(baseline_ver, ss_base, screenshots_rel)
+        if ss_cand:
+            items += _render_evidence_item(candidate_ver, ss_cand, screenshots_rel)
+        evidence = f'<div class="evidence">{items}</div>'
+
+    return (
+        f'<div class="finding-card" id="{esc(fid)}">'
+        f"{header}{title_html}{comparison}{meta}{evidence}"
+        "</div>"
+    )
+
+
+def _render_section(
+    section_id: str,
+    title: str,
+    description: str,
+    findings: List[Dict[str, str]],
+    baseline_ver: str,
+    candidate_ver: str,
+    jira_url: str,
+    screenshots_rel: str,
+) -> str:
+    """Render a collapsible section with finding cards."""
+    if not findings:
+        return ""
+    cards = "\n".join(
+        _render_finding(f, baseline_ver, candidate_ver, jira_url, screenshots_rel)
+        for f in findings
+    )
+    return (
+        f'<div class="section-wrap" id="{esc(section_id)}">'
+        f'<div class="container">'
+        f'<details class="section-collapse" open>'
+        f"<summary><h2>{esc(title)} ({len(findings)})</h2></summary>"
+        f'<p class="section-desc">{esc(description)}</p>'
+        f"{cards}"
+        f"</details></div></div>"
+    )
+
+
+def _render_toc(findings: List[Dict[str, str]]) -> str:
+    """Render the All Findings index as a TOC-style list."""
+    lines: List[str] = []
+    for row in findings:
+        fid = _cell(row, "ID")
+        title = _cell(row, "Title")
+        cls = _cell(row, "Classification").lower()
+        tag = TOC_TAGS.get(cls, "???")
+        color = TOC_TAG_COLORS.get(tag, "#6b7280")
+        display = title[:70] + ("..." if len(title) > 70 else "")
+        lines.append(
+            f'<a href="#{esc(fid)}">{esc(fid)} '
+            f'<span class="toc-tag" style="color:{color}">[{tag}]</span> '
+            f"{esc(display)}</a>"
+        )
+    return "\n".join(lines)
+
+
+def _render_hero_video(video_path: str) -> str:
+    """Render optional hero video at the top."""
+    return (
+        '<div class="section-wrap" id="hero-video"><div class="container">'
+        "<h2>Video Overview</h2>"
+        f'<div class="hero-video">'
+        f'<video controls preload="metadata" playsinline>'
+        f'<source src="{esc(video_path)}"></video></div>'
+        "</div></div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Full report assembly
+# ---------------------------------------------------------------------------
+
+def generate_html(
+    findings: List[Dict[str, str]],
+    *,
+    title: str,
+    baseline_version: str,
+    candidate_version: str,
+    video_path: Optional[str],
+    jira_url: str,
+    screenshots_rel: str,
+) -> str:
+    """Assemble the complete HTML report string."""
+    groups = classify_findings(findings)
+    pr_count = _unique_prs(findings)
+
+    # Build main body sections.
+    body_sections: List[str] = []
+
+    # Optional hero video.
+    if video_path:
+        body_sections.append(_render_hero_video(video_path))
+
+    for sec_id, sec_title, cls_key, sec_desc in MAIN_SECTIONS:
+        if cls_key is not None:
+            section_findings = groups.get(cls_key, [])
+        else:
+            # "improvements" merges behavior-change + new-feature.
+            section_findings = (
+                groups.get("behavior-change", []) + groups.get("new-feature", [])
+            )
+        body_sections.append(
+            _render_section(
+                sec_id, sec_title, sec_desc, section_findings,
+                baseline_version, candidate_version, jira_url, screenshots_rel,
+            )
+        )
+
+    # All Findings index (includes superseded).
+    toc_html = _render_toc(findings)
+    superseded_count = len(groups.get("superseded", []))
+    active_count = len(findings) - superseded_count
+    body_sections.append(
+        '<div class="section-wrap" id="all-findings"><div class="container">'
+        '<details class="section-collapse" open>'
+        f"<summary><h2>All Findings ({len(findings)})</h2></summary>"
+        f'<p class="section-desc">{active_count} active + {superseded_count} superseded</p>'
+        f'<div class="toc">{toc_html}</div>'
+        "</details></div></div>"
+    )
+
+    # Navigation links (only for non-empty sections).
+    nav_items: List[str] = []
+    if video_path:
+        nav_items.append('<a href="#hero-video">Video</a>')
+    for sec_id, sec_title, cls_key, _ in MAIN_SECTIONS:
+        if cls_key is not None:
+            if groups.get(cls_key):
+                nav_items.append(f'<a href="#{sec_id}">{sec_title}</a>')
+        else:
+            if groups.get("behavior-change") or groups.get("new-feature"):
+                nav_items.append(f'<a href="#{sec_id}">{sec_title}</a>')
+    nav_items.append('<a href="#all-findings">All Findings</a>')
+
+    # Stats grid.
+    stats = _render_stats(groups, pr_count)
+
+    # Timestamp.
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{esc(title)}</title>
+<style>
+{_css()}
+</style>
+</head>
+<body>
+
+<header>
+<div class="container">
+<h1>{esc(title)}</h1>
+<p class="subtitle">{esc(baseline_version)} vs {esc(candidate_version)}</p>
+{stats}
+</div>
+</header>
+
+<nav><div class="container">{''.join(nav_items)}</div></nav>
+
+{''.join(s for s in body_sections if s)}
+
+<footer>
+<p>Generated {now}</p>
+</footer>
+
+</body>
+</html>"""
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate an interactive HTML regression report from a findings CSV."
+    )
+    parser.add_argument("--csv", required=True, type=Path,
+                        help="Path to findings CSV (required)")
+    parser.add_argument("--screenshots", type=Path, default=None,
+                        help="Directory containing screenshot/video evidence assets")
+    parser.add_argument("--output", type=Path, default=None,
+                        help="Output HTML file path")
+    parser.add_argument("--title", default="Regression Report",
+                        help="Report title (default: Regression Report)")
+    parser.add_argument("--baseline-version", default="baseline",
+                        help="Baseline version label")
+    parser.add_argument("--candidate-version", default="candidate",
+                        help="Candidate version label")
+    parser.add_argument("--video", default=None,
+                        help="Optional hero video path (relative to output)")
+    parser.add_argument("--jira-url", default=DEFAULT_JIRA_URL,
+                        help=f"Jira browse URL prefix (default: {DEFAULT_JIRA_URL})")
+    parser.add_argument("--validate", action="store_true",
+                        help="Validate screenshot references and exit")
+    parser.add_argument("--strict", action="store_true",
+                        help="Exit 1 if any findings are unverified")
+
+    args = parser.parse_args()
+
+    # Load CSV.
+    if not args.csv.exists():
+        print(f"Error: CSV not found: {args.csv}", file=sys.stderr)
+        sys.exit(1)
+    findings = load_findings(args.csv)
+    print(f"Loaded {len(findings)} findings from {args.csv}", file=sys.stderr)
+
+    # Validation.
+    errors = validate_findings(
+        findings,
+        screenshots_dir=args.screenshots if args.validate else None,
+        strict=args.strict,
+    )
+    if errors:
+        for err in errors:
+            print(f"Error: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.validate:
+        print("Validation passed.", file=sys.stderr)
+        sys.exit(0)
+
+    # Generation requires --output.
+    if not args.output:
+        print("Error: --output is required when generating a report.", file=sys.stderr)
+        sys.exit(1)
+
+    # Determine relative path from output to screenshots dir for <img src>.
+    screenshots_rel = "screenshots"
+    if args.screenshots and args.output:
+        try:
+            screenshots_rel = str(
+                args.screenshots.resolve().relative_to(args.output.resolve().parent)
+            )
+        except ValueError:
+            # Not relative — use absolute or keep default.
+            screenshots_rel = str(args.screenshots.resolve())
+
+    html_content = generate_html(
+        findings,
+        title=args.title,
+        baseline_version=args.baseline_version,
+        candidate_version=args.candidate_version,
+        video_path=args.video,
+        jira_url=args.jira_url,
+        screenshots_rel=screenshots_rel,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(html_content, encoding="utf-8")
+
+    # Summary.
+    groups = classify_findings(findings)
+    print(f"\nGenerated: {args.output}", file=sys.stderr)
+    print(f"  Regressions:  {len(groups.get('regression', []))}", file=sys.stderr)
+    print(f"  Fixed:        {len(groups.get('fixed', []))}", file=sys.stderr)
+    print(f"  Pre-existing: {len(groups.get('pre-existing', []))}", file=sys.stderr)
+    n_imp = len(groups.get("behavior-change", [])) + len(groups.get("new-feature", []))
+    print(f"  Improvements: {n_imp}", file=sys.stderr)
+    print(f"  Superseded:   {len(groups.get('superseded', []))}", file=sys.stderr)
+    print(f"  PRs:          {_unique_prs(findings)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/regression-report.sh
+++ b/scripts/regression-report.sh
@@ -1,0 +1,641 @@
+#!/bin/bash
+# regression-report.sh — Orchestrator for regression testing workflow.
+#
+# Sets up the regression workspace, runs automated tools, and generates
+# the final report and Jira tickets.
+#
+# Usage:
+#   scripts/regression-report.sh setup   --ticket PP-XXXX --output-dir ~/Desktop/regression-PP-XXXX
+#   scripts/regression-report.sh auto    --output-dir ~/Desktop/regression-PP-XXXX [--baseline-tag 2.2.5] [--candidate-branch modernize/whole-shot]
+#   scripts/regression-report.sh report  --output-dir ~/Desktop/regression-PP-XXXX --baseline-version 2.2.5 --candidate-version 3.0.0
+#   scripts/regression-report.sh tickets --output-dir ~/Desktop/regression-PP-XXXX --ticket PP-XXXX [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE_CSV="$SCRIPT_DIR/templates/regression-findings.csv"
+
+# Sim selection: prefer harness sim pool when present so parallel agents/QA
+# testers don't collide. Fall back to a sane default. Override per-invocation
+# with --sim-id (auto cmd) or by exporting SIM_ID before running.
+default_sim_id() {
+  local harness_default="$HOME/harness/projects/palace-ios.yml"
+  if [[ -f "$harness_default" ]]; then
+    awk -F: '/^[[:space:]]*default_sim_id:/ {gsub(/[" \047]/, "", $2); print $2; exit}' "$harness_default" 2>/dev/null
+  fi
+}
+SIM_ID="${SIM_ID:-$(default_sim_id)}"
+SIM_ID="${SIM_ID:-DF4A2A27-9888-429D-A749-2E157A049A37}"
+
+usage() {
+  cat << 'EOF'
+Palace iOS Regression Testing Orchestrator
+
+Commands:
+  setup    Create regression workspace with directories and CSV template
+  auto     Run automated testing tools (sync, mutation, push notifications)
+  report   Generate interactive HTML report from findings CSV
+  tickets  Generate Jira tickets from findings CSV
+  checklist Print the manual testing checklist
+
+Options:
+  --ticket PP-XXXX           Parent Jira ticket
+  --output-dir DIR           Regression workspace directory
+  --baseline-tag TAG         Git tag for baseline build (for mutation testing)
+  --candidate-branch BRANCH  Branch for candidate build (for mutation testing)
+  --baseline-version VER     Version label for baseline (e.g., "2.2.5")
+  --candidate-version VER    Version label for candidate (e.g., "3.0.0")
+  --dry-run                  Preview without making changes
+
+Options (auto command):
+  --run-sync-tests           Invoke xcodebuild with curated sync test classes
+  --skip-sync-tests          Explicitly skip sync tests
+  --run-push                 Force-run push tests even without cached token
+  --skip-push                Explicitly skip push tests
+  --push-token TOKEN         FCM token for push tests (overrides cache/capture)
+  --mutation-run             Execute mutants (default: dry-run enumeration only)
+  --mutation-limit N         Cap number of files to mutate (default: all changed)
+  --mutation-max-per-file N  Cap mutations per file (passthrough; default 8)
+  --mutation-files LIST      Comma-separated list of source files to mutate
+                              (overrides the changed-files derivation)
+  --sim-id UDID              Override the simulator UDID
+  --baseline-ref REF         Alias for --baseline-tag (any git ref accepted)
+  --yes-long-mutation        Bypass the wallclock-estimate guard for >30 min runs
+
+Workflow:
+  1. scripts/regression-report.sh setup --ticket PP-XXXX --output-dir ~/Desktop/regression-PP-XXXX
+  2. (Run automated tests)
+     scripts/regression-report.sh auto --output-dir ~/Desktop/regression-PP-XXXX
+  3. (Manual side-by-side testing — log findings to findings.csv)
+  4. scripts/regression-report.sh report --output-dir ~/Desktop/regression-PP-XXXX
+  5. scripts/regression-report.sh tickets --output-dir ~/Desktop/regression-PP-XXXX --ticket PP-XXXX --dry-run
+
+Tip: --help / -h on any subcommand prints these options and exits cleanly.
+EOF
+}
+
+# Derive an XCTestCase class name to test a given source file. Looks for a
+# matching <basename>Tests.swift under PalaceTests/, falls back to scanning for
+# any XCTestCase subclass declared in that file. Returns empty string on no
+# match — caller must handle the fallback.
+derive_test_class_for() {
+  local source_file="$1"   # e.g. "Palace/Accounts/Library/AccountsManager.swift"
+  local base
+  base=$(basename "$source_file" .swift)
+  # Try Foo.swift -> FooTests.swift first.
+  local candidate
+  candidate=$(find "$REPO_DIR/PalaceTests" -name "${base}Tests.swift" -not -path '*/Mocks/*' 2>/dev/null | head -1)
+  if [[ -z "$candidate" ]]; then
+    # Fallback: any test file mentioning the source class name.
+    candidate=$(grep -rl "@testable import Palace" "$REPO_DIR/PalaceTests" 2>/dev/null \
+      | xargs grep -l "\\b${base}\\b" 2>/dev/null \
+      | head -1)
+  fi
+  if [[ -z "$candidate" ]]; then
+    return 0  # no match — caller handles it
+  fi
+  # Pull the first XCTestCase subclass from the file. Matches both 'class X:'
+  # and 'final class X:'.
+  awk '/^[[:space:]]*(final[[:space:]]+)?class[[:space:]]+[A-Za-z0-9_]+[[:space:]]*:[[:space:]]*XCTestCase/ {
+    for (i=1; i<=NF; i++) if ($i == "class") { print $(i+1); exit }
+  }' "$candidate" | tr -d ':'
+}
+
+# ============================================================
+# SETUP — Create regression workspace
+# ============================================================
+cmd_setup() {
+  local ticket=""
+  local output_dir=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help|help) usage; exit 0 ;;
+      --ticket) ticket="$2"; shift 2 ;;
+      --output-dir) output_dir="$2"; shift 2 ;;
+      *) echo "Unknown option: $1"; usage; exit 1 ;;
+    esac
+  done
+
+  if [[ -z "$output_dir" ]]; then
+    echo "Error: --output-dir is required"
+    usage; exit 1
+  fi
+
+  if [[ -d "$output_dir" ]]; then
+    echo "Workspace already exists at $output_dir (existing findings.csv preserved)"
+  else
+    echo "=== Creating regression workspace ==="
+  fi
+
+  # Always (re)create the canonical subdir layout. mkdir -p is idempotent;
+  # this also recovers from manual archival of automated/* dirs between runs.
+  mkdir -p "$output_dir"/{screenshots,video,report/assets/{screenshots,video,data},automated/{specterqa,sync,screenshots,mutation}}
+
+  # CSV: only seed if missing (never overwrite a populated findings.csv).
+  if [[ ! -f "$output_dir/findings.csv" ]]; then
+    if [[ -f "$TEMPLATE_CSV" ]]; then
+      cp "$TEMPLATE_CSV" "$output_dir/findings.csv"
+      echo "  CSV template copied to $output_dir/findings.csv"
+    else
+      echo "  Warning: template not found at $TEMPLATE_CSV"
+      echo "ID,Title,Area,Test ID,Classification,Severity,Verified,Baseline Behavior,Candidate Behavior,Steps,Screenshot Baseline,Screenshot Candidate,Notes,PR,Jira Ticket" > "$output_dir/findings.csv"
+      echo "  Created blank CSV at $output_dir/findings.csv"
+    fi
+  fi
+
+  # Test matrix: always sync (the matrix can evolve between runs).
+  if [[ -f "$REPO_DIR/docs/Testing/REGRESSION_TEST_MATRIX.md" ]]; then
+    cp "$REPO_DIR/docs/Testing/REGRESSION_TEST_MATRIX.md" "$output_dir/TEST_MATRIX.md"
+  fi
+
+  # ENVIRONMENT.md: only seed if missing. Tester edits MUST be preserved.
+  if [[ -f "$output_dir/ENVIRONMENT.md" ]]; then
+    echo "  ENVIRONMENT.md preserved (tester-edited)"
+  else
+    cat > "$output_dir/ENVIRONMENT.md" << ENVEOF
+# Regression Test Environment
+
+**Ticket:** ${ticket:-TBD}
+**Date:** $(date +%Y-%m-%d)
+**Tester:** $(git config user.name)
+
+## Builds
+
+| Build | Version | Source | Device |
+|-------|---------|--------|--------|
+| Baseline | TBD | TBD | TBD |
+| Candidate | TBD | TBD | TBD |
+
+## Simulators
+
+| Simulator | ID | OS |
+|-----------|-----|-----|
+| iPhone 16 Pro | $SIM_ID | iOS 18.4 |
+
+## Test Libraries
+
+| Library | Auth Type | Credentials |
+|---------|-----------|-------------|
+| A1QA Test Library | Basic | See ~/.specterqa/credentials/a1qa-test.env |
+| Lyrasis Reads | None | N/A |
+| Palace Bookshelf | Anonymous | N/A |
+
+## Setup Commands
+
+\`\`\`bash
+# Boot simulator and configure
+xcrun simctl boot $SIM_ID 2>/dev/null || true
+xcrun simctl spawn $SIM_ID defaults write org.thepalaceproject.palace showDeveloperSettings -bool true
+xcrun simctl spawn $SIM_ID defaults write org.thepalaceproject.palace NYPLUseBetaLibrariesKey -bool true
+\`\`\`
+ENVEOF
+    echo "  ENVIRONMENT.md seeded from template (fill in build/sim details)"
+  fi
+
+  echo ""
+  echo "=== Workspace ready at $output_dir ==="
+  echo ""
+  echo "Next steps:"
+  echo "  1. Fill in ENVIRONMENT.md with build details"
+  echo "  2. Run automated sweep: scripts/regression-report.sh auto --output-dir $output_dir"
+  echo "  3. Do manual side-by-side testing (see TEST_MATRIX.md)"
+  echo "  4. Log findings to findings.csv (Verified=false until confirmed)"
+  echo "  5. Generate report: scripts/regression-report.sh report --output-dir $output_dir"
+}
+
+# ============================================================
+# AUTO — Run automated testing tools
+# ============================================================
+cmd_auto() {
+  local output_dir=""
+  local baseline_tag=""
+  local candidate_branch=""
+  local push_token=""
+  local push_mode="auto"          # auto | run | skip
+  local sync_mode="auto"          # auto | run | skip
+  local mutation_run="false"      # dry-run by default; --mutation-run to execute
+  local mutation_limit=""         # empty = no cap (all changed files)
+  local mutation_max_per_file="8" # sensible cap; tester can override
+  local mutation_files=""         # comma-separated; overrides --baseline-tag derivation
+  local mutation_test_class=""    # override per-file test-class derivation
+  local yes_long_mutation="false"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help|help) usage; exit 0 ;;
+      --output-dir) output_dir="$2"; shift 2 ;;
+      --baseline-tag|--baseline-ref) baseline_tag="$2"; shift 2 ;;
+      --candidate-branch) candidate_branch="$2"; shift 2 ;;
+      --sim-id) SIM_ID="$2"; shift 2 ;;
+      --push-token) push_token="$2"; shift 2 ;;
+      --run-push) push_mode="run"; shift ;;
+      --skip-push) push_mode="skip"; shift ;;
+      --run-sync-tests) sync_mode="run"; shift ;;
+      --skip-sync-tests) sync_mode="skip"; shift ;;
+      --mutation-run) mutation_run="true"; shift ;;
+      --mutation-limit) mutation_limit="$2"; shift 2 ;;
+      --mutation-max-per-file) mutation_max_per_file="$2"; shift 2 ;;
+      --mutation-files) mutation_files="$2"; shift 2 ;;
+      --mutation-test-class) mutation_test_class="$2"; shift 2 ;;
+      --yes-long-mutation) yes_long_mutation="true"; shift ;;
+      *) echo "Unknown option: $1"; usage; exit 1 ;;
+    esac
+  done
+
+  if [[ -z "$output_dir" ]]; then
+    echo "Error: --output-dir is required"; usage; exit 1
+  fi
+
+  # Defensive mkdir — auto can run after a manual cleanup of automated/*.
+  mkdir -p "$output_dir/automated"/{specterqa,sync,screenshots,mutation}
+
+  local exit_code=0
+
+  echo "=== Running automated regression tools ==="
+  echo "  sim: $SIM_ID"
+  echo ""
+
+  # --- Annotation sync tests (curated xcodebuild run) ---
+  # Curated list of sync-related XCTestCase classes. These are the test classes
+  # that exercise annotation/position/bookmark/notification sync paths and
+  # should pass cleanly on both baseline and candidate.
+  local sync_test_classes=(
+    "PalaceTests/PositionSyncTests"
+    "PalaceTests/PositionPersistenceTests"
+    "PalaceTests/SyncConflictResolutionTests"
+    "PalaceTests/TPPLastReadPositionSynchronizerTests"
+    "PalaceTests/TPPLastReadPositionSynchronizerIntegrationTests"
+    "PalaceTests/ReadingPositionTests"
+    "PalaceTests/PositionSyncServiceTests"
+    "PalaceTests/TPPAnnotationsTests"
+    "PalaceTests/TPPAnnotationsHermeticTests"
+    "PalaceTests/BookRegistrySyncTests"
+    "PalaceTests/CrossDeviceBookmarkSyncTests"
+    "PalaceTests/AudiobookDataManagerNetworkSyncTests"
+    "PalaceTests/AudiobookDataManagerErrorHandlingTests"
+    "PalaceTests/NotificationSyncThrottleTests"
+    "PalaceTests/HoldNotificationClassificationTests"
+  )
+
+  if [[ "$sync_mode" == "skip" ]]; then
+    echo "--- Annotation sync tests: SKIPPED (--skip-sync-tests) ---"
+  elif [[ "$sync_mode" == "auto" ]]; then
+    echo "--- Annotation sync tests: SKIPPED (pass --run-sync-tests to invoke xcodebuild on ${#sync_test_classes[@]} classes) ---"
+    printf '%s\n' "${sync_test_classes[@]}" > "$output_dir/automated/sync/planned-classes.txt"
+  else
+    echo "--- Annotation sync tests (xcodebuild on ${#sync_test_classes[@]} classes) ---"
+    local only_args=()
+    for c in "${sync_test_classes[@]}"; do only_args+=("-only-testing:$c"); done
+    (
+      cd "$REPO_DIR" && \
+      xcodebuild -project Palace.xcodeproj -scheme Palace \
+        -destination "platform=iOS Simulator,id=$SIM_ID" \
+        "${only_args[@]}" test
+    ) > "$output_dir/automated/sync/results.txt" 2>&1 && \
+      echo "  PASS — results at automated/sync/results.txt" || \
+      { echo "  FAIL — check automated/sync/results.txt"; exit_code=1; }
+  fi
+
+  # --- Push notification tests ---
+  local push_cache="$HOME/.palace/fcm-token-cache.json"
+  local push_sa="$HOME/.palace/firebase-service-account.json"
+  local push_out="$output_dir/automated/sync/push-results.txt"
+
+  if [[ ! -f "$SCRIPT_DIR/test-push-notifications.py" ]]; then
+    echo "--- Push notification tests: SKIPPED (scripts/test-push-notifications.py not found) ---"
+  elif [[ "$push_mode" == "skip" ]]; then
+    echo "--- Push notification tests: SKIPPED (--skip-push) ---"
+  elif [[ ! -f "$push_sa" ]]; then
+    echo "--- Push notification tests: SKIPPED (no Firebase service account at $push_sa) ---"
+    echo "To enable: see scripts/test-push-notifications.py --help" > "$push_out"
+  elif [[ "$push_mode" == "auto" && -z "$push_token" && ! -f "$push_cache" ]]; then
+    echo "--- Push notification tests: SKIPPED (no cached FCM token; pass --push-token or plug in device + run 'scripts/test-push-notifications.py capture-token') ---"
+    {
+      echo "SKIPPED — no FCM token available."
+      echo "To enable: capture a token from a physical device first:"
+      echo "  python3 scripts/test-push-notifications.py capture-token"
+      echo "Then re-run with --run-push (or pass --push-token TOKEN)."
+    } > "$push_out"
+  else
+    echo "--- Push notification tests ---"
+    local push_args=()
+    if [[ -n "$push_token" ]]; then push_args+=("--token" "$push_token"); fi
+    push_args+=("all")
+    python3 "$SCRIPT_DIR/test-push-notifications.py" "${push_args[@]}" > "$push_out" 2>&1 && \
+      echo "  PASS — results at automated/sync/push-results.txt" || \
+      { echo "  FAIL — check automated/sync/push-results.txt"; exit_code=1; }
+  fi
+
+  # --- Mutation testing on changed files ---
+  if [[ ! -f "$SCRIPT_DIR/palace_mutate.py" ]]; then
+    echo "--- Mutation testing: SKIPPED (palace_mutate.py not found at $SCRIPT_DIR) ---"
+  elif [[ -z "$mutation_files" && ( -z "$baseline_tag" || -z "$candidate_branch" ) ]]; then
+    echo "--- Mutation testing: SKIPPED (need --baseline-tag (or --baseline-ref) + --candidate-branch, OR --mutation-files LIST) ---"
+  else
+    local mode_label; mode_label=$([[ "$mutation_run" == "true" ]] && echo "REAL execution" || echo "dry-run")
+    if [[ -n "$mutation_files" ]]; then
+      echo "--- Mutation testing [$mode_label] (--mutation-files override: $(echo "$mutation_files" | tr ',' '\n' | wc -l | tr -d ' ') files) ---"
+    else
+      echo "--- Mutation testing [$mode_label] (changed files between $baseline_tag and $candidate_branch) ---"
+    fi
+
+    local changed_files
+    if [[ -n "$mutation_files" ]]; then
+      changed_files=$(echo "$mutation_files" | tr ',' '\n')
+    else
+      changed_files=$(git -C "$REPO_DIR" diff --name-only "$baseline_tag...$candidate_branch" -- '*.swift' \
+        | grep -Ev '(^|/)(PalaceTests|PalaceUITests|Tests)/' || true)
+    fi
+
+    if [[ -n "$mutation_limit" ]]; then
+      changed_files=$(echo "$changed_files" | head -n "$mutation_limit")
+    fi
+    if [[ -z "$changed_files" ]]; then
+      echo "  No source files to mutate."
+    else
+      echo "$changed_files" > "$output_dir/automated/mutation/changed-files.txt"
+      : > "$output_dir/automated/mutation/results.txt"
+      local total
+      total=$(echo "$changed_files" | wc -l | tr -d ' ')
+      local reports_dir="$output_dir/automated/mutation/reports"
+      mkdir -p "$reports_dir"
+
+      # Wallclock guard: only fires for real execution. ~90s/mutation × max
+      # ~20/file (palace_mutate default) gives a rough upper bound. Actual cost
+      # depends on test-class compile time, but the order of magnitude is right.
+      local guard_skip="false"
+      if [[ "$mutation_run" == "true" && "$yes_long_mutation" != "true" ]]; then
+        local per_file_cap="${mutation_max_per_file:-20}"
+        local est_min=$(( total * per_file_cap * 90 / 60 ))
+        if [[ "$est_min" -gt 30 ]]; then
+          echo ""
+          echo "  ⚠  Estimated wallclock for real mutation: ${est_min} min."
+          echo "      total_files=$total × per_file=$per_file_cap × 90s/mutation"
+          echo "      Pass --yes-long-mutation to proceed, or tighten --mutation-limit /"
+          echo "      --mutation-max-per-file. Skipping mutation execution."
+          echo "Mutation execution skipped: estimated ${est_min} min exceeds 30 min guard." \
+            >> "$output_dir/automated/mutation/results.txt"
+          guard_skip="true"
+        fi
+      fi
+
+      local count=0
+      local mutated=0
+      local empty=0
+      local skipped=0
+      local extra_args=()
+      [[ "$mutation_run" != "true" ]] && extra_args+=(--dry-run)
+      [[ -n "$mutation_max_per_file" ]] && extra_args+=(--max-mutations "$mutation_max_per_file")
+
+      while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        count=$((count + 1))
+        if [[ ! -f "$REPO_DIR/$file" ]]; then
+          echo "  [$count/$total] $file  (SKIP — file does not exist in candidate)"
+          echo "SKIP $file (deleted or renamed)" >> "$output_dir/automated/mutation/results.txt"
+          skipped=$((skipped + 1))
+          continue
+        fi
+
+        # Derive the right XCTestCase class name. Override > derivation > fallback.
+        local cls="$mutation_test_class"
+        if [[ -z "$cls" ]]; then
+          cls=$(derive_test_class_for "$file")
+        fi
+        if [[ -z "$cls" ]]; then
+          echo "  [$count/$total] $file  (SKIP — no matching test class found)"
+          echo "SKIP $file (no test class — pass --mutation-test-class to force)" \
+            >> "$output_dir/automated/mutation/results.txt"
+          skipped=$((skipped + 1))
+          continue
+        fi
+
+        echo "  [$count/$total] $file  (tests: PalaceTests/$cls)"
+
+        local slug
+        slug=$(echo "$file" | tr '/' '_' | sed 's/\.swift$//')
+        (
+          cd "$REPO_DIR" && \
+          python3 "$SCRIPT_DIR/palace_mutate.py" \
+            --file "$file" \
+            --tests "PalaceTests/$cls" \
+            --report "$reports_dir/$slug.json" \
+            "${extra_args[@]}"
+        ) >> "$output_dir/automated/mutation/results.txt" 2>&1 || true
+
+        # Track files-with-mutations vs no-mutation files for honest reporting.
+        if grep -q "No mutation points found in $file" "$output_dir/automated/mutation/results.txt" 2>/dev/null; then
+          empty=$((empty + 1))
+        else
+          mutated=$((mutated + 1))
+        fi
+      done <<< "$([[ "$guard_skip" == "true" ]] && echo "" || echo "$changed_files")"
+
+      # --- Aggregate summary ---
+      local summary="$output_dir/automated/mutation/summary.txt"
+      {
+        echo "Mutation summary ($mode_label)"
+        echo "  files scanned: $count"
+        echo "  files with mutations: $mutated"
+        echo "  files with no mutations (skipped — pure-shape source): $empty"
+        echo "  files skipped (missing / no test class): $skipped"
+        if [[ "$mutation_run" == "true" ]]; then
+          # Real execution: parse per-file JSON reports for kill rates.
+          python3 "$SCRIPT_DIR/summarize-mutation-reports.py" "$reports_dir" 2>/dev/null \
+            | sed 's/^/  /' || echo "  (summarize-mutation-reports.py not found)"
+        else
+          # Dry-run: parse results.txt for mutation-point counts.
+          local total_pts
+          total_pts=$(grep -oE "total mutation points discovered: [0-9]+" \
+            "$output_dir/automated/mutation/results.txt" | awk '{sum+=$NF} END{print sum+0}')
+          echo "  total mutation points discovered: $total_pts"
+          echo ""
+          echo "  Top 10 by mutation surface:"
+          awk '/^palace-mutate:/{file=$2} /total mutation points discovered:/{print $NF, file}' \
+            "$output_dir/automated/mutation/results.txt" 2>/dev/null \
+            | sort -nr | head -10 | awk '{printf "    %4d  %s\n", $1, $2}'
+          echo ""
+          echo "  (re-run with --mutation-run to get real kill/survive data)"
+        fi
+      } > "$summary"
+      echo "  Results: automated/mutation/results.txt"
+      echo "  Per-file JSON reports: automated/mutation/reports/"
+      echo "  Aggregate summary: automated/mutation/summary.txt"
+      sed 's/^/    /' "$summary"
+    fi
+  fi
+
+  # --- BrowserStack screenshot walker ---
+  if [[ -f "$SCRIPT_DIR/browserstack-screenshot-walker.py" ]]; then
+    echo "--- BrowserStack screenshot walker ---"
+    echo "  Run manually: python3 $SCRIPT_DIR/browserstack-screenshot-walker.py"
+    echo "  Save output to: $output_dir/automated/screenshots/"
+  else
+    echo "--- BrowserStack screenshots: SKIPPED (script not found) ---"
+  fi
+
+  echo ""
+  echo "=== Automated sweep complete (exit=$exit_code) ==="
+  echo ""
+  echo "Next: manual side-by-side testing. Run 'scripts/regression-report.sh checklist' for the test matrix."
+  return $exit_code
+}
+
+# ============================================================
+# REPORT — Generate HTML report
+# ============================================================
+cmd_report() {
+  local output_dir=""
+  local baseline_version=""
+  local candidate_version=""
+  local title=""
+  local video=""
+  local strict=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help|help) usage; exit 0 ;;
+      --output-dir) output_dir="$2"; shift 2 ;;
+      --baseline-version) baseline_version="$2"; shift 2 ;;
+      --candidate-version) candidate_version="$2"; shift 2 ;;
+      --title) title="$2"; shift 2 ;;
+      --video) video="$2"; shift 2 ;;
+      --strict) strict="--strict"; shift ;;
+      *) echo "Unknown option: $1"; usage; exit 1 ;;
+    esac
+  done
+
+  if [[ -z "$output_dir" ]]; then
+    echo "Error: --output-dir is required"; usage; exit 1
+  fi
+
+  local csv="$output_dir/findings.csv"
+  local screenshots="$output_dir/screenshots"
+  local report_output="$output_dir/report/index.html"
+
+  if [[ ! -f "$csv" ]]; then
+    echo "Error: findings.csv not found at $csv"
+    exit 1
+  fi
+
+  # Backup CSV before any processing
+  cp "$csv" "${csv}.$(date +%Y%m%d_%H%M%S).bak"
+
+  local video_arg=""
+  if [[ -n "$video" ]]; then
+    video_arg="--video $video"
+  fi
+
+  echo "=== Generating regression report ==="
+
+  # Two-stage: validate first (fast, exits non-zero on bad CSV), then generate.
+  # generate-regression-report.py treats --validate as exit-after-validation, so
+  # passing it to the same call as --output silently skips file write.
+  python3 "$SCRIPT_DIR/generate-regression-report.py" \
+    --csv "$csv" \
+    --screenshots "$screenshots" \
+    --validate \
+    $strict
+
+  python3 "$SCRIPT_DIR/generate-regression-report.py" \
+    --csv "$csv" \
+    --screenshots "$screenshots" \
+    --output "$report_output" \
+    --baseline-version "${baseline_version:-baseline}" \
+    --candidate-version "${candidate_version:-candidate}" \
+    ${title:+--title "$title"} \
+    $video_arg
+
+  if [[ ! -f "$report_output" ]]; then
+    echo "Error: report generation reported success but $report_output is missing." >&2
+    echo "  Check the python output above for clues; this should not happen." >&2
+    exit 2
+  fi
+
+  echo ""
+  echo "Report generated at: $report_output ($(wc -c < "$report_output" | tr -d ' ') bytes)"
+  echo "Open: open $report_output"
+}
+
+# ============================================================
+# TICKETS — Generate Jira tickets
+# ============================================================
+cmd_tickets() {
+  local output_dir=""
+  local ticket=""
+  local dry_run=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help|help) usage; exit 0 ;;
+      --output-dir) output_dir="$2"; shift 2 ;;
+      --ticket) ticket="$2"; shift 2 ;;
+      --dry-run) dry_run="--dry-run"; shift ;;
+      *) echo "Unknown option: $1"; usage; exit 1 ;;
+    esac
+  done
+
+  if [[ -z "$output_dir" || -z "$ticket" ]]; then
+    echo "Error: --output-dir and --ticket are required"; usage; exit 1
+  fi
+
+  local csv="$output_dir/findings.csv"
+
+  if [[ ! -f "$csv" ]]; then
+    echo "Error: findings.csv not found at $csv"
+    exit 1
+  fi
+
+  # Load Jira credentials
+  if [[ -z "${JIRA_EMAIL:-}" || -z "${JIRA_API_TOKEN:-}" ]]; then
+    if [[ -f "$REPO_DIR/.jira-config" ]]; then
+      source "$REPO_DIR/.jira-config"
+      export JIRA_EMAIL JIRA_API_TOKEN
+    else
+      echo "Error: Set JIRA_EMAIL and JIRA_API_TOKEN environment variables, or create .jira-config"
+      exit 1
+    fi
+  fi
+
+  echo "=== Generating Jira tickets ==="
+  python3 "$SCRIPT_DIR/generate-jira-tickets.py" \
+    --csv "$csv" \
+    --parent "$ticket" \
+    --component iOS \
+    --update-csv \
+    $dry_run
+}
+
+# ============================================================
+# CHECKLIST — Print manual testing checklist
+# ============================================================
+cmd_checklist() {
+  if [[ -f "$REPO_DIR/docs/Testing/REGRESSION_TEST_MATRIX.md" ]]; then
+    cat "$REPO_DIR/docs/Testing/REGRESSION_TEST_MATRIX.md"
+  else
+    echo "Test matrix not found at docs/Testing/REGRESSION_TEST_MATRIX.md"
+    exit 1
+  fi
+}
+
+# ============================================================
+# Main dispatcher
+# ============================================================
+if [[ $# -lt 1 ]]; then
+  usage; exit 0
+fi
+
+command="$1"
+shift
+
+case "$command" in
+  -h|--help|help) usage; exit 0 ;;
+  setup) cmd_setup "$@" ;;
+  auto) cmd_auto "$@" ;;
+  report) cmd_report "$@" ;;
+  tickets) cmd_tickets "$@" ;;
+  checklist) cmd_checklist "$@" ;;
+  *) echo "Unknown command: $command" >&2; usage >&2; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary

Promote the regression-testing skill (orchestrator + Claude skill instructions + Jira ticket creator) from local-only files into the tracked tree so QA can run the same workflow across machines.

5 new files, 2,334 insertions:
- \`scripts/regression-report.sh\` — orchestrator (\`setup\` / \`auto\` / \`report\` / \`tickets\` / \`checklist\`)
- \`scripts/generate-regression-report.py\` — HTML report generator from \`findings.csv\`
- \`scripts/generate-jira-tickets.py\` — Jira ticket creator (env-var auth, no embedded secrets)
- \`.claude/skills/regression/SKILL.md\` — Claude skill definition
- \`.claude/skills/regression/QA_QUICKSTART.md\` — QA-facing quickstart

## What's different from the in-flight version

13 of 14 dogfood-pass friction items resolved on PP-4164 ([workspace handoff](https://ebce-lyrasis.atlassian.net/browse/PP-4164)). Two BLOCKERs that would have hit QA on day one:

- \`cmd_report\` no longer drops \`--validate\` — was silently skipping the HTML write while printing \"Report generated at:\". Split into validate-then-generate calls; verifies file exists + reports byte count.
- \`cmd_auto --mutation-run\` auto-derives the right XCTest class per source file via \`derive_test_class_for\` — was always passing \`PalaceTests/\` (a directory) and timing out at the 600s baseline. \`--mutation-test-class CLASS\` available as an explicit override.

Other notable improvements:
- Wallclock-estimate guard with \`--yes-long-mutation\` opt-in (was running ~78 hours on full delta with no warning)
- Hardcoded SIM_ID replaced with harness sim-pool lookup + \`--sim-id\` flag
- Setup preserves tester-edited \`ENVIRONMENT.md\` (was clobbering on re-run)
- Setup always recreates canonical subdirs (recovers from manual archival)
- \`--mutation-files file1,file2,...\` for explicit file-list targeting (was alphabetical-only via \`--mutation-limit\`)
- Dry-run mutation summary surfaces top-N-by-surface histogram + total points
- All subcommands accept \`-h\` / \`--help\` / \`help\`

Two items deferred (captured in \`_dogfood_notes.md\` in the PP-4164 workspace):
- Auto-archive of stale prior-run artifacts on setup re-run (interactive prompt; polish)
- Jira ticket lookup at setup to populate scope (requires API token)

## Verification

End-to-end on the PP-4164 workspace through the orchestrator (no python-direct workarounds):

- \`setup\` → workspace created, idempotent on re-run, ENVIRONMENT.md preserved
- \`auto --run-sync-tests --skip-push\` → 15-class sync test suite **PASS** on candidate
- Mutation enumeration over 207 changed Swift files (release/3.0.0..develop): **2,166 mutation points across 157 files** with histogram
- Real mutation on 4 files: kill rates **0% / 50% / 75%** (pre-existing test fluff on AccountsManager.swift confirmed via baseline comparison)
- \`report --baseline-version 3.0.0 --candidate-version 3.0.1\` → **11.5 KB HTML, 3 pre-existing findings, 0 regressions**

Bash syntax: \`bash -n scripts/regression-report.sh\` clean.

## ForgeOS

- Changeset: \`cs_9dd60f37\`
- Initiative: \`init_e7603d4e\` (PalaceProject)
- Risk: 5/100 (low — net-new tooling, no edits to existing iOS modules)
- Gates: review (architect approved) → testing (qa_test approved) → release — **all 3 passed**
- 5 SharedMind observations seeded for the new domains (\`tooling/regression\`, \`qa-workflow\`, \`claude-skills\`)

## Test plan

- [ ] CI build green (target: \`Palace\` scheme, iPhone 16 Pro sim)
- [ ] Verify \`scripts/regression-report.sh --help\` prints usage and exits 0
- [ ] Verify \`scripts/regression-report.sh setup --ticket TEST-001 --output-dir /tmp/test-regression\` creates the workspace and seeds CSV/ENVIRONMENT.md
- [ ] Re-run setup; confirm ENVIRONMENT.md is preserved, automated/* subdirs are recreated
- [ ] (Optional) \`scripts/regression-report.sh auto --output-dir /tmp/test-regression --skip-sync-tests --skip-push --mutation-files Palace/Settings/TPPSettings.swift\` produces a dry-run summary with the right test class derivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)