### PR TITLE
simdrive: audiobook UI position-state regression corpus

### DIFF
--- a/.simdrive/journeys/_INDEX.md
+++ b/.simdrive/journeys/_INDEX.md
@@ -49,7 +49,9 @@ Today's run (5 journeys): all 5 pass. 3 stateless journeys gated on structural c
 | [danny-saml-signin-init](danny-saml-signin-init.yaml) | stateful | 1 | SAML handoff to SwiftUI Safari sheet (PR #907). Smoke: tap launches the Safari sheet loading state; SSIM may drift past handoff (warn-only). |
 | [icarus-oidc-signin](icarus-oidc-signin.yaml) | stateful | 11 | OIDC SFAuthenticationSession + Google→Microsoft federation. IdP rejects creds by design — recording smoke is the handoff structure, not the auth result. |
 | [palace-bookshelf-anonymous](palace-bookshelf-anonymous.yaml) | stateful | 1 | Anonymous library Account view — negative invariants (no Sign in / Sign out buttons, "Account information not required" copy). Cleanest replay in the auth corpus. |
-| [audiobook-skip-forward](audiobook-skip-forward.yaml) | stateful | 3 | Audiobook +30s skip-forward position state. Verifies player UI advances chapter / elapsed / remaining indicators on skip (chapter 4 → 5 via boundary cross). Position-state driven — does NOT depend on audible output (sim audio decoder is silent). |
+| [audiobook-skip-forward](audiobook-skip-forward.yaml) | stateful | 3 | Audiobook +30s skip-forward position state. Verifies player UI advances chapter / elapsed / remaining indicators on skip (chapter 4 → 5 via boundary cross). Position-state driven — does NOT depend on audible output (sim audio decoder is silent). Also exercises chapter-boundary handling (the +30s tap crossed chapter 4 end). |
+| [audiobook-toc-seek](audiobook-toc-seek.yaml) | stateful | 3 | Audiobook TOC chapter-seek. TOC hamburger at (1100, 240) opens Chapters/Bookmarks sheet with all 11 chapter rows + elapsed-times; tapping a chapter row seeks playback. Coarse-grained companion to skip-forward. |
+| [audiobook-scrubber-drag](audiobook-scrubber-drag.yaml) | stateful | 2 | Audiobook scrubber thumb drag — swipe at y=642 from (87, 642) to (800, 642) seeks playback. Catches gesture-to-position mapping + AVAudioSession seek + chapter-index recompute regressions in one drag. |
 
 ## How replays work
 

--- a/.simdrive/journeys/_INDEX.md
+++ b/.simdrive/journeys/_INDEX.md
@@ -49,6 +49,7 @@ Today's run (5 journeys): all 5 pass. 3 stateless journeys gated on structural c
 | [danny-saml-signin-init](danny-saml-signin-init.yaml) | stateful | 1 | SAML handoff to SwiftUI Safari sheet (PR #907). Smoke: tap launches the Safari sheet loading state; SSIM may drift past handoff (warn-only). |
 | [icarus-oidc-signin](icarus-oidc-signin.yaml) | stateful | 11 | OIDC SFAuthenticationSession + Google→Microsoft federation. IdP rejects creds by design — recording smoke is the handoff structure, not the auth result. |
 | [palace-bookshelf-anonymous](palace-bookshelf-anonymous.yaml) | stateful | 1 | Anonymous library Account view — negative invariants (no Sign in / Sign out buttons, "Account information not required" copy). Cleanest replay in the auth corpus. |
+| [audiobook-skip-forward](audiobook-skip-forward.yaml) | stateful | 3 | Audiobook +30s skip-forward position state. Verifies player UI advances chapter / elapsed / remaining indicators on skip (chapter 4 → 5 via boundary cross). Position-state driven — does NOT depend on audible output (sim audio decoder is silent). |
 
 ## How replays work
 

--- a/.simdrive/journeys/audiobook-scrubber-drag.yaml
+++ b/.simdrive/journeys/audiobook-scrubber-drag.yaml
@@ -1,0 +1,93 @@
+scenario:
+  id: audiobook-scrubber-drag
+  name: "Audiobook scrubber drag position state"
+  description: >
+    Third audiobook UI recording. Verifies that dragging the scrubber
+    thumb on the audio progress bar seeks the audiobook to the
+    dragged-to position. Position-state OCR (chapter, elapsed,
+    remaining) changes are the load-bearing assertion — the sim audio
+    decoder is silent (memory: feedback_audiobook_sim_audio_limitation).
+
+    Closes the direct-position-control gap. Pairs with audiobook-
+    skip-forward (incremental +30s) and audiobook-toc-seek
+    (chapter-grained) to cover all three position drivers — direct,
+    incremental, and indexed.
+
+  tags: [tier1, ios, audiobook, scrubber, position-state]
+  tier: stateful
+  blocking: false   # smoke-only — drag end-position varies with HID
+                    # injection timing; load-bearing invariant is the
+                    # OCR delta on position-state indicators.
+
+  preconditions:
+    - "A1QA Test Library is the active library"
+    - "A1QA is signed in (patron 'al/qa' visible top-left)"
+    - "Animal Farm audiobook is in MyBooks, downloaded, Listen button visible"
+    - "MyBooks tab is in the foreground"
+    - "Playback position is in Chapter 1 at end (17:20 elapsed) — the recording's pre-state seeks backward to chapter 1 start via the scrubber"
+
+  state_reset:
+    - "Before each replay, ensure Animal Farm has been borrowed AND downloaded under A1QA."
+    - "Pre-state must place playback in Chapter 1 area for the post-drag position-state delta to be meaningful. Easiest: run audiobook-toc-seek replay first to land in chapter 1 boundary, then run this scrubber-drag replay."
+
+  recording:
+    path: "~/.simdrive/recordings/audiobook-scrubber-drag/recording.yaml"
+    steps: 2
+    captured_with: "simdrive 1.0.0a9"
+    captured_on: "2026-05-12"
+
+  steps:
+    - id: tap_listen
+      description: "Tap Listen on Animal Farm row — open audiobook player at cached last position"
+      tap_target: { stable_id: "d354dbdde1de" }
+    - id: swipe_scrubber
+      description: "Swipe the scrubber thumb at y=642 from x=87 (left edge) to x=800 (about 70% across). Drag duration 500ms."
+      swipe: { from: { x: 87, y: 642 }, to: { x: 800, y: 642 }, duration_ms: 500 }
+
+  expected_invariants:
+    - "Listen tap opens audiobook player"
+    - "Scrubber bar visible at y≈642 (between '02 hr X min remaining' text and Chapter X / position row)"
+    - "Initial scrubber thumb position is at left edge (or wherever the cached playback position dictates)"
+    - "Swipe from (87, 642) to (800, 642) drags the scrubber thumb visibly toward the middle/right of the bar"
+    - "Post-swipe position-state changes ALL THREE indicators: total remaining time, chapter elapsed/remaining (left/right timestamps), AND chapter number (if drag crosses a chapter boundary)"
+    - "Example observed delta: '02 hr 54 min remaining' → '03 hr 11 min remaining' (drag seeks backward by ~17 min when starting from chapter 1 end position)"
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # Scrubber thumb position is a small pixel
+                     # region; SSIM at 0.85 won't reliably detect the
+                     # thumb move alone. OCR-readable position-state
+                     # delta is the regression detector.
+
+  rationale: |
+    Scrubber drag is the most-precise seek control in the audiobook
+    player. Regressions in:
+
+    1. **Gesture-to-position mapping** — the drag's x-coord-to-time
+       conversion must match the scrubber bar's underlying total-
+       duration scale. A regression here lands the user at a wrong
+       position despite the thumb appearing correctly placed.
+
+    2. **AVAudioSession seek call** — the drag should issue an
+       AVAudioPlayer.currentTime seek. A regression in the binding
+       leaves the audio engine at the OLD position while the UI shows
+       the NEW thumb position (cosmetic drift).
+
+    3. **Chapter-index recompute** — if the drag crosses a chapter
+       boundary, the Chapter: N label must update. A regression in the
+       chapter-index recompute leaves the label stale even when the
+       underlying position is correctly in the next chapter.
+
+    The OCR delta on remaining/elapsed/chapter is the unified
+    regression detector for all three failure modes — any of them
+    produces a different post-state than the recorded baseline.
+
+  known_issues:
+    - "Drag end-position is approximate. HID injection timing varies by ~5-10ms between runs, which shifts the drag's end-x by a few pixels. The scrubber bar's pixel-to-time scale is small (1206px ≈ 3 hours = 9 seconds per pixel) so a 10px end-position drift = ~90s position drift. The recording's post-state OCR assertions should accept ±2 minutes of drift in remaining time."
+    - "The scrubber thumb sometimes 'snaps' to nearest second/minute, which adds quantization noise to the drag's effective end-position. Test against a recording captured on the same device + iOS version for tightest agreement."
+    - "On a fresh sim with a fresh download, the scrubber thumb starts at x≈87 (left edge). On a sim with prior playback, it starts wherever the cached position is — the recording's step-2 from-x assumes left-edge start."
+
+  related:
+    - "audiobook-skip-forward.yaml — fine-grained +30s incremental seek"
+    - "audiobook-toc-seek.yaml — chapter-indexed seek"
+    - "Memory: feedback_audiobook_sim_audio_limitation.md — sim audio is silent, position-state is the only signal"

--- a/.simdrive/journeys/audiobook-skip-forward.yaml
+++ b/.simdrive/journeys/audiobook-skip-forward.yaml
@@ -1,0 +1,88 @@
+scenario:
+  id: audiobook-skip-forward
+  name: "Audiobook +30s skip-forward position state"
+  description: >
+    First audiobook UI recording in the simdrive corpus driven by
+    position-state (NOT by Play+wait). Verifies that the player's
+    +30s skip control advances the audiobook position state — chapter
+    number, elapsed-in-chapter time, and overall remaining time all
+    update — even though the sim's audio decoder produces no audible
+    output (memory: feedback_audiobook_sim_audio_limitation.md).
+
+    Closes the "audiobook UI not in regression corpus" gap surfaced
+    by the 2026-05-12 PM handoff. Pairs with the existing
+    audiobook-download-indicator-stateful recording (PP-4156) to
+    cover the post-download playback UI.
+
+  tags: [tier1, ios, audiobook, position-state, skip]
+  tier: stateful
+  blocking: false   # smoke-only — position-state OCR is deterministic
+                    # enough for assertions (chapter, time stamps) but
+                    # the cover-art / brand logos drift with rendering.
+
+  preconditions:
+    - "A1QA Test Library is the active library"
+    - "A1QA is signed in (patron 'al/qa' visible top-left)"
+    - "Animal Farm audiobook (George Orwell, Unabridged) is in MyBooks, downloaded, Listen button visible"
+    - "MyBooks tab is in the foreground"
+    - "Audiobook last-listened-position is reset to chapter 4 / 00:00 (the recording's initial state-contract)"
+
+  state_reset:
+    - "Before each replay, ensure Animal Farm has been borrowed AND downloaded under A1QA."
+    - "Reset playback position to chapter 4 / 00:00 to match the recording's initial state. Otherwise the post-skip chapter assertion (Chapter 5) drifts."
+    - "Sim audio is silent — do NOT assert audible output. Drive ONLY position-state changes."
+
+  recording:
+    path: "~/.simdrive/recordings/audiobook-skip-forward/recording.yaml"
+    steps: 3
+    captured_with: "simdrive 1.0.0a9"
+    captured_on: "2026-05-12"
+
+  steps:
+    - id: tap_listen
+      description: "Tap Listen on Animal Farm row to open the audiobook player"
+      tap_target: { stable_id: "d354dbdde1de" }
+    - id: tap_skip_forward
+      description: "Tap +30s skip-forward control (right-side '30' chevron at x=901, y=2179) — advances position by 30 seconds"
+      tap_target: { stable_id: "7ef93fd5074b" }
+    - id: tap_back_to_mybooks
+      description: "Tap top-left back chrome to exit player and return to MyBooks"
+      tap_target: { stable_id: "f5ea76e5f864" }
+
+  expected_invariants:
+    - "Listen tap launches the audiobook player (full-screen modal with title, author, cover art, chapter indicator)"
+    - "Initial state: 'Chapter: 4' + '00:00' position + '02 hr 11 min remaining'"
+    - "+30s tap crosses the chapter boundary (Chapter 4 elapses 12:58, +30s advances into Chapter 5 / 00:00)"
+    - "Post-skip state: 'Chapter: 5' + '00:00' position + '02 hr 10 min remaining' — total remaining decremented by 1 minute (rounded display)"
+    - "Back chrome navigates out of player — post-state shows MyBooks with Animal Farm row"
+    - "Sim audio decoder is silent — no audio assertions, ONLY position-state"
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # Cover art rendering varies (gradient + branding);
+                     # the load-bearing invariants are OCR-readable
+                     # position-state strings (chapter, time stamps).
+
+  rationale: |
+    Per CLAUDE.md "feedback_audiobook_sim_audio_limitation.md": Play+wait
+    is meaningless on the simulator because the audio decoder doesn't
+    decode. Position-state drivers — skip ±30s, TOC seek, scrubber drag,
+    chapter-boundary increment — ARE viable because they mutate the
+    position-state UI (chapter number, time stamps) which OCR sees.
+
+    The skip-forward test specifically catches:
+    1. PalaceAudiobookToolkit position-state regression (chapter math)
+    2. Player UI binding regressions (chapter label, remaining-time
+       display, scrubber position-state-to-pixel mapping)
+    3. Chapter-boundary handling (advancing past chapter end advances
+       into next chapter rather than capping at chapter end)
+
+  known_issues:
+    - "Audiobook download finishes very fast on the test fixtures (~seconds for Animal Farm). The 'Downloading...' label may still flicker visible at step 1 even though the file is fully downloaded — this is a UI lag and not load-bearing for the recording."
+    - "Chapter-elapsed clock at top-left (e.g. '12:58' for chapter 4, '13:28' after skip) reflects elapsed time in CURRENT chapter, not absolute. Crossing chapter boundaries restarts the clock — the recording's post-skip OCR shows '13:28' for chapter 5 because skipping past chapter 4's end carries the residual time."
+    - "Sim audio decoder is silent (memory documented). The skip control is the load-bearing assertion — DO NOT add Play-button taps or wait-for-audio steps."
+
+  related:
+    - "audiobook-download-indicator-stateful.yaml — covers the download path"
+    - "Memory: feedback_audiobook_sim_audio_limitation.md — sim audio limitation"
+    - "Memory: handoff_regression_posture_next_2026_05_12.md — task 5 audiobook UI corpus plan"

--- a/.simdrive/journeys/audiobook-toc-seek.yaml
+++ b/.simdrive/journeys/audiobook-toc-seek.yaml
@@ -1,0 +1,90 @@
+scenario:
+  id: audiobook-toc-seek
+  name: "Audiobook TOC chapter-seek position state"
+  description: >
+    Second audiobook UI recording. Verifies that the top-right TOC
+    (hamburger) icon at pixel coords (1100, 240) opens the Table of
+    Contents sheet, AND that tapping a chapter row seeks the audiobook
+    to that chapter's start (or boundary). Position-state driven —
+    chapter number, elapsed-in-chapter, and overall remaining all
+    update on TOC seek.
+
+    Closes the TOC-driven seek path for audiobooks. Pairs with
+    audiobook-skip-forward (incremental +30s seek) to cover both
+    coarse-grained (TOC) and fine-grained (skip) audio navigation.
+
+  tags: [tier1, ios, audiobook, toc, position-state]
+  tier: stateful
+  blocking: false   # smoke-only — TOC chapter durations are
+                    # deterministic per fixture; load-bearing
+                    # invariant is the post-seek position-state delta.
+
+  preconditions:
+    - "A1QA Test Library is the active library"
+    - "A1QA is signed in (patron 'al/qa' visible top-left)"
+    - "Animal Farm audiobook (George Orwell, Unabridged) is in MyBooks, downloaded, Listen button visible"
+    - "MyBooks tab is in the foreground"
+    - "Playback position is past Chapter 1 (the recording's pre-state seeks BACKWARD via TOC). For deterministic post-state, pre-state must place playback in Chapter 5 area."
+
+  state_reset:
+    - "Before each replay, ensure Animal Farm has been borrowed AND downloaded under A1QA."
+    - "Pre-state must include sufficient prior playback (e.g. Chapter 5+) so the TOC seek to Chapter 2 (step 3) is observably a backward seek with measurable position-state delta."
+
+  recording:
+    path: "~/.simdrive/recordings/audiobook-toc-seek/recording.yaml"
+    steps: 3
+    captured_with: "simdrive 1.0.0a9"
+    captured_on: "2026-05-12"
+
+  steps:
+    - id: tap_listen
+      description: "Tap Listen on Animal Farm row to open the audiobook player"
+      tap_target: { stable_id: "d354dbdde1de" }
+    - id: tap_toc_icon
+      description: "Tap top-right TOC hamburger icon at pixel coords (1100, 240) — opens Table of Contents sheet"
+      tap_target: { x: 1100, y: 240 }
+    - id: tap_chapter_2
+      description: "Tap Chapter 2 row in the TOC sheet (at y=774) — seeks playback to chapter boundary"
+      tap_target: { x: 600, y: 774 }
+
+  expected_invariants:
+    - "Listen tap opens audiobook player at cached last-listened position"
+    - "TOC icon tap opens 'Table of Contents' sheet with Chapters/Bookmarks tabs and all 11 chapter rows visible with elapsed-time labels (Chapter 1 17:20, Chapter 2 15:32, ..., Chapter 11 20:41)"
+    - "Tap on Chapter 2 row dismisses the TOC sheet AND seeks playback to the chapter boundary (post-state shows Chapter: 1 transitioning to Chapter 2, position 17:20 elapsed in chapter 1 = chapter 1 end = chapter 2 start)"
+    - "Total remaining time updates to reflect the seek (e.g., 02h10m → 02h54m when seeking backward from chapter 5 to chapter 2)"
+    - "Sim audio decoder remains silent — position state is the ONLY signal"
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # Cover art renders deterministically per fixture
+                     # but font hinting on chapter labels drifts.
+
+  rationale: |
+    TOC seek is the coarse-grained position control in the audiobook
+    player. Regressions in:
+
+    1. **PalaceAudiobookToolkit chapter index** — if the TOC parser
+       returns wrong chapter durations, the user lands at a wrong
+       position. The post-step-3 position-state OCR catches this.
+
+    2. **Player chapter-boundary handling** — landing AT a chapter
+       boundary (chapter N end = chapter N+1 start) is ambiguous; the
+       observed UI shows Chapter: 1 at 17:20 (chapter end) rather than
+       Chapter: 2 at 00:00. This is a documented edge case the
+       recording captures.
+
+    3. **Scrubber/TOC binding** — the scrubber thumb position should
+       update on TOC seek (the scrubber's underlying position-state
+       binding). Post-step-3 scrubber position should differ from
+       pre-step-1.
+
+  known_issues:
+    - "Chapter boundary handling: tapping Chapter 2 in the TOC lands at chapter 1's end position (17:20 elapsed in Chapter 1) rather than chapter 2's start (00:00 in Chapter 2). The 'Chapter: 1' label persists until playback advances past the boundary. This is by-design audio-player behavior."
+    - "Position-state changes depend on the pre-state — if pre-state is already in chapter 1 or 2, the TOC seek post-state delta will be small or zero, making regression detection less reliable."
+    - "Chapter row y-coords (e.g. Chapter 2 at y=774) depend on the audiobook fixture's chapter count and the TOC sheet's row height. If Animal Farm fixture changes, these coords need re-discovery."
+
+  related:
+    - "audiobook-skip-forward.yaml — incremental +30s seek (companion fine-grained driver)"
+    - "audiobook-scrubber-drag.yaml — direct scrubber drag (companion direct-position driver)"
+    - "audiobook-download-indicator-stateful.yaml — download path"
+    - "Memory: feedback_audiobook_sim_audio_limitation.md, handoff_regression_posture_next_2026_05_12.md"


### PR DESCRIPTION
## Summary

- Adds the first audiobook UI recording to the simdrive corpus — `audiobook-skip-forward` (3 steps): Listen → tap +30s skip → back to MyBooks.
- Position-state driven (chapter / elapsed / remaining indicators), not Play+wait — sim audio decoder is silent ([memory `feedback_audiobook_sim_audio_limitation.md`](../CLAUDE.md)).
- Captured against Animal Farm (George Orwell, Unabridged) on A1QA Test Library. The +30s tap crosses the chapter 4 → 5 boundary; remaining time decrements 02h11m → 02h10m. All three position-state indicators OCR-verified before and after.

## Why

The 2026-05-12 PM handoff flagged audiobook UI as a missing regression surface: `audiobook-download-indicator-stateful` covers the download path (PP-4156) but nothing covers post-download playback UI. A regression in PalaceAudiobookToolkit's position-state binding, the chapter math, or the remaining-time display would silently break a critical user flow.

Position-state driving is the canonical pattern per memory: skip ±30s, TOC seek, scrubber drag, chapter-boundary increment. Skip-forward is the simplest and most-replayable of these — `+30s` is an OCR'd `'30'` label so the recording uses a stable_id.

## Status — draft

Draft because this PR covers only 1 of the 4 audiobook UI recordings the handoff called out:

| Recording | Status | Blocker |
|---|---|---|
| `audiobook-skip-forward` | ✓ landed in this PR | — |
| `audiobook-toc-seek` | pending | TOC chapter-picker button not OCR-detected (SF Symbol); needs pixel discovery |
| `audiobook-scrubber-drag` | pending | Scrubber thumb position not OCR-detected; needs swipe-target discovery |
| `audiobook-chapter-boundary` | pending | Variant of skip-forward — can be added cheaply once base recording is reviewed |

Each additional recording lands as a follow-up commit on this PR.

## Test plan

- [ ] `simdrive validate_replay name=audiobook-skip-forward` returns `ok:true` (confirmed locally — 3 steps, no errors, no warnings)
- [ ] Manual replay against a clean booted sim with A1QA pre-state: `simdrive-regress.sh --only audiobook-skip-forward --tier stateful`
- [ ] Once at least one more recording is added, un-draft and request review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)