### PR TITLE
chore(registry): bundled cache sentinel + Xcode build-phase freshness check (PR #992 follow-ups)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -6028,6 +6028,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 73EB0B7225821DF4006BC997 /* Build configuration list for PBXNativeTarget "Palace-noDRM" */;
 			buildPhases = (
+				5B51E4AE08FCC5573C9D3542 /* Check Registry Snapshot Freshness */,
 				73EB0A6425821DF4006BC997 /* Sources */,
 				73EB0B2C25821DF4006BC997 /* Frameworks */,
 				73EB0B5825821DF4006BC997 /* Resources */,
@@ -6071,6 +6072,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A823D839192BABA400B55DE2 /* Build configuration list for PBXNativeTarget "Palace" */;
 			buildPhases = (
+				3A3692EDBADAC0E5D5FEAC50 /* Check Registry Snapshot Freshness */,
 				A823D809192BABA400B55DE2 /* Sources */,
 				A823D80A192BABA400B55DE2 /* Frameworks */,
 				A823D80B192BABA400B55DE2 /* Resources */,
@@ -6387,6 +6389,48 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		3A3692EDBADAC0E5D5FEAC50 /* Check Registry Snapshot Freshness */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Palace/Accounts/Library/bundled_registry.json",
+			);
+			name = "Check Registry Snapshot Freshness";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Emits an Xcode-style warning when bundled_registry.json is stale.\n# Always exits 0; the warning is the signal.\nbash \"$SRCROOT/scripts/check_registry_snapshot_freshness.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5B51E4AE08FCC5573C9D3542 /* Check Registry Snapshot Freshness */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Palace/Accounts/Library/bundled_registry.json",
+			);
+			name = "Check Registry Snapshot Freshness";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Emits an Xcode-style warning when bundled_registry.json is stale.\n# Always exits 0; the warning is the signal.\nbash \"$SRCROOT/scripts/check_registry_snapshot_freshness.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		73DA43AD2404CA9500985482 /* Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -10,6 +10,32 @@ let currentAccountIdentifierKey = "TPPCurrentAccountIdentifier"
 struct CatalogCacheMetadata: Codable {
     let timestamp: Date
     let hash: String
+    /// `true` when this cache entry was populated from the build-time
+    /// bundled snapshot (`Palace/Accounts/Library/bundled_registry.json`),
+    /// `false` for entries written from a network response. Bundled-origin
+    /// caches return `true` from `isStale(serverMaxAge:now:)` regardless
+    /// of timestamp so the refresh trigger keeps firing on every
+    /// `loadCatalogs` call until a real network response overwrites the
+    /// metadata with `isBundled = false`. Decodes as `false` for legacy
+    /// metadata files written before this field existed.
+    let isBundled: Bool
+
+    init(timestamp: Date, hash: String, isBundled: Bool = false) {
+        self.timestamp = timestamp
+        self.hash = hash
+        self.isBundled = isBundled
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case timestamp, hash, isBundled
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.timestamp = try container.decode(Date.self, forKey: .timestamp)
+        self.hash = try container.decode(String.self, forKey: .hash)
+        self.isBundled = try container.decodeIfPresent(Bool.self, forKey: .isBundled) ?? false
+    }
 
     /// Default stale TTL: 6 hours (half the server's typical Cache-Control
     /// max-age of 12hr). Overridden dynamically by `staleTTL(serverMaxAge:)`.
@@ -35,7 +61,13 @@ struct CatalogCacheMetadata: Codable {
     }
 
     func isStale(serverMaxAge: TimeInterval?, now: Date) -> Bool {
-        now.timeIntervalSince(timestamp) > Self.staleTTL(serverMaxAge: serverMaxAge)
+        // Bundled-origin caches are always stale for refresh purposes
+        // regardless of timestamp. The bundled bytes are usable for
+        // immediate display but not authoritative, so refresh has to
+        // keep firing until a real network response overwrites with
+        // `isBundled = false`.
+        if isBundled { return true }
+        return now.timeIntervalSince(timestamp) > Self.staleTTL(serverMaxAge: serverMaxAge)
     }
 
     /// Returns true if cache is stale using the default TTL (no server hint).
@@ -519,7 +551,10 @@ struct CatalogCacheMetadata: Codable {
         // was cut, so this is purely a fast-path for cold first launch.
         if let bundledData = BundledRegistrySnapshot.load() {
             Log.info(#file, "First launch — loading bundled registry snapshot for hash \(hash), dataSize=\(bundledData.count)")
-            cacheAccountsCatalogData(bundledData, hash: hash)
+            // isBundled=true keeps the cache flagged as non-authoritative so
+            // every subsequent loadCatalogs call still triggers refresh until
+            // a real network response overwrites the metadata.
+            cacheAccountsCatalogData(bundledData, hash: hash, isBundled: true)
             loadAccountSetsAndAuthDoc(fromCatalogData: bundledData, key: hash) { _ in
                 NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
             }
@@ -728,13 +763,15 @@ struct CatalogCacheMetadata: Codable {
         return appSupport.appendingPathComponent("accounts_catalog_metadata_\(hash).json")
     }
 
-    private func cacheAccountsCatalogData(_ data: Data, hash: String) {
+    private func cacheAccountsCatalogData(_ data: Data, hash: String, isBundled: Bool = false) {
         // Save catalog data
         guard let url = accountsCatalogUrl(hash: hash) else { return }
         try? data.write(to: url)
 
-        // Save metadata with current timestamp
-        let metadata = CatalogCacheMetadata(timestamp: Date(), hash: hash)
+        // Save metadata with current timestamp. `isBundled` distinguishes
+        // build-time-snapshot writes from authoritative network writes so
+        // staleness logic can keep refresh alive on bundled-origin caches.
+        let metadata = CatalogCacheMetadata(timestamp: Date(), hash: hash, isBundled: isBundled)
         if let metadataUrl = cacheMetadataUrl(hash: hash),
            let metadataData = try? JSONEncoder().encode(metadata) {
             try? metadataData.write(to: metadataUrl)

--- a/PalaceTests/Accounts/CatalogCacheMetadataTests.swift
+++ b/PalaceTests/Accounts/CatalogCacheMetadataTests.swift
@@ -190,4 +190,105 @@ final class CatalogCacheMetadataTests: XCTestCase {
         XCTAssertTrue(epoch.isStale)
         XCTAssertTrue(epoch.isExpired)
     }
+
+    // MARK: - isBundled sentinel (force-stale on build-time snapshot writes)
+
+    func testIsBundled_DefaultsFalse_ForBackCompat() {
+        // Convenience initializer omits isBundled so existing call sites
+        // and legacy decoded metadata continue to behave like network caches.
+        let metadata = CatalogCacheMetadata(timestamp: Date(), hash: "h")
+        XCTAssertFalse(metadata.isBundled)
+    }
+
+    func testIsBundled_True_ForcesStaleness_RegardlessOfFreshTimestamp() {
+        // A bundled-origin cache MUST always trip refresh, even when the
+        // timestamp says it was just written. The disk-cached bytes are
+        // usable for immediate display but not authoritative.
+        let justWritten = CatalogCacheMetadata(
+            timestamp: Date(),
+            hash: "h",
+            isBundled: true
+        )
+        XCTAssertTrue(justWritten.isStale)
+        XCTAssertTrue(justWritten.isStale(serverMaxAge: 43200))
+        XCTAssertTrue(justWritten.isStale(serverMaxAge: nil))
+    }
+
+    func testIsBundled_True_ForcesStaleness_AcrossAllServerMaxAges() {
+        // Sweep the bracketing values that affect the network-cache TTL
+        // (the floor at 5min, mid-range, and the ceiling at 12h) — none
+        // of them should override the bundled force-stale path.
+        let bundled = CatalogCacheMetadata(
+            timestamp: Date(),
+            hash: "h",
+            isBundled: true
+        )
+        for maxAge in [TimeInterval?.none, 60, 600, 3600, 43200, 86400] {
+            XCTAssertTrue(
+                bundled.isStale(serverMaxAge: maxAge),
+                "isBundled=true must force stale for serverMaxAge=\(String(describing: maxAge))"
+            )
+        }
+    }
+
+    func testIsBundled_False_PreservesExistingStalenessBehavior() {
+        // The opposite branch: a network-origin cache (isBundled=false)
+        // must still respect the timestamp + serverMaxAge logic that
+        // existed before the sentinel landed.
+        let freshNetwork = CatalogCacheMetadata(
+            timestamp: Date(),
+            hash: "h",
+            isBundled: false
+        )
+        let oldNetwork = CatalogCacheMetadata(
+            timestamp: Date().addingTimeInterval(-25200), // 7h
+            hash: "h",
+            isBundled: false
+        )
+        XCTAssertFalse(freshNetwork.isStale)
+        XCTAssertTrue(oldNetwork.isStale)
+    }
+
+    func testDecode_LegacyMetadataWithoutIsBundledField_DefaultsToFalse() throws {
+        // On-disk metadata written before this field existed must still
+        // decode cleanly and default to isBundled=false so legacy caches
+        // continue to behave like the network-origin caches they were.
+        let legacyJSON = #"""
+        {"timestamp": 750000000, "hash": "legacy-hash"}
+        """#.data(using: .utf8)!
+
+        let metadata = try JSONDecoder().decode(CatalogCacheMetadata.self, from: legacyJSON)
+        XCTAssertEqual(metadata.hash, "legacy-hash")
+        XCTAssertFalse(metadata.isBundled,
+                       "Legacy metadata without isBundled must default to false")
+    }
+
+    func testEncodeDecode_PreservesIsBundledTrue() throws {
+        let original = CatalogCacheMetadata(
+            timestamp: Date(),
+            hash: "bundled-hash",
+            isBundled: true
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CatalogCacheMetadata.self, from: data)
+        XCTAssertTrue(decoded.isBundled)
+        XCTAssertEqual(decoded.hash, original.hash)
+        XCTAssertTrue(decoded.isStale,
+                      "Round-tripped bundled cache must still report stale")
+    }
+
+    func testEncodeDecode_PreservesIsBundledFalse_Explicitly() throws {
+        // Distinct from the legacy-decode case — when the field IS written
+        // with `false`, the round-trip must preserve `false` (not flip to
+        // some surprise default).
+        let original = CatalogCacheMetadata(
+            timestamp: Date(),
+            hash: "network-hash",
+            isBundled: false
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CatalogCacheMetadata.self, from: data)
+        XCTAssertFalse(decoded.isBundled)
+        XCTAssertFalse(decoded.isStale)
+    }
 }

--- a/scripts/check_registry_snapshot_freshness.sh
+++ b/scripts/check_registry_snapshot_freshness.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# check_registry_snapshot_freshness.sh
+#
+# Emits an Xcode-style `warning:` line if Palace/Accounts/Library/bundled_registry.json
+# is older than REGISTRY_SNAPSHOT_THRESHOLD_DAYS (default 30 days). Designed to
+# run as an Xcode "Run Script" build phase AND as a Fastlane pre-build step,
+# so distribution paths that bypass `fastlane refresh_registry_snapshot`
+# (e.g. manual Xcode Organizer archives) still surface the stale-snapshot
+# signal at build time.
+#
+# Always exits 0 — this is a developer-facing warning, not a hard gate.
+# A missing snapshot file is logged as a warning too (a fresh checkout
+# without `fastlane refresh_registry_snapshot` having ever run will hit
+# this path).
+
+set -euo pipefail
+
+THRESHOLD_DAYS="${REGISTRY_SNAPSHOT_THRESHOLD_DAYS:-30}"
+
+# Resolve project root: prefer Xcode's $SRCROOT (set in build-phase context),
+# fall back to repo-root detection from the script's own location, then to cwd.
+if [ -n "${SRCROOT:-}" ]; then
+    SCRIPT_ROOT="$SRCROOT"
+elif [ -n "${BASH_SOURCE[0]:-}" ]; then
+    SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+else
+    SCRIPT_ROOT="$(pwd)"
+fi
+
+SNAPSHOT_PATH="$SCRIPT_ROOT/Palace/Accounts/Library/bundled_registry.json"
+
+if [ ! -f "$SNAPSHOT_PATH" ]; then
+    echo "warning: bundled_registry.json missing at $SNAPSHOT_PATH — run 'fastlane refresh_registry_snapshot' before shipping" >&2
+    exit 0
+fi
+
+now_epoch=$(date +%s)
+# macOS uses `stat -f %m`, GNU uses `stat -c %Y`. Try BSD first, then GNU.
+if file_epoch=$(stat -f %m "$SNAPSHOT_PATH" 2>/dev/null); then
+    :
+elif file_epoch=$(stat -c %Y "$SNAPSHOT_PATH" 2>/dev/null); then
+    :
+else
+    echo "warning: bundled_registry.json freshness check could not read file mtime (unsupported stat)" >&2
+    exit 0
+fi
+
+age_seconds=$(( now_epoch - file_epoch ))
+age_days=$(( age_seconds / 86400 ))
+
+if [ "$age_days" -gt "$THRESHOLD_DAYS" ]; then
+    echo "warning: bundled_registry.json is $age_days days old (threshold ${THRESHOLD_DAYS}d) — run 'fastlane refresh_registry_snapshot' to refresh before shipping" >&2
+fi
+
+exit 0

--- a/scripts/pbxproj_add_registry_freshness_phase.rb
+++ b/scripts/pbxproj_add_registry_freshness_phase.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# pbxproj_add_registry_freshness_phase.rb — adds a "Check Registry Snapshot
+# Freshness" Run Script build phase to the Palace and Palace-noDRM targets.
+#
+# The script (scripts/check_registry_snapshot_freshness.sh) emits an Xcode-style
+# `warning:` line if Palace/Accounts/Library/bundled_registry.json is older than
+# REGISTRY_SNAPSHOT_THRESHOLD_DAYS (default 30 days). The build phase runs on
+# every build — including manual Xcode Organizer archives — so distribution
+# paths that bypass `fastlane refresh_registry_snapshot` still surface the
+# stale-snapshot signal.
+#
+# Idempotent: re-running this script when the phase already exists is a no-op.
+
+require 'xcodeproj'
+
+REPO_ROOT = File.expand_path('..', __dir__)
+PROJECT_PATH = File.join(REPO_ROOT, 'Palace.xcodeproj')
+PHASE_NAME = 'Check Registry Snapshot Freshness'
+TARGETS = %w[Palace Palace-noDRM].freeze
+SHELL_SCRIPT = <<~SH
+  # Emits an Xcode-style warning when bundled_registry.json is stale.
+  # Always exits 0; the warning is the signal.
+  bash "$SRCROOT/scripts/check_registry_snapshot_freshness.sh"
+SH
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+added = 0
+skipped = 0
+
+TARGETS.each do |target_name|
+  target = project.native_targets.find { |t| t.name == target_name }
+  unless target
+    warn "skip: target #{target_name} not found"
+    next
+  end
+
+  existing = target.shell_script_build_phases.find { |p| p.name == PHASE_NAME }
+  if existing
+    puts "skip: '#{PHASE_NAME}' already present on #{target_name}"
+    skipped += 1
+    next
+  end
+
+  phase = target.new_shell_script_build_phase(PHASE_NAME)
+  phase.shell_path = '/bin/sh'
+  phase.shell_script = SHELL_SCRIPT
+  phase.input_paths = ['$(SRCROOT)/Palace/Accounts/Library/bundled_registry.json']
+  phase.output_paths = []
+  # Always run — the freshness check is cheap and idempotent. Skipping it
+  # on dependency analysis would defeat its purpose (catching stale data
+  # the engineer hasn't touched).
+  phase.always_out_of_date = '1'
+  phase.run_only_for_deployment_postprocessing = '0'
+  phase.show_env_vars_in_log = '0'
+
+  # Reorder so the freshness check runs first — surfacing the warning
+  # early in the build log keeps it visible above the Swift compile noise.
+  target.build_phases.delete(phase)
+  target.build_phases.unshift(phase)
+
+  added += 1
+  puts "added: '#{PHASE_NAME}' to #{target_name}"
+end
+
+if added.zero?
+  puts "nothing to do (skipped #{skipped})"
+else
+  project.save
+  puts "saved Palace.xcodeproj (added #{added}, skipped #{skipped})"
+end


### PR DESCRIPTION
## Summary

Closes the 2 non-blocking architect warnings on **#992**. Stacks on top of `feat/registry-paging-PP-4258-4259` — diff narrows to this branch's 1 commit (`b11177cd7`) once #992 merges.

### 1. Bundled-origin cache sentinel

The bundled-snapshot fall-through in `AccountsManager.loadCatalogs` writes the build-time bytes to the disk cache with a fresh `Date()` stamp. On a subsequent in-process `loadCatalogs` (e.g. library switch in the same session), the warm-path `if isCacheStale(hash:)` returned **false** — so no refresh fired and the bundled bytes persisted as the warm copy until the cache TTL elapsed. The architect's exact concern in their #992 review.

**Fix:** add `isBundled: Bool` to `CatalogCacheMetadata` (defaults to `false`; `decodeIfPresent` keeps back-compat for legacy metadata files written before this field existed). `isStale(serverMaxAge:now:)` short-circuits **true** when `isBundled == true` so refresh keeps firing until a real network response overwrites with `isBundled = false`. `cacheAccountsCatalogData` takes an `isBundled: Bool = false` parameter; the bundled fall-through call site passes `true`; all other writers (lines 556, 585, 609, 660, 687) keep the default.

### 2. Build-phase snapshot freshness check

`fastlane refresh_registry_snapshot` only fires on the `beta` / `appstore` lanes, so manual Xcode Organizer archives or future CI paths that call `build_app` directly would ship a stale snapshot. PP-4259 incremental refresh recovers, but defense-in-depth wants a build-time signal.

**Fix:** new `scripts/check_registry_snapshot_freshness.sh` emits an Xcode-style `warning:` when `bundled_registry.json` exceeds `REGISTRY_SNAPSHOT_THRESHOLD_DAYS` (default 30 days). New `scripts/pbxproj_add_registry_freshness_phase.rb` one-shot helper wires it as a Run Script build phase on both `Palace` and `Palace-noDRM` targets (idempotent — re-running is a no-op). Phase is positioned first in the build-phase order so the warning surfaces above the Swift compile noise. Always-out-of-date so it fires on every build. Fastlane lanes already call `refresh_registry_snapshot` before `build_app`, so the Fastfile itself didn't need a change.

## Verification

**Unit tests: 84/84 pass** on iPhone 16 Pro sim (iOS 26.2), 1.17s wall.

| Suite | Tests | Result |
|---|---:|---|
| `CatalogCacheMetadataTests` | 21 (+7 new) | ✅ |
| `AccountsManagerCacheTests` | 16 | ✅ (no regression on `cacheAccountsCatalogData` signature change with default param) |
| `BundledRegistrySnapshotTests` | 5 | ✅ |
| `CrawlStateTests` | 16 | ✅ |
| `CrawlerFallbackTests` | 12 | ✅ |
| `LibraryRegistryCrawlerTests` | 14 | ✅ |

**New tests in `CatalogCacheMetadataTests` cover:**

- `testIsBundled_DefaultsFalse_ForBackCompat` — convenience init omits `isBundled` so existing call sites preserve behavior
- `testIsBundled_True_ForcesStaleness_RegardlessOfFreshTimestamp` — bundled cache trips refresh even when timestamp says it was just written
- `testIsBundled_True_ForcesStaleness_AcrossAllServerMaxAges` — sweeps the bracketing TTL values (5min floor, mid, 12h ceiling) — none override the bundled force-stale path
- `testIsBundled_False_PreservesExistingStalenessBehavior` — network-origin cache still respects timestamp + serverMaxAge
- `testDecode_LegacyMetadataWithoutIsBundledField_DefaultsToFalse` — on-disk metadata written before this field decodes cleanly with `isBundled = false`
- `testEncodeDecode_PreservesIsBundledTrue` — round-trip preserves bundled flag
- `testEncodeDecode_PreservesIsBundledFalse_Explicitly` — explicit `false` round-trip preserves (not flipped by default-collision)

**Build phase fires on every build:**

> `note: Run script build phase 'Check Registry Snapshot Freshness' will be run during every build because the option to run the script phase "Based on dependency analysis" is unchecked.`

**Script smoke-verified end-to-end:** fresh `bundled_registry.json` → silent; `touch -t 200001010000` on the file → `warning: bundled_registry.json is 9638 days old (threshold 30d) — run 'fastlane refresh_registry_snapshot' to refresh before shipping`.

**Lint:** 0 violations on `CatalogCacheMetadataTests.swift` per `scripts/lint-test-quality.py`.

**ForgeOS:** changeset `cs_0060d43f` (initiative `init_b0b93d85`), all 3 gates promoted. Architect + QA reviews via the server-side AI review path.

## Test plan

- [x] Local: 84/84 affected tests pass on iPhone 16 Pro sim iOS 26.2
- [x] Lint clean on `CatalogCacheMetadataTests.swift`
- [x] ForgeOS architect + QA reviews approved, gates promoted
- [x] Pre-push test gate passes (4 class(es) green)
- [ ] CI green on the stacked branch
- [ ] Merge after #992
- [ ] Manual smoke: cold install → bundled snapshot displays → kill app before network completes → relaunch → verify refresh STILL fires (proves the sentinel kept the warm-path refresh alive)
- [ ] Manual smoke: artificially age `bundled_registry.json` (`touch -t 200001010000`) → xcodebuild archive → confirm `warning:` line appears in the build log

🤖 Generated with [Claude Code](https://claude.com/claude-code)