### PR TITLE
[3.1.0] LCP: catch escaping C++ exceptions from R2LCPClient (Crashlytics 0ca62d8244)

### DIFF
--- a/Palace/Reader2/ReaderStackConfiguration/LCP/TPPLCPClient.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LCP/TPPLCPClient.swift
@@ -8,6 +8,7 @@ import PalaceLogging
 
 enum LCPContextError: Error {
     case creationReturnedNil
+    case nativeException(name: String, reason: String)
 }
 
 let lcpService = LCPLibraryService()
@@ -38,17 +39,35 @@ class TPPLCPClient: ReadiumLCP.LCPClient {
     ) throws -> LCPClientContext {
         var rawResult: LCPClientContext?
         var caughtError: Error?
+        var caughtNativeException: NSException?
 
+        // R2LCPClient → LCPWrapper (ObjC) → lcp::DRMService (C++) → Botan can
+        // throw C++ exceptions that escape the binary framework's bridge
+        // unhandled (notably Botan::Decoding_Error when the CRL bytes are
+        // malformed). A Swift do/catch cannot catch those — they bypass the
+        // Swift error machinery entirely and reach std::terminate. We catch
+        // both NSException AND C++ exceptions here so a bad CRL surfaces as
+        // a Swift-throwable error instead of crashing the app
+        // (Crashlytics 0ca62d8244 — 27 users, 249 events).
         contextQueue.sync {
-            do {
-                rawResult = try R2LCPClient.createContext(
-                    jsonLicense: jsonLicense,
-                    hashedPassphrase: hashedPassphrase,
-                    pemCrl: pemCrl
-                )
-            } catch {
-                caughtError = error
+            caughtNativeException = TPPObjCExceptionCatcher.catchAllExceptions {
+                do {
+                    rawResult = try R2LCPClient.createContext(
+                        jsonLicense: jsonLicense,
+                        hashedPassphrase: hashedPassphrase,
+                        pemCrl: pemCrl
+                    )
+                } catch {
+                    caughtError = error
+                }
             }
+        }
+
+        if let exception = caughtNativeException {
+            let name = exception.name.rawValue
+            let reason = exception.reason ?? "Unknown native exception"
+            Log.error(#file, "LCP createContext threw native exception: \(name) — \(reason)")
+            throw LCPContextError.nativeException(name: name, reason: reason)
         }
 
         if let error = caughtError {

--- a/Palace/Utilities/TPPObjCExceptionCatcher.h
+++ b/Palace/Utilities/TPPObjCExceptionCatcher.h
@@ -11,6 +11,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// Executes @p block inside @try and returns the caught NSException, or nil.
 + (nullable NSException *)catchExceptionInBlock:(void (NS_NOESCAPE ^)(void))block;
 
+/// Like @c catchExceptionInBlock: but also catches escaping C++ exceptions
+/// (e.g. @c Botan::Decoding_Error from R2LCPClient) and wraps them in a
+/// synthetic @c NSException whose @c reason carries @c std::exception::what().
+/// Use at FFI seams where C++ exceptions can otherwise propagate to
+/// @c std::terminate and crash the app.
++ (nullable NSException *)catchAllExceptionsInBlock:(void (NS_NOESCAPE ^)(void))block;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Jira: [PP-4301](https://ebce-lyrasis.atlassian.net/browse/PP-4301)

## Summary
- Wraps `R2LCPClient.createContext` in `TPPObjCExceptionCatcher.catchAllExceptions { ... }`. Escaping C++ exceptions (notably `Botan::Decoding_Error` on malformed CRL data) are converted into a synthesized `NSException`, then surfaced as a Swift-throwable `LCPContextError.nativeException(name:reason:)`.
- Exposes the existing `+[TPPObjCExceptionCatcher catchAllExceptionsInBlock:]` method in the `.h` header. The `.mm` implementation was already shipping in production — it just wasn't visible to Swift.

## Crashlytics issue
[`0ca62d8244e96706c4649b97e20851ff`](https://console.firebase.google.com/v1/appid/project/the-palace-project/crashlytics/app/1:716454087792:ios:11eb8d287ec88c2784f8b5/issues/0ca62d8244e96706c4649b97e20851ff) — **249 events / 27 users** on 3.0.0, **`processState: FOREGROUND`** (user-impacting LCP book opens crashing).

## Why this is NOT Adobe RMSDK (despite the empty-stack title)
The issue summary shows `<empty stack> - Botan::Decoding_Error - X509 CRL decoding failed with BER: Tag mismatch...`. Sample event thread dump shows the actual call path:

```
Botan::X509_Object::load_data(Botan::DataSource&)
Botan::X509_CRL::X509_CRL(Botan::DataSource&)
lcp::LicenseChecker::checkCertificateRevocation()
lcp::DRMService::createContext(...)
+[LCPWrapper createContext:hashedPassphrase:pemCrl:error:]    ← ObjC bridge
$s11R2LCPClient13createContext...                              ← Swift wrapper
closure #1 in TPPLCPClient.createContext (TPPLCPClient.swift:42)
```

This is **Readium LCP's bundled Botan** (not Adobe RMSDK). `LCPWrapper.framework` is closed-source binary; its ObjC++ implementation should catch the C++ exception and surface it via the `errorCode` out-param, but doesn't. Swift's `do/catch` cannot catch C++ exceptions across the FFI boundary, so they reach `std::terminate`.

## How the fix works
`TPPObjCExceptionCatcher.mm` already had `+catchAllExceptionsInBlock:`:

```objc
@catch (...) {
    NSString *reason = @"Unknown C++ exception";
    try {
        std::rethrow_exception(std::current_exception());
    } catch (const std::exception &e) {
        reason = [NSString stringWithUTF8String:e.what()];
    } catch (...) { /* keep default */ }
    return [NSException exceptionWithName:@"CppException" reason:reason userInfo:nil];
}
```

It was just missing from the header, so Swift couldn't see it. PR exposes it and uses it from `TPPLCPClient.createContext`. Caught exception's reason carries `std::exception::what()` (e.g. `"X509 CRL decoding failed with BER: Tag mismatch..."`) which we surface via the new `LCPContextError.nativeException(name:reason:)`.

## Test plan
- [x] xcodebuild build SUCCEEDED on iPhone 16 Pro Sim DF4A2A27
- [x] AudiobookLoaderTests + AccountDetailsURLTests still pass (regression coverage)
- [ ] Watch issue 0ca62d8244 event count on next 3.1.0 TestFlight — should drop to ~zero (catch path converts C++ throw into a thrown Swift error that surfaces as the existing borrow/open error UI)

## Governance
- ForgeOS changeset: `cs_c4293d64`
- Initiative: `init_71435f73` ("3.1.0 Crashlytics long-tail cleanup")
- All gates passed (review / testing / release)

## Follow-up
- Server-side: investigate why some users are receiving malformed CRL bytes from the LCP CRL endpoint. The catch path turns the crash into a clean error, but the user still can't open the book. Worth a backend ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PP-4301]: https://ebce-lyrasis.atlassian.net/browse/PP-4301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ