### PR TITLE
3.2.0 crash triage: keychain read() race + ImageCache continuation leak

### DIFF
--- a/.forgeos/intent/3.2.0-crash-triage.md
+++ b/.forgeos/intent/3.2.0-crash-triage.md
@@ -1,0 +1,66 @@
+---
+name: 3.2.0-crash-triage
+created: 2026-06-08
+author: claude-opus-4-8
+tracking: 3.2.0 pre-regression crash triage (Crashlytics 3.1.0 scan; no dedicated Jira ticket)
+crashlytics: ["0bbbd8feb9313f52d6395be3620d24cb", "ab80dbb0d8083163c00d55e5f8461c1b"]
+---
+
+## Summary
+
+From the Crashlytics scan of 3.1.0 (build 478), landing fixes before the 3.2.0
+regression cycle. PR #1 of 2 carries the two high-confidence, well-scoped fixes
+(keychain read() race + ImageCache.getAsync continuation leak). The two
+audiobook items (CarPlay `.playerNotReady`, OverDrive expired-URL re-fulfill)
+are deferred to a reviewed follow-up. Worktree `fix/3.2.0-crash-triage` off
+`origin/develop`, isolated from a concurrent session on
+`fix/token-request-transient-resilience`.
+
+## Claims
+
+1. **Keychain read() data race (auth critical path).** `TPPKeychainVariable.read()`
+   and `TPPKeychainCodableVariable.read()` return `cachedValue` *outside* the
+   `transaction.perform` serial-queue block, so the final read races a concurrent
+   `write(nil)`/`invalidateCache` (e.g. sign-out while a background URLSession
+   continuation reads `TPPUserAccount.credentials`) → torn read of `TPPCredentials`
+   → EXC_BAD_ACCESS. Fix: `TPPKeychainVariableTransaction.perform` is generalized
+   to return a value and `read()` returns the cached value from *inside* the
+   synchronized block, so every read is serialized with every write. Crashlytics
+   issue `0bbbd8fe`.
+
+2. **ImageCache.getAsync continuation leak (OOM amplifier).** Every
+   `continuation.resume` in `ImageCacheType.getAsync` lives inside the
+   `processingQueue.addOperation` block; `cancelAllOperations()` in
+   `handleMemoryWarning` cancels queued ops before they run → continuation never
+   resumes → suspended Task + captured view-model graph pinned in memory, working
+   against the relief the warning handler is trying to achieve. Fix: a
+   lock-guarded one-shot resume plus an operation completion block guarantee
+   exactly one resume whether the op runs or is cancelled. `processingQueue` is
+   made internal (not public) so the test can drive the cancel path
+   deterministically. Crashlytics issue `ab80dbb0` (amplifier; root SIGABRT is
+   memory pressure).
+
+## Anti-claims (out of scope / deferred)
+
+- **CarPlay OpenAccess `.playerNotReady` (Crashlytics `d45f5aa9`)** — deferred to a
+  reviewed follow-up. App-side seam confirmed (`PlaybackBootstrapper.activateAudioSession()`
+  bounded retry on `AVAudioSession.setActive`), but that method runs on the
+  MainActor during CarPlay cold launch, so the retry must be made async to avoid a
+  ~1s main-thread block. Needs architect + SoD review and a cross-vendor smoke test.
+- **OverDrive expired-URL dead-end (Crashlytics `04373e48`, `d2c9e0ef`)** — deferred.
+  App-side seam confirmed (re-fulfill branch in `AudiobookSessionManager.handleManagerState`
+  `.playbackFailed`), but must first verify re-fulfillment yields fresh signed URLs
+  (not a replayed cached manifest) and be bounded to one attempt to avoid a
+  re-fulfill loop on a handler shared by every vendor.
+- **F-011 LCP-load gate (Crashlytics `e19f5e54`)** — toolkit-side change in
+  `LCPStreamingPlayer.swift`; separate submodule pass (PP-4436).
+- No changes to the `ios-audiobooktoolkit` submodule in this changeset.
+- No new user-facing copy.
+
+## Files in scope
+
+- `Palace/Packages/PalaceKeychain/Sources/PalaceKeychain/TPPKeychainStoredVariable.swift`
+- `Palace/Packages/PalaceKeychain/Tests/PalaceKeychainTests/TPPKeychainStoredVariableTests.swift`
+- `Palace/Utilities/ImageCache/ImageCacheType.swift`
+- `PalaceTests/ImageLoading/ImageCacheContinuationTests.swift`
+- `Palace.xcodeproj/project.pbxproj` (test-file registration)

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		6D1A2EAA9359F95A03E24924 /* TriageBotUI in Frameworks */ = {isa = PBXBuildFile; productRef = EC7C8BCB15CB04F41C93E21B /* TriageBotUI */; };
 		6D31B0C0854BA3F8E14FA904 /* NotificationSyncThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF4B6BD211B2BF0AEA436A7 /* NotificationSyncThrottleTests.swift */; };
 		6D3D58AD5A55DDE5581A5F27 /* BookmarkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB330CAB808179B0760D6BBA /* BookmarkManagerTests.swift */; };
+		6D575E8878F3E8BC9FA43DE3 /* ImageCacheContinuationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B004B00FB1D06292BE7578B9 /* ImageCacheContinuationTests.swift */; };
 		6DE653A3D142F458434351BB /* LCPBotanCRLGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C9565C8C9D4F8F6DA585CE /* LCPBotanCRLGuardTests.swift */; };
 		6DEB021C53F567192EC579C5 /* Badge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B60ACDE3E15FC832885E932 /* Badge.swift */; };
 		6E9551F7FA91C42B1F5021A8 /* PerformanceMonitorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC313C7F61C891527F159B /* PerformanceMonitorProtocol.swift */; };
@@ -2680,6 +2681,7 @@
 		ANNOT001T260955EF008E1DC3 /* TPPAnnotationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TPPAnnotationsTests.swift; path = Bookmarks/TPPAnnotationsTests.swift; sourceTree = "<group>"; };
 		APICONTRACT01FILEREF001 /* APIContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIContractTests.swift; sourceTree = "<group>"; };
 		AUTHREDTESTSFILEREF001ZZZZ /* AuthReducerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthReducerTests.swift; sourceTree = "<group>"; };
+		B004B00FB1D06292BE7578B9 /* ImageCacheContinuationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageCacheContinuationTests.swift; sourceTree = "<group>"; };
 		B0B284DD9A4739D34937C4D0 /* CatalogViewContinueRowsIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogViewContinueRowsIntegrationTests.swift; sourceTree = "<group>"; };
 		B16FBDE7626549B79736A665 /* TPPCredentialIsolationE2ETests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPCredentialIsolationE2ETests.swift; sourceTree = "<group>"; };
 		B1A2B3C4D5E6F7A8B9C0D1E2 /* RedirectPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectPolicy.swift; sourceTree = "<group>"; };
@@ -5502,6 +5504,7 @@
 			isa = PBXGroup;
 			children = (
 				58CCD6D02A703C447C36C65D /* ImageLoaderTests.swift */,
+				B004B00FB1D06292BE7578B9 /* ImageCacheContinuationTests.swift */,
 			);
 			name = ImageLoading;
 			path = ImageLoading;
@@ -7350,6 +7353,7 @@
 				07A5AAEF6F9B32DC06C0C3E8 /* AudiobookPlaytimesLifecycleTests.swift in Sources */,
 				32910EA3300D7728B6FF2268 /* ScopedResetTests.swift in Sources */,
 				151C578EEB3CBF8B804952F6 /* DeveloperSettingsTierTests.swift in Sources */,
+				6D575E8878F3E8BC9FA43DE3 /* ImageCacheContinuationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Packages/PalaceKeychain/Sources/PalaceKeychain/TPPKeychainStoredVariable.swift
+++ b/Palace/Packages/PalaceKeychain/Sources/PalaceKeychain/TPPKeychainStoredVariable.swift
@@ -34,19 +34,18 @@ public class TPPKeychainVariable<VariableType>: Keyable {
     }
 
     public func read() -> VariableType? {
+        // Read the cached value from *inside* the synchronized block so the
+        // return is serialized with every write/invalidate. Returning
+        // `cachedValue` after the block races a concurrent `write(nil)` (e.g.
+        // sign-out vs. a background network thread reading credentials) and
+        // tears the value → EXC_BAD_ACCESS (Crashlytics 0bbbd8fe).
         transaction.perform {
-            // If currently cached value is valid, return from cache
-            guard !alreadyInited else { return }
-
-            // Otherwise, obtain the latest value from keychain
-            cachedValue = TPPKeychain.shared.object(forKey: key) as? VariableType
-
-            // set a flag indicating that current cache is good to use
-            alreadyInited = true
+            if !alreadyInited {
+                cachedValue = TPPKeychain.shared.object(forKey: key) as? VariableType
+                alreadyInited = true
+            }
+            return cachedValue
         }
-
-        // return cached value
-        return cachedValue
     }
 
     public func write(_ newValue: VariableType?) {
@@ -80,15 +79,20 @@ public class TPPKeychainVariable<VariableType>: Keyable {
 
 public class TPPKeychainCodableVariable<VariableType: Codable>: TPPKeychainVariable<VariableType> {
     public override func read() -> VariableType? {
+        // Return from inside the synchronized block — see base `read()`. The
+        // unsynchronized `return cachedValue` after the block is the
+        // EXC_BAD_ACCESS race (Crashlytics 0bbbd8fe): a background URLSession
+        // continuation reading `TPPUserAccount.credentials` tore a
+        // `TPPCredentials` mid sign-out `write(nil)`.
         transaction.perform {
-            guard !alreadyInited else { return }
+            guard !alreadyInited else { return cachedValue }
 
             // Try new format first (direct JSON), then fall back to old format (NSKeyedArchiver-wrapped)
             if let jsonData = readJSONDataDirectly(forKey: key) {
                 do {
                     cachedValue = try JSONDecoder().decode(VariableType.self, from: jsonData)
                     alreadyInited = true
-                    return
+                    return cachedValue
                 } catch {
                     Log.error(#file, "Failed to decode JSON keychain data for key \(key): \(error)")
                 }
@@ -102,7 +106,7 @@ public class TPPKeychainCodableVariable<VariableType: Codable>: TPPKeychainVaria
 
                     // Migrate to new format
                     writeJSONDataDirectly(legacyData, forKey: key)
-                    return
+                    return cachedValue
                 } catch {
                     Log.error(#file, "Failed to decode legacy keychain data for key \(key): \(error)")
                 }
@@ -110,8 +114,8 @@ public class TPPKeychainCodableVariable<VariableType: Codable>: TPPKeychainVaria
 
             cachedValue = nil
             alreadyInited = true
+            return cachedValue
         }
-        return cachedValue
     }
 
     public override func write(_ newValue: VariableType?) {
@@ -353,11 +357,17 @@ public class TPPKeychainVariableTransaction {
         self.accountInfoQueue.setSpecific(key: queueKey, value: ())
     }
 
-    public func perform(tasks: () -> Void) {
+    @discardableResult
+    // PUBLIC_INTENT: pre-existing public PalaceKeychain SPM API consumed
+    // cross-package by TPPUserAccount; signature generalized from
+    // `(() -> Void)` to `<T>(() -> T) -> T` so read() can return its value
+    // from inside the synchronized block (the EXC_BAD_ACCESS race fix). Not
+    // new surface.
+    public func perform<T>(_ tasks: () -> T) -> T {
         if DispatchQueue.getSpecific(key: queueKey) != nil {
-            tasks()
+            return tasks()
         } else {
-            accountInfoQueue.sync {
+            return accountInfoQueue.sync {
                 tasks()
             }
         }

--- a/Palace/Packages/PalaceKeychain/Tests/PalaceKeychainTests/TPPKeychainStoredVariableTests.swift
+++ b/Palace/Packages/PalaceKeychain/Tests/PalaceKeychainTests/TPPKeychainStoredVariableTests.swift
@@ -132,4 +132,71 @@ final class TPPKeychainStoredVariableTests: XCTestCase {
         variable.write("second")
         XCTAssertEqual(variable.read(), "second")
     }
+
+    // MARK: - Read serialization (Crashlytics 0bbbd8fe — EXC_BAD_ACCESS race)
+
+    /// `read()` must return the value produced *inside* the synchronized block.
+    /// This pins the contract that `perform` now yields a value; a regression
+    /// that reverts to returning `cachedValue` after the block (the original
+    /// torn-read bug) cannot satisfy this through the transaction seam.
+    func testTransactionPerform_returnsValueComputedInsideLock() {
+        let transaction = TPPKeychainVariableTransaction(accountInfoQueue: testQueue)
+
+        let result: Int = transaction.perform {
+            // Value originates entirely within the critical section.
+            return 7 * 6
+        }
+
+        XCTAssertEqual(result, 42, "perform must return the value computed inside the synchronized block")
+    }
+
+    /// Regression test for the keychain read race. A background thread reading
+    /// credentials while another thread signs out (`write(nil)`/overwrite) tore
+    /// the returned value because the read happened outside the lock. With the
+    /// read serialized, every non-nil `read()` must observe a *whole* value
+    /// that was actually written — never a torn/garbage struct (which would
+    /// crash on retain) — and the final state must be consistent.
+    ///
+    /// Note: this is a *probabilistic* mutation-killer — a revert to the
+    /// unsynchronized `return cachedValue` won't tear on every run. A genuine
+    /// tear crashes loudly (retain on a torn struct), and
+    /// `testTransactionPerform_returnsValueComputedInsideLock` deterministically
+    /// backstops the `perform<T>` signature the fix depends on.
+    func testRead_underConcurrentWritesAndInvalidation_neverTearsValue() throws {
+        try KeychainAvailability.skipIfUnavailable()
+
+        struct Cred: Codable, Equatable, Hashable {
+            let token: String
+            let identifier: String
+        }
+        let key = "concurrent_cred_\(UUID().uuidString)"
+        let variable = TPPKeychainCodableVariable<Cred>(key: key, accountInfoQueue: testQueue)
+        defer { TPPKeychain.shared.removeObject(forKey: key) }
+
+        // Two disjoint sentinels. A torn read would mix fields across the two
+        // (or crash); `valid.contains` catches the mix.
+        let a = Cred(token: "AAAAAAAAAAAAAAAA", identifier: "id-aaaa")
+        let b = Cred(token: "BBBBBBBBBBBBBBBB", identifier: "id-bbbb")
+        let valid: Set<Cred> = [a, b]
+        variable.write(a)
+
+        DispatchQueue.concurrentPerform(iterations: 4_000) { i in
+            switch i % 3 {
+            case 0:
+                variable.write(i % 2 == 0 ? a : b)
+            case 1:
+                // Force a fresh keychain decode under contention.
+                variable.invalidateCache()
+            default:
+                if let got = variable.read() {
+                    XCTAssertTrue(valid.contains(got),
+                                  "read() returned a torn/invalid value: \(got)")
+                }
+            }
+        }
+
+        let final = variable.read()
+        XCTAssertTrue(final == a || final == b || final == nil,
+                      "final state must be a whole written value or nil, got: \(String(describing: final))")
+    }
 }

--- a/Palace/Utilities/ImageCache/ImageCacheType.swift
+++ b/Palace/Utilities/ImageCache/ImageCacheType.swift
@@ -25,7 +25,11 @@ public final class ImageCache: ImageCacheType {
     private let defaultTTL: TimeInterval = 14 * 24 * 60 * 60
     private let maxDimension: CGFloat
     private let compressionQuality: CGFloat = 0.7
-    private let processingQueue: OperationQueue = {
+    // Internal (not private) so tests can deterministically exercise the
+    // cancellation path of `getAsync` (suspend → enqueue → cancelAllOperations
+    // → resume) without spamming a global memory-warning notification through
+    // the whole app. Not part of the public API.
+    let processingQueue: OperationQueue = {
         let queue = OperationQueue()
         queue.qualityOfService = .utility
         queue.name = "org.thepalaceproject.imageprocessing"
@@ -204,29 +208,59 @@ public final class ImageCache: ImageCacheType {
             return img
         }
         return await withCheckedContinuation { continuation in
-            processingQueue.addOperation { [weak self] in
-                guard let self else {
-                    continuation.resume(returning: nil)
+            // The continuation must resume exactly once. Every resume below
+            // lives inside the operation's execution block, but
+            // `handleMemoryWarning` calls `processingQueue.cancelAllOperations()`
+            // — and a cancelled `BlockOperation` never runs its block, which
+            // would orphan the continuation forever (Crashlytics ab80dbb0:
+            // "leaked its continuation" breadcrumb under memory pressure, where
+            // each orphaned continuation pins the suspended Task + captured
+            // graph and works *against* the memory relief the warning is trying
+            // to achieve). A lock-guarded one-shot resume plus a completion
+            // block guarantees exactly one resume whether the op runs or is
+            // cancelled before it starts.
+            let resumeLock = NSLock()
+            var hasResumed = false
+            func resumeOnce(_ image: UIImage?) {
+                resumeLock.lock()
+                defer { resumeLock.unlock() }
+                guard !hasResumed else { return }
+                hasResumed = true
+                continuation.resume(returning: image)
+            }
+
+            let operation = BlockOperation()
+            operation.addExecutionBlock { [weak self, weak operation] in
+                guard let self, operation?.isCancelled != true else {
+                    resumeOnce(nil)
                     return
                 }
                 // Double-check memory (another task may have promoted it)
                 if let img = self.memoryImages.object(forKey: key as NSString) {
-                    continuation.resume(returning: img)
+                    resumeOnce(img)
                     return
                 }
                 guard let data = self.dataCache.get(for: key) else {
-                    continuation.resume(returning: nil)
+                    resumeOnce(nil)
                     return
                 }
                 guard let img = UIImage(data: data) else {
                     self.remove(for: key)
-                    continuation.resume(returning: nil)
+                    resumeOnce(nil)
                     return
                 }
                 let cost = self.imageCost(img)
                 self.memoryImages.setObject(img, forKey: key as NSString, cost: cost)
-                continuation.resume(returning: img)
+                resumeOnce(img)
             }
+            // Runs for both finished and cancelled operations. If the op was
+            // cancelled before its execution block ran, `resumeOnce` was never
+            // called — resume here so the awaiter never hangs. The one-shot
+            // guard makes this a no-op on the normal completion path.
+            operation.completionBlock = {
+                resumeOnce(nil)
+            }
+            processingQueue.addOperation(operation)
         }
     }
 

--- a/PalaceTests/ImageLoading/ImageCacheContinuationTests.swift
+++ b/PalaceTests/ImageLoading/ImageCacheContinuationTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import UIKit
+@testable import Palace
+
+/// Regression test for the `ImageCache.getAsync` continuation leak
+/// (Crashlytics `ab80dbb0`).
+///
+/// `handleMemoryWarning()` calls `processingQueue.cancelAllOperations()`. Before
+/// the fix, every `continuation.resume` lived *inside* the processing
+/// operation's block, so a cancelled-while-queued operation never ran its block
+/// and orphaned its continuation — the awaiting Task then hung forever, pinning
+/// the suspended Task + captured graph in memory under the exact pressure the
+/// warning was trying to relieve. The fix guarantees exactly one resume via the
+/// operation's completion block.
+///
+/// `ImageCache` has a private init, so only `.shared` is constructible. To make
+/// the cancellation deterministic (and avoid spamming a global memory-warning
+/// notification through the whole launched app), we suspend the processing
+/// queue, enqueue the awaits so they are *guaranteed* still queued, cancel all
+/// operations, then resume the queue. Every cancelled-while-queued operation
+/// must still resume its continuation.
+final class ImageCacheContinuationTests: XCTestCase {
+
+    override func tearDown() {
+        // This test deliberately suspends the shared cache's processing queue.
+        // Restore it (and drain any operations) so a mid-test assertion failure
+        // can't leave the singleton queue suspended and pollute later tests that
+        // call `ImageCache.shared.getAsync`. Required by TearDownRequiredLintTests.
+        ImageCache.shared.processingQueue.cancelAllOperations()
+        ImageCache.shared.processingQueue.isSuspended = false
+        super.tearDown()
+    }
+
+    func testGetAsync_whenOperationsCancelledWhileQueued_everyCallResumes() {
+        let cache = ImageCache.shared
+
+        // Suspend so nothing starts running: the operations we enqueue below
+        // are deterministically still *queued* when we cancel them.
+        cache.processingQueue.isSuspended = true
+
+        let count = 50
+        let allResumed = expectation(description: "every getAsync call resumes")
+        allResumed.expectedFulfillmentCount = count
+
+        let enqueued = expectation(description: "all getAsync operations enqueued")
+        enqueued.expectedFulfillmentCount = count
+
+        // Disk-only/nonexistent keys force each call past the memory-cache
+        // short-circuit and into a queued processing operation.
+        for i in 0..<count {
+            let key = "imagecache_leak_probe_\(i)_\(UUID().uuidString)"
+            Task {
+                enqueued.fulfill()
+                _ = await cache.getAsync(for: key)
+                allResumed.fulfill()
+            }
+        }
+
+        // The `enqueued` fulfillments fire as each Task begins; once all have
+        // fired, every operation has been added to the (suspended) queue.
+        wait(for: [enqueued], timeout: 10.0)
+        // Small settle so the synchronous `addOperation` inside each
+        // `withCheckedContinuation` body has run before we cancel.
+        let settle = expectation(description: "settle")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { settle.fulfill() }
+        wait(for: [settle], timeout: 2.0)
+
+        // Cancel every queued operation, then let the queue run. Pre-fix the
+        // cancelled operations never resume → `allResumed` under-fulfills →
+        // timeout. Post-fix the completion block resumes each one.
+        cache.processingQueue.cancelAllOperations()
+        cache.processingQueue.isSuspended = false
+
+        wait(for: [allResumed], timeout: 15.0)
+    }
+}


### PR DESCRIPTION
From the Crashlytics 3.1.0 (build 478) scan ahead of the 3.2.0 regression cycle. Two high-confidence, well-scoped crash fixes. Two audiobook items found in the same scan are deferred to a reviewed follow-up (see below).

## 1. Keychain `read()` data race — EXC_BAD_ACCESS (Crashlytics `0bbbd8fe`)

`TPPKeychainVariable.read()` and `TPPKeychainCodableVariable.read()` did their keychain access under the transaction's serial queue but then returned `cachedValue` **outside** the lock. A background URLSession continuation reading `TPPUserAccount.credentials` could tear a multi-word `TPPCredentials` struct against a concurrent sign-out `write(nil)`/`invalidateCache` → retain on garbage → crash. The sample event matched exactly (`SIGNED_OUT_USER` + in-flight catalog searches).

**Fix:** `TPPKeychainVariableTransaction.perform` is generalized to `perform<T>(_:) -> T` (pre-existing public SPM API, annotated `PUBLIC_INTENT`), so `read()` returns the value from **inside** the synchronized block. Every read is now serialized with every write. The `DispatchSpecific` reentrancy guard is preserved, so the nested-`perform` call sites in `TPPUserAccount` still run inline without self-deadlock.

## 2. `ImageCache.getAsync` continuation leak — OOM amplifier (Crashlytics `ab80dbb0`)

Every `continuation.resume` lived inside the `processingQueue` operation block, but `handleMemoryWarning()` calls `cancelAllOperations()` — a cancelled `BlockOperation` never runs its block, orphaning the continuation and pinning the suspended Task + captured view-model graph in memory under the exact pressure the warning was trying to relieve.

**Fix:** a lock-guarded one-shot resume plus an operation completion-block fallback guarantees exactly one resume whether the op runs or is cancelled. `processingQueue` is now `internal` (not public) so the test can drive the cancel path deterministically.

## Verification

- **iPhone 16 Pro simulator**, both fixes' tests pass; consumer regression (`ImageLoaderTests` + `AccountDetailCredentialStateTests` + `ImageCacheContinuationTests`) = **19 passed, 0 failed**.
- **ImageCache test is a proven mutant-killer:** removing the completion-block resume line makes it time out (verified), restored → passes in 0.25s.
- **Keychain:** 4000-iteration concurrent read/write/invalidate stress (no torn value) + deterministic `perform<T>` contract test. Package `swift test` green except the pre-existing macOS-only `testKeyChange_invalidatesCache` quirk (confirmed against baseline — not introduced here).
- DoD self-checks (blast-radius, test-name-vs-body, superpartner) exit 0. Architect + QA review approved.

## Deferred to a reviewed follow-up

Same scan surfaced two audiobook items with confirmed app-side surfaces but critical-path risk that warrants its own review + cross-vendor smoke test:
- **CarPlay OpenAccess `.playerNotReady`** (`d45f5aa9`) — AVAudioSession activation retry must be made async (MainActor cold-launch block risk).
- **OverDrive expired-URL re-fulfill** (`04373e48`/`d2c9e0ef`) — needs verification that re-fulfillment yields fresh signed URLs + one-attempt bound to avoid a loop.
- **F-011 LCP-load gate** (`e19f5e54`) — toolkit submodule pass (PP-4436).

🤖 Generated with [Claude Code](https://claude.com/claude-code)