### PR TITLE
test-pollution: order-independent factory resetter registration (TPPUserAccountIsolationLint flake)

### DIFF
--- a/PalaceTests/Support/TPPUserAccountTestFactory.swift
+++ b/PalaceTests/Support/TPPUserAccountTestFactory.swift
@@ -58,18 +58,26 @@ struct TPPUserAccountTestFactory {
 
     // MARK: - Resetter wiring
 
-    /// Process-wide flag — set once on first `makeIsolated()` call. The
-    /// `SingletonResetRegistry` API allows duplicate registrations (later
-    /// ones overwrite in-place), but doing it once keeps the registered-
-    /// names diagnostic clean.
-    private static let registerOnce: Void = {
-        SingletonResetRegistry.shared.register("TPPUserAccountTestFactory.minted") {
+    /// Name of the resetter this factory registers with `SingletonResetRegistry`.
+    static let resetterName = "TPPUserAccountTestFactory.minted"
+
+    /// Registers the minted-account resetter **idempotently on every**
+    /// `makeIsolated()` call — register-if-absent, NOT fire-once.
+    ///
+    /// Why not fire-once: `SingletonResetRegistry` can be cleared mid-suite
+    /// (`PalaceTestSetupObservationTests` calls `_removeAllForTests()`, restoring
+    /// only the built-ins). A fire-once registration is then permanently lost,
+    /// so later minted accounts leak (no `removeAll()` at `testCaseDidFinish`)
+    /// and `TPPUserAccountIsolationLintTests.testResetterIsRegisteredAfterFactoryUse`
+    /// flakes depending on full-suite order. Re-registering when absent makes
+    /// every mint self-healing and order-independent. The registry allows
+    /// duplicate registration (overwrites in-place); the `contains` guard keeps
+    /// the registered-names diagnostic clean (no redundant churn).
+    private static func registerResetterIfNeeded() {
+        guard !SingletonResetRegistry.shared.registeredNames().contains(resetterName) else { return }
+        SingletonResetRegistry.shared.register(resetterName) {
             Tracker.shared.resetAll()
         }
-    }()
-
-    private static func registerResetterIfNeeded() {
-        _ = registerOnce
     }
 
     /// Process-wide tracker of accounts minted by the factory. The list

--- a/PalaceTests/Support/TPPUserAccountTestFactoryTests.swift
+++ b/PalaceTests/Support/TPPUserAccountTestFactoryTests.swift
@@ -29,6 +29,40 @@ final class TPPUserAccountTestFactoryTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    // MARK: - Invariant 0: resetter registration is order-independent (flake hardening)
+
+    /// `TPPUserAccountIsolationLintTests.testResetterIsRegisteredAfterFactoryUse`
+    /// flaked by full-suite order: the resetter used to register fire-once, so
+    /// once a predecessor fired it and a later test cleared the registry
+    /// (`PalaceTestSetupObservationTests._removeAllForTests()`), a subsequent
+    /// mint never re-registered — leaking minted accounts AND failing the lint.
+    /// This pins the fix DETERMINISTICALLY (no 35-min full-suite repro needed):
+    /// it recreates the exact register → clear → register condition in one test.
+    func testMakeIsolated_reRegistersResetter_afterRegistryCleared() {
+        // Restore the built-in resetters even if an assertion below fails, so
+        // this test (which deliberately clears the registry) can't itself become
+        // the polluter it's guarding against.
+        defer { _ = PalaceTestSetup.bootstrap() }
+
+        let name = TPPUserAccountTestFactory.resetterName
+
+        // 1. First mint registers the resetter.
+        _ = TPPUserAccountTestFactory.makeIsolated(libraryUUID: "order-probe-1")
+        XCTAssertTrue(SingletonResetRegistry.shared.registeredNames().contains(name),
+                      "First makeIsolated() must register the minted-account resetter")
+
+        // 2. A later test clears the registry — the resetter is dropped.
+        SingletonResetRegistry.shared._removeAllForTests()
+        XCTAssertFalse(SingletonResetRegistry.shared.registeredNames().contains(name),
+                       "Precondition: clearing the registry drops the resetter")
+
+        // 3. A subsequent mint MUST re-register it. Under the old fire-once
+        //    registration this stayed false — the root cause of the flake.
+        _ = TPPUserAccountTestFactory.makeIsolated(libraryUUID: "order-probe-2")
+        XCTAssertTrue(SingletonResetRegistry.shared.registeredNames().contains(name),
+                      "makeIsolated() must re-register the resetter after a registry clear — fire-once registration leaks minted accounts and flakes by suite order")
+    }
+
     // MARK: - Invariant 1: each call mints a fresh UUID-namespaced account
 
     func testMakeIsolated_eachCallReturnsDistinctLibraryUUID() {


### PR DESCRIPTION
## Summary

First de-pollution pass from the polluter hunt. Fixes the `TPPUserAccountIsolationLintTests.testResetterIsRegisteredAfterFactoryUse` flake at its root by making `TPPUserAccountTestFactory`'s resetter registration **order-independent**.

## Root cause

The factory registered its minted-account resetter **fire-once** (a `static let registerOnce`). When the suite ran long enough that a predecessor fired the token and a *later* test cleared the registry — `PalaceTestSetupObservationTests._removeAllForTests()`, which restores only the 5 built-in resetters — the `TPPUserAccountTestFactory.minted` resetter was **permanently lost**. Subsequent mints then leaked (no `removeAll()` at `testCaseDidFinish`) and the lint assertion failed, depending on full-suite order.

## Fix

`registerResetterIfNeeded()` now registers **if-absent on every `makeIsolated()`** instead of fire-once. The registry already allows re-registration (the old code comment said so); a `contains` guard keeps the registered-names diagnostic clean. Every mint is now self-healing and order-independent.

## Proof (deterministic — no 35-min full-suite repro)

New test `testMakeIsolated_reRegistersResetter_afterRegistryCleared` recreates the exact `register → clear → register` condition in a single test. It **FAILS on the old fire-once factory and PASSES on the fix** (verified by reverting the production change and re-running). `TPPUserAccountIsolationLintTests` also passes.

## Why not the bisect tool

`scripts/find-test-polluter.sh` (pairwise) **could not** reproduce this: the pollution is cumulative and depends on the full-suite execution order, which in CI is **not alphabetical** and is not reproducible via local `-only-testing` (xcodebuild reorders selectors). That's a genuine limitation of the pairwise approach for cumulative-order pollution — so the scalable strategy for the remaining victims (`CatalogCacheKeyAndIsolationTests`, `CarPlayAudiobookBridge…`, `AudiobookCrossVendorSmoke`) is the same **order-independent test-design hardening** demonstrated here, not per-polluter bisection.

## Scope

Test infrastructure only (`PalaceTests/Support`). No production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)