### PR TITLE
Fix BookDetailViewModelTests flake: drain main queue, don't sleep

### DIFF
--- a/PalaceTests/ViewModels/BookDetailViewModelTests.swift
+++ b/PalaceTests/ViewModels/BookDetailViewModelTests.swift
@@ -1017,11 +1017,27 @@ final class BookDetailViewModelTests: XCTestCase {
         let (vm, registry, book) = makeVM(state: .downloadSuccessful)
         vm.bookState = .returning
 
-        // Override should prevent state changing back to .downloadSuccessful from registry event
-        let exp = expectation(description: "registry emission processed")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { exp.fulfill() }
+        // The override should prevent bookState reverting to .downloadSuccessful
+        // when the registry emits. The pre-fix version of this test "synced"
+        // with the registry pipeline by `DispatchQueue.main.asyncAfter(0.1)
+        // { exp.fulfill() }` — but that fulfills regardless of whether the
+        // production sink (which routes via .receive(on: RunLoop.main)) has
+        // actually run. Under CI scheduling pressure the run-loop hop can take
+        // longer than 100 ms, so on slow runners the assertion fired before
+        // the override path was even exercised. Worse, on really backed-up
+        // runners the asyncAfter itself didn't fire within the 1 s wait,
+        // tripping the timeout — that's the recurring flake on develop.
+        //
+        // Real fix: drain the main queue with a sentinel. DispatchQueue.main
+        // .async runs after currently-pending main events (incl. Combine's
+        // .receive(on: RunLoop.main) deliveries), so when this fulfills, the
+        // production sink has been called and bookState has settled. Same
+        // pattern is used at line 923-925 in this file.
         registry.setState(.downloadSuccessful, for: book.identifier)
-        wait(for: [exp], timeout: 1.0)
+        let drain = expectation(description: "main-queue events drained")
+        DispatchQueue.main.async { drain.fulfill() }
+        wait(for: [drain], timeout: 5.0)
+
         XCTAssertEqual(vm.bookState, .returning,
                        "While override=.returning, non-unregistered registry state should be ignored")
     }


### PR DESCRIPTION
## Summary

`testBookState_SetReturning_SetsLocalOverride_HidesViaRegistryOnlyWhenUnregistered` was flaking on develop's `build-and-test` job (most recently caught on PR #900's CI). Root cause was a fake-expectation pattern in the test, not a production bug.

## Root cause

```swift
let exp = expectation(description: "registry emission processed")
DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { exp.fulfill() }
registry.setState(.downloadSuccessful, for: book.identifier)
wait(for: [exp], timeout: 1.0)
```

The fulfillment is a 100ms timer — it has nothing to do with the registry pipeline it claims to be syncing with. The production code subscribes to `registry.bookStatePublisher` with `.receive(on: RunLoop.main)`, so under CI's RunLoop.main scheduling pressure two failure modes both reduce to "the sink hadn't run yet":

- **Spurious pass on fast runners** — assertion fires before the sink runs, sees `bookState == .returning` (the value we just set), reports green even if the override logic is broken.
- **Timeout flake on slow runners** — `asyncAfter(0.1)` itself takes >1s to fire because RunLoop.main is saturated. `wait(for:)` times out → test fails. This is the flake pattern hitting develop.

## Fix

Drain the main queue with a sentinel. `DispatchQueue.main.async` runs after pending main-queue events (including Combine's `.receive(on: RunLoop.main)` deliveries), so when this fulfills the production sink has been called and `bookState` has settled. Same pattern is already documented in this file at lines 923-925 ("Drain one main-queue cycle so that pending event is delivered and any resulting @Published changes are settled").

## Stability check

Ran the test 5× in a row with `-test-iterations 5 -run-tests-until-failure` on the same iPhone 16 Pro sim CI uses (`DF4A2A27-9888-429D-A749-2E157A049A37`):

```
Iteration 1 of 5 — passed (0.081 seconds)
Iteration 2 of 5 — passed (0.022 seconds)
Iteration 3 of 5 — passed (0.008 seconds)
Iteration 4 of 5 — passed (0.009 seconds)
Iteration 5 of 5 — passed (0.011 seconds)
Executed 5 tests, with 0 failures
** TEST SUCCEEDED **
```

Each iteration runs in well under the 1s timeout that was tripping, leaving no realistic CI margin for the flake to recur.

## Test plan

- [x] `BookDetailViewModelTests.testBookState_SetReturning_*` passes 5×
- [x] Same test class otherwise unmodified
- [ ] CI green on this branch
- [ ] Re-run any other PR's `build-and-test` that hit this flake (#900 already kicked back off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)