### PR TITLE
fix(PP-3846): restore Sync Bookmarks instructional copy (3.1.x hotfix)

### DIFF
--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -424,7 +424,7 @@ struct Strings {
         static let forgotPassword = NSLocalizedString("Forgot your password?", comment: "")
         static let signUpForCard = NSLocalizedString("Sign up for a library card", comment: "")
         static let eulaAgreement = NSLocalizedString("By signing in, you agree to the End User License Agreement.", comment: "")
-        static let syncDescription = NSLocalizedString("Save your reading position and bookmarks to all your other devices.", comment: "")
+        static let syncDescription = NSLocalizedString("Toggle on sync bookmarks to save your reading position and bookmarks across all of your devices. This must be done on all devices where you are accessing Palace to synchronize reading position.", comment: "Instructional text under Sync Bookmarks in Settings")
         static let authenticateToRevealPIN = NSLocalizedString("Authenticate to reveal your PIN.", comment: "")
         static let deleteServerData = NSLocalizedString("Delete Server Data", comment: "")
         static let downloads = NSLocalizedString("Downloads", comment: "Section header for download-related settings")


### PR DESCRIPTION
## Summary

Cherry-portable hotfix branch off \`release/3.1.0\` carrying the [PP-3846](https://ebce-lyrasis.atlassian.net/browse/PP-3846) restoration so it can be included in the next 3.1.x point release.

## Forensic

| When | What |
|---|---|
| 2026-02-04 | Tara Carpenter files PP-3846 on behalf of OSL |
| 2026-02-?? | Fix lands in **PR #785** (\`ca4d9cd2\`) |
| 2026-03-11 | Ticket marked **Done** |
| 2026-04-21 | **PR #811** (Modernization Sprint mega-PR, \`69a6a9b3\`) inadvertently reverts the string |
| 3.0.0 → 3.1.0 | All releases ship the old copy. Nobody catches it. |

## Change

\`Palace/Utilities/Localization/Strings.swift:427\` — identical restoration to the develop-targeting companion PR. +1 / -1 LOC.

## Companion PR

Sibling PR open against develop with the same change. Standard hotfix flow: land here for 3.1.x, then forward-port verifies the develop PR carries the same content.

## Why now

OSL has been seeing the original confusion-pattern in support tickets since the regression shipped in 3.0.0. Re-landing per user direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PP-3846]: https://ebce-lyrasis.atlassian.net/browse/PP-3846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ