### PR TITLE
PP-4114: stop download buttons going stale on network loss

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1552,6 +1552,8 @@
 		TSETUP01BTST00000001 /* PalaceTestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = TSETUP01FREF00000001 /* PalaceTestSetup.swift */; };
 		UAAS00010001SIMPLYE001 /* UserAccountAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = UAAS00010000FILEREF01 /* UserAccountAuthState.swift */; };
 		UAAS00010002PALACE0001 /* UserAccountAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = UAAS00010000FILEREF01 /* UserAccountAuthState.swift */; };
+		PP4114MOCKREACH00000001 /* MockReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = PP4114MOCKREACHREF00001 /* MockReachability.swift */; };
+		PP4114OFFLINETESTS00001 /* BookCellModelOfflineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PP4114OFFLINETESTSREF1 /* BookCellModelOfflineTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2782,6 +2784,8 @@
 		SETVM003T260955EF008E1DC3 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		TSETUP01FREF00000001 /* PalaceTestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceTestSetup.swift; sourceTree = "<group>"; };
 		UAAS00010000FILEREF01 /* UserAccountAuthState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccountAuthState.swift; sourceTree = "<group>"; };
+		PP4114MOCKREACHREF00001 /* MockReachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockReachability.swift; sourceTree = "<group>"; };
+		PP4114OFFLINETESTSREF1 /* BookCellModelOfflineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCellModelOfflineTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3570,6 +3574,7 @@
 				6C493684B84FF9EDBEBCD104 /* MockCredentialsProvider.swift */,
 				79DE74A085DC8D24F0CC2348 /* MockBackgroundDownloadDelegate.swift */,
 				3432D61958317AD796B90005 /* MockFeatureFlagProvider.swift */,
+				PP4114MOCKREACHREF00001 /* MockReachability.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -4717,6 +4722,7 @@
 				4DCF14A6A237EADD5978E148 /* DownloadAnnouncementServiceTests.swift */,
 				EEE0C3EAFC52054E7144B795 /* DownloadStateManagerTests.swift */,
 				D96122327A49810CC4ACD7CB /* TokenRefreshInterceptorTests.swift */,
+				PP4114OFFLINETESTSREF1 /* BookCellModelOfflineTests.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -6304,6 +6310,8 @@
 				7D39F891C8E9A0B7DC2A2306 /* MockFeatureFlagProvider.swift in Sources */,
 				DD6A760B2C7336C887F0B1C7 /* MarksFixture.swift in Sources */,
 				C911BB897D0420A06D49D6CA /* AnonymousBorrowFixtureTests.swift in Sources */,
+				PP4114MOCKREACH00000001 /* MockReachability.swift in Sources */,
+				PP4114OFFLINETESTS00001 /* BookCellModelOfflineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
+++ b/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
@@ -12,6 +12,7 @@ import SwiftUI
 import SafariServices
 import PalaceAudiobookToolkit
 import PalaceLogging
+import PalaceNetwork
 
 enum BookCellState {
     case normal(BookButtonState)
@@ -69,6 +70,7 @@ class BookCellModel: ObservableObject {
     private let accountsManager: AccountsManager
     private let samplePreviewManager: SamplePreviewManager
     private let readerService: ReaderService
+    private let reachability: Reachability
     private var isFetchingImage = false
     #if LCP
     private var didPrefetchLCPStreaming = false
@@ -125,7 +127,8 @@ class BookCellModel: ObservableObject {
             downloadCenter: appContainer.downloadCenter,
             accountsManager: appContainer.accountsManager,
             samplePreviewManager: appContainer.samplePreviewManager,
-            readerService: appContainer.readerService
+            readerService: appContainer.readerService,
+            reachability: appContainer.reachability
         )
     }
 
@@ -138,7 +141,8 @@ class BookCellModel: ObservableObject {
         downloadCenter: MyBooksDownloadCenter,
         accountsManager: AccountsManager,
         samplePreviewManager: SamplePreviewManager,
-        readerService: ReaderService
+        readerService: ReaderService,
+        reachability: Reachability = AppContainer.production().reachability
     ) {
         self.book = book
         self.bookRegistry = bookRegistry
@@ -146,6 +150,7 @@ class BookCellModel: ObservableObject {
         self.accountsManager = accountsManager
         self.samplePreviewManager = samplePreviewManager
         self.readerService = readerService
+        self.reachability = reachability
         self.isLoading = bookRegistry.processing(forIdentifier: book.identifier)
         self.currentBookIdentifier = book.identifier
         self.imageCache = imageCache
@@ -169,6 +174,7 @@ class BookCellModel: ObservableObject {
         registerForNotifications()
         loadBookCoverImage()
         bindRegistryState()
+        bindReachability()
         setupStableButtonState()
         #if LCP
         prefetchLCPStreamingIfPossible()
@@ -349,6 +355,45 @@ class BookCellModel: ObservableObject {
             .assign(to: &$stableButtonState)
     }
 
+    /// PP-4114: react to mid-flight network drops. The pre-flight check on
+    /// Download/Reserve handles the cold-offline tap; this subscription
+    /// handles the case where reachability drops AFTER the user already
+    /// kicked off a borrow/download (so isLoading is true and the spinner
+    /// would otherwise sit there for ~60s waiting on URLSession's timeout).
+    /// `dropFirst()` skips the CurrentValueSubject's replay so we only act
+    /// on actual transitions.
+    private func bindReachability() {
+        reachability.connectivityPublisher
+            .dropFirst()
+            .filter { !$0 }
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self, self.isLoading else { return }
+                self.isLoading = false
+                self.presentOfflineAlert()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func presentOfflineAlert() {
+        // The retry routes back through `callDelegate(for: .download)` (not
+        // straight into `didSelectDownload`) so the pre-flight reachability
+        // check fires again. If the user taps Retry while still offline, the
+        // alert reappears — same UX as a fresh tap, no spinner-of-death.
+        let alert = AlertModel.retryable(
+            title: Strings.MyDownloadCenter.noConnectionTitle,
+            message: Strings.MyDownloadCenter.noConnectionMessage,
+            retryAction: { [weak self] in self?.callDelegate(for: .download) }
+        )
+        if showHalfSheet {
+            downloadErrorAlert = alert
+            showAlert = nil
+        } else {
+            showAlert = alert
+            downloadErrorAlert = nil
+        }
+    }
+
     // MARK: - State Consistency Validation
 
     /// Validates that the model's state is consistent with the registry.
@@ -401,6 +446,23 @@ class BookCellModel: ObservableObject {
 
 extension BookCellModel {
     func callDelegate(for action: BookButtonType) {
+        // PP-4114 pre-flight: Download/Retry/Get/Reserve all hit the network
+        // (borrow → fulfillment → download). If we're offline, surface the
+        // retryable no-connection alert instead of setting isLoading=true and
+        // waiting ~60s for URLSession to time out (the original "stale button"
+        // bug). Other actions (Read, Listen, Cancel, Return, Remove) are
+        // either local or have their own confirmation paths and don't need
+        // a connection to begin.
+        switch action {
+        case .download, .retry, .get, .reserve:
+            if !reachability.isConnectedToNetwork() {
+                presentOfflineAlert()
+                return
+            }
+        default:
+            break
+        }
+
         // Set loading state for actions that need it.
         // .return and .cancelHold are excluded here because they show a
         // confirmation alert first; loading starts only after the patron confirms.

--- a/Palace/Packages/PalaceNetwork/Sources/PalaceNetwork/Reachability.swift
+++ b/Palace/Packages/PalaceNetwork/Sources/PalaceNetwork/Reachability.swift
@@ -20,7 +20,7 @@ extension Notification.Name {
 }
 
 @objcMembers
-public class Reachability: NSObject {
+open class Reachability: NSObject {
     private let connectionMonitor = NWPathMonitor()
     private let monitorQueue = DispatchQueue(label: "NetworkMonitor")
     private let stateLock = NSLock()
@@ -29,7 +29,7 @@ public class Reachability: NSObject {
     private let connectivitySubject = CurrentValueSubject<Bool, Never>(false)
 
     /// Publisher for connectivity state. Use instead of observing `.TPPReachabilityChanged`.
-    public var connectivityPublisher: AnyPublisher<Bool, Never> {
+    open var connectivityPublisher: AnyPublisher<Bool, Never> {
         connectivitySubject
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
@@ -83,7 +83,7 @@ public class Reachability: NSObject {
 
     // MARK: - Reachability Check
 
-    public func isConnectedToNetwork() -> Bool {
+    open func isConnectedToNetwork() -> Bool {
         if connectionMonitor.currentPath.status == .satisfied {
             return true
         }

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -627,6 +627,8 @@ struct Strings {
         static let libraryLoadErrorLegacy = NSLocalizedString("We can\u{2019}t get your library right now. Please close and reopen the app to try again.", comment: "Alert message when library data fails to load, no retry available")
         static let wifiRequired = Strings.Settings.wifiRequired
         static let downloadRestrictedToWiFi = Strings.Settings.downloadRestrictedToWiFi
+        static let noConnectionTitle = NSLocalizedString("No Connection", comment: "Alert title shown when the user attempts to download or reserve a book while offline")
+        static let noConnectionMessage = NSLocalizedString("You don\u{2019}t appear to be connected to the internet. Reconnect and try again.", comment: "Alert message shown when the user attempts to download or reserve a book while offline")
     }
 
     struct BookDetailView {

--- a/PalaceTests/Mocks/MockReachability.swift
+++ b/PalaceTests/Mocks/MockReachability.swift
@@ -1,0 +1,42 @@
+//
+//  MockReachability.swift
+//  PalaceTests
+//
+//  Test double for `Reachability`. Lets tests drive `isConnectedToNetwork()`
+//  and `connectivityPublisher` without booting `NWPathMonitor` or hitting the
+//  host's actual connectivity. Used by PP-4114 regression tests so offline
+//  behavior is deterministic on CI.
+//
+
+import Combine
+import Foundation
+import PalaceNetwork
+
+final class MockReachability: Reachability {
+    private let subject: CurrentValueSubject<Bool, Never>
+    private var stubbedConnected: Bool
+
+    init(initiallyConnected: Bool = true) {
+        self.subject = CurrentValueSubject<Bool, Never>(initiallyConnected)
+        self.stubbedConnected = initiallyConnected
+        super.init()
+    }
+
+    override var connectivityPublisher: AnyPublisher<Bool, Never> {
+        subject
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
+    override func isConnectedToNetwork() -> Bool {
+        stubbedConnected
+    }
+
+    /// Drive a connectivity transition from tests. Mirrors what the real
+    /// `NWPathMonitor` callback does: updates the underlying state and then
+    /// publishes to subscribers.
+    func simulate(connected: Bool) {
+        stubbedConnected = connected
+        subject.send(connected)
+    }
+}

--- a/PalaceTests/MyBooks/BookCellModelOfflineTests.swift
+++ b/PalaceTests/MyBooks/BookCellModelOfflineTests.swift
@@ -1,0 +1,311 @@
+//
+//  BookCellModelOfflineTests.swift
+//  PalaceTests
+//
+//  Regression coverage for PP-4114 — "iOS: F-063: Download buttons become
+//  stale on network loss". Before the fix, tapping Download (or Reserve)
+//  while offline would set `isLoading = true`, fire a network request that
+//  hung against URLSession's default timeout, and leave the button stuck
+//  with a spinner for ~60s. Recovery only happened when the user backgrounded
+//  the app and a `.TPPReachabilityChanged` notification eventually fired.
+//
+//  These tests pin the post-fix behavior:
+//    1. Pre-flight reachability check on Download/Reserve — if offline, we
+//       surface a retryable "No connection" alert and DO NOT call into
+//       MyBooksDownloadCenter (no spinner-of-death).
+//    2. While a request is in flight, a connectivity transition to offline
+//       clears `isLoading` and surfaces the same alert (covers the
+//       race where reachability drops mid-borrow).
+//    3. The alert's primary action retries — and when reachability has
+//       returned, the retry actually fires the download.
+//
+//  Each test simulates an offline reachability state via `MockReachability`,
+//  which overrides `isConnectedToNetwork()` and `connectivityPublisher`. The
+//  alternative — driving real `NWPathMonitor` — would couple the suite to
+//  the host's network state and flake on CI.
+//
+
+import Combine
+import XCTest
+@testable import Palace
+
+@MainActor
+final class BookCellModelOfflineTests: XCTestCase {
+
+    private var mockRegistry: TPPBookRegistryMock!
+    private var mockImageCache: MockImageCache!
+    private var mockReachability: MockReachability!
+    private var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        mockRegistry = TPPBookRegistryMock()
+        mockImageCache = MockImageCache()
+        mockReachability = MockReachability(initiallyConnected: true)
+        cancellables = Set<AnyCancellable>()
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        mockReachability = nil
+        mockImageCache = nil
+        mockRegistry = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeBook(id: String = "pp-4114-book") -> TPPBook {
+        TPPBook(dictionary: [
+            "acquisitions": [TPPFake.genericAcquisition.dictionaryRepresentation()],
+            "title": "Network Loss Regression",
+            "categories": ["Fiction"],
+            "id": id,
+            "updated": "2024-01-01T00:00:00Z"
+        ])!
+    }
+
+    private func makeModel(book: TPPBook) -> BookCellModel {
+        BookCellModel(
+            book: book,
+            imageCache: mockImageCache,
+            bookRegistry: mockRegistry,
+            downloadCenter: AppContainer.production().downloadCenter,
+            accountsManager: AppContainer.production().accountsManager,
+            samplePreviewManager: AppContainer.production().samplePreviewManager,
+            readerService: AppContainer.production().readerService,
+            reachability: mockReachability
+        )
+    }
+
+    // MARK: - Pre-flight check on tap
+
+    /// PP-4114 root cause #1: tapping Download while offline previously set
+    /// isLoading=true and fired a doomed URLSession request. We now bail out
+    /// before either side effect.
+    func testDidSelectDownload_whenOffline_doesNotSetIsLoading() {
+        let book = makeBook(id: "offline-no-loading")
+        mockRegistry.addBook(book, state: .downloadNeeded)
+        mockReachability = MockReachability(initiallyConnected: false)
+        let model = makeModel(book: book)
+        drainMainQueue() // settle init-time async (image fetch)
+        XCTAssertFalse(model.isLoading, "precondition: model not loading at start")
+
+        model.callDelegate(for: .download)
+        drainMainQueue()
+
+        XCTAssertFalse(
+            model.isLoading,
+            "Tapping Download while offline must NOT leave isLoading=true. " +
+            "That state — combined with the disabled-on-isProcessing button — " +
+            "is the exact 'stale button' UX the bug describes."
+        )
+    }
+
+    /// The user-visible signal that the download is blocked. Before the fix
+    /// there was no signal — the spinner just sat there.
+    func testDidSelectDownload_whenOffline_surfacesRetryableNoConnectionAlert() {
+        let book = makeBook(id: "offline-shows-alert")
+        mockRegistry.addBook(book, state: .downloadNeeded)
+        mockReachability = MockReachability(initiallyConnected: false)
+        let model = makeModel(book: book)
+        drainMainQueue()
+
+        model.callDelegate(for: .download)
+        drainMainQueue()
+
+        guard let alert = model.showAlert else {
+            XCTFail("Offline tap must populate showAlert with a retryable model")
+            return
+        }
+        XCTAssertEqual(alert.title, Strings.MyDownloadCenter.noConnectionTitle)
+        XCTAssertEqual(alert.message, Strings.MyDownloadCenter.noConnectionMessage)
+        XCTAssertEqual(
+            alert.buttonTitle, Strings.MyDownloadCenter.retry,
+            "Alert must offer Retry, not just OK — manual retry is point #3 of the PP-4114 fix."
+        )
+        XCTAssertEqual(
+            alert.secondaryButtonTitle, Strings.Generic.cancel,
+            "Retryable alerts pair Retry with Cancel; the one-button form would be a regression."
+        )
+    }
+
+    /// Regression for the ticket's "Recovery happens implicitly on app
+    /// foreground" note: foregrounding only worked because reachability happened
+    /// to fire. We now act eagerly without depending on a foreground callback.
+    func testDidSelectDownload_whenOffline_doesNotInvokeDownloadCenter() {
+        let book = makeBook(id: "offline-no-network-call")
+        mockRegistry.addBook(book, state: .downloadNeeded)
+        mockReachability = MockReachability(initiallyConnected: false)
+        let model = makeModel(book: book)
+        drainMainQueue()
+
+        let initialDownloadingState = mockRegistry.state(for: book.identifier)
+        model.callDelegate(for: .download)
+        drainMainQueue()
+
+        // Pre-flight bail-out means the registry should never transition to
+        // `.downloading` — the download center is the only thing that flips
+        // state to .downloading via DownloadTaskLifecycleService.
+        XCTAssertEqual(
+            mockRegistry.state(for: book.identifier),
+            initialDownloadingState,
+            "Offline pre-flight must short-circuit BEFORE downloadCenter.startDownload " +
+            "is called. If it didn't, DownloadTaskLifecycleService would mark the book " +
+            "as .downloading and we'd be back to the stale-spinner bug while URLSession " +
+            "spent 60s timing out."
+        )
+    }
+
+    /// Online path — make sure the pre-flight check doesn't accidentally
+    /// strangle the happy path.
+    func testDidSelectDownload_whenOnline_proceedsWithoutAlert() {
+        let book = makeBook(id: "online-happy-path")
+        mockRegistry.addBook(book, state: .downloadNeeded)
+        mockReachability = MockReachability(initiallyConnected: true)
+        let model = makeModel(book: book)
+        drainMainQueue()
+
+        model.callDelegate(for: .download)
+        drainMainQueue()
+
+        XCTAssertNil(
+            model.showAlert,
+            "Online tap must not surface the offline alert. The pre-flight " +
+            "check must be predicated on `isConnectedToNetwork() == false`, " +
+            "not on the inverse."
+        )
+    }
+
+    // MARK: - Reactive reachability (mid-flight drop)
+
+    /// The race that the original ticket calls out: user taps download while
+    /// online, then loses network mid-borrow. URLSession will eventually fail
+    /// but until it does the spinner sits there. The reactive subscription
+    /// kicks in immediately on the offline transition.
+    func testReachabilityDropsToOffline_whileLoading_clearsLoadingAndShowsAlert() {
+        let book = makeBook(id: "midflight-drop")
+        mockRegistry.addBook(book, state: .downloadNeeded)
+        let model = makeModel(book: book)
+        drainMainQueue()
+
+        // Simulate an in-flight borrow: button-handler set isLoading=true
+        // before reachability dropped.
+        model.isLoading = true
+
+        mockReachability.simulate(connected: false)
+
+        awaitCondition(timeout: 2.0) { !model.isLoading }
+        XCTAssertFalse(
+            model.isLoading,
+            "A mid-flight reachability drop must clear isLoading so the button " +
+            "becomes responsive. Otherwise we re-introduce the original bug — the " +
+            "user just won't be able to do anything for ~60s while URLSession times out."
+        )
+        XCTAssertNotNil(
+            model.showAlert,
+            "Mid-flight drop must surface the same retryable no-connection alert " +
+            "users see on a cold offline tap. Consistent UX = consistent regression test."
+        )
+    }
+
+    /// Subscribers to a CurrentValueSubject get the current value immediately.
+    /// We must NOT show the alert just because the model spawned while
+    /// already offline and isLoading is false — that would alert-spam every
+    /// list cell during an offline launch.
+    func testReachabilityInitialState_offline_withoutLoading_doesNotShowAlert() {
+        let book = makeBook(id: "cold-offline-init")
+        mockRegistry.addBook(book, state: .downloadNeeded)
+        mockReachability = MockReachability(initiallyConnected: false)
+        let model = makeModel(book: book)
+        drainMainQueue()
+
+        XCTAssertNil(
+            model.showAlert,
+            "Cold-launching offline must not auto-populate the alert; the alert " +
+            "is a response to a user action (tap) or a transition (loss while " +
+            "loading), not a steady-state property."
+        )
+    }
+
+    /// When connectivity returns we must NOT auto-fire a download. The user
+    /// must explicitly retry. Auto-retry would be a different (and surprising)
+    /// behavior — and would re-create thundering-herd risk on the CM after a
+    /// flaky-WiFi blip.
+    func testReachabilityRecovers_doesNotAutoStartDownload() {
+        let book = makeBook(id: "recover-no-auto")
+        mockRegistry.addBook(book, state: .downloadNeeded)
+        mockReachability = MockReachability(initiallyConnected: false)
+        let model = makeModel(book: book)
+        drainMainQueue()
+
+        // Tap while offline → alert shown, no download.
+        model.callDelegate(for: .download)
+        drainMainQueue()
+        XCTAssertNotNil(model.showAlert, "precondition: offline tap shows alert")
+
+        // Connectivity returns.
+        mockReachability.simulate(connected: true)
+        drainMainQueue()
+
+        // No state change should have happened in the registry — the user
+        // hasn't tapped retry yet.
+        XCTAssertEqual(
+            mockRegistry.state(for: book.identifier),
+            .downloadNeeded,
+            "Reconnecting must not auto-start the download. Users tap Retry; the " +
+            "system does not."
+        )
+    }
+
+    // MARK: - Reserve path
+
+    /// Reserve hits the same network endpoints (`borrowAsync`) as Download
+    /// — same vulnerability, same fix.
+    func testDidSelectReserve_whenOffline_doesNotSetIsLoading() {
+        let book = makeBook(id: "reserve-offline")
+        mockRegistry.addBook(book, state: .holding)
+        mockReachability = MockReachability(initiallyConnected: false)
+        let model = makeModel(book: book)
+        drainMainQueue()
+
+        model.callDelegate(for: .reserve)
+        drainMainQueue()
+
+        XCTAssertFalse(
+            model.isLoading,
+            "didSelectReserve must use the same offline pre-flight as Download; " +
+            "otherwise PP-4114 returns under a different button label."
+        )
+        XCTAssertNotNil(
+            model.showAlert,
+            "Reserve while offline must surface the same retryable no-connection alert."
+        )
+    }
+
+    // MARK: - Other actions are unaffected
+
+    /// Read/Listen/Cancel/Return don't go to the network the same way and
+    /// must NOT be gated by the offline pre-flight. A reader-presentation
+    /// path that asked the user to reconnect would be absurd.
+    func testReadAction_whenOffline_isNotGatedByReachability() {
+        let book = makeBook(id: "offline-read")
+        mockRegistry.addBook(book, state: .downloadSuccessful)
+        mockReachability = MockReachability(initiallyConnected: false)
+        let model = makeModel(book: book)
+        drainMainQueue()
+
+        model.callDelegate(for: .read)
+        drainMainQueue()
+
+        // We don't assert that the reader actually opened (that requires
+        // a coordinator stack we don't have here). We only assert the
+        // pre-flight didn't abort the action with our offline alert.
+        XCTAssertNil(
+            model.showAlert,
+            "Reader-presentation actions are local: they must not be gated by " +
+            "reachability. Otherwise users couldn't read downloaded books on " +
+            "the subway."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- **Pre-flight reachability check** in `BookCellModel.callDelegate` for `.download/.retry/.get/.reserve` — surfaces a retryable "No Connection" alert and bails out before flipping `isLoading=true`, instead of stalling on URLSession's ~60s default timeout (the original "stale button" bug from F-063 / PP-4020 regression).
- **Reactive Combine subscription** to `Reachability.connectivityPublisher` (`dropFirst().filter { !$0 }`) clears `isLoading` and shows the same alert if connectivity drops mid-flight, instead of waiting on the timeout.
- **Retry routes back through `callDelegate`** so a still-offline tap re-shows the alert (no spinner-of-death loop). `Reachability` is now constructor-injected with default `AppContainer.production().reachability` and made `open class` so `MockReachability` can subclass for tests.

## Bug

[PP-4114](https://ebce-lyrasis.atlassian.net/browse/PP-4114) — F-063: tapping Download offline left the button disabled with a spinner; recovery only happened implicitly on app foreground when reachability re-evaluated. No explicit retry, no error indication.

## TDD

9 regression tests in `PalaceTests/MyBooks/BookCellModelOfflineTests.swift`. **TDD red verified per-layer**:
- Removing the pre-flight switch in `callDelegate` → 5 tests fail.
- Removing `bindReachability()` → mid-flight-drop test fails.

Tests use `MockReachability` (overridable subclass) + `TPPBookRegistryMock` — no real network, no flake.

## Test plan

- [x] `xcodebuild test -only-testing:PalaceTests/BookCellModelOfflineTests` — 9/9 pass on rebased branch (iPhone 16 Pro, 0.558s)
- [x] Adjacent suites unchanged: `BookCellModelStateTests`, `BookCellModelActionTests`, `ButtonStateTests`, `BookButtonMapperTests`, `BookCellModelCacheInvalidationTests`, `ReachabilityTests` — 74/74 pass
- [x] simdrive smoke: app launches, catalog renders books (proves `BookCellModel` constructs cleanly through the new init), tab nav works
- [ ] Manual QA: borrowed book in `downloadNeeded` state → toggle airplane mode → tap Download → expect retryable "No Connection" alert (not stuck spinner). Reconnect, tap Retry, download proceeds.
- [ ] Manual QA: start a download → drop wifi mid-borrow → expect alert + button responsive within ~1 cycle (not 60s)

## Scope

- `BookCellModel` + injected `Reachability` + new offline strings + test mock. No other view models touched.
- `BookCellModelCache` uses the production default for reachability so no production wiring change needed.

## Not done

- Book detail view (`BookDetailViewModel`) has its own download buttons that hit `MyBooksDownloadCenter.startDownload` directly — same bug likely lives there. Out of scope for PP-4114; will file a follow-up if QA confirms it reproduces from the detail view.

## Deferred

- Mutation kill-rate not improved on the touched surface. The mutator's `==`/`||`/`return` operators don't intersect the new code (`!` / Combine `dropFirst`/`filter` / method calls); TDD red phase serves the same regression-detection purpose.

## ForgeOS

- Initiative: `init_b9cc3c3e`
- Changeset: `cs_7b1200a1`
- Gates: review ✓, testing ✓, release ✓ (all promoted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PP-4114]: https://ebce-lyrasis.atlassian.net/browse/PP-4114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ