### PR TITLE
ci(mutation-gate): render useful PR comment on timeout + bump timeout 60→90 min

### DIFF
--- a/.github/workflows/mutation-gate.yml
+++ b/.github/workflows/mutation-gate.yml
@@ -26,7 +26,13 @@ concurrency:
 jobs:
   mutation-gate:
     runs-on: macos-26
-    timeout-minutes: 60
+    # 90 min budget vs the previous 60: per-mutant cost is ~7 min on cold
+    # runners (xcodebuild rebuild + test run), and 8 mutants × 7 min = 56 min
+    # left zero headroom for checkout + sim boot + summary. Account.swift
+    # exceeded the 60-min cap in PR #948 with no reports written — the gate
+    # appeared to fail but had simply timed out. 90 min gives ~25% headroom
+    # without re-tuning per-file mutant counts.
+    timeout-minutes: 90
     permissions:
       contents: read
       pull-requests: write
@@ -158,19 +164,102 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const reportsDir = 'mutation-results/automated/mutation/reports';
-            if (!fs.existsSync(reportsDir)) return;
+            const resultsTxt = 'mutation-results/automated/mutation/results.txt';
+            const changedFiles = (process.env.MUTATION_FILES || '').split(',').filter(Boolean);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-            const reports = fs.readdirSync(reportsDir)
-              .filter(f => f.endsWith('.json'))
-              .map(f => JSON.parse(fs.readFileSync(path.join(reportsDir, f), 'utf8')));
+            // Detect skip-reason from the wallclock guard message the
+            // orchestrator writes when it punts. If results.txt says
+            // "Mutation execution skipped", the rest of the pipeline
+            // never produced reports — surface that explicitly.
+            let skipReason = null;
+            if (fs.existsSync(resultsTxt)) {
+              try {
+                const txt = fs.readFileSync(resultsTxt, 'utf8');
+                const m = txt.match(/Mutation execution skipped:.*/);
+                if (m) skipReason = m[0].trim();
+              } catch (_) { /* fall through */ }
+            }
 
-            const lines = ['### Mutation gate — kill rates per critical-path file', '',
-              '| File | Killed / Run | Kill % | Verdict |', '|---|---|---|---|'];
-            for (const r of reports) {
-              const k = r.summary.killed, run = r.summary.killed + r.summary.survived;
-              const pct = run === 0 ? 0 : Math.round(k / run * 100);
-              const verdict = pct >= 75 ? '✅' : pct >= 50 ? '⚠️ borderline' : '❌ insufficient';
-              lines.push(`| ${r.file} | ${k} / ${run} | ${pct}% | ${verdict} |`);
+            // Empty / missing reports dir = orchestrator never wrote any
+            // JSON. Most common cause: job timeout (palace_mutate.py only
+            // flushes the report on completion, not incrementally).
+            const reportsExist = fs.existsSync(reportsDir);
+            const reportFiles = reportsExist
+              ? fs.readdirSync(reportsDir).filter(f => f.endsWith('.json'))
+              : [];
+
+            // Parse + filter to reports that have a usable summary block.
+            // A truncated/partial JSON write would also land here as a
+            // skip; surfacing that distinguishes "ran but timed out" from
+            // "ran and reported".
+            const reports = [];
+            const skipped = [];
+            for (const f of reportFiles) {
+              try {
+                const r = JSON.parse(fs.readFileSync(path.join(reportsDir, f), 'utf8'));
+                if (r && r.summary) reports.push(r);
+                else skipped.push(`${f}: missing summary block`);
+              } catch (e) {
+                skipped.push(`${f}: ${e.message}`);
+              }
+            }
+
+            const lines = ['### Mutation gate — kill rates per critical-path file', ''];
+
+            if (reports.length === 0) {
+              // No usable reports — explain WHY rather than posting an
+              // empty table. Three distinguishable cases:
+              //   1. results.txt says "skipped" → orchestrator guard fired
+              //   2. results.txt absent AND reports dir empty → timeout
+              //   3. reports dir has JSON but none parse → tooling bug
+              lines.push('> ⚠️ **No kill-rate data produced for this run.**', '');
+              if (skipReason) {
+                lines.push(`Orchestrator skipped execution: \`${skipReason}\``);
+                lines.push('');
+                lines.push('Pass `--yes-long-mutation` in the workflow if the estimate is intentional, or tighten `--mutation-max-per-file`.');
+              } else if (reportFiles.length === 0) {
+                lines.push('Mutation testing did not write any reports. Most likely cause: **job timed out** before `palace_mutate.py` flushed its JSON (reports are written on completion, not incrementally).');
+                lines.push('');
+                lines.push('To unblock this PR:');
+                lines.push('- Re-run the workflow on a less-loaded runner, or');
+                lines.push('- Run mutation locally on the changed file(s) and post results manually:');
+                lines.push('  ```bash');
+                for (const f of changedFiles) {
+                  lines.push(`  python3 scripts/palace_mutate.py --file ${f} --tests PalaceTests/<TestClass> --max-mutations 8`);
+                }
+                lines.push('  ```');
+              } else {
+                lines.push('Reports were produced but none parsed cleanly. Tooling bug — see workflow log.');
+                lines.push('');
+                lines.push('Parse errors:');
+                for (const s of skipped) lines.push(`- \`${s}\``);
+              }
+              lines.push('');
+              lines.push(`Workflow run: ${runUrl}`);
+            } else {
+              lines.push('| File | Killed / Run | Kill % | Verdict |', '|---|---|---|---|');
+              for (const r of reports) {
+                const k = r.summary.killed || 0;
+                const run = (r.summary.killed || 0) + (r.summary.survived || 0);
+                const pct = run === 0 ? 0 : Math.round(k / run * 100);
+                const verdict = pct >= 75 ? '✅' : pct >= 50 ? '⚠️ borderline' : '❌ insufficient';
+                lines.push(`| ${r.file} | ${k} / ${run} | ${pct}% | ${verdict} |`);
+              }
+              // If some files were expected but only some produced reports,
+              // call out the gap — that's the "partial completion" case.
+              const reportedFiles = new Set(reports.map(r => r.file));
+              const missing = changedFiles.filter(f => !reportedFiles.has(f));
+              if (missing.length > 0) {
+                lines.push('');
+                lines.push(`> ⚠️ **${missing.length} changed file(s) produced no report** (likely timed out mid-run):`);
+                for (const f of missing) lines.push(`> - \`${f}\``);
+              }
+              if (skipped.length > 0) {
+                lines.push('');
+                lines.push('Skipped (parse errors):');
+                for (const s of skipped) lines.push(`- \`${s}\``);
+              }
             }
 
             await github.rest.issues.createComment({
@@ -179,3 +268,5 @@ jobs:
               repo: context.repo.repo,
               body: lines.join('\n')
             });
+        env:
+          MUTATION_FILES: ${{ steps.changed.outputs.files }}


### PR DESCRIPTION
## Summary

#948's mutation-gate hit the 60-min job timeout while mutation-testing `Palace/Accounts/Library/Account.swift` and ended up posting an empty kill-rate table back to the PR ([visible here](https://github.com/ThePalaceProject/ios-core/pull/948#issuecomment-)). The data wasn't actually missing — `palace_mutate.py` only writes its JSON report on completion (not incrementally), so when the job is cancelled mid-run no report file exists, the comment-posting step reads zero entries, and the PR shows a header with no rows. From the author's POV: "build failed but no data."

Two changes here:

## 1. Comment-posting step now distinguishes three cases

| Case | What the comment now says |
|---|---|
| **Orchestrator skipped** (wallclock guard fired before any execution) | Surfaces the skip reason from `results.txt` verbatim; points at `--yes-long-mutation` / `--mutation-max-per-file` |
| **No reports at all** (most common = timeout) | Explains reports are written on completion only, lists changed files, prints a copy-pasteable local-run command per file, links the workflow run |
| **Some reports but some files missing** (partial completion) | Renders the table for files that did produce data AND calls out the missing files in a sub-note |

Also tolerates parse errors per-file (skips bad JSON and lists it separately rather than crashing the whole comment).

## 2. Timeout bumped 60 → 90 min

Per-mutant cost is ~7 min on cold GH macOS runners (xcodebuild incremental rebuild + targeted test class). 8 mutants × 7 min ≈ 56 min — zero headroom over 60. Account.swift was repeatable proof that the budget was too tight. 90 min gives ~25% margin without having to re-tune `--mutation-max-per-file` per file.

Cost is marginal — the gate still cancels in-progress runs when a new push lands (`concurrency.cancel-in-progress: true`), so the higher ceiling only matters when a run actually goes long.

## Risk

- Workflow-only change. No production code touched.
- YAML validated with `python3 -c 'yaml.safe_load(...)'`.
- The github-script comment logic is defensive: every code path either renders a table OR renders an explanation OR posts a tooling-bug note; there's no path that crashes the script.

## Test plan

- [x] YAML validates
- [x] Diff scope: workflow file only, 105+/14-
- [ ] Land a critical-path PR (this one doesn't touch critical paths so it won't self-exercise) and confirm the new comment shape

## Not done

Incremental report flush in `palace_mutate.py` would fully solve the data-loss-on-timeout problem rather than just explaining it. Worth a follow-up if 90 min still proves tight on a given file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)