### PR TITLE
3.0.3 hotfix — Marketplace LCP audiobook open (PP-4407)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -7397,7 +7397,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 475;
+				CURRENT_PROJECT_VERSION = 476;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7418,7 +7418,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.2;
+				MARKETING_VERSION = 3.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7454,7 +7454,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 475;
+				CURRENT_PROJECT_VERSION = 476;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7475,7 +7475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.2;
+				MARKETING_VERSION = 3.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7640,7 +7640,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 475;
+				CURRENT_PROJECT_VERSION = 476;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -7666,7 +7666,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.2;
+				MARKETING_VERSION = 3.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -7700,7 +7700,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 475;
+				CURRENT_PROJECT_VERSION = 476;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7727,7 +7727,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.2;
+				MARKETING_VERSION = 3.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "App Store";

--- a/Palace/Audiobooks/AudiobookLoader.swift
+++ b/Palace/Audiobooks/AudiobookLoader.swift
@@ -90,6 +90,50 @@ final class AudiobookLoader {
         isCancelled = true
     }
 
+    /// Recursive flatten of a `TPPOPDSIndirectAcquisition` chain into a flat
+    /// list of MIME types, for diagnostic logging only.
+    fileprivate static func flattenIndirectTypes(_ indirect: [TPPOPDSIndirectAcquisition]) -> [String] {
+        indirect.flatMap { entry in [entry.type] + flattenIndirectTypes(entry.indirectAcquisitions) }
+    }
+
+    #if LCP
+    /// Returns a URL whose `pathExtension` is `lcpa`, regardless of the input
+    /// extension. If the input already has `.lcpa` extension, returns it
+    /// unchanged. Otherwise creates a sibling symlink with `.lcpa` extension
+    /// pointing at the original file and returns the symlink URL. Failures
+    /// (symlink-already-exists, permission errors, unsupported filesystem)
+    /// fall back to returning the original URL — the caller's LCP-load
+    /// attempt will surface the resulting error via its own path.
+    ///
+    /// Why a symlink and not a rename: existing call sites (registry sync,
+    /// download book-state, etc.) look up the file at the original path via
+    /// `MyBooksDownloadCenter.fileUrl(for:)`. Renaming would break those
+    /// lookups for legacy `.epub`-named LCP content. A sibling symlink
+    /// leaves the canonical file in place and gives ReadiumStreamer the
+    /// `.lcpa`-extension URL it needs for its extension-based parser
+    /// dispatch.
+    fileprivate static func ensureLCPExtensionLink(for url: URL) -> URL {
+        if url.pathExtension.lowercased() == "lcpa" {
+            return url
+        }
+        let lcpaURL = url.deletingPathExtension().appendingPathExtension("lcpa")
+        let fm = FileManager.default
+
+        if fm.fileExists(atPath: lcpaURL.path) {
+            return lcpaURL
+        }
+
+        do {
+            try fm.createSymbolicLink(at: lcpaURL, withDestinationURL: url)
+            Log.info(#file, "  🔗 Created .lcpa symlink → \(url.lastPathComponent)")
+            return lcpaURL
+        } catch {
+            Log.warn(#file, "  ⚠️ Could not create .lcpa symlink (\(error.localizedDescription)) — falling back to original URL")
+            return url
+        }
+    }
+    #endif
+
     // MARK: - Token refresh
 
     private func refreshTokenIfNeeded(for book: TPPBook, completion: @escaping (Result<Void, AudiobookLoadError>) -> Void) {
@@ -176,6 +220,57 @@ final class AudiobookLoader {
 
             guard let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
                 Log.error(#file, "  ❌ Failed to parse local file as JSON")
+
+                // Diagnostic dump so support has enough context from a single
+                // failing log: 3.0.2's audiobook-open regression is rooted in
+                // Marketplace audiobooks getting saved with `.epub` extension
+                // because the OPDS feed wraps the LCP MIME inside the indirect
+                // chain and `canOpenBook` misses it.
+                let prefix = data.prefix(16).map { String(format: "%02x", $0) }.joined(separator: " ")
+                Log.error(#file, "    diag: bytes=\(data.count), first16=\(prefix), ext=\(url.pathExtension)")
+                let topLevelTypes = book.acquisitions.map { $0.type }.joined(separator: " | ")
+                Log.error(#file, "    diag: acquisitions[*].type=[\(topLevelTypes)]")
+                for (i, acq) in book.acquisitions.enumerated() {
+                    let indirectFlat = Self.flattenIndirectTypes(acq.indirectAcquisitions).joined(separator: " | ")
+                    Log.error(#file, "    diag: acquisitions[\(i)].indirect=[\(indirectFlat)]")
+                }
+                Log.error(#file, "    diag: defaultAcquisition.type=\(book.defaultAcquisition?.type ?? "nil"), defaultBookContentType=\(book.defaultBookContentType.rawValue)")
+                #if LCP
+                Log.error(#file, "    diag: LCPAudiobooks.canOpenBook=\(LCPAudiobooks.canOpenBook(book)), hasLCPAcquisition=\(LCPAudiobooks.hasLCPAcquisition(book))")
+                #endif
+
+                #if LCP
+                // Marketplace audiobook recovery: the OPDS acquisition chain
+                // for Marketplace books is `opds-publication+json →
+                // [LCP license → audiobook+lcp]`, with the LCP MIME nested
+                // inside the indirect chain. `LCPAudiobooks.canOpenBook`
+                // only inspects `defaultAcquisition.type` so it returns
+                // false, which makes `MyBooksDownloadCenter.pathExtension`
+                // save the file with `.epub` extension. The downloaded
+                // bytes ARE the LCP audiobook .lcpa ZIP container, but
+                // ReadiumStreamer's parser dispatch is extension-based —
+                // `.epub` routes to the EPUB parser which then fails on
+                // missing META-INF/container.xml.
+                //
+                // Recovery: create a `.lcpa` symlink alongside the `.epub`
+                // file pointing at the same data, pass the symlink URL to
+                // LCPAudiobooks so the extension-based dispatch picks the
+                // audiobook parser. The underlying `.epub` file is left
+                // alone so any other reader code that already knows the
+                // path keeps working.
+                //
+                // Going forward, `MyBooksDownloadCenter.pathExtension(for:)`
+                // uses `hasLCPAcquisition` so new downloads save with
+                // `.lcpa` directly. This recovery only fires for legacy
+                // downloads saved under the old logic.
+                if LCPAudiobooks.hasLCPAcquisition(book) {
+                    Log.info(#file, "  🔁 Local file failed JSON parse but book has an LCP acquisition — retrying via LCP path")
+                    let lcpSourceURL = Self.ensureLCPExtensionLink(for: url)
+                    self.loadLCPContent(book: book, lcpSourceURL: lcpSourceURL, completion: completion)
+                    return
+                }
+                #endif
+
                 completion(.failure(.manifestParseFailed))
                 return
             }
@@ -371,7 +466,30 @@ final class AudiobookLoader {
                     if isHTML {
                         Log.error(#file, "    ⚠️ Server returned HTML instead of JSON - likely a redirect to login or error page")
                     }
+                    let contentType = (httpResponse.allHeaderFields["Content-Type"] as? String) ?? "unknown"
+                    Log.error(#file, "    diag: content-type=\(contentType)")
                 }
+                // Diagnostic dump: the manifest fetch path (Marketplace audiobook
+                // route via `opds-publication+json` borrow URL) is one of the
+                // failure modes that's hard to root-cause from logs alone.
+                // Capture the response shape so we can decide between array-vs-dict
+                // JSON, OPDS Publication doc that contains an LCP indirect chain
+                // we should follow, or some other server-side surprise.
+                let prefix = data.prefix(64).map { String(format: "%02x", $0) }.joined(separator: " ")
+                Log.error(#file, "    diag: bytes=\(data.count), first64=\(prefix)")
+                if let preview = String(data: data.prefix(256), encoding: .utf8) {
+                    Log.error(#file, "    diag: utf8-preview=\(preview)")
+                }
+                let topLevelTypes = book.acquisitions.map { $0.type }.joined(separator: " | ")
+                Log.error(#file, "    diag: acquisitions[*].type=[\(topLevelTypes)]")
+                for (i, acq) in book.acquisitions.enumerated() {
+                    let indirectFlat = Self.flattenIndirectTypes(acq.indirectAcquisitions).joined(separator: " | ")
+                    Log.error(#file, "    diag: acquisitions[\(i)].indirect=[\(indirectFlat)]")
+                }
+                Log.error(#file, "    diag: defaultAcquisition.type=\(book.defaultAcquisition?.type ?? "nil")")
+                #if LCP
+                Log.error(#file, "    diag: hasLCPAcquisition=\(LCPAudiobooks.hasLCPAcquisition(book))")
+                #endif
                 completion(nil)
                 return
             }

--- a/Palace/Audiobooks/LCP/LCPAudiobooks.swift
+++ b/Palace/Audiobooks/LCP/LCPAudiobooks.swift
@@ -199,6 +199,34 @@ import Foundation
         return book.defaultBookContentType == .audiobook && defaultAcquisition.type == expectedAcquisitionType
     }
 
+    /// Whether the book has *any* LCP-licensed acquisition entry, looking at
+    /// the entire acquisition chain (top-level `type` AND all nested
+    /// `indirectAcquisitions[*].type`). Marketplace audiobook OPDS 2 feeds
+    /// wrap the LCP license MIME inside an `application/opds-publication+json`
+    /// envelope — the LCP MIME sits one or two levels deep in the indirect
+    /// chain. `canOpenBook` only inspects `defaultAcquisition.type`, so it
+    /// returns false for these books even though the downloaded content is
+    /// the LCP-encrypted audiobook ZIP. This recursive predicate is what
+    /// `AudiobookLoader` uses to decide whether to retry through the LCP
+    /// path after a JSON-parse failure on the local file, and what
+    /// `MyBooksDownloadCenter.pathExtension` uses so new downloads save
+    /// under the correct `.lcpa` extension.
+    @objc static func hasLCPAcquisition(_ book: TPPBook) -> Bool {
+        for acquisition in book.acquisitions {
+            if acquisition.type == expectedAcquisitionType { return true }
+            if indirectChainContainsLCP(acquisition.indirectAcquisitions) { return true }
+        }
+        return false
+    }
+
+    private static func indirectChainContainsLCP(_ indirect: [TPPOPDSIndirectAcquisition]) -> Bool {
+        for entry in indirect {
+            if entry.type == expectedAcquisitionType { return true }
+            if indirectChainContainsLCP(entry.indirectAcquisitions) { return true }
+        }
+        return false
+    }
+
     /// Creates an NSError for Objective-C code
     /// - Parameter error: Error object
     /// - Returns: NSError object

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -2799,10 +2799,25 @@ extension MyBooksDownloadCenter {
         return directoryURL
     }
 
+    /// File extension for the book's on-disk artefact. LCP audiobooks land
+    /// as `.lcpa`, LCP PDFs as `.zip`, everything else as `.epub`.
+    ///
+    /// LCP audiobook detection uses `hasLCPAcquisition` (recursive scan of
+    /// the full acquisition chain including indirect entries) rather than
+    /// `canOpenBook` (which inspects only `defaultAcquisition.type`).
+    /// Marketplace audiobook OPDS feeds have the structure
+    /// `opds-publication+json → [LCP license → audiobook+lcp]` with the
+    /// LCP MIME *nested* in the indirect chain — `canOpenBook` misses
+    /// this and the file gets saved as `.epub`. ReadiumStreamer's
+    /// extension-based dispatch then routes the LCP audiobook container
+    /// to the EPUB parser and fails on missing META-INF/container.xml.
+    /// Using the recursive predicate makes new downloads save with the
+    /// correct extension; the `AudiobookLoader` recovery handles legacy
+    /// `.epub`-named LCP content saved under the old logic.
     func pathExtension(for book: TPPBook?) -> String {
         #if LCP
         if let book = book {
-            if LCPAudiobooks.canOpenBook(book) {
+            if LCPAudiobooks.hasLCPAcquisition(book) {
                 return "lcpa"
             }
 


### PR DESCRIPTION
## Summary

3.0.3 hotfix. Single fix on top of 3.0.2 (which already shipped via PR #953).

**Fix (PP-4407):**
- `LCPAudiobooks.hasLCPAcquisition` — recursive predicate walking the whole acquisition chain (top-level + nested `indirectAcquisitions[*]`) so LCP audiobooks are detected regardless of which feed (`/loans/` XML vs `/groups/` JSON) built the book record. Closes the F-016-race-derived symptom where Marketplace audiobooks were saved as `.epub` and failed to open with "Failed to parse local file as JSON".
- `MyBooksDownloadCenter.pathExtension(for:)` — uses `hasLCPAcquisition` instead of `canOpenBook`; new downloads save as `.lcpa` directly.
- `AudiobookLoader.resolveManifestAndDecryptor` — on JSON-parse failure, creates a `.lcpa` symlink alongside the legacy `.epub` and re-tries through ReadiumStreamer. Plus diagnostic dumps so support has telemetry if anything similar surfaces.

**Version:** `MARKETING_VERSION` 3.0.2 → 3.0.3, `CURRENT_PROJECT_VERSION` 475 → 476.

**Diff vs main:** 4 files, +170 / −9. Single commit cherry-picked fresh off `main` (the prior PR #971 against `hotfix/3.0.3-marketplace-audiobook-lcp-fallback` was conflicted because GitHub couldn't reconcile the a11y/launch commits with the squash of #953 already on main).

## Why merge

Merging triggers `Palace Release` (`release-on-merge.yml`) on `macos-26 + Xcode 26`, which:
1. Runs `create-release-notes.sh`
2. Creates the GitHub release tagged `3.0.3` on the Releases tab with changelog
3. The `release: published` event fires `Jira Release Sync` automatically — creates Jira version `iOS 3.0.3` + sets `fixVersion` on PP-4407 (and any other `PP-*` referenced in the release body)

(The `Palace Manual Release` workflow is currently stale — runs on `macOS-latest` / Xcode 16, fails SPM resolution on `sqlite.swift@0.15.5` which needs Swift 6.1. Separate cleanup, not blocking 3.0.3.)

## Test plan
- [x] Build green on iPhone 16 Pro sim (verified in #959 when this was merged into `release/3.0.3`).
- [x] Marketplace LCP audiobook open re-verified on Moes Max via simdrive + curl with test creds against `demo.thepalaceproject.org/GA0000`.
- [ ] After merge: `Palace Release` workflow run succeeds.
- [ ] `3.0.3` appears on https://github.com/ThePalaceProject/ios-core/releases with generated changelog.
- [ ] `Jira Release Sync` auto-fires on `release: published` (fallback: manual dispatch with `tag=3.0.3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)