### PR TITLE
Add 'Reset This Library Account' button — patron-self-service stuck-state recovery (PP-4282 / HelpSpot 17716)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -450,6 +450,8 @@
 		730FC05125128224004D7C2D /* TPPSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5677122B7ECE3001F0C83 /* TPPSettings.swift */; };
 		7311FD2B25CBD086004447CB /* TPPSignInOutBusinessLogicUIDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7311FD2A25CBD086004447CB /* TPPSignInOutBusinessLogicUIDelegateMock.swift */; };
 		7314D1402551E73C00723E26 /* TPPSignInBusinessLogic+SignOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7314D13F2551E73C00723E26 /* TPPSignInBusinessLogic+SignOut.swift */; };
+		D7937D99995045ADA5F0828C /* TPPSignInBusinessLogic+ForceReset.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16A8F928810410482669BF6 /* TPPSignInBusinessLogic+ForceReset.swift */; };
+		4C0017B99F494FE3A7A69887 /* TPPSignInBusinessLogic+ForceReset.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16A8F928810410482669BF6 /* TPPSignInBusinessLogic+ForceReset.swift */; };
 		731A5B1224621F2B00B5E663 /* TPPSignInBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731A5B1124621F2B00B5E663 /* TPPSignInBusinessLogic.swift */; };
 		732327B22478504500A041E6 /* NSError+NYPLAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732327B12478504500A041E6 /* NSError+NYPLAdditions.swift */; };
 		7327A89323EE017300954748 /* TPPMainThreadChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7327A89223EE017300954748 /* TPPMainThreadChecker.swift */; };
@@ -469,6 +471,7 @@
 		735350B724918432006021BD /* URLRequest+NYPLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735350B624918432006021BD /* URLRequest+NYPLTests.swift */; };
 		7353940D25085DBB0043C800 /* TPPPresentationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E192502DE88008F6244 /* TPPPresentationUtils.swift */; };
 		735771A02537635600067CEA /* TPPSignInBusinessLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7357719F2537635600067CEA /* TPPSignInBusinessLogicTests.swift */; };
+		88EFF2030D2D45419813717D /* ForceResetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1557BA5E024E70AE55ACE2 /* ForceResetTests.swift */; };
 		735771A8253763E800067CEA /* TPPBookRegistryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735771A7253763E800067CEA /* TPPBookRegistryMock.swift */; };
 		735771AB2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735771AA2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift */; };
 		735771AE2537687D00067CEA /* TPPURLSettingsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735771AD2537687D00067CEA /* TPPURLSettingsProviderMock.swift */; };
@@ -2083,6 +2086,7 @@
 		731272AC259CF6F90032D7B4 /* xcode-export-appstore.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-export-appstore.sh"; sourceTree = "<group>"; };
 		731272B1259CFB180032D7B4 /* testflight-upload.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "testflight-upload.sh"; sourceTree = "<group>"; };
 		7314D13F2551E73C00723E26 /* TPPSignInBusinessLogic+SignOut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TPPSignInBusinessLogic+SignOut.swift"; sourceTree = "<group>"; };
+		F16A8F928810410482669BF6 /* TPPSignInBusinessLogic+ForceReset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TPPSignInBusinessLogic+ForceReset.swift"; sourceTree = "<group>"; };
 		731A5B1124621F2B00B5E663 /* TPPSignInBusinessLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPSignInBusinessLogic.swift; sourceTree = "<group>"; };
 		731B2B12244A1D6500A7A649 /* R2Streamer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Streamer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		731B2B18244A1D8600A7A649 /* R2Navigator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Navigator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2109,6 +2113,7 @@
 		735350B624918432006021BD /* URLRequest+NYPLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+NYPLTests.swift"; sourceTree = "<group>"; };
 		735394012508161A0043C800 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		7357719F2537635600067CEA /* TPPSignInBusinessLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPSignInBusinessLogicTests.swift; sourceTree = "<group>"; };
+		EF1557BA5E024E70AE55ACE2 /* ForceResetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForceResetTests.swift; sourceTree = "<group>"; };
 		735771A7253763E800067CEA /* TPPBookRegistryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookRegistryMock.swift; sourceTree = "<group>"; };
 		735771AA2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLLibraryAccountsProviderMock.swift; sourceTree = "<group>"; };
 		735771AD2537687D00067CEA /* TPPURLSettingsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPURLSettingsProviderMock.swift; sourceTree = "<group>"; };
@@ -3538,6 +3543,7 @@
 				E50546CD2E6F8A0007CCFA01 /* TPPSignInBusinessLogic+OIDC.swift */,
 				E50546D12E6F8C0007CCFA04 /* TPPSignInBusinessLogic+SAML.swift */,
 				7314D13F2551E73C00723E26 /* TPPSignInBusinessLogic+SignOut.swift */,
+				F16A8F928810410482669BF6 /* TPPSignInBusinessLogic+ForceReset.swift */,
 				73A794A525477D8F00C59CC1 /* TPPSignInBusinessLogic+UI.swift */,
 				739062D125358CF900D0743D /* TPPSignInBusinessLogicUIDelegate.swift */,
 				73B501C024F48D4B00FBAD7D /* TPPUserAccountFrontEndValidation.swift */,
@@ -4203,6 +4209,7 @@
 				F8091A2B3C4D5E6F70819213 /* TPPPreferredAuthSelectionTests.swift */,
 				091A2B3C4D5E6F708192A3B4 /* TPPCredentialSnapshotCoherenceTests.swift */,
 				AUTHREDTESTSFILEREF001ZZZZ /* AuthReducerTests.swift */,
+				EF1557BA5E024E70AE55ACE2 /* ForceResetTests.swift */,
 			);
 			path = SignInLogic;
 			sourceTree = "<group>";
@@ -5995,6 +6002,7 @@
 				7307A5ED23FF1A8500DE53DE /* TPPOpenSearchDescriptionTests.swift in Sources */,
 				735771A8253763E800067CEA /* TPPBookRegistryMock.swift in Sources */,
 				735771A02537635600067CEA /* TPPSignInBusinessLogicTests.swift in Sources */,
+				88EFF2030D2D45419813717D /* ForceResetTests.swift in Sources */,
 				17BE24DA25F85D2300AE707F /* TPPAgeCheckTests.swift in Sources */,
 				17BE24E025FABA0900AE707F /* TPPAgeCheckChoiceStorageMock.swift in Sources */,
 				7375AE5A25382AC900C85211 /* TPPUserAccountMock.swift in Sources */,
@@ -6720,6 +6728,7 @@
 				73EB0B0125821DF4006BC997 /* UIColor+Extensions.swift in Sources */,
 				73EB0B0225821DF4006BC997 /* TPPNetworkResponder.swift in Sources */,
 				73EB0B0525821DF4006BC997 /* TPPSignInBusinessLogic+SignOut.swift in Sources */,
+				4C0017B99F494FE3A7A69887 /* TPPSignInBusinessLogic+ForceReset.swift in Sources */,
 				E50546CF2E6F8A0007CCFA02 /* TPPSignInBusinessLogic+OIDC.swift in Sources */,
 				E50546D32E6F8C0007CCFA06 /* TPPSignInBusinessLogic+SAML.swift in Sources */,
 				213998FE268F9E3000B4EB60 /* TPPRegistryDebuggingCell.swift in Sources */,
@@ -7193,6 +7202,7 @@
 				E5AD65DD2684FACA00C62951 /* TPPAccountListCell.swift in Sources */,
 				7386C1F4245225A5004C78BD /* TPPReaderPositionsVC.swift in Sources */,
 				7314D1402551E73C00723E26 /* TPPSignInBusinessLogic+SignOut.swift in Sources */,
+				D7937D99995045ADA5F0828C /* TPPSignInBusinessLogic+ForceReset.swift in Sources */,
 				E50546CE2E6F8A0007CCFA01 /* TPPSignInBusinessLogic+OIDC.swift in Sources */,
 				E50546D22E6F8C0007CCFA05 /* TPPSignInBusinessLogic+SAML.swift in Sources */,
 				E5AA6F4129A6BA4000601B02 /* RefreshableView.swift in Sources */,

--- a/Palace/AppInfrastructure/FirebaseManager.swift
+++ b/Palace/AppInfrastructure/FirebaseManager.swift
@@ -55,6 +55,7 @@ final class FirebaseManager {
         case circuitBreakerEnabled = "circuit_breaker_enabled"
         case carPlayEnabled = "carplay_enabled"
         case opds2Enabled = "opds2_enabled"
+        case resetAccountEnabled = "reset_account_enabled"
     }
 
     // MARK: - Initialization
@@ -97,7 +98,8 @@ final class FirebaseManager {
             RemoteConfigKey.downloadRetryEnabled.rawValue: NSNumber(value: true),
             RemoteConfigKey.circuitBreakerEnabled.rawValue: NSNumber(value: true),
             RemoteConfigKey.carPlayEnabled.rawValue: NSNumber(value: true),
-            RemoteConfigKey.opds2Enabled.rawValue: NSNumber(value: true)
+            RemoteConfigKey.opds2Enabled.rawValue: NSNumber(value: true),
+            RemoteConfigKey.resetAccountEnabled.rawValue: NSNumber(value: false)
         ])
     }
 

--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -34,6 +34,7 @@ final class RemoteFeatureFlags {
         case opds2Enabled = "opds2_enabled"
         case readingStatsEnabled = "reading_stats_enabled"
         case advancedTypographyEnabled = "advanced_typography_enabled"
+        case resetAccountEnabled = "reset_account_enabled"
 
         var defaultValue: Bool {
             switch self {
@@ -61,8 +62,23 @@ final class RemoteFeatureFlags {
                 return .carPlayEnabled
             case .opds2Enabled:
                 return .opds2Enabled
+            case .resetAccountEnabled:
+                return .resetAccountEnabled
             default:
                 return nil
+            }
+        }
+
+        /// Whether this flag also looks up a per-device override key
+        /// (`<rawValue>_device_<sanitizedDeviceID>`). Used for staged rollouts
+        /// where support enables a feature for one patron at a time via
+        /// Firebase Remote Config conditions.
+        var supportsDeviceSpecificOverride: Bool {
+            switch self {
+            case .enhancedErrorLogging, .resetAccountEnabled:
+                return true
+            default:
+                return false
             }
         }
     }
@@ -114,7 +130,7 @@ final class RemoteFeatureFlags {
         if let managerKey = feature.managerKey {
             return FirebaseManager.shared.getBoolValue(
                 forKey: managerKey,
-                checkingDeviceSpecific: feature == .enhancedErrorLogging
+                checkingDeviceSpecific: feature.supportsDeviceSpecificOverride
             )
         }
 
@@ -166,6 +182,25 @@ final class RemoteFeatureFlags {
     /// Default: true. Set to false in Firebase Remote Config to disable.
     var isOPDS2Enabled: Bool {
         isFeatureEnabled(.opds2Enabled)
+    }
+
+    /// PP-4282: UserDefaults override that lets QA / support force the Reset
+    /// Account button on for a specific device without a Firebase round-trip.
+    /// Settable from `TPPDeveloperSettingsTableViewController`. Falls through
+    /// to the Remote Config flag when nil.
+    static let resetAccountLocalOverrideKey = "RemoteFeatureFlags.resetAccountLocalOverride"
+
+    /// PP-4282 / HelpSpot 17716: gate for the destructive "Reset This Library
+    /// Account" button in `AccountDetailView`. Defaults OFF in production.
+    /// Enable per-patron via Firebase Remote Config key
+    /// `reset_account_enabled_device_<sanitizedDeviceID>` (support workflow),
+    /// or globally via `reset_account_enabled` (broad rollout). Local override
+    /// via `resetAccountLocalOverrideKey` UserDefault is for QA only.
+    var isResetAccountEnabled: Bool {
+        if let override = UserDefaults.standard.object(forKey: Self.resetAccountLocalOverrideKey) as? Bool {
+            return override
+        }
+        return isFeatureEnabled(.resetAccountEnabled)
     }
 
     // MARK: - Device Info for Targeting

--- a/Palace/MyBooks/TokenRefreshInterceptor.swift
+++ b/Palace/MyBooks/TokenRefreshInterceptor.swift
@@ -523,9 +523,13 @@ final class TokenRefreshInterceptor {
             }
         }
 
-        // Present the session — uses existing system browser cookies for silent SSO
+        // Present the session — uses existing system browser cookies for silent SSO,
+        // EXCEPT when the patron just ran "Reset Account" (PP-4282 / HelpSpot 17716)
+        // which sets a one-shot flag forcing ephemeral cookies for this single
+        // session. Flag self-clears on consumption.
         session.presentationContextProvider = OIDCPresentationContextProvider.shared
-        session.prefersEphemeralWebBrowserSession = false
+        session.prefersEphemeralWebBrowserSession =
+            TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag()
         session.start()
     }
 

--- a/Palace/Settings/AccountDetailView.swift
+++ b/Palace/Settings/AccountDetailView.swift
@@ -283,6 +283,8 @@ struct AccountDetailView: View {
             pinInputCell
         case .logInSignOut:
             logInSignOutCell
+        case .resetAccount:
+            resetAccountCell
         case .ageCheck:
             ageCheckCell
         case .syncButton:
@@ -431,6 +433,26 @@ struct AccountDetailView: View {
         .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
         .accessibilityIdentifier(AccessibilityID.SignIn.signInButton)
         .accessibilityLabel(viewModel.isSignedIn ? DisplayStrings.signOut : Strings.Generic.signin)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityRemoveTraits(.isStaticText)
+    }
+
+    /// PP-4282 / HelpSpot 17716: destructive "Reset This Library Account"
+    /// button. Patron-self-service recovery for stuck-state cases that
+    /// Sign Out alone can't fix (CM DELETE hangs, broken-state-survives-
+    /// reinstall, etc.). See `TPPSignInBusinessLogic+ForceReset.swift`.
+    private var resetAccountCell: some View {
+        Button(action: {
+            viewModel.confirmResetAccount()
+        }, label: {
+            Text(NSLocalizedString("Reset This Library Account", comment: "Destructive reset-account button label"))
+                .foregroundColor(.red)
+                .horizontallyCentered()
+        })
+        .buttonStyle(.plain)
+        .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+        .accessibilityLabel(NSLocalizedString("Reset This Library Account", comment: "Accessibility label for the destructive reset-account button"))
+        .accessibilityHint(NSLocalizedString("Deletes downloads, bookmarks, and sign-in for this library so you can start fresh", comment: "Accessibility hint for the reset-account button"))
         .accessibilityAddTraits(.isButton)
         .accessibilityRemoveTraits(.isStaticText)
     }

--- a/Palace/Settings/AccountDetailViewModel.swift
+++ b/Palace/Settings/AccountDetailViewModel.swift
@@ -364,11 +364,11 @@ class AccountDetailViewModel: NSObject, ObservableObject {
         // OIDC was missing here, so signed-in OIDC accounts were rendering
         // the barcode/PIN/sign-in cells inappropriately.
         if auth.isOauth || auth.isOidc {
-            return [.logInSignOut]
+            return appendResetIfSignedIn([.logInSignOut])
         }
 
         if auth.isSaml && isSignedIn {
-            return [.logInSignOut]
+            return appendResetIfSignedIn([.logInSignOut])
         }
 
         if auth.isSaml {
@@ -376,10 +376,17 @@ class AccountDetailViewModel: NSObject, ObservableObject {
         }
 
         if auth.pinKeyboard != .none {
-            return [.barcode, .pin, .logInSignOut]
+            return appendResetIfSignedIn([.barcode, .pin, .logInSignOut])
         }
 
-        return [.barcode, .logInSignOut]
+        return appendResetIfSignedIn([.barcode, .logInSignOut])
+    }
+
+    /// Conditionally appends the destructive `.resetAccount` cell. Reset is
+    /// only meaningful when there's actually signed-in state to clear, so
+    /// signed-out renderings (e.g., SAML IdP picker) don't get the button.
+    private func appendResetIfSignedIn(_ cells: [CellType]) -> [CellType] {
+        isSignedIn ? cells + [.resetAccount] : cells
     }
 
     // MARK: - Actions
@@ -448,6 +455,56 @@ class AccountDetailViewModel: NSObject, ObservableObject {
         ))
 
         return alert
+    }
+
+    // MARK: - Reset Account (PP-4282 / HelpSpot 17716)
+
+    /// Entry point for the destructive "Reset This Library Account" button.
+    /// Presents a confirmation alert before tearing down all local state.
+    /// See `TPPSignInBusinessLogic+ForceReset.swift` for the cleanup contract.
+    func confirmResetAccount() {
+        TPPPresentationUtils.safelyPresent(makeResetAccountConfirmationAlert(), animated: true)
+    }
+
+    /// Builds the destructive confirmation alert. Library name is interpolated
+    /// into the message so the patron can confirm they're resetting the right
+    /// account (relevant for multi-library installs).
+    func makeResetAccountConfirmationAlert() -> UIAlertController {
+        let libraryName = businessLogic.libraryAccount?.name ?? DisplayStrings.account
+        let alert = UIAlertController(
+            title: NSLocalizedString("Reset \(libraryName)?", comment: "Title for the reset-account confirmation alert"),
+            message: NSLocalizedString(
+                "This will sign you out, delete your downloaded books and bookmarks for this library, and clear local sign-in state. Your loans and holds on the server are not affected. You'll need to sign in again.",
+                comment: "Body for the reset-account confirmation alert"
+            ),
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(
+            title: NSLocalizedString("Reset", comment: "Destructive confirmation button for reset-account"),
+            style: .destructive,
+            handler: { [weak self] _ in self?.performResetAccount() }
+        ))
+
+        alert.addAction(UIAlertAction(
+            title: Strings.Generic.cancel,
+            style: .cancel
+        ))
+
+        return alert
+    }
+
+    /// Invokes the unconditional cleanup. After completion, refreshes the
+    /// view-model's sign-in state so the UI shows the unsigned state and
+    /// the patron can sign back in immediately. Diagnostic logging lives
+    /// inside `performForceReset(...)` itself.
+    func performResetAccount() {
+        isSigningOut = true
+        businessLogic.performForceReset { [weak self] in
+            guard let self = self else { return }
+            self.isSigningOut = false
+            self.refreshSignInState()
+        }
     }
 
     func togglePINVisibility() {
@@ -606,6 +663,7 @@ enum CellType: Hashable {
     case barcode
     case pin
     case logInSignOut
+    case resetAccount
     case registration
     case syncButton
     case about
@@ -631,6 +689,8 @@ enum CellType: Hashable {
             hasher.combine("pin")
         case .logInSignOut:
             hasher.combine("logInSignOut")
+        case .resetAccount:
+            hasher.combine("resetAccount")
         case .registration:
             hasher.combine("registration")
         case .syncButton:

--- a/Palace/Settings/AccountDetailViewModel.swift
+++ b/Palace/Settings/AccountDetailViewModel.swift
@@ -382,11 +382,15 @@ class AccountDetailViewModel: NSObject, ObservableObject {
         return appendResetIfSignedIn([.barcode, .logInSignOut])
     }
 
-    /// Conditionally appends the destructive `.resetAccount` cell. Reset is
-    /// only meaningful when there's actually signed-in state to clear, so
-    /// signed-out renderings (e.g., SAML IdP picker) don't get the button.
+    /// Conditionally appends the destructive `.resetAccount` cell. Two gates:
+    /// (1) signed-in (no state to clear when signed-out), (2) the
+    /// `reset_account_enabled` feature flag is on for this device. Default in
+    /// production is OFF; support enables it per-patron via Firebase Remote
+    /// Config (`reset_account_enabled_device_<id>`) when a stuck-state ticket
+    /// comes in, then disables it again after the patron recovers.
     private func appendResetIfSignedIn(_ cells: [CellType]) -> [CellType] {
-        isSignedIn ? cells + [.resetAccount] : cells
+        guard isSignedIn, RemoteFeatureFlags.shared.isResetAccountEnabled else { return cells }
+        return cells + [.resetAccount]
     }
 
     // MARK: - Actions

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -1,5 +1,6 @@
 import MessageUI
 import SwiftUI
+import WebKit
 import PalaceCatalog
 
 @objcMembers
@@ -18,6 +19,7 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         case errorSimulation
         #if DEBUG
         case mockBackend
+        case resetAccountTesting
         #endif
     }
 
@@ -106,6 +108,7 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             #endif
         #if DEBUG
         case .mockBackend: return 1
+        case .resetAccountTesting: return 3  // simulate stuck state + inspect + set ephemeral flag
         #endif
         default: return 1
         }
@@ -163,6 +166,12 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         #if DEBUG
         case .mockBackend:
             return cellForMockBackend()
+        case .resetAccountTesting:
+            switch indexPath.row {
+            case 0: return cellForResetAccountSimulateStuck()
+            case 1: return cellForResetAccountInspect()
+            default: return cellForResetAccountSetEphemeral()
+            }
         #endif
         }
     }
@@ -193,6 +202,8 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         #if DEBUG
         case .mockBackend:
             return "Mock Backend"
+        case .resetAccountTesting:
+            return "Reset Account Testing (PP-4282)"
         #endif
         }
     }
@@ -662,6 +673,12 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         #if DEBUG
         case .mockBackend:
             showMockBackendPicker()
+        case .resetAccountTesting:
+            switch indexPath.row {
+            case 0: simulateResetAccountStuckState()
+            case 1: inspectResetAccountState()
+            default: setNextOIDCEphemeralFlagForTesting()
+            }
         #endif
 
         default:
@@ -893,6 +910,150 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         controller.dismiss(animated: true, completion: nil)
     }
+
+    // MARK: - Reset Account Testing (PP-4282 / HelpSpot 17716)
+    //
+    // Test harness for the patron-self-service Reset Account button. Lets QA
+    // and support reproduce the stuck-state condition (so they can verify
+    // Reset Account actually unblocks the patron) and inspect post-reset
+    // state. All three handlers are #if DEBUG so the section + code never
+    // ship to production builds.
+
+    #if DEBUG
+    private func cellForResetAccountSimulateStuck() -> UITableViewCell {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "resetAccountSimulateStuckCell")
+        cell.textLabel?.text = "1. Simulate Stuck State"
+        cell.detailTextLabel?.text = "Marks current account as if push-reg silently failed and SAML credentials went stale. Then go tap Reset Account."
+        cell.detailTextLabel?.numberOfLines = 0
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+
+    private func cellForResetAccountInspect() -> UITableViewCell {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "resetAccountInspectCell")
+        cell.textLabel?.text = "2. Inspect Account State"
+        cell.detailTextLabel?.text = "Shows current values for everything Reset Account touches. Use after Simulate (state should look broken) and after Reset (state should look clean)."
+        cell.detailTextLabel?.numberOfLines = 0
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+
+    private func cellForResetAccountSetEphemeral() -> UITableViewCell {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "resetAccountSetEphemeralCell")
+        cell.textLabel?.text = "3. Set One-Shot Ephemeral Flag"
+        cell.detailTextLabel?.text = "Manually sets the next-OIDC-session-ephemeral flag without running a full Reset. Lets you verify the OIDC consume path independently."
+        cell.detailTextLabel?.numberOfLines = 0
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+
+    /// Step 1: programmatically force the patron's app into the broken state
+    /// that Reset Account is designed to recover from. Sets the flags +
+    /// state Reset Account checks for, but does NOT actually break network
+    /// access (so post-Reset sign-in can succeed).
+    private func simulateResetAccountStuckState() {
+        guard let account = accountsManager.currentAccount else {
+            presentResetAccountAlert(title: "No Current Account",
+                                     message: "Add and select a library first, then come back here.")
+            return
+        }
+
+        // 1. Simulate "we think we registered FCM but actually didn't" — the
+        //    PP-4275 silent-failure mode that Reset Account heals on next launch.
+        account.hasUpdatedToken = true
+
+        // 2. Simulate stale SAML/OIDC session — the credentialsStale state that
+        //    triggers the audiobook-OPEN re-auth in PP-4276 and that Reset clears.
+        accountsManager.currentUserAccount.markCredentialsStale()
+
+        // 3. Pre-set the one-shot ephemeral flag to the OPPOSITE of what Reset
+        //    sets, so we can confirm Reset (a) sets it AND (b) the OIDC path
+        //    consumes-and-clears it. (No-op for non-OIDC libraries — see step 3
+        //    cell.)
+        UserDefaults.standard.removeObject(forKey: TPPSignInBusinessLogic.nextOIDCSessionEphemeralKey)
+
+        presentResetAccountAlert(
+            title: "Stuck State Simulated",
+            message: """
+                Set on \(account.name):
+                • hasUpdatedToken = true (push-reg short-circuit)
+                • authState = credentialsStale
+                • nextOIDCSessionEphemeral flag = unset (cleared)
+
+                Now: Settings → Accounts → tap \(account.name) → Reset This Library Account.
+
+                After Reset, come back here and tap Inspect — every line should look CLEAN (false / loggedOut / true for the ephemeral flag if the library is OIDC).
+                """
+        )
+    }
+
+    /// Step 2: dump the state Reset Account touches. Lets QA confirm
+    /// before/after.
+    private func inspectResetAccountState() {
+        guard let account = accountsManager.currentAccount else {
+            presentResetAccountAlert(title: "No Current Account",
+                                     message: "Add and select a library first.")
+            return
+        }
+        let user = accountsManager.currentUserAccount
+
+        // We use UserDefaults.bool here rather than the consume helper so
+        // inspecting doesn't side-effect-clear the flag.
+        let ephemeralFlagSet = UserDefaults.standard.bool(forKey: TPPSignInBusinessLogic.nextOIDCSessionEphemeralKey)
+
+        let webDataStore = WKWebsiteDataStore.default()
+        webDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { [weak self] records in
+            DispatchQueue.main.async {
+                let lines = [
+                    "Library: \(account.name) (\(account.uuid))",
+                    "",
+                    "hasUpdatedToken: \(account.hasUpdatedToken)",
+                    "authState: \(user.authState)",
+                    "hasCredentials: \(user.hasCredentials())",
+                    "barcode present: \(user.barcode != nil)",
+                    "PIN present: \(user.PIN != nil)",
+                    "authToken present: \(user.authToken != nil)",
+                    "",
+                    "WKWebsiteDataStore records: \(records.count)",
+                    "  (cookies, local storage, IndexedDB, etc. across ALL hosts — Reset wipes everything)",
+                    "",
+                    "nextOIDCSessionEphemeral flag: \(ephemeralFlagSet ? "SET (next OIDC session will be ephemeral)" : "unset (silent SSO active)")",
+                    "",
+                    "Expected after Reset: hasUpdatedToken=false, authState=loggedOut, hasCredentials=false, ephemeral flag SET (consumed-and-cleared by next OIDC sign-in)."
+                ]
+                self?.presentResetAccountAlert(
+                    title: "Account State",
+                    message: lines.joined(separator: "\n")
+                )
+            }
+        }
+    }
+
+    /// Step 3: directly set the one-shot flag (without running a full Reset).
+    /// Use this to test the OIDC consume path in isolation — sign in to an
+    /// OIDC library and confirm the ASWebAuthenticationSession was created
+    /// with prefersEphemeralWebBrowserSession = true (visible if the patron
+    /// is forced through a real IdP login instead of silent SSO).
+    private func setNextOIDCEphemeralFlagForTesting() {
+        UserDefaults.standard.set(true, forKey: TPPSignInBusinessLogic.nextOIDCSessionEphemeralKey)
+        presentResetAccountAlert(
+            title: "Ephemeral Flag Set",
+            message: """
+                The next OIDC ASWebAuthenticationSession will be created with prefersEphemeralWebBrowserSession = true.
+
+                To verify: sign out of an OIDC library, then sign back in. You should be forced through a real IdP authentication (not a silent SSO redirect).
+
+                After that one session, the flag self-clears and silent SSO is restored.
+                """
+        )
+    }
+
+    private func presentResetAccountAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+    #endif
 }
 
 extension TPPDeveloperSettingsTableViewController: TPPRegistryDebugger {}

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -958,18 +958,34 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             return
         }
 
+        let user = accountsManager.currentUserAccount
+
         // 1. Simulate "we think we registered FCM but actually didn't" — the
         //    PP-4275 silent-failure mode that Reset Account heals on next launch.
         account.hasUpdatedToken = true
 
         // 2. Simulate stale SAML/OIDC session — the credentialsStale state that
         //    triggers the audiobook-OPEN re-auth in PP-4276 and that Reset clears.
-        accountsManager.currentUserAccount.markCredentialsStale()
+        user.markCredentialsStale()
 
-        // 3. Pre-set the one-shot ephemeral flag to the OPPOSITE of what Reset
-        //    sets, so we can confirm Reset (a) sets it AND (b) the OIDC path
-        //    consumes-and-clears it. (No-op for non-OIDC libraries — see step 3
-        //    cell.)
+        // 3. ACTUALLY corrupt the bearer token so server-side operations
+        //    (borrow, return, sync, fulfillment) start returning 401. Without
+        //    this step, the simulation only flips flags and the bearer keeps
+        //    working — patrons reported "I can still borrow", which proves
+        //    the previous simulation was too soft. Preserves barcode + pin so
+        //    the next sign-in flow is the natural credential-prompt path.
+        let corruptedToken = "INVALID_SIMULATED_STUCK_STATE_BEARER_TOKEN"
+        let pastDate = Date(timeIntervalSinceNow: -3600)
+        user.setAuthToken(
+            corruptedToken,
+            barcode: user.barcode,
+            pin: user.PIN,
+            expirationDate: pastDate
+        )
+
+        // 4. Pre-clear the one-shot ephemeral flag so we can confirm Reset
+        //    (a) sets it AND (b) the OIDC path consumes-and-clears it.
+        //    (No-op for non-OIDC libraries — see step 3 cell.)
         UserDefaults.standard.removeObject(forKey: TPPSignInBusinessLogic.nextOIDCSessionEphemeralKey)
 
         presentResetAccountAlert(
@@ -978,11 +994,15 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
                 Set on \(account.name):
                 • hasUpdatedToken = true (push-reg short-circuit)
                 • authState = credentialsStale
+                • bearer token = corrupted (next borrow/sync will 401)
+                • token expirationDate = 1 hour ago
                 • nextOIDCSessionEphemeral flag = unset (cleared)
 
-                Now: Settings → Accounts → tap \(account.name) → Reset This Library Account.
+                Now: try a borrow or pull-to-refresh — should fail with auth error. THEN: Settings → Accounts → tap \(account.name) → Reset This Library Account.
 
                 After Reset, come back here and tap Inspect — every line should look CLEAN (false / loggedOut / true for the ephemeral flag if the library is OIDC).
+
+                NOTE — Reset Account does NOT clear Adobe DRM device activation. If a patron's symptom is "can borrow but can't READ", that's PP-3649 (Adobe DRM regression in 3.0.0) and lives in the private DRM submodule. Reset Account fixes the SAML/OIDC/push-token surfaces; PP-3649 needs its own fix.
                 """
         )
     }

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+ForceReset.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+ForceReset.swift
@@ -1,0 +1,125 @@
+//
+// TPPSignInBusinessLogic+ForceReset.swift
+// The Palace Project
+//
+// "Reset This Library Account" — patron-self-service stuck-state recovery.
+// Mirrors the cleanup work in TPPSignInBusinessLogic+SignOut.swift but
+// runs UNCONDITIONALLY: every step proceeds regardless of whether the
+// CM-side DELETE call succeeded. This is the difference that matters for
+// patrons whose app is already broken (HelpSpot 17716 Cornell SAML and
+// the broader pattern Carissa flagged on 2026-05-05) — Sign Out's network
+// DELETE often hangs or fails for them, leaving downstream cleanup
+// short-circuited and the patron stuck across delete-and-reinstall.
+//
+// What this clears (locally):
+//   - FCM device-token registration with the CM (best-effort DELETE; no gating)
+//   - Stored credentials in Keychain (`userAccount.removeAll`)
+//   - Account.hasUpdatedToken flag
+//   - bookDownloadsCenter + bookRegistry state for this library
+//   - selectedIDP + samlHelper state
+//   - NetworkExecutor cache + URLCache
+//   - WKWebsiteDataStore.default() — ALL data types (cookies, local storage,
+//     IndexedDB, the lot) — unconditionally
+//   - Sets a one-shot flag so the NEXT OIDC `ASWebAuthenticationSession`
+//     forces `prefersEphemeralWebBrowserSession = true`. This defeats the
+//     Safari-shared-cookie reuse that survives app deletion for OIDC
+//     libraries (PR #909 / cross-platform audit finding).
+//
+// What this does NOT clear (out of client reach):
+//   - CM-side device-token rows for this patron (CM team intervention or
+//     reaper task — recommended in audit)
+//   - The library's IdP-side session at the identity provider
+//   - iCloud-backup-restored stale state (next reset still helps once the
+//     user re-launches and writes new state)
+//
+// Diagnostic: every step emits a `[RESET_ACCOUNT]` log line so a patron
+// sysdiagnose can be grepped to confirm the reset ran end-to-end.
+//
+// Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import WebKit
+import PalaceLogging
+
+extension TPPSignInBusinessLogic {
+
+    /// UserDefaults key for the one-shot "use ephemeral browser session for
+    /// the next OIDC sign-in" flag. Set by `performForceReset(...)`. Read
+    /// (and cleared) by the OIDC sign-in entry points.
+    public static let nextOIDCSessionEphemeralKey =
+        "PalaceForceReset.nextOIDCSessionEphemeral"
+
+    /// Reads-and-clears the one-shot ephemeral-session flag. Returns true
+    /// exactly once after `performForceReset` set it; subsequent reads
+    /// return false until the next reset. The OIDC sign-in code calls this
+    /// to decide whether to force `prefersEphemeralWebBrowserSession = true`
+    /// for this single session, defeating Safari-shared-cookie reuse.
+    @objc public static func consumeNextOIDCSessionEphemeralFlag() -> Bool {
+        let value = UserDefaults.standard.bool(forKey: nextOIDCSessionEphemeralKey)
+        if value {
+            UserDefaults.standard.removeObject(forKey: nextOIDCSessionEphemeralKey)
+            Log.info(#file, "[RESET_ACCOUNT] consumed nextOIDCSessionEphemeral flag — next ASWebAuthenticationSession will use ephemeral cookies")
+        }
+        return value
+    }
+
+    /// Patron-driven force reset. UNCONDITIONALLY clears every piece of
+    /// local state for this library account. Used by the Settings →
+    /// Account → "Reset This Library Account" button.
+    ///
+    /// - Parameter completion: invoked on the main queue after every
+    ///   cleanup step has finished (or skipped). Always called exactly once.
+    @objc public func performForceReset(completion: @escaping () -> Void) {
+        Log.info(#file, "[RESET_ACCOUNT] start — libraryAccountID=\(libraryAccountID)")
+
+        // 1. Best-effort DELETE FCM token from CM. Don't gate any cleanup on
+        //    the result — that's the bug Sign Out has when the patron's app
+        //    is already in a broken state.
+        if let account = libraryAccountsProvider.account(libraryAccountID) {
+            NotificationService.shared.deleteToken(for: account)
+            account.hasUpdatedToken = false
+            Log.info(#file, "[RESET_ACCOUNT] step 1 ok — FCM token DELETE dispatched (fire-and-forget); hasUpdatedToken cleared")
+        } else {
+            Log.warn(#file, "[RESET_ACCOUNT] step 1 skipped — no Account for libraryAccountID=\(libraryAccountID)")
+        }
+
+        // 2. Reset book downloads + registry for this library.
+        bookDownloadsCenter.reset(libraryAccountID)
+        bookRegistry.reset(libraryAccountID)
+        Log.info(#file, "[RESET_ACCOUNT] step 2 ok — bookDownloadsCenter + bookRegistry reset for \(libraryAccountID)")
+
+        // 3. Wipe stored credentials. After this, hasCredentials() returns
+        //    false and any in-flight authenticated request will fail cleanly
+        //    instead of replaying a stale token.
+        userAccount.removeAll()
+        selectedIDP = nil
+        samlHelper.clearState()
+        Log.info(#file, "[RESET_ACCOUNT] step 3 ok — userAccount.removeAll, selectedIDP=nil, samlHelper.clearState")
+
+        // 4. Network + URL caches. Catches any cached responses that might
+        //    replay stale auth state on next request.
+        AppContainer.production().networkExecutor.clearCache()
+        URLCache.shared.removeAllCachedResponses()
+        Log.info(#file, "[RESET_ACCOUNT] step 4 ok — networkExecutor cache + URLCache cleared")
+
+        // 5. Set the one-shot ephemeral-session flag for the next OIDC
+        //    sign-in. Defeats Safari-shared-cookie reuse that otherwise
+        //    survives app deletion for OIDC libraries.
+        UserDefaults.standard.set(true, forKey: Self.nextOIDCSessionEphemeralKey)
+        Log.info(#file, "[RESET_ACCOUNT] step 5 ok — nextOIDCSessionEphemeral flag set")
+
+        // 6. WKWebsiteDataStore — ALL data types, unconditionally. This is
+        //    the big one Sign Out gates on auth-type routing; reset doesn't.
+        let dataStore = WKWebsiteDataStore.default()
+        let dataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
+        let epoch = Date(timeIntervalSince1970: 0)
+        dataStore.removeData(ofTypes: dataTypes, modifiedSince: epoch) {
+            Log.info(#file, "[RESET_ACCOUNT] step 6 ok — WKWebsiteDataStore wiped (all types, since epoch)")
+            Log.info(#file, "[RESET_ACCOUNT] complete — patron should be returned to sign-in flow")
+            DispatchQueue.main.async {
+                completion()
+            }
+        }
+    }
+}

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+ForceReset.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+ForceReset.swift
@@ -89,6 +89,26 @@ extension TPPSignInBusinessLogic {
         bookRegistry.reset(libraryAccountID)
         Log.info(#file, "[RESET_ACCOUNT] step 2 ok — bookDownloadsCenter + bookRegistry reset for \(libraryAccountID)")
 
+        // 2.5. Best-effort Adobe DRM device deauthorize. CRITICAL for the
+        //      patron-visible "can borrow but can't read" symptom: server-side
+        //      operations (borrow/return/sync) use the CM bearer token, but
+        //      reading requires the local Adobe RMSDK device activation to
+        //      decrypt the EPUB. When activation gets desynced (PP-3649,
+        //      Crashlytics "On-demand Adobe device activation failed" — 89
+        //      events / 15 users on 3.0.0), the patron downloads books fine
+        //      but Read just spins. Without this deauth, Reset Account would
+        //      clear credentials but the local activation files would persist
+        //      — the next sign-in would try to refresh the broken activation
+        //      instead of doing a clean activation, and the patron would stay
+        //      stuck. Mirrors the call site in TPPSignInBusinessLogic+SignOut.swift
+        //      `deauthorizeDevice()`. Fire-and-forget: RMSDK clears local
+        //      activation state regardless of network result; success=false
+        //      with E_DEACT_USER_MISMATCH or similar is expected for stuck
+        //      patrons and that's exactly the case we want to recover.
+        //      MUST run BEFORE step 3 (credential clear) — deauth needs the
+        //      licensor + Adobe userID/deviceID stored on userAccount.
+        deauthorizeDeviceForReset()
+
         // 3. Wipe stored credentials. After this, hasCredentials() returns
         //    false and any in-flight authenticated request will fail cleanly
         //    instead of replaying a stale token.
@@ -120,6 +140,51 @@ extension TPPSignInBusinessLogic {
             DispatchQueue.main.async {
                 completion()
             }
+        }
+    }
+
+    /// Best-effort Adobe DRM device deauthorize. Mirrors the licensor-parsing
+    /// + deauthorize call from `TPPSignInBusinessLogic+SignOut.swift:337-396`,
+    /// but fire-and-forget — Reset Account explicitly does NOT gate downstream
+    /// cleanup on the deauth callback (the callback may never fire if Adobe's
+    /// deauth endpoint is the thing that's broken). RMSDK clears the local
+    /// activation files regardless of network result; that's what enables a
+    /// clean re-activation on the next sign-in.
+    ///
+    /// Skipped (with log) when there's no DRM authorizer (e.g. -noDRM build)
+    /// or no licensor (e.g. patron never activated). In those cases there's
+    /// no Adobe state to clear and the rest of Reset proceeds unchanged.
+    private func deauthorizeDeviceForReset() {
+        guard let drmAuthorizer = drmAuthorizer else {
+            Log.info(#file, "[RESET_ACCOUNT] step 2.5 skipped — no drmAuthorizer (likely -noDRM build)")
+            return
+        }
+        guard let licensor = userAccount.licensor else {
+            Log.info(#file, "[RESET_ACCOUNT] step 2.5 skipped — no licensor on userAccount (patron never activated)")
+            return
+        }
+
+        var licensorItems = (licensor["clientToken"] as? String)?
+            .replacingOccurrences(of: "\n", with: "")
+            .components(separatedBy: "|")
+        let tokenPassword = licensorItems?.last
+        licensorItems?.removeLast()
+        let tokenUsername = licensorItems?.joined(separator: "|")
+        let adobeUserID = userAccount.userID
+        let adobeDeviceID = userAccount.deviceID
+
+        Log.info(#file, "[RESET_ACCOUNT] step 2.5 — dispatching DRM deauthorize (fire-and-forget)")
+
+        drmAuthorizer.deauthorize(
+            withUsername: tokenUsername,
+            password: tokenPassword,
+            userID: adobeUserID,
+            deviceID: adobeDeviceID
+        ) { success, error in
+            // Non-success is expected for stuck patrons (E_DEACT_USER_MISMATCH
+            // or similar) — RMSDK still clears local activation, which is what
+            // matters for the next sign-in's clean re-activation.
+            Log.info(#file, "[RESET_ACCOUNT] step 2.5 — DRM deauthorize callback (success=\(success), error=\(error?.localizedDescription ?? "nil")). Local activation cleared regardless.")
         }
     }
 }

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+OIDC.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+OIDC.swift
@@ -233,7 +233,13 @@ extension TPPSignInBusinessLogic {
             } else {
                 session.presentationContextProvider = self
             }
-            session.prefersEphemeralWebBrowserSession = false
+            // PP-4282 (HelpSpot 17716): the patron-driven "Reset Account"
+            // button sets a one-shot UserDefaults flag. When set, force this
+            // session to use ephemeral cookies — defeats the Safari-shared-
+            // cookie reuse that otherwise survives app deletion for OIDC
+            // libraries. Flag self-clears on consumption.
+            session.prefersEphemeralWebBrowserSession =
+                TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag()
             session.start()
         }
     }

--- a/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
+++ b/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
@@ -113,6 +113,48 @@ final class RemoteFeatureFlagsTests: XCTestCase {
                        "getDeviceInfo() must return the same set of keys across calls")
     }
 
+    // MARK: - Reset Account Flag (PP-4282 / HelpSpot 17716)
+
+    /// The flag must default OFF in production. Support enables it per-patron
+    /// via Firebase Remote Config; if we ever default it ON, the destructive
+    /// Reset button ships to every patron unexpectedly.
+    func testIsResetAccountEnabled_defaultsOff_withoutOverrideOrFirebase() {
+        UserDefaults.standard.removeObject(forKey: RemoteFeatureFlags.resetAccountLocalOverrideKey)
+        defer { UserDefaults.standard.removeObject(forKey: RemoteFeatureFlags.resetAccountLocalOverrideKey) }
+
+        XCTAssertFalse(RemoteFeatureFlags.shared.isResetAccountEnabled,
+                       "Reset Account button must default OFF when no override and no Firebase remote value")
+    }
+
+    /// The local UserDefaults override is the per-device QA escape hatch. A
+    /// `true` value must enable the flag even when the remote default is OFF.
+    func testIsResetAccountEnabled_localOverrideTrue_enablesFlag() {
+        UserDefaults.standard.set(true, forKey: RemoteFeatureFlags.resetAccountLocalOverrideKey)
+        defer { UserDefaults.standard.removeObject(forKey: RemoteFeatureFlags.resetAccountLocalOverrideKey) }
+
+        XCTAssertTrue(RemoteFeatureFlags.shared.isResetAccountEnabled,
+                      "Local override = true must enable the Reset Account button regardless of remote config")
+    }
+
+    /// Override = false must also win — prevents a misconfigured Firebase value
+    /// from forcing the button on for a specific QA device that's been
+    /// explicitly opted out.
+    func testIsResetAccountEnabled_localOverrideFalse_disablesFlag() {
+        UserDefaults.standard.set(false, forKey: RemoteFeatureFlags.resetAccountLocalOverrideKey)
+        defer { UserDefaults.standard.removeObject(forKey: RemoteFeatureFlags.resetAccountLocalOverrideKey) }
+
+        XCTAssertFalse(RemoteFeatureFlags.shared.isResetAccountEnabled,
+                       "Local override = false must disable the Reset Account button regardless of remote config")
+    }
+
+    /// `resetAccountEnabled` must declare device-specific support so per-patron
+    /// rollouts work via the `<key>_device_<id>` Firebase RC pattern. If this
+    /// regresses to false, support's per-patron enablement breaks silently.
+    func testResetAccountEnabled_supportsDeviceSpecificOverride() {
+        XCTAssertTrue(RemoteFeatureFlags.FeatureFlag.resetAccountEnabled.supportsDeviceSpecificOverride,
+                      "resetAccountEnabled must opt into the per-device Firebase RC override pattern")
+    }
+
     // MARK: - Fetch
 
     func testFetchIfNeeded_doesNotCrash() async {

--- a/PalaceTests/SignInLogic/ForceResetTests.swift
+++ b/PalaceTests/SignInLogic/ForceResetTests.swift
@@ -1,0 +1,130 @@
+//
+//  ForceResetTests.swift
+//  PalaceTests
+//
+//  Locks the patron-self-service "Reset Account" contract:
+//   1. The one-shot ephemeral-session flag (set by `performForceReset`,
+//      consumed by the OIDC sign-in entry points) self-clears on read so
+//      it forces ephemeral cookies for exactly one OIDC session and no more.
+//   2. Reading the flag when it was never set returns false (no-op).
+//   3. Writing-then-reading-twice returns true once and false after.
+//
+//  Why this matters (HelpSpot 17716, PP-4282):
+//  Carissa from support flagged that "delete app + reinstall" doesn't fix
+//  patrons stuck in a weird state. For OIDC libraries this is partially
+//  caused by Safari-shared cookies that survive app deletion (the
+//  `ASWebAuthenticationSession` was created with
+//  `prefersEphemeralWebBrowserSession = false` to support silent borrow
+//  re-auth). The "Reset Account" button defeats that for one cycle by
+//  flipping the flag — but only for one cycle, so silent SSO still works
+//  for normal future borrows.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class ForceResetTests: XCTestCase {
+
+    private let key = TPPSignInBusinessLogic.nextOIDCSessionEphemeralKey
+
+    override func setUp() {
+        super.setUp()
+        // Each test starts from a clean flag state.
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: key)
+        super.tearDown()
+    }
+
+    // MARK: - One-shot consume contract
+
+    /// Default state: the flag is not set, so consume returns false.
+    func testConsume_whenFlagNeverSet_returnsFalse() {
+        XCTAssertFalse(
+            TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag(),
+            "Fresh consume with no prior set must return false — silent SSO stays on by default"
+        )
+    }
+
+    /// Set then immediately consume returns true exactly once.
+    func testConsume_whenFlagSet_returnsTrueOnce() {
+        UserDefaults.standard.set(true, forKey: key)
+
+        let first = TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag()
+
+        XCTAssertTrue(first, "First consume after set must return true so the next OIDC session uses ephemeral cookies")
+    }
+
+    /// After one consume, the flag is cleared — subsequent consumes return false.
+    /// This is the entire point of "one-shot": defeat Safari cookie reuse for
+    /// the next sign-in only, then silently restore default behavior so future
+    /// borrow-time silent-SSO still works.
+    func testConsume_secondCallAfterSet_returnsFalse() {
+        UserDefaults.standard.set(true, forKey: key)
+
+        _ = TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag()
+        let second = TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag()
+
+        XCTAssertFalse(second, "Second consume must return false — flag is one-shot; silent SSO restored after one ephemeral session")
+    }
+
+    /// The consume side-effect (clearing the UserDefaults key) is verified
+    /// directly so a future refactor that returns true without clearing
+    /// would fail this test.
+    func testConsume_clearsTheUserDefaultsKey() {
+        UserDefaults.standard.set(true, forKey: key)
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: key), "Pre-condition: flag is set in UserDefaults")
+
+        _ = TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag()
+
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: key),
+            "Consume must remove the key from UserDefaults so the next read returns false"
+        )
+    }
+
+    /// Repeated set+consume cycles each return true once. Locks against a
+    /// future refactor that latches the flag permanently after first set.
+    func testConsume_supportsMultipleSetThenConsumeCycles() {
+        for cycle in 1...3 {
+            UserDefaults.standard.set(true, forKey: key)
+            XCTAssertTrue(
+                TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag(),
+                "Cycle \(cycle): set-then-consume must return true"
+            )
+            XCTAssertFalse(
+                TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag(),
+                "Cycle \(cycle): second consume must return false"
+            )
+        }
+    }
+
+    // MARK: - Cross-cutting: regression guard
+
+    /// The fix-is-real test — directly exercises the patron scenario in
+    /// HelpSpot 17716. After a patron taps "Reset Account" (which sets the
+    /// flag), the very next OIDC sign-in attempt must use ephemeral cookies
+    /// to defeat the Safari-shared-cookie reuse that would otherwise
+    /// silently sign the patron back into the SAME stale identity.
+    func testRegressionForBug_resetAccountForcesNextOIDCSessionEphemeral_perHelpSpot17716() {
+        // Simulate Reset Account writing the flag — actual performForceReset
+        // also clears credentials, downloads, etc., but the OIDC-specific
+        // "Safari cookie reuse defeat" is the part that survives across
+        // app deletion. Test the exact contract: flag is set, next OIDC
+        // sign-in consumes it as true.
+        UserDefaults.standard.set(true, forKey: key)
+
+        XCTAssertTrue(
+            TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag(),
+            "REGRESSION GUARD (HelpSpot 17716 / PP-4282): the next OIDC ASWebAuthenticationSession after Reset Account MUST use ephemeral cookies, otherwise Safari's shared cookie jar silently re-signs the patron back into the broken state"
+        )
+        XCTAssertFalse(
+            TPPSignInBusinessLogic.consumeNextOIDCSessionEphemeralFlag(),
+            "REGRESSION GUARD: the ephemeral-session forcing is one-shot only — silent SSO must restore for normal borrows after the patron has signed back in"
+        )
+    }
+}


### PR DESCRIPTION
**JIRA:** [PP-4282](https://ebce-lyrasis.atlassian.net/browse/PP-4282)

## Summary

Origin: support flagged on 2026-05-05 that "delete app + reinstall" doesn't fix patrons stuck in a weird state due to a stale SAML/OIDC session (HelpSpot 17716 SAML library is the canonical example). Today support has to walk patrons through a 6-step ladder (sign-out → delete-app → Safari clear → IdP logout → disable iCloud backup → escalate to CM) and patrons frequently bail out partway.

Fix: a red destructive **"Reset This Library Account"** button in Settings → Account → AccountDetailView (below Sign Out, only visible when signed in). On confirmation, runs a NEW `TPPSignInBusinessLogic.performForceReset(...)` helper that **unconditionally** clears every piece of local state regardless of whether the CM-side DELETE call succeeded — that's the difference vs Sign Out, which gates downstream cleanup on the CM call succeeding (the bug class for already-broken-state patrons).

Plus a one-shot `nextOIDCSessionEphemeral` UserDefaults flag set by `performForceReset` and consumed by both OIDC sign-in entry points. Forces `prefersEphemeralWebBrowserSession = true` for exactly ONE OIDC sign-in after reset, defeating the Safari-shared-cookie reuse that otherwise survives app deletion for OIDC libraries. Self-clears on consumption so silent SSO restores for normal future borrows.

## HelpSpot tickets addressed

- **17716** — SAML library Even after delete + reinstall the patron remained stuck. After 3.1.x ships, support can give the patron a one-tap workaround.
- **Indirectly** — also helps the push-notification-gap class (HelpSpot 17680 / PP-4275) for patrons whose registration silently failed: they can reset and re-register in one tap instead of waiting for cold-launch retry.

## Cleanup steps (every one logged with `[RESET_ACCOUNT]` prefix)

1. Best-effort DELETE FCM token from CM (don't gate on result)
2. Reset bookDownloadsCenter + bookRegistry for this library
3. `userAccount.removeAll` + `selectedIDP=nil` + `samlHelper.clearState`
4. Clear NetworkExecutor cache + URLCache
5. Set one-shot UserDefaults flag for next OIDC ephemeral session
6. WKWebsiteDataStore — ALL data types, since epoch — unconditionally

A patron sysdiagnose can be grepped for `[RESET_ACCOUNT]` to confirm the reset ran end-to-end and which step (if any) skipped.

## What this does NOT fix (out of client reach)

- **CM-side stale device-token rows.** Needs CM-side reaper task per cross-platform audit recommendation. Patron's NEXT sign-in will write fresh state, so this is more about old rows accumulating than blocking recovery.
- **iCloud-backup-restored stale state from before this fix landed.** Once the user re-launches after reset, fresh state is written.
- **IdP-side session at the library's identity provider.** Shibboleth-style federated IdPs, etc. — the IdP has its own session. The one-shot ephemeral flag forces the IdP to actually re-authenticate the patron rather than silently SSO-ing with a stale cookie.

## ForgeOS

- Changeset: `cs_abf78649` (risk score 40/100, auth + database + security + ui domains)
- Gates passed: **review** (architect approved), **testing** (qa_test approved)
- Release gate: pending PR merge

## Feature flag (added 2026-05-06 per support feedback)

The destructive button is **OFF by default** in production. Support enables it per-patron via Firebase Remote Config when a stuck-state ticket comes in, then disables again after the patron recovers.

**Firebase Remote Config keys to add:**
| Key | Type | Default | Notes |
|-----|------|---------|-------|
| `reset_account_enabled` | Boolean | `false` | Global default — keep `false` so the button stays hidden everywhere |
| `reset_account_enabled_device_<sanitizedDeviceID>` | Boolean | n/a | Per-patron override. Set to `true` for one specific device; takes precedence over global. `<sanitizedDeviceID>` = patron's `PalaceDeviceID` UUID with hyphens stripped (32 hex chars). Find via Crashlytics custom key `PalaceDeviceID` |

Alternative: use a Firebase Remote Config **Condition** on the global key targeting `device_id == <patron-UUID-with-hyphens>` (Analytics user property). Same end result, easier to audit in the Firebase console.

QA escape hatch (no Firebase round-trip): `defaults write org.thepalaceproject.palace RemoteFeatureFlags.resetAccountLocalOverrideKey -bool true`. UserDefaults override wins over Firebase, settable on TestFlight or DEBUG builds.

## Toolkit submodule bump (in this PR)

Bumps `ios-audiobooktoolkit` from `a7970b0` → `797d546b` (toolkit `main`). Picks up:
- toolkit #168 — DownloadWatchdog teardown race fix (Crashlytics `738711ca`, 10 events / 2 users on 3.0.0)
- toolkit #170 — PP-4156 download indicator restoration (already on develop)
- toolkit #171 — chunk-stall retry on transient network errors (HelpSpot 17725)

Supersedes PR #911 which carried only the watchdog fix in isolation.

## Test plan

- [x] 6/6 `ForceResetTests` pass on iPhone 16 Pro / iOS 26.2 sim. Locks the one-shot consume contract exhaustively + named regression guard for HelpSpot 17716.
- [x] 4 new tests in `RemoteFeatureFlagsTests` lock the flag-gate contract (defaults OFF, local override = true enables, local override = false disables, supportsDeviceSpecificOverride is true). All 13 RemoteFeatureFlagsTests + 19 AccountDetailViewModelTests pass.
- [x] No new compiler warnings on changed files.
- [x] Sign Out semantics unchanged.
- [ ] **End-to-end button → alert → cleanup → sign-in-restart** flow not driven by simdrive in this PR. Manual smoke recommended pre-merge given the destructive nature:
 - Tap Reset on a signed-in library → confirmation alert appears with library name interpolated into the title
 - Confirm → patron returned to sign-in flow
 - Sysdiagnose grep for `[RESET_ACCOUNT]` shows all step lines
 - Sign back in successfully → hold notifications resume

## Out of scope / deferred

- E2E simdrive journey for the destructive flow (would need a stub auth backend).
- A "Reset all libraries" variant for multi-library patrons (current scope is per-library; matches existing Sign Out semantics).
- Snapshot test for the Reset button in AccountDetailView (would lock the visual style but not behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PP-4282]: https://ebce-lyrasis.atlassian.net/browse/PP-4282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

