### PR TITLE
Fix mutation-gate CI: pass CI_GITHUB_ACCESS_TOKEN for private DRM submodules

### DIFF
--- a/.github/workflows/mutation-gate.yml
+++ b/.github/workflows/mutation-gate.yml
@@ -42,6 +42,11 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          # Private DRM submodules (adept-ios, adobe-content-filter,
+          # ios-audiobook-overdrive) require this token. Without it the
+          # checkout step fails before mutation gating ever runs.
+          # Matches the pattern in unit-testing.yml.
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
 
       - name: Detect critical-path files changed in this PR
         id: changed


### PR DESCRIPTION
## Summary

The mutation-gate workflow added in `5c83e82d6` was failing on **every** PR at the checkout step, never reaching the actual mutation gating. Cause: `actions/checkout@v4` with `submodules: recursive` was trying to clone private DRM submodules (adept-ios, adobe-content-filter, ios-audiobook-overdrive) without an access token.

```
fatal: repository 'https://github.com/ThePalaceProject/ios-drm-adobe.git/' not found
fatal: clone of 'git@github.com:ThePalaceProject/ios-drm-adobe.git' into submodule path '...' failed
```

Fix mirrors the working pattern in `unit-testing.yml`: pass `secrets.CI_GITHUB_ACCESS_TOKEN` to the checkout step so the recursive submodule clone has private-repo access.

## Currently blocking

- #889 — Visual-regression test infra (mutation-gate red, blocks merge)
- #890 — Phase 7 MyBooksDownloadCenter decomp (mutation-gate red)
- #891 — F-007 anonymous bookshelf 401 loop fix (mutation-gate red)

## Test plan

- [x] One-line config change; matches the pattern that already works in `unit-testing.yml`
- [ ] Once merged, the three blocked PRs will re-run mutation-gate automatically and either pass (no critical-path source files touched → skip step exits cleanly) or actually run mutation testing (the case we wanted all along)

ForgeOS: `cs_f5f776e8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)