### PR TITLE
OPDSFeedService: handle recoverable SAML auth problem docs

### DIFF
--- a/Palace/OPDS2/OPDSFeedService.swift
+++ b/Palace/OPDS2/OPDSFeedService.swift
@@ -218,12 +218,25 @@ actor OPDSFeedService: OPDSFeedFetching {
         return .parsing(.opdsFeedInvalid)
     }
 
-    private func parseProblemDocument(_ problemDoc: TPPProblemDocument) -> PalaceError {
+    func parseProblemDocument(_ problemDoc: TPPProblemDocument) -> PalaceError {
         guard let type = problemDoc.type else {
             // Unknown problem document - use title/detail if available
             let message = problemDoc.title ?? problemDoc.detail ?? "Unknown server error"
             Log.warn(#file, "Problem document with no type: \(message)")
             return .network(.serverError)
+        }
+
+        // The explicit switch below only covers the librarysimplified.org namespace.
+        // palaceproject.io serves auth state via /auth/recoverable/* and /auth/unrecoverable/*
+        // namespaces — recognise them so callers see the recoverability signal instead
+        // of a generic credentials/server error.
+        if problemDoc.isRecoverableAuthError {
+            Log.info(#file, "Recoverable auth problem document '\(type)' — credentials should be marked stale")
+            return .authentication(.tokenExpired)
+        }
+        if problemDoc.isUnrecoverableAuthError {
+            Log.info(#file, "Unrecoverable auth problem document '\(type)' — re-auth will not help")
+            return .authentication(.invalidCredentials)
         }
 
         switch type {

--- a/PalaceTests/OPDS2/OPDSFeedServiceTests.swift
+++ b/PalaceTests/OPDS2/OPDSFeedServiceTests.swift
@@ -42,6 +42,85 @@ final class OPDSFeedServiceTests: XCTestCase {
         XCTAssertEqual(awaitedCallsCompleted, 2,
                        "Both cancelAll awaits completed — actor did not crash, hang, or trap")
     }
+
+    // MARK: - Problem Document Mapping
+
+    /// SAML session expiry returns a recoverable-auth problem document under the
+    /// palaceproject.io namespace. Before this fix, OPDSFeedService only knew
+    /// the librarysimplified.org namespace and fell through to .network(.serverError)
+    /// or generic .invalidCredentials, hiding the recoverability signal from
+    /// callers (loans refresh, /patrons/me/, /annotations/).
+    func testParseProblemDocument_recoverableSAMLSessionExpired_returnsTokenExpired() async {
+        let dict: [String: Any] = [
+            "type": "http://palaceproject.io/terms/problem/auth/recoverable/saml/session-expired",
+            "title": "SAML session expired",
+            "status": 401
+        ]
+        let problemDoc = TPPProblemDocument.fromDictionary(dict)
+        let service = OPDSFeedService.shared
+
+        let result = await service.parseProblemDocument(problemDoc)
+
+        guard case .authentication(.tokenExpired) = result else {
+            XCTFail("Expected .authentication(.tokenExpired) for recoverable SAML, got \(result)")
+            return
+        }
+    }
+
+    func testParseProblemDocument_recoverableTokenExpired_returnsTokenExpired() async {
+        let dict: [String: Any] = [
+            "type": "http://palaceproject.io/terms/problem/auth/recoverable/token/expired",
+            "title": "Token expired",
+            "status": 401
+        ]
+        let problemDoc = TPPProblemDocument.fromDictionary(dict)
+        let service = OPDSFeedService.shared
+
+        let result = await service.parseProblemDocument(problemDoc)
+
+        guard case .authentication(.tokenExpired) = result else {
+            XCTFail("Expected .authentication(.tokenExpired) for recoverable token, got \(result)")
+            return
+        }
+    }
+
+    func testParseProblemDocument_unrecoverableNoActiveAccount_returnsInvalidCredentials() async {
+        let dict: [String: Any] = [
+            "type": "http://palaceproject.io/terms/problem/auth/unrecoverable/no-active-account",
+            "title": "No active account",
+            "status": 403
+        ]
+        let problemDoc = TPPProblemDocument.fromDictionary(dict)
+        let service = OPDSFeedService.shared
+
+        let result = await service.parseProblemDocument(problemDoc)
+
+        guard case .authentication(.invalidCredentials) = result else {
+            XCTFail("Expected .authentication(.invalidCredentials) for unrecoverable, got \(result)")
+            return
+        }
+    }
+
+    /// Mutation guard: a truly unrecognised type that is neither recoverable nor
+    /// unrecoverable auth must still fall through to the existing HTTP-status mapping.
+    /// This catches a regression where the new branches accidentally swallow non-auth
+    /// problem documents.
+    func testParseProblemDocument_unrecognisedTypeWith404_returnsNetworkNotFound() async {
+        let dict: [String: Any] = [
+            "type": "http://example.com/problem/something-weird",
+            "title": "Something weird",
+            "status": 404
+        ]
+        let problemDoc = TPPProblemDocument.fromDictionary(dict)
+        let service = OPDSFeedService.shared
+
+        let result = await service.parseProblemDocument(problemDoc)
+
+        guard case .network(.notFound) = result else {
+            XCTFail("Expected .network(.notFound) for unrecognised type with 404, got \(result)")
+            return
+        }
+    }
 }
 
 // MARK: - Palace Error Tests


### PR DESCRIPTION
## Summary

- Forward-port of the 3.0.1 hotfix to develop. Map `http://palaceproject.io/terms/problem/auth/recoverable/*` (e.g. SAML session expired, token expired) → `.authentication(.tokenExpired)` and `/auth/unrecoverable/*` → `.authentication(.invalidCredentials)`, instead of falling through to the "Unknown problem document type" warning + generic `.network(.serverError)` (or generic `.invalidCredentials` for 401). Uses the existing `TPPProblemDocument.isRecoverableAuthError` helper from PP-3716.
- 4 new mutation-resilient unit tests in `OPDSFeedServiceTests`.
- No version bump (develop owns its own versioning).

## Why now

Crashlytics scan (2026-04-30) on v3.0.0 (470) found two events from a Cornell SAML installation showing the SAML session-expired problem doc unhandled, leading to `/loans/` 401 + `Loans sync failed: PalaceError 5` and stuck stale state. Symptom matches HelpSpot 17716.

## What's _not_ in this change

Automatic re-auth UI on receipt of `.authentication(.tokenExpired)`. `TPPNetworkResponder` already calls `markCredentialsStale()` on SAML 401 (since PP-3716), but no UI layer currently observes the staleness signal to present the SAML web view. Callers see the corrected error type now; surfacing the re-auth prompt is a follow-up.

## Sibling PR

Hotfix to release/3.0.0: `hotfix/3.0.1-saml-recoverable-auth`.

## ForgeOS

Changeset \`cs_fb9bf549\` (initiative \`init_67d79332\`). Review + Testing + Release gates all passed.

## Test plan

- [ ] CI builds clean (local build was blocked by Adobe RMSDK header missing in standalone worktree — CI is the authoritative verifier here).
- [ ] CI runs `OPDSFeedServiceTests` — 4 new tests pass.
- [ ] Confirm the change is identical to the hotfix-branch sibling for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)