### PR TITLE
[3.1.0] BookReturnService: route SAML/OIDC expired-token returns through re-auth modal

### DIFF
--- a/Palace/MyBooks/BookReturnService.swift
+++ b/Palace/MyBooks/BookReturnService.swift
@@ -282,13 +282,39 @@ final class BookReturnService {
             return
         }
 
-        // Invalid credentials — re-authenticate and retry
-        if problemType == TPPProblemDocument.TypeInvalidCredentials {
-            Log.info(#file, "Invalid credentials on return — triggering re-auth")
+        // Auth error — re-authenticate and retry. Mirrors BorrowOperation's
+        // detection logic so SAML/OIDC token expiry on return surfaces the
+        // same sign-in modal that borrow already shows. Without the broader
+        // detection, an expired SAML bearer token returned a generic 401
+        // (no `invalid-credentials` problem-doc type) and fell through to
+        // the alert path, contradicting the borrow UX.
+        let nsError = error as NSError
+        let isAuthError: Bool = {
+            if problemType == TPPProblemDocument.TypeInvalidCredentials { return true }
+            if problemDoc?.isRecoverableAuthError == true { return true }
+            if nsError.code == TPPErrorCode.invalidCredentials.rawValue { return true }
+            return false
+        }()
+
+        if isAuthError {
+            let userAccount = userAccountProvider()
+            let authDef = userAccount.authDefinition
+            let needsBrowserReauth = (authDef?.isSaml == true || authDef?.isOidc == true)
+                && userAccount.hasCredentials()
+
+            if needsBrowserReauth {
+                // Force the SignInModal to drive a fresh browser auth instead
+                // of silently reusing the expired credentials.
+                Log.info(#file, "Auth error on return for SAML/OIDC account — marking credentials stale and presenting re-auth modal")
+                userAccount.markCredentialsStale()
+            } else {
+                Log.info(#file, "Auth error on return — triggering re-auth")
+            }
+
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                let userAccount = self.userAccountProvider()
-                self.reauthenticator.authenticateIfNeeded(userAccount, usingExistingCredentials: false) { [weak self] in
+                let user = self.userAccountProvider()
+                self.reauthenticator.authenticateIfNeeded(user, usingExistingCredentials: false) { [weak self] in
                     guard let self else { return }
                     if self.userAccountProvider().hasCredentials() {
                         self.returnBook(withIdentifier: identifier, completion: completion)


### PR DESCRIPTION
Jira: [PP-4304](https://ebce-lyrasis.atlassian.net/browse/PP-4304)

## Summary
- Extends `BookReturnService.handleRevokeError`'s auth-error detection to mirror `BorrowOperation`. Previously only matched `TPPProblemDocument.TypeInvalidCredentials`; now also matches `problemDoc.isRecoverableAuthError` and `NSError` code `TPPErrorCode.invalidCredentials.rawValue`.
- For SAML/OIDC accounts with credentials, calls `userAccount.markCredentialsStale()` before re-auth so `SignInModalPresenter` drives a fresh browser auth instead of silently reusing the expired credentials (matches BorrowOperation line 487).
- Reuses the existing `reauthenticator` + recursive `returnBook` retry plumbing — no new types, no new dependencies.

## User report
> SAML when you attempt a return with an expired token, an error is shown instead of a login modal. Should be the same experience as borrow.

## Why the bug existed
The borrow path (`BorrowOperation.handleBorrowAuthErrorIfNeeded`) accepts three signals as auth errors:
1. `TPPProblemDocument.TypeInvalidCredentials`
2. `problemDoc.isRecoverableAuthError` (matches `…/auth/recoverable/…` URLs)
3. `NSError.code == TPPErrorCode.invalidCredentials.rawValue`

The return path was only checking #1. An expired SAML bearer comes back as a generic 401 with no problem-doc type, hits the NSError-code path, but the return service didn't recognize it and fell through to `presentReturnFailureAlert`.

For SAML/OIDC, BorrowOperation also calls `userAccount.markCredentialsStale()` so the modal forces a fresh browser auth. Without that call, the existing credentials look valid to the auth machinery and the modal would no-op. This PR adds the same call on the return path.

## Test plan
- [x] `xcodebuild test -only-testing:PalaceTests/BookReturnServiceTests` — 8/8 PASS
- [x] Existing `testReturnBook_revokeURLReturnsInvalidCredentials_reauthenticatesAndRetries` continues to validate the reauth+retry plumbing
- [ ] Manual verification on next 3.1.0 TestFlight: return a SAML book on the A1QA test library after letting the bearer expire — should see the same sign-in modal that borrow shows, not the error alert

## Governance
- ForgeOS changeset: `cs_5d22c2f1`
- Initiative: `init_71435f73` ("3.1.0 Crashlytics long-tail cleanup")
- Risk score: 20 (auth-sensitive); all gates passed (review / testing / release)

## Scope / Not done
- **Scope:** `BookReturnService.handleRevokeError` detection block only (single function, ~32 LOC). `Reauthenticator` / `SignInModalPresenter` plumbing unchanged. Borrow-side behavior unchanged.
- **Not done:** No new unit tests for the two added auth-detection branches (isRecoverableAuthError, NSError-code). They share the existing reauth plumbing that `testReturnBook_revokeURLReturnsInvalidCredentials_reauthenticatesAndRetries` exercises. Worth a follow-up to add explicit branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PP-4304]: https://ebce-lyrasis.atlassian.net/browse/PP-4304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ