### PR TITLE
Add mutation-gate CI workflow + lint/summary fixes (PP-4164)

### DIFF
--- a/.github/workflows/mutation-gate.yml
+++ b/.github/workflows/mutation-gate.yml
@@ -1,0 +1,154 @@
+name: Mutation Gate (critical paths)
+
+# Fails a PR when mutation-testing kill rates drop on touched critical-path files.
+# Triggered automatically on PRs that change files in known-risky areas (auth,
+# borrow, download, DRM, registry). Skipped otherwise to keep PR latency low.
+#
+# Background: PP-4164 surfaced AccountsManager.swift at 0% mutation kill rate.
+# This gate exists so the next 0% file is caught at PR review, not in production.
+
+on:
+  pull_request:
+    paths:
+      - 'Palace/Accounts/**/*.swift'
+      - 'Palace/SignInLogic/**/*.swift'
+      - 'Palace/Book/Models/TPPBookRegistry*.swift'
+      - 'Palace/MyBooks/MyBooksDownloadCenter*.swift'
+      - 'Palace/Reader2/ReaderStackConfiguration/AdobeDRM/**/*.swift'
+      - 'Palace/Reader2/ReaderStackConfiguration/LCP/**/*.swift'
+      - 'Palace/Settings/TPPSettings.swift'
+      - 'Palace/AppInfrastructure/AppContainer.swift'
+
+concurrency:
+  group: mutation-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation-gate:
+    runs-on: macos-26
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Set up Xcode 26
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26'
+
+      - name: Checkout PR with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Detect critical-path files changed in this PR
+        id: changed
+        run: |
+          set -euo pipefail
+          # Only run mutation on the curated critical-path list. The workflow's
+          # `paths:` filter is a coarse trigger; this step is the precise filter.
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          BASE="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "$BASE...HEAD" -- \
+            'Palace/Accounts/**/*.swift' \
+            'Palace/SignInLogic/**/*.swift' \
+            'Palace/Book/Models/TPPBookRegistry*.swift' \
+            'Palace/MyBooks/MyBooksDownloadCenter*.swift' \
+            'Palace/Reader2/ReaderStackConfiguration/AdobeDRM/**/*.swift' \
+            'Palace/Reader2/ReaderStackConfiguration/LCP/**/*.swift' \
+            'Palace/Settings/TPPSettings.swift' \
+            'Palace/AppInfrastructure/AppContainer.swift' \
+            | grep -v -E '(Tests|Mock)' || true)
+
+          if [[ -z "$CHANGED" ]]; then
+            echo "No critical-path source files changed; skipping mutation gate."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Critical-path files changed:"
+          echo "$CHANGED"
+          # Output as a comma-separated list for downstream steps.
+          echo "files=$(echo "$CHANGED" | tr '\n' ',' | sed 's/,$//')" >> "$GITHUB_OUTPUT"
+
+      - name: Run mutation testing on changed critical-path files
+        if: steps.changed.outputs.files != ''
+        env:
+          MUTATION_FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          set -euo pipefail
+
+          # Boot a sim for the underlying xcodebuild test runs. Pick the first
+          # 'iPhone 16 Pro' available; runner provides a fresh sim per job so
+          # claim/release coordination isn't needed here.
+          UDID=$(xcrun simctl list devices 'iPhone 16 Pro' \
+            | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}' \
+            | head -1)
+          if [[ -z "$UDID" ]]; then
+            echo "::error::No 'iPhone 16 Pro' simulator available on runner."
+            exit 1
+          fi
+          xcrun simctl boot "$UDID" || true
+
+          mkdir -p mutation-results
+
+          # Use the regression orchestrator's auto cmd in mutation-only mode.
+          # --mutation-files passes through to palace_mutate.py which derives
+          # the right XCTest class per source file. --mutation-max-per-file 8
+          # keeps the wallclock under the timeout.
+          scripts/regression-report.sh auto \
+            --output-dir "$PWD/mutation-results" \
+            --skip-sync-tests \
+            --skip-push \
+            --mutation-run \
+            --mutation-max-per-file 8 \
+            --mutation-files "$MUTATION_FILES" \
+            --sim-id "$UDID" \
+            --yes-long-mutation
+
+      - name: Enforce kill-rate threshold (75% on critical paths)
+        if: steps.changed.outputs.files != ''
+        run: |
+          set -euo pipefail
+          REPORTS=mutation-results/automated/mutation/reports
+
+          if [[ ! -d "$REPORTS" ]]; then
+            echo "::error::No mutation reports produced; tooling failure."
+            exit 1
+          fi
+
+          python3 scripts/summarize-mutation-reports.py "$REPORTS" \
+            --threshold 75 \
+            --strict
+
+      - name: Comment kill-rate summary on PR
+        if: always() && steps.changed.outputs.files != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const reportsDir = 'mutation-results/automated/mutation/reports';
+            if (!fs.existsSync(reportsDir)) return;
+
+            const reports = fs.readdirSync(reportsDir)
+              .filter(f => f.endsWith('.json'))
+              .map(f => JSON.parse(fs.readFileSync(path.join(reportsDir, f), 'utf8')));
+
+            const lines = ['### Mutation gate — kill rates per critical-path file', '',
+              '| File | Killed / Run | Kill % | Verdict |', '|---|---|---|---|'];
+            for (const r of reports) {
+              const k = r.summary.killed, run = r.summary.killed + r.summary.survived;
+              const pct = run === 0 ? 0 : Math.round(k / run * 100);
+              const verdict = pct >= 75 ? '✅' : pct >= 50 ? '⚠️ borderline' : '❌ insufficient';
+              lines.push(`| ${r.file} | ${k} / ${run} | ${pct}% | ${verdict} |`);
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: lines.join('\n')
+            });

--- a/scripts/lint-test-quality.py
+++ b/scripts/lint-test-quality.py
@@ -61,7 +61,10 @@ def find_test_methods(content: str) -> List[dict]:
         body = content[start:i-1]
 
         lines = [l.strip() for l in body.split('\n') if l.strip() and not l.strip().startswith('//')]
-        asserts = len(re.findall(r'XCTAssert|XCTFail', body))
+        # wait(for:) on an XCTestExpectation IS an assertion — it raises
+        # XCTFail on timeout. Treating it the same as XCTAssert* fixes a
+        # false-positive MISSING-001 on legitimate expectation-based tests.
+        asserts = len(re.findall(r'XCTAssert|XCTFail|wait\(for:', body))
         has_mock = bool(re.search(r'Mock|mock|stub|Stub', body))
         has_async = bool(re.search(r'await |expectation|fulfillment', body))
 

--- a/scripts/summarize-mutation-reports.py
+++ b/scripts/summarize-mutation-reports.py
@@ -1,22 +1,33 @@
 #!/usr/bin/env python3
 """Aggregate per-file palace_mutate JSON reports into a kill-rate summary.
 
-Usage: summarize-mutation-reports.py <reports-dir>
+Usage: summarize-mutation-reports.py <reports-dir> [--threshold PCT] [--strict]
 
 If the directory contains no JSON files, emits a note that mutation was run in
 dry-run mode (palace_mutate.py doesn't write a --report in dry-run).
+
+Flags:
+  --threshold PCT  Minimum acceptable per-file kill rate (default: 50).
+  --strict         Exit non-zero if ANY individual file falls below --threshold,
+                   not just the aggregate. Use this in CI to gate critical-path
+                   files (one weak file shouldn't be hidden by a strong average).
 """
+import argparse
 import json
 import sys
 from pathlib import Path
 
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        print("usage: summarize-mutation-reports.py <reports-dir>", file=sys.stderr)
-        return 2
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("reports_dir", type=Path, help="Directory of per-file JSON reports")
+    parser.add_argument("--threshold", type=float, default=50.0,
+                        help="Minimum kill-rate %% (default: 50)")
+    parser.add_argument("--strict", action="store_true",
+                        help="Fail if any single file is below threshold (not just aggregate)")
+    args = parser.parse_args()
 
-    reports_dir = Path(sys.argv[1])
+    reports_dir = args.reports_dir
     if not reports_dir.is_dir():
         print(f"no reports dir at {reports_dir}")
         return 0
@@ -75,8 +86,23 @@ def main() -> int:
         for f in sorted(rated, key=lambda x: x["rate"])[:5]:
             print(f"  {f['rate']:5.1f}%  {f['killed']:>3}k/{f['survived']:>3}s  {f['file']}")
 
-    # Exit non-zero if overall kill rate is concerning
-    return 1 if overall_total > 0 and overall_rate < 50 else 0
+    # Threshold gate
+    threshold = args.threshold
+    weak = [f for f in rated if f["rate"] < threshold]
+
+    if args.strict and weak:
+        print()
+        print(f"::error::{len(weak)} file(s) below {threshold:g}% kill rate (strict mode):")
+        for f in weak:
+            print(f"  ::error file={f['file']}::kill rate {f['rate']:.1f}% < {threshold:g}%")
+        return 1
+
+    if overall_total > 0 and overall_rate < threshold:
+        print()
+        print(f"::warning::Aggregate kill rate {overall_rate:.1f}% below threshold {threshold:g}%")
+        return 1
+
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to PP-4164. Three small changes that don't touch any iOS production code:

- **`.github/workflows/mutation-gate.yml`** — new CI gate that runs \`palace_mutate.py\` on PRs touching critical-path files (Accounts, SignInLogic, BookRegistry, MyBooksDownloadCenter, Adobe/LCP DRM, TPPSettings, AppContainer). Fails the PR if **any** single file drops below **75% kill rate** (per-file gate, not aggregate). Comments a kill-rate table back on the PR.
- **`scripts/lint-test-quality.py`** — recognize \`wait(for:)\` on \`XCTestExpectation\` as an assertion form (raises \`XCTFail\` on timeout). Clears 3 false-positive \`MISSING-001\` violations on tests that were correct all along (\`PalaceTests/Settings/TPPSettingsTests.swift\`).
- **`scripts/summarize-mutation-reports.py`** — add \`--threshold PCT\` and \`--strict\` flags so CI can fail per-file instead of just on aggregate. Existing aggregate-warning behavior preserved.

## Why

PP-4164's dogfood pass found \`AccountsManager.swift\` at **0% mutation kill rate** (8 of 8 mutations survive). Pre-existing, not a regression — but means the test suite has zero discriminating power on that critical-path file. This gate is the structural defense: **the next 0% file gets caught at PR review, not in production**.

The gate threshold is 75% — chosen to match what \`TPPSignInBusinessLogic.swift\` already achieves. Files currently below threshold (AccountsManager 0%, TPPSettings 50%) become flagged as soon as any PR touches them.

## Verified locally

- \`python3 scripts/lint-test-quality.py\` — 327 violations across 85 files (was 330/86); MISSING asserts: **0** (was 3); fluff and shallow tiers unchanged.
- \`python3 scripts/summarize-mutation-reports.py ~/Desktop/regression-PP-4164/automated/mutation/real --strict --threshold 75\` exits **1**, flags \`AccountsManager.swift\` (0%) and \`TPPSettings.swift\` (50%) as below threshold with GitHub-native \`::error file=\` annotations.
- \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/mutation-gate.yml'))\"\` — clean.

## Dependency

This depends on **PR #886** (introduces \`scripts/regression-report.sh\`) merging first. The mutation-gate workflow's \`paths:\` filter is set so this PR itself doesn't trigger the workflow — first PR after both #886 and this one merge that touches a critical-path source file is the real validation.

## What's NOT in this PR

I had originally planned to add 2-3 mutation-killing tests to \`AccountsManagerTests.swift\` to move the kill rate off 0%. After examining all 8 surviving mutations:
- All live in **private methods, async paths, or use \`ImageCache.shared\`** (a global with no test seam)
- Fixing the 0% kill rate requires **injecting \`ImageCache\`** and **exposing \`isAccountSwitching\` state via a publisher** — that's a refactor, not a test addition
- Writing tests that just call public methods without real assertions would be exactly the fluff CLAUDE.md bans (\"set-then-assert\" pattern)

Filed as a structural finding in the PP-4164 dogfood notes. Recommendation: include the AccountsManager test-seam refactor in the next architectural-triad phase.

## ForgeOS

- Changeset: \`cs_42c6fc80\`
- Risk: 10/100 (low — CI infra + tooling)
- Gates: review (architect ✓) → testing (qa_test ✓) → release ✓

## Test plan

- [ ] CI on this PR is green (the mutation-gate workflow itself doesn't fire — by design)
- [ ] After #886 + this PR merge, open a follow-up PR that touches \`Palace/Accounts/Library/AccountsManager.swift\` to verify the gate fires and posts the kill-rate table back

🤖 Generated with [Claude Code](https://claude.com/claude-code)