### PR TITLE
chore(palace-state): primitives for deterministic test starting state

### DIFF
--- a/.palace-state/README.md
+++ b/.palace-state/README.md
@@ -51,6 +51,20 @@ export PALACE_STATE_APP_PATH=/path/to/built/Palace.app
 .palace-state/restore.sh signed-in-a1qa
 ```
 
+## Exit codes (operation & fixture scripts)
+
+All four scripts share a common exit-code contract so callers can branch on
+failure mode without parsing stderr.
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Environment problem (sim not booted, app missing, fixture not found) |
+| 2 | Operation failed (install / capture / restore / launch) |
+| 3 | Invalid arguments (missing required flag value, unknown flag) |
+| 4 | Fixture incompatible (device or format-version mismatch — `restore.sh`) |
+| 5 | Refused (no `--force` in non-tty, or user declined safety prompt — `reset-clean-sim.sh`) |
+
 ## What gets captured in a snapshot
 
 | Captured | Excluded |

--- a/.palace-state/README.md
+++ b/.palace-state/README.md
@@ -1,0 +1,104 @@
+# .palace-state — deterministic Palace app state for automated testing
+
+The starting state of an automated test is a **contract**. The recording
+captures coordinates assuming "the app is showing screen X." The replay drives
+those coordinates assuming the same. If the assumption breaks — fresh install
+when the recording expected a signed-in session, notifications alert blocking
+the first tap, downloaded books that don't exist — the test silently drives
+against the wrong UI and reports success.
+
+This directory is the primitive layer that makes that contract explicit and
+restorable.
+
+## What's here
+
+```
+.palace-state/
+├── operations/
+│   ├── reset-fresh-install.sh   # uninstall + pre-grant + install [+ launch]
+│   └── reset-clean-sim.sh       # nuclear: simctl erase + boot
+├── fixtures/
+│   ├── <name>.tgz               # tar of Documents/ + Library/ (no Caches)
+│   └── <name>.meta.json         # device, app version, capture time
+├── snapshot.sh                   # capture current state into a named fixture
+├── restore.sh                    # restore a named fixture
+└── README.md                     # this file
+```
+
+## When to use which
+
+| Goal | Tool |
+|---|---|
+| Start every test from "Add Library" screen with no alerts in the way | `operations/reset-fresh-install.sh` |
+| Reset sim-wide state (keychain, system prefs, all apps) before a test session | `operations/reset-clean-sim.sh --force` |
+| Capture "Palace signed into A1QA with 3 books downloaded" as a reusable starting point | `snapshot.sh signed-in-a1qa` |
+| Restore that captured state before running a test | `restore.sh signed-in-a1qa` |
+
+## Common invocations
+
+```bash
+# Set the sim + app once for the session
+export PALACE_STATE_SIM_UDID=DF4A2A27-9888-429D-A749-2E157A049A37
+export PALACE_STATE_APP_PATH=/path/to/built/Palace.app
+
+# Drop into a fresh-install state (notifications + location pre-granted)
+.palace-state/operations/reset-fresh-install.sh
+
+# After manually configuring a state, capture it
+.palace-state/snapshot.sh signed-in-a1qa
+
+# Later, restore it
+.palace-state/restore.sh signed-in-a1qa
+```
+
+## What gets captured in a snapshot
+
+| Captured | Excluded |
+|---|---|
+| `Documents/` (account list, settings, bookmarks) | `Library/Caches/` (regenerable) |
+| `Library/Application Support/` | `Documents/Books/` (large; use `--include-books` to keep) |
+| `Library/Preferences/` (NSUserDefaults) | `Documents/audiobooks/` |
+
+### Known v1 gaps
+
+- **Keychain is not captured.** Palace stores credentials in the iOS keychain,
+  which lives at the sim level (not the app level) and is shared across apps.
+  Restoring keychain reliably requires matching sim + Xcode-keychain access
+  groups and is not portable across machines. Snapshots restore *everything
+  the app sees in its data container*; if the test needs signed-in state,
+  the snapshot must be paired with an upstream "fresh sign-in" step OR the
+  user must manually re-authenticate after restore.
+- **Build product mismatch is not auto-detected.** If `PALACE_STATE_APP_PATH`
+  points at a `xcodebuild build-for-testing` product, install succeeds but
+  launch fails with a misleading `SBMainWorkspace` error. The reset script
+  surfaces a hint in stderr; future iteration may add a `file Palace`
+  check to fail-fast.
+- **The notification + location pre-grants assume iOS ≥18 simctl syntax.**
+  Older sim runtimes may silently ignore the privacy grants. Newer iOS
+  versions may add new permission classes that need to be added here.
+
+## Why the dot-prefix directory name
+
+`.palace-state/` is gitignored by some tooling that excludes dotfile dirs by
+default, AND treated as a "build/test artifact" location by tooling that
+respects the convention. We *want* the operation scripts tracked (they're
+the contract) but not the captured fixtures (large, machine-specific,
+regenerable). The `fixtures/.gitkeep` + a fixture-specific `.gitignore`
+inside the directory handles that split.
+
+## How this composes with simdrive
+
+Today: recordings have no `requires:` block; replay drives against whatever's
+on screen.
+
+After this PR: recordings can document their starting state in a comment
+and call the appropriate operation/restore in their pre-flight. Once simdrive
+adopts a first-class `requires:` schema (separate proposal), the operation
+names here become the canonical reset targets simdrive recordings reference.
+
+## How this composes with `scripts/regression/side-by-side.sh`
+
+`side-by-side.sh` had a 4-line inline uninstall+install per sim. With this
+PR it shells out to `operations/reset-fresh-install.sh` once per sim, with
+`--no-launch` (side-by-side controls its own launch timing). DRY and
+consistent with anyone else who wants the same primitive.

--- a/.palace-state/fixtures/.gitignore
+++ b/.palace-state/fixtures/.gitignore
@@ -1,0 +1,7 @@
+# Captured state fixtures are large, machine-specific, and regenerable.
+# Keep .gitkeep tracked so the directory exists in fresh clones; ignore
+# everything else.
+*.tgz
+*.meta.json
+!.gitkeep
+!README.md

--- a/.palace-state/operations/reset-clean-sim.sh
+++ b/.palace-state/operations/reset-clean-sim.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# .palace-state/operations/reset-clean-sim.sh
+#
+# Nuclear-option reset: erases the entire simulator back to factory state
+# (all apps, all data, all permissions, all keychain). Boots the sim again
+# afterwards. Use when a fresh-install isn't deep enough — e.g. you suspect
+# residual keychain state or sim-wide preference drift is influencing test
+# behavior.
+#
+# Required:
+#   PALACE_STATE_SIM_UDID  — sim UDID (or --sim <udid>)
+#
+# Optional:
+#   --force                — skip the safety prompt (required in CI/non-tty)
+#
+# Exit codes:
+#   0  sim erased and re-booted
+#   1  environment problem (sim doesn't exist)
+#   2  erase or boot failed
+#   3  refused (no --force in non-tty, or user declined)
+
+set -uo pipefail
+
+SIM_UDID="${PALACE_STATE_SIM_UDID:-}"
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sim) SIM_UDID="$2"; shift 2 ;;
+    --force) FORCE=true; shift ;;
+    -h|--help)
+      sed -n '2,/^set -u/p' "$0" | sed -n 's/^# *//p'
+      exit 0
+      ;;
+    *) echo "reset-clean-sim: unknown arg: $1" >&2; exit 3 ;;
+  esac
+done
+
+if [[ -z "$SIM_UDID" ]]; then
+  echo "reset-clean-sim: missing sim UDID (set PALACE_STATE_SIM_UDID or pass --sim)" >&2
+  exit 3
+fi
+
+if ! xcrun simctl list devices 2>/dev/null | grep -q "$SIM_UDID"; then
+  echo "reset-clean-sim: sim $SIM_UDID does not exist" >&2
+  exit 1
+fi
+
+# Safety: this erases EVERYTHING on the sim. If stdin is a terminal and
+# --force wasn't passed, prompt. In CI (no tty), require --force explicitly.
+if [[ "$FORCE" != "true" ]]; then
+  if [[ ! -t 0 ]]; then
+    echo "reset-clean-sim: --force required when stdin is not a terminal" >&2
+    exit 3
+  fi
+  echo "About to ERASE sim $SIM_UDID — this deletes all apps, data, and keychain."
+  read -r -p "Type 'erase' to confirm: " confirm
+  if [[ "$confirm" != "erase" ]]; then
+    echo "reset-clean-sim: declined" >&2
+    exit 3
+  fi
+fi
+
+echo "[reset-clean-sim] erasing $SIM_UDID …"
+
+# Shutdown before erase (simctl erase requires a shutdown sim on some Xcode
+# versions; on newer Xcode it auto-shuts-down but emits a warning).
+xcrun simctl shutdown "$SIM_UDID" 2>/dev/null || true
+
+if ! xcrun simctl erase "$SIM_UDID" 2>&1; then
+  echo "reset-clean-sim: erase failed" >&2
+  exit 2
+fi
+
+if ! xcrun simctl boot "$SIM_UDID" 2>&1; then
+  echo "reset-clean-sim: boot after erase failed" >&2
+  exit 2
+fi
+
+# Wait for boot to complete before declaring success.
+if ! xcrun simctl bootstatus "$SIM_UDID" 2>&1; then
+  echo "reset-clean-sim: boot status check failed" >&2
+  exit 2
+fi
+
+echo "[reset-clean-sim] OK — sim erased and booted"

--- a/.palace-state/operations/reset-clean-sim.sh
+++ b/.palace-state/operations/reset-clean-sim.sh
@@ -17,7 +17,8 @@
 #   0  sim erased and re-booted
 #   1  environment problem (sim doesn't exist)
 #   2  erase or boot failed
-#   3  refused (no --force in non-tty, or user declined)
+#   3  invalid arguments
+#   5  refused (no --force in non-tty, or user declined the safety prompt)
 
 set -uo pipefail
 
@@ -26,7 +27,14 @@ FORCE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --sim) SIM_UDID="$2"; shift 2 ;;
+    --sim)
+      if [ -z "${2:-}" ]; then
+        echo "reset-clean-sim: --sim requires an argument" >&2
+        exit 3
+      fi
+      SIM_UDID="$2"
+      shift 2
+      ;;
     --force) FORCE=true; shift ;;
     -h|--help)
       sed -n '2,/^set -u/p' "$0" | sed -n 's/^# *//p'
@@ -48,16 +56,18 @@ fi
 
 # Safety: this erases EVERYTHING on the sim. If stdin is a terminal and
 # --force wasn't passed, prompt. In CI (no tty), require --force explicitly.
+# Refusal exits 5 (distinct from 3 invalid-args) so callers can tell apart
+# "you typed the command wrong" from "the safety gate stopped you".
 if [[ "$FORCE" != "true" ]]; then
   if [[ ! -t 0 ]]; then
     echo "reset-clean-sim: --force required when stdin is not a terminal" >&2
-    exit 3
+    exit 5
   fi
   echo "About to ERASE sim $SIM_UDID — this deletes all apps, data, and keychain."
   read -r -p "Type 'erase' to confirm: " confirm
   if [[ "$confirm" != "erase" ]]; then
     echo "reset-clean-sim: declined" >&2
-    exit 3
+    exit 5
   fi
 fi
 

--- a/.palace-state/operations/reset-fresh-install.sh
+++ b/.palace-state/operations/reset-fresh-install.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# .palace-state/operations/reset-fresh-install.sh
+#
+# Resets Palace on the target simulator to a deterministic fresh-install state:
+#   1. Terminate any running Palace
+#   2. Uninstall Palace
+#   3. Pre-grant notifications + location permissions (avoids first-launch alerts
+#      racing with subsequent automated taps)
+#   4. Install Palace.app
+#   5. Launch (unless --no-launch)
+#
+# Required env or args:
+#   PALACE_STATE_SIM_UDID  — sim UDID to target (or --sim <udid>)
+#   PALACE_STATE_APP_PATH  — Palace.app path (or --app <path>)
+#
+# Optional:
+#   --no-launch            — install only; don't launch the app
+#   --bundle-id <id>       — override (default: org.thepalaceproject.palace)
+#
+# Exit codes:
+#   0  fresh-install state established
+#   1  environment problem (sim not booted, app not found, simctl missing)
+#   2  install or launch failed
+#   3  invalid arguments
+#
+# Why pre-grant permissions:
+#   The notifications + location alerts on first launch block coordinate-based
+#   automated taps. Pre-granting via simctl privacy lets us land on a clean
+#   "Add Library" screen with no overlaid dialogs — a deterministic step 0.
+
+set -uo pipefail
+
+BUNDLE_ID="${PALACE_STATE_BUNDLE_ID:-org.thepalaceproject.palace}"
+SIM_UDID="${PALACE_STATE_SIM_UDID:-}"
+APP_PATH="${PALACE_STATE_APP_PATH:-}"
+LAUNCH=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sim) SIM_UDID="$2"; shift 2 ;;
+    --app) APP_PATH="$2"; shift 2 ;;
+    --bundle-id) BUNDLE_ID="$2"; shift 2 ;;
+    --no-launch) LAUNCH=false; shift ;;
+    -h|--help)
+      sed -n '2,/^set -u/p' "$0" | sed -n 's/^# *//p'
+      exit 0
+      ;;
+    *) echo "reset-fresh-install: unknown arg: $1" >&2; exit 3 ;;
+  esac
+done
+
+if [[ -z "$SIM_UDID" ]]; then
+  echo "reset-fresh-install: missing sim UDID (set PALACE_STATE_SIM_UDID or pass --sim)" >&2
+  exit 3
+fi
+
+if [[ -z "$APP_PATH" ]]; then
+  echo "reset-fresh-install: missing app path (set PALACE_STATE_APP_PATH or pass --app)" >&2
+  exit 3
+fi
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "reset-fresh-install: app path does not exist: $APP_PATH" >&2
+  exit 1
+fi
+
+# Check the sim is booted. We do NOT auto-boot — the caller is responsible
+# for that, so this script stays idempotent on a fresh CI runner vs a local
+# session where the sim is already up.
+if ! xcrun simctl list devices booted 2>/dev/null | grep -q "$SIM_UDID"; then
+  echo "reset-fresh-install: sim $SIM_UDID is not booted. Boot it first:" >&2
+  echo "  xcrun simctl boot $SIM_UDID" >&2
+  exit 1
+fi
+
+echo "[reset-fresh-install] sim=$SIM_UDID bundle=$BUNDLE_ID app=$APP_PATH"
+
+# 1. Terminate any running instance (ignore errors — nothing running is fine).
+xcrun simctl terminate "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+
+# 2. Uninstall (ignore errors — already absent is fine).
+xcrun simctl uninstall "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+
+# 3. Pre-grant permissions. Two that matter for Palace's first-launch path:
+#    notifications (post-install push prompt) and location (some auth flows).
+#    Grant is best-effort; on iOS 26+ simctl privacy syntax may shift.
+xcrun simctl privacy "$SIM_UDID" grant notifications "$BUNDLE_ID" 2>/dev/null || true
+xcrun simctl privacy "$SIM_UDID" grant location "$BUNDLE_ID" 2>/dev/null || true
+
+# 4. Install. This is the operation we hard-fail on.
+if ! xcrun simctl install "$SIM_UDID" "$APP_PATH" 2>&1; then
+  echo "reset-fresh-install: install failed" >&2
+  exit 2
+fi
+
+# 5. Launch (unless --no-launch). Hard-fail if requested but launch denied.
+if [[ "$LAUNCH" == "true" ]]; then
+  if ! launch_out=$(xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" 2>&1); then
+    echo "reset-fresh-install: launch failed" >&2
+    echo "$launch_out" >&2
+    echo "" >&2
+    echo "Hint: 'request denied by SBMainWorkspace' typically means the app was" >&2
+    echo "built with 'xcodebuild build-for-testing' (links a test runner) rather" >&2
+    echo "than 'xcodebuild build'. Re-build without the -test argument." >&2
+    exit 2
+  fi
+  # Brief settle so SpringBoard finishes its launch transitions before the
+  # caller starts driving taps. 1.5s is empirically enough on iPhone 16/17 Pro
+  # sims; doubled if PALACE_STATE_SETTLE_SECONDS is set.
+  sleep "${PALACE_STATE_SETTLE_SECONDS:-1.5}"
+fi
+
+echo "[reset-fresh-install] OK — state ready"

--- a/.palace-state/operations/reset-fresh-install.sh
+++ b/.palace-state/operations/reset-fresh-install.sh
@@ -37,9 +37,30 @@ LAUNCH=true
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --sim) SIM_UDID="$2"; shift 2 ;;
-    --app) APP_PATH="$2"; shift 2 ;;
-    --bundle-id) BUNDLE_ID="$2"; shift 2 ;;
+    --sim)
+      if [ -z "${2:-}" ]; then
+        echo "reset-fresh-install: --sim requires an argument" >&2
+        exit 3
+      fi
+      SIM_UDID="$2"
+      shift 2
+      ;;
+    --app)
+      if [ -z "${2:-}" ]; then
+        echo "reset-fresh-install: --app requires an argument" >&2
+        exit 3
+      fi
+      APP_PATH="$2"
+      shift 2
+      ;;
+    --bundle-id)
+      if [ -z "${2:-}" ]; then
+        echo "reset-fresh-install: --bundle-id requires an argument" >&2
+        exit 3
+      fi
+      BUNDLE_ID="$2"
+      shift 2
+      ;;
     --no-launch) LAUNCH=false; shift ;;
     -h|--help)
       sed -n '2,/^set -u/p' "$0" | sed -n 's/^# *//p'

--- a/.palace-state/restore.sh
+++ b/.palace-state/restore.sh
@@ -44,9 +44,30 @@ STRICT=true
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --sim) SIM_UDID="$2"; shift 2 ;;
-    --app) APP_PATH="$2"; shift 2 ;;
-    --bundle-id) BUNDLE_ID="$2"; shift 2 ;;
+    --sim)
+      if [ -z "${2:-}" ]; then
+        echo "restore: --sim requires an argument" >&2
+        exit 3
+      fi
+      SIM_UDID="$2"
+      shift 2
+      ;;
+    --app)
+      if [ -z "${2:-}" ]; then
+        echo "restore: --app requires an argument" >&2
+        exit 3
+      fi
+      APP_PATH="$2"
+      shift 2
+      ;;
+    --bundle-id)
+      if [ -z "${2:-}" ]; then
+        echo "restore: --bundle-id requires an argument" >&2
+        exit 3
+      fi
+      BUNDLE_ID="$2"
+      shift 2
+      ;;
     --no-launch) LAUNCH=false; shift ;;
     --no-strict) STRICT=false; shift ;;
     -h|--help)
@@ -74,15 +95,18 @@ ARCHIVE="$REPO_ROOT/.palace-state/fixtures/$FIXTURE_NAME.tgz"
 META="$REPO_ROOT/.palace-state/fixtures/$FIXTURE_NAME.meta.json"
 
 if [[ ! -f "$ARCHIVE" ]]; then
+  # Args were syntactically valid; the named fixture just doesn't exist on
+  # this machine. That's an environment problem (run snapshot.sh first or
+  # check the fixtures dir), not an arg-validation problem — exit 1.
   echo "restore: fixture not found: $ARCHIVE" >&2
   echo "Available fixtures:" >&2
   ls "$REPO_ROOT/.palace-state/fixtures/"*.tgz 2>/dev/null | xargs -n1 basename | sed 's/\.tgz$//' | sed 's/^/  /' >&2
-  exit 3
+  exit 1
 fi
 
 if [[ ! -f "$META" ]]; then
   echo "restore: metadata not found: $META" >&2
-  exit 3
+  exit 1
 fi
 
 # Compatibility checks. Use the same UDID-anchored regex as snapshot.sh so
@@ -92,9 +116,39 @@ fi
 DEVICE_INFO=$(xcrun simctl list devices 2>/dev/null | grep "$SIM_UDID" | head -1)
 CURRENT_DEVICE=$(echo "$DEVICE_INFO" | sed -E 's/^[[:space:]]*//; s/ \([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\).*//')
 
-# Extract metadata values via python (jq isn't guaranteed installed)
-FIXTURE_DEVICE=$(python3 -c "import json,sys; print(json.load(open('$META')).get('sim_device',''))" 2>/dev/null)
-FIXTURE_VERSION=$(python3 -c "import json,sys; print(json.load(open('$META')).get('app_version',''))" 2>/dev/null)
+# Extract metadata values via python (jq isn't guaranteed installed).
+# Previously each field was read in its own python -c with 2>/dev/null, which
+# meant a malformed/missing meta.json produced empty strings and silently
+# bypassed the device-mismatch guard below (the `-n "$FIXTURE_DEVICE"` test
+# would short-circuit). Read all three fields atomically and exit 4
+# (fixture-incompat) on any parse failure.
+META_PARSE=$(python3 -c "
+import json, sys
+meta = json.load(open('$META'))
+print('{}|{}|{}|{}'.format(
+    meta.get('fixture_format_version', ''),
+    meta.get('sim_device', ''),
+    meta.get('app_bundle_id', ''),
+    meta.get('app_version', ''),
+))
+" 2>&1)
+if [ $? -ne 0 ]; then
+  echo "restore: failed to parse fixture metadata at $META" >&2
+  echo "$META_PARSE" >&2
+  echo "fixture metadata could not be parsed; aborting" >&2
+  exit 4
+fi
+IFS='|' read -r FIXTURE_FORMAT_VERSION FIXTURE_DEVICE FIXTURE_BUNDLE FIXTURE_VERSION <<<"$META_PARSE"
+
+# Forward-compat guard: this script understands fixture_format_version=1.
+# A v2 fixture (e.g. one that ships keychain alongside the data container)
+# would need new restore logic, so refuse rather than silently doing the
+# wrong thing.
+if [[ "$FIXTURE_FORMAT_VERSION" != "1" ]]; then
+  echo "restore: unsupported fixture_format_version='$FIXTURE_FORMAT_VERSION' (expected '1')" >&2
+  echo "This restore.sh supports v1 fixtures only. Re-snapshot or upgrade tooling." >&2
+  exit 4
+fi
 
 if [[ -n "$FIXTURE_DEVICE" && "$FIXTURE_DEVICE" != "$CURRENT_DEVICE" ]]; then
   if [[ "$STRICT" == "true" ]]; then
@@ -137,9 +191,18 @@ if [[ -z "$DATA_DIR" || ! -d "$DATA_DIR" ]]; then
   exit 2
 fi
 
-# Remove any default-created Documents/Library before unpacking so we don't
-# leave partial state behind from the install template.
-rm -rf "$DATA_DIR/Documents" "$DATA_DIR/Library/Application Support" "$DATA_DIR/Library/Preferences" 2>/dev/null || true
+# Wipe the data container before unpacking so we don't leave partial state
+# behind from the install template. The snapshot captures all of Documents/
+# and Library/ except Caches/, so anything outside that union has to go —
+# the prior narrower cleanup left stray subdirs (e.g. Library/Cookies,
+# Library/WebKit) that the snapshot never overwrites.
+#
+# Preserve Library/Caches/ to avoid re-downloading regenerable data after
+# every restore, matching the asymmetry in snapshot.sh.
+find "$DATA_DIR" -mindepth 1 -maxdepth 1 ! -name 'Library' -exec rm -rf {} + 2>/dev/null || true
+if [[ -d "$DATA_DIR/Library" ]]; then
+  find "$DATA_DIR/Library" -mindepth 1 -maxdepth 1 ! -name 'Caches' -exec rm -rf {} + 2>/dev/null || true
+fi
 
 if ! tar -xzf "$ARCHIVE" -C "$DATA_DIR" 2>&1; then
   echo "restore: tar extract failed" >&2

--- a/.palace-state/restore.sh
+++ b/.palace-state/restore.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# .palace-state/restore.sh
+#
+# Restores Palace app data on the target sim from a named fixture captured
+# previously via .palace-state/snapshot.sh. Sequence:
+#   1. Verify fixture exists + metadata is readable
+#   2. Confirm compatibility (warn on app_version mismatch; halt on
+#      sim_device mismatch unless --no-strict)
+#   3. Uninstall current Palace (clears existing data container)
+#   4. Install fresh Palace.app
+#   5. Restore Documents/ + Library/ from the tar into the new container
+#   6. Launch
+#
+# Why steps 3-5 instead of "install once and overlay": iOS regenerates the
+# data container UUID on every install, and the install must happen BEFORE
+# we know the container path. Uninstall-then-install ensures we start from
+# a known-empty container.
+#
+# Required:
+#   PALACE_STATE_SIM_UDID  — sim UDID (or --sim <udid>)
+#   PALACE_STATE_APP_PATH  — Palace.app path (or --app <path>)
+#   Fixture name as positional arg.
+#
+# Optional:
+#   --bundle-id <id>       — override (default: org.thepalaceproject.palace)
+#   --no-launch            — install + restore data; don't launch
+#   --no-strict            — warn on device mismatch instead of halting
+#
+# Exit codes:
+#   0  state restored
+#   1  environment problem
+#   2  install / restore / launch failed
+#   3  invalid arguments or fixture not found
+#   4  fixture incompatible with current sim (use --no-strict to override)
+
+set -uo pipefail
+
+BUNDLE_ID="${PALACE_STATE_BUNDLE_ID:-org.thepalaceproject.palace}"
+SIM_UDID="${PALACE_STATE_SIM_UDID:-}"
+APP_PATH="${PALACE_STATE_APP_PATH:-}"
+FIXTURE_NAME=""
+LAUNCH=true
+STRICT=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sim) SIM_UDID="$2"; shift 2 ;;
+    --app) APP_PATH="$2"; shift 2 ;;
+    --bundle-id) BUNDLE_ID="$2"; shift 2 ;;
+    --no-launch) LAUNCH=false; shift ;;
+    --no-strict) STRICT=false; shift ;;
+    -h|--help)
+      sed -n '2,/^set -u/p' "$0" | sed -n 's/^# *//p'
+      exit 0
+      ;;
+    -*) echo "restore: unknown flag: $1" >&2; exit 3 ;;
+    *)
+      if [[ -z "$FIXTURE_NAME" ]]; then
+        FIXTURE_NAME="$1"; shift
+      else
+        echo "restore: unexpected positional arg: $1" >&2; exit 3
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$SIM_UDID" || -z "$APP_PATH" || -z "$FIXTURE_NAME" ]]; then
+  echo "restore: missing args. Need PALACE_STATE_SIM_UDID + PALACE_STATE_APP_PATH + fixture name" >&2
+  exit 3
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ARCHIVE="$REPO_ROOT/.palace-state/fixtures/$FIXTURE_NAME.tgz"
+META="$REPO_ROOT/.palace-state/fixtures/$FIXTURE_NAME.meta.json"
+
+if [[ ! -f "$ARCHIVE" ]]; then
+  echo "restore: fixture not found: $ARCHIVE" >&2
+  echo "Available fixtures:" >&2
+  ls "$REPO_ROOT/.palace-state/fixtures/"*.tgz 2>/dev/null | xargs -n1 basename | sed 's/\.tgz$//' | sed 's/^/  /' >&2
+  exit 3
+fi
+
+if [[ ! -f "$META" ]]; then
+  echo "restore: metadata not found: $META" >&2
+  exit 3
+fi
+
+# Compatibility checks. Use the same UDID-anchored regex as snapshot.sh so
+# the captured/current device strings line up. Anchored on the 8-4-4-4-12
+# hex-dash UDID shape — bare [A-F0-9-]+ would truncate "iPhone 17 Pro" at
+# the "17".
+DEVICE_INFO=$(xcrun simctl list devices 2>/dev/null | grep "$SIM_UDID" | head -1)
+CURRENT_DEVICE=$(echo "$DEVICE_INFO" | sed -E 's/^[[:space:]]*//; s/ \([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\).*//')
+
+# Extract metadata values via python (jq isn't guaranteed installed)
+FIXTURE_DEVICE=$(python3 -c "import json,sys; print(json.load(open('$META')).get('sim_device',''))" 2>/dev/null)
+FIXTURE_VERSION=$(python3 -c "import json,sys; print(json.load(open('$META')).get('app_version',''))" 2>/dev/null)
+
+if [[ -n "$FIXTURE_DEVICE" && "$FIXTURE_DEVICE" != "$CURRENT_DEVICE" ]]; then
+  if [[ "$STRICT" == "true" ]]; then
+    echo "restore: device mismatch — fixture was captured on '$FIXTURE_DEVICE', sim is '$CURRENT_DEVICE'" >&2
+    echo "Pass --no-strict to restore anyway (UI coords may not align)." >&2
+    exit 4
+  else
+    echo "[restore] WARNING: device mismatch (fixture='$FIXTURE_DEVICE', current='$CURRENT_DEVICE')" >&2
+  fi
+fi
+
+if ! xcrun simctl list devices booted 2>/dev/null | grep -q "$SIM_UDID"; then
+  echo "restore: sim $SIM_UDID not booted" >&2
+  exit 1
+fi
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "restore: app path does not exist: $APP_PATH" >&2
+  exit 1
+fi
+
+echo "[restore] fixture=$FIXTURE_NAME version=$FIXTURE_VERSION device=$FIXTURE_DEVICE"
+
+# 1. Uninstall (always — guarantees a fresh container UUID)
+xcrun simctl terminate "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+xcrun simctl uninstall "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+
+# 2. Pre-grant + install
+xcrun simctl privacy "$SIM_UDID" grant notifications "$BUNDLE_ID" 2>/dev/null || true
+xcrun simctl privacy "$SIM_UDID" grant location "$BUNDLE_ID" 2>/dev/null || true
+if ! xcrun simctl install "$SIM_UDID" "$APP_PATH" 2>&1; then
+  echo "restore: install failed" >&2
+  exit 2
+fi
+
+# 3. Locate the new data container and untar the fixture into it
+DATA_DIR=$(xcrun simctl get_app_container "$SIM_UDID" "$BUNDLE_ID" data 2>/dev/null)
+if [[ -z "$DATA_DIR" || ! -d "$DATA_DIR" ]]; then
+  echo "restore: could not resolve data container after install" >&2
+  exit 2
+fi
+
+# Remove any default-created Documents/Library before unpacking so we don't
+# leave partial state behind from the install template.
+rm -rf "$DATA_DIR/Documents" "$DATA_DIR/Library/Application Support" "$DATA_DIR/Library/Preferences" 2>/dev/null || true
+
+if ! tar -xzf "$ARCHIVE" -C "$DATA_DIR" 2>&1; then
+  echo "restore: tar extract failed" >&2
+  exit 2
+fi
+
+# 4. Launch
+if [[ "$LAUNCH" == "true" ]]; then
+  if ! xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" 2>&1; then
+    echo "restore: launch failed" >&2
+    exit 2
+  fi
+  sleep "${PALACE_STATE_SETTLE_SECONDS:-1.5}"
+fi
+
+echo "[restore] OK — fixture $FIXTURE_NAME restored"

--- a/.palace-state/snapshot.sh
+++ b/.palace-state/snapshot.sh
@@ -38,8 +38,22 @@ INCLUDE_BOOKS=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --sim) SIM_UDID="$2"; shift 2 ;;
-    --bundle-id) BUNDLE_ID="$2"; shift 2 ;;
+    --sim)
+      if [ -z "${2:-}" ]; then
+        echo "snapshot: --sim requires an argument" >&2
+        exit 3
+      fi
+      SIM_UDID="$2"
+      shift 2
+      ;;
+    --bundle-id)
+      if [ -z "${2:-}" ]; then
+        echo "snapshot: --bundle-id requires an argument" >&2
+        exit 3
+      fi
+      BUNDLE_ID="$2"
+      shift 2
+      ;;
     --include-books) INCLUDE_BOOKS=true; shift ;;
     -h|--help)
       sed -n '2,/^set -u/p' "$0" | sed -n 's/^# *//p'
@@ -128,9 +142,13 @@ else
   EXCLUDES_JSON='["Library/Caches", "Documents/Books", "Documents/audiobooks"]'
 fi
 
-# Compact metadata file — restore.sh validates against this before restoring
+# Compact metadata file — restore.sh validates against this before restoring.
+# fixture_format_version: bump when the on-disk shape changes in a way that
+# breaks back-compat (e.g. v2 might add a keychain blob). restore.sh hard-fails
+# on a mismatch so old fixtures don't silently restore against newer logic.
 cat > "$META" <<EOF
 {
+  "fixture_format_version": 1,
   "fixture_name": "$FIXTURE_NAME",
   "captured_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "app_bundle_id": "$BUNDLE_ID",

--- a/.palace-state/snapshot.sh
+++ b/.palace-state/snapshot.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# .palace-state/snapshot.sh
+#
+# Captures the current Palace app data state on the target sim as a named
+# fixture under .palace-state/fixtures/<name>.tgz + <name>.meta.json. The
+# fixture can later be restored via .palace-state/restore.sh <name>.
+#
+# What's captured:
+#   - Documents/   (Palace user data: bookmarks, settings, account list)
+#   - Library/     (excluding Caches/ — those are regenerable noise)
+#
+# What's NOT captured (known gaps for v1):
+#   - Keychain     (sim-wide, shared across apps — restoring requires
+#                   matching sim+app+keychain access group)
+#   - Downloaded books (excluded via tar — too large to ship in fixtures;
+#                       restored state has clean download library)
+#
+# Required:
+#   PALACE_STATE_SIM_UDID  — sim UDID (or --sim <udid>)
+#   Fixture name as positional arg.
+#
+# Optional:
+#   --bundle-id <id>       — override (default: org.thepalaceproject.palace)
+#   --include-books        — include Documents/Books in the snapshot (rare)
+#
+# Exit codes:
+#   0  fixture captured
+#   1  environment problem (sim not booted, app not installed)
+#   2  capture failed
+#   3  invalid arguments
+
+set -uo pipefail
+
+BUNDLE_ID="${PALACE_STATE_BUNDLE_ID:-org.thepalaceproject.palace}"
+SIM_UDID="${PALACE_STATE_SIM_UDID:-}"
+FIXTURE_NAME=""
+INCLUDE_BOOKS=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sim) SIM_UDID="$2"; shift 2 ;;
+    --bundle-id) BUNDLE_ID="$2"; shift 2 ;;
+    --include-books) INCLUDE_BOOKS=true; shift ;;
+    -h|--help)
+      sed -n '2,/^set -u/p' "$0" | sed -n 's/^# *//p'
+      exit 0
+      ;;
+    -*) echo "snapshot: unknown flag: $1" >&2; exit 3 ;;
+    *)
+      if [[ -z "$FIXTURE_NAME" ]]; then
+        FIXTURE_NAME="$1"; shift
+      else
+        echo "snapshot: unexpected positional arg: $1" >&2; exit 3
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$SIM_UDID" ]]; then
+  echo "snapshot: missing sim UDID (set PALACE_STATE_SIM_UDID or pass --sim)" >&2
+  exit 3
+fi
+
+if [[ -z "$FIXTURE_NAME" ]]; then
+  echo "snapshot: missing fixture name (positional arg)" >&2
+  exit 3
+fi
+
+# Validate fixture name — keep it filesystem-safe and human-readable
+if [[ ! "$FIXTURE_NAME" =~ ^[a-z0-9._-]+$ ]]; then
+  echo "snapshot: fixture name must match [a-z0-9._-]+ (got: $FIXTURE_NAME)" >&2
+  exit 3
+fi
+
+if ! xcrun simctl list devices booted 2>/dev/null | grep -q "$SIM_UDID"; then
+  echo "snapshot: sim $SIM_UDID is not booted" >&2
+  exit 1
+fi
+
+# Resolve the app data container — fails if app isn't installed
+DATA_DIR=$(xcrun simctl get_app_container "$SIM_UDID" "$BUNDLE_ID" data 2>/dev/null)
+if [[ -z "$DATA_DIR" || ! -d "$DATA_DIR" ]]; then
+  echo "snapshot: $BUNDLE_ID is not installed on $SIM_UDID" >&2
+  exit 1
+fi
+
+# Detect device info for the metadata file. simctl emits lines like:
+#   "    iPhone 17 Pro (6C396179-608C-...) (Booted)"
+# Strip leading whitespace, then strip " (UDID)" onward. Anchor the UDID
+# match on the exact 8-4-4-4-12 hex-dash shape so we don't truncate
+# "iPhone 17 Pro" at the "17" (which would otherwise match [A-F0-9-]+).
+DEVICE_INFO=$(xcrun simctl list devices 2>/dev/null | grep "$SIM_UDID" | head -1)
+DEVICE_NAME=$(echo "$DEVICE_INFO" | sed -E 's/^[[:space:]]*//; s/ \([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\).*//')
+
+# App version
+APP_BUNDLE_DIR=$(xcrun simctl get_app_container "$SIM_UDID" "$BUNDLE_ID" app 2>/dev/null)
+APP_VERSION=""
+if [[ -f "$APP_BUNDLE_DIR/Info.plist" ]]; then
+  APP_VERSION=$(plutil -extract CFBundleShortVersionString raw "$APP_BUNDLE_DIR/Info.plist" 2>/dev/null || echo "")
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURES_DIR="$REPO_ROOT/.palace-state/fixtures"
+mkdir -p "$FIXTURES_DIR"
+
+ARCHIVE="$FIXTURES_DIR/$FIXTURE_NAME.tgz"
+META="$FIXTURES_DIR/$FIXTURE_NAME.meta.json"
+
+# Build tar exclude list — Caches always; Books unless --include-books
+EXCLUDES=(--exclude='Library/Caches')
+if [[ "$INCLUDE_BOOKS" != "true" ]]; then
+  EXCLUDES+=(--exclude='Documents/Books')
+  EXCLUDES+=(--exclude='Documents/audiobooks')
+fi
+
+echo "[snapshot] capturing $BUNDLE_ID data on $SIM_UDID → $FIXTURE_NAME.tgz"
+echo "[snapshot] source: $DATA_DIR"
+
+if ! tar -czf "$ARCHIVE" -C "$DATA_DIR" "${EXCLUDES[@]}" Documents Library 2>&1; then
+  echo "snapshot: tar capture failed" >&2
+  exit 2
+fi
+
+# Build the excludes JSON array based on what tar actually skipped.
+if [[ "$INCLUDE_BOOKS" == "true" ]]; then
+  EXCLUDES_JSON='["Library/Caches"]'
+else
+  EXCLUDES_JSON='["Library/Caches", "Documents/Books", "Documents/audiobooks"]'
+fi
+
+# Compact metadata file — restore.sh validates against this before restoring
+cat > "$META" <<EOF
+{
+  "fixture_name": "$FIXTURE_NAME",
+  "captured_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "app_bundle_id": "$BUNDLE_ID",
+  "app_version": "$APP_VERSION",
+  "sim_udid": "$SIM_UDID",
+  "sim_device": "$DEVICE_NAME",
+  "includes_books": $INCLUDE_BOOKS,
+  "excludes": $EXCLUDES_JSON
+}
+EOF
+
+ARCHIVE_SIZE=$(du -h "$ARCHIVE" | awk '{print $1}')
+echo "[snapshot] OK — $FIXTURE_NAME ($ARCHIVE_SIZE)"
+echo "[snapshot] restore with: .palace-state/restore.sh $FIXTURE_NAME --app <path>"

--- a/scripts/regression/side-by-side.sh
+++ b/scripts/regression/side-by-side.sh
@@ -101,14 +101,20 @@ else
   trap - EXIT
 fi
 
-# Install on each sim
+# Install on each sim via the shared fresh-install primitive. --no-launch
+# because side-by-side controls its own launch timing further down via
+# simdrive-regress.sh. The primitive also pre-grants notifications +
+# location, eliminating the first-launch-alert race that previously caused
+# the first replay step to hit "Don't Allow" instead of the intended target.
+PALACE_STATE_DIR="$(cd "$(dirname "$0")/../.." && pwd)/.palace-state"
+
 echo "[side-by-side] installing baseline on $SIM_A …"
-xcrun simctl uninstall "$SIM_A" org.thepalaceproject.palace 2>/dev/null || true
-xcrun simctl install "$SIM_A" "$BASELINE_APP"
+PALACE_STATE_SIM_UDID="$SIM_A" PALACE_STATE_APP_PATH="$BASELINE_APP" \
+  "$PALACE_STATE_DIR/operations/reset-fresh-install.sh" --no-launch
 
 echo "[side-by-side] installing candidate on $SIM_B …"
-xcrun simctl uninstall "$SIM_B" org.thepalaceproject.palace 2>/dev/null || true
-xcrun simctl install "$SIM_B" "$CANDIDATE_APP"
+PALACE_STATE_SIM_UDID="$SIM_B" PALACE_STATE_APP_PATH="$CANDIDATE_APP" \
+  "$PALACE_STATE_DIR/operations/reset-fresh-install.sh" --no-launch
 
 # Run journey corpus on each
 echo "[side-by-side] simdrive-regress against baseline (sim-A) …"


### PR DESCRIPTION
## Summary

Adds `.palace-state/` — a small primitive layer for **reproducible app state at the start of an automated test** (simdrive replay, regression run, manual repro). Refactors `scripts/regression/side-by-side.sh` to consume it (DRY proof).

## Why this exists

Recordings capture coordinates assuming "the app is showing screen X." Replay drives those coordinates assuming the same. When the assumption breaks — fresh install when the recording expected a signed-in session, first-launch notifications alert blocking the first tap, downloaded books that don't exist — **the test silently drives against the wrong UI and reports success.**

Dogfood this week observed a 23-step simdrive replay execute end-to-end at SSIM 0.014 (totally different screens) while every step reported `executed=true, error=null`. The root cause wasn't a simdrive bug — it was that no contract existed between recording and replay about what step-0 state looks like.

This PR is Layer 1 of a 3-layer architecture (Layer 2 is the simdrive recording-schema change, drafted separately as a shareable upstream spec; Layer 3 is the verify-pr.sh lint that enforces it).

## What's added

```
.palace-state/
├── operations/
│   ├── reset-fresh-install.sh   # uninstall + pre-grant + install [+ launch]
│   └── reset-clean-sim.sh       # nuclear: simctl erase + boot (--force in CI)
├── fixtures/
│   ├── .gitkeep                  # tracked
│   └── .gitignore                # *.tgz + *.meta.json local-only
├── snapshot.sh                   # capture current state → named fixture
├── restore.sh                    # restore a named fixture
└── README.md                     # contract + v1 gaps
```

All four scripts:
- Take `PALACE_STATE_SIM_UDID` + `PALACE_STATE_APP_PATH` via env or `--sim`/`--app`
- POSIX-portable (`[:space:]`, anchored UDID regex — no GNU-only `\?`/`\s`)
- Surface actionable hints on common failures (e.g. `SBMainWorkspace` launch denial → "did you build with `build-for-testing`? use `build`")
- Documented exit codes: `0` ok, `1` env, `2` op failed, `3` args, `4` fixture-incompat

## What changes in `side-by-side.sh`

Before:
```bash
xcrun simctl uninstall "$SIM_A" org.thepalaceproject.palace 2>/dev/null || true
xcrun simctl install "$SIM_A" "$BASELINE_APP"
xcrun simctl uninstall "$SIM_B" org.thepalaceproject.palace 2>/dev/null || true
xcrun simctl install "$SIM_B" "$CANDIDATE_APP"
```

After:
```bash
PALACE_STATE_SIM_UDID="$SIM_A" PALACE_STATE_APP_PATH="$BASELINE_APP" \
  "$PALACE_STATE_DIR/operations/reset-fresh-install.sh" --no-launch
PALACE_STATE_SIM_UDID="$SIM_B" PALACE_STATE_APP_PATH="$CANDIDATE_APP" \
  "$PALACE_STATE_DIR/operations/reset-fresh-install.sh" --no-launch
```

DRY, plus gains the missing pre-grant step (notifications + location) — the same step that prevents the first-launch alert from blocking the first replay tap.

## Smoke verified

On iPhone 17 Pro / iOS 26.2 sim, against a clean `xcodebuild build` of Palace:
- ✅ `reset-fresh-install.sh` → install + launch + PID confirmed
- ✅ `reset-fresh-install.sh --no-launch` → install only, no launch
- ✅ `snapshot.sh smoke-test` → 48K fixture + valid JSON `meta.json`
- ✅ `restore.sh smoke-test` (strict) → fixture restored, device matched
- ✅ `restore.sh smoke-test --no-strict` → warns on device mismatch instead of halting
- ✅ `--help` renders cleanly on all 4 scripts (POSIX-sed bug found + fixed during dogfood)

## What's intentionally NOT in this PR

**Layer 2** — simdrive recording-YAML schema change (`requires:` block). That's an upstream simdrive proposal; lives outside the Palace repo and lands once simdrive adopts it.

**Layer 3** — `verify-pr.sh` lint that fails any recording without a `requires:` block. Lands once Layer 2 ships.

**XCUITest target** — Palace has no XCUITest target today. Adding one is bigger scaffolding; will follow once there's a specific signin/auth test worth gating on it. The shell primitives here will be the foundation that target's `PalaceTestStates` Swift helper shells out to.

**Keychain capture** — known v1 gap, documented in `.palace-state/README.md`. Keychain is sim-wide (not app-scoped) and shared across apps; restoring it cleanly requires matching access groups and is not portable across machines. Snapshots restore *everything the app sees in its data container*; signed-in state currently requires manual re-authentication after restore.

## Test plan

- [x] `bash -n` syntax-check on all 4 scripts
- [x] `--help` renders cleanly on all 4 scripts
- [x] End-to-end smoke test on a real sim (reset → snapshot → restore)
- [x] `python3 -m json.tool` validates `meta.json`
- [x] `side-by-side.sh --help` still works after refactor
- [ ] Reviewer dry-runs `.palace-state/operations/reset-fresh-install.sh --help` to confirm contract is readable
- [ ] Reviewer reads `.palace-state/README.md` for the v1 gaps + intent

## Related

- Surfaced by: `simdrive_v1_0_0a7_smoke_2026_05_11.md` smoke-test memory entry (private)
- Companion (upstream simdrive): `requires:` schema spec being filed separately
- Foundation for: future `PalaceUITests` XCUITest target (when it lands)