### PR TITLE
verify-pr: add coverage_by_fr step (FR↔Tests matrix integrity)

### DIFF
--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -302,6 +302,31 @@ else
   fi
 fi
 
+# 8. FR↔Tests coverage matrix integrity (skipped if harness not installed —
+#    the matrix is maintained by the optional harness governance layer; outside
+#    contributors aren't blocked by its absence).
+echo "--- Coverage by FR ---"
+HARNESS_BIN="$HOME/harness/bin/harness"
+if [ ! -x "$HARNESS_BIN" ]; then
+  record "coverage_by_fr" "pass" "harness not installed (skipped)"
+elif ! "$HARNESS_BIN" srd coverage --json >/dev/null 2>&1; then
+  record "coverage_by_fr" "pass" "harness srd coverage subcommand not available (skipped)"
+else
+  COV_JSON=$("$HARNESS_BIN" srd coverage --json 2>/dev/null)
+  COV_GAPS=$(printf '%s' "$COV_JSON" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('fr_gaps', [])))" 2>/dev/null || echo "?")
+  COV_MISSING=$(printf '%s' "$COV_JSON" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('missing_test_areas', [])))" 2>/dev/null || echo "?")
+  COV_STALE=$(printf '%s' "$COV_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('fr_stale',[]))+len(d.get('nfr_stale',[])))" 2>/dev/null || echo "?")
+  if [ "$COV_GAPS" = "0" ] && [ "$COV_MISSING" = "0" ] && [ "$COV_STALE" = "0" ]; then
+    if "$HARNESS_BIN" srd diff --code-vs-narrative --strict >/dev/null 2>&1; then
+      record "coverage_by_fr" "pass" "FR↔Tests matrix clean (0 gaps, 0 missing, 0 stale, 0 drift)"
+    else
+      record "coverage_by_fr" "fail" "FR↔Tests matrix has code-vs-narrative drift > 10% — run: harness srd diff --code-vs-narrative"
+    fi
+  else
+    record "coverage_by_fr" "fail" "FR↔Tests matrix issues — gaps=$COV_GAPS missing=$COV_MISSING stale=$COV_STALE — run: harness srd coverage"
+  fi
+fi
+
 # Summary
 echo ""
 echo "=== Summary ==="

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -305,11 +305,16 @@ fi
 # 8. FR↔Tests coverage matrix integrity (skipped if harness not installed —
 #    the matrix is maintained by the optional harness governance layer; outside
 #    contributors aren't blocked by its absence).
+#
+# Presence-probe: `harness srd --help` lists subcommands (exit 0 always,
+# regardless of matrix state). Don't probe with `srd coverage --json` exit
+# code — that returns 1 when the matrix is dirty (the case this step is
+# meant to catch), which would falsely route to "skipped".
 echo "--- Coverage by FR ---"
 HARNESS_BIN="$HOME/harness/bin/harness"
 if [ ! -x "$HARNESS_BIN" ]; then
   record "coverage_by_fr" "pass" "harness not installed (skipped)"
-elif ! "$HARNESS_BIN" srd coverage --json >/dev/null 2>&1; then
+elif ! "$HARNESS_BIN" srd --help 2>&1 | grep -q '\bcoverage\b'; then
   record "coverage_by_fr" "pass" "harness srd coverage subcommand not available (skipped)"
 else
   COV_JSON=$("$HARNESS_BIN" srd coverage --json 2>/dev/null)


### PR DESCRIPTION
## Summary

- Adds step 8 to `scripts/verify-pr.sh`: `coverage_by_fr` — invokes the harness FR↔Tests matrix tooling (`harness srd coverage --json` + `harness srd diff --code-vs-narrative --strict`) and fails the PR if the matrix has GAP rows, missing test areas, stale rows (>90d), or code-vs-narrative drift > 10%.
- Skip-path for external contributors who don't have the harness installed: records `pass` with `harness not installed (skipped)`. Their PR is not blocked by an absence of the optional governance layer.
- Sub-check of the existing ForgeOS `verification` gate, not a new gate.

## Verification

- `bash -n scripts/verify-pr.sh` passes (syntax-check).
- Presence-probe verified: `harness srd --help | grep -q '\bcoverage\b'` exits 0 cleanly regardless of matrix state. (First version of the probe used `harness srd coverage --json`'s exit code to detect availability — but that command returns rc=1 when the matrix is dirty, which would silently skip the gate in the exact case it's meant to catch. Caught in architect review and fixed in `cffca4e1` before this PR was opened.)
- Step 8 is purely additive: no modification to `record()`, summary aggregation, exit-code computation, or steps 1–7's behavior.
- The harness subcommands invoked have their own per-tool tests in `~/harness/.git`.

## ForgeOS

- Changeset: `cs_50b36897`
- Risk score: 20/100 (cross-module + security flags are false-positives from name matches)
- Gates: review (architect ✅ rev_b441562b) → testing (qa_test ✅ rev_a0c4cb27) → release ✅ (maurice)
- `forge_release_check`: `can_release: true`

## Test plan

- [ ] Verify the new step appears as `--- Coverage by FR ---` in CI output on this PR
- [ ] Verify CI's `verify-pr.sh` reports `pass` with the matrix in its current clean state (0 gaps after triage)
- [ ] Confirm step is the 8th and final check (between simdrive and Summary)
- [ ] Manual smoke: temporarily introduce a GAP row in the matrix sidecar, confirm `verify-pr.sh` step transitions to `fail` with a useful message
- [ ] Manual smoke (skip-path): rename `~/harness/bin/harness` momentarily, confirm step records `pass: harness not installed (skipped)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)