### PR TITLE
Fix mutation-gate CI: robust simulator selection on macos-26 runners

### DIFF
--- a/.github/workflows/mutation-gate.yml
+++ b/.github/workflows/mutation-gate.yml
@@ -85,17 +85,39 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Boot a sim for the underlying xcodebuild test runs. Pick the first
-          # 'iPhone 16 Pro' available; runner provides a fresh sim per job so
-          # claim/release coordination isn't needed here.
-          UDID=$(xcrun simctl list devices 'iPhone 16 Pro' \
-            | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}' \
-            | head -1)
+          # Resolve a usable iPhone simulator UDID. The previous regex-based
+          # approach was brittle: device-name renames between runner-image
+          # versions (and case variations in `simctl list devices` output)
+          # silently produced an empty UDID and exited 1 before anything ran.
+          # Mirrors the ui-testing.yml pattern: prefer iPhone 16 Pro, fall
+          # back to any available iPhone, and surface what's on the runner
+          # when nothing is found.
+          echo "Available iPhone simulators on runner:"
+          xcrun simctl list devices available | grep iPhone | head -20 || true
+
+          UDID=$(xcrun simctl list devices available -j | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          preferred = 'iPhone 16 Pro'
+          for runtime, devices in data.get('devices', {}).items():
+              if 'iOS' not in runtime: continue
+              for d in devices:
+                  if d['name'] == preferred and d['isAvailable']:
+                      print(d['udid']); sys.exit(0)
+          for runtime, devices in data.get('devices', {}).items():
+              if 'iOS' not in runtime: continue
+              for d in devices:
+                  if 'iPhone' in d['name'] and d['isAvailable']:
+                      print(d['udid']); sys.exit(0)
+          sys.exit(1)
+          ")
           if [[ -z "$UDID" ]]; then
-            echo "::error::No 'iPhone 16 Pro' simulator available on runner."
+            echo "::error::No iPhone simulator available on runner."
             exit 1
           fi
-          xcrun simctl boot "$UDID" || true
+          echo "Using simulator UDID: $UDID"
+          xcrun simctl boot "$UDID" 2>/dev/null || true
+          xcrun simctl bootstatus "$UDID" -b
 
           mkdir -p mutation-results
 


### PR DESCRIPTION
## Summary

Replace mutation-gate.yml's brittle `[0-9A-F]{8}-...` regex against `xcrun simctl list devices 'iPhone 16 Pro'` with the JSON+Python device-resolution pattern already proven in `ui-testing.yml`. The previous regex produced an empty UDID on macos-26 runners (whether through case-mismatch in simctl output or device-name renames between runner-image versions), so every mutation-gate run exited 1 in ~9 seconds before any test executed. PRs #889/#890/#891 have all been red on this with no test signal.

The new logic prefers iPhone 16 Pro, falls back to any available iPhone, prints the device list for diagnostics, and waits for the boot to complete via `simctl bootstatus -b`.

## Why now

Mutation-gate landed in 5c83e82d6 + #893 and is currently 100% red on every PR that touches a critical-path file. This blocks Phase 7 (#890), simdrive infra (#889), and the F-007 fix (#891). Workflow-only change — no app-runtime or test-target impact possible.

## Test plan

- [x] Workflow YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] New logic line-matches the proven `ui-testing.yml` pattern (lines 96-117)
- [ ] **Real verification:** rebase #889/#890/#891 onto develop after merge; their mutation-gate runs become the proof point. The path filter on this workflow does NOT trigger on `.github/workflows/**`, so this PR's own CI will not exercise the change.

ForgeOS: cs_1fc0e0ea (init_7d6a51ce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)