### PR TITLE
fix: surface server 403 error message in token-based sign-in

### DIFF
--- a/Palace/SignInLogic/TokenRequest.swift
+++ b/Palace/SignInLogic/TokenRequest.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import PalaceLogging
+import PalaceCatalog
 
 @objc class TokenResponse: NSObject, Codable {
     @objc let accessToken: String
@@ -80,9 +81,21 @@ import PalaceLogging
                 if httpResponse.statusCode != 200 {
                     let errorMsg = String(data: data, encoding: .utf8) ?? "No error message"
                     Log.error(#file, "Token request failed with status \(httpResponse.statusCode): \(errorMsg)")
-                    let error = NSError(domain: "TokenRequest", code: httpResponse.statusCode,
-                                        userInfo: [NSLocalizedDescriptionKey: "Server returned status \(httpResponse.statusCode)"])
-                    return .failure(error)
+
+                    // Attempt to surface a server-supplied problem document so callers can
+                    // show the real reason to the user (e.g. "Expired card") instead of the
+                    // generic "Invalid Credentials" fallback.
+                    if let problemDoc = TPPProblemDocument.fromProblemResponseData(data) {
+                        return .failure(NSError.makeFromProblemDocument(
+                            problemDoc,
+                            domain: "TokenRequest",
+                            code: httpResponse.statusCode,
+                            userInfo: [NSLocalizedDescriptionKey: "Server returned status \(httpResponse.statusCode)"]
+                        ))
+                    }
+
+                    return .failure(NSError(domain: "TokenRequest", code: httpResponse.statusCode,
+                                            userInfo: [NSLocalizedDescriptionKey: "Server returned status \(httpResponse.statusCode)"]))
                 }
             }
 

--- a/PalaceTests/SignInLogic/TokenRequestTests.swift
+++ b/PalaceTests/SignInLogic/TokenRequestTests.swift
@@ -126,6 +126,68 @@ class TokenRequestTests: XCTestCase {
         XCTAssertEqual(capturedMethod, "POST")
     }
 
+    // MARK: - Problem document surfacing
+
+    func testExecute403WithProblemDocument_EmbedsProblemDocInError() async {
+        let tokenURL = URL(string: "https://auth.example.com/token")!
+        let problemJSON = """
+        {
+            "type": "http://librarysimplified.org/terms/problem/expired-credentials",
+            "title": "Expired Card",
+            "detail": "Your library card has expired.",
+            "status": 403
+        }
+        """
+
+        HTTPStubURLProtocol.register { request in
+            guard request.url == tokenURL else { return nil }
+            return .init(statusCode: 403,
+                         headers: ["Content-Type": "application/problem+json"],
+                         body: Data(problemJSON.utf8))
+        }
+
+        let session = URLSession.stubbedSession()
+        let tokenRequest = TokenRequest(url: tokenURL, username: "user", password: "pass")
+        let result = await tokenRequest.execute(session: session)
+
+        switch result {
+        case .success:
+            XCTFail("Expected failure for 403 response")
+        case .failure(let error):
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.code, 403)
+            XCTAssertEqual(nsError.problemDocument?.title, "Expired Card",
+                           "Server-supplied title should be surfaced so the UI can show it instead of 'Invalid Credentials'")
+            XCTAssertEqual(nsError.problemDocument?.detail, "Your library card has expired.",
+                           "Server-supplied detail should be surfaced for the user")
+        }
+    }
+
+    func testExecute403WithNonJSONBody_FallsBackToGenericError() async {
+        let tokenURL = URL(string: "https://auth.example.com/token")!
+
+        HTTPStubURLProtocol.register { request in
+            guard request.url == tokenURL else { return nil }
+            return .init(statusCode: 403,
+                         headers: ["Content-Type": "text/plain"],
+                         body: Data("Forbidden".utf8))
+        }
+
+        let session = URLSession.stubbedSession()
+        let tokenRequest = TokenRequest(url: tokenURL, username: "user", password: "pass")
+        let result = await tokenRequest.execute(session: session)
+
+        switch result {
+        case .success:
+            XCTFail("Expected failure for 403 response")
+        case .failure(let error):
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.code, 403)
+            XCTAssertNil(nsError.problemDocument,
+                         "Non-JSON body should not produce a problem document; generic error is the correct fallback")
+        }
+    }
+
     func testExecuteNon200StatusReturnsFailure() async {
         let tokenURL = URL(string: "https://auth.example.com/token")!
 


### PR DESCRIPTION
## Summary for JIRA

**JIRA:** https://ebce-lyrasis.atlassian.net/browse/PP-3956
**Root cause:** `TokenRequest.execute()` read the 403 response body for logging purposes but then discarded it, building a bare `NSError` with no `problemDocument` in `userInfo`. Every other 4xx path in the app goes through `TPPNetworkResponder`, which parses RFC 7807 problem documents and embeds them via `NSError.makeFromProblemDocument`. Token requests bypassed that plumbing entirely, causing `handleNetworkError` → `userFacingSignInError` to always fall through to the generic "Invalid Credentials" message — even when the server returned a specific explanation (e.g. "Expired card", "Account suspended").

**Solution:** Before building the error, attempt `TPPProblemDocument.fromProblemResponseData(data)`. If the body parses as a problem document, wrap the error with `NSError.makeFromProblemDocument(...)` so the problem doc travels up to `userFacingSignInError`, which already gives server-supplied title/detail the highest display priority. Falls back to the existing generic error when the body is not valid JSON — no behaviour change for servers that don't return problem documents.

**How to verify:**
1. Sign in to a library that uses token-based auth and whose server returns a 403 with a JSON problem document (e.g. `{"title":"Expired Card","detail":"Your library card has expired."}`).
2. Before fix: alert shows "Invalid Credentials / Please check your username and password".
3. After fix: alert shows the server-supplied title and detail.

---

## What changed

| File | Change |
|---|---|
| `Palace/SignInLogic/TokenRequest.swift` | `import PalaceCatalog`; parse + embed problem doc on non-200 response |
| `PalaceTests/SignInLogic/TokenRequestTests.swift` | 2 new tests: RFC 7807 body → problem doc embedded; plain-text body → nil problem doc (graceful fallback) |

## Reviewer notes

- The downstream display path (`handleNetworkError` → `userFacingSignInError` → SwiftUI alert) required **no changes** — it already handles problem documents correctly when they're present on the error.
- `TPPProblemDocument.fromProblemResponseData` is the lenient parser; it handles strict RFC 7807, concatenated JSON objects, and common key variants (`message`, `title`). Returning `nil` on unparseable input is the designed fallback.
- Tests require the full RMSDK build environment (`scripts/verify-pr.sh --quick`) to execute due to a pre-existing Xcode 16 explicit-module scanning issue with the `AdobeDRMContainer.mm` bridging header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)