### PR TITLE
ci: trustworthy board + put the gate tooling under CI

### DIFF
--- a/.github/workflows/tooling-checks.yml
+++ b/.github/workflows/tooling-checks.yml
@@ -1,0 +1,76 @@
+name: Tooling Checks
+# Fast integrity gate for the harness/CI tooling itself — the scripts, hooks,
+# and detectors that gate everything else. CI historically only ran
+# `xcodebuild test`, so a broken verify-pr.sh (bash syntax error) or a
+# commit-blocking pre-commit hook could ship green (PR #1045). This job runs
+# on every PR in ~1 minute on an ubuntu runner (no Xcode) and closes that gap:
+#   1. bash -n on every committed shell script  (catches syntax breaks)
+#   2. pytest on the detector suite              (catches detector logic regressions)
+#   3. the pre-commit hook fixture test          (catches hook-wiring regressions)
+on: [ pull_request, workflow_dispatch ]
+concurrency:
+  group: tooling-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tooling-integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (no submodules — tooling is in-repo)
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install test deps
+        run: pip install --quiet pytest
+
+      # 1. Syntax-check every committed shell script. `scripts/hooks` is a
+      #    machine-local symlink into the harness (absent on CI), so it is
+      #    excluded via -type f (symlinks are skipped by find -type f).
+      - name: bash -n all shell scripts
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r f; do
+            if ! bash -n "$f"; then
+              echo "::error file=$f::bash syntax error"
+              fail=1
+            fi
+          done < <(find scripts -type f -name '*.sh' 2>/dev/null | sort)
+          if [ "$fail" -ne 0 ]; then
+            echo "One or more shell scripts have a syntax error."
+            exit 1
+          fi
+          echo "All committed shell scripts pass bash -n."
+
+      # 1b. verify-pr.sh is the pre-PR battery — assert it specifically parses,
+      #     since a break there silently aborts the whole local gate.
+      - name: bash -n verify-pr.sh (explicit)
+        run: bash -n scripts/verify-pr.sh
+
+      # 2. Detector logic suite. These are the Phase 3.5 class-detectable
+      #    detectors + the M1 checks that have pytest coverage.
+      - name: pytest detector suite
+        run: |
+          if [ -d scripts/tests ]; then
+            python3 -m pytest scripts/tests/ -q
+          else
+            echo "No scripts/tests/ — skipping."
+          fi
+
+      # 3. Hook-wiring fixture test. Proves the pre-commit detector hook
+      #    correctly blocks on a violation, identifies the detector, and honors
+      #    bypass envvars — and that every wired detector is invoked with an
+      #    interface it accepts (the bug that would have blocked every commit).
+      - name: pre-commit detector hook fixture test
+        run: |
+          if [ -f scripts/tests/test_pre_commit_phase35_detectors.sh ]; then
+            bash scripts/tests/test_pre_commit_phase35_detectors.sh
+          else
+            echo "No hook fixture test — skipping."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,52 @@ xcodebuild -project Palace.xcodeproj -scheme Palace \
 - Two targets: `Palace` (full DRM) and `Palace-noDRM` (open-source)
 - DRM builds run natively on Apple Silicon — Rosetta is no longer required
 
+## CI/CD reliability — the green-board contract
+
+A CI board that is usually-red-from-flakes provides **no signal** — it trains
+everyone to ignore CI and admin-merge, and a real failure then hides in the
+noise. (That is exactly how PR #1045 shipped a `verify-pr.sh` that didn't pass
+`bash -n` and a pre-commit hook that would have blocked every commit: the board
+was already red from pollution, so nobody trusted it.) The contract below keeps
+the board trustworthy.
+
+**1. Flakes don't redden the board; real failures do.** `scripts/xcode-test-optimized.sh`
+runs with `-retry-tests-on-failure -test-iterations 3`. A test that passes on
+any of 3 attempts counts as a pass; a real failure fails all 3 and stays red.
+Retry is a safety net, **not** a substitute for fixing pollution — see #2.
+
+**2. Fix test pollution at the root; do not just document flake #N.** The
+recurring red is shared mutable state bleeding across tests (`.shared`
+singletons, `AccountsManager()` background `loadCatalogs` outliving the test,
+layout-engine-off-main, keychain/UserDefaults bleed). When a flake appears: run
+the polluter-diagnosis (`scripts/find-test-polluter.sh`) to find the test that
+leaves state dirty, then fix the leak (tear down the singleton, await the
+background task, force main-thread layout). Adding a sixth "known flake" memo is
+not a fix.
+
+**3. The tooling is under CI too.** `verify-pr.sh`, the detectors, and the
+pre-commit hooks gate everything else, so they get their own gate:
+`.github/workflows/tooling-checks.yml` runs `bash -n` on every committed shell
+script, the detector pytests (`scripts/tests/`), and the hook fixture test on
+every PR (~1 min, ubuntu). A broken gate script is a CI failure, not a
+ship-green surprise.
+
+**4. Don't land a gate faster than you can verify it.** A new detector / hook /
+verify-pr gate does not merge until: (a) it has a pytest in `scripts/tests/`;
+(b) its **wiring** is end-to-end tested — the hook fixture test
+(`test_pre_commit_phase35_detectors.sh`) must exercise the new detector,
+including a **clean-diff pass** assertion (a detector invoked with an interface
+it rejects must not block); (c) it's been dry-run on the current tree for zero
+false positives. Wiring bugs (a scan-only detector called with `--diff`) are
+invisible to a fixture that only ever stages a violation — always assert the
+clean path passes too.
+
+**5. Retire the admin-merge reflex.** Once the board is trustworthy (1–4), red
+means **stop**. `--admin` over a red check is allowed ONLY when the failure is a
+specific, named, already-tracked flake that passes in isolation — and that flake
+must have a de-flake item per #2. Never `--admin` over a red board whose failure
+you have not individually identified; that is how real breakage lands.
+
 ## Project Structure
 
 ```

--- a/scripts/find-test-polluter.sh
+++ b/scripts/find-test-polluter.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# find-test-polluter.sh — diagnose test-pollution flakes by bisection.
+#
+# Flaky CI failures in this repo are almost always test pollution: a test that
+# passes in isolation but fails in the full suite because an earlier test left
+# shared mutable state dirty (`.shared` singletons, AccountsManager() background
+# loadCatalogs outliving the test, layout-engine-off-main, keychain/UserDefaults
+# bleed). Retry (-retry-tests-on-failure) masks these on the board; this tool
+# finds the ACTUAL polluter so it can be fixed at the root.
+#
+# Strategy:
+#   1. Run the VICTIM class alone. If it fails alone, it's a real bug, not
+#      pollution — stop and say so.
+#   2. If it passes alone, run each SUSPECT class immediately before the victim
+#      (`-only-testing:SUSPECT -only-testing:VICTIM`, in that order). The first
+#      suspect that makes the victim fail is a polluter — report it.
+#
+# Usage:
+#   scripts/find-test-polluter.sh --victim AudiobookBookmarkBusinessLogicTests \
+#       [--suspects "ClassA ClassB ClassC"] \
+#       [--sim <UDID>]
+#
+#   --victim    Required. The XCTest class that flakes in the full suite.
+#   --suspects  Space-separated candidate polluter classes. If omitted, supply
+#               the classes that ran BEFORE the victim in the failing run
+#               (xcodebuild runs classes alphabetically by default, so the
+#               polluter is usually alphabetically-earlier and shares a
+#               subsystem — auth, audiobook, registry, account).
+#   --sim       Simulator UDID. Defaults to first booted, else first available
+#               iPhone 16 Pro.
+#
+# Output: the first suspect that reproduces the victim's failure, or "no
+# polluter found among suspects" (widen the suspect list).
+
+set -uo pipefail
+
+PROJECT="Palace.xcodeproj"
+SCHEME="Palace"
+VICTIM=""
+SUSPECTS=""
+SIM_UDID=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --victim)   VICTIM="$2"; shift 2 ;;
+    --suspects) SUSPECTS="$2"; shift 2 ;;
+    --sim)      SIM_UDID="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$VICTIM" ]; then
+  echo "ERROR: --victim <TestClass> is required." >&2
+  exit 2
+fi
+
+if [ -z "$SIM_UDID" ]; then
+  SIM_UDID=$(xcrun simctl list devices iPhone | awk '/Booted/ {print $NF; exit}' | tr -d '()')
+  if [ -z "$SIM_UDID" ]; then
+    SIM_UDID=$(xcrun simctl list devices available \
+      | grep "iPhone 16 Pro (" | grep -oE '[0-9A-Fa-f-]{36}' | head -1)
+  fi
+fi
+if [ -z "$SIM_UDID" ]; then
+  echo "ERROR: no simulator found; pass --sim <UDID>." >&2
+  exit 2
+fi
+echo "Simulator: $SIM_UDID"
+
+DD=$(mktemp -d -t polluter-dd.XXXX)
+trap 'rm -rf "$DD"' EXIT
+
+# Returns 0 if the given -only-testing selectors all pass, non-zero otherwise.
+run_tests() {
+  local label="$1"; shift
+  local args=()
+  local sel
+  for sel in "$@"; do args+=(-only-testing:"PalaceTests/$sel"); done
+  echo "  → $label: ${args[*]}"
+  xcodebuild test \
+    -project "$PROJECT" -scheme "$SCHEME" \
+    -destination "platform=iOS Simulator,id=$SIM_UDID" \
+    -derivedDataPath "$DD" \
+    "${args[@]}" >/tmp/polluter-run.log 2>&1
+  return $?
+}
+
+echo ""
+echo "=== Step 1: does $VICTIM pass in isolation? ==="
+if run_tests "isolation" "$VICTIM"; then
+  echo "  PASS alone → $VICTIM is a pollution VICTIM (real bug ruled out)."
+else
+  echo ""
+  echo "RESULT: $VICTIM FAILS in isolation — this is a REAL bug, not pollution."
+  echo "        Fix the test/production code; pollution bisection does not apply."
+  echo "        (tail of run log:)"
+  tail -15 /tmp/polluter-run.log | sed 's/^/    /'
+  exit 1
+fi
+
+if [ -z "$SUSPECTS" ]; then
+  echo ""
+  echo "No --suspects given. Re-run with the classes that executed BEFORE"
+  echo "$VICTIM in the failing run, e.g.:"
+  echo "  scripts/find-test-polluter.sh --victim $VICTIM \\"
+  echo "      --suspects \"TokenRefreshAndRetryQueueTests AccountsManagerStateMachineWiringTests ...\""
+  exit 0
+fi
+
+echo ""
+echo "=== Step 2: bisect suspects (each run: SUSPECT then $VICTIM) ==="
+FOUND=""
+for s in $SUSPECTS; do
+  if run_tests "pair" "$s" "$VICTIM"; then
+    echo "    $s → victim still passes (not the polluter)"
+  else
+    echo "    $s → victim FAILS after this class ran first ***"
+    FOUND="$s"
+    break
+  fi
+done
+
+echo ""
+if [ -n "$FOUND" ]; then
+  echo "RESULT: polluter is '$FOUND'."
+  echo "  '$FOUND' leaves shared state dirty that breaks '$VICTIM'."
+  echo "  Fix at the root: tear down the singleton / await the background task /"
+  echo "  reset UserDefaults+keychain in '$FOUND' tearDown (or the SUT it drives)."
+  exit 1
+else
+  echo "RESULT: no polluter found among the given suspects."
+  echo "  Widen --suspects (the polluter may be a class you didn't list), or the"
+  echo "  failure may need ≥2 classes in combination. Tail of last run:"
+  tail -10 /tmp/polluter-run.log | sed 's/^/    /'
+  exit 0
+fi

--- a/scripts/tests/test_pre_commit_phase35_detectors.sh
+++ b/scripts/tests/test_pre_commit_phase35_detectors.sh
@@ -106,5 +106,36 @@ if echo "$PERDET_OUT" | grep -q "FOREIGN_HOST_401_SCOPING.*BLOCK"; then
   exit 1
 fi
 
-echo "PASS: 4 assertions — hook correctly captures non-zero exits + bypass envvars honored"
+# --- Assert 5: a CLEAN (non-violating) diff passes ALL detectors with exit 0 ---
+# Regression guard for the LCP-detector wiring bug (2026-06-08). The hook
+# passed `--diff` to check-lcp-acquisition-recursive.py, which only accepts
+# `--scan` (tree-scan). The argparse error (exit 2) was treated as a block —
+# so the hook would have blocked EVERY commit, even clean ones, regardless of
+# content. Asserts 1-4 only ever staged a violating diff, so they stayed green
+# while the hook was broken. A clean diff MUST pass: any detector invoked with
+# an interface it rejects errors out and reddens this assertion.
+git rm -q --cached Palace/Violation.swift
+rm -f Palace/Violation.swift
+cat > Palace/Clean.swift <<'EOF'
+import Foundation
+
+struct Clean {
+    func add(_ a: Int, _ b: Int) -> Int { a + b }
+}
+EOF
+git add Palace/Clean.swift
+set +e
+CLEAN_OUT=$(echo "$JSON_INPUT" | bash "$HOOK" 2>&1)
+CLEAN_EXIT=$?
+set -e
+if [ "$CLEAN_EXIT" -ne 0 ]; then
+  echo "FAIL: hook blocked a CLEAN diff (exit $CLEAN_EXIT) — a detector spuriously errored."
+  echo "  Regression guard: a wired detector invoked with an interface it rejects"
+  echo "  (e.g. --diff passed to a scan-only detector) errors → spurious block on every commit."
+  echo "$CLEAN_OUT" | sed 's/^/    /'
+  exit 1
+fi
+
+echo "PASS: 5 assertions — hook blocks violations, identifies detector, honors both"
+echo "      bypass envvars, and passes a clean diff (no detector spuriously blocks)."
 exit 0

--- a/scripts/xcode-test-optimized.sh
+++ b/scripts/xcode-test-optimized.sh
@@ -74,6 +74,8 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
         -configuration Debug \
         -resultBundlePath TestResults.xcresult \
         -enableCodeCoverage YES \
+        -retry-tests-on-failure \
+        -test-iterations 3 \
         -parallel-testing-enabled NO \
         CODE_SIGNING_REQUIRED=NO \
         CODE_SIGNING_ALLOWED=NO \
@@ -124,6 +126,8 @@ else
                 -configuration Debug \
                 -resultBundlePath TestResults.xcresult \
                 -enableCodeCoverage YES \
+                -retry-tests-on-failure \
+                -test-iterations 3 \
                 -parallel-testing-enabled YES \
                 -maximum-parallel-testing-workers 4 \
                 CODE_SIGNING_REQUIRED=NO \
@@ -152,6 +156,8 @@ else
             -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
             -configuration Debug \
             -resultBundlePath TestResults.xcresult \
+            -retry-tests-on-failure \
+            -test-iterations 3 \
             -enableCodeCoverage YES \
             -parallel-testing-enabled YES \
             -maximum-parallel-testing-workers 4 \


### PR DESCRIPTION
## Why

The recurring CI pain behind #1044/#1045: a board that's **usually-red-from-flakes gives no signal**, so we admin-merge — and that's exactly how #1045 shipped a `verify-pr.sh` that didn't pass `bash -n` and a pre-commit hook that would have blocked *every* commit. Both went green because CI only runs `xcodebuild test`; it never runs the gate tooling itself.

This PR makes the board trustworthy and puts the tooling under test.

## What

1. **Test-retry net** — `scripts/xcode-test-optimized.sh` now runs `-retry-tests-on-failure -test-iterations 3` (all 3 invocations). A flake that passes on any attempt no longer reddens the run; a real failure fails all 3 and stays red. Safety net, not a substitute for #3.

2. **Tooling under CI** — new `.github/workflows/tooling-checks.yml` (ubuntu, ~1 min, every PR): `bash -n` on every committed shell script, the detector pytests (`scripts/tests/`), and the pre-commit hook fixture test. This would have caught both of #1045's tooling defects before merge.

3. **Root-cause diagnosis** — new `scripts/find-test-polluter.sh` bisects pollution flakes: proves the victim passes in isolation (rules out a real bug), then finds which preceding class leaves shared state dirty. Validated end-to-end on `AudiobookBookmarkBusinessLogicTests`.

4. **Fixture hardening** — `test_pre_commit_phase35_detectors.sh` gains **Assert 5**: a *clean* diff must pass ALL detectors (exit 0). This is the exact regression guard for the LCP wiring bug (a scan-only detector called with `--diff` errors → blocks every commit). The old fixture only ever staged a violation, so it stayed green while the hook was broken. Proven: **fails on the buggy hook, passes on the fixed one.**

5. **`CLAUDE.md` → "CI/CD reliability — the green-board contract"** — the five rules as policy, including *don't land a gate faster than you can verify it* and *retire the admin-merge reflex*.

## Verification

- `bash -n` clean on all committed scripts
- `pytest scripts/tests/` → 35/35
- hook fixture test → 5/5 (and 1/1 **fail** on a deliberately re-broken hook — proves the new assert isn't theater)
- `find-test-polluter.sh` exercised on a real victim (isolation + pairwise paths)
- `tooling-checks.yml` valid YAML

## Scope / Not done

**Scope:** harness/CI tooling + CLAUDE.md only. **0 production LOC under `Palace/`.**

**Not done (tracked follow-up):**
- Pinpointing + fixing each specific pollution flake — iterative work the new bisect tool enables; retry keeps the board stable meanwhile.
- The committed `scripts/hooks` symlink is **self-referential/broken** (it points to itself, so the Claude Code Edit hooks fail with "too many levels of symbolic links"). It's machine-local harness wiring, not fixed here — flagged for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)