### PR TITLE
SignInLogic: close SignInModalView mutation-gate 0% kill rate

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -338,6 +338,7 @@
 		5419E00285822EDBFB4ED932 /* SendableSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BD75A5447FB7BD0DA90F57 /* SendableSubject.swift */; };
 		544B4387437E609DFF7E6757 /* OPDS2PublicationExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023DFFACC986541965F1560 /* OPDS2PublicationExtended.swift */; };
 		547B90CF7E8D4CABA5A59BFD /* TPPIdleSignOutRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D448C588C99441528CE12FD5 /* TPPIdleSignOutRegressionTests.swift */; };
+		54A659E3268D9EB2F8A0C8A5 /* SignInModalPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F258C065A0415A61F22E0C /* SignInModalPredicateTests.swift */; };
 		54B670BB3ED649CA9730B820 /* ErrorActivityTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A40759C732F4FC1B0587021 /* ErrorActivityTracker.swift */; };
 		54E99B7757E6F82038D5F0D6 /* PerformanceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61585F7AD2A0D6CDAF2EF098 /* PerformanceMonitor.swift */; };
 		55104FF85DE440C78F18B4E7 /* TPPLastReadPositionSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706130D4BA8B4FE88304EC9C /* TPPLastReadPositionSynchronizerTests.swift */; };
@@ -2422,6 +2423,7 @@
 		D6EF9481386FFCE35AA787B5 /* ReadingChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingChartView.swift; sourceTree = "<group>"; };
 		D72DFEC346C543E50A57BE49 /* ReaderAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderAccessibilityTests.swift; sourceTree = "<group>"; };
 		D76D4FC473DA9FC4F507B0B6 /* ReaderSettingsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderSettingsTests.swift; sourceTree = "<group>"; };
+		D7F258C065A0415A61F22E0C /* SignInModalPredicateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SignInModalPredicateTests.swift; sourceTree = "<group>"; };
 		D8594B752B9EB47CACE89C7C /* SAMLPlusBiblioBoardExpirationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAMLPlusBiblioBoardExpirationTests.swift; sourceTree = "<group>"; };
 		D8CCF14B8043FB410CB53DFB /* TPPMyBooksSimplifiedBearerToken.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPMyBooksSimplifiedBearerToken.swift; sourceTree = "<group>"; };
 		D9308AC13830467FB0C7F3F7 /* SignInModalSAMLOIDCTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SignInModalSAMLOIDCTests.swift; sourceTree = "<group>"; };
@@ -4248,6 +4250,7 @@
 				AUTHREDTESTSFILEREF001ZZZZ /* AuthReducerTests.swift */,
 				EF1557BA5E024E70AE55ACE2 /* ForceResetTests.swift */,
 				4EF041C7CEA6592C3141FA49 /* AuthErrorProblemDocSeamTests.swift */,
+				D7F258C065A0415A61F22E0C /* SignInModalPredicateTests.swift */,
 			);
 			path = SignInLogic;
 			sourceTree = "<group>";
@@ -6397,6 +6400,7 @@
 				16E9A34D3D9D5833B73139CF /* iPadOnMacRMSDKGuardTests.swift in Sources */,
 				85CA12FDD8CAF6227F7040FD /* FindawayChapterStatusGuardTests.swift in Sources */,
 				F2B9AED795FF681027B7C67C /* AuthErrorProblemDocSeamTests.swift in Sources */,
+				54A659E3268D9EB2F8A0C8A5 /* SignInModalPredicateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/SignInLogic/SignInModalView.swift
+++ b/Palace/SignInLogic/SignInModalView.swift
@@ -50,12 +50,19 @@ struct SignInModalView: View {
                     // `presentingViewController == nil` — i.e. AFTER the UIKit transition has
                     // fully completed. Downstream sheet presentation then runs on a clean
                     // presenter chain.
-                    if authState == .loggedIn {
+                    if Self.shouldAutoDismiss(authState: authState) {
                         dismiss()
                     }
                 }
         }
         .navigationViewStyle(.stack)
+    }
+
+    /// Pure-function predicate for the auto-dismiss-on-loggedIn branch.
+    /// Extracted from the body's `onChange` so the mutation gate can verify
+    /// callers don't silently regress to "dismiss when NOT logged in".
+    static func shouldAutoDismiss(authState: TPPAccountAuthState) -> Bool {
+        return authState == .loggedIn
     }
 
     private var cancelButton: some View {
@@ -76,7 +83,7 @@ struct SignInModalView: View {
 /// not just when SwiftUI's `dismiss()` was called. SwiftUI's dismiss is
 /// non-blocking; without this, fast user re-taps race the in-flight
 /// dismiss and produce "transitioning already" stuck-modal lock-ups.
-private final class SignInModalHostingController<Content: View>: UIHostingController<Content> {
+final class SignInModalHostingController<Content: View>: UIHostingController<Content> {
     private let onDidFullyDismiss: () -> Void
     private var firedOnce = false
 
@@ -96,9 +103,17 @@ private final class SignInModalHostingController<Content: View>: UIHostingContro
         // only want to reset isPresenting when this hosting controller is
         // actually torn down — `presentingViewController == nil` is true
         // after dismissal has fully completed.
-        guard !firedOnce, presentingViewController == nil else { return }
+        guard Self.shouldFireDismissCallback(firedOnce: firedOnce, presentingViewController: presentingViewController) else { return }
         firedOnce = true
         onDidFullyDismiss()
+    }
+
+    /// Pure-function predicate for the once-after-dismissal completion guard.
+    /// Extracted from `viewDidDisappear` so the mutation gate can verify a
+    /// regression to "fire while still presenting" is caught by a unit test
+    /// rather than discovered as a stuck-modal user report.
+    static func shouldFireDismissCallback(firedOnce: Bool, presentingViewController: UIViewController?) -> Bool {
+        return !firedOnce && presentingViewController == nil
     }
 }
 

--- a/PalaceTests/SignInLogic/SignInModalPredicateTests.swift
+++ b/PalaceTests/SignInLogic/SignInModalPredicateTests.swift
@@ -1,0 +1,75 @@
+//
+//  SignInModalPredicateTests.swift
+//  PalaceTests
+//
+//  Closes the SignInModalView 0% mutation kill rate identified in the
+//  2026-05-11 regression. Both predicates were extracted into static
+//  helpers so the mutation gate can verify a regression to the inverted
+//  branch is caught by a focused unit test rather than escaping as a
+//  stuck-modal user report.
+//
+//  Mutation surface covered:
+//    - `SignInModalView.shouldAutoDismiss(authState:)` — `==` flip on .loggedIn
+//    - `SignInModalHostingController.shouldFireDismissCallback(...)` — `==` flip on presentingViewController
+//
+
+import XCTest
+import SwiftUI
+@testable import Palace
+
+final class SignInModalPredicateTests: XCTestCase {
+
+    // MARK: - shouldAutoDismiss
+
+    func testShouldAutoDismiss_whenLoggedIn_returnsTrue() {
+        XCTAssertTrue(SignInModalView.shouldAutoDismiss(authState: .loggedIn))
+    }
+
+    func testShouldAutoDismiss_whenLoggedOut_returnsFalse() {
+        XCTAssertFalse(SignInModalView.shouldAutoDismiss(authState: .loggedOut))
+    }
+
+    func testShouldAutoDismiss_whenCredentialsStale_returnsFalse() {
+        // Stale credentials must NOT auto-dismiss the modal — the user
+        // is mid-re-auth and the form is still showing.
+        XCTAssertFalse(SignInModalView.shouldAutoDismiss(authState: .credentialsStale))
+    }
+
+    // MARK: - shouldFireDismissCallback
+
+    func testShouldFireDismissCallback_firstTimeAndDismissed_returnsTrue() {
+        XCTAssertTrue(SignInModalHostingController<EmptyView>.shouldFireDismissCallback(
+            firedOnce: false,
+            presentingViewController: nil
+        ))
+    }
+
+    func testShouldFireDismissCallback_firstTimeButStillPresented_returnsFalse() {
+        // The protective guard: viewDidDisappear fires during normal
+        // nav-stack pushes BEFORE the modal is actually torn down. The
+        // hosting controller still has a presentingViewController.
+        // Firing the callback here would race the in-flight dismissal
+        // and lock the BookDetail half-sheet (the bug this guard exists
+        // to prevent).
+        let presenter = UIViewController()
+        XCTAssertFalse(SignInModalHostingController<EmptyView>.shouldFireDismissCallback(
+            firedOnce: false,
+            presentingViewController: presenter
+        ))
+    }
+
+    func testShouldFireDismissCallback_alreadyFired_returnsFalse() {
+        XCTAssertFalse(SignInModalHostingController<EmptyView>.shouldFireDismissCallback(
+            firedOnce: true,
+            presentingViewController: nil
+        ))
+    }
+
+    func testShouldFireDismissCallback_alreadyFiredAndStillPresented_returnsFalse() {
+        let presenter = UIViewController()
+        XCTAssertFalse(SignInModalHostingController<EmptyView>.shouldFireDismissCallback(
+            firedOnce: true,
+            presentingViewController: presenter
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `SignInModalView`'s auto-dismiss-on-loggedIn predicate into a static helper `shouldAutoDismiss(authState:)`
- Extract `SignInModalHostingController`'s once-after-dismissal completion guard into a static helper `shouldFireDismissCallback(firedOnce:presentingViewController:)`
- Drop `private` from `SignInModalHostingController` so the test target can construct it (still constructed only via `SignInModalPresenter` in production)
- Add 7 tests in `PalaceTests/SignInLogic/SignInModalPredicateTests.swift` covering the full predicate matrix

## Why

The 2026-05-11 develop-branch regression mutation gate reported **0% kill rate** on `SignInModalView` — both auth-flow predicates were embedded inside the SwiftUI view body / private UIKit hosting class, unreachable by unit tests despite controlling user-facing dismissal behavior. A regression that flipped `==` to `!=` on either predicate would silently break login auto-dismiss or fire the completion callback during in-flight navigation (the BookDetail half-sheet lock-up these guards exist to prevent).

## What I verified locally against origin/develop

- 7/7 new tests pass in <0.025s when run in isolation
- 104/104 broader SignInLogic surface tests still pass (SignInModalSAMLOIDCTests, SignInWebSheetIntegrationTests, SignInWebSheetViewModelTests, AuthReducerTests, TPPSAMLFlowTests, TPPCredentialsTests, new SignInModalPredicateTests)
- Mutation gate post-refactor: **3/3 killed = 100% kill rate** (was 0/2)
- Zero behavior change — call sites still execute the same logic, just through a static helper

## Conflict check with PR #936

PR #936 (PalaceAuth leaf extraction) does NOT touch `Palace/SignInLogic/SignInModalView.swift` — `SignInModalView` stays Palace-target code because it depends on `AccountDetailView`/`AppContainer`. File is byte-identical between `develop` and `refactor/palaceauth-spm-leaf-extraction`. Safe to land either before or after #936.

## Test plan
- [ ] CI build passes
- [ ] CI tests pass (new `SignInModalPredicateTests` runs as part of `PalaceTests`)
- [ ] Manual sanity: present sign-in modal from a 401-requiring borrow, sign in, modal dismisses, no stuck-sheet on BookDetail

🤖 Generated with [Claude Code](https://claude.com/claude-code)