### PR TITLE
fix: suppress holds error banner on anonymous libraries (BUG-004)

### DIFF
--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -313,6 +313,18 @@ protocol AccountLogoDelegate: AnyObject {
         // this will tell if any authentication method requires age check
         return auths.contains(where: { $0.needsAgeCheck })
     }
+    /// Whether any of this library's authentication methods require user
+    /// credentials. Returns `false` for anonymous libraries (e.g. Palace
+    /// Bookshelf) — those have no patron concept, so per-patron endpoints
+    /// like loans / holds must not be fetched (BUG-004).
+    ///
+    /// This is a *library-state* signal, distinct from `TPPUserAccount.needsAuth`
+    /// which can race during library switches when `currentAccountId` is
+    /// transiently nil and `lastKnownCurrentUserAccount` returns the previous
+    /// (still-credentialed) library.
+    var needsAuth: Bool {
+        return auths.contains(where: { $0.needsAuth })
+    }
 
     fileprivate var urlAnnotations: URL?
     fileprivate var urlAcknowledgements: URL?
@@ -531,6 +543,16 @@ protocol AccountLogoDelegate: AnyObject {
 
     var loansUrl: URL? {
         return details?.loansUrl
+    }
+
+    /// Whether any of this library's authentication methods require user
+    /// credentials. Returns `false` for anonymous libraries (Palace
+    /// Bookshelf etc.) once the auth document has been parsed; `nil` while
+    /// the auth document is still loading. Callers in critical-path code
+    /// (e.g. holds-fetch suppression, BUG-004) should default-deny when this
+    /// returns nil to avoid swallowing legitimate failures on cold launch.
+    var needsAuth: Bool? {
+        return details?.needsAuth
     }
 
     init(publication: OPDS2Publication, imageCache: ImageCacheType) {

--- a/Palace/Holds/HoldsViewModel.swift
+++ b/Palace/Holds/HoldsViewModel.swift
@@ -44,6 +44,7 @@ final class HoldsViewModel: ObservableObject {
     private let settings: TPPSettings
     private let debugSettings: DebugSettings
     private let hasCredentials: () -> Bool
+    private let currentLibraryNeedsAuth: () -> Bool
     private let presentSignIn: (@escaping () -> Void) -> Void
     private let store: Store<HoldsState, HoldsAction, HoldsEnvironment>
     private var cancellables = Set<AnyCancellable>()
@@ -68,6 +69,7 @@ final class HoldsViewModel: ObservableObject {
         settings: TPPSettings,
         debugSettings: DebugSettings,
         hasCredentials: (() -> Bool)? = nil,
+        currentLibraryNeedsAuth: (() -> Bool)? = nil,
         presentSignIn: ((@escaping () -> Void) -> Void)? = nil
     ) {
         self.bookRegistry = bookRegistry
@@ -76,6 +78,19 @@ final class HoldsViewModel: ObservableObject {
         self.debugSettings = debugSettings
         self.hasCredentials = hasCredentials ?? { [accountsManager] in
             accountsManager.currentUserAccount.hasCredentials()
+        }
+        // BUG-004: anonymous libraries (e.g. Palace Bookshelf) have no patron
+        // concept; per-patron endpoints (loans/holds) must not be fetched. We
+        // read the *library*'s auth surface rather than the user account's
+        // because the user-account path races during library switches —
+        // `lastKnownCurrentUserAccount` falls back to the previous (still-
+        // credentialed) library while `currentAccountId` is briefly nil.
+        // Library-state (Account.needsAuth) reflects the new selection
+        // synchronously and returns nil while the auth document is still
+        // loading — we default-deny in that window so we don't swallow real
+        // failures on cold launch (the BookRegistrySync hydration-race guard).
+        self.currentLibraryNeedsAuth = currentLibraryNeedsAuth ?? { [accountsManager] in
+            return accountsManager.currentAccount?.needsAuth ?? true
         }
         self.presentSignIn = presentSignIn ?? { [accountsManager] completion in
             SignInModalPresenter.presentSignInModalForCurrentAccount(
@@ -188,11 +203,20 @@ final class HoldsViewModel: ObservableObject {
             return text
         }()
         let cached = !visibleBooks.isEmpty
-        let anonymous = !hasCredentials()
+        // `anonymous` collapses two distinct anonymous-state signals:
+        //   1. The current *library* declares no credential-based auth method
+        //      (Palace Bookshelf etc.) — holds aren't a concept here at all.
+        //      This is the BUG-004 fix: library state is durable across the
+        //      switch, so it catches the race window where the user-account
+        //      view of credentials is briefly stale.
+        //   2. The user has no credentials stored for the current library —
+        //      existing PP-3811 behaviour, kept verbatim so the auth-required
+        //      code path doesn't change.
+        let anonymous = !currentLibraryNeedsAuth() || !hasCredentials()
         if cached {
             Log.debug(#file, "Sync failed but holds are cached — suppressing error banner")
         } else if anonymous {
-            Log.debug(#file, "Sync failed for anonymous user — suppressing error banner")
+            Log.debug(#file, "Sync failed for anonymous library/user — suppressing error banner")
         }
         store.send(.syncFailed(errorMessage: detail, cached: cached, anonymous: anonymous))
     }

--- a/PalaceTests/Accounts/AccountDetailsTests.swift
+++ b/PalaceTests/Accounts/AccountDetailsTests.swift
@@ -9,6 +9,7 @@
 //
 
 import XCTest
+import PalaceCatalog
 @testable import Palace
 
 // MARK: - LoginKeyboard Tests
@@ -209,6 +210,137 @@ final class AuthenticationTests: XCTestCase {
             coppaUnderUrl: URL(string: "https://example.com/under13"),
             coppaOverUrl: URL(string: "https://example.com/over13")
         )
+    }
+}
+
+// MARK: - AccountDetails / Account needsAuth aggregate tests (BUG-004)
+
+/// Tests for the library-level `needsAuth` aggregate exposed on
+/// `AccountDetails` and the `Account` passthrough. This signal drives the
+/// BUG-004 holds-fetch suppression — when an anonymous library
+/// (Palace Bookshelf) is selected, holds must not be fetched and the error
+/// banner must not appear.
+final class AccountDetailsNeedsAuthAggregateTests: XCTestCase {
+
+    func testAccountDetails_NeedsAuth_BasicOnly_ReturnsTrue() {
+        let details = makeAccountDetails(authTypes: ["http://opds-spec.org/auth/basic"])
+        XCTAssertTrue(details.needsAuth,
+                      "Basic auth library must report needsAuth=true so loans/holds fetches are gated by credentials, not skipped")
+    }
+
+    func testAccountDetails_NeedsAuth_SamlOnly_ReturnsTrue() {
+        let details = makeAccountDetails(authTypes: ["http://librarysimplified.org/authtype/SAML-2.0"])
+        XCTAssertTrue(details.needsAuth,
+                      "SAML library must report needsAuth=true")
+    }
+
+    func testAccountDetails_NeedsAuth_AnonymousOnly_ReturnsFalse() {
+        // The Palace Bookshelf shape: a single anonymous auth method, no patron concept.
+        let details = makeAccountDetails(authTypes: ["http://librarysimplified.org/rel/auth/anonymous"])
+        XCTAssertFalse(details.needsAuth,
+                       "Anonymous-only library (Palace Bookshelf) must report needsAuth=false — this is the BUG-004 guard")
+    }
+
+    func testAccountDetails_NeedsAuth_CoppaOnly_ReturnsFalse() {
+        // COPPA gate is age-restriction, not credential-based — should not trigger holds fetch.
+        let details = makeAccountDetails(authTypes: ["http://librarysimplified.org/terms/authentication/gate/coppa"])
+        XCTAssertFalse(details.needsAuth,
+                       "COPPA-only library must report needsAuth=false (age gate, not credentials)")
+    }
+
+    func testAccountDetails_NeedsAuth_AnonymousMixedWithBasic_ReturnsTrue() {
+        // If ANY auth method requires credentials, the library as a whole needs auth —
+        // anonymous "guest mode" alongside credentialed access still means holds are
+        // a real concept for signed-in patrons.
+        let details = makeAccountDetails(authTypes: [
+            "http://librarysimplified.org/rel/auth/anonymous",
+            "http://opds-spec.org/auth/basic"
+        ])
+        XCTAssertTrue(details.needsAuth,
+                      "Mixed anonymous+basic library must report needsAuth=true — credentialed patrons exist here")
+    }
+
+    func testAccountDetails_NeedsAuth_OAuthOnly_ReturnsTrue() {
+        let details = makeAccountDetails(authTypes: ["http://librarysimplified.org/authtype/OAuth-with-intermediary"])
+        XCTAssertTrue(details.needsAuth, "OAuth library must report needsAuth=true")
+    }
+
+    func testAccountDetails_NeedsAuth_OidcOnly_ReturnsTrue() {
+        let details = makeAccountDetails(authTypes: ["http://palaceproject.io/authtype/OpenIDConnect"])
+        XCTAssertTrue(details.needsAuth, "OIDC library must report needsAuth=true")
+    }
+
+    // MARK: - Account passthrough
+
+    /// `Account.needsAuth` must return `nil` before the auth document is
+    /// loaded (no `details`). Critical-path callers default-deny to avoid
+    /// suppressing real failures during the hydration window.
+    func testAccount_NeedsAuth_BeforeAuthDocLoaded_ReturnsNil() {
+        let account = makeAccountWithoutAuthDoc()
+        XCTAssertNil(account.details, "Precondition: auth document not loaded yet")
+        XCTAssertNil(account.needsAuth,
+                     "Account.needsAuth must be nil while auth doc is still loading — callers default-deny in this window")
+    }
+
+    /// `Account.needsAuth` must reflect `details.needsAuth` once the auth
+    /// document has been parsed. This is the property that the BUG-004
+    /// holds-fetch guard consults.
+    func testAccount_NeedsAuth_AnonymousDetailsLoaded_ReturnsFalse() {
+        let account = makeAccountWithoutAuthDoc()
+        account.authenticationDocument = makeAuthDocument(authTypes: ["http://librarysimplified.org/rel/auth/anonymous"])
+        XCTAssertNotNil(account.details, "Precondition: details now populated")
+        XCTAssertEqual(account.needsAuth, false,
+                       "Account.needsAuth must reflect details.needsAuth=false for anonymous library (BUG-004 contract)")
+    }
+
+    func testAccount_NeedsAuth_BasicDetailsLoaded_ReturnsTrue() {
+        let account = makeAccountWithoutAuthDoc()
+        account.authenticationDocument = makeAuthDocument(authTypes: ["http://opds-spec.org/auth/basic"])
+        XCTAssertEqual(account.needsAuth, true,
+                       "Account.needsAuth must reflect details.needsAuth=true for credentialed library")
+    }
+
+    // MARK: - Helpers
+
+    private func makeAccountDetails(authTypes: [String]) -> AccountDetails {
+        let doc = makeAuthDocument(authTypes: authTypes)
+        let uuid = "needsauth-test-\(UUID().uuidString)"
+        return AccountDetails(authenticationDocument: doc, uuid: uuid)
+    }
+
+    private func makeAuthDocument(authTypes: [String]) -> OPDS2AuthenticationDocument {
+        let auths: [[String: Any]] = authTypes.map { type in
+            [
+                "type": type,
+                "inputs": [
+                    "login": ["keyboard": "Default"],
+                    "password": ["keyboard": "Default"]
+                ],
+                "labels": ["login": "Login", "password": "Password"]
+            ]
+        }
+        let json: [String: Any] = [
+            "id": "urn:uuid:needsauth-test",
+            "title": "NeedsAuth Test Library",
+            "authentication": auths,
+            "features": ["enabled": [], "disabled": []]
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! OPDS2AuthenticationDocument.fromData(data)
+    }
+
+    private func makeAccountWithoutAuthDoc() -> Account {
+        let publication = OPDS2Publication(
+            links: [],
+            metadata: OPDS2Publication.Metadata(
+                updated: Date(),
+                description: nil,
+                id: "urn:uuid:needsauth-account-test",
+                title: "NeedsAuth Account Test"
+            ),
+            images: nil
+        )
+        return Account(publication: publication, imageCache: MockImageCache())
     }
 }
 

--- a/PalaceTests/ViewModels/HoldsViewModelTests.swift
+++ b/PalaceTests/ViewModels/HoldsViewModelTests.swift
@@ -665,6 +665,74 @@ final class HoldsSyncFailureTests: XCTestCase {
         XCTAssertFalse(viewModel.isLoading, "Not stuck in loading state")
     }
 
+    // MARK: - BUG-004: anonymous library (Palace Bookshelf) on sync failure
+
+    /// BUG-004: switching to an anonymous library (Palace Bookshelf) while a
+    /// previously signed-in account's sync was in flight surfaces a spurious
+    /// "There was a problem loading your holds" banner. The credential-only
+    /// suppression path (`!hasCredentials()`) races against the account-switch
+    /// window in AccountsManager — `lastKnownCurrentUserAccount` falls back to
+    /// the previous (still-credentialed) library while `currentAccountId` is
+    /// briefly nil. The fix adds a *library-state* guard
+    /// (`currentLibraryNeedsAuth`) that reflects the new selection
+    /// synchronously and overrides the stale credential view.
+    ///
+    /// Scenario simulated: user has cached credentials (race window —
+    /// `hasCredentials() == true`) but the library no longer requires auth.
+    /// Without the fix, the banner appears; with the fix, it's suppressed.
+    func testSyncFailure_AnonymousLibrary_SuppressesErrorBanner_EvenWhenHasCredentialsRacesTrue() async {
+        let viewModel = HoldsViewModel(
+            bookRegistry: mockRegistry,
+            accountsManager: AppContainer.production().accountsManager,
+            settings: TPPSettings(),
+            debugSettings: AppContainer.production().debugSettings,
+            // Simulate the AccountsManager race: stale lastKnownCurrentUserAccount
+            // returns the previous (signed-in) library, so hasCredentials() is true.
+            hasCredentials: { true },
+            // New (current) library is anonymous — no patron auth at all.
+            currentLibraryNeedsAuth: { false }
+        )
+        XCTAssertTrue(viewModel.visibleBooks.isEmpty, "Precondition: no cached holds on freshly-switched library")
+
+        NotificationCenter.default.post(name: .TPPSyncFailed, object: nil, userInfo: nil)
+
+        let exp = XCTestExpectation(description: "notification processed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { exp.fulfill() }
+        await fulfillment(of: [exp], timeout: 2.0)
+
+        XCTAssertNil(viewModel.syncError,
+                     "Error banner must be suppressed when the current library is anonymous, even when stale credentials are present (BUG-004)")
+        XCTAssertFalse(viewModel.isLoading, "Not stuck in loading state")
+    }
+
+    /// Guard against regression: when the library *does* require auth and the
+    /// user has credentials, the banner must still appear on a real failure.
+    /// This is the contrast case for the BUG-004 fix — proving the new
+    /// library-state guard doesn't blanket-suppress all errors.
+    func testSyncFailure_LibraryNeedsAuth_AndHasCredentials_ShowsBanner() async {
+        let viewModel = HoldsViewModel(
+            bookRegistry: mockRegistry,
+            accountsManager: AppContainer.production().accountsManager,
+            settings: TPPSettings(),
+            debugSettings: AppContainer.production().debugSettings,
+            hasCredentials: { true },
+            currentLibraryNeedsAuth: { true }
+        )
+
+        let errorExpectation = XCTestExpectation(description: "syncError surfaced")
+        viewModel.$syncError
+            .dropFirst()
+            .first { $0 != nil }
+            .sink { _ in errorExpectation.fulfill() }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.post(name: .TPPSyncFailed, object: nil, userInfo: nil)
+        await fulfillment(of: [errorExpectation], timeout: 1.0)
+
+        XCTAssertNotNil(viewModel.syncError,
+                        "Signed-in users on credentialed libraries must still see real sync errors")
+    }
+
     func testSyncFailure_AuthenticatedUser_ShowsErrorBanner() async {
         // Authenticated user — sync failed for a real reason. Banner still appears.
         let viewModel = HoldsViewModel(


### PR DESCRIPTION
## Summary

Fixes **BUG-004 (3.1.0 release validation)**: switching to Palace Bookshelf (an anonymous library) raised a spurious orange warning banner reading *"There was a problem loading your holds. Please try again later."* on the Holds tab. Anonymous libraries have no patron concept, so a holds-fetch failure for them is meaningless noise — but the existing suppression chain in `HoldsViewModel` was racing with the library-switch window in `AccountsManager`.

## Where the bug lived

`Palace/Holds/HoldsViewModel.swift:191` — `dispatchSyncFailure` computed `anonymous = !hasCredentials()`. The closure reads `accountsManager.currentUserAccount.hasCredentials()`, which during the library-switch window can return the previous (still-credentialed) library because `currentAccountId` is transiently nil and `currentUserAccount` falls back to `lastKnownCurrentUserAccount` (AccountsManager.swift:279). Result: `anonymous` evaluates to `false` for what is now an anonymous library, the suppression doesn't fire, and the banner appears.

`BookRegistrySync.sync` already skips the loans fetch for anonymous libraries via its own `hasCredentials` guard — so the failure that surfaces here is from a **previously-credentialed** library's sync that was cancelled by `cancelNonEssentialTasks()` mid-switch, posting `TPPSyncFailed` after `currentAccountId` already flipped. The HoldsViewModel listener then had to suppress correctly — and didn't.

## The guard added

A new **library-state** signal alongside the existing credential signal:

- `AccountDetails.needsAuth` — true if any auth method is `basic` / `oauth` / `saml` / `token` / `oidc`. False for `.anonymous` and `.coppa`.
- `Account.needsAuth: Bool?` — returns `details?.needsAuth`. Nil while the auth doc is still loading; callers default-deny in that window so legitimate cold-launch failures aren't swallowed (the same hydration-race the existing `BookRegistrySync` comment warns about).
- `HoldsViewModel.currentLibraryNeedsAuth: () -> Bool` — DI-friendly closure (parallel to `hasCredentials`) that defaults to reading `accountsManager.currentAccount?.needsAuth ?? true`.
- `dispatchSyncFailure` now sets `anonymous = !currentLibraryNeedsAuth() || !hasCredentials()` — either signal suppresses.

The auth-required code path is unchanged: when the library needs auth and the user has credentials, banners still surface (the existing `testSyncFailure_AuthenticatedUser_ShowsErrorBanner` test still passes, and a new contrast test asserts this explicitly).

## Tests

**TDD path:**
- `PalaceTests/Accounts/AccountDetailsTests.swift` — `AccountDetailsNeedsAuthAggregateTests` (10 tests). Covers `needsAuth` across `basic`, `SAML`, `OIDC`, `OAuth`, `anonymous`, `COPPA`, and mixed `anonymous+basic` shapes. Account passthrough returns `nil` pre-hydration and reflects details once populated.
- `PalaceTests/ViewModels/HoldsViewModelTests.swift` — `HoldsSyncFailureTests` +2 tests:
  - `testSyncFailure_AnonymousLibrary_SuppressesErrorBanner_EvenWhenHasCredentialsRacesTrue` — failing test before the fix; simulates the race by injecting `hasCredentials: { true }` + `currentLibraryNeedsAuth: { false }` and asserts no banner.
  - `testSyncFailure_LibraryNeedsAuth_AndHasCredentials_ShowsBanner` — guards against blanket-suppression regression.

**Local verification on iPhone 17 Pro sim:**
- New tests: 22/22 PASS (12 HoldsSyncFailureTests + 10 AccountDetailsNeedsAuthAggregateTests).
- Regression check across related suites: 67/67 PASS (HoldsViewModelTests, HoldsBookViewModelTests, HoldsBadgeCountTests, HoldsReducerTests, AccountModelTests).

## Reproduction (from BUG-004 bug-findings doc)

1. Sign in to A1QA Test Library.
2. Tap Palace logo (top-left) → library switcher.
3. Tap "Palace Bookshelf" (anonymous library).
4. Without fix: orange banner *"There was a problem loading your holds. Please try again later."* appears on the Holds tab. With fix: empty-state copy renders cleanly.

**Before-state screenshots:**
- `/Users/mauricework/.simdrive/sessions/mYKySDszWlk/observations/observe-1778607027071.png` (first repro)
- `/Users/mauricework/.simdrive/sessions/mYKySDszWlk/observations/observe-1778607113166.png` (second repro)
- Repro recording: `/Users/mauricework/.simdrive/recordings/bug-palace-bookshelf-holds-error/`

## Scope

Holds-tab banner only. Does NOT touch `BookRegistrySync`'s existing `hasCredentials` skip-guard (separate code path, already correct). Does NOT change the auth-required code path. No new dependencies. No `.pbxproj` changes — tests live in existing files.

## Not done / deferred

The `BookRegistrySync.sync` failure path (line 320-328) doesn't guard against stale `syncUrl` the way the success path does (line 333) — so an in-flight sync from a previous library still posts `TPPSyncFailed` after the switch. The HoldsViewModel suppression catches it cleanly with this fix, but a separate PR could nil `syncUrl` on stale-account completion as a parallel race mitigation. Out of scope for this single-bug fix.

## Test plan

- [x] New unit tests pass locally (22/22).
- [x] Related Holds + Account test suites still pass (67/67).
- [ ] Manual sim verification on develop after merge: switch A1QA → Palace Bookshelf → Holds tab shows empty-state without banner.
- [ ] Manual sim verification: switch A1QA → Danny SAML (anonymously browsable) → Holds tab shows empty-state without banner.
- [ ] Manual sim verification: A1QA signed-in user, force a real sync failure (network off, pull-to-refresh) → banner still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)