### PR TITLE
F-013: close mutation gaps in AppTabHostView/Announcements/AccountsManager

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -746,6 +746,9 @@
 		9D5DE68418C31F9D88044C89 /* ReadingStatsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F16E79F7C14C0F72FC36B3 /* ReadingStatsStoreTests.swift */; };
 		9D907CE6820AD963A7C1AD9C /* FuzzCorpus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E49448110C43EB199A09AD3 /* FuzzCorpus.swift */; };
 		9E482D5D89E03F23F7451DE6 /* MyBooksViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9CA89B135C85E23F0D907B /* MyBooksViewModelTests.swift */; };
+		F0130001ABC0DEF000000001 /* AppTabHostViewBadgeCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0130000ABC0DEF000000001 /* AppTabHostViewBadgeCountTests.swift */; };
+		F0130003ABC0DEF000000003 /* AnnouncementChainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0130002ABC0DEF000000003 /* AnnouncementChainTests.swift */; };
+		F0130005ABC0DEF000000005 /* AccountsManagerHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0130004ABC0DEF000000005 /* AccountsManagerHelpersTests.swift */; };
 		9EB44CD30C94D33258B12A16 /* DebugSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E709829F912BC2766AEA30 /* DebugSettingsTests.swift */; };
 		A00ED9F1A5D549B6B9685E48 /* TPPAlertUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3401E6313A459D9496ECF2 /* TPPAlertUtilsTests.swift */; };
 		A06CCF8F38B4B5ADA1C02BE2 /* PlaybackBootstrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7460F23BAEC7FED016069 /* PlaybackBootstrapper.swift */; };
@@ -2357,6 +2360,9 @@
 		CAE35BBA1B86289500BF9BC5 /* Palace.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Palace.xcconfig; path = ../Palace.xcconfig; sourceTree = "<group>"; };
 		CB84A55CE7F9823DCEFBAE90 /* TPPAccountAuthStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPAccountAuthStateTests.swift; sourceTree = "<group>"; };
 		CB9CA89B135C85E23F0D907B /* MyBooksViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyBooksViewModelTests.swift; sourceTree = "<group>"; };
+		F0130000ABC0DEF000000001 /* AppTabHostViewBadgeCountTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppTabHostViewBadgeCountTests.swift; sourceTree = "<group>"; };
+		F0130002ABC0DEF000000003 /* AnnouncementChainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnnouncementChainTests.swift; sourceTree = "<group>"; };
+		F0130004ABC0DEF000000005 /* AccountsManagerHelpersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerHelpersTests.swift; sourceTree = "<group>"; };
 		CBA39820CBA75D6BA9B763E2 /* CatalogRepositoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogRepositoryTests.swift; sourceTree = "<group>"; };
 		CBBDD4C17EA45C71D8076A34 /* PerformanceMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMetric.swift; sourceTree = "<group>"; };
 		CCB1E4A5E6A1E450001D2751 /* TPPProblemReportViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPProblemReportViewController.swift; sourceTree = "<group>"; };
@@ -4417,6 +4423,9 @@
 				TSETUP01FREF00000001 /* PalaceTestSetup.swift */,
 				DR41NMQUEUE2026042760BBFE /* XCTestCase+drainMainQueue.swift */,
 				E50546742E6201D4007CCFAB /* OPDSFeedParsingTests.swift */,
+				F0130000ABC0DEF000000001 /* AppTabHostViewBadgeCountTests.swift */,
+				F0130002ABC0DEF000000003 /* AnnouncementChainTests.swift */,
+				F0130004ABC0DEF000000005 /* AccountsManagerHelpersTests.swift */,
 				2D2B47761D08F808007F7764 /* Info.plist */,
 				2D2B47621D08F1ED007F7764 /* PalaceTests-Bridging-Header.h */,
 				730EF23226093DE3008E1DC3 /* Bookmarks */,
@@ -6050,6 +6059,9 @@
 				681FBB4C5C3E2B2A10DAD273 /* CatalogViewModelTests.swift in Sources */,
 				653039BB32BF46048D5DFEA0 /* CatalogLaneRowViewAccessibilityTests.swift in Sources */,
 				9E482D5D89E03F23F7451DE6 /* MyBooksViewModelTests.swift in Sources */,
+				F0130001ABC0DEF000000001 /* AppTabHostViewBadgeCountTests.swift in Sources */,
+				F0130003ABC0DEF000000003 /* AnnouncementChainTests.swift in Sources */,
+				F0130005ABC0DEF000000005 /* AccountsManagerHelpersTests.swift in Sources */,
 				E5A09A7F2F0D72B500CC23EA /* DeviceOrientationTests.swift in Sources */,
 				1E021B71311B221A7777B6F7 /* EPUBPositionTests.swift in Sources */,
 				3F950AC5136B638265B1AB87 /* BookDetailViewModelTests.swift in Sources */,

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -168,7 +168,7 @@ struct CatalogCacheMetadata: Codable {
             TPPErrorLogger.setUserID(self.currentUserAccount.barcode)
             // isAccountSwitching is reset asynchronously by cleanupActiveContentBeforeAccountSwitch
             // after navigation cleanup completes — NOT here, to avoid premature reset (F-032).
-            if previousAccountId == newAccountId || previousAccountId == nil {
+            if Self.shouldFinishSwitchingImmediately(previousAccountId: previousAccountId, newAccountId: newAccountId) {
                 isAccountSwitching = false
             }
             NotificationCenter.default.post(name: .TPPCurrentAccountDidChange, object: nil)
@@ -186,7 +186,7 @@ struct CatalogCacheMetadata: Codable {
                 let pathCount = coordinator.path.count
                 Log.debug(#file, "  Navigation path has \(pathCount) items")
 
-                if pathCount > 0 {
+                if Self.shouldPopToRoot(navigationPathCount: pathCount) {
                     Log.info(#file, "  🔄 Popping to root to clean up active content before account switch")
                     coordinator.popToRoot()
 
@@ -608,13 +608,43 @@ struct CatalogCacheMetadata: Codable {
 
     /// Returns true if cache exists and is stale (needs background refresh)
     private func isCacheStale(hash: String) -> Bool {
-        guard let metadata = readCacheMetadata(hash: hash) else {
+        let metadata = readCacheMetadata(hash: hash)
+        let serverMaxAge = readCrawlState(hash: hash)?.serverMaxAge
+        return Self.isCacheStale(metadata: metadata, serverMaxAge: serverMaxAge)
+    }
+
+    /// Pure variant of `isCacheStale(hash:)` that doesn't touch the file
+    /// system. Returns `true` when metadata is missing OR when the metadata
+    /// reports staleness against `serverMaxAge`. Extracted from the private
+    /// version so tests can exercise the nil-metadata → refresh path that
+    /// previously had no test coverage (F-013).
+    static func isCacheStale(
+        metadata: CatalogCacheMetadata?,
+        serverMaxAge: TimeInterval?
+    ) -> Bool {
+        guard let metadata else {
             // No metadata means we should refresh
             return true
         }
-        // Use server's Cache-Control max-age if available from crawl state
-        let serverMaxAge = readCrawlState(hash: hash)?.serverMaxAge
         return metadata.isStale(serverMaxAge: serverMaxAge)
+    }
+
+    /// Pure helper for `cleanupActiveContentBeforeAccountSwitch`'s
+    /// `pathCount > 0` guard — extracted so the bound check is testable.
+    static func shouldPopToRoot(navigationPathCount: Int) -> Bool {
+        return navigationPathCount > 0
+    }
+
+    /// Pure helper for the `currentAccount.didSet` decision of whether to
+    /// finish the account-switch synchronously. The previous implementation
+    /// had `previousAccountId == newAccountId || previousAccountId == nil`
+    /// inline in the setter; extracting it keeps the equality and identity
+    /// branches testable and kills the surviving == ↔ != mutants.
+    static func shouldFinishSwitchingImmediately(
+        previousAccountId: String?,
+        newAccountId: String?
+    ) -> Bool {
+        return previousAccountId == newAccountId || previousAccountId == nil
     }
 
     /// Reads crawl state for the given hash (used for dynamic TTL adjustment)

--- a/Palace/Accounts/User/Announcements/TPPAnnouncementBusinessLogic.swift
+++ b/Palace/Accounts/User/Announcements/TPPAnnouncementBusinessLogic.swift
@@ -89,18 +89,20 @@ class TPPAnnouncementBusinessLogic {
             UIAlertController.init(title: title, message: $0.content, preferredStyle: .alert)
         }
 
-        // Present another alert when the current alert is being dismiss
-        // Add the presented announcement to the presentedAnnouncement document
-        for (i, alert) in alerts.enumerated() {
-            if i > 0 {
-                let action = UIAlertAction.init(title: DisplayStrings.ok,
-                                                style: .default) { [weak self] _ in
-                    TPPPresentationUtils.safelyPresent(alert, animated: true, completion: nil)
-                    self?.addPresentedAnnouncement(id: announcements[i - 1].id)
-                }
-                currentAlert?.addAction(action)
+        // Present another alert when the current alert is being dismiss.
+        // For announcement count N, alerts[k-1] gets the action that presents
+        // alerts[k] and marks announcements[k-1] as presented (1 ≤ k ≤ N-1).
+        for pair in Self.chainAttachmentIndices(forAnnouncementCount: alerts.count) {
+            let nextAlert = alerts[pair.present]
+            let action = UIAlertAction.init(title: DisplayStrings.ok,
+                                            style: .default) { [weak self] _ in
+                TPPPresentationUtils.safelyPresent(nextAlert, animated: true, completion: nil)
+                self?.addPresentedAnnouncement(id: announcements[pair.attach].id)
             }
-            currentAlert = alert
+            alerts[pair.attach].addAction(action)
+        }
+        if let last = alerts.last {
+            currentAlert = last
         }
 
         // Add dismiss button to the last announcement
@@ -111,6 +113,18 @@ class TPPAnnouncementBusinessLogic {
         }
 
         return alerts.first
+    }
+}
+
+extension TPPAnnouncementBusinessLogic {
+    /// For an announcement count of N, returns N-1 (attach, present) pairs:
+    /// `alerts[attach]` gets a tap-action that presents `alerts[present]`.
+    /// Pure helper extracted from `alert(announcements:)` so the i > 0 / i - 1
+    /// conditional logic that was previously embedded in the loop body can
+    /// be exercised by unit tests.
+    static func chainAttachmentIndices(forAnnouncementCount count: Int) -> [(attach: Int, present: Int)] {
+        guard count > 1 else { return [] }
+        return (1..<count).map { i in (attach: i - 1, present: i) }
     }
 }
 

--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -107,6 +107,45 @@ struct AppTabHostView: View {
     }
 }
 
+extension AppTabHostView {
+    /// Pure helpers extracted for unit testability — these were previously
+    /// inline closures inside `updateHoldsBadge()` that could not be exercised
+    /// by tests, leaving mutations like `+= 1` → `-= 1` undetected.
+    static func computeReadyCount(books: [TPPBook]) -> Int {
+        var count = 0
+        for book in books {
+            book.defaultAcquisition?.availability.match(
+                unavailable: nil,
+                limited: nil,
+                unlimited: nil,
+                reserved: nil,
+                ready: { _ in count += 1 }
+            )
+        }
+        return count
+    }
+
+    static func computeReservedCount(books: [TPPBook]) -> Int {
+        var count = 0
+        for book in books {
+            book.defaultAcquisition?.availability.match(
+                unavailable: nil,
+                limited: nil,
+                unlimited: nil,
+                reserved: { _ in count += 1 },
+                ready: nil
+            )
+        }
+        return count
+    }
+
+    /// `state == .loaded || state == .synced` factored out of `updateHoldsBadge`
+    /// so the OR/equality conditions can be exercised by tests directly.
+    static func shouldUpdateBadge(for state: TPPBookRegistry.RegistryState) -> Bool {
+        return state == .loaded || state == .synced
+    }
+}
+
 private extension AppTabHostView {
     /// VoiceOver announcement label for each tab (matches tab item text).
     static func accessibilityLabel(for tab: AppTab) -> String {
@@ -120,7 +159,7 @@ private extension AppTabHostView {
     }
 
     func updateHoldsBadge() {
-        guard bookRegistry.state == .loaded || bookRegistry.state == .synced else {
+        guard Self.shouldUpdateBadge(for: bookRegistry.state) else {
             return
         }
 
@@ -136,23 +175,11 @@ private extension AppTabHostView {
             let held = bookRegistry.heldBooks
             #endif
 
-            var readyCount = 0
-
-            for book in held {
-                book.defaultAcquisition?.availability.match(unavailable: nil,
-                                                                       limited: nil,
-                                                                       unlimited: nil,
-                                                                       reserved: nil,
-                                                                       ready: { _ in readyCount += 1 })
-            }
+            let readyCount = Self.computeReadyCount(books: held)
 
             #if DEBUG
             if debugSettings.isBadgeLoggingEnabled {
-                var reservedCount = 0
-                for book in held {
-                    book.defaultAcquisition?.availability.match(unavailable: nil, limited: nil, unlimited: nil,
-                                                                           reserved: { _ in reservedCount += 1 }, ready: nil)
-                }
+                let reservedCount = Self.computeReservedCount(books: held)
                 Log.info(#file, "[DEBUG-BADGE] updateHoldsBadge: source=\(usingTestBooks ? "TEST BOOKS" : "registry"), totalHeld=\(held.count), reserved=\(reservedCount), ready=\(readyCount)")
                 for (index, book) in held.enumerated() {
                     var status = "unknown"

--- a/PalaceTests/AccountsManagerHelpersTests.swift
+++ b/PalaceTests/AccountsManagerHelpersTests.swift
@@ -1,0 +1,119 @@
+//
+//  AccountsManagerHelpersTests.swift
+//  PalaceTests
+//
+//  F-013 follow-up: kills surviving mutants in AccountsManager by exercising
+//  the pure helpers extracted from `currentAccount.didSet`,
+//  `cleanupActiveContentBeforeAccountSwitch`, and `isCacheStale`.
+//
+
+import XCTest
+@testable import Palace
+
+final class AccountsManagerHelpersTests: XCTestCase {
+
+    // MARK: - shouldFinishSwitchingImmediately
+    //
+    // Mirrors the previous L171 condition:
+    //   `if previousAccountId == newAccountId || previousAccountId == nil`
+    // Kills the `==` ↔ `!=` mutants on the comparison + the `||` ↔ `&&` mutant.
+
+    func test_shouldFinishSwitchingImmediately_sameAccount_returnsTrue() {
+        let result = AccountsManager.shouldFinishSwitchingImmediately(
+            previousAccountId: "abc",
+            newAccountId: "abc"
+        )
+        XCTAssertTrue(result)
+    }
+
+    func test_shouldFinishSwitchingImmediately_differentAccounts_returnsFalse() {
+        let result = AccountsManager.shouldFinishSwitchingImmediately(
+            previousAccountId: "abc",
+            newAccountId: "xyz"
+        )
+        XCTAssertFalse(result)
+    }
+
+    func test_shouldFinishSwitchingImmediately_previousNil_returnsTrue() {
+        let result = AccountsManager.shouldFinishSwitchingImmediately(
+            previousAccountId: nil,
+            newAccountId: "xyz"
+        )
+        XCTAssertTrue(result)
+    }
+
+    func test_shouldFinishSwitchingImmediately_bothNil_returnsTrue() {
+        let result = AccountsManager.shouldFinishSwitchingImmediately(
+            previousAccountId: nil,
+            newAccountId: nil
+        )
+        XCTAssertTrue(result)
+    }
+
+    func test_shouldFinishSwitchingImmediately_newNilWithExistingPrevious_returnsFalse() {
+        // previous=abc, new=nil → not the same, not previous=nil → false.
+        // Kills the `||` → `&&` mutant: under `&&` this would still return
+        // false too, but combined with the bothNil/previousNil tests above,
+        // an `&&` swap fails the previousNil case which expects true.
+        let result = AccountsManager.shouldFinishSwitchingImmediately(
+            previousAccountId: "abc",
+            newAccountId: nil
+        )
+        XCTAssertFalse(result)
+    }
+
+    // MARK: - shouldPopToRoot
+
+    func test_shouldPopToRoot_zeroPath_returnsFalse() {
+        XCTAssertFalse(AccountsManager.shouldPopToRoot(navigationPathCount: 0))
+    }
+
+    func test_shouldPopToRoot_onePath_returnsTrue() {
+        XCTAssertTrue(AccountsManager.shouldPopToRoot(navigationPathCount: 1))
+    }
+
+    /// Negative shouldn't happen in practice but kills `> 0` → `>= 0`:
+    /// `>= 0` would return true for 0 (which we want false).
+    func test_shouldPopToRoot_threePath_returnsTrue() {
+        XCTAssertTrue(AccountsManager.shouldPopToRoot(navigationPathCount: 3))
+    }
+
+    // MARK: - isCacheStale (pure variant)
+
+    func test_isCacheStale_nilMetadata_returnsTrue() {
+        // Kills the `return true` → `return false` mutant on the
+        // nil-metadata path.
+        XCTAssertTrue(AccountsManager.isCacheStale(metadata: nil, serverMaxAge: nil))
+    }
+
+    func test_isCacheStale_freshMetadata_returnsFalse() {
+        let fresh = CatalogCacheMetadata(timestamp: Date(), hash: "h")
+        XCTAssertFalse(AccountsManager.isCacheStale(metadata: fresh, serverMaxAge: nil))
+    }
+
+    func test_isCacheStale_staleMetadata_returnsTrue() {
+        // 7 hours ago is past the 6-hour default stale TTL.
+        let stale = CatalogCacheMetadata(
+            timestamp: Date().addingTimeInterval(-7 * 3600),
+            hash: "h"
+        )
+        XCTAssertTrue(AccountsManager.isCacheStale(metadata: stale, serverMaxAge: nil))
+    }
+
+    func test_isCacheStale_serverMaxAgeRespected() {
+        // serverMaxAge=600s → staleTTL = max(300, min(300, 43200)) = 300s.
+        // Metadata 4 minutes old: not stale (< 5min TTL).
+        let recent = CatalogCacheMetadata(
+            timestamp: Date().addingTimeInterval(-4 * 60),
+            hash: "h"
+        )
+        XCTAssertFalse(AccountsManager.isCacheStale(metadata: recent, serverMaxAge: 600))
+
+        // Same metadata 10 minutes old → stale (> 5min TTL).
+        let older = CatalogCacheMetadata(
+            timestamp: Date().addingTimeInterval(-10 * 60),
+            hash: "h"
+        )
+        XCTAssertTrue(AccountsManager.isCacheStale(metadata: older, serverMaxAge: 600))
+    }
+}

--- a/PalaceTests/AnnouncementChainTests.swift
+++ b/PalaceTests/AnnouncementChainTests.swift
@@ -1,0 +1,59 @@
+//
+//  AnnouncementChainTests.swift
+//  PalaceTests
+//
+//  F-013 follow-up: kills the 2 surviving mutants on TPPAnnouncementBusinessLogic
+//  L95 (`if i > 0`) by extracting the index-pair calculation into a pure helper
+//  and exercising it under empty / 1 / 2 / N announcement counts.
+//
+
+import XCTest
+@testable import Palace
+
+final class AnnouncementChainTests: XCTestCase {
+
+    // MARK: - chainAttachmentIndices
+
+    func test_chainAttachmentIndices_zeroAnnouncements_returnsEmpty() {
+        let pairs = TPPAnnouncementBusinessLogic.chainAttachmentIndices(forAnnouncementCount: 0)
+        XCTAssertTrue(pairs.isEmpty)
+    }
+
+    /// Single announcement is shown directly with its own dismiss button —
+    /// no chaining needed. Kills the `> 0` → `>= 0` mutant: `>= 0` would
+    /// emit a (-1, 0) pair and crash on `announcements[-1]`.
+    func test_chainAttachmentIndices_oneAnnouncement_returnsEmpty() {
+        let pairs = TPPAnnouncementBusinessLogic.chainAttachmentIndices(forAnnouncementCount: 1)
+        XCTAssertTrue(pairs.isEmpty)
+    }
+
+    /// Two announcements: alerts[0] gets the action that presents alerts[1]
+    /// and marks announcements[0] as presented when tapped.
+    func test_chainAttachmentIndices_twoAnnouncements_returnsOnePair() {
+        let pairs = TPPAnnouncementBusinessLogic.chainAttachmentIndices(forAnnouncementCount: 2)
+        XCTAssertEqual(pairs.count, 1)
+        XCTAssertEqual(pairs[0].attach, 0)
+        XCTAssertEqual(pairs[0].present, 1)
+    }
+
+    /// Three announcements: chain alerts[0]→alerts[1] and alerts[1]→alerts[2].
+    /// Kills the `> 0` → `< 0` mutant (returns no pairs at all) and the
+    /// `i - 1` index calculation.
+    func test_chainAttachmentIndices_threeAnnouncements_returnsTwoChainedPairs() {
+        let pairs = TPPAnnouncementBusinessLogic.chainAttachmentIndices(forAnnouncementCount: 3)
+        XCTAssertEqual(pairs.count, 2)
+        XCTAssertEqual(pairs[0].attach, 0)
+        XCTAssertEqual(pairs[0].present, 1)
+        XCTAssertEqual(pairs[1].attach, 1)
+        XCTAssertEqual(pairs[1].present, 2)
+    }
+
+    func test_chainAttachmentIndices_fiveAnnouncements_returnsFourChainedPairs() {
+        let pairs = TPPAnnouncementBusinessLogic.chainAttachmentIndices(forAnnouncementCount: 5)
+        XCTAssertEqual(pairs.count, 4)
+        for (idx, pair) in pairs.enumerated() {
+            XCTAssertEqual(pair.attach, idx)
+            XCTAssertEqual(pair.present, idx + 1)
+        }
+    }
+}

--- a/PalaceTests/AppTabHostViewBadgeCountTests.swift
+++ b/PalaceTests/AppTabHostViewBadgeCountTests.swift
@@ -1,0 +1,118 @@
+//
+//  AppTabHostViewBadgeCountTests.swift
+//  PalaceTests
+//
+//  F-013 follow-up: kills the 6 surviving mutants in AppTabHostView's
+//  badge-count update path. Previously these counts were inline closures
+//  inside `updateHoldsBadge()` and could not be exercised by tests.
+//
+
+import XCTest
+@testable import Palace
+
+final class AppTabHostViewBadgeCountTests: XCTestCase {
+
+    // MARK: - computeReadyCount
+
+    func test_computeReadyCount_emptyArray_returnsZero() {
+        XCTAssertEqual(AppTabHostView.computeReadyCount(books: []), 0)
+    }
+
+    func test_computeReadyCount_oneReadyBook_returnsOne() {
+        let book = TPPBookMocker.snapshotReadyBook()
+        XCTAssertEqual(AppTabHostView.computeReadyCount(books: [book]), 1)
+    }
+
+    func test_computeReadyCount_threeReadyBooks_returnsThree() {
+        let books = (0..<3).map { idx in
+            TPPBookMocker.snapshotReadyBook(
+                identifier: "ready-\(idx)",
+                title: "Ready \(idx)",
+                author: "Author \(idx)"
+            )
+        }
+        XCTAssertEqual(AppTabHostView.computeReadyCount(books: books), 3)
+    }
+
+    /// Reserved books (still in the hold queue) must NOT be counted as ready.
+    /// Kills the mutant where the `ready:` callback is replaced by a no-op.
+    func test_computeReadyCount_reservedBooksOnly_returnsZero() {
+        let books = (0..<3).map { idx in
+            TPPBookMocker.snapshotReservedBook(
+                identifier: "reserved-\(idx)",
+                title: "Reserved \(idx)",
+                author: "Author \(idx)",
+                holdPosition: UInt(idx + 1)
+            )
+        }
+        XCTAssertEqual(AppTabHostView.computeReadyCount(books: books), 0)
+    }
+
+    /// Mixed input: reserved books filter out, ready books are counted.
+    /// Kills the `+= 1` → `-= 1` mutant directly: a `-=` would yield -2 not 2.
+    func test_computeReadyCount_mixedReservedAndReady_returnsOnlyReadyCount() {
+        let ready = (0..<2).map { idx in
+            TPPBookMocker.snapshotReadyBook(
+                identifier: "ready-\(idx)",
+                title: "R\(idx)",
+                author: "A\(idx)"
+            )
+        }
+        let reserved = (0..<3).map { idx in
+            TPPBookMocker.snapshotReservedBook(
+                identifier: "res-\(idx)",
+                title: "Res\(idx)",
+                author: "Ax\(idx)",
+                holdPosition: UInt(idx + 1)
+            )
+        }
+        XCTAssertEqual(AppTabHostView.computeReadyCount(books: ready + reserved), 2)
+    }
+
+    // MARK: - computeReservedCount
+
+    func test_computeReservedCount_emptyArray_returnsZero() {
+        XCTAssertEqual(AppTabHostView.computeReservedCount(books: []), 0)
+    }
+
+    func test_computeReservedCount_twoReservedBooks_returnsTwo() {
+        let books = (0..<2).map { idx in
+            TPPBookMocker.snapshotReservedBook(
+                identifier: "res-\(idx)",
+                title: "Res \(idx)",
+                author: "Author \(idx)",
+                holdPosition: UInt(idx + 1)
+            )
+        }
+        XCTAssertEqual(AppTabHostView.computeReservedCount(books: books), 2)
+    }
+
+    /// Ready books must NOT be counted as reserved. Kills the mutant where
+    /// the `reserved:` callback is replaced by the `ready:` callback.
+    func test_computeReservedCount_readyBooksOnly_returnsZero() {
+        let books = (0..<2).map { idx in
+            TPPBookMocker.snapshotReadyBook(
+                identifier: "ready-\(idx)",
+                title: "Ready \(idx)",
+                author: "Author \(idx)"
+            )
+        }
+        XCTAssertEqual(AppTabHostView.computeReservedCount(books: books), 0)
+    }
+
+    // MARK: - shouldUpdateBadge
+
+    /// Kills the mutants on `state == .loaded` and `state == .synced` —
+    /// flipping `==` to `!=` or `||` to `&&` makes the badge skip work
+    /// when it should run, or run when it should skip.
+    func test_shouldUpdateBadge_loadedOrSynced_returnsTrue() {
+        XCTAssertTrue(AppTabHostView.shouldUpdateBadge(for: .loaded))
+        XCTAssertTrue(AppTabHostView.shouldUpdateBadge(for: .synced))
+    }
+
+    func test_shouldUpdateBadge_unloadedOrLoadingOrSyncing_returnsFalse() {
+        XCTAssertFalse(AppTabHostView.shouldUpdateBadge(for: .unloaded))
+        XCTAssertFalse(AppTabHostView.shouldUpdateBadge(for: .loading))
+        XCTAssertFalse(AppTabHostView.shouldUpdateBadge(for: .syncing))
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts pure static helpers from inline closures and one-shot conditionals in `AppTabHostView`, `TPPAnnouncementBusinessLogic`, and `AccountsManager`, then routes the production code through them so the previously-untestable logic can be exercised by unit tests.
- Closes the 0% mutation kill rates that the PP-4164 / F-013 sweep flagged on these three files: AppTabHostView 0%→62.5%, Announcements 0%→50%, AccountsManager 0%→25% (5 of 20 mutants now killed; 3 of the original 6 baseline survivors closed).
- Behavior preserving — no functional changes, just refactor + tests.

## Mutation impact

| File | Before | After | Helpers extracted |
|---|---|---|---|
| `AppTabHostView.swift` | 0% (0/6) | 62.5% (5/8) | `computeReadyCount`, `computeReservedCount`, `shouldUpdateBadge` |
| `TPPAnnouncementBusinessLogic.swift` | 0% (0/2) | 50% (1/2; survivor equivalent) | `chainAttachmentIndices(forAnnouncementCount:)` |
| `AccountsManager.swift` | 0% (0/6 baseline) | 25% (5/20 superset; 3 of original 6 killed) | `shouldFinishSwitchingImmediately`, `shouldPopToRoot`, `isCacheStale(metadata:serverMaxAge:)` |

27 new test cases added across `AppTabHostViewBadgeCountTests`, `AnnouncementChainTests`, `AccountsManagerHelpersTests`.

## Not done

- AccountsManager L157 / L346 / L686 / L699-L701 / L752 still survive — they require a mockable `AppContainer` / `UserDefaults` harness, beyond scope of a TDD-only pass.
- The 3 AppTabHostView survivors are inside the SwiftUI `.onChange(of:)` body, which needs a view-rendering harness to exercise.

## Deferred (F-003)

The PP-4164 search-Cancel ~9 MB/cycle leak finding (F-003) is **not** addressed here. Drove 20+ tap-search→type→Cancel cycles on the candidate via simdrive `perf_baseline` + `perf_compare`; RSS held steady at 592.31 MB (delta 0). The original simdrive-regress journey-level measurement is not reproducing under interactive cycles. `xctrace` CLI doesn't surface Allocations summaries via XPath, so confirming F-003 needs a GUI Instruments Allocations+Leaks pass under the exact original journey. Tracked in `~/Desktop/regression-PP-4164/findings.csv`.

## Test plan

- [x] `xcodebuild test -only-testing:PalaceTests/AppTabHostViewBadgeCountTests` — 10 pass
- [x] `xcodebuild test -only-testing:PalaceTests/AnnouncementChainTests` — 5 pass
- [x] `xcodebuild test -only-testing:PalaceTests/AccountsManagerHelpersTests` — 12 pass
- [x] Co-run with `MyBooksViewModelTests` + `AccountsManagerTests` — 78 pass total, no regression
- [x] `python3 scripts/palace_mutate.py --file <each>` — kill-rate measurements above are real-execution numbers
- [ ] Mutation-gate CI runs on this PR confirms aggregate kill-rate improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)