### PR TITLE
[3.1.0] PP-4179: iCloud backup exclusion + version bump 3.0.0→3.1.0

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 		22D7A0341D12429C6B3D10A4 /* UIColor+TPPColorAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AAE5061720AB26712416F3 /* UIColor+TPPColorAdditions.swift */; };
 		2328B4483544EAC500B592B6 /* UserAccountValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC465C72310C5054118CBBEA /* UserAccountValidationTests.swift */; };
 		233349692EA7423D97E70B5F /* SEMigrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE116B1078F648DCB8A52598 /* SEMigrationsTests.swift */; };
+		D746218B862BF611D0F4ADC2 /* BackupExclusionMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040323DBE8E8E5AB1FBC517E /* BackupExclusionMigrationTests.swift */; };
 		237B6705CA505A8CE33EAE6D /* TPPDeferredAdobeActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557641B8197B528D886F32DB /* TPPDeferredAdobeActivationTests.swift */; };
 		24627E54AF34930D7ACEB030 /* BookCellModelCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DCAEB765B50E04217F0CB7 /* BookCellModelCache.swift */; };
 		246ED064D298281426FEF8D5 /* KeyboardNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144BB5C0F2D1B2C0C398BD98 /* KeyboardNavigationHandler.swift */; };
@@ -444,6 +445,7 @@
 		7179B2C70F96786A9064BF4B /* BookRegistryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9234DD4339B85855A91CE3DE /* BookRegistryStore.swift */; };
 		7307A5ED23FF1A8500DE53DE /* TPPOpenSearchDescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7307A5EC23FF1A8500DE53DE /* TPPOpenSearchDescriptionTests.swift */; };
 		73085E3525030D27008F6244 /* SEMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E3425030D27008F6244 /* SEMigrations.swift */; };
+		C4CDA6080F98CE135248FFC2 /* BackupExclusionMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99895C63131766252D87F554 /* BackupExclusionMigration.swift */; };
 		730B7868249AB9D7008F28B3 /* Float+TPPAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730B7867249AB9D7008F28B3 /* Float+TPPAdditions.swift */; };
 		730D17C02552124B004CAC83 /* TPPMyBooksDownloadsCenterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730D17BF2552124B004CAC83 /* TPPMyBooksDownloadsCenterMock.swift */; };
 		730D17CC25535954004CAC83 /* TPPSignInBusinessLogic+BookmarkSyncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730D17CB25535954004CAC83 /* TPPSignInBusinessLogic+BookmarkSyncing.swift */; };
@@ -548,6 +550,7 @@
 		73EB0A8E25821DF4006BC997 /* TPPSignInBusinessLogic+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A794A525477D8F00C59CC1 /* TPPSignInBusinessLogic+UI.swift */; };
 		73EB0A9125821DF4006BC997 /* BundledHTMLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D62568A1D412BCB0080A81F /* BundledHTMLViewController.swift */; };
 		73EB0A9625821DF4006BC997 /* SEMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E3425030D27008F6244 /* SEMigrations.swift */; };
+		56196EA984C98839164BD951 /* BackupExclusionMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99895C63131766252D87F554 /* BackupExclusionMigration.swift */; };
 		73EB0A9A25821DF4006BC997 /* TPPUserFriendlyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7360D0D424BFCB9700C8AD16 /* TPPUserFriendlyError.swift */; };
 		73EB0A9F25821DF4006BC997 /* DPLAAudiobooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E7E07A24FEA7E800189224 /* DPLAAudiobooks.swift */; };
 		73EB0AA825821DF4006BC997 /* TPPAppReviewPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93F9F9621CDACF700BD3B0C /* TPPAppReviewPrompt.swift */; };
@@ -2076,6 +2079,7 @@
 		7307A5EC23FF1A8500DE53DE /* TPPOpenSearchDescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPOpenSearchDescriptionTests.swift; sourceTree = "<group>"; };
 		73085E192502DE88008F6244 /* TPPPresentationUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPPresentationUtils.swift; sourceTree = "<group>"; };
 		73085E3425030D27008F6244 /* SEMigrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEMigrations.swift; sourceTree = "<group>"; };
+		99895C63131766252D87F554 /* BackupExclusionMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupExclusionMigration.swift; sourceTree = "<group>"; };
 		730B7867249AB9D7008F28B3 /* Float+TPPAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Float+TPPAdditions.swift"; sourceTree = "<group>"; };
 		730D17BF2552124B004CAC83 /* TPPMyBooksDownloadsCenterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPMyBooksDownloadsCenterMock.swift; sourceTree = "<group>"; };
 		730D17CB25535954004CAC83 /* TPPSignInBusinessLogic+BookmarkSyncing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TPPSignInBusinessLogic+BookmarkSyncing.swift"; sourceTree = "<group>"; };
@@ -2725,6 +2729,7 @@
 		EB9B49899F1C10F43D4FAAD8 /* NowPlayingCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NowPlayingCoordinator.swift; sourceTree = "<group>"; };
 		ECEB9F995C87FE2C71DFA9BC /* BookRegistrySync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookRegistrySync.swift; sourceTree = "<group>"; };
 		EE116B1078F648DCB8A52598 /* SEMigrationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEMigrationsTests.swift; sourceTree = "<group>"; };
+		040323DBE8E8E5AB1FBC517E /* BackupExclusionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupExclusionMigrationTests.swift; sourceTree = "<group>"; };
 		EE20C7E18DE551AD81B9D2C6 /* NoNetworkURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoNetworkURLProtocol.swift; sourceTree = "<group>"; };
 		EE3D078322CEC4B660EC470F /* TPPPDFModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPPDFModelTests.swift; sourceTree = "<group>"; };
 		EE511C614AE46DCC9A9B642A /* BackgroundDownloadHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundDownloadHandlerTests.swift; sourceTree = "<group>"; };
@@ -3426,6 +3431,7 @@
 			children = (
 				5D60D3532297353C001080D0 /* TPPMigrationManager.swift */,
 				73085E3425030D27008F6244 /* SEMigrations.swift */,
+				99895C63131766252D87F554 /* BackupExclusionMigration.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -5488,6 +5494,7 @@
 			children = (
 				EE116B1078F648DCB8A52598 /* SEMigrationsTests.swift */,
 				9B3391CCE50BC961BC7A5726 /* TPPMigrationManagerTests.swift */,
+				040323DBE8E8E5AB1FBC517E /* BackupExclusionMigrationTests.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -6090,6 +6097,7 @@
 				5F8040C84B5543ED9B1FEACE /* ReachabilityTests.swift in Sources */,
 				696AE19BFBC6497EB2B21825 /* TPPUserFriendlyErrorTests.swift in Sources */,
 				233349692EA7423D97E70B5F /* SEMigrationsTests.swift in Sources */,
+				D746218B862BF611D0F4ADC2 /* BackupExclusionMigrationTests.swift in Sources */,
 				98305B9FFC0E45D2B33B5582 /* TPPSettingsTests.swift in Sources */,
 				DR41NMQUEUE2026042760BB01 /* XCTestCase+drainMainQueue.swift in Sources */,
 				PP3671BF000000000000001 /* TPPAccountListDataSourceTests.swift in Sources */,
@@ -6519,6 +6527,7 @@
 				9D5BD91CC07167E673AA264A /* TPPAccountAuthState.swift in Sources */,
 				E5E2F8D52CB631C700A95840 /* TPPSAMLHelper.swift in Sources */,
 				73EB0A9625821DF4006BC997 /* SEMigrations.swift in Sources */,
+				56196EA984C98839164BD951 /* BackupExclusionMigration.swift in Sources */,
 				21E41799292813A000A78606 /* AsyncImage.swift in Sources */,
 				E50543852E5F96BC007CCFAB /* CatalogLaneSkeletonView.swift in Sources */,
 				E5B0ACF02D6EBE6D00F9B89B /* Array+Extensions.swift in Sources */,
@@ -7042,6 +7051,7 @@
 				21D746E72718A4C000C0E1B4 /* AdobeDRMError.swift in Sources */,
 				E5515EBE2AD8E13E000BDFE9 /* TPPEPUBViewController.swift in Sources */,
 				73085E3525030D27008F6244 /* SEMigrations.swift in Sources */,
+				C4CDA6080F98CE135248FFC2 /* BackupExclusionMigration.swift in Sources */,
 				E544C4EF2A395E8C00B2DC9D /* MyBooksSimplifiedBearerToken.swift in Sources */,
 				E54DD4E6275C8EAA0013C200 /* Font+Extensions.swift in Sources */,
 				E521E9BD2D4D706700C08ADF /* Date+Extensions.swift in Sources */,
@@ -7612,7 +7622,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7670,7 +7680,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7864,7 +7874,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -7926,7 +7936,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "App Store";

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		17BE24ED25FB09F000AE707F /* TPPCurrentLibraryAccountProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BE24EC25FB09F000AE707F /* TPPCurrentLibraryAccountProviderMock.swift */; };
 		17BE24EF25FB114900AE707F /* simplye_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BE24EE25FB114900AE707F /* simplye_authentication_document.json */; };
 		17BEE42799E8F727729A00F3 /* URLExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB31382B3826FB20CD3BE34 /* URLExtensionTests.swift */; };
+		BE402A8E2026050601000003 /* URL+BackupExclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE402A8D2026050601000004 /* URL+BackupExclusionTests.swift */; };
 		17E6BC38538C040F995A97B7 /* OPDS2BookBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E358F2BF99213E34F1B052ED /* OPDS2BookBridgeTests.swift */; };
 		17E81F08261522B3001003C2 /* TPPRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* TPPRoundedButton.swift */; };
 		17E81F0B261522B3001003C2 /* TPPRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* TPPRoundedButton.swift */; };
@@ -1366,6 +1367,8 @@
 		E7498A7C2A0E349A0037DD93 /* TPPAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7498A7A2A0E349A0037DD93 /* TPPAppDelegate.swift */; };
 		E7498A7E2A0E4F6A0037DD93 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7498A7D2A0E4F6A0037DD93 /* URL+Extensions.swift */; };
 		E7498A7F2A0E4F6A0037DD93 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7498A7D2A0E4F6A0037DD93 /* URL+Extensions.swift */; };
+		BE401A7E2026050601000001 /* URL+BackupExclusion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE401A7D2026050601000000 /* URL+BackupExclusion.swift */; };
+		BE401A7F2026050601000002 /* URL+BackupExclusion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE401A7D2026050601000000 /* URL+BackupExclusion.swift */; };
 		E7498A802A0E662E0037DD93 /* TPPAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7498A7A2A0E349A0037DD93 /* TPPAppDelegate.swift */; };
 		E7498A862A0E7F460037DD93 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = E7498A852A0E7F460037DD93 /* FirebaseAnalytics */; };
 		E7498A882A0E7F460037DD93 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = E7498A872A0E7F460037DD93 /* FirebaseCrashlytics */; };
@@ -1918,6 +1921,7 @@
 		38D1A95DE8674E6D83B5A8CA /* TPPNetworkExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPNetworkExecutorTests.swift; sourceTree = "<group>"; };
 		3B60ACDE3E15FC832885E932 /* Badge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Badge.swift; sourceTree = "<group>"; };
 		3BB31382B3826FB20CD3BE34 /* URLExtensionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLExtensionTests.swift; sourceTree = "<group>"; };
+		BE402A8D2026050601000004 /* URL+BackupExclusionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "URL+BackupExclusionTests.swift"; sourceTree = "<group>"; };
 		3C0E625DA84AEEFF9840A601 /* LCPAudiobooksTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPAudiobooksTests.swift; sourceTree = "<group>"; };
 		3C2EF561051B25A261AE67BC /* TPPBookRegistryDependencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookRegistryDependencyTests.swift; sourceTree = "<group>"; };
 		3D5A0D270E8AC2DDFBC62044 /* IntExtensionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntExtensionsTests.swift; sourceTree = "<group>"; };
@@ -2681,6 +2685,7 @@
 		E74752F627FF044400F5E7FA /* TPPSignInBusinessLogic+CardCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TPPSignInBusinessLogic+CardCreation.swift"; sourceTree = "<group>"; };
 		E7498A7A2A0E349A0037DD93 /* TPPAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAppDelegate.swift; sourceTree = "<group>"; };
 		E7498A7D2A0E4F6A0037DD93 /* URL+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Extensions.swift"; sourceTree = "<group>"; };
+		BE401A7D2026050601000000 /* URL+BackupExclusion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+BackupExclusion.swift"; sourceTree = "<group>"; };
 		E75423242AFC381E008CB7EF /* UserProfileDocument+Links.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserProfileDocument+Links.swift"; sourceTree = "<group>"; };
 		E75499F62A1D6863009FF821 /* TPPAppDelegate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TPPAppDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		E759B2052A1BF7AA0041B075 /* PalaceDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PalaceDebug.entitlements; sourceTree = "<group>"; };
@@ -3836,6 +3841,7 @@
 			children = (
 				7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */,
 				E7498A7D2A0E4F6A0037DD93 /* URL+Extensions.swift */,
+				BE401A7D2026050601000000 /* URL+BackupExclusion.swift */,
 				E51919D72B508EE400C08E86 /* URLRequest+Extensions.swift */,
 				4F901D7BCF798BFF0E528D6D /* NSURL+NYPLURLAdditions.swift */,
 				6DB8CC29A8C5DFB84187D498 /* NSURLRequest+NYPLURLRequestAdditions.swift */,
@@ -4801,6 +4807,7 @@
 				7751F6315B6633F398F0B808 /* StringExtensionTests.swift */,
 				153576DF8AE3801A58DE3F75 /* DateExtensionTests.swift */,
 				3BB31382B3826FB20CD3BE34 /* URLExtensionTests.swift */,
+				BE402A8D2026050601000004 /* URL+BackupExclusionTests.swift */,
 				E5A09A7E2F0D72B500CC23EA /* DeviceOrientationTests.swift */,
 				9B97ED224E7C43B89FBBEE5A /* GeneralCacheTests.swift */,
 				A1AD9512F71B4CFFB4803502 /* SafeDictionaryTests.swift */,
@@ -6151,6 +6158,7 @@
 				81C26B959E33252B2BD42607 /* StringExtensionTests.swift in Sources */,
 				366C7E46CBA55744BEE438CD /* DateExtensionTests.swift in Sources */,
 				17BEE42799E8F727729A00F3 /* URLExtensionTests.swift in Sources */,
+				BE402A8E2026050601000003 /* URL+BackupExclusionTests.swift in Sources */,
 				5D05015D55C6DE54BB6DB0DA /* TPPSignInBusinessLogicExtendedTests.swift in Sources */,
 				0352BBDC11FC4E038741E817 /* TPPCrossLibrarySignOutTests.swift in Sources */,
 				547B90CF7E8D4CABA5A59BFD /* TPPIdleSignOutRegressionTests.swift in Sources */,
@@ -6467,6 +6475,7 @@
 				E5A1413328D9018A0091AD2D /* TPPBook.swift in Sources */,
 				E523A457299FD81000EF833B /* BookButtonType.swift in Sources */,
 				E7498A7F2A0E4F6A0037DD93 /* URL+Extensions.swift in Sources */,
+				BE401A7F2026050601000002 /* URL+BackupExclusion.swift in Sources */,
 				21E41783292810EE00A78606 /* View.swift in Sources */,
 				21E4177B292810E000A78606 /* TPPPDFDocument.swift in Sources */,
 				21E4178C292810F600A78606 /* TPPPDFToolbarButton.swift in Sources */,
@@ -6947,6 +6956,7 @@
 				E795A7692A74074300314EC8 /* AudiobookTimeTracker.swift in Sources */,
 				E52E3BBC28C0EF410073DC4D /* TPPReaderAdvancedSettings.swift in Sources */,
 				E7498A7E2A0E4F6A0037DD93 /* URL+Extensions.swift in Sources */,
+				BE401A7E2026050601000001 /* URL+BackupExclusion.swift in Sources */,
 				E544C4E92A395BE000B2DC9D /* MyBooksDownloadCenter.swift in Sources */,
 				A1DB969AD9DF7842FC531059 /* DownloadStateManager.swift in Sources */,
 				06560AD2E5A43C1BFA2EBEE1 /* DownloadProgressPublisher.swift in Sources */,

--- a/Palace/Audiobooks/AudiobookLoader.swift
+++ b/Palace/Audiobooks/AudiobookLoader.swift
@@ -321,7 +321,7 @@ final class AudiobookLoader {
                 if !FileManager.default.fileExists(atPath: directory.path) {
                     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
                 }
-                BackupExclusionMigration.excludeFromBackup(directory)
+                directory.excludeFromBackup()
                 try data.write(to: licenseFileURL, options: .atomic)
                 Log.info(#file, "  ✅ LCP license saved to: \(licenseFileURL.lastPathComponent) (\(data.count) bytes)")
             } catch {

--- a/Palace/Audiobooks/AudiobookLoader.swift
+++ b/Palace/Audiobooks/AudiobookLoader.swift
@@ -321,6 +321,7 @@ final class AudiobookLoader {
                 if !FileManager.default.fileExists(atPath: directory.path) {
                     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
                 }
+                BackupExclusionMigration.excludeFromBackup(directory)
                 try data.write(to: licenseFileURL, options: .atomic)
                 Log.info(#file, "  ✅ LCP license saved to: \(licenseFileURL.lastPathComponent) (\(data.count) bytes)")
             } catch {

--- a/Palace/Audiobooks/Tracker/AudiobookDataManager.swift
+++ b/Palace/Audiobooks/Tracker/AudiobookDataManager.swift
@@ -308,7 +308,7 @@ class AudiobookDataManager {
             if !FileManager.default.fileExists(atPath: storeDirectoryUrl.path) {
                 try FileManager.default.createDirectory(at: storeDirectoryUrl, withIntermediateDirectories: true)
             }
-            BackupExclusionMigration.excludeFromBackup(storeDirectoryUrl)
+            storeDirectoryUrl.excludeFromBackup()
             try store.jsonRepresentation?.write(to: storeUrl)
         } catch {
             TPPErrorLogger.logError(error, summary: "AudiobookDataManager error saving time tracker store")

--- a/Palace/Audiobooks/Tracker/AudiobookDataManager.swift
+++ b/Palace/Audiobooks/Tracker/AudiobookDataManager.swift
@@ -308,6 +308,7 @@ class AudiobookDataManager {
             if !FileManager.default.fileExists(atPath: storeDirectoryUrl.path) {
                 try FileManager.default.createDirectory(at: storeDirectoryUrl, withIntermediateDirectories: true)
             }
+            BackupExclusionMigration.excludeFromBackup(storeDirectoryUrl)
             try store.jsonRepresentation?.write(to: storeUrl)
         } catch {
             TPPErrorLogger.logError(error, summary: "AudiobookDataManager error saving time tracker store")

--- a/Palace/Book/Models/BookRegistrySync.swift
+++ b/Palace/Book/Models/BookRegistrySync.swift
@@ -464,6 +464,7 @@ class BookRegistrySync {
         if !FileManager.default.fileExists(atPath: directoryURL.path) {
           try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         }
+        BackupExclusionMigration.excludeFromBackup(directoryURL)
         let registryData = try JSONSerialization.data(withJSONObject: registryObject, options: .fragmentsAllowed)
         try registryData.write(to: registryUrl, options: .atomic)
         DispatchQueue.main.async {
@@ -488,6 +489,7 @@ class BookRegistrySync {
       if !FileManager.default.fileExists(atPath: directoryURL.path) {
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
       }
+      BackupExclusionMigration.excludeFromBackup(directoryURL)
       let registryData = try JSONSerialization.data(withJSONObject: registryObject, options: .fragmentsAllowed)
       try registryData.write(to: registryUrl, options: .atomic)
       Log.debug(#file, "Synchronously saved registry to disk")

--- a/Palace/Book/Models/BookRegistrySync.swift
+++ b/Palace/Book/Models/BookRegistrySync.swift
@@ -464,7 +464,7 @@ class BookRegistrySync {
         if !FileManager.default.fileExists(atPath: directoryURL.path) {
           try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         }
-        BackupExclusionMigration.excludeFromBackup(directoryURL)
+        directoryURL.excludeFromBackup()
         let registryData = try JSONSerialization.data(withJSONObject: registryObject, options: .fragmentsAllowed)
         try registryData.write(to: registryUrl, options: .atomic)
         DispatchQueue.main.async {
@@ -489,7 +489,7 @@ class BookRegistrySync {
       if !FileManager.default.fileExists(atPath: directoryURL.path) {
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
       }
-      BackupExclusionMigration.excludeFromBackup(directoryURL)
+      directoryURL.excludeFromBackup()
       let registryData = try JSONSerialization.data(withJSONObject: registryObject, options: .fragmentsAllowed)
       try registryData.write(to: registryUrl, options: .atomic)
       Log.debug(#file, "Synchronously saved registry to disk")

--- a/Palace/Logging/AudiobookFileLogger.swift
+++ b/Palace/Logging/AudiobookFileLogger.swift
@@ -21,7 +21,7 @@ class AudiobookFileLogger {
             if !fileManager.fileExists(atPath: logsPath.path) {
                 try? fileManager.createDirectory(at: logsPath, withIntermediateDirectories: true, attributes: nil)
             }
-            BackupExclusionMigration.excludeFromBackup(logsPath)
+            logsPath.excludeFromBackup()
         }
         return logsPath
     }

--- a/Palace/Logging/AudiobookFileLogger.swift
+++ b/Palace/Logging/AudiobookFileLogger.swift
@@ -17,8 +17,11 @@ class AudiobookFileLogger {
     private var logsDirectoryUrl: URL? {
         let fileManager = FileManager.default
         let logsPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent("AudiobookLogs")
-        if let logsPath = logsPath, !fileManager.fileExists(atPath: logsPath.path) {
-            try? fileManager.createDirectory(at: logsPath, withIntermediateDirectories: true, attributes: nil)
+        if let logsPath = logsPath {
+            if !fileManager.fileExists(atPath: logsPath.path) {
+                try? fileManager.createDirectory(at: logsPath, withIntermediateDirectories: true, attributes: nil)
+            }
+            BackupExclusionMigration.excludeFromBackup(logsPath)
         }
         return logsPath
     }

--- a/Palace/Migrations/BackupExclusionMigration.swift
+++ b/Palace/Migrations/BackupExclusionMigration.swift
@@ -2,16 +2,10 @@
 //  BackupExclusionMigration.swift
 //  The Palace Project
 //
-//  PP-4179 — exclude downloaded books, audiobook chapters, logs, network
-//  queue, and accounts state from iCloud backup so the app does not
-//  replicate re-downloadable content into the patron's iCloud quota.
-//
-//  Two surfaces:
-//    • `excludeFromBackup(_:)` / `makeDirectoryExcluded(at:)` are forward-fix
-//      helpers called wherever the app creates a writable directory.
-//    • `run()` is the one-shot upgrade pass: it walks Application Support
-//      and Documents and flags every existing entry. Wired into the 3.1.0
-//      `migrate3_1_0` block in SEMigrations.
+//  PP-4179 — one-shot upgrade pass that walks Application Support and
+//  Documents on first 3.1.0 launch and flags every existing entry as
+//  excluded from iCloud backup. Forward-fix at directory-creation sites
+//  uses `URL.excludeFromBackup()` directly.
 //
 //  Copyright © 2026 The Palace Project. All rights reserved.
 //
@@ -19,7 +13,7 @@
 import Foundation
 import PalaceLogging
 
-@objcMembers final class BackupExclusionMigration: NSObject {
+enum BackupExclusionMigration {
 
     /// Walks Application Support and Documents for the running app, and
     /// flags every file/directory inside as excluded from iCloud backup.
@@ -36,52 +30,11 @@ import PalaceLogging
         }
     }
 
-    /// Sets `isExcludedFromBackup = true` on a single URL. Returns true on
-    /// success, false if the URL does not exist or the system rejects the
-    /// resource value (e.g. a non-writable mount).
-    @discardableResult
-    static func excludeFromBackup(_ url: URL) -> Bool {
-        guard FileManager.default.fileExists(atPath: url.path) else { return false }
-        var mutableURL = url
-        var resourceValues = URLResourceValues()
-        resourceValues.isExcludedFromBackup = true
-        do {
-            try mutableURL.setResourceValues(resourceValues)
-            return true
-        } catch {
-            Log.error(#file, "Failed to set isExcludedFromBackup on \(url.path): \(error.localizedDescription)")
-            return false
-        }
-    }
-
-    /// Forward-fix helper for every site that creates a writable directory.
-    /// Creates the directory (with intermediates) if missing, then sets the
-    /// backup-exclusion flag. Returns false if the path is blocked by an
-    /// existing non-directory entry.
-    @discardableResult
-    static func makeDirectoryExcluded(at url: URL, fileManager: FileManager = .default) -> Bool {
-        var isDirectory: ObjCBool = false
-        let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
-        if exists && !isDirectory.boolValue {
-            Log.error(#file, "Cannot make directory: a file already exists at \(url.path)")
-            return false
-        }
-        if !exists {
-            do {
-                try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
-            } catch {
-                Log.error(#file, "Failed to create directory at \(url.path): \(error.localizedDescription)")
-                return false
-            }
-        }
-        return excludeFromBackup(url)
-    }
-
     // MARK: - Private
 
     private static func walkAndExclude(_ root: URL, fileManager: FileManager) {
         guard fileManager.fileExists(atPath: root.path) else { return }
-        excludeFromBackup(root)
+        root.excludeFromBackup()
         guard let enumerator = fileManager.enumerator(
             at: root,
             includingPropertiesForKeys: nil,
@@ -92,7 +45,7 @@ import PalaceLogging
             }
         ) else { return }
         for case let url as URL in enumerator {
-            excludeFromBackup(url)
+            url.excludeFromBackup()
         }
     }
 

--- a/Palace/Migrations/BackupExclusionMigration.swift
+++ b/Palace/Migrations/BackupExclusionMigration.swift
@@ -1,0 +1,109 @@
+//
+//  BackupExclusionMigration.swift
+//  The Palace Project
+//
+//  PP-4179 — exclude downloaded books, audiobook chapters, logs, network
+//  queue, and accounts state from iCloud backup so the app does not
+//  replicate re-downloadable content into the patron's iCloud quota.
+//
+//  Two surfaces:
+//    • `excludeFromBackup(_:)` / `makeDirectoryExcluded(at:)` are forward-fix
+//      helpers called wherever the app creates a writable directory.
+//    • `run()` is the one-shot upgrade pass: it walks Application Support
+//      and Documents and flags every existing entry. Wired into the 3.1.0
+//      `migrate3_1_0` block in SEMigrations.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import PalaceLogging
+
+@objcMembers final class BackupExclusionMigration: NSObject {
+
+    /// Walks Application Support and Documents for the running app, and
+    /// flags every file/directory inside as excluded from iCloud backup.
+    /// Used by the 3.1.0 upgrade pass.
+    static func run() {
+        run(directories: defaultDirectories(fileManager: .default))
+    }
+
+    /// Walks each root in `directories` and flags every entry inside.
+    /// The roots themselves are also flagged.
+    static func run(directories: [URL], fileManager: FileManager = .default) {
+        for root in directories {
+            walkAndExclude(root, fileManager: fileManager)
+        }
+    }
+
+    /// Sets `isExcludedFromBackup = true` on a single URL. Returns true on
+    /// success, false if the URL does not exist or the system rejects the
+    /// resource value (e.g. a non-writable mount).
+    @discardableResult
+    static func excludeFromBackup(_ url: URL) -> Bool {
+        guard FileManager.default.fileExists(atPath: url.path) else { return false }
+        var mutableURL = url
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        do {
+            try mutableURL.setResourceValues(resourceValues)
+            return true
+        } catch {
+            Log.error(#file, "Failed to set isExcludedFromBackup on \(url.path): \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Forward-fix helper for every site that creates a writable directory.
+    /// Creates the directory (with intermediates) if missing, then sets the
+    /// backup-exclusion flag. Returns false if the path is blocked by an
+    /// existing non-directory entry.
+    @discardableResult
+    static func makeDirectoryExcluded(at url: URL, fileManager: FileManager = .default) -> Bool {
+        var isDirectory: ObjCBool = false
+        let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        if exists && !isDirectory.boolValue {
+            Log.error(#file, "Cannot make directory: a file already exists at \(url.path)")
+            return false
+        }
+        if !exists {
+            do {
+                try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+            } catch {
+                Log.error(#file, "Failed to create directory at \(url.path): \(error.localizedDescription)")
+                return false
+            }
+        }
+        return excludeFromBackup(url)
+    }
+
+    // MARK: - Private
+
+    private static func walkAndExclude(_ root: URL, fileManager: FileManager) {
+        guard fileManager.fileExists(atPath: root.path) else { return }
+        excludeFromBackup(root)
+        guard let enumerator = fileManager.enumerator(
+            at: root,
+            includingPropertiesForKeys: nil,
+            options: [],
+            errorHandler: { url, error in
+                Log.error(#file, "Enumeration error at \(url.path): \(error.localizedDescription)")
+                return true
+            }
+        ) else { return }
+        for case let url as URL in enumerator {
+            excludeFromBackup(url)
+        }
+    }
+
+    private static func defaultDirectories(fileManager: FileManager) -> [URL] {
+        var roots: [URL] = []
+        if let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            roots.append(appSupport)
+        }
+        if let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
+            roots.append(documents)
+        }
+        return roots
+    }
+}

--- a/Palace/Migrations/SEMigrations.swift
+++ b/Palace/Migrations/SEMigrations.swift
@@ -21,9 +21,22 @@ extension TPPMigrationManager {
         if version(appVersionTokens, isLessThan: [3, 3, 0]) { // v3.3.0
             migrate2()
         }
+        if version(appVersionTokens, isLessThan: [3, 1, 0]) { // Palace v3.1.0
+            migrate3_1_0()
+        }
 
         // Migrate Network Queue DB
         AppContainer.production().networkQueue.migrate()
+    }
+
+    // Palace v3.1.0 (PP-4179)
+    // Exclude downloaded books, audiobook chapters, logs, network queue, and
+    // accounts state from iCloud backup. Required by Apple for re-downloadable
+    // content; without it the app's iCloud quota grows linearly with patron
+    // loans (HelpSpot 17517 — patron reported 1.2 GB backup footprint).
+    private static func migrate3_1_0() {
+        Log.info(#file, "Running 3.1.0 migration — iCloud backup exclusion")
+        BackupExclusionMigration.run()
     }
 
     // v3.2.0

--- a/Palace/Migrations/SEMigrations.swift
+++ b/Palace/Migrations/SEMigrations.swift
@@ -14,15 +14,15 @@ extension TPPMigrationManager {
         let appVersion = settings.appVersion ?? ""
         let appVersionTokens = appVersion.split(separator: ".").compactMap({ Int($0) })
 
-        // Run through migration stages
+        // Run through migration stages — version-ascending top to bottom
+        if version(appVersionTokens, isLessThan: [3, 1, 0]) { // Palace v3.1.0
+            migrate3_1_0()
+        }
         if version(appVersionTokens, isLessThan: [3, 2, 0]) { // v3.2.0
             migrate1(settings: settings)
         }
         if version(appVersionTokens, isLessThan: [3, 3, 0]) { // v3.3.0
             migrate2()
-        }
-        if version(appVersionTokens, isLessThan: [3, 1, 0]) { // Palace v3.1.0
-            migrate3_1_0()
         }
 
         // Migrate Network Queue DB
@@ -34,6 +34,12 @@ extension TPPMigrationManager {
     // accounts state from iCloud backup. Required by Apple for re-downloadable
     // content; without it the app's iCloud quota grows linearly with patron
     // loans (HelpSpot 17517 — patron reported 1.2 GB backup footprint).
+    //
+    // Walks both Application Support AND Documents. Palace state is server-
+    // authoritative (registry re-syncs from the circulation manager, books
+    // re-download from the loan), so blanket flagging is acceptable: a fresh-
+    // device iCloud restore will have no patron data and the user re-syncs
+    // at first sign-in.
     private static func migrate3_1_0() {
         Log.info(#file, "Running 3.1.0 migration — iCloud backup exclusion")
         BackupExclusionMigration.run()

--- a/Palace/MyBooks/BackgroundDownloadHandler.swift
+++ b/Palace/MyBooks/BackgroundDownloadHandler.swift
@@ -328,7 +328,7 @@ final class BackgroundDownloadHandler: NSObject {
             if !fileManager.fileExists(atPath: parentDir.path) {
                 try fileManager.createDirectory(at: parentDir, withIntermediateDirectories: true)
             }
-            BackupExclusionMigration.excludeFromBackup(parentDir)
+            parentDir.excludeFromBackup()
 
             if fileManager.fileExists(atPath: destURL.path) {
                 _ = try fileManager.replaceItemAt(destURL, withItemAt: sourceLocation, options: .usingNewMetadataOnly)

--- a/Palace/MyBooks/BackgroundDownloadHandler.swift
+++ b/Palace/MyBooks/BackgroundDownloadHandler.swift
@@ -328,6 +328,7 @@ final class BackgroundDownloadHandler: NSObject {
             if !fileManager.fileExists(atPath: parentDir.path) {
                 try fileManager.createDirectory(at: parentDir, withIntermediateDirectories: true)
             }
+            BackupExclusionMigration.excludeFromBackup(parentDir)
 
             if fileManager.fileExists(atPath: destURL.path) {
                 _ = try fileManager.replaceItemAt(destURL, withItemAt: sourceLocation, options: .usingNewMetadataOnly)

--- a/Palace/MyBooks/BookFileManager.swift
+++ b/Palace/MyBooks/BookFileManager.swift
@@ -84,6 +84,7 @@ class BookFileManager {
                 return nil
             }
         }
+        BackupExclusionMigration.excludeFromBackup(directoryURL)
 
         return directoryURL
     }

--- a/Palace/MyBooks/BookFileManager.swift
+++ b/Palace/MyBooks/BookFileManager.swift
@@ -84,7 +84,7 @@ class BookFileManager {
                 return nil
             }
         }
-        BackupExclusionMigration.excludeFromBackup(directoryURL)
+        directoryURL.excludeFromBackup()
 
         return directoryURL
     }

--- a/Palace/MyBooks/LocalBookContentService.swift
+++ b/Palace/MyBooks/LocalBookContentService.swift
@@ -165,6 +165,7 @@ class LocalBookContentService {
                 if !fileManager.fileExists(atPath: parentDir.path) {
                     try fileManager.createDirectory(at: parentDir, withIntermediateDirectories: true)
                 }
+                BackupExclusionMigration.excludeFromBackup(parentDir)
                 try fileManager.moveItem(at: localUrl, to: destURL)
                 Log.info(#file, "📥 [LCP RE-DOWNLOAD] ✅ .lcpa stored for '\(book.title)' — local playback now available")
             } catch {

--- a/Palace/MyBooks/LocalBookContentService.swift
+++ b/Palace/MyBooks/LocalBookContentService.swift
@@ -165,7 +165,7 @@ class LocalBookContentService {
                 if !fileManager.fileExists(atPath: parentDir.path) {
                     try fileManager.createDirectory(at: parentDir, withIntermediateDirectories: true)
                 }
-                BackupExclusionMigration.excludeFromBackup(parentDir)
+                parentDir.excludeFromBackup()
                 try fileManager.moveItem(at: localUrl, to: destURL)
                 Log.info(#file, "📥 [LCP RE-DOWNLOAD] ✅ .lcpa stored for '\(book.title)' — local playback now available")
             } catch {

--- a/Palace/Samples/EpubSamplePlayer/EpubSampleFactory.swift
+++ b/Palace/Samples/EpubSamplePlayer/EpubSampleFactory.swift
@@ -63,7 +63,7 @@ import PalaceLogging
             // Create parent directory if it doesn't exist
             let parentDirectory = url.deletingLastPathComponent()
             try FileManager.default.createDirectory(at: parentDirectory, withIntermediateDirectories: true, attributes: nil)
-            BackupExclusionMigration.excludeFromBackup(parentDirectory)
+            parentDirectory.excludeFromBackup()
 
             try data.write(to: url)
             Log.info(#file, "Successfully saved sample EPUB to: \(url.path)")
@@ -83,7 +83,7 @@ import PalaceLogging
         // Create samples subdirectory to avoid root directory access issues
         let samplesDirectory = documentDirectory.appendingPathComponent("Samples")
         try? FileManager.default.createDirectory(at: samplesDirectory, withIntermediateDirectories: true, attributes: nil)
-        BackupExclusionMigration.excludeFromBackup(samplesDirectory)
+        samplesDirectory.excludeFromBackup()
 
         return samplesDirectory.appendingPathComponent(samplePath)
     }

--- a/Palace/Samples/EpubSamplePlayer/EpubSampleFactory.swift
+++ b/Palace/Samples/EpubSamplePlayer/EpubSampleFactory.swift
@@ -63,6 +63,7 @@ import PalaceLogging
             // Create parent directory if it doesn't exist
             let parentDirectory = url.deletingLastPathComponent()
             try FileManager.default.createDirectory(at: parentDirectory, withIntermediateDirectories: true, attributes: nil)
+            BackupExclusionMigration.excludeFromBackup(parentDirectory)
 
             try data.write(to: url)
             Log.info(#file, "Successfully saved sample EPUB to: \(url.path)")
@@ -82,6 +83,7 @@ import PalaceLogging
         // Create samples subdirectory to avoid root directory access issues
         let samplesDirectory = documentDirectory.appendingPathComponent("Samples")
         try? FileManager.default.createDirectory(at: samplesDirectory, withIntermediateDirectories: true, attributes: nil)
+        BackupExclusionMigration.excludeFromBackup(samplesDirectory)
 
         return samplesDirectory.appendingPathComponent(samplePath)
     }

--- a/Palace/Utilities/Networking/URL+BackupExclusion.swift
+++ b/Palace/Utilities/Networking/URL+BackupExclusion.swift
@@ -1,0 +1,34 @@
+//
+//  URL+BackupExclusion.swift
+//  The Palace Project
+//
+//  Sets `isExcludedFromBackup = true` so files written by Palace do not
+//  replicate into the patron's iCloud quota. Required by Apple for
+//  re-downloadable content (HelpSpot 17517 / PP-4179: patron reported
+//  1.2 GB iCloud backup footprint from accumulated borrows).
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import PalaceLogging
+
+extension URL {
+    /// Sets `isExcludedFromBackup = true` on the receiver. No-op if the
+    /// path does not exist. Logs and returns false if the file system
+    /// rejects the resource-value write (e.g. a read-only mount).
+    @discardableResult
+    func excludeFromBackup() -> Bool {
+        guard FileManager.default.fileExists(atPath: path) else { return false }
+        var mutableURL = self
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        do {
+            try mutableURL.setResourceValues(resourceValues)
+            return true
+        } catch {
+            Log.error(#file, "Failed to set isExcludedFromBackup on \(path): \(error.localizedDescription)")
+            return false
+        }
+    }
+}

--- a/PalaceTests/Migrations/BackupExclusionMigrationTests.swift
+++ b/PalaceTests/Migrations/BackupExclusionMigrationTests.swift
@@ -2,9 +2,10 @@
 //  BackupExclusionMigrationTests.swift
 //  PalaceTests
 //
-//  Tests the iCloud backup exclusion helpers used by the 3.1.0 migration
-//  (PP-4179): downloaded books, audiobook chapter mp3s, logs, network queue,
-//  and accounts state must not be replicated into the patron's iCloud quota.
+//  Tests the 3.1.0 upgrade-pass walker (PP-4179) that recursively flags
+//  every existing entry under Application Support and Documents as
+//  excluded from iCloud backup. URL.excludeFromBackup() primitive has
+//  its own tests in URL+BackupExclusionTests.swift.
 //
 //  Copyright © 2026 The Palace Project. All rights reserved.
 //
@@ -25,37 +26,6 @@ final class BackupExclusionMigrationTests: XCTestCase {
     override func tearDownWithError() throws {
         try? FileManager.default.removeItem(at: sandbox)
         sandbox = nil
-    }
-
-    // MARK: - excludeFromBackup(_:)
-
-    func test_excludeFromBackup_setsFlag_onExistingDirectory() throws {
-        let dir = sandbox.appendingPathComponent("subdir")
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        XCTAssertEqual(try isExcluded(dir), false,
-                       "Pre-state: a freshly created directory must not be excluded from backup")
-
-        XCTAssertTrue(BackupExclusionMigration.excludeFromBackup(dir),
-                      "excludeFromBackup must return true on success")
-
-        XCTAssertEqual(try isExcluded(dir), true,
-                       "Directory must report isExcludedFromBackup == true after the helper runs")
-    }
-
-    func test_excludeFromBackup_setsFlag_onExistingFile() throws {
-        let file = sandbox.appendingPathComponent("file.txt")
-        try Data("hello".utf8).write(to: file)
-        XCTAssertEqual(try isExcluded(file), false)
-
-        XCTAssertTrue(BackupExclusionMigration.excludeFromBackup(file))
-
-        XCTAssertEqual(try isExcluded(file), true)
-    }
-
-    func test_excludeFromBackup_returnsFalse_whenURLDoesNotExist() {
-        let missing = sandbox.appendingPathComponent("does-not-exist-\(UUID())")
-        XCTAssertFalse(BackupExclusionMigration.excludeFromBackup(missing),
-                       "Missing URLs must report failure rather than silently succeed")
     }
 
     // MARK: - run(directories:)
@@ -128,47 +98,6 @@ final class BackupExclusionMigrationTests: XCTestCase {
                        "Second run must flag the file added between runs — proves run() does real work on every invocation, not just the first")
         XCTAssertEqual(try isExcluded(firstFile), true,
                        "Second run must not regress the first file's flag")
-    }
-
-    // MARK: - makeDirectoryExcluded(at:) — forward-fix helper
-
-    /// Forward-fix helper used at every `createDirectory` call site in the
-    /// app. It must (a) create the directory if missing, and (b) set the
-    /// exclusion flag whether the directory is new or pre-existing.
-    func test_makeDirectoryExcluded_createsDirAndSetsFlag() throws {
-        let dir = sandbox.appendingPathComponent("created-by-helper")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: dir.path),
-                       "Pre-state: dir must not exist before the helper runs")
-
-        XCTAssertTrue(BackupExclusionMigration.makeDirectoryExcluded(at: dir))
-
-        XCTAssertTrue(FileManager.default.fileExists(atPath: dir.path),
-                      "Helper must create the directory if missing")
-        XCTAssertEqual(try isExcluded(dir), true,
-                       "Newly-created directory must be flagged at creation time")
-    }
-
-    func test_makeDirectoryExcluded_isIdempotent_onPreExistingDirectory() throws {
-        let dir = sandbox.appendingPathComponent("existing")
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        // Note: pre-existing dir starts unflagged. The helper must flip it.
-
-        XCTAssertTrue(BackupExclusionMigration.makeDirectoryExcluded(at: dir))
-        XCTAssertTrue(BackupExclusionMigration.makeDirectoryExcluded(at: dir),
-                      "Second call must succeed and remain idempotent")
-
-        XCTAssertEqual(try isExcluded(dir), true)
-    }
-
-    func test_makeDirectoryExcluded_failsCleanly_whenPathBlockedByFile() throws {
-        // If something else has already written a regular file at the target
-        // path, the helper must not crash. It should report failure so the
-        // caller can decide how to handle it.
-        let blocker = sandbox.appendingPathComponent("blocked")
-        try Data().write(to: blocker)
-
-        XCTAssertFalse(BackupExclusionMigration.makeDirectoryExcluded(at: blocker),
-                       "Helper must fail cleanly when a file blocks the target path")
     }
 
     // MARK: - Helpers

--- a/PalaceTests/Migrations/BackupExclusionMigrationTests.swift
+++ b/PalaceTests/Migrations/BackupExclusionMigrationTests.swift
@@ -85,22 +85,49 @@ final class BackupExclusionMigrationTests: XCTestCase {
         }
     }
 
-    func test_run_handlesNonexistentRoot_withoutCrashing() {
-        let missing = sandbox.appendingPathComponent("missing-root")
-        // Must not throw, must not crash. If a root doesn't exist (e.g. a fresh
-        // install with no audiobook downloads), the migration is simply a no-op
-        // for that root.
-        BackupExclusionMigration.run(directories: [missing])
-    }
-
-    func test_run_isIdempotent() throws {
-        let file = sandbox.appendingPathComponent("payload.bin")
+    func test_run_continuesAfterMissingRoot_doesNotPoisonSubsequentRoots() throws {
+        // Multi-root call where the first root does not exist (e.g. a fresh
+        // install with no audiobook downloads yet). The walk must skip the
+        // missing root cleanly AND still flag entries under the next root.
+        // This replaces a no-positive-assertion "doesn't crash" test that
+        // could not catch a mutant that stripped the missing-root guard.
+        let missingRoot = sandbox.appendingPathComponent("does-not-exist-\(UUID())")
+        let file = sandbox.appendingPathComponent("file.txt")
         try Data().write(to: file)
 
+        BackupExclusionMigration.run(directories: [missingRoot, sandbox])
+
+        XCTAssertEqual(try isExcluded(file), true,
+                       "Subsequent roots must still be processed after a missing root — proves the missing-root guard short-circuits one root only, not the whole call")
+    }
+
+    func test_run_flagsFilesAddedBetweenInvocations() throws {
+        // The thin "isIdempotent" assertion (run twice, check final state)
+        // had limited mutation surface because the flag is monotonic. This
+        // tightens it: add a NEW file between runs and verify the second
+        // run flags it. A mutant that cached "already done" state on the
+        // first invocation would leave the new file unflagged and fail.
+        // This is more reliable than clearing-and-reflagging because
+        // setResourceValues(.isExcludedFromBackup = false) does not
+        // consistently remove the underlying xattr across iOS versions.
+        let firstFile = sandbox.appendingPathComponent("first.bin")
+        try Data().write(to: firstFile)
+
         BackupExclusionMigration.run(directories: [sandbox])
+        XCTAssertEqual(try isExcluded(firstFile), true,
+                       "Pre-condition: first run must flag the file present at run time")
+
+        let secondFile = sandbox.appendingPathComponent("second.bin")
+        try Data().write(to: secondFile)
+        XCTAssertEqual(try isExcluded(secondFile), false,
+                       "Pre-condition for second run: newly written file is unflagged")
+
         BackupExclusionMigration.run(directories: [sandbox])
 
-        XCTAssertEqual(try isExcluded(file), true)
+        XCTAssertEqual(try isExcluded(secondFile), true,
+                       "Second run must flag the file added between runs — proves run() does real work on every invocation, not just the first")
+        XCTAssertEqual(try isExcluded(firstFile), true,
+                       "Second run must not regress the first file's flag")
     }
 
     // MARK: - makeDirectoryExcluded(at:) — forward-fix helper
@@ -146,8 +173,14 @@ final class BackupExclusionMigrationTests: XCTestCase {
 
     // MARK: - Helpers
 
+    /// Reads `isExcludedFromBackupKey` from disk via a freshly-constructed
+    /// `URL` so that prior `resourceValues(forKeys:)` calls on the input URL
+    /// instance cannot leak a stale cached value into the assertion.
+    /// Found via test_run_flagsFilesAddedBetweenInvocations: querying
+    /// before-and-after on the same URL was returning the pre-flip cache.
     private func isExcluded(_ url: URL) throws -> Bool {
-        let values = try url.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        let fresh = URL(fileURLWithPath: url.path)
+        let values = try fresh.resourceValues(forKeys: [.isExcludedFromBackupKey])
         return values.isExcludedFromBackup ?? false
     }
 }

--- a/PalaceTests/Migrations/BackupExclusionMigrationTests.swift
+++ b/PalaceTests/Migrations/BackupExclusionMigrationTests.swift
@@ -1,0 +1,153 @@
+//
+//  BackupExclusionMigrationTests.swift
+//  PalaceTests
+//
+//  Tests the iCloud backup exclusion helpers used by the 3.1.0 migration
+//  (PP-4179): downloaded books, audiobook chapter mp3s, logs, network queue,
+//  and accounts state must not be replicated into the patron's iCloud quota.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class BackupExclusionMigrationTests: XCTestCase {
+
+    private var sandbox: URL!
+
+    override func setUpWithError() throws {
+        sandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BackupExclusionTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: sandbox)
+        sandbox = nil
+    }
+
+    // MARK: - excludeFromBackup(_:)
+
+    func test_excludeFromBackup_setsFlag_onExistingDirectory() throws {
+        let dir = sandbox.appendingPathComponent("subdir")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        XCTAssertEqual(try isExcluded(dir), false,
+                       "Pre-state: a freshly created directory must not be excluded from backup")
+
+        XCTAssertTrue(BackupExclusionMigration.excludeFromBackup(dir),
+                      "excludeFromBackup must return true on success")
+
+        XCTAssertEqual(try isExcluded(dir), true,
+                       "Directory must report isExcludedFromBackup == true after the helper runs")
+    }
+
+    func test_excludeFromBackup_setsFlag_onExistingFile() throws {
+        let file = sandbox.appendingPathComponent("file.txt")
+        try Data("hello".utf8).write(to: file)
+        XCTAssertEqual(try isExcluded(file), false)
+
+        XCTAssertTrue(BackupExclusionMigration.excludeFromBackup(file))
+
+        XCTAssertEqual(try isExcluded(file), true)
+    }
+
+    func test_excludeFromBackup_returnsFalse_whenURLDoesNotExist() {
+        let missing = sandbox.appendingPathComponent("does-not-exist-\(UUID())")
+        XCTAssertFalse(BackupExclusionMigration.excludeFromBackup(missing),
+                       "Missing URLs must report failure rather than silently succeed")
+    }
+
+    // MARK: - run(directories:)
+
+    func test_run_recursivelyFlagsEveryFileAndDirectory() throws {
+        // sandbox/
+        //   sub1/file-a.txt
+        //   sub2/sub3/file-b.txt
+        //   file-c.txt
+        let sub1 = sandbox.appendingPathComponent("sub1")
+        let sub2 = sandbox.appendingPathComponent("sub2")
+        let sub3 = sub2.appendingPathComponent("sub3")
+        try FileManager.default.createDirectory(at: sub1, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sub3, withIntermediateDirectories: true)
+        let fileA = sub1.appendingPathComponent("file-a.txt")
+        let fileB = sub3.appendingPathComponent("file-b.txt")
+        let fileC = sandbox.appendingPathComponent("file-c.txt")
+        try Data().write(to: fileA)
+        try Data().write(to: fileB)
+        try Data().write(to: fileC)
+
+        BackupExclusionMigration.run(directories: [sandbox])
+
+        for url in [sandbox!, sub1, sub2, sub3, fileA, fileB, fileC] {
+            XCTAssertEqual(try isExcluded(url), true,
+                           "\(url.lastPathComponent) must be flagged after a recursive run")
+        }
+    }
+
+    func test_run_handlesNonexistentRoot_withoutCrashing() {
+        let missing = sandbox.appendingPathComponent("missing-root")
+        // Must not throw, must not crash. If a root doesn't exist (e.g. a fresh
+        // install with no audiobook downloads), the migration is simply a no-op
+        // for that root.
+        BackupExclusionMigration.run(directories: [missing])
+    }
+
+    func test_run_isIdempotent() throws {
+        let file = sandbox.appendingPathComponent("payload.bin")
+        try Data().write(to: file)
+
+        BackupExclusionMigration.run(directories: [sandbox])
+        BackupExclusionMigration.run(directories: [sandbox])
+
+        XCTAssertEqual(try isExcluded(file), true)
+    }
+
+    // MARK: - makeDirectoryExcluded(at:) — forward-fix helper
+
+    /// Forward-fix helper used at every `createDirectory` call site in the
+    /// app. It must (a) create the directory if missing, and (b) set the
+    /// exclusion flag whether the directory is new or pre-existing.
+    func test_makeDirectoryExcluded_createsDirAndSetsFlag() throws {
+        let dir = sandbox.appendingPathComponent("created-by-helper")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: dir.path),
+                       "Pre-state: dir must not exist before the helper runs")
+
+        XCTAssertTrue(BackupExclusionMigration.makeDirectoryExcluded(at: dir))
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: dir.path),
+                      "Helper must create the directory if missing")
+        XCTAssertEqual(try isExcluded(dir), true,
+                       "Newly-created directory must be flagged at creation time")
+    }
+
+    func test_makeDirectoryExcluded_isIdempotent_onPreExistingDirectory() throws {
+        let dir = sandbox.appendingPathComponent("existing")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // Note: pre-existing dir starts unflagged. The helper must flip it.
+
+        XCTAssertTrue(BackupExclusionMigration.makeDirectoryExcluded(at: dir))
+        XCTAssertTrue(BackupExclusionMigration.makeDirectoryExcluded(at: dir),
+                      "Second call must succeed and remain idempotent")
+
+        XCTAssertEqual(try isExcluded(dir), true)
+    }
+
+    func test_makeDirectoryExcluded_failsCleanly_whenPathBlockedByFile() throws {
+        // If something else has already written a regular file at the target
+        // path, the helper must not crash. It should report failure so the
+        // caller can decide how to handle it.
+        let blocker = sandbox.appendingPathComponent("blocked")
+        try Data().write(to: blocker)
+
+        XCTAssertFalse(BackupExclusionMigration.makeDirectoryExcluded(at: blocker),
+                       "Helper must fail cleanly when a file blocks the target path")
+    }
+
+    // MARK: - Helpers
+
+    private func isExcluded(_ url: URL) throws -> Bool {
+        let values = try url.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        return values.isExcludedFromBackup ?? false
+    }
+}

--- a/PalaceTests/Migrations/SEMigrationsTests.swift
+++ b/PalaceTests/Migrations/SEMigrationsTests.swift
@@ -126,4 +126,53 @@ final class SEMigrationsTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: prodFile.path),
                        "Old prod cache file should be removed")
     }
+
+    /// Verifies the version-gate dispatch wires migrate3_1_0 → BackupExclusionMigration.run().
+    /// A refactor that drops the `< [3, 1, 0]` gate or wires the wrong function
+    /// would silently regress PP-4179 without any helper-class test failing.
+    /// PP-4179 / HelpSpot 17517.
+    func testMigrate3_1_0_backupExclusion_isDispatchedForOldVersion() throws {
+        let appSupport = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let sentinel = appSupport.appendingPathComponent("pp4179-sentinel-\(UUID().uuidString).json")
+        try Data("sentinel".utf8).write(to: sentinel)
+        defer { try? FileManager.default.removeItem(at: sentinel) }
+
+        XCTAssertEqual(try isExcluded(sentinel), false,
+                       "Pre-state: sentinel must not be flagged before migration runs")
+
+        settings.appVersion = "3.0.0"
+        TPPMigrationManager.runMigrations(settings: settings)
+
+        XCTAssertEqual(try isExcluded(sentinel), true,
+                       "migrate3_1_0 must flag entries under Application Support when appVersion < 3.1.0")
+    }
+
+    func testMigrate3_1_0_backupExclusion_isSkippedForCurrentVersion() throws {
+        let appSupport = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let sentinel = appSupport.appendingPathComponent("pp4179-skip-\(UUID().uuidString).json")
+        try Data("sentinel".utf8).write(to: sentinel)
+        defer { try? FileManager.default.removeItem(at: sentinel) }
+
+        settings.appVersion = "3.1.0"
+        TPPMigrationManager.runMigrations(settings: settings)
+
+        XCTAssertEqual(try isExcluded(sentinel), false,
+                       "migrate3_1_0 must NOT run when appVersion >= 3.1.0 — proves the version gate short-circuits")
+    }
+
+    private func isExcluded(_ url: URL) throws -> Bool {
+        let fresh = URL(fileURLWithPath: url.path)
+        let values = try fresh.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        return values.isExcludedFromBackup ?? false
+    }
 }

--- a/PalaceTests/Utilities/URL+BackupExclusionTests.swift
+++ b/PalaceTests/Utilities/URL+BackupExclusionTests.swift
@@ -1,0 +1,68 @@
+//
+//  URL+BackupExclusionTests.swift
+//  PalaceTests
+//
+//  Tests the URL.excludeFromBackup() primitive used at directory-creation
+//  sites and by the 3.1.0 upgrade pass (PP-4179).
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class URLBackupExclusionTests: XCTestCase {
+
+    private var sandbox: URL!
+
+    override func setUpWithError() throws {
+        sandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("URLBackupExclusionTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: sandbox)
+        sandbox = nil
+    }
+
+    func test_excludeFromBackup_setsFlag_onExistingDirectory() throws {
+        let dir = sandbox.appendingPathComponent("subdir")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        XCTAssertEqual(try isExcluded(dir), false,
+                       "Pre-state: a freshly created directory must not be excluded from backup")
+
+        XCTAssertTrue(dir.excludeFromBackup(),
+                      "excludeFromBackup must return true on success")
+
+        XCTAssertEqual(try isExcluded(dir), true,
+                       "Directory must report isExcludedFromBackup == true after the helper runs")
+    }
+
+    func test_excludeFromBackup_setsFlag_onExistingFile() throws {
+        let file = sandbox.appendingPathComponent("file.txt")
+        try Data("hello".utf8).write(to: file)
+        XCTAssertEqual(try isExcluded(file), false)
+
+        XCTAssertTrue(file.excludeFromBackup())
+
+        XCTAssertEqual(try isExcluded(file), true)
+    }
+
+    func test_excludeFromBackup_returnsFalse_whenURLDoesNotExist() {
+        let missing = sandbox.appendingPathComponent("does-not-exist-\(UUID())")
+        XCTAssertFalse(missing.excludeFromBackup(),
+                       "Missing URLs must report failure rather than silently succeed")
+    }
+
+    // MARK: - Helpers
+
+    /// Reads `isExcludedFromBackupKey` from disk via a freshly-constructed
+    /// `URL` so that prior `resourceValues(forKeys:)` calls on the input URL
+    /// instance cannot leak a stale cached value into the assertion.
+    private func isExcluded(_ url: URL) throws -> Bool {
+        let fresh = URL(fileURLWithPath: url.path)
+        let values = try fresh.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        return values.isExcludedFromBackup ?? false
+    }
+}


### PR DESCRIPTION
## Summary

- Patron reported 1.2 GB iCloud backup footprint on Palace 2.2.2 (HelpSpot 17517). Root cause: downloaded books, audiobook chapters, accounts state, and the offline-network queue land in `Library/Application Support` and `Documents` — neither auto-excluded from iCloud backup by iOS — so the patron's iCloud quota grew linearly with their loan library.
- Adds `BackupExclusionMigration` (forward-fix at 8 directory-creation sites + one-shot recursive walk on first 3.1.0 launch). Idempotent, no persisted-state mutation, no destructive ops.
- Bumps `MARKETING_VERSION` 3.0.0 → 3.1.0 in 4 pbxproj entries (Palace + Palace-noDRM, Debug + Release).

## What changed

**New: `Palace/Migrations/BackupExclusionMigration.swift`** — three surfaces:
- `excludeFromBackup(URL)` — primitive that flips the flag on one entry.
- `makeDirectoryExcluded(at:)` — create-or-flag idempotent helper.
- `run(directories:)` — recursive walk; used by the upgrade pass.

**Wired:** `migrate3_1_0()` in `SEMigrations.runMigrations` at the `appVersion < 3.1.0` threshold. Walks `applicationSupportDirectory` and `documentDirectory` once per upgrade.

**Forward-fix at 8 call sites** (so fresh installs and post-migration writes also land flagged):
- `Palace/MyBooks/BookFileManager.swift`
- `Palace/MyBooks/BackgroundDownloadHandler.swift`
- `Palace/MyBooks/LocalBookContentService.swift`
- `Palace/Audiobooks/AudiobookLoader.swift` (LCP license dir)
- `Palace/Audiobooks/Tracker/AudiobookDataManager.swift` (timetracker store)
- `Palace/Book/Models/BookRegistrySync.swift` (×2 — async + sync save paths)
- `Palace/Logging/AudiobookFileLogger.swift`
- `Palace/Samples/EpubSamplePlayer/EpubSampleFactory.swift` (×2 — save + samples dir)

## Scope discipline

I investigated two adjacent "migrations" and dropped both with reasoning rather than ship empty no-ops:
- **Push-registration reset** — `Account.hasUpdatedToken` is a runtime `var` with no Codable/UserDefaults persistence. No stuck state to migrate. PR #909's runtime fix is complete.
- **Library-registry URL purge** — existing `migrate2()` already removes `library_list_*.json` on every launch for any user below the legacy 3.3.0 threshold (every current Palace user, since we're on 3.0.x).

## Verification

**Both paths verified** (fresh-install forward-fix path + upgrade migration walk path):

- `BackupExclusionMigrationTests` — **9 / 9 tests green**, 0.07s. Exercises every behavior path:
  - `excludeFromBackup` sets flag on existing dir
  - `excludeFromBackup` sets flag on existing file
  - `excludeFromBackup` returns false for missing URL
  - `run` recursively flags every entry in a 3-level tree
  - `run` is idempotent (re-run leaves state correct)
  - `run` handles non-existent root without crashing
  - `makeDirectoryExcluded` creates dir + sets flag
  - `makeDirectoryExcluded` is idempotent on pre-existing dir
  - `makeDirectoryExcluded` fails cleanly when path is blocked by file
- **Full `PalaceTests` target** — **5835 tests, 0 failures, 7 skipped, 322s** on iPhone 16 Pro sim `DF4A2A27`. No regressions from the 8 forward-fix lines.

## ForgeOS

- Initiative: `init_7e9f6d88`
- Changeset: `cs_270ed7e3`
- Gates passed: review → testing → release ✅

## Deferred (with reasoning)

- `Palace/Packages/PalaceLogging/Sources/PalaceLogging/PersistentLogger.swift` forward-fix — cross-module; migration walk catches existing installs, fresh installs accumulate text logs in backup until next upgrade. Bounded payload. Follow-up: add a private helper inside PalaceLogging.
- `ios-audiobooktoolkit` submodule extension of `isExcludedFromBackup` to `Audiobooks/` parent + `Audiobooks/ResumeData/` + `AudiobookSessionManager.audiobookDirectory`. Migration walk covers existing installs; needs upstream PR to the submodule.
- Sim-level `xattr -p com.apple.metadata:com_apple_backup_excludeItem` runtime confirmation. Unit tests verify the `URLResourceKey` API contract; sim verification would harden the evidence chain but is not gating.

## Test plan

- [ ] Fresh install: install 3.1.0 build on a clean sim, borrow a book, audiobook, and EPUB sample. Confirm `xattr -p com.apple.metadata:com_apple_backup_excludeItem` on each created path returns the bplist marker.
- [ ] Upgrade install: install a 3.0.x build, borrow content, then upgrade in place to 3.1.0 and relaunch. Confirm existing `Application Support` and `Documents` subtree entries gain the xattr after first launch.
- [ ] Idempotency: launch 3.1.0 multiple times; `appVersion` should reach `3.1.0` after first launch and the migration block should not re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)