### PR TITLE
PP-4340: upgrade Readium swift-toolkit to 3.9.0

### DIFF
--- a/.forgeos/intent/PP-4340-readium-3.9.0.md
+++ b/.forgeos/intent/PP-4340-readium-3.9.0.md
@@ -1,0 +1,131 @@
+---
+name: PP-4340-readium-3.9.0
+created: 2026-06-05
+author: claude-opus-4-8
+ticket: PP-4340
+---
+
+## Summary
+
+Upgrade Readium swift-toolkit from 3.7.0 to 3.9.0 in `ios-core` and the
+`ios-audiobooktoolkit` submodule (which links `ReadiumShared` directly and
+must move in lockstep). Apply the 3.8.0 + 3.9.0 breaking-change migrations:
+JSONValue type-safe JSON, EPUB + PDF navigators no longer require an HTTP
+server (remove `ReadiumAdapterGCDWebServer` / `GCDHTTPServer` entirely), and
+migrate LCP license/passphrase storage from the deprecated
+`ReadiumAdapterLCPSQLite` repositories to the built-in Keychain repositories
+with a one-time SQLite→Keychain data migration for existing users.
+
+User decisions (2026-06-05): migrate LCP to Keychain **now** (with data
+migration); bump + migrate the **submodule** in this same pass.
+
+## Claims
+
+### SPM version pins
+- bumps `swift-toolkit` from `exactVersion 3.7.0` → `3.9.0` in
+  `Palace.xcodeproj/project.pbxproj` and updates `Package.resolved`
+- bumps `swift-toolkit` from `exactVersion 3.7.0` → `3.9.0` in
+  `ios-audiobooktoolkit/PalaceAudiobookToolkit.xcodeproj/project.pbxproj`
+- updates the submodule pointer in `ios-core` to the migrated submodule commit
+
+### JSONValue migration (3.9.0)
+- `Palace/Reader2/Bookmarks/TPPBookLocation+Locator.swift`: replaces the two
+  `serializeJSONString(dict)` calls (removed free function) with Foundation
+  `JSONSerialization` serialization of the `[String: Any]` dict; reads
+  `otherLocations[...]?.string` and constructs `Locator.Locations(otherLocations:)`
+  with `[String: JSONValue]` (was `[String: Any]`)
+- `Palace/Reader2/BusinessLogic/TPPLastReadPositionPoster.swift`: changes
+  `locator.jsonString` (property) → `try? locator.jsonString()` (throwing method)
+- `Palace/Reader2/Internal/Publication+NYPLAdditions.swift`: `link.properties["id"]`
+  is now `JSONValue?` → read via `?.string`
+- `ios-audiobooktoolkit/.../Player/RangeResource.swift` +
+  `Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift`:
+  `ResourceProperties` subscript now requires `JSONValueEncodable & JSONValueDecodable`;
+  `UInt64` is encode-only, so length is stored as `Int` and bridged to `UInt64`
+
+Note: the EPUB/PDF `httpServer:` inits and the LCP SQLite repos are **deprecations**
+in 3.9.0 (old APIs still compile), not hard removals — the project builds with
+warnings before migration. `ReadiumAdapterLCPSQLite` is **kept** in the project
+because the one-time migrator must read the legacy store; its removal is deferred to
+a follow-up once migration adoption is complete (the single remaining, intentional,
+self-documented deprecation warning).
+
+### EPUB HTTP-server removal (3.8.0)
+- drops the `httpServer:` argument from the `EPUBNavigatorViewController(...)`
+  init in `Palace/Reader2/UI/TPPEPUBViewController.swift`
+- unwinds the `resourcesServer: HTTPServer` plumbing through
+  `TPPEPUBViewController.init`, `TPPR3Owner` (`ReaderModule(resourcesServer:)`),
+  and the `ReaderModule`/format-module chain
+
+### PDF HTTP-server removal (3.9.0)
+- drops the `httpServer:` argument from the `PDFNavigatorViewController(...)`
+  init in `Palace/PDF/ReadiumPDF/ReadiumPDFViewController.swift`
+- unwinds the `httpServer` plumbing through `ReadiumPDFViewController`,
+  `ReadiumPDFContainer`, `ReadiumPDFReaderView`,
+  `Palace/AppInfrastructure/NavigationHostView.swift`, and
+  `ReaderService.httpServer`
+
+### GCDWebServer removal
+- removes `GCDHTTPServer` creation/`serve`/`remove`/`releaseServedPublication`
+  from `Palace/Reader2/ReaderStackConfiguration/LibraryService.swift`
+- removes `import ReadiumAdapterGCDWebServer` from all sites
+- removes the `ReadiumAdapterGCDWebServer` SPM product link from
+  `Palace.xcodeproj/project.pbxproj` (both targets)
+- removes the orphan Carthage `GCDWebServer.{framework,xcframework}` and
+  `ReadiumLCP.{framework,xcframework}` PBXGroup file references (dead refs)
+
+### LCP SQLite→Keychain migration (3.8.0)
+- `Palace/Reader2/ReaderStackConfiguration/LCP/LCPLibraryService.swift`:
+  swaps `LCPSQLiteLicenseRepository`/`LCPSQLitePassphraseRepository` for
+  `LCPKeychainLicenseRepository`/`LCPKeychainPassphraseRepository`; the new
+  repos are non-throwing
+- adds a one-time SQLite→Keychain data migration (gated, runs once) under
+  `Palace/Migrations/` so existing users' stored LCP licenses/passphrases
+  carry over; removes `import ReadiumAdapterLCPSQLite` once migration is the
+  only remaining SQLite consumer
+- removes the `ReadiumAdapterLCPSQLite` SPM product link after migration is
+  wired (kept only if the one-time migrator still imports it; tracked)
+
+### Submodule ReadiumShared API migration
+- applies whatever `ReadiumShared` API drift surfaces at build in
+  `ios-audiobooktoolkit` (Resource/streaming APIs in `RangeResource`,
+  `StreamingResourceProvider`, `LCPStreamingPlayer`, `HTTPRangeRetriever`,
+  `LCPResourceLoaderDelegate`, `Audiobook`); submodule JSON code is plain
+  Foundation `JSONSerialization` and is expected to be unaffected
+
+## Anti-claims
+- does NOT change the LCP-PDF disk-extract architecture or the
+  decrypt/OOM-guard logic in `ReaderService.openPDF` (only removes the now-unused
+  `httpServer` plumbing around it)
+- does NOT change EPUB/PDF reading-position persistence wire format
+  (`TPPBookLocation` JSON shape is preserved byte-for-byte)
+- does NOT change audiobook playback logic beyond ReadiumShared API renames
+- does NOT alter sign-in/borrow/return/download flows
+- does NOT change the LCP passphrase-authentication UX
+
+## Files in scope
+- `Palace.xcodeproj/project.pbxproj`
+- `Palace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
+- `Palace/Reader2/Bookmarks/TPPBookLocation+Locator.swift`
+- `Palace/Reader2/BusinessLogic/TPPLastReadPositionPoster.swift`
+- `Palace/Reader2/UI/TPPEPUBViewController.swift`
+- `Palace/Reader2/ReaderStackConfiguration/TPPR3Owner.swift`
+- `Palace/Reader2/ReaderStackConfiguration/LibraryService.swift`
+- `Palace/Reader2/ReaderStackConfiguration/LCP/LCPLibraryService.swift`
+- `Palace/Reader2/.../ReaderModule` + EPUB format module (resourcesServer plumbing)
+- `Palace/PDF/ReadiumPDF/ReadiumPDFViewController.swift`
+- `Palace/PDF/ReadiumPDF/ReadiumPDFReaderView.swift`
+- `Palace/AppInfrastructure/ReaderService.swift`
+- `Palace/AppInfrastructure/NavigationHostView.swift`
+- `Palace/Migrations/` (new one-time LCP SQLite→Keychain migrator)
+- `ios-audiobooktoolkit/PalaceAudiobookToolkit.xcodeproj/project.pbxproj`
+- `ios-audiobooktoolkit/PalaceAudiobookToolkit/...` (ReadiumShared API drift)
+- test files under `PalaceTests/` for JSON round-trip + LCP migration
+
+## Verification plan
+- submodule builds standalone at 3.9.0
+- `xcodebuild ... build` clean for Palace + Palace-noDRM
+- `scripts/verify-pr.sh --quick`
+- simdrive smoke (AC): EPUB paginated + scroll, PDF, LCP-protected PDF,
+  audiobook, EPUB search, PDF search, EPUB TTS, rotation-preserves-preferences
+- no new deprecation warnings (LCP SQLite deprecation resolved by Keychain swap)

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		040A3BFC88229A27C34A9E3B /* AudiobookFullPlayerCoverContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F4A943502B7E2966FF50B0D /* AudiobookFullPlayerCoverContainer.swift */; };
 		0469ADBAE6CAC0F21823D1E7 /* BadgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59814D0AE9FAF49E9A52426A /* BadgeService.swift */; };
 		048495C6D7E8F90A1B2C3D4E /* DownloadThrottlingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B2C3D4E5F60718293A4B5C /* DownloadThrottlingServiceTests.swift */; };
+		04D627FB804AFA2A05C53C01 /* ResourcePropertiesLengthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50E8682DF2CC80AA981B91C /* ResourcePropertiesLengthTests.swift */; };
 		054576899AB2C3D4E5F60829 /* CredentialPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1657899AB2C3D4E5F608291A /* CredentialPromptCoordinator.swift */; };
 		059C1DFA5BF79EEE154645E3 /* LCPSessionOrphaningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C1C5F7FE43056D96C9DE5C /* LCPSessionOrphaningTests.swift */; };
 		05A425DB12A6A7B0F202D793 /* PositionSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683C04EF0CA60F4A118D597A /* PositionSyncServiceTests.swift */; };
@@ -2816,6 +2817,7 @@
 		D4E5F6A7B8C9D0E1F2A3B4C5 /* DownloadCompletionParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadCompletionParserTests.swift; sourceTree = "<group>"; };
 		D4F432B33DEBD1715E2687C7 /* LegacySAMLAuthAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LegacySAMLAuthAdapter.swift; sourceTree = "<group>"; };
 		D4FA6A7940BE4470BD0A3515 /* TPPBookmarkR3LocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookmarkR3LocationTests.swift; sourceTree = "<group>"; };
+		D50E8682DF2CC80AA981B91C /* ResourcePropertiesLengthTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResourcePropertiesLengthTests.swift; sourceTree = "<group>"; };
 		D56E264DEDFBBEDF6D4E79E3 /* AccessibleAnimation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AccessibleAnimation.swift; path = ../../../Palace/Utilities/SwiftUI/AccessibleAnimation.swift; sourceTree = "<group>"; };
 		D598423237C04DE7B3834ABC /* AccountsManagerCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsManagerCacheTests.swift; sourceTree = "<group>"; };
 		D6EF9481386FFCE35AA787B5 /* ReadingChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingChartView.swift; sourceTree = "<group>"; };
@@ -6134,6 +6136,7 @@
 				DRMCHAR0002FILEREF000001 /* LCPCharacterizationTests.swift */,
 				A99D2B5025CDB8D6035651D6 /* LCPClientTests.swift */,
 				64194E4EA4AE55F677AC1714 /* OverdriveFulfillmentTests.swift */,
+				D50E8682DF2CC80AA981B91C /* ResourcePropertiesLengthTests.swift */,
 			);
 			name = DRM;
 			path = DRM;
@@ -7326,6 +7329,7 @@
 				EA4E793DB293880E4CFCADC7 /* AppContainerIsolationLintTests.swift in Sources */,
 				A135764473E7ED860F338914 /* TearDownRequiredLintTests.swift in Sources */,
 				E0B9FECCEC6BA3D470A77FD7 /* LCPKeychainMigrationTests.swift in Sources */,
+				04D627FB804AFA2A05C53C01 /* ResourcePropertiesLengthTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -132,7 +132,6 @@
 		184131D3C04F95ED70463EB4 /* TPPCredentialsCoverageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B55BD3620F51707395548D0 /* TPPCredentialsCoverageTests.swift */; };
 		1841AF92E817CC9D4A6CE829 /* Reachability+StreamingReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A713A1D24A900119FC662F7 /* Reachability+StreamingReader.swift */; };
 		18559B71BD63A3042A18173C /* AudiobookMiniPlayerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D58394DB2697343CDFCF230 /* AudiobookMiniPlayerViewTests.swift */; };
-		18559B71BD63A3042A18173C /* AudiobookMiniPlayerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D58394DB2697343CDFCF230 /* AudiobookMiniPlayerViewTests.swift */; };
 		18A238CEB797BE2EFE126036 /* TPPUserAccountIsolationLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04289C0CE368109EA2C59E70 /* TPPUserAccountIsolationLintTests.swift */; };
 		18D12239FFDAE2F35CE3201F /* LCPAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D27685071B8A1E07185FD0 /* LCPAdapter.swift */; };
 		18EAAA05A58EBDD4FCD5B5E8 /* StatsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17628BE0EB1E554ECF46071E /* StatsCardView.swift */; };
@@ -447,6 +446,7 @@
 		5BCEAC8C8D29E0CE661E127D /* PresetCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B293519F9B55B6F4F17CC7 /* PresetCard.swift */; };
 		5C18E172DE3CB39994F64C3E /* PositionSyncBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BA6F84CC20612B8D4969FE /* PositionSyncBanner.swift */; };
 		5C5CFDA86E67C6186A24EFF9 /* BackgroundDownloadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDB637C01812EEB10919A6E /* BackgroundDownloadHandler.swift */; };
+		5C89F2830C766E791E48CE21 /* LCPKeychainMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A303E282D7EFD80AED446401 /* LCPKeychainMigration.swift */; };
 		5CD40DBE898E0C7AE14CB1F0 /* AccountsManagerIsolationLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A399B178C9ECF3F62C62172 /* AccountsManagerIsolationLintTests.swift */; };
 		5CDD263A7FFB392F96FA4F03 /* LegacySAMLAuthAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F432B33DEBD1715E2687C7 /* LegacySAMLAuthAdapter.swift */; };
 		5CEBAAD3ED3AF6889F45F38C /* UserAccountPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3332DED915E45913181C82D /* UserAccountPublisherTests.swift */; };
@@ -904,6 +904,7 @@
 		A93F9F9721CDACF700BD3B0C /* TPPAppReviewPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93F9F9621CDACF700BD3B0C /* TPPAppReviewPrompt.swift */; };
 		A961D381DEBCF6341C9C7AA2 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA10178BD2885EBF24673F3 /* FontManager.swift */; };
 		A9701CD50E8850215EA9FD69 /* ReadingRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422FFD436DFCCB056CCF6302 /* ReadingRulerView.swift */; };
+		AA225D8E76E146A5132FEA43 /* LCPKeychainMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A303E282D7EFD80AED446401 /* LCPKeychainMigration.swift */; };
 		AAAA00032ECCC53200CDA626 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = AAAA00012ECCC53200CDA626 /* SnapshotTesting */; };
 		AAB502EE6AB7156C9D7D5C19 /* NetworkRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F31B83CAB15F0245AEEE83C /* NetworkRetryTests.swift */; };
 		AAC98E03ABBDB9DA0D80BE08 /* TypographySettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA121652A5D3675E6CEE9849 /* TypographySettingsViewModel.swift */; };
@@ -1181,6 +1182,7 @@
 		E0A3B4C5D6E7F8A9B0C1D2E3 /* DownloadStartDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A2B3C4D5E6F7A8B9C0D1E2 /* DownloadStartDispatcher.swift */; };
 		E0A4B5C6D7E8F9A0B1C2D3E4 /* DownloadStartDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A2B3C4D5E6F7A8B9C0D1E2 /* DownloadStartDispatcher.swift */; };
 		E0A6B7C8D9E0F1A2B3C4D5E6 /* DownloadStartDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A5B6C7D8E9F0A1B2C3D4E5 /* DownloadStartDispatcherTests.swift */; };
+		E0B9FECCEC6BA3D470A77FD7 /* LCPKeychainMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD56A046E056AE23C0ACBFA /* LCPKeychainMigrationTests.swift */; };
 		E1216C1165CF4C0181C3A475 /* TPPBookContentMetadataFilesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118EDF27766F4A129C46852F /* TPPBookContentMetadataFilesHelperTests.swift */; };
 		E18A0DC8C00A41B8841DBBE7 /* TPPBookRegistryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A71EC60193844F386CAC4F4 /* TPPBookRegistryIntegrationTests.swift */; };
 		E19DC417601BC7CAFF15FE3F /* ContinueRowSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFC5BB5B5F0627FFE2FDFA6 /* ContinueRowSection.swift */; };
@@ -1451,7 +1453,6 @@
 		E5D8C8DE2D829B2000667A99 /* HTMLTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D8C8DC2D829B2000667A99 /* HTMLTextView.swift */; };
 		E5D8C8DF2D829B2000667A99 /* HTMLTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D8C8DC2D829B2000667A99 /* HTMLTextView.swift */; };
 		E5DA92E52D06A412005AEEC3 /* ReadiumAdapterLCPSQLite in Frameworks */ = {isa = PBXBuildFile; productRef = E5E9B2172CC1A5C100366A2E /* ReadiumAdapterLCPSQLite */; };
-		E5DA92E62D06A412005AEEC3 /* ReadiumAdapterGCDWebServer in Frameworks */ = {isa = PBXBuildFile; productRef = E5E9B2192CC1A7AC00366A2E /* ReadiumAdapterGCDWebServer */; };
 		E5DE86FD2D6C39D7003D356E /* BookImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DE86FB2D6C39C6003D356E /* BookImageView.swift */; };
 		E5DE86FE2D6C39D7003D356E /* BookImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DE86FB2D6C39C6003D356E /* BookImageView.swift */; };
 		E5DF75312E6B4AF700971F19 /* SamplePreviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DF75302E6B4AF700971F19 /* SamplePreviewManager.swift */; };
@@ -1492,7 +1493,6 @@
 		E5E9AFFC2CC035AC00366A2E /* ReadiumNavigator in Frameworks */ = {isa = PBXBuildFile; productRef = E5E9AFFB2CC035AC00366A2E /* ReadiumNavigator */; };
 		E5E9B0002CC035AC00366A2E /* ReadiumStreamer in Frameworks */ = {isa = PBXBuildFile; productRef = E5E9AFFF2CC035AC00366A2E /* ReadiumStreamer */; };
 		E5E9B2142CC1A5AE00366A2E /* ReadiumAdapterLCPSQLite in Frameworks */ = {isa = PBXBuildFile; productRef = E5E9B2132CC1A5AE00366A2E /* ReadiumAdapterLCPSQLite */; };
-		E5E9B21E2CC1A7BB00366A2E /* ReadiumAdapterGCDWebServer in Frameworks */ = {isa = PBXBuildFile; productRef = E5E9B21D2CC1A7BB00366A2E /* ReadiumAdapterGCDWebServer */; };
 		E5EE380B2D5DA75600252001 /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5EE38092D5DA74C00252001 /* Int+Extensions.swift */; };
 		E5EE380C2D5DA75600252001 /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5EE38092D5DA74C00252001 /* Int+Extensions.swift */; };
 		E5EE380E2D5DB1A100252001 /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5EE380D2D5DB19D00252001 /* Color+Extension.swift */; };
@@ -1526,7 +1526,6 @@
 		E671FF7D1E3A7068002AB13F /* TPPNetworkQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E671FF7C1E3A7068002AB13F /* TPPNetworkQueue.swift */; };
 		E68CCFC51F9F80CF003DDA6C /* TPPBarcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68CCFC41F9F80CF003DDA6C /* TPPBarcode.swift */; };
 		E6AD769F2BD7FF95C7023DBE /* BookOpenTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54010275AF91385B8410DF1 /* BookOpenTracker.swift */; };
-		E6B1F4FB1DD20EA900D73CA1 /* TPPSettingsAccountsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B1F4FA1DD20EA900D73CA1 /* TPPSettingsAccountsList.swift */; };
 		E6B6E76F1F6859A4007EE361 /* TPPKeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B6E76E1F6859A4007EE361 /* TPPKeychainManager.swift */; };
 		E6BA02B81DE4B6F600F76404 /* RemoteHTMLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA02B71DE4B6F600F76404 /* RemoteHTMLViewController.swift */; };
 		E6BC315D1E009F3E0021B65E /* TPPAgeCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BC315C1E009F3E0021B65E /* TPPAgeCheck.swift */; };
@@ -2512,6 +2511,7 @@
 		7BA4D17463BADFD0DEBC53FA /* ReadingStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStats.swift; sourceTree = "<group>"; };
 		7BFD7CCC67838590BD9E203D /* FuzzRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzRunner.swift; sourceTree = "<group>"; };
 		7CBC313C7F61C891527F159B /* PerformanceMonitorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMonitorProtocol.swift; sourceTree = "<group>"; };
+		7DD56A046E056AE23C0ACBFA /* LCPKeychainMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPKeychainMigrationTests.swift; sourceTree = "<group>"; };
 		7E62D6F6D6313094B90E80E5 /* AdobeRightsParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AdobeRightsParser.swift; sourceTree = "<group>"; };
 		7EA3C09A7973CF58C57F23C0 /* AudiobookLoaderOPDSShapeMatrixTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookLoaderOPDSShapeMatrixTests.swift; sourceTree = "<group>"; };
 		7ED5DCD8E5494F99E3E01D1D /* BookRegistrySyncReadinessTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookRegistrySyncReadinessTests.swift; sourceTree = "<group>"; };
@@ -2610,6 +2610,7 @@
 		A256A501E6AB55F352D674FE /* AccessibilityPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferencesTests.swift; sourceTree = "<group>"; };
 		A2A352697B589358F91035A1 /* MockVisualNavigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockVisualNavigator.swift; path = PalaceTests/Mocks/MockVisualNavigator.swift; sourceTree = "<group>"; };
 		A2E5C9EA3B9B15FEF2555CE3 /* TPPBasicAuthTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBasicAuthTests.swift; sourceTree = "<group>"; };
+		A303E282D7EFD80AED446401 /* LCPKeychainMigration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPKeychainMigration.swift; sourceTree = "<group>"; };
 		A325872EF1D517D66C0FA15F /* TokenResponseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenResponseTests.swift; sourceTree = "<group>"; };
 		A3332DED915E45913181C82D /* UserAccountPublisherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserAccountPublisherTests.swift; sourceTree = "<group>"; };
 		A42A18057E6441D9B4142F50 /* OPDSFeedMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDSFeedMigrationTests.swift; sourceTree = "<group>"; };
@@ -3290,7 +3291,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5DA92E62D06A412005AEEC3 /* ReadiumAdapterGCDWebServer in Frameworks */,
 				E5DA92E52D06A412005AEEC3 /* ReadiumAdapterLCPSQLite in Frameworks */,
 				E5F2E9B72CEE8550007EA6C9 /* PureLayout in Frameworks */,
 				E7FFEAA62A745F600006030A /* ULID in Frameworks */,
@@ -3348,7 +3348,6 @@
 				E5E9B2142CC1A5AE00366A2E /* ReadiumAdapterLCPSQLite in Frameworks */,
 				03B092301E78871A00AD338D /* MediaPlayer.framework in Frameworks */,
 				E7E96BB32B0E82220036B23A /* PalaceUIKit.framework in Frameworks */,
-				E5E9B21E2CC1A7BB00366A2E /* ReadiumAdapterGCDWebServer in Frameworks */,
 				03B092281E78859E00AD338D /* CoreMedia.framework in Frameworks */,
 				E5E4AAD32EB2929600CC1D67 /* FirebaseRemoteConfigSwift in Frameworks */,
 				03B0922E1E7886ED00AD338D /* CoreVideo.framework in Frameworks */,
@@ -3977,6 +3976,7 @@
 				5D60D3532297353C001080D0 /* TPPMigrationManager.swift */,
 				73085E3425030D27008F6244 /* SEMigrations.swift */,
 				99895C63131766252D87F554 /* BackupExclusionMigration.swift */,
+				A303E282D7EFD80AED446401 /* LCPKeychainMigration.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -6235,6 +6235,7 @@
 				EE116B1078F648DCB8A52598 /* SEMigrationsTests.swift */,
 				9B3391CCE50BC961BC7A5726 /* TPPMigrationManagerTests.swift */,
 				040323DBE8E8E5AB1FBC517E /* BackupExclusionMigrationTests.swift */,
+				7DD56A046E056AE23C0ACBFA /* LCPKeychainMigrationTests.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -6323,7 +6324,6 @@
 				E5E9AFFB2CC035AC00366A2E /* ReadiumNavigator */,
 				E5E9AFFF2CC035AC00366A2E /* ReadiumStreamer */,
 				E5E9B2172CC1A5C100366A2E /* ReadiumAdapterLCPSQLite */,
-				E5E9B2192CC1A7AC00366A2E /* ReadiumAdapterGCDWebServer */,
 				E5F2E9B62CEE8550007EA6C9 /* PureLayout */,
 				E5E4AAD42EB292B600CC1D67 /* FirebaseRemoteConfig */,
 				E5E4AAD62EB292B600CC1D67 /* FirebaseRemoteConfigSwift */,
@@ -6372,7 +6372,6 @@
 				E5E9AFEF2CC0357500366A2E /* ReadiumNavigator */,
 				E5E9AFF32CC0357500366A2E /* ReadiumStreamer */,
 				E5E9B2132CC1A5AE00366A2E /* ReadiumAdapterLCPSQLite */,
-				E5E9B21D2CC1A7BB00366A2E /* ReadiumAdapterGCDWebServer */,
 				E5E4AAD02EB2929600CC1D67 /* FirebaseRemoteConfig */,
 				E5E4AAD22EB2929600CC1D67 /* FirebaseRemoteConfigSwift */,
 				7CE7C1867C784CE1A1ECBC0E /* stduritemplate */,
@@ -7326,6 +7325,7 @@
 				9C79111B63FEB6F84F93E2B0 /* TestAppContainerFactoryTests.swift in Sources */,
 				EA4E793DB293880E4CFCADC7 /* AppContainerIsolationLintTests.swift in Sources */,
 				A135764473E7ED860F338914 /* TearDownRequiredLintTests.swift in Sources */,
+				E0B9FECCEC6BA3D470A77FD7 /* LCPKeychainMigrationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7867,6 +7867,7 @@
 				9CB5EF8AC5E07776433AE678 /* StreamingReaderView.swift in Sources */,
 				1841AF92E817CC9D4A6CE829 /* Reachability+StreamingReader.swift in Sources */,
 				002A9388476ED8D595661599 /* LibrariesSectionViewModel.swift in Sources */,
+				AA225D8E76E146A5132FEA43 /* LCPKeychainMigration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8411,6 +8412,7 @@
 				DF972EB37CCA299788F9443E /* StreamingReaderView.swift in Sources */,
 				DF3CA61B57101027DA63290B /* Reachability+StreamingReader.swift in Sources */,
 				C4CDA0FAB4E0815ED71715E0 /* LibrariesSectionViewModel.swift in Sources */,
+				5C89F2830C766E791E48CE21 /* LCPKeychainMigration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9248,7 +9250,7 @@
 			repositoryURL = "https://github.com/readium/swift-toolkit.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.7.0;
+				version = 3.9.0;
 			};
 		};
 		E77D02232931357400544180 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {
@@ -9475,16 +9477,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E77D02182931337000544180 /* XCRemoteSwiftPackageReference "swift-toolkit" */;
 			productName = ReadiumAdapterLCPSQLite;
-		};
-		E5E9B2192CC1A7AC00366A2E /* ReadiumAdapterGCDWebServer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E77D02182931337000544180 /* XCRemoteSwiftPackageReference "swift-toolkit" */;
-			productName = ReadiumAdapterGCDWebServer;
-		};
-		E5E9B21D2CC1A7BB00366A2E /* ReadiumAdapterGCDWebServer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E77D02182931337000544180 /* XCRemoteSwiftPackageReference "swift-toolkit" */;
-			productName = ReadiumAdapterGCDWebServer;
 		};
 		E5F2E9B62CEE8550007EA6C9 /* PureLayout */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Palace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Palace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6555ca8e84d894b4be57b7ea8ac61e0892b411223d7ebba5d9a00d3fd9fe4899",
+  "originHash" : "6b3d05989d7ed978a5123126bc368d7901ded954f588f07dd50a100a638360e5",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/readium/swift-toolkit.git",
       "state" : {
-        "revision" : "907f35b67193e53361b7c7042ff1c2dee258f743",
-        "version" : "3.7.0"
+        "revision" : "de07026e9f825a5791f27a7ac4cd6bb1a784ab8d",
+        "version" : "3.9.0"
       }
     },
     {

--- a/Palace/AppInfrastructure/NavigationHostView.swift
+++ b/Palace/AppInfrastructure/NavigationHostView.swift
@@ -65,14 +65,12 @@ struct NavigationHostView<Content: View>: View {
                         // does NOT need the modifier (no reader → no
                         // suppression needed).
                         if let (publication, metadata) = coordinator.resolveReadiumPDF(for: bookRoute),
-                           let book = coordinator.resolveBook(for: bookRoute),
-                           let httpServer = AppContainer.production().readerService.httpServer {
+                           let book = coordinator.resolveBook(for: bookRoute) {
                             let toc = coordinator.resolveReadiumPDFTableOfContents(for: bookRoute)
                             ZStack {
                                 ReadiumPDFReaderView(
                                     publication: publication,
                                     book: book,
-                                    httpServer: httpServer,
                                     tableOfContents: toc?.toc ?? [],
                                     pageCount: toc?.pageCount ?? 0
                                 )

--- a/Palace/AppInfrastructure/ReaderService.swift
+++ b/Palace/AppInfrastructure/ReaderService.swift
@@ -1,7 +1,6 @@
 import UIKit
 import Combine
 import ReadiumShared
-import ReadiumAdapterGCDWebServer
 import PalaceLogging
 #if LCP
 import ReadiumLCP
@@ -38,20 +37,11 @@ final class ReaderService {
         return base
     }
 
-    /// Exposes the shared `GCDHTTPServer` so the PDF navigator (and any other
-    /// Readium-backed view) can serve decrypted publication resources through
-    /// the same server the EPUB path already uses — one server, one endpoint
-    /// registry, one lifecycle.
-    var httpServer: ReadiumAdapterGCDWebServer.GCDHTTPServer? {
-        r3Owner.libraryService.httpServer
-    }
-
     /// Tears down all in-memory state for an LCP-protected PDF: drops the
-    /// `Publication` from the navigation coordinator, removes the
-    /// `GCDHTTPServer` endpoint that was registered for the publication,
-    /// and clears the pending-open marker. The TOC + page-count snapshot
-    /// is intentionally preserved across this teardown so a re-open
-    /// repopulates side panels instantly.
+    /// `Publication` from the navigation coordinator and clears the
+    /// pending-open marker. The TOC + page-count snapshot is intentionally
+    /// preserved across this teardown so a re-open repopulates side panels
+    /// instantly.
     @MainActor
     func releaseReadiumPDF(forBookIdentifier identifier: String) {
         // Bump the generation so any in-flight openBook completion still
@@ -65,7 +55,6 @@ final class ReaderService {
         if LCPPDFOpenProgress.shared.bookIdentifier == identifier {
             LCPPDFOpenProgress.shared.finish()
         }
-        r3Owner.libraryService.releaseServedPublication(forBookIdentifier: identifier)
         AppContainer.production().navigationCoordinatorHub.coordinator?
             .removeReadiumPDF(forBookId: identifier)
     }
@@ -243,15 +232,14 @@ final class ReaderService {
                                     return
                                 }
                                 Log.info(#file, "[PERF] [LCP-PDF] T3 extracted+ready (+\(Self.ms(since: openStartedAt))ms total, extract=\(extractMs)ms)")
-                                // Release Readium publication — its work
-                                // is done, free its memory now.
-                                self.r3Owner.libraryService.releaseServedPublication(forBookIdentifier: bookIdentifier)
+                                // Readium publication's work is done (decrypt
+                                // context provided) — drop it; ARC frees it as
+                                // the enclosing closure's reference goes away.
                                 self.handOffExtractedPDF(at: extractedURL, for: book, openStartedAt: openStartedAt)
                             }
                         } catch {
                             Log.error(#file, "[PERF] [LCP-PDF] extract failed: \(error)")
                             await MainActor.run {
-                                self.r3Owner.libraryService.releaseServedPublication(forBookIdentifier: bookIdentifier)
                                 self.abortRunawayOpen(for: book)
                             }
                         }
@@ -260,7 +248,6 @@ final class ReaderService {
                     // Non-LCP build (open-source) — should never reach
                     // here because openPDF is only invoked for LCP books,
                     // but bail safely if it does.
-                    self.r3Owner.libraryService.releaseServedPublication(forBookIdentifier: book.identifier)
                     self.abortRunawayOpen(for: book)
                     #endif
                 }

--- a/Palace/Migrations/LCPKeychainMigration.swift
+++ b/Palace/Migrations/LCPKeychainMigration.swift
@@ -1,0 +1,79 @@
+//
+//  LCPKeychainMigration.swift
+//  Palace
+//
+//  One-time migration of LCP licenses + passphrases from the deprecated
+//  Readium `ReadiumAdapterLCPSQLite` repositories (Readium ≤ 3.7) to the
+//  built-in Keychain repositories introduced in Readium 3.8.0. The Keychain
+//  store is more secure, survives app reinstalls, and is iCloud-syncable.
+//
+//  The migration is idempotent and gated by a `UserDefaults` flag so it runs
+//  at most once per install. It degrades gracefully: a license that hasn't
+//  been migrated yet is simply re-validated from its stored `.lcpl` the next
+//  time the book is opened, so a missed or delayed run never loses access.
+//
+
+#if LCP
+
+import Foundation
+import ReadiumLCP
+import ReadiumAdapterLCPSQLite
+import PalaceLogging
+
+enum LCPKeychainMigration {
+    /// `UserDefaults` key recording that the SQLite→Keychain migration has
+    /// completed successfully. Once set, the migration is never re-run.
+    static let didMigrateKey = "TPP.lcpKeychainMigrationCompleted"
+
+    /// Runs the migration once, if it hasn't already completed.
+    ///
+    /// The actual repository copy is injected as `migrate` so the gating
+    /// behavior can be unit-tested without touching the real Keychain.
+    ///
+    /// - The flag is set **only on success**. If the copy throws (e.g. a
+    ///   transient Keychain error) the flag is left unset so the next launch
+    ///   retries — the underlying Readium `migrate(to:)` is idempotent.
+    static func runIfNeeded(
+        defaults: UserDefaults = .standard,
+        migrate: (() async throws -> Void)? = nil
+    ) async {
+        guard !defaults.bool(forKey: didMigrateKey) else { return }
+
+        do {
+            if let migrate {
+                try await migrate()
+            } else {
+                try await performReadiumMigration()
+            }
+            defaults.set(true, forKey: didMigrateKey)
+            Log.info(#file, "LCP SQLite→Keychain migration completed")
+        } catch {
+            Log.warn(#file, "LCP SQLite→Keychain migration did not complete (will retry next launch): \(error.localizedDescription)")
+        }
+    }
+
+    /// Copies all stored licenses and passphrases from the legacy SQLite
+    /// repositories into the Keychain repositories. A fresh install has no
+    /// legacy database, in which case the copy is a no-op.
+    ///
+    /// Marked `deprecated` so the *intentional* reads of the deprecated
+    /// `ReadiumAdapterLCPSQLite` repositories don't emit warnings — reading
+    /// the legacy store is the entire point of a one-time migration. This
+    /// function (and the `ReadiumAdapterLCPSQLite` dependency) should be
+    /// removed in a follow-up once migration adoption is complete.
+    @available(*, deprecated, message: "Intentionally reads the deprecated SQLite store for one-time migration.")
+    private static func performReadiumMigration() async throws {
+        let sqliteLicenses = try LCPSQLiteLicenseRepository()
+        let sqlitePassphrases = try LCPSQLitePassphraseRepository()
+        let keychainLicenses = LCPKeychainLicenseRepository()
+        let keychainPassphrases = LCPKeychainPassphraseRepository()
+
+        // Readium's `migrate(to:)` returns whether any rows were copied; we
+        // intentionally discard it — the migration is flag-gated and
+        // idempotent, so "did anything move" doesn't affect control flow.
+        _ = try await sqliteLicenses.migrate(to: keychainLicenses)
+        _ = try await sqlitePassphrases.migrate(to: keychainPassphrases)
+    }
+}
+
+#endif

--- a/Palace/Migrations/TPPMigrationManager.swift
+++ b/Palace/Migrations/TPPMigrationManager.swift
@@ -25,6 +25,13 @@ class TPPMigrationManager: NSObject {
         runMigrations(settings: settings)
         performPostUpdateTasksIfNeeded()
 
+        #if LCP
+        // Readium 3.8.0+: carry existing LCP licenses/passphrases from the
+        // deprecated SQLite store into the Keychain store. Idempotent and
+        // gated by its own flag; safe to fire-and-forget at launch.
+        Task { await LCPKeychainMigration.runIfNeeded() }
+        #endif
+
         // Update app version
         settings.appVersion = targetVersion
     }

--- a/Palace/PDF/ReadiumPDF/ReadiumPDFReaderView.swift
+++ b/Palace/PDF/ReadiumPDF/ReadiumPDFReaderView.swift
@@ -18,7 +18,6 @@
 
 import SwiftUI
 import ReadiumShared
-import ReadiumAdapterGCDWebServer
 import PalaceUIKit
 
 struct ReadiumPDFReaderView: View {
@@ -27,7 +26,6 @@ struct ReadiumPDFReaderView: View {
 
     let publication: Publication
     let book: TPPBook
-    let httpServer: GCDHTTPServer
 
     @EnvironmentObject var metadata: TPPPDFDocumentMetadata
     @EnvironmentObject var coordinator: NavigationCoordinator
@@ -40,10 +38,9 @@ struct ReadiumPDFReaderView: View {
     /// snapshot so the side panels stay referentially stable.
     private let document: TPPPDFDocument
 
-    init(publication: Publication, book: TPPBook, httpServer: GCDHTTPServer, tableOfContents: [TPPPDFLocation], pageCount: Int) {
+    init(publication: Publication, book: TPPBook, tableOfContents: [TPPPDFLocation], pageCount: Int) {
         self.publication = publication
         self.book = book
-        self.httpServer = httpServer
         self.document = TPPPDFDocument(tableOfContents: tableOfContents, pageCount: pageCount)
     }
 
@@ -89,7 +86,6 @@ struct ReadiumPDFReaderView: View {
         ReadiumPDFContainer(
             publication: publication,
             book: book,
-            httpServer: httpServer,
             initialPageIndex: metadata.currentPage,
             onLocationChange: { locator in
                 // First emission means page 1 actually rendered — flip

--- a/Palace/PDF/ReadiumPDF/ReadiumPDFViewController.swift
+++ b/Palace/PDF/ReadiumPDF/ReadiumPDFViewController.swift
@@ -13,7 +13,6 @@ import SwiftUI
 import PalaceLogging
 import ReadiumShared
 import ReadiumNavigator
-import ReadiumAdapterGCDWebServer
 
 /// Bridges Readium's `PDFNavigatorViewController` into Palace's reading-position
 /// sync (via `onLocationChange`) without Palace-layer code depending on
@@ -22,7 +21,6 @@ final class ReadiumPDFViewController: UIViewController {
 
     private let publication: Publication
     private let book: TPPBook
-    private let httpServer: GCDHTTPServer
 
     /// Legacy page index from the pre-migration pipeline (0-indexed). We can't
     /// build an accurate Locator at init time because `positionsByReadingOrder`
@@ -39,10 +37,9 @@ final class ReadiumPDFViewController: UIViewController {
     /// `TPPPDFDocumentMetadata.currentPage` → `TPPBookRegistry.setLocation`).
     var onLocationChange: ((Locator) -> Void)?
 
-    init(publication: Publication, book: TPPBook, httpServer: GCDHTTPServer, initialPageIndex: Int?) {
+    init(publication: Publication, book: TPPBook, initialPageIndex: Int?) {
         self.publication = publication
         self.book = book
-        self.httpServer = httpServer
         self.initialPageIndex = initialPageIndex
         super.init(nibName: nil, bundle: nil)
     }
@@ -65,12 +62,13 @@ final class ReadiumPDFViewController: UIViewController {
             let config = PDFNavigatorViewController.Configuration(
                 editingActions: ReaderEditingActions.resolve(for: book)
             )
+            // Readium 3.9.0: the PDF navigator no longer needs an HTTP server;
+            // it reads publication resources directly. Use the no-server init.
             let nav = try PDFNavigatorViewController(
                 publication: publication,
                 initialLocation: nil,
                 config: config,
-                delegate: self,
-                httpServer: httpServer
+                delegate: self
             )
             addChild(nav)
             view.addSubview(nav.view)
@@ -155,7 +153,6 @@ extension ReadiumPDFViewController: PDFNavigatorDelegate {
 struct ReadiumPDFContainer: UIViewControllerRepresentable {
     let publication: Publication
     let book: TPPBook
-    let httpServer: GCDHTTPServer
     let initialPageIndex: Int?
     let onLocationChange: (Locator) -> Void
 
@@ -163,7 +160,6 @@ struct ReadiumPDFContainer: UIViewControllerRepresentable {
         let vc = ReadiumPDFViewController(
             publication: publication,
             book: book,
-            httpServer: httpServer,
             initialPageIndex: initialPageIndex
         )
         vc.onLocationChange = onLocationChange

--- a/Palace/Reader2/Bookmarks/TPPBookLocation+Locator.swift
+++ b/Palace/Reader2/Bookmarks/TPPBookLocation+Locator.swift
@@ -17,10 +17,10 @@ extension TPPBookLocation {
             TPPBookLocation.bookProgressKey: locator.locations.totalProgression ?? 0.0,
             TPPBookLocation.titleKey: locator.title ?? "",
             TPPBookLocation.positionKey: locator.locations.position ?? 0,
-            TPPBookLocation.cssSelector: locator.locations.otherLocations[TPPBookLocation.cssSelector] ?? ""
+            TPPBookLocation.cssSelector: locator.locations.otherLocations[TPPBookLocation.cssSelector]?.string ?? ""
         ]
 
-        guard let jsonString = serializeJSONString(dict) else {
+        guard let jsonString = TPPBookLocation.jsonString(from: dict) else {
             Log.warn(#file, "Failed to serialize JSON string from dictionary - \(dict.debugDescription)")
             return nil
         }
@@ -60,12 +60,24 @@ extension TPPBookLocation {
             TPPBookLocation.cssSelector: cssSelector ?? ""
         ]
 
-        guard let jsonString = serializeJSONString(dict) else {
+        guard let jsonString = TPPBookLocation.jsonString(from: dict) else {
             Log.warn(#file, "Failed to serialize JSON string from dictionary - \(dict.debugDescription)")
             return nil
         }
 
         self.init(locationString: jsonString, renderer: renderer)
+    }
+
+    /// Serializes a location dictionary to a JSON string. Replaces Readium's
+    /// `serializeJSONString` free function, removed in the 3.9.0 JSONValue
+    /// migration. The payload is a plain Foundation `[String: Any]`, so
+    /// Foundation's `JSONSerialization` is the natural fit and round-trips with
+    /// the `JSONSerialization.jsonObject` deserialization in `convertToLocator`.
+    private static func jsonString(from dict: [String: Any]) -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: []) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
     }
 
     func convertToLocator(publication: Publication) async -> Locator? {
@@ -95,7 +107,7 @@ extension TPPBookLocation {
             progression: dict[TPPBookLocation.chapterProgressKey] as? Double,
             totalProgression: dict[TPPBookLocation.bookProgressKey] as? Double,
             position: position,
-            otherLocations: dict[TPPBookLocation.cssSelector].map { [TPPBookLocation.cssSelector: $0] } ?? [:]
+            otherLocations: JSONValue(dict[TPPBookLocation.cssSelector]).map { [TPPBookLocation.cssSelector: $0] } ?? [:]
         )
 
         return Locator(

--- a/Palace/Reader2/BusinessLogic/TPPLastReadPositionPoster.swift
+++ b/Palace/Reader2/BusinessLogic/TPPLastReadPositionPoster.swift
@@ -114,7 +114,7 @@ class TPPLastReadPositionPoster {
     /// it round-trips through `TPPAnnotations.postReadingPosition`'s
     /// existing `selectorValue` parameter.
     private func makeSnapshot(from locator: Locator) -> PositionSnapshot? {
-        guard let selectorValue = locator.jsonString else { return nil }
+        guard let selectorValue = try? locator.jsonString() else { return nil }
         return PositionSnapshot(
             bookID: book.identifier,
             format: .epubLocator,

--- a/Palace/Reader2/Internal/Publication+NYPLAdditions.swift
+++ b/Palace/Reader2/Internal/Publication+NYPLAdditions.swift
@@ -27,7 +27,7 @@ extension Publication {
         // The Publication stores all bookmarks (and TOC; positions in general) in
         // the `readingOrder` list. Each `Link` stores its metadata in a
         // `properties` dictionary.
-        return readingOrder.first { $0.properties["id"] as? String == idref }
+        return readingOrder.first { $0.properties["id"]?.string == idref }
     }
 
     /// Derives the `idref` (often used in Readium 1) from a Readium 2 `href`.
@@ -45,7 +45,7 @@ extension Publication {
     /// be usable in R1 contexts.
     func idref(forHref href: String) -> String? {
         let link = Link(href: href)
-        return link.properties["id"] as? String
+        return link.properties["id"]?.string
     }
 
     /// Shortcut helper to get the publication ID.

--- a/Palace/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Palace/Reader2/ReaderPresentation/ReaderModule.swift
@@ -57,7 +57,6 @@ final class ReaderModule: ReaderModuleAPI {
     var formatModules: [ReaderFormatModule] = []
 
     init(delegate: ModuleDelegate?,
-         resourcesServer: HTTPServer,
          bookRegistry: TPPBookRegistryProvider,
          userAccount: TPPUserAccount = AppContainer.production().accountsManager.currentUserAccount) {
         self.delegate = delegate
@@ -66,7 +65,7 @@ final class ReaderModule: ReaderModuleAPI {
         self.progressSynchronizer = TPPLastReadPositionSynchronizer(bookRegistry: bookRegistry)
 
         formatModules = [
-            EPUBModule(delegate: self.delegate, resourcesServer: resourcesServer)
+            EPUBModule(delegate: self.delegate)
         ]
     }
 

--- a/Palace/Reader2/ReaderPresentation/ReadingFormats/EPUBModule.swift
+++ b/Palace/Reader2/ReaderPresentation/ReadingFormats/EPUBModule.swift
@@ -17,11 +17,9 @@ import ReadiumShared
 final class EPUBModule: ReaderFormatModule {
 
     weak var delegate: ModuleDelegate?
-    let resourcesServer: HTTPServer
 
-    init(delegate: ModuleDelegate?, resourcesServer: HTTPServer) {
+    init(delegate: ModuleDelegate?) {
         self.delegate = delegate
-        self.resourcesServer = resourcesServer
     }
 
     func supports(_ publication: Publication) -> Bool {
@@ -42,7 +40,6 @@ final class EPUBModule: ReaderFormatModule {
         let epubVC = try TPPEPUBViewController(publication: publication,
                                                book: book,
                                                initialLocation: initialLocation,
-                                               resourcesServer: resourcesServer,
                                                forSample: forSample)
         epubVC.moduleDelegate = delegate
         return epubVC

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
@@ -250,8 +250,14 @@ public actor DRMDataResource: Resource {
 
 extension ResourceProperties {
     public var length: UInt64? {
-        get { self["length"] }
-        set { self["length"] = newValue }
+        // Readium 3.9.0: ResourceProperties values must be JSONValueEncodable
+        // *and* JSONValueDecodable. UInt64 is only Encodable, so persist as Int
+        // (which conforms to both) and bridge to UInt64 at this typed accessor.
+        get {
+            let value: Int? = self["length"]
+            return value.map(UInt64.init)
+        }
+        set { self["length"] = newValue.map { Int($0) } }
     }
 }
 

--- a/Palace/Reader2/ReaderStackConfiguration/LCP/LCPLibraryService.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LCP/LCPLibraryService.swift
@@ -15,7 +15,6 @@ import UIKit
 import PalaceAudiobookToolkit
 import ReadiumShared
 import ReadiumLCP
-import ReadiumAdapterLCPSQLite
 
 @objc class LCPLibraryService: NSObject, DRMLibraryService {
 
@@ -36,27 +35,25 @@ import ReadiumAdapterLCPSQLite
     private var lcpService: LCPService? {
         serviceQueue.sync {
             if _lcpService == nil {
-                do {
-                    let licenseRepo = try LCPSQLiteLicenseRepository()
-                    let passphraseRepo = try LCPSQLitePassphraseRepository()
+                serviceLock.lock()
+                defer { serviceLock.unlock() }
 
-                    serviceLock.lock()
-                    defer { serviceLock.unlock() }
+                // Readium 3.8.0+: license/passphrase storage moved from the
+                // deprecated SQLite repositories to the Keychain repositories
+                // (more secure, survives reinstall, iCloud-syncable). Existing
+                // patrons' SQLite data is carried over once by
+                // `LCPKeychainMigration` (run at launch); a license that hasn't
+                // migrated yet simply re-validates from its stored `.lcpl`.
+                let licenseRepo = LCPKeychainLicenseRepository()
+                let passphraseRepo = LCPKeychainPassphraseRepository()
 
-                    _lcpService = LCPService(
-                        client: TPPLCPClient(),
-                        licenseRepository: licenseRepo,
-                        passphraseRepository: passphraseRepo,
-                        assetRetriever: AssetRetriever(httpClient: LCPCredentialStrippingHTTPClient()),
-                        httpClient: LCPCredentialStrippingHTTPClient()
-                    )
-                } catch {
-                    TPPErrorLogger.logError(error, summary: "Failed to initialize LCPService", metadata: [
-                        "error": error.localizedDescription,
-                        "errorType": String(describing: type(of: error))
-                    ])
-                    return nil
-                }
+                _lcpService = LCPService(
+                    client: TPPLCPClient(),
+                    licenseRepository: licenseRepo,
+                    passphraseRepository: passphraseRepo,
+                    assetRetriever: AssetRetriever(httpClient: LCPCredentialStrippingHTTPClient()),
+                    httpClient: LCPCredentialStrippingHTTPClient()
+                )
             }
             return _lcpService
         }

--- a/Palace/Reader2/ReaderStackConfiguration/LibraryService.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LibraryService.swift
@@ -2,25 +2,21 @@ import Foundation
 import UIKit
 import ReadiumShared
 import ReadiumStreamer
-import ReadiumAdapterGCDWebServer
 
 /// The LibraryService makes a book ready for presentation without dealing
 /// with the specifics of how a book should be presented.
 ///
 /// It sets up the various components necessary for presenting a book,
-/// such as the HTTP server, DRM systems, etc.
+/// such as the DRM systems and publication opener.
 final class LibraryService: Loggable {
 
     private let assetRetriever: AssetRetriever
     private let publicationOpener: PublicationOpener
     private var drmLibraryServices = [DRMLibraryService]()
 
-    let httpServer: GCDHTTPServer
-
     init() {
         let httpClient = DefaultHTTPClient()
         assetRetriever = AssetRetriever(httpClient: httpClient)
-        httpServer = GCDHTTPServer(assetRetriever: assetRetriever)
 
         // DRM configurations
         #if LCP
@@ -59,7 +55,6 @@ final class LibraryService: Loggable {
                 if !self.validatePublication(publication, for: book.identifier, completion: completion) {
                     return
                 }
-                self.preparePresentation(of: publication, book: book)
                 completion(.success(publication))
 
             case .failure(let error):
@@ -82,7 +77,6 @@ final class LibraryService: Loggable {
                 if !self.validatePublication(publication, for: book.identifier, completion: completion) {
                     return
                 }
-                self.preparePresentation(of: publication, book: book)
                 completion(.success(publication))
 
             case .failure(let error):
@@ -112,43 +106,6 @@ final class LibraryService: Loggable {
         }
     }
 
-    private func preparePresentation(of publication: Publication, book: TPPBook) {
-        guard let selfLink = publication.linkWithRel(.self), selfLink.href.isHTTPURL else {
-            let endpoint = "/publications/\(book.identifier)"
-
-            do {
-                try httpServer.serve(at: endpoint, publication: publication)
-            } catch {
-                log(.error, "Failed to serve publication at endpoint \(endpoint): \(error)")
-            }
-            return
-        }
-
-        if let selfLinkURL = URL(string: selfLink.href)?.standardized {
-            log(.debug, "Serving at URL: \(selfLinkURL)")
-        } else {
-            log(.error, "Malformed self link: \(selfLink.href)")
-        }
-    }
-
-    /// Deregisters the HTTP-server endpoint that was created in
-    /// `preparePresentation` so the per-publication handlers +
-    /// resource transformers can be released. Call from the reader's
-    /// dismiss path — without this, every open accumulates a new
-    /// endpoint handler in `GCDHTTPServer.handlers` even after the
-    /// publication itself releases.
-    @MainActor
-    func releaseServedPublication(forBookIdentifier identifier: String) {
-        let endpoint = "/publications/\(identifier)"
-        do {
-            try httpServer.remove(at: endpoint)
-        } catch {
-            // Endpoint may already be gone (publication never opened
-            // via `preparePresentation`, or was served at a self-link
-            // URL instead). Not actionable; log and move on.
-            log(.debug, "GCDHTTPServer.remove(at: \(endpoint)) no-op: \(error.localizedDescription)")
-        }
-    }
     private func validatePublication(_ publication: Publication, for identifier: String, completion: (Result<Publication, LibraryServiceError>) -> Void) -> Bool {
         guard !publication.isRestricted else {
             stopOpeningIndicator(identifier: identifier)
@@ -171,11 +128,3 @@ final class LibraryService: Loggable {
     }
 }
 
-extension String {
-    var isHTTPURL: Bool {
-        if let url = URL(string: self), url.scheme == "http" || url.scheme == "https" {
-            return true
-        }
-        return false
-    }
-}

--- a/Palace/Reader2/ReaderStackConfiguration/TPPR3Owner.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/TPPR3Owner.swift
@@ -28,7 +28,6 @@ import PalaceLogging
         super.init()
         libraryService = LibraryService()
         readerModule = ReaderModule(delegate: self,
-                                    resourcesServer: libraryService.httpServer,
                                     bookRegistry: bookRegistry)
 
         ReadiumEnableLog(withMinimumSeverityLevel: .debug)

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -28,7 +28,6 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
     init(publication: Publication,
          book: TPPBook,
          initialLocation: Locator?,
-         resourcesServer: HTTPServer,
          preferences: EPUBPreferences = TPPReaderPreferencesLoad(),
          forSample: Bool = false,
          navigationHub: NavigationCoordinatorHub = AppContainer.production().navigationCoordinatorHub) throws {
@@ -66,11 +65,13 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
             debugState: true
         )
 
+        // Readium 3.8.0+: the EPUB navigator serves publication resources via
+        // an internal custom URL-scheme handler and no longer needs an HTTP
+        // server. The `httpServer:` init is deprecated; use the no-server init.
         let navigator = try EPUBNavigatorViewController(
             publication: publication,
             initialLocation: initialLocation,
-            config: config,
-            httpServer: resourcesServer
+            config: config
         )
 
         super.init(navigator: navigator, publication: publication, book: book, forSample: forSample, initialLocation: initialLocation)

--- a/PalaceTests/DRM/ResourcePropertiesLengthTests.swift
+++ b/PalaceTests/DRM/ResourcePropertiesLengthTests.swift
@@ -1,0 +1,43 @@
+//
+//  ResourcePropertiesLengthTests.swift
+//  PalaceTests
+//
+//  Pins the Readium 3.9.0 JSONValue bridge in the `ResourceProperties.length`
+//  extension (AdobeDRMContentProtection.swift). 3.9.0 made the
+//  `ResourceProperties` subscript require `JSONValueEncodable & JSONValueDecodable`;
+//  `UInt64` is encode-only, so length is persisted as `Int` and bridged back to
+//  `UInt64` at this accessor. A regression — storing the wrong type, dropping
+//  the bridge, or truncating to 32 bits — breaks one of these round-trips.
+//
+//  The `length` extension is `public` and compiled into the (DRM) Palace
+//  module, so it is reachable here via `@testable import Palace` without a
+//  `FEATURE_DRM_CONNECTOR` guard — which the PalaceTests target does not define.
+//
+
+import XCTest
+import ReadiumShared
+@testable import Palace
+
+final class ResourcePropertiesLengthTests: XCTestCase {
+
+    func testLength_roundTripsLargeValueWithoutTruncation() {
+        var props = ResourceProperties()
+        // > UInt32.max so a 32-bit truncation regression is caught.
+        let value: UInt64 = 4_294_967_296
+        props.length = value
+        XCTAssertEqual(props.length, value,
+                       "length must round-trip unchanged through the Int-backed JSONValue store")
+    }
+
+    func testLength_isNilWhenUnset() {
+        let props = ResourceProperties()
+        XCTAssertNil(props.length, "length must be nil when nothing was stored")
+    }
+
+    func testLength_zeroRoundTrips() {
+        var props = ResourceProperties()
+        props.length = 0
+        XCTAssertEqual(props.length, 0,
+                       "a stored zero must read back as zero, not nil")
+    }
+}

--- a/PalaceTests/Migrations/LCPKeychainMigrationTests.swift
+++ b/PalaceTests/Migrations/LCPKeychainMigrationTests.swift
@@ -1,0 +1,76 @@
+//
+//  LCPKeychainMigrationTests.swift
+//  PalaceTests
+//
+//  Verifies the one-time gating contract of the LCP SQLite→Keychain
+//  migration: it runs once when unflagged, skips when already done, and
+//  leaves the flag unset on failure so the next launch retries. The actual
+//  Readium repository copy is injected so these tests never touch the real
+//  Keychain.
+//
+
+#if LCP
+
+import XCTest
+@testable import Palace
+
+final class LCPKeychainMigrationTests: XCTestCase {
+
+    private let suiteName = "LCPKeychainMigrationTests.suite"
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testRunIfNeeded_whenFlagUnset_runsMigrationAndSetsFlag() async {
+        var ran = false
+
+        await LCPKeychainMigration.runIfNeeded(defaults: defaults, migrate: { ran = true })
+
+        XCTAssertTrue(ran, "Migration work must run when the flag is unset")
+        XCTAssertTrue(defaults.bool(forKey: LCPKeychainMigration.didMigrateKey),
+                      "Flag must be set after a successful migration")
+    }
+
+    func testRunIfNeeded_whenFlagAlreadySet_skipsMigration() async {
+        defaults.set(true, forKey: LCPKeychainMigration.didMigrateKey)
+        var ran = false
+
+        await LCPKeychainMigration.runIfNeeded(defaults: defaults, migrate: { ran = true })
+
+        XCTAssertFalse(ran, "Migration work must NOT run once the flag is set")
+    }
+
+    func testRunIfNeeded_whenMigrationThrows_leavesFlagUnsetAndRetriesNextTime() async {
+        struct MigrationError: Error {}
+        var attempts = 0
+
+        await LCPKeychainMigration.runIfNeeded(defaults: defaults, migrate: {
+            attempts += 1
+            throw MigrationError()
+        })
+
+        XCTAssertEqual(attempts, 1, "Migration should have been attempted once")
+        XCTAssertFalse(defaults.bool(forKey: LCPKeychainMigration.didMigrateKey),
+                       "Flag must stay unset on failure so the next launch retries")
+
+        // A subsequent launch must retry because the flag is still unset.
+        await LCPKeychainMigration.runIfNeeded(defaults: defaults, migrate: {
+            attempts += 1
+            throw MigrationError()
+        })
+
+        XCTAssertEqual(attempts, 2, "An unflagged failed migration must retry on the next run")
+    }
+}
+
+#endif

--- a/PalaceTests/Reader/EPUBPositionTests.swift
+++ b/PalaceTests/Reader/EPUBPositionTests.swift
@@ -8,6 +8,7 @@
 //
 
 import XCTest
+import ReadiumShared
 @testable import Palace
 
 final class EPUBPositionTests: XCTestCase {
@@ -116,5 +117,78 @@ final class EPUBPositionTests: XCTestCase {
                              "Throttling interval must be positive to prevent infinite sync loops")
         XCTAssertLessThan(TPPLastReadPositionPoster.throttlingInterval, 60,
                           "Throttling interval must be less than 60s to ensure position is saved frequently enough")
+    }
+
+    // MARK: - Locator round-trip (PP-4340 JSONValue migration)
+
+    /// Covers the serialization path changed by the Readium 3.9.0 JSONValue
+    /// migration: `init?(locator:)` reads `otherLocations[cssSelector]?.string`
+    /// and serializes via the new Foundation `jsonString(from:)` helper, and
+    /// `convertToLocator` rebuilds `otherLocations` as `[String: JSONValue]`.
+    /// A regression on any changed line — dropping `.string`, failing to wrap
+    /// the value in `JSONValue`, or a broken serializer — breaks this
+    /// round-trip while leaving the pre-existing string/dictionary tests green.
+    func testLocatorRoundTrip_preservesCssSelectorPositionProgression_throughJSONValue() async {
+        let publication = Self.makeTestPublication()
+        guard let href = AnyURL(string: "/chapter1.xhtml") else {
+            return XCTFail("invalid test href")
+        }
+        let original = Locator(
+            href: href,
+            mediaType: .xhtml,
+            title: "Chapter One",
+            locations: Locator.Locations(
+                progression: 0.5,
+                totalProgression: 0.25,
+                position: 7,
+                otherLocations: ["cssSelector": .string("#para-3")]
+            )
+        )
+
+        guard let bookLocation = TPPBookLocation(locator: original,
+                                                 type: "LocatorHrefProgression",
+                                                 publication: publication) else {
+            return XCTFail("TPPBookLocation(locator:) returned nil")
+        }
+        // The `?.string` read + `jsonString(from:)` serializer must have emitted the selector.
+        XCTAssertTrue(bookLocation.locationString.contains("#para-3"),
+                      "cssSelector must appear in the serialized locationString")
+
+        let restored = await bookLocation.convertToLocator(publication: publication)
+        XCTAssertEqual(restored?.locations.otherLocations["cssSelector"]?.string, "#para-3",
+                       "cssSelector must survive the JSONValue bridge in convertToLocator")
+        XCTAssertEqual(restored?.locations.position, 7)
+        XCTAssertEqual(restored?.locations.progression, 0.5)
+        XCTAssertEqual(restored?.title, "Chapter One")
+    }
+
+    /// Edge: no cssSelector exercises the `?? ""` / `?? [:]` branches — the
+    /// round-trip must still succeed and must not fabricate a non-empty selector.
+    func testLocatorRoundTrip_withoutCssSelector_succeedsAndPreservesPosition() async {
+        let publication = Self.makeTestPublication()
+        guard let href = AnyURL(string: "/chapter1.xhtml") else {
+            return XCTFail("invalid test href")
+        }
+        let original = Locator(
+            href: href,
+            mediaType: .xhtml,
+            locations: Locator.Locations(progression: 0.1, totalProgression: 0.1, position: 2)
+        )
+        guard let bookLocation = TPPBookLocation(locator: original,
+                                                 type: "LocatorHrefProgression",
+                                                 publication: publication) else {
+            return XCTFail("TPPBookLocation(locator:) returned nil")
+        }
+        let restored = await bookLocation.convertToLocator(publication: publication)
+        XCTAssertNotNil(restored, "round-trip must succeed without a cssSelector")
+        XCTAssertEqual(restored?.locations.position, 2)
+        XCTAssertEqual(restored?.locations.otherLocations["cssSelector"]?.string ?? "", "",
+                       "no real selector should be fabricated when none was provided")
+    }
+
+    private static func makeTestPublication() -> Publication {
+        let metadata = Metadata(title: "Test", languages: ["en"])
+        let readingOrder = [Link(href: "/chapter1.xhtml", mediaType: .xhtml)]
+        return Publication(manifest: Manifest(metadata: metadata, readingOrder: readingOrder))
     }
 }


### PR DESCRIPTION
Upgrades Readium swift-toolkit 3.7.0 → 3.9.0 in ios-core and the `ios-audiobooktoolkit` submodule (which links `ReadiumShared` directly and must move in lockstep — submodule PR: ThePalaceProject/ios-audiobooktoolkit#181, already merged).

## Breaking-change migrations applied

**JSONValue (3.9.0)** — `serializeJSONString` was removed and `Locator.jsonString`/`otherLocations`/`Link.properties`/`ResourceProperties` are now `JSONValue`-typed:
- `TPPBookLocation+Locator`: serialize via Foundation `JSONSerialization`; read `otherLocations[...]?.string`; build `Locator.Locations(otherLocations:)` with `[String: JSONValue]`.
- `TPPLastReadPositionPoster`: `locator.jsonString` (property) → `try? locator.jsonString()` (throwing method).
- `Publication+NYPLAdditions`: `link.properties["id"]?.string`.
- `AdobeDRMContentProtection`: `ResourceProperties.length` stored as `Int` (the subscript now requires `JSONValueEncodable & JSONValueDecodable`; `UInt64` is encode-only) and bridged back to `UInt64`.

**HTTP-server removal (EPUB 3.8.0, PDF 3.9.0)** — both navigators serve resources via an internal custom URL-scheme handler now:
- EPUB + PDF navigators migrated off the deprecated `httpServer:` inits.
- `GCDHTTPServer` infrastructure removed from `LibraryService`/`ReaderService` and the `resourcesServer` plumbing chain; the `ReadiumAdapterGCDWebServer` SPM product removed from the project.

**LCP SQLite → Keychain (3.8.0)** — `LCPLibraryService` now uses the Keychain license/passphrase repositories; a new one-time, flag-gated, idempotent `LCPKeychainMigration` carries existing patrons' licenses over at launch (degrades gracefully — an un-migrated license re-validates from its stored `.lcpl`). `ReadiumAdapterLCPSQLite` is intentionally kept solely for the migrator (one self-documented deprecation; removal deferred to a follow-up).

## Verification
- `Palace` + `Palace-noDRM` build clean on 3.9.0.
- Full unit suite + 26 reader-position/bookmark round-trip tests pass; 5 new tests (Locator↔TPPBookLocation round-trip + `ResourceProperties.length` bridge) close the changed-line coverage gaps.
- Runtime smoke (sim): app launches stable; LCP migration fires without crash; **EPUB open → render → 144-page paginate → swipe page-turn → cross-session position-resume** all validated via the new no-HTTP-server navigator.
- Architect + QA (SoD) reviews approved.

## Follow-up (regression next week)
PDF / LCP-PDF, audiobook playback, in-reader search, TTS, and rotation-preserves-preferences need a backend-connected smoke (A1QA fixtures); EPUB is already covered above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)