### PR TITLE
test: fix two CI flakes — Typography debounce race + WebView cold-start timeouts

### DIFF
--- a/PalaceTests/Reader2/Typography/TypographyServiceTests.swift
+++ b/PalaceTests/Reader2/Typography/TypographyServiceTests.swift
@@ -283,30 +283,29 @@ final class TypographyServiceTests: XCTestCase {
     // MARK: - Persistence
 
     func testSettingsPersistedAfterDebounce() {
-        let expectation = expectation(description: "Settings persisted")
-
-        // Capture into locals so the async block doesn't reach back through
-        // self.testDefaults — under CI load the asyncAfter can fire after
-        // tearDown has already nulled the implicitly-unwrapped optional,
-        // crashing the next test that's running. Captured locals keep the
-        // UserDefaults and service alive for the closure's lifetime.
+        // Capture into a local so the predicate block doesn't reach back through
+        // self.testDefaults — under CI load the predicate can fire after tearDown
+        // has already nulled the implicitly-unwrapped optional, crashing the
+        // next test that's running. The captured local keeps UserDefaults alive
+        // for the predicate's lifetime.
         let capturedDefaults = testDefaults!
         service.updateFontSize(28)
 
-        // Wait for debounce (500ms + buffer)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+        // Poll the persisted value rather than guess at debounce + scheduling
+        // drift. The previous fixed-700ms wait raced the 500ms debounce on
+        // RunLoop.main and intermittently read the default 18pt back on loaded
+        // CI runners (the main run loop can be starved past the debounce
+        // deadline). Polling lets the test pass as soon as the value lands.
+        let predicate = NSPredicate { _, _ in
             let reloaded = TypographyService(userDefaults: capturedDefaults)
-            XCTAssertEqual(reloaded.currentSettings.fontSize, 28, "Font size should be persisted")
-            // Other default settings should also be preserved on reload
-            XCTAssertEqual(reloaded.currentSettings.fontFamily, .georgia,
-                           "Default fontFamily should be preserved alongside the changed fontSize")
-            expectation.fulfill()
+            return reloaded.currentSettings.fontSize == 28
         }
+        wait(for: [XCTNSPredicateExpectation(predicate: predicate, object: nil)], timeout: 5.0)
 
-        // Bumped 2s → 10s for CI: the main queue is shared across the entire
-        // test bundle and 700ms asyncAfter scheduling can drift well beyond 2s
-        // under load (same fix pattern as F-010 TokenRefreshInterceptorTests).
-        waitForExpectations(timeout: 10)
+        let reloaded = TypographyService(userDefaults: capturedDefaults)
+        XCTAssertEqual(reloaded.currentSettings.fontSize, 28, "Font size should be persisted")
+        XCTAssertEqual(reloaded.currentSettings.fontFamily, .georgia,
+                       "Default fontFamily should be preserved alongside the changed fontSize")
     }
 
     func testSettingsPublisherEmitsOnChange() {

--- a/PalaceTests/SignInLogic/SignInWebSheetIntegrationTests.swift
+++ b/PalaceTests/SignInLogic/SignInWebSheetIntegrationTests.swift
@@ -95,8 +95,13 @@ final class SignInWebSheetIntegrationTests: XCTestCase {
         // ACT
         webView.loadHTMLString(html, baseURL: URL(string: "https://idp.test.local"))
 
-        // ASSERT — wait up to 5s for the redirect navigation to be intercepted
-        await fulfillment(of: [loginExpectation], timeout: 5.0)
+        // ASSERT — wait up to 15s for the redirect navigation to be intercepted.
+        // 5s isn't enough on shared GH macOS runners: WKWebView cold-starts three
+        // helper processes (WebContent, GPU, Networking) and CI logs have shown
+        // ~1.4s WebContent + ~1.6s GPU launch alone, leaving <2s for HTML parse,
+        // JS exec, and navigation policy IPC — which intermittently misses the
+        // deadline. (Same defensive bump pattern as TypographyServiceTests.)
+        await fulfillment(of: [loginExpectation], timeout: 15.0)
         XCTAssertEqual(capturedURL?.absoluteString, "\(universalLinks.absoluteString)?token=test123")
     }
 
@@ -167,8 +172,8 @@ final class SignInWebSheetIntegrationTests: XCTestCase {
         }
         webView.loadHTMLString("<html><body>OK</body></html>", baseURL: URL(string: "https://idp.test.local"))
 
-        // ASSERT
-        await fulfillment(of: [exp], timeout: 5.0)
+        // ASSERT — 15s for the same WebKit cold-start reason as the test above.
+        await fulfillment(of: [exp], timeout: 15.0)
         XCTAssertFalse(viewModel.isLoading, "Post-load: overlay must be hidden")
         cancellable.cancel()
     }


### PR DESCRIPTION
## Summary

Two unrelated tests have been intermittently failing on shared GH macOS runners. Both have the same root cause: a fixed-duration wait that doesn't survive runner load. Caught while landing PR #935 — 3 CI attempts, 2 hangs at the test-runner step + 1 failure on these specific tests, despite the PR's surface having nothing to do with typography or WebKit.

No production code changes. 26 lines added, 22 removed in `PalaceTests/`.

## Root causes + fixes

### 1. `TypographyServiceTests.testSettingsPersistedAfterDebounce`

`TypographyService` debounces persistence by **500ms on `RunLoop.main`** (`TypographyService.swift:46-51`). The test waited a fixed **700ms** then read from a fresh service — a 200ms grace window that's too tight when CI's main run loop is starved past the debounce deadline. On those runs the test reads back the default 18pt instead of the 28pt it set.

> ```
> XCTAssertEqual failed: ("18.0") is not equal to ("28.0") - Font size should be persisted
> ```

**Fix:** replaced the fixed wait with `XCTNSPredicateExpectation` that polls the persisted value, passing as soon as the write lands and tolerating arbitrary scheduler drift up to a 5s ceiling. Apple's recommended pattern for async observation tests.

### 2. `SignInWebSheetIntegrationTests` (two cases)

- `test_navigatingToUniversalLinksURL_firesLoginCompletionWithCookies`
- `test_loadingOverlay_startsTrueAndBecomesFalseOnNavigationFinish`

Each waited **5s** for a WKWebView navigation event. WKWebView is multi-process — every fresh instance cold-starts WebContent + GPU + Networking helpers. The CI logs showed:

> ```
> [Process] WebContent process (0x110846800) took 1.355253 seconds to launch
> [Process] GPU process (0x156ce95d0) took 1.603423 seconds to launch
> ```

That's ~3s of pure cold-start eaten before HTML parses. 5s left <2s for HTML parse + JS exec + navigation policy IPC, which intermittently misses the deadline.

**Fix:** bumped both timeouts to **15s** — same defensive margin `TypographyService` had already adopted (`Bumped 2s → 10s for CI` per its existing comment in the same test file).

## Why bump rather than warm WebKit / mock WKNavigationAction

- WKNavigationAction has no public initializer — can't be mocked, hence the integration tests in the first place.
- A class-level WebKit warm-up adds static state and AsyncStream wiring for marginal benefit (XCTest runs the bundle in one process, so once WebContent is warm via the first test, subsequent tests reuse it). A simple timeout bump is cheaper and equally effective for the observed cold-start range.

## Test plan

- [ ] CI build-and-test green on this PR
- [ ] Watch the next 2-3 PRs that follow and confirm the flake count on these test names drops to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)