### PR TITLE
feat(rigor): doc-lifecycle system — frontmatter schema + decay CLI + SessionStart surfacing

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,6 +57,12 @@
             "command": "bash scripts/hooks/pre-critical-path-mutation.sh",
             "timeout": 5,
             "statusMessage": "Checking mutation evidence for critical-path changes..."
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/pre-commit-doc-lifecycle.sh",
+            "timeout": 10,
+            "statusMessage": "Validating governance doc frontmatter..."
           }
         ]
       },

--- a/.claude/skills/regression-qa/QA_QUICKSTART.md
+++ b/.claude/skills/regression-qa/QA_QUICKSTART.md
@@ -1,3 +1,14 @@
+---
+name: regression-qa-qa-quickstart
+type: evolving
+status: active
+created: 2026-05-11
+last_refresh: 2026-05-12
+freshness_window: 365d
+owners: [general]
+description: QA Quickstart — Manual Regression with Claude Code
+---
+
 # QA Quickstart — Manual Regression with Claude Code
 
 This is the manual-only regression flow. No simdrive, no automation tooling, no maintainer-only setup. Everything runs from a fresh ios-core clone.

--- a/.claude/skills/regression-qa/SKILL.md
+++ b/.claude/skills/regression-qa/SKILL.md
@@ -3,6 +3,13 @@ name: regression-qa
 description: Guide a QA tester through a manual release regression — setup, side-by-side testing, codebase-aware triage, report, and Jira tickets. No simdrive or maintainer-only tooling required. Use this when running a manual regression pass against a release candidate.
 argument-hint: <ticket> [--baseline-version X.Y.Z] [--candidate-version X.Y.Z]
 allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, Agent
+# doc-lifecycle metadata (added by Module B sweep)
+type: evolving
+status: active
+created: 2026-05-11
+last_refresh: 2026-05-11
+freshness_window: 365d
+owners: [general]
 ---
 
 # Palace iOS — QA Regression (manual)

--- a/.claude/skills/regression/QA_QUICKSTART.md
+++ b/.claude/skills/regression/QA_QUICKSTART.md
@@ -1,3 +1,14 @@
+---
+name: regression-qa-quickstart
+type: evolving
+status: active
+created: 2026-04-29
+last_refresh: 2026-04-29
+freshness_window: 365d
+owners: [general]
+description: QA Quick Start — Regression Testing with Claude Code
+---
+
 # QA Quick Start — Regression Testing with Claude Code
 
 ## Prerequisites

--- a/.claude/skills/regression/SKILL.md
+++ b/.claude/skills/regression/SKILL.md
@@ -3,6 +3,13 @@ name: regression
 description: Run a full release regression test — sets up workspace, runs automated tools, guides manual testing, generates report and Jira tickets. Use for release gates and QA cycles.
 argument-hint: <ticket> [--baseline-version X.X.X] [--candidate-version X.X.X]
 allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, Agent
+# doc-lifecycle metadata (added by Module B sweep)
+type: evolving
+status: active
+created: 2026-04-29
+last_refresh: 2026-05-15
+freshness_window: 365d
+owners: [general]
 ---
 
 # Palace iOS Release Regression

--- a/.claude/skills/rigorous-fix/SKILL.md
+++ b/.claude/skills/rigorous-fix/SKILL.md
@@ -2,6 +2,13 @@
 name: rigorous-fix
 description: Architect + SoD-review rigor for single-module critical-path changes that don't warrant a full /swarm but DO warrant more than bare /clean-code. Use when touching auth, sign-in, borrow, return, download, DRM fulfillment, audiobook playback, persistence migrations, or any code where a regression would hit users — regardless of LOC count. Invoke via "/rigorous-fix <task>" or when the user says "rigorous fix for X", "do this with SoD review", "critical path change to Y". For multi-module work, use /swarm. For non-critical bug fixes <50 LOC, /clean-code is sufficient.
 tools: Agent, Bash, Read, Write, Edit, Grep, Glob, mcp__forgeos__forge_propose_changeset, mcp__forgeos__forge_submit_evidence, mcp__forgeos__forge_check_gates, mcp__forgeos__forge_promote_gate, mcp__forgeos__forge_get_context
+# doc-lifecycle metadata (added by Module B sweep)
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
 ---
 
 # /rigorous-fix — architect + SoD review for single-module critical-path work

--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -2,6 +2,13 @@
 name: swarm
 description: Triage→dispatch→integrate→promote loop for multi-module Palace iOS work. Architect agent identifies touched modules, writes contract deltas, then parallel module-implementer subagents land changes against those contracts. forge-review and verify-pr.sh gate the integration. Use when a feature, refactor, or extraction touches ≥2 top-level Palace modules; for single-module work, do it directly. Invoke via "/swarm <task>" or when the user says "swarm this", "extract X via swarm", "run swarm for...", or asks to coordinate multi-module changes.
 tools: Agent, Bash, Read, Write, Edit, mcp__forgeos__forge_propose_changeset, mcp__forgeos__forge_submit_evidence, mcp__forgeos__forge_check_gates, mcp__forgeos__forge_promote_gate, mcp__forgeos__forge_get_context
+# doc-lifecycle metadata (added by Module B sweep)
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
 ---
 
 # /swarm — multi-module orchestration loop

--- a/.forgeos/audits/phase7-BookButtonMapper.md
+++ b/.forgeos/audits/phase7-BookButtonMapper.md
@@ -1,0 +1,310 @@
+---
+name: audit-phase7-BookButtonMapper
+type: ephemeral
+status: active
+created: 2026-05-26
+last_refresh: 2026-05-26
+freshness_window: 180d
+owners: [mybooks]
+description: "Phase 7 Audit — `BookButtonMapper.swift`"
+---
+
+# Phase 7 Audit — `BookButtonMapper.swift`
+
+## Summary
+
+**Verdict: 0 BUG / 3 NEEDS-TEST / 1 CLEAN.** No live F-011/F-014/F-017 defect — the
+mapper is byte-identical to its 3.0.2 ancestor (other than the `import
+PalaceCatalog` line added during Phase 6 SPM extraction). However, the file is
+**not** on the strict critical-path mutation list per memory's warning, and the
+test suite leaves `.SAMLStarted` completely uncovered, the `isProcessingDownload
+|| .returning` interaction unpinned at the mapper boundary, and the implicit
+`default` (`.unsupported` fall-through) untestable as a regression net for
+future enum additions. Any new `TPPBookState` case added later would silently
+collapse into `.unsupported` with zero test failure — that's the F-011 shape
+exactly.
+
+---
+
+## File:line citations
+
+### Code under audit
+
+- `Palace/Book/UI/BookDetail/BookButtonMapper.swift:17-58` — `map(registryState:availability:isProcessingDownload:)`
+- `Palace/Book/UI/BookDetail/BookButtonMapper.swift:22` — short-circuit `if registryState == .downloading || isProcessingDownload`
+- `Palace/Book/UI/BookDetail/BookButtonMapper.swift:34-36` — `.downloadNeeded` branch (the F-011 historical fall-through site in the inline original)
+- `Palace/Book/UI/BookDetail/BookButtonMapper.swift:49-51` — `.returning` branch (comes AFTER `.holding`, BEFORE availability fallback)
+- `Palace/Book/UI/BookDetail/BookButtonMapper.swift:53-57` — implicit `default` via cascade fall-off → `.unsupported`
+
+### Caller seam (relevant context, not under audit but informs findings)
+
+- `Palace/Book/UI/BookDetail/BookDetailViewModel.swift:379-390` — `computeButtonState(...)` constructs `isProcessingDownload` and calls the mapper.
+- `Palace/Book/UI/BookDetail/BookDetailViewModel.swift:382-383` —
+  ```swift
+  let downloadRelatedButtons: Set<BookButtonType> = [.download, .get, .retry, .reserve]
+  let isProcessingDownload = state == .downloading || processingButtons.intersection(downloadRelatedButtons).count > 0
+  ```
+  Explicitly excludes `.return` from the processing-download intersection, so a
+  `.returning` book with `processingButtons = [.returning]` correctly produces
+  `isProcessingDownload = false`. This is the F-017-class fix — the caller is
+  defensive — but the mapper has no test that pins this invariant.
+
+### 3.0.2 reference
+
+- `git show 3.0.2:Palace/Book/UI/BookDetail/BookButtonMapper.swift` — byte-identical
+  to `HEAD` except for the `import PalaceCatalog` line. **No regression vs.
+  3.0.2.** The Phase 7 decomposition that landed this file did not introduce a
+  defect here; the file shipped clean and stayed clean.
+
+### Mutation-list policy
+
+- `scripts/verify-pr.sh:73` — `CRITICAL_MUTATION_PATHS_REGEX='^Palace/(Audiobooks|SignInLogic|MyBooks/Download)'`
+- `BookButtonMapper.swift` lives under `Palace/Book/UI/BookDetail/` → **does not
+  match** the strict critical-path regex. Mutation kill-rate is advisory, not
+  enforced. Per memory's call-out, this should be tightened (see notes below).
+
+---
+
+## Findings
+
+### Finding 1 — NEEDS-TEST: `.SAMLStarted` is the live F-011 latent
+
+**Why this matters.** `TPPBookState.SAMLStarted` (`Palace/Book/Models/TPPBookState.swift:25`)
+is a real, reachable state — `BookDetailViewModel` and the borrow flow transition
+into it during SAML-gated downloads. The mapper has NO branch for it; it falls
+through the entire `if`-cascade and exits at `BookButtonMapper.swift:57` as
+`.unsupported`. The user would see no actionable button for an in-flight SAML
+download.
+
+Today no test pins this. `BookButtonMapperTests.swift` and
+`BookButtonMapperHoldReadyTests.swift` both omit `.SAMLStarted` entirely
+(confirmed: grep returns 0 hits). A future contributor could rename `.SAMLStarted`
+or add a new state, and the mapper would silently regress.
+
+**Mutant that survives.** Comment out lines 34-36 (`.downloadNeeded` branch). The
+existing test `testMap_downloadNeeded_returnsDownloadNeeded`
+(`BookButtonMapperTests.swift:56-63`) catches that — so `.downloadNeeded` is
+mutant-killed. But add an `if false &&` guard to line 49 (`.returning` branch),
+or remove it outright — `testMap_returning_returnsReturning`
+(`BookButtonMapperTests.swift:74-81`) catches THAT too. The mutants that survive
+are the ones in the `default` zone:
+
+1. **Add a hypothetical `case .borrowing` to `TPPBookState`** — every existing
+   test still passes, but the mapper now returns `.unsupported` for an in-flight
+   borrow. There is no test that proves "all `TPPBookState` cases get an explicit
+   branch."
+2. **`.SAMLStarted` produces `.unsupported`** — this is current production
+   behavior and may be deliberate, but no test exists that pins it as a
+   *contract* vs. an *oversight*.
+
+**Suggested test (add to `BookButtonMapperTests.swift`).**
+
+```swift
+// MARK: - Exhaustive State Coverage (catches F-011 regressions)
+
+/// Every TPPBookState case must produce a defined mapping. Adding a new
+/// case to the enum without updating BookButtonMapper.map(...) is the F-011
+/// shape — this parameterized test forces the question.
+func testMap_everyTPPBookStateCase_producesNonNilBookButtonState() {
+    for state in TPPBookState.allCases {
+        let result = BookButtonMapper.map(
+            registryState: state,
+            availability: nil,
+            isProcessingDownload: false
+        )
+        // .unsupported is allowed as an outcome — but it must be the
+        // mapper's deliberate choice, not the result of a fallen-off
+        // cascade. Pin the contract by enumerating expectations:
+        let expected: BookButtonState = {
+            switch state {
+            case .unregistered, .unsupported, .SAMLStarted: return .unsupported
+            case .downloadNeeded:     return .downloadNeeded
+            case .downloading:        return .downloadInProgress
+            case .downloadFailed:     return .downloadFailed
+            case .downloadSuccessful: return .downloadSuccessful
+            case .returning:          return .returning
+            case .holding:            return .holding
+            case .used:               return .used
+            }
+        }()
+        XCTAssertEqual(result, expected,
+                       "TPPBookState.\(state) must map to \(expected), got \(result)")
+    }
+}
+```
+
+The `switch state` is **exhaustive** (no `default:`) so adding a new
+`TPPBookState` case causes a compile-time failure in the test — that's the
+parameterized-test pattern the prelude calls out as the F-011 safety net.
+
+### Finding 2 — NEEDS-TEST: `isProcessingDownload || .returning` boundary unpinned
+
+**Why this matters.** The `.returning` branch sits at lines 49-51, AFTER the
+`isProcessingDownload` short-circuit at line 22. If a regression in the caller
+ever flipped `BookDetailViewModel.swift:382-383` to include `.return` in
+`downloadRelatedButtons` (or if a new processing button leaked in), the mapper
+would silently return `.downloadInProgress` instead of `.returning` for a book
+the user just tapped Return on — the F-017 shape (in-flight return state not
+reflected to UI).
+
+The mapper itself is correct: `isProcessingDownload` is an input, not derived,
+so the mapper can't be defensive. But **no test pins the boundary**: there is
+no `testMap_returning_withIsProcessingDownloadTrue_???` covering what should
+happen when both are set. Today the mapper returns `.downloadInProgress` for
+`(registryState: .returning, isProcessingDownload: true)` — and that IS the
+current contract — but it's an untested contract.
+
+**Mutant that survives.** Move the `.returning` branch (lines 49-51) above the
+`isProcessingDownload` short-circuit (line 22). No existing test fails:
+- `testMap_returning_returnsReturning` passes `isProcessingDownload: false` so
+  the move doesn't matter.
+- `testMap_isProcessingDownloadOverridesEverything`
+  (`BookButtonMapperTests.swift:263-272`) uses `registryState: .downloadFailed`,
+  not `.returning`.
+
+This is a silent priority-inversion mutant the tests miss.
+
+**Suggested test.**
+
+```swift
+/// .returning + isProcessingDownload=true: download-in-progress wins.
+/// This pins the priority ordering — a mutant that moves .returning
+/// above the isProcessingDownload short-circuit must fail here.
+func testMap_returning_withIsProcessingDownloadTrue_returnsDownloadInProgress() {
+    let result = BookButtonMapper.map(
+        registryState: .returning,
+        availability: nil,
+        isProcessingDownload: true
+    )
+    XCTAssertEqual(result, .downloadInProgress,
+                   "isProcessingDownload must override .returning — moving the .returning branch above line 22 should fail this test")
+}
+
+/// Inverse: .returning + isProcessingDownload=false stays .returning.
+/// Already covered by testMap_returning_returnsReturning, but pairing
+/// the two is the round-trip pattern from CLAUDE.md.
+```
+
+### Finding 3 — NEEDS-TEST: implicit `default` falls off to `.unsupported`
+
+**Why this matters.** Line 57 (`return .unsupported`) is reached in two
+semantically distinct cases:
+1. `registryState` is a state the mapper doesn't recognize (the F-011 path).
+2. `registryState` is a recognized state with no opinion AND `availability` is
+   nil or returned nil from `stateForAvailability(_)`.
+
+The mapper conflates these. From the prelude: "Enum cases reused with two
+meanings get an explicit semantics test." `BookButtonState.unsupported` is
+exactly such a case here.
+
+**Mutant that survives.** Change line 57 to `return .canBorrow`. `testMap_unregistered_withNilAvailability_returnsUnsupported`
+(`BookButtonMapperTests.swift:144-151`) catches that. Good — that mutant is
+killed. But change line 57 to `return .downloadNeeded` — still killed by the
+same test. The mutant that survives: change line 57 to a switch that returns
+`.unsupported` only for `.unregistered` and crashes for everything else. The
+test passes (it only exercises `.unregistered`); production silently misbehaves
+on any future state.
+
+**Suggested test.** This is partially absorbed by Finding 1's exhaustive
+parameterized test. Recommend keeping the existing
+`testMap_unregistered_withNilAvailability_returnsUnsupported` as the
+"`.unregistered` is deliberate" pin, and adding a `.SAMLStarted` companion to
+distinguish the two meanings of `.unsupported`:
+
+```swift
+/// .SAMLStarted falls through to .unsupported by current design.
+/// Pin it explicitly — if SAML-started should ever show a download-in-progress
+/// button (likely the right behavior!), this test forces the conversation.
+func testMap_SAMLStarted_fallsThroughToUnsupported_DOCUMENTED_GAP() {
+    let result = BookButtonMapper.map(
+        registryState: .SAMLStarted,
+        availability: nil,
+        isProcessingDownload: false
+    )
+    XCTAssertEqual(result, .unsupported,
+                   ".SAMLStarted currently has no mapper branch and falls through to .unsupported. " +
+                   "If that's wrong, fix the mapper AND update this test.")
+}
+```
+
+### Finding 4 — CLEAN: cascade ordering vs. 3.0.2 reference
+
+The if-cascade order (lines 22, 26, 30, 34, 38, 42, 49, 53) matches the 3.0.2
+reference exactly. No condition was inverted (no F-014). No enum case was
+silently dropped from a `switch` (no F-011 in the literal sense — the file uses
+an if-cascade, not a switch, so there's no `default:` clause to fall through).
+The PP-3702 hold-ready logic (lines 42-47) is preserved with the same precedence:
+`registryState == .holding && availability is Ready` → `.canBorrow` BEFORE the
+plain `.holding` return. Covered by 7 tests in `BookButtonMapperHoldReadyTests.swift`
+(lines 23-115).
+
+`stateForAvailability(_)` (lines 62-89) — the 5-arm match on
+`TPPOPDSAcquisitionAvailability` (unavailable / limited / unlimited / reserved
+/ ready) — has full per-arm test coverage AND the dispatch-table cross-check
+test at `BookButtonMapperTests.swift:218-237` that catches constant-return
+mutants. This is the well-tested part of the file.
+
+---
+
+## Mutation-testing notes
+
+**Memory explicitly asks:** "Mutation kill-rate on this file is unknown — should
+be in the strict critical-path mutation list."
+
+**Verified.** `scripts/verify-pr.sh:73` defines:
+
+```
+CRITICAL_MUTATION_PATHS_REGEX='^Palace/(Audiobooks|SignInLogic|MyBooks/Download)'
+```
+
+`BookButtonMapper.swift` lives at `Palace/Book/UI/BookDetail/BookButtonMapper.swift`
+— **does not match.** Mutation enforcement on this file today is advisory only;
+a low kill-rate would not fail `verify-pr.sh` without `--enforce-mutations`.
+
+**Recommendation.** Extend the regex to include `Book/UI/BookDetail/BookButtonMapper`:
+
+```diff
+- CRITICAL_MUTATION_PATHS_REGEX='^Palace/(Audiobooks|SignInLogic|MyBooks/Download)'
++ CRITICAL_MUTATION_PATHS_REGEX='^Palace/(Audiobooks|SignInLogic|MyBooks/Download|Book/UI/BookDetail/BookButtonMapper)'
+```
+
+Rationale per memory: BookButtonMapper sits on the borrow / download / return /
+hold UI surface — every patron action funnels through `BookButtonMapper.map(...)`
+into `BookButtonState.buttonTypes(...)` which renders the actionable button.
+A silent wrong-state here yields exactly the F-011 / F-017 user impact: visible
+button no longer matches actual book state.
+
+**Expected kill rate after adding Finding 1's parameterized test:** ~90%+. The
+file is small (90 LOC, ~12 mutation points), pure (no side effects), and the
+exhaustive-state test plus the existing 22 tests would cover branches densely.
+The remaining survivors are likely in `stateForAvailability(_)`'s `var state =
+.unsupported` initial-value assignment (line 67) — a mutant changing the default
+would only manifest if `match(...)` ever returned without writing to `state`,
+which the OPDS contract prevents.
+
+**Suggested command for the next mutation pass.**
+
+```bash
+python3 scripts/palace_mutate.py \
+  --file Palace/Book/UI/BookDetail/BookButtonMapper.swift \
+  --tests PalaceTests/BookButtonMapperExtendedTests
+# AND
+python3 scripts/palace_mutate.py \
+  --file Palace/Book/UI/BookDetail/BookButtonMapper.swift \
+  --tests PalaceTests/BookButtonMapperHoldReadyTests
+```
+
+`scripts/resolve-tests-for.py` may or may not pick up both classes — verify the
+selector before relying on it. The 50% strict threshold should be trivially met
+after Finding 1.
+
+---
+
+## Headline
+
+**No live bug; the file is clean vs. 3.0.2.** But `.SAMLStarted` is uncovered,
+the if-cascade has an implicit `default` that any future `TPPBookState` case
+will silently inherit, and the file is **not on the strict mutation list**
+despite sitting on every patron-action UI path. Add the exhaustive parameterized
+test from Finding 1 AND extend `CRITICAL_MUTATION_PATHS_REGEX` to include this
+file. Both changes are <30 LOC and close the F-011-class window memory flagged.

--- a/.forgeos/audits/phase7-DownloadAuthRetryHandler.md
+++ b/.forgeos/audits/phase7-DownloadAuthRetryHandler.md
@@ -1,0 +1,253 @@
+---
+name: audit-phase7-DownloadAuthRetryHandler
+type: ephemeral
+status: active
+created: 2026-05-26
+last_refresh: 2026-05-26
+freshness_window: 180d
+owners: [mybooks]
+description: Phase 7 audit — DownloadAuthRetryHandler
+---
+
+# Phase 7 audit — DownloadAuthRetryHandler
+
+**Audit target:** `Palace/MyBooks/DownloadAuthRetryHandler.swift` (307 LOC)
+**Test file:** `PalaceTests/MyBooks/DownloadAuthRetryHandlerTests.swift` (340 LOC, 8 branch tests)
+**Reference:** `git show 3.0.2:Palace/MyBooks/MyBooksDownloadCenter.swift` lines 1757-1942 (inline pre-extraction equivalent)
+
+## Summary
+
+**Verdict: 0 BUG, 3 NEEDS-TEST, 4 CLEAN.** No F-011/F-014/F-017-class defects. Decision-path logic line-matches the 3.0.2 inline source for all six branches. Test gaps cluster around (1) the auto-borrow `attemptDownload: true` parameter direction, (2) the auto-borrow post-completion `newState != .downloading && newState != .downloadSuccessful` predicate, and (3) the `.credentialPrompt` reauthStrategy case which falls through unexercised.
+
+## File:line findings
+
+### CLEAN-1 — Outer auth-needs-refresh predicate is preserved
+
+`DownloadAuthRetryHandler.swift:95`
+```swift
+if httpResponse?.indicatesAuthenticationNeedsRefresh(with: problemDoc, originalRequestURL: originalURL) == true {
+```
+Matches `MyBooksDownloadCenter.swift:1767` (3.0.2). Direction `== true`, no negation. The
+`originalURL` and `problemDoc` arguments are forwarded identically. Not F-014.
+
+### CLEAN-2 — `hasCredentials` / `loginRequired` predicate directions match 3.0.2
+
+| Branch | new (3.1+) | 3.0.2 | match |
+|--------|-----------|-------|-------|
+| 401 + has-creds outer | `:97` `if hasCredentials {` | `:1769` `if hasCredentials {` | yes |
+| 401 + no-creds inner | `:113` `} else if loginRequired {` | `:1839` `} else if loginRequired {` | yes |
+| non-401 + no-creds outer | `:119` `} else if !hasCredentials && loginRequired {` | `:1853` `} else if !hasCredentials && loginRequired {` | yes |
+| no-active-loan session-expiry | `:130` `if reauthStrategy == .browser && hasCredentials {` | `:1879` `if reauthStrategy == .browser && hasCredentials {` | yes |
+
+No condition direction flipped. Not F-014.
+
+### CLEAN-3 — `switch reauthStrategy` is exhaustive, no `default:`
+
+`DownloadAuthRetryHandler.swift:101-112` enumerates `.browser`, `.tokenRefresh`,
+`.credentialPrompt`, `.none` explicitly. Adding a new enum case to
+`ReauthStrategy` would force a compile error, not silent fall-through. This is
+the F-011 safety pattern applied correctly.
+
+### CLEAN-4 — `markCredentialsStale()` side-effect preserved
+
+`:99` (401 + hasCredentials path) and `:131` (no-active-loan + browser + hasCredentials
+path) both call `userAccount.markCredentialsStale()`. Matches 3.0.2 `:1771` and `:1880`
+respectively. Not F-017 (no observed side-effect dropped).
+
+### NEEDS-TEST-1 — `attemptDownload: true` parameter is uncovered
+
+**File:** `DownloadAuthRetryHandler.swift:229`
+```swift
+delegate?.startBorrow(for: book, attemptDownload: true, borrowCompletion: { [weak self] in
+```
+
+**Mutant that survives:** flip `attemptDownload: true` → `attemptDownload: false`.
+
+**Why it matters:** if the auto-borrow doesn't include `attemptDownload: true`,
+`BorrowOperation` does not auto-start the download after the loan is reissued
+(`BorrowOperation.swift:435` gates download-start on `attemptDownload &&
+mapping.state == .downloadNeeded`). The post-borrow completion callback at
+`:235` then sees `newState != .downloading && != .downloadSuccessful` and
+alerts the user — silently degrading auto-retry to "borrow succeeded, manual
+re-tap required". This is exactly the F-014 shape: a boolean param flipped in
+the extraction would produce a hard-to-diagnose UX regression that ships
+silently.
+
+**Why the existing test misses it:** `SpyDelegate.startBorrow` at
+`DownloadAuthRetryHandlerTests.swift:336-338` accepts `attemptDownload: Bool`
+but never records it:
+```swift
+func startBorrow(for book: TPPBook, attemptDownload: Bool, borrowCompletion: (() -> Void)?) {
+    startBorrowCalls.append((book, book.identifier))   // attemptDownload dropped
+}
+```
+The Branch-6b test at `:286-306` only asserts the book identifier and the
+post-state.
+
+**Suggested fix:** record + assert the param.
+
+```swift
+// In SpyDelegate:
+private(set) var startBorrowCalls: [(book: TPPBook, identifier: String, attemptDownload: Bool)] = []
+func startBorrow(for book: TPPBook, attemptDownload: Bool, borrowCompletion: (() -> Void)?) {
+    startBorrowCalls.append((book, book.identifier, attemptDownload))
+}
+
+// In testHandle_noActiveLoan_basicAuth_triggersAutoBorrowAndAlertsOnBorrowFailure:
+XCTAssertEqual(spyDelegate.startBorrowCalls.map { $0.attemptDownload }, [true],
+    "Auto-borrow must request attemptDownload=true so BorrowOperation auto-starts download")
+```
+
+### NEEDS-TEST-2 — Auto-borrow completion-callback predicate is uncovered
+
+**File:** `DownloadAuthRetryHandler.swift:232-241`
+```swift
+let newState = self.bookRegistry.state(for: book.identifier)
+...
+if newState != .downloading && newState != .downloadSuccessful {
+    // Borrow failed or didn't result in download
+    ...
+    self.alertPresenter.alertForProblemDocument(problemDoc, error: failureError, book: book)
+} else {
+    Log.info(#file, ...)
+}
+```
+
+**Mutants that survive:**
+1. `!= .downloading` → `== .downloading` (test alerts on success, swallows on failure)
+2. `&& newState != .downloadSuccessful` → `|| newState != .downloadSuccessful` (alert never fires)
+3. Drop the `&& newState != .downloadSuccessful` clause entirely (rare-case noise on success)
+
+**Why the existing test misses it:** `testHandle_noActiveLoan_basicAuth_triggersAutoBorrowAndAlertsOnBorrowFailure`
+at `:286-306` **never invokes the borrowCompletion closure** — explicit
+comment at `:293-296`:
+> "we leave borrowCompletion uncalled so we focus on the dispatch contract"
+
+The test name "AlertsOnBorrowFailure" is aspirational; the body asserts only
+the dispatch, not the alert. The predicate inside the callback is 100%
+uncovered.
+
+**Suggested fix:** spy the borrow callback and drive both branches.
+
+```swift
+private final class SpyDelegate: DownloadAuthRetryHandlerDelegate {
+    private(set) var startBorrowCalls: [(book: TPPBook, identifier: String, attemptDownload: Bool, completion: (() -> Void)?)] = []
+    func startBorrow(for book: TPPBook, attemptDownload: Bool, borrowCompletion: (() -> Void)?) {
+        startBorrowCalls.append((book, book.identifier, attemptDownload, borrowCompletion))
+    }
+}
+
+func testAutoBorrow_whenBorrowSucceedsAndDownloadStarts_doesNotAlert() async throws {
+    // ... setup as Branch 6b ...
+    let handled = handler.handleAuthFailureIfApplicable(...)
+    XCTAssertTrue(handled)
+
+    // Simulate BorrowOperation flipping state to .downloading then invoking completion
+    registry.setState(.downloading, for: book.identifier)
+    spyDelegate.startBorrowCalls.first?.completion?()
+
+    // No alert presented — verify alertPresenter was not used.
+    // (Requires injecting a spy DownloadAlertPresenter or asserting on a
+    //  spy AccessibilityAnnouncements / progressReporter signal.)
+}
+
+func testAutoBorrow_whenBorrowFails_alertsForProblemDoc() async throws {
+    // ... setup as Branch 6b ...
+    let handled = handler.handleAuthFailureIfApplicable(...)
+    // State stays .unregistered (borrow failed)
+    spyDelegate.startBorrowCalls.first?.completion?()
+
+    // Assert alertPresenter.alertForProblemDocument was called with the
+    // expected problemDoc + error + book — requires a spy or a stub
+    // DownloadAlertPresenter (the production one in setUp uses a real
+    // DownloadProgressReporter that emits to a publisher we can subscribe).
+}
+```
+
+**Mutation-testing note:** This is also a good `palace_mutate.py --diff-only`
+candidate because the predicate has 3 mutation points and the cache currently
+shows 0% kill rate on those lines (predicted — confirm with a local run).
+
+### NEEDS-TEST-3 — `.credentialPrompt` case is unexercised
+
+**File:** `DownloadAuthRetryHandler.swift:109` — the case `.credentialPrompt, .none:`
+arm of `switch reauthStrategy`.
+
+**Mutant that survives:** removing `.credentialPrompt` from the case list and
+adding `default:` falling through to alert. Compiler still passes (because
+`.none` covers fallback semantics), behavior unchanged for `.none`, but
+`.credentialPrompt` now hits the `default` (which is identical behavior — so
+not a runtime bug today).
+
+**Why it matters:** the F-011 pattern is *exactly* "previously-exhaustive
+switch with `default:` silently drops a case". If a future
+`AccountDetails.Authentication.ReauthStrategy` adds a new case (say
+`.deviceAttestation`), the current exhaustive switch will compile-error and
+force the author to think. If the switch instead used `default:`, the new case
+falls through silently. The existing test `Branch 3 (tokenRefresh)` only
+proves the `.tokenRefresh` arm exists — it doesn't prove `.credentialPrompt`
+is enumerated.
+
+**Suggested test:** parameterized over all `ReauthStrategy` cases.
+
+```swift
+// Iterate each ReauthStrategy case and assert the expected handler outcome.
+// If a new case is added without updating this test, the test fails — and
+// the production switch would have already compile-errored (defense in depth).
+func testHandle_401_withCredentials_credentialPromptStrategy_returnsFalse() {
+    userAccount._authDefinition = makeAuth(typeRaw: "...basic-token-or-similar-credentialPrompt-type...")
+    userAccount._credentials = .barcodeAndPin(barcode: "b", pin: "p")
+    let task = makeFakeTask(statusCode: 401)
+    let handled = handler.handleAuthFailureIfApplicable(book: book, task: task, problemDoc: nil, failureError: nil)
+    XCTAssertFalse(handled, ".credentialPrompt + 401 + has-creds falls through to alert")
+    XCTAssertFalse(reauthenticator.authenticateIfNeededCalled)
+}
+```
+
+This is **lower priority** than NEEDS-TEST-1 / -2 because the compile-time
+exhaustivity check is the primary safety net; the test is belt-and-braces.
+
+## Mutation-testing notes
+
+Run the diff-scoped mutation gate to confirm the predicted gaps:
+
+```bash
+python3 scripts/palace_mutate.py \
+  --file Palace/MyBooks/DownloadAuthRetryHandler.swift \
+  --tests PalaceTests/MyBooks/DownloadAuthRetryHandlerTests \
+  --diff-only --diff-base origin/develop
+```
+
+Predicted survivors (pre-fix):
+- Line 229: `attemptDownload: true` → `false`
+- Line 235: `newState != .downloading` → `==`
+- Line 235: `&&` → `||`
+
+Expected kill rate after applying the suggested test additions: 100% on lines
+229 + 235 (the spy-recorded param + the completion-driven assertion).
+
+## Architecture notes
+
+- The handler is correctly stateless (`/// Holds no state of its own —
+  every decision is a fresh read of the current TPPUserAccount`).
+  `userAccountProvider` is invoked fresh inside each callback (`:251`, `:258`,
+  `:278`, `:285`) — preserves the 3.0.2 just-in-time semantics across library
+  switches. Not F-017.
+- The `Task { ... await MainActor.run { ... } }` cleanup-then-mutate pattern at
+  `:155-164`, `:169-178`, `:191-200`, `:203-212` mirrors 3.0.2 verbatim. No GCD
+  hybrid introduced. Aligns with "Swift concurrency > GCD+closure hybrids"
+  guidance.
+- The handler has 6 mutually-exclusive branches; all 6 have positive coverage
+  in the test file plus 1 fall-through case. The gaps are within-branch
+  parameter / predicate gaps, not missing-branch gaps.
+
+## Headline
+
+**No bugs. Three test gaps that would let real defects slip:** the auto-borrow
+`attemptDownload: true` parameter is uncovered (NEEDS-TEST-1), the post-borrow
+`newState != .downloading && != .downloadSuccessful` predicate is uncovered
+(NEEDS-TEST-2), and `.credentialPrompt` strategy is implicitly covered only by
+the exhaustive switch (NEEDS-TEST-3). NEEDS-TEST-1 and NEEDS-TEST-2 are
+F-014-shape gaps in the auto-borrow no-active-loan path — the same code shape
+that produced F-014 in `BorrowOperation`. Recommend adding the spy parameter
+recording + driven completion callback before tag-cut on 3.2.0.

--- a/.forgeos/audits/phase7-DownloadStartDispatcher.md
+++ b/.forgeos/audits/phase7-DownloadStartDispatcher.md
@@ -1,0 +1,455 @@
+---
+name: audit-phase7-DownloadStartDispatcher
+type: ephemeral
+status: active
+created: 2026-05-26
+last_refresh: 2026-05-26
+freshness_window: 180d
+owners: [mybooks]
+description: Phase 7 audit — DownloadStartDispatcher.swift
+---
+
+# Phase 7 audit — DownloadStartDispatcher.swift
+
+## Summary
+
+**Verdict: 0 BUG / 6 NEEDS-TEST / 1 CLEAN.**
+
+Production logic in `Palace/MyBooks/DownloadStartDispatcher.swift` is a faithful
+lift of 3.0.2's `MyBooksDownloadCenter.processUnregisteredState /
+processDownloadWithCredentials / processRegularDownload`. Every conditional in
+the current file matches the pre-Phase-7 expression byte-for-byte (modulo
+delegate-routing). **No F-011 / F-014 / F-017-class defect is present.**
+
+However, `PalaceTests/MyBooks/DownloadStartDispatcherTests.swift` (256 lines,
+11 tests) leaves six concrete F-014-class mutants unkilled. None of them are
+catastrophic individually, but the pattern that lets F-014 slip past CI in the
+first place is "extraction landed, tests pass, but a flipped condition would
+still pass." Recommendation: add the six tests sketched below before the next
+extraction pass in this file's neighborhood.
+
+---
+
+## File:line citations and findings
+
+### Production file `Palace/MyBooks/DownloadStartDispatcher.swift`
+
+Reference points throughout: 3.0.2 inline source is at
+`git show 3.0.2:Palace/MyBooks/MyBooksDownloadCenter.swift` lines 434–700.
+
+| # | Conditional | Current line | 3.0.2 line | Identical? |
+|---|---|---|---|---|
+| 1 | `book.defaultAcquisitionIfBorrow == nil && (book.defaultAcquisitionIfOpenAccess != nil \|\| !(loginRequired ?? false))` | L101 | L435 | YES |
+| 2 | `state == .unregistered \|\| state == .holding` → startBorrow | L121 | L508 | YES |
+| 3 | `book.distributor == OverdriveDistributorKey && book.defaultBookContentType == .audiobook` | L126 | L513 | YES |
+| 4 | `MyBooksDownloadCenter.shouldDeferOverdriveFulfillment(for:state:)` (delegated) | L127 | L514 (inline) | YES (delegates to same static) |
+| 5 | `currentBook.isExpired && currentBook.defaultAcquisitionIfBorrow != nil` | L152 | L633 | YES |
+| 6 | `state == .downloadNeeded && currentBook.defaultAcquisitionIfBorrow != nil` | L159 | L642 | YES |
+| 7 | Auto-borrow completion check: `newState != .downloading && newState != .downloadSuccessful && newState != .downloadNeeded` | L166 | L655 | YES |
+| 8 | `isWifiOnlyEnforced` guard | L173 | L660 | YES (now via injected `isOnWiFi: () -> Bool` closure) |
+| 9 | Request resolution: prefer `initedRequest`, else `currentBook.defaultAcquisition?.hrefURL`, else logInvalidURL | L178–186 | L666–674 | YES |
+| 10 | `guard request.url != nil` | L188 | L676 | YES |
+| 11 | `memoryPressureMonitor.reclaimDiskSpaceIfNeeded(minimumFreeMegabytes: 512)` | L198 | L688 | YES |
+| 12 | `state == .SAMLStarted, let cookies = userAccount.cookies` | L200 | L687 | YES |
+
+**F-011 (missing enum case via `default:`)** — *impossible by construction* in
+this file. There is no `switch` statement on `TPPBookState` anywhere in
+`DownloadStartDispatcher.swift`. All state checks are explicit `==` /
+`!=` equality. This is the **CLEAN** finding.
+
+**F-014 (inverted condition)** — see NEEDS-TEST entries below; no live bug
+present, but several conditions are insufficiently pinned by tests.
+
+**F-017 (missing state observation)** — *not applicable*. `DownloadStartDispatcher`
+publishes nothing (`@Published` count = 0), exposes no Combine subjects, and
+is invoked imperatively from `MyBooksDownloadCenter.startDownloadAsync`. There
+is no readiness-gate / state-observation surface to mis-wire.
+
+---
+
+## NEEDS-TEST findings (6)
+
+All six describe **F-014-class mutants** (flipped operator / equality) that
+the current `DownloadStartDispatcherTests` would NOT catch.
+
+### NT-1 — `processRegularDownload` expired-re-borrow branch is untested
+
+**File:** `Palace/MyBooks/DownloadStartDispatcher.swift:152`
+
+```swift
+if currentBook.isExpired && currentBook.defaultAcquisitionIfBorrow != nil {
+    ...
+    delegate.startBorrow(for: currentBook, attemptDownload: true, borrowCompletion: nil)
+    return
+}
+```
+
+**Surviving mutants:**
+- Flip `&&` to `||` (would re-borrow on every expired book, even those
+  without a borrow link — would silently regress fulfillment-only titles).
+- Drop the `isExpired` check (would re-borrow on EVERY borrowable book,
+  conflating with the auto-borrow branch at L159).
+- Flip `!= nil` to `== nil` (would never re-borrow expired books, leaving
+  the user with a stale entry).
+
+**No existing test invokes the expired branch.** `TPPBook.isExpired` reads
+the acquisition availability; the test helpers in
+`DownloadStartDispatcherTests.swift:91–125` (`makeBook`) always pass
+`TPPOPDSAcquisitionAvailabilityUnlimited()`, so `isExpired == false` for
+every test book.
+
+**Suggested fix:**
+
+```swift
+func testProcessRegularDownload_expiredBookWithBorrowLink_triggersReBorrow() {
+    let book = makeBook(
+        relation: .borrow,
+        availability: TPPOPDSAcquisitionAvailabilityUnavailable(
+            untilDate: Date(timeIntervalSinceNow: -86400) // yesterday
+        )
+    )
+    registry.addBook(book, location: nil, state: .downloadSuccessful, ...)
+
+    dispatcher.processRegularDownload(for: book, withState: .downloadSuccessful, andRequest: nil)
+
+    XCTAssertEqual(spyDelegate.startBorrowCalls.count, 1)
+    XCTAssertTrue(spyDelegate.addDownloadTaskCalls.isEmpty,
+                  "Expired-rebborrow must NOT addDownloadTask itself")
+    XCTAssertEqual(registry.state(for: book.identifier), .unregistered,
+                   "Expired re-borrow must reset registry state to unregistered")
+}
+```
+
+Plus a negative test where an expired book WITHOUT a borrow link falls
+through to the normal request resolution path.
+
+---
+
+### NT-2 — Auto-borrow completion guard (`newState` check) is untested
+
+**File:** `Palace/MyBooks/DownloadStartDispatcher.swift:164–168`
+
+```swift
+let newState = delegate.bookRegistry.state(for: book.identifier)
+Log.debug(#file, "Auto-borrow completed for \(book.identifier), new state: \(newState)")
+if newState != .downloading && newState != .downloadSuccessful && newState != .downloadNeeded {
+    Log.warn(#file, "Auto-borrow completed but book is not downloadable, state: \(newState)")
+}
+```
+
+**Surviving mutants:**
+- Drop any of the three `!=` clauses (e.g. `!= .downloading`) — the warning
+  would still log on most paths, but specific transitions (auto-borrow that
+  succeeds and lands in `.downloading`) would mis-log "not downloadable."
+- Flip `&&` to `||` — would log warning on every successful borrow.
+
+**Coverage gap:** `testProcessRegularDownload_downloadNeededWithBorrowLink_triggersAutoBorrow`
+(`DownloadStartDispatcherTests.swift:246–255`) invokes the branch but the
+`spyDelegate.startBorrow` implementation doesn't synchronously call
+`borrowCompletion`. The closure passed at L162–169 of the production code
+is never executed under test. A surviving mutant in that closure would
+not fail any current test.
+
+**Suggested fix:** make `SpyDispatcherDelegate.startBorrow` accept a
+post-borrow-state hook and invoke `borrowCompletion?()` with the registry
+in a desired state, then assert no spurious log/announcement. Even simpler:
+extract the post-borrow logging predicate into a small pure helper
+(`isDownloadableState(_:) -> Bool`) and test that directly — the predicate
+is the part that has F-014 surface.
+
+```swift
+// Add to DownloadStartDispatcher:
+static func isDownloadableState(_ state: TPPBookState) -> Bool {
+    state == .downloading || state == .downloadSuccessful || state == .downloadNeeded
+}
+
+// And use at L166:
+if !Self.isDownloadableState(newState) { Log.warn(...) }
+
+// Test all 10 enum cases:
+func testIsDownloadableState_pinsAllCases() {
+    XCTAssertTrue(DownloadStartDispatcher.isDownloadableState(.downloading))
+    XCTAssertTrue(DownloadStartDispatcher.isDownloadableState(.downloadSuccessful))
+    XCTAssertTrue(DownloadStartDispatcher.isDownloadableState(.downloadNeeded))
+    XCTAssertFalse(DownloadStartDispatcher.isDownloadableState(.unregistered))
+    XCTAssertFalse(DownloadStartDispatcher.isDownloadableState(.holding))
+    XCTAssertFalse(DownloadStartDispatcher.isDownloadableState(.SAMLStarted))
+    XCTAssertFalse(DownloadStartDispatcher.isDownloadableState(.downloadFailed))
+    XCTAssertFalse(DownloadStartDispatcher.isDownloadableState(.used))
+    XCTAssertFalse(DownloadStartDispatcher.isDownloadableState(.returning))
+    XCTAssertFalse(DownloadStartDispatcher.isDownloadableState(.unsupported))
+}
+```
+
+---
+
+### NT-3 — `isWifiOnlyEnforced` only verified on one branch
+
+**File:** `Palace/MyBooks/DownloadStartDispatcher.swift:61–63, 173–176`
+
+```swift
+private var isWifiOnlyEnforced: Bool {
+    settings.downloadOnlyOnWiFi && !isOnWiFi()
+}
+```
+
+**Surviving mutants:**
+- Flip `&&` to `||` — would block downloads whenever `downloadOnlyOnWiFi`
+  is on OR off-Wi-Fi, broadly breaking download on cellular even with the
+  toggle off.
+- Drop the `!` from `!isOnWiFi()` — would invert: blocks ON Wi-Fi.
+
+**Coverage gap:** existing `testProcessRegularDownload_wifiOnlyEnforced_failsAndDoesNotStartDownload`
+(L193–204) sets both flags true (toggle on, off Wi-Fi). It does not cover:
+- toggle on, ON Wi-Fi (must proceed)
+- toggle off, off Wi-Fi (must proceed)
+
+**Suggested fix:**
+
+```swift
+func testProcessRegularDownload_wifiOnly_onWiFi_proceedsWithDownload() {
+    settings.downloadOnlyOnWiFi = true
+    isOnWiFiValue = true
+    let book = openAccessBook()
+    registry.addBook(book, ...)
+
+    dispatcher.processRegularDownload(for: book, withState: .downloadSuccessful, andRequest: nil)
+
+    XCTAssertTrue(spyDelegate.failWithWifiCalls.isEmpty)
+    XCTAssertEqual(spyDelegate.addDownloadTaskCalls.count, 1)
+}
+
+func testProcessRegularDownload_wifiOff_offWiFi_proceedsWithDownload() {
+    settings.downloadOnlyOnWiFi = false
+    isOnWiFiValue = false
+    let book = openAccessBook()
+    registry.addBook(book, ...)
+
+    dispatcher.processRegularDownload(for: book, withState: .downloadSuccessful, andRequest: nil)
+
+    XCTAssertTrue(spyDelegate.failWithWifiCalls.isEmpty)
+    XCTAssertEqual(spyDelegate.addDownloadTaskCalls.count, 1)
+}
+```
+
+---
+
+### NT-4 — `processDownloadWithCredentials` non-borrow states (`.downloading`, `.downloadFailed`, `.SAMLStarted`, `.downloadNeeded`, `.downloadSuccessful`, `.used`, `.returning`, `.unsupported`) are untested for the fall-through
+
+**File:** `Palace/MyBooks/DownloadStartDispatcher.swift:121–135`
+
+```swift
+if state == .unregistered || state == .holding {
+    delegate.startBorrow(...)
+    return
+}
+... overdrive branch ...
+processRegularDownload(for: book, withState: state, andRequest: initedRequest)
+```
+
+**Surviving mutants:**
+- Flip `||` to `&&` — `state == .unregistered && state == .holding` is
+  always false, so EVERY call would skip the borrow branch and fall to
+  `processRegularDownload`. The only test that pins the borrow branch is
+  for `.unregistered` (L172) and `.holding` (L182); for each of those a
+  fall-through would manifest as no `startBorrow` call PLUS a download
+  attempt — but the tests only assert "1 startBorrow call." If the mutant
+  ALSO produced `addDownloadTask` calls, the existing tests wouldn't
+  notice (`spyDelegate.addDownloadTaskCalls` is not asserted empty in
+  the borrow tests).
+- Drop `state == .unregistered` — `.unregistered` falls through to
+  processRegularDownload, which queries the registry, finds no book,
+  and calls `logInvalidURLRequest`. Existing test would still pass:
+  `startBorrowCalls.count == 1` becomes 0, that part fires, but no
+  other test catches that downstream side effect.
+
+**Coverage gap:**
+- `testProcessDownloadWithCredentials_unregistered_routesToStartBorrow` (L172)
+  does not assert `spyDelegate.addDownloadTaskCalls.isEmpty` until the very
+  last line — but actually it DOES, line 179. Good. Same for `.holding`
+  test? Line 187 only checks borrow count; line 188 checks first
+  identifier. **No `addDownloadTaskCalls.isEmpty` assertion for the
+  `.holding` branch.** That's the gap.
+
+**Suggested fix:** Add `XCTAssertTrue(spyDelegate.addDownloadTaskCalls.isEmpty)`
+to `testProcessDownloadWithCredentials_holding_routesToStartBorrow` (L182).
+Then add a parametrized test that runs every non-borrow, non-Overdrive
+state through `processDownloadWithCredentials` and asserts it routes to
+`addDownloadTask` (or `failWithWifi` / `logInvalid` as appropriate),
+NEVER to `startBorrow`:
+
+```swift
+func testProcessDownloadWithCredentials_nonBorrowStates_doNotStartBorrow() {
+    let nonBorrowStates: [TPPBookState] = [
+        .downloading, .downloadFailed, .downloadSuccessful,
+        .downloadNeeded, .used, .returning, .unsupported, .SAMLStarted
+    ]
+    for state in nonBorrowStates {
+        let book = openAccessBook() // no borrow link → no auto-borrow
+        registry.addBook(book, location: nil, state: state, fulfillmentId: nil,
+                         readiumBookmarks: nil, genericBookmarks: nil)
+        spyDelegate.reset()
+
+        dispatcher.processDownloadWithCredentials(for: book, withState: state, andRequest: nil)
+
+        XCTAssertEqual(spyDelegate.startBorrowCalls.count, 0,
+                       "State \(state): must NOT call startBorrow")
+    }
+}
+```
+
+This is the canonical "exhaustive switch substitute" pattern referenced in
+CLAUDE.md TDD section.
+
+---
+
+### NT-5 — Auto-borrow branch resets registry to `.unregistered` (untested)
+
+**File:** `Palace/MyBooks/DownloadStartDispatcher.swift:159–171`
+
+```swift
+if state == .downloadNeeded && currentBook.defaultAcquisitionIfBorrow != nil {
+    ...
+    delegate.bookRegistry.setState(.unregistered, for: book.identifier)   // ← L161
+    delegate.startBorrow(for: currentBook, attemptDownload: true) { ... }
+    return
+}
+```
+
+**Surviving mutants:**
+- Change `.unregistered` to `.downloadNeeded` (no-op self-write) — auto-borrow
+  would still trigger, but the registry would not reflect the
+  in-progress-borrow state. Tests would still pass.
+- Drop the `setState` call entirely.
+
+**Coverage gap:** `testProcessRegularDownload_downloadNeededWithBorrowLink_triggersAutoBorrow`
+(L246) asserts `startBorrowCalls.count == 1` and addDownloadTask empty,
+but does NOT inspect the registry post-call. A mutant that drops the
+`setState(.unregistered, ...)` survives.
+
+**Suggested fix:** add `XCTAssertEqual(registry.state(for: book.identifier), .unregistered)`
+after the dispatcher call. Same applies to NT-1 (expired re-borrow) — both
+auto-borrow paths reset registry state and that is a load-bearing side
+effect (the next sync depends on it).
+
+---
+
+### NT-6 — SAML branch missing-cookies fallthrough untested
+
+**File:** `Palace/MyBooks/DownloadStartDispatcher.swift:200–211`
+
+```swift
+if state == .SAMLStarted, let cookies = userAccount.cookies {
+    Log.info(#file, "SAML authentication flow for '\(currentBook.title)'")
+    delegate.handleSAMLStartedState(for: currentBook, withRequest: request, cookies: cookies)
+} else {
+    ...
+    delegate.clearAndSetCookies()
+    delegate.addDownloadTask(with: request, book: currentBook)
+}
+```
+
+**Surviving mutants:**
+- Flip `state == .SAMLStarted` to `state != .SAMLStarted` — every non-SAML
+  call would attempt SAML handling, but the `let cookies = userAccount.cookies`
+  guard would short-circuit on the common case (no cookies). On the SAML
+  branch the cookies-present path would route to the else clause —
+  inverting SAML handling entirely.
+- Flip `.SAMLStarted` to another case (e.g. `.downloading`) — SAML
+  downloads would never use the SAML branch.
+
+**Coverage gap:** `testProcessRegularDownload_samlState_routesThroughSAMLHandler`
+(L234–244) covers the happy path: `.SAMLStarted` state + cookies present.
+**Missing:** `.SAMLStarted` state with NO cookies (must fall through to
+`addDownloadTask`); non-SAML state with cookies present (must NOT route
+to SAML handler).
+
+**Suggested fix:**
+
+```swift
+func testProcessRegularDownload_samlStateNoCookies_fallsThroughToAddDownloadTask() {
+    let book = openAccessBook()
+    registry.addBook(book, location: nil, state: .SAMLStarted, ...)
+    userAccount.setCookies(nil)   // explicitly no cookies
+
+    dispatcher.processRegularDownload(for: book, withState: .SAMLStarted, andRequest: nil)
+
+    XCTAssertTrue(spyDelegate.samlHandlerCalls.isEmpty,
+                  "SAMLStarted without cookies must NOT enter SAML handler")
+    XCTAssertEqual(spyDelegate.addDownloadTaskCalls.count, 1)
+}
+
+func testProcessRegularDownload_nonSamlStateWithCookies_doesNotRouteToSAMLHandler() {
+    let book = openAccessBook()
+    registry.addBook(book, location: nil, state: .downloadNeeded, ...)
+    userAccount.setCookies([HTTPCookie(properties: [.name: "S", .value: "x",
+                                                     .domain: "e.com", .path: "/"])!])
+
+    dispatcher.processRegularDownload(for: book, withState: .downloadSuccessful, andRequest: nil)
+
+    XCTAssertTrue(spyDelegate.samlHandlerCalls.isEmpty)
+    XCTAssertEqual(spyDelegate.addDownloadTaskCalls.count, 1)
+}
+```
+
+---
+
+## CLEAN findings (1)
+
+### CL-1 — F-011 (missing enum case) is impossible by construction
+
+**File:** `Palace/MyBooks/DownloadStartDispatcher.swift` (whole file)
+
+The dispatcher has **zero `switch` statements** on `TPPBookState` (or any
+enum). All state-machine decisions use `if state == .X` / `if state == .X ||
+state == .Y` comparisons. F-011 requires a `switch` with `default:` falling
+through silently for a case it should have named explicitly; the pattern
+cannot occur here.
+
+(For comparison, the F-011 site in `BookButtonMapper` IS a switch — this
+file does not have the precondition for that defect class.)
+
+### F-017 not applicable
+
+Dispatcher publishes nothing. `final class DownloadStartDispatcher { weak
+var delegate; private let ...; }` — no `@Published` properties, no
+`PassthroughSubject`, no `CurrentValueSubject`, no Combine pipeline at all.
+F-017 (missing state observation in a `@Published` reducer) does not have
+a target surface.
+
+---
+
+## Mutation-testing notes
+
+A diff-only mutation run pinned to this file's changed lines vs. 3.0.2
+would surface the 13+ mutants enumerated above. The current test file
+would survive ~6 of them, putting the file in the "below 50% kill rate"
+band when measured strictly. Recommend:
+
+```bash
+python3 scripts/palace_mutate.py \
+  --file Palace/MyBooks/DownloadStartDispatcher.swift \
+  --tests PalaceTests/MyBooks/DownloadStartDispatcherTests \
+  --diff-only --diff-base 3.0.2
+```
+
+after adding the NT-1 / NT-3 / NT-4 / NT-5 / NT-6 tests above (NT-2 is a
+production-side refactor + test).
+
+Critical-path note: `Palace/MyBooks/Download*` is in the strict-mutation
+allowlist per CLAUDE.md ("Default mode keeps strict-only on critical
+paths: `Palace/Audiobooks/`, `Palace/SignInLogic/`, `Palace/MyBooks/Download*`").
+So the 50% gate is enforced for this file under
+`verify-pr.sh --quick` already. The NEEDS-TEST gaps above are real CI
+risk for the next PR that touches this file.
+
+---
+
+## Headline
+
+**No bug present.** The Phase 7 extraction of `DownloadStartDispatcher`
+preserved 3.0.2 logic faithfully and F-011 / F-017 are impossible by
+construction. The most important issue is **NT-4**: the
+`processDownloadWithCredentials` borrow-routing branch is only pinned for
+2 of the 10 `TPPBookState` cases — a parametrized "non-borrow states never
+call startBorrow" test is the highest-leverage addition.

--- a/.forgeos/audits/phase7-synthesis-2026-05-26.md
+++ b/.forgeos/audits/phase7-synthesis-2026-05-26.md
@@ -1,0 +1,105 @@
+---
+name: audit-phase7-synthesis-2026-05-26
+type: ephemeral
+status: active
+created: 2026-05-26
+last_refresh: 2026-05-26
+freshness_window: 180d
+owners: [mybooks]
+description: Phase 7 siblings audit — synthesis (2026-05-26)
+---
+
+# Phase 7 siblings audit — synthesis (2026-05-26)
+
+Three parallel subagents audited `DownloadStartDispatcher`, `DownloadAuthRetryHandler`, and `BookButtonMapper` for F-011 / F-014 / F-017-class regressions following the patterns documented in `phase7_borrow_path_regressions_2026_05_14.md`.
+
+## Verdict
+
+**No live defects. 12 test gaps. 1 build-system fix needed.**
+
+| File | BUG | NEEDS-TEST | CLEAN |
+|---|---:|---:|---:|
+| `DownloadStartDispatcher` | 0 | 6 | 1 |
+| `DownloadAuthRetryHandler` | 0 | 3 | 4 |
+| `BookButtonMapper` | 0 | 3 | 1 |
+| **Total** | **0** | **12** | **6** |
+
+All three files match the 3.0.2 inline equivalents byte-for-byte on the relevant control-flow surfaces (verified via `git show 3.0.2:Palace/MyBooks/MyBooksDownloadCenter.swift` comparisons in each subagent's report). The Phase 7 decomposition did NOT introduce silent F-011/F-014/F-017 siblings in these classes.
+
+The risk surface that remains is test coverage, not production code: 12 mutants would survive across the three test suites. Until those tests are tightened, a future PR touching these files could regress them without CI noticing.
+
+## Highest-priority findings
+
+### 1. `BookButtonMapper` not on the strict mutation-gate critical path (build system bug)
+
+`scripts/verify-pr.sh:73` regex: `^Palace/(Audiobooks|SignInLogic|MyBooks/Download)`. `Palace/Book/UI/BookDetail/BookButtonMapper.swift` does not match. Memory pin `phase7_borrow_path_regressions_2026_05_14` explicitly flags this file as belonging to the strict list. **Fix is one regex update.**
+
+### 2. `BookButtonMapper.SAMLStarted` falls through to `.unsupported` silently (F-011 shape, latent)
+
+`BookButtonMapper.swift:53-57` — the if-cascade has no explicit `.SAMLStarted` branch. The state reaches the mapper (verified via grep against current `TPPBookState`) and produces `.unsupported`. Zero tests pin this. **Same risk class as the original F-011** (silent fall-through on a real enum case). Any new `TPPBookState` case added later inherits the same trap.
+
+**Fix shape:** convert the if-cascade to an exhaustive `switch state` (no `default:`) + add `for state in TPPBookState.allCases` parameterized test that asserts each case produces a defined non-`.unsupported` mapping or explicitly documents `.unsupported` as intentional. This is the safety net the prelude recommends.
+
+### 3. `DownloadAuthRetryHandler:229` `attemptDownload: true` parameter is unpinned (F-014 shape)
+
+The handler passes `attemptDownload: true` to `startBorrow` on the auto-borrow path — but `SpyDelegate.startBorrow` in `DownloadAuthRetryHandlerTests.swift` drops the parameter entirely. Flipping `true → false` survives every test. **Same surface where F-014 originally lived** in `BorrowOperation`.
+
+**Fix shape:** spy delegate captures `attemptDownload`; tests assert `spy.startBorrowCalls.first?.attemptDownload == true`.
+
+### 4. `DownloadAuthRetryHandler:235` post-borrow state predicate uncovered
+
+`newState != .downloading && newState != .downloadSuccessful` runs only when `borrowCompletion` is invoked — and the audit subagent found a comment in the test admitting `borrowCompletion` is never invoked under test. Three mutants survive on that line. F-014 shape.
+
+### 5. `DownloadStartDispatcher` borrow-routing branch covers only 2 of 10 `TPPBookState` cases (NEEDS-TEST-4)
+
+The dispatcher's `processDownloadWithCredentials:121` checks `state == .unregistered || state == .holding` to route to borrow. The test suite pins only those two cases. A regression that ALSO routed (say) `.downloadNeeded` to borrow would not fail any test. **Highest-leverage gap of the six in this file.**
+
+**Fix shape:** parameterized test over `TPPBookState.allCases.subtract([.unregistered, .holding])` asserting `spy.startBorrowCalls` stays empty.
+
+## Other findings (summarized)
+
+| ID | File | Pattern | Severity |
+|---|---|---|---|
+| NT-1 | `DownloadStartDispatcher:152` | Expired re-borrow branch — no test exercises `isExpired == true` | Medium |
+| NT-2 | `DownloadStartDispatcher:166` | Auto-borrow completion guard — closure never invoked under test | Medium |
+| NT-3 | `DownloadStartDispatcher:61` | `isWifiOnlyEnforced` — only 1 of 4 boolean combinations tested | Low |
+| NT-5 | `DownloadStartDispatcher:161` | `setState(.unregistered, ...)` registry reset not asserted | Low |
+| NT-6 | `DownloadStartDispatcher:200` | SAML branch — no test for `.SAMLStarted` without cookies, etc. | Medium |
+| NT-7 | `DownloadAuthRetryHandler:.credentialPrompt` strategy | No direct test (compile-time exhaustivity is primary defense) | Low |
+| NT-8 | `BookButtonMapper:22` `.returning + isProcessingDownload` priority | Boundary unpinned — refactor mutant survives | Medium |
+
+## Suggested follow-up PRs
+
+1. **`fix(verify-pr): add BookButtonMapper to strict mutation-gate regex`** (1-line change, finding #1)
+2. **`test(BookButtonMapper): exhaustive switch + .allCases parameterized test`** (finding #2; closes F-011 sibling window permanently)
+3. **`test(DownloadAuthRetryHandler): capture attemptDownload in SpyDelegate + assert on auto-borrow path`** (findings #3, #4)
+4. **`test(DownloadStartDispatcher): parameterize borrow-routing branch over TPPBookState.allCases`** (finding #5; closes the highest-leverage F-011 sibling)
+5. (Lower priority) round out the remaining NT-1 through NT-8 gaps in follow-up commits.
+
+## Methodology evaluation — did the subagent-prelude shift reasoning?
+
+This audit doubled as a real-world test of the `harness subagent-prelude --domain mybooks` capability landed earlier today. Honest assessment:
+
+**The prelude was load-bearing in three observable ways:**
+
+1. **Pattern definitions made findings precise.** All three subagents used the F-011 / F-014 / F-017 vocabulary verbatim in their reports — "F-014 shape," "F-011 latent" — anchoring each finding to a specific failure mode rather than vague "this could break." Without the prelude, a generic audit subagent would describe these as "missing test for branch X" without the framing.
+
+2. **The prelude's "for state-machine switches, the exhaustive-switch + `.allCases` parameterized test is the safety net" sentence appears in TWO of the three subagent reports as the recommended fix shape.** The BookButtonMapper subagent in particular proposed the exact `for state in TPPBookState.allCases` test pattern that memory pin documents — that's the prelude propagating into design decisions, not just framing.
+
+3. **Cross-reference to other memory ("`Reachability subscriptions come in pairs`", "isProcessingDownload short-circuits before `.downloadNeeded`") was used as a search heuristic.** The BookButtonMapper subagent specifically tested the "what if `.returning` leaked into the short-circuit predicate?" hypothesis — a question only the prelude content would prompt.
+
+**Caveats:**
+
+- The audit found ZERO live bugs, so I can't conclusively prove the prelude prevented a wrong diagnosis. The counter-test (run the same audit cold) would burn parallel-agent budget unnecessarily for a session that already produced its result.
+- The 12 NEEDS-TEST findings are real but lower-stakes than a live bug would be. The prelude's real ROI shows up on bug fixes / refactors, not read-only audits.
+- The prelude IS 193 lines of context per subagent dispatch. For tasks where domain knowledge isn't load-bearing, that's overhead. The branch-aware SessionStart hints + per-task discretion remain the right model — don't blindly include the prelude.
+
+**Net:** the capability worked as designed. The artifacts (`.forgeos/audits/phase7-*.md`) are concrete proof. Recommend continuing to use it for multi-agent investigations in well-covered SharedMind domains (audiobook, accounts, mybooks).
+
+## Sources
+
+- Per-file audits: `.forgeos/audits/phase7-{DownloadStartDispatcher,DownloadAuthRetryHandler,BookButtonMapper}.md`
+- Subagent prelude generated: `harness subagent-prelude --domain mybooks` (193 lines)
+- Memory pin: `phase7_borrow_path_regressions_2026_05_14.md`
+- Test patterns reference: `feedback_test_patterns_phase7.md`
+- Verify-pr.sh: `scripts/verify-pr.sh:73` (the regex that needs `BookButtonMapper` added)

--- a/.forgeos/lint-exclude-active-swarms.md
+++ b/.forgeos/lint-exclude-active-swarms.md
@@ -1,3 +1,14 @@
+---
+name: forgeos-lint-exclude-active-swarms
+type: evolving
+status: active
+created: 2026-05-26
+last_refresh: 2026-05-26
+freshness_window: 365d
+owners: [general]
+description: Files claimed by non-complete swarms — excluded from this cleanup PR
+---
+
 # Files claimed by non-complete swarms — excluded from this cleanup PR
 # Generated 2026-05-22T16:05:16Z from .forgeos/swarms/*/manifest.yaml status != complete
 

--- a/.forgeos/lint-initial-report.md
+++ b/.forgeos/lint-initial-report.md
@@ -1,3 +1,14 @@
+---
+name: forgeos-lint-initial-report
+type: evolving
+status: active
+created: 2026-05-26
+last_refresh: 2026-05-26
+freshness_window: 365d
+owners: [general]
+description: Harness Lint — palace-ios
+---
+
 # Harness Lint — palace-ios
 
 - **Scope:** Palace/

--- a/.forgeos/schemas/doc-frontmatter-v1.md
+++ b/.forgeos/schemas/doc-frontmatter-v1.md
@@ -1,0 +1,208 @@
+---
+name: doc-frontmatter-v1
+type: immutable
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: never
+owners: [governance]
+description: Canonical YAML frontmatter schema for governance markdown docs.
+---
+
+# Doc-frontmatter schema, v1
+
+This is the canonical human-readable spec for the YAML frontmatter that
+every governance markdown doc in this repo must carry. The Python
+validator at `~/harness/core/lib/validate-doc-frontmatter.py` enforces
+this schema; pre-commit hooks (Module C) gate pushes against it; the
+harness docs-decay command (Module D) consumes the JSON report to
+surface stale docs at SessionStart (Module E).
+
+## Why this exists
+
+Governance docs (wall failures, ADRs, swarm contracts, skill definitions,
+area checklists) accumulate without a lifecycle signal. We can't tell at
+a glance which docs are immutable historical record vs. living docs that
+have decayed past their refresh window. Frontmatter makes the lifecycle
+explicit and machine-checkable.
+
+## Where the schema applies
+
+In-scope (validator walks these):
+
+- `.forgeos/**/*.md` — except `.forgeos/swarms/**` (transcripts churn
+  faster than schema), `.forgeos/wall-failures/archive/**`,
+  `.forgeos/mutation-cache/**`, `.forgeos/audits/**`,
+  `.forgeos/contracts/**`, and the `lint-baseline` /
+  `crashlytics-baseline` generated artifacts.
+- `docs/architecture/**/*.md`
+- `.claude/skills/**/*.md`
+
+Out-of-scope: top-level `README.md`, `CLAUDE.md`, `PalaceTests/**`,
+`Palace/**` source-tree docs, generated artifacts, anything under the
+exclusions above.
+
+## Required fields
+
+```yaml
+---
+name: <unique-kebab-case-slug>
+type: immutable | evolving | ephemeral
+status: active | stale | archived | superseded
+created: <YYYY-MM-DD>
+last_refresh: <YYYY-MM-DD>
+freshness_window: 90d | 180d | 365d | never
+owners: [<area-slug>, ...]
+---
+```
+
+### `name` (required, string)
+
+A unique kebab-case slug. Lowercase ASCII alphanumerics plus dashes; must
+start and end with an alphanumeric. Used as the cross-doc reference key
+in `supersedes` / `superseded_by` / `related`. Must be unique within the
+repo (validator flags duplicates).
+
+### `type` (required, enum)
+
+- **`immutable`** — historical record. Wall-failure entries, post-mortems,
+  ADR rationale dumps. Frontmatter MUST set `freshness_window: never`
+  because the doc is not supposed to be refreshed.
+- **`evolving`** — living document that's expected to be refreshed
+  periodically. Area checklists, skill definitions, this schema spec.
+  Frontmatter MUST set a finite `freshness_window` (90d / 180d / 365d).
+- **`ephemeral`** — short-lived doc (sprint handoff, regression run
+  report). Frontmatter MUST set a finite window; the doc is expected to
+  be archived or superseded within ~one window.
+
+### `status` (required, enum)
+
+- **`active`** — currently authoritative.
+- **`stale`** — past its refresh window, not yet refreshed. Set
+  automatically by the docs-decay command (Module D) when
+  `now - last_refresh > freshness_window`. Owners are expected to either
+  refresh-and-bump-`last_refresh` or move to `archived` / `superseded`.
+- **`archived`** — kept for archaeology; not authoritative. Move into a
+  `archive/` subdirectory if one exists.
+- **`superseded`** — replaced by a newer doc. MUST also set
+  `superseded_by: <new-doc-name>`.
+
+### `created` (required, ISO date)
+
+`YYYY-MM-DD` of doc creation. Never changes.
+
+### `last_refresh` (required, ISO date)
+
+`YYYY-MM-DD` of the most recent substantive update. Must be `>= created`.
+For `immutable` docs, equals `created` and never changes. For `evolving`
+/ `ephemeral` docs, owners bump this whenever they review the doc and
+confirm it's still accurate.
+
+### `freshness_window` (required, enum)
+
+How long the doc is presumed authoritative after `last_refresh`. Values:
+
+- `90d` — typical evolving doc (skills, area checklists).
+- `180d` — slower-moving doc (architectural ADRs that still get touched).
+- `365d` — annual review cadence.
+- `never` — required for `type: immutable`; invalid for evolving /
+  ephemeral.
+
+### `owners` (required, non-empty list of strings)
+
+Area slugs (e.g. `auth`, `audiobook`, `network`, `governance`,
+`infrastructure`). Used by docs-decay to route stale-doc surfacing to the
+right area. At least one owner; lowercase kebab-case.
+
+## Optional fields
+
+- **`supersedes`** — list of names of older docs this doc replaces. The
+  named docs MUST have `superseded_by: <this-name>` set (validator checks
+  reciprocity).
+- **`superseded_by`** — name of the doc that replaces this one. MUST be
+  set together with `status: superseded` for clean lifecycle.
+- **`related`** — list of cross-link names; consumed by the query layer.
+- **`description`** — single-line summary; recommended.
+
+## Examples
+
+### Immutable wall-failure entry
+
+```yaml
+---
+name: 2026-05-27-pr1018-arch1
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [governance, infrastructure]
+description: Submodule gitlinks accidentally staged as absolute-path symlinks.
+---
+```
+
+### Evolving skill / area doc
+
+```yaml
+---
+name: swarm-skill
+type: evolving
+status: active
+created: 2026-04-15
+last_refresh: 2026-05-21
+freshness_window: 90d
+owners: [governance]
+description: Multi-module triage→dispatch→integrate→promote loop.
+---
+```
+
+### Superseded ADR
+
+```yaml
+---
+name: account-state-machine-v1
+type: evolving
+status: superseded
+created: 2026-04-01
+last_refresh: 2026-05-10
+freshness_window: 180d
+owners: [auth]
+superseded_by: account-state-machine-v2
+description: Original Phase 1 state-machine design.
+---
+```
+
+## Validator surface
+
+```bash
+python3 ~/harness/core/lib/validate-doc-frontmatter.py [options]
+```
+
+| Flag | Effect |
+| --- | --- |
+| `--path ROOT` | Tree to walk (default `.`). |
+| `--strict-windows` | Treat past-window `last_refresh` as a failure (not just a warning). |
+| `--json` | Emit a JSON report to stdout (consumed by `harness docs-decay`). |
+| `--quiet` | Suppress per-file stderr output; exit code only. |
+| `--help` | Usage. |
+
+Exit codes:
+
+- `0` — all in-scope docs pass.
+- `1` — one or more failed.
+- `2` — usage error.
+
+The validator's cross-doc consistency rules:
+
+- **Unique `name`** — duplicate names across docs are an error.
+- **Reciprocal supersession** — if `A.superseded_by = B`, then
+  `B.supersedes` must contain `A`.
+- **Type ↔ window coupling** — `immutable` requires `never`; `evolving` /
+  `ephemeral` forbid `never`.
+
+## Compatibility
+
+This is `v1`. Schema changes that add optional fields are non-breaking and
+do not bump the version. Changes that add required fields, remove fields,
+or change enum values bump to `v2` (and the validator gains a `version:`
+sniff to gate which checks run on which docs).

--- a/.forgeos/schemas/swarm-manifest-v2.md
+++ b/.forgeos/schemas/swarm-manifest-v2.md
@@ -1,3 +1,14 @@
+---
+name: swarm-manifest-v2
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
+description: Swarm manifest schema v2 — architect post-review enforcement
+---
+
 <!-- audit-verified: A4 from .forgeos/wall-failures/derived-improvements.md — this schema enforces architect post-review per PR #1018 architect under-estimating test surface 7x. -->
 
 # Swarm manifest schema v2 — architect post-review enforcement

--- a/.forgeos/swarms/swarm_03acb10a/contracts/A-AppContainerWiring.md
+++ b/.forgeos/swarms/swarm_03acb10a/contracts/A-AppContainerWiring.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-contract-A-AppContainerWiring
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [accounts]
+description: Module A — AppContainer audiobook wiring
+---
+
 # Module A — AppContainer audiobook wiring
 
 **Status:** REFINED post-triage.

--- a/.forgeos/swarms/swarm_03acb10a/contracts/B-SingletonElimination.md
+++ b/.forgeos/swarms/swarm_03acb10a/contracts/B-SingletonElimination.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-contract-B-SingletonElimination
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: Module B — Singleton elimination
+---
+
 # Module B — Singleton elimination
 
 **Status:** REFINED post-triage.

--- a/.forgeos/swarms/swarm_03acb10a/contracts/C-AsyncAfterSweep.md
+++ b/.forgeos/swarms/swarm_03acb10a/contracts/C-AsyncAfterSweep.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-contract-C-AsyncAfterSweep
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: Module C — AsyncAfter sweep (NowPlayingCoordinator only)
+---
+
 # Module C — AsyncAfter sweep (NowPlayingCoordinator only)
 
 **Status:** REFINED post-triage — **scope reduced to ONE file**.

--- a/.forgeos/swarms/swarm_03acb10a/contracts/D-TestCleanup.md
+++ b/.forgeos/swarms/swarm_03acb10a/contracts/D-TestCleanup.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-contract-D-TestCleanup
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: Module D — Test cleanup
+---
+
 # Module D — Test cleanup
 
 **Status:** REFINED post-triage — file list LOCKED.

--- a/.forgeos/swarms/swarm_03acb10a/outcome.md
+++ b/.forgeos/swarms/swarm_03acb10a/outcome.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-outcome
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: Swarm 3 — Outcome
+---
+
 # Swarm 3 — Outcome
 
 **Status:** complete (open PR)

--- a/.forgeos/swarms/swarm_03acb10a/plan.md
+++ b/.forgeos/swarms/swarm_03acb10a/plan.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-plan
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: Swarm 3 — Singleton Elimination + Async Sweep
+---
+
 # Swarm 3 — Singleton Elimination + Async Sweep
 
 **Phase 3 of [audiobook-systemic-overhaul](../../../docs/architecture/audiobook-systemic-overhaul.md).**

--- a/.forgeos/swarms/swarm_03acb10a/transcripts/A-AppContainerWiring.md
+++ b/.forgeos/swarms/swarm_03acb10a/transcripts/A-AppContainerWiring.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-transcript-A-AppContainerWiring
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [accounts]
+description: Module A — AppContainer Audiobook Factory Wiring
+---
+
 # Module A — AppContainer Audiobook Factory Wiring
 
 Swarm: `swarm_03acb10a` (Phase 3 of audiobook systemic overhaul)

--- a/.forgeos/swarms/swarm_03acb10a/transcripts/B-SingletonElimination.md
+++ b/.forgeos/swarms/swarm_03acb10a/transcripts/B-SingletonElimination.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-transcript-B-SingletonElimination
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [general]
+description: Module B — Singleton Elimination — Transcript
+---
+
 # Module B — Singleton Elimination — Transcript
 
 Swarm: `swarm_03acb10a` (Phase 3 of audiobook systemic overhaul)

--- a/.forgeos/swarms/swarm_03acb10a/transcripts/C-AsyncAfterSweep.md
+++ b/.forgeos/swarms/swarm_03acb10a/transcripts/C-AsyncAfterSweep.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-transcript-C-AsyncAfterSweep
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [general]
+description: Module C — AsyncAfter Sweep Transcript
+---
+
 # Module C — AsyncAfter Sweep Transcript
 
 Swarm: `swarm_03acb10a`

--- a/.forgeos/swarms/swarm_03acb10a/transcripts/D-TestCleanup.md
+++ b/.forgeos/swarms/swarm_03acb10a/transcripts/D-TestCleanup.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-transcript-D-TestCleanup
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [general]
+description: Module D — Test Cleanup — Transcript
+---
+
 # Module D — Test Cleanup — Transcript
 
 Swarm: `swarm_03acb10a` (Phase 3 of audiobook systemic overhaul)

--- a/.forgeos/swarms/swarm_03acb10a/transcripts/triage.md
+++ b/.forgeos/swarms/swarm_03acb10a/transcripts/triage.md
@@ -1,3 +1,14 @@
+---
+name: swarm_03acb10a-transcript-triage
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [general]
+description: Swarm 3 Triage Transcript — swarm_03acb10a
+---
+
 # Swarm 3 Triage Transcript — swarm_03acb10a
 
 **Architect:** orchestrator agent

--- a/.forgeos/swarms/swarm_5c8ddbd5/contracts/A-AdapterProtocol.md
+++ b/.forgeos/swarms/swarm_5c8ddbd5/contracts/A-AdapterProtocol.md
@@ -1,3 +1,14 @@
+---
+name: swarm_5c8ddbd5-contract-A-AdapterProtocol
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [network]
+description: Module A — AudiobookVendorAdapter protocol
+---
+
 # Module A — AudiobookVendorAdapter protocol
 
 ## In-scope files (exclusive write)

--- a/.forgeos/swarms/swarm_5c8ddbd5/contracts/B-NetworkAdapters.md
+++ b/.forgeos/swarms/swarm_5c8ddbd5/contracts/B-NetworkAdapters.md
@@ -1,3 +1,14 @@
+---
+name: swarm_5c8ddbd5-contract-B-NetworkAdapters
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [network]
+description: Module B — OpenAccess + BearerToken + LocalFile adapters
+---
+
 # Module B — OpenAccess + BearerToken + LocalFile adapters
 
 ## In-scope files (exclusive write)

--- a/.forgeos/swarms/swarm_5c8ddbd5/contracts/C-LCPAdapter.md
+++ b/.forgeos/swarms/swarm_5c8ddbd5/contracts/C-LCPAdapter.md
@@ -1,3 +1,14 @@
+---
+name: swarm_5c8ddbd5-contract-C-LCPAdapter
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [audiobook]
+description: Module C — LCP adapter + recursive acquisition predicate
+---
+
 # Module C — LCP adapter + recursive acquisition predicate
 
 ## In-scope files (exclusive write)

--- a/.forgeos/swarms/swarm_5c8ddbd5/contracts/D-LoaderDispatch.md
+++ b/.forgeos/swarms/swarm_5c8ddbd5/contracts/D-LoaderDispatch.md
@@ -1,3 +1,14 @@
+---
+name: swarm_5c8ddbd5-contract-D-LoaderDispatch
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [network]
+description: Module D — Loader dispatch rewrite + OPDS shape matrix tests
+---
+
 # Module D — Loader dispatch rewrite + OPDS shape matrix tests
 
 ## In-scope files (exclusive write)

--- a/.forgeos/swarms/swarm_5c8ddbd5/outcome.md
+++ b/.forgeos/swarms/swarm_5c8ddbd5/outcome.md
@@ -1,3 +1,14 @@
+---
+name: swarm_5c8ddbd5-outcome
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: Swarm 1 — Outcome
+---
+
 # Swarm 1 — Outcome
 
 **Status:** complete (open PR)

--- a/.forgeos/swarms/swarm_5c8ddbd5/plan.md
+++ b/.forgeos/swarms/swarm_5c8ddbd5/plan.md
@@ -1,3 +1,14 @@
+---
+name: swarm_5c8ddbd5-plan
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: Swarm 1 — Audiobook Vendor Adapter Extraction
+---
+
 # Swarm 1 — Audiobook Vendor Adapter Extraction
 
 **Swarm ID:** `swarm_5c8ddbd5`

--- a/.forgeos/swarms/swarm_5c8ddbd5/transcripts/A-AdapterProtocol.md
+++ b/.forgeos/swarms/swarm_5c8ddbd5/transcripts/A-AdapterProtocol.md
@@ -1,3 +1,14 @@
+---
+name: swarm_5c8ddbd5-transcript-A-AdapterProtocol
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [network]
+description: Module A — AudiobookVendorAdapter Protocol — Implementer Transcript
+---
+
 # Module A — AudiobookVendorAdapter Protocol — Implementer Transcript
 
 **Status:** success

--- a/.forgeos/swarms/swarm_5c8ddbd5/transcripts/B-NetworkAdapters.md
+++ b/.forgeos/swarms/swarm_5c8ddbd5/transcripts/B-NetworkAdapters.md
@@ -1,3 +1,14 @@
+---
+name: swarm_5c8ddbd5-transcript-B-NetworkAdapters
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [network]
+description: Module B transcript — Network Adapters
+---
+
 # Module B transcript — Network Adapters
 
 **Swarm:** `swarm_5c8ddbd5` (Audiobook Vendor Adapter Extraction)

--- a/.forgeos/swarms/swarm_5c8ddbd5/transcripts/C-LCPAdapter.md
+++ b/.forgeos/swarms/swarm_5c8ddbd5/transcripts/C-LCPAdapter.md
@@ -1,3 +1,14 @@
+---
+name: swarm_5c8ddbd5-transcript-C-LCPAdapter
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [audiobook]
+description: Module C — LCP adapter + recursive acquisition predicate
+---
+
 # Module C — LCP adapter + recursive acquisition predicate
 
 **Status:** complete (transcript written by integrator after agent stream timeout — files were fully written and verified disjoint before timeout)

--- a/.forgeos/swarms/swarm_5c8ddbd5/transcripts/D-LoaderDispatch.md
+++ b/.forgeos/swarms/swarm_5c8ddbd5/transcripts/D-LoaderDispatch.md
@@ -1,3 +1,14 @@
+---
+name: swarm_5c8ddbd5-transcript-D-LoaderDispatch
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [network]
+description: Module D — Loader dispatch rewrite + OPDS shape matrix tests — transcript
+---
+
 # Module D — Loader dispatch rewrite + OPDS shape matrix tests — transcript
 
 **Status:** complete

--- a/.forgeos/swarms/swarm_66819d80/contracts/A-PalaceAuth.md
+++ b/.forgeos/swarms/swarm_66819d80/contracts/A-PalaceAuth.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-contract-A-PalaceAuth
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: never
+owners: [auth]
+description: "Module A — PalaceAuth: `AuthErrorClassifier` + `AuthCoordinator`"
+---
+
 # Module A — PalaceAuth: `AuthErrorClassifier` + `AuthCoordinator`
 
 **Swarm:** `swarm_66819d80`  •  **Base SHA:** `d7f115adeb69032fb3abed33ba07b3deeb245f4b`  •  **Depends on:** none (Day 1 parallel with Module B)

--- a/.forgeos/swarms/swarm_66819d80/contracts/B-isBrowserBased.md
+++ b/.forgeos/swarms/swarm_66819d80/contracts/B-isBrowserBased.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-contract-B-isBrowserBased
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: never
+owners: [auth]
+description: "Module B — `AccountDetails.Authentication.isBrowserBased`"
+---
+
 # Module B — `AccountDetails.Authentication.isBrowserBased`
 
 **Swarm:** `swarm_66819d80`  •  **Base SHA:** `d7f115adeb69032fb3abed33ba07b3deeb245f4b`  •  **Depends on:** none (Day 1 parallel with Module A)

--- a/.forgeos/swarms/swarm_66819d80/contracts/C-CallerMigration.md
+++ b/.forgeos/swarms/swarm_66819d80/contracts/C-CallerMigration.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-contract-C-CallerMigration
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: never
+owners: [auth]
+description: "Module C — Caller migration: route 401/403 sites through `AuthCoordinator`"
+---
+
 # Module C — Caller migration: route 401/403 sites through `AuthCoordinator`
 
 **Swarm:** `swarm_66819d80`  •  **Base SHA:** `d7f115adeb69032fb3abed33ba07b3deeb245f4b`  •  **Depends on:** Module A (must merge first)

--- a/.forgeos/swarms/swarm_66819d80/contracts/D-TelemetryFixtures.md
+++ b/.forgeos/swarms/swarm_66819d80/contracts/D-TelemetryFixtures.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-contract-D-TelemetryFixtures
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: never
+owners: [auth]
+description: Module D — Telemetry instrumentation + simdrive fixture gap report
+---
+
 # Module D — Telemetry instrumentation + simdrive fixture gap report
 
 **Swarm:** `swarm_66819d80`  •  **Base SHA:** `d7f115adeb69032fb3abed33ba07b3deeb245f4b`  •  **Depends on:** Module A (must merge first); runs parallel to Module C

--- a/.forgeos/swarms/swarm_66819d80/outcome.md
+++ b/.forgeos/swarms/swarm_66819d80/outcome.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-outcome
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: never
+owners: [auth]
+description: swarm_66819d80 — outcome
+---
+
 # swarm_66819d80 — outcome
 
 **Status:** complete

--- a/.forgeos/swarms/swarm_66819d80/plan.md
+++ b/.forgeos/swarms/swarm_66819d80/plan.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-plan
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: never
+owners: [auth]
+description: "Plan — swarm_66819d80: 3.2.0 auth architecture remediation (classifier + coordinator + isBrowserBased)"
+---
+
 # Plan — swarm_66819d80: 3.2.0 auth architecture remediation (classifier + coordinator + isBrowserBased)
 
 **Architect:** Maurice Carrier (this session)  •  **Base:** `origin/develop` @ `d7f115adeb69032fb3abed33ba07b3deeb245f4b`  •  **Branch:** `swarm/swarm_66819d80-scaffold`

--- a/.forgeos/swarms/swarm_66819d80/transcripts/A-PalaceAuth.md
+++ b/.forgeos/swarms/swarm_66819d80/transcripts/A-PalaceAuth.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-transcript-A-PalaceAuth
+type: ephemeral
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [auth]
+description: "Module A — PalaceAuth: AuthErrorClassifier + AuthCoordinator"
+---
+
 # Module A — PalaceAuth: AuthErrorClassifier + AuthCoordinator
 
 **Swarm:** `swarm_66819d80`  •  **Branch:** `swarm/swarm_66819d80-scaffold`  •  **Implementer:** subagent

--- a/.forgeos/swarms/swarm_66819d80/transcripts/B-isBrowserBased.md
+++ b/.forgeos/swarms/swarm_66819d80/transcripts/B-isBrowserBased.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-transcript-B-isBrowserBased
+type: ephemeral
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [auth]
+description: "Module B transcript — `AccountDetails.Authentication.isBrowserBased`"
+---
+
 # Module B transcript — `AccountDetails.Authentication.isBrowserBased`
 
 **Swarm:** `swarm_66819d80`  •  **Implementer session:** 2026-05-27  •  **Base SHA:** `d7f115adeb69032fb3abed33ba07b3deeb245f4b`  •  **Branch:** `swarm/swarm_66819d80-scaffold`

--- a/.forgeos/swarms/swarm_66819d80/transcripts/C-CallerMigration.md
+++ b/.forgeos/swarms/swarm_66819d80/transcripts/C-CallerMigration.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-transcript-C-CallerMigration
+type: ephemeral
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [auth]
+description: "Module C — Caller migration: scaffold complete, 2/7 sites migrated"
+---
+
 # Module C — Caller migration: scaffold complete, 2/7 sites migrated
 
 **Swarm:** `swarm_66819d80`  •  **Branch:** `swarm/swarm_66819d80-scaffold`  •  **Implementer:** subagent

--- a/.forgeos/swarms/swarm_66819d80/transcripts/D-TelemetryFixtures.md
+++ b/.forgeos/swarms/swarm_66819d80/transcripts/D-TelemetryFixtures.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-transcript-D-TelemetryFixtures
+type: ephemeral
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [auth]
+description: Module D — Telemetry + simdrive fixture gap report
+---
+
 # Module D — Telemetry + simdrive fixture gap report
 
 **Swarm:** `swarm_66819d80`  •  **Branch:** `swarm/swarm_66819d80-scaffold`  •  **Implementer:** subagent

--- a/.forgeos/swarms/swarm_66819d80/transcripts/D-fixtures-gap-report.md
+++ b/.forgeos/swarms/swarm_66819d80/transcripts/D-fixtures-gap-report.md
@@ -1,3 +1,14 @@
+---
+name: swarm_66819d80-transcript-D-fixtures-gap-report
+type: ephemeral
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [auth]
+description: Auth fixture gap report (Module D, swarm_66819d80)
+---
+
 # Auth fixture gap report (Module D, swarm_66819d80)
 
 **Generated:** 2026-05-27  •  **Inventory source:** `~/.simdrive/recordings/` (67 directories total; 5 auth-relevant)  •  **Catalog source:** `docs/3.2.0-auth-idp-catalog.md` (38 grounded rows + 11 UNKNOWN-pending-recording)

--- a/.forgeos/swarms/swarm_81b5099e/contracts/Accounts-Wiring.md
+++ b/.forgeos/swarms/swarm_81b5099e/contracts/Accounts-Wiring.md
@@ -1,3 +1,14 @@
+---
+name: swarm_81b5099e-contract-Accounts-Wiring
+type: immutable
+status: active
+created: 2026-05-18T19:30:00Z
+last_refresh: 2026-05-19
+freshness_window: never
+owners: [accounts]
+description: "Contract: Accounts-Wiring (swarm_81b5099e)"
+---
+
 # Contract: Accounts-Wiring (swarm_81b5099e)
 
 **Sequence:** PREREQUISITE — must merge before parallel implementers start.

--- a/.forgeos/swarms/swarm_81b5099e/contracts/Audiobooks-MyBooks-Reader2Sync.md
+++ b/.forgeos/swarms/swarm_81b5099e/contracts/Audiobooks-MyBooks-Reader2Sync.md
@@ -1,3 +1,14 @@
+---
+name: swarm_81b5099e-contract-Audiobooks-MyBooks-Reader2Sync
+type: immutable
+status: active
+created: 2026-05-18T19:30:00Z
+last_refresh: 2026-05-19
+freshness_window: never
+owners: [audiobook]
+description: "Contract: Audiobooks-MyBooks-Reader2Sync (swarm_81b5099e)"
+---
+
 # Contract: Audiobooks-MyBooks-Reader2Sync (swarm_81b5099e)
 
 **Sequence:** Parallel (after Accounts-Wiring merges).

--- a/.forgeos/swarms/swarm_81b5099e/contracts/Network-OPDS.md
+++ b/.forgeos/swarms/swarm_81b5099e/contracts/Network-OPDS.md
@@ -1,3 +1,14 @@
+---
+name: swarm_81b5099e-contract-Network-OPDS
+type: immutable
+status: active
+created: 2026-05-18T19:30:00Z
+last_refresh: 2026-05-19
+freshness_window: never
+owners: [network]
+description: "Contract: Network-OPDS (swarm_81b5099e)"
+---
+
 # Contract: Network-OPDS (swarm_81b5099e)
 
 **Sequence:** Parallel (after Accounts-Wiring merges).

--- a/.forgeos/swarms/swarm_81b5099e/contracts/SignIn-AgeCheck-Notifications.md
+++ b/.forgeos/swarms/swarm_81b5099e/contracts/SignIn-AgeCheck-Notifications.md
@@ -1,3 +1,14 @@
+---
+name: swarm_81b5099e-contract-SignIn-AgeCheck-Notifications
+type: immutable
+status: active
+created: 2026-05-18T19:30:00Z
+last_refresh: 2026-05-19
+freshness_window: never
+owners: [signin-modal]
+description: "Contract: SignIn-AgeCheck-Notifications (swarm_81b5099e)"
+---
+
 # Contract: SignIn-AgeCheck-Notifications (swarm_81b5099e)
 
 **Sequence:** Parallel (after Accounts-Wiring merges).

--- a/.forgeos/swarms/swarm_81b5099e/plan.md
+++ b/.forgeos/swarms/swarm_81b5099e/plan.md
@@ -1,3 +1,14 @@
+---
+name: swarm_81b5099e-plan
+type: immutable
+status: active
+created: 2026-05-18T19:30:00Z
+last_refresh: 2026-05-19
+freshness_window: never
+owners: [general]
+description: Phase 1 Plan — Account State Machine Migration (swarm_81b5099e)
+---
+
 # Phase 1 Plan — Account State Machine Migration (swarm_81b5099e)
 
 **Initiative:** init_dde7f99a · **ADR:** docs/architecture/account-state-machine.md

--- a/.forgeos/swarms/swarm_81b5099e/transcripts/Accounts-Wiring.md
+++ b/.forgeos/swarms/swarm_81b5099e/transcripts/Accounts-Wiring.md
@@ -1,3 +1,14 @@
+---
+name: swarm_81b5099e-transcript-Accounts-Wiring
+type: ephemeral
+status: active
+created: 2026-05-18T19:30:00Z
+last_refresh: 2026-05-19
+freshness_window: 180d
+owners: [accounts]
+description: "Transcript: Accounts-Wiring (swarm_81b5099e)"
+---
+
 # Transcript: Accounts-Wiring (swarm_81b5099e)
 
 **Module:** Accounts-Wiring (sequential prerequisite)

--- a/.forgeos/swarms/swarm_81b5099e/transcripts/Audiobooks-MyBooks-Reader2Sync.md
+++ b/.forgeos/swarms/swarm_81b5099e/transcripts/Audiobooks-MyBooks-Reader2Sync.md
@@ -1,3 +1,14 @@
+---
+name: swarm_81b5099e-transcript-Audiobooks-MyBooks-Reader2Sync
+type: ephemeral
+status: active
+created: 2026-05-18T19:30:00Z
+last_refresh: 2026-05-19
+freshness_window: 180d
+owners: [audiobook]
+description: "Transcript: Audiobooks-MyBooks-Reader2Sync (swarm_81b5099e)"
+---
+
 # Transcript: Audiobooks-MyBooks-Reader2Sync (swarm_81b5099e)
 
 **Module:** Audiobooks-MyBooks-Reader2Sync (parallel — Bucket A migration)

--- a/.forgeos/swarms/swarm_81b5099e/transcripts/Network-OPDS.md
+++ b/.forgeos/swarms/swarm_81b5099e/transcripts/Network-OPDS.md
@@ -1,3 +1,14 @@
+---
+name: swarm_81b5099e-transcript-Network-OPDS
+type: ephemeral
+status: active
+created: 2026-05-18T19:30:00Z
+last_refresh: 2026-05-19
+freshness_window: 180d
+owners: [network]
+description: Network-OPDS implementer transcript — swarm_81b5099e
+---
+
 # Network-OPDS implementer transcript — swarm_81b5099e
 
 ## Summary

--- a/.forgeos/swarms/swarm_81b5099e/transcripts/SignIn-AgeCheck-Notifications.md
+++ b/.forgeos/swarms/swarm_81b5099e/transcripts/SignIn-AgeCheck-Notifications.md
@@ -1,3 +1,14 @@
+---
+name: swarm_81b5099e-transcript-SignIn-AgeCheck-Notifications
+type: ephemeral
+status: active
+created: 2026-05-18T19:30:00Z
+last_refresh: 2026-05-19
+freshness_window: 180d
+owners: [signin-modal]
+description: "Transcript: SignIn-AgeCheck-Notifications (swarm_81b5099e)"
+---
+
 # Transcript: SignIn-AgeCheck-Notifications (swarm_81b5099e)
 
 **Module:** SignIn-AgeCheck-Notifications (parallel batch, after Accounts-Wiring)

--- a/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-A-Audiobook.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-A-Audiobook.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-contract-Module-A-Audiobook
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [audiobook]
+description: Module A — Audiobook (CI-flake migration)
+---
+
 # Module A — Audiobook (CI-flake migration)
 
 ## Files in scope (5)

--- a/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-B-MyBooks.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-B-MyBooks.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-contract-Module-B-MyBooks
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [mybooks]
+description: Module B — MyBooks (CI-flake migration + URLSession.shared sweep)
+---
+
 # Module B — MyBooks (CI-flake migration + URLSession.shared sweep)
 
 ## Files in scope (6)

--- a/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-C-AccountsSignIn.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-C-AccountsSignIn.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-contract-Module-C-AccountsSignIn
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [signin-modal]
+description: Module C — Accounts/SignIn (CI-flake migration)
+---
+
 # Module C — Accounts/SignIn (CI-flake migration)
 
 ## Files in scope (8)

--- a/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-D-HoldsBookDetailCatalog.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-D-HoldsBookDetailCatalog.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-contract-Module-D-HoldsBookDetailCatalog
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [holds]
+description: Module D — Holds/BookDetail/Catalog (CI-flake migration)
+---
+
 # Module D — Holds/BookDetail/Catalog (CI-flake migration)
 
 ## Files in scope (5)

--- a/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-E-NetworkErrorsUtilities.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-E-NetworkErrorsUtilities.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-contract-Module-E-NetworkErrorsUtilities
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [network]
+description: Module E — Network/Errors/Utilities (CI-flake migration)
+---
+
 # Module E — Network/Errors/Utilities (CI-flake migration)
 
 ## Files in scope (8)

--- a/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-F-IntegrationReader2BookRegistry.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/contracts/Module-F-IntegrationReader2BookRegistry.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-contract-Module-F-IntegrationReader2BookRegistry
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [reader]
+description: Module F — Integration/Reader2/BookRegistry (CI-flake migration)
+---
+
 # Module F — Integration/Reader2/BookRegistry (CI-flake migration)
 
 ## Files in scope (6)

--- a/.forgeos/swarms/swarm_9d3d2fab/plan.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/plan.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-plan
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [general]
+description: Swarm 9d3d2fab — CI-flake migration (Phase 1)
+---
+
 # Swarm 9d3d2fab — CI-flake migration (Phase 1)
 
 ## Goal

--- a/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-a-audiobook.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-a-audiobook.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-transcript-module-a-audiobook
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: 180d
+owners: [audiobook]
+description: Module A — Audiobook (CI-flake migration) — transcript
+---
+
 # Module A — Audiobook (CI-flake migration) — transcript
 
 Swarm `swarm_9d3d2fab`, branch `swarm/swarm_9d3d2fab-a-audiobook`,

--- a/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-b-mybooks.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-b-mybooks.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-transcript-module-b-mybooks
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: 180d
+owners: [mybooks]
+description: Module B — MyBooks (FLAKE migration + URLSession.shared sweep)
+---
+
 # Module B — MyBooks (FLAKE migration + URLSession.shared sweep)
 
 Branch: `swarm/swarm_9d3d2fab-b-mybooks`

--- a/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-c-accounts-signin.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-c-accounts-signin.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-transcript-module-c-accounts-signin
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: 180d
+owners: [signin-modal]
+description: Module C — Accounts/SignIn (CI-flake migration)
+---
+
 # Module C — Accounts/SignIn (CI-flake migration)
 
 ## Scope (8 files)

--- a/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-d-holds-bookdetail-catalog.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-d-holds-bookdetail-catalog.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-transcript-module-d-holds-bookdetail-catalog
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: 180d
+owners: [holds]
+description: Module D — Holds/BookDetail/Catalog — transcript
+---
+
 # Module D — Holds/BookDetail/Catalog — transcript
 
 **Worktree:** `.claude/worktrees/swarm_9d3d2fab-d-holds-bookdetail-catalog`

--- a/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-e-network-errors-utilities.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-e-network-errors-utilities.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-transcript-module-e-network-errors-utilities
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: 180d
+owners: [network]
+description: Module E — Network/Errors/Utilities — implementer transcript
+---
+
 # Module E — Network/Errors/Utilities — implementer transcript
 
 **Branch:** `swarm/swarm_9d3d2fab-e-network-errors-utilities`

--- a/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-f-integration-reader2-bookregistry.md
+++ b/.forgeos/swarms/swarm_9d3d2fab/transcripts/module-f-integration-reader2-bookregistry.md
@@ -1,3 +1,14 @@
+---
+name: swarm_9d3d2fab-transcript-module-f-integration-reader2-bookregistry
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-22
+freshness_window: 180d
+owners: [reader]
+description: Module F — Integration / Reader2 / BookRegistry transcript
+---
+
 # Module F — Integration / Reader2 / BookRegistry transcript
 
 Worktree: `.claude/worktrees/swarm_9d3d2fab-f-integration-reader2-bookregistry`

--- a/.forgeos/swarms/swarm_d5a3d473/contracts/ImageLoading-Consolidation.md
+++ b/.forgeos/swarms/swarm_d5a3d473/contracts/ImageLoading-Consolidation.md
@@ -1,3 +1,14 @@
+---
+name: swarm_d5a3d473-contract-ImageLoading-Consolidation
+type: immutable
+status: active
+created: 2026-05-19T00:00:00Z
+last_refresh: 2026-05-19
+freshness_window: never
+owners: [general]
+description: "Contract: ImageLoading-Consolidation (swarm_d5a3d473, Track A)"
+---
+
 # Contract: ImageLoading-Consolidation (swarm_d5a3d473, Track A)
 
 **Sequence:** Parallel with Logging-TestSeams. File scopes are disjoint.

--- a/.forgeos/swarms/swarm_d5a3d473/contracts/Logging-TestSeams.md
+++ b/.forgeos/swarms/swarm_d5a3d473/contracts/Logging-TestSeams.md
@@ -1,3 +1,14 @@
+---
+name: swarm_d5a3d473-contract-Logging-TestSeams
+type: immutable
+status: active
+created: 2026-05-19T00:00:00Z
+last_refresh: 2026-05-19
+freshness_window: never
+owners: [general]
+description: "Contract: Logging-TestSeams (swarm_d5a3d473, Track B)"
+---
+
 # Contract: Logging-TestSeams (swarm_d5a3d473, Track B)
 
 **Sequence:** Parallel with ImageLoading-Consolidation. File scopes are disjoint.

--- a/.forgeos/swarms/swarm_d5a3d473/plan.md
+++ b/.forgeos/swarms/swarm_d5a3d473/plan.md
@@ -1,3 +1,14 @@
+---
+name: swarm_d5a3d473-plan
+type: immutable
+status: active
+created: 2026-05-19T00:00:00Z
+last_refresh: 2026-05-19
+freshness_window: never
+owners: [general]
+description: Phase 1 Plan — Singleton Reduction (swarm_d5a3d473)
+---
+
 # Phase 1 Plan — Singleton Reduction (swarm_d5a3d473)
 
 **Initiative:** 3.2.0 singleton-reduction sweep · **Base:** develop

--- a/.forgeos/swarms/swarm_d5a3d473/transcripts/ImageLoading-Consolidation.md
+++ b/.forgeos/swarms/swarm_d5a3d473/transcripts/ImageLoading-Consolidation.md
@@ -1,3 +1,14 @@
+---
+name: swarm_d5a3d473-transcript-ImageLoading-Consolidation
+type: ephemeral
+status: active
+created: 2026-05-19T00:00:00Z
+last_refresh: 2026-05-20
+freshness_window: 180d
+owners: [general]
+description: Transcript — ImageLoading-Consolidation (swarm_d5a3d473, Track A)
+---
+
 # Transcript — ImageLoading-Consolidation (swarm_d5a3d473, Track A)
 
 ## 1. Summary

--- a/.forgeos/swarms/swarm_d5a3d473/transcripts/Logging-TestSeams.md
+++ b/.forgeos/swarms/swarm_d5a3d473/transcripts/Logging-TestSeams.md
@@ -1,3 +1,14 @@
+---
+name: swarm_d5a3d473-transcript-Logging-TestSeams
+type: ephemeral
+status: active
+created: 2026-05-19T00:00:00Z
+last_refresh: 2026-05-20
+freshness_window: 180d
+owners: [general]
+description: Logging-TestSeams — Implementation Transcript (swarm_d5a3d473, Track B)
+---
+
 # Logging-TestSeams — Implementation Transcript (swarm_d5a3d473, Track B)
 
 ## Summary

--- a/.forgeos/swarms/swarm_dfdaf7ad/outcome.md
+++ b/.forgeos/swarms/swarm_dfdaf7ad/outcome.md
@@ -1,3 +1,14 @@
+---
+name: swarm_dfdaf7ad-outcome
+type: immutable
+status: active
+created: 2026-05-19T00:00:00Z
+last_refresh: 2026-05-19
+freshness_window: never
+owners: [general]
+description: Outcome — swarm_dfdaf7ad (bundled)
+---
+
 # Outcome — swarm_dfdaf7ad (bundled)
 
 **Status:** bundled — single PR to `develop` ready for push

--- a/.forgeos/swarms/swarm_dfdaf7ad/transcripts/AudiobookToolkit.md
+++ b/.forgeos/swarms/swarm_dfdaf7ad/transcripts/AudiobookToolkit.md
@@ -1,3 +1,14 @@
+---
+name: swarm_dfdaf7ad-transcript-AudiobookToolkit
+type: ephemeral
+status: active
+created: 2026-05-19T00:00:00Z
+last_refresh: 2026-05-19
+freshness_window: 180d
+owners: [audiobook]
+description: Transcript — AudiobookToolkit (swarm_dfdaf7ad, HelpSpot 17865)
+---
+
 # Transcript — AudiobookToolkit (swarm_dfdaf7ad, HelpSpot 17865)
 
 ## Summary

--- a/.forgeos/swarms/swarm_dfdaf7ad/transcripts/Settings-AccountDetail.md
+++ b/.forgeos/swarms/swarm_dfdaf7ad/transcripts/Settings-AccountDetail.md
@@ -1,3 +1,14 @@
+---
+name: swarm_dfdaf7ad-transcript-Settings-AccountDetail
+type: ephemeral
+status: active
+created: 2026-05-19T00:00:00Z
+last_refresh: 2026-05-19
+freshness_window: 180d
+owners: [signin-modal]
+description: "Transcript: Settings-AccountDetail (swarm_dfdaf7ad)"
+---
+
 # Transcript: Settings-AccountDetail (swarm_dfdaf7ad)
 
 **HelpSpot:** 17923 — Sign-in placeholder reads as disabled

--- a/.forgeos/swarms/swarm_dfdaf7ad/transcripts/SignInLogic-ErrorPropagation.md
+++ b/.forgeos/swarms/swarm_dfdaf7ad/transcripts/SignInLogic-ErrorPropagation.md
@@ -1,3 +1,14 @@
+---
+name: swarm_dfdaf7ad-transcript-SignInLogic-ErrorPropagation
+type: ephemeral
+status: active
+created: 2026-05-19T00:00:00Z
+last_refresh: 2026-05-19
+freshness_window: 180d
+owners: [signin-modal]
+description: "Transcript: SignInLogic-ErrorPropagation (swarm_dfdaf7ad)"
+---
+
 # Transcript: SignInLogic-ErrorPropagation (swarm_dfdaf7ad)
 
 **HelpSpot:** 17870 — SAML "patron ID extraction" silent failure

--- a/.forgeos/swarms/swarm_eefef87a/contracts/A-AccountsMyBooksAccountIdThreading.md
+++ b/.forgeos/swarms/swarm_eefef87a/contracts/A-AccountsMyBooksAccountIdThreading.md
@@ -1,3 +1,14 @@
+---
+name: swarm_eefef87a-contract-A-AccountsMyBooksAccountIdThreading
+type: immutable
+status: active
+created: 2026-05-26T15:00:00Z
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [mybooks]
+description: Module A — TPPUserAccount.sharedAccount() fallback removal (Option 1)
+---
+
 # Module A — TPPUserAccount.sharedAccount() fallback removal (Option 1)
 
 **Improvement #1 from the A+ posture push.** Auth-critical. Round-trip wiring test mandatory per `feedback_round_trip_wiring_tests.md`. Memory pin `reference_tpp_user_account_migration_retro.md` is load-bearing — read it before writing code.

--- a/.forgeos/swarms/swarm_eefef87a/contracts/B-AudiobookCrossVendorSmoke.md
+++ b/.forgeos/swarms/swarm_eefef87a/contracts/B-AudiobookCrossVendorSmoke.md
@@ -1,3 +1,14 @@
+---
+name: swarm_eefef87a-contract-B-AudiobookCrossVendorSmoke
+type: immutable
+status: active
+created: 2026-05-26T15:00:00Z
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [audiobook]
+description: Module B — Audiobook cross-vendor smoke (Swift tests only)
+---
+
 # Module B — Audiobook cross-vendor smoke (Swift tests only)
 
 **Improvement #2 from the A+ posture push (Swift portion).** Memory pin `reference_audiobook_toolkit_risk_profile.md` is load-bearing — read before writing. Module C owns the `scripts/verify-pr.sh` gating change; this module owns only the Swift smoke-test file that the gate invokes.

--- a/.forgeos/swarms/swarm_eefef87a/contracts/C-Tooling.md
+++ b/.forgeos/swarms/swarm_eefef87a/contracts/C-Tooling.md
@@ -1,3 +1,14 @@
+---
+name: swarm_eefef87a-contract-C-Tooling
+type: immutable
+status: active
+created: 2026-05-26T15:00:00Z
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [accounts, mybooks]
+description: "Module C — Tooling: verify-pr.sh gate + critical-path ADR"
+---
+
 # Module C — Tooling: verify-pr.sh gate + critical-path ADR
 
 **Improvements #2 (script portion) and #3 (regex audit + ADR) merged into one tooling-side contract.** Reason: both edit `scripts/verify-pr.sh`. Merging into one implementer is the simplest disjoint partition.

--- a/.forgeos/swarms/swarm_eefef87a/contracts/D-Reader2ContractSnapshots.md
+++ b/.forgeos/swarms/swarm_eefef87a/contracts/D-Reader2ContractSnapshots.md
@@ -1,3 +1,14 @@
+---
+name: swarm_eefef87a-contract-D-Reader2ContractSnapshots
+type: immutable
+status: active
+created: 2026-05-26T15:00:00Z
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [reader]
+description: Module D — Reader2 contract-snapshot tests
+---
+
 # Module D — Reader2 contract-snapshot tests
 
 **Improvement #4 from the A+ posture push.** Reader2 (Readium 3.x WKWebView) is XCTest-invisible. Contract snapshots pin the dependency-call surface without WKWebView introspection.

--- a/.forgeos/swarms/swarm_eefef87a/plan.md
+++ b/.forgeos/swarms/swarm_eefef87a/plan.md
@@ -1,3 +1,14 @@
+---
+name: swarm_eefef87a-plan
+type: immutable
+status: active
+created: 2026-05-26T15:00:00Z
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [general]
+description: "Swarm `swarm_eefef87a` — A+ Posture Push"
+---
+
 # Swarm `swarm_eefef87a` — A+ Posture Push
 
 Four parallel improvements to close documented-not-closed structural risks from the engineering-posture review (`.forgeos/audits/phase7-synthesis-2026-05-26.md`).

--- a/.forgeos/swarms/swarm_eefef87a/transcripts/A-AccountsMyBooksAccountIdThreading.md
+++ b/.forgeos/swarms/swarm_eefef87a/transcripts/A-AccountsMyBooksAccountIdThreading.md
@@ -1,3 +1,14 @@
+---
+name: swarm_eefef87a-transcript-A-AccountsMyBooksAccountIdThreading
+type: ephemeral
+status: active
+created: 2026-05-26T15:00:00Z
+last_refresh: 2026-05-27
+freshness_window: 180d
+owners: [mybooks]
+description: Module A — Accounts + MyBooks AccountId Threading — Transcript
+---
+
 # Module A — Accounts + MyBooks AccountId Threading — Transcript
 
 Branch: `swarm/swarm_eefef87a-module-A`

--- a/.forgeos/swarms/swarm_eefef87a/transcripts/B-AudiobookCrossVendorSmoke.md
+++ b/.forgeos/swarms/swarm_eefef87a/transcripts/B-AudiobookCrossVendorSmoke.md
@@ -1,3 +1,14 @@
+---
+name: swarm_eefef87a-transcript-B-AudiobookCrossVendorSmoke
+type: ephemeral
+status: active
+created: 2026-05-26T15:00:00Z
+last_refresh: 2026-05-27
+freshness_window: 180d
+owners: [audiobook]
+description: Module B — Audiobook cross-vendor smoke transcript
+---
+
 # Module B — Audiobook cross-vendor smoke transcript
 
 Swarm: `swarm_eefef87a`

--- a/.forgeos/swarms/swarm_eefef87a/transcripts/C-Tooling.md
+++ b/.forgeos/swarms/swarm_eefef87a/transcripts/C-Tooling.md
@@ -1,3 +1,14 @@
+---
+name: swarm_eefef87a-transcript-C-Tooling
+type: ephemeral
+status: active
+created: 2026-05-26T15:00:00Z
+last_refresh: 2026-05-27
+freshness_window: 180d
+owners: [accounts, mybooks]
+description: Module C — Tooling transcript
+---
+
 # Module C — Tooling transcript
 
 Status: complete

--- a/.forgeos/swarms/swarm_eefef87a/transcripts/D-Reader2ContractSnapshots.md
+++ b/.forgeos/swarms/swarm_eefef87a/transcripts/D-Reader2ContractSnapshots.md
@@ -1,3 +1,14 @@
+---
+name: swarm_eefef87a-transcript-D-Reader2ContractSnapshots
+type: ephemeral
+status: active
+created: 2026-05-26T15:00:00Z
+last_refresh: 2026-05-27
+freshness_window: 180d
+owners: [reader]
+description: Module D — Reader2 Contract Snapshots (transcript)
+---
+
 # Module D — Reader2 Contract Snapshots (transcript)
 
 **Swarm:** `swarm_eefef87a`

--- a/.forgeos/swarms/swarm_efd1f0c3/contracts/T1-Player-Protocol-OpenAccess.md
+++ b/.forgeos/swarms/swarm_efd1f0c3/contracts/T1-Player-Protocol-OpenAccess.md
@@ -1,3 +1,14 @@
+---
+name: swarm_efd1f0c3-contract-T1-Player-Protocol-OpenAccess
+type: immutable
+status: active
+created: 2026-05-21T00:00:00Z
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [audiobook]
+description: "Bucket T1 — `Player` async protocol + OpenAccessPlayer + LCPStreamingPlayer migration"
+---
+
 # Bucket T1 — `Player` async protocol + OpenAccessPlayer + LCPStreamingPlayer migration
 
 ## Scope summary

--- a/.forgeos/swarms/swarm_efd1f0c3/contracts/T2-Player-LCP-Findaway.md
+++ b/.forgeos/swarms/swarm_efd1f0c3/contracts/T2-Player-LCP-Findaway.md
@@ -1,3 +1,14 @@
+---
+name: swarm_efd1f0c3-contract-T2-Player-LCP-Findaway
+type: immutable
+status: active
+created: 2026-05-21T00:00:00Z
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [audiobook]
+description: Bucket T2 — FindawayPlayer migration + external caller migration
+---
+
 # Bucket T2 — FindawayPlayer migration + external caller migration
 
 ## Scope summary

--- a/.forgeos/swarms/swarm_efd1f0c3/contracts/T3-Rename-DownloadCoordinator.md
+++ b/.forgeos/swarms/swarm_efd1f0c3/contracts/T3-Rename-DownloadCoordinator.md
@@ -1,3 +1,14 @@
+---
+name: swarm_efd1f0c3-contract-T3-Rename-DownloadCoordinator
+type: immutable
+status: active
+created: 2026-05-21T00:00:00Z
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [audiobook]
+description: "Bucket T3 — Rename toolkit's `AudiobookSessionManager` → `AudiobookDownloadCoordinator`"
+---
+
 # Bucket T3 — Rename toolkit's `AudiobookSessionManager` → `AudiobookDownloadCoordinator`
 
 ## Scope summary

--- a/.forgeos/swarms/swarm_efd1f0c3/outcome.md
+++ b/.forgeos/swarms/swarm_efd1f0c3/outcome.md
@@ -1,3 +1,14 @@
+---
+name: swarm_efd1f0c3-outcome
+type: immutable
+status: active
+created: 2026-05-21T00:00:00Z
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [general]
+description: "Swarm Outcome — `swarm_efd1f0c3` — Audiobook toolkit overhaul (T1 + T2 + T3)"
+---
+
 # Swarm Outcome — `swarm_efd1f0c3` — Audiobook toolkit overhaul (T1 + T2 + T3)
 
 **Status:** complete

--- a/.forgeos/swarms/swarm_efd1f0c3/plan.md
+++ b/.forgeos/swarms/swarm_efd1f0c3/plan.md
@@ -1,3 +1,14 @@
+---
+name: swarm_efd1f0c3-plan
+type: immutable
+status: active
+created: 2026-05-21T00:00:00Z
+last_refresh: 2026-05-22
+freshness_window: never
+owners: [general]
+description: "Swarm `swarm_efd1f0c3` — Audiobook toolkit overhaul (T1 + T2 + T3)"
+---
+
 # Swarm `swarm_efd1f0c3` — Audiobook toolkit overhaul (T1 + T2 + T3)
 
 **Scope:** Toolkit-side residuals from the Palace audiobook systemic overhaul (ADR §"Toolkit-side remaining work"). Three buckets dispatched in parallel-where-safe.

--- a/.forgeos/swarms/swarm_efd1f0c3/transcripts/T1.md
+++ b/.forgeos/swarms/swarm_efd1f0c3/transcripts/T1.md
@@ -1,3 +1,14 @@
+---
+name: swarm_efd1f0c3-transcript-T1
+type: ephemeral
+status: active
+created: 2026-05-21T00:00:00Z
+last_refresh: 2026-05-22
+freshness_window: 180d
+owners: [audiobook]
+description: "Swarm `swarm_efd1f0c3` — T1 transcript"
+---
+
 # Swarm `swarm_efd1f0c3` — T1 transcript
 
 **Status: SHIPPED — Toolkit PR open. Awaiting T2 + Palace integration.**

--- a/.forgeos/swarms/swarm_efd1f0c3/transcripts/T2.md
+++ b/.forgeos/swarms/swarm_efd1f0c3/transcripts/T2.md
@@ -1,3 +1,14 @@
+---
+name: swarm_efd1f0c3-transcript-T2
+type: ephemeral
+status: active
+created: 2026-05-21T00:00:00Z
+last_refresh: 2026-05-22
+freshness_window: 180d
+owners: [audiobook]
+description: "Swarm `swarm_efd1f0c3` — T2 transcript"
+---
+
 # Swarm `swarm_efd1f0c3` — T2 transcript
 
 **Status: SHIPPED — Toolkit PR open (stacked on T1).**

--- a/.forgeos/swarms/swarm_efd1f0c3/transcripts/T3.md
+++ b/.forgeos/swarms/swarm_efd1f0c3/transcripts/T3.md
@@ -1,3 +1,14 @@
+---
+name: swarm_efd1f0c3-transcript-T3
+type: ephemeral
+status: active
+created: 2026-05-21T00:00:00Z
+last_refresh: 2026-05-22
+freshness_window: 180d
+owners: [audiobook]
+description: "T3 transcript — toolkit `AudiobookSessionManager` -> `AudiobookDownloadCoordinator`"
+---
+
 # T3 transcript — toolkit `AudiobookSessionManager` -> `AudiobookDownloadCoordinator`
 
 ## Summary

--- a/.forgeos/swarms/swarm_f3b9b087/contracts/Audiobook-Position.md
+++ b/.forgeos/swarms/swarm_f3b9b087/contracts/Audiobook-Position.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f3b9b087-contract-Audiobook-Position
+type: immutable
+status: active
+created: 2026-05-21T03:25:00Z
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [audiobook]
+description: "Contract: Audiobook-Position"
+---
+
 # Contract: Audiobook-Position
 
 **Bucket items:** P0 #4, #5, P3 #10 (audiobook position state machine + TOC normalization)

--- a/.forgeos/swarms/swarm_f3b9b087/contracts/MyBooks-Borrow.md
+++ b/.forgeos/swarms/swarm_f3b9b087/contracts/MyBooks-Borrow.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f3b9b087-contract-MyBooks-Borrow
+type: immutable
+status: active
+created: 2026-05-21T03:25:00Z
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [mybooks]
+description: "Contract: MyBooks-Borrow"
+---
+
 # Contract: MyBooks-Borrow
 
 **Bucket items:** P2 #7, #8 + P3 #12 (BorrowOperation 401-no-problem-doc fallthrough + SQ-007 spinner cleanup + Downloads task-identifier recycle)

--- a/.forgeos/swarms/swarm_f3b9b087/contracts/Notifications-OPDS-Errors.md
+++ b/.forgeos/swarms/swarm_f3b9b087/contracts/Notifications-OPDS-Errors.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f3b9b087-contract-Notifications-OPDS-Errors
+type: immutable
+status: active
+created: 2026-05-21T03:25:00Z
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [network]
+description: "Contract: Notifications-OPDS-Errors"
+---
+
 # Contract: Notifications-OPDS-Errors
 
 **Bucket items:** P1 #6 (Notifications-FCM SAML-stale retry) + P2 #9 (OPDS user-facing error strings) + P3 #11 (Info.plist UIBackgroundModes verify)

--- a/.forgeos/swarms/swarm_f3b9b087/contracts/Reader2-ReadState.md
+++ b/.forgeos/swarms/swarm_f3b9b087/contracts/Reader2-ReadState.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f3b9b087-contract-Reader2-ReadState
+type: immutable
+status: active
+created: 2026-05-21T03:25:00Z
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [reader]
+description: "Contract: Reader2-ReadState"
+---
+
 # Contract: Reader2-ReadState
 
 **Bucket items:** P0 #1, #2, #3 (read-position correctness — EPUB/PDF reader)

--- a/.forgeos/swarms/swarm_f3b9b087/outcome.md
+++ b/.forgeos/swarms/swarm_f3b9b087/outcome.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f3b9b087-outcome
+type: immutable
+status: active
+created: 2026-05-21T03:25:00Z
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: "Swarm Outcome — `swarm_f3b9b087` — 3.2.0 review-driven quality pass"
+---
+
 # Swarm Outcome — `swarm_f3b9b087` — 3.2.0 review-driven quality pass
 
 **Status:** complete

--- a/.forgeos/swarms/swarm_f3b9b087/plan.md
+++ b/.forgeos/swarms/swarm_f3b9b087/plan.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f3b9b087-plan
+type: immutable
+status: active
+created: 2026-05-21T03:25:00Z
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: "Swarm Plan — `swarm_f3b9b087` — 3.2.0 review-driven quality pass"
+---
+
 # Swarm Plan — `swarm_f3b9b087` — 3.2.0 review-driven quality pass
 
 ## Goal

--- a/.forgeos/swarms/swarm_f3b9b087/transcripts/Audiobook-Position.md
+++ b/.forgeos/swarms/swarm_f3b9b087/transcripts/Audiobook-Position.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f3b9b087-transcript-Audiobook-Position
+type: ephemeral
+status: active
+created: 2026-05-21T03:25:00Z
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [audiobook]
+description: Audiobook-Position implementer transcript
+---
+
 # Audiobook-Position implementer transcript
 
 **Swarm:** `swarm_f3b9b087`

--- a/.forgeos/swarms/swarm_f3b9b087/transcripts/MyBooks-Borrow.md
+++ b/.forgeos/swarms/swarm_f3b9b087/transcripts/MyBooks-Borrow.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f3b9b087-transcript-MyBooks-Borrow
+type: ephemeral
+status: active
+created: 2026-05-21T03:25:00Z
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [mybooks]
+description: "MyBooks-Borrow implementer transcript — `swarm_f3b9b087`"
+---
+
 # MyBooks-Borrow implementer transcript — `swarm_f3b9b087`
 
 **Bucket:** P2 #7, P2 #8, P3 #12

--- a/.forgeos/swarms/swarm_f3b9b087/transcripts/Notifications-OPDS-Errors.md
+++ b/.forgeos/swarms/swarm_f3b9b087/transcripts/Notifications-OPDS-Errors.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f3b9b087-transcript-Notifications-OPDS-Errors
+type: ephemeral
+status: active
+created: 2026-05-21T03:25:00Z
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [network]
+description: Implementer Transcript — Notifications-OPDS-Errors
+---
+
 # Implementer Transcript — Notifications-OPDS-Errors
 
 **Bucket:** P1 #6 (Notifications-FCM SAML-stale retry) + P2 #9 (OPDS user-facing error strings) + P3 #11 (Info.plist UIBackgroundModes verify)

--- a/.forgeos/swarms/swarm_f3b9b087/transcripts/Reader2-ReadState.md
+++ b/.forgeos/swarms/swarm_f3b9b087/transcripts/Reader2-ReadState.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f3b9b087-transcript-Reader2-ReadState
+type: ephemeral
+status: active
+created: 2026-05-21T03:25:00Z
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [reader]
+description: Implementer Transcript — Reader2-ReadState
+---
+
 # Implementer Transcript — Reader2-ReadState
 
 **Bucket:** Reader2-ReadState (P0 #1, #2, #3)

--- a/.forgeos/swarms/swarm_f4fbef9c/contracts/A-PalaceReadingPositionSPM.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/contracts/A-PalaceReadingPositionSPM.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-contract-A-PalaceReadingPositionSPM
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [reader, audiobook]
+description: "Module A — `PalaceReadingPosition` SPM package"
+---
+
 # Module A — `PalaceReadingPosition` SPM package
 
 **Status:** refined by architect 2026-05-21. See `transcripts/triage.md` Deviation 4 for the Platform-migration rationale.

--- a/.forgeos/swarms/swarm_f4fbef9c/contracts/B-AudiobookMigration.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/contracts/B-AudiobookMigration.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-contract-B-AudiobookMigration
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [audiobook]
+description: Module B — Audiobook position-write migration
+---
+
 # Module B — Audiobook position-write migration
 
 **Status:** refined by architect 2026-05-21. **Major scope correction** — see `transcripts/triage.md` Deviations 1, 2, 3.

--- a/.forgeos/swarms/swarm_f4fbef9c/contracts/C-Reader2Migration.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/contracts/C-Reader2Migration.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-contract-C-Reader2Migration
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [reader]
+description: Module C — Reader2 + PDF position-write migration
+---
+
 # Module C — Reader2 + PDF position-write migration
 
 **Status:** refined by architect 2026-05-21. PDF locked IN; one-line TPPBaseReaderViewController edit confirmed.

--- a/.forgeos/swarms/swarm_f4fbef9c/contracts/D-ContractTests.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/contracts/D-ContractTests.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-contract-D-ContractTests
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [reader, audiobook]
+description: Module D — Contract-snapshot tests
+---
+
 # Module D — Contract-snapshot tests
 
 **Status:** refined by architect 2026-05-21. Scenario count locked at 13.

--- a/.forgeos/swarms/swarm_f4fbef9c/outcome.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/outcome.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-outcome
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: Swarm 2 — Outcome
+---
+
 # Swarm 2 — Outcome
 
 **Status:** complete (open PR)

--- a/.forgeos/swarms/swarm_f4fbef9c/plan.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/plan.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-plan
+type: immutable
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: never
+owners: [general]
+description: Swarm 2 — PositionWriter Unification
+---
+
 # Swarm 2 — PositionWriter Unification
 
 **Phase 2 of [audiobook-systemic-overhaul](../../../docs/architecture/audiobook-systemic-overhaul.md).**

--- a/.forgeos/swarms/swarm_f4fbef9c/transcripts/A-PalaceReadingPositionSPM.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/transcripts/A-PalaceReadingPositionSPM.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-transcript-A-PalaceReadingPositionSPM
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [reader, audiobook]
+description: Module A — PalaceReadingPosition SPM
+---
+
 # Module A — PalaceReadingPosition SPM
 
 Status: complete

--- a/.forgeos/swarms/swarm_f4fbef9c/transcripts/B-AudiobookMigration.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/transcripts/B-AudiobookMigration.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-transcript-B-AudiobookMigration
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [audiobook]
+description: Module B — Audiobook Migration Transcript
+---
+
 # Module B — Audiobook Migration Transcript
 
 Implementer: Module B

--- a/.forgeos/swarms/swarm_f4fbef9c/transcripts/C-Reader2Migration.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/transcripts/C-Reader2Migration.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-transcript-C-Reader2Migration
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [reader]
+description: Module C — Reader2 + PDF Migration
+---
+
 # Module C — Reader2 + PDF Migration
 
 Status: complete

--- a/.forgeos/swarms/swarm_f4fbef9c/transcripts/D-ContractTests.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/transcripts/D-ContractTests.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-transcript-D-ContractTests
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [reader, audiobook]
+description: Module D — Contract Tests (transcript)
+---
+
 # Module D — Contract Tests (transcript)
 
 Swarm: `swarm_f4fbef9c` (Phase 2 — Audiobook systemic overhaul)

--- a/.forgeos/swarms/swarm_f4fbef9c/transcripts/triage.md
+++ b/.forgeos/swarms/swarm_f4fbef9c/transcripts/triage.md
@@ -1,3 +1,14 @@
+---
+name: swarm_f4fbef9c-transcript-triage
+type: ephemeral
+status: active
+created: 2026-05-21
+last_refresh: 2026-05-21
+freshness_window: 180d
+owners: [reader, audiobook]
+description: Swarm 2 (swarm_f4fbef9c) — Architect Triage
+---
+
 # Swarm 2 (swarm_f4fbef9c) — Architect Triage
 
 **Architect:** Opus 4.7 (1M)

--- a/.forgeos/wall-failures/2026-05-27-pr1018-arch1.md
+++ b/.forgeos/wall-failures/2026-05-27-pr1018-arch1.md
@@ -6,8 +6,17 @@ reviewer_ids: [rev_61cc1bc4]
 changeset_id: cs_8f163b41
 wall: implementer
 severity: high
-status: proposed
+wall_status: proposed
 applied_in: ""
+# doc-lifecycle metadata (added by Module B sweep)
+name: 2026-05-27-pr1018-arch1
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [governance, auth]
+description: Submodule gitlinks accidentally staged as absolute-path symlinks
 ---
 
 # Submodule gitlinks accidentally staged as absolute-path symlinks

--- a/.forgeos/wall-failures/2026-05-27-pr1018-arch2.md
+++ b/.forgeos/wall-failures/2026-05-27-pr1018-arch2.md
@@ -6,8 +6,17 @@ reviewer_ids: [rev_61cc1bc4]
 changeset_id: cs_8f163b41
 wall: contract
 severity: medium
-status: proposed
+wall_status: proposed
 applied_in: ""
+# doc-lifecycle metadata (added by Module B sweep)
+name: 2026-05-27-pr1018-arch2
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [governance, auth]
+description: Wiring test claimed production round-trip but built fresh spies
 ---
 
 # Wiring test claimed production round-trip but built fresh spies

--- a/.forgeos/wall-failures/2026-05-27-pr1018-arch3.md
+++ b/.forgeos/wall-failures/2026-05-27-pr1018-arch3.md
@@ -6,8 +6,17 @@ reviewer_ids: [rev_61cc1bc4]
 changeset_id: cs_8f163b41
 wall: contract+implementer
 severity: high
-status: proposed
+wall_status: proposed
 applied_in: ""
+# doc-lifecycle metadata (added by Module B sweep)
+name: 2026-05-27-pr1018-arch3
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [governance, auth]
+description: TPPNetworkResponder called classifier but only logged outcome — legacy path still ran
 ---
 
 # TPPNetworkResponder called classifier but only logged outcome — legacy path still ran

--- a/.forgeos/wall-failures/2026-05-27-pr1018-qa1.md
+++ b/.forgeos/wall-failures/2026-05-27-pr1018-qa1.md
@@ -6,8 +6,17 @@ reviewer_ids: [rev_3d0048c7]
 changeset_id: cs_8f163b41
 wall: implementer+mutation
 severity: high
-status: proposed
+wall_status: proposed
 applied_in: ""
+# doc-lifecycle metadata (added by Module B sweep)
+name: 2026-05-27-pr1018-qa1
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [governance, auth]
+description: Circuit-breaker test ran ONE attempt; second half was comments
 ---
 
 # Circuit-breaker test ran ONE attempt; second half was comments

--- a/.forgeos/wall-failures/2026-05-27-pr1018-qa2.md
+++ b/.forgeos/wall-failures/2026-05-27-pr1018-qa2.md
@@ -6,8 +6,17 @@ reviewer_ids: [rev_3d0048c7]
 changeset_id: cs_8f163b41
 wall: contract+orchestrator
 severity: critical
-status: proposed
+wall_status: proposed
 applied_in: ""
+# doc-lifecycle metadata (added by Module B sweep)
+name: 2026-05-27-pr1018-qa2
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [governance, auth]
+description: TPPNetworkResponderAuthCoordinatorTests never instantiated TPPNetworkResponder
 ---
 
 # TPPNetworkResponderAuthCoordinatorTests never instantiated TPPNetworkResponder

--- a/.forgeos/wall-failures/2026-05-27-pr1018-qa3.md
+++ b/.forgeos/wall-failures/2026-05-27-pr1018-qa3.md
@@ -6,8 +6,17 @@ reviewer_ids: [rev_3d0048c7]
 changeset_id: cs_8f163b41
 wall: contract+orchestrator
 severity: critical
-status: proposed
+wall_status: proposed
 applied_in: ""
+# doc-lifecycle metadata (added by Module B sweep)
+name: 2026-05-27-pr1018-qa3
+type: immutable
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-27
+freshness_window: never
+owners: [governance, auth]
+description: BookReturnServiceAuthCoordinatorTests never instantiated BookReturnService
 ---
 
 # BookReturnServiceAuthCoordinatorTests never instantiated BookReturnService

--- a/.forgeos/wall-failures/INDEX.md
+++ b/.forgeos/wall-failures/INDEX.md
@@ -1,16 +1,27 @@
+---
+name: wall-failures-index
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
+description: Wall-failure catalog — index
+---
+
 # Wall-failure catalog — index
 
 One line per entry. Sortable by date, wall, status. Most recent first.
 
-| Date | PR | Wall | Severity | Status | Entry | One-line |
-|------|----|------|----------|--------|-------|----------|
-| 2026-05-28 | n/a (backtest) | reviewer | high | proposed | [backtest-2026-05-28](backtest-2026-05-28.md) | Paper analysis of 10 prior shipped bugs vs. SoD reviewer agent prompts — 0% definitive WOULD-CATCH; 5 prompt-addition recommendations |
-| 2026-05-27 | #1018 | implementer | high | proposed | [arch1-discipline](2026-05-27-pr1018-arch1.md) | 7 submodule gitlinks accidentally staged as symlinks |
-| 2026-05-27 | #1018 | contract | medium | proposed | [arch2-fake-wiring-test](2026-05-27-pr1018-arch2.md) | Wiring test claimed production round-trip but built fresh spies |
-| 2026-05-27 | #1018 | contract+implementer | high | proposed | [arch3-dead-classifier-call](2026-05-27-pr1018-arch3.md) | TPPNetworkResponder called classifier but only logged outcome — legacy path still ran |
-| 2026-05-27 | #1018 | implementer+mutation | high | proposed | [qa1-half-done-test](2026-05-27-pr1018-qa1.md) | Circuit-breaker test ran ONE attempt; second half was comments |
-| 2026-05-27 | #1018 | contract+orchestrator | critical | proposed | [qa2-fake-test-instantiation](2026-05-27-pr1018-qa2.md) | TPPNetworkResponderAuthCoordinatorTests never instantiated TPPNetworkResponder |
-| 2026-05-27 | #1018 | contract+orchestrator | critical | proposed | [qa3-fake-test-instantiation](2026-05-27-pr1018-qa3.md) | BookReturnServiceAuthCoordinatorTests never instantiated BookReturnService |
+| Date | PR | Wall | Severity | Status | Contributing-docs? | Entry | One-line |
+|------|----|------|----------|--------|--------------------|-------|----------|
+| 2026-05-28 | n/a (backtest) | reviewer | high | proposed | N | [backtest-2026-05-28](backtest-2026-05-28.md) | Paper analysis of 10 prior shipped bugs vs. SoD reviewer agent prompts — 0% definitive WOULD-CATCH; 5 prompt-addition recommendations |
+| 2026-05-27 | #1018 | implementer | high | proposed | N | [arch1-discipline](2026-05-27-pr1018-arch1.md) | 7 submodule gitlinks accidentally staged as symlinks |
+| 2026-05-27 | #1018 | contract | medium | proposed | N | [arch2-fake-wiring-test](2026-05-27-pr1018-arch2.md) | Wiring test claimed production round-trip but built fresh spies |
+| 2026-05-27 | #1018 | contract+implementer | high | proposed | N | [arch3-dead-classifier-call](2026-05-27-pr1018-arch3.md) | TPPNetworkResponder called classifier but only logged outcome — legacy path still ran |
+| 2026-05-27 | #1018 | implementer+mutation | high | proposed | N | [qa1-half-done-test](2026-05-27-pr1018-qa1.md) | Circuit-breaker test ran ONE attempt; second half was comments |
+| 2026-05-27 | #1018 | contract+orchestrator | critical | proposed | N | [qa2-fake-test-instantiation](2026-05-27-pr1018-qa2.md) | TPPNetworkResponderAuthCoordinatorTests never instantiated TPPNetworkResponder |
+| 2026-05-27 | #1018 | contract+orchestrator | critical | proposed | N | [qa3-fake-test-instantiation](2026-05-27-pr1018-qa3.md) | BookReturnServiceAuthCoordinatorTests never instantiated BookReturnService |
 
 ## Cluster patterns (updated when a cluster emerges)
 

--- a/.forgeos/wall-failures/README.md
+++ b/.forgeos/wall-failures/README.md
@@ -1,3 +1,14 @@
+---
+name: wall-failures-readme
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
+description: Wall-failure catalog
+---
+
 # Wall-failure catalog
 
 **Purpose:** every reviewer-blocked finding is a system bug, not just an implementer bug. This catalog records what escaped, which wall should have caught it, and what permanent improvement closes the gap so the next swarm can't repeat it.
@@ -58,6 +69,7 @@ When classifying, pick the *innermost* wall that should have caught it:
 | **orchestrator** | Integration pass between implementer return and review | Orchestrator trusted the transcript without verifying claims |
 | **reviewer** | SoD architect or qa_test agent | Reviewer prompt didn't ask the right question |
 | **hook** | Pre-commit / pre-push enforcement | Hook didn't catch missing scope stanza for the change class |
+| **stale-doc** | Out-of-date documentation contributed to the failure | Engineer followed an area checklist that hadn't been refreshed in 11 months; the documented invariant had been broken by an intervening change without checklist update |
 
 ## Why this works
 

--- a/.forgeos/wall-failures/TEMPLATE.md
+++ b/.forgeos/wall-failures/TEMPLATE.md
@@ -5,9 +5,27 @@ source: reviewer-block | shipped-bug | near-miss | retro-observation
 reviewer_ids: [rev_xxxxxxxx]
 changeset_id: cs_xxxxxxxx
 wall: contract | implementer | TDD | mutation | verify-pr | orchestrator | reviewer | hook
+walls: []  # array form, preferred for new entries; multiple walls can contribute.
+           # Values: contract | implementer | TDD | mutation | verify-pr | orchestrator | reviewer | hook | stale-doc
+           # Legacy single-value `wall:` above stays for backward compatibility.
 severity: low | medium | high | critical
-status: open | proposed | applied
+wall_status: open | proposed | applied
 applied_in: ""  # commit SHA or PR # where the permanent fix landed
+contributing_docs:  # optional; populate when a stale doc contributed to the failure.
+                    # Each entry: {path, last_refresh_at_failure, decay_days}
+                    # decay_days = (failure_date - last_refresh_at_failure)
+  # - path: docs/architecture/areas/<area>/verification-checklist.md
+  #   last_refresh_at_failure: YYYY-MM-DD
+  #   decay_days: 0
+# doc-lifecycle metadata (added by Module B sweep)
+name: wall-failures-template
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
+description: Title — one-line summary of what escaped
 ---
 
 # Title — one-line summary of what escaped
@@ -33,6 +51,18 @@ Concrete and grep-able. *Not* "be more careful next time." Examples:
 - Add pre-commit hook: *"Block commits that add `_ = newFn()` without an inline `// rationale: ...` comment."*
 
 The fix should make the finding **structurally impossible to land**, not "more likely to be noticed."
+
+## Stale-doc contribution
+
+Fill this section only when `stale-doc` is in `walls:`. For each contributing doc:
+
+- **Doc path:** `docs/architecture/areas/<area>/verification-checklist.md`
+- **Last refresh before failure:** YYYY-MM-DD (commit SHA optional)
+- **Decay at failure:** N days (= failure_date − last_refresh)
+- **What the doc said vs. reality:** plain-English diff — the invariant the doc asserted and the intervening change that broke it without a checklist update.
+- **Freshness-window implication:** does this doc's category need a tighter refresh cadence? Link the proposed cadence change.
+
+If `stale-doc` is NOT in `walls:`, delete this section.
 
 ## Application log
 

--- a/.forgeos/wall-failures/backtest-2026-05-28.md
+++ b/.forgeos/wall-failures/backtest-2026-05-28.md
@@ -1,11 +1,20 @@
 ---
 date: 2026-05-28
-type: backtest-analysis
+wall_type: backtest-analysis
 scope: forge-architect-reviewer + forge-qa-reviewer agents
 sample_size: 10 bugs
 window: 2026-03-01 → 2026-05-28 (90d)
-status: proposed
+wall_status: proposed
 applied_in: ""  # prompt updates land in a follow-up commit
+# doc-lifecycle metadata (added by Module B sweep)
+name: wall-failures-backtest-2026-05-28
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
+description: Backtest — would SoD reviewers have caught the last 90 days of shipped Palace iOS bugs?
 ---
 
 # Backtest — would SoD reviewers have caught the last 90 days of shipped Palace iOS bugs?

--- a/.forgeos/wall-failures/derived-improvements.md
+++ b/.forgeos/wall-failures/derived-improvements.md
@@ -1,3 +1,14 @@
+---
+name: wall-failures-derived-improvements
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
+description: Derived improvements
+---
+
 # Derived improvements
 
 Cluster-level fixes promoted from wall-failure entries. Each row links back to the entries that motivated it.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,3 +1,14 @@
+---
+name: architecture-readme
+type: evolving
+status: active
+created: 2026-04-27
+last_refresh: 2026-05-22
+freshness_window: 365d
+owners: [general]
+description: Palace iOS Architecture Documentation
+---
+
 # Palace iOS Architecture Documentation
 
 Engineering decisions and case studies for major architectural work in this codebase. These docs capture *why* we did things, not just *what* — the rationale future maintainers (and outside contributors curious about the design) need.

--- a/docs/architecture/account-state-machine.md
+++ b/docs/architecture/account-state-machine.md
@@ -1,3 +1,14 @@
+---
+name: account-state-machine
+type: evolving
+status: active
+created: 2026-05-19
+last_refresh: 2026-05-19
+freshness_window: 365d
+owners: [general]
+description: "Account State Machine — Systemic Fix for the Load-Readiness Race Class"
+---
+
 # Account State Machine — Systemic Fix for the Load-Readiness Race Class
 
 **Status:** Proposed (2026-05-18) — PoC on `feature/account-state-machine-3.2.0`. Ships 3.2.0.

--- a/docs/architecture/architectural-triad.md
+++ b/docs/architecture/architectural-triad.md
@@ -1,3 +1,14 @@
+---
+name: architectural-triad
+type: evolving
+status: active
+created: 2026-04-27
+last_refresh: 2026-04-27
+freshness_window: 365d
+owners: [general]
+description: "Architectural Triad — Plan and Decision Log"
+---
+
 # Architectural Triad — Plan and Decision Log
 
 > Multi-phase architectural work to close the gap between the modernize/whole-shot refactor's claimed state and the actual state. Three axes: dependency injection adoption, the Store reducer pattern, and the singleton / god-class purge.

--- a/docs/architecture/areas/accounts/verification-checklist.md
+++ b/docs/architecture/areas/accounts/verification-checklist.md
@@ -1,3 +1,14 @@
+---
+name: accounts-verification-checklist
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [accounts]
+description: Per-area verification reference; refresh before next swarm/rigorous-fix
+---
+
 <!-- audit-verified: All file:line citations below were re-confirmed against current HEAD on chore/swarm-rigor-meta-improvement (2026-05-28) by reading the cited source files and grepping for the cited symbols (e.g. `awaitReady`, `currentAccount =`, `_setState`, `.accountNotFound`, `noAccountSentinelUUID`). Recent commit history (14100c62a redrive fix, dce81974e currentAccount setter driver, 49c591b24 wiring-suite isolation flag, 222137d3a state machine PoC, e8cc87d26 develop merge) was verified via `git log --oneline origin/develop -- Palace/Accounts/`. Memories referenced (enum_conflation_account_not_found, phase1_account_state_machine_2026_05_19, reference_tpp_user_account_migration_retro, feedback_wiring_suite_test_isolation) were read in full and their claims cross-checked against current code. Sections marked UNKNOWN are explicitly flagged as unverified at refresh time. -->
 
 # Accounts area — verification checklist

--- a/docs/architecture/areas/audiobook/verification-checklist.md
+++ b/docs/architecture/areas/audiobook/verification-checklist.md
@@ -1,3 +1,14 @@
+---
+name: audiobook-verification-checklist
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [audiobook]
+description: Per-area verification reference; refresh before next swarm/rigorous-fix
+---
+
 <!-- audit-verified: file paths and line ranges in Section 1 verified by direct Read of Palace/Audiobooks/*.swift and Palace/CarPlay/*.swift on 2026-05-28. Test inventory in Section 6 verified by `find PalaceTests/Audiobook* PalaceTests/CarPlay -name '*.swift'` (37 files). Known-trap claims in Section 7 sourced from MEMORY.md entries explicitly listed in Section 9. Items I could not verify by reading code (regression history details, in-field crash signatures, sim-environment audio limitations) are attributed to their source memory or HelpSpot ticket and not asserted as live code state. -->
 
 # Audiobook area — verification checklist

--- a/docs/architecture/areas/auth/verification-checklist.md
+++ b/docs/architecture/areas/auth/verification-checklist.md
@@ -1,3 +1,14 @@
+---
+name: auth-verification-checklist
+type: evolving
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-27
+freshness_window: 180d
+owners: [auth]
+description: Per-area verification reference; refresh before next swarm/rigorous-fix
+---
+
 <!-- audit-verified: PR #1018 and swarm_66819d80 are real; I orchestrated this swarm today (2026-05-27 → 2026-05-28) and the artifacts referenced exist at .forgeos/swarms/swarm_66819d80/. Migration status per Section 1 was verified by grep/file-read during the swarm's Phase 4/4.5/5. -->
 
 # Auth area — verification checklist

--- a/docs/architecture/areas/holds/verification-checklist.md
+++ b/docs/architecture/areas/holds/verification-checklist.md
@@ -1,3 +1,14 @@
+---
+name: holds-verification-checklist
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [holds]
+description: Per-area verification reference; refresh before next swarm/rigorous-fix
+---
+
 <!-- audit-verified: All file paths and line numbers were spot-read against the working tree on 2026-05-28 (branch chore/swarm-rigor-meta-improvement). Palace/Holds/ contains exactly the 3 files listed in Section 1 per `ls Palace/Holds/`. Test inventory verified via `find PalaceTests -name '*Hold*Tests.swift'`. Regression matrix rows B3/B4/B7/C4/N1/N4 quoted from docs/Testing/REGRESSION_TEST_MATRIX.md. HelpSpot ticket numbers (17960 Derryl, 17971 Heather), F-numbers (F-035, F-065, F-072, F-081), and JIRA ticket IDs (PP-3702, PP-3811, PP-4020, PP-4258, PP-4259, PP-4358) sourced from the regression matrix + git log -- Palace/Holds/. NotificationService.swift line numbers (484-579) verified via Read of that range. -->
 
 # Holds area — verification checklist

--- a/docs/architecture/areas/mybooks/verification-checklist.md
+++ b/docs/architecture/areas/mybooks/verification-checklist.md
@@ -1,3 +1,14 @@
+---
+name: mybooks-verification-checklist
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [mybooks]
+description: Per-area verification reference; refresh before next swarm/rigorous-fix
+---
+
 <!-- audit-verified: file paths under Palace/MyBooks/, Palace/Book/UI/BookDetail/BorrowReducer.swift, and PalaceTests/{MyBooks,Contract,ViewModels}/ all verified via `ls` and `find` against current `chore/swarm-rigor-meta-improvement` HEAD (a71b070bf). Line citations for hasBorrowReauthBeenAttempted (BorrowOperation.swift:92, 601), tokenRefreshAttempts (TPPNetworkResponder.swift:34, 369), BookReturnService setProcessing/removeBook (BookReturnService.swift:139, 221) verified via grep. Contract snapshots inventoried from PalaceTests/Contract/__Snapshots__/. The Phase 7 audit synthesis at .forgeos/audits/phase7-synthesis-2026-05-26.md was confirmed referenced by phase7_borrow_path_regressions_2026_05_14.md. The PR #1018 *AuthCoordinator*Tests cited in the user prompt are NOT present locally on this branch and are listed as "scheduled" rather than "extant." -->
 
 # MyBooks area — verification checklist

--- a/docs/architecture/areas/network/verification-checklist.md
+++ b/docs/architecture/areas/network/verification-checklist.md
@@ -1,3 +1,14 @@
+---
+name: network-verification-checklist
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [network]
+description: Per-area verification reference; refresh before next swarm/rigorous-fix
+---
+
 <!-- audit-verified: Owner files in Palace/Network/ confirmed by `ls Palace/Network/` (Core/, TPPNetworkExecutor.swift, TPPNetworkResponder.swift, TPPNetworkQueue.swift, TPPRequestExecuting.swift, TPPUserFriendlyError.swift, Bundled/RemoteHTMLViewController.swift). Line citations in Sections 1, 4, and 7 verified by grep against the current branch (chore/swarm-rigor-meta-improvement). The "MIGRATED in PR #1018 / swarm_66819d80" status reflects the swarm-scaffold branch (swarm/swarm_66819d80-scaffold, commit f9e57f7f5) — that work has NOT yet landed on develop, so on develop the responder still routes via `indicatesAuthenticationNeedsRefresh`. Section 1's "Migration status" column therefore describes the design baseline this checklist documents, not the develop tip. Refresh the next architect: re-grep before assuming. -->
 
 # Network area — verification checklist

--- a/docs/architecture/areas/reader/verification-checklist.md
+++ b/docs/architecture/areas/reader/verification-checklist.md
@@ -1,3 +1,14 @@
+---
+name: reader-verification-checklist
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [reader]
+description: Per-area verification reference; refresh before next swarm/rigorous-fix
+---
+
 <!-- audit-verified: file paths in Section 1 (Palace/Reader2/UI/TPPEPUBViewController.swift, Palace/Reader2/UI/ReaderEditingActions.swift, Palace/PDF/Views/PalacePDFView.swift, Palace/PDF/Views/TPPPDFView.swift, Palace/PDF/LCP/LCPPDFs.swift, Palace/PDF/ReadiumPDF/ReadiumPDFViewController.swift, Palace/AppInfrastructure/ReaderService.swift, Palace/AppInfrastructure/NavigationHostView.swift, Palace/Reader2/BusinessLogic/*) were all confirmed to exist via ls/grep on 2026-05-28. PR #1012 (PP-4297) and PR #1008 (PP-4454) verified in `git log --oneline origin/develop -- Palace/Reader2/ Palace/Reader3/`. `TPPBook.isDRMProtected` definition confirmed at Palace/Book/Models/TPPBook.swift:652. simdrive journeys enumerated from `.simdrive/journeys/reader2-*.yaml`. Regression matrix rows E1, E1-LCP, E1-Adobe, E2, E2-Hang verified in docs/Testing/REGRESSION_TEST_MATRIX.md. Reader3/ confirmed empty except for .DS_Store + an empty ReaderStackConfiguration/ subdirectory — there is no live "Reader3" code; PDF lives under Palace/PDF/. -->
 
 # Reader area — verification checklist

--- a/docs/architecture/areas/signin-modal/verification-checklist.md
+++ b/docs/architecture/areas/signin-modal/verification-checklist.md
@@ -1,3 +1,14 @@
+---
+name: signin-modal-verification-checklist
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 180d
+owners: [signin-modal]
+description: Per-area verification reference; refresh before next swarm/rigorous-fix
+---
+
 <!-- audit-verified: file list, line citations, call-site counts, test inventory, and commit SHAs (8ed7451c1 PR #905, ca5a2fb80/24dc6021d/9ffcfcfcf SignInModal predicate extraction, da9875e28 PR #907 SAML SwiftUI conversion) all confirmed via `ls Palace/SignInLogic/`, `git log --oneline origin/develop`, `grep -rn`, and `wc -l` on 2026-05-28. PP-4421 placeholder fix landed in `Palace/Settings/AccountDetailView.swift` lines 344 & 369 (verified). HelpSpot 17923 revert per `feedback_no_new_copy_without_design.md`. -->
 
 # Sign-in modal area — verification checklist

--- a/docs/architecture/audiobook-systemic-overhaul.md
+++ b/docs/architecture/audiobook-systemic-overhaul.md
@@ -1,3 +1,14 @@
+---
+name: audiobook-systemic-overhaul
+type: evolving
+status: active
+created: 2026-05-22
+last_refresh: 2026-05-22
+freshness_window: 365d
+owners: [general]
+description: "Audiobook Systemic Overhaul — Plan and Retrospective"
+---
+
 # Audiobook Systemic Overhaul — Plan and Retrospective
 
 > Three-phase refactor of the Palace-side audiobook stack to close six recurring failure surfaces. Originally drafted as a forward-looking ADR; reconstructed here after all three Palace-side phases shipped on **2026-05-21** (PRs #979 / #980 / #982).

--- a/docs/architecture/critical-path-mutation-coverage.md
+++ b/docs/architecture/critical-path-mutation-coverage.md
@@ -1,3 +1,14 @@
+---
+name: critical-path-mutation-coverage
+type: evolving
+status: active
+created: 2026-05-27
+last_refresh: 2026-05-27
+freshness_window: 365d
+owners: [general]
+description: "Critical-path mutation coverage — regex methodology"
+---
+
 # Critical-path mutation coverage — regex methodology
 
 <!-- audit-verified -->

--- a/docs/architecture/critical-path-review-policy.md
+++ b/docs/architecture/critical-path-review-policy.md
@@ -1,3 +1,14 @@
+---
+name: critical-path-review-policy
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
+description: Critical-path review policy
+---
+
 <!-- audit-verified: B5 from .forgeos/wall-failures/derived-improvements.md — policy implementation lives at ~/harness/core/hooks/pre-push-critical-path-review.sh; registered in .claude/settings.json. Hook code reviewed and verified at time of writing. -->
 
 # Critical-path review policy

--- a/docs/architecture/parallel-agent-rebase-walkthrough.md
+++ b/docs/architecture/parallel-agent-rebase-walkthrough.md
@@ -1,3 +1,14 @@
+---
+name: parallel-agent-rebase-walkthrough
+type: evolving
+status: active
+created: 2026-04-27
+last_refresh: 2026-04-27
+freshness_window: 365d
+owners: [general]
+description: "Parallel-Agent Refactor — How We Ran 5 Concurrent Agents and Linearized the Stack"
+---
+
 # Parallel-Agent Refactor — How We Ran 5 Concurrent Agents and Linearized the Stack
 
 > A case study in how Phase 4 of the [architectural triad](./architectural-triad.md) was decomposed into 5 disjoint file partitions, run in parallel by independent agents on isolated branches, then merged into a single linear stack via cherry-pick + rebase. What worked, what we'd change.

--- a/docs/architecture/pp4156-retro-2026-05-04.md
+++ b/docs/architecture/pp4156-retro-2026-05-04.md
@@ -1,3 +1,14 @@
+---
+name: pp4156-retro-2026-05-04
+type: evolving
+status: active
+created: 2026-05-05
+last_refresh: 2026-05-05
+freshness_window: 365d
+owners: [general]
+description: "PP-4156 Audiobook Download Indicator — Retrospective (2026-05-04)"
+---
+
 # PP-4156 Audiobook Download Indicator — Retrospective (2026-05-04)
 
 > Debug-and-fix retrospective for [PP-4156](https://ebce-lyrasis.atlassian.net/browse/PP-4156) ("iOS: Add download indicator for all audiobooks"). Captures the misattribution near-miss, the layered-bug structure, and the verification protocol that worked.

--- a/docs/architecture/release-merge-policy.md
+++ b/docs/architecture/release-merge-policy.md
@@ -1,3 +1,14 @@
+---
+name: release-merge-policy
+type: evolving
+status: active
+created: 2026-05-26
+last_refresh: 2026-05-26
+freshness_window: 365d
+owners: [general]
+description: Release & Hotfix Merge Policy
+---
+
 # Release & Hotfix Merge Policy
 
 **TL;DR:** Merges into `main` use regular merge commits (`--no-ff`). Squash-merge is forbidden on `main`-bound work because it destroys commit SHAs, which causes the next release-branch → main merge to hit catastrophic conflicts even when content is logically identical.

--- a/docs/architecture/session-observability-context.md
+++ b/docs/architecture/session-observability-context.md
@@ -1,3 +1,14 @@
+---
+name: session-observability-context
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
+description: Session-observability → session-start context (C2 stub)
+---
+
 <!-- audit-verified: C2 stub from .forgeos/wall-failures/derived-improvements.md — design + minimal scaffolding. Full implementation depends on Crashlytics MCP + HelpSpot MCP integration with files-about-to-be-edited inference. -->
 
 # Session-observability → session-start context (C2 stub)

--- a/docs/architecture/swarm-rigor-followups.md
+++ b/docs/architecture/swarm-rigor-followups.md
@@ -1,3 +1,14 @@
+---
+name: swarm-rigor-followups
+type: evolving
+status: active
+created: 2026-05-28
+last_refresh: 2026-05-28
+freshness_window: 365d
+owners: [general]
+description: "Swarm rigor — follow-up backlog"
+---
+
 <!-- audit-verified: PR #1018 is real; I orchestrated swarm_66819d80 today; the items below are derived from the wall-failure entries at .forgeos/wall-failures/2026-05-27-pr1018-*.md and the gaps explicitly named in this PR's commits. -->
 
 # Swarm rigor — follow-up backlog

--- a/docs/architecture/swarm-workflow.md
+++ b/docs/architecture/swarm-workflow.md
@@ -1,3 +1,14 @@
+---
+name: swarm-workflow
+type: evolving
+status: active
+created: 2026-05-11
+last_refresh: 2026-05-11
+freshness_window: 365d
+owners: [general]
+description: "/swarm — multi-module orchestration loop"
+---
+
 # /swarm — multi-module orchestration loop
 
 This doc captures the **why** for the `/swarm` skill that lives at

--- a/docs/architecture/triad-retro-2026-04-27.md
+++ b/docs/architecture/triad-retro-2026-04-27.md
@@ -1,3 +1,14 @@
+---
+name: triad-retro-2026-04-27
+type: evolving
+status: active
+created: 2026-04-27
+last_refresh: 2026-05-06
+freshness_window: 365d
+owners: [general]
+description: "Architectural Triad — Retrospective (2026-04-27)"
+---
+
 # Architectural Triad — Retrospective (2026-04-27)
 
 > Retrospective on the [architectural triad epic](./architectural-triad.md) at the moment Phases 1–5 landed in PRs #866 + #867. What we delivered, what surprised us, what we'd change.


### PR DESCRIPTION
## Summary

The systemic fix for the curation question from PR #1019 (\"are we saving too much data?\"). Every governance doc declares its lifecycle via YAML frontmatter; a validator + pre-commit hook enforce schema at write time; \`harness docs-decay\` walks the tree and reports stale / archival / condensation candidates; SessionStart surfaces decay into agent context. Same pattern as the rest of the rigor system — declarative metadata + automated checks + enforcement at action time + feedback loop into wall-failures.

## Six modules

| Module | What | Files |
|---|---|---|
| **A** — Schema + validator | YAML frontmatter spec + Python validator + 16 tests | \`.forgeos/schemas/doc-frontmatter-v1.md\`, \`~/harness/core/lib/validate-doc-frontmatter.py\` |
| **B** — Retroactive sweep | 147 existing governance docs migrated to valid frontmatter; resolved wall-failure schema collision via \`wall_status\`/\`wall_type\` namespace | 147 \`.md\` files across \`.forgeos/\`, \`docs/architecture/\`, \`.claude/skills/\` |
| **C** — Pre-commit hook | Blocks commits adding/modifying governance docs without valid frontmatter OR stale \`last_refresh\` on changed-content | \`~/harness/core/hooks/pre-commit-doc-lifecycle.sh\`, symlink, \`.claude/settings.json\` |
| **D** — Decay CLI | \`harness docs-decay [--apply]\` classifier + condensation script + 21 tests | \`~/harness/core/lib/docs_decay.py\`, \`condense_transcript.py\`, \`bin/harness\` |
| **E** — SessionStart surfacing | Compact \`=== docs hygiene ===\` block when actionable; silent when clean; 1.46s total hook time | \`~/harness/core/lib/session_docs_hygiene.py\`, \`session-start.sh\` |
| **F** — Wall-failure schema | New \`stale-doc\` wall category + \`contributing_docs\` field for feedback loop | \`.forgeos/wall-failures/{README,TEMPLATE,INDEX}.md\` |

## What this fixes

The 1.6 MB of governance artifacts today are fine in absolute bytes (0.14% annual repo growth). The real concerns were:
1. **Discoverability bloat** — fixed by INDEX.md + frontmatter-driven query
2. **Maintenance bloat** — fixed by declarative freshness windows + automated decay surfacing
3. **Cognitive bloat** — fixed by SessionStart prioritization (silent when clean; surfaces only what needs attention)

Now curation becomes mechanical: stale → SessionStart shows it → \`harness docs-decay --apply\` archives or condenses → wall-failure catches failures caused by stale docs → freshness windows auto-tune.

## Verification

- **47 tests across 3 suites: 100% pass** (16 validator + 21 decay + 10 SessionStart)
- Validator against Palace iOS: 0 failures (silent pass; Module B's sweep is clean)
- Docs-decay CLI against current Palace state: **104 fresh / 0 inconsistent**
- Pre-commit hook: \`bash -n\` syntax OK, symlink resolves, \`settings.json\` valid JSON
- Wall-failure schema additions verified by grep (\`stale-doc\` in README; \`walls:\` + \`contributing_docs\` in TEMPLATE)
- SessionStart hook execution: **1.46s** (well under 5s budget)

## Test plan

- [x] All 47 tests pass
- [x] Validator works against current Palace iOS tree
- [x] Pre-commit hook blocks invalid frontmatter (smoke-tested with deliberate malformed doc)
- [x] Pre-commit hook allows valid frontmatter
- [x] Decay CLI \`--apply\` mocked-tested (real apply deferred — Palace docs are all fresh today)
- [x] SessionStart silent on clean repo (correct behavior — Palace is fresh)
- [x] SessionStart byte-cap enforced (pathological input test)
- [ ] **Reviewer focus on:** (1) wall-failure schema collision resolution (wall_status / wall_type namespacing vs renaming the lifecycle keys) — does the dual-namespace pattern hold up? (2) freshness window defaults (90d/180d/365d) — calibrated reasonably or too aggressive/lax? (3) Module B's 147-file sweep — any false positives or judgment calls that should have been different?
- [ ] First real \`--apply\` run when something legitimately ages out — will validate the archival mechanics in practice

## Companion harness commit

\`~/harness/\` local-only repo per Maurice's setup. Commit \`0db08ee\` ships validators / hooks / CLI / SessionStart bodies. Palace branch ships the schema spec + retroactive frontmatter sweep + \`.claude/settings.json\` registration that references the harness paths via symlinks and absolute paths.

## Force-add note

\`.claude/skills/\` and \`.claude/settings.json\` force-added consistent with PR #1019 precedent — team-shared skills/configs live under \`.claude/\` despite local \`.git/info/exclude\` blanket pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)