### PR TITLE
PP-4156: Restore audiobook download indicator for all player types

### DIFF
--- a/.simdrive/journeys/_INDEX.md
+++ b/.simdrive/journeys/_INDEX.md
@@ -43,6 +43,7 @@ Today's run (5 journeys): all 5 pass. 3 stateless journeys gated on structural c
 | [settings-tour-stateless](settings-tour-stateless.yaml) | stateless | 4 | Settings sections render, no toggle drift, return to catalog |
 | [search-flow-stateful](search-flow-stateful.yaml) | stateful | 3 | UITextField focus on iOS 26 (the regression simdrive was built for); auto-capitalize; auto-submit |
 | [reader2-page-forward](reader2-page-forward.yaml) | stateful | 9 | Readium WKWebView reachability — OCR sees page content and chrome (back, TT). The use case with no XCTest equivalent. |
+| [audiobook-download-indicator-stateful](audiobook-download-indicator-stateful.yaml) | stateful | 3 | PP-4156 regression — download indicator visible (text + percentage) while an LCP audiobook is mid-download. Catches both visibility-rule and color-contrast bugs. |
 
 ## How replays work
 

--- a/.simdrive/journeys/audiobook-download-indicator-stateful.yaml
+++ b/.simdrive/journeys/audiobook-download-indicator-stateful.yaml
@@ -1,0 +1,96 @@
+scenario:
+  id: audiobook-download-indicator-stateful
+  name: "Audiobook player — download indicator visible while downloading"
+  description: >
+    Open a borrowed-but-not-yet-downloaded LCP audiobook from My Books on the
+    A1QA Test Library, tap Listen, and assert the download-indicator capsule is
+    visible (icon + percentage + "Downloading..." caption). Catches PP-4156-class
+    regressions: either (a) the rule that drives indicator visibility silently
+    excludes a player type (LCPStreamingPlayer was hidden in commit e5d5f13), or
+    (b) the indicator's foreground colors collapse to white-on-white against the
+    light-mode player background (introduced in commit 4f738d9, the "modern
+    download progress" UI refresh). Both bugs were silent — the indicator
+    rendered with zero visual height or zero visual contrast, so playback worked
+    fine and only the download feedback was missing.
+  tags: [tier1, ios, audiobook, lcp, pp-4156, download-indicator]
+  tier: stateful
+  blocking: false   # smoke-only — depends on network speed, A1QA library state
+
+  preconditions:
+    - "Palace app launched, signed into A1QA Test Library"
+    - "An LCP audiobook from the 'Unlimited Listens ODL Feed' has been borrowed but NOT yet fully downloaded"
+    - "Recommended: borrow a long audiobook (e.g., Anna Karenina, 40+ hr) to ensure the download window outlasts the journey"
+    - "If only a short audiobook is borrowed, return + re-borrow before running this journey to reset the download state"
+
+  state_reset:
+    - "If the audiobook's tracks are already cached, the indicator will hide at 100% and the journey will fail the structural check"
+    - "Reset: in My Books, tap the audiobook → Return → re-borrow from the catalog → run journey immediately"
+
+  recording:
+    path: "~/.simdrive/recordings/audiobook-download-indicator-stateful/recording.yaml"
+    captured_with: "simdrive 0.1.0a1"
+    captured_on: "2026-05-04"
+    note: |
+      Stable IDs below are placeholders — re-record on the target sim with
+      `record_start/record_stop` to populate `~/.simdrive/recordings/<id>/`.
+      The structural_checks below are the load-bearing assertions and are
+      independent of stable_id drift.
+
+  steps:
+    - { id: tap_my_books,    description: "Tap 'My Books' tab",                                  tap_target: { text: "My Books" } }
+    - { id: tap_listen,      description: "Tap 'Listen' on the borrowed LCP audiobook",          tap_target: { text: "Listen" } }
+    - { id: settle,          description: "Allow the player to load and download to register",   wait: { ms: 2000 } }
+
+  expected_invariants:
+    - "Player screen renders cover, title, author, playback slider"
+    - "Download indicator is visible: '↓' arrow, percentage label, 'Downloading...' caption"
+    - "Indicator percentage is non-zero (download has begun)"
+    - "Indicator percentage is less than 100% (download is still in progress at the moment of capture)"
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # cover varies; download progress changes per run
+
+  structural_checks:
+    - after_step: 3
+      required_text: ["Downloading"]
+      required_text_regex: ['\\d+%']
+      min_marks: 8
+      rationale: |
+        PP-4156 invariant: the audiobook player MUST render a "Downloading..."
+        caption + a percentage label whenever overall download progress is
+        below 100%. The text "Downloading" is the literal string from
+        Strings.ScrubberView.downloading. The percentage regex \\d+% catches
+        any value 0–99 (100% would imply the download finished mid-journey,
+        which falsifies the precondition rather than the invariant).
+
+        Two regression classes this catches:
+        1. Visibility-rule bug (e5d5f13): if a player-type branch hard-codes
+           isDownloading=false, the indicator's frame collapses to height 0
+           and neither "Downloading" nor a percentage will appear in OCR.
+        2. Color-contrast bug (4f738d9): if foreground colors are white-on-
+           light-background, OCR cannot extract the rendered text — both
+           assertions fail even though the view tree is correct.
+
+        Both failure modes manifest as the same observable outcome (no
+        visible feedback during a real download), and both are caught here.
+
+  rationale: |
+    PP-4156 was a layered regression: an LCP-specific binding bug on top of a
+    shared color-contrast bug. Either alone would have been less harmful; the
+    combination silently broke download feedback for every audiobook on every
+    light-mode device. Code review missed both bugs (each was a 1-line change
+    in a "polish" commit), unit tests didn't cover the rendering path, and the
+    issue surfaced only in production via a Helpspot-equivalent ticket.
+
+    This journey closes the gap by asserting on the *user-visible* outcome:
+    text on screen during a real download. It can't be unit-tested because the
+    bug only manifests when SwiftUI's view tree resolves against the live
+    color scheme — and it can't be replaced with a snapshot test alone because
+    the cover and percentage churn between runs. Structural OCR + a percentage
+    regex is the right granularity.
+
+  known_issues:
+    - "Stateful preconditions: this journey requires a freshly-borrowed LCP audiobook. If the only borrowed audiobook in My Books has already finished downloading, the structural check fails."
+    - "The journey does not assert *which* LCP title is open — A1QA's ODL feed contents may change."
+    - "If the simulator is offline or the LCP DRM service is unreachable, the indicator may stay at 0% with no progress events; the structural check still passes (0% counts as < 100%) but the test isn't exercising the regression path. Verify by manual inspection on first runs."

--- a/docs/architecture/pp4156-retro-2026-05-04.md
+++ b/docs/architecture/pp4156-retro-2026-05-04.md
@@ -1,0 +1,95 @@
+# PP-4156 Audiobook Download Indicator — Retrospective (2026-05-04)
+
+> Debug-and-fix retrospective for [PP-4156](https://ebce-lyrasis.atlassian.net/browse/PP-4156) ("iOS: Add download indicator for all audiobooks"). Captures the misattribution near-miss, the layered-bug structure, and the verification protocol that worked.
+
+## The bug, in one sentence
+
+Two independent regressions stacked on top of each other in the audiobook player: a binding rule that hard-coded `isDownloading = false` for `LCPStreamingPlayer` (commit `e5d5f13`, Jan 15), and a UI refresh that gave the indicator's icon, fill, and text `.white.opacity(...)` foreground colors against the player's white system background (commit `4f738d9`, Mar 19, the "modern download progress" polish). Each alone would have been less severe; together they made the download-progress UI silently invisible for every audiobook on every light-mode device.
+
+## What landed
+
+| File | Change | LOC |
+|---|---|---|
+| `ios-audiobooktoolkit/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift` | Restored `isDownloading = overallProgress < 1`, factored into `shouldShowDownloadIndicator(forOverallProgress:)` static helper | +14/−2 |
+| `ios-audiobooktoolkit/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift` | Replaced hard-coded `.white.opacity(...)` with semantic colors (`.secondary`, `.primary.opacity(0.15)`, `.accentColor`) | +5/−4 |
+| `ios-audiobooktoolkit/PalaceAudiobookToolkitTests/AudiobookPlaybackModelTests.swift` | New — 4 boundary tests covering 0.0, partial, 1.0, and >1.0 progress | +43 |
+| `.simdrive/journeys/audiobook-download-indicator-stateful.yaml` | New — stateful regression journey: borrow LCP audiobook → open player → assert "Downloading" + percentage visible | +90 |
+
+Total: ~150 LOC, two production files plus tests + regression infra.
+
+## What surprised us
+
+### 1. Two bugs masked each other in production
+
+A single ticket described the symptom; the implementation needed two independent fixes. With only the LCP-streaming fix applied, the indicator would still have been invisible because the white-on-white color bug was upstream of every audiobook type. With only the color fix applied, LCP titles still wouldn't show the indicator because `isDownloading` stayed false. Visual verification on Findaway titles (which never hit the LCP path) would have looked like Fix #2 alone was sufficient — and Fix #1 would have shipped untested.
+
+The two bugs both lived in routine "polish" commits, not feature work — easy to miss in code review.
+
+### 2. The first reproduction title was the wrong family
+
+Initial visual verification on Dune showed the indicator working, and we declared the fix verified. The user pushed back: *"make sure this is an LCP title."* It wasn't. Dune is Findaway (`application/vnd.librarysimplified.findaway.license+json` in the registry). The Dune screenshot only proved Fix #2 (color visibility for non-LCP titles). Fix #1 was unverified.
+
+The reattribution rescue: re-borrowing **Anna Karenina** from the Unlimited Listens ODL feed gave us a true LCP title (confirmed by the sha256-hashed `.mp3` filenames in `Audiobooks/Downloads/`, which is the exact pattern produced by `LCPDownloadTask.decryptedFileURL(for:)`). With that title, the A/B between unfixed and fixed builds was unambiguous: same audiobook, same conditions, same simulator — indicator absent without the fix, indicator visible with it.
+
+### 3. Fast test-library downloads kept hiding the in-progress state
+
+A1QA Test Library audiobooks download in 1–3 seconds. Borrow → tap Listen → observe lands on the player after the indicator has already correctly hidden itself at 100%. The first three reproduction attempts all showed an empty player, which looked like the fix was correct but actually only proved the *post-download* state. We needed a long-enough audiobook (Dune at 21+ hours, Anna Karenina at 40+ hours) to keep the download window open during observation.
+
+The state machine had three modes — *not-started*, *in-progress*, and *complete* — and the bug only manifests in the middle one. Every verification needed to land observation inside that window.
+
+## What worked
+
+### A/B against the same exact title on the same simulator
+
+The clean A/B was the gold standard:
+
+1. `git stash` the fix in the toolkit submodule.
+2. Rebuild the main app, install on the sim.
+3. Borrow Anna Karenina, tap Listen — confirm indicator absent.
+4. `git stash pop`.
+5. Rebuild, install.
+6. Re-open the same title — confirm indicator visible.
+
+Same library, same audiobook, same simulator UDID, same OCR pipeline, same network conditions. The only variable was the source code state. This rules out alternative explanations like "downloads happened to be done," "wrong title," "color theme change," or "Fix #2 was sufficient alone."
+
+### Filesystem-level type confirmation
+
+Reading the app's `Audiobooks/Downloads/` directory and matching the filename pattern (sha256 hex + `.mp3`) against `LCPDownloadTask.decryptedFileURL(for:)` source code was a more reliable proof of LCP-ness than any UI-level evidence or log message. The OPDS acquisition type alone (`application/audiobook+json`) was ambiguous between LCP and OpenAccess; the on-disk artifacts disambiguated.
+
+### The harness creds vault as a continuity primitive
+
+We added `palace-ios.lib.a1qa` to the harness keychain mid-session. Any future session driving a regression on A1QA can `harness creds get palace-ios.lib.a1qa` instead of asking the user. The cred entry survives sim reinstalls, so the next session that needs to re-borrow Anna Karenina to reset state has the path teed up.
+
+## What we'd do differently
+
+### 1. Verify media type before claiming visual attribution
+
+The single check that would have prevented the misattribution is asking, before declaring a fix verified, *what player class is this title using?* A two-line registry lookup or a simctl filesystem check is cheap. We were 30 minutes into "fix verified" before catching the issue, and only because the user explicitly asked. A standing rule: when fixing a bug scoped to a specific player/DRM, the verification reproduction MUST use a title from that exact class — and we say so explicitly in the report ("Anna Karenina, confirmed LCP via sha256-hashed cache filenames"), not implicitly.
+
+### 2. Treat color-contrast bugs as first-class regressions
+
+The white-on-white bug was the harder-to-suspect of the two. SwiftUI's `Color.white.opacity(...)` against a `Color(.systemBackground)` parent renders fine in dark mode and silently invisible in light mode. Snapshot tests in light + dark would have caught it; we don't currently have snapshot infrastructure for the audiobook player. The simdrive journey now closes the gap, but unit-level snapshot coverage on critical-path views is an outstanding TODO worth the investment.
+
+### 3. Don't stop at "the binary contains the new symbols"
+
+Mid-debug we confirmed the new build was installed by `strings` on the framework binary and matching the file mtime. Both checks were correct but both were also pre-conditions, not proof of the fix. Proof required a same-conditions A/B. "The right code is on disk" and "the right pixels appear on screen" are different claims.
+
+### 4. The LCP-streaming exclusion should never have shipped without a test
+
+Commit `e5d5f13` is a one-line change with no test, no commit-message rationale, no PR description, and no review trace. Three months later it caused a regression that needed an LCP-specific reproduction to verify the fix. The retrospective insight: *every one-line change to a binding that gates user-visible UI state needs to leave a tested invariant in its wake.* The `shouldShowDownloadIndicator(forOverallProgress:)` extraction in this PR is small, but it locks the rule's input set into the type system — anyone re-introducing player-type branching now has to either change the function signature (breaking the build) or bypass the helper entirely (visible in code review).
+
+## The verification protocol, codified
+
+For future regressions like this, the protocol that worked:
+
+1. **Read the buggy code.** Before any UI work, prove the bug from the source. If you can't trace the failure mode through the code path, the visual repro will mislead.
+2. **Identify the player/DRM class your title uses.** Either via OPDS acquisition type + indirect chain, or via filesystem artifacts after a borrow. Don't assume.
+3. **Pick a title with a long enough work window** (here: 40+ hour audiobook for a download-progress test) so the in-progress state outlasts your observation latency.
+4. **A/B against the same title on the same sim.** `git stash` → rebuild → install → observe → `git stash pop` → rebuild → install → observe. Anything else admits alternative explanations.
+5. **Document your attribution explicitly** in the PR body and the retro: which fix is responsible for which observable change.
+
+## Outstanding follow-ups
+
+- 2 unrelated pre-existing failing tests in the toolkit (`testPP3594_audiobookProgress_throttlesAnnouncements`, `testOriginHost_noSelfLink_returnsNil`) are out of scope here but flagged for a separate cleanup pass.
+- Consider adding light/dark snapshot tests for the audiobook player view to catch future color-contrast regressions before they reach production.
+- The `recording.yaml` for the new simdrive journey is a placeholder — the next session that re-borrows Anna Karenina on a clean A1QA login should `record_start/record_stop` the flow to populate stable IDs.


### PR DESCRIPTION
## Summary

Two stacked regressions in the audiobook player made the download-progress indicator silently invisible for every audiobook on every light-mode device. Tracks downloaded fine in the background but the user had no UI feedback that work was happening — exactly what [PP-4156](https://ebce-lyrasis.atlassian.net/browse/PP-4156) reports.

This PR bumps the toolkit submodule pointer to pick up the fix (toolkit-side PR: ThePalaceProject/ios-audiobooktoolkit#170) and adds the regression coverage that lives in this repo: a simdrive journey + a debug retrospective.

## Root cause

### Bug 1 — LCP-streaming exclusion (`AudiobookPlaybackModel.swift`)

Commit [`e5d5f13`](https://github.com/ThePalaceProject/ios-audiobooktoolkit/commit/e5d5f13) (Jan 15) added a one-line player-type branch that hard-coded `isDownloading = false` for every `LCPStreamingPlayer`. `AudiobookPlayerView` collapses the indicator's frame to height 0 when `isDownloading` is false, so for every LCP audiobook the indicator simply did not render — even while `LCPDownloadTask` was actively decrypting tracks. Findaway and OpenAccess paths were unaffected.

### Bug 2 — White-on-white indicator (`AudiobookPlayerView.swift`)

Commit [`4f738d9`](https://github.com/ThePalaceProject/ios-audiobooktoolkit/commit/4f738d9) (Mar 19, "Smooth cover loading, modern download progress, and adaptive typography") gave the indicator's icon, fill bar, percentage, and "Downloading…" caption `.white.opacity(...)` foreground colors. Against the player's system background (white in light mode), this rendered as white-on-white — invisible regardless of the `isDownloading` flag. **This bug affected ALL audiobook types**, which is why the ticket said "for all audiobooks."

## Fix (toolkit-side, PR #170)

- **`AudiobookPlaybackModel.swift`**: removed the LCP-streaming branch; routed visibility through a new `shouldShowDownloadIndicator(forOverallProgress:)` static helper. The function signature takes only progress — re-introducing player-type branching now requires changing the signature, which would fail the build.
- **`AudiobookPlayerView.swift`**: replaced `.white.opacity(...)` with semantic colors (`.secondary`, `.primary.opacity(0.15)`, `.accentColor`). Adapts to light/dark mode automatically.

## What this PR adds

| File | Purpose |
|---|---|
| `ios-audiobooktoolkit` (submodule pointer) | Bump to pick up #170's fix |
| `.simdrive/journeys/audiobook-download-indicator-stateful.yaml` | Stateful regression journey: borrow LCP audiobook → open player → assert "Downloading" text + percentage regex render mid-download. Catches both visibility-rule and color-contrast failures via the same structural OCR check. |
| `.simdrive/journeys/_INDEX.md` | New journey row |
| `docs/architecture/pp4156-retro-2026-05-04.md` | Debug-and-fix retrospective. Documents the misattribution near-miss (initial visual repro on Dune was Findaway, not LCP) and the A/B-against-same-title verification protocol that worked. |

## Verification

A/B test on iPhone 17 Pro sim with **Anna Karenina** (LCP audiobook from A1QA Test Library "Unlimited Listens ODL Feed", 40 hr 59 min remaining). LCP path confirmed by sha256-hashed `.mp3` cache filenames matching `LCPDownloadTask.decryptedFileURL(for:)` source pattern.

| State | Indicator | Same title? | Same simulator? |
|---|---|---|---|
| **Unfixed** (`git stash` of fix, full rebuild) | ❌ Absent (frame collapsed to 0) | ✓ Anna Karenina | ✓ |
| **Fixed** (stash popped, rebuilt) | ✅ Visible at 6%, "Downloading…" + percentage | ✓ Anna Karenina | ✓ |

Same audiobook, same simulator, same login session, same network conditions. The only variable was the source code state — rules out flakiness or environmental confounds.

Findaway sanity-check on Dune (also A1QA): indicator visible after fix, confirming Fix 2 applies uniformly.

## Test plan

- [x] Toolkit-side `AudiobookPlaybackModelTests` — 4/4 passing in 0.003s (boundary tests for 0.0 / partial / 1.0 / >1.0)
- [x] A/B verification on confirmed LCP title
- [x] Findaway sanity-check (no regression on non-LCP path)
- [x] Build clean for both `Palace` and `Palace-noDRM` schemes
- [ ] CI green
- [ ] Toolkit PR #170 merged before this PR lands (otherwise the submodule pointer here resolves to a branch HEAD, not a develop-tip commit)

## Notes for reviewers

- 2 unrelated pre-existing failing tests in the toolkit (`testPP3594_audiobookProgress_throttlesAnnouncements`, `testOriginHost_noSelfLink_returnsNil`) are out of scope here and flagged in the retrospective for separate cleanup.
- The `shouldShowDownloadIndicator(forOverallProgress:)` extraction is a single-line helper. The point isn't reuse — it's locking the rule's input set in the type system so anyone re-adding player-type branching has to either change the signature (visible in code review) or bypass the helper entirely (also visible in review).
- Per the retrospective, the recommended verification protocol for any fix scoped to a specific player/DRM class is now: (1) confirm media type before claiming attribution, (2) reproduce on a long-enough title that the in-progress state outlasts observation latency, (3) A/B against the same exact title on the same sim.

ForgeOS: `cs_6857deda` — review, testing, release gates all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PP-4156]: https://ebce-lyrasis.atlassian.net/browse/PP-4156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ