### PR TITLE
fix(PP-3846): restore Sync Bookmarks instructional copy

### DIFF
--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -424,7 +424,7 @@ struct Strings {
         static let forgotPassword = NSLocalizedString("Forgot your password?", comment: "")
         static let signUpForCard = NSLocalizedString("Sign up for a library card", comment: "")
         static let eulaAgreement = NSLocalizedString("By signing in, you agree to the End User License Agreement.", comment: "")
-        static let syncDescription = NSLocalizedString("Save your reading position and bookmarks to all your other devices.", comment: "")
+        static let syncDescription = NSLocalizedString("Toggle on sync bookmarks to save your reading position and bookmarks across all of your devices. This must be done on all devices where you are accessing Palace to synchronize reading position.", comment: "Instructional text under Sync Bookmarks in Settings")
         static let authenticateToRevealPIN = NSLocalizedString("Authenticate to reveal your PIN.", comment: "")
         static let deleteServerData = NSLocalizedString("Delete Server Data", comment: "")
         static let downloads = NSLocalizedString("Downloads", comment: "Section header for download-related settings")


### PR DESCRIPTION
## Summary

Restores the [PP-3846](https://ebce-lyrasis.atlassian.net/browse/PP-3846) Settings → Sync Bookmarks copy that was inadvertently reverted by the Modernization Sprint mega-PR in 2026-04.

## Forensic

| When | What |
|---|---|
| 2026-02-04 | Tara Carpenter files PP-3846 on behalf of OSL — original copy was unclear that the toggle must be flipped on every device |
| 2026-02-?? | Fix lands in **PR #785** (commit `ca4d9cd2`) — updates `Strings.syncDescription` |
| 2026-03-11 | Ticket marked **Done** |
| 2026-04-21 | **PR #811** (Modernization Sprint mega-PR, 150+ commits, `69a6a9b3`) inadvertently reverts the string while rebasing against develop |
| 2026-04-21 → today | 3.0.0, 3.0.1, 3.0.2, 3.0.3, **3.1.0** all ship with the old copy. Nobody catches the regression. |

This PR re-applies PR #785's change verbatim.

## Change

Single-line update to `Palace/Utilities/Localization/Strings.swift:427`:

**Before:**
> Save your reading position and bookmarks to all your other devices.

**After:**
> Toggle on sync bookmarks to save your reading position and bookmarks across all of your devices. This must be done on all devices where you are accessing Palace to synchronize reading position.

## Companion PR

Sibling PR opened against `release/3.1.0` so the fix can be picked up by the next 3.1.x point release without waiting for 3.2.0 to ship from develop.

## Scope

One localized string. +1 / -1 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PP-3846]: https://ebce-lyrasis.atlassian.net/browse/PP-3846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ