### PR TITLE
fix(verify-pr): add BookButtonMapper to strict mutation-gate regex

### DIFF
--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -70,7 +70,7 @@ MUTATION_MIN_KILL_RATE=50
 # Critical paths: every changed file matching one of these prefixes is held to
 # the strict kill-rate floor unless explicitly opted out via --no-enforce-mutations.
 # These are the user-money / access-bearing paths memory flagged as air-tight.
-CRITICAL_MUTATION_PATHS_REGEX='^Palace/(Audiobooks|SignInLogic|MyBooks/Download)'
+CRITICAL_MUTATION_PATHS_REGEX='^Palace/(Audiobooks|SignInLogic|MyBooks/Download|Book/UI/BookDetail/BookButtonMapper)'
 # Sim selection. Honors the harness allocator's per-session UDID so parallel
 # agents on the same machine don't collide on one device. Falls back to the
 # pool default when the harness isn't claiming. CLAUDE.md: "NEVER hardcode a


### PR DESCRIPTION
## Summary

One-line regex extension to `scripts/verify-pr.sh` so that `Palace/Book/UI/BookDetail/BookButtonMapper.swift` is held to the strict 50% mutation kill-rate floor alongside the other critical borrow/download/auth paths.

## Why

The Phase 7 siblings audit (`.forgeos/audits/phase7-synthesis-2026-05-26.md`, in the main checkout — not pushed) cross-checked the critical-path mutation list in `verify-pr.sh` against the memory pin `phase7_borrow_path_regressions_2026_05_14.md`. The pin explicitly flags `BookButtonMapper` as a borrow-path sibling that belongs to the critical list, but the regex in `scripts/verify-pr.sh:73` didn't include it. This PR closes that gap.

`BookButtonMapper` maps borrow/return/download state to the visible action button — a wrong mapping silently breaks the user-facing borrow flow with no crash signal, exactly the class of regression the strict mutation gate exists to catch.

## Change

```diff
-CRITICAL_MUTATION_PATHS_REGEX='^Palace/(Audiobooks|SignInLogic|MyBooks/Download)'
+CRITICAL_MUTATION_PATHS_REGEX='^Palace/(Audiobooks|SignInLogic|MyBooks/Download|Book/UI/BookDetail/BookButtonMapper)'
```

## Verification

Regex is tight — it matches `BookButtonMapper.swift` (including any future `BookButtonMapperTests`-style sibling) but does NOT match other files in `Palace/Book/UI/BookDetail/`:

```
Palace/Book/UI/BookDetail/BookButtonMapper.swift  → MATCH
Palace/Book/UI/BookDetail/OtherFile.swift         → NO MATCH
Palace/Book/UI/Other/Foo.swift                    → NO MATCH
Palace/Audiobooks/Foo.swift                       → MATCH (unchanged)
Palace/SignInLogic/Bar.swift                      → MATCH (unchanged)
Palace/MyBooks/DownloadCenter.swift               → MATCH (unchanged)
```

## Scope

`scripts/verify-pr.sh` regex only. No other files touched. No production / test code changes — this is bash-only.

## Test plan

- [x] Regex matches `Palace/Book/UI/BookDetail/BookButtonMapper.swift`
- [x] Regex does NOT match other files in `Palace/Book/UI/BookDetail/`
- [x] Existing strict paths (Audiobooks, SignInLogic, MyBooks/Download) still match
- [x] Unrelated paths (Catalog, Book/UI/Other) still excluded

Effect on next `verify-pr.sh --enforce-mutations` (or default mode when BookButtonMapper is in the changed set): the file is held to the 50% kill-rate floor instead of advisory.