### PR TITLE
docs(release): never squash-merge into main — release & hotfix merge policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,23 @@ Library reading app supporting EPUB, PDF, and audiobooks with multiple DRM syste
 
 **Architecture decisions:** see [`docs/architecture/`](./docs/architecture/) for the rationale behind major refactors (the post-modernization triad work, the parallel-agent rebase pattern, post-PR retros).
 
+## Release & hotfix merge policy
+
+**Merges into `main` use regular merge commits (`--no-ff`), never squash.** Applies to:
+- `release/X.Y.Z` → `main` (full release cycle)
+- `hotfix/X.Y.Z-*` → `main` (point hotfix)
+- Forward-port merges of those hotfix branches into `develop` (so the next release branch absorbs them with original SHAs)
+
+`gh pr merge <num> --merge` — NOT `--squash`.
+
+**Why:** squash-merge replaces a branch's commits with a single new commit that has no SHA-level relationship to the original work. When the next release branch tries to merge into main, git treats the squashed commits as different history from the original commits the release branch absorbed via forward-port — even though the content is logically identical. The result is a conflict storm that's pure squash-merge identity loss, not real divergence.
+
+This is what happened to 3.1.0: PR #953 (3.0.2 hotfix) and PR #972 (3.0.3 hotfix) were squash-merged into main, then `release/3.1.0 → main` produced **296 conflicts** that all had to be resolved manually before the release could ship. PR #998 ultimately landed via a custom merge commit built with `git commit-tree`. See [`docs/architecture/release-merge-policy.md`](./docs/architecture/release-merge-policy.md) for the full forensic + the recovery recipe.
+
+**Squash-merge is fine for feature PRs into `develop`** (or any branch that doesn't feed back into main). The damage is specifically squash on commits that later need to be reconciled by another branch — that's a release-branch-to-main scenario, not a feature-to-develop one.
+
+**Branch protection:** `main` should be configured to allow only "Create a merge commit" — disable both "Squash and merge" and "Rebase and merge" in repo settings → branch protection rules. UI change; verify periodically.
+
 ## Build & Test
 
 ```bash

--- a/docs/architecture/release-merge-policy.md
+++ b/docs/architecture/release-merge-policy.md
@@ -1,0 +1,120 @@
+# Release & Hotfix Merge Policy
+
+**TL;DR:** Merges into `main` use regular merge commits (`--no-ff`). Squash-merge is forbidden on `main`-bound work because it destroys commit SHAs, which causes the next release-branch → main merge to hit catastrophic conflicts even when content is logically identical.
+
+## The policy
+
+| Source branch | Target | Merge type |
+|---|---|---|
+| `release/X.Y.Z` | `main` | `--merge` (no-ff) |
+| `hotfix/X.Y.Z-*` | `main` | `--merge` (no-ff) |
+| Hotfix forward-port branch | `develop` | `--merge` (no-ff) |
+| Feature PR | `develop` | `--squash` is fine |
+
+GitHub UI: use **"Create a merge commit"**. CLI: `gh pr merge <num> --merge`.
+
+GitHub branch protection on `main` should restrict the merge-method allowlist to "Create a merge commit" only. Disable "Squash and merge" and "Rebase and merge" for this branch.
+
+## Why squash-merge on main is harmful
+
+Squash-merge replaces a branch's history (N commits, each with its own SHA) with a single new commit with a different SHA. From git's three-way-merge perspective, that new commit has no relationship to the originals — even though the *content* is identical.
+
+This breaks the next release-branch merge in a specific, deterministic way:
+
+1. A hotfix branch (`hotfix/3.0.2-a11y-launch`) is squash-merged into `main`. Original commits → discarded. One new commit on main with a new SHA.
+2. The same hotfix content is forward-ported into `develop` (and from there into the next release branch, e.g. `release/3.1.0`) as the *original commits* — preserving their SHAs via cherry-pick or merge.
+3. When `release/3.1.0` → `main` is attempted:
+   - git looks for a merge base. The base is the last commit both branches share — which is BEFORE the squash.
+   - git compares both sides to that base.
+   - On main's side: 1 squash commit with a new SHA, modifying many files.
+   - On release/3.1.0's side: the original N commits (different SHAs), modifying the same files.
+   - git sees this as **two different branches modifying the same files**, not as "main has the same fix as release/3.1.0."
+   - Result: conflict on every file the hotfix touched.
+
+This is **identity loss**: the content is reconcilable, but the SHAs aren't.
+
+## What happened to 3.1.0 (post-mortem)
+
+The 3.1.0 release-branch merge into `main` hit **296 file conflicts**. Every one was a squash-merge identity-loss artifact, not real content divergence.
+
+Trace:
+- **PR #953** (3.0.2 hotfix — VoiceOver activation + library-selector multi-modal) was squash-merged into `main` on 2026-05-18. Originals SHAs → discarded.
+- **PR #972** (3.0.3 hotfix — Marketplace LCP audiobook open) was squash-merged into `main` on 2026-05-20. Originals → discarded.
+- Meanwhile, those same fixes had been forward-ported into `develop` (and then into `release/3.1.0`) via PR #954 and the equivalent for 3.0.3 — preserving the original commit identities.
+- 2026-05-26: `release/3.1.0 → main` was attempted (PR #997). 296 files conflicted. Most were squash-merge artifacts; a handful were genuine cross-cycle changes.
+- Auto-resolution with `git merge -X theirs` introduced its own noise: duplicated `PBXBuildFile` entries in `Palace.xcodeproj/project.pbxproj`, and `.specterqa/*` files were preserved on the merge result even though release/3.1.0 had deleted them as part of the simdrive cutover (PR #895).
+
+### The fix that landed
+
+PR #997 was closed. A new branch `release-3.1.0-final` was created off main, and a merge commit was built manually with `git commit-tree`:
+
+```bash
+git checkout -b release-3.1.0-final origin/main
+TREE=$(git rev-parse origin/release/3.1.0^{tree})
+COMMIT=$(echo "<message>" | git commit-tree "$TREE" -p origin/main -p origin/release/3.1.0)
+git update-ref refs/heads/release-3.1.0-final "$COMMIT"
+git reset --hard release-3.1.0-final
+git push -u origin release-3.1.0-final   # required SKIP_PRE_PUSH_TESTS=1 — see below
+```
+
+The merge commit's tree is byte-identical to `origin/release/3.1.0^{tree}` (the regression-signed-off content); parents are `[main, release/3.1.0]`. PR #998 landed cleanly.
+
+### Downstream damage
+
+The squash-merge problem produced secondary failures even after the merge resolved:
+
+- **Release-notes script attribution broken.** `mobile-certificates/Certificates/Palace/iOS/ReleaseNotes.py` walks PRs merged into main since the last release tag. With only PR #998 visible on main (the merge commit), every PP-* ticket it found in #998's body got attributed to #998's title. The auto-generated changelog listed 42 tickets — **31 of them had already shipped in 2.2.4 / 3.0.0 / 3.0.2 / 3.0.3** and were verified via Jira `fixVersion`.
+- **Jira pollution narrowly avoided.** The `Jira Release Sync` workflow chain from `release-on-merge.yml` would have stamped `iOS 3.1.0` onto all 42 tickets, including the 31 already-shipped ones. The auto-chain did not fire on the 3.1.0 release-on-merge run (cause unclear; pre-existing bug?), so the bad data never reached Jira. The release body was manually corrected and `jira-release-sync.yml` was re-dispatched against the 11-ticket cleaned version.
+
+If the auto-chain had fired, cleanup would have been ~30 Jira tickets needing a fixVersion removal.
+
+## When you still need the recovery recipe
+
+This policy prevents future cases. But the existing squash-merge commits on `main` are permanent — they're already part of main's history. Any release-branch you merge into main going forward will compare against those existing squash commits.
+
+**Strategy:** As long as future hotfixes use `--merge`, the squash artifacts shrink as a percentage of main's history. Eventually `release/3.2.0` and later will have a clean base to merge from. Until then, expect *some* conflicts on the next release-branch merge if it touches files modified by the 3.0.2 or 3.0.3 squash commits.
+
+If you hit the `git commit-tree` recovery scenario again, the recipe is:
+
+```bash
+# From main:
+git checkout -b release-X.Y.Z-final origin/main
+
+# Build the merge commit by hand
+TREE=$(git rev-parse origin/release/X.Y.Z^{tree})
+COMMIT=$(echo "Merge release/X.Y.Z → main for X.Y.Z release" | \
+  git commit-tree "$TREE" -p origin/main -p origin/release/X.Y.Z)
+git update-ref refs/heads/release-X.Y.Z-final "$COMMIT"
+git reset --hard release-X.Y.Z-final
+
+# Push — pre-push test gate needs bypass (release merges always exceed its 180s budget)
+SKIP_PRE_PUSH_TESTS=1 git push -u origin release-X.Y.Z-final
+
+# Open PR with --merge as the merge method
+gh pr create --base main --head release-X.Y.Z-final --title "X.Y.Z release"
+```
+
+Verify before pushing:
+
+```bash
+# Tree must be byte-identical to the release branch
+diff <(git rev-parse HEAD^{tree}) <(git rev-parse origin/release/X.Y.Z^{tree})
+
+# Parents must be [main, release/X.Y.Z]
+git log -1 --format='%P'
+
+# Diff vs release branch must be empty
+git diff HEAD origin/release/X.Y.Z
+```
+
+## Implementation checklist
+
+- [ ] **Repo settings → Branches → main protection rule:** restrict merge methods to "Create a merge commit" only.
+- [ ] **Release runbook / CLAUDE.md:** policy documented (this doc + the section in `CLAUDE.md`).
+- [ ] **`mobile-certificates/Certificates/Palace/iOS/ReleaseNotes.py`:** improve to walk merge-commit second-parent history so ticket attribution survives even when older squash commits exist in main. Separate ticket; not blocking on this doc.
+- [ ] **Going forward:** when merging hotfix or release PRs into main, use the GitHub UI's "Create a merge commit" option. If using CLI, `gh pr merge <num> --merge`.
+
+## Related
+
+- [Forward-port discipline (memory: `feedback_hotfix_then_port.md`)](https://github.com/ThePalaceProject/ios-core/blob/develop/) — hotfixes are merged to main first, then forward-ported to develop. This policy preserves identity through that loop so the next release branch absorbs everything cleanly.
+- The fact that release/3.1.0's tree was a strict superset of main's intended content (modulo squash-merge SHAs) is *only* true because of disciplined forward-port. Without it, tree-from-theirs would not be safe.


### PR DESCRIPTION
## Summary

Documents the merge-strategy fix that prevents the squash-merge identity-loss conflict storm we hit on 3.1.0 (PR #997 closed → PR #998 manually resolved).

- **CLAUDE.md** — new top-level 'Release & hotfix merge policy' section. Short version: release/hotfix → main uses `--no-ff` regular merge commits; squash on feature → develop is still fine.
- **docs/architecture/release-merge-policy.md** — full ADR with the policy table, the 3.1.0 forensic, and the `git commit-tree` recovery recipe (verbatim from PR #998's resolution) for future cases that still hit historical squash artifacts in main.

## Why now

The 3.1.0 release merge produced 296 conflicts that were all squash-merge identity loss from PR #953 (3.0.2) and PR #972 (3.0.3). The downstream consequences nearly polluted Jira with `iOS 3.1.0` fixVersions on 31 already-shipped tickets (caught + cleaned up out-of-band). The root cause is one merge-strategy choice; documenting it prevents the repeat.

## Scope

Doc-only. No code, no workflow changes.

**Not done:** `mobile-certificates/Certificates/Palace/iOS/ReleaseNotes.py` improvement to walk merge-commit history — separate ticket; not blocking on this PR.

**Deferred:** GitHub branch-protection rule on `main` to restrict merge-method to "Create a merge commit" only. Has to happen in repo settings UI; PR can't change it. Called out in the ADR's checklist.

## Test plan

- [x] CLAUDE.md renders cleanly on GitHub
- [x] `docs/architecture/release-merge-policy.md` follows the existing ADR README's voice + structure
- [x] No code touched; verify-pr.sh not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)