### PR TITLE
fix(accounts): currentAccount setter drives NEW account auth-doc (state-machine driver gap #2)

### DIFF
--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -242,6 +242,17 @@ struct CatalogCacheMetadata: Codable {
                 )
             }
 
+            // Account state-machine wiring (3.2.0): drive the NEW
+            // currentAccount past `.basicInfoLoaded` after the switch.
+            // Sibling of the `loadCatalogs` warm-path driver (PR #975) —
+            // same disease class, different trigger. Without this, every
+            // `awaitReady()` caller (audiobook open, token refresh,
+            // bookmark sync, CarPlay auth) hangs forever the first time
+            // the user opens content on the newly-selected library.
+            // Single-flight guard inside `fetchAuthDocumentWithStateMachine`
+            // dedupes against any concurrent fetch from refresh-in-background.
+            driveCurrentAccountAuthDocIfNeeded()
+
             TPPErrorLogger.setUserID(self.currentUserAccount.barcode)
             // isAccountSwitching is reset asynchronously by cleanupActiveContentBeforeAccountSwitch
             // after navigation cleanup completes — NOT here, to avoid premature reset (F-032).

--- a/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
@@ -672,6 +672,92 @@ final class AccountsManagerStateMachineWiringTests: XCTestCase {
         }
     }
 
+    // MARK: - Test 5b: Library switch — NEW account gets auth-doc driver fired
+
+    /// Contract: when the user switches libraries, the NEW currentAccount's
+    /// LoadState must be driven past `.basicInfoLoaded` (or `.notLoaded`)
+    /// just like the cold-launch warm-path. Without this, every
+    /// `awaitReady()` caller (audiobook open, token refresh, bookmark
+    /// sync, CarPlay auth) blocks forever the first time the user opens
+    /// content on the newly-selected library — same disease class as
+    /// the cold-launch spinner fix (PR #975), different trigger.
+    func testLibrarySwitch_drivesNewCurrentAccountPastBasicInfoLoaded() throws {
+        let catalogs = try loadFeedCatalogs()
+        guard catalogs.count >= 2 else {
+            throw XCTSkip("Fixture needs at least 2 catalogs to test library switch")
+        }
+        let priorUUID = catalogs[0].metadata.id
+        let newUUID = catalogs[1].metadata.id
+
+        // Seed disk cache + populate accountSets via preload so the
+        // manager's currentAccount accessor can resolve UUIDs back to
+        // Account instances after the switch.
+        let manager = AccountsManager()
+        let backgroundSettled = expectation(description: "background loadCatalogs settled")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.4) { backgroundSettled.fulfill() }
+        wait(for: [backgroundSettled], timeout: 2.0)
+
+        let activeHash = TPPConfiguration.customUrlHash()
+            ?? (TPPSettings().useBetaLibraries
+                ? TPPConfiguration.betaUrlHash
+                : TPPConfiguration.prodUrlHash)
+        try seedDiskCache(for: activeHash, data: feedData)
+        defer { tearDownDiskCache(for: activeHash) }
+
+        UserDefaults.standard.set(priorUUID, forKey: currentAccountIdentifierKey)
+        defer { UserDefaults.standard.removeObject(forKey: currentAccountIdentifierKey) }
+
+        #if DEBUG
+        AccountStateStore.shared._resetAllForTesting()
+        #endif
+
+        manager.preloadAccountsFromDiskCacheSync()
+
+        // Pre-state: newUUID is at .basicInfoLoaded after preload.
+        switch AccountStateStore.shared.state(for: newUUID) {
+        case .basicInfoLoaded:
+            break // expected
+        default:
+            XCTFail("Setup: newUUID must be at .basicInfoLoaded after preload; got \(label(AccountStateStore.shared.state(for: newUUID)))")
+            return
+        }
+
+        // Act: switch to a different library.
+        guard let newAccount = manager.account(newUUID) else {
+            XCTFail("Setup: manager must resolve newUUID via account()"); return
+        }
+        manager.currentAccount = newAccount
+
+        // Assert: the new account's state moves past .basicInfoLoaded
+        // within a bounded window. The setter must fire the auth-doc
+        // driver — staying at .basicInfoLoaded means the regression is
+        // open and awaitReady() callers hang after every library switch.
+        let movedExpectation = expectation(description: "new account moved past .basicInfoLoaded")
+        var observedFinalState: Account.LoadState = AccountStateStore.shared.state(for: newUUID)
+        let deadline = Date().addingTimeInterval(3.0)
+        DispatchQueue.global().async {
+            while Date() < deadline {
+                let s = AccountStateStore.shared.state(for: newUUID)
+                switch s {
+                case .detailsLoading, .detailsLoaded, .detailsFailed:
+                    observedFinalState = s
+                    movedExpectation.fulfill()
+                    return
+                default:
+                    Thread.sleep(forTimeInterval: 0.05)
+                }
+            }
+        }
+        wait(for: [movedExpectation], timeout: 4.0)
+
+        switch observedFinalState {
+        case .detailsLoading, .detailsLoaded, .detailsFailed:
+            break // wiring fired
+        default:
+            XCTFail("Library-switch setter must drive new currentAccount past .basicInfoLoaded; observed \(label(observedFinalState))")
+        }
+    }
+
     // MARK: - Test 6: Re-entry after reselect resets state
 
     /// Contract: after a library reselect terminates the prior UUID at


### PR DESCRIPTION
## Summary

Sibling fix to PR #975's `loadCatalogs` warm-path driver. Same disease class, different trigger.

**Root cause.** `AccountsManager.currentAccount.didSet` terminates the OUTGOING account's `LoadState` at `.detailsFailed(.accountNotFound)` but does NOT drive the NEW account's auth-doc fetch. The new currentAccount stays at whatever state it was in (typically `.basicInfoLoaded` from preload, or `.notLoaded` if never visited). Every `awaitReady()` caller hangs forever the first time the user opens content on the newly-selected library — same symptom as PR #975's cold-launch spinner, just triggered by library switch instead of cold launch.

### Fix

One line: `driveCurrentAccountAuthDocIfNeeded()` immediately after the outgoing-account termination. The helper (added in PR #975) reads the NEW currentAccount via UUID lookup, checks if state is non-terminal, fires `fetchAuthDocumentWithStateMachine` with the existing single-flight guard. No-op when state is already terminal.

Placement is between the outgoing-account `.accountNotFound` termination and the `TPPCurrentAccountDidChange` notification — so the ~25 downstream subscribers (`TPPBookRegistry`, `BookCellModelCache`, `MyBooksView`, `CatalogView`, `CarPlay`, etc.) see state that's already being driven, not stuck at `.basicInfoLoaded`.

### Test

`testLibrarySwitch_drivesNewCurrentAccountPastBasicInfoLoaded` — seeds disk cache, runs preload (populates accountSets so `currentAccount` accessor resolves), starts user on prior UUID, swaps to new UUID, polls for state convergence within 3s. **Verified RED at HEAD-1** (state stuck at `.basicInfoLoaded`, fails at 6.1s) and **GREEN at HEAD** (state transitions through `.detailsLoading` → terminal within ~1s).

## Verification

- `AccountsManagerStateMachineWiringTests`: **9/0/0** in 6.57s on iPhone 16 Pro sim (iOS 18.4) — 8 existing + 1 new
- Builds green

## ForgeOS governance

- Changeset: `cs_94c872a5` (initiative `init_dde7f99a` — 3.2.0 Account state machine)
- Architect review: `rev_f9567a07` — APPROVED. Verified placement correctness (between cleanup + notification), single-flight behavior (in-flight refresh resolves via stateStream broadcast — no wasted RTT), no TOCTOU.
- QA review: `rev_3cfa9495` — APPROVED. Verified mutation kill (removing the call leaves no other path to advance the state in this scenario), pre-state sequencing is robust (same recipe as existing passing Tests 2a/2b/4/6), polling pattern is CI-safe (outer XCTestExpectation + wait(for:) fails loudly).
- Gates: review / testing / release — all PASSED. `can_release: true`.

## Scope / Not done / Deferred

**Scope:** 1 prod file (`AccountsManager.swift` — 1-line addition + comment), 1 test file (~95 LOC new test). Public API unchanged.

**Not done:** None — this closes the sibling gap. Together with PR #975's warm-path driver fix and the existing Phase 1/2 readers, the state-machine invariant ("any account in accountSets reaches a terminal LoadState") now holds across all three entry points: cold launch, in-memory warm cache, and library switch.

**Deferred (non-blocking from architect):** Debug-build invariant assertion — "every UUID in `accountSets` has state != `.notLoaded` after currentAccount selection." Catches future regressions of either driver path. Separate hygiene ticket.

## Test plan

- [x] Targeted xctest suite green
- [x] RED-at-HEAD-1 / GREEN-at-HEAD evidence verified
- [x] ForgeOS architect + QA approved
- [ ] **For reviewer / merger:** device-level smoke — switch libraries in Settings, then open an audiobook/book in the new library. Confirm the open completes (vs hanging at a spinner before this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)