### PR TITLE
[3.0.1] OPDSFeedService: handle recoverable SAML auth problem docs

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -7389,7 +7389,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 470;
+				CURRENT_PROJECT_VERSION = 471;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7410,7 +7410,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7446,7 +7446,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 470;
+				CURRENT_PROJECT_VERSION = 471;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7467,7 +7467,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7632,7 +7632,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 470;
+				CURRENT_PROJECT_VERSION = 471;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -7658,7 +7658,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -7692,7 +7692,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 470;
+				CURRENT_PROJECT_VERSION = 471;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7719,7 +7719,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "App Store";

--- a/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
@@ -620,13 +620,28 @@ final class BookDetailViewModel: ObservableObject {
                 guard let self = self else { return }
 
                 let account = AccountsManager.shared.currentUserAccount
-                if account.needsAuth && !account.hasCredentials() {
+                let needsSignIn = account.needsAuth && !account.hasCredentials()
+                // .credentialsStale means we still hold credentials but a 401
+                // has marked the session expired. Reading the cached book
+                // proceeds straight to a hung reader (no fresh fulfillment,
+                // no fresh DRM grant) without an intervening sign-in. Force
+                // re-auth here so the user has a path to recover without
+                // reinstalling. HelpSpot 17716 (Cornell SAML).
+                let needsReauth = account.authState == .credentialsStale
+                if needsSignIn || needsReauth {
+                    Log.info(#file, "[SAML-REAUTH] ensureAuthAndExecute presenting modal: needsSignIn=\(needsSignIn) needsReauth=\(needsReauth)")
                     self.showHalfSheet = false
                     SignInModalPresenter.presentSignInModalForCurrentAccount { [weak self] in
                         guard let self else { return }
-                        // Only proceed if user successfully logged in, not if they cancelled
-                        guard AccountsManager.shared.currentUserAccount.hasCredentials() else {
-                            Log.info(#file, "Sign-in cancelled or failed, not proceeding with action")
+                        let post = AccountsManager.shared.currentUserAccount
+                        // Proceed only if the user actually re-authenticated
+                        // — they have credentials AND state is loggedIn.
+                        // Cancelling the modal leaves authState unchanged
+                        // (still .credentialsStale) and we should NOT call
+                        // the action; otherwise we'd hand the reader a stale
+                        // book and reproduce the original hang.
+                        guard post.hasCredentials() && post.authState == .loggedIn else {
+                            Log.info(#file, "[SAML-REAUTH] Sign-in cancelled or incomplete (hasCredentials=\(post.hasCredentials()) authState=\(post.authState)) — not proceeding with action")
                             // Clear any processing state for download-related buttons
                             self.processingButtons.remove(.download)
                             self.processingButtons.remove(.get)

--- a/Palace/Network/TPPNetworkResponder.swift
+++ b/Palace/Network/TPPNetworkResponder.swift
@@ -401,10 +401,26 @@ private func handleExpiredTokenIfNeeded(for response: HTTPURLResponse,
         }
 
         // Mark credentials as stale - preserves Adobe DRM activation
-        AccountsManager.shared.userAccount(for: accountId ?? "").markCredentialsStale()
+        let user = AccountsManager.shared.userAccount(for: accountId ?? "")
+        user.markCredentialsStale()
 
         if authDef?.reauthStrategy == .browser {
-            Log.info(#file, "Server returned 401 for browser-based auth - credentials marked stale, will trigger re-auth flow")
+            // SAML/OIDC: a 401 here means the IdP cookie/assertion expired.
+            // markCredentialsStale() above only fires the publisher on the
+            // .loggedIn → .credentialsStale transition; once stale, subsequent
+            // 401s are no-ops. So we hand off to SAMLReauthCoordinator on
+            // every 401 — its own single-flight + foreground gates dedupe,
+            // which also handles the case where the account was already
+            // stale at app launch (publisher quiet, but UI still missing).
+            // HelpSpot 17716 (Cornell SAML).
+            Log.info(#file, "Server returned 401 for browser-based auth - credentials marked stale, requesting SAML reauth")
+            Task { @MainActor in
+                SAMLReauthCoordinator.shared.requestReauth(
+                    for: user,
+                    authDef: authDef,
+                    triggerURL: originalURL
+                )
+            }
             return false
         }
 

--- a/Palace/OPDS2/OPDSFeedService.swift
+++ b/Palace/OPDS2/OPDSFeedService.swift
@@ -203,12 +203,25 @@ actor OPDSFeedService {
         return .parsing(.opdsFeedInvalid)
     }
 
-    private func parseProblemDocument(_ problemDoc: TPPProblemDocument) -> PalaceError {
+    func parseProblemDocument(_ problemDoc: TPPProblemDocument) -> PalaceError {
         guard let type = problemDoc.type else {
             // Unknown problem document - use title/detail if available
             let message = problemDoc.title ?? problemDoc.detail ?? "Unknown server error"
             Log.warn(#file, "Problem document with no type: \(message)")
             return .network(.serverError)
+        }
+
+        // The explicit switch below only covers the librarysimplified.org namespace.
+        // palaceproject.io serves auth state via /auth/recoverable/* and /auth/unrecoverable/*
+        // namespaces — recognise them so callers see the recoverability signal instead
+        // of a generic credentials/server error.
+        if problemDoc.isRecoverableAuthError {
+            Log.info(#file, "Recoverable auth problem document '\(type)' — credentials should be marked stale")
+            return .authentication(.tokenExpired)
+        }
+        if problemDoc.isUnrecoverableAuthError {
+            Log.info(#file, "Unrecoverable auth problem document '\(type)' — re-auth will not help")
+            return .authentication(.invalidCredentials)
         }
 
         switch type {

--- a/Palace/SignInLogic/TPPReauthenticator.swift
+++ b/Palace/SignInLogic/TPPReauthenticator.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 protocol Reauthenticator: NSObject {
     func authenticateIfNeeded(_ user: TPPUserAccount,
@@ -55,5 +56,88 @@ protocol Reauthenticator: NSObject {
                 authenticationCompletion?()
             }
         }
+    }
+}
+
+// MARK: - SAMLReauthCoordinator
+
+/// Single-flight coordinator for browser-based (SAML/OIDC) re-authentication.
+///
+/// Without this, `TPPNetworkResponder` marks the account `.credentialsStale`
+/// when /patrons/me/ or /loans/ returns 401 but no UI ever surfaces — SAML
+/// users are left polling 401s forever with no way to recover short of
+/// uninstalling the app. HelpSpot 17716 (Cornell SAML).
+///
+/// We can't simply call `SignInModalPresenter` from the responder on every
+/// 401: loans-refresh polls fire continuously while stale, which would stack
+/// modals. The publisher's `removeDuplicates()` only deduplicates on state
+/// transitions, so once the account is stale every subsequent 401 still
+/// flows in. This coordinator dedupes via an `isPresenting` flag plus a
+/// foreground gate.
+@MainActor
+final class SAMLReauthCoordinator {
+
+    static let shared = SAMLReauthCoordinator()
+
+    /// True while the sign-in modal owned by this coordinator is on screen.
+    /// Reset when the modal's completion fires (whether the user signed in
+    /// or cancelled). Visible for tests.
+    private(set) var isPresenting: Bool = false
+
+    private let reauthenticator: Reauthenticator
+    private let applicationStateProvider: () -> UIApplication.State
+
+    init(reauthenticator: Reauthenticator = TPPReauthenticator(),
+         applicationStateProvider: @escaping () -> UIApplication.State = { UIApplication.shared.applicationState }) {
+        self.reauthenticator = reauthenticator
+        self.applicationStateProvider = applicationStateProvider
+    }
+
+    /// Present the SAML/OIDC re-auth modal if all preconditions hold:
+    /// browser-based reauth strategy, account in `.credentialsStale`,
+    /// app foreground, no other reauth modal already presenting.
+    ///
+    /// Caller (typically `TPPNetworkResponder`) may invoke on every 401 —
+    /// the coordinator's gates make repeated calls cheap and idempotent.
+    func requestReauth(for user: TPPUserAccount,
+                       authDef: AccountDetails.Authentication?,
+                       triggerURL: URL?) {
+        let urlStr = triggerURL?.absoluteString ?? "<nil>"
+        let strategy = String(describing: authDef?.reauthStrategy)
+        Log.info(#file, "[SAML-REAUTH] requestReauth url=\(urlStr) state=\(user.authState) strategy=\(strategy)")
+
+        guard authDef?.reauthStrategy == .browser else {
+            Log.info(#file, "[SAML-REAUTH] skip: reauthStrategy is not .browser (got \(strategy))")
+            return
+        }
+        guard user.authState == .credentialsStale else {
+            Log.info(#file, "[SAML-REAUTH] skip: authState is \(user.authState), not .credentialsStale")
+            return
+        }
+        let appState = applicationStateProvider()
+        guard appState == .active else {
+            Log.info(#file, "[SAML-REAUTH] skip: app not active (state.rawValue=\(appState.rawValue))")
+            return
+        }
+        guard !isPresenting else {
+            Log.info(#file, "[SAML-REAUTH] skip: another reauth modal already presenting")
+            return
+        }
+
+        isPresenting = true
+        Log.info(#file, "[SAML-REAUTH] presenting sign-in modal for browser-based reauth")
+        reauthenticator.authenticateIfNeeded(user, usingExistingCredentials: true) { [weak self] in
+            Task { @MainActor in
+                guard let self = self else { return }
+                self.isPresenting = false
+                Log.info(#file, "[SAML-REAUTH] modal dismissed; isPresenting reset")
+            }
+        }
+    }
+
+    /// Test-only: reset the single-flight flag without going through the
+    /// modal. Production code must never call this.
+    func _resetForTesting() {
+        isPresenting = false
     }
 }

--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
@@ -439,6 +439,11 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
 
     /// Initiates process of signing in with the server.
     @objc func logIn(with tokenURL: URL? = nil) {
+        // Nothing to do without a selected auth method. Posting TPPIsSigningIn
+        // here would leave downstream observers stuck in a "signing in" state
+        // while we silently bail. (Forward-port of develop's logIn early-return.)
+        guard let wrapped = selectedAuthentication else { return }
+
         NotificationCenter.default.post(name: .TPPIsSigningIn, object: true)
 
         capturedBarcode = uiDelegate?.username
@@ -448,11 +453,7 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
             self.uiDelegate?.businessLogicWillSignIn(self)
         }
 
-        switch selectedAuthentication {
-        case .none:
-            return
-        case .some(let wrapped):
-            switch wrapped.authType {
+        switch wrapped.authType {
             case .oauthIntermediary:
                 oauthLogIn()
             case .saml:
@@ -473,7 +474,6 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
                 getBearerToken(username: username, password: password, tokenURL: tokenURL)
             default:
                 validateCredentials()
-            }
         }
     }
 

--- a/PalaceTests/Accounts/TPPCredentialIsolationE2ETests.swift
+++ b/PalaceTests/Accounts/TPPCredentialIsolationE2ETests.swift
@@ -10,6 +10,15 @@ final class TPPCredentialIsolationE2ETests: XCTestCase {
     private let uuidB = "urn:uuid:e2e-isolation-library-b"
     private let uuidC = "urn:uuid:e2e-isolation-library-c"
 
+    override func setUpWithError() throws {
+        // CI iOS Simulator runners lack keychain entitlement (errSec -34018)
+        // — every credential read/write returns nil and the isolation
+        // assertions fall through to "nil != Optional(barcode)" failures.
+        // Skip rather than report false negatives.
+        try super.setUpWithError()
+        try KeychainAvailability.skipIfUnavailable()
+    }
+
     override func tearDown() {
         AccountsManager.shared.userAccount(for: uuidA).removeAll()
         AccountsManager.shared.userAccount(for: uuidB).removeAll()

--- a/PalaceTests/Accounts/TPPPerAccountIsolationTests.swift
+++ b/PalaceTests/Accounts/TPPPerAccountIsolationTests.swift
@@ -8,6 +8,16 @@ final class TPPPerAccountIsolationTests: XCTestCase {
     private let uuidA = "urn:uuid:isolation-test-library-a"
     private let uuidB = "urn:uuid:isolation-test-library-b"
 
+    override func setUpWithError() throws {
+        // GitHub Actions iOS Simulator runners have no keychain entitlement,
+        // so SecItemAdd fails with errSecMissingEntitlement (-34018) and
+        // every credential read returns nil. These tests REQUIRE a writable
+        // keychain (they assert credential isolation across accounts), so
+        // skip them in that environment rather than report false failures.
+        try super.setUpWithError()
+        try KeychainAvailability.skipIfUnavailable()
+    }
+
     override func tearDown() {
         // Clean up any keychain data written during tests
         AccountsManager.shared.userAccount(for: uuidA).removeAll()

--- a/PalaceTests/OPDS2/OPDSFeedServiceTests.swift
+++ b/PalaceTests/OPDS2/OPDSFeedServiceTests.swift
@@ -65,6 +65,85 @@ final class OPDSFeedServiceTests: XCTestCase {
         let service2 = await OPDSFeedService.shared
         XCTAssertTrue(service === service2, "fetchCatalogRoot lives on the shared singleton")
     }
+
+    // MARK: - Problem Document Mapping
+
+    /// SAML session expiry returns a recoverable-auth problem document under the
+    /// palaceproject.io namespace. Before this hotfix, OPDSFeedService only knew
+    /// the librarysimplified.org namespace and fell through to .network(.serverError)
+    /// or generic .invalidCredentials, hiding the recoverability signal from
+    /// callers (loans refresh, /patrons/me/, /annotations/).
+    func testParseProblemDocument_recoverableSAMLSessionExpired_returnsTokenExpired() async {
+        let dict: [String: Any] = [
+            "type": "http://palaceproject.io/terms/problem/auth/recoverable/saml/session-expired",
+            "title": "SAML session expired",
+            "status": 401
+        ]
+        let problemDoc = TPPProblemDocument.fromDictionary(dict)
+        let service = OPDSFeedService.shared
+
+        let result = await service.parseProblemDocument(problemDoc)
+
+        guard case .authentication(.tokenExpired) = result else {
+            XCTFail("Expected .authentication(.tokenExpired) for recoverable SAML, got \(result)")
+            return
+        }
+    }
+
+    func testParseProblemDocument_recoverableTokenExpired_returnsTokenExpired() async {
+        let dict: [String: Any] = [
+            "type": "http://palaceproject.io/terms/problem/auth/recoverable/token/expired",
+            "title": "Token expired",
+            "status": 401
+        ]
+        let problemDoc = TPPProblemDocument.fromDictionary(dict)
+        let service = OPDSFeedService.shared
+
+        let result = await service.parseProblemDocument(problemDoc)
+
+        guard case .authentication(.tokenExpired) = result else {
+            XCTFail("Expected .authentication(.tokenExpired) for recoverable token, got \(result)")
+            return
+        }
+    }
+
+    func testParseProblemDocument_unrecoverableNoActiveAccount_returnsInvalidCredentials() async {
+        let dict: [String: Any] = [
+            "type": "http://palaceproject.io/terms/problem/auth/unrecoverable/no-active-account",
+            "title": "No active account",
+            "status": 403
+        ]
+        let problemDoc = TPPProblemDocument.fromDictionary(dict)
+        let service = OPDSFeedService.shared
+
+        let result = await service.parseProblemDocument(problemDoc)
+
+        guard case .authentication(.invalidCredentials) = result else {
+            XCTFail("Expected .authentication(.invalidCredentials) for unrecoverable, got \(result)")
+            return
+        }
+    }
+
+    /// Mutation guard: a truly unrecognised type that is neither recoverable nor
+    /// unrecoverable auth must still fall through to the existing HTTP-status mapping.
+    /// This catches a regression where the new branches accidentally swallow non-auth
+    /// problem documents.
+    func testParseProblemDocument_unrecognisedTypeWith404_returnsNetworkNotFound() async {
+        let dict: [String: Any] = [
+            "type": "http://example.com/problem/something-weird",
+            "title": "Something weird",
+            "status": 404
+        ]
+        let problemDoc = TPPProblemDocument.fromDictionary(dict)
+        let service = OPDSFeedService.shared
+
+        let result = await service.parseProblemDocument(problemDoc)
+
+        guard case .network(.notFound) = result else {
+            XCTFail("Expected .network(.notFound) for unrecognised type with 404, got \(result)")
+            return
+        }
+    }
 }
 
 // MARK: - Palace Error Tests

--- a/PalaceTests/Performance/BookCellModelCacheTests.swift
+++ b/PalaceTests/Performance/BookCellModelCacheTests.swift
@@ -424,28 +424,40 @@ final class BookCellModelCacheTests: XCTestCase {
         XCTAssertEqual(model1.book.identifier, originalBook.identifier)
     }
 
-    /// Tests that older book versions don't trigger updates
-    func testModelUpdate_WithOlderBook_DoesNotUpdate() async throws {
-        let oldDate = Date(timeIntervalSince1970: 1000)
-        let newDate = Date(timeIntervalSince1970: 2000)
+    /// Cache update semantics: identity beats timestamp.
+    ///
+    /// Historical note: the cache used to gate updates on
+    /// `book.updated >= cached.book.updated`, but that left MyBooks cells
+    /// rendering stale metadata when a fresh registry fetch produced a
+    /// TPPBook with a slightly-older `updated` (sub-second disk round-trip
+    /// drift between the catalog feed and the loans feed). The fix:
+    /// trust identity — if the registry hands us a different TPPBook
+    /// instance for the same identifier, that's the authoritative one,
+    /// regardless of timestamp. See BookCellModelCache.swift:135-147.
+    /// This test pins the new contract.
+    func testModelUpdate_DifferentBookInstance_UpdatesRegardlessOfTimestamp() async throws {
+        let newerDate = Date(timeIntervalSince1970: 2000)
+        let olderDate = Date(timeIntervalSince1970: 1000)
 
-        let newBook = makeTestBook(identifier: "older-test", title: "New Title", updated: newDate)
-        let oldBook = makeTestBook(identifier: "older-test", title: "Old Title", updated: oldDate)
+        let firstBook = makeTestBook(identifier: "older-test", title: "First Title", updated: newerDate)
+        let secondBook = makeTestBook(identifier: "older-test", title: "Second Title", updated: olderDate)
 
-        // Cache the newer book first
-        let model = sut.model(for: newBook)
-        XCTAssertEqual(model.book.title, "New Title")
+        let model = sut.model(for: firstBook)
+        XCTAssertEqual(model.book.title, "First Title")
 
-        // Request with older book - should not update
-        let sameModel = sut.model(for: oldBook)
-        XCTAssertTrue(model === sameModel)
+        // Different instance for the same identifier — must update the
+        // cached model even though `updated` is older.
+        let sameModel = sut.model(for: secondBook)
+        XCTAssertTrue(model === sameModel,
+                      "Same identifier must return the same cached model instance")
 
-        // Yield to allow any deferred Task { @MainActor } a chance to run (it shouldn't update)
+        // Update is dispatched to MainActor; yield to drain it.
         await Task.yield(); await Task.yield(); await Task.yield()
 
-        // Book should still be the newer version
-        XCTAssertEqual(model.book.title, "New Title")
-        XCTAssertEqual(model.book.updated, newDate)
+        XCTAssertEqual(model.book.title, "Second Title",
+                       "Identity-over-timestamp: different TPPBook instance must overwrite the cached book")
+        XCTAssertEqual(model.book.updated, olderDate,
+                       "Updated timestamp must mirror the new instance, even if older")
     }
 
     // MARK: - Helpers

--- a/PalaceTests/SignInLogic/TPPCredentialSnapshotCoherenceTests.swift
+++ b/PalaceTests/SignInLogic/TPPCredentialSnapshotCoherenceTests.swift
@@ -33,8 +33,14 @@ final class TPPCredentialSnapshotCoherenceTests: XCTestCase {
     private var writer: TPPUserAccount!
     private var reader: TPPUserAccount!
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // CI iOS Simulator runners have no keychain entitlement, so every
+        // setBarcode/setAuthToken silently no-ops and these cache-coherence
+        // assertions all fail with `nil != "test-barcode"`. Skip rather
+        // than report false negatives — the regression these tests guard
+        // against can only happen on a host with a real keychain.
+        try KeychainAvailability.skipIfUnavailable()
         writer = TPPUserAccount(libraryUUID: testLibraryUUID)
         reader = TPPUserAccount(libraryUUID: testLibraryUUID)
         writer.removeAll()

--- a/PalaceTests/SignInLogic/TPPReauthenticatorTests.swift
+++ b/PalaceTests/SignInLogic/TPPReauthenticatorTests.swift
@@ -120,3 +120,207 @@ final class TPPReauthenticatorMockTests: XCTestCase {
                       "authenticateIfNeededCalled flag must be set after completion")
     }
 }
+
+// MARK: - SAMLReauthCoordinator Tests
+
+/// Tests for the single-flight coordinator that auto-presents the SAML/OIDC
+/// re-auth modal when /patrons/me/ returns 401. Without these guards we'd
+/// stack a modal per polling 401 (every 30s while stale) — these tests
+/// pin the gates that keep that from happening. HelpSpot 17716.
+@MainActor
+final class SAMLReauthCoordinatorTests: XCTestCase {
+
+    private var mockReauthenticator: TPPReauthenticatorMock!
+    private var userAccount: TPPUserAccountMock!
+    private var coordinator: SAMLReauthCoordinator!
+    private var appState: UIApplication.State = .active
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        mockReauthenticator = TPPReauthenticatorMock()
+        userAccount = TPPUserAccountMock()
+        userAccount.setBarcode("barcode", PIN: "pin")
+        userAccount.setAuthState(.credentialsStale)
+        appState = .active
+        coordinator = SAMLReauthCoordinator(
+            reauthenticator: mockReauthenticator,
+            applicationStateProvider: { [weak self] in self?.appState ?? .active }
+        )
+    }
+
+    override func tearDownWithError() throws {
+        coordinator = nil
+        userAccount = nil
+        mockReauthenticator = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Happy path
+
+    func testRequestReauth_browserStrategy_andStaleAndActive_invokesReauthenticator() {
+        let auth = makeAuthentication(.saml)
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: URL(string: "https://example.org/patrons/me/"))
+
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 1,
+                       "Browser-based reauth on a stale, foreground account must call the reauthenticator exactly once")
+        XCTAssertEqual(mockReauthenticator.lastUsingExistingCredentials, true,
+                       "Coordinator must pass usingExistingCredentials=true so the SAML helper short-circuits to the IdP web view")
+    }
+
+    func testRequestReauth_oidcStrategy_invokesReauthenticator() {
+        // OIDC also resolves to .browser via reauthStrategy. Verifies the
+        // coordinator doesn't accidentally hard-code SAML.
+        let auth = makeAuthentication(.oidc)
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 1,
+                       "OIDC must trigger the same reauth path as SAML — both have reauthStrategy == .browser")
+    }
+
+    // MARK: - Strategy gate
+
+    func testRequestReauth_basicAuth_doesNotInvokeReauthenticator() {
+        // Basic auth uses a credential prompt, not the modal — token-refresh
+        // path or local prompt handles it. Coordinator must skip.
+        let auth = makeAuthentication(.basic)
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 0,
+                       "Basic-auth reauth must NOT go through SAMLReauthCoordinator — wrong UX")
+    }
+
+    func testRequestReauth_tokenAuth_doesNotInvokeReauthenticator() {
+        let auth = makeAuthentication(.token)
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 0,
+                       "Token-refresh path is owned by TPPNetworkExecutor — coordinator must not race with it")
+    }
+
+    func testRequestReauth_nilAuthDef_doesNotInvokeReauthenticator() {
+        coordinator.requestReauth(for: userAccount, authDef: nil, triggerURL: nil)
+
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 0,
+                       "A nil authDef means we don't know the strategy yet — must not present a modal")
+    }
+
+    // MARK: - State gate
+
+    func testRequestReauth_loggedInState_doesNotInvokeReauthenticator() {
+        // A logged-in account that hits this path means somebody upstream
+        // skipped markCredentialsStale. We must NOT flash a modal at a
+        // working session — it'd wipe their cookies on cancel.
+        userAccount.setAuthState(.loggedIn)
+        let auth = makeAuthentication(.saml)
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 0,
+                       "Logged-in account must never see an unsolicited reauth modal")
+    }
+
+    func testRequestReauth_loggedOutState_doesNotInvokeReauthenticator() {
+        // .loggedOut means the user explicitly signed out. Don't auto-prompt.
+        userAccount.setAuthState(.loggedOut)
+        let auth = makeAuthentication(.saml)
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 0,
+                       "Logged-out account must not be auto-prompted — they intentionally signed out")
+    }
+
+    // MARK: - App state gate
+
+    func testRequestReauth_backgroundApp_doesNotInvokeReauthenticator() {
+        // Background polls happen via NSURLSession refresh; we must not
+        // queue a modal that pops the moment the app comes forward —
+        // surprises the user. The next /patrons/me/ poll once foreground
+        // re-triggers the call.
+        appState = .background
+        let auth = makeAuthentication(.saml)
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 0,
+                       "Background app must not present the reauth modal")
+    }
+
+    func testRequestReauth_inactiveApp_doesNotInvokeReauthenticator() {
+        // .inactive = transitioning, e.g. control center pulled down. Same
+        // rationale — wait for .active.
+        appState = .inactive
+        let auth = makeAuthentication(.saml)
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 0,
+                       "Inactive app must not present the reauth modal")
+    }
+
+    // MARK: - Single-flight
+
+    func testRequestReauth_secondCallWhilePresenting_doesNotStackModal() {
+        // The mock with completionDelay > 0 simulates a modal that hasn't
+        // dismissed yet. Two fast-arriving 401s must produce exactly one
+        // present, not two — Adam's logs show /patrons/me/ polls every 30s.
+        mockReauthenticator.completionDelay = 5.0
+        let auth = makeAuthentication(.saml)
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 1,
+                       "Single-flight: second request while modal is on screen must be a no-op")
+        XCTAssertTrue(coordinator.isPresenting,
+                      "isPresenting must remain true until the modal completion fires")
+    }
+
+    func testRequestReauth_afterModalDismissed_canPresentAgain() {
+        // After the user dismisses (cancels or completes auth), a future
+        // 401 — for instance because they cancelled and the next poll
+        // 401s again — must be able to re-present.
+        mockReauthenticator.completionDelay = 0  // synchronous completion
+        let auth = makeAuthentication(.saml)
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 1)
+
+        // Drain the @MainActor Task that resets isPresenting.
+        let drained = expectation(description: "isPresenting reset")
+        Task { @MainActor in
+            // Two hops: one for the reauthenticator's Task, one for the
+            // coordinator's Task that resets the flag.
+            await Task.yield()
+            await Task.yield()
+            drained.fulfill()
+        }
+        wait(for: [drained], timeout: 1.0)
+
+        XCTAssertFalse(coordinator.isPresenting,
+                       "isPresenting must reset after the modal completion fires")
+
+        coordinator.requestReauth(for: userAccount, authDef: auth, triggerURL: nil)
+        XCTAssertEqual(mockReauthenticator.authenticateCallCount, 2,
+                       "Subsequent 401 after dismissal must be allowed to re-present the modal")
+    }
+
+    // MARK: - Helpers
+
+    private func makeAuthentication(_ type: AccountDetails.AuthType) -> AccountDetails.Authentication {
+        let dict: [String: Any] = [
+            "authType": type.rawValue,
+            "authPasscodeLength": 4,
+            "patronIDKeyboard": LoginKeyboard.standard.rawValue,
+            "pinKeyboard": LoginKeyboard.numeric.rawValue,
+            "supportsBarcodeScanner": false,
+            "supportsBarcodeDisplay": false
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: dict)
+        return try! JSONDecoder().decode(AccountDetails.Authentication.self, from: data)
+    }
+}

--- a/PalaceTests/TPPBookCreationTests.swift
+++ b/PalaceTests/TPPBookCreationTests.swift
@@ -46,14 +46,20 @@ class TPPBookCreationTests: XCTestCase {
         XCTAssertNoThrow(book?.loggableShortString())
         XCTAssertNoThrow(book?.loggableDictionary())
 
+        // Missing UpdatedKey: production relaxed to use .distantPast rather than
+        // dropping the book (TPPBook.swift:282) — older catalog feeds occasionally
+        // omit this. Verify the book is still constructed with a sentinel updated.
         let bookNoUpdatedDate = TPPBook(dictionary: [
             "acquisitions": acquisitions,
             "categories": ["Fantasy"],
             "id": "666",
             "title": "The Lord of the Rings"
         ])
-        XCTAssertNil(bookNoUpdatedDate)
+        XCTAssertNotNil(bookNoUpdatedDate, "Missing 'updated' must not drop the book — defaults to .distantPast")
+        XCTAssertEqual(bookNoUpdatedDate?.updated, .distantPast)
 
+        // Missing TitleKey: production drops the book (TPPBook.swift:225). A book
+        // with no title is unrenderable, so this stricter guard remains.
         let bookNoTitle = TPPBook(dictionary: [
             "acquisitions": acquisitions,
             "categories": ["Fantasy"],
@@ -62,6 +68,7 @@ class TPPBookCreationTests: XCTestCase {
         ])
         XCTAssertNil(bookNoTitle)
 
+        // Missing IdentifierKey: production drops the book (TPPBook.swift:221).
         let bookNoId = TPPBook(dictionary: [
             "acquisitions": acquisitions,
             "categories": ["Fantasy"],
@@ -70,13 +77,16 @@ class TPPBookCreationTests: XCTestCase {
         ])
         XCTAssertNil(bookNoId)
 
+        // Missing CategoriesKey: production relaxed to default to [] rather than
+        // dropping (TPPBook.swift:230) — categories are optional metadata.
         let bookNoCategories = TPPBook(dictionary: [
             "acquisitions": acquisitions,
             "id": "666",
             "title": "The Lord of the Rings",
             "updated": "2020-09-08T09:22:45Z"
         ])
-        XCTAssertNil(bookNoCategories)
+        XCTAssertNotNil(bookNoCategories, "Missing 'categories' must not drop the book — defaults to []")
+        XCTAssertEqual(bookNoCategories?.categoryStrings, [])
 
         /*
          Note that we do not test the absence of acquisitions. The current code

--- a/PalaceTests/ViewModels/AccountDetailViewModelTests.swift
+++ b/PalaceTests/ViewModels/AccountDetailViewModelTests.swift
@@ -621,8 +621,15 @@ final class AccountDetailCredentialStateTests: XCTestCase {
 @MainActor
 final class AccountDetailPINVisibilityTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // CI iOS Simulator runners lack keychain entitlement (errSec -34018).
+        // Most tests in this class call `account.setBarcode(..., PIN: ...)`
+        // and assert against subsequent reads — every one of those will fail
+        // with `nil != Optional("barcode")` on a keychain-less host. Skip
+        // rather than report false negatives. Local hosts and runners with
+        // entitlement continue to exercise the full suite.
+        try KeychainAvailability.skipIfUnavailable()
         // Reset shared user account state to prevent test pollution from
         // previous tests (in this class or elsewhere) that set credentials.
         if let libraryID = AccountsManager.shared.currentAccountId {


### PR DESCRIPTION
## Summary

Hotfix for HelpSpot 17716 (Cornell SAML, Adam Chandler) — SAML/OIDC users hit by an expired session were stuck in a 401-poll loop with no path to recover short of uninstalling the app. This PR ships in two layers:

**Layer 1 — error-mapping fix (original scope, cs_482ec456):** `OPDSFeedService` now recognises `palaceproject.io/terms/problem/auth/recoverable/*` (e.g. SAML session-expired) and `/auth/unrecoverable/*` namespaces, mapping them to `.authentication(.tokenExpired)` and `.authentication(.invalidCredentials)` respectively. Without this, callers (loans refresh, `/patrons/me/`, `/annotations/`) saw a generic `.network(.serverError)` and could not signal recoverability.

**Layer 2 — user-facing recovery (cs_98564e04):** the network layer was already calling `markCredentialsStale()` on a SAML 401, but no UI ever surfaced the staleness signal. This was explicitly deferred in the original hotfix — Adam's 2026-05-01 follow-up showed the bug isn't actually closed without it. This PR adds:

- **`SAMLReauthCoordinator`** (`Palace/SignInLogic/TPPReauthenticator.swift`) — `@MainActor` singleton wrapping `TPPReauthenticator` with single-flight + foreground + state + strategy gates, all logged with `[SAML-REAUTH]` prefixes. Single-flight is required because `/patrons/me/` polls fire every 30s while stale; the publisher's `removeDuplicates()` only triggers on the `.loggedIn → .credentialsStale` transition, so once stale every subsequent 401 still flows through this code path.
- **`TPPNetworkResponder`** — after `markCredentialsStale()` for `reauthStrategy == .browser`, dispatches to the coordinator. Replaces the previous "credentials marked stale, will trigger re-auth flow" log line which was aspirational.
- **`BookDetailViewModel.ensureAuthAndExecute`** — previous gate was `account.needsAuth && !account.hasCredentials()`. Adam has credentials (just stale), so the gate fell through to `openBook` → reader hangs on a stale book. Now also handles `authState == .credentialsStale` and only proceeds to `action()` if the user actually re-authenticates.
- **`TPPSignInBusinessLogic.logIn()`** — backport from develop: early-return on nil `selectedAuthentication` BEFORE posting `TPPIsSigningIn`. Required to make the existing `testLogIn_withNoSelectedAuth_doesNotCrash` test pass on this branch.

Bumps version 3.0.0 (470) → 3.0.1 (471).

## Why now

Adam Chandler (Cornell) reported on 2026-05-01 that v3.0.0 still hangs after sign-out + sign-in + Safari website-data clear: 8 separate `/patrons/me/` 401 cycles in 13 minutes, no UI prompt, all books cached but reader hangs because the cached fulfillment URLs need fresh SAML cookies. The original error-mapping fix (Layer 1) is correct but insufficient.

## What's _not_ in this hotfix

- **Launch-time auto-prompt.** If the app cold-starts in `.credentialsStale` and the user does no action that hits `/patrons/me/`, no modal surfaces. The hotfix relies on a network-driven trigger; broader app-launch observation is develop-track work.
- **IdP session pre-fill.** We present the SAML web view; we don't pre-fill at the IdP. The user enters Cornell's NetID/2FA again. Acceptable for the hotfix; longer-term we can store and replay an IdP-issued refresh artefact.
- **DRM-side recovery.** If Adam's cached EPUB references an Adobe ACSM the server has invalidated, fresh SAML auth alone won't decrypt it — he'd need to return + re-borrow to get a fresh fulfillment. We've added the modal so he can recover the auth state; the DRM artifact path is unchanged.

## Sibling PR

Forward-port to develop: `fix/saml-recoverable-auth-opds` (#899) — Layer 1 only as currently scoped. Layer 2 (the auto-reauth coordinator + ensureAuthAndExecute gate) needs a sibling forward-port; the develop shape differs (DI'd `accountsManager`, AuthReducer wiring) so it's not a clean cherry-pick.

## CI fixes (out of scope but required to land)

When the keychain skips landed, CI proceeded past the previous blocker and surfaced 5 pre-existing failures on this branch — none related to the SAML changes:

- `TPPCredentialIsolationE2ETests` and `AccountDetailPINVisibilityTests` failed with `errSec -34018` on macos-26 GH runners (no keychain entitlement). Same class as the `TPPPerAccountIsolationTests` / `TPPCredentialSnapshotCoherenceTests` issue we already gate. Added `KeychainAvailability.skipIfUnavailable()` to setUpWithError in both.
- `TPPBookCreationTests.testBookCreationViaDictionary` asserted obsolete strict-validation. Production `TPPBook(dictionary:)` was relaxed: missing `updated` defaults to `.distantPast` (`TPPBook.swift:282`); missing `categories` defaults to `[]` (`TPPBook.swift:230`). Updated test to assert the new behaviour. Strict guards on missing `id` and `title` are unchanged and still asserted.
- `BookCellModelCacheTests.testModelUpdate_WithOlderBook_DoesNotUpdate` rewritten as `testModelUpdate_DifferentBookInstance_UpdatesRegardlessOfTimestamp` to match production's identity-over-timestamp cache contract (`BookCellModelCache.swift:135-147`).
- One `CatalogPreloaderTests` test hung the runner once on attempt 1 (likely a macos-26 flake — same test ran in 4ms on the prior CI run from this same branch). Resolved on rerun without code changes.

## ForgeOS

- `cs_482ec456` (Layer 1, OPDS problem-doc mapping). Original gates passed.
- `cs_98564e04` (Layer 2, SAMLReauthCoordinator + UI gates + CI fixes). Review + Testing + Release gates all promoted.

Both under initiative `init_67d79332`.

## Test plan

- [x] CI build-and-test green on run 25224585240.
- [x] 11 new SAMLReauthCoordinator unit tests cover the four gates (browser strategy, credentialsStale state, app foreground, !isPresenting), single-flight (concurrent calls → 1 invocation), reset-after-dismissal, and OIDC parity.
- [x] 4 OPDSFeedService problem-document tests (recoverable SAML, recoverable token, unrecoverable, unrecognised → falls through).
- [ ] Manual verification post-merge: a Cornell SAML user with an expired session opens the app, hits `/patrons/me/`, sees the SAML web view modal, signs in, and proceeds. Coordinate with Carissa on Adam Chandler's HelpSpot 17716 case.
- [ ] If Adam's reader still hangs after this ships, the `[SAML-REAUTH]` log lines will name the exact gate that fired (or didn't) — one-round-trip iteration loop on his next log paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)