### PR TITLE
Forward-port 3.0.1 SAML hotfix stack to develop

### DIFF
--- a/Palace/Book/Models/TPPBookRegistry.swift
+++ b/Palace/Book/Models/TPPBookRegistry.swift
@@ -267,6 +267,58 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
     func load() { load(account: nil, completion: nil) }
 
     func sync(completion: ((_ errorDocument: [AnyHashable: Any]?, _ newBooks: Bool) -> Void)? = nil) {
+        // `BookRegistrySync.sync` bails when state is `.unloaded`/`.loading`
+        // to protect against the feed-only reconciliation path overwriting
+        // on-disk records — but post-sign-in (and any other caller hitting
+        // a not-yet-loaded registry) legitimately wants a sync.
+        //
+        // Two races land us here in production for SAML re-auth:
+        //   (a) state == .unloaded — sign-out cleared the in-memory store
+        //       and nothing has triggered a re-load yet.
+        //   (b) state == .loading — a load is already in flight; calling
+        //       `load()` again returns its completion immediately via the
+        //       duplicate-skip guard inside BookRegistrySync, so chaining
+        //       sync off `load()`'s completion misses the in-flight load
+        //       and runs sync against still-unloaded state.
+        //
+        // Both cases: subscribe to `TPPBookRegistryStateDidChange` and run
+        // sync once state reaches `.loaded`/`.synced`. Then kick off a
+        // load (no-op if one is already in flight). Either path drives
+        // the observer to the .loaded transition.
+        if state == .unloaded || state == .loading {
+            waitForLoadThenRunSync(completion: completion)
+            if state == .unloaded {
+                load()
+            }
+            return
+        }
+        runSync(completion: completion)
+    }
+
+    func sync() { sync(completion: nil) }
+
+    /// Subscribes to the registry state-change notification and runs sync
+    /// the first time state reaches `.loaded`/`.synced`. The observer
+    /// removes itself on first match so it's a one-shot.
+    private func waitForLoadThenRunSync(completion: ((_ errorDocument: [AnyHashable: Any]?, _ newBooks: Bool) -> Void)?) {
+        var token: NSObjectProtocol?
+        token = NotificationCenter.default.addObserver(
+            forName: .TPPBookRegistryStateDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else {
+                if let token { NotificationCenter.default.removeObserver(token) }
+                return
+            }
+            if self.state == .loaded || self.state == .synced {
+                if let token { NotificationCenter.default.removeObserver(token) }
+                self.runSync(completion: completion)
+            }
+        }
+    }
+
+    private func runSync(completion: ((_ errorDocument: [AnyHashable: Any]?, _ newBooks: Bool) -> Void)?) {
         let priorState = state
         syncEngine.sync(currentState: priorState, setState: { [weak self] newState in
             self?.state = newState
@@ -277,8 +329,6 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
             completion?(errorDocument, newBooks)
         })
     }
-
-    func sync() { sync(completion: nil) }
 
     func validateDownloadedContent() {
         syncEngine.validateDownloadedContent()

--- a/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
@@ -644,19 +644,49 @@ final class BookDetailViewModel: ObservableObject {
                 guard let self = self else { return }
 
                 let account = self.accountsManager.currentUserAccount
-                if account.needsAuth && !account.hasCredentials() {
+                let needsSignIn = account.needsAuth && !account.hasCredentials()
+                // .credentialsStale means we still hold credentials but a 401
+                // has marked the session expired. Reading the cached book
+                // proceeds straight to a hung reader (no fresh fulfillment,
+                // no fresh DRM grant) without an intervening sign-in. Force
+                // re-auth here so the user has a path to recover without
+                // reinstalling. HelpSpot 17716 (Cornell SAML).
+                let needsReauth = account.authState == .credentialsStale
+                if needsSignIn || needsReauth {
+                    Log.info(#file, "[SAML-REAUTH] ensureAuthAndExecute presenting modal: needsSignIn=\(needsSignIn) needsReauth=\(needsReauth)")
+                    let halfSheetWasShowing = self.showHalfSheet
                     self.showHalfSheet = false
                     SignInModalPresenter.presentSignInModalForCurrentAccount(accountsManager: self.accountsManager) { [weak self] in
                         guard let self else { return }
-                        // Only proceed if user successfully logged in, not if they cancelled
-                        guard self.accountsManager.currentUserAccount.hasCredentials() else {
-                            Log.info(#file, "Sign-in cancelled or failed, not proceeding with action")
-                            // Clear any processing state for download-related buttons
-                            self.processingButtons.remove(.download)
-                            self.processingButtons.remove(.get)
-                            self.processingButtons.remove(.retry)
-                            self.processingButtons.remove(.reserve)
+                        let post = self.accountsManager.currentUserAccount
+                        // Proceed only if the user actually re-authenticated
+                        // — they have credentials AND state is loggedIn.
+                        // Cancelling the modal leaves authState unchanged
+                        // (still .credentialsStale) and we should NOT call
+                        // the action; otherwise we'd hand the reader a stale
+                        // book and reproduce the original hang.
+                        guard post.hasCredentials() && post.authState == .loggedIn else {
+                            Log.info(#file, "[SAML-REAUTH] Sign-in cancelled or incomplete (hasCredentials=\(post.hasCredentials()) authState=\(post.authState)) — not proceeding with action")
+                            // Clear ALL processing state. A bailed-out modal can
+                            // leave .read/.listen/.reserve/etc. stuck in the set,
+                            // and `handleAction` ignores any tap whose button is
+                            // already processing — i.e. the next Read tap is
+                            // silently dropped until the view is recreated.
+                            self.processingButtons.removeAll()
+                            // Restore the half-sheet so the patron can retry. We
+                            // only re-show it if the caller had it open before
+                            // the modal stole the screen (e.g. download in
+                            // flight); pure book-detail actions like Read don't
+                            // use the half-sheet and shouldn't summon it now.
+                            if halfSheetWasShowing {
+                                self.showHalfSheet = true
+                            }
                             return
+                        }
+                        // Restore the half-sheet on the success path too — it
+                        // was only dismissed to make room for the SAML modal.
+                        if halfSheetWasShowing {
+                            self.showHalfSheet = true
                         }
                         action()
                     }

--- a/Palace/ErrorHandling/TPPPresentationUtils.swift
+++ b/Palace/ErrorHandling/TPPPresentationUtils.swift
@@ -61,6 +61,21 @@ class TPPPresentationUtils: NSObject {
             }
         }
 
+        // If a presentation/dismiss/push is already in flight on `base`,
+        // calling present() here is the failure mode behind the SAML re-auth
+        // lock-up: UIKit rejects the present with "transitioning already",
+        // leaves the form sheet half-mounted, and the app freezes. Wait for
+        // the in-flight transition to complete, then re-walk to the (possibly
+        // new) topmost VC and present there. HelpSpot 17716 follow-up.
+        if let coordinator = base.transitionCoordinator {
+            coordinator.animate(alongsideTransition: nil) { _ in
+                DispatchQueue.main.async {
+                    safelyPresent(vc, animated: animated, completion: completion)
+                }
+            }
+            return
+        }
+
         base.present(vc, animated: animated, completion: completion)
     }
 }

--- a/Palace/Holds/HoldsViewModel.swift
+++ b/Palace/Holds/HoldsViewModel.swift
@@ -132,6 +132,27 @@ final class HoldsViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        // Force a registry refresh on any transition into `.loggedIn`
+        // (fresh sign-in OR SAML re-auth from `.credentialsStale`). See the
+        // matching observer in MyBooksViewModel for the full reasoning.
+        // Short version: `hasCredentials`-based publishers miss SAML
+        // re-auth because `hasCredentials` stays true through stale →
+        // loggedIn; `authState` flips, so observe that. The hasCredentials
+        // check inside the sink is for test isolation —
+        // `UserAccountPublisher.shared` is singleton-backed and leaks
+        // authState across XCTest cases.
+        UserAccountPublisher.shared.authStateDidChangePublisher
+            .dropFirst()
+            .filter { $0 == .loggedIn }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self,
+                      self.accountsManager.currentUserAccount.hasCredentials()
+                else { return }
+                self.refresh()
+            }
+            .store(in: &cancellables)
+
         reloadData()
     }
 

--- a/Palace/MyBooks/MyBooks/MyBooksViewModel.swift
+++ b/Palace/MyBooks/MyBooks/MyBooksViewModel.swift
@@ -321,5 +321,39 @@ enum Group: Int {
                 self.sortData()
             }
             .store(in: &observers)
+
+        // Force a registry sync + reload on any transition into `.loggedIn`
+        // (fresh sign-in OR SAML re-auth from `.credentialsStale`). The
+        // post-sign-in `bookRegistry.sync()` wired into
+        // `TPPSignInBusinessLogic.updateUserAccount` is supposed to
+        // repopulate loans, but in practice the propagation through
+        // `TPPBookRegistryDidChange` doesn't always reach this view model
+        // in time — especially when the registry is in the `.unloaded`
+        // race window between sign-out and sign-in (handled at the
+        // TPPBookRegistry.sync wrapper level, but the safety net here
+        // covers the case where sync itself didn't fire).
+        //
+        // We can't use a `hasCredentials`-based publisher because
+        // `hasCredentials` is true for both `.credentialsStale` AND
+        // `.loggedIn` — SAML re-auth keeps the keychain populated through
+        // both states, no false→true transition fires.
+        //
+        // The hasCredentials guard inside the sink is for test isolation:
+        // `UserAccountPublisher.shared` is a singleton whose authState
+        // leaks across XCTest cases, so without the guard the observer
+        // fires in tests against a mock account that has no real
+        // credentials and clobbers test fixtures (18 MyBooks tests
+        // regressed locally without this guard during 3.0.1 hotfix work).
+        UserAccountPublisher.shared.authStateDidChangePublisher
+            .dropFirst()
+            .filter { $0 == .loggedIn }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self,
+                      self.accountsManager.currentUserAccount.hasCredentials()
+                else { return }
+                self.reloadData()
+            }
+            .store(in: &observers)
     }
 }

--- a/Palace/Network/TPPNetworkResponder.swift
+++ b/Palace/Network/TPPNetworkResponder.swift
@@ -290,6 +290,26 @@ extension TPPNetworkResponder: URLSessionDataDelegate {
                 // Success! Clear retry tracking for this URL
                 clearRetry(url: requestURL)
                 result = .success(info.progressData, task.response)
+
+                // Self-heal: a 2xx from an authenticated request means the
+                // server accepted our credentials. If our local state is
+                // `.credentialsStale` we should reconcile to `.loggedIn` —
+                // otherwise a transient /patrons/me/ 401 from a prior session
+                // can persist across launches and prompt the user to re-sign-in
+                // even though their bearer token is still valid (the SAML
+                // two-surface case: IdP cookie expires but bearer stays good).
+                // Only heal on requests that actually carried an Authorization
+                // header, so we don't false-heal off /authentication_document
+                // or other unauthenticated discovery calls.
+                let sentAuthHeader = (task.originalRequest?.value(forHTTPHeaderField: "Authorization") != nil)
+                    || (task.currentRequest?.value(forHTTPHeaderField: "Authorization") != nil)
+                if sentAuthHeader {
+                    let user = AppContainer.production().accountsManager.currentUserAccount
+                    if user.authState == .credentialsStale {
+                        Log.info(#file, "Authenticated request \(taskID) returned \(http.statusCode) — server accepted credentials, reconciling authState credentialsStale → loggedIn")
+                        user.setAuthState(.loggedIn)
+                    }
+                }
             }
         } else {
             let err = NSError(domain: "Api call with failure HTTP status",
@@ -404,13 +424,48 @@ private func handleExpiredTokenIfNeeded(for response: HTTPURLResponse,
             return false
         }
 
-        // Mark credentials as stale - preserves Adobe DRM activation
-        accountsManager.userAccount(for: accountId ?? "").markCredentialsStale()
-
         if authDef?.reauthStrategy == .browser {
-            Log.info(#file, "Server returned 401 for browser-based auth - credentials marked stale, will trigger re-auth flow")
+            // SAML/OIDC have TWO auth surfaces: the bearer token (used for
+            // /borrow, /fulfillment, /loans/) and the IdP session cookie
+            // (used only for /patrons/me/). The IdP cookie expires faster
+            // than the bearer in Gorgon and many institutional deployments,
+            // so /patrons/me/ keeps 401-ing as a background poll while the
+            // user can still borrow and read fine.
+            //
+            // The previous behavior was to mark credentials stale here on
+            // ANY browser-auth 401 (including /patrons/me/), which left
+            // authState=credentialsStale persisted across app launches. The
+            // moment the user touched a book detail view, ensureAuthAndExecute
+            // saw the stale state and prompted re-auth — even though the
+            // user's bearer token was still good and nothing was broken.
+            // HelpSpot 17716 follow-up, hotfix-branch device test 2026-05-01.
+            //
+            // Narrow the rule: only mark stale on browser-auth 401s from
+            // ACTION endpoints (borrow, fulfillment, loans). A 401 from the
+            // user-profile endpoint is non-actionable noise — let it pass.
+            // The borrow/download path's `handleBorrowAuthErrorIfNeeded`
+            // marks stale itself when an actual borrow fails, and that is
+            // the right time to surface the modal.
+            let isUserProfilePoll = originalURL.flatMap { url -> Bool in
+                let path = url.path
+                return path.contains("/patrons/me") || path.hasSuffix("/patrons/me/")
+            } ?? false
+
+            if isUserProfilePoll {
+                Log.info(#file, "Browser-auth 401 from /patrons/me/ poll — IdP cookie expired but bearer still likely valid; not marking credentials stale (user-action paths will mark stale only on a real borrow/fulfillment failure)")
+                return false
+            }
+
+            // Mark credentials as stale - preserves Adobe DRM activation
+            accountsManager.userAccount(for: accountId ?? "").markCredentialsStale()
+            Log.info(#file, "Server returned 401 for browser-based auth on action endpoint - credentials marked stale; user-action paths will surface re-auth on next interaction")
             return false
         }
+
+        // Non-browser auth (basic, token, oauth): a 401 here is unambiguous —
+        // the credential we sent is no longer accepted. Mark stale and fall
+        // through to the token-refresh path below.
+        accountsManager.userAccount(for: accountId ?? "").markCredentialsStale()
 
         let canRefreshToken = (authDef?.isToken == true || authDef?.isOauth == true) &&
             authDef?.tokenURL != nil &&

--- a/Palace/OPDS2/OPDSFeedService.swift
+++ b/Palace/OPDS2/OPDSFeedService.swift
@@ -218,12 +218,25 @@ actor OPDSFeedService: OPDSFeedFetching {
         return .parsing(.opdsFeedInvalid)
     }
 
-    private func parseProblemDocument(_ problemDoc: TPPProblemDocument) -> PalaceError {
+    func parseProblemDocument(_ problemDoc: TPPProblemDocument) -> PalaceError {
         guard let type = problemDoc.type else {
             // Unknown problem document - use title/detail if available
             let message = problemDoc.title ?? problemDoc.detail ?? "Unknown server error"
             Log.warn(#file, "Problem document with no type: \(message)")
             return .network(.serverError)
+        }
+
+        // The explicit switch below only covers the librarysimplified.org namespace.
+        // palaceproject.io serves auth state via /auth/recoverable/* and /auth/unrecoverable/*
+        // namespaces — recognise them so callers see the recoverability signal instead
+        // of a generic credentials/server error.
+        if problemDoc.isRecoverableAuthError {
+            Log.info(#file, "Recoverable auth problem document '\(type)' — credentials should be marked stale")
+            return .authentication(.tokenExpired)
+        }
+        if problemDoc.isUnrecoverableAuthError {
+            Log.info(#file, "Unrecoverable auth problem document '\(type)' — re-auth will not help")
+            return .authentication(.invalidCredentials)
         }
 
         switch type {
@@ -239,16 +252,32 @@ actor OPDSFeedService: OPDSFeedFetching {
             return .bookRegistry(.invalidState)
         case TPPProblemDocument.TypeCannotRender:
             return .parsing(.contentNotSupported)
+        case TPPProblemDocument.TypePatronLoanLimit,
+             TPPProblemDocument.TypePatronHoldLimit:
+            // Patron quota errors. NOT auth — re-signing in won't help. Surface as
+            // an invalid-state book registry error so the caller shows the server's
+            // title/detail rather than spuriously triggering a re-auth modal.
+            return .bookRegistry(.invalidState)
+        case TPPProblemDocument.TypeCredentialsSuspended:
+            return .authentication(.invalidCredentials)
         default:
             // Unknown problem document type - log it for future support
             let message = problemDoc.title ?? problemDoc.detail ?? "Unknown error"
             Log.warn(#file, "⚠️ Unknown problem document type '\(type)': \(message)")
 
-            // Determine appropriate error category based on HTTP status if available
+            // Determine appropriate error category based on HTTP status if available.
+            // CAUTION: do NOT auto-classify 401/403 as `.authentication` here — many
+            // non-auth problem docs (e.g. loan-limit-reached, hold-limit-reached)
+            // arrive with status 403 and used to be misclassified as auth failures,
+            // which flipped authState to `.credentialsStale` and triggered a
+            // spurious re-auth modal on every borrow attempt. The dedicated cases
+            // above (and `isRecoverableAuthError` / `isUnrecoverableAuthError` checks
+            // earlier in this method) already cover auth — anything reaching this
+            // default with 401/403 is an unrecognized server condition, not auth.
             if let status = problemDoc.status {
                 switch status {
                 case 401, 403:
-                    return .authentication(.invalidCredentials)
+                    return .network(.forbidden)
                 case 404:
                     return .network(.notFound)
                 case 429:


### PR DESCRIPTION
## Summary

Forward-ports the full 3.0.1 SAML hotfix stack from `release/3.0.0` and `fix/pp-4114b-audiobook-manifest-locale` (PR #903) onto `develop`. Consolidates the **final state** of all the auth/UI fixes — does not re-introduce the auto-present pattern that was reverted in commit 8d1dacafb on the hotfix branch.

PR #899 was the original develop sibling and was closed without merging, so this is the canonical forward-port entry point.

## What's included

- **OPDSFeedService.parseProblemDocument** — palaceproject.io recoverable/unrecoverable auth namespaces, explicit cases for patron loan-limit/hold-limit/credentials-suspended, and default 401/403 fallback maps to `.network(.forbidden)` instead of `.authentication` so unknown server conditions don't trigger spurious re-auth.
- **TPPNetworkResponder** — for SAML/OIDC, skip stale-marking on `/patrons/me/` 401s (the IdP cookie expires faster than the bearer; user can still borrow & read fine). Plus a self-heal: 2xx from an authenticated request reconciles `credentialsStale` → `loggedIn`.
- **BookDetailViewModel.ensureAuthAndExecute** — gate on `credentialsStale`, clear ALL processing buttons on cancel (so `.read`/`.listen` don't get silently stuck), restore half-sheet on both success and cancel paths.
- **SignInModalPresenter / SignInModalHostingController** — reset `isPresenting` from `viewDidDisappear` after UIKit dismissal completes, not from the SwiftUI dismiss closure (fixes the "transitioning already" lock-up on fast re-taps).
- **TPPPresentationUtils.safelyPresent** — wait for in-flight transition coordinator before calling `present()`.
- **ios-audiobooktoolkit** — bumped to `bc8ffbedf` for HelpSpot 17727 manifest date locale fix.

## Origin commits (on hotfix branches)

- `b97e0e199` + `06dd794a7` + `7c15c3002` (squashed as `3704647d8` from PR #898)
- `4d360a88b` — modal lock-up
- `d09617f5f` — isPresenting reset
- `74095e04e` — audiobook toolkit bump
- `8d1dacafb` — drop auto-present from /patrons/me/ 401
- `46da46fb7` — SAML two-surface 401s, unknown 4xx, half-sheet/processingButtons cleanup

## ForgeOS

`cs_1c223608` — review / testing / release all passed.

## Test plan

- [ ] On-device launch with stale state (Danny Test Library on Gorgon staging, SAML) — should NOT auto-prompt re-auth on first action
- [ ] Borrow when at loan limit — should display server's loan-limit message, not a re-auth modal
- [ ] Cancel SAML modal mid-Read — subsequent Read tap should still work (not silently dropped)
- [ ] Audiobook with non-`en` manifest locale — dates decode correctly
- [ ] Verify CI green (Mutation Gate, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)