### PR TITLE
fix(my-books): port airplane-mode + LCP audiobook downgrade fix to develop

### DIFF
--- a/Palace/MyBooks/DownloadAlertPresenter.swift
+++ b/Palace/MyBooks/DownloadAlertPresenter.swift
@@ -99,8 +99,17 @@ final class DownloadAlertPresenter {
                 category: .download
             )
             guard let self else { return }
-            // CRITICAL: Remove from bookIdentifierToDownloadInfo so retry works
+            // CRITICAL: Remove from bookIdentifierToDownloadInfo so retry
+            // works. Also sweep any matching taskIdentifierToBook entries so
+            // a later airplane-mode toggle can't misread a no-longer-active
+            // task as in-flight and flip the book to .downloadFailed again
+            // (the regression of PP-4114 — same root cause as the
+            // success-path leak).
             await self.stateManager.bookIdentifierToDownloadInfo.remove(book.identifier)
+            let stalePairs = await self.stateManager.taskIdentifierToBook.allPairs()
+            for (taskId, mappedBook) in stalePairs where mappedBook.identifier == book.identifier {
+                await self.stateManager.taskIdentifierToBook.remove(taskId)
+            }
             await self.stateManager.downloadCoordinator.removeCachedDownloadInfo(for: book.identifier)
             await self.stateManager.downloadCoordinator.registerCompletion(identifier: book.identifier)
             let remainingCount = await self.stateManager.downloadCoordinator.activeCount

--- a/Palace/MyBooks/LCPFulfillmentHandler.swift
+++ b/Palace/MyBooks/LCPFulfillmentHandler.swift
@@ -120,6 +120,23 @@ final class LCPFulfillmentHandler {
                     "licenseURL": licenseUrl.absoluteString,
                     "localURL": localUrl?.absoluteString ?? "N/A"
                 ])
+
+                // PP-4114-adjacent: LCP audiobooks are marked
+                // `.downloadSuccessful` the moment the .lcpl license lands
+                // (streaming-ready). A phase-2 .lcpa content download
+                // failure — typically airplane mode mid-fetch from
+                // googleapis.com — must NOT downgrade an already-readable
+                // audiobook back to `.downloadFailed`. The user reported
+                // this on iPad: previously-downloaded audiobooks losing
+                // the Read/Listen affordance the second they went offline.
+                // Streaming still works off the license; offline playback
+                // just isn't ready until they retry.
+                let currentState = self.bookRegistry.state(for: book.identifier)
+                if book.defaultBookContentType == .audiobook && currentState == .downloadSuccessful {
+                    Log.warn(#file, "LCP audiobook content download failed but streaming license intact — leaving '\(book.title)' (\(book.identifier)) as .downloadSuccessful")
+                    return
+                }
+
                 let errorMessage = "Fulfilment Error: \(error.localizedDescription)"
                 self.alertPresenter.failDownloadWithAlert(for: book, withMessage: errorMessage)
                 return

--- a/Palace/MyBooks/LCPFulfillmentHandler.swift
+++ b/Palace/MyBooks/LCPFulfillmentHandler.swift
@@ -131,9 +131,18 @@ final class LCPFulfillmentHandler {
                 // the Read/Listen affordance the second they went offline.
                 // Streaming still works off the license; offline playback
                 // just isn't ready until they retry.
+                //
+                // `.used` is included for future-proofing — audiobooks
+                // don't transition through `.used` today (only PDFs do, see
+                // TPPPDFDocumentMetadata), but mirroring the established
+                // `(.downloadSuccessful || .used)` pattern from
+                // BookReturnService keeps the guard correct if audiobook
+                // playback ever wires through the open-once → `.used`
+                // transition.
                 let currentState = self.bookRegistry.state(for: book.identifier)
-                if book.defaultBookContentType == .audiobook && currentState == .downloadSuccessful {
-                    Log.warn(#file, "LCP audiobook content download failed but streaming license intact — leaving '\(book.title)' (\(book.identifier)) as .downloadSuccessful")
+                let isStreamingReady = currentState == .downloadSuccessful || currentState == .used
+                if book.defaultBookContentType == .audiobook && isStreamingReady {
+                    Log.warn(#file, "LCP audiobook content download failed but streaming license intact — leaving '\(book.title)' (\(book.identifier)) as \(currentState)")
                     return
                 }
 

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -820,10 +820,30 @@ import OverdriveProcessor
             let activeInfos = await self.stateManager.bookIdentifierToDownloadInfo.values()
             guard !activePairs.isEmpty else { return }
 
-            // Cancel pending tasks first so iOS stops trying to drive them.
+            // Filter to books that are *genuinely* in flight. `taskIdentifierToBook`
+            // can retain stale entries from previously-completed downloads (the
+            // success path doesn't always clear it), and without this guard
+            // airplane-mode flips already-downloaded books to .downloadFailed —
+            // the regression of PP-4114 reported on iPad. Only states that
+            // represent an in-progress URLSession task warrant the failure
+            // transition; everything else (e.g. .downloadSuccessful, .used)
+            // must be left alone.
+            let registry = self.bookRegistry
+            let booksToFail: [TPPBook] = await MainActor.run {
+                activePairs.compactMap { (_, book) -> TPPBook? in
+                    let state = registry.state(for: book.identifier)
+                    return (state == .downloading || state == .SAMLStarted) ? book : nil
+                }
+            }
+
+            // Cancel pending URLSession tasks first so iOS stops trying to
+            // drive them. Safe to cancel all active infos here — cancel is a
+            // no-op for tasks the system has already finished.
             for info in activeInfos {
                 info.downloadTask.cancel()
             }
+
+            guard !booksToFail.isEmpty else { return }
 
             // Surface the alert + state transition for each book.
             let message = NSLocalizedString(
@@ -832,7 +852,7 @@ import OverdriveProcessor
             )
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                for (_, book) in activePairs {
+                for book in booksToFail {
                     self.failDownloadWithAlert(for: book, withMessage: message)
                 }
             }
@@ -1239,8 +1259,12 @@ extension MyBooksDownloadCenter: URLSessionDownloadDelegate {
 
         broadcastUpdate()
 
-        // CRITICAL: Remove from bookIdentifierToDownloadInfo so retry works
+        // CRITICAL: Remove from bookIdentifierToDownloadInfo so retry works.
+        // Also remove the taskIdentifierToBook entry so the airplane-mode
+        // handler doesn't later misread the completed task as in-flight and
+        // flip the (now-downloaded) book to .downloadFailed.
         await bookIdentifierToDownloadInfo.remove(book.identifier)
+        await taskIdentifierToBook.remove(task.taskIdentifier)
         await downloadCoordinator.removeCachedDownloadInfo(for: book.identifier)
         await downloadCoordinator.registerCompletion(identifier: book.identifier)
         let remainingCount = await downloadCoordinator.activeCount

--- a/PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift
+++ b/PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift
@@ -202,6 +202,88 @@ final class LCPFulfillmentHandlerTests: XCTestCase {
                        "Audiobook books mark .downloadSuccessful immediately so streaming works")
     }
 
+    // MARK: - LCP audiobook phase-2 download failure must not downgrade
+
+    /// Regression of PP-4114-adjacent iPad bug.
+    ///
+    /// LCP audiobooks have a two-phase download: the .lcpl license file
+    /// completes first and the book is immediately marked `.downloadSuccessful`
+    /// (playable via streaming). The LCP toolkit then runs a SECONDARY
+    /// background download for the .lcpa content file from googleapis.com
+    /// so offline playback also works.
+    ///
+    /// If that secondary download fails — for example, the user toggles
+    /// airplane mode mid-fetch — `lcpCompletion` was previously firing
+    /// `failDownloadWithAlert`, which flipped the audiobook from
+    /// `.downloadSuccessful` back to `.downloadFailed`. The user reported
+    /// this on iPad: previously-downloaded audiobooks lost the Read/Listen
+    /// affordance and showed "The download could not be completed." the
+    /// moment they went offline.
+    ///
+    /// Fix: when the book is an audiobook AND already at
+    /// `.downloadSuccessful` (license is in place, streaming is viable),
+    /// the secondary-fetch error is logged but does NOT publish a failure
+    /// alert or mutate the registry state. Offline playback isn't
+    /// available until they retry, but the book stays readable.
+    func testFulfill_audiobook_secondaryDownloadError_doesNotFlipStreamingReadyBook() async throws {
+        let audiobook = TPPBookMocker.mockBook(distributorType: .AudiobookLCP)
+        let sourceURL = try writeSourceFile(ext: "lcpa")
+        let downloadTask = FakeDownloadTask(state: .completed, identifier: 1)
+
+        handler.fulfillLCPLicense(fileUrl: sourceURL, forBook: audiobook, downloadTask: downloadTask)
+
+        // Mirror production: the audiobook path's synchronous
+        // markDownloadSuccessful runs immediately. We assert the spy saw
+        // it (sanity), then stage the registry state production would be
+        // in when the phase-2 error fires.
+        XCTAssertEqual(spyDelegate.markSuccessfulCalls, [audiobook.identifier],
+                       "precondition: audiobook is marked .downloadSuccessful at license-fulfilled time")
+        registry.addBook(audiobook, state: .downloadSuccessful)
+
+        // Fire the secondary-fetch failure (airplane mode in production).
+        let completion = try XCTUnwrap(lcpService.lastCompletion)
+        let networkLost = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorNetworkConnectionLost,
+            userInfo: [NSLocalizedDescriptionKey: "The network connection was lost."]
+        )
+        completion(nil, networkLost)
+
+        // Give the async error handler time to run; without the guard it
+        // calls failDownloadWithAlert synchronously off the completion.
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        await Task.yield()
+
+        XCTAssertEqual(registry.state(for: audiobook.identifier), .downloadSuccessful,
+                       "LCP audiobook with streaming-ready license must NOT flip to .downloadFailed when the phase-2 content download fails")
+        XCTAssertTrue(capturedErrors.isEmpty,
+                      "No user-facing 'Fulfilment Error' alert should publish for an audiobook that's still streaming-playable")
+    }
+
+    /// Sibling check: a non-audiobook (e.g. LCP EPUB) does NOT get the
+    /// pass — its content file is essential, and a phase-2 failure means
+    /// the book can't be opened. The existing alert path must remain.
+    func testFulfill_epub_secondaryDownloadError_stillSurfacesAlert() async throws {
+        let book = TPPBookMocker.mockBook(distributorType: .ReadiumLCP)
+        let sourceURL = try writeSourceFile()
+        let downloadTask = FakeDownloadTask(state: .completed, identifier: 1)
+
+        handler.fulfillLCPLicense(fileUrl: sourceURL, forBook: book, downloadTask: downloadTask)
+        // Even if an EPUB were somehow at .downloadSuccessful (it isn't
+        // until the secondary completes), the alert must still fire — the
+        // user can't read it without the content file.
+        registry.addBook(book, state: .downloadSuccessful)
+
+        let completion = try XCTUnwrap(lcpService.lastCompletion)
+        completion(nil, NSError(domain: NSURLErrorDomain,
+                                code: NSURLErrorNetworkConnectionLost,
+                                userInfo: [NSLocalizedDescriptionKey: "lost"]))
+        await waitForPublishedError()
+
+        XCTAssertFalse(capturedErrors.isEmpty,
+                       "EPUB/PDF LCP books still need the alert — no content file = no read")
+    }
+
     // MARK: - Fulfillment task tracking
 
     func testFulfill_storesReturnedDownloadTaskInStateManager() async throws {

--- a/PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift
+++ b/PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift
@@ -260,6 +260,33 @@ final class LCPFulfillmentHandlerTests: XCTestCase {
                       "No user-facing 'Fulfilment Error' alert should publish for an audiobook that's still streaming-playable")
     }
 
+    /// Future-proofing for the `.used` transition. Audiobooks don't
+    /// transition through `.used` today (only PDFs do), but the guard
+    /// matches the established `(.downloadSuccessful || .used)` pattern
+    /// from BookReturnService — so if audiobook open ever wires through
+    /// open-once → `.used`, the regression doesn't silently return.
+    func testFulfill_audiobook_inUsedState_secondaryDownloadError_doesNotFlipToFailed() async throws {
+        let audiobook = TPPBookMocker.mockBook(distributorType: .AudiobookLCP)
+        let sourceURL = try writeSourceFile(ext: "lcpa")
+        let downloadTask = FakeDownloadTask(state: .completed, identifier: 1)
+
+        handler.fulfillLCPLicense(fileUrl: sourceURL, forBook: audiobook, downloadTask: downloadTask)
+        // Stage the future state: book has been opened at least once.
+        registry.addBook(audiobook, state: .used)
+
+        let completion = try XCTUnwrap(lcpService.lastCompletion)
+        completion(nil, NSError(domain: NSURLErrorDomain,
+                                code: NSURLErrorNetworkConnectionLost,
+                                userInfo: [NSLocalizedDescriptionKey: "lost"]))
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        await Task.yield()
+
+        XCTAssertEqual(registry.state(for: audiobook.identifier), .used,
+                       "Audiobook in .used (already-opened) must survive a phase-2 failure same as .downloadSuccessful")
+        XCTAssertTrue(capturedErrors.isEmpty,
+                      "No alert should publish for an already-opened audiobook on phase-2 failure")
+    }
+
     /// Sibling check: a non-audiobook (e.g. LCP EPUB) does NOT get the
     /// pass — its content file is essential, and a phase-2 failure means
     /// the book can't be opened. The existing alert path must remain.

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterOfflineTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterOfflineTests.swift
@@ -238,4 +238,110 @@ final class MyBooksDownloadCenterOfflineTests: XCTestCase {
         // No expectations — this test passes if nothing crashes or asserts.
         _ = center
     }
+
+    // MARK: - Stale-entry regression (airplane-mode flips downloaded books)
+
+    /// Regression of PP-4114's airplane-mode handler.
+    ///
+    /// Reproduces the user-visible iPad bug: previously-downloaded books
+    /// show "The download could not be completed." and the Read button
+    /// disappears the moment airplane mode is toggled.
+    ///
+    /// Root cause: `taskIdentifierToBook` is never cleaned up on download
+    /// success, so completed books leave stale `(taskId, book)` entries.
+    /// `failActiveDownloadsForNetworkLoss()` iterates that map and calls
+    /// `failDownloadWithAlert` on every entry — regardless of whether the
+    /// book is actually downloading. A `.downloadSuccessful` book with a
+    /// stale entry gets flipped to `.downloadFailed`.
+    ///
+    /// Defensive fix: the handler must consult the registry's current state
+    /// for each book and skip those not in {.downloading, .SAMLStarted}.
+    func testReachabilityDrop_WithStaleTaskEntryForDownloadedBook_DoesNotFlipToFailed() async {
+        let book = makeBook(id: "previously-downloaded")
+        mockRegistry.addBook(book, state: .downloadSuccessful)
+
+        // Stage the leak: a stale taskId entry for a book that has already
+        // finished downloading. `bookIdentifierToDownloadInfo` is correctly
+        // empty (post-success cleanup), but `taskIdentifierToBook` retains
+        // the entry — exactly what production looks like today after any
+        // successful download.
+        await stateManager.taskIdentifierToBook.set(7, value: book)
+
+        let center = MyBooksDownloadCenter(
+            bookRegistry: mockRegistry,
+            stateManager: stateManager,
+            reachability: mockReachability
+        )
+        await drainMainQueueAsync()
+        XCTAssertEqual(mockRegistry.state(for: book.identifier), .downloadSuccessful,
+                       "precondition: book is downloaded and readable offline")
+
+        mockReachability.simulate(connected: false)
+        // Give the handler time to run; the bug flips state inside ~10ms.
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        await drainMainQueueAsync()
+
+        XCTAssertEqual(mockRegistry.state(for: book.identifier), .downloadSuccessful,
+                       "Airplane mode must NOT flip a previously-downloaded book to .downloadFailed just because a stale taskIdentifierToBook entry exists")
+        _ = center
+    }
+
+    /// Coexistence: a stale-entry book AND a genuinely-downloading book.
+    /// The handler must fail the latter (PP-4114's intent) but leave the
+    /// former alone (this hotfix's intent).
+    func testReachabilityDrop_StaleAndActive_FailsOnlyTheActiveDownload() async {
+        let downloadedBook = makeBook(id: "previously-downloaded-mix")
+        let activeBook = makeBook(id: "actively-downloading-mix")
+        mockRegistry.addBook(downloadedBook, state: .downloadSuccessful)
+        mockRegistry.addBook(activeBook, state: .downloading)
+
+        // Stale entry for the completed book.
+        await stateManager.taskIdentifierToBook.set(11, value: downloadedBook)
+        // Genuine in-flight download for the active one.
+        _ = await registerActiveDownload(book: activeBook, taskIdentifier: 12)
+
+        let center = MyBooksDownloadCenter(
+            bookRegistry: mockRegistry,
+            stateManager: stateManager,
+            reachability: mockReachability
+        )
+        await drainMainQueueAsync()
+
+        mockReachability.simulate(connected: false)
+        await waitForState(.downloadFailed, on: activeBook.identifier)
+
+        XCTAssertEqual(mockRegistry.state(for: activeBook.identifier), .downloadFailed,
+                       "PP-4114 intent preserved: genuinely in-flight downloads still fail on network loss")
+        XCTAssertEqual(mockRegistry.state(for: downloadedBook.identifier), .downloadSuccessful,
+                       "Hotfix: previously-downloaded books with stale taskId entries are NOT touched by the airplane-mode handler")
+        _ = center
+    }
+
+    /// Cleanup-on-success contract: once we wire up `cleanupDownload`, a book
+    /// that transitions through the success path must not leave a stale
+    /// `taskIdentifierToBook` entry. This is the root-cause fix; even
+    /// without the defensive filter above, this prevents the bug from
+    /// occurring in the first place because there are no stale entries
+    /// for the airplane-mode handler to misinterpret.
+    ///
+    /// We exercise it via `DownloadStateManager.cleanupDownload` directly
+    /// (which is the seam production code uses for terminal-state cleanup).
+    func testCleanupDownload_RemovesTaskIdentifierToBookEntry() async {
+        let book = makeBook(id: "cleanup-contract")
+        await stateManager.taskIdentifierToBook.set(99, value: book)
+        await stateManager.bookIdentifierToDownloadInfo.set(book.identifier, value: MyBooksDownloadInfo(
+            downloadProgress: 1.0,
+            downloadTask: MockURLSessionDownloadTask(taskIdentifier: 99),
+            rightsManagement: .none
+        ))
+
+        await stateManager.cleanupDownload(for: book.identifier, taskIdentifier: 99)
+
+        let taskEntry = await stateManager.taskIdentifierToBook.get(99)
+        let infoEntry = await stateManager.bookIdentifierToDownloadInfo.get(book.identifier)
+        XCTAssertNil(taskEntry,
+                     "cleanupDownload(for:taskIdentifier:) must remove the taskIdentifierToBook entry — root-cause fix for the airplane-mode regression")
+        XCTAssertNil(infoEntry,
+                     "cleanupDownload must also remove the bookIdentifierToDownloadInfo entry")
+    }
 }


### PR DESCRIPTION
## Summary

Develop port of release/3.1.0 hotfix PR #986 (merged) — same two fixes for the iPad airplane-mode regression, plus one defensive broadening.

**Fix 1** (cherry-pick e54a1f48a → 0fa2df9ea): `MyBooksDownloadCenter.failActiveDownloadsForNetworkLoss` no longer flips previously-downloaded books to `.downloadFailed` based on stale `taskIdentifierToBook` entries. Root-cause cleanup added in `handleDownloadCompletion` + `DownloadAlertPresenter.failDownloadWithAlert`; defensive registry-state filter on the airplane-mode handler.

**Fix 2** (cherry-pick 44895d2b8 → 4e56e3c2e): `LCPFulfillmentHandler` no longer flips a streaming-ready LCP audiobook back to `.downloadFailed` when its phase-2 `.lcpa` content download fails (typical airplane-mode-mid-fetch scenario).

**New for develop port** (9b953633e): broadens the LCP audiobook guard from `currentState == .downloadSuccessful` to `currentState == .downloadSuccessful || currentState == .used`, per architect review note `rev_b4231540` on the hotfix. Mirrors the established `(.downloadSuccessful || .used)` pattern from `BookReturnService`. Adds one sibling test pinning the `.used` branch.

## Reviews

- Architect `rev_d3530e0e` — approved. Cherry-picks land cleanly against develop; no semantic interaction with recent landings (#979 audiobook adapter, #980 PalaceReadingPosition, #982 CarPlay singleton removal).
- QA `rev_c56ae4ba` — approved. New `.used` sibling test kills the mutant (flipping `||` → `&&` makes the guard never trigger, the failure path runs, assertion fails). No regression conflicts.

## Test plan

- [x] **TDD coverage** — 16/16 LCPFulfillmentHandlerTests + MyBooksDownloadCenterOfflineTests pass on this branch.
- [x] **ForgeOS changeset** — `cs_43441719` (low risk 0/100), all 3 gates promoted (review/testing/release).
- [x] **Hotfix verified in production** — release/3.1.0 PR #986 merged + build 478 cut.
- [ ] **CI** — Develop regression suite green.

## Scope

5 files, ~30 LOC production + ~210 LOC tests. Same surface as the hotfix plus a 1-line `||` broadening and a 20-line sibling test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)