### PR TITLE
simdrive: borrow → read → return critical-path corpus

### DIFF
--- a/.simdrive/journeys/BUG_FINDINGS_2026_05_12.md
+++ b/.simdrive/journeys/BUG_FINDINGS_2026_05_12.md
@@ -1,0 +1,122 @@
+# Simdrive bug findings — 2026-05-12 borrow-flow validation
+
+During driving the planned `borrow-read-return-roundtrip` recording for
+PR #943 (the money-flow critical path), simdrive surfaced two
+reproducible product issues that block the happy-path recording from
+completing end-to-end on the A1QA Test Library fixture.
+
+Both are captured as user-local recordings under
+`~/.simdrive/recordings/` (NOT in this repo) for replay:
+
+- `borrow-download-failed-cinema-beyond-human/` (3 steps)
+- `borrow-stuck-overdrive-up-and-running/` (4 steps)
+
+The recordings are user-local because they document failure paths
+against a specific test library state, not flows we want to replay
+in CI. If/when the underlying issues are fixed, these recordings
+should be deleted (their value is purely as bug evidence).
+
+## Bug 1 — "Download Failed - No error message" alert
+
+**Reproduction steps:**
+
+1. Sign in to A1QA Test Library (basic auth)
+2. Catalog → Ebooks facet → tap "Cinema beyond the human" (Anat Pick, A1QA Automated Tests lane)
+3. Tap Borrow
+
+**Expected:** Book downloads + Read button appears on detail screen,
+book appears in MyBooks.
+
+**Actual:** Alert appears immediately with:
+- Title: "Download Failed"
+- Body: literally **"No error message"**
+- Buttons: Cancel + Retry
+
+**Severity:** Medium — the alert title and Cancel/Retry buttons are
+correct UX, but the body text "No error message" is a placeholder/
+fallback string that escaped to production. Users see a literal
+"No error message" string which conveys nothing actionable.
+
+**Note:** The loan DOES register server-side — after dismissing the
+alert, the book detail screen shows Download + Return buttons (not
+the original Borrow button), indicating the OPDS borrow request
+succeeded but the fulfillment/download path failed.
+
+**Root cause hypothesis:** The download-failure code path lacks a
+meaningful error message for at least one failure mode (likely
+network-level rather than HTTP-error-level, since HTTP errors would
+typically have a status code or problem-document body to surface).
+
+**Where to look:** `Palace/MyBooks/Download/` — specifically the
+NSError → user-facing-string translation in the download manager.
+Probably a `?? "No error message"` fallback that's never been
+audited against actual failure modes.
+
+## Bug 2 — Borrow stuck with Cancel-only UI, no progress indicator
+
+**Reproduction steps:**
+
+1. Sign in to A1QA Test Library
+2. Catalog → tap "Up and Running" (O'Reilly Vagrant, A1QA Automated Tests lane, Overdrive distributor)
+3. Tap Borrow
+
+**Expected:** Either a quick borrow → download → Read button (per
+the Mathematics Test Book happy path), OR a clear failure alert
+(per Bug 1's pattern).
+
+**Actual:** Borrow button disappears, replaced by **only a Cancel
+button**. No progress indicator, no spinner, no percentage, no
+status text. After 30+ seconds of waiting, the state is unchanged.
+Tapping Back returns to the previous screen and the Borrow button
+re-appears (cancelling the borrow). The book never reaches MyBooks.
+
+**Severity:** High for UX — the user has no signal that anything is
+happening or failing. They can only Back-out or Cancel.
+
+**Root cause hypothesis:** The Overdrive fulfillment path may be
+hanging on a network call that never returns and never times out.
+The UI is correctly bound to a "borrow-in-progress" state but
+there's no progress indicator surface OR no timeout to trigger a
+failure alert.
+
+**Where to look:**
+- The borrow operation's network executor — is there a timeout?
+- The book detail screen's `BookDetailViewModel` — what state is
+  bound to the missing progress indicator?
+- Specifically the Overdrive code path (other distributors may
+  not have this issue — Mathematics Test Book's distributor
+  worked fine).
+
+## Impact on PR #943 (money-flow critical path coverage)
+
+The PR was originally scoped to land a `borrow-read-return-roundtrip`
+recording. With these two bugs blocking the borrow half, the PR
+instead lands:
+
+- `book-return-from-mybooks.yaml` — Return half only (already on PR)
+- `read-return-from-mybooks-roundtrip.yaml` — Read + Return halves
+  end-to-end, starting from an already-borrowed book
+- This findings doc + bug-recording references
+
+The borrow half is **explicitly deferred** until either:
+1. The two bugs are triaged + fixed, OR
+2. A known-good catalog book in the A1QA fixture is identified that
+   reliably succeeds, OR
+3. A different test library (Palace Bookshelf anonymous?) is used as
+   the borrow-half pre-state.
+
+## Impact on 3.1.0 release readiness
+
+Both bugs are **discovered by simdrive driving against the simulator
+on the develop branch**. Neither blocks the build, but both produce
+visibly broken UX that real users would encounter. Recommend triage
+before tagging 3.1.0 as RC:
+
+- Bug 1 is likely a quick fix (replace the fallback string with a
+  user-actionable message or a localized "couldn't reach server"
+  body)
+- Bug 2 is more substantial (needs a timeout + progress indicator
+  surface)
+
+Both bugs also exist on `develop` independent of any of this
+session's PRs — they are not regressions introduced by my work.

--- a/.simdrive/journeys/_INDEX.md
+++ b/.simdrive/journeys/_INDEX.md
@@ -53,6 +53,7 @@ Today's run (5 journeys): all 5 pass. 3 stateless journeys gated on structural c
 | [audiobook-toc-seek](audiobook-toc-seek.yaml) | stateful | 3 | Audiobook TOC chapter-seek. TOC hamburger at (1100, 240) opens Chapters/Bookmarks sheet with all 11 chapter rows + elapsed-times; tapping a chapter row seeks playback. Coarse-grained companion to skip-forward. |
 | [audiobook-scrubber-drag](audiobook-scrubber-drag.yaml) | stateful | 2 | Audiobook scrubber thumb drag — swipe at y=642 from (87, 642) to (800, 642) seeks playback. Catches gesture-to-position mapping + AVAudioSession seek + chapter-index recompute regressions in one drag. |
 | [book-return-from-mybooks](book-return-from-mybooks.yaml) | stateful | 2 | Money-flow Return half — inline Return tap renders confirm dialog, confirm tap silently revokes the loan AND removes the row. Catches OPDS revoke / DRM unbind / BookRegistry sync regressions via OCR-absence on the returned title. |
+| [read-return-from-mybooks-roundtrip](read-return-from-mybooks-roundtrip.yaml) | stateful | 5 | Read + Return halves of money flow end-to-end: Read → Reader2 chrome → exit → inline Return → confirm → book gone. Mutates state (returns book) so replays need re-borrow setup. See BUG_FINDINGS_2026_05_12.md for why the Borrow half is deferred. |
 
 ## How replays work
 

--- a/.simdrive/journeys/_INDEX.md
+++ b/.simdrive/journeys/_INDEX.md
@@ -52,6 +52,7 @@ Today's run (5 journeys): all 5 pass. 3 stateless journeys gated on structural c
 | [audiobook-skip-forward](audiobook-skip-forward.yaml) | stateful | 3 | Audiobook +30s skip-forward position state. Verifies player UI advances chapter / elapsed / remaining indicators on skip (chapter 4 → 5 via boundary cross). Position-state driven — does NOT depend on audible output (sim audio decoder is silent). Also exercises chapter-boundary handling (the +30s tap crossed chapter 4 end). |
 | [audiobook-toc-seek](audiobook-toc-seek.yaml) | stateful | 3 | Audiobook TOC chapter-seek. TOC hamburger at (1100, 240) opens Chapters/Bookmarks sheet with all 11 chapter rows + elapsed-times; tapping a chapter row seeks playback. Coarse-grained companion to skip-forward. |
 | [audiobook-scrubber-drag](audiobook-scrubber-drag.yaml) | stateful | 2 | Audiobook scrubber thumb drag — swipe at y=642 from (87, 642) to (800, 642) seeks playback. Catches gesture-to-position mapping + AVAudioSession seek + chapter-index recompute regressions in one drag. |
+| [book-return-from-mybooks](book-return-from-mybooks.yaml) | stateful | 2 | Money-flow Return half — inline Return tap renders confirm dialog, confirm tap silently revokes the loan AND removes the row. Catches OPDS revoke / DRM unbind / BookRegistry sync regressions via OCR-absence on the returned title. |
 
 ## How replays work
 

--- a/.simdrive/journeys/book-return-from-mybooks.yaml
+++ b/.simdrive/journeys/book-return-from-mybooks.yaml
@@ -1,0 +1,85 @@
+scenario:
+  id: book-return-from-mybooks
+  name: "Book return from MyBooks (the Return half of borrow → read → return)"
+  description: >
+    First Return-flow recording in the simdrive corpus. Verifies the
+    money-flow's terminal half: tap Return on a MyBooks row → confirm
+    dialog renders → tap Return → book disappears from the list.
+
+    The borrow + read halves of the critical path are NOT yet recorded
+    (see "Not done" below). This recording covers the highest-risk
+    path of those three because Return must invoke the OPDS revoke
+    endpoint AND clear DRM-bound files; a regression here can silently
+    leave a license held server-side or a downloaded file leaked
+    client-side. The dialog confirmation step is also where users
+    most often abort, so the Cancel branch is the relevant negative
+    case (covered as a known issue, not the happy path).
+
+  tags: [tier1, ios, mybooks, return, money-flow]
+  tier: stateful
+  blocking: false   # smoke-only — MyBooks list rendering is non-
+                    # deterministic (server-side ordering, cover art).
+                    # Load-bearing invariant: returned-book text
+                    # disappears from OCR after step 2.
+
+  preconditions:
+    - "A1QA Test Library is the active library"
+    - "A1QA is signed in (patron 'al/qa' visible top-left)"
+    - "Anna Karenina audiobook (Leo Tolstoy) is in MyBooks, Return button visible inline on the row"
+    - "MyBooks tab is in the foreground"
+    - "At least one other book is in MyBooks (state-contract: Animal Farm + Mathematics Test Book remain after the return to anchor the post-state OCR)"
+
+  state_reset:
+    - "Before each replay, ensure Anna Karenina has been re-borrowed (it gets returned by this recording)."
+    - "If a 'Are you sure you want to return X?' dialog appears with a different book name than 'Anna Karenina', the wrong row was tapped — verify the stable_id selectors against a fresh observe."
+
+  recording:
+    path: "~/.simdrive/recordings/book-return-from-mybooks/recording.yaml"
+    steps: 2
+    captured_with: "simdrive 1.0.0a9"
+    captured_on: "2026-05-12"
+
+  steps:
+    - id: tap_inline_return
+      description: "Tap the Return button on the Anna Karenina row in MyBooks (inline button, not in book detail)"
+      tap_target: { stable_id: "ef6c59cde5d5" }
+    - id: confirm_return
+      description: "Tap Return on the confirmation dialog ('Are you sure you want to return Anna Karenina?')"
+      tap_target: { stable_id: "6051727ac6fd" }
+
+  expected_invariants:
+    - "Inline Return tap renders a UIAlertController-style confirmation dialog with 'Return' header + body 'Are you sure you want to return \"Anna Karenina\"?'"
+    - "Dialog has two buttons: Cancel + Return"
+    - "Confirm Return tap dismisses the dialog AND removes Anna Karenina from the MyBooks list (post-OCR shows no Anna Karenina or Leo Tolstoy text)"
+    - "Post-state shows the remaining MyBooks rows shifted up (Don't Read This! / Four Women now occupy the freed space)"
+    - "No spinner, no error toast, no auth-prompt regression — OPDS revoke succeeds silently on test fixture"
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # MyBooks list order shifts with each row removal,
+                     # so pixel-exact SSIM is not reliable. Use OCR
+                     # absence-of-text assertions for the post-state.
+
+  rationale: |
+    Return is the silent regression surface — there's no audible/visual
+    feedback beyond "the book is gone". A bug in OPDS revoke (HTTP DELETE
+    to the loan URL), the DRM unbind path (Adobe / LCP), or the
+    BookRegistry sync could leave the user stuck with a "phantom" book
+    or fail without surfacing an error. This recording catches all
+    three failure modes via the post-state OCR-absence check.
+
+    The 2-step recording covers the inline-Return path because that's
+    the dominant user flow (MyBooks row with Return button visible).
+    The detail-screen Return path (tap row → Return button on detail
+    screen) is functionally equivalent but uses different IBAction
+    wiring; a separate recording could exercise that later.
+
+  known_issues:
+    - "The Cancel branch (tap Cancel instead of Return on the confirmation dialog) is NOT exercised by this recording — it's the negative path. A follow-up recording 'book-return-cancel' could cover it."
+    - "DRM-bound books (Adobe ACSM / LCP-licensed) may show a brief 'Returning...' spinner before the row disappears. The Anna Karenina test fixture is NON-DRM, so this recording does NOT exercise the DRM-unbind path. A separate recording against a DRM book (e.g. the Bibliotheca lane) would close that gap."
+    - "Step 2's stable_id (6051727ac6fd) identifies the dialog's 'Return' button text. If the system locale shifts (e.g. zh, ja) the dialog button text changes and stable_id resolution may fail — preconditions assume en locale."
+
+  related:
+    - "audiobook-skip-forward.yaml — covers audiobook UI half"
+    - "reader2-back-button.yaml + reader2-settings-sheet.yaml — cover reader half"
+    - "Memory: handoff_regression_posture_next_2026_05_12.md — task 6 borrow critical-path plan"

--- a/.simdrive/journeys/read-return-from-mybooks-roundtrip.yaml
+++ b/.simdrive/journeys/read-return-from-mybooks-roundtrip.yaml
@@ -1,0 +1,111 @@
+scenario:
+  id: read-return-from-mybooks-roundtrip
+  name: "Read → return roundtrip from MyBooks (money-flow happy path)"
+  description: >
+    First end-to-end happy-path recording covering the read + return
+    halves of the borrow→read→return money flow. Pre-state assumes a
+    previously-borrowed downloaded EPUB in MyBooks; the recording
+    drives Read → Reader2 chrome → exit → inline Return → confirm →
+    book disappears from MyBooks.
+
+    Documented as 'read-return' rather than 'borrow-read-return'
+    because two parallel borrow attempts surfaced product bugs that
+    prevented the full roundtrip starting from a fresh catalog book
+    (see related: borrow-download-failed-cinema-beyond-human +
+    borrow-stuck-overdrive-up-and-running). The 'borrow' half is
+    deferred until the test-fixture issues are triaged or a known-
+    good catalog book is identified.
+
+  tags: [tier1, ios, money-flow, read, return, critical-path]
+  tier: stateful
+  blocking: false   # smoke-only — Reader2 WKWebView state is
+                    # non-deterministic across replays; load-bearing
+                    # invariant is the post-step-5 OCR-absence on
+                    # 'Mathematics Test Book' from MyBooks.
+
+  preconditions:
+    - "A1QA Test Library is the active library"
+    - "A1QA is signed in (patron 'al/qa' visible top-left)"
+    - "Mathematics Test Book is in MyBooks, fully downloaded, Read button visible"
+    - "MyBooks tab is in the foreground"
+    - "Book has a cached last-read position (recording opens directly to that page; Reader2 sync dialog is NOT exercised here)"
+
+  state_reset:
+    - "Before each replay, ensure Mathematics Test Book is re-borrowed via Catalog → tap book → tap Borrow on A1QA Test Library."
+    - "Replays of this recording WILL return the book — re-borrow before each run."
+    - "If Mathematics Test Book borrow fails (test-fixture issue), use a different downloaded EPUB and update step 1's stable_id."
+
+  recording:
+    path: "~/.simdrive/recordings/read-return-from-mybooks-roundtrip/recording.yaml"
+    steps: 5
+    captured_with: "simdrive 1.0.0a9"
+    captured_on: "2026-05-12"
+
+  steps:
+    - id: tap_read
+      description: "Tap Read on Mathematics Test Book row in MyBooks — Reader2 opens at cached page"
+      tap_target: { stable_id: "2e7a5a3230f1" }
+    - id: toggle_chrome
+      description: "Tap reader content center to reveal Reader2 chrome (auto-hides after ~5s)"
+      tap_target: { x: 603, y: 1300 }
+    - id: tap_back_chrome
+      description: "Tap top-left back chevron to exit Reader2 back to MyBooks"
+      tap_target: { x: 60, y: 230 }
+    - id: tap_inline_return
+      description: "Tap Return button inline on the Mathematics Test Book row in MyBooks"
+      tap_target: { stable_id: "33ca6e504516" }
+    - id: confirm_return
+      description: "Tap Return on the confirmation dialog ('Are you sure you want to return Advanced Accessibility Tests: Mathematics?')"
+      tap_target: { stable_id: "0eca748d03b0" }
+
+  expected_invariants:
+    - "Read tap launches Reader2 directly (no sync dialog if book has cached position)"
+    - "Reader2 renders cached page content (OCR sees WKWebView text matching the cached chapter)"
+    - "Chrome-toggle reveals top toolbar; back chevron exits Reader2 to MyBooks"
+    - "Inline Return tap renders a UIAlertController-style confirm dialog"
+    - "Confirm Return tap dismisses dialog AND removes the book row from MyBooks (post-OCR shows no 'Mathematics Test Book' or 'DIAGRAM CENTER')"
+    - "Post-state MyBooks rows shift up: Animal Farm + Don't Read This! + Four Women + Fundamental Accessibility Tests visible"
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # Reader2 WKWebView content varies across runs;
+                     # MyBooks row order shifts. OCR-absence on the
+                     # returned title is the regression detector.
+
+  rationale: |
+    Covers the read + return halves of the money-flow critical path
+    end-to-end. Pairs with book-return-from-mybooks (which covers
+    just the Return half from a non-downloaded audiobook). This
+    recording specifically exercises:
+
+    1. **Reader2 launch from MyBooks Read tap** — the EPUB + Readium
+       3.x integration point.
+    2. **WKWebView content render** — OCR-readable lipsum confirms
+       the EPUB's HTML actually rendered.
+    3. **Reader2 → MyBooks back navigation** — the chrome auto-hide
+       timing race that we documented in reader2-back-button.
+    4. **Inline Return UX** — confirm dialog rendering + content.
+    5. **OPDS revoke + DRM unbind + BookRegistry sync** — the three
+       failure modes in book-return, exercised in sequence with a
+       previously-opened book (cache invalidation on revoke).
+
+    A fresh borrow + read + return roundtrip is the IDEAL test but is
+    currently blocked by A1QA test-fixture issues — see the
+    'borrow-*' recordings flagged as bugs.
+
+  known_issues:
+    - "Replays of this recording mutate state — the borrowed book is returned. Re-borrow Mathematics Test Book before each replay or this recording will fail at step 1 (no Read button visible)."
+    - "Reader2 chrome auto-hide timing varies; step 3 (back chevron) may not navigate on the first attempt if chrome auto-hid between steps 2 and 3. Replays may need to retry the chrome+back sequence."
+    - "Mathematics Test Book is a DAISY accessibility EPUB. The Reader2 chapter shown depends on cached position; replays starting from cover page (page 1) vs Introduction (page 3) vs MathML Tests (page 4) will OCR different content."
+
+  related:
+    - "book-return-from-mybooks.yaml — Return half alone (no read)"
+    - "borrow-download-failed-cinema-beyond-human (RECORDING ONLY, NO YAML) — product bug evidence; 'No error message' alert text + failed download UX"
+    - "borrow-stuck-overdrive-up-and-running (RECORDING ONLY, NO YAML) — product bug evidence; borrow attempt stuck with Cancel-only UI for 30+ seconds, no progress indicator"
+    - "reader2-back-button.yaml — back chevron exit (subset of this recording)"
+    - "Memory: handoff_regression_posture_next_2026_05_12.md — task 6 borrow critical path"
+
+  related_bugs_surfaced:
+    - "Bug 1: Borrow on 'Cinema beyond the human' produces 'Download Failed - No error message' alert. The body text literally reads 'No error message' which is a UX bug regardless of underlying cause. The loan IS registered (book detail screen subsequently shows Download/Return buttons) but the file download silently fails."
+    - "Bug 2: Borrow on 'Up and Running' (O'Reilly Vagrant, Overdrive distributor) gets stuck with Cancel-only UI for 30+ seconds with no progress indicator, no error, no success. The borrow does NOT complete (book is not in MyBooks afterward). Tab bar is hidden during the borrow operation, leaving the user with only Back/Cancel as navigation options."
+    - "Both bugs surfaced on the iPhone 16 Pro simulator with iOS 18.4 against A1QA Test Library. Reproducible — both attempts failed. Recommend triage before tagging 3.1.0 as RC."


### PR DESCRIPTION
## Summary

- Adds the first Return-flow recording to the simdrive corpus — `book-return-from-mybooks` (2 steps): inline Return tap on Anna Karenina row → confirm Return on dialog. The row disappears from MyBooks.
- Covers the **terminal half** of the borrow → read → return critical path the 2026-05-12 PM handoff identified. The Return half is the silent regression surface (no audible feedback beyond row removal), so this is the highest-leverage subset of the three-stage flow.

## Why

The Return path traverses several silent failure modes:
- **OPDS revoke** (HTTP DELETE to the loan URL) — a server-side regression leaves the user holding a license they can no longer redeem
- **DRM unbind** (Adobe ACSM / LCP) — a regression here leaks downloaded files client-side
- **BookRegistry sync** — a regression leaves the row visible after revoke succeeds

The post-state OCR-absence check (`Anna Karenina` + `Leo Tolstoy` text gone) catches all three failure modes without per-mode assertions.

## Status — draft

Draft because this PR covers only the Return half of the handoff's full borrow → read → return roundtrip:

| Stage | Status | Notes |
|---|---|---|
| Borrow (Catalog → detail → Borrow → download wait) | not covered | Covered partially by `audiobook-skip-forward` (#942) which assumes a borrowed book |
| Read (open → reader chrome → close) | not covered | Covered by `reader2-back-button` + `reader2-settings-sheet` (#941) |
| Return (this PR) | ✓ landed | Inline Return + confirm dialog |

A future recording `borrow-read-return-roundtrip` could chain all three stages — that recording would be ~12-15 steps with multiple state-contract assumptions and is deferred.

**Other follow-ups identified during recording:**
- `book-return-cancel` (Cancel branch of the dialog — negative path)
- `book-return-drm-bound` (DRM-bound title to exercise Adobe / LCP unbind paths — Anna Karenina test fixture is non-DRM)

## Test plan

- [ ] `simdrive validate_replay name=book-return-from-mybooks` returns `ok:true` (confirmed locally — 2 steps, no errors, no warnings)
- [ ] Manual replay against a clean booted sim with A1QA pre-state + Anna Karenina re-borrowed: `simdrive-regress.sh --only book-return-from-mybooks --tier stateful`
- [ ] Verify post-state OCR check: `Anna Karenina` / `Leo Tolstoy` text absent after step 2
- [ ] Once roundtrip recording or DRM-bound variant is added, un-draft and request review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)