### PR TITLE
PP-4358: Audiobook speed slider + presets (replace cycling UI)

### DIFF
--- a/Palace/AppInfrastructure/NavigationHostView.swift
+++ b/Palace/AppInfrastructure/NavigationHostView.swift
@@ -66,10 +66,7 @@ struct NavigationHostView<Content: View>: View {
                         }
                     case .audio(let bookRoute):
                         if let model = coordinator.resolveAudioModel(for: bookRoute) {
-                            AudiobookPlayerView(
-                                model: model,
-                                useIncrementalSpeedSlider: appContainer.debugSettings.isIncrementalSpeedSliderEnabled
-                            )
+                            AudiobookPlayerView(model: model)
                             .toolbar(.hidden, for: .tabBar)
                             // CarMode prototype — not compiled
                             // .overlay { CarModeEntryButton ... }

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -452,14 +452,17 @@ public final class AudiobookSessionManager: ObservableObject {
         Log.debug(#file, "Skipping to chapter: '\(chapter.title)'")
     }
 
-    /// Cycles through playback rates
+    /// Cycles through playback rates. Driven by CarPlay / remote-control
+    /// "change playback rate" commands — the now-playing screen UI uses the
+    /// speed bottom sheet instead of cycling.
     public func cyclePlaybackRate() -> PlaybackRate {
         guard let player = manager?.audiobook.player else {
             return .normalTime
         }
 
-        let rates: [PlaybackRate] = [.threeQuartersTime, .normalTime, .oneAndAQuarterTime, .oneAndAHalfTime, .doubleTime]
-        let currentIndex = rates.firstIndex(of: player.playbackRate) ?? 1
+        let rates = PlaybackRate.presets
+        let currentIndex = rates.firstIndex(of: player.playbackRate)
+            ?? (rates.firstIndex(of: .normalTime) ?? 0)
         let nextIndex = (currentIndex + 1) % rates.count
         let newRate = rates[nextIndex]
 

--- a/Palace/Settings/Debug/DebugSettings.swift
+++ b/Palace/Settings/Debug/DebugSettings.swift
@@ -25,7 +25,6 @@ final class DebugSettings {
         static let badgeLoggingEnabled = "debug.badgeLoggingEnabled"
         static let testHoldsConfiguration = "debug.testHoldsConfiguration"
         static let syncFailureType = "debug.syncFailureType"
-        static let incrementalSpeedSliderEnabled = "debug.incrementalSpeedSliderEnabled"
     }
 
     // MARK: - Simulated Error Types
@@ -372,15 +371,6 @@ final class DebugSettings {
         )
     }
 
-    // MARK: - Incremental Speed Slider
-
-    /// Enables the stepped speed-slider sheet instead of the legacy action-sheet speed picker.
-    /// Off by default; toggle in Developer Settings to preview before production release.
-    var isIncrementalSpeedSliderEnabled: Bool {
-        get { defaults.bool(forKey: Keys.incrementalSpeedSliderEnabled) }
-        set { defaults.set(newValue, forKey: Keys.incrementalSpeedSliderEnabled) }
-    }
-
     // MARK: - Reset
 
     /// Resets all debug settings to defaults
@@ -389,7 +379,6 @@ final class DebugSettings {
         simulatedSyncFailure = .none
         isBadgeLoggingEnabled = false
         testHoldsConfiguration = .none
-        isIncrementalSpeedSliderEnabled = false
     }
 
     init() {}

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -14,7 +14,6 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         case dataManagement
         case developerTools
         case pushNotificationTesting
-        case featurePreviews
         case badgeTesting
         case errorSimulation
         #if DEBUG
@@ -30,7 +29,6 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
     private let emailLogsCellIdentifier = "emailLogsCell"
     private let sendErrorLogsCellIdentifier = "sendErrorLogsCell"
     private let errorSimulationCellIdentifier = "errorSimulationCell"
-    private let incrementalSpeedSliderCellIdentifier = "incrementalSpeedSliderCell"
     private let badgeLoggingCellIdentifier = "badgeLoggingCell"
     private let testHoldsCellIdentifier = "testHoldsCell"
 
@@ -80,7 +78,6 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: emailLogsCellIdentifier)
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: sendErrorLogsCellIdentifier)
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: errorSimulationCellIdentifier)
-        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: incrementalSpeedSliderCellIdentifier)
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: badgeLoggingCellIdentifier)
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: testHoldsCellIdentifier)
     }
@@ -93,7 +90,6 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         case .librarySettings: return 2
         case .developerTools: return 2
         case .pushNotificationTesting: return 3
-        case .featurePreviews: return 1
         case .badgeTesting:
             #if DEBUG
             return 2
@@ -141,8 +137,6 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             case 1: return cellForTestHoldNotification()
             default: return cellForTestLoanExpiryNotification()
             }
-        case .featurePreviews:
-            return cellForIncrementalSpeedSlider()
         case .badgeTesting:
             #if DEBUG
             switch indexPath.row {
@@ -189,8 +183,6 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             return "Developer Tools"
         case .pushNotificationTesting:
             return "Push Notification Testing"
-        case .featurePreviews:
-            return "Feature Previews"
         case .badgeTesting:
             #if DEBUG
             return "Badge Testing"
@@ -285,24 +277,6 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
     }
 
     #if DEBUG
-    @objc func incrementalSpeedSliderSwitchDidChange(sender: UISwitch) {
-        self.debugSettings.isIncrementalSpeedSliderEnabled = sender.isOn
-    }
-
-    private func cellForIncrementalSpeedSlider() -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: incrementalSpeedSliderCellIdentifier) else {
-            fatalError("Failed to dequeue cell with identifier \(incrementalSpeedSliderCellIdentifier)")
-        }
-        cell.selectionStyle = .none
-        cell.textLabel?.text = "Incremental Speed Slider"
-        cell.textLabel?.adjustsFontSizeToFitWidth = true
-        cell.accessoryView = createSwitch(
-            isOn: self.debugSettings.isIncrementalSpeedSliderEnabled,
-            action: #selector(incrementalSpeedSliderSwitchDidChange)
-        )
-        return cell
-    }
-
     @objc func badgeLoggingSwitchDidChange(sender: UISwitch) {
         self.debugSettings.isBadgeLoggingEnabled = sender.isOn
     }
@@ -333,21 +307,6 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         return cell
     }
     #else
-    private func cellForIncrementalSpeedSlider() -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: incrementalSpeedSliderCellIdentifier) else {
-            fatalError("Failed to dequeue cell with identifier \(incrementalSpeedSliderCellIdentifier)")
-        }
-        cell.selectionStyle = .none
-        cell.textLabel?.text = "Incremental Speed Slider"
-        cell.textLabel?.adjustsFontSizeToFitWidth = true
-        // In non-DEBUG builds, the switch reads the same DebugSettings property
-        let switchControl = UISwitch()
-        switchControl.isOn = self.debugSettings.isIncrementalSpeedSliderEnabled
-        switchControl.isEnabled = false
-        cell.accessoryView = switchControl
-        return cell
-    }
-
     private func cellForBadgeLogging() -> UITableViewCell {
         return UITableViewCell()
     }

--- a/PalaceTests/PlaybackRateTests.swift
+++ b/PalaceTests/PlaybackRateTests.swift
@@ -24,6 +24,7 @@ class PlaybackRateTests: XCTestCase {
     XCTAssertEqual(PlaybackRate.convert(rate: .p080), 0.80, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .p095), 0.95, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .p110), 1.10, accuracy: 0.001)
+    XCTAssertEqual(PlaybackRate.convert(rate: .p120), 1.20, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .p145), 1.45, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .p175), 1.75, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .p195), 1.95, accuracy: 0.001)
@@ -31,24 +32,47 @@ class PlaybackRateTests: XCTestCase {
 
   // MARK: - presets
 
-  /// presets is the user-facing 5-rate ladder. Lock the exact set here so
-  /// a mutant that adds/removes a preset (e.g. accidentally exposing an
-  /// intermediate `.p080`) fails on the equality. Pinning the set, not
-  /// just the count, kills mutants that swap one named rate for another.
-  func testPresets_isExactly_ThreeQuarters_Normal_OneAndAQuarter_OneAndAHalf_Double() {
+  /// PP-4358 locks the user-facing preset ladder to exactly five rates
+  /// [0.75×, 1.0×, 1.2×, 1.5×, 2.0×]. Pinning the *order* and the
+  /// *exact* enum cases together kills mutants that:
+  ///   - shuffle the order
+  ///   - drop/add a preset
+  ///   - swap 1.2× for 1.25× (the design-review change vs PP-4233 prototype)
+  ///   - substitute an intermediate `.p###` step for a named rate (or vice versa)
+  func testPresets_isExactly_0p75_1p0_1p2_1p5_2p0_inAscendingOrder() {
     let expected: [PlaybackRate] = [
-      .threeQuartersTime, .normalTime, .oneAndAQuarterTime, .oneAndAHalfTime, .doubleTime,
+      .threeQuartersTime, .normalTime, .p120, .oneAndAHalfTime, .doubleTime,
     ]
     XCTAssertEqual(PlaybackRate.presets, expected,
-                   "presets must be exactly the 5 named-rate ladder, in ascending order")
+                   "PP-4358 acceptance: presets must be exactly [0.75×, 1.0×, 1.2×, 1.5×, 2.0×] in ascending order")
+  }
+
+  /// Independent assertion of the multipliers — separate from enum-case identity —
+  /// so a mutant that re-numbers a case's raw value still trips this test.
+  func testPresets_MultipliersAreExactly_0p75_1p0_1p2_1p5_2p0() {
+    let expected: [Float] = [0.75, 1.0, 1.2, 1.5, 2.0]
+    let actual = PlaybackRate.presets.map { PlaybackRate.convert(rate: $0) }
+    XCTAssertEqual(actual.count, expected.count, "PP-4358 presets must be exactly 5 multipliers")
+    for (index, (actualMultiplier, expectedMultiplier)) in zip(actual, expected).enumerated() {
+      XCTAssertEqual(actualMultiplier, expectedMultiplier, accuracy: 0.001,
+                     "PP-4358 preset[\(index)] multiplier must be \(expectedMultiplier)×, got \(actualMultiplier)×")
+    }
   }
 
   func testPresets_ContainsAllNamedRates() {
     XCTAssertTrue(PlaybackRate.presets.contains(.threeQuartersTime))
     XCTAssertTrue(PlaybackRate.presets.contains(.normalTime))
-    XCTAssertTrue(PlaybackRate.presets.contains(.oneAndAQuarterTime))
+    XCTAssertTrue(PlaybackRate.presets.contains(.p120))
     XCTAssertTrue(PlaybackRate.presets.contains(.oneAndAHalfTime))
     XCTAssertTrue(PlaybackRate.presets.contains(.doubleTime))
+  }
+
+  /// The earlier prototype shipped 1.25× as the third preset; design review
+  /// changed it to 1.2×. Lock this so a regression that re-introduces 1.25×
+  /// to the preset row fails immediately.
+  func testPresets_DoesNotContain1p25x() {
+    XCTAssertFalse(PlaybackRate.presets.contains(.oneAndAQuarterTime),
+                   "1.25× must not appear in the preset row — design approved 1.2× (.p120)")
   }
 
   func testPresets_DoesNotContainIntermediateCases() {

--- a/PalaceUITests/Tests/AudiobookUITests.swift
+++ b/PalaceUITests/Tests/AudiobookUITests.swift
@@ -146,7 +146,10 @@ final class AudiobookUITests: PalaceUITestCase {
 
     // MARK: - Speed Control
 
-    func testPlaybackSpeedButtonCyclesRates() throws {
+    /// Tapping the speed chip on the now-playing screen opens the speed
+    /// bottom sheet (slider + presets). Cycling-on-tap is gone — the sheet
+    /// is the only speed-control surface.
+    func testPlaybackSpeedButton_OpensSpeedSheet() throws {
         try skipIfNoAudiobook()
         XCTExpectFailure("Depends on audiobook availability")
 
@@ -154,17 +157,15 @@ final class AudiobookUITests: PalaceUITestCase {
 
         let speedButton = app.buttons["audiobookPlayer.playbackSpeedButton"]
         waitForElement(speedButton)
-
-        let labelBefore = speedButton.label
         speedButton.tap()
 
-        // After tapping, the speed should cycle to the next value
-        Thread.sleep(forTimeInterval: 0.5)
-        // Speed button label or value should have changed
-        let labelAfter = speedButton.label
-        // Just assert the button is still there; exact cycling depends on implementation
-        XCTAssertTrue(speedButton.exists, "Speed button should remain visible after tap")
-        _ = (labelBefore, labelAfter) // suppress unused warnings
+        // The "Playback Speed" header text only exists inside the sheet, so
+        // its presence is sufficient to prove the sheet opened. A direct
+        // slider query would race with the audiobook progress slider — the
+        // sheet view lives in the PalaceAudiobookToolkit submodule and needs
+        // its own a11y identifier before we can assert the slider here.
+        let sheetHeader = app.staticTexts["Playback Speed"]
+        waitForElement(sheetHeader)
     }
 
     // MARK: - Sleep Timer


### PR DESCRIPTION
## Summary
- Story: [PP-4358](https://ebce-lyrasis.atlassian.net/browse/PP-4358). Promote the [PP-4233](https://ebce-lyrasis.atlassian.net/browse/PP-4233) design-approved prototype to a shipping feature: the audiobook now-playing screen uses the SpeedSliderSheet bottom sheet (slider 0.75×–2.0× in 0.05× steps + ± step buttons + 5 preset chips + live speed display + VoiceOver) as the **only** speed-control surface.
- Preset row is now exactly `[0.75×, 1.0×, 1.2×, 1.5×, 2.0×]` — design picked 1.2× (`.p120`) over the prototype's 1.25× (`.oneAndAQuarterTime`).
- Removes the `useIncrementalSpeedSlider` debug toggle (DebugSettings flag + Developer-Settings cell + `featurePreviews` section + NavigationHostView wiring). The toolkit's legacy ActionSheet code path also goes away.
- CarPlay/remote `cyclePlaybackRate()` now reads from `PlaybackRate.presets` (DRY) — the 1.2× ladder is consistent on both phone and CarPlay.

Submodule pin bumps `ios-audiobooktoolkit` to the PP-4358 branch (PR: ThePalaceProject/ios-audiobooktoolkit#175 — must merge first, then this PR re-bumps to main SHA).

## Test plan
- [ ] `PalaceTests/PlaybackRateTests` — 16/16 pass on iPhone 16 Pro / iOS 18.4. New TDD tests lock the preset identity, the multipliers (independently), and an explicit "must not contain 1.25×" guard.
- [ ] `PalaceUITests/Tests/AudiobookUITests.testPlaybackSpeedButton_OpensSpeedSheet` — asserts the sheet opens on speed-chip tap (replaces the prior `…CyclesRates` test).
- [ ] Manual on a sim with a downloaded audiobook: drag the slider end-to-end, tap each preset, +/- at the 0.75/2.0 bounds, force-quit + relaunch + reopen → speed persists, open a second audiobook → speed carries over.
- [ ] VoiceOver: speed-chip label reads current speed; sheet header combines title + speed; ± + presets have descriptive labels; active preset has `.isSelected` trait.
- [ ] CarPlay (or AirPlay remote): rate-change command lands on `.p120` for 1.2× and still accepts `1.25` (raw 125) for backward compatibility.

## Backward-compat
- `UserDefaults["playback_rate"]` key is unchanged. The enum case `.oneAndAQuarterTime = 125` is retained, so users with 1.25× saved keep their saved rate (the preset row simply stops offering 1.25× as a one-tap chip; the slider can still land on 1.25× because rawValue 125 is still in `.steps`).
- Architect-reviewer-noted user-facing shift: a user with 1.25× saved who hits the CarPlay `CPNowPlayingPlaybackRateButton` will land on 1.2× on first tap (rather than 1.5×) because 1.25× is no longer in the cycle ladder. Small cohort, recovers on second press, matches the new phone sheet ladder.

## Governance
- ForgeOS changeset: `cs_57e6263b` — all gates passed (review / testing / release).
- Architect review: `rev_efd28414` — approved.
- QA review: `rev_3c0fbd2a` — approved with 3 advisory warnings (cyclePlaybackRate under-tested, UI test is `XCTExpectFailure`-gated, pre-existing UserDefaults persistence has no tests).

## Not done (carry into QA)
- End-to-end simdrive walk of the sheet (slider drag / each preset / ± bounds / persistence across relaunch + book switch) is deferred — Animal Farm download stalled on the fresh sim container during this session. Behavior is locked by the unit tests + the UI test asserting the sheet opens. QA: run the full walk on a sim/device with a pre-downloaded audiobook.
- After ThePalaceProject/ios-audiobooktoolkit#175 merges to its `main`, this PR's submodule pin must be re-bumped to the main SHA before merging to `ios-core/develop`.

## Deferred
- Android mirror of these controls — separate ticket per PP-4358 "Out of scope".
- Speed range beyond 0.75×–2.0× — PP-4233 evaluated 0.5×–3.0× as a stretch; design approved the current range. Revisit later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PP-4358]: https://ebce-lyrasis.atlassian.net/browse/PP-4358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PP-4233]: https://ebce-lyrasis.atlassian.net/browse/PP-4233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ