### PR TITLE
fix(signin): PP-4421 — darken sign-in placeholder via SwiftUI prompt:

### DIFF
--- a/Palace/Settings/AccountDetailView.swift
+++ b/Palace/Settings/AccountDetailView.swift
@@ -341,7 +341,11 @@ struct AccountDetailView: View {
 
     private var barcodeInputCell: some View {
         let label = viewModel.businessLogic.selectedAuthentication?.patronIDLabel ?? DisplayStrings.barcodeOrUsername
-        return TextField(label, text: $viewModel.usernameText)
+        // PP-4421: explicit prompt with `.secondary` foreground overrides the
+        // default `.placeholderText` (~30% gray) that patrons read as a
+        // disabled field. Entered text retains its own .foregroundColor
+        // below — only the empty-state hint is darkened.
+        return TextField(label, text: $viewModel.usernameText, prompt: Text(label).foregroundColor(.secondary))
             .textContentType(.username)
             .autocapitalization(.none)
             .autocorrectionDisabled()
@@ -362,9 +366,14 @@ struct AccountDetailView: View {
     }
 
     private var pinInputCell: some View {
+        // PP-4421: explicit prompt with `.secondary` foreground overrides
+        // the default `.placeholderText` (~30% gray) that patrons read as
+        // a disabled field. Both visible (TextField) and masked (SecureField)
+        // branches get the same prompt — empty-state hint is darker, entered
+        // text retains its own .foregroundColor below.
         HStack {
             if viewModel.isPINHidden {
-                SecureField(pinLabel, text: $viewModel.pinText)
+                SecureField(pinLabel, text: $viewModel.pinText, prompt: Text(pinLabel).foregroundColor(.secondary))
                     .textContentType(.password)
                     .keyboardType(keyboardType(for: viewModel.businessLogic.selectedAuthentication?.pinKeyboard))
                     .disabled(viewModel.isSignedIn)
@@ -375,7 +384,7 @@ struct AccountDetailView: View {
                     .onSubmit { if viewModel.canSignIn { viewModel.signIn() } }
                     .submitLabel(.go)
             } else {
-                TextField(pinLabel, text: $viewModel.pinText)
+                TextField(pinLabel, text: $viewModel.pinText, prompt: Text(pinLabel).foregroundColor(.secondary))
                     .textContentType(.password)
                     .keyboardType(keyboardType(for: viewModel.businessLogic.selectedAuthentication?.pinKeyboard))
                     .disabled(viewModel.isSignedIn)


### PR DESCRIPTION
## Summary

Solves the underlying patron complaint that motivated the just-reverted HelpSpot 17923 fix (PR #976): *"the sign-in fields look disabled, I can't tell if they accept input."*

Root cause is SwiftUI's default `.placeholderText` (~30% gray) reading as a disabled treatment for long labels like *"Barcode or Username"* and *"PIN"*.

The prior engineering attempt (commit 547e185aa) wrapped each input cell in a VStack with a permanently-visible non-tappable *"Tap here to enter your X"* caption — un-approved user-facing copy, wrong UX semantics. Reverted in PR #976.

**This PR** takes the design-safe path: SwiftUI's `prompt:` parameter overrides only the placeholder rendering. No new copy. No new UI element. No impact on entered-text appearance.

### What changes

```swift
// before (post-revert)
TextField(label, text: $viewModel.usernameText)
    .foregroundColor(viewModel.isSignedIn ? .secondary : .primary)
    ...

// after (this PR)
TextField(label, text: $viewModel.usernameText, prompt: Text(label).foregroundColor(.secondary))
    .foregroundColor(viewModel.isSignedIn ? .secondary : .primary)
    ...
```

Three call sites in `AccountDetailView.swift`:
- `barcodeInputCell` TextField
- `pinInputCell` SecureField (PIN-hidden)
- `pinInputCell` TextField (PIN-visible)

All three pass `prompt: Text(label).foregroundColor(.secondary)`. Two short doc comments at the cell scope explain the choice.

### What this PR does NOT touch

- **Entered-text appearance** — the existing `.foregroundColor(viewModel.isSignedIn ? .secondary : .primary)` controls typed text. Empty (~60% via `.secondary`) and filled (~100% via `.primary`) stay visually distinct.
- **Field label string** — the prompt Text uses the SAME existing `label`/`pinLabel`. No `Strings.swift` additions, no new copy.
- **Structural UI** — no VStack, no caption-above-field. No changes to padding / `alignmentGuide` / `accessibilityElement`.
- **Accessibility** — `.accessibilityLabel` / `.accessibilityIdentifier` preserved.

### Why `.secondary`

It's the platform semantic color for "secondary text" — adapts to dark/light mode and dynamic type. The swap is `.placeholderText` (~30% opacity) → `.secondary` (~60% opacity), both Apple-supplied semantic colors. No custom RGB, no new pattern. Per HIG, `.secondary` is the standard "darker than placeholder but lighter than primary" treatment. The existing file already uses `.secondary` for non-active text (lines 354 / 380 / 391 — entered-text when `isSignedIn`), so this is consistent with the file's conventions.

Design can refine the exact shade in a follow-up if they want — the structural fix stays right regardless.

## Verification

- `AccountDetailViewModelTests`: **19/0/0** (0.60s) on iPhone 16 Pro sim (iOS 18.4)
- Palace target: **BUILD SUCCEEDED**
- Palace-noDRM target: **BUILD SUCCEEDED**

## ForgeOS governance

- Changeset: `cs_8f46f5db` (initiative `init_3c329b8c` — 3.2.0 HelpSpot bug-fix swarm)
- Architect review: `rev_0e72ae9c` — **APPROVED**. *"Clean platform-semantic fix. `prompt:` is the right seam, `.secondary` is correct over a Palace design token, PP-4421 in doc comments earns its keep, no premature `.palacePlaceholder()` extraction."*
- QA review: `rev_d5b4bc65` — **APPROVED** with 2 non-blocking warnings (no `prompt:` source-introspection test, mutation kill rate 0% on the placeholder — both deemed proportionate for styling-only change with no SwiftUI snapshot testing in the repo).
- Gates: review / testing / release — **all PASSED**. `can_release: true`.

## PR stack

This PR is based on `revert/helpspot-17923-tap-to-enter` (PR #976) so the diff is purely the `prompt:` addition on the clean post-revert form. Together the two PRs:

1. **PR #976** — remove the unapproved *"Tap here to enter your X"* caption (no behavior fix yet).
2. **This PR** — darken the placeholder via platform-semantic-color swap (actual fix for the underlying patron complaint).

Either can land first mechanically — the changes are orthogonal. Recommended merge order: PR #976 → this PR → retarget this PR's base to `develop`.

## Scope / Not done / Deferred

**Scope:** UI styling. 1 file, +12/-3 LOC. Public API unchanged.

**Not done:**
- Design review of `.secondary` color choice — skipped per direction (platform-semantic-color swap, no new pattern). Design can refine in a follow-up.
- Source-introspection test pinning the `prompt:` parameter — proportionate skip per QA review for styling-only change.

**Deferred:**
- General design-review gate in ForgeOS for changesets touching `Strings.swift` or new SwiftUI `Text()` user-facing copy. Worth proposing in a separate audit.

## Test plan

- [x] AccountDetailViewModelTests green
- [x] Palace + Palace-noDRM build green
- [x] No new strings, no new UI elements
- [x] ForgeOS architect + QA reviews approved
- [ ] **For reviewer / merger:** device-level smoke — open sign-in screen, confirm placeholder reads as darker grey (not as light/disabled), confirm field is still tappable and accepts input, confirm entered text contrasts visually with placeholder (i.e. empty vs filled are clearly distinct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)