### PR TITLE
docs(readme): link Reset Account support workflow page

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Feature branch names (for features whose development is a month or more): `featu
 
 Continuous integration is enabled on merge events on `develop` branch. Palace device builds are uploaded to [ios-binaries](https://github.com/ThePalaceProject/ios-binaries).
 
+# Support tooling
+
+Helping a patron whose Palace app is in a stuck state that sign-out + uninstall + reinstall does **not** clear? See the [Reset Library Account support workflow](https://thepalaceproject.github.io/ios-core/operations/reset-account.html) — an interactive console with the recovery steps, an inline Device-ID → Firebase Remote Config parameter generator, and a sysdiagnose log verifier. Ships in Palace iOS 3.1.0+.
+
 # Contributing
 
 Tests are required for production changes. The full workflow — TDD discipline, the local self-check, and the public/private boundary between outside contributors and maintainer-internal agent tooling — is documented in [`CONTRIBUTING.md`](./CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Adds a 3-line "Support tooling" section to the README pointing at the deployed [Reset Account support workflow console](https://thepalaceproject.github.io/ios-core/operations/reset-account.html).

The console itself ships via the parallel develop-targeted PR #1015. This PR is a docs-only README-link cherry-pick straight to \`main\` because:

- The README on github.com/ThePalaceProject/ios-core's home page renders from the default branch (\`main\`).
- Without this small cherry-pick, the link would be invisible on the home page until the next release merge to \`main\` (3.2.0 cycle).
- Three lines, no code changes, no risk surface — the standard "develop-only" flow is a poor fit.

## Merge strategy

⚠️ **Use \`--merge\` (regular merge commit), NOT \`--squash\`** when merging this — per the project's [release merge policy](./docs/architecture/release-merge-policy.md) and \`CLAUDE.md\`. Squash-merge to main causes identity-loss conflicts on the next release-branch merge (this is what produced 296 conflicts on the 3.1.0 release — PR #998's forensic).

Even for a README-only PR, keep the discipline so \`main\` never picks up the squash habit.

## Test plan

- [x] README renders correctly on GitHub
- [x] Link target https://thepalaceproject.github.io/ios-core/operations/reset-account.html is live (HTTP 200)
- [x] No code or test changes — README-only diff

## Linked

Parallel: #1015 (full docs + HTML console → develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)