### PR TITLE
PP-4230: Fix PP-4230: surface narrator on audiobook book details

### DIFF
--- a/Palace/OPDS2/Models/OPDS2PublicationExtended.swift
+++ b/Palace/OPDS2/Models/OPDS2PublicationExtended.swift
@@ -295,6 +295,13 @@ extension OPDS2Publication {
             TPPBookAuthor(authorName: $0.name, relatedBooksURL: $0.links?.first?.hrefURL)
         }
 
+        // PP-4230: surface narrator into TPPBook.contributors so audiobook
+        // details show the "Narrator" row. Mirrors OPDS2FullPublication.toBook().
+        var contributors: [String: Any]?
+        if let narrators = metadata.narrator, !narrators.isEmpty {
+            contributors = ["nrt": narrators.map { $0.name }]
+        }
+
         return TPPBook(
             acquisitions: acquisitions,
             authors: authors,
@@ -318,7 +325,7 @@ extension OPDS2Publication {
             revokeURL: specialLinks.revoke,
             reportURL: specialLinks.report,
             timeTrackingURL: specialLinks.timeTracking,
-            contributors: nil,
+            contributors: contributors,
             bookDuration: nil,
             imageCache: ImageCache.shared
         )

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDS2Publication.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDS2Publication.swift
@@ -15,19 +15,21 @@ public struct OPDS2Publication: Codable, Equatable, Sendable {
         public let id: String
         public let title: String
         public let author: [OPDS2Contributor]?
+        public let narrator: [OPDS2Contributor]?
 
         private enum CodingKeys: String, CodingKey {
-            case updated, description, id, title, author
+            case updated, description, id, title, author, narrator
             case atId = "@id"
             case identifier
         }
 
-        public init(updated: Date? = nil, description: String? = nil, id: String, title: String, author: [OPDS2Contributor]? = nil) {
+        public init(updated: Date? = nil, description: String? = nil, id: String, title: String, author: [OPDS2Contributor]? = nil, narrator: [OPDS2Contributor]? = nil) {
             self.updated = updated
             self.description = description
             self.id = id
             self.title = title
             self.author = author
+            self.narrator = narrator
         }
 
         public init(from decoder: Decoder) throws {
@@ -46,6 +48,18 @@ public struct OPDS2Publication: Codable, Equatable, Sendable {
                 author = [single]
             } else {
                 author = nil
+            }
+
+            // Narrator follows the same array-or-single shape — PP-4230
+            // regression was that we never decoded this field at all on the
+            // lightweight publication, so audiobook details lost the narrator
+            // row whenever a feed served the lean publication shape.
+            if let list = try? container.decodeIfPresent([OPDS2Contributor].self, forKey: .narrator) {
+                narrator = list
+            } else if let single = try? container.decodeIfPresent(OPDS2Contributor.self, forKey: .narrator) {
+                narrator = [single]
+            } else {
+                narrator = nil
             }
 
             // id can come as "id", "@id", or "identifier"
@@ -67,6 +81,7 @@ public struct OPDS2Publication: Codable, Equatable, Sendable {
             try container.encodeIfPresent(updated, forKey: .updated)
             try container.encodeIfPresent(description, forKey: .description)
             try container.encodeIfPresent(author, forKey: .author)
+            try container.encodeIfPresent(narrator, forKey: .narrator)
         }
     }
 

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSEntry.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSEntry.swift
@@ -100,7 +100,14 @@ import PalaceLogging
     var contribs = [String: [String]]()
 
     for contributorNode in entryXML.childrenWithName("contributor") {
-      let role = (contributorNode.attributes as? [String: String])?["opf:role"] ?? ""
+      // PP-4230: Foundation's XMLParser with shouldProcessNamespaces=true
+      // strips the `opf:` prefix from attribute names when the feed declares
+      // `xmlns:opf` (real-world feeds do — A1QA, Bibliotheca, BiblioBoard,
+      // ODL providers). The unprefixed `"role"` is the canonical key in that
+      // case; legacy feeds without the namespace declaration keep the literal
+      // `"opf:role"`. Read either, prefer the unprefixed form.
+      let attrs = (contributorNode.attributes as? [String: String]) ?? [:]
+      let role = attrs["role"] ?? attrs["opf:role"] ?? ""
       if let name = contributorNode.firstChild(withName: "name")?.value.stringByDecodingHTMLEntities {
         contribs[role, default: []].append(name)
       }

--- a/PalaceTests/OPDS/OPDSParsingTests.swift
+++ b/PalaceTests/OPDS/OPDSParsingTests.swift
@@ -411,6 +411,78 @@ final class OPDSParsingTests: XCTestCase {
         XCTAssertEqual(entry.contributors?["editor"]?.first, "Chief Editor")
     }
 
+    /// PP-4230: real OPDS 1.x feeds (e.g. A1QA Test Library, Bibliotheca,
+    /// BiblioBoard) declare `xmlns:opf="http://www.idpf.org/2007/opf"` at
+    /// the feed root. Foundation's XMLParser with `shouldProcessNamespaces`
+    /// then STRIPS the `opf:` prefix from attribute names — so what the
+    /// element-attribute dict actually contains is the unprefixed `"role"`,
+    /// not `"opf:role"`. Before this fix, the parser only looked up
+    /// `"opf:role"` and dropped narrator/editor data into an empty-string
+    /// key, which TPPBook.narrators (reads `contributors["nrt"]`) never
+    /// surfaced. Result: audiobook details for Dune, A Game of Thrones,
+    /// Dungeon Crawler Carl, etc. all hid the narrator row even though
+    /// the feed served it.
+    func testEntryWithNamespacedContributorRoles_ParsesNarrator() {
+        let xml = """
+        <entry xmlns="http://www.w3.org/2005/Atom"
+               xmlns:opf="http://www.idpf.org/2007/opf">
+            <id>urn:uuid:dune-test</id>
+            <title>Dune</title>
+            <updated>2024-01-19T12:00:00Z</updated>
+            <author><name>Frank Herbert</name></author>
+            <contributor opf:role="nrt">
+                <name>Scott Brick</name>
+            </contributor>
+            <contributor opf:role="nrt">
+                <name>Orlagh Cassidy</name>
+            </contributor>
+            <link href="https://example.org/acquire" rel="http://opds-spec.org/acquisition/borrow" type="application/audiobook+json"/>
+        </entry>
+        """
+        guard let data = xml.data(using: .utf8),
+              let xmlDoc = TPPXML(data: data),
+              let entry = TPPOPDSEntry(xml: xmlDoc) else {
+            XCTFail("Failed to create entry")
+            return
+        }
+
+        XCTAssertNotNil(entry.contributors, "Namespaced contributors should still parse")
+        XCTAssertEqual(entry.contributors?["nrt"]?.count, 2,
+                       "PP-4230: both narrators must be stored under \"nrt\" — the key TPPBook.narrators reads")
+        XCTAssertTrue(entry.contributors?["nrt"]?.contains("Scott Brick") == true)
+        XCTAssertTrue(entry.contributors?["nrt"]?.contains("Orlagh Cassidy") == true)
+        XCTAssertNil(entry.contributors?[""],
+                     "PP-4230: contributors must not collect under an empty-string key when xmlns:opf is declared")
+    }
+
+    /// Negative: parsing must still work when the feed does NOT declare
+    /// `xmlns:opf` (older feed shapes). The attribute key is then the literal
+    /// `opf:role`. Catches a fix that over-corrects and only handles the
+    /// stripped form.
+    func testEntryWithUnnamespacedContributorRole_StillParses() {
+        let xml = """
+        <entry xmlns="http://www.w3.org/2005/Atom">
+            <id>urn:uuid:legacy-test</id>
+            <title>Legacy Feed</title>
+            <updated>2024-01-19T12:00:00Z</updated>
+            <author><name>Author</name></author>
+            <contributor opf:role="nrt">
+                <name>Legacy Narrator</name>
+            </contributor>
+            <link href="https://example.org/acquire" rel="http://opds-spec.org/acquisition/borrow" type="application/audiobook+json"/>
+        </entry>
+        """
+        guard let data = xml.data(using: .utf8),
+              let xmlDoc = TPPXML(data: data),
+              let entry = TPPOPDSEntry(xml: xmlDoc) else {
+            XCTFail("Failed to create entry")
+            return
+        }
+
+        XCTAssertEqual(entry.contributors?["nrt"]?.count, 1,
+                       "Feed without xmlns:opf must still surface the narrator under \"nrt\"")
+    }
+
     func testEntryWithCategories() {
         guard let data = entryWithCategoriesXML.data(using: .utf8),
               let xml = TPPXML(data: data),

--- a/PalaceTests/OPDS2/OPDS2LinkAndPublicationTests.swift
+++ b/PalaceTests/OPDS2/OPDS2LinkAndPublicationTests.swift
@@ -342,6 +342,104 @@ final class OPDS2PublicationImageTests: XCTestCase {
     }
 }
 
+// MARK: - PP-4230: Narrator survives lightweight OPDS2Publication.toBook()
+//
+// The full-metadata path (OPDS2FullPublication) already maps narrator into
+// the TPPBook contributors dict; the lightweight OPDS2Publication path was
+// silently dropping it, so audiobooks served via the lightweight feed have
+// no narrator row in the book details view (PP-4230).
+
+final class OPDS2PublicationNarratorTests: XCTestCase {
+
+    /// Behavioral: an OPDS2 publication JSON that includes `narrator` must
+    /// surface that name through TPPBook's `narrators` computed property.
+    /// Before PP-4230, OPDS2Publication.toBook() hardcoded `contributors: nil`,
+    /// so this assertion failed even when the feed contained the data.
+    func testToBook_WithNarratorInJSON_ExposesNarratorOnBook() throws {
+        let json = """
+        {
+          "metadata": {
+            "@id": "urn:test:animal-farm",
+            "title": "Animal Farm",
+            "author": [{"name": "George Orwell"}],
+            "narrator": [{"name": "Ralph Cosham"}]
+          },
+          "links": [
+            {
+              "href": "https://example.com/borrow/animal-farm",
+              "rel": "http://opds-spec.org/acquisition/borrow",
+              "type": "application/audiobook+json"
+            }
+          ]
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let publication = try OPDS2Feed.makeDecoder().decode(OPDS2Publication.self, from: data)
+        let book = publication.toBook()
+
+        XCTAssertNotNil(book, "Audiobook publication with valid borrow link must convert to TPPBook")
+        XCTAssertEqual(book?.narrators, "Ralph Cosham",
+                       "PP-4230: narrator from OPDS2 feed must reach TPPBook.narrators")
+    }
+
+    /// Structural: multiple narrators must concatenate the way the book detail
+    /// view renders them (semicolon-joined, matching TPPBook.narrators).
+    func testToBook_WithMultipleNarrators_JoinsWithSemicolons() throws {
+        let json = """
+        {
+          "metadata": {
+            "@id": "urn:test:multi",
+            "title": "Multi-Narrator Book",
+            "narrator": [{"name": "Alice"}, {"name": "Bob"}]
+          },
+          "links": [
+            {
+              "href": "https://example.com/borrow/multi",
+              "rel": "http://opds-spec.org/acquisition/borrow",
+              "type": "application/audiobook+json"
+            }
+          ]
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let publication = try OPDS2Feed.makeDecoder().decode(OPDS2Publication.self, from: data)
+        let book = publication.toBook()
+
+        XCTAssertEqual(book?.narrators, "Alice; Bob",
+                       "Multiple narrators must join with '; ' the way TPPBook.narrators expects")
+    }
+
+    /// Negative: a publication with no narrator must NOT invent one. Catches
+    /// mutations that hardcode a fallback narrator string.
+    func testToBook_WithoutNarrator_BookHasNilNarrators() throws {
+        let json = """
+        {
+          "metadata": {
+            "@id": "urn:test:no-narrator",
+            "title": "Ebook"
+          },
+          "links": [
+            {
+              "href": "https://example.com/borrow/no-narrator",
+              "rel": "http://opds-spec.org/acquisition/borrow",
+              "type": "application/audiobook+json"
+            }
+          ]
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let publication = try OPDS2Feed.makeDecoder().decode(OPDS2Publication.self, from: data)
+        let book = publication.toBook()
+
+        XCTAssertNotNil(book)
+        XCTAssertNil(book?.narrators,
+                     "A publication with no narrator field must not synthesise one")
+    }
+}
+
 // MARK: - OPDS2FullPublication Tests
 
 /// SRS: CAT-002 — OPDS 2.0 feed parsing with authentication documents


### PR DESCRIPTION
# PP-4230 — bugfix ledger

**Branch:** `fix/PP-4230-pp-4230`
**Base:**   `develop`
**Worktree:** `/Users/mauricework/PalaceProject/ios-core/.claude/worktrees/pp-4230`
**Started:** 2026-05-01T16:14:03Z

## Reproduce

<!-- repro started: 2026-05-01T16:16:56Z | installed: 3.0.0 (468) -->
<!-- harness bugfix reproduce — paste baseline screenshot path + steps to reproduce -->

## Root cause

- **Where:** `Palace/OPDS2/Models/OPDS2PublicationExtended.swift:321` — `OPDS2Publication.toBook()` hardcoded `contributors: nil`.
- **Why nil:** `Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDS2Publication.swift` — the lightweight `OPDS2Publication.Metadata` struct never declared a `narrator` field, so even if the OPDS feed served it, the decoder dropped it before `toBook()` ran.

**Archaeology:** OPDS2 catalog support landed in commit `3f221b3c0` (PP-484, 2026-03-30, _Full OPDS 2 feed support — catalog browsing, search, and borrow flows_). That commit added narrator parsing to the Full publication variant but did not implement it for the lightweight variant. Strictly speaking the gap was always there, not a regression — but it surfaced when audiobook feeds started getting served as the lightweight shape.
- **Sister path that works:** `OPDS2FullPublication.toBook()` at line 403–407 of the same file correctly maps `metadata.narrator` to `contributors["nrt"]`. Audiobook feeds served as the lightweight publication shape silently lost the narrator on the way to TPPBook.


## Fix

- `PalaceCatalog/OPDS2Publication.swift` — added `public let narrator: [OPDS2Contributor]?` to `Metadata`, decoded it (array-or-single shape, matching the existing author handling), encoded it on the way out, plumbed through the memberwise init.
- `OPDS2/Models/OPDS2PublicationExtended.swift` — `OPDS2Publication.toBook()` now maps `metadata.narrator` to `contributors["nrt"]` exactly like the Full path does.


## Verify

<!-- verify built: 2026-05-01T16:28:34Z | app: /tmp/dd-PP-4230/Build/Products/Debug-iphonesimulator/Palace.app -->

**Unit-test evidence (airtight):**
- `OPDS2PublicationNarratorTests` — 3 tests, all green:
  - `testToBook_WithNarratorInJSON_ExposesNarratorOnBook` — JSON with single narrator → `book.narrators == "Ralph Cosham"`
  - `testToBook_WithMultipleNarrators_JoinsWithSemicolons` — multi-narrator → `"Alice; Bob"` (matches the join the BookDetailView's infoRow expects)
  - `testToBook_WithoutNarrator_BookHasNilNarrators` — negative test; catches mutations that synthesise a fallback

**Symbol verification:**
- `nm | swift-demangle` against `PackageFrameworks/PalaceCatalog_*.framework/PalaceCatalog_*` confirms `OPDS2Publication.Metadata.narrator.getter` and the new memberwise-init signature are in the compiled framework.

**End-to-end note:** simdrive against A1QA Test Library's Animal Farm did not surface the narrator row even after a clean reinstall. Two possible causes:
1. The QA circulation manager's lightweight publication shape for that title may not include a `narrator` JSON key (cover-art "READ BY RALPH COSHAM" is rendered into the image, not necessarily exposed as structured metadata).
2. Per-book detail fetch path may use a different decoder that we haven't touched.
The unit tests above prove the code path is correct given the data; if QA still sees missing narrators on specific titles, that is a feed/publisher data issue, not a code defect. Filed for follow-up if QA confirms specific affected titles still drop narrator after this lands.

<!-- harness bugfix verify — symbol check output + e2e simdrive screenshot path -->

## Tests

- `PalaceTests/OPDS2/OPDS2LinkAndPublicationTests.swift` — new `OPDS2PublicationNarratorTests` class, 3 tests, all green.
- Adjacent classes (`OPDS2PublicationImageTests`, `OPDS2FullPublicationTests`) re-run; 22/22 pass — no regression.


## Retro

<!-- harness bugfix retro fills this in after PR is opened -->

---
_PR opened via `harness bugfix pr`. Ledger source: `.claude/bugfixes/PP-4230.md`._

---

## End-to-end verification — both code paths fixed (added 2026-05-01)

First commit on this branch fixed OPDS 2 lightweight publication path. End-to-end driving against the rebuilt app on A1QA Test Library uncovered that **the bug also reproduces on the OPDS 1.x XML path** — what real circulation managers serve. Second commit fixes that path.

### Root cause #2 (OPDS 1.x)

A1QA, Bibliotheca, BiblioBoard, and ODL providers declare `xmlns:opf="http://www.idpf.org/2007/opf"` at the feed root. `XMLParser` with `shouldProcessNamespaces = true` strips the `opf:` prefix from attribute names — so `<contributor opf:role="nrt">` becomes a contributor with attributes `["role": "nrt"]`, NOT `["opf:role": "nrt"]`. The previous parser only checked `attributes["opf:role"]`, fell back to empty string, and stored every narrator under the empty-string key. `TPPBook.narrators` reads `contributors["nrt"]`, so the row stayed empty for every audiobook served by a real CM.

Fix: read both unprefixed `"role"` and legacy `"opf:role"` keys, prefer unprefixed (canonical shape from Foundation's namespace-aware parser).

### End-to-end evidence

Driven via simdrive against the rebuilt app on iPhone 16 Pro (DF4A2A27), A1QA Test Library.

**Before (without OPDS 1.x fix):** INFORMATION section listed FORMAT, PUBLISHED, PUBLISHER, CATEGORIES, DISTRIBUTOR — no NARRATORS row, even though the feed includes `<contributor opf:role="nrt"><name>Simon Vance</name></contributor>`.

**After (both commits):** INFORMATION section now includes FORMAT, PUBLISHED, PUBLISHER, CATEGORIES, DISTRIBUTOR, **NARRATORS — Simon Vance**.

Screenshots attached as a comment on this PR (gh API does not support image upload via CLI).

### Tests added

| Test | What it asserts |
|---|---|
| `OPDS2PublicationNarratorTests.testToBook_WithNarratorInJSON_ExposesNarratorOnBook` | OPDS 2 single-narrator JSON → `book.narrators` non-nil |
| `OPDS2PublicationNarratorTests.testToBook_WithMultipleNarrators_JoinsWithSemicolons` | Multi-narrator → `"Alice; Bob"` join |
| `OPDS2PublicationNarratorTests.testToBook_WithoutNarrator_BookHasNilNarrators` | Negative — no synthesised narrator |
| `OPDSParsingTests.testEntryWithNamespacedContributorRoles_ParsesNarrator` | OPDS 1.x with `xmlns:opf` → narrator under `"nrt"` (regression) |
| `OPDSParsingTests.testEntryWithUnnamespacedContributorRole_StillParses` | OPDS 1.x without namespace → still parses (mutation guard) |

All 5 tests green. Existing OPDS contributor tests still pass.

### Known scope cut

Duration is also hardcoded `nil` at `OPDS2PublicationExtended.swift:322` (lightweight path) — same bug class as the narrator gap, deferred to a follow-up since PP-4230 explicitly scopes to narrator.
