### PR TITLE
test(infra): fix silent-timeout polling helpers across MyBooks/DRM/Contract/SignInLogic

### DIFF
--- a/PalaceTests/Contract/BorrowOperationContractTests.swift
+++ b/PalaceTests/Contract/BorrowOperationContractTests.swift
@@ -240,12 +240,12 @@ final class BorrowOperationContractTests: XCTestCase {
     // MARK: - Helpers
 
     /// Wait up to ~1s for the log to contain a record with the given method.
-    private func waitForLog(containing method: String, timeout: TimeInterval = 1.0) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if log.snapshot().contains(where: { $0.method == method }) { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
+    /// Wraps the shared `awaitConditionAsync` helper. The prior local
+    /// copy silently swallowed timeouts — see
+    /// PalaceTests/XCTestCase+drainMainQueue.swift for rationale.
+    private func waitForLog(containing method: String, timeout: TimeInterval = 10.0) async {
+        await awaitConditionAsync(timeout: timeout) { [log] in
+            log?.snapshot().contains(where: { $0.method == method }) ?? false
         }
     }
 

--- a/PalaceTests/Contract/BorrowOperationContractTests.swift
+++ b/PalaceTests/Contract/BorrowOperationContractTests.swift
@@ -240,11 +240,15 @@ final class BorrowOperationContractTests: XCTestCase {
     // MARK: - Helpers
 
     /// Wait up to ~1s for the log to contain a record with the given method.
-    /// Wraps the shared `awaitConditionAsync` helper. The prior local
-    /// copy silently swallowed timeouts — see
-    /// PalaceTests/XCTestCase+drainMainQueue.swift for rationale.
-    private func waitForLog(containing method: String, timeout: TimeInterval = 10.0) async {
-        await awaitConditionAsync(timeout: timeout) { [log] in
+    /// Wraps the shared `awaitConditionAsync` helper.
+    /// `file`/`line` forwarded so timeout XCTFail blames the call site.
+    private func waitForLog(
+        containing method: String,
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [log] in
             log?.snapshot().contains(where: { $0.method == method }) ?? false
         }
     }

--- a/PalaceTests/Contract/DownloadStartCoordinatorContractTests.swift
+++ b/PalaceTests/Contract/DownloadStartCoordinatorContractTests.swift
@@ -165,11 +165,15 @@ final class DownloadStartCoordinatorContractTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Wraps the shared `awaitConditionAsync` helper. The prior local
-    /// copy silently swallowed timeouts — see
-    /// PalaceTests/XCTestCase+drainMainQueue.swift for rationale.
-    private func waitForLog(containing method: String, timeout: TimeInterval = 10.0) async {
-        await awaitConditionAsync(timeout: timeout) { [log] in
+    /// Wraps the shared `awaitConditionAsync` helper.
+    /// `file`/`line` forwarded so timeout XCTFail blames the call site.
+    private func waitForLog(
+        containing method: String,
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [log] in
             log?.snapshot().contains(where: { $0.method == method }) ?? false
         }
     }

--- a/PalaceTests/Contract/DownloadStartCoordinatorContractTests.swift
+++ b/PalaceTests/Contract/DownloadStartCoordinatorContractTests.swift
@@ -165,12 +165,12 @@ final class DownloadStartCoordinatorContractTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func waitForLog(containing method: String, timeout: TimeInterval = 1.5) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if log.snapshot().contains(where: { $0.method == method }) { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
+    /// Wraps the shared `awaitConditionAsync` helper. The prior local
+    /// copy silently swallowed timeouts — see
+    /// PalaceTests/XCTestCase+drainMainQueue.swift for rationale.
+    private func waitForLog(containing method: String, timeout: TimeInterval = 10.0) async {
+        await awaitConditionAsync(timeout: timeout) { [log] in
+            log?.snapshot().contains(where: { $0.method == method }) ?? false
         }
     }
 

--- a/PalaceTests/DRM/OverdriveFulfillmentTests.swift
+++ b/PalaceTests/DRM/OverdriveFulfillmentTests.swift
@@ -115,11 +115,14 @@ final class OverdriveFulfillmentTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Wraps the shared `awaitConditionAsync` helper. The prior local
-    /// copy silently swallowed timeouts — see
-    /// PalaceTests/XCTestCase+drainMainQueue.swift for rationale.
-    private func waitForPublishedError(timeout: TimeInterval = 10.0) async {
-        await awaitConditionAsync(timeout: timeout) { [weak self] in
+    /// Wraps the shared `awaitConditionAsync` helper.
+    /// `file`/`line` forwarded so timeout XCTFail blames the call site.
+    private func waitForPublishedError(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [weak self] in
             self?.capturedErrors.isEmpty == false
         }
     }

--- a/PalaceTests/DRM/OverdriveFulfillmentTests.swift
+++ b/PalaceTests/DRM/OverdriveFulfillmentTests.swift
@@ -115,12 +115,12 @@ final class OverdriveFulfillmentTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func waitForPublishedError(timeout: TimeInterval = 1.0) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if !capturedErrors.isEmpty { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
+    /// Wraps the shared `awaitConditionAsync` helper. The prior local
+    /// copy silently swallowed timeouts — see
+    /// PalaceTests/XCTestCase+drainMainQueue.swift for rationale.
+    private func waitForPublishedError(timeout: TimeInterval = 10.0) async {
+        await awaitConditionAsync(timeout: timeout) { [weak self] in
+            self?.capturedErrors.isEmpty == false
         }
     }
 

--- a/PalaceTests/MyBooks/BookReturnServiceTests.swift
+++ b/PalaceTests/MyBooks/BookReturnServiceTests.swift
@@ -111,13 +111,15 @@ final class BookReturnServiceTests: XCTestCase {
     /// Wait for the service's async Tasks (OPDS fetch + cleanup hops) to
     /// drain. The service uses Task { } extensively — assertions need to
     /// run after those finish.
-    private func waitForCompletion(timeout: TimeInterval = 1.0, _ predicate: @escaping () -> Bool) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if predicate() { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
-        }
+    /// Wraps the shared `awaitConditionAsync` helper. `file`/`line`
+    /// forwarded so timeout XCTFail blames the call site.
+    private func waitForCompletion(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ predicate: @escaping () -> Bool
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line, predicate)
     }
 
     // MARK: - Branch 1: book not in registry

--- a/PalaceTests/MyBooks/BookSignInRedirectHandlerTests.swift
+++ b/PalaceTests/MyBooks/BookSignInRedirectHandlerTests.swift
@@ -86,13 +86,11 @@ final class BookSignInRedirectHandlerTests: XCTestCase {
         return try XCTUnwrap(TPPProblemDocument.fromProblemResponseData(data))
     }
 
-    private func waitForAsync(timeout: TimeInterval = 1.0, _ predicate: @escaping () -> Bool) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if predicate() { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
-        }
+    /// Thin wrapper around the shared `awaitConditionAsync` helper.
+    /// See PalaceTests/XCTestCase+drainMainQueue.swift for rationale —
+    /// the prior local copy silently swallowed timeouts under CI load.
+    private func waitForAsync(timeout: TimeInterval = 10.0, _ predicate: @escaping () -> Bool) async {
+        await awaitConditionAsync(timeout: timeout, predicate)
     }
 
     // MARK: - handleLoginCancellation

--- a/PalaceTests/MyBooks/BookSignInRedirectHandlerTests.swift
+++ b/PalaceTests/MyBooks/BookSignInRedirectHandlerTests.swift
@@ -87,10 +87,14 @@ final class BookSignInRedirectHandlerTests: XCTestCase {
     }
 
     /// Thin wrapper around the shared `awaitConditionAsync` helper.
-    /// See PalaceTests/XCTestCase+drainMainQueue.swift for rationale —
-    /// the prior local copy silently swallowed timeouts under CI load.
-    private func waitForAsync(timeout: TimeInterval = 10.0, _ predicate: @escaping () -> Bool) async {
-        await awaitConditionAsync(timeout: timeout, predicate)
+    /// `file`/`line` forwarded so timeout XCTFail blames the call site.
+    private func waitForAsync(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ predicate: @escaping () -> Bool
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line, predicate)
     }
 
     // MARK: - handleLoginCancellation

--- a/PalaceTests/MyBooks/BorrowErrorPresenterTests.swift
+++ b/PalaceTests/MyBooks/BorrowErrorPresenterTests.swift
@@ -72,12 +72,15 @@ final class BorrowErrorPresenterTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    private func waitForPublishedError(timeout: TimeInterval = 1.0) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if !capturedErrors.isEmpty { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
+    /// Wraps the shared `awaitConditionAsync` helper. `file`/`line`
+    /// forwarded so timeout XCTFail blames the call site.
+    private func waitForPublishedError(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [weak self] in
+            self?.capturedErrors.isEmpty == false
         }
     }
 

--- a/PalaceTests/MyBooks/CredentialPromptCoordinatorTests.swift
+++ b/PalaceTests/MyBooks/CredentialPromptCoordinatorTests.swift
@@ -66,13 +66,15 @@ final class CredentialPromptCoordinatorTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    private func waitForAsync(timeout: TimeInterval = 1.0, _ predicate: @escaping () -> Bool) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if predicate() { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
-        }
+    /// Wraps the shared `awaitConditionAsync` helper. `file`/`line`
+    /// forwarded so timeout XCTFail blames the call site.
+    private func waitForAsync(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ predicate: @escaping () -> Bool
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line, predicate)
     }
 
     // MARK: - Re-entrancy guard

--- a/PalaceTests/MyBooks/DownloadAlertPresenterTests.swift
+++ b/PalaceTests/MyBooks/DownloadAlertPresenterTests.swift
@@ -79,12 +79,15 @@ final class DownloadAlertPresenterTests: XCTestCase {
         return try XCTUnwrap(TPPProblemDocument.fromProblemResponseData(data))
     }
 
-    private func waitForPublishedError(timeout: TimeInterval = 1.0) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if !capturedErrors.isEmpty { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
+    /// Wraps the shared `awaitConditionAsync` helper. `file`/`line`
+    /// forwarded so timeout XCTFail blames the call site.
+    private func waitForPublishedError(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [weak self] in
+            self?.capturedErrors.isEmpty == false
         }
     }
 

--- a/PalaceTests/MyBooks/DownloadCancellationHandlerTests.swift
+++ b/PalaceTests/MyBooks/DownloadCancellationHandlerTests.swift
@@ -50,10 +50,14 @@ final class DownloadCancellationHandlerTests: XCTestCase {
     }
 
     /// Thin wrapper around the shared `awaitConditionAsync` helper.
-    /// See PalaceTests/XCTestCase+drainMainQueue.swift for rationale —
-    /// the prior local copy silently swallowed timeouts under CI load.
-    private func waitForAsync(timeout: TimeInterval = 10.0, _ predicate: @escaping () -> Bool) async {
-        await awaitConditionAsync(timeout: timeout, predicate)
+    /// `file`/`line` forwarded so timeout XCTFail blames the call site.
+    private func waitForAsync(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ predicate: @escaping () -> Bool
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line, predicate)
     }
 
     // MARK: - No task: nonsensical state

--- a/PalaceTests/MyBooks/DownloadCancellationHandlerTests.swift
+++ b/PalaceTests/MyBooks/DownloadCancellationHandlerTests.swift
@@ -49,13 +49,11 @@ final class DownloadCancellationHandlerTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    private func waitForAsync(timeout: TimeInterval = 1.0, _ predicate: @escaping () -> Bool) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if predicate() { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
-        }
+    /// Thin wrapper around the shared `awaitConditionAsync` helper.
+    /// See PalaceTests/XCTestCase+drainMainQueue.swift for rationale —
+    /// the prior local copy silently swallowed timeouts under CI load.
+    private func waitForAsync(timeout: TimeInterval = 10.0, _ predicate: @escaping () -> Bool) async {
+        await awaitConditionAsync(timeout: timeout, predicate)
     }
 
     // MARK: - No task: nonsensical state

--- a/PalaceTests/MyBooks/DownloadQueueOrchestratorTests.swift
+++ b/PalaceTests/MyBooks/DownloadQueueOrchestratorTests.swift
@@ -57,13 +57,15 @@ final class DownloadQueueOrchestratorTests: XCTestCase {
         bookRegistry.addBook(book, state: state)
     }
 
-    private func waitForAsync(timeout: TimeInterval = 1.0, _ predicate: @escaping () -> Bool) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if predicate() { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
-        }
+    /// Wraps the shared `awaitConditionAsync` helper. `file`/`line`
+    /// forwarded so timeout XCTFail blames the call site.
+    private func waitForAsync(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ predicate: @escaping () -> Bool
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line, predicate)
     }
 
     /// Marks `book` active in the coordinator so `activeCount` reflects an
@@ -95,13 +97,14 @@ final class DownloadQueueOrchestratorTests: XCTestCase {
 
         // The orchestrator hops onto a detached Task to enqueue; poll the
         // actor until the append lands so the assertion isn't racey.
-        var observedCount = 0
-        let deadline = Date().addingTimeInterval(1.0)
-        while Date() < deadline {
-            observedCount = await stateManager.downloadCoordinator.queueCount
-            if observedCount >= 1 { break }
-            try? await Task.sleep(nanoseconds: 20_000_000)
+        // Uses awaitConditionAsync's async-predicate overload to read the
+        // actor-isolated queueCount without leaking a hand-rolled silent
+        // while-deadline loop.
+        await awaitConditionAsync(timeout: 10.0) { [stateManager] in
+            let count = await stateManager?.downloadCoordinator.queueCount ?? 0
+            return count >= 1
         }
+        let observedCount = await stateManager.downloadCoordinator.queueCount
 
         XCTAssertEqual(observedCount, 1,
                        "enqueuePending must append the book onto the DownloadCoordinator pending queue")

--- a/PalaceTests/MyBooks/DownloadResumeAfterKillTests.swift
+++ b/PalaceTests/MyBooks/DownloadResumeAfterKillTests.swift
@@ -227,11 +227,8 @@ final class DownloadResumeAfterKillTests: XCTestCase {
         cancelHandler.cancelDownload(for: book.identifier)
 
         // Wait for the async cleanup task to settle.
-        let deadline = Date().addingTimeInterval(2.0)
-        while Date() < deadline {
-            if spy.scheduleCount > 0 { break }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
+        await awaitConditionAsync(timeout: 10.0) {
+            spy.scheduleCount > 0
         }
 
         XCTAssertEqual(stubTask.cancelByProducingResumeDataCount, 1,

--- a/PalaceTests/MyBooks/DownloadStartCoordinatorTests.swift
+++ b/PalaceTests/MyBooks/DownloadStartCoordinatorTests.swift
@@ -81,13 +81,13 @@ final class DownloadStartCoordinatorTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    private func waitForAsync(timeout: TimeInterval = 1.5, _ predicate: @escaping () -> Bool) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if predicate() { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
-        }
+    /// Thin wrapper around the shared `awaitConditionAsync` helper.
+    /// Replaces the prior local copy that silently swallowed timeouts —
+    /// the post-timeout assertions read stale values and surfaced as
+    /// confusing assertion failures on CI. `awaitConditionAsync` fails
+    /// the test loudly when the predicate never converges.
+    private func waitForAsync(timeout: TimeInterval = 10.0, _ predicate: @escaping () -> Bool) async {
+        await awaitConditionAsync(timeout: timeout, predicate)
     }
 
     // MARK: - startBorrow slot-release semantics

--- a/PalaceTests/MyBooks/DownloadStartCoordinatorTests.swift
+++ b/PalaceTests/MyBooks/DownloadStartCoordinatorTests.swift
@@ -82,12 +82,16 @@ final class DownloadStartCoordinatorTests: XCTestCase {
     }
 
     /// Thin wrapper around the shared `awaitConditionAsync` helper.
-    /// Replaces the prior local copy that silently swallowed timeouts —
-    /// the post-timeout assertions read stale values and surfaced as
-    /// confusing assertion failures on CI. `awaitConditionAsync` fails
-    /// the test loudly when the predicate never converges.
-    private func waitForAsync(timeout: TimeInterval = 10.0, _ predicate: @escaping () -> Bool) async {
-        await awaitConditionAsync(timeout: timeout, predicate)
+    /// Replaces the prior local copy that silently swallowed timeouts.
+    /// `file`/`line` forwarded so a timeout XCTFail blames the call
+    /// site, not this wrapper.
+    private func waitForAsync(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ predicate: @escaping () -> Bool
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line, predicate)
     }
 
     // MARK: - startBorrow slot-release semantics

--- a/PalaceTests/MyBooks/DownloadThrottlingServiceTests.swift
+++ b/PalaceTests/MyBooks/DownloadThrottlingServiceTests.swift
@@ -56,13 +56,15 @@ final class DownloadThrottlingServiceTests: XCTestCase {
         return (book, task)
     }
 
-    private func waitForAsync(timeout: TimeInterval = 1.0, _ predicate: @escaping () -> Bool) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if predicate() { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
-        }
+    /// Wraps the shared `awaitConditionAsync` helper. `file`/`line`
+    /// forwarded so timeout XCTFail blames the call site.
+    private func waitForAsync(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ predicate: @escaping () -> Bool
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line, predicate)
     }
 
     // MARK: - limitActiveDownloads — over the cap

--- a/PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift
+++ b/PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift
@@ -114,12 +114,15 @@ final class LCPFulfillmentHandlerTests: XCTestCase {
         return url
     }
 
-    private func waitForPublishedError(timeout: TimeInterval = 1.0) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if !capturedErrors.isEmpty { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
+    /// Wraps the shared `awaitConditionAsync` helper. `file`/`line`
+    /// forwarded so timeout XCTFail blames the call site.
+    private func waitForPublishedError(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [weak self] in
+            self?.capturedErrors.isEmpty == false
         }
     }
 

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterConcurrencyTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterConcurrencyTests.swift
@@ -82,13 +82,15 @@ final class MyBooksDownloadCenterConcurrencyTests: XCTestCase {
         await stateManager.downloadCoordinator.registerStart(identifier: book.identifier)
     }
 
-    private func waitForAsync(timeout: TimeInterval = 1.0, _ predicate: @escaping () -> Bool) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if predicate() { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
-        }
+    /// Wraps the shared `awaitConditionAsync` helper. `file`/`line`
+    /// forwarded so timeout XCTFail blames the call site.
+    private func waitForAsync(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ predicate: @escaping () -> Bool
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line, predicate)
     }
 
     private func attach(task: URLSessionDownloadTask, to book: TPPBook) async {

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterOfflineTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterOfflineTests.swift
@@ -89,17 +89,20 @@ final class MyBooksDownloadCenterOfflineTests: XCTestCase {
         await fulfillment(of: [drained], timeout: timeout)
     }
 
-    /// Spin until the registry reflects the expected state, or timeout.
+    /// Wait until the registry reflects the expected state. Wraps the
+    /// shared `awaitConditionAsync` helper so timeout produces a loud
+    /// XCTFail attributed to the call site rather than a silent return
+    /// that lets downstream assertions read stale state.
     /// Production transition is async (Task in DownloadAlertPresenter).
     private func waitForState(
         _ expected: TPPBookState,
         on identifier: String,
-        timeout: TimeInterval = 2.0
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line
     ) async {
-        let deadline = Date(timeIntervalSinceNow: timeout)
-        while mockRegistry.state(for: identifier) != expected, Date() < deadline {
-            await Task.yield()
-            try? await Task.sleep(nanoseconds: 20_000_000)  // 20ms
+        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [weak self] in
+            self?.mockRegistry.state(for: identifier) == expected
         }
     }
 

--- a/PalaceTests/MyBooks/OverdriveDownloadHandlerTests.swift
+++ b/PalaceTests/MyBooks/OverdriveDownloadHandlerTests.swift
@@ -120,12 +120,16 @@ final class OverdriveDownloadHandlerTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func waitForPublishedError(timeout: TimeInterval = 1.0) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if !capturedErrors.isEmpty { return }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-            await Task.yield()
+    /// Wraps the shared `awaitConditionAsync` helper. Replaces the prior
+    /// local copy that silently swallowed timeouts. `file`/`line`
+    /// forwarded so timeout XCTFail blames the call site.
+    private func waitForPublishedError(
+        timeout: TimeInterval = 10.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [weak self] in
+            self?.capturedErrors.isEmpty == false
         }
     }
 

--- a/PalaceTests/SignInLogic/TPPAgeCheckDeepTests.swift
+++ b/PalaceTests/SignInLogic/TPPAgeCheckDeepTests.swift
@@ -151,7 +151,14 @@ final class TPPAgeCheckCompletionTests: XCTestCase {
         ageCheck.flushPendingForTests()
         ageCheck.didCompleteAgeCheck(birthYear)
 
-        wait(for: [verifyDone], timeout: 5.0)
+        // 30s budget — the serialQueue chain (verify append → flush →
+        // didCompleteAgeCheck enqueue → handler fanout) can race CI
+        // runner load. The previous 5s budget started timing out
+        // intermittently, surfacing as the *subsequent* line-205
+        // XCTAssertTrue failure (userPresentedAgeCheck never flipped to
+        // true because the didCompleteAgeCheck block hadn't run yet
+        // when the wait returned).
+        wait(for: [verifyDone], timeout: 30.0)
         return capturedAboveAgeLimit ?? false
     }
 

--- a/PalaceTests/XCTestCase+drainMainQueue.swift
+++ b/PalaceTests/XCTestCase+drainMainQueue.swift
@@ -105,4 +105,34 @@ extension XCTestCase {
             line: line
         )
     }
+
+    /// Async-predicate sibling of `awaitConditionAsync` for waits that need
+    /// to read actor-isolated state inside the predicate (e.g. polling an
+    /// actor's queue count, awaiting a NotificationCenter publish on a
+    /// specific thread). Same loud-on-timeout semantics.
+    ///
+    /// Prefer the sync-predicate overload when the predicate doesn't
+    /// require `await`; this overload exists so callers can avoid
+    /// hand-rolling another silent while-deadline loop just because their
+    /// observable is `async`.
+    func awaitConditionAsync(
+        timeout: TimeInterval = 10.0,
+        pollInterval: TimeInterval = 0.025,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ predicate: @escaping () async -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await predicate() { return }
+            try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+            await Task.yield()
+        }
+        XCTFail(
+            "awaitConditionAsync timed out after \(timeout)s without the async predicate becoming true. " +
+            "Bump timeout if CI is the issue, OR fix the production code that should have signalled.",
+            file: file,
+            line: line
+        )
+    }
 }

--- a/PalaceTests/XCTestCase+drainMainQueue.swift
+++ b/PalaceTests/XCTestCase+drainMainQueue.swift
@@ -67,4 +67,42 @@ extension XCTestCase {
         poll()
         wait(for: [met], timeout: timeout)
     }
+
+    /// Async sibling of `awaitCondition` for `async` test bodies that need
+    /// to poll a synchronous predicate between awaits. Same semantics:
+    /// fails the test loudly via `XCTFail` on timeout — never returns
+    /// silently with a stale predicate, which causes the next assertion
+    /// to read the wrong value (the historic test-flake pattern this
+    /// helper replaces).
+    ///
+    /// Use over a hand-rolled `while Date() < deadline { ... }` loop.
+    /// Default timeout 10s — async test bodies typically chain more
+    /// actor hops than sync ones; the extra headroom tolerates CI-runner
+    /// load without masking real stuck conditions.
+    ///
+    /// - Parameters:
+    ///   - timeout: Maximum seconds to wait. Default 10s.
+    ///   - pollInterval: How often to re-check. Default 25ms.
+    ///   - file/line: For accurate XCTFail attribution.
+    ///   - predicate: Synchronous closure returning true once converged.
+    func awaitConditionAsync(
+        timeout: TimeInterval = 10.0,
+        pollInterval: TimeInterval = 0.025,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ predicate: @escaping () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+            await Task.yield()
+        }
+        XCTFail(
+            "awaitConditionAsync timed out after \(timeout)s without the predicate becoming true. " +
+            "Bump timeout if CI is the issue, OR fix the production code that should have signalled.",
+            file: file,
+            line: line
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Eliminates the silent-timeout polling-helper pattern that caused last night's two admin-merged PRs (#975, #978) to ship through misleading downstream-assertion failures on CI. Twelve test files across **MyBooks / DRM / Contract / SignInLogic** consolidated to a single shared `awaitConditionAsync` helper with **XCTFail on timeout** and **accurate `file`/`line` attribution** through wrappers to the call site.

### Disease class

Twelve private polling helpers (or inline while-deadline loops) shared the same broken pattern:

```swift
let deadline = Date().addingTimeInterval(timeout)
while Date() < deadline {
    if predicate() { return }
    try? await Task.sleep(nanoseconds: 20_000_000)
    await Task.yield()
}
// silent return on timeout — next assertion reads stale value
```

When the predicate never converges within timeout, the helper SILENTLY returns. The next assertion then reads stale state and surfaces as a confusing `XCTAssertEqual("0") != ("1")` or `XCTAssertTrue` failure — sending the reader chasing the wrong bug, not the timeout.

Real cost: PRs #975 and #978 had to be admin-merged because of this. Two distinct flakes blocked them, both turned out to be the same disease class.

### Fix

**`PalaceTests/XCTestCase+drainMainQueue.swift`** — new `awaitConditionAsync` (async-sibling of existing sync `awaitCondition`) with:
- Same loud-on-timeout semantics — `XCTFail` with clear message
- Accurate `file`/`line` attribution via parameter forwarding
- Default 10s (async test bodies have longer actor-hop chains)
- Async-predicate overload — supports actor-isolated reads in the predicate (`await actor.queueCount`) without forcing each test to re-roll a silent loop

**12 test files** consolidated to thin wrappers around the new helper. Public signatures preserved so call sites don't change. Defaults bumped from 1.0–1.5s to 10s. Two rounds of sweep needed — the architect reviewer caught residual scope in MyBooks/ both times. Final grep across `PalaceTests/{MyBooks, DRM, Contract, SignInLogic}/` for `while Date()` returns **zero matches**.

| File | Helper | Was | Now |
|---|---|---|---|
| `MyBooks/DownloadStartCoordinatorTests.swift` | `waitForAsync` | 1.5s silent | 10s loud |
| `MyBooks/DownloadCancellationHandlerTests.swift` | `waitForAsync` | 1.0s silent | 10s loud |
| `MyBooks/BookSignInRedirectHandlerTests.swift` | `waitForAsync` | 1.0s silent | 10s loud |
| `Contract/BorrowOperationContractTests.swift` | `waitForLog` | 1.0s silent | 10s loud |
| `Contract/DownloadStartCoordinatorContractTests.swift` | `waitForLog` | 1.5s silent | 10s loud |
| `DRM/OverdriveFulfillmentTests.swift` | `waitForPublishedError` | 1.0s silent | 10s loud |
| `MyBooks/OverdriveDownloadHandlerTests.swift` | `waitForPublishedError` | 1.0s silent | 10s loud |
| `MyBooks/DownloadAlertPresenterTests.swift` | `waitForPublishedError` | 1.0s silent | 10s loud |
| `MyBooks/BorrowErrorPresenterTests.swift` | `waitForPublishedError` | 1.0s silent | 10s loud |
| `MyBooks/CredentialPromptCoordinatorTests.swift` | `waitForAsync` | 1.0s silent | 10s loud |
| `MyBooks/DownloadQueueOrchestratorTests.swift` | `waitForAsync` + inline | 1.0s silent | 10s loud |
| `MyBooks/LCPFulfillmentHandlerTests.swift` | `waitForPublishedError` | 1.0s silent | 10s loud |
| `MyBooks/BookReturnServiceTests.swift` | `waitForCompletion` | 1.0s silent | 10s loud |
| `MyBooks/MyBooksDownloadCenterConcurrencyTests.swift` | `waitForAsync` | 1.0s silent | 10s loud |
| `MyBooks/DownloadThrottlingServiceTests.swift` | `waitForAsync` | 1.0s silent | 10s loud |
| `MyBooks/MyBooksDownloadCenterOfflineTests.swift` | `waitForState` | 2.0s silent | 10s loud |
| `MyBooks/DownloadResumeAfterKillTests.swift` | inline | 2.0s silent | 10s loud |
| `SignInLogic/TPPAgeCheckDeepTests.swift` | `wait(for:timeout:)` | 5s | 30s |

**`SignInLogic/TPPAgeCheckDeepTests.swift`** — verify-completion `wait(for:timeout:)` bumped 5s → 30s. The path that hit #978's misleading assertion. (The serialQueue chain has a possible race the bump now papers over — flagged in Not done.)

**Intentionally not touched:** 3 `waitForCondition` helpers in `PalaceTests/Network/` return `Bool` — caller controls loudness (`XCTAssertTrue(waitForCondition...)` is loud; `_ = waitForCondition(0.3) { false }` is a deliberate fixed-delay idiom). `waitForAsyncCleanup` in `DownloadAuthRetryHandlerTests` is a fixed-duration drain (5×30ms = 150ms), not a polling helper.

## Verification

- 18 affected suites: **134/0/0 in <6s** on iPhone 16 Pro sim (iOS 18.4)
- Build green
- Final grep across declared-complete scope: zero `while Date()` matches

## ForgeOS governance

- Changeset: `cs_39b67714` (initiative `init_7d6a51ce` — Mutation-gate CI hardening)
- Architect review: `rev_57515af2` (BLOCKED — scope) → `rev_b5790484` (BLOCKED — more residuals) → `rev_1c0b356f` (APPROVED)
- QA review: `rev_a216a118` (APPROVED with non-blocking warnings)
- All gates passed. `can_release: true`.

## Scope / Not done / Deferred

**Scope:** 13 files, ~150 net LOC delta. Test-infra only. No production code touched.

**Not done (acknowledged from QA review):**
- ~16 more `while Date() < deadline` patterns in `Catalog/`, `Logging/`, `Network/Cookie/`, `Accounts/`, `Integration/`. Separate sweep — same mechanical transform, separate scope.
- TPPAgeCheck production serialQueue-race audit. The 5s→30s bump is honest tolerance, not a fix.

**Deferred:**
- Lint rule against `while Date() < deadline` patterns in tests. Would catch the next reintroduction at PR time. Worth filing after this lands.

## Test plan

- [x] 18 affected suites green locally (134/0/0)
- [x] Final grep across `MyBooks/DRM/Contract/SignInLogic` returns zero silent-timeout patterns
- [x] ForgeOS architect + QA approved
- [ ] **For reviewer / merger:** verify the build-and-test job passes on CI without the flakes that necessitated last night's admin-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)