### PR TITLE
fix(borrow): surface indeterminate spinner during borrow-network phase

### DIFF
--- a/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
@@ -78,6 +78,22 @@ final class BookDetailViewModel: ObservableObject {
     }
     @Published var isProcessing: Bool = false
 
+    /// `true` while BorrowOperation has the registry's processing flag set
+    /// for this book — i.e. a borrow request is in flight. Distinct from
+    /// `downloadProgress` (which is 0 for the entire borrow phase, before
+    /// the download itself starts) and from `processingButtons` (which
+    /// tracks user-initiated UI spinners on individual buttons).
+    ///
+    /// Surfacing this flag fixes the "borrow stuck with Cancel-only UI" bug
+    /// on slow distributors (Overdrive in particular): before this, the
+    /// half-sheet rendered a 0%-linear progress bar and an inert Cancel
+    /// button with no indeterminate spinner, so the user had no signal that
+    /// anything was happening. BorrowOperation's setProcessing(true:false)
+    /// pair is the canonical truth here; we mirror it via the existing
+    /// `.TPPBookProcessingDidChange` notification so unit tests can flip it
+    /// without standing up the full download stack.
+    @Published private(set) var isBorrowProcessing: Bool = false
+
     var isShowingSample = false
     var isProcessingSample = false
 
@@ -167,6 +183,12 @@ final class BookDetailViewModel: ObservableObject {
         self.bookState = registry.state(for: book.identifier)
         self.bookIdentifier = book.identifier
         self.stableButtonState = self.computeButtonState(book: book, state: self.bookState, isManagingHold: self.isManagingHold)
+        // Seed isBorrowProcessing from the registry's processing flag so a
+        // borrow that's already in flight when the detail view opens (e.g.
+        // user kicked it off from a swimlane, then navigated into details
+        // before the network round-trip returned) shows the spinner from
+        // first frame instead of looking idle until the next emission.
+        self.isBorrowProcessing = registry.processing(forIdentifier: book.identifier)
 
         bindRegistryState()
         setupStableButtonState()
@@ -275,6 +297,24 @@ final class BookDetailViewModel: ObservableObject {
             name: .TPPBookRegistryDidChange,
             object: nil
         )
+
+        // BorrowOperation posts .TPPBookProcessingDidChange via the registry
+        // when it starts a borrow request and again when it finishes. Mirror
+        // it onto an @Published flag the half-sheet can observe, filtered to
+        // this VM's book identifier so unrelated borrows don't spin our UI.
+        NotificationCenter.default.publisher(for: .TPPBookProcessingDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] note in
+                guard let self else { return }
+                guard let info = note.userInfo as? [String: Any],
+                      let identifier = info[TPPNotificationKeys.bookProcessingBookIDKey] as? String,
+                      identifier == self.bookIdentifier,
+                      let value = info[TPPNotificationKeys.bookProcessingValueKey] as? Bool else { return }
+                if self.isBorrowProcessing != value {
+                    self.isBorrowProcessing = value
+                }
+            }
+            .store(in: &cancellables)
 
         // Avoid general download center change notifications; we already subscribe to fine-grained progress and registry state publishers
 

--- a/Palace/Book/UI/BookDetail/HalfSheetview.swift
+++ b/Palace/Book/UI/BookDetail/HalfSheetview.swift
@@ -10,6 +10,14 @@ protocol HalfSheetProvider: ObservableObject, BookButtonProvider {
     var downloadProgress: Double { get }
     var book: TPPBook { get }
 
+    /// `true` while a borrow request is in flight at the network layer
+    /// (set by `BorrowOperation` via `bookRegistry.setProcessing`). The
+    /// half-sheet uses this to show an indeterminate spinner + "Borrowing…"
+    /// label during the borrow phase, before the download itself begins
+    /// emitting progress. Default `false` so legacy providers (e.g.
+    /// `BookCellModel`) don't have to opt in mechanically.
+    var isBorrowProcessing: Bool { get }
+
     /// Error alert to present via SwiftUI `.alert` on the half sheet.
     var downloadErrorAlert: AlertModel? { get set }
 
@@ -33,6 +41,10 @@ extension HalfSheetProvider {
             false
         }
     }
+
+    /// Default for legacy providers (BookCellModel) that don't track a
+    /// distinct borrow phase. They render the previous behavior.
+    var isBorrowProcessing: Bool { false }
 }
 
 struct HalfSheetView<ViewModel: HalfSheetProvider>: View {
@@ -68,11 +80,7 @@ struct HalfSheetView<ViewModel: HalfSheetProvider>: View {
             bookInfoView
             statusInfoView
 
-            // Reserve consistent space for progress bar to prevent layout shifts
-            ProgressView(value: viewModel.downloadProgress, total: 1.0)
-                .progressViewStyle(LinearProgressViewStyle())
-                .frame(height: 6)
-                .opacity(viewModel.bookState == .downloading && viewModel.buttonState != .downloadSuccessful ? 1 : 0)
+            progressIndicator
 
             if viewModel.isFullSize {
                 BookButtonsView(provider: viewModel, previewEnabled: false, onButtonTapped: { type in
@@ -235,6 +243,41 @@ struct HalfSheetView<ViewModel: HalfSheetProvider>: View {
 
 // MARK: - Subviews
 private extension HalfSheetView {
+
+    /// Renders the borrow/download progress UI cue. Three states:
+    /// 1. Borrow request in flight (registry's processing flag is set, and
+    ///    the download itself hasn't started yet) → indeterminate spinner
+    ///    + "Borrowing…" label. This is the slow-distributor case (e.g.
+    ///    Overdrive) that previously showed an inert 0%-linear bar.
+    /// 2. Download running → existing linear bar at the current %.
+    /// 3. Idle → invisible spacer to preserve layout height.
+    @ViewBuilder
+    var progressIndicator: some View {
+        if viewModel.isBorrowProcessing && viewModel.downloadProgress == 0 {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle())
+                    .controlSize(.small)
+                Text(Strings.BookDetailView.borrowingInProgress)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                Spacer(minLength: 0)
+            }
+            .frame(height: 6)
+            .accessibilityIdentifier(AccessibilityID.BookDetail.borrowingProgress)
+            .accessibilityLabel(Strings.BookDetailView.borrowingInProgress)
+        } else if viewModel.bookState == .downloading && viewModel.buttonState != .downloadSuccessful {
+            ProgressView(value: viewModel.downloadProgress, total: 1.0)
+                .progressViewStyle(LinearProgressViewStyle())
+                .frame(height: 6)
+        } else {
+            // Reserve consistent space so the layout doesn't jump when the
+            // indicator appears/disappears.
+            Color.clear
+                .frame(height: 6)
+        }
+    }
+
     @ViewBuilder
     var bookInfoView: some View {
         VStack(alignment: .leading) {

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -651,6 +651,11 @@ struct Strings {
         static let otherBooks = NSLocalizedString("Other books by this author", comment: "Section header for related books")
         static let borrowedUntil = NSLocalizedString("Borrowed until", comment: "")
         static let borrowingFor = NSLocalizedString("Borrowing for", comment: "")
+        /// Status text shown alongside the indeterminate spinner during the
+        /// borrow phase (network request to the borrow URL is in flight,
+        /// before the download itself starts). Distinct from `borrowingFor`,
+        /// which renders a loan-duration label on already-borrowed books.
+        static let borrowingInProgress = NSLocalizedString("Borrowing…", comment: "Status label shown while a borrow request is in flight, before the download begins.")
         static let due = NSLocalizedString("Due", comment: "")
         static let holdStatus = NSLocalizedString(
             "You are %1$@ in line. %2$d %3$@ in use.",

--- a/Palace/Utilities/Testing/AccessibilityIdentifiers.swift
+++ b/Palace/Utilities/Testing/AccessibilityIdentifiers.swift
@@ -116,6 +116,11 @@ public enum AccessibilityID {
 
         // Progress
         public static let downloadProgress = "bookDetail.downloadProgress"
+        /// Indeterminate spinner + "Borrowing…" label shown during the borrow
+        /// phase (network round-trip to the borrow URL is in flight). Distinct
+        /// from `downloadProgress` (linear bar that appears once the download
+        /// itself begins).
+        public static let borrowingProgress = "bookDetail.borrowingProgress"
 
         // Half sheet
         public static let halfSheet = "bookDetail.halfSheet"

--- a/PalaceTests/ViewModels/BookDetailViewModelTests.swift
+++ b/PalaceTests/ViewModels/BookDetailViewModelTests.swift
@@ -1341,4 +1341,121 @@ final class BookDetailViewModelTests: XCTestCase {
             XCTAssertTrue(vm.isFullSize == true || vm.isFullSize == false)
         }
     }
+
+    // MARK: - Borrow-in-progress UI cue
+    // Regression: borrow request was in-flight for 30+s on slow distributors
+    // (Overdrive) with no UI signal — Borrow button hid, only a static Cancel
+    // button appeared, no spinner / no "Borrowing…" text. BorrowOperation
+    // already sets bookRegistry.setProcessing(true,for:) at the start of the
+    // borrow request and clears it on completion; the detail VM just wasn't
+    // surfacing that signal so the half-sheet had no indeterminate progress
+    // indicator. These tests pin the wiring.
+
+    func testIsBorrowProcessing_DefaultsToRegistryProcessingFlagAtInit() {
+        let book = createTestBook()
+        let registry = TPPBookRegistryMock()
+        registry.addBook(book, location: nil, state: .unregistered, fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
+        registry.setProcessing(true, for: book.identifier)
+
+        let vm = BookDetailViewModel(
+            book: book,
+            registry: registry,
+            downloadCenter: AppContainer.production().downloadCenter,
+            accountsManager: AppContainer.production().accountsManager,
+            settings: TPPSettings(),
+            opdsFeedService: AppContainer.production().opdsFeedService,
+            samplePreviewManager: AppContainer.production().samplePreviewManager,
+            readerService: AppContainer.production().readerService
+        )
+
+        XCTAssertTrue(
+            vm.isBorrowProcessing,
+            "VM must seed isBorrowProcessing from registry.processing(forIdentifier:) at init — otherwise a borrow already in flight when the detail view opens shows no spinner."
+        )
+    }
+
+    func testIsBorrowProcessing_FlipsOnProcessingNotification_ForSameBook() {
+        let (vm, _, book) = makeVM()
+        XCTAssertFalse(vm.isBorrowProcessing, "Pre-condition: VM starts idle")
+
+        let exp = expectation(description: "isBorrowProcessing flips true")
+        var cancellables = Set<AnyCancellable>()
+        vm.$isBorrowProcessing.filter { $0 }.first()
+            .sink { _ in exp.fulfill() }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.post(
+            name: .TPPBookProcessingDidChange,
+            object: nil,
+            userInfo: [
+                TPPNotificationKeys.bookProcessingBookIDKey: book.identifier,
+                TPPNotificationKeys.bookProcessingValueKey: true
+            ]
+        )
+
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertTrue(vm.isBorrowProcessing)
+    }
+
+    func testIsBorrowProcessing_FlipsBackToFalseOnCompletionNotification() {
+        let book = createTestBook()
+        let registry = TPPBookRegistryMock()
+        registry.addBook(book, location: nil, state: .unregistered, fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
+        registry.setProcessing(true, for: book.identifier)
+
+        let vm = BookDetailViewModel(
+            book: book,
+            registry: registry,
+            downloadCenter: AppContainer.production().downloadCenter,
+            accountsManager: AppContainer.production().accountsManager,
+            settings: TPPSettings(),
+            opdsFeedService: AppContainer.production().opdsFeedService,
+            samplePreviewManager: AppContainer.production().samplePreviewManager,
+            readerService: AppContainer.production().readerService
+        )
+        XCTAssertTrue(vm.isBorrowProcessing, "Pre-condition: VM seeded true")
+
+        let exp = expectation(description: "flips false")
+        var cancellables = Set<AnyCancellable>()
+        vm.$isBorrowProcessing.dropFirst().filter { !$0 }.first()
+            .sink { _ in exp.fulfill() }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.post(
+            name: .TPPBookProcessingDidChange,
+            object: nil,
+            userInfo: [
+                TPPNotificationKeys.bookProcessingBookIDKey: book.identifier,
+                TPPNotificationKeys.bookProcessingValueKey: false
+            ]
+        )
+
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertFalse(vm.isBorrowProcessing)
+    }
+
+    func testIsBorrowProcessing_IgnoresNotificationsForDifferentBook() {
+        let (vm, _, _) = makeVM()
+        XCTAssertFalse(vm.isBorrowProcessing)
+
+        // Notification for a *different* book ID — must NOT affect this VM.
+        NotificationCenter.default.post(
+            name: .TPPBookProcessingDidChange,
+            object: nil,
+            userInfo: [
+                TPPNotificationKeys.bookProcessingBookIDKey: "some-other-book-id",
+                TPPNotificationKeys.bookProcessingValueKey: true
+            ]
+        )
+
+        // Drain the main run loop so any (incorrect) delivery has a chance to fire.
+        let drain = expectation(description: "drain run loop")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { drain.fulfill() }
+        wait(for: [drain], timeout: 1.0)
+
+        XCTAssertFalse(
+            vm.isBorrowProcessing,
+            "Processing notifications must be filtered by book identifier — otherwise an unrelated book's borrow puts every detail view into a spinning state."
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Surfaces a clear "borrow in flight" UI cue on the book-detail half-sheet so users don't stare at an inert Cancel button while the OPDS borrow round-trip completes. Fixes the bug Maurice surfaced during 3.1.0 regression on the A1QA "Up and Running" (Overdrive) test book where the Borrow button collapsed to a static `[Cancel]` with no spinner / no status text for 30+ seconds.

- **Why it happens:** the `bookState = .downloading` is set optimistically the moment `startDownloadAfterAuth` fires — but the OPDS borrow request hasn't even left yet. `BookButtonState.downloadInProgress` correctly returns `[.cancel]`, and the half-sheet's linear progress bar is correctly at 0% (no bytes yet). There was simply no "borrow phase" indicator anywhere in the UI.
- **What's already there:** `BorrowOperation.borrowAsync` already calls `bookRegistry.setProcessing(true:false:)` around the network round-trip, which posts `.TPPBookProcessingDidChange`. `BookCellModel` already mirrors this onto `isLoading` for grid cells. `BookDetailViewModel` was the missing link.
- **What this PR adds:** `BookDetailViewModel.isBorrowProcessing` (seeded at init from the registry, kept in sync via the notification), promoted through `HalfSheetProvider`, rendered as an indeterminate `ProgressView()` + "Borrowing…" label on the half-sheet while `downloadProgress == 0`. Layout stays stable — no jump when the indicator appears/disappears.

## Scope

- Detail-view borrow phase UI only.
- No state-machine changes (no new `TPPBookState` case).
- No network-timeout changes.
- BookCellModel keeps its existing `isLoading` plumbing — protocol default `false` preserves current cell rendering.

## Test plan

- [x] `testIsBorrowProcessing_DefaultsToRegistryProcessingFlagAtInit` — a borrow already in flight when the detail view opens shows the spinner from frame zero.
- [x] `testIsBorrowProcessing_FlipsOnProcessingNotification_ForSameBook` — `.TPPBookProcessingDidChange` posted with our identifier flips the flag.
- [x] `testIsBorrowProcessing_FlipsBackToFalseOnCompletionNotification` — completion notification flips it back.
- [x] `testIsBorrowProcessing_IgnoresNotificationsForDifferentBook` — unrelated book IDs don't spin our UI.
- [x] All 85 existing `BookDetailViewModelTests` still pass.
- [x] Mutation kill verified: flipped `identifier == self.bookIdentifier` to `!=` → 2 tests failed; reset to `registry.processing(...)` to `false` → init-seed test failed.
- [ ] Manual sim-drive against A1QA "Up and Running" (Overdrive) — confirm spinner + "Borrowing…" label render during the slow round-trip.
- [ ] Manual sim-drive against DAISY Mathematics Test Book — confirm no visible regression on the fast path.

## Not done / Deferred

See commit body for the full stanza. Notable deferrals:

- No timeout reduction (URLSession 30s still applies — but the user has a clear signal now).
- No inline-button-bar spinner (half-sheet is on top during borrow; if we ever surface borrow phase outside the half-sheet, the inline Cancel button needs the same treatment).
- Bug 1 from the simdrive findings ("Download Failed - No error message" placeholder leaking) is a separate PR.

Refs: `.simdrive/journeys/BUG_FINDINGS_2026_05_12.md` on `feat/simdrive-borrow-flow-coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)