### PR TITLE
test(infra): CI hygiene follow-up — sweep #2 + TIMEOUT-001 lint rule

### DIFF
--- a/PalaceTests/Logging/LogTests.swift
+++ b/PalaceTests/Logging/LogTests.swift
@@ -79,8 +79,14 @@ final class LogTests: XCTestCase {
     // MARK: - Error Persistence Tests
 
     /// Polls PersistentLogger until the marker appears, with a short interval
-    /// and a bounded total wait — far more reliable than a fixed sleep.
-    private func pollForLog(marker: String, timeout: TimeInterval = 2.0) async -> String {
+    /// and a bounded total wait. Returns the final logs string for the
+    /// caller's downstream `XCTAssertTrue(logs.contains(marker))` to fire
+    /// a clear failure if the marker never landed — this is the "silent
+    /// return with informative downstream assertion" pattern, distinct
+    /// from the silent-timeout patterns `awaitConditionAsync` replaces.
+    /// 10s timeout — CI runner load + PersistentLogger actor hops can
+    /// race past tighter budgets; local runs resolve in <0.1s.
+    private func pollForLog(marker: String, timeout: TimeInterval = 10.0) async -> String {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             let logs = await PersistentLogger.shared.retrieveAllLogs()

--- a/scripts/lint-test-quality.py
+++ b/scripts/lint-test-quality.py
@@ -52,17 +52,16 @@ FLUFF_PATTERNS = [
 # Files exempt from TIMEOUT-001. Each entry needs a written reason so a
 # future reader understands WHY this file is allowlisted instead of
 # silently filtering it out.
+#
+# Keep this list small. Prefer fixing the rule's heuristic (below) to
+# catch a loud-via-X pattern over hardcoding an allowlist entry.
+# CatalogDomain helpers used to live here — removed once the
+# `is_loud_via_xctfail` heuristic was confirmed to catch them.
 SILENT_TIMEOUT_ALLOWLIST = {
     "PalaceTests/XCTestCase+drainMainQueue.swift":
         "Canonical implementation — `awaitConditionAsync` is the helper this rule recommends.",
     "PalaceTests/Logging/LogTests.swift":
         "pollForLog returns the polled value; caller asserts on its contents — informative downstream failure.",
-    "PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift":
-        "Inline polling is wrapped in DispatchQueue.async + XCTestExpectation; outer wait(for:) fires loudly on timeout.",
-    "PalaceTests/CatalogDomain/CatalogCacheKeyAndIsolationTests.swift":
-        "Helper already calls XCTFail on timeout (file/line forwarded).",
-    "PalaceTests/CatalogDomain/CatalogRepositoryStaleWhileRevalidateTests.swift":
-        "Helper already calls XCTFail on timeout (file/line forwarded).",
 }
 
 def lint_silent_timeout(content: str, filepath: str) -> List["Violation"]:
@@ -85,10 +84,19 @@ def lint_silent_timeout(content: str, filepath: str) -> List["Violation"]:
         return []
 
     findings: List[Violation] = []
-    for m in re.finditer(r'while Date\(\) < deadline', content):
-        # Look at the surrounding 600 chars (typical helper body span)
-        # for indicators of "this helper is actually loud."
-        window_start = max(0, m.start() - 50)
+    # Use a multi-line regex anchored to line start (with optional
+    # leading whitespace) to skip the same pattern appearing inside
+    # `///` doc comments that describe the anti-pattern. Skipping doc-
+    # comments via a separate strip pass risks shifting line numbers in
+    # the reported violation — anchoring is simpler.
+    for m in re.finditer(r'^\s*while Date\(\) < deadline', content, re.MULTILINE):
+        # Look at the surrounding window for indicators of "this helper
+        # is actually loud." The pre-window (~300 chars before the
+        # match) catches the function signature + any `expectation`
+        # declarations that precede the while loop; the post-window
+        # (~600 chars after) catches XCTFail/return-condition at the
+        # end of the helper body.
+        window_start = max(0, m.start() - 300)
         window_end = min(len(content), m.end() + 600)
         window = content[window_start:window_end]
 

--- a/scripts/lint-test-quality.py
+++ b/scripts/lint-test-quality.py
@@ -44,6 +44,82 @@ FLUFF_PATTERNS = [
      "FLUFF-004: Enum raw value assertion. Tests the enum definition, not behavior."),
 ]
 
+# File-level patterns — scanned across the whole file, not just inside
+# `func test*` bodies. Helper functions (private) live outside test
+# methods but harbor structural test-infrastructure bugs that show up as
+# misleading assertion failures inside the tests that call them.
+
+# Files exempt from TIMEOUT-001. Each entry needs a written reason so a
+# future reader understands WHY this file is allowlisted instead of
+# silently filtering it out.
+SILENT_TIMEOUT_ALLOWLIST = {
+    "PalaceTests/XCTestCase+drainMainQueue.swift":
+        "Canonical implementation — `awaitConditionAsync` is the helper this rule recommends.",
+    "PalaceTests/Logging/LogTests.swift":
+        "pollForLog returns the polled value; caller asserts on its contents — informative downstream failure.",
+    "PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift":
+        "Inline polling is wrapped in DispatchQueue.async + XCTestExpectation; outer wait(for:) fires loudly on timeout.",
+    "PalaceTests/CatalogDomain/CatalogCacheKeyAndIsolationTests.swift":
+        "Helper already calls XCTFail on timeout (file/line forwarded).",
+    "PalaceTests/CatalogDomain/CatalogRepositoryStaleWhileRevalidateTests.swift":
+        "Helper already calls XCTFail on timeout (file/line forwarded).",
+}
+
+def lint_silent_timeout(content: str, filepath: str) -> List["Violation"]:
+    """
+    TIMEOUT-001: silent `while Date() < deadline` polling loops in tests.
+
+    The disease: a polling helper that silently `return`s on timeout
+    causes the next assertion to read stale values and surface as a
+    misleading downstream-assertion failure ("0 != 1") instead of a
+    clear "the poll timed out" message. See PR #983 for the rationale +
+    PalaceTests/XCTestCase+drainMainQueue.swift `awaitConditionAsync`
+    for the recommended replacement.
+
+    Heuristic: flag any `while Date() < deadline` whose enclosing
+    function neither (a) ends with an explicit `XCTFail`, nor
+    (b) returns Bool back to a loud caller, nor (c) is in the
+    allowlist above with a documented reason.
+    """
+    if filepath in SILENT_TIMEOUT_ALLOWLIST:
+        return []
+
+    findings: List[Violation] = []
+    for m in re.finditer(r'while Date\(\) < deadline', content):
+        # Look at the surrounding 600 chars (typical helper body span)
+        # for indicators of "this helper is actually loud."
+        window_start = max(0, m.start() - 50)
+        window_end = min(len(content), m.end() + 600)
+        window = content[window_start:window_end]
+
+        is_loud_via_xctfail = 'XCTFail(' in window
+        # Bool-returning helpers end with `return condition()` or
+        # `return predicate()` — caller checks the bool to surface the
+        # timeout (XCTAssertTrue(waitForCondition...)) so the loop
+        # itself doesn't need XCTFail.
+        is_loud_via_bool_return = bool(re.search(r'return\s+(?:condition|predicate)\(\)', window))
+        # An outer XCTestExpectation + wait(for:) makes the surrounding
+        # test loud even if the inline loop is silent — the expectation
+        # never fulfills and the outer wait fires.
+        is_loud_via_expectation = ('XCTestExpectation' in window or 'expectation(description:' in window) and 'wait(for:' in window
+
+        if is_loud_via_xctfail or is_loud_via_bool_return or is_loud_via_expectation:
+            continue
+
+        line_no = content[:m.start()].count('\n') + 1
+        findings.append(Violation(
+            file=filepath,
+            line=line_no,
+            method='<file scope>',
+            rule="TIMEOUT-001",
+            detail="TIMEOUT-001: silent `while Date() < deadline` polling loop. "
+                   "Use `awaitConditionAsync` from PalaceTests/XCTestCase+drainMainQueue.swift — "
+                   "fails the test loudly on timeout with accurate file/line attribution. "
+                   "If this loop IS intentionally silent, add the file to "
+                   "SILENT_TIMEOUT_ALLOWLIST in scripts/lint-test-quality.py with a written reason.",
+        ))
+    return findings
+
 def find_test_methods(content: str) -> List[dict]:
     """Extract test methods with their bodies and line numbers."""
     methods = []
@@ -85,6 +161,10 @@ def lint_file(filepath: str) -> List[Violation]:
 
     with open(filepath) as f:
         content = f.read()
+
+    # File-level checks (scan the whole file body, not just inside test
+    # methods — covers private helpers + inline patterns).
+    violations.extend(lint_silent_timeout(content, filepath))
 
     methods = find_test_methods(content)
 
@@ -177,17 +257,23 @@ def main():
     fluff = sum(1 for v in all_violations if v.rule.startswith('FLUFF'))
     shallow = sum(1 for v in all_violations if v.rule.startswith('SHALLOW'))
     missing = sum(1 for v in all_violations if v.rule.startswith('MISSING'))
+    timeout = sum(1 for v in all_violations if v.rule.startswith('TIMEOUT'))
     print(f"  Fluff (should replace):    {fluff}")
     print(f"  Shallow (should deepen):   {shallow}")
     print(f"  Missing asserts (broken):  {missing}")
+    print(f"  Silent timeouts (CI-flake fuel): {timeout}")
 
     if fix_mode:
         print("\n--fix mode: review violations above and replace manually.")
         print("Each fluff test should be replaced 1:1 with a test that exercises")
         print("real logic in the same class (edge case, error path, state transition).")
 
-    # Exit with error if there are MISSING assertion tests (those are actually broken)
-    if missing > 0:
+    # Exit with error on MISSING (broken tests that can never fail) and
+    # TIMEOUT (silent-timeout polling that produces misleading downstream
+    # assertion failures on CI — see PR #983). Both are structural test
+    # quality bugs that have produced production CI crises this session;
+    # gating prevents reintroduction.
+    if missing > 0 or timeout > 0:
         sys.exit(1)
 
     sys.exit(0)


### PR DESCRIPTION
## Summary

Follow-up to PR #983. Closes the disease class structurally with a lint rule that gates reintroduction at PR time.

### Sweep #2 — reality vs. estimate

PR #983's QA review estimated ~16 more `while Date() < deadline` patterns across Catalog/Logging/Network/Accounts/Integration. Independent survey found **11 syntactic matches, 1 genuinely silent**:

| File | Pattern | Verdict |
|---|---|---|
| `PalaceTests/Logging/LogTests.swift:83` | `pollForLog` returns String, caller asserts on contents | Loud via downstream — but bumped 2s → 10s for CI tolerance |
| 4 × `PalaceTests/Network/*Tests.swift` | Bool-returning `waitForCondition` | Loud via caller (`XCTAssertTrue(waitForCondition...)`) — left alone per PR #983 reasoning |
| 2 × `PalaceTests/CatalogDomain/*Tests.swift` | Helper ends with `XCTFail` | Already loud |
| `PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift:326` | Inline inside `DispatchQueue.async` + outer `XCTestExpectation` + `wait(for:)` | Loud via outer wait |
| `PalaceTests/XCTestCase+drainMainQueue.swift` | Canonical helper | Implementation, not call site |

So the "16" estimate was syntactic-pattern counting; the disease-class count is 1.

### TIMEOUT-001 lint rule

New rule in `scripts/lint-test-quality.py`. Flags any `while Date() < deadline` in `PalaceTests/` whose enclosing function is neither:

1. Loud via `XCTFail(...)` in the surrounding window, OR
2. Loud via `return condition()` / `return predicate()` (Bool-returning helper with loud caller), OR
3. Loud via an outer `XCTestExpectation` + `wait(for:)`, OR
4. In `SILENT_TIMEOUT_ALLOWLIST` with a documented reason.

Allowlist has 2 entries (down from 5 in the first commit — the heuristic caught 3 of them via XCTFail/expectation detection, so the allowlist entries were redundant duplicates).

Script exits non-zero on TIMEOUT-001 violations. **Honest gating state:** the existing call sites (`scripts/verify-pr.sh`, `scripts/forgeos-session.sh`) invoke the script with `|| true`, so push-time gating on TIMEOUT-001 needs explicit hook integration — that's the Not done below. But the rule + non-zero exit are in place; wiring is mechanical.

Regex is anchored to `^\s*while Date()` so `///` doc comments describing the anti-pattern don't false-positive.

### Verification

- `PalaceTests/LogTests`: 14/0/0 in 0.69s on iPhone 16 Pro sim (iOS 18.4)
- Lint script self-check: 0 TIMEOUT-001 violations on develop after PR #983
- Pre-existing FLUFF/SHALLOW/MISSING counts unchanged (234 = 10 + 188 + 36 + 0)

### ForgeOS governance

- Changeset: `cs_cf105959` (initiative `init_7d6a51ce` — Mutation-gate CI hardening)
- Architect review: `rev_5bba7785` — APPROVED with 4 non-blocking warnings; all addressed in a follow-up commit on this branch
- QA review: `rev_cb72bfd7` — APPROVED with 2 non-blocking warnings
- All gates passed. `can_release: true`.

## Scope / Not done / Deferred

**Scope:** 2 files, +110/-15 LOC. Test-infra + CI tooling. No production code.

**Not done:**
- Wire `scripts/lint-test-quality.py` TIMEOUT-001 check honestly into the pre-push hook chain. Currently the script exits correctly but the call sites swallow it with `|| true`. Push-time gating requires a small hook edit — separate follow-up.

**Deferred:**
- Future migration of the 4 `Network/` `waitForCondition` Bool-returning helpers to `awaitConditionAsync`. Possible cleanup but not blocking — the loud-via-caller pattern is reasonable.

## Test plan

- [x] LogTests green locally
- [x] Lint script: 0 TIMEOUT-001 violations on develop
- [x] ForgeOS architect + QA approved
- [ ] **For reviewer / merger:** confirm CI passes (TIMEOUT-001 won't gate here yet per Not done, but FLUFF/MISSING checks remain unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)