### PR TITLE
fix(carplay): forward-port SIGABRT dedupe from 3.1.0 PR #968

### DIFF
--- a/Palace/CarPlay/CarPlayTemplateManager.swift
+++ b/Palace/CarPlay/CarPlayTemplateManager.swift
@@ -43,6 +43,15 @@ final class CarPlayTemplateManager: NSObject {
     private var lastSelectedBookId: String?
     private var lastSelectionTime: Date?
     private var hasConfiguredNowPlaying = false
+    // Tracks whether a CPAlertTemplate is in-flight or visible. AudiobookSessionManager
+    // surfaces a single failure via TWO channels — its async openAudiobook result AND
+    // sessionManager.errorPublisher — which races a second presentTemplate(alert) call
+    // through handlePlaybackError. CarPlay rejects a second modal while one is
+    // presented; with completion: nil the rejection raises NSException at
+    // CPInterfaceController.m:481 (TF crash 9A269135 on 3.1.0 build 476, iOS 26.4.2).
+    // Dedupe at the present site; non-nil completion handlers below catch the
+    // rejection in the closure instead of letting CarPlay raise.
+    private var isPresentingAlert = false
 
     // MARK: - Initialization
 
@@ -87,7 +96,11 @@ final class CarPlayTemplateManager: NSObject {
             Log.error(#file, "CarPlay: Failed to create library template")
             return
         }
-        interfaceController?.setRootTemplate(libraryTemplate, animated: true, completion: nil)
+        interfaceController?.setRootTemplate(libraryTemplate, animated: true) { _, error in
+            if let error = error {
+                Log.warn(#file, "CarPlay: setRootTemplate(library) failed: \(error)")
+            }
+        }
 
         Log.info(#file, "CarPlay root template configured")
 
@@ -130,7 +143,11 @@ final class CarPlayTemplateManager: NSObject {
         if let controller = interfaceController {
             let newLibraryTemplate = createLibraryTemplate()
             self.libraryTemplate = newLibraryTemplate
-            controller.setRootTemplate(newLibraryTemplate, animated: true, completion: nil)
+            controller.setRootTemplate(newLibraryTemplate, animated: true) { _, error in
+                if let error = error {
+                    Log.warn(#file, "CarPlay: setRootTemplate(new library) failed: \(error)")
+                }
+            }
             Log.info(#file, "🚗 CarPlay library template replaced with new name: '\(libraryName)'")
         }
     }
@@ -377,16 +394,41 @@ final class CarPlayTemplateManager: NSObject {
     private func showErrorAlert(title: String, message: String) {
         guard let interfaceController = interfaceController else { return }
 
+        // Dedupe: the dual-channel error path (async openAudiobook result + errorPublisher)
+        // can race a second presentTemplate while the first alert is in-flight or visible.
+        // CarPlay rejects the second present and raises NSException at
+        // CPInterfaceController.m:481 if completion is nil. Suppress here AND catch in
+        // the completion handler below.
+        guard !isPresentingAlert, interfaceController.presentedTemplate == nil else {
+            Log.info(#file, "CarPlay: Suppressing duplicate error alert — modal already presented")
+            return
+        }
+
+        isPresentingAlert = true
+
         let alert = CPAlertTemplate(
             titleVariants: [title],
             actions: [
-                CPAlertAction(title: Strings.Generic.ok, style: .default) { _ in
-                    interfaceController.dismissTemplate(animated: true, completion: nil)
+                CPAlertAction(title: Strings.Generic.ok, style: .default) { [weak self] _ in
+                    self?.interfaceController?.dismissTemplate(animated: true) { _, error in
+                        if let error = error {
+                            Log.warn(#file, "CarPlay: dismissTemplate(alert) failed: \(error)")
+                        }
+                        self?.isPresentingAlert = false
+                    }
                 }
             ]
         )
 
-        interfaceController.presentTemplate(alert, animated: true, completion: nil)
+        interfaceController.presentTemplate(alert, animated: true) { [weak self] _, error in
+            if let error = error {
+                // CarPlay rejected the present (typically because another modal slipped
+                // in between our guard and this call). Logged, NOT raised. Clear the flag
+                // so the next attempt isn't blocked by a stuck `isPresentingAlert`.
+                Log.warn(#file, "CarPlay: presentTemplate(errorAlert) failed: \(error)")
+                self?.isPresentingAlert = false
+            }
+        }
     }
 
     /// Shows an alert when the user tries to play a book but the main phone app


### PR DESCRIPTION
## Summary

Forward-ports the only material 3.1.0 fix that wasn't on develop. Surfaced by cross-referencing release/3.1.0 vs develop after the Crashlytics post-3.0.3 analysis. All other 3.1.0 fixes (PP-4407 hasLCPAcquisition, F-002 PEM CRL, F-016 OIDC re-auth, airplane-mode) are confirmed on develop already.

## Crash signature

**TF crash 9A269135, 3.1.0 build 476, iOS 26.4.2:** NSException at `CPInterfaceController.m:481` when the dual-channel error path from `AudiobookSessionManager` (async `openAudiobook` result + `sessionManager.errorPublisher`) races a second `presentTemplate(alert)` while the first alert is still in-flight or visible. CarPlay rejects the second present; with `completion: nil` the rejection raises NSException instead of being catchable.

## Fix (three surgical changes)

1. Add private `isPresentingAlert` flag with explanatory comment pinning the crash signature
2. `showErrorAlert` dedupes at the present site (guard against in-flight alert + check `interfaceController.presentedTemplate == nil`)
3. Non-nil completion handlers on `setRootTemplate` calls (2 sites) and on `presentTemplate` / `dismissTemplate` inside `showErrorAlert` — catch the rejection in the closure instead of letting CarPlay raise

## Not ported from PR #968 (intentional)

- `CarPlaySceneDelegate.swift` switch from `AppContainer.production().playbackBootstrapper` → `PlaybackBootstrapper.shared` — develop eliminated that singleton via PR #982. Develop's DI path is the correct one.
- `CarPlayTests.swift` `AudiobookSessionManager.shared` cleanup — develop eliminated that singleton too. Tests adapted to the new model.

## Cross-reference with Crashlytics (post-3.0.3)

After the 2026-05-20 release, comparing week-over-week:

| Status | Issue |
|---|---|
| ✅ Already fixed on develop | PP-4407 (Marketplace LCP) — `lastSeenVersion: 3.0.2`, 57% event drop |
| ✅ Already fixed on develop | F-002 PEM CRL — 89% event drop (user-mix shift; fix on develop awaits 3.2.0 ship) |
| ✅ Already on develop | F-016 OIDC re-auth (`89da0ce72`) |
| ✅ Already on develop | Airplane-mode (PR #988 forward-port) |
| ✅ Already on develop | HTMLTextView hardening (`guard !html.isEmpty`, `TPPObjCExceptionCatcher`) |
| 🔧 **THIS PR** | CarPlay SIGABRT (PR #968 forward-port) |
| ⚪ Not actionable | `recursive_mutex` (libxml2 destructor / iOS watchdog termination on iPad-on-Mac; not Palace code) |
| ⚪ Not actionable | `ReadiumCSS.injections` (single user, 3.0.0 only, no reproducible pattern) |
| ⚪ Aging out | TPPBookCoverRegistry / TPPBook+Presentation / LCPDecryptor (3.0.0-only; users migrating; superseded by image-loading + vendor-adapter work on develop) |

## Scope

`Palace/CarPlay/CarPlayTemplateManager.swift` only. +47 / -5 LOC.

## Verification

Worktree build environment (AudioEngine duplicate-command landmine) prevented running `CarPlayTests` locally — same blocker we hit on PR #1009. The change is small, isolated, and verifiable by inspection against the canonical PR #968 fix. CI will run the full test battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)