### PR TITLE
Forward-port 3.0.2 hotfix to develop — PP-4326 + PP-4329 + F-016

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		292DACBF794B4FA5B1A9DAEB /* UIApplication+MainScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D50821D42294719B5E6F62C /* UIApplication+MainScene.swift */; };
 		29464A0CE4E2E995CCFF6DEB /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3592F6473F87F4D7C96FB483 /* NotificationServiceTests.swift */; };
 		2A34C74881B37E0DE564B774 /* PalaceCatalog in Frameworks */ = {isa = PBXBuildFile; productRef = 7AA8A6B3C2C375EC4328722F /* PalaceCatalog */; };
+		29D8F99A3730BCAD7334FB9D /* BookListViewAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3E4B69D4B62EDE3F7B9288 /* BookListViewAccessibilityTests.swift */; };
 		2A71783008E7BB879EFB5029 /* NSURL+NYPLURLAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F901D7BCF798BFF0E528D6D /* NSURL+NYPLURLAdditions.swift */; };
 		2B7EC298A55FA3351E113B6B /* PerformanceReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D80DA377151AE41BEF67F7 /* PerformanceReport.swift */; };
 		2B820846966DE6DDDBD29DCB /* AccessibilitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E518F27E3FF9A05071B82305 /* AccessibilitySettingsView.swift */; };
@@ -2294,6 +2295,7 @@
 		AC1B8AF7EB40C9DE22ED5ED0 /* TypographyServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographyServiceProtocol.swift; sourceTree = "<group>"; };
 		ACE8017D2ECF7E0FEBFAAB1A /* OPDSFeedCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OPDSFeedCache.swift; path = OPDS2/Cache/OPDSFeedCache.swift; sourceTree = "<group>"; };
 		AD3401E6313A459D9496ECF2 /* TPPAlertUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAlertUtilsTests.swift; sourceTree = "<group>"; };
+		AD3E4B69D4B62EDE3F7B9288 /* BookListViewAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookListViewAccessibilityTests.swift; sourceTree = "<group>"; };
 		AD8E3191A2EB8DC922B993FD /* AppHealthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHealthViewModel.swift; sourceTree = "<group>"; };
 		ADDA3478B2DF503D6CBD4575 /* TPPBookDetailDownloadFailedView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookDetailDownloadFailedView.swift; sourceTree = "<group>"; };
 		AE5F6A7B8C9D0E1F2A3B4C5D /* DownloadThrottlingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadThrottlingService.swift; sourceTree = "<group>"; };
@@ -5478,6 +5480,7 @@
 				FE2159403F0FCBE90CFC6858 /* BookImageViewAccessibilityTests.swift */,
 				44B9D77A2797816A93F9D35B /* PDFAccessibilityToolbarTests.swift */,
 				5A8468ADD34076BF5935E56B /* TPPBookAccessibilityLabelTests.swift */,
+				AD3E4B69D4B62EDE3F7B9288 /* BookListViewAccessibilityTests.swift */,
 			);
 			path = Accessibility;
 			sourceTree = "<group>";
@@ -6403,6 +6406,7 @@
 				85CA12FDD8CAF6227F7040FD /* FindawayChapterStatusGuardTests.swift in Sources */,
 				F2B9AED795FF681027B7C67C /* AuthErrorProblemDocSeamTests.swift in Sources */,
 				54A659E3268D9EB2F8A0C8A5 /* SignInModalPredicateTests.swift in Sources */,
+				29D8F99A3730BCAD7334FB9D /* BookListViewAccessibilityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -122,8 +122,40 @@ struct CatalogCacheMetadata: Codable {
             object: nil
         )
 
+        // Synchronously pre-populate accountSets from the on-disk cache before
+        // returning. Without this, AppContainer.production() returns while
+        // loadCatalogs() is still running on a background queue, so any UI
+        // mounted in that window — including Settings -> Libraries and the
+        // sign-in modal — calls account(uuid) against an empty dict and renders
+        // an empty list. The async refresh below still runs to pick up any
+        // server-side registry changes.
+        preloadAccountsFromDiskCacheSync()
+
         DispatchQueue.global(qos: .background).async { [weak self] in
             self?.loadCatalogs(completion: nil)
+        }
+    }
+
+    /// Hydrate `accountSets[accountSet]` from the on-disk OPDS2 catalog cache
+    /// without dispatching to a background queue. Safe to call from `init()`
+    /// because the cache read is local I/O measured in single-digit ms.
+    private func preloadAccountsFromDiskCacheSync() {
+        let hash = self.accountSet
+        guard hasCachedCatalogData(hash: hash),
+              let cachedData = readCachedAccountsCatalogData(hash: hash) else {
+            return
+        }
+        do {
+            let feed = try OPDS2CatalogsFeed.fromData(cachedData)
+            let accounts = feed.catalogs.map {
+                Account(publication: $0, imageCache: ImageCache.shared)
+            }
+            performWrite { self.accountSets[hash] = accounts }
+            Log.info(#file, "Pre-loaded \(accounts.count) accounts from disk cache (sync, hash=\(hash))")
+        } catch {
+            // Best-effort. If the cached blob is corrupt or schema-shifted,
+            // we silently fall through to the async network refresh.
+            Log.warn(#file, "Sync disk-cache pre-load failed: \(error). Will refresh from network async.")
         }
     }
 

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -16,6 +16,20 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     let audiobookLifecycleManager = AudiobookLifecycleManager()
     var isSigningIn = false
 
+    // PP-4329: state for the first-run library picker. Without these,
+    // presentFirstRunFlowIfNeeded leaked a new .TPPCatalogDidLoad observer
+    // on every recursive call (AccountsManager posts that notification
+    // from 8 sites — main catalog load, fallback GET, beta/prod hash
+    // switch, etc.). Each observer re-invoked presentFirstRunFlowIfNeeded,
+    // which presented another TPPAccountList modal, stacking 2-4 selectors
+    // on a fresh install depending on how many posts fired before the
+    // user picked. The token lets us remove the previous observer before
+    // adding a new one (and after we've successfully gone past the
+    // deferred-load state); the flag prevents re-presentation once a
+    // selector is already on screen.
+    private var firstRunFlowObserver: NSObjectProtocol?
+    private var hasPresentedFirstRunFlow = false
+
     // MARK: - Application Lifecycle
 
     func applicationDidFinishLaunching(_ application: UIApplication) {
@@ -24,6 +38,14 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
         Log.crashlyticsBridge = FirebaseCrashlyticsBridge()
 
         let startupQueue = DispatchQueue.global(qos: .userInitiated)
+
+        // Build identifier marker — logged on every app launch so a sysdiagnose
+        // unambiguously identifies which 3.0.2 build is running.
+        let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let buildNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        let iosVersion = UIDevice.current.systemVersion
+        let deviceModel = UIDevice.current.model
+        Log.info(#file, "[BUILD MARKER] release/3.0.2 — App=\(appVersion) (\(buildNumber)), iOS=\(iosVersion), device=\(deviceModel)")
 
         // CRITICAL: Initialize playback infrastructure FIRST for CarPlay cold starts
         // This ensures MPRemoteCommandCenter handlers are registered before any UI loads
@@ -431,14 +453,40 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: - First Run Flow
 extension TPPAppDelegate {
     private func presentFirstRunFlowIfNeeded() {
+        // PP-4329: idempotency — once we've presented the picker this
+        // launch, any further .TPPCatalogDidLoad posts (the main catalog
+        // load triggers up to 8 of them in worst-case fallback paths)
+        // must NOT re-present. Without this guard, a fresh install on
+        // iOS 26.4.2 stacked 4 TPPAccountList modals.
+        guard !hasPresentedFirstRunFlow else { return }
+
         let accountsManager = AppContainer.production().accountsManager
         // Defer until accounts have loaded to avoid false negatives on currentAccount
         if !accountsManager.accountsHaveLoaded {
-            NotificationCenter.default.addObserver(forName: .TPPCatalogDidLoad, object: nil, queue: .main) { [weak self] _ in
+            // PP-4329: remove the previous deferred observer (if any)
+            // before adding a new one — otherwise observers accumulate
+            // every time this method re-enters itself.
+            if let token = firstRunFlowObserver {
+                NotificationCenter.default.removeObserver(token)
+                firstRunFlowObserver = nil
+            }
+            firstRunFlowObserver = NotificationCenter.default.addObserver(
+                forName: .TPPCatalogDidLoad,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
                 self?.presentFirstRunFlowIfNeeded()
             }
             accountsManager.loadCatalogs(completion: nil)
             return
+        }
+
+        // We're past the deferred-load state; remove the observer so the
+        // remaining 7 possible .TPPCatalogDidLoad posts from the same
+        // load cycle don't re-fire this method.
+        if let token = firstRunFlowObserver {
+            NotificationCenter.default.removeObserver(token)
+            firstRunFlowObserver = nil
         }
 
         // Use persisted currentAccountId rather than computed currentAccount to avoid timing issues
@@ -448,7 +496,7 @@ extension TPPAppDelegate {
         guard let top = topViewController() else { return }
 
         var nav: UINavigationController!
-        let accountList = TPPAccountList { account in
+        let accountList = TPPAccountList { [weak self] account in
             let settings = AppContainer.production().settings
             if !settings.settingsAccountIdsList.contains(account.uuid) {
                 settings.settingsAccountIdsList.append(account.uuid)
@@ -464,9 +512,16 @@ extension TPPAppDelegate {
 
             NotificationCenter.default.post(name: .TPPCurrentAccountDidChange, object: nil)
             nav?.dismiss(animated: true)
+            // Allow a future cold launch with no account to present again,
+            // but on the current launch we're done.
+            self?.hasPresentedFirstRunFlow = true
         }
         accountList.requiresSelectionBeforeDismiss = true
         nav = UINavigationController(rootViewController: accountList)
+        // Mark presented BEFORE the present call so any synchronous
+        // re-entry from a notification fired during the present sees
+        // the guard.
+        hasPresentedFirstRunFlow = true
         top.present(nav, animated: true)
     }
 

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -45,7 +45,7 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
         let buildNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
         let iosVersion = UIDevice.current.systemVersion
         let deviceModel = UIDevice.current.model
-        Log.info(#file, "[BUILD MARKER] release/3.0.2 — App=\(appVersion) (\(buildNumber)), iOS=\(iosVersion), device=\(deviceModel)")
+        Log.info(#file, "[BUILD MARKER] App=\(appVersion) (\(buildNumber)), iOS=\(iosVersion), device=\(deviceModel)")
 
         // CRITICAL: Initialize playback infrastructure FIRST for CarPlay cold starts
         // This ensures MPRemoteCommandCenter handlers are registered before any UI loads

--- a/Palace/MyBooks/MyBooks/BookListView.swift
+++ b/Palace/MyBooks/MyBooks/BookListView.swift
@@ -22,22 +22,41 @@ struct BookListView: View {
     var body: some View {
         LazyVGrid(columns: gridLayout, spacing: 0) {
             ForEach(books, id: \.identifier) { book in
-                Button(action: { onSelect(book) }, label: {
-                    // Use cached model instead of creating new one each render
-                    BookCell(model: modelCache.model(for: book), previewEnabled: previewEnabled)
-                })
-                .buttonStyle(.plain)
-                .applyBorderStyle()
-                // PP-3968: collapse the cell into a single VoiceOver element
-                // with the canonical "Title, by Author" label and drop the
-                // "button" trait so it sounds like a list item — matches the
-                // Audible/Libby UX. The cell is still tappable.
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel(book.voiceOverLabel)
-                .accessibilityRemoveTraits(.isButton)
-                .onAppear {
-                    handleCellAppear(book: book)
-                }
+                // PP-4326: No outer Button — when the row IS a Button
+                // and the cell content contains inner Buttons, VoiceOver's
+                // double-tap routes through SwiftUI hit-test to the first
+                // inner action button (Borrow/Read/Listen/Return) rather
+                // than firing the outer Button's action. .accessibilityAction
+                // doesn't reliably override the Button's own activation in
+                // that nested-button case. Using a plain .onTapGesture for
+                // visual taps + an explicit .accessibilityAction for
+                // VoiceOver eliminates the precedence conflict entirely.
+                let cellModel = modelCache.model(for: book)
+                BookCell(model: cellModel, previewEnabled: previewEnabled)
+                    .applyBorderStyle()
+                    .contentShape(Rectangle())
+                    .onTapGesture { onSelect(book) }
+                    // Single VoiceOver element per row using the canonical
+                    // "Title, by Author" label (PP-3968). Inner action
+                    // buttons stay accessible through the rotor (below).
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel(book.voiceOverLabel)
+                    .accessibilityHint(Strings.Accessibility.opensBookDetails)
+                    // Default action — VoiceOver's double-tap calls this
+                    // directly. Decoupled from SwiftUI hit-testing.
+                    .accessibilityAction { onSelect(book) }
+                    // Expose the in-row action buttons (Borrow/Read/Listen/
+                    // Return) as VoiceOver rotor custom actions so screen-
+                    // reader users can perform them without losing focus
+                    // on the row — Apple-canonical pattern (Mail, Reminders,
+                    // Messages).
+                    .accessibilityActions {
+                        BookRowAccessibilityActions(model: cellModel, previewEnabled: previewEnabled)
+                    }
+                    .onAppear {
+                        handleCellAppear(book: book)
+                    }
             }
 
             if isLoadingMore {
@@ -126,6 +145,32 @@ struct BookListView: View {
 extension View {
     func applyBorderStyle() -> some View {
         modifier(BorderStyleModifier())
+    }
+}
+
+// MARK: - PP-4326: VoiceOver rotor actions for a book row
+
+/// Renders one Button per available BookButtonType (Borrow, Read, Listen,
+/// Return, etc.). Used inside `.accessibilityActions { ... }` so VoiceOver
+/// users can perform any in-row action via the rotor "Actions" menu
+/// without leaving focus on the row. Mirrors the Apple-canonical pattern
+/// used by Mail, Reminders, and Messages for list rows with auxiliary
+/// actions.
+struct BookRowAccessibilityActions: View {
+    @ObservedObject var model: BookCellModel
+    var previewEnabled: Bool = true
+
+    private var availableButtonTypes: [BookButtonType] {
+        guard !previewEnabled else { return model.buttonTypes }
+        return model.buttonTypes.filter { $0 != .sample && $0 != .audiobookSample }
+    }
+
+    var body: some View {
+        ForEach(availableButtonTypes, id: \.self) { type in
+            Button(type.title(for: model.book)) {
+                model.handleAction(for: type)
+            }
+        }
     }
 }
 

--- a/Palace/Settings/TPPSettingsAccountsList.swift
+++ b/Palace/Settings/TPPSettingsAccountsList.swift
@@ -71,18 +71,20 @@ import SwiftUI
         }
         view.addSubview(reloadView)
 
-        // cleanup accounts, remove demo account or accounts not supported through accounts.json // will be refactored when implementing librsry registry
-        var accountsToRemove = [String]()
-
-        for account in accounts {
-            if manager.account(account.uuid) == nil {
-                accountsToRemove.append(account.uuid)
-            }
-        }
-
-        for remove in accountsToRemove {
-            accounts = accounts.filter { $0.uuid == remove }
-        }
+        // Drop persisted UUIDs that no longer resolve in the registry — libraries
+        // the user previously added that have since been renamed, removed, or whose
+        // server-assigned UUID changed. Pre-fix this used a two-pass loop whose
+        // inner filter was inverted (`$0.uuid == remove` instead of `!=`), which
+        // clobbered the entire accounts list down to the last to-remove uuid
+        // whenever ANY persisted account failed to resolve. That bug existed since
+        // 2026-02-12 but was masked by the broader launch race fixed in
+        // AccountsManager.preloadAccountsFromDiskCacheSync(): when the registry
+        // hadn't loaded yet, every account failed to resolve and the inverted
+        // filter happened to fall through (empty accountsToRemove → no filter
+        // applied). With the registry now populated synchronously, this loop
+        // started firing and dropping the user's added libraries. Replaced with
+        // a single forward-pass filter that does what the original comment said.
+        accounts = accounts.filter { manager.account($0.uuid) != nil }
 
         self.userAddedSecondaryAccounts = accounts.filter { $0.uuid != manager.currentAccount?.uuid }
 

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -15,6 +15,12 @@ struct Strings {
         static let navigationTitle = "navigationTitle"
         static let librarySwitchButton = "librarySwitchButton"
         static let viewBookmarksAndTocButton = "viewBookmarksAndTocButton"
+        // PP-4326: VoiceOver hint announced after the book row's canonical
+        // "Title, by Author" label so users hear what activating the row does.
+        static let opensBookDetails = NSLocalizedString(
+            "Opens book details",
+            comment: "VoiceOver hint for the tap target on a book row in search results, More…, My Books, and Holds — announced after 'Title, by Author' to explain that activating the row opens the Book Details screen."
+        )
     }
 
     struct AgeCheck {

--- a/PalaceTests/Accessibility/BookListViewAccessibilityTests.swift
+++ b/PalaceTests/Accessibility/BookListViewAccessibilityTests.swift
@@ -1,0 +1,147 @@
+//
+//  BookListViewAccessibilityTests.swift
+//  PalaceTests
+//
+//  PP-4326 (3.0.2 hotfix). Regression tests for the VoiceOver activation
+//  contract on the shared BookListView row used by search, More…, MyBooks,
+//  and Holds. The bug: PP-3968's collapse-to-single-element +
+//  .accessibilityRemoveTraits(.isButton) on the outer Button stripped the
+//  activation contract, so VoiceOver's synthesized double-tap routed
+//  through SwiftUI hit-test to the first inner action button (Borrow/Read)
+//  instead of calling onSelect to open the detail view.
+//
+//  The fix keeps the outer Button (so visual taps still work and the row
+//  is announced as a button), restores the .isButton trait by NOT removing
+//  it, and exposes the in-row action buttons (Borrow/Read/Listen/Return)
+//  as VoiceOver rotor custom actions — the Apple-canonical pattern used by
+//  Mail, Reminders, and Messages for list rows with auxiliary actions.
+//
+//  SwiftUI's accessibility tree is not materialized in unit tests without
+//  VoiceOver running, so these tests are source-level sentinels (same
+//  pattern as the existing PP-3980 test in
+//  CatalogLaneRowViewAccessibilityTests) plus mocker-backed behavior
+//  checks of the canonical voiceOverLabel that the fix relies on.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class BookListViewAccessibilityTests: XCTestCase {
+
+    // MARK: - Source-level sentinels (BookListView)
+
+    /// The row wrapper must NOT remove the .isButton trait — that was the
+    /// regression introduced by PP-3968 and reported as PP-4326. Removing
+    /// the trait left VoiceOver's synthesized double-tap to route through
+    /// SwiftUI's hit-test, which lands on the first inner action button
+    /// instead of firing the row's onSelect closure.
+    func testBookListView_doesNotRemoveButtonTrait() throws {
+        let source = try Self.source(for: "Palace/MyBooks/MyBooks/BookListView.swift")
+        XCTAssertFalse(
+            source.contains(".accessibilityRemoveTraits(.isButton)"),
+            "BookListView must not strip the .isButton trait from the row — that breaks VoiceOver activation and routes the synthesized tap to the first inner action button (PP-4326)."
+        )
+    }
+
+    /// The row must use the canonical voiceOverLabel from
+    /// TPPBook+Accessibility (PP-3968) — VoiceOver should hear
+    /// "Title, by Author" rather than the raw concatenation of the cell's
+    /// inner Text views.
+    func testBookListView_usesCanonicalVoiceOverLabel() throws {
+        let source = try Self.source(for: "Palace/MyBooks/MyBooks/BookListView.swift")
+        XCTAssertTrue(
+            source.contains("voiceOverLabel"),
+            "BookListView must apply TPPBook.voiceOverLabel as the row's accessibilityLabel so VoiceOver announces the canonical 'Title, by Author' (PP-3968 + PP-4326)."
+        )
+    }
+
+    /// The row must announce its activation effect via an
+    /// .accessibilityHint so VoiceOver users hear what double-tap does
+    /// after the title is read.
+    func testBookListView_announcesOpenDetailsHint() throws {
+        let source = try Self.source(for: "Palace/MyBooks/MyBooks/BookListView.swift")
+        XCTAssertTrue(
+            source.contains("opensBookDetails") || source.contains("Opens book details"),
+            "BookListView must apply an .accessibilityHint that describes the row's default action — 'Opens book details' — so VoiceOver users know what activation does (PP-4326)."
+        )
+    }
+
+    /// The row must expose its in-row action buttons (Borrow/Read/Listen/
+    /// Return, etc.) as VoiceOver rotor actions via .accessibilityActions
+    /// so screen-reader users can perform them without leaving the row in
+    /// linear navigation. This is the Apple-canonical pattern for list
+    /// rows with auxiliary actions.
+    func testBookListView_exposesRotorActionsForInRowButtons() throws {
+        let source = try Self.source(for: "Palace/MyBooks/MyBooks/BookListView.swift")
+        XCTAssertTrue(
+            source.contains(".accessibilityActions"),
+            "BookListView must apply .accessibilityActions to expose in-row Borrow/Read/Listen/Return actions as VoiceOver rotor custom actions (PP-4326)."
+        )
+    }
+
+    /// The rotor actions block must drive the actions via the cell's
+    /// model (handleAction(for:)) so each action type fires the correct
+    /// behavior — the same path as a touch on the visible button.
+    func testBookListView_rotorActionsRouteThroughModel() throws {
+        let source = try Self.source(for: "Palace/MyBooks/MyBooks/BookListView.swift")
+        XCTAssertTrue(
+            source.contains("BookRowAccessibilityActions"),
+            "BookListView must use BookRowAccessibilityActions inside .accessibilityActions to ensure each rotor action calls model.handleAction(for:) — the same code path as a touch on the visible button (PP-4326)."
+        )
+    }
+
+    /// BookRowAccessibilityActions must be defined and must iterate over
+    /// the model's available button types so rotor actions stay in sync
+    /// with the visible in-row buttons (the actions list is driven by
+    /// download/loan state, not a hardcoded list).
+    func testBookRowAccessibilityActions_iteratesModelButtonTypes() throws {
+        let source = try Self.source(for: "Palace/MyBooks/MyBooks/BookListView.swift")
+        XCTAssertTrue(
+            source.contains("struct BookRowAccessibilityActions"),
+            "BookListView.swift must define BookRowAccessibilityActions so rotor actions are co-located with the row that uses them (PP-4326)."
+        )
+        XCTAssertTrue(
+            source.contains("model.buttonTypes"),
+            "BookRowAccessibilityActions must iterate over model.buttonTypes so VoiceOver rotor actions match the visible button list per book state (PP-4326)."
+        )
+        XCTAssertTrue(
+            source.contains("handleAction(for:"),
+            "BookRowAccessibilityActions must call model.handleAction(for:) so the rotor action follows the same code path as a touch on the visible button (PP-4326)."
+        )
+    }
+
+    // MARK: - voiceOverLabel canonical-format behavior checks
+
+    /// Sanity check that voiceOverLabel still produces the expected
+    /// "Title, by Author" form that the row announces. If this regresses,
+    /// PP-3968's canonical label is broken regardless of the PP-4326
+    /// wiring.
+    func testVoiceOverLabel_ebook_titleByAuthor() {
+        let book = TPPBookMocker.mockBook(title: "Frankenstein", authors: "Mary Shelley")
+        XCTAssertEqual(book.voiceOverLabel, "Frankenstein, by Mary Shelley")
+    }
+
+    /// Audiobook label must include the "audiobook" designation so
+    /// VoiceOver users distinguish audiobook rows from ebook rows by ear.
+    func testVoiceOverLabel_audiobook_includesAudiobookDesignation() {
+        let audiobook = TPPBookMocker.snapshotAudiobook()
+        XCTAssertTrue(audiobook.isAudiobook, "Test prerequisite: must be an audiobook")
+        XCTAssertTrue(
+            audiobook.voiceOverLabel.lowercased().contains(Strings.Generic.audiobook.lowercased()),
+            "voiceOverLabel must include the 'audiobook' designation for audiobook rows (PP-3968)."
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func source(for repoRelativePath: String) throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()        // Accessibility
+            .deletingLastPathComponent()        // PalaceTests
+            .deletingLastPathComponent()        // repo root
+            .appendingPathComponent(repoRelativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary

Forward-port of the slim 3.0.2 hotfix (PR #953) to develop so the next release off develop doesn't lose the fix. Standard git-flow: hotfix branches land on both main (release path) and develop (integration path).

## What's in this PR

| Commit | Fix | Files |
|---|---|---|
| `483a17d30` | **F-016** — close `AccountsManager.init()` launch race + filter cleanup in `TPPSettingsAccountsList` (no-op on fresh install; latent benefit on upgrade-from-3.0.x and matches develop's existing F-016 expectation in `release/3.1.0`) | `AccountsManager.swift`, `TPPSettingsAccountsList.swift` |
| `82bd0eac9` | **PP-4326 VoiceOver activation fix** — drop the outer `Button` wrapper, register `.accessibilityAction` for VoiceOver double-tap (decoupled from SwiftUI hit-testing), expose Borrow/Read/Listen/Return via `.accessibilityActions` rotor menu (Apple-canonical Mail/Reminders/Messages pattern). 8 new source-level sentinel tests. | `BookListView.swift`, `Strings.swift`, new `BookListViewAccessibilityTests.swift`, pbxproj wiring |
| `0bbbf2b4a` | **PP-4329 observer-leak fix** — capture the `.TPPCatalogDidLoad` observer token + add a `hasPresentedFirstRunFlow` idempotency guard so `presentFirstRunFlowIfNeeded` doesn't stack 2-4 library-selector modals on a brand-new install. Adapted to develop's `AppContainer.production().accountsManager` pattern (where the fat hotfix used `AccountsManager.shared`). | `TPPAppDelegate.swift` |
| `b7339b2a8` | Drop the `release/3.0.2` prefix from the build-marker log line — develop's next release isn't 3.0.2 and the per-launch log already includes the actual `CFBundleShortVersionString` | `TPPAppDelegate.swift` |

## How this differs from PR #953 (the main-bound 3.0.2 hotfix)

- **No version bump**: develop has its own versioning cadence — left as-is.
- **`AppContainer.production()` adaptation in `presentFirstRunFlowIfNeeded`**: develop has migrated off the `AccountsManager.shared` literal call site to the container-injected pattern. The PP-4329 cherry-pick conflicted on this and the resolution preserves develop's pattern while adding the observer-cleanup + idempotency-guard logic.
- **Build marker generalized**: dropped the hardcoded "release/3.0.2" prefix.

## Validation

- **Source-level sentinels**: all 8 `BookListViewAccessibilityTests` pass on this branch (build-for-testing + test-without-building on iPhone 16 Pro sim).
- **Build**: green for iPhone 16 Pro sim with isolated `derivedData`.
- **Physical-device validation** of the underlying fixes was already done by Maurice on the slim 3.0.2 build (PR #953) — same code shipping here.

## Test plan

- [ ] Reviewer: smoke test that develop's catalog still renders correctly (no regression from the BookListView changes).
- [ ] Reviewer: fresh install behavior — exactly one library selector.
- [ ] Reviewer: VoiceOver-on book row activation opens detail.
- [ ] CI: `verify-pr.sh` + full test suite run clean against develop.

## Not in this PR

Deferred to a separate larger forward-port (tracked):
- Cornell SAML cookie-injection bandage (HelpSpot 17716) — needs re-application to the SPM-extracted `PalaceAuth/TPPSAMLHelper.swift` location.
- TPPBookRegistry sync-chain fix (3.0.1 deferred).
- MyBooks/Holds reload-on-signin + observer guards (3.0.1 deferred).
- SAMLReauthCoordinator (3.0.1 deferred).
- Reset Account feature (already on `release/3.1.0` per earlier audit; develop is its origin so already present here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)