### PR TITLE
test(accounts): kill wiring-suite test-isolation race

### DIFF
--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -153,6 +153,23 @@ struct CatalogCacheMetadata: Codable {
     private var inflightAuthDocFetches = Set<String>()
     private let inflightAuthDocLock = NSLock()
 
+    #if DEBUG
+    /// Test-only opt-out from the post-init background `loadCatalogs` spawn.
+    /// When `true`, `AccountsManager.init()` skips the
+    /// `DispatchQueue.global(qos: .background).async { loadCatalogs(...) }`
+    /// dispatch — eliminating the cross-test race where lingering background
+    /// work from a previously-constructed AccountsManager instance writes
+    /// through to `accountSets` / `AccountStateStore.shared` mid-test.
+    ///
+    /// Production callers never set this. The suite-level `setUp` of any
+    /// XCTestCase that constructs multiple `AccountsManager()` instances
+    /// should set it to `true` in `setUp` and reset to `false` in `tearDown`
+    /// to keep the flag flip scoped. NOT compiled into release builds.
+    ///
+    /// See `feedback_wiring_suite_test_isolation.md` for the underlying race.
+    internal static var deferInitialLoadCatalogsForTesting: Bool = false
+    #endif
+
     /// Initializer is `internal` rather than `private` so `AppContainer` can
     /// construct the single live instance directly. Outside of `AppContainer`
     /// (and tests that need an isolated instance), do not call this directly
@@ -180,6 +197,18 @@ struct CatalogCacheMetadata: Codable {
         // an empty list. The async refresh below still runs to pick up any
         // server-side registry changes.
         preloadAccountsFromDiskCacheSync()
+
+        #if DEBUG
+        if Self.deferInitialLoadCatalogsForTesting {
+            // Test-only path: skip the background dispatch. The wiring suite
+            // (and any future XCTestCase constructing multiple instances)
+            // sets this flag to eliminate the cross-test race where lingering
+            // background work writes through state mid-test. Tests that need
+            // `loadCatalogs` semantics call `manager.loadCatalogs(...)`
+            // explicitly. Production never takes this branch.
+            return
+        }
+        #endif
 
         DispatchQueue.global(qos: .background).async { [weak self] in
             self?.loadCatalogs(completion: nil)

--- a/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
@@ -31,6 +31,18 @@ final class AccountsManagerStateMachineWiringTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
+        // Eliminate the suite-ordering race: every `AccountsManager()` we
+        // construct in this class would otherwise spawn a background
+        // `loadCatalogs` that outlives the test and writes through to
+        // `AccountStateStore.shared` / `accountSets` at unpredictable times.
+        // Flipping this flag tells `AccountsManager.init()` to skip the
+        // background dispatch — tests that need `loadCatalogs` semantics
+        // call `manager.loadCatalogs(...)` explicitly. See
+        // feedback_wiring_suite_test_isolation.md for the underlying race.
+        #if DEBUG
+        AccountsManager.deferInitialLoadCatalogsForTesting = true
+        #endif
+
         let bundle = Bundle(for: type(of: self))
         feedURL = bundle.url(forResource: "OPDS2CatalogsFeed", withExtension: "json")
         guard let feedURL else {
@@ -50,6 +62,7 @@ final class AccountsManagerStateMachineWiringTests: XCTestCase {
         // OPDS2CatalogsFeed fixture reuses real library UUIDs).
         #if DEBUG
         AccountStateStore.shared._resetAllForTesting()
+        AccountsManager.deferInitialLoadCatalogsForTesting = false
         #endif
         super.tearDown()
     }


### PR DESCRIPTION
## Summary

- Adds `#if DEBUG` static flag `AccountsManager.deferInitialLoadCatalogsForTesting` that lets a test class skip the post-init background `loadCatalogs` spawn.
- Wires the flag through `AccountsManagerStateMachineWiringTests`'s class-level `setUpWithError` / `tearDown` — eliminating the cross-test race where lingering background work from prior tests' `AccountsManager()` instances writes through to `accountSets` / `AccountStateStore.shared` mid-test.
- Production unaffected — default flag value is `false`; the `#if DEBUG` guard strips it from release builds.

## Background

`AccountsManagerStateMachineWiringTests` constructs `AccountsManager()` 9 times across its 14 tests. Each `init()` spawns:

```swift
DispatchQueue.global(qos: .background).async { [weak self] in
    self?.loadCatalogs(completion: nil)
}
```

That work outlives the test that spawned it. Under suite-ordering load (e.g. the pre-push test gate's 7-class set), lingering background `loadCatalogs` from prior instances writes through `accountSets` and `AccountStateStore.shared` at unpredictable times, racing subsequent tests' setup reads.

**Symptoms:** `testDriveCurrentAccountAuthDoc_terminalState_isNoOp` and `testLibrarySwitch_drivesNewCurrentAccountPastBasicInfoLoaded` flake on setup ("currentAccount must resolve after preload", "manager must resolve newUUID via account()") — but pass in isolation.

## Why this approach

- **Sync-barrier in `preloadAccountsFromDiskCacheSync`** (tried): accelerated the warm-path driver, breaking 2 unrelated tests that asserted on the `.basicInfoLoaded` intermediate window.
- **Test-side polling-retry** (tried): bounced off the same 2+ second race — lingering background work wins.
- **Per-class gate iteration** (considered): would 7× wall-clock cost (~5 min) without addressing the underlying defect.
- **Static flag** (chosen): one-line check at the init dispatch site, `#if DEBUG`-gated so it's stripped from release, opt-in per test class. Tests that need `loadCatalogs` semantics call it explicitly (which is what every existing test that exercises that path already does — see `testLoadCatalogs_warmPath_drivesCurrentAccountPastBasicInfoLoaded`).

## Test plan

- [x] Pre-push gate's 5-class set runs locally — 118 tests, 0 failures, 12s.
- [x] In-isolation wiring suite runs continue to pass.
- [x] Production behavior unchanged — default flag is `false`, code path identical.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)