### PR TITLE
fix(account): route Report-an-Issue + Content-Licenses rows correctly (BUG-001 + BUG-005)

### DIFF
--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -563,8 +563,16 @@ protocol AccountLogoDelegate: AnyObject {
         if let link = publication.links.first(where: { $0.rel == "help" })?.href {
             if let emailAddress = EmailAddress(rawValue: link) {
                 supportEmail = emailAddress
-            } else {
-                supportURL = URL(string: link)
+            } else if let url = URL(string: link),
+                      !Account.isAboutAppMarketingURL(url) {
+                // BUG-001: some libraries misconfigure their auth-document
+                // `help` link to point at the Palace marketing site
+                // (e.g. http://thepalaceproject.org/). That URL is the same
+                // page Settings -> About App renders, so wiring it under
+                // "Report an Issue" sends users to a marketing splash with
+                // no way to report anything. Drop the misconfiguration on
+                // the floor so the row is suppressed by hasSupportOption.
+                supportURL = url
             }
         }
         authenticationDocumentUrl = publication.links.first(where: { $0.type == "application/vnd.opds.authentication.v1.0+json" })?.href
@@ -573,6 +581,26 @@ protocol AccountLogoDelegate: AnyObject {
         logoUrl = publication.thumbnailURL
         self.imageCache = imageCache
         super.init()
+    }
+
+    /// Returns true when `url`'s host is the Palace marketing site root
+    /// (the same destination as Settings -> About App), regardless of
+    /// scheme (http/https) or trailing-slash variance. We suppress any
+    /// `help` link that resolves to this URL — it never contains issue
+    /// reporting content and would otherwise present a marketing splash
+    /// under "Report an Issue" (BUG-001).
+    static func isAboutAppMarketingURL(_ url: URL) -> Bool {
+        guard let marketingURL = URL(string: TPPSettings.TPPAboutPalaceURLString),
+              let marketingHost = marketingURL.host?.lowercased(),
+              let candidateHost = url.host?.lowercased(),
+              candidateHost == marketingHost else {
+            return false
+        }
+        // Same host — only suppress if the help link is the bare site root
+        // ("" or "/"). Any real support page on the same host (e.g.
+        // "/help/contact") is preserved.
+        let path = url.path
+        return path.isEmpty || path == "/"
     }
 
     /// Load authentication documents from the network or cache.

--- a/Palace/Settings/AccountDetailView.swift
+++ b/Palace/Settings/AccountDetailView.swift
@@ -524,12 +524,17 @@ struct AccountDetailView: View {
         })
     }
 
+    @ViewBuilder
     private var privacyPolicyView: some View {
         // BUG-005 hardening: anchor `.navigationBarTitle` outside the
         // `if let` to prevent SwiftUI from leaking the previous push's
         // title when the URL is unavailable. Same fix as the
         // contentLicenseView / reportIssueWebView destinations.
-        Group {
+        // `@ViewBuilder` is required so the if/else is wrapped in
+        // `_ConditionalContent` before `SwiftUI.Group` sees it — without
+        // it Xcode 26's type-checker can't pick `Group.init(content:)`
+        // and cascades to a CodingKey overload.
+        SwiftUI.Group {
             if let url = viewModel.selectedAccount?.details?.getLicenseURL(.privacyPolicy) {
                 UIViewControllerWrapper(
                     RemoteHTMLViewController(
@@ -546,6 +551,7 @@ struct AccountDetailView: View {
         .navigationBarTitle(Text(DisplayStrings.privacyPolicy))
     }
 
+    @ViewBuilder
     private var contentLicenseView: some View {
         // BUG-005: `.navigationBarTitle` must live *outside* the `if let`.
         // When the destination body is empty SwiftUI silently falls back to
@@ -553,7 +559,9 @@ struct AccountDetailView: View {
         // "Report an Issue" title here. Anchoring the title on the outer
         // view (and providing a non-empty unavailable-state body) prevents
         // both the title leak and the blank-screen symptoms.
-        Group {
+        // See `privacyPolicyView` for the SwiftUI.Group + @ViewBuilder
+        // typecheck-disambiguation rationale.
+        SwiftUI.Group {
             if let url = viewModel.selectedAccount?.details?.getLicenseURL(.contentLicenses) {
                 UIViewControllerWrapper(
                     RemoteHTMLViewController(
@@ -598,6 +606,7 @@ struct AccountDetailView: View {
         }
     }
 
+    @ViewBuilder
     private var reportIssueWebView: some View {
         // BUG-001 + BUG-005: anchor `.navigationBarTitle` outside the
         // optional binding so the title is committed even when the URL is
@@ -606,7 +615,9 @@ struct AccountDetailView: View {
         // `BundledHTMLViewController` (designed for bundled file:// URLs)
         // — `supportURL` is always a remote http URL fetched from the
         // library's auth document.
-        Group {
+        // See `privacyPolicyView` for the SwiftUI.Group + @ViewBuilder
+        // typecheck-disambiguation rationale.
+        SwiftUI.Group {
             if let url = viewModel.selectedAccount?.supportURL {
                 UIViewControllerWrapper(
                     RemoteHTMLViewController(

--- a/Palace/Settings/AccountDetailView.swift
+++ b/Palace/Settings/AccountDetailView.swift
@@ -524,34 +524,63 @@ struct AccountDetailView: View {
         })
     }
 
-    @ViewBuilder
     private var privacyPolicyView: some View {
-        if let url = viewModel.selectedAccount?.details?.getLicenseURL(.privacyPolicy) {
-            UIViewControllerWrapper(
-                RemoteHTMLViewController(
-                    URL: url,
-                    title: DisplayStrings.privacyPolicy,
-                    failureMessage: Strings.Error.pageLoadFailedError
-                ),
-                updater: { _ in }
-            )
-            .navigationBarTitle(Text(DisplayStrings.privacyPolicy))
+        // BUG-005 hardening: anchor `.navigationBarTitle` outside the
+        // `if let` to prevent SwiftUI from leaking the previous push's
+        // title when the URL is unavailable. Same fix as the
+        // contentLicenseView / reportIssueWebView destinations.
+        Group {
+            if let url = viewModel.selectedAccount?.details?.getLicenseURL(.privacyPolicy) {
+                UIViewControllerWrapper(
+                    RemoteHTMLViewController(
+                        URL: url,
+                        title: DisplayStrings.privacyPolicy,
+                        failureMessage: Strings.Error.pageLoadFailedError
+                    ),
+                    updater: { _ in }
+                )
+            } else {
+                unavailableInfoView
+            }
         }
+        .navigationBarTitle(Text(DisplayStrings.privacyPolicy))
     }
 
-    @ViewBuilder
     private var contentLicenseView: some View {
-        if let url = viewModel.selectedAccount?.details?.getLicenseURL(.contentLicenses) {
-            UIViewControllerWrapper(
-                RemoteHTMLViewController(
-                    URL: url,
-                    title: DisplayStrings.contentLicenses,
-                    failureMessage: Strings.Error.pageLoadFailedError
-                ),
-                updater: { _ in }
-            )
-            .navigationBarTitle(Text(DisplayStrings.contentLicenses))
+        // BUG-005: `.navigationBarTitle` must live *outside* the `if let`.
+        // When the destination body is empty SwiftUI silently falls back to
+        // the previous push's title, so a nil URL would render the
+        // "Report an Issue" title here. Anchoring the title on the outer
+        // view (and providing a non-empty unavailable-state body) prevents
+        // both the title leak and the blank-screen symptoms.
+        Group {
+            if let url = viewModel.selectedAccount?.details?.getLicenseURL(.contentLicenses) {
+                UIViewControllerWrapper(
+                    RemoteHTMLViewController(
+                        URL: url,
+                        title: DisplayStrings.contentLicenses,
+                        failureMessage: Strings.Error.pageLoadFailedError
+                    ),
+                    updater: { _ in }
+                )
+            } else {
+                unavailableInfoView
+            }
         }
+        .navigationBarTitle(Text(DisplayStrings.contentLicenses))
+    }
+
+    private var unavailableInfoView: some View {
+        VStack {
+            Spacer()
+            Text(Strings.Error.pageLoadFailedError)
+                .palaceFont(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Layout.horizontalPadding)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     @ViewBuilder
@@ -569,18 +598,29 @@ struct AccountDetailView: View {
         }
     }
 
-    @ViewBuilder
     private var reportIssueWebView: some View {
-        if let url = viewModel.selectedAccount?.supportURL {
-            UIViewControllerWrapper(
-                BundledHTMLViewController(
-                    fileURL: url,
-                    title: viewModel.selectedAccount?.name ?? ""
-                ),
-                updater: { _ in }
-            )
-            .navigationBarTitle(Text(DisplayStrings.reportIssue))
+        // BUG-001 + BUG-005: anchor `.navigationBarTitle` outside the
+        // optional binding so the title is committed even when the URL is
+        // unavailable. Use `RemoteHTMLViewController` (designed for http
+        // URLs with activity indicator + failure alert) rather than
+        // `BundledHTMLViewController` (designed for bundled file:// URLs)
+        // — `supportURL` is always a remote http URL fetched from the
+        // library's auth document.
+        Group {
+            if let url = viewModel.selectedAccount?.supportURL {
+                UIViewControllerWrapper(
+                    RemoteHTMLViewController(
+                        URL: url,
+                        title: DisplayStrings.reportIssue,
+                        failureMessage: Strings.Error.pageLoadFailedError
+                    ),
+                    updater: { _ in }
+                )
+            } else {
+                unavailableInfoView
+            }
         }
+        .navigationBarTitle(Text(DisplayStrings.reportIssue))
     }
 
     private var passwordResetCell: some View {

--- a/PalaceTests/Accounts/AccountModelTests.swift
+++ b/PalaceTests/Accounts/AccountModelTests.swift
@@ -90,6 +90,100 @@ final class AccountModelTests: XCTestCase {
         XCTAssertEqual(account.supportURL?.absoluteString, "https://support.example.com")
     }
 
+    // MARK: - BUG-001 regression: marketing-URL filter on `help` link
+    //
+    // Real-world repro (3.1.0 release validation, A1QA Test Library):
+    // the library's auth doc published `rel="help"` pointing at the public
+    // Palace marketing site (http://thepalaceproject.org/). The Account
+    // screen's "Report an Issue" row then pushed a webview titled
+    // "Report an Issue" but rendering the About-App marketing page
+    // ("Migrating from Boundless?…"). Users could not report issues.
+    //
+    // Fix: when a `help` href resolves to the same marketing host as
+    // TPPSettings.TPPAboutPalaceURLString, drop it on the floor — the row
+    // (and its destination) must not be exposed.
+
+    func testAccount_InitFromPublication_DropsHelpLink_WhenItPointsAtAboutAppMarketingURL() {
+        // Arrange: a library that misconfigures `help` as the Palace
+        // marketing URL (BUG-001 reproduction).
+        let helpLink = OPDS2Link(
+            href: "http://thepalaceproject.org/",
+            rel: "help"
+        )
+        let publication = makePublication(links: [helpLink])
+
+        // Act
+        let account = Account(publication: publication, imageCache: mockImageCache)
+
+        // Assert: support entry is suppressed in all surfaces — neither a
+        // URL push nor a mailto compose should be offered to the user.
+        XCTAssertNil(account.supportURL,
+                     "Help link equal to the Palace marketing URL must not become supportURL")
+        XCTAssertNil(account.supportEmail,
+                     "Marketing help link is not an email and must not become supportEmail")
+        XCTAssertFalse(account.hasSupportOption,
+                       "hasSupportOption must be false when the only `help` link is the marketing URL (BUG-001)")
+    }
+
+    func testAccount_InitFromPublication_DropsHelpLink_WhenItPointsAtAboutAppMarketingURL_HTTPSScheme() {
+        // Arrange: same case, but normalised over HTTPS — the filter must
+        // be scheme-insensitive (the constant in TPPSettings is http but
+        // the live host serves https).
+        let helpLink = OPDS2Link(
+            href: "https://thepalaceproject.org/",
+            rel: "help"
+        )
+        let publication = makePublication(links: [helpLink])
+
+        // Act
+        let account = Account(publication: publication, imageCache: mockImageCache)
+
+        // Assert
+        XCTAssertNil(account.supportURL,
+                     "HTTPS variant of the Palace marketing URL must also be suppressed")
+        XCTAssertFalse(account.hasSupportOption,
+                       "hasSupportOption must be false for the HTTPS marketing URL as well")
+    }
+
+    func testAccount_InitFromPublication_DropsHelpLink_TrailingSlashAndPathInsensitive() {
+        // Arrange: vendors sometimes drop the trailing slash or add an
+        // empty path — the filter must still match.
+        let helpLink = OPDS2Link(
+            href: "http://thepalaceproject.org",
+            rel: "help"
+        )
+        let publication = makePublication(links: [helpLink])
+
+        // Act
+        let account = Account(publication: publication, imageCache: mockImageCache)
+
+        // Assert
+        XCTAssertNil(account.supportURL,
+                     "Marketing URL without trailing slash must also be suppressed")
+        XCTAssertFalse(account.hasSupportOption)
+    }
+
+    func testAccount_InitFromPublication_KeepsHelpLink_WhenItPointsAtRealSupportPage() {
+        // Arrange: a library that publishes a genuine support URL —
+        // distinct host, not the marketing site.
+        let helpLink = OPDS2Link(
+            href: "https://thepalaceproject.org/help/contact",
+            rel: "help"
+        )
+        let publication = makePublication(links: [helpLink])
+
+        // Act
+        let account = Account(publication: publication, imageCache: mockImageCache)
+
+        // Assert: real support pages on the same host (with a path) must
+        // pass through — only the bare marketing root is suspect.
+        XCTAssertEqual(account.supportURL?.absoluteString,
+                       "https://thepalaceproject.org/help/contact",
+                       "A non-empty path on the marketing host is a real support page and must be preserved")
+        XCTAssertTrue(account.hasSupportOption,
+                      "hasSupportOption must be true when the help URL has real support content")
+    }
+
     func testAccount_InitFromPublication_SetsAuthDocUrl() {
         let authLink = OPDS2Link(
             href: "https://example.com/auth",


### PR DESCRIPTION
## Summary

3.1.0 release validation on the A1QA test library surfaced two correlated defects on the library Account screen. Both share a root cause and are fixed in this PR.

- **BUG-001 (Medium)** — Settings > Libraries > A1QA > **Report an Issue** pushed a webview titled \"Report an Issue\" but rendering the **About App marketing page** (\"Migrating from Boundless?…\", App Store / Google Play buttons). Users could not report issues from this entry point.
- **BUG-005 (High, two-layered)** — Settings > Libraries > A1QA > **Content Licenses** pushed a screen titled **\"Report an Issue\"** (wrong title leaked from the previous push) with a **completely blank body**.

### Shared root cause

Two defects compound on these two rows:

1. **A1QA's auth document publishes `rel=\"help\"` at `http://thepalaceproject.org/`** — the same URL Settings > About App uses. The iOS code accepted that as `supportURL` and served the marketing splash under a \"Report an Issue\" title.
2. **`.navigationBarTitle()` was applied *inside* the destination's `if let url = …` ViewBuilder** in `AccountDetailView.contentLicenseView` / `privacyPolicyView` / `reportIssueWebView`. When the URL resolved nil during navigation, the body was empty AND the title was never set, so SwiftUI silently fell back to the previously pushed screen's title — yielding both the title leak (BUG-005) and the blank body symptom together.

`reportIssueWebView` additionally used `BundledHTMLViewController` (designed for bundled `file://` URLs) when `supportURL` is always a remote http URL, departing from the pattern used by privacy / content-licenses.

### What changed

- **`Palace/Accounts/Library/Account.swift`** — new `Account.isAboutAppMarketingURL(_:)` static helper + filter in the publication init. Drops `help` links whose host matches `TPPSettings.TPPAboutPalaceURLString` *and* whose path is the bare site root (`\"\"` or `\"/\"`). Scheme-insensitive (http/https) and trailing-slash-insensitive. Real support pages on the same host with a non-empty path pass through. When the only `help` link is the marketing URL, `hasSupportOption` becomes false and the entire \"Report an Issue\" cell is suppressed.
- **`Palace/Settings/AccountDetailView.swift`** — anchor `.navigationBarTitle` *outside* the optional binding in `contentLicenseView`, `privacyPolicyView`, and `reportIssueWebView`. Each destination now always renders a non-empty body (the URL-backed webview or a new `unavailableInfoView` empty state) and always commits its title. Switch `reportIssueWebView` from `BundledHTMLViewController` → `RemoteHTMLViewController` (activity indicator + failure alert; matches privacy/content-licenses).
- **`PalaceTests/Accounts/AccountModelTests.swift`** — 4 new tests pinning the marketing-URL filter behavior: exact match, https variant, no-trailing-slash variant, and a kept-passthrough case where a real support page lives on the same host with a path.

### Reproduction (before this PR)

BUG-001:

1. Sign in to A1QA Test Library
2. Settings > Libraries > A1QA Test Library
3. Tap \"Report an Issue\"
4. **Observe:** Title \"Report an Issue\" + About App marketing page contents

BUG-005:

1. Sign in to A1QA Test Library
2. Settings > Libraries > A1QA Test Library
3. Tap \"Content Licenses\"
4. **Observe:** Title \"Report an Issue\" (wrong) + completely blank body

### Expected after-behavior

- **\"Report an Issue\"** — row only appears when the library publishes a genuine `mailto:` help link OR a non-marketing `help` URL. When it appears, tapping pushes a `RemoteHTMLViewController` with activity indicator + failure alert. For A1QA specifically, the row no longer appears at all (their only help link was the suppressed marketing URL).
- **\"Content Licenses\"** — title is always \"Content Licenses\", never leaks \"Report an Issue\" or any prior title. If the URL is somehow nil at navigation time, the body shows a localized \"page could not load\" message instead of going blank.

### Before-state screenshots

Captured by agent-3 during the 3.1.0 reproduction sweep. (PR descriptions can't inline images cleanly — paths follow.)

- BUG-001: `/Users/mauricework/.simdrive/sessions/mYKySDszWlk/observations/observe-1778606583456.png`
- BUG-005: `/Users/mauricework/.simdrive/sessions/mYKySDszWlk/observations/observe-1778607608229.png`
- Findings doc: `/Users/mauricework/.simdrive/sessions/mYKySDszWlk/bug-findings.md`

## Test plan

- [ ] CI: build passes against the iPhone 16 Pro simulator.
- [ ] CI: `AccountModelTests.testAccount_InitFromPublication_DropsHelpLink_WhenItPointsAtAboutAppMarketingURL` passes.
- [ ] CI: 3 sibling marketing-URL tests pass (https variant, no-trailing-slash, kept-passthrough).
- [ ] Manual on A1QA Test Library: Settings > Libraries > A1QA > confirm \"Report an Issue\" row no longer appears (A1QA's only help link was the marketing URL).
- [ ] Manual on A1QA Test Library: Tap \"Content Licenses\" — confirm title is \"Content Licenses\" and the license HTML loads. (URL is set in their auth doc.)
- [ ] Manual on a library whose `help` link is a real `mailto:` (e.g. NYPL): confirm \"Report an Issue\" still opens the mail composer.
- [ ] Manual on a library whose `help` link is a real distinct support URL: confirm \"Report an Issue\" still pushes that URL with the correct title.
- [ ] swiftlint: no new violations introduced (verified locally; pre-existing file-length warnings unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)