### PR TITLE
hotfix(3.0.3): Marketplace audiobook open — pathExtension + LCP fallback (a11y-launch line)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -7397,7 +7397,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 475;
+				CURRENT_PROJECT_VERSION = 476;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7418,7 +7418,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.2;
+				MARKETING_VERSION = 3.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7454,7 +7454,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 475;
+				CURRENT_PROJECT_VERSION = 476;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7475,7 +7475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.2;
+				MARKETING_VERSION = 3.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7640,7 +7640,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 475;
+				CURRENT_PROJECT_VERSION = 476;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -7666,7 +7666,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.2;
+				MARKETING_VERSION = 3.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -7700,7 +7700,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 475;
+				CURRENT_PROJECT_VERSION = 476;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7727,7 +7727,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.2;
+				MARKETING_VERSION = 3.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "App Store";

--- a/Palace/Audiobooks/AudiobookLoader.swift
+++ b/Palace/Audiobooks/AudiobookLoader.swift
@@ -90,6 +90,50 @@ final class AudiobookLoader {
         isCancelled = true
     }
 
+    /// Recursive flatten of a `TPPOPDSIndirectAcquisition` chain into a flat
+    /// list of MIME types, for diagnostic logging only.
+    fileprivate static func flattenIndirectTypes(_ indirect: [TPPOPDSIndirectAcquisition]) -> [String] {
+        indirect.flatMap { entry in [entry.type] + flattenIndirectTypes(entry.indirectAcquisitions) }
+    }
+
+    #if LCP
+    /// Returns a URL whose `pathExtension` is `lcpa`, regardless of the input
+    /// extension. If the input already has `.lcpa` extension, returns it
+    /// unchanged. Otherwise creates a sibling symlink with `.lcpa` extension
+    /// pointing at the original file and returns the symlink URL. Failures
+    /// (symlink-already-exists, permission errors, unsupported filesystem)
+    /// fall back to returning the original URL — the caller's LCP-load
+    /// attempt will surface the resulting error via its own path.
+    ///
+    /// Why a symlink and not a rename: existing call sites (registry sync,
+    /// download book-state, etc.) look up the file at the original path via
+    /// `MyBooksDownloadCenter.fileUrl(for:)`. Renaming would break those
+    /// lookups for legacy `.epub`-named LCP content. A sibling symlink
+    /// leaves the canonical file in place and gives ReadiumStreamer the
+    /// `.lcpa`-extension URL it needs for its extension-based parser
+    /// dispatch.
+    fileprivate static func ensureLCPExtensionLink(for url: URL) -> URL {
+        if url.pathExtension.lowercased() == "lcpa" {
+            return url
+        }
+        let lcpaURL = url.deletingPathExtension().appendingPathExtension("lcpa")
+        let fm = FileManager.default
+
+        if fm.fileExists(atPath: lcpaURL.path) {
+            return lcpaURL
+        }
+
+        do {
+            try fm.createSymbolicLink(at: lcpaURL, withDestinationURL: url)
+            Log.info(#file, "  🔗 Created .lcpa symlink → \(url.lastPathComponent)")
+            return lcpaURL
+        } catch {
+            Log.warn(#file, "  ⚠️ Could not create .lcpa symlink (\(error.localizedDescription)) — falling back to original URL")
+            return url
+        }
+    }
+    #endif
+
     // MARK: - Token refresh
 
     private func refreshTokenIfNeeded(for book: TPPBook, completion: @escaping (Result<Void, AudiobookLoadError>) -> Void) {
@@ -176,6 +220,57 @@ final class AudiobookLoader {
 
             guard let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
                 Log.error(#file, "  ❌ Failed to parse local file as JSON")
+
+                // Diagnostic dump so support has enough context from a single
+                // failing log: 3.0.2's audiobook-open regression is rooted in
+                // Marketplace audiobooks getting saved with `.epub` extension
+                // because the OPDS feed wraps the LCP MIME inside the indirect
+                // chain and `canOpenBook` misses it.
+                let prefix = data.prefix(16).map { String(format: "%02x", $0) }.joined(separator: " ")
+                Log.error(#file, "    diag: bytes=\(data.count), first16=\(prefix), ext=\(url.pathExtension)")
+                let topLevelTypes = book.acquisitions.map { $0.type }.joined(separator: " | ")
+                Log.error(#file, "    diag: acquisitions[*].type=[\(topLevelTypes)]")
+                for (i, acq) in book.acquisitions.enumerated() {
+                    let indirectFlat = Self.flattenIndirectTypes(acq.indirectAcquisitions).joined(separator: " | ")
+                    Log.error(#file, "    diag: acquisitions[\(i)].indirect=[\(indirectFlat)]")
+                }
+                Log.error(#file, "    diag: defaultAcquisition.type=\(book.defaultAcquisition?.type ?? "nil"), defaultBookContentType=\(book.defaultBookContentType.rawValue)")
+                #if LCP
+                Log.error(#file, "    diag: LCPAudiobooks.canOpenBook=\(LCPAudiobooks.canOpenBook(book)), hasLCPAcquisition=\(LCPAudiobooks.hasLCPAcquisition(book))")
+                #endif
+
+                #if LCP
+                // Marketplace audiobook recovery: the OPDS acquisition chain
+                // for Marketplace books is `opds-publication+json →
+                // [LCP license → audiobook+lcp]`, with the LCP MIME nested
+                // inside the indirect chain. `LCPAudiobooks.canOpenBook`
+                // only inspects `defaultAcquisition.type` so it returns
+                // false, which makes `MyBooksDownloadCenter.pathExtension`
+                // save the file with `.epub` extension. The downloaded
+                // bytes ARE the LCP audiobook .lcpa ZIP container, but
+                // ReadiumStreamer's parser dispatch is extension-based —
+                // `.epub` routes to the EPUB parser which then fails on
+                // missing META-INF/container.xml.
+                //
+                // Recovery: create a `.lcpa` symlink alongside the `.epub`
+                // file pointing at the same data, pass the symlink URL to
+                // LCPAudiobooks so the extension-based dispatch picks the
+                // audiobook parser. The underlying `.epub` file is left
+                // alone so any other reader code that already knows the
+                // path keeps working.
+                //
+                // Going forward, `MyBooksDownloadCenter.pathExtension(for:)`
+                // uses `hasLCPAcquisition` so new downloads save with
+                // `.lcpa` directly. This recovery only fires for legacy
+                // downloads saved under the old logic.
+                if LCPAudiobooks.hasLCPAcquisition(book) {
+                    Log.info(#file, "  🔁 Local file failed JSON parse but book has an LCP acquisition — retrying via LCP path")
+                    let lcpSourceURL = Self.ensureLCPExtensionLink(for: url)
+                    self.loadLCPContent(book: book, lcpSourceURL: lcpSourceURL, completion: completion)
+                    return
+                }
+                #endif
+
                 completion(.failure(.manifestParseFailed))
                 return
             }
@@ -371,7 +466,30 @@ final class AudiobookLoader {
                     if isHTML {
                         Log.error(#file, "    ⚠️ Server returned HTML instead of JSON - likely a redirect to login or error page")
                     }
+                    let contentType = (httpResponse.allHeaderFields["Content-Type"] as? String) ?? "unknown"
+                    Log.error(#file, "    diag: content-type=\(contentType)")
                 }
+                // Diagnostic dump: the manifest fetch path (Marketplace audiobook
+                // route via `opds-publication+json` borrow URL) is one of the
+                // failure modes that's hard to root-cause from logs alone.
+                // Capture the response shape so we can decide between array-vs-dict
+                // JSON, OPDS Publication doc that contains an LCP indirect chain
+                // we should follow, or some other server-side surprise.
+                let prefix = data.prefix(64).map { String(format: "%02x", $0) }.joined(separator: " ")
+                Log.error(#file, "    diag: bytes=\(data.count), first64=\(prefix)")
+                if let preview = String(data: data.prefix(256), encoding: .utf8) {
+                    Log.error(#file, "    diag: utf8-preview=\(preview)")
+                }
+                let topLevelTypes = book.acquisitions.map { $0.type }.joined(separator: " | ")
+                Log.error(#file, "    diag: acquisitions[*].type=[\(topLevelTypes)]")
+                for (i, acq) in book.acquisitions.enumerated() {
+                    let indirectFlat = Self.flattenIndirectTypes(acq.indirectAcquisitions).joined(separator: " | ")
+                    Log.error(#file, "    diag: acquisitions[\(i)].indirect=[\(indirectFlat)]")
+                }
+                Log.error(#file, "    diag: defaultAcquisition.type=\(book.defaultAcquisition?.type ?? "nil")")
+                #if LCP
+                Log.error(#file, "    diag: hasLCPAcquisition=\(LCPAudiobooks.hasLCPAcquisition(book))")
+                #endif
                 completion(nil)
                 return
             }

--- a/Palace/Audiobooks/LCP/LCPAudiobooks.swift
+++ b/Palace/Audiobooks/LCP/LCPAudiobooks.swift
@@ -199,6 +199,34 @@ import Foundation
         return book.defaultBookContentType == .audiobook && defaultAcquisition.type == expectedAcquisitionType
     }
 
+    /// Whether the book has *any* LCP-licensed acquisition entry, looking at
+    /// the entire acquisition chain (top-level `type` AND all nested
+    /// `indirectAcquisitions[*].type`). Marketplace audiobook OPDS 2 feeds
+    /// wrap the LCP license MIME inside an `application/opds-publication+json`
+    /// envelope — the LCP MIME sits one or two levels deep in the indirect
+    /// chain. `canOpenBook` only inspects `defaultAcquisition.type`, so it
+    /// returns false for these books even though the downloaded content is
+    /// the LCP-encrypted audiobook ZIP. This recursive predicate is what
+    /// `AudiobookLoader` uses to decide whether to retry through the LCP
+    /// path after a JSON-parse failure on the local file, and what
+    /// `MyBooksDownloadCenter.pathExtension` uses so new downloads save
+    /// under the correct `.lcpa` extension.
+    @objc static func hasLCPAcquisition(_ book: TPPBook) -> Bool {
+        for acquisition in book.acquisitions {
+            if acquisition.type == expectedAcquisitionType { return true }
+            if indirectChainContainsLCP(acquisition.indirectAcquisitions) { return true }
+        }
+        return false
+    }
+
+    private static func indirectChainContainsLCP(_ indirect: [TPPOPDSIndirectAcquisition]) -> Bool {
+        for entry in indirect {
+            if entry.type == expectedAcquisitionType { return true }
+            if indirectChainContainsLCP(entry.indirectAcquisitions) { return true }
+        }
+        return false
+    }
+
     /// Creates an NSError for Objective-C code
     /// - Parameter error: Error object
     /// - Returns: NSError object

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -2799,10 +2799,25 @@ extension MyBooksDownloadCenter {
         return directoryURL
     }
 
+    /// File extension for the book's on-disk artefact. LCP audiobooks land
+    /// as `.lcpa`, LCP PDFs as `.zip`, everything else as `.epub`.
+    ///
+    /// LCP audiobook detection uses `hasLCPAcquisition` (recursive scan of
+    /// the full acquisition chain including indirect entries) rather than
+    /// `canOpenBook` (which inspects only `defaultAcquisition.type`).
+    /// Marketplace audiobook OPDS feeds have the structure
+    /// `opds-publication+json → [LCP license → audiobook+lcp]` with the
+    /// LCP MIME *nested* in the indirect chain — `canOpenBook` misses
+    /// this and the file gets saved as `.epub`. ReadiumStreamer's
+    /// extension-based dispatch then routes the LCP audiobook container
+    /// to the EPUB parser and fails on missing META-INF/container.xml.
+    /// Using the recursive predicate makes new downloads save with the
+    /// correct extension; the `AudiobookLoader` recovery handles legacy
+    /// `.epub`-named LCP content saved under the old logic.
     func pathExtension(for book: TPPBook?) -> String {
         #if LCP
         if let book = book {
-            if LCPAudiobooks.canOpenBook(book) {
+            if LCPAudiobooks.hasLCPAcquisition(book) {
                 return "lcpa"
             }
 


### PR DESCRIPTION
## Summary

- **Companion to #957** — same fix, rebased onto the `hotfix/3.0.2-a11y-launch` line which is the actual TestFlight 3.0.2 source. PR #957 already merged the fix into `release/3.0.2` for archival completeness; this PR brings the same fix into `release/3.0.3` so the next TestFlight cut from the a11y-launch line carries it.
- **Root cause:** Marketplace LCP audiobooks save as `.epub` because the OPDS 2.0 JSON catalog feed wraps the LCP MIME inside `application/opds-publication+json`, and `LCPAudiobooks.canOpenBook` only inspects `defaultAcquisition.type` — it misses the nested LCP MIME. The F-016 launch-race fix (`eadfc500c`) exposed this by populating `accountSets` synchronously before `Account.details.loansURL` is loaded — the audiobook open path never fetches the `/loans/` OPDS 1.x XML feed (which has LCP at top level), falling back to OPDS 2 JSON instead. Verified on Moes Max via simdrive + curl against `demo.thepalaceproject.org/GA0000`.
- **Fix (3 coordinated changes):**
  - **`LCPAudiobooks.hasLCPAcquisition`** — recursive predicate walks the whole acquisition chain (top-level + nested `indirectAcquisitions[*].type`) for the LCP MIME.
  - **`MyBooksDownloadCenter.pathExtension(for:)`** — uses `hasLCPAcquisition` instead of `canOpenBook` so new downloads save as `.lcpa`.
  - **`AudiobookLoader` symlink recovery** — when local-file JSON parse fails AND `hasLCPAcquisition` is true, create a `.lcpa` symlink alongside the legacy `.epub` file and route through the LCP path. ReadiumStreamer's extension dispatch picks the audiobook parser via the symlink. Plus diagnostic dumps (local + network fetch) so support has root-cause data from a single failing log.
- **Version bump:** `MARKETING_VERSION 3.0.2 → 3.0.3`, `CURRENT_PROJECT_VERSION 475 → 476` across all four Palace target configs.
- **ForgeOS changeset:** `cs_0405ea00` on `init_71435f73`.

## Test plan

- [x] Build green on iPhone 16 Pro sim (`xcodebuild build` succeeded)
- [x] Local device validation on Moes Max (iPhone 17 Pro Max, iOS 26.4.2) — Crying in H Mart + Mexican Gothic open via the LCP path; no "Failed to open" alert
- [x] User confirmed locally: "tested locally, works great"
- [x] TestFlight install → cold-launch with F-016 race window present → tap Listen on Marketplace audiobook before `Account.details` loads → expect successful open
- [ ] Spot-check 1+ existing pre-fix `.epub`-named download → tap Listen → expect symlink recovery (`🔗 Created .lcpa symlink` log)
- [ ] Verify non-Marketplace audiobooks (Findaway, Open Access) still open unchanged
- [ ] Verify a11y polish on this line (the existing 3.0.2 a11y work) still passes — no regressions to PP-4326 / reader navbar / BookListView VoiceOver

## Not done

- Test fixture for the recursive indirect-acquisition walk — see #958 (the 3.1.0 PR) for the test additions enabled by `PalaceCatalog` SPM.
- Cleanup of `Log.error` diagnostic dumps — keep until TestFlight validates the fix.
- Root-cause fix for F-016 race — `hasLCPAcquisition` defends against the race regardless of which feed populated the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)