### PR TITLE
fix(audiobook): restore TOC/Bookmarks in in-app-nav player (+ collision, crash, phantom)

### DIFF
--- a/.forgeos/intent/fix-audiobook-nav-player-toc-bookmarks.md
+++ b/.forgeos/intent/fix-audiobook-nav-player-toc-bookmarks.md
@@ -1,0 +1,51 @@
+---
+name: fix-audiobook-nav-player-toc-bookmarks
+created: 2026-06-08
+author: claude-opus-4-8
+tracking: (none — user-reported regression in in-app-nav audiobook playback)
+related_prs: ["#1029 (feat: in-app navigation during audiobook playback — introduced the regressions)"]
+submodule_change: ios-audiobooktoolkit (branch fix/audiobook-nav-view-public)
+---
+
+## Summary
+
+The in-app-nav audiobook playback flow (flag `in_app_playback_nav_enabled`, shipped in PR #1029) lost the **Table of Contents button** — and with it access to the **Chapters and Bookmarks** lists — in the full player. While fixing it, two adjacent #1029 bugs surfaced and are fixed here too: a **Done/Back button collision** and a **phantom mini-player** that lingered after a failed open.
+
+Root cause of the TOC loss: the toolkit's `AudiobookPlayerView` declares its back + TOC buttons as `.toolbar { ToolbarItem(placement: .navigationBar*) }`. SwiftUI only renders `.navigationBar*` toolbar items inside a `NavigationStack`. The legacy flow hosts the player inside `NavigationHostView`'s `NavigationStack`; the new nav flow hosts it in a bare `ZStack` inside `AudiobookFullPlayerCoverContainer` with no `NavigationStack` ancestor, so the toolbar items silently no-op.
+
+**Approach (Option B, user-approved after Option A was rejected by live testing):** an earlier attempt wrapped the player in a nested `NavigationStack`; live simdrive testing proved that crashes (`NavigationRequestObserver tried to update multiple times per frame` → crash-relaunch on back-nav) and collides the Done button with the nav-bar back button. Option B instead presents the toolkit's `AudiobookNavigationView` (Chapters + Bookmarks) in an isolated `fullScreenCover` launched from a TOC button in the overlay — no nested `NavigationStack` in the live hierarchy, player view untouched.
+
+## Claims
+
+### Module A — toolkit `ios-audiobooktoolkit`
+
+- Makes `AudiobookNavigationView` (the Chapters + Bookmarks screen) `public` (`public struct` + `public init(model:)` + `public var body`) so the app can present it. No behavior change; visibility only.
+
+### Module B — app `Palace`
+
+- `AudiobookFullPlayerCoverContainer`: presents `AudiobookNavigationView(model:)` in a `fullScreenCover` (in its own `NavigationStack`), driven by a new `showTableOfContents` `@State`. Adds a `topControlsOverlay` (HStack) with the existing chevron-down Done button (leading) and a new `tableOfContentsButton` (trailing, `list.bullet`, a11y label `Strings.Generic.tableOfContents`). Removes the nested-`NavigationStack` wrap. No new user-facing copy (reuses `Strings.Generic.tableOfContents`).
+- `AudiobookSessionPresenter.subscribeToSessionState`: on a terminal `.error` state, calls `clearActiveSession()` so the mini-player + full-player overlay tear down after a failed open (phantom-view fix).
+- `AudiobookSessionManager` load-failure path: publishes the terminal `.error` to `playbackStatePublisher` (it previously set `state = .error` without publishing, so the presenter never saw the failure — the phantom's root cause).
+- Adds `testErrorState_tearsDownSession_soPlaybackViewDoesNotLingerAfterFailedOpen` to `AudiobookSessionPresenterTests`.
+
+## Anti-claims
+
+- Does **not** wrap the player in a nested `NavigationStack` (the rejected Option A).
+- Does **not** change the legacy (flag-OFF) playback flow.
+- Does **not** change `AudiobookPlayerView` behavior or the persistent-overlay mount semantics.
+- Does **not** add or change any user-facing copy.
+- Does **not** change the mini-player's `hasActiveSession && !isReaderActive` visibility predicate.
+
+## Files in scope
+
+- `ios-audiobooktoolkit/PalaceAudiobookToolkit/UI/AudiobookNavigationView.swift`
+- `Palace/AppInfrastructure/AudiobookFullPlayerCoverContainer.swift`
+- `Palace/Audiobooks/AudiobookSessionPresenter.swift`
+- `Palace/Audiobooks/AudiobookSessionManager.swift`
+- `PalaceTests/Audiobooks/AudiobookSessionPresenterTests.swift`
+
+## Verification
+
+- Build clean (Palace scheme, iPhone 16 Pro).
+- Unit: `testErrorState_tearsDownSession_...` (phantom-view teardown, mutation-checked).
+- simdrive (Dune, flag ON): TOC button → Chapters/Bookmarks cover → Back (no crash, playback continues) → Done → real mini-player. Zero per-interaction nav-faults, no crash-relaunch (vs Option A: 3 faults + 2 crashes). Before/after screenshots in PR body.

--- a/Palace/AppInfrastructure/AudiobookFullPlayerCoverContainer.swift
+++ b/Palace/AppInfrastructure/AudiobookFullPlayerCoverContainer.swift
@@ -57,13 +57,29 @@ struct AudiobookFullPlayerCoverContainer: View {
     /// the player chrome.
     static let minimizeSwipeMaxHorizontalDrift: CGFloat = 60
 
+    /// Drives the Table-of-Contents / Bookmarks `fullScreenCover`. The
+    /// toolkit's own TOC button is a `.navigationBar` toolbar item +
+    /// `NavigationLink` that only works inside a `NavigationStack` — which
+    /// this persistent overlay deliberately does NOT provide (a nested
+    /// `NavigationStack` inside the `TabView`'s nav stacks triggers SwiftUI's
+    /// "NavigationRequestObserver tried to update multiple times per frame"
+    /// fault and crashes on back-nav). Instead we present the toolkit's
+    /// `AudiobookNavigationView` (Chapters + Bookmarks) in an isolated
+    /// `fullScreenCover`, which has its own clean navigation context.
+    @State private var showTableOfContents = false
+
     @ViewBuilder
     var body: some View {
         if let model = presenter.playbackModel {
-            ZStack(alignment: .topLeading) {
+            ZStack(alignment: .top) {
                 AudiobookPlayerView(model: model)
                     .gesture(swipeDownToMinimize)
-                doneButtonOverlay
+                topControlsOverlay
+            }
+            .fullScreenCover(isPresented: $showTableOfContents) {
+                NavigationStack {
+                    AudiobookNavigationView(model: model)
+                }
             }
             .onAppear {
                 postVoiceOverLayoutChangeIfNeeded()
@@ -80,13 +96,30 @@ struct AudiobookFullPlayerCoverContainer: View {
         }
     }
 
-    /// Top-leading chevron-down Done button overlay (Bug 1 fix —
-    /// in-app-nav-polish-2026-06-01). iOS HIG convention for
-    /// dismissing a sheet/cover is top-leading "Done" or top-trailing
-    /// "X"; we picked top-leading chevron-down because the matching
-    /// gesture is also vertical (swipe down), giving the user a
-    /// consistent mental model: "going down = dismiss."
-    private var doneButtonOverlay: some View {
+    /// Top chrome for the full player: the non-destructive chevron-down
+    /// Done button (leading, minimizes to the mini-player) and the
+    /// Table-of-Contents button (trailing, presents Chapters/Bookmarks).
+    /// Mirrors the legacy player's leading-back / trailing-TOC layout
+    /// without the toolkit's `.navigationBar` toolbar (which needs a
+    /// `NavigationStack` the overlay can't safely host).
+    private var topControlsOverlay: some View {
+        HStack {
+            doneButton
+            Spacer()
+            tableOfContentsButton
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 12)
+        .frame(maxWidth: .infinity, alignment: .top)
+    }
+
+    /// Leading chevron-down Done button (Bug 1 fix —
+    /// in-app-nav-polish-2026-06-01). iOS HIG convention for dismissing a
+    /// sheet/cover is top-leading "Done"; we use chevron-down because the
+    /// matching gesture is also vertical (swipe down), giving a consistent
+    /// "going down = dismiss" mental model. Positioning is handled by
+    /// `topControlsOverlay`.
+    private var doneButton: some View {
         Button(action: minimizeWithMotionPreference) {
             Image(systemName: "chevron.down")
                 .resizable()
@@ -98,9 +131,28 @@ struct AudiobookFullPlayerCoverContainer: View {
         .buttonStyle(.plain)
         .tint(.primary)
         .frame(width: 44, height: 44)
-        .padding(.leading, 12)
-        .padding(.top, 12)
         .accessibilityLabel(Strings.Generic.dismissPlayer)
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// Trailing Table-of-Contents button. Presents the toolkit's
+    /// `AudiobookNavigationView` (Chapters + Bookmarks) via the
+    /// `showTableOfContents` `fullScreenCover` — the overlay's
+    /// nested-`NavigationStack`-free replacement for the toolkit's own
+    /// `.navigationBar` TOC button.
+    private var tableOfContentsButton: some View {
+        Button { showTableOfContents = true } label: {
+            Image(systemName: "list.bullet")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 20, height: 20)
+                .padding(12)
+                .background(.regularMaterial, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .tint(.primary)
+        .frame(width: 44, height: 44)
+        .accessibilityLabel(Strings.Generic.tableOfContents)
         .accessibilityAddTraits(.isButton)
     }
 

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -437,6 +437,11 @@ public final class AudiobookSessionManager: ObservableObject {
                         Log.error(#file, "Failed to load audiobook: \(loadError)")
                         let sessionError = Self.mapLoadError(loadError)
                         self.state = .error(bookId: book.identifier, message: sessionError.localizedDescription)
+                        // Publish the terminal `.error` so the session presenter
+                        // (mini-player + full-player overlay) tears down. Without
+                        // this the presenter never sees the failure and the chrome
+                        // lingers in its last-published `.loading` look.
+                        self.playbackStatePublisher.send(self.state)
                         self.errorPublisher.send(sessionError)
                         // Surface the retry-with-dialog UX (PP-3707) for user-visible
                         // load failures. Skip for cancellation so a superseded open

--- a/Palace/Audiobooks/AudiobookSessionPresenter.swift
+++ b/Palace/Audiobooks/AudiobookSessionPresenter.swift
@@ -289,6 +289,14 @@ class AudiobookSessionPresenter: ObservableObject {
                 } else {
                     self.isPlaying = false
                 }
+                // A failed open leaves the session in a terminal `.error`
+                // state. Tear down the view-facing session so neither the
+                // mini-player nor the full-player overlay lingers with no
+                // book actually loaded — otherwise the chrome sits in its
+                // last-published `.loading` look (the phantom-playback bug).
+                if case .error = state {
+                    self.clearActiveSession()
+                }
             }
             .store(in: &cancellables)
     }

--- a/PalaceTests/Audiobooks/AudiobookSessionPresenterTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookSessionPresenterTests.swift
@@ -152,6 +152,42 @@ final class AudiobookSessionPresenterTests: XCTestCase {
                        "Session return to .idle must drive `hasActiveSession == false` — a latched-true bug would leave the mini-player visible after stopPlayback")
     }
 
+    /// PRE: presenter observes an active, expanded session that adopted a book
+    /// and is sitting in `.loading` (the exact pre-state of a failed audiobook
+    /// open — mini-player visible, full player expanded).
+    /// EXPECTED: when the manager publishes `.error`, the presenter fully tears
+    /// down the view-facing session (`hasActiveSession` false, `isPlayerExpanded`
+    /// false, `playbackModel`/`currentBook` nil) so neither the mini-player nor
+    /// the full-player overlay lingers with no loaded book.
+    /// Mutates: removing the `.error` teardown leaves `isPlayerExpanded == true`
+    /// and `currentBook` set → the phantom-playback-view bug returns.
+    func testErrorState_tearsDownSession_soPlaybackViewDoesNotLingerAfterFailedOpen() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        let book = TPPBookMocker.mockBook(title: "Stuck Open", authors: "Author")
+
+        presenter.adoptBook(book)
+        presenter.expand()
+        spySession.state = .loading(bookId: book.identifier)
+        spySession.playbackStatePublisher.send(.loading(bookId: book.identifier))
+        spinRunLoopForPublisherDelivery()
+        XCTAssertTrue(presenter.hasActiveSession, "PRECONDITION: session active during load")
+        XCTAssertTrue(presenter.isPlayerExpanded, "PRECONDITION: full player expanded")
+        XCTAssertNotNil(presenter.currentBook, "PRECONDITION: book adopted")
+
+        spySession.state = .error(bookId: book.identifier, message: "open failed")
+        spySession.playbackStatePublisher.send(.error(bookId: book.identifier, message: "open failed"))
+        spinRunLoopForPublisherDelivery()
+
+        XCTAssertFalse(presenter.hasActiveSession,
+                       "Errored session must report inactive — mini-player hidden")
+        XCTAssertFalse(presenter.isPlayerExpanded,
+                       "Errored session must collapse the full player")
+        XCTAssertNil(presenter.playbackModel,
+                     "Errored session must drop the playback model so the overlay tears down")
+        XCTAssertNil(presenter.currentBook,
+                     "Errored session must drop the current book so no chrome lingers after a failed open")
+    }
+
     // MARK: - First-open expand (§7.4 / F-011)
 
     /// PRE: presenter has `isPlayerExpanded == false`.


### PR DESCRIPTION
## Problem

In the in-app-navigation audiobook flow (flag `in_app_playback_nav_enabled`, shipped #1029), the full player lost its **Table of Contents button** — and with it access to **Chapters and Bookmarks**. The toolkit's TOC button is a `.navigationBar`-placement toolbar item + `NavigationLink`, which SwiftUI only renders inside a `NavigationStack`. The legacy flow hosts the player inside `NavigationHostView`'s `NavigationStack`; the new persistent overlay does not, so the button silently disappeared.

Three further issues surfaced while fixing it (all in the #1029 surface):
- The **Done/Back buttons collided** in the player chrome.
- An early **nested-`NavigationStack`** attempt **crashed** on back-nav (`NavigationRequestObserver tried to update multiple times per frame`).
- A **phantom mini-player** lingered after a *failed* open.

## Fix

- **TOC restore:** present the toolkit's `AudiobookNavigationView` (Chapters + Bookmarks) in a `fullScreenCover` — its own isolated navigation context — launched from a new TOC button in the player overlay. No nested `NavigationStack` in the live hierarchy (which is what crashed). The player view is untouched. Done (leading) + TOC (trailing) live in a clean top overlay → no collision. Reuses `Strings.Generic.tableOfContents` (no new copy).
- **Phantom mini-player:** the load-failure path set `state = .error` but never published it, so the session presenter never tore down. It now publishes `.error`, and the presenter clears the active session on any terminal `.error` — neither the mini-player nor the overlay lingers after a failed open.

**Depends on** ThePalaceProject/ios-audiobooktoolkit#182 (makes `AudiobookNavigationView` public). The submodule pointer here references that branch commit; rebase/re-point once #182 merges.

## Verification (simulator, iPhone 16 Pro, flag ON)

Driven via simdrive (toolbar rendering is invisible to XCTest):

**Happy path (Dune):** open player → Done (⌄) + TOC (☰) render cleanly, no collision → tap TOC → Chapters/Bookmarks cover opens → tap a tab → Back → returns to player, **playback continues** → Done → minimizes to a **real** mini-player (`4:10 / 21:04:34`). Repeated TOC open/close cycles: **0 nav-faults, 0 crashes**, PID stable.

**Failed-open path (Private Down Under, Overdrive — won't fulfill on sim):** Listen → "couldn't open" error → **no phantom mini-player**, no crash.

The earlier nested-`NavigationStack` approach produced 3 nav-faults + 2 crash-relaunches doing the same things; this approach produces zero.

**Unit:** `AudiobookSessionPresenterTests` 16/16, incl. new `testErrorState_tearsDownSession_soPlaybackViewDoesNotLingerAfterFailedOpen` (mutation-killing — removing the teardown call fails it). Build clean.

## Review

Critical-path SoD: architect + qa_test both approved (approve-with-comments). One agreed non-blocking follow-up: a manager-level contract test asserting the load-failure path publishes `.error` (currently simdrive-covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)