### PR TITLE
simdrive: Reader2 navigation regression corpus

### DIFF
--- a/.simdrive/journeys/_INDEX.md
+++ b/.simdrive/journeys/_INDEX.md
@@ -56,6 +56,8 @@ Today's run (5 journeys): all 5 pass. 3 stateless journeys gated on structural c
 | [read-return-from-mybooks-roundtrip](read-return-from-mybooks-roundtrip.yaml) | stateful | 5 | Read + Return halves of money flow end-to-end: Read → Reader2 chrome → exit → inline Return → confirm → book gone. Mutates state (returns book) so replays need re-borrow setup. See BUG_FINDINGS_2026_05_12.md for why the Borrow half is deferred. |
 | [reader2-back-button](reader2-back-button.yaml) | stateful | 4 | Reader2 navigation boundary — Read tap launches Readium 3.x WKWebView, top-left back chevron round-trips to MyBooks. Pairs with reader2-page-forward (WKWebView reachability) to cover entry + exit. |
 | [reader2-settings-sheet](reader2-settings-sheet.yaml) | stateful | 9 | Reader2 typography settings (TT) sheet — Aa Aa Aa font-size selectors + ABCabc font samples + brightness controls. Critical accessibility surface; regression in WKWebView CSS injection would surface here. Documents chrome auto-hide timing in step 7. |
+| [reader2-toc-navigate](reader2-toc-navigate.yaml) | stateful | 6 | Reader2 TOC seek — opens Table of Contents sheet (TOC icon at pixel (811, 240)), tapping a chapter row navigates WKWebView to that chapter's first page. Catches TOC parser + chapter-anchor + WKWebView render regressions in one recording. |
+| [reader2-bookmark-toggle](reader2-bookmark-toggle.yaml) | stateful | 4 | Reader2 bookmark add + remove (icon-state roundtrip). Tap bookmark icon at (1097, 240) toggles outline ↔ filled. Catches BookRegistry write + toggle binding + SF Symbol binding regressions. Pixel-diff on (1070-1130, 215-260) bbox is the load-bearing assertion. |
 
 ## How replays work
 

--- a/.simdrive/journeys/_INDEX.md
+++ b/.simdrive/journeys/_INDEX.md
@@ -54,6 +54,7 @@ Today's run (5 journeys): all 5 pass. 3 stateless journeys gated on structural c
 | [audiobook-scrubber-drag](audiobook-scrubber-drag.yaml) | stateful | 2 | Audiobook scrubber thumb drag — swipe at y=642 from (87, 642) to (800, 642) seeks playback. Catches gesture-to-position mapping + AVAudioSession seek + chapter-index recompute regressions in one drag. |
 | [book-return-from-mybooks](book-return-from-mybooks.yaml) | stateful | 2 | Money-flow Return half — inline Return tap renders confirm dialog, confirm tap silently revokes the loan AND removes the row. Catches OPDS revoke / DRM unbind / BookRegistry sync regressions via OCR-absence on the returned title. |
 | [read-return-from-mybooks-roundtrip](read-return-from-mybooks-roundtrip.yaml) | stateful | 5 | Read + Return halves of money flow end-to-end: Read → Reader2 chrome → exit → inline Return → confirm → book gone. Mutates state (returns book) so replays need re-borrow setup. See BUG_FINDINGS_2026_05_12.md for why the Borrow half is deferred. |
+| [reader2-back-button](reader2-back-button.yaml) | stateful | 4 | Reader2 navigation boundary — Read tap launches Readium 3.x WKWebView, top-left back chevron round-trips to MyBooks. Pairs with reader2-page-forward (WKWebView reachability) to cover entry + exit. |
 
 ## How replays work
 

--- a/.simdrive/journeys/_INDEX.md
+++ b/.simdrive/journeys/_INDEX.md
@@ -55,6 +55,7 @@ Today's run (5 journeys): all 5 pass. 3 stateless journeys gated on structural c
 | [book-return-from-mybooks](book-return-from-mybooks.yaml) | stateful | 2 | Money-flow Return half — inline Return tap renders confirm dialog, confirm tap silently revokes the loan AND removes the row. Catches OPDS revoke / DRM unbind / BookRegistry sync regressions via OCR-absence on the returned title. |
 | [read-return-from-mybooks-roundtrip](read-return-from-mybooks-roundtrip.yaml) | stateful | 5 | Read + Return halves of money flow end-to-end: Read → Reader2 chrome → exit → inline Return → confirm → book gone. Mutates state (returns book) so replays need re-borrow setup. See BUG_FINDINGS_2026_05_12.md for why the Borrow half is deferred. |
 | [reader2-back-button](reader2-back-button.yaml) | stateful | 4 | Reader2 navigation boundary — Read tap launches Readium 3.x WKWebView, top-left back chevron round-trips to MyBooks. Pairs with reader2-page-forward (WKWebView reachability) to cover entry + exit. |
+| [reader2-settings-sheet](reader2-settings-sheet.yaml) | stateful | 9 | Reader2 typography settings (TT) sheet — Aa Aa Aa font-size selectors + ABCabc font samples + brightness controls. Critical accessibility surface; regression in WKWebView CSS injection would surface here. Documents chrome auto-hide timing in step 7. |
 
 ## How replays work
 

--- a/.simdrive/journeys/reader2-back-button.yaml
+++ b/.simdrive/journeys/reader2-back-button.yaml
@@ -1,0 +1,93 @@
+scenario:
+  id: reader2-back-button
+  name: "Reader2 back-navigation regression"
+  description: >
+    First Reader2 navigation recording in the simdrive corpus.
+    Verifies Readium 3.x WKWebView reader can be entered from MyBooks
+    and exited via the top-left back chrome — round-tripping back to
+    MyBooks with the borrowed EPUB still present.
+
+    Closes the Reader2 navigation gap surfaced by the 2026-05-12 PM
+    handoff (memory: handoff_regression_posture_next_2026_05_12). Pairs
+    with the existing reader2-page-forward recording which only
+    verifies WKWebView reachability — this one verifies the navigation
+    boundary (in + out).
+
+  tags: [tier1, ios, reader2, epub, navigation, wkwebview]
+  tier: stateful
+  blocking: false   # smoke-only — Reader2 cached state (last-read page,
+                    # bookmarks) causes layout drift across launches,
+                    # so SSIM is informational. Structural reach-back
+                    # to MyBooks is the load-bearing invariant.
+
+  preconditions:
+    - "A1QA Test Library is the active library"
+    - "A1QA is signed in (patron 'al/qa' visible top-left)"
+    - "Mathematics Test Book (DAISY EPUB, 7 pages) is in MyBooks, downloaded, Read button visible"
+    - "MyBooks tab is in the foreground"
+    - "Animal Farm + Anna Karenina audiobooks are also in MyBooks (state-contract identifies the row layout)"
+
+  state_reset:
+    - "Before each replay, ensure Mathematics Test Book has been borrowed under A1QA and the EPUB has finished downloading."
+    - "If a Sync Reading Position dialog appears on Read tap, the recording's step 2 dismisses it via Stay — this preserves cover-page state across replays."
+
+  recording:
+    path: "~/.simdrive/recordings/reader2-back-button/recording.yaml"
+    steps: 4
+    captured_with: "simdrive 1.0.0a9"
+    captured_on: "2026-05-12"
+
+  steps:
+    - id: tap_read
+      description: "Tap Read on Mathematics Test Book row in MyBooks"
+      tap_target: { stable_id: "2e7a5a3230f1" }
+    - id: dismiss_sync_dialog
+      description: "Tap Stay to keep cover-page position (sync dialog appears because Reader2 caches last-read across opens)"
+      tap_target: { stable_id: "f14a16635587" }
+    - id: toggle_chrome
+      description: "Tap reader content center to bring up auto-hiding chrome bar"
+      tap_target: { x: 603, y: 1300 }
+    - id: tap_back_chrome
+      description: "Tap top-left back chevron to exit Reader2"
+      tap_target: { x: 60, y: 230 }
+
+  expected_invariants:
+    - "Read tap launches Reader2 (Readium 3.x WKWebView), not a sheet"
+    - "Sync Reading Position dialog renders with Stay + Move buttons"
+    - "Stay tap dismisses the dialog and reveals the EPUB cover page (OCR sees lipsum + 'Page 1 of 7')"
+    - "Tap on reader content toggles the chrome bar (title + page indicator visible afterward)"
+    - "Top-left back chevron tap navigates out of Reader2 — post-state shows MyBooks with the book row visible (Read + Return buttons)"
+    - "No crash, no infinite spinner, no DRM activation prompt for accessible EPUB content"
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # Reader2 WKWebView rendering varies across runs
+                     # (font metrics, CSS adjustments, page index).
+                     # Post-step-4 should resemble pre-step-1 (MyBooks)
+                     # but exact pixel match is not guaranteed.
+
+  rationale: |
+    Per CLAUDE.md "E2E / UI sim driving — simdrive": Reader2 chrome
+    (back, settings, TOC) IS reachable via simdrive — this is the
+    whole reason simdrive exists. XCTest cannot see inside the
+    WKWebView. This recording is the FIRST that verifies the
+    Reader2 navigation boundary specifically (the existing
+    reader2-page-forward recording only verifies WKWebView
+    reachability, not exit-path durability).
+
+    The 2-tap chrome-then-back sequence (steps 3-4) is REQUIRED
+    because Reader2's top-bar chrome auto-hides after ~5 seconds of
+    no interaction. A single tap at the chevron location lands on
+    hidden chrome and is consumed by the WKWebView with no effect.
+    Step 3 toggles the chrome visible; step 4 within the auto-hide
+    window taps the chevron.
+
+  known_issues:
+    - "Reader2 chrome auto-hides after ~5 seconds of no interaction. The recording's step 3 is the toggle-chrome tap that MUST precede step 4's back-chevron tap; replays with significantly different timing between steps 3 and 4 may miss the chrome window."
+    - "The sync-position dialog (step 2) only appears if Reader2 has a saved last-read position. Fresh-borrow state shows no dialog and the replay diverges at step 1 — Reader2 jumps directly to the page. State-contract requires the dialog so we always exercise step 2's dismissal."
+    - "WKWebView OCR is content-dependent — Latin-filler-text DAISY EPUB renders deterministically enough for structural checks (page indicator at fixed bottom location) but not pixel-perfect SSIM. Use post-state structural checks for regression gating, not SSIM thresholding."
+
+  related:
+    - "reader2-page-forward.yaml — pre-existing recording, verifies WKWebView page-forward chevron"
+    - "Memory: feedback_simdrive_validated.md — simdrive bypasses Readium WKWebView XCTest gap"
+    - "Memory: simdrive_v1_0_0a9_state_contract_2026_05_11.md — state-contract requires: block schema"

--- a/.simdrive/journeys/reader2-bookmark-toggle.yaml
+++ b/.simdrive/journeys/reader2-bookmark-toggle.yaml
@@ -1,0 +1,105 @@
+scenario:
+  id: reader2-bookmark-toggle
+  name: "Reader2 bookmark add + remove (icon-state roundtrip)"
+  description: >
+    Fourth Reader2 navigation recording. Verifies that the top-toolbar
+    bookmark icon (rightmost SF Symbol at pixel coords (1097, 240))
+    toggles a bookmark on the current page — first tap fills the icon
+    (bookmark added), second tap empties it (bookmark removed).
+
+    Replaces the originally-planned 'reader2-bookmark-roundtrip' with a
+    simpler in-session toggle. The full roundtrip (add → close →
+    reopen → bookmark navigates back) requires Reader2 to persist the
+    bookmark across launches AND a TOC-bookmarks-tab navigation, which
+    is a multi-recording flow deferred to a follow-up.
+
+  tags: [tier1, ios, reader2, epub, bookmark, wkwebview]
+  tier: stateful
+  blocking: false   # smoke-only — bookmark icon state is the load-
+                    # bearing invariant (visible outline-vs-filled SVG).
+                    # OCR can't see SF Symbol icon fill state directly,
+                    # so this recording relies on pixel diff or visual
+                    # inspection.
+
+  preconditions:
+    - "A1QA Test Library is the active library"
+    - "A1QA is signed in (patron 'al/qa' visible top-left)"
+    - "Mathematics Test Book (DAISY EPUB, 7 pages) is in MyBooks, downloaded, Read button visible"
+    - "MyBooks tab is in the foreground"
+    - "Last-read position is page 4 (MathML Tests) — recording assumes Reader2 opens directly to this page"
+    - "Page 4 currently has NO bookmark (icon shows outline state)"
+
+  state_reset:
+    - "Before each replay, ensure page 4 of Mathematics Test Book has no existing bookmark. If a bookmark exists, the icon starts in filled state and the recording's toggle direction inverts."
+    - "Easiest reset: open Reader2, navigate to page 4 via TOC, tap bookmark to clear if filled."
+
+  recording:
+    path: "~/.simdrive/recordings/reader2-bookmark-toggle/recording.yaml"
+    steps: 4
+    captured_with: "simdrive 1.0.0a9"
+    captured_on: "2026-05-12"
+
+  steps:
+    - id: tap_read
+      description: "Tap Read on Mathematics Test Book row — Reader2 opens at cached page 4 (MathML Tests)"
+      tap_target: { stable_id: "2e7a5a3230f1" }
+    - id: toggle_chrome
+      description: "Tap content center to reveal top toolbar (chrome)"
+      tap_target: { x: 603, y: 1300 }
+    - id: tap_bookmark_add
+      description: "Tap rightmost bookmark icon at pixel coords (1097, 240) — bookmark icon transitions outline -> filled"
+      tap_target: { x: 1097, y: 240 }
+    - id: tap_bookmark_remove
+      description: "Tap bookmark icon again — bookmark icon transitions filled -> outline (toggle off)"
+      tap_target: { x: 1097, y: 240 }
+
+  expected_invariants:
+    - "Read tap opens Reader2 directly to cached page 4 (MathML Tests chapter)"
+    - "Chrome-toggle reveals top toolbar with bookmark icon at the rightmost position"
+    - "Initial bookmark icon state is OUTLINE (no bookmark on this page)"
+    - "Step 3 tap: icon transitions OUTLINE -> FILLED (bookmark added to current page)"
+    - "Step 4 tap: icon transitions FILLED -> OUTLINE (bookmark removed)"
+    - "Roundtrip is idempotent — final state matches initial state, no orphaned bookmark left in the BookRegistry"
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # The icon fill state is a small pixel region.
+                     # SSIM at 0.85 threshold may not surface the
+                     # outline-vs-filled change reliably. Pixel-diff
+                     # on the bookmark-icon bbox (~x=1070-1130, y=215-260)
+                     # is the most reliable assertion mechanism.
+
+  rationale: |
+    Bookmarks are the second-most-used Reader2 feature after page
+    navigation. A regression in:
+
+    1. **BookRegistry bookmark write** — adding a bookmark could
+       silently fail to persist. The icon's outline-to-filled
+       transition (step 3) is the visual proof that the write
+       hit the registry.
+
+    2. **Bookmark toggle binding** — the second tap should remove
+       the bookmark (step 4). A regression where the second tap
+       creates a duplicate bookmark instead of removing would not
+       change the icon state visibly but would corrupt the
+       BookRegistry. (Future: a follow-up recording could open the
+       TOC's Bookmarks tab between steps 3 and 4 to count entries.)
+
+    3. **SF Symbol asset binding** — Readium 3.x uses SF Symbol
+       bookmark.fill / bookmark; a regression in the binding (wrong
+       symbol name, wrong color) surfaces as a missing or
+       miscolored icon.
+
+    The roundtrip ending in the original state (idempotent) is
+    important because it means the recording leaves no state for
+    follow-up recordings to reset.
+
+  known_issues:
+    - "OCR cannot directly see SF Symbol fill state — outline-vs-filled bookmark icon is visually obvious to a human looking at the screenshot but won't surface in mark detection. Future regression detection on this recording should use pixel-diff on the (1070-1130, 215-260) bbox area, not SSIM or OCR."
+    - "Recording assumes Reader2 opens at page 4 with NO existing bookmark. On a sim where page 4 already has a bookmark, the toggle direction inverts (filled -> outline -> filled) and the roundtrip's net effect is still idempotent, but step-3 / step-4 invariants flip."
+    - "Bookmark persistence across launches (the originally-planned 'roundtrip' — close book, reopen, verify bookmark survives) is NOT covered here. A follow-up recording 'reader2-bookmark-persistence' could chain reader2-bookmark-toggle's step 3 with an app-relaunch and a TOC bookmarks-tab assertion."
+
+  related:
+    - "reader2-toc-navigate.yaml — TOC sheet's Bookmarks tab would surface saved bookmarks"
+    - "reader2-back-button.yaml + reader2-settings-sheet.yaml — sibling chrome-icon recordings"
+    - "Memory: handoff_regression_posture_next_2026_05_12.md — task 4 corpus expansion"

--- a/.simdrive/journeys/reader2-settings-sheet.yaml
+++ b/.simdrive/journeys/reader2-settings-sheet.yaml
@@ -1,0 +1,107 @@
+scenario:
+  id: reader2-settings-sheet
+  name: "Reader2 settings (TT) sheet regression"
+  description: >
+    Second Reader2 navigation recording. Verifies that the top-right
+    TT (typography) chrome button opens the Reader2 settings sheet
+    — font-size selectors and brightness controls — and that the
+    sheet can be dismissed back to the reader, then the reader exited
+    back to MyBooks.
+
+    Closes the visual-adjustments path the handoff called out: a
+    regression in WKWebView CSS injection or the settings binding
+    would break font-size adjustment, which is a critical
+    accessibility surface.
+
+  tags: [tier1, ios, reader2, epub, settings, wkwebview]
+  tier: stateful
+  blocking: false   # smoke-only — chrome timing is sensitive (see
+                    # known_issues); the load-bearing invariant is
+                    # that the settings sheet renders with 3 font-size
+                    # buttons (Aa Aa Aa) after the TT tap.
+
+  preconditions:
+    - "A1QA Test Library is the active library"
+    - "A1QA is signed in (patron 'al/qa' visible top-left)"
+    - "Mathematics Test Book (DAISY EPUB, 7 pages) is in MyBooks, downloaded, Read button visible"
+    - "MyBooks tab is in the foreground"
+    - "Animal Farm + Anna Karenina audiobooks are also in MyBooks (state-contract identifies row layout)"
+
+  state_reset:
+    - "Before each replay, ensure Mathematics Test Book is borrowed under A1QA and the EPUB has finished downloading."
+    - "If a Sync Reading Position dialog appears on Read tap, step 2 dismisses it via Stay."
+    - "Settings sheet is dismissed via a second TT tap; the recording exits Reader2 cleanly back to MyBooks for clean post-state."
+
+  recording:
+    path: "~/.simdrive/recordings/reader2-settings-sheet/recording.yaml"
+    steps: 9
+    captured_with: "simdrive 1.0.0a9"
+    captured_on: "2026-05-12"
+
+  steps:
+    - id: tap_read
+      description: "Tap Read on Mathematics Test Book row"
+      tap_target: { stable_id: "2e7a5a3230f1" }
+    - id: dismiss_sync_dialog
+      description: "Tap Stay to keep cover-page position"
+      tap_target: { stable_id: "f14a16635587" }
+    - id: toggle_chrome_initial
+      description: "Tap content center to reveal Reader2 chrome"
+      tap_target: { x: 603, y: 1300 }
+    - id: tap_tt_open_settings
+      description: "Tap top-right TT button to open settings sheet"
+      tap_target: { x: 952, y: 237 }
+    - id: tap_tt_close_settings
+      description: "Tap TT again to close the settings sheet, back to reader content"
+      tap_target: { x: 952, y: 237 }
+    - id: toggle_chrome_after_dismiss
+      description: "Re-toggle chrome (it auto-hid while settings sheet was open)"
+      tap_target: { x: 603, y: 1300 }
+    - id: tap_back_first_attempt
+      description: "First back-chevron attempt — captures the chrome auto-hide timing window. May be a no-op if chrome hid between steps 6 and 7; the recording captures this real-world timing variability."
+      tap_target: { x: 60, y: 230 }
+    - id: toggle_chrome_retry
+      description: "Retry chrome toggle to recover from step 7 timing"
+      tap_target: { x: 603, y: 1300 }
+    - id: tap_back_exit
+      description: "Back-chevron exits Reader2 to MyBooks"
+      tap_target: { x: 60, y: 230 }
+
+  expected_invariants:
+    - "TT tap opens a settings sheet over the reader content"
+    - "Settings sheet contains 3 font-size buttons (OCR 'Aa Aa Aa' across the top row)"
+    - "Settings sheet contains font sample previews ('ABCabc' three font families) and brightness controls"
+    - "Tapping TT again closes the settings sheet — post-state shows reader content without the sheet"
+    - "Reader2 chrome auto-hides ~5s after the settings sheet closes"
+    - "Back-chevron exits Reader2 once chrome is re-toggled — post-state is MyBooks with the book row visible"
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # Pixel-exact comparisons fail on reader content
+                     # (WKWebView font metrics). The settings-sheet
+                     # contents are deterministic enough for OCR but
+                     # not pixel-perfect across runs.
+
+  rationale: |
+    Visual-adjustments path is THE accessibility surface of Reader2.
+    A regression in CSS injection (font-size, line-height, brightness)
+    would silently break a critical user-facing feature. XCTest cannot
+    enumerate the settings sheet — it's rendered inside Readium's
+    SwiftUI overlay, not as a UIAlertController.
+
+    The 9-step recording is longer than ideal because Reader2's chrome
+    auto-hide behavior is real — when the user dismisses a sheet, the
+    chrome below auto-hides and a single back-tap fails. Step 7's
+    "no-op" tap is intentional: it documents the auto-hide timing
+    window so future regressions on the auto-hide timer (currently ~5s)
+    surface as a step 7 drift.
+
+  known_issues:
+    - "Steps 6-9 reflect the chrome auto-hide timing reality: tap chrome (6), back fails (7, hidden), re-tap chrome (8), back succeeds (9). Replays with significantly different inter-step latency may collapse these into fewer effective taps."
+    - "Settings sheet dismissal via TT-toggle is the documented path; tapping outside the sheet OR a Done button (if present) would also work but aren't captured here."
+    - "OCR sees 'Aa Aa Aa' as three buttons but may not distinguish them positionally without explicit stable_id — the recording uses pixel coords (952, 237) for TT because it's an SF Symbol not OCR-detected text."
+
+  related:
+    - "reader2-back-button.yaml — pre-state for this recording validates the back-chevron path independently"
+    - "reader2-page-forward.yaml — verifies WKWebView reachability"
+    - "Memory: handoff_regression_posture_next_2026_05_12.md — task 4 corpus expansion plan"

--- a/.simdrive/journeys/reader2-toc-navigate.yaml
+++ b/.simdrive/journeys/reader2-toc-navigate.yaml
@@ -1,0 +1,107 @@
+scenario:
+  id: reader2-toc-navigate
+  name: "Reader2 TOC seek to specific chapter"
+  description: >
+    Third Reader2 navigation recording. Verifies that the top-toolbar
+    TOC icon (3-line list, SF Symbol at pixel coords (811, 240)) opens
+    the Table of Contents sheet AND that tapping a chapter row
+    navigates the Reader2 WKWebView to that chapter's first page.
+
+    This is THE Readium 3.x TOC parser regression surface — a bug in
+    the TOC parser, the chapter-anchor JavaScript, or the WKWebView
+    page-index binding would surface as either no TOC entries, a wrong
+    starting page on chapter tap, or a silent no-op.
+
+  tags: [tier1, ios, reader2, epub, toc, navigation, wkwebview]
+  tier: stateful
+  blocking: false   # smoke-only — TOC sheet entry order is
+                    # deterministic per spec but visual layout depends
+                    # on Readium 3.x rendering; OCR-based assertions
+                    # on the Page X of N indicator are the load-bearing
+                    # invariant.
+
+  preconditions:
+    - "A1QA Test Library is the active library"
+    - "A1QA is signed in (patron 'al/qa' visible top-left)"
+    - "Mathematics Test Book (DAISY EPUB, 7 pages) is in MyBooks, downloaded, Read button visible"
+    - "MyBooks tab is in the foreground"
+    - "Last-read position in Mathematics Test Book is page 3 (Introduction) — the recording assumes Reader2 opens directly to that page (no sync dialog)"
+
+  state_reset:
+    - "Before each replay, ensure Mathematics Test Book has been opened to page 3 (Introduction). Otherwise a sync dialog appears at step 1 and step 2-3 fail."
+    - "If sync dialog appears, manually dismiss with Stay before starting the replay."
+
+  recording:
+    path: "~/.simdrive/recordings/reader2-toc-navigate/recording.yaml"
+    steps: 6
+    captured_with: "simdrive 1.0.0a9"
+    captured_on: "2026-05-12"
+
+  steps:
+    - id: tap_read
+      description: "Tap Read on Mathematics Test Book row — Reader2 opens at cached page 3 (Introduction)"
+      tap_target: { stable_id: "2e7a5a3230f1" }
+    - id: toggle_chrome
+      description: "Tap content center to reveal top toolbar (chrome)"
+      tap_target: { x: 603, y: 1300 }
+    - id: tap_toc
+      description: "Tap TOC icon (3-line list, SF Symbol) at pixel coords (811, 240)"
+      tap_target: { x: 811, y: 240 }
+    - id: tap_chapter_row
+      description: "Tap 'MathML Tests' chapter row in the TOC sheet (third entry, at y=910)"
+      tap_target: { x: 600, y: 910 }
+    - id: toggle_chrome_for_exit
+      description: "Tap content center to reveal chrome for the exit step"
+      tap_target: { x: 603, y: 1300 }
+    - id: tap_back_chrome
+      description: "Tap top-left back chevron to exit Reader2 (best-effort; may need retry on chrome auto-hide)"
+      tap_target: { x: 60, y: 230 }
+
+  expected_invariants:
+    - "Read tap opens Reader2 directly to the cached last-position (page 3 in this recording — Introduction chapter)"
+    - "Chrome-toggle tap reveals the top toolbar with: back chevron, title, search, TOC, TT, bookmark"
+    - "TOC tap opens 'Table of Contents' sheet with Contents/Bookmarks tabs and entries: Cover Page, Introduction, MathML Tests, MathML Block Test, MathML Inline Test, Image of Math..., Math Image Block Test, Math Image Inline Test"
+    - "Tap on 'MathML Tests' row dismisses the TOC sheet AND navigates Reader2 to page 4 (the chapter's first page)"
+    - "Post-state OCR shows 'Native Block MathML' (chapter heading) AND 'Page 4 of 7 (MathML Tests)' bottom indicator"
+    - "Back chrome exit returns to MyBooks (best-effort — chrome auto-hide may delay this)"
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # Reader2 WKWebView rendering and chapter content
+                     # are deterministic enough for OCR-based assertions
+                     # but the TOC sheet's font hinting drifts across runs.
+
+  rationale: |
+    TOC navigation has THREE independent failure modes that this single
+    recording catches:
+
+    1. **TOC parser regression** — Readium 3.x's TOC parser silently
+       returns empty entries if the EPUB's nav doc is malformed. The
+       post-step-3 OCR-presence check on 'Cover Page' + 'Introduction'
+       + 'MathML Tests' verifies the parser produced entries.
+
+    2. **Chapter anchor regression** — even with correct TOC entries,
+       tapping a chapter could land at the wrong page if the
+       anchor-to-page-index binding regresses. The post-step-4
+       'Page 4 of 7' assertion verifies the navigation landed at the
+       intended position.
+
+    3. **WKWebView render regression** — even with correct page index,
+       the WKWebView might fail to load the chapter content. The
+       'Native Block MathML' chapter heading OCR confirms content
+       rendered.
+
+    XCTest cannot verify any of these because the TOC sheet (SwiftUI)
+    AND the WKWebView content are both invisible to the accessibility
+    tree.
+
+  known_issues:
+    - "Steps 5-6 (chrome toggle + back exit) are best-effort cleanup. If chrome auto-hides between steps 5 and 6, step 6 lands on WKWebView content and is consumed without navigation. The recording's load-bearing assertions are steps 1-4 (the TOC navigate flow itself); 5-6 are documentation of the user's exit intent."
+    - "Recording assumes Reader2 opens directly to page 3 (cached last-read). On a fresh sim with no cached position, Reader2 opens to cover page (1) and shows no sync dialog. The TOC seek would still work, but the post-step-2 chrome-reveal might land on a slightly different toolbar layout."
+    - "TOC chapter row positions (e.g. 'MathML Tests' at y=910) depend on the EPUB's nav structure. If the Mathematics Test Book fixture is updated, this y-coord may shift — re-record."
+
+  related:
+    - "reader2-back-button.yaml — back-chevron exit path validated separately"
+    - "reader2-settings-sheet.yaml — TT typography sheet validated separately"
+    - "reader2-bookmark-toggle.yaml — bookmark icon toggle validated separately"
+    - "reader2-page-forward.yaml — WKWebView reachability (page-forward chevron)"


### PR DESCRIPTION
## Summary

- Adds the first Reader2 navigation recording to the simdrive corpus — `reader2-back-button` (4 steps): Read → Stay sync-dialog → toggle chrome → back chevron round-trips to MyBooks.
- Pairs with existing `reader2-page-forward` (verifies WKWebView reachability) to cover Reader2 entry + exit.
- Captured against simdrive 1.0.0a9 with A1QA Test Library + the DAISY Mathematics Test Book EPUB.

## Why

Per [`CLAUDE.md`'s simdrive section](../CLAUDE.md): Reader2 navigation chrome (back, settings, TOC) IS reachable via simdrive — this is the whole point. XCTest cannot see inside the Readium 3.x WKWebView. The handoff at `~/.claude/projects/.../memory/handoff_regression_posture_next_2026_05_12.md` called out the navigation-corpus gap as one of the highest-leverage next-session moves.

The 2-tap chrome-then-back sequence is REQUIRED because Reader2's top-bar chrome auto-hides after ~5 seconds of no interaction. A single tap at the chevron location lands on hidden chrome and is consumed by WKWebView with no effect (verified during recording — first attempt's `tap (60, 230)` was a no-op until preceded by a center tap to re-show chrome).

## Status — draft

Draft because this PR covers only 1 of the 4 Reader2 nav recordings the handoff identified:

| Recording | Status | Blocker |
|---|---|---|
| `reader2-back-button` | ✓ landed in this PR | — |
| `reader2-settings-sheet` | pending | TT settings icon located at ~(952, 237); recording pending |
| `reader2-toc-navigate` | pending | TOC icon not OCR-detected (SF Symbol); needs pixel discovery |
| `reader2-bookmark-roundtrip` | pending | Bookmark icon not OCR-detected (SF Symbol); needs pixel discovery |

Each additional recording lands as a follow-up commit on this PR; I'll un-draft once at least settings is added.

## Test plan

- [ ] `simdrive validate_replay name=reader2-back-button` returns `ok:true` (confirmed locally — 4 steps, no errors, no warnings)
- [ ] Manual replay against a clean booted sim with A1QA pre-state: `simdrive-regress.sh --only reader2-back-button --tier stateful`
- [ ] Once at least one more recording is added, un-draft and request review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)