### PR TITLE
tooling: world-class mutation testing — coverage-gating, parallel pool, smarter gate

### DIFF
--- a/.forgeos/intent/mutation-testing-world-class.md
+++ b/.forgeos/intent/mutation-testing-world-class.md
@@ -1,0 +1,77 @@
+---
+name: mutation-testing-world-class
+created: 2026-06-09
+author: claude-opus-4-8
+tracking: (none — internal tooling improvement; user-requested "make mutation testing faster + world-class")
+related_prs: []
+---
+
+## Summary
+
+Make Palace's custom Swift mutation tester (`scripts/palace_mutate.py`) faster
+AND smarter. First-principles reframe: cost = #mutants × cost-per-run. The big
+wins are **doing less work** and **measuring the right thing**, not just doing the
+same work faster. We own the harness, not the technique (DeMillo–Lipton–Sayward
+1978). Built as a dependency pipeline of mostly-disjoint components (coverage
+engine → core engine → {parallel pool ‖ gate wiring} → docs/integration).
+
+## Claims
+
+- **Coverage-gating (keystone):** capture coverage from the baseline run palace_mutate
+  already does (`-enableCodeCoverage YES -resultBundlePath`), parse via `xcrun xccov
+  view --archive`, and never run mutants on lines no test executes (guaranteed
+  survivors). Uncovered mutation points become a free coverage-gap report.
+- **Tier-1 per-build flags** in `run_targeted_tests`: skip SPM resolution + plugin
+  validation + index-store + parallel-testing per invocation. Env-overridable
+  (`PALACE_MUTATE_XCB_EXTRA_FLAGS`, `PALACE_MUTATE_NO_FAST_FLAGS`). NOT `-quiet`
+  (would break `any_tests_ran`).
+- **Per-mutant incremental cache** (`.forgeos/mutation-cache/mutants/<leaf>.json`)
+  keyed on host-line content + surrounding context (not line number) so editing one
+  method only re-tests changed-line mutants. Whole-file cache kept as fast path.
+- **Critical-path metric:** zero survivors tolerated on critical-path consequential
+  mutants (cmp/bool/bound/retval/cond) → exit 1 regardless of kill rate. Added to
+  report summary; enforced in verify-pr.sh.
+- **Diff-scoped by default** for the PR mutation gate (`--mutation-whole-file`
+  opts back to full at release).
+- **Equivalent-mutant suppress-list** (`.forgeos/mutation-suppressions/<leaf>.json`)
+  so known-unkillable survivors stop nagging.
+- **Parallel worker pool** (`scripts/palace_mutate_parallel.py`): file-level fan-out
+  across isolated git-worktree + pool-sim + own DerivedData workers. ISOLATION, not
+  batching, so no result conflation. Gated on file count.
+- Backward-compatible report schema (only ADD keys); preserved exit-code contract
+  (0/1/2) and the verbatim `killed:/survived:` line verify-pr.sh greps.
+- Every pure-logic addition has unit tests that do NOT invoke xcodebuild.
+
+## Anti-claims
+
+- Does **not** batch multiple mutants into one build/test run (masks survivors).
+- Does **not** change the meaning of any existing report key or the kill-rate
+  computation (still derived only from RUN mutants; uncovered/suppressed tracked
+  separately).
+- Does **not** remove the whole-file cache.
+- Does **not** build mutant schemata (compile-once) — noted as future work.
+
+## Scope deferral (explicit, not buried)
+
+- **Test-selection (run only covering test methods per mutant) is wired but inert.**
+  `mutate_coverage.tests_for_lines` returns `None` because reliable per-test
+  attribution from an Xcode 26 xcresult is not yet solved; the core engine falls
+  back to running the full resolved test class (today's behavior). The seam exists
+  for when per-test coverage parsing lands. This is a graceful no-op, not a bug.
+
+## Safety property
+
+Coverage-gating and test-selection are OPTIMIZATIONS that degrade to today's
+behavior on any failure: `covered_lines`/`tests_for_lines` return `None` on parse
+error, missing bundle, or unsupported Xcode → the loop mutates every line / runs
+the full class. The worst case is "no speedup," never "wrong verdict." This is
+what made the change safe to make on critical quality tooling.
+
+## Files in scope
+
+- `scripts/mutate_coverage.py` (new) + `scripts/test_mutate_coverage.py` (new)
+- `scripts/palace_mutate.py` + `scripts/test_palace_mutate.py`
+- `scripts/palace_mutate_parallel.py` (new) + `scripts/test_palace_mutate_parallel.py` (new)
+- `scripts/verify-pr.sh`, `scripts/post-mutation-pr-comment.py` + `scripts/test_post_mutation_pr_comment.py` (new)
+- `docs/architecture/mutation-testing.md` (new)
+- `.forgeos/mutation-suppressions/` (README + EXAMPLE)

--- a/.forgeos/mutation-suppressions/EXAMPLE.json
+++ b/.forgeos/mutation-suppressions/EXAMPLE.json
@@ -1,0 +1,14 @@
+[
+  {
+    "line_text": "for i in 0 ..< buffer.count {",
+    "original": "<",
+    "mutated": "<=",
+    "reason": "EXAMPLE ONLY — not loaded for any real source (no EXAMPLE.swift exists). Demonstrates a loop-bound equivalence: i is bounded by count and never reaches it, so < vs <= on the range operator is observably identical here."
+  },
+  {
+    "line_text": "guard retryCount >= 0 else { return }",
+    "original": ">=",
+    "mutated": ">",
+    "reason": "EXAMPLE ONLY. retryCount is initialized to 0 and only incremented, so >= 0 and > -1 (== > here against an always-non-negative value... ) — illustrative entry showing the original/mutated token pair shape; do not copy verbatim."
+  }
+]

--- a/.forgeos/mutation-suppressions/README.md
+++ b/.forgeos/mutation-suppressions/README.md
@@ -1,0 +1,58 @@
+# Equivalent-mutant suppressions
+
+`palace_mutate.py` flips operators in production Swift and checks that some test
+fails (the mutant is "killed"). A mutant that no test kills usually means a
+coverage gap — but occasionally the mutant is **equivalent**: it changes the
+source text without changing any observable behavior, so *no* test can ever kill
+it. Re-flagging an equivalent mutant every run is noise. This directory lets a
+human suppress one **once, with a reason**, after review.
+
+Suppress sparingly. A surviving mutant is far more often a missing test than a
+true equivalence. Only add an entry after you have convinced yourself (and ideally
+a reviewer) that the two operators are provably interchangeable on that line.
+
+## File naming
+
+One JSON file per source file, named by the source **leaf without `.swift`**:
+
+| Source file                                   | Suppressions file                                  |
+| --------------------------------------------- | -------------------------------------------------- |
+| `Palace/Audiobooks/AudiobookLoader.swift`     | `.forgeos/mutation-suppressions/AudiobookLoader.json` |
+| `Palace/Book/Models/TPPBookState.swift`       | `.forgeos/mutation-suppressions/TPPBookState.json`    |
+
+`load_suppressions(repo_root, source_relpath)` derives the leaf from
+`source_relpath`, so a file named `EXAMPLE.json` (this directory's sample) is
+**never** loaded for any real source file — there is no `EXAMPLE.swift`.
+
+## Format
+
+A JSON **list** of objects. Each object:
+
+```json
+{
+  "line_text": "for i in 0 ..< count {",
+  "original": "<",
+  "mutated": "<=",
+  "reason": "count is the array length; i never reaches it, so < vs <= on the loop bound is equivalent here"
+}
+```
+
+Field semantics (must match the mutation's fields in `palace_mutate.py`):
+
+- `line_text` — the full source line the mutation sits on. Compared **stripped**
+  of leading/trailing whitespace on both sides, so a re-indent does not silently
+  un-suppress a reviewed mutant. (A change to the line's actual content WILL
+  un-suppress it — which is correct: the line you reviewed no longer exists.)
+- `original` — the operator token as it appears in source (e.g. `>=`, `&&`,
+  `return true`, `+= 1`). Matched **exactly**.
+- `mutated` — the operator token the mutator would substitute (e.g. `>`, `||`).
+  Matched **exactly**.
+- `reason` — free text. Required by convention (this is the whole point of a
+  reviewed suppression); ignored by the matcher.
+
+A suppression matches a discovered mutant iff all three of
+`(line_text.strip(), original, mutated)` match. A malformed or non-list file is
+treated as empty (suppresses nothing) — a broken suppressions file must never
+crash a mutation run.
+
+See `EXAMPLE.json` for a complete sample.

--- a/.forgeos/swarms/mutation-wc/workflow.js
+++ b/.forgeos/swarms/mutation-wc/workflow.js
@@ -1,0 +1,392 @@
+export const meta = {
+  name: 'mutation-testing-world-class',
+  description: 'Build world-class mutation testing for Palace iOS: coverage-gating, test-selection, per-build flags, diff-default, critical-path metric, per-mutant cache, parallel pool, equivalent-mutant suppress-list',
+  phases: [
+    { title: 'Coverage engine (A)' },
+    { title: 'Core engine (C)' },
+    { title: 'Parallel + Gate (B, D)' },
+    { title: 'Docs + integration gate (E)' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Shared context every implementer needs.
+// ---------------------------------------------------------------------------
+const REPO = '/Users/mauricework/PalaceProject/ios-core'
+
+const COMMON = `
+You are a careful implementer on Palace iOS's CRITICAL quality tooling (mutation
+testing). Coherence and correctness matter more than raw speed. This is Python +
+bash tooling under scripts/, NOT Swift — ignore xcodebuild/ForgeOS/pbxproj swarm
+ceremony.
+
+Repo root: ${REPO}
+
+HARD CONSTRAINTS (all components):
+- Every pure-logic addition gets unit tests that DO NOT invoke xcodebuild or boot
+  a simulator. Mock subprocess. The xcodebuild path is the slow thing we are
+  fixing; tests must run in <5s. Follow the style of scripts/test_palace_mutate.py.
+- Read the files you touch IN FULL before editing. Preserve ALL existing careful
+  comments in palace_mutate.py and resolve-tests-for.py.
+- Do NOT commit, stage, or push. Leave changes in the working tree; the
+  orchestrator integrates.
+- Python 3, no third-party deps beyond stdlib (no pip installs).
+- When you finish, your StructuredOutput IS your report. In 'evidence' paste the
+  ACTUAL output of running your unit tests (python3 -m unittest ...), not a claim.
+`
+
+// ---------------------------------------------------------------------------
+// THE A<->C INTERFACE CONTRACT (orchestrator-pinned; both A and C obey it).
+// ---------------------------------------------------------------------------
+const INTERFACE_CONTRACT = `
+=== PINNED INTERFACE CONTRACT: scripts/mutate_coverage.py (A) <-> palace_mutate.py (C) ===
+
+A creates scripts/mutate_coverage.py exposing EXACTLY these callables. C imports
+and calls them. Neither side may change the signatures without the other.
+
+  def covered_lines(xcresult_path, source_relpath, repo_root):
+      """Return a set[int] of 1-indexed line numbers in source_relpath that were
+      EXECUTED by the tests recorded in the xcresult bundle. Return None on ANY
+      failure (bundle missing, parse error, unsupported Xcode version, file not in
+      coverage). None means 'coverage unknown' and C MUST fall back to NOT gating
+      (i.e. behave exactly as today: mutate every discovered line). This graceful
+      degradation is the safety property that makes coverage-gating low-risk."""
+
+  def tests_for_lines(xcresult_path, source_relpath, lines, repo_root):
+      """Best-effort per-test attribution for TEST SELECTION. Given a set[int] of
+      lines, return dict[int, list[str]] mapping each line to the
+      'PalaceTests/<Class>/<method>' selectors whose execution covered it. Return
+      None if per-test coverage is unavailable in this xcresult (then C falls back
+      to running the whole resolved test class — today's behavior). Partial maps
+      are fine: a line absent from the dict means 'unknown, run the full class'."""
+
+  def load_suppressions(repo_root, source_relpath):
+      """Load human-curated equivalent-mutant suppressions for this source file.
+      Storage: .forgeos/mutation-suppressions/<file-leaf-without-.swift>.json,
+      a JSON list of objects: {"line_text": "...", "original": ">=", "mutated": ">",
+      "reason": "loop bound is provably equivalent"}. line_text is compared
+      STRIPPED of leading/trailing whitespace. Return [] if the file is absent.
+      Document the format with a committed example file + a README in that dir."""
+
+  def is_suppressed(suppressions, line_text, original, mutated):
+      """True iff (line_text.strip(), original, mutated) matches a suppression
+      entry. Pure function, trivially unit-testable without any xcresult."""
+
+C calls these as: from a module import (sys.path already includes scripts/ dir
+in palace_mutate.py). C must guard the import so palace_mutate.py still works if
+mutate_coverage.py is somehow absent (try/except ImportError -> disable gating).
+`
+
+// ---------------------------------------------------------------------------
+const IMPL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    status: { type: 'string', enum: ['READY', 'BLOCKED'] },
+    files_changed: { type: 'array', items: { type: 'string' } },
+    tests_added: { type: 'array', items: { type: 'string' } },
+    interface: { type: 'string', description: 'For A: final public signatures + suppress-list path/format + the exact xccov/xcresulttool command used + whether tests_for_lines is real or returns None. For C: final CLI flags, report-schema additions, per-mutant cache path/format, exit-code semantics.' },
+    evidence: { type: 'string', description: 'ACTUAL pasted output of running the new unit tests + any DoD greps.' },
+    notes: { type: 'string' },
+    blocked_reason: { type: 'string' },
+  },
+  required: ['status', 'files_changed', 'interface', 'evidence'],
+}
+
+const E_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    status: { type: 'string', enum: ['PASS', 'FAIL'] },
+    pytest_summary: { type: 'string' },
+    bash_n_summary: { type: 'string' },
+    docs_written: { type: 'array', items: { type: 'string' } },
+    fixes_applied: { type: 'array', items: { type: 'string' } },
+    remaining_issues: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['status', 'pytest_summary', 'bash_n_summary'],
+}
+
+// ===========================================================================
+// Phase A — coverage engine (no deps)
+// ===========================================================================
+phase('Coverage engine (A)')
+const a = await agent(`${COMMON}
+
+COMPONENT A — Coverage engine. Create scripts/mutate_coverage.py and
+scripts/test_mutate_coverage.py.
+
+${INTERFACE_CONTRACT}
+
+Your deliverables:
+1. scripts/mutate_coverage.py implementing the four callables above EXACTLY.
+   - covered_lines / tests_for_lines: figure out the correct Xcode 26 incantation.
+     Try: 'xcrun xccov view --report --json <xcresult>' for file-level, and for
+     LINE-level use 'xcrun xccov view --archive --file <abs-source> <xcresult>'
+     (the .xcresult contains the coverage archive; if that form fails, probe
+     'xcrun xcresulttool' / the .xccovarchive inside DerivedData). You do NOT
+     have a real xcresult handy — you cannot fully run this end to end. That is
+     OK: design defensively so EVERY failure path returns None, and unit-test the
+     PARSING logic by feeding the functions saved/synthetic xccov JSON/text
+     fixtures (capture the documented output shapes; commit small fixtures under
+     scripts/fixtures/ if helpful). Per-test attribution (tests_for_lines) is
+     genuinely hard in Xcode 26 — if you cannot do it reliably from the xcresult,
+     implement it to return None (graceful fallback) and document WHY in a
+     comment. Returning None is acceptable and expected; a wrong map is not.
+   - load_suppressions / is_suppressed: fully implementable + fully testable now.
+2. Create .forgeos/mutation-suppressions/README.md documenting the JSON format and
+   an example file .forgeos/mutation-suppressions/EXAMPLE.json (a sample, clearly
+   marked as an example, that load_suppressions for a real leaf will NOT pick up).
+3. scripts/test_mutate_coverage.py: unit tests for is_suppressed (match/no-match,
+   whitespace-insensitive line_text), load_suppressions (present/absent/malformed
+   -> []), and the coverage PARSER fed synthetic fixtures (covered lines extracted
+   correctly; malformed/empty -> None). All tests pure-Python, no xcodebuild.
+
+Run: python3 -m unittest scripts.test_mutate_coverage  (paste real output in evidence).
+Report via StructuredOutput. In 'interface' give C the EXACT final signatures and
+note whether tests_for_lines is real or stubbed-to-None.`,
+  { label: 'A:coverage-engine', phase: 'Coverage engine (A)', schema: IMPL_SCHEMA })
+
+if (!a || a.status === 'BLOCKED') {
+  log(`A BLOCKED: ${a ? a.blocked_reason : 'agent returned null'}`)
+  return { aborted: 'A failed', a }
+}
+log(`A READY. interface:\n${a.interface}`)
+
+// ===========================================================================
+// Phase C — core engine (depends on A's interface)
+// ===========================================================================
+phase('Core engine (C)')
+const c = await agent(`${COMMON}
+
+COMPONENT C — Core engine. You are the SINGLE OWNER of scripts/palace_mutate.py
+and scripts/test_palace_mutate.py. Read both in full first.
+
+Component A has shipped scripts/mutate_coverage.py. Its FINAL interface (obey it):
+${a.interface}
+
+${INTERFACE_CONTRACT}
+
+Implement ALL of the following in palace_mutate.py, preserving every existing
+comment and the existing behavior/exit-code contract:
+
+1. TIER 1 per-build waste flags in run_targeted_tests(). Add to the xcodebuild
+   command: -disableAutomaticPackageResolution -onlyUsePackageVersionsFromResolvedFile
+   -skipPackagePluginValidation -parallel-testing-enabled NO, and the build setting
+   COMPILER_INDEX_STORE_ENABLE=NO. Do NOT add -quiet (any_tests_ran parses
+   'Executed N tests'). Make the whole extra-flag set overridable via env var
+   PALACE_MUTATE_XCB_EXTRA_FLAGS (space-split; if set, REPLACES the defaults) and
+   suppressible via PALACE_MUTATE_NO_FAST_FLAGS=1. Keep a module-level constant
+   listing the defaults so a unit test can assert their presence.
+
+2. COVERAGE-GATING (keystone). The BASELINE run (run before any mutation) should
+   additionally pass -enableCodeCoverage YES -resultBundlePath <tmpdir bundle>.
+   Add a helper that runs the baseline with coverage and returns the xcresult path.
+   Then (unless --no-coverage-gate) call mutate_coverage.covered_lines(...) for
+   args.file; intersect with the discovered mutation lines. Mutations on UNCOVERED
+   lines are recorded with status 'uncovered' and NEVER run (a guaranteed survivor
+   -> free coverage-gap signal). If covered_lines returns None, gating is DISABLED
+   and behavior is exactly as today (mutate all lines). Default: gating ON;
+   --no-coverage-gate disables. Guard the import with try/except ImportError so
+   palace_mutate.py still runs if mutate_coverage.py is absent.
+
+3. TEST SELECTION. Unless --no-test-selection, call tests_for_lines for the
+   covered mutation lines. For a mutant whose line has a non-empty selector list,
+   run ONLY those '-only-testing:Class/method' selectors instead of the full
+   args.tests. Fall back to args.tests when the map is None or lacks that line.
+
+4. PER-MUTANT INCREMENTAL CACHE (in addition to the existing whole-file cache —
+   keep that as the fast path / check it first). New layer at
+   .forgeos/mutation-cache/mutants/<leaf>.json: a JSON object mapping
+   mutant_key -> {status, elapsed_sec, stored_at}. mutant_key = sha256 over
+   (CACHE_VERSION, sorted(tests), context_before + '\\n' + line_text + '\\n' +
+   context_after, original, mutated)[:16], where context_before/after are the
+   stripped text of the immediately preceding/following source lines (so the key
+   survives edits ELSEWHERE in the file but disambiguates two identical lines in
+   different locations). Compute context at discovery time (store on the Mutation
+   dataclass). On a run (unless --no-cache): for each planned mutant look up the
+   per-mutant cache; reuse cached status; only execute misses; persist updates
+   atomically. Add a tiny pure function compute_mutant_key(...) that is unit-tested
+   for stability (same inputs -> same key) and disambiguation (same line_text,
+   different context -> different key).
+
+5. CRITICAL-PATH METRIC. Add a module-level CRITICAL_PATH_REGEX matching
+   Palace/Audiobooks/, Palace/SignInLogic/, Palace/MyBooks/Download, Palace/MyBooks/Borrow,
+   Palace/MyBooks/BookReturn, Palace/Migrations/, Palace/Network/TPPNetworkResponder,
+   Palace/Network/TPPNetworkExecutor, Palace/Packages/PalaceAuth/. Add to the report
+   summary: is_critical_path (bool, does args.file match), and
+   critical_path_survivors (count of SURVIVED mutants whose op is consequential —
+   cmp/bool/bound/retval/cond; exclude assign). When is_critical_path and
+   critical_path_survivors > 0, the process exit code is 1 (gate fail) REGARDLESS
+   of kill rate. PRESERVE the existing exit contract otherwise: 0 ok, 1 low-kill
+   (<50%), 2 error. PRESERVE the printed summary line containing
+   'killed: N  survived: N  errored: N  kill rate: P%' verbatim (verify-pr.sh
+   greps it). Also keep emitting that line in the CACHED branch.
+
+6. SUPPRESS-LIST. Load mutate_coverage.load_suppressions for args.file once.
+   Mutants matching is_suppressed are recorded status 'suppressed' and NOT run and
+   NOT counted as survived/killed.
+
+7. Report schema additions (BACKWARD COMPATIBLE — only ADD keys). summary gains:
+   uncovered, suppressed, is_critical_path, critical_path_survivors. Add a
+   top-level 'coverage_gap' list of {line, op} for uncovered mutation points.
+   Existing keys (killed/survived/errored/kill_rate_pct/partial/...) UNCHANGED.
+
+8. Extend scripts/test_palace_mutate.py: keep all existing tests passing; add
+   tests for compute_mutant_key (stability + disambiguation), the critical-path
+   classification + critical_path_survivors counting (build a fake report dict),
+   the Tier-1 default-flags constant presence, and the suppress/uncovered status
+   accounting. NONE may invoke xcodebuild — test the pure functions; refactor
+   small pure helpers OUT of the xcodebuild-calling code if needed to make them
+   testable.
+
+Run: python3 -m unittest scripts.test_palace_mutate  (paste real output).
+Report via StructuredOutput; in 'interface' give B and D the FINAL CLI flags, the
+report-schema additions, the per-mutant cache path/format, and the exact
+exit-code semantics.`,
+  { label: 'C:core-engine', phase: 'Core engine (C)', schema: IMPL_SCHEMA })
+
+if (!c || c.status === 'BLOCKED') {
+  log(`C BLOCKED: ${c ? c.blocked_reason : 'agent returned null'}`)
+  return { aborted: 'C failed', a, c }
+}
+log(`C READY. interface:\n${c.interface}`)
+
+// ===========================================================================
+// Phase B + D — parallel orchestrator and gate wiring (both depend on C, disjoint files)
+// ===========================================================================
+phase('Parallel + Gate (B, D)')
+const [b, d] = await parallel([
+  () => agent(`${COMMON}
+
+COMPONENT B — Parallel worker-pool orchestrator. Create
+scripts/palace_mutate_parallel.py and scripts/test_palace_mutate_parallel.py.
+
+It shells out to the improved palace_mutate.py. Its FINAL interface:
+${c.interface}
+
+Design:
+- CLI: --files F [F ...] OR --changed (compute changed prod Swift vs --base,
+  default origin/develop); --workers N (default = min(#sims, max(1, ncpu//4),
+  #files)); --base; pass-through flags (--diff-only, --max-mutations, --no-cache,
+  etc.) forwarded to each palace_mutate.py invocation; --report-dir.
+- FILE-LEVEL fan-out (NOT mutant-level): each worker processes whole files so
+  within-file DerivedData stays warm. ISOLATION via one git worktree + one pool
+  sim + one PALACE_MUTATE_DERIVED_DATA_PATH per worker. NEVER batch mutants into
+  one build (that masks survivors behind killed mutants — explicitly forbidden).
+- Sim pool UDIDs: 141BD227-6E9A-4409-8D99-2D4FE818238D,
+  BFB9B169-4E06-4087-BD6B-F54BB56EAA6B, 6C6BD82F-D659-4F77-8B9E-C2CBDF3A6CF8.
+- Worktree setup: reuse the Palace recipe (Carthage/Build via 'cp -RL' not symlink;
+  ios-audiobooktoolkit a REAL 'git submodule update --init'; other 7 submodules +
+  adobe-rmsdk symlinked; copy gitignored secrets). See
+  .claude/skills/swarm/SKILL.md Phase 0 for the exact recipe — replicate it.
+- GATE parallelism on cost: if #files < 2 OR --workers 1, run SERIALLY in the main
+  tree (no worktree/cold-build overhead) — small PRs must not get slower. log() the
+  decision and what was parallelized vs serial (no silent caps).
+- Aggregate each file's JSON report into a combined summary (total killed/survived/
+  uncovered/suppressed, per-file kill rates, any critical_path_survivors>0 ->
+  overall fail). Exit non-zero if any file fails its gate (mirror palace_mutate's
+  contract).
+
+TESTS (scripts/test_palace_mutate_parallel.py, pure-Python, mock subprocess +
+worktree creation + filesystem): worker-count computation across (#files, #sims,
+ncpu) edge cases incl. 0/1/many; serial-vs-parallel gating decision; sim
+round-robin assignment to workers; report AGGREGATION from synthetic per-file
+report dicts (sums, overall pass/fail, critical-path override). DO NOT create real
+worktrees or run xcodebuild in tests — factor the orchestration so the pure logic
+is callable in isolation.
+
+Run: python3 -m unittest scripts.test_palace_mutate_parallel  (paste real output).
+Report via StructuredOutput.`,
+    { label: 'B:parallel-pool', phase: 'Parallel + Gate (B, D)', schema: IMPL_SCHEMA }),
+
+  () => agent(`${COMMON}
+
+COMPONENT D — Gate wiring. Modify scripts/verify-pr.sh and
+scripts/post-mutation-pr-comment.py (read both first; verify-pr.sh is large —
+read the '--- Mutation Testing ---' section thoroughly, roughly lines 610-735).
+Touch scripts/resolve-tests-for.py ONLY if strictly needed.
+
+palace_mutate.py's FINAL interface (from component C):
+${c.interface}
+
+Deliverables:
+1. DIFF-SCOPED BY DEFAULT for the PR gate. In verify-pr.sh's mutation loop, pass
+   --diff-only to palace_mutate.py BY DEFAULT (whole-file only when a new flag
+   --mutation-whole-file is given — for release runs). Keep --enforce-mutations /
+   --no-enforce-mutations / --mutation-min-kill-rate working. Update the header
+   usage comment block.
+2. CRITICAL-PATH ENFORCEMENT. After each palace_mutate run, read the per-file JSON
+   report (jq or python one-liner) and if summary.critical_path_survivors > 0, mark
+   that file a STRICT FAIL with a clear message naming the survivors' lines, even
+   if the kill rate is >= the floor. Preserve the existing kill-rate parsing from
+   the printed 'killed:/survived:' line and the exit-code handling (2 = hard error).
+3. post-mutation-pr-comment.py: render new report sections — coverage_gap
+   (uncovered lines as a 'free coverage-gap' callout), suppressed count, and
+   critical_path_survivors prominently (these BLOCK). Keep existing table output.
+4. DO NOT break the existing flow when the new report keys are absent (older cached
+   reports) — default-missing-keys defensively.
+
+VERIFICATION (no full xcodebuild needed):
+- bash -n scripts/verify-pr.sh  (paste output; must be clean).
+- python3 -c 'import ast; ast.parse(open("scripts/post-mutation-pr-comment.py").read())' (paste).
+- If post-mutation-pr-comment.py has or can take a small pytest for its rendering
+  given a synthetic report dict, add one under scripts/ and run it.
+Report via StructuredOutput; paste real command output in 'evidence'.`,
+    { label: 'D:gate-wiring', phase: 'Parallel + Gate (B, D)', schema: IMPL_SCHEMA }),
+])
+
+log(`B: ${b ? b.status : 'null'}; D: ${d ? d.status : 'null'}`)
+
+// ===========================================================================
+// Phase E — docs + whole-suite integration gate
+// ===========================================================================
+phase('Docs + integration gate (E)')
+const e = await agent(`${COMMON}
+
+COMPONENT E — Docs + integration gate. Two jobs:
+
+1. Write docs/architecture/mutation-testing.md: the first-principles rationale for
+   the whole system. Cover: the cost model (cost = #mutants x cost-per-run); the
+   theory (DeMillo-Lipton-Sayward 1978, Competent Programmer Hypothesis, Coupling
+   Effect); each lever and WHY it helps (coverage-gating, test-selection, Tier-1
+   flags, diff-default, critical-path metric, per-mutant cache, parallel pool via
+   ISOLATION-not-batching with the masking explanation, equivalent-mutant
+   suppress-list); the graceful-degradation safety property (coverage parse fail ->
+   behaves as before); and a 'Future work: mutant schemata' note (compile-once
+   behind runtime switches — the real fix for the build being the bottleneck, hard
+   in Swift). Include a short decision log. Keep it accurate to what actually
+   shipped — read the changed scripts to verify claims before writing them.
+
+2. INTEGRATION GATE — run and report (this is the real tooling contract):
+   - Run EVERY python test in scripts: 'python3 -m unittest discover -s scripts -p "test_*.py" -v'
+     AND any pytest suite under scripts/tests/ ('python3 -m pytest scripts/tests/ -q'
+     if pytest is available; else note it). Paste the real summary lines.
+   - 'bash -n' on every shell script changed by this swarm (at minimum
+     scripts/verify-pr.sh). Paste output.
+   - 'python3 -c "import ast,glob,sys; [ast.parse(open(f).read()) for f in
+     glob.glob(\\'scripts/*.py\\')]"' to confirm all scripts parse.
+   - Import-smoke: 'cd ${REPO} && python3 -c "import sys; sys.path.insert(0,\\'scripts\\');
+     import palace_mutate, mutate_coverage, palace_mutate_parallel"' (paste).
+   If any test FAILS, FIX the smallest cause directly (you may edit any scripts/
+   file) and re-run until green, OR if a failure reveals a genuine design conflict
+   between components, report status FAIL with remaining_issues so the orchestrator
+   resolves it. Do not paper over a real failure by deleting tests.
+
+Report via StructuredOutput (E_SCHEMA): status PASS only if all gates green.`,
+  { label: 'E:docs+gate', phase: 'Docs + integration gate (E)', schema: E_SCHEMA })
+
+return {
+  A: a && a.status,
+  C: c && c.status,
+  B: b && b.status,
+  D: d && d.status,
+  E: e && e.status,
+  e_remaining: e && e.remaining_issues,
+  files: {
+    A: a && a.files_changed,
+    C: c && c.files_changed,
+    B: b && b.files_changed,
+    D: d && d.files_changed,
+  },
+}

--- a/docs/architecture/mutation-testing.md
+++ b/docs/architecture/mutation-testing.md
@@ -1,0 +1,458 @@
+---
+name: mutation-testing
+type: evolving
+status: active
+created: 2026-06-08
+last_refresh: 2026-06-08
+freshness_window: 365d
+owners: [general]
+description: First-principles rationale for the Palace iOS mutation-testing system (palace_mutate.py and friends)
+---
+
+<!-- audit-verified -->
+<!--
+  Factual claims in this doc were verified against ground truth before landing:
+  - Cost figures ($0.08/min, 90-120 min, $7-10/push) and the AudiobookLoader
+    9->6 mutant / 0%->100% example are quoted verbatim from CLAUDE.md.
+  - Every code-behavior claim (operators, DEFAULT_FAST_FLAGS, -quiet rejection,
+    CRITICAL_PATH_REGEX, CONSEQUENTIAL_OPS, compute_exit_code ordering, the two
+    caches, tests_for_lines->None, covered_lines->None degradation, the
+    file-level-not-mutant-level masking constraint, the cost gate) was read
+    directly out of scripts/palace_mutate.py, scripts/mutate_coverage.py, and
+    scripts/palace_mutate_parallel.py in this session.
+  - The "introduced by"/"introduced ... (1978/1993)" phrasings are academic
+    attributions (DeMillo-Lipton-Sayward; Untch-Offutt-Harrold), not causality
+    claims about a code regression.
+  - "100% coverage / 0% protection" is an illustrative argument about tautology
+    tests, not a measured percentage-delta on this codebase.
+-->
+
+# Mutation testing — first-principles rationale
+
+This document explains *why* the Palace iOS mutation-testing system is built the
+way it is. It is the design rationale behind `scripts/palace_mutate.py`,
+`scripts/mutate_coverage.py`, `scripts/palace_mutate_parallel.py`, and their
+integration into `scripts/verify-pr.sh`.
+
+The short version: mutation testing is the only test-quality metric we have that
+**cannot be gamed by assertion-free tests** — but a naive implementation is so
+slow it never runs, and a tool that never runs has zero value. Every lever in
+this system exists to drive *cost down* (or *signal up*) without changing the
+core guarantee. The rest of this doc is the chain of reasoning from the theory
+to each lever.
+
+---
+
+## 1. Why mutation testing at all
+
+Line coverage answers "did a test *execute* this line?" It does not answer the
+question we actually care about: "would a test *fail* if this line were wrong?"
+A test that runs a line but asserts nothing about its effect contributes full
+coverage and zero protection. The Palace `CLAUDE.md` test-quality rules exist
+precisely because coverage-chasing produced tautology tests
+(`XCTAssertNotNil(Singleton.shared)`, `vm.x = 5; XCTAssertEqual(vm.x, 5)`) that
+inflate the number while catching nothing.
+
+Mutation testing closes that gap directly. The procedure:
+
+1. Take a production file that has passing tests.
+2. Introduce a small, behavior-changing defect (a **mutant**) — flip `>` to
+   `>=`, `&&` to `||`, `return true` to `return false`, negate an `if`.
+3. Re-run the tests.
+4. If a test now **fails**, the mutant is **killed** — the test suite detects
+   that class of bug. If all tests still **pass**, the mutant **survived** — a
+   real defect of that shape would ship undetected.
+
+The **kill rate** (killed / mutants-actually-run) is a direct measure of test
+*effectiveness*, not test *presence*. A tautology test cannot kill mutants,
+because nothing it asserts depends on the mutated behavior. This is why
+`CLAUDE.md` makes "every test must survive the mutation question" the bar for
+critical paths, and why this tool is wired into `/regression` and the pre-release
+self-check.
+
+### The theory
+
+Mutation testing was introduced by **DeMillo, Lipton & Sayward (1978)** ("Hints
+on Test Data Selection: Help for the Practicing Programmer", *IEEE Computer*).
+Two hypotheses justify why testing against *tiny* injected faults generalizes to
+real bugs:
+
+- **The Competent Programmer Hypothesis.** Programmers write code that is
+  *nearly* correct — real bugs are small deviations from a correct program, not
+  arbitrary wrong programs. So the space of mutants (small syntactic deltas)
+  models the space of real defects well.
+- **The Coupling Effect.** Test data that distinguishes a program from all its
+  *simple* (single-token) mutants will also, with high probability, distinguish
+  it from *complex* (multi-fault) errors. Empirically validated since (Offutt
+  et al.): a suite that kills simple mutants tends to catch compound bugs too.
+
+Together: a small, cheap-to-generate set of single-operator mutants is a
+*sufficient* proxy for "would this suite catch a real bug here?" That is the
+whole foundation. Everything below is engineering to make the proxy affordable.
+
+### The mutation operators we use
+
+`palace_mutate.py` discovers mutation points by regex (see `_MUTATORS`), in six
+operator categories:
+
+| Op       | Mutation                                              |
+|----------|------------------------------------------------------|
+| `cmp`    | `==`↔`!=`, `>=`→`<=`/`>`, `<=`→`>=`/`<`              |
+| `bool`   | `&&`↔`\|\|`                                          |
+| `bound`  | `<`→`<=`, `>`→`>=`, `<=`→`<`, `>=`→`>` (off-by-one)  |
+| `retval` | `return true`↔`return false` (inside Bool funcs)     |
+| `cond`   | `if x` → `if !x` (top-level conditional negation)    |
+| `assign` | `+= 1`↔`-= 1`                                         |
+
+These target the decision logic where bugs hide and tests most often go shallow.
+`palace_mutate.py` deliberately **skips** mutation points inside logging calls
+(`Log.{trace,debug,info,warn,error}`, `print`, `NSLog`, `os_log`, `Logger`) —
+flipping a string interpolation inside a log line changes no observable behavior,
+so such a "survivor" deflates the kill rate while saying nothing about test
+quality. (Per `CLAUDE.md`: AudiobookLoader.swift went from 9 discovered mutants /
+0% kill rate to 6 real mutants / 100% after this skip rule landed.)
+
+---
+
+## 2. The cost model — why naive mutation testing never runs
+
+The total cost of a mutation run is, to first order:
+
+```
+cost  ≈  (number of mutants)  ×  (cost per mutant run)
+```
+
+For an iOS app, **cost per mutant run is brutal**: each mutant requires an
+`xcodebuild test` invocation — a compile + link + boot-sim + run cycle measured
+in minutes, not milliseconds. The reference Swift mutation tester (Muter) makes
+this worse two ways: it copies the *entire* project to a sibling directory (which
+breaks on Palace's submodules and signing certs) and it runs the **full** test
+suite per mutant. On a real PR that is hours of walltime. `CLAUDE.md` records the
+empirical number: a cold first-touch PR with 16+ changed files is **90–120 min /
+$7–10 per push** on macOS GitHub-hosted runners ($0.08/min). That is why
+mutation testing was **removed from CI** (the `mutation-on-pr.yml` /
+`mutation-gate.yml` workflows) and made a **local-only, pre-release** gate.
+
+A tool that costs that much per push gets disabled, and a disabled tool provides
+no signal — the same failure mode `CLAUDE.md`'s green-board contract warns about.
+
+So the entire system is organized around the two factors of the cost product.
+There are exactly two ways to make it cheaper:
+
+- **Shrink the numerator** — run *fewer* mutants (coverage-gating, diff-default,
+  equivalent-mutant suppression).
+- **Shrink the per-run cost** — make each `xcodebuild` cycle cheaper or skip it
+  entirely (Tier-1 flags, per-mutant cache, test-selection), or do several
+  *files* at once (the parallel pool).
+
+And one way to make the same cost buy *more signal*:
+
+- **Spend the budget where a bug hurts most** (the critical-path metric).
+
+Each lever maps to one of those. The guiding invariant: **no lever may change
+the killed/survived verdict of a mutant that actually runs.** Cost levers may
+only decide *whether* a mutant runs or *how fast*; they may never flip a
+SURVIVED to a KILLED.
+
+---
+
+## 3. The levers
+
+### 3.1 Coverage-gating — don't mutate dead lines
+
+*(`mutate_coverage.covered_lines`, integrated in `palace_mutate.main`)*
+
+A mutant on a line **no test executes** is a *guaranteed* survivor: if no test
+runs the code, nothing can fail, so the mutant always survives. Running it costs
+a full `xcodebuild` cycle to learn nothing, **and** it deflates the kill rate
+with a "survivor" that reflects missing coverage, not a weak assertion.
+
+So the baseline test run is done **with coverage on** (into a temp `.xcresult`
+bundle), and `covered_lines()` parses which lines were actually executed. Any
+mutation point on an unexecuted line is recorded `uncovered` and **never run**.
+`uncovered` mutants are tracked in their own counter and surfaced as a
+`coverage_gap` in the report — they are an honest "you have no test here" signal,
+not a kill-rate penalty. Kill rate is computed over **run** mutants only, so
+coverage gaps neither inflate nor deflate it.
+
+This is pure win: fewer `xcodebuild` cycles **and** a more honest metric.
+
+### 3.2 Per-line test selection — run only the tests that touch the line
+
+*(`mutate_coverage.tests_for_lines`, integrated in `palace_mutate.main`)*
+
+In principle, a mutant only needs to be graded against tests that actually
+execute its line; running the whole class is wasted compile/run time. The
+interface for this exists (`tests_for_lines` returns `line -> [selectors]`, and
+`main` narrows `selected_tests` per mutant when a mapping is present).
+
+**Honest limitation, deliberately shipped as a no-op.** `tests_for_lines`
+currently returns `None`. Xcode 26's coverage archive aggregates execution counts
+across the *entire* test run; it does not segment counts per individual test, and
+there is no stable, documented `xcresulttool` form that yields per-test *line*
+coverage. The only way to get true per-test attribution would be to run each test
+in isolation with coverage on and diff the archives — which is exactly the
+expensive thing this tool exists to avoid.
+
+Returning a *wrong* map would be actively harmful: the caller would narrow to a
+subset that does **not** exercise the mutated line, grade the mutant SURVIVED
+against tests that could never kill it, and silently lie about coverage.
+Returning `None` is the honest, safe signal — "attribution unavailable, run the
+full class" — which is exactly today's behavior. The signature is kept stable so
+a future Xcode (or an isolation-based implementation behind a flag) can fill it
+in without touching the caller. This is the one lever that is wired but
+intentionally dormant, because shipping it wrong would violate the
+core invariant (it could flip a real SURVIVED to a false KILLED).
+
+### 3.3 Tier-1 flags — shave per-build waste off every `xcodebuild`
+
+*(`DEFAULT_FAST_FLAGS` in `palace_mutate.py`)*
+
+Each mutant run is a targeted `xcodebuild test`. Several per-invocation steps are
+pure waste *inside a mutation loop*, because the tree's package state is already
+resolved and pinned and the run is inherently serial (one narrow class):
+
+| Flag                                          | Why it's safe here                        |
+|-----------------------------------------------|-------------------------------------------|
+| `-disableAutomaticPackageResolution`          | SPM graph is already resolved; don't re-resolve every run |
+| `-onlyUsePackageVersionsFromResolvedFile`     | trust `Package.resolved` verbatim         |
+| `-skipPackagePluginValidation`                | skip plugin fingerprint prompts           |
+| `-parallel-testing-enabled NO`                | we run ONE narrow class — parallelism overhead, not gain |
+| `COMPILER_INDEX_STORE_ENABLE=NO`              | mutation loop needs no index store writes |
+
+**Deliberately NOT added: `-quiet`.** `any_tests_ran()` greps the
+`Executed N tests` summary lines to distinguish "0 tests ran" (a
+misconfiguration → ERROR) from a real pass/fail. `-quiet` suppresses those lines,
+which would make every mutant grade as a 0-tests-ran ERROR. This is a concrete
+example of the core invariant: a speed flag that would corrupt the verdict is
+rejected even though it would be faster.
+
+### 3.4 Diff-default — mutate only what this PR changed
+
+*(`changed_lines` + `--diff-only`, default for the PR gate in `verify-pr.sh`)*
+
+A file with pre-existing low-coverage areas shouldn't punish a PR that didn't
+touch them, and re-mutating unchanged code on every push is pure cost. So
+`palace_mutate.py` supports `--diff-only` (with `--diff-base`, default
+`origin/develop`): restrict mutation points to lines this branch changed,
+discovered via `git diff --unified=0`. The PR gate in `verify-pr.sh` runs
+**diff-scoped by default**; `--mutation-whole-file` flips it for release runs
+that want full-file coverage.
+
+Result: the reported kill rate reflects **your diff's** test quality, not the
+file's historical coverage — fewer mutants per push, and a fairer metric.
+Graceful degradation applies here too: if `git diff` fails (unknown base ref), it
+falls back to a whole-file scan rather than crashing.
+
+### 3.5 Critical-path metric — spend the budget where bugs hurt
+
+*(`CRITICAL_PATH_REGEX` + `CONSEQUENTIAL_OPS` + `compute_exit_code`)*
+
+`CLAUDE.md`'s risk-driven rigor bar says a 30-LOC change to a return flow gets
+the same rigor as a 500-LOC refactor, because the *consequences* of a bug are the
+same. Mutation gating mirrors that: a **surviving consequential mutant on a
+critical-path file fails the gate regardless of kill rate.** A kill rate that
+looks perfect on paper cannot mask a single surviving auth/borrow/return/
+download/DRM/audiobook/migration mutant.
+
+- `CRITICAL_PATH_REGEX` matches the same roots as the `CLAUDE.md` critical-path
+  list (`Palace/Audiobooks/`, `SignInLogic/`, `MyBooks/Download|Borrow|
+  BookReturn`, `Migrations/`, `Network/TPPNetworkResponder|Executor`,
+  `Packages/PalaceAuth/`).
+- `CONSEQUENTIAL_OPS` = `{cmp, bool, bound, retval, cond}`. An `assign` flip
+  (`+= 1`→`-= 1`) surviving is far less alarming than a flipped auth comparison,
+  so `assign` is intentionally excluded from the override.
+- `compute_exit_code` returns `1` if `is_critical_path` and
+  `critical_path_survivors > 0`, **before** the `<50%` kill-rate check — so the
+  critical-path override is independent of the kill-rate floor.
+
+`verify-pr.sh` reinforces this: critical paths are **strict by default** (kill
+rate below `--mutation-min-kill-rate`, default 50, fails the gate), non-critical
+changed files are advisory (low rates surface as warnings). `--enforce-mutations`
+promotes every changed file to strict.
+
+### 3.6 Per-mutant cache — never re-run an unchanged mutant
+
+*(`compute_mutant_key` + `mutant_cache_*`, alongside the whole-file cache)*
+
+There are two caches, by design:
+
+- **Whole-file cache** (`.forgeos/mutation-cache/<leaf>.<key>.json`): keyed by
+  file SHA + test selection + seed + max-mutations + diff flags. If the exact
+  file content + selection was already run, the whole report is reused
+  instantly (the verbatim summary line `verify-pr.sh` greps for is preserved in
+  the cached branch). All-or-nothing: any edit invalidates the whole report.
+
+- **Per-mutant incremental cache**
+  (`.forgeos/mutation-cache/mutants/<leaf>.json`): finer-grained. The mutant key
+  (`compute_mutant_key`) is *content-addressed by local context* — the stripped
+  line text, its immediate neighbours (`context_before`/`context_after`), and the
+  operator delta — **not** by line number. So editing one function does not
+  invalidate untouched mutants elsewhere in the file (only moved/changed mutants
+  re-run), and two byte-identical lines in different surroundings are
+  disambiguated. The map is persisted **atomically** (tmp + rename) after every
+  mutant, so a CI-timeout-killed run leaves a consistent cache for the next run.
+
+Both caches honor `--no-cache`. The report itself is also written atomically
+after every mutation (`_write_report_atomic`) with a `partial` flag, so an
+externally-killed run never leaves a half-written report — the symptom that once
+made a CI comment say "no data."
+
+### 3.7 Parallel pool — fan out by FILE, never by mutant
+
+*(`palace_mutate_parallel.py`)*
+
+`palace_mutate.py` mutates one file serially. On a multi-file PR the per-file
+cold-build cost dominates, so `palace_mutate_parallel.py` fans **files** out
+across a small worker pool — each worker owns one git worktree + one pool
+simulator + one private `DerivedData` path — so several files mutate concurrently
+while `DerivedData` stays warm *within* each file.
+
+**The masking problem — why file-level, never mutant-level.** It is tempting to
+batch several mutants into one build to amortize compile cost. *This is forbidden,
+and the constraint is the single most important design decision in the parallel
+layer.* If you apply mutant A and mutant B to the tree and run the tests once, a
+single failure cannot tell you *which* mutant caused it. If A is killed (its
+mutation breaks a test) but B survives, the batch's tests fail, the whole batch
+grades as KILLED, and **B's survival is invisible** — a killed mutant masks a
+surviving one, and the survivor is exactly the test hole you were hunting. So
+each `palace_mutate.py` invocation owns exactly **one file** and reverts between
+mutants as it does today. Parallelism comes from **isolation** (running several
+single-file mutation processes side by side in separate worktrees), never from
+**batching** (combining mutants into one build).
+
+**Isolation per worker** is what makes concurrency safe:
+- a dedicated **git worktree** so concurrent in-place mutate+revert edits never
+  collide (the worktree setup replicates the swarm Phase 0 Palace recipe —
+  Carthage/Build *copied* not symlinked, `ios-audiobooktoolkit` a real submodule
+  clone, the other submodules + adobe-rmsdk symlinked, gitignored secrets
+  copied);
+- a dedicated **pool sim UDID** (round-robin via `assign_sims`) so two
+  `xcodebuild` runs don't fight over one booted device;
+- a dedicated **`PALACE_MUTATE_DERIVED_DATA_PATH`** so build databases don't
+  corrupt each other.
+
+**The cost gate** (`should_run_parallel`): parallel only pays off with **≥2
+files AND ≥2 workers**. Otherwise the worktree + cold-build setup is pure
+overhead, so a small PR runs **serially in the main tree** — no worktree, no cold
+build. The decision is always logged, never silent. Worker count
+(`compute_worker_count`) is `min(#sims, max(1, ncpu//4), #files)` by default:
+each `xcodebuild` is itself massively parallel, so ~1 worker per 4 logical cores
+is the empirical sweet spot, and we never spawn more workers than files (idle
+sim claims) or sims (workers would serialize on a shared device).
+
+Aggregation (`aggregate_reports`) sums per-file outcomes, computes the overall
+kill rate over **run** mutants only (mirroring the single-file rule), and fails
+overall if **any** file failed its own gate — which already encodes both the
+`<50%` rule and the critical-path override.
+
+### 3.8 Equivalent-mutant suppression — silence a once-reviewed non-bug
+
+*(`mutate_coverage.load_suppressions` / `is_suppressed`)*
+
+Some surviving mutants are **provably equivalent** to the original program — e.g.
+a `>` vs `>=` on a loop bound that can never hit the boundary value. No test can
+ever kill them because they change no observable behavior. Re-flagging them every
+run is noise. A human can review one once and add it to a per-file suppression
+list at
+`.forgeos/mutation-suppressions/<file-leaf>.json`, a JSON list of
+`{"line_text", "original", "mutated", "reason"}` entries. A suppressed mutant is
+recorded `suppressed`, never run, and never counted as survived/killed.
+
+Matching is whitespace-insensitive on the line text (so a re-indent doesn't
+silently un-suppress a reviewed equivalent), but exact on the operator tokens. A
+missing or malformed suppressions file suppresses **nothing** and never crashes a
+run — same graceful-degradation discipline as everywhere else. This lever is
+human-gated by construction: it can only ever *remove* noise a person has
+explicitly signed off on.
+
+---
+
+## 4. The graceful-degradation safety property
+
+The thread running through every lever is one safety property:
+
+> **If a cost optimization cannot do its job, the tool falls back to the
+> previous (correct, if slower) behavior — it never crashes and never corrupts a
+> verdict.**
+
+Concretely:
+
+- `mutate_coverage.py` is an **optional import**. If it's absent (fresh checkout
+  before it lands, partial sync), `_COVERAGE_AVAILABLE` is `False` and every
+  call site is skipped — `palace_mutate.py` mutates every line exactly as it did
+  before coverage-gating existed.
+- `covered_lines()` returns `None` on **any** failure (bundle missing, parse
+  error, unsupported Xcode, xccov timeout, file not in archive). `None` means
+  "coverage unknown" → the caller **does not gate** → mutate every line. The
+  coverage-parse functions are pure (operate on captured text) and return `None`
+  on malformed/empty/unexpected JSON.
+- `tests_for_lines()` returns `None` → run the full class (today's behavior).
+- `changed_lines()` (`--diff-only`) falls back to a whole-file scan if `git diff`
+  fails.
+- `load_suppressions()` returns `[]` on a missing/broken file → suppress nothing.
+- The whole-file and per-mutant caches honor `--no-cache` and write atomically;
+  a killed run leaves consistent state.
+- The Tier-1 flags are chosen so none of them can corrupt the
+  "Executed N tests" detection (`-quiet` is rejected for exactly this reason).
+
+This is what makes the whole system **low-risk to adopt**: the worst case of any
+optimization failing is that the tool gets *slower*, never *wrong*. A coverage
+extraction that breaks under a future Xcode does not silently pass a PR with no
+mutation data — it falls back to mutating everything, which is the conservative
+direction.
+
+---
+
+## 5. Future work: mutant schemata
+
+The cost product is `#mutants × cost-per-run`, and the levers above attack
+`#mutants` (coverage-gating, diff-default, suppression) and per-run overhead
+(Tier-1 flags, caches, file-level parallelism). The one factor we have **not**
+fundamentally attacked is the dominant term: **a full Swift compile per mutant.**
+
+The known research answer is **mutant schemata** (Untch, Offutt & Harrold, 1993):
+instead of compiling N separate mutated programs, compile **one** metaprogram
+that contains *all* mutation points behind runtime switches, then select which
+mutant is "live" per test run via a variable — turning N compiles into one
+compile + N cheap runs. This is the real fix for "the build is the bottleneck."
+
+It is **hard in Swift** because the conditions that make schemata easy in
+dynamically-typed or JIT-compiled languages are absent: Swift is statically typed
+and whole-module-optimized, mutation points span types (a `Bool` retval flip vs an
+`Int` comparison flip) so a single uniform switch type doesn't fit, and injecting
+a runtime selector without changing type-checking or triggering different
+optimizer behavior is delicate. A faithful schema would likely need to operate at
+the SIL level or via a source-level transform that is provably
+type-and-behavior-neutral except at the selected point. Until that exists, the
+per-mutant compile stays the bottleneck and the levers above are how we keep the
+tool affordable enough to actually run.
+
+---
+
+## 6. Decision log
+
+| Decision | Rationale |
+|---|---|
+| Mutation testing is **local-only / pre-release**, removed from CI | 90–120 min / $7–10 per push on macOS runners; a per-push gate trains everyone to ignore CI. Pay it once locally before tag-cut (`/regression`, `verify-pr.sh --enforce-mutations`). |
+| **Fewer mutants** before **cheaper runs** | Cost is a product; killing a mutant entirely (coverage-gate, diff-default, suppress) beats running it faster. |
+| Coverage-gating **on by default**, opt-out via `--no-coverage-gate` | Uncovered lines are guaranteed survivors; running them wastes builds and deflates the metric. Default to the honest, cheap behavior. |
+| Per-line test selection **wired but dormant** (`tests_for_lines` → `None`) | Xcode 26 has no stable per-test line coverage. A wrong map would flip real SURVIVED to false KILLED — worse than not having it. Return `None` (run full class) until Xcode exposes it. |
+| Reject `-quiet` from the Tier-1 flag set | It suppresses the "Executed N tests" lines `any_tests_ran()` greps, turning every mutant into a 0-tests ERROR. A speed flag that corrupts the verdict is not worth it. |
+| Diff-scoped **by default** for the PR gate; whole-file for release | Kill rate should reflect *this PR's* coverage, not the file's history; full-file is the release-time check. |
+| Critical-path survivor **fails the gate regardless of kill rate** | Risk-driven rigor: a surviving consequential auth/borrow/DRM/audiobook mutant is a real hole even at a perfect on-paper kill rate. |
+| `assign` excluded from `CONSEQUENTIAL_OPS` | A `+= 1`→`-= 1` survivor is far less alarming than a flipped auth comparison; the critical-path override is for decision logic. |
+| **Two** caches: whole-file (all-or-nothing, fast path) + per-mutant (context-addressed, fine-grained) | Whole-file gives instant reuse on unchanged content; per-mutant means editing one function doesn't re-run untouched mutants elsewhere. |
+| Per-mutant key is **content/context-addressed**, not line-numbered | A reformat or unrelated edit shifts line numbers but not behavior; keying on stripped line + neighbours + operator delta keeps cache hits valid and disambiguates identical lines. |
+| Parallel fan-out is **file-level, never mutant-level** | Batching mutants into one build lets a killed mutant mask a surviving one — the survivor is exactly the hole we're hunting. Concurrency comes from isolation, not batching. |
+| Parallel **cost gate**: serial unless ≥2 files AND ≥2 workers | Worktree + cold-build setup is pure overhead for a small PR; never make a small PR slower. Decision is logged, never silent. |
+| Every optimization **degrades gracefully** to the prior behavior | Worst case of any lever failing is *slower*, never *wrong* — the property that makes the system safe to adopt and safe under future Xcode changes. |
+| Skip mutation points inside log/print/os_log lines | Flipping a log-string interpolation changes no observable behavior; counting it as a survivor deflates the kill rate for nothing. |
+
+---
+
+## Related docs
+
+- [`critical-path-mutation-coverage.md`](./critical-path-mutation-coverage.md) — which critical-path files are mutation-gated vs contract-snapshot-covered, and the exemption rationale.
+- [`superpartner-spectrum.md`](./superpartner-spectrum.md) — the "is there a test at all?" floor; mutation testing is the "does the test catch bugs?" proof above it.
+- `CLAUDE.md` → "Mutation testing", "TDD & Test Quality", "Definition of Done" check #5 — the policy that consumes this tooling.

--- a/scripts/mutate_coverage.py
+++ b/scripts/mutate_coverage.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+mutate_coverage.py — coverage-gating + equivalent-mutant suppression support
+for palace_mutate.py.
+
+Why this exists:
+    palace_mutate.py mutates EVERY discovered line and runs the full resolved
+    test class for each mutant. Two wastes follow:
+      1. Mutating a line NO test executes is pure cost — the mutant is
+         guaranteed to SURVIVE (no test runs the code, so nothing can fail),
+         which both burns an xcodebuild cycle AND deflates the kill rate with
+         a mutant that says nothing about test quality.
+      2. Some surviving mutants are provably EQUIVALENT (e.g. a `>` vs `>=`
+         on a loop bound that can never hit the boundary value). Re-flagging
+         them every run is noise; humans should be able to suppress them once.
+
+    This module gives palace_mutate.py two opt-in capabilities, both designed
+    to DEGRADE GRACEFULLY to today's behavior on any failure:
+
+      - covered_lines(): which lines a prior test run actually executed, so
+        the caller can skip mutating dead lines. Returns None on ANY failure
+        → caller mutates everything (today's behavior). This graceful
+        degradation is the safety property that makes coverage-gating low-risk.
+
+      - load_suppressions()/is_suppressed(): human-curated equivalent-mutant
+        list, so a once-reviewed equivalent mutant stops being re-reported.
+
+Xcode 26 coverage incantation (validated against a real .xcresult on this host):
+
+    The .xcresult bundle embeds a coverage ARCHIVE. Two relevant forms:
+
+      xcrun xccov view --archive --file-list <bundle.xcresult>
+          → newline-delimited list of the ABSOLUTE source paths recorded in
+            the archive. CRUCIAL: these are the paths *as they existed at build
+            time* — on a worktree/CI build they will NOT match the current
+            repo_root (we observed `.../.claude/worktrees/swarm_.../Palace/...`).
+            So we never pass repo_root's path directly; we suffix-match the
+            file-list against source_relpath to recover the recorded path.
+
+      xcrun xccov view --archive --file <recorded-abs-path> --json <bundle.xcresult>
+          → JSON dict keyed by that path → list of per-line entries:
+              {"isExecutable": false, "line": 1}
+              {"isExecutable": true,  "line": 86, "executionCount": 4}
+            A line is COVERED iff isExecutable == true AND executionCount > 0.
+
+    Passing a path that isn't in the archive yields a non-zero exit with
+    "Failed to find coverage lines for ..." — which we treat as None.
+
+Per-test attribution (tests_for_lines) is genuinely hard in Xcode 26: the
+coverage archive aggregates execution counts across the WHOLE test run and
+does not segment counts per-test. xcresulttool can enumerate test results but
+does not expose per-test line coverage in a stable, documented form. Rather
+than ship a wrong attribution map (which would cause palace_mutate to run the
+WRONG narrowed test subset and grade mutants against tests that never touch the
+line), this function returns None — the honest "unavailable" signal that makes
+the caller fall back to running the whole resolved test class. See the function
+docstring for the full rationale.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+# Storage for human-curated equivalent-mutant suppressions, keyed by source
+# file leaf (basename without the .swift extension). Documented in the README
+# committed alongside this module.
+SUPPRESSIONS_DIRNAME = os.path.join(".forgeos", "mutation-suppressions")
+
+# Bound the xccov subprocess so a wedged invocation can never hang a mutation
+# run. Coverage extraction on a single file is sub-second in practice; a
+# generous ceiling still protects against a stuck process.
+_XCCOV_TIMEOUT_SEC = 120
+
+
+# ---------------------------------------------------------------------------
+# Coverage extraction — line-level
+# ---------------------------------------------------------------------------
+
+def _run_xccov(args: list[str]) -> str | None:
+    """Run `xcrun xccov <args>` and return stdout, or None on ANY failure.
+
+    Isolated so the parsing functions stay pure (they take already-captured
+    text and are unit-testable without a real bundle). Every failure mode —
+    xcrun missing, non-zero exit, timeout, OS error — collapses to None, which
+    upstream means "coverage unknown, mutate everything."
+    """
+    try:
+        result = subprocess.run(
+            ["xcrun", "xccov"] + args,
+            capture_output=True, text=True,
+            timeout=_XCCOV_TIMEOUT_SEC, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _recorded_path_for(file_list_text: str, source_relpath: str) -> str | None:
+    """Find the archive's recorded absolute path whose tail matches
+    source_relpath.
+
+    The archive records build-time paths (possibly a worktree/CI path that
+    differs from the current repo_root), so we cannot reconstruct the recorded
+    path — we have to discover it by suffix-matching the file-list. Pure
+    function over the file-list text; unit-tested with synthetic input.
+
+    Match rule: a recorded path matches if it ends with source_relpath at a
+    path-component boundary (so `Palace/Book/Foo.swift` matches
+    `/a/b/Palace/Book/Foo.swift` but `OtherFoo.swift` does NOT match `Foo.swift`).
+    Returns the first match in file order, or None.
+    """
+    rel = source_relpath.lstrip("/")
+    suffix = "/" + rel
+    for line in file_list_text.splitlines():
+        candidate = line.strip()
+        if not candidate:
+            continue
+        # Exact equality OR ends with /<relpath> (component boundary).
+        if candidate == rel or candidate.endswith(suffix):
+            return candidate
+    return None
+
+
+def parse_archive_covered_lines(archive_json_text: str) -> set[int] | None:
+    """Parse `xccov view --archive --file ... --json` output into the set of
+    1-indexed COVERED line numbers.
+
+    Covered := isExecutable is True AND executionCount > 0.
+
+    Pure function over the captured text — this is the unit-tested core. Returns
+    None on malformed/empty/unexpected JSON so callers fall back to no-gating.
+    """
+    if not archive_json_text or not archive_json_text.strip():
+        return None
+    try:
+        data = json.loads(archive_json_text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    # Shape: { "<recorded-abs-path>": [ {isExecutable, line, executionCount?}, ... ] }
+    if not isinstance(data, dict) or not data:
+        return None
+    # There is exactly one key (the file we asked for); take the first list value.
+    entries = None
+    for value in data.values():
+        if isinstance(value, list):
+            entries = value
+            break
+    if entries is None:
+        return None
+
+    covered: set[int] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            return None  # unexpected shape — treat the whole parse as unknown
+        if not entry.get("isExecutable"):
+            continue
+        line = entry.get("line")
+        count = entry.get("executionCount", 0)
+        if not isinstance(line, int):
+            continue
+        if isinstance(count, int) and count > 0:
+            covered.add(line)
+    return covered
+
+
+def covered_lines(xcresult_path: str, source_relpath: str, repo_root: str) -> set[int] | None:
+    """Return a set[int] of 1-indexed line numbers in source_relpath that were
+    EXECUTED by the tests recorded in the xcresult bundle. Return None on ANY
+    failure (bundle missing, parse error, unsupported Xcode version, file not in
+    coverage). None means 'coverage unknown' and the caller MUST fall back to
+    NOT gating (i.e. behave exactly as today: mutate every discovered line).
+    This graceful degradation is the safety property that makes coverage-gating
+    low-risk.
+
+    repo_root is accepted for interface symmetry / future path-equivalence use;
+    suffix-matching the recorded file-list against source_relpath already makes
+    us robust to a build-time path that differs from repo_root, so we do not
+    currently need it to locate the file.
+    """
+    if not xcresult_path or not os.path.exists(xcresult_path):
+        return None
+
+    file_list = _run_xccov(["view", "--archive", "--file-list", xcresult_path])
+    if file_list is None:
+        return None
+    recorded = _recorded_path_for(file_list, source_relpath)
+    if recorded is None:
+        return None
+
+    archive_json = _run_xccov(
+        ["view", "--archive", "--file", recorded, "--json", xcresult_path]
+    )
+    if archive_json is None:
+        return None
+    return parse_archive_covered_lines(archive_json)
+
+
+# ---------------------------------------------------------------------------
+# Per-test attribution — intentionally stubbed to None (see module docstring)
+# ---------------------------------------------------------------------------
+
+def tests_for_lines(xcresult_path: str, source_relpath: str, lines, repo_root: str):
+    """Best-effort per-test attribution for TEST SELECTION. Given a set[int] of
+    lines, return dict[int, list[str]] mapping each line to the
+    'PalaceTests/<Class>/<method>' selectors whose execution covered it. Return
+    None if per-test coverage is unavailable in this xcresult (then the caller
+    falls back to running the whole resolved test class — today's behavior).
+    Partial maps are fine: a line absent from the dict means 'unknown, run the
+    full class'.
+
+    IMPLEMENTATION NOTE — this returns None by design.
+
+    Xcode 26's coverage archive aggregates execution counts across the ENTIRE
+    test run; it does not segment counts per individual test. There is no stable,
+    documented xcresulttool form that yields per-test LINE coverage. The only way
+    to get true per-test attribution would be to run each test in isolation with
+    coverage on and diff the archives — which is exactly the expensive thing this
+    tooling exists to avoid.
+
+    Returning a WRONG map is actively harmful: the caller would narrow the test
+    selection to a subset that does NOT actually exercise the mutated line, then
+    grade the mutant as SURVIVED against tests that could never kill it —
+    silently deflating the kill rate and lying about coverage. Returning None is
+    the honest, safe signal: "attribution unavailable, run the full class."
+
+    The signature is kept stable so a future Xcode that exposes per-test
+    coverage (or an isolation-based implementation behind a flag) can fill this
+    in without touching the caller.
+    """
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Equivalent-mutant suppressions
+# ---------------------------------------------------------------------------
+
+def _suppressions_path(repo_root: str, source_relpath: str) -> str:
+    leaf = os.path.basename(source_relpath)
+    if leaf.endswith(".swift"):
+        leaf = leaf[: -len(".swift")]
+    return os.path.join(repo_root, SUPPRESSIONS_DIRNAME, f"{leaf}.json")
+
+
+def load_suppressions(repo_root: str, source_relpath: str) -> list:
+    """Load human-curated equivalent-mutant suppressions for this source file.
+
+    Storage: .forgeos/mutation-suppressions/<file-leaf-without-.swift>.json,
+    a JSON list of objects:
+        {"line_text": "...", "original": ">=", "mutated": ">",
+         "reason": "loop bound is provably equivalent"}
+    line_text is compared STRIPPED of leading/trailing whitespace (matching is
+    done in is_suppressed). Returns [] if the file is absent OR malformed — a
+    broken suppressions file must never crash a mutation run, it just suppresses
+    nothing.
+    """
+    path = _suppressions_path(repo_root, source_relpath)
+    if not os.path.isfile(path):
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(data, list):
+        return []
+    # Keep only well-formed entries (dicts carrying the three match keys);
+    # tolerate extra keys like "reason".
+    clean = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        if "line_text" in entry and "original" in entry and "mutated" in entry:
+            clean.append(entry)
+    return clean
+
+
+def is_suppressed(suppressions: list, line_text: str, original: str, mutated: str) -> bool:
+    """True iff (line_text.strip(), original, mutated) matches a suppression
+    entry. Pure function, trivially unit-testable without any xcresult.
+
+    line_text comparison is whitespace-insensitive on BOTH sides (the stored
+    entry and the live line are each stripped) so a re-indent doesn't silently
+    un-suppress a reviewed equivalent mutant. original/mutated must match exactly
+    (they are operator tokens, not free text).
+    """
+    if not suppressions:
+        return False
+    target_line = (line_text or "").strip()
+    for entry in suppressions:
+        if not isinstance(entry, dict):
+            continue
+        if (str(entry.get("line_text", "")).strip() == target_line
+                and entry.get("original") == original
+                and entry.get("mutated") == mutated):
+            return True
+    return False
+
+
+if __name__ == "__main__":
+    # Minimal CLI for manual inspection: print covered lines for a file given an
+    # xcresult bundle. Not used by palace_mutate (it imports the callables) — this
+    # is purely a debugging aid.
+    if len(sys.argv) != 3:
+        print("usage: mutate_coverage.py <bundle.xcresult> <source-relpath>", file=sys.stderr)
+        sys.exit(2)
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    cov = covered_lines(sys.argv[1], sys.argv[2], repo_root)
+    if cov is None:
+        print("coverage unknown (None) — caller would mutate every line")
+        sys.exit(1)
+    print(f"{len(cov)} covered line(s): {sorted(cov)}")

--- a/scripts/palace_mutate.py
+++ b/scripts/palace_mutate.py
@@ -62,7 +62,70 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # pick a different UDID via env without code changes.
 SIM_ID = os.environ.get("HARNESS_SESSION_SIM_UDID", "DF4A2A27-9888-429D-A749-2E157A049A37")
 DEFAULT_CACHE_DIR = os.path.join(REPO_ROOT, ".forgeos", "mutation-cache")
+# Per-mutant incremental cache lives in a subdir so it never collides with the
+# whole-file cache files (which sit directly in DEFAULT_CACHE_DIR).
+DEFAULT_MUTANT_CACHE_DIR = os.path.join(DEFAULT_CACHE_DIR, "mutants")
 CACHE_VERSION = 1  # bump when cache schema changes
+
+# Coverage-gating support is OPTIONAL — palace_mutate must still run if Component
+# A's mutate_coverage.py is somehow absent (fresh checkout before that file lands,
+# a partial sync, etc.). Guard the import so a missing module disables gating
+# rather than crashing the whole tool. _COVERAGE_AVAILABLE gates every call site.
+# Ensure the scripts/ dir is importable regardless of how palace_mutate was
+# invoked (cwd-relative `scripts/palace_mutate.py`, `python -m scripts.…`, etc.).
+if os.path.dirname(os.path.abspath(__file__)) not in sys.path:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import mutate_coverage  # noqa: E402  (intentional optional import after sys.path setup)
+    _COVERAGE_AVAILABLE = True
+except ImportError:
+    mutate_coverage = None  # type: ignore[assignment]
+    _COVERAGE_AVAILABLE = False
+
+# --- Tier-1 per-build waste flags ------------------------------------------
+# These shave per-invocation overhead off every targeted xcodebuild test run.
+# They are SAFE for a mutation loop because the tree's package state is already
+# resolved and pinned, and mutation runs are inherently serial per file:
+#   -disableAutomaticPackageResolution        don't re-resolve SPM graph each run
+#   -onlyUsePackageVersionsFromResolvedFile    trust Package.resolved verbatim
+#   -skipPackagePluginValidation               skip plugin fingerprint prompts
+#   -parallel-testing-enabled NO               serial — we run ONE narrow class
+#   COMPILER_INDEX_STORE_ENABLE=NO  (build setting) no index store writes
+# NOTE: we deliberately do NOT add -quiet — any_tests_ran() greps the
+# 'Executed N tests' summary lines, which -quiet suppresses, so adding it would
+# make every mutant grade as a 0-tests-ran ERROR.
+DEFAULT_FAST_FLAGS: list[str] = [
+    "-disableAutomaticPackageResolution",
+    "-onlyUsePackageVersionsFromResolvedFile",
+    "-skipPackagePluginValidation",
+    "-parallel-testing-enabled", "NO",
+    "COMPILER_INDEX_STORE_ENABLE=NO",
+]
+
+# Critical-path source roots. A SURVIVED consequential mutant on any of these
+# files fails the gate (exit 1) regardless of kill rate — a surviving cmp/bool/
+# bound/retval/cond flip on auth/borrow/return/download/DRM/audiobook/migration
+# code is a real test-coverage hole on a path that handles user money/access.
+# Mirrors the "Critical paths" list in CLAUDE.md.
+CRITICAL_PATH_REGEX = re.compile(
+    r"(?:^|/)Palace/(?:"
+    r"Audiobooks/"
+    r"|SignInLogic/"
+    r"|MyBooks/Download"
+    r"|MyBooks/Borrow"
+    r"|MyBooks/BookReturn"
+    r"|Migrations/"
+    r"|Network/TPPNetworkResponder"
+    r"|Network/TPPNetworkExecutor"
+    r"|Packages/PalaceAuth/"
+    r")"
+)
+
+# Mutation operators whose survival on a critical path is CONSEQUENTIAL. An
+# `assign` flip (+= 1 -> -= 1) surviving is far less alarming than a cmp/bool/
+# bound/retval/cond flip surviving on an auth decision, so the critical-path
+# gate counts only these ops. (assign is intentionally excluded.)
+CONSEQUENTIAL_OPS = frozenset({"cmp", "bool", "bound", "retval", "cond"})
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +141,13 @@ class Mutation:
     mutated: str      # text we replace with
     line_text: str    # original full line for context
     mutated_line: str # mutated full line
+    # Stripped text of the immediately preceding / following source lines.
+    # These anchor the per-mutant cache key so it (a) survives edits ELSEWHERE
+    # in the file and (b) disambiguates two byte-identical lines in different
+    # locations. "" when at the file boundary. Defaulted so older callers /
+    # tests constructing Mutation without them still work.
+    context_before: str = ""
+    context_after: str = ""
 
 
 # (regex, replacement_pairs, op_name)
@@ -201,6 +271,10 @@ def discover_mutations(source: str) -> list[Mutation]:
                 if line_text[start_in_line:end_in_line] != orig:
                     continue  # alignment lost; skip
                 mutated_line = line_text[:start_in_line] + repl + line_text[end_in_line:]
+                # Capture stripped neighbouring lines for the per-mutant cache
+                # key (see Mutation.context_before/after). Boundaries -> "".
+                context_before = lines[ln_no - 2].strip() if ln_no - 2 >= 0 else ""
+                context_after = lines[ln_no].strip() if ln_no < len(lines) else ""
                 out.append(Mutation(
                     line=ln_no,
                     col=col,
@@ -209,6 +283,8 @@ def discover_mutations(source: str) -> list[Mutation]:
                     mutated=repl,
                     line_text=line_text,
                     mutated_line=mutated_line,
+                    context_before=context_before,
+                    context_after=context_after,
                 ))
     return out
 
@@ -248,7 +324,51 @@ def any_tests_ran(output: str) -> bool:
 _DEFAULT_TARGETED_TEST_TIMEOUT = int(os.environ.get("PALACE_MUTATE_TEST_TIMEOUT", "1200"))
 
 
-def run_targeted_tests(test_class_paths: list[str], timeout: int = _DEFAULT_TARGETED_TEST_TIMEOUT) -> tuple[bool, str]:
+def resolve_fast_flags() -> list[str]:
+    """The Tier-1 per-build waste flags to splice into the xcodebuild command.
+
+    Pure (reads env only) so a unit test can assert the defaults and the
+    override/suppress behaviour without invoking xcodebuild.
+
+      PALACE_MUTATE_NO_FAST_FLAGS=1   -> no extra flags at all
+      PALACE_MUTATE_XCB_EXTRA_FLAGS   -> space-split; REPLACES DEFAULT_FAST_FLAGS
+      (unset)                          -> DEFAULT_FAST_FLAGS
+    """
+    if os.environ.get("PALACE_MUTATE_NO_FAST_FLAGS") == "1":
+        return []
+    override = os.environ.get("PALACE_MUTATE_XCB_EXTRA_FLAGS")
+    if override is not None:
+        return override.split()
+    return list(DEFAULT_FAST_FLAGS)
+
+
+def build_xcodebuild_command(test_class_paths: list[str],
+                             fast_flags: list[str],
+                             derived_data_args: list[str],
+                             coverage_bundle_path: str | None = None) -> list[str]:
+    """Assemble the full xcodebuild test argv. Pure — no subprocess, no env
+    reads beyond what the caller passed in — so the flag-splicing logic is
+    unit-testable. When coverage_bundle_path is set, the BASELINE coverage run
+    appends `-enableCodeCoverage YES -resultBundlePath <path>`.
+    """
+    only_testing_args: list[str] = []
+    for path in test_class_paths:
+        only_testing_args.extend(["-only-testing:" + path])
+    coverage_args: list[str] = []
+    if coverage_bundle_path is not None:
+        coverage_args = ["-enableCodeCoverage", "YES",
+                         "-resultBundlePath", coverage_bundle_path]
+    return [
+        "xcodebuild",
+        "-project", "Palace.xcodeproj",
+        "-scheme", "Palace",
+        "-destination", f"platform=iOS Simulator,id={SIM_ID}",
+        "test",
+    ] + derived_data_args + fast_flags + coverage_args + only_testing_args
+
+
+def run_targeted_tests(test_class_paths: list[str], timeout: int = _DEFAULT_TARGETED_TEST_TIMEOUT,
+                       coverage_bundle_path: str | None = None) -> tuple[bool, str]:
     """
     Run xcodebuild test scoped to the given test classes.
     Returns (all_passed, last_lines_of_output).
@@ -263,9 +383,6 @@ def run_targeted_tests(test_class_paths: list[str], timeout: int = _DEFAULT_TARG
     Override with PALACE_MUTATE_TEST_TIMEOUT env var if a faster environment
     only needs the smaller budget.
     """
-    only_testing_args: list[str] = []
-    for path in test_class_paths:
-        only_testing_args.extend(["-only-testing:" + path])
     # Parallel swarm agents need to point xcodebuild at a per-worktree DerivedData
     # directory so they don't fight over the default `~/Library/Developer/Xcode/DerivedData/Palace-*`
     # build database. PALACE_MUTATE_DERIVED_DATA_PATH lets an outer harness pin a
@@ -274,13 +391,12 @@ def run_targeted_tests(test_class_paths: list[str], timeout: int = _DEFAULT_TARG
     dd_path = os.environ.get("PALACE_MUTATE_DERIVED_DATA_PATH")
     if dd_path:
         derived_data_args = ["-derivedDataPath", dd_path]
-    cmd = [
-        "xcodebuild",
-        "-project", "Palace.xcodeproj",
-        "-scheme", "Palace",
-        "-destination", f"platform=iOS Simulator,id={SIM_ID}",
-        "test",
-    ] + derived_data_args + only_testing_args
+    cmd = build_xcodebuild_command(
+        test_class_paths,
+        fast_flags=resolve_fast_flags(),
+        derived_data_args=derived_data_args,
+        coverage_bundle_path=coverage_bundle_path,
+    )
     try:
         result = subprocess.run(
             cmd,
@@ -377,6 +493,187 @@ def cache_store(cache_dir: str, file_relpath: str, key: str, report: dict) -> st
 
 
 # ---------------------------------------------------------------------------
+# Per-mutant incremental cache
+# ---------------------------------------------------------------------------
+#
+# The whole-file cache (above) is all-or-nothing: any edit to the file
+# invalidates the WHOLE report and every mutant re-runs. The per-mutant cache
+# is finer: it keys each mutant on its LOCAL context (the line + its immediate
+# neighbours + the operator flip + the test selection), so an edit elsewhere in
+# the file reuses every untouched mutant's result and only the genuinely new /
+# moved mutants re-run. The whole-file cache stays the fast path (checked
+# first); this layer is the incremental fallback when the whole-file key misses.
+
+def compute_mutant_key(tests: list[str], context_before: str, line_text: str,
+                       context_after: str, original: str, mutated: str) -> str:
+    """Stable 16-hex key for one mutant.
+
+    Hashed over (CACHE_VERSION, sorted(tests), context_before + '\\n' +
+    line_text + '\\n' + context_after, original, mutated). Properties:
+      - STABILITY: identical inputs -> identical key (so a re-run on an
+        unchanged file reuses the cached status).
+      - LOCALITY: edits ELSEWHERE in the file don't change a mutant's key
+        (context is only the immediate neighbours, not line numbers).
+      - DISAMBIGUATION: two byte-identical lines in different surrounding
+        context get DIFFERENT keys, so their results never collide.
+    Pure — unit-tested for stability and disambiguation.
+    """
+    h = hashlib.sha256()
+    h.update(f"v{CACHE_VERSION}\n".encode())
+    h.update(b"--tests--\n")
+    for t in sorted(tests):
+        h.update(t.encode())
+        h.update(b"\n")
+    h.update(b"--context--\n")
+    h.update((context_before + "\n" + line_text + "\n" + context_after).encode())
+    h.update(b"\n--ops--\n")
+    h.update(original.encode())
+    h.update(b"\n")
+    h.update(mutated.encode())
+    h.update(b"\n")
+    return h.hexdigest()[:16]
+
+
+def mutant_cache_path(mutant_cache_dir: str, file_relpath: str) -> str:
+    """Per-mutant cache file: <mutant-cache-dir>/<file-leaf>.json — one JSON
+    object per source file mapping mutant_key -> {status, elapsed_sec, stored_at}.
+    """
+    leaf = os.path.basename(file_relpath).replace(".swift", "")
+    return os.path.join(mutant_cache_dir, f"{leaf}.json")
+
+
+def mutant_cache_load(mutant_cache_dir: str, file_relpath: str) -> dict:
+    """Load the per-mutant cache map for a file. Returns {} (never None) on
+    absence or corruption so callers can unconditionally `.get(key)`."""
+    path = mutant_cache_path(mutant_cache_dir, file_relpath)
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def mutant_cache_store(mutant_cache_dir: str, file_relpath: str, cache_map: dict) -> str:
+    """Persist the per-mutant cache map atomically (tmp + rename)."""
+    os.makedirs(mutant_cache_dir, exist_ok=True)
+    path = mutant_cache_path(mutant_cache_dir, file_relpath)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(cache_map, f, indent=2)
+    os.replace(tmp, path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Critical-path classification
+# ---------------------------------------------------------------------------
+
+def is_critical_path(file_relpath: str) -> bool:
+    """True iff file_relpath is on a critical path (CRITICAL_PATH_REGEX)."""
+    return bool(CRITICAL_PATH_REGEX.search(file_relpath))
+
+
+def count_critical_path_survivors(results: list[dict]) -> int:
+    """Count SURVIVED mutants whose op is CONSEQUENTIAL (cmp/bool/bound/retval/
+    cond; assign excluded). Operates on the report `results` list so it can be
+    unit-tested against a hand-built fake report dict.
+    """
+    count = 0
+    for r in results:
+        if r.get("status") != "survived":
+            continue
+        op = (r.get("mutation") or {}).get("op")
+        if op in CONSEQUENTIAL_OPS:
+            count += 1
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+def build_report(*, file_relpath: str, tests: list[str], seed: int,
+                 results: list[dict], planned: int, partial: bool) -> dict:
+    """Assemble the report dict from the accumulated per-mutant results.
+
+    BACKWARD COMPATIBLE: every pre-existing key
+    (killed/survived/errored/kill_rate_pct/partial/completed_mutations/
+    planned_mutations + the file/tests/seed/results top-levels) keeps its exact
+    meaning. The coverage/suppress/critical-path work only ADDS keys:
+      summary.uncovered, summary.suppressed,
+      summary.is_critical_path, summary.critical_path_survivors,
+      top-level coverage_gap.
+
+    killed/survived counts derive ONLY from mutants we actually RAN — 'uncovered'
+    and 'suppressed' mutants are tracked in their own counters and never inflate
+    or deflate the kill rate. Pure (no I/O) so it is unit-testable.
+    """
+    killed = sum(1 for r in results if r.get("status") == "killed")
+    survived = sum(1 for r in results if r.get("status") == "survived")
+    errored = sum(1 for r in results if r.get("status") in ("skipped", "errored"))
+    uncovered = sum(1 for r in results if r.get("status") == "uncovered")
+    suppressed = sum(1 for r in results if r.get("status") == "suppressed")
+
+    total = killed + survived
+    rate = (killed / total * 100) if total else 0.0
+
+    critical = is_critical_path(file_relpath)
+    cp_survivors = count_critical_path_survivors(results) if critical else 0
+
+    coverage_gap = [
+        {"line": (r.get("mutation") or {}).get("line"),
+         "op": (r.get("mutation") or {}).get("op")}
+        for r in results if r.get("status") == "uncovered"
+    ]
+
+    return {
+        "file": file_relpath,
+        "tests": tests,
+        "seed": seed,
+        "summary": {
+            "killed": killed,
+            "survived": survived,
+            "errored": errored,
+            "kill_rate_pct": round(rate, 1),
+            "partial": partial,
+            "completed_mutations": total + errored,
+            "planned_mutations": planned,
+            # --- additive keys ---
+            "uncovered": uncovered,
+            "suppressed": suppressed,
+            "is_critical_path": critical,
+            "critical_path_survivors": cp_survivors,
+        },
+        "coverage_gap": coverage_gap,
+        "results": results,
+    }
+
+
+def compute_exit_code(summary: dict) -> int:
+    """Map a report summary to the process exit code.
+
+    Exit contract (PRESERVED + extended):
+      2  reserved for hard errors (handled by callers before this point)
+      1  low kill rate (<50% over RUN mutants) OR — NEW — a critical-path file
+         with >=1 consequential SURVIVED mutant, REGARDLESS of kill rate
+      0  otherwise
+    Pure so the critical-path-overrides-kill-rate rule is unit-testable.
+    """
+    killed = summary.get("killed", 0) or 0
+    survived = summary.get("survived", 0) or 0
+    total_run = killed + survived
+    kill_rate = summary.get("kill_rate_pct", 0.0) or 0.0
+    if summary.get("is_critical_path") and (summary.get("critical_path_survivors", 0) or 0) > 0:
+        return 1
+    if total_run > 0 and kill_rate < 50:
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -401,6 +698,15 @@ def main() -> int:
                         "not the whole file's historical coverage.")
     p.add_argument("--diff-base", default="origin/develop",
                    help="git ref to diff against when --diff-only is set (default: origin/develop)")
+    p.add_argument("--no-coverage-gate", action="store_true",
+                   help="disable coverage-gating: mutate every discovered line even if no "
+                        "test executes it (today's pre-coverage behavior). Default: gating ON "
+                        "— mutations on UNCOVERED lines are recorded 'uncovered' and never run.")
+    p.add_argument("--no-test-selection", action="store_true",
+                   help="disable per-line test selection: always run the full --tests class "
+                        "for every mutant instead of the narrowed selectors that cover its line.")
+    p.add_argument("--mutant-cache-dir", default=DEFAULT_MUTANT_CACHE_DIR,
+                   help=f"per-mutant incremental cache dir (default: {DEFAULT_MUTANT_CACHE_DIR})")
     args = p.parse_args()
 
     file_path = os.path.join(REPO_ROOT, args.file)
@@ -445,14 +751,14 @@ def main() -> int:
             summary = report.get("summary", {})
             print(f"palace-mutate: {args.file}  [CACHED]")
             print(f"  cache key: {key} (stored {cached.get('stored_at', '?')})")
+            # PRESERVE the verbatim summary line verify-pr.sh greps for, in the
+            # cached branch too.
             print(f"  killed: {summary.get('killed')}  survived: {summary.get('survived')}  "
                   f"errored: {summary.get('errored')}  kill rate: {summary.get('kill_rate_pct')}%")
             with open(args.report, "w") as f:
                 json.dump(report, f, indent=2)
             print(f"  report: {args.report}")
-            kill_rate = summary.get("kill_rate_pct", 0.0) or 0.0
-            total_run = (summary.get("killed", 0) or 0) + (summary.get("survived", 0) or 0)
-            return 1 if total_run > 0 and kill_rate < 50 else 0
+            return compute_exit_code(summary)
 
     # Stable randomized order so each run is reproducible but covers diverse mutations.
     rng = random.Random(args.seed)
@@ -472,42 +778,81 @@ def main() -> int:
             print(f"        + {m.mutated_line}")
         return 0
 
-    # Sanity-check baseline: tests pass before we mutate anything
+    # Suppress-list: load human-curated equivalent-mutant suppressions ONCE.
+    # Mutants matching is_suppressed are recorded 'suppressed', never run, and
+    # never counted as survived/killed. Absent / disabled coverage module -> [].
+    suppressions: list = []
+    if _COVERAGE_AVAILABLE:
+        try:
+            suppressions = mutate_coverage.load_suppressions(REPO_ROOT, args.file)
+        except Exception as e:  # defensive: a broken module must not crash the run
+            print(f"suppressions load failed (non-fatal): {e}", file=sys.stderr)
+
+    # Sanity-check baseline: tests pass before we mutate anything. The baseline
+    # additionally runs with COVERAGE ON (into a temp .xcresult bundle) so we can
+    # gate mutations to lines tests actually execute and (best-effort) narrow the
+    # test selection per line. The coverage bundle lives in a tmpdir we clean up.
+    import tempfile  # local import: only the baseline path needs it
+    coverage_enabled = _COVERAGE_AVAILABLE and not args.no_coverage_gate
+    cov_tmpdir = None
+    coverage_bundle = None
+    if coverage_enabled or (_COVERAGE_AVAILABLE and not args.no_test_selection):
+        cov_tmpdir = tempfile.mkdtemp(prefix="palace-mutate-cov-")
+        # xcodebuild REQUIRES the resultBundlePath to NOT already exist.
+        coverage_bundle = os.path.join(cov_tmpdir, "baseline.xcresult")
+
     print("baseline: running tests with no mutations...")
     t0 = time.time()
-    baseline_ok, baseline_out = run_targeted_tests(args.tests)
+    baseline_ok, baseline_out = run_targeted_tests(args.tests, coverage_bundle_path=coverage_bundle)
     t1 = time.time()
     print(f"baseline: {'PASS' if baseline_ok else 'FAIL'} in {t1-t0:.1f}s")
     if not baseline_ok:
         print("error: baseline test run failed. Cannot mutation-test against a broken suite.", file=sys.stderr)
         print("last lines:")
         print(baseline_out)
+        if cov_tmpdir:
+            shutil.rmtree(cov_tmpdir, ignore_errors=True)
         return 2
     print()
 
-    results: list[dict] = []
-    killed = 0
-    survived = 0
-    errored = 0
+    # Coverage gating: intersect discovered mutation lines with the lines tests
+    # actually executed. covered_lines() returns None on ANY failure -> gating
+    # DISABLED, behavior exactly as today (mutate all lines). This graceful
+    # degradation is the safety property that makes coverage-gating low-risk.
+    covered: set[int] | None = None
+    if coverage_enabled and coverage_bundle:
+        try:
+            covered = mutate_coverage.covered_lines(coverage_bundle, args.file, REPO_ROOT)
+        except Exception as e:
+            print(f"coverage extraction failed (non-fatal); gating disabled: {e}", file=sys.stderr)
+            covered = None
+        if covered is None:
+            print("coverage: unknown (None) — gating DISABLED, mutating every line")
+        else:
+            print(f"coverage: {len(covered)} executed line(s) recorded for gating")
 
-    def _build_report(partial: bool) -> dict:
-        total = killed + survived
-        rate = (killed / total * 100) if total else 0.0
-        return {
-            "file": args.file,
-            "tests": args.tests,
-            "seed": args.seed,
-            "summary": {
-                "killed": killed,
-                "survived": survived,
-                "errored": errored,
-                "kill_rate_pct": round(rate, 1),
-                "partial": partial,
-                "completed_mutations": total + errored,
-                "planned_mutations": len(mutations),
-            },
-            "results": results,
-        }
+    # Per-line test selection: best-effort map line -> [Class/method selectors].
+    # None / missing line -> fall back to the full --tests class for that mutant.
+    line_to_tests: dict | None = None
+    if _COVERAGE_AVAILABLE and not args.no_test_selection and coverage_bundle:
+        covered_mutation_lines = {m.line for m in mutations}
+        try:
+            line_to_tests = mutate_coverage.tests_for_lines(
+                coverage_bundle, args.file, covered_mutation_lines, REPO_ROOT)
+        except Exception as e:
+            print(f"test-selection attribution failed (non-fatal); using full class: {e}", file=sys.stderr)
+            line_to_tests = None
+
+    if cov_tmpdir:
+        shutil.rmtree(cov_tmpdir, ignore_errors=True)
+
+    # Per-mutant incremental cache (in ADDITION to the whole-file cache, which
+    # already missed if we got here). Reuse cached statuses for mutants whose
+    # local context is unchanged; only execute misses; persist atomically.
+    mutant_cache = {} if args.no_cache else mutant_cache_load(args.mutant_cache_dir, args.file)
+    mutant_cache_dirty = False
+
+    results: list[dict] = []
 
     def _write_report_atomic(report: dict) -> None:
         # Write to <path>.tmp then rename. POSIX rename is atomic on the same
@@ -521,34 +866,78 @@ def main() -> int:
             json.dump(report, f, indent=2)
         os.replace(tmp_path, args.report)
 
+    def _flush(partial: bool) -> dict:
+        report = build_report(file_relpath=args.file, tests=args.tests, seed=args.seed,
+                              results=results, planned=len(mutations), partial=partial)
+        _write_report_atomic(report)
+        return report
+
     for i, m in enumerate(mutations, 1):
         prefix = f"[{i}/{len(mutations)}]"
         if not args.quiet:
             print(f"{prefix} line {m.line} {m.op}: {m.original!r} -> {m.mutated!r}")
+
+        # SUPPRESSED: human-reviewed equivalent mutant. Record + skip; not run,
+        # not counted as survived/killed.
+        if _COVERAGE_AVAILABLE and suppressions and mutate_coverage.is_suppressed(
+                suppressions, m.line_text, m.original, m.mutated):
+            if not args.quiet:
+                print("  SUPPRESSED (equivalent mutant)")
+            results.append({"mutation": dataclasses.asdict(m), "status": "suppressed"})
+            _flush(partial=True)
+            continue
+
+        # UNCOVERED: no test executes this line. It is a guaranteed survivor;
+        # running it wastes an xcodebuild cycle and would deflate the kill rate.
+        # Record it as a free coverage-gap signal and never run it.
+        if covered is not None and m.line not in covered:
+            if not args.quiet:
+                print("  UNCOVERED (no test executes this line)")
+            results.append({"mutation": dataclasses.asdict(m), "status": "uncovered"})
+            _flush(partial=True)
+            continue
+
+        # PER-MUTANT CACHE: reuse a prior status for an unchanged-context mutant.
+        mkey = compute_mutant_key(args.tests, m.context_before, m.line_text,
+                                  m.context_after, m.original, m.mutated)
+        if not args.no_cache and mkey in mutant_cache:
+            cached_entry = mutant_cache[mkey]
+            cached_status = cached_entry.get("status")
+            if cached_status in ("killed", "survived"):
+                if not args.quiet:
+                    print(f"  {cached_status.upper()} (cached)")
+                results.append({
+                    "mutation": dataclasses.asdict(m),
+                    "status": cached_status,
+                    "elapsed_sec": cached_entry.get("elapsed_sec", 0.0),
+                    "from_cache": True,
+                })
+                _flush(partial=True)
+                continue
+
+        # TEST SELECTION: run only the selectors that cover this line, if known.
+        selected_tests = args.tests
+        if line_to_tests is not None:
+            sel = line_to_tests.get(m.line)
+            if sel:
+                selected_tests = sel
 
         try:
             apply_mutation(file_path, m)
         except RuntimeError as e:
             print(f"  SKIP — {e}")
             results.append({"mutation": dataclasses.asdict(m), "status": "skipped", "reason": str(e)})
-            errored += 1
-            _write_report_atomic(_build_report(partial=True))
+            _flush(partial=True)
             continue
 
         try:
             t0 = time.time()
-            passed, last = run_targeted_tests(args.tests)
+            passed, last = run_targeted_tests(selected_tests)
             elapsed = time.time() - t0
         finally:
             revert_file(file_path, original)
 
-        if passed:
-            status = "SURVIVED"
-            survived += 1
-        else:
-            status = "KILLED"
-            killed += 1
-
+        status = "SURVIVED" if passed else "KILLED"
         if not args.quiet:
             print(f"  {status}  ({elapsed:.1f}s)")
 
@@ -558,28 +947,45 @@ def main() -> int:
             "elapsed_sec": round(elapsed, 1),
         })
 
+        # Update the per-mutant cache and persist atomically each time, so a
+        # killed process leaves a consistent cache for the next run.
+        if not args.no_cache:
+            mutant_cache[mkey] = {
+                "status": status.lower(),
+                "elapsed_sec": round(elapsed, 1),
+                "stored_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            }
+            mutant_cache_dirty = True
+            try:
+                mutant_cache_store(args.mutant_cache_dir, args.file, mutant_cache)
+            except OSError as e:
+                print(f"per-mutant cache write failed (non-fatal): {e}", file=sys.stderr)
+
         # Flush AFTER every mutation. If the process is killed by a CI
         # timeout (the original symptom) or Ctrl-C, the report on disk
         # already reflects everything completed so far — including a
         # partial=True flag the consumer can use to distinguish "ran to
         # completion" from "ran but got cut off."
-        _write_report_atomic(_build_report(partial=True))
+        _flush(partial=True)
 
-    total_run = killed + survived
-    kill_rate = (killed / total_run * 100) if total_run else 0.0
+    # Final report flips partial=False since we made it through the loop.
+    report = _flush(partial=False)
+    summary = report["summary"]
 
     print()
     print("=" * 60)
     print(f"palace-mutate complete")
-    print(f"  killed:   {killed}")
-    print(f"  survived: {survived}")
-    print(f"  errored:  {errored}")
-    print(f"  kill rate: {kill_rate:.1f}%")
+    print(f"  killed:   {summary['killed']}")
+    print(f"  survived: {summary['survived']}")
+    print(f"  errored:  {summary['errored']}")
+    print(f"  uncovered: {summary['uncovered']}")
+    print(f"  suppressed: {summary['suppressed']}")
+    if summary["is_critical_path"]:
+        print(f"  critical-path survivors: {summary['critical_path_survivors']}")
+    # PRESERVE the verbatim summary line verify-pr.sh greps for.
+    print(f"  killed: {summary['killed']}  survived: {summary['survived']}  "
+          f"errored: {summary['errored']}  kill rate: {summary['kill_rate_pct']}%")
     print("=" * 60)
-
-    # Final report flips partial=False since we made it through the loop.
-    report = _build_report(partial=False)
-    _write_report_atomic(report)
     print(f"report: {args.report}")
 
     if not args.no_cache:
@@ -588,11 +994,15 @@ def main() -> int:
             print(f"cached: {os.path.relpath(stored, REPO_ROOT)}")
         except OSError as e:
             print(f"cache write failed (non-fatal): {e}", file=sys.stderr)
+        if mutant_cache_dirty:
+            try:
+                mutant_cache_store(args.mutant_cache_dir, args.file, mutant_cache)
+            except OSError as e:
+                print(f"per-mutant cache write failed (non-fatal): {e}", file=sys.stderr)
 
-    # Exit non-zero if survival rate is concerningly high
-    if total_run > 0 and kill_rate < 50:
-        return 1
-    return 0
+    if summary["is_critical_path"] and summary["critical_path_survivors"] > 0:
+        print("GATE FAIL: critical-path file has surviving consequential mutant(s).", file=sys.stderr)
+    return compute_exit_code(summary)
 
 
 if __name__ == "__main__":

--- a/scripts/palace_mutate_parallel.py
+++ b/scripts/palace_mutate_parallel.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""
+palace-mutate-parallel — file-level worker-pool orchestrator over palace_mutate.py.
+
+Why this exists:
+    palace_mutate.py mutation-tests ONE file at a time, serially. On a PR that
+    touches several production files the per-file cold-build cost dominates. This
+    orchestrator fans the files out across a small worker pool — each worker owns
+    one git worktree + one pool simulator + one private DerivedData path — so
+    several files mutate concurrently while DerivedData stays warm WITHIN each
+    file (file-level fan-out, never mutant-level batching).
+
+CRITICAL design constraints (all enforced/tested):
+    - FILE-LEVEL fan-out only. We NEVER batch multiple mutants into one build:
+      that would mask a surviving mutant behind a killed one (the killed mutant
+      fails the build/test, the whole batch grades as KILLED, the real survivor
+      is invisible). Each palace_mutate.py invocation owns one file and reverts
+      between mutants exactly as it does today.
+    - ISOLATION per worker: a dedicated git worktree (so concurrent in-place
+      mutate+revert edits never collide), a dedicated pool sim UDID (so two
+      xcodebuild runs don't fight over the same booted device), and a dedicated
+      PALACE_MUTATE_DERIVED_DATA_PATH (so build databases don't corrupt each
+      other).
+    - COST GATE: if there are fewer than 2 files OR --workers 1, we run SERIALLY
+      in the MAIN tree (no worktree, no cold build) — a small PR must not get
+      slower because of orchestration overhead. The decision is logged, never
+      silent.
+
+The pure orchestration logic (worker-count math, serial/parallel decision, sim
+round-robin, report aggregation) is factored into module-level functions so the
+unit tests exercise it without creating real worktrees or invoking xcodebuild.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+
+# REPO_ROOT derivation mirrors palace_mutate.py: derive from this file's location
+# so the tool works on any host (local dev, CI runners, contributor clones).
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Pool simulator UDIDs. One worker pins one UDID via round-robin so concurrent
+# xcodebuild runs never fight over a booted device. These are the harness's
+# allocated iPhone 16 Pro sims for this project.
+DEFAULT_SIM_UDIDS: list[str] = [
+    "141BD227-6E9A-4409-8D99-2D4FE818238D",
+    "BFB9B169-4E06-4087-BD6B-F54BB56EAA6B",
+    "6C6BD82F-D659-4F77-8B9E-C2CBDF3A6CF8",
+]
+
+DEFAULT_BASE_REF = "origin/develop"
+DEFAULT_REPORT_DIR = os.path.join(REPO_ROOT, ".forgeos", "mutation-reports")
+PALACE_MUTATE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "palace_mutate.py")
+
+
+def log(msg: str) -> None:
+    """Single logging seam so the serial/parallel decision and per-worker
+    progress are always visible (no silent caps). Prefixed for grep-ability."""
+    print(f"[palace-mutate-parallel] {msg}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Pure orchestration logic (unit-tested without worktrees / xcodebuild)
+# ---------------------------------------------------------------------------
+
+def compute_worker_count(num_files: int, num_sims: int, ncpu: int,
+                         requested: int | None = None) -> int:
+    """Decide how many workers to run.
+
+    Default (requested is None): min(#sims, max(1, ncpu//4), #files). The
+    ncpu//4 term keeps a single mutation worker from starving the machine —
+    each xcodebuild test build is itself massively parallel, so 1 worker per
+    4 logical cores is the empirical sweet spot. We never spawn more workers
+    than there are files (idle workers waste a sim claim) or sims (two workers
+    on one sim serialize anyway and corrupt each other's device state).
+
+    An explicit `requested` is honored but still clamped to [1, #files] — you
+    can't usefully run more workers than files, and 0/negative is meaningless.
+    With zero files the answer is 0 (nothing to do).
+    """
+    if num_files <= 0:
+        return 0
+    if requested is not None:
+        # Honor the explicit ask, clamped to a sane range.
+        return max(1, min(requested, num_files))
+    cpu_term = max(1, ncpu // 4)
+    sim_term = max(1, num_sims)
+    return max(1, min(sim_term, cpu_term, num_files))
+
+
+def should_run_parallel(num_files: int, worker_count: int) -> bool:
+    """COST GATE. Parallel only pays off when there are >=2 files AND we'd
+    actually run >=2 workers. Otherwise the worktree + cold-build setup is pure
+    overhead and we should run serially in the main tree.
+    """
+    return num_files >= 2 and worker_count >= 2
+
+
+def assign_sims(num_workers: int, sims: list[str]) -> list[str]:
+    """Round-robin assign a sim UDID to each worker index. With more workers
+    than sims (shouldn't happen given compute_worker_count clamps to #sims, but
+    defended anyway), workers wrap around and share — they will serialize on the
+    shared device, which is correct-but-slow rather than broken.
+    """
+    if not sims:
+        return []
+    return [sims[i % len(sims)] for i in range(num_workers)]
+
+
+def changed_prod_swift_files(base_ref: str, repo_root: str = REPO_ROOT,
+                             runner=None) -> list[str]:
+    """Return production Swift files changed vs base_ref (relative to repo root).
+
+    Production = under Palace/ and NOT a test file (PalaceTests/ excluded, and
+    files whose name ends in Tests.swift excluded). `runner` is injectable so
+    the unit tests can feed synthetic `git diff` output without a real repo.
+    """
+    if runner is None:
+        runner = lambda argv: subprocess.run(  # noqa: E731
+            argv, cwd=repo_root, capture_output=True, text=True, check=False)
+    result = runner(["git", "diff", "--name-only", f"{base_ref}...HEAD"])
+    if result.returncode != 0:
+        log(f"--changed: git diff exit {result.returncode}; no files resolved")
+        log(result.stderr.strip())
+        return []
+    return filter_prod_swift(result.stdout.splitlines())
+
+
+def filter_prod_swift(paths) -> list[str]:
+    """Keep only production Swift sources from a list of repo-relative paths.
+
+    Excludes: non-Swift, anything under PalaceTests/, and any *Tests.swift file
+    (a test that happens to live under Palace/). Pure — unit-tested directly.
+    """
+    out: list[str] = []
+    for raw in paths:
+        path = raw.strip()
+        if not path or not path.endswith(".swift"):
+            continue
+        if path.startswith("PalaceTests/") or "/PalaceTests/" in path:
+            continue
+        leaf = os.path.basename(path)
+        if leaf.endswith("Tests.swift"):
+            continue
+        if not (path.startswith("Palace/") or "/Palace/" in path):
+            continue
+        out.append(path)
+    return out
+
+
+@dataclass
+class FileResult:
+    """Outcome of mutation-testing one file."""
+    file: str
+    exit_code: int
+    report: dict | None = None  # parsed palace_mutate JSON report, if any
+    error: str = ""             # populated when the report couldn't be produced
+
+
+def aggregate_reports(results: list[FileResult]) -> dict:
+    """Combine per-file FileResults into one summary.
+
+    Sums killed/survived/uncovered/suppressed/errored across files, computes the
+    overall kill rate over RUN mutants only (mirrors palace_mutate: uncovered and
+    suppressed never inflate/deflate it), records per-file kill rates, and
+    decides overall pass/fail.
+
+    OVERALL FAIL when ANY file failed its own gate (non-zero palace_mutate exit),
+    which already encodes both the <50% kill-rate rule and the critical-path
+    consequential-survivor override. We additionally surface the total
+    critical_path_survivors so a caller can see the override reason at a glance.
+
+    Pure (no I/O) so it is unit-testable against synthetic report dicts.
+    """
+    total = {
+        "killed": 0, "survived": 0, "errored": 0,
+        "uncovered": 0, "suppressed": 0, "critical_path_survivors": 0,
+    }
+    per_file: list[dict] = []
+    any_failed = False
+    any_critical_survivor = False
+
+    for r in results:
+        if r.exit_code != 0:
+            any_failed = True
+        summary = (r.report or {}).get("summary", {}) if r.report else {}
+        for k in ("killed", "survived", "errored", "uncovered", "suppressed",
+                  "critical_path_survivors"):
+            total[k] += int(summary.get(k, 0) or 0)
+        cps = int(summary.get("critical_path_survivors", 0) or 0)
+        if summary.get("is_critical_path") and cps > 0:
+            any_critical_survivor = True
+        run = int(summary.get("killed", 0) or 0) + int(summary.get("survived", 0) or 0)
+        per_file.append({
+            "file": r.file,
+            "exit_code": r.exit_code,
+            "killed": int(summary.get("killed", 0) or 0),
+            "survived": int(summary.get("survived", 0) or 0),
+            "uncovered": int(summary.get("uncovered", 0) or 0),
+            "suppressed": int(summary.get("suppressed", 0) or 0),
+            "is_critical_path": bool(summary.get("is_critical_path", False)),
+            "critical_path_survivors": cps,
+            "kill_rate_pct": round((summary.get("killed", 0) / run * 100), 1) if run else 0.0,
+            "passed": r.exit_code == 0,
+            "error": r.error,
+        })
+
+    run_total = total["killed"] + total["survived"]
+    overall_rate = round((total["killed"] / run_total * 100), 1) if run_total else 0.0
+
+    return {
+        "overall_passed": not any_failed,
+        "any_critical_path_survivor": any_critical_survivor,
+        "files_tested": len(results),
+        "files_failed": sum(1 for r in results if r.exit_code != 0),
+        "totals": total,
+        "overall_kill_rate_pct": overall_rate,
+        "per_file": per_file,
+    }
+
+
+def aggregate_exit_code(aggregate: dict) -> int:
+    """Mirror palace_mutate's contract at the batch level: non-zero if any file
+    failed its gate. Pure."""
+    return 0 if aggregate.get("overall_passed") else 1
+
+
+def build_palace_mutate_argv(file_relpath: str, tests: list[str],
+                             report_path: str, passthrough: list[str]) -> list[str]:
+    """Assemble the argv for one palace_mutate.py invocation. Pure so the
+    forwarded-flag wiring is unit-testable."""
+    argv = [sys.executable, PALACE_MUTATE, "--file", file_relpath,
+            "--report", report_path]
+    for t in tests:
+        argv += ["--tests", t]
+    argv += passthrough
+    return argv
+
+
+def resolve_tests_for_file(file_relpath: str, repo_root: str = REPO_ROOT,
+                           runner=None) -> list[str]:
+    """Resolve XCTest class selectors for a production file via
+    scripts/resolve-tests-for.py. Returns [] if resolution fails (caller skips
+    the file with a logged warning — an uncovered file is a real signal, not a
+    crash). `runner` injectable for tests.
+    """
+    resolver = os.path.join(os.path.dirname(os.path.abspath(__file__)), "resolve-tests-for.py")
+    if runner is None:
+        runner = lambda argv: subprocess.run(  # noqa: E731
+            argv, cwd=repo_root, capture_output=True, text=True, check=False)
+    result = runner([sys.executable, resolver, file_relpath])
+    if result.returncode != 0:
+        return []
+    return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Worktree setup (impure — replicates the swarm Phase 0 Palace recipe)
+# ---------------------------------------------------------------------------
+
+def _sh(argv: list[str], cwd: str) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, cwd=cwd, capture_output=True, text=True, check=False)
+
+
+def setup_worker_worktree(worker_idx: int, base_ref: str, sim_udid: str) -> dict:
+    """Create one isolated git worktree for a worker and wire up the Palace
+    build prerequisites (Carthage/Build copy, real ios-audiobooktoolkit clone,
+    other submodule symlinks, adobe-rmsdk symlink, gitignored secrets).
+
+    Replicates the swarm SKILL.md Phase 0 recipe verbatim — the same rules apply
+    here (Carthage copied not symlinked; ios-audiobooktoolkit a real submodule;
+    the other 7 submodules + adobe-rmsdk symlinked) for the same reason: a
+    symlinked Carthage/Build resolves to MAIN's path and produces duplicate
+    XCFramework build commands on a fresh DerivedData.
+
+    Returns a dict with `path`, `derived_data`, `sim_udid` for the worker.
+    """
+    wt_root = os.path.join(REPO_ROOT, ".claude", "worktrees")
+    os.makedirs(wt_root, exist_ok=True)
+    wt_path = os.path.join(wt_root, f"mutate-parallel-w{worker_idx}-{int(time.time())}")
+    branch = f"mutate-parallel/w{worker_idx}-{int(time.time())}"
+
+    _sh(["git", "worktree", "add", "-b", branch, wt_path, base_ref], cwd=REPO_ROOT)
+
+    # Carthage/Build — copy, do not symlink.
+    cb_src = os.path.join(REPO_ROOT, "Carthage", "Build")
+    if os.path.isdir(cb_src):
+        os.makedirs(os.path.join(wt_path, "Carthage", "Build"), exist_ok=True)
+        _sh(["cp", "-RL", cb_src + "/.", os.path.join(wt_path, "Carthage", "Build") + "/"], cwd=wt_path)
+
+    # ios-audiobooktoolkit — REAL submodule clone.
+    _sh(["git", "submodule", "update", "--init", "--", "ios-audiobooktoolkit"], cwd=wt_path)
+
+    # Other 7 submodules — symlinks are safe.
+    for sub in ("adept-ios", "adobe-content-filter", "ios-audiobook-overdrive",
+                "ios-tenprintcover", "mobile-bookmark-spec", "readium-sdk",
+                "readium-shared-js"):
+        dst = os.path.join(wt_path, sub)
+        src = os.path.join(REPO_ROOT, sub)
+        if not os.path.islink(dst):
+            if os.path.isdir(dst) and not os.listdir(dst):
+                os.rmdir(dst)
+            if not os.path.exists(dst) and os.path.exists(os.path.join(src, ".git")):
+                os.symlink(src, dst)
+
+    # adobe-rmsdk — external private repo.
+    adobe = "/Users/mauricework/PalaceProject/ios-drm-adeptconnector/connector"
+    adobe_dst = os.path.join(wt_path, "adobe-rmsdk")
+    if not os.path.exists(adobe_dst) and os.path.isdir(adobe):
+        os.symlink(adobe, adobe_dst)
+
+    # Gitignored secrets.
+    for f in ("Palace/AppInfrastructure/APIKeys.swift",
+              "Palace/TPPSecrets.swift",
+              "PalaceConfig/GoogleService-Info.plist",
+              "PalaceConfig/ReaderClientCert.sig"):
+        src = os.path.join(REPO_ROOT, f)
+        dst = os.path.join(wt_path, f)
+        if os.path.exists(src) and not os.path.exists(dst):
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.copy(src, dst)
+
+    dd = os.path.join(wt_path, ".derived")
+    return {"path": wt_path, "derived_data": dd, "branch": branch, "sim_udid": sim_udid}
+
+
+def teardown_worker_worktree(wt: dict) -> None:
+    """Remove a worker worktree and its branch. Best-effort; never raises."""
+    _sh(["git", "worktree", "remove", "--force", wt["path"]], cwd=REPO_ROOT)
+    _sh(["git", "branch", "-D", wt["branch"]], cwd=REPO_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Per-file execution (impure — invokes palace_mutate.py)
+# ---------------------------------------------------------------------------
+
+def run_one_file(file_relpath: str, tests: list[str], report_path: str,
+                 passthrough: list[str], cwd: str, env_overrides: dict) -> FileResult:
+    """Invoke palace_mutate.py for a single file in `cwd` with env overrides
+    (sim UDID + DerivedData path). Reads back the JSON report it wrote."""
+    argv = build_palace_mutate_argv(file_relpath, tests, report_path, passthrough)
+    env = dict(os.environ)
+    env.update(env_overrides)
+    log(f"start {file_relpath} (cwd={os.path.relpath(cwd, REPO_ROOT)}, "
+        f"sim={env_overrides.get('HARNESS_SESSION_SIM_UDID', '?')[:8]})")
+    proc = subprocess.run(argv, cwd=cwd, env=env, capture_output=True, text=True, check=False)
+    report = None
+    error = ""
+    # palace_mutate writes its report relative to its cwd.
+    abs_report = report_path if os.path.isabs(report_path) else os.path.join(cwd, report_path)
+    if os.path.isfile(abs_report):
+        try:
+            with open(abs_report) as f:
+                report = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            error = f"report unreadable: {e}"
+    else:
+        error = f"no report produced (exit {proc.returncode})\n{proc.stdout[-2000:]}\n{proc.stderr[-2000:]}"
+    log(f"done  {file_relpath}: exit {proc.returncode}")
+    return FileResult(file=file_relpath, exit_code=proc.returncode, report=report, error=error)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration drivers
+# ---------------------------------------------------------------------------
+
+def run_serial(files: list[str], file_tests: dict, passthrough: list[str],
+               report_dir: str) -> list[FileResult]:
+    """Run every file serially in the MAIN tree — no worktree, no cold build.
+    Used when the cost gate says parallel doesn't pay off."""
+    results: list[FileResult] = []
+    for f in files:
+        report_path = os.path.join(report_dir, os.path.basename(f).replace(".swift", "") + ".json")
+        results.append(run_one_file(f, file_tests[f], report_path, passthrough,
+                                    cwd=REPO_ROOT, env_overrides={}))
+    return results
+
+
+def run_parallel(files: list[str], file_tests: dict, passthrough: list[str],
+                 report_dir: str, worker_count: int, sims: list[str]) -> list[FileResult]:
+    """Run files across `worker_count` isolated worktrees, one pool sim each.
+
+    Each worker owns ONE worktree for its whole batch (so DerivedData stays warm
+    across the files it processes). Files are sharded round-robin across workers.
+    """
+    sim_assignment = assign_sims(worker_count, sims)
+    # Shard files round-robin so each worker gets a roughly equal slice.
+    shards: list[list[str]] = [[] for _ in range(worker_count)]
+    for i, f in enumerate(files):
+        shards[i % worker_count].append(f)
+
+    worktrees: list[dict] = []
+    try:
+        for w in range(worker_count):
+            wt = setup_worker_worktree(w, DEFAULT_BASE_REF, sim_assignment[w])
+            worktrees.append(wt)
+
+        results: list[FileResult] = []
+
+        def _worker(w_idx: int) -> list[FileResult]:
+            wt = worktrees[w_idx]
+            env = {
+                "HARNESS_SESSION_SIM_UDID": wt["sim_udid"],
+                "PALACE_MUTATE_DERIVED_DATA_PATH": wt["derived_data"],
+            }
+            out: list[FileResult] = []
+            for f in shards[w_idx]:
+                # Report written into the shared report_dir (absolute) so the
+                # main process can aggregate without reaching into worktrees.
+                report_path = os.path.join(
+                    report_dir, os.path.basename(f).replace(".swift", "") + ".json")
+                out.append(run_one_file(f, file_tests[f], report_path, passthrough,
+                                        cwd=wt["path"], env_overrides=env))
+            return out
+
+        with ThreadPoolExecutor(max_workers=worker_count) as pool:
+            futures = {pool.submit(_worker, w): w for w in range(worker_count)
+                       if shards[w]}
+            for fut in as_completed(futures):
+                results.extend(fut.result())
+        return results
+    finally:
+        for wt in worktrees:
+            teardown_worker_worktree(wt)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Parallel file-level mutation orchestrator for Palace iOS")
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--files", nargs="+", help="explicit list of production Swift files to mutate")
+    src.add_argument("--changed", action="store_true",
+                     help="auto-discover changed production Swift files vs --base")
+    p.add_argument("--base", default=DEFAULT_BASE_REF,
+                   help=f"git ref to diff against for --changed (default: {DEFAULT_BASE_REF})")
+    p.add_argument("--workers", type=int, default=None,
+                   help="worker count (default: min(#sims, max(1, ncpu//4), #files))")
+    p.add_argument("--sims", nargs="+", default=DEFAULT_SIM_UDIDS,
+                   help="pool simulator UDIDs (one per worker, round-robin)")
+    p.add_argument("--report-dir", default=DEFAULT_REPORT_DIR,
+                   help=f"directory for per-file JSON reports (default: {DEFAULT_REPORT_DIR})")
+    p.add_argument("--summary-report", default=None,
+                   help="optional path to write the aggregated summary JSON")
+    # Pass-through flags forwarded verbatim to each palace_mutate.py invocation.
+    args, passthrough = p.parse_known_args(argv)
+
+    # 1. Resolve the file set.
+    if args.changed:
+        files = changed_prod_swift_files(args.base)
+    else:
+        files = filter_prod_swift(args.files)
+    if not files:
+        log("no production Swift files to mutate — nothing to do.")
+        return 0
+    log(f"files to mutate ({len(files)}): {', '.join(files)}")
+
+    # 2. Resolve tests per file; skip uncovered files with a logged warning.
+    file_tests: dict = {}
+    runnable: list[str] = []
+    for f in files:
+        tests = resolve_tests_for_file(f)
+        if not tests:
+            log(f"WARNING: no resolvable tests for {f} — skipping (uncovered file).")
+            continue
+        file_tests[f] = tests
+        runnable.append(f)
+    if not runnable:
+        log("no files with resolvable tests — nothing to mutate.")
+        return 0
+    files = runnable
+
+    # 3. Worker count + cost-gate decision.
+    worker_count = compute_worker_count(len(files), len(args.sims), os.cpu_count() or 1,
+                                        requested=args.workers)
+    parallel = should_run_parallel(len(files), worker_count)
+
+    os.makedirs(args.report_dir, exist_ok=True)
+
+    if parallel:
+        log(f"PARALLEL: {len(files)} file(s) across {worker_count} worker(s) "
+            f"(sims: {len(args.sims)}, ncpu: {os.cpu_count()}).")
+        results = run_parallel(files, file_tests, passthrough, args.report_dir,
+                               worker_count, args.sims)
+    else:
+        log(f"SERIAL: {len(files)} file(s) in main tree (cost gate: <2 files or "
+            f"workers=1; worker_count={worker_count}). No worktree/cold-build overhead.")
+        results = run_serial(files, file_tests, passthrough, args.report_dir)
+
+    # 4. Aggregate + report.
+    aggregate = aggregate_reports(results)
+    if args.summary_report:
+        with open(args.summary_report, "w") as f:
+            json.dump(aggregate, f, indent=2)
+
+    log("=" * 60)
+    log(f"aggregate: {aggregate['files_tested']} file(s), "
+        f"{aggregate['files_failed']} failed gate")
+    t = aggregate["totals"]
+    log(f"  killed: {t['killed']}  survived: {t['survived']}  "
+        f"uncovered: {t['uncovered']}  suppressed: {t['suppressed']}  "
+        f"overall kill rate: {aggregate['overall_kill_rate_pct']}%")
+    if aggregate["any_critical_path_survivor"]:
+        log("  CRITICAL-PATH survivor(s) present — gate FAIL.")
+    for pf in aggregate["per_file"]:
+        flag = "PASS" if pf["passed"] else "FAIL"
+        log(f"  [{flag}] {pf['file']}: kill {pf['kill_rate_pct']}% "
+            f"(k{pf['killed']}/s{pf['survived']}/u{pf['uncovered']})"
+            + (f"  ERROR: {pf['error'].splitlines()[0]}" if pf["error"] else ""))
+    log("=" * 60)
+
+    return aggregate_exit_code(aggregate)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/post-mutation-pr-comment.py
+++ b/scripts/post-mutation-pr-comment.py
@@ -55,9 +55,14 @@ def is_critical(path: str) -> bool:
 def load_reports(reports_dir: Path) -> list[dict]:
     """Load every *.json file in reports_dir, returning rows for the table.
 
-    Each row: {file, killed, survived, errored, kill_rate, critical}.
+    Each row: {file, killed, survived, errored, kill_rate, critical,
+    uncovered, suppressed, critical_path_survivors, coverage_gap, error}.
     Files that fail to parse are surfaced as-is so the table never lies about
     "0 survivors" when the truth is "report unreadable".
+
+    The coverage/suppress/critical-path keys are ADDITIVE — older cached reports
+    that predate them parse fine: every new key defaults to 0 / empty so the
+    table and callouts degrade gracefully rather than KeyError-ing.
     """
     rows: list[dict] = []
     if not reports_dir.is_dir():
@@ -73,6 +78,10 @@ def load_reports(reports_dir: Path) -> list[dict]:
                 "errored": None,
                 "kill_rate": None,
                 "critical": False,
+                "uncovered": 0,
+                "suppressed": 0,
+                "critical_path_survivors": 0,
+                "coverage_gap": [],
                 "error": str(exc),
             })
             continue
@@ -84,13 +93,26 @@ def load_reports(reports_dir: Path) -> list[dict]:
         total = killed + survived
         rate = (killed / total * 100.0) if total > 0 else None
         file_path = data.get("file") or path.stem
+        # Additive keys — default-missing defensively for older reports.
+        uncovered = int(summary.get("uncovered", 0) or 0)
+        suppressed = int(summary.get("suppressed", 0) or 0)
+        # Prefer the report's own is_critical_path flag (authoritative — it
+        # reflects palace_mutate's CRITICAL_PATH_REGEX). Fall back to the local
+        # prefix heuristic only when the report predates the flag.
+        critical = bool(summary.get("is_critical_path", is_critical(file_path)))
+        cp_survivors = int(summary.get("critical_path_survivors", 0) or 0)
+        coverage_gap = data.get("coverage_gap") or []
         rows.append({
             "file": file_path,
             "killed": killed,
             "survived": survived,
             "errored": errored,
             "kill_rate": rate,
-            "critical": is_critical(file_path),
+            "critical": critical,
+            "uncovered": uncovered,
+            "suppressed": suppressed,
+            "critical_path_survivors": cp_survivors,
+            "coverage_gap": coverage_gap,
             "error": None,
         })
     return rows
@@ -113,8 +135,31 @@ def render_table(rows: list[dict], threshold: float) -> str:
     lines.append(f"Threshold: **{threshold:g}%** "
                  "(critical paths strict, others advisory)")
     lines.append("")
-    lines.append("| File | Killed | Survived | Kill Rate | Verdict |")
-    lines.append("|---|---:|---:|---:|---|")
+
+    # --- Critical-path survivor banner (BLOCKS — render first, most visible) ---
+    # A critical-path file with a surviving consequential mutant blocks merge
+    # regardless of kill rate, so it gets a banner above the table. Default-0
+    # for older reports means the banner only appears when the data is present.
+    cp_blocking = [r for r in rows if (r.get("critical_path_survivors") or 0) > 0]
+    if cp_blocking:
+        n = sum(r["critical_path_survivors"] for r in cp_blocking)
+        lines.append(
+            f"> 🚨 **BLOCKS MERGE — {n} surviving consequential mutant(s) on "
+            f"{len(cp_blocking)} critical-path file(s).**"
+        )
+        lines.append(">")
+        lines.append("> A surviving mutant on a user-money path means a real "
+                     "code change there would NOT be caught by tests. This "
+                     "blocks regardless of kill rate.")
+        for r in cp_blocking:
+            lines.append(
+                f"> - `{r['file']}` — "
+                f"{r['critical_path_survivors']} consequential survivor(s)"
+            )
+        lines.append("")
+
+    lines.append("| File | Killed | Survived | Uncovered | Kill Rate | Verdict |")
+    lines.append("|---|---:|---:|---:|---:|---|")
 
     # Sort: critical first, then by kill rate ascending so the weakest
     # files are most visible (the gate is about exposing weak coverage).
@@ -127,12 +172,25 @@ def render_table(rows: list[dict], threshold: float) -> str:
 
     strict_failures = 0
     advisory_warnings = 0
+    cp_survivor_blocks = 0
+    total_uncovered = 0
+    total_suppressed = 0
     for r in rows_sorted:
         if r.get("error"):
-            lines.append(f"| {r['file']} | — | — | parse error | "
+            lines.append(f"| {r['file']} | — | — | — | parse error | "
                          f"`{r['error']}` |")
             continue
-        if r["kill_rate"] is None:
+
+        total_uncovered += int(r.get("uncovered") or 0)
+        total_suppressed += int(r.get("suppressed") or 0)
+        cp_survivors = int(r.get("critical_path_survivors") or 0)
+
+        # Critical-path survivor verdict takes priority over the kill-rate
+        # verdict — it blocks even at 100% kill rate.
+        if cp_survivors > 0:
+            verdict = f"🚨 BLOCKS ({cp_survivors} consequential survivor(s))"
+            cp_survivor_blocks += 1
+        elif r["kill_rate"] is None:
             verdict = "no mutants"
         elif r["kill_rate"] >= threshold:
             verdict = "PASS" if not r["critical"] else "PASS (critical)"
@@ -146,17 +204,66 @@ def render_table(rows: list[dict], threshold: float) -> str:
         rate_cell = (
             f"{r['kill_rate']:.0f}%" if r["kill_rate"] is not None else "—"
         )
+        uncovered_cell = str(r.get("uncovered") or 0)
         critical_marker = " *(critical path)*" if r["critical"] else ""
         lines.append(
             f"| `{r['file']}`{critical_marker} | "
-            f"{r['killed']} | {r['survived']} | {rate_cell} | {verdict} |"
+            f"{r['killed']} | {r['survived']} | {uncovered_cell} | "
+            f"{rate_cell} | {verdict} |"
         )
 
     lines.append("")
 
+    # --- Coverage-gap callout (free, non-blocking) ---
+    # Uncovered mutants sit on lines NO test executed; they never run, so they
+    # don't deflate the kill rate, but they ARE a free signal of where to add a
+    # test. Surface the specific lines so the contributor gets a to-do list.
+    gap_entries: list[tuple[str, int, str]] = []
+    for r in rows_sorted:
+        for g in (r.get("coverage_gap") or []):
+            line_no = g.get("line")
+            op = g.get("op") or "?"
+            if line_no is not None:
+                gap_entries.append((r["file"], int(line_no), str(op)))
+    if gap_entries:
+        lines.append(f"<details><summary>📉 Coverage gap — "
+                     f"{total_uncovered} mutant(s) on lines no test executed "
+                     f"(free coverage to-do, non-blocking)</summary>")
+        lines.append("")
+        lines.append("| File | Line | Mutated op |")
+        lines.append("|---|---:|---|")
+        for fpath, line_no, op in gap_entries:
+            lines.append(f"| `{fpath}` | {line_no} | `{op}` |")
+        lines.append("")
+        lines.append("These lines have no executing test — adding one is the "
+                     "cheapest kill-rate improvement available.")
+        lines.append("</details>")
+        lines.append("")
+
+    # --- Suppressed callout (equivalent mutants, informational) ---
+    if total_suppressed > 0:
+        lines.append(
+            f"_{total_suppressed} mutant(s) suppressed as equivalent "
+            "(matched the suppress-list) — not run, not counted against the "
+            "kill rate._"
+        )
+        lines.append("")
+
     # Footer summary so the reader doesn't have to scan every row to know
-    # whether anything blocks merge.
-    if strict_failures > 0:
+    # whether anything blocks merge. Critical-path survivors are the strongest
+    # block and are reported first.
+    if cp_survivor_blocks > 0:
+        lines.append(
+            f"**🚨 {cp_survivor_blocks} critical-path file(s) with surviving "
+            "consequential mutant(s) — gate blocks merge regardless of kill "
+            "rate.**"
+        )
+        if strict_failures > 0:
+            lines.append(
+                f"_Additionally, {strict_failures} critical-path file(s) below "
+                f"{threshold:g}%._"
+            )
+    elif strict_failures > 0:
         lines.append(
             f"**{strict_failures} critical-path file(s) below "
             f"{threshold:g}% — gate blocks merge.**"
@@ -231,6 +338,10 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     if args.fail_on_critical:
         for r in rows:
+            # A surviving consequential mutant on a critical path blocks
+            # regardless of kill rate.
+            if (r.get("critical_path_survivors") or 0) > 0:
+                return 1
             if (
                 r.get("critical")
                 and r.get("kill_rate") is not None

--- a/scripts/test_mutate_coverage.py
+++ b/scripts/test_mutate_coverage.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+Unit tests for mutate_coverage.py helpers.
+
+All tests are PURE Python: no xcodebuild, no simulator, no real .xcresult. The
+coverage PARSER is fed synthetic fixtures whose JSON shape matches the real
+`xcrun xccov view --archive --file ... --json` output captured from an Xcode 26
+bundle on this host (dict keyed by recorded path → list of
+{isExecutable, line, executionCount?} entries; covered := isExecutable AND
+executionCount > 0).
+
+Run: python3 -m unittest scripts.test_mutate_coverage
+  or: python3 scripts/test_mutate_coverage.py
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import mutate_coverage as mc
+
+
+# --- realistic archive JSON fixture (shape matches captured Xcode 26 output) ---
+def _archive_json(path, entries):
+    """Build an archive-JSON string: { "<path>": [ {entry}, ... ] }."""
+    return json.dumps({path: entries})
+
+
+_RECORDED_PATH = "/build/worktrees/swarm_x/Palace/OPDS/Foo.swift"
+_GOOD_ENTRIES = [
+    {"isExecutable": False, "line": 1},                      # not executable → skip
+    {"isExecutable": False, "line": 2},
+    {"isExecutable": True, "line": 10, "executionCount": 0},  # executable but uncovered → skip
+    {"isExecutable": True, "line": 11, "executionCount": 0},
+    {"isExecutable": True, "line": 86, "executionCount": 4},  # covered
+    {"isExecutable": True, "line": 87, "executionCount": 1},  # covered
+    {"isExecutable": True, "line": 99, "executionCount": 42}, # covered
+]
+
+
+class ParseArchiveCoveredLines(unittest.TestCase):
+
+    def test_covered_lines_extractedCorrectly(self):
+        text = _archive_json(_RECORDED_PATH, _GOOD_ENTRIES)
+        self.assertEqual(mc.parse_archive_covered_lines(text), {86, 87, 99})
+
+    def test_uncovered_executable_isExcluded(self):
+        # executionCount 0 on an executable line must NOT be reported as covered.
+        text = _archive_json(_RECORDED_PATH, [
+            {"isExecutable": True, "line": 5, "executionCount": 0},
+        ])
+        self.assertEqual(mc.parse_archive_covered_lines(text), set())
+
+    def test_nonExecutable_withCount_isExcluded(self):
+        # Defensive: a non-executable line should never count even if a count
+        # leaks in.
+        text = _archive_json(_RECORDED_PATH, [
+            {"isExecutable": False, "line": 5, "executionCount": 9},
+        ])
+        self.assertEqual(mc.parse_archive_covered_lines(text), set())
+
+    def test_emptyString_returnsNone(self):
+        self.assertIsNone(mc.parse_archive_covered_lines(""))
+        self.assertIsNone(mc.parse_archive_covered_lines("   \n  "))
+
+    def test_malformedJson_returnsNone(self):
+        self.assertIsNone(mc.parse_archive_covered_lines("{not json"))
+        self.assertIsNone(mc.parse_archive_covered_lines("[1, 2, 3"))
+
+    def test_unexpectedTopShape_returnsNone(self):
+        # A JSON list (not the expected dict) → unknown.
+        self.assertIsNone(mc.parse_archive_covered_lines("[]"))
+        self.assertIsNone(mc.parse_archive_covered_lines("[{\"line\": 1}]"))
+
+    def test_emptyDict_returnsNone(self):
+        self.assertIsNone(mc.parse_archive_covered_lines("{}"))
+
+    def test_valueNotList_returnsNone(self):
+        self.assertIsNone(mc.parse_archive_covered_lines('{"path": "nope"}'))
+
+    def test_entryNotDict_returnsNone(self):
+        # A non-dict entry signals an unexpected shape → don't half-trust it.
+        text = _archive_json(_RECORDED_PATH, ["unexpected", {"isExecutable": True, "line": 1, "executionCount": 1}])
+        self.assertIsNone(mc.parse_archive_covered_lines(text))
+
+    def test_missingExecutionCount_treatedAsZero(self):
+        # An executable entry with no executionCount key → not covered.
+        text = _archive_json(_RECORDED_PATH, [
+            {"isExecutable": True, "line": 7},
+        ])
+        self.assertEqual(mc.parse_archive_covered_lines(text), set())
+
+    def test_nonIntLine_isSkipped(self):
+        text = _archive_json(_RECORDED_PATH, [
+            {"isExecutable": True, "line": "x", "executionCount": 3},
+            {"isExecutable": True, "line": 8, "executionCount": 3},
+        ])
+        self.assertEqual(mc.parse_archive_covered_lines(text), {8})
+
+
+class RecordedPathFor(unittest.TestCase):
+
+    def test_suffixMatch_findsWorktreePath(self):
+        # Recorded paths are build-time paths that differ from repo_root.
+        file_list = (
+            "/Users/x/.claude/worktrees/swarm_a/Palace/Accounts/AccountsManager.swift\n"
+            "/Users/x/.claude/worktrees/swarm_a/Palace/OPDS/Foo.swift\n"
+        )
+        self.assertEqual(
+            mc._recorded_path_for(file_list, "Palace/OPDS/Foo.swift"),
+            "/Users/x/.claude/worktrees/swarm_a/Palace/OPDS/Foo.swift",
+        )
+
+    def test_componentBoundary_preventsPartialLeafMatch(self):
+        # `Foo.swift` must NOT match a path ending in `OtherFoo.swift`.
+        file_list = "/build/Palace/OPDS/OtherFoo.swift\n"
+        self.assertIsNone(mc._recorded_path_for(file_list, "Palace/OPDS/Foo.swift"))
+
+    def test_noMatch_returnsNone(self):
+        file_list = "/build/Palace/Other/Bar.swift\n"
+        self.assertIsNone(mc._recorded_path_for(file_list, "Palace/OPDS/Foo.swift"))
+
+    def test_leadingSlashInRelpath_isTolerated(self):
+        file_list = "/build/Palace/OPDS/Foo.swift\n"
+        self.assertEqual(
+            mc._recorded_path_for(file_list, "/Palace/OPDS/Foo.swift"),
+            "/build/Palace/OPDS/Foo.swift",
+        )
+
+    def test_blankLines_ignored(self):
+        file_list = "\n\n/build/Palace/OPDS/Foo.swift\n\n"
+        self.assertEqual(
+            mc._recorded_path_for(file_list, "Palace/OPDS/Foo.swift"),
+            "/build/Palace/OPDS/Foo.swift",
+        )
+
+
+class CoveredLinesIntegration(unittest.TestCase):
+    """covered_lines() top-level guards (no xccov subprocess invoked)."""
+
+    def test_missingBundle_returnsNone(self):
+        self.assertIsNone(mc.covered_lines("/no/such/bundle.xcresult", "Palace/Foo.swift", "/repo"))
+
+    def test_emptyBundlePath_returnsNone(self):
+        self.assertIsNone(mc.covered_lines("", "Palace/Foo.swift", "/repo"))
+
+    def test_fileListFailure_returnsNone(self):
+        # If xccov can't produce a file-list (returns None), degrade to None.
+        # We point at an existing path (this test file) so the os.path.exists
+        # guard passes, then _run_xccov fails because it isn't a real bundle.
+        here = os.path.abspath(__file__)
+        self.assertIsNone(mc.covered_lines(here, "Palace/Foo.swift", "/repo"))
+
+
+class TestsForLines(unittest.TestCase):
+    """tests_for_lines is intentionally stubbed to None (per-test attribution
+    is unavailable in Xcode 26 — see module docstring). Pin that contract so a
+    future change that returns a (possibly wrong) map is a deliberate decision,
+    not an accident."""
+
+    def test_returnsNone_always(self):
+        self.assertIsNone(mc.tests_for_lines("/any.xcresult", "Palace/Foo.swift", {1, 2, 3}, "/repo"))
+        self.assertIsNone(mc.tests_for_lines("", "Palace/Foo.swift", set(), "/repo"))
+
+
+class IsSuppressed(unittest.TestCase):
+
+    def setUp(self):
+        self.supps = [
+            {"line_text": "for i in 0 ..< count {", "original": "<", "mutated": "<=",
+             "reason": "loop bound equivalent"},
+            {"line_text": "guard x >= 0 else { return }", "original": ">=", "mutated": ">",
+             "reason": "x is non-negative"},
+        ]
+
+    def test_exactMatch_isSuppressed(self):
+        self.assertTrue(mc.is_suppressed(self.supps, "for i in 0 ..< count {", "<", "<="))
+
+    def test_whitespaceInsensitive_lineText(self):
+        # A re-indent of the same line must still match (both sides stripped).
+        self.assertTrue(mc.is_suppressed(self.supps, "      for i in 0 ..< count {   ", "<", "<="))
+
+    def test_differentOriginal_notSuppressed(self):
+        self.assertFalse(mc.is_suppressed(self.supps, "for i in 0 ..< count {", "<=", "<="))
+
+    def test_differentMutated_notSuppressed(self):
+        self.assertFalse(mc.is_suppressed(self.supps, "for i in 0 ..< count {", "<", "<"))
+
+    def test_differentLineText_notSuppressed(self):
+        self.assertFalse(mc.is_suppressed(self.supps, "while i < count {", "<", "<="))
+
+    def test_emptySuppressions_neverSuppresses(self):
+        self.assertFalse(mc.is_suppressed([], "for i in 0 ..< count {", "<", "<="))
+
+    def test_secondEntry_alsoMatches(self):
+        self.assertTrue(mc.is_suppressed(self.supps, "guard x >= 0 else { return }", ">=", ">"))
+
+    def test_noneLineText_doesNotCrash(self):
+        self.assertFalse(mc.is_suppressed(self.supps, None, "<", "<="))
+
+
+class LoadSuppressions(unittest.TestCase):
+
+    def _write(self, repo_root, leaf, content_str):
+        d = os.path.join(repo_root, ".forgeos", "mutation-suppressions")
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, f"{leaf}.json"), "w", encoding="utf-8") as f:
+            f.write(content_str)
+
+    def test_absentFile_returnsEmptyList(self):
+        with tempfile.TemporaryDirectory() as repo:
+            self.assertEqual(mc.load_suppressions(repo, "Palace/Foo/Bar.swift"), [])
+
+    def test_presentFile_loadsEntries(self):
+        with tempfile.TemporaryDirectory() as repo:
+            self._write(repo, "Bar", json.dumps([
+                {"line_text": "a > b", "original": ">", "mutated": ">=", "reason": "r"},
+            ]))
+            supps = mc.load_suppressions(repo, "Palace/Foo/Bar.swift")
+            self.assertEqual(len(supps), 1)
+            self.assertEqual(supps[0]["original"], ">")
+
+    def test_leafDerivation_stripsSwiftAndPath(self):
+        # source_relpath Palace/A/B/TPPBookState.swift → leaf TPPBookState.json
+        with tempfile.TemporaryDirectory() as repo:
+            self._write(repo, "TPPBookState", json.dumps([
+                {"line_text": "x == y", "original": "==", "mutated": "!=", "reason": "r"},
+            ]))
+            supps = mc.load_suppressions(repo, "Palace/Book/Models/TPPBookState.swift")
+            self.assertEqual(len(supps), 1)
+
+    def test_malformedJson_returnsEmptyList(self):
+        with tempfile.TemporaryDirectory() as repo:
+            self._write(repo, "Bar", "{ this is not valid json")
+            self.assertEqual(mc.load_suppressions(repo, "Palace/Foo/Bar.swift"), [])
+
+    def test_nonListTopLevel_returnsEmptyList(self):
+        with tempfile.TemporaryDirectory() as repo:
+            self._write(repo, "Bar", json.dumps({"line_text": "a > b"}))
+            self.assertEqual(mc.load_suppressions(repo, "Palace/Foo/Bar.swift"), [])
+
+    def test_malformedEntries_filteredOut(self):
+        # Mix of well-formed and ill-formed entries: keep only the complete ones.
+        with tempfile.TemporaryDirectory() as repo:
+            self._write(repo, "Bar", json.dumps([
+                {"line_text": "a > b", "original": ">", "mutated": ">=", "reason": "ok"},
+                {"line_text": "missing operators"},          # dropped
+                "not a dict",                                  # dropped
+                {"original": ">", "mutated": ">="},            # missing line_text → dropped
+            ]))
+            supps = mc.load_suppressions(repo, "Palace/Foo/Bar.swift")
+            self.assertEqual(len(supps), 1)
+            self.assertEqual(supps[0]["line_text"], "a > b")
+
+    def test_loadThenIsSuppressed_roundTrip(self):
+        # End-to-end: a written suppression actually suppresses its mutant.
+        with tempfile.TemporaryDirectory() as repo:
+            self._write(repo, "Bar", json.dumps([
+                {"line_text": "  for i in 0 ..< n {  ", "original": "<", "mutated": "<=", "reason": "r"},
+            ]))
+            supps = mc.load_suppressions(repo, "Palace/Foo/Bar.swift")
+            self.assertTrue(mc.is_suppressed(supps, "for i in 0 ..< n {", "<", "<="))
+            self.assertFalse(mc.is_suppressed(supps, "for i in 0 ..< n {", ">", ">="))
+
+
+class ExampleFileIsNeverLoadedForRealSource(unittest.TestCase):
+    """The committed EXAMPLE.json must never be picked up by load_suppressions
+    for a real source file (there is no EXAMPLE.swift). Guards the README claim."""
+
+    def test_exampleLeafDoesNotCollideWithRealSources(self):
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        # A real source whose leaf is NOT 'EXAMPLE' must load [] from the real dir
+        # (assuming no suppressions committed for it). This also proves the real
+        # committed README/EXAMPLE.json don't accidentally suppress anything.
+        self.assertEqual(
+            mc.load_suppressions(repo_root, "Palace/Book/Models/TPPBookState.swift"),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_palace_mutate.py
+++ b/scripts/test_palace_mutate.py
@@ -12,7 +12,19 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from palace_mutate import any_tests_ran
+from palace_mutate import (
+    any_tests_ran,
+    compute_mutant_key,
+    is_critical_path,
+    count_critical_path_survivors,
+    build_report,
+    compute_exit_code,
+    resolve_fast_flags,
+    build_xcodebuild_command,
+    discover_mutations,
+    DEFAULT_FAST_FLAGS,
+    CONSEQUENTIAL_OPS,
+)
 
 
 class AnyTestsRan(unittest.TestCase):
@@ -61,6 +73,323 @@ Test Suite 'TPPSignInBusinessLogicTests' passed at 2026-04-27
         # Boundary: exactly 1 test executed must be detected (regex must accept [1-9]\d*)
         output = "\t Executed 1 test, with 0 failures"
         self.assertTrue(any_tests_ran(output))
+
+
+class ComputeMutantKey(unittest.TestCase):
+    """compute_mutant_key must be STABLE (same inputs -> same key) and
+    DISAMBIGUATING (same line_text, different context -> different key)."""
+
+    def _key(self, **over):
+        base = dict(
+            tests=["PalaceTests/FooTests"],
+            context_before="let a = 1",
+            line_text="if x > 0 {",
+            context_after="return a",
+            original=">",
+            mutated=">=",
+        )
+        base.update(over)
+        return compute_mutant_key(**base)
+
+    def test_stability_sameInputs_sameKey(self):
+        self.assertEqual(self._key(), self._key())
+
+    def test_keyIs16Hex(self):
+        k = self._key()
+        self.assertEqual(len(k), 16)
+        int(k, 16)  # raises if not hex
+
+    def test_disambiguation_sameLineDifferentContextBefore(self):
+        a = self._key(context_before="let a = 1")
+        b = self._key(context_before="let b = 99")
+        self.assertNotEqual(a, b, "identical line in different preceding context must key differently")
+
+    def test_disambiguation_sameLineDifferentContextAfter(self):
+        a = self._key(context_after="return a")
+        b = self._key(context_after="return b")
+        self.assertNotEqual(a, b, "identical line in different following context must key differently")
+
+    def test_locality_lineNumberNotInKey(self):
+        # Two mutants with identical local context but (implicitly) at different
+        # file positions produce the SAME key — the key intentionally does not
+        # encode the absolute line number, so edits elsewhere reuse the result.
+        self.assertEqual(self._key(), self._key())
+
+    def test_testSelectionChangesKey(self):
+        a = self._key(tests=["PalaceTests/FooTests"])
+        b = self._key(tests=["PalaceTests/BarTests"])
+        self.assertNotEqual(a, b)
+
+    def test_testOrderDoesNotChangeKey(self):
+        a = self._key(tests=["PalaceTests/A", "PalaceTests/B"])
+        b = self._key(tests=["PalaceTests/B", "PalaceTests/A"])
+        self.assertEqual(a, b, "tests are sorted before hashing")
+
+    def test_operatorFlipChangesKey(self):
+        a = self._key(original=">", mutated=">=")
+        b = self._key(original=">", mutated="<")
+        self.assertNotEqual(a, b)
+
+
+class CriticalPathClassification(unittest.TestCase):
+
+    def test_audiobooks_isCritical(self):
+        self.assertTrue(is_critical_path("Palace/Audiobooks/AudiobookLoader.swift"))
+
+    def test_signInLogic_isCritical(self):
+        self.assertTrue(is_critical_path("Palace/SignInLogic/TPPSignInBusinessLogic.swift"))
+
+    def test_downloadPrefix_isCritical(self):
+        self.assertTrue(is_critical_path("Palace/MyBooks/DownloadAuthRetryHandler.swift"))
+
+    def test_borrowPrefix_isCritical(self):
+        self.assertTrue(is_critical_path("Palace/MyBooks/BorrowOperation.swift"))
+
+    def test_bookReturnPrefix_isCritical(self):
+        self.assertTrue(is_critical_path("Palace/MyBooks/BookReturnService.swift"))
+
+    def test_migrations_isCritical(self):
+        self.assertTrue(is_critical_path("Palace/Migrations/SomeMigration.swift"))
+
+    def test_networkResponder_isCritical(self):
+        self.assertTrue(is_critical_path("Palace/Network/TPPNetworkResponder.swift"))
+
+    def test_networkExecutor_isCritical(self):
+        self.assertTrue(is_critical_path("Palace/Network/TPPNetworkExecutor.swift"))
+
+    def test_palaceAuth_isCritical(self):
+        self.assertTrue(is_critical_path("Palace/Packages/PalaceAuth/AuthThing.swift"))
+
+    def test_absolutePrefix_isCritical(self):
+        # CRITICAL_PATH_REGEX anchors on (^|/) before Palace/, so an absolute
+        # worktree path still classifies.
+        self.assertTrue(is_critical_path("/Users/x/wt/Palace/Audiobooks/Player.swift"))
+
+    def test_unrelatedFile_isNotCritical(self):
+        self.assertFalse(is_critical_path("Palace/Catalog/CatalogView.swift"))
+
+    def test_networkOtherFile_isNotCritical(self):
+        # Only the two named Network files are critical, not the whole dir.
+        self.assertFalse(is_critical_path("Palace/Network/TPPNetworkQueue.swift"))
+
+    def test_myBooksOtherFile_isNotCritical(self):
+        self.assertFalse(is_critical_path("Palace/MyBooks/MyBooksView.swift"))
+
+
+class CountCriticalPathSurvivors(unittest.TestCase):
+
+    @staticmethod
+    def _r(status, op):
+        return {"status": status, "mutation": {"op": op, "line": 1}}
+
+    def test_countsConsequentialSurvivorsOnly(self):
+        results = [
+            self._r("survived", "cmp"),     # counts
+            self._r("survived", "bool"),    # counts
+            self._r("survived", "assign"),  # excluded (assign)
+            self._r("killed", "cmp"),       # not a survivor
+            self._r("uncovered", "cond"),   # not a survivor
+            self._r("survived", "retval"),  # counts
+        ]
+        self.assertEqual(count_critical_path_survivors(results), 3)
+
+    def test_assignSurvivorExcluded(self):
+        results = [self._r("survived", "assign")]
+        self.assertEqual(count_critical_path_survivors(results), 0)
+
+    def test_allConsequentialOpsCounted(self):
+        results = [self._r("survived", op) for op in sorted(CONSEQUENTIAL_OPS)]
+        self.assertEqual(count_critical_path_survivors(results), len(CONSEQUENTIAL_OPS))
+
+    def test_empty(self):
+        self.assertEqual(count_critical_path_survivors([]), 0)
+
+
+class BuildReportSchema(unittest.TestCase):
+    """build_report must ADD keys without changing the existing schema, and must
+    keep killed/survived counts free of uncovered/suppressed mutants."""
+
+    @staticmethod
+    def _r(status, op="cmp", line=10):
+        return {"status": status, "mutation": {"op": op, "line": line}}
+
+    def test_uncoveredAndSuppressedNotCountedAsRun(self):
+        results = [
+            self._r("killed"),
+            self._r("survived"),
+            self._r("uncovered", line=20),
+            self._r("suppressed"),
+        ]
+        rep = build_report(file_relpath="Palace/Catalog/X.swift", tests=["T"],
+                           seed=1, results=results, planned=4, partial=False)
+        s = rep["summary"]
+        self.assertEqual(s["killed"], 1)
+        self.assertEqual(s["survived"], 1)
+        self.assertEqual(s["uncovered"], 1)
+        self.assertEqual(s["suppressed"], 1)
+        # kill rate over RUN mutants only: 1 killed / (1+1) = 50%
+        self.assertEqual(s["kill_rate_pct"], 50.0)
+
+    def test_additiveKeysPresent(self):
+        rep = build_report(file_relpath="Palace/Catalog/X.swift", tests=["T"],
+                           seed=1, results=[self._r("killed")], planned=1, partial=False)
+        s = rep["summary"]
+        for k in ("uncovered", "suppressed", "is_critical_path", "critical_path_survivors"):
+            self.assertIn(k, s)
+        self.assertIn("coverage_gap", rep)
+
+    def test_existingKeysPreserved(self):
+        rep = build_report(file_relpath="Palace/Catalog/X.swift", tests=["T"],
+                           seed=1, results=[self._r("killed")], planned=1, partial=True)
+        s = rep["summary"]
+        for k in ("killed", "survived", "errored", "kill_rate_pct", "partial",
+                  "completed_mutations", "planned_mutations"):
+            self.assertIn(k, s)
+        self.assertTrue(s["partial"])
+        self.assertEqual(s["planned_mutations"], 1)
+        for k in ("file", "tests", "seed", "results"):
+            self.assertIn(k, rep)
+
+    def test_coverageGapListsUncoveredPoints(self):
+        results = [self._r("uncovered", op="bound", line=42),
+                   self._r("killed", line=43)]
+        rep = build_report(file_relpath="Palace/Catalog/X.swift", tests=["T"],
+                           seed=1, results=results, planned=2, partial=False)
+        self.assertEqual(rep["coverage_gap"], [{"line": 42, "op": "bound"}])
+
+    def test_criticalPathSurvivorsCountedOnlyForCriticalFile(self):
+        results = [self._r("survived", op="cmp")]
+        # Non-critical file: survivors NOT counted as critical.
+        non_crit = build_report(file_relpath="Palace/Catalog/X.swift", tests=["T"],
+                                seed=1, results=results, planned=1, partial=False)
+        self.assertFalse(non_crit["summary"]["is_critical_path"])
+        self.assertEqual(non_crit["summary"]["critical_path_survivors"], 0)
+        # Critical file: counted.
+        crit = build_report(file_relpath="Palace/Audiobooks/Y.swift", tests=["T"],
+                            seed=1, results=results, planned=1, partial=False)
+        self.assertTrue(crit["summary"]["is_critical_path"])
+        self.assertEqual(crit["summary"]["critical_path_survivors"], 1)
+
+
+class ComputeExitCode(unittest.TestCase):
+    """Exit contract: 0 ok, 1 low-kill (<50%) OR critical-path consequential
+    survivor regardless of kill rate."""
+
+    def test_highKillRate_nonCritical_exit0(self):
+        s = {"killed": 9, "survived": 1, "kill_rate_pct": 90.0,
+             "is_critical_path": False, "critical_path_survivors": 0}
+        self.assertEqual(compute_exit_code(s), 0)
+
+    def test_lowKillRate_exit1(self):
+        s = {"killed": 1, "survived": 9, "kill_rate_pct": 10.0,
+             "is_critical_path": False, "critical_path_survivors": 0}
+        self.assertEqual(compute_exit_code(s), 1)
+
+    def test_criticalPathSurvivor_overridesHighKillRate_exit1(self):
+        # 90% kill rate would normally pass, but a critical-path consequential
+        # survivor fails the gate REGARDLESS.
+        s = {"killed": 9, "survived": 1, "kill_rate_pct": 90.0,
+             "is_critical_path": True, "critical_path_survivors": 1}
+        self.assertEqual(compute_exit_code(s), 1)
+
+    def test_criticalPath_noConsequentialSurvivor_highKill_exit0(self):
+        s = {"killed": 10, "survived": 0, "kill_rate_pct": 100.0,
+             "is_critical_path": True, "critical_path_survivors": 0}
+        self.assertEqual(compute_exit_code(s), 0)
+
+    def test_noRunMutants_exit0(self):
+        # All uncovered/suppressed -> nothing ran -> not a low-kill failure.
+        s = {"killed": 0, "survived": 0, "kill_rate_pct": 0.0,
+             "is_critical_path": False, "critical_path_survivors": 0}
+        self.assertEqual(compute_exit_code(s), 0)
+
+
+class FastFlags(unittest.TestCase):
+
+    def setUp(self):
+        # Snapshot + clear the env vars these tests manipulate.
+        self._saved = {k: os.environ.get(k) for k in
+                       ("PALACE_MUTATE_NO_FAST_FLAGS", "PALACE_MUTATE_XCB_EXTRA_FLAGS")}
+        for k in self._saved:
+            os.environ.pop(k, None)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_defaultFlagsPresent(self):
+        for flag in ("-disableAutomaticPackageResolution",
+                     "-onlyUsePackageVersionsFromResolvedFile",
+                     "-skipPackagePluginValidation",
+                     "-parallel-testing-enabled",
+                     "COMPILER_INDEX_STORE_ENABLE=NO"):
+            self.assertIn(flag, DEFAULT_FAST_FLAGS)
+        # -parallel-testing-enabled is followed by NO
+        idx = DEFAULT_FAST_FLAGS.index("-parallel-testing-enabled")
+        self.assertEqual(DEFAULT_FAST_FLAGS[idx + 1], "NO")
+
+    def test_quietNotInDefaults(self):
+        # -quiet would break any_tests_ran's 'Executed N tests' grep.
+        self.assertNotIn("-quiet", DEFAULT_FAST_FLAGS)
+
+    def test_resolve_default(self):
+        self.assertEqual(resolve_fast_flags(), DEFAULT_FAST_FLAGS)
+
+    def test_resolve_suppressed(self):
+        os.environ["PALACE_MUTATE_NO_FAST_FLAGS"] = "1"
+        self.assertEqual(resolve_fast_flags(), [])
+
+    def test_resolve_overrideReplaces(self):
+        os.environ["PALACE_MUTATE_XCB_EXTRA_FLAGS"] = "-foo -bar BAZ=NO"
+        self.assertEqual(resolve_fast_flags(), ["-foo", "-bar", "BAZ=NO"])
+
+    def test_buildCommand_includesFlagsAndOnlyTesting(self):
+        cmd = build_xcodebuild_command(
+            ["PalaceTests/FooTests"],
+            fast_flags=DEFAULT_FAST_FLAGS,
+            derived_data_args=[],
+            coverage_bundle_path=None,
+        )
+        self.assertIn("-disableAutomaticPackageResolution", cmd)
+        self.assertIn("-only-testing:PalaceTests/FooTests", cmd)
+        self.assertNotIn("-enableCodeCoverage", cmd)
+
+    def test_buildCommand_coverageBundle(self):
+        cmd = build_xcodebuild_command(
+            ["PalaceTests/FooTests"],
+            fast_flags=[],
+            derived_data_args=[],
+            coverage_bundle_path="/tmp/x.xcresult",
+        )
+        self.assertIn("-enableCodeCoverage", cmd)
+        i = cmd.index("-enableCodeCoverage")
+        self.assertEqual(cmd[i + 1], "YES")
+        self.assertIn("-resultBundlePath", cmd)
+        self.assertIn("/tmp/x.xcresult", cmd)
+
+
+class DiscoverMutationsContext(unittest.TestCase):
+    """discover_mutations must populate context_before/after so the per-mutant
+    cache key can disambiguate identical lines."""
+
+    def test_contextCaptured(self):
+        src = "let a = 1\nif x > 0 {\nreturn a\n"
+        muts = discover_mutations(src)
+        bound = [m for m in muts if m.op == "bound" and m.line == 2]
+        self.assertTrue(bound, "expected a bound mutant on the `>` line")
+        m = bound[0]
+        self.assertEqual(m.context_before, "let a = 1")
+        self.assertEqual(m.context_after, "return a")
+
+    def test_contextAtFileBoundary(self):
+        src = "x > 0\n"
+        muts = discover_mutations(src)
+        m = [mm for mm in muts if mm.op == "bound"][0]
+        self.assertEqual(m.context_before, "")
+        self.assertEqual(m.context_after, "")
 
 
 if __name__ == "__main__":

--- a/scripts/test_palace_mutate_parallel.py
+++ b/scripts/test_palace_mutate_parallel.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""
+Unit tests for palace_mutate_parallel.py PURE orchestration logic.
+
+These tests NEVER create a real git worktree, boot a simulator, or invoke
+xcodebuild. Everything exercised here is the factored pure logic (worker-count
+math, the serial/parallel cost gate, sim round-robin, file filtering, report
+aggregation, argv assembly). subprocess-touching helpers are exercised only via
+injected `runner` callables.
+
+Run: python3 -m unittest scripts.test_palace_mutate_parallel
+  or: python3 scripts/test_palace_mutate_parallel.py
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from palace_mutate_parallel import (
+    compute_worker_count,
+    should_run_parallel,
+    assign_sims,
+    filter_prod_swift,
+    changed_prod_swift_files,
+    resolve_tests_for_file,
+    aggregate_reports,
+    aggregate_exit_code,
+    build_palace_mutate_argv,
+    FileResult,
+    DEFAULT_SIM_UDIDS,
+)
+
+
+# Small stand-in for subprocess.CompletedProcess for injected runners.
+class _FakeProc:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class ComputeWorkerCount(unittest.TestCase):
+    """Default = min(#sims, max(1, ncpu//4), #files); explicit honored+clamped."""
+
+    def test_zeroFiles_zeroWorkers(self):
+        self.assertEqual(compute_worker_count(0, 3, 24), 0)
+
+    def test_oneFile_oneWorker(self):
+        # Clamped to #files even though sims=3 and ncpu//4=6.
+        self.assertEqual(compute_worker_count(1, 3, 24), 1)
+
+    def test_manyFiles_clampedBySims(self):
+        # 10 files, 3 sims, ncpu//4 = 6 -> sims wins (3).
+        self.assertEqual(compute_worker_count(10, 3, 24), 3)
+
+    def test_manyFiles_clampedByCpu(self):
+        # 10 files, 8 sims, ncpu=8 -> ncpu//4=2 wins.
+        self.assertEqual(compute_worker_count(10, 8, 8), 2)
+
+    def test_manyFiles_clampedByFiles(self):
+        # 2 files, 8 sims, ncpu=24 (//4=6) -> files wins (2).
+        self.assertEqual(compute_worker_count(2, 8, 24), 2)
+
+    def test_lowCpu_floorOfOne(self):
+        # ncpu=2 -> //4 == 0, but max(1, ...) keeps at least one worker.
+        self.assertEqual(compute_worker_count(5, 3, 2), 1)
+
+    def test_zeroSims_floorOfOne(self):
+        # Pathological: no sims declared. max(1, num_sims) keeps a worker so
+        # the run degrades to serial-ish rather than producing 0 workers.
+        self.assertEqual(compute_worker_count(5, 0, 24), 1)
+
+    def test_explicitRequested_honored(self):
+        self.assertEqual(compute_worker_count(10, 3, 24, requested=2), 2)
+
+    def test_explicitRequested_clampedToFiles(self):
+        # Can't run more workers than files.
+        self.assertEqual(compute_worker_count(2, 8, 24, requested=8), 2)
+
+    def test_explicitRequested_zeroClampedToOne(self):
+        self.assertEqual(compute_worker_count(5, 3, 24, requested=0), 1)
+
+    def test_explicitRequested_negativeClampedToOne(self):
+        self.assertEqual(compute_worker_count(5, 3, 24, requested=-4), 1)
+
+
+class ShouldRunParallel(unittest.TestCase):
+    """Cost gate: parallel only when >=2 files AND >=2 workers."""
+
+    def test_oneFile_serial(self):
+        self.assertFalse(should_run_parallel(1, 1))
+
+    def test_oneFile_evenWithManyWorkers_serial(self):
+        # worker_count can't actually be 5 for 1 file, but the gate is robust.
+        self.assertFalse(should_run_parallel(1, 5))
+
+    def test_twoFilesOneWorker_serial(self):
+        # --workers 1 forces serial even with 2 files.
+        self.assertFalse(should_run_parallel(2, 1))
+
+    def test_twoFilesTwoWorkers_parallel(self):
+        self.assertTrue(should_run_parallel(2, 2))
+
+    def test_manyFilesManyWorkers_parallel(self):
+        self.assertTrue(should_run_parallel(10, 3))
+
+    def test_zeroFiles_serial(self):
+        self.assertFalse(should_run_parallel(0, 0))
+
+
+class AssignSims(unittest.TestCase):
+
+    def test_roundRobin_fewerWorkersThanSims(self):
+        sims = ["A", "B", "C"]
+        self.assertEqual(assign_sims(2, sims), ["A", "B"])
+
+    def test_roundRobin_equalWorkersAndSims(self):
+        sims = ["A", "B", "C"]
+        self.assertEqual(assign_sims(3, sims), ["A", "B", "C"])
+
+    def test_roundRobin_moreWorkersThanSims_wraps(self):
+        # Defended pathological case: workers wrap and share sims.
+        sims = ["A", "B", "C"]
+        self.assertEqual(assign_sims(5, sims), ["A", "B", "C", "A", "B"])
+
+    def test_oneWorker_firstSim(self):
+        self.assertEqual(assign_sims(1, ["A", "B", "C"]), ["A"])
+
+    def test_noSims_empty(self):
+        self.assertEqual(assign_sims(3, []), [])
+
+    def test_defaultSimsAreThree(self):
+        # The pool has exactly three UDIDs; assigning 3 workers uses each once.
+        self.assertEqual(len(set(assign_sims(3, DEFAULT_SIM_UDIDS))), 3)
+
+
+class FilterProdSwift(unittest.TestCase):
+
+    def test_keepsProductionSwift(self):
+        paths = ["Palace/Audiobooks/Player.swift", "Palace/MyBooks/Borrow.swift"]
+        self.assertEqual(filter_prod_swift(paths), paths)
+
+    def test_dropsNonSwift(self):
+        self.assertEqual(filter_prod_swift(["Palace/Foo.m", "README.md"]), [])
+
+    def test_dropsTestBundle(self):
+        self.assertEqual(filter_prod_swift(["PalaceTests/Audiobooks/PlayerTests.swift"]), [])
+
+    def test_dropsTestSuffixedSwiftUnderPalace(self):
+        # A *Tests.swift file that happens to live under Palace/ is still a test.
+        self.assertEqual(filter_prod_swift(["Palace/Audiobooks/PlayerTests.swift"]), [])
+
+    def test_dropsNonPalacePath(self):
+        self.assertEqual(filter_prod_swift(["scripts/foo.swift"]), [])
+
+    def test_stripsWhitespaceAndBlanks(self):
+        self.assertEqual(
+            filter_prod_swift(["  Palace/A.swift  ", "", "   "]),
+            ["Palace/A.swift"])
+
+    def test_mixed(self):
+        paths = [
+            "Palace/Audiobooks/Player.swift",       # keep
+            "PalaceTests/PlayerTests.swift",        # drop (test bundle)
+            "Palace/MyBooks/BorrowTests.swift",     # drop (Tests suffix)
+            "docs/notes.md",                        # drop (non-swift)
+            "Palace/SignInLogic/Login.swift",       # keep
+        ]
+        self.assertEqual(
+            filter_prod_swift(paths),
+            ["Palace/Audiobooks/Player.swift", "Palace/SignInLogic/Login.swift"])
+
+
+class ChangedProdSwiftFiles(unittest.TestCase):
+    """changed_prod_swift_files via injected runner — no real git."""
+
+    def test_parsesAndFilters(self):
+        def runner(argv):
+            return _FakeProc(0, stdout=(
+                "Palace/Audiobooks/Player.swift\n"
+                "PalaceTests/PlayerTests.swift\n"
+                "Palace/MyBooks/BorrowTests.swift\n"
+                "Palace/SignInLogic/Login.swift\n"))
+        out = changed_prod_swift_files("origin/develop", runner=runner)
+        self.assertEqual(out, ["Palace/Audiobooks/Player.swift",
+                               "Palace/SignInLogic/Login.swift"])
+
+    def test_gitFailure_returnsEmpty(self):
+        def runner(argv):
+            return _FakeProc(128, stderr="fatal: bad revision")
+        self.assertEqual(changed_prod_swift_files("nope", runner=runner), [])
+
+    def test_emptyDiff_returnsEmpty(self):
+        self.assertEqual(
+            changed_prod_swift_files("x", runner=lambda a: _FakeProc(0, "")), [])
+
+
+class ResolveTestsForFile(unittest.TestCase):
+
+    def test_parsesSelectors(self):
+        def runner(argv):
+            return _FakeProc(0, stdout="PalaceTests/PlayerTests\nPalaceTests/LoaderTests\n")
+        self.assertEqual(
+            resolve_tests_for_file("Palace/Audiobooks/Player.swift", runner=runner),
+            ["PalaceTests/PlayerTests", "PalaceTests/LoaderTests"])
+
+    def test_resolverFailure_returnsEmpty(self):
+        self.assertEqual(
+            resolve_tests_for_file("x", runner=lambda a: _FakeProc(1)), [])
+
+    def test_emptyOutput_returnsEmpty(self):
+        self.assertEqual(
+            resolve_tests_for_file("x", runner=lambda a: _FakeProc(0, "")), [])
+
+
+class BuildPalaceMutateArgv(unittest.TestCase):
+
+    def test_forwardsFileTestsReportAndPassthrough(self):
+        argv = build_palace_mutate_argv(
+            "Palace/Audiobooks/Player.swift",
+            ["PalaceTests/PlayerTests", "PalaceTests/LoaderTests"],
+            "/tmp/r.json",
+            ["--diff-only", "--max-mutations", "10", "--no-cache"])
+        self.assertIn("--file", argv)
+        self.assertIn("Palace/Audiobooks/Player.swift", argv)
+        # Each test becomes its own --tests pair.
+        self.assertEqual(argv.count("--tests"), 2)
+        self.assertIn("PalaceTests/PlayerTests", argv)
+        self.assertIn("PalaceTests/LoaderTests", argv)
+        self.assertIn("--report", argv)
+        self.assertIn("/tmp/r.json", argv)
+        # Passthrough forwarded verbatim at the tail.
+        for flag in ("--diff-only", "--max-mutations", "10", "--no-cache"):
+            self.assertIn(flag, argv)
+        # Targets palace_mutate.py.
+        self.assertTrue(any(a.endswith("palace_mutate.py") for a in argv))
+
+
+def _file_result(file, exit_code, *, killed=0, survived=0, uncovered=0,
+                 suppressed=0, errored=0, is_critical=False, cps=0, error=""):
+    """Build a synthetic FileResult with an embedded palace_mutate-shaped
+    report. Mirrors build_report's summary schema so aggregation is exercised
+    against the real key names."""
+    report = {
+        "file": file,
+        "summary": {
+            "killed": killed, "survived": survived, "errored": errored,
+            "uncovered": uncovered, "suppressed": suppressed,
+            "is_critical_path": is_critical, "critical_path_survivors": cps,
+        },
+    }
+    return FileResult(file=file, exit_code=exit_code, report=report, error=error)
+
+
+class AggregateReports(unittest.TestCase):
+
+    def test_sumsAcrossFiles(self):
+        results = [
+            _file_result("a.swift", 0, killed=8, survived=2, uncovered=1, suppressed=1),
+            _file_result("b.swift", 0, killed=6, survived=4, uncovered=2),
+        ]
+        agg = aggregate_reports(results)
+        t = agg["totals"]
+        self.assertEqual(t["killed"], 14)
+        self.assertEqual(t["survived"], 6)
+        self.assertEqual(t["uncovered"], 3)
+        self.assertEqual(t["suppressed"], 1)
+        # Overall kill rate over RUN mutants only: 14 / (14+6) = 70%.
+        self.assertEqual(agg["overall_kill_rate_pct"], 70.0)
+
+    def test_uncoveredSuppressedDoNotAffectKillRate(self):
+        # 100 uncovered, but 1 killed / 1 survived among run -> 50%, not buried.
+        results = [_file_result("a.swift", 1, killed=1, survived=1,
+                                uncovered=100, suppressed=50)]
+        agg = aggregate_reports(results)
+        self.assertEqual(agg["overall_kill_rate_pct"], 50.0)
+
+    def test_overallPassWhenAllFilesPass(self):
+        results = [_file_result("a.swift", 0, killed=10),
+                   _file_result("b.swift", 0, killed=5)]
+        agg = aggregate_reports(results)
+        self.assertTrue(agg["overall_passed"])
+        self.assertEqual(agg["files_failed"], 0)
+        self.assertEqual(aggregate_exit_code(agg), 0)
+
+    def test_overallFailWhenAnyFileFails(self):
+        results = [_file_result("a.swift", 0, killed=10),
+                   _file_result("b.swift", 1, killed=1, survived=9)]
+        agg = aggregate_reports(results)
+        self.assertFalse(agg["overall_passed"])
+        self.assertEqual(agg["files_failed"], 1)
+        self.assertEqual(aggregate_exit_code(agg), 1)
+
+    def test_criticalPathSurvivorOverride_surfaced(self):
+        # A critical-path file with a consequential survivor: palace_mutate would
+        # have exited 1, so the file fails, the aggregate fails, AND the
+        # any_critical_path_survivor flag is set for visibility.
+        results = [
+            _file_result("Palace/Audiobooks/P.swift", 1, killed=9, survived=1,
+                         is_critical=True, cps=1),
+        ]
+        agg = aggregate_reports(results)
+        self.assertFalse(agg["overall_passed"])
+        self.assertTrue(agg["any_critical_path_survivor"])
+        self.assertEqual(agg["totals"]["critical_path_survivors"], 1)
+        self.assertEqual(aggregate_exit_code(agg), 1)
+
+    def test_criticalSurvivorNotSetForNonCriticalFile(self):
+        # A non-critical file with survivors does NOT trip the critical flag.
+        results = [_file_result("Palace/Catalog/X.swift", 1, killed=1, survived=9,
+                                is_critical=False, cps=0)]
+        agg = aggregate_reports(results)
+        self.assertFalse(agg["any_critical_path_survivor"])
+
+    def test_perFileKillRates(self):
+        results = [
+            _file_result("a.swift", 0, killed=3, survived=1),  # 75%
+            _file_result("b.swift", 1, killed=1, survived=3),  # 25%
+        ]
+        agg = aggregate_reports(results)
+        rates = {pf["file"]: pf["kill_rate_pct"] for pf in agg["per_file"]}
+        self.assertEqual(rates["a.swift"], 75.0)
+        self.assertEqual(rates["b.swift"], 25.0)
+        passed = {pf["file"]: pf["passed"] for pf in agg["per_file"]}
+        self.assertTrue(passed["a.swift"])
+        self.assertFalse(passed["b.swift"])
+
+    def test_fileWithNoReport_countedAsFailWithError(self):
+        # A worker whose palace_mutate crashed before writing a report: exit
+        # non-zero, no report. Must count toward files_failed and NOT crash.
+        fr = FileResult(file="a.swift", exit_code=2, report=None,
+                        error="no report produced (exit 2)")
+        agg = aggregate_reports([fr])
+        self.assertFalse(agg["overall_passed"])
+        self.assertEqual(agg["files_failed"], 1)
+        self.assertEqual(agg["per_file"][0]["error"], "no report produced (exit 2)")
+
+    def test_zeroRunMutants_killRateZero_butNotAutoFail(self):
+        # All uncovered: nothing ran. palace_mutate exits 0; aggregate passes.
+        results = [_file_result("a.swift", 0, uncovered=5)]
+        agg = aggregate_reports(results)
+        self.assertEqual(agg["overall_kill_rate_pct"], 0.0)
+        self.assertTrue(agg["overall_passed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_post_mutation_pr_comment.py
+++ b/scripts/test_post_mutation_pr_comment.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Unit tests for post-mutation-pr-comment.py rendering.
+
+Pure-logic tests only — no gh, no subprocess, no network. Feeds synthetic
+report dicts (written to a tmp reports dir) through load_reports + render_table
+and asserts on the markdown body. Runs in well under 5s.
+
+Run: python3 -m unittest scripts.test_post_mutation_pr_comment
+  or: python3 scripts/test_post_mutation_pr_comment.py
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# The script has a hyphenated filename, so import it via importlib rather than
+# a normal `import` statement.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "post_mutation_pr_comment",
+    os.path.join(_HERE, "post-mutation-pr-comment.py"),
+)
+pmpc = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(pmpc)
+
+
+def _write_report(d: Path, slug: str, report: dict) -> None:
+    (d / f"{slug}.json").write_text(json.dumps(report))
+
+
+def _modern_report(*, file, killed, survived, critical=False,
+                   cp_survivors=0, uncovered=0, suppressed=0,
+                   coverage_gap=None, results=None):
+    return {
+        "file": file,
+        "tests": ["PalaceTests/Foo"],
+        "seed": 1,
+        "summary": {
+            "killed": killed,
+            "survived": survived,
+            "errored": 0,
+            "kill_rate_pct": round(killed / (killed + survived) * 100, 1)
+            if (killed + survived) else 0.0,
+            "partial": False,
+            "completed_mutations": killed + survived,
+            "planned_mutations": killed + survived,
+            "uncovered": uncovered,
+            "suppressed": suppressed,
+            "is_critical_path": critical,
+            "critical_path_survivors": cp_survivors,
+        },
+        "coverage_gap": coverage_gap or [],
+        "results": results or [],
+    }
+
+
+class CriticalPathSurvivorBlocks(unittest.TestCase):
+
+    def test_survivorOnCriticalPath_blocksEvenAt100PercentKillRate(self):
+        # 10 killed, 0 survived => 100% kill rate, but a consequential survivor
+        # is recorded separately. The render must BLOCK, not PASS.
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_report(d, "audiobk", _modern_report(
+                file="Palace/Audiobooks/AudiobookSessionManager.swift",
+                killed=10, survived=0, critical=True, cp_survivors=2,
+            ))
+            rows = pmpc.load_reports(d)
+            body = pmpc.render_table(rows, threshold=50.0)
+
+        self.assertIn("BLOCKS MERGE", body,
+                      "critical-path survivor must produce a blocking banner")
+        self.assertIn("regardless of kill rate", body)
+        # The per-row verdict must not say PASS for this file.
+        self.assertNotIn("PASS (critical)", body)
+        # fail-on-critical equivalent: the loader row carries the count.
+        self.assertEqual(rows[0]["critical_path_survivors"], 2)
+
+    def test_noSurvivors_highKillRate_doesNotBlock(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_report(d, "audiobk", _modern_report(
+                file="Palace/Audiobooks/AudiobookSessionManager.swift",
+                killed=10, survived=0, critical=True, cp_survivors=0,
+            ))
+            rows = pmpc.load_reports(d)
+            body = pmpc.render_table(rows, threshold=50.0)
+        self.assertNotIn("BLOCKS MERGE", body)
+        self.assertIn("PASS (critical)", body)
+
+
+class CoverageGapCallout(unittest.TestCase):
+
+    def test_uncoveredLines_renderAsCoverageGapTodo(self):
+        gap = [{"line": 42, "op": "cmp"}, {"line": 88, "op": "bool"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_report(d, "f", _modern_report(
+                file="Palace/Foo/Bar.swift",
+                killed=3, survived=1, uncovered=2, coverage_gap=gap,
+            ))
+            rows = pmpc.load_reports(d)
+            body = pmpc.render_table(rows, threshold=50.0)
+        self.assertIn("Coverage gap", body)
+        self.assertIn("42", body)
+        self.assertIn("88", body)
+        self.assertIn("`cmp`", body)
+        # Coverage gap is NON-blocking — it's a to-do callout, not a fail.
+        self.assertIn("free coverage to-do", body)
+        self.assertNotIn("BLOCKS MERGE", body)
+
+
+class SuppressedCallout(unittest.TestCase):
+
+    def test_suppressedMutants_surfacedAsInformational(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_report(d, "f", _modern_report(
+                file="Palace/Foo/Bar.swift",
+                killed=4, survived=0, suppressed=3,
+            ))
+            rows = pmpc.load_reports(d)
+            body = pmpc.render_table(rows, threshold=50.0)
+        self.assertIn("3 mutant(s) suppressed", body)
+        self.assertIn("not counted against the", body)
+
+
+class BackwardCompatMissingKeys(unittest.TestCase):
+
+    def test_oldReportWithoutNewKeys_rendersWithoutError(self):
+        # An older cached report: summary has ONLY the original keys.
+        old = {
+            "file": "Palace/Legacy/Old.swift",
+            "summary": {
+                "killed": 2,
+                "survived": 2,
+                "errored": 0,
+                "kill_rate_pct": 50.0,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_report(d, "old", old)
+            rows = pmpc.load_reports(d)
+            body = pmpc.render_table(rows, threshold=50.0)
+        # No KeyError, no crash; defaults applied.
+        self.assertEqual(rows[0]["critical_path_survivors"], 0)
+        self.assertEqual(rows[0]["uncovered"], 0)
+        self.assertEqual(rows[0]["suppressed"], 0)
+        self.assertEqual(rows[0]["coverage_gap"], [])
+        self.assertNotIn("BLOCKS MERGE", body)
+        self.assertNotIn("Coverage gap", body)
+        self.assertIn("Old.swift", body)
+
+    def test_isCriticalPathFlag_overridesPrefixHeuristic(self):
+        # File path is NOT under a critical prefix, but the report flags it.
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_report(d, "f", _modern_report(
+                file="Palace/Accounts/Library/AccountsManager.swift",
+                killed=1, survived=1, critical=True, cp_survivors=0,
+            ))
+            rows = pmpc.load_reports(d)
+        self.assertTrue(rows[0]["critical"],
+                        "report's is_critical_path flag must win over the "
+                        "local prefix heuristic")
+
+
+class FooterPriority(unittest.TestCase):
+
+    def test_criticalSurvivorAndLowKillRate_survivorBannerWinsFooter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            # Critical file: low kill rate AND a survivor — survivor block wins.
+            _write_report(d, "a", _modern_report(
+                file="Palace/SignInLogic/TPPSignInBusinessLogic.swift",
+                killed=1, survived=4, critical=True, cp_survivors=1,
+            ))
+            rows = pmpc.load_reports(d)
+            body = pmpc.render_table(rows, threshold=50.0)
+        footer = body.rsplit("\n", 6)[-1] if "\n" in body else body
+        self.assertIn("surviving", body)
+        self.assertIn("gate blocks merge", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -32,6 +32,13 @@
 #   scripts/verify-pr.sh --mutation-min-kill-rate N
 #                                              # Override the per-file kill-rate
 #                                              # floor (default: 50%).
+#   scripts/verify-pr.sh --mutation-whole-file # Mutate the WHOLE file instead of
+#                                              # only the lines this PR changed.
+#                                              # Default for the PR gate is
+#                                              # --diff-only (kill rate reflects
+#                                              # YOUR diff, not the file's whole
+#                                              # history). Pass this for release
+#                                              # runs that want full-file coverage.
 #   scripts/verify-pr.sh --simdrive            # Also replay .simdrive/journeys/*.yaml
 #                                              # via simdrive. MAINTAINER-INTERNAL:
 #                                              # simdrive is not yet publicly
@@ -48,6 +55,17 @@
 #   are advisory: low kill rates are surfaced as warnings but do not fail.
 #   --enforce-mutations promotes every changed file to strict.
 #   --no-enforce-mutations demotes critical paths to advisory.
+#
+#   DIFF-SCOPED BY DEFAULT: the PR gate runs palace_mutate.py with --diff-only,
+#   so the kill rate reflects the lines THIS PR changed, not the file's whole
+#   history. Pass --mutation-whole-file for release runs that want full-file
+#   coverage.
+#
+#   CRITICAL-PATH SURVIVOR OVERRIDE: independent of the kill-rate floor, any
+#   critical-path file whose JSON report shows summary.critical_path_survivors > 0
+#   (a SURVIVED mutant with a consequential op — cmp/bool/bound/retval/cond) is a
+#   STRICT FAIL. A 100%-on-paper kill rate cannot mask a surviving consequential
+#   mutant on a user-money path.
 #
 # Designed to be called by:
 #   - Claude Code agents before PR creation
@@ -76,6 +94,10 @@ MUTATION_ONLY=false
 # Per-file kill-rate floor. CLAUDE.md says 50%; tunable via flag for the rare
 # case where a sweep needs a higher bar (e.g. critical-path hardening sprint).
 MUTATION_MIN_KILL_RATE=50
+# Diff-scoped by default for the PR gate: palace_mutate.py only mutates the lines
+# this PR changed (kill rate reflects YOUR diff, not the whole file's history).
+# --mutation-whole-file flips this for release runs that want full-file coverage.
+MUTATION_WHOLE_FILE=false
 
 # Critical paths: every changed file matching one of these prefixes is held to
 # the strict kill-rate floor unless explicitly opted out via --no-enforce-mutations.
@@ -103,6 +125,7 @@ while [[ $# -gt 0 ]]; do
     --no-enforce-mutations) MUTATION_POLICY="advisory_all"; shift ;;
     --mutation-only) MUTATION_ONLY=true; QUICK=false; shift ;;
     --mutation-min-kill-rate) MUTATION_MIN_KILL_RATE="$2"; shift 2 ;;
+    --mutation-whole-file) MUTATION_WHOLE_FILE=true; shift ;;
     *) shift ;;
   esac
 done
@@ -622,8 +645,23 @@ elif [ -f scripts/palace_mutate.py ] && [ -n "$CHANGED_SWIFT" ]; then
   TOTAL_MUTATIONS=0
   STRICT_FAIL_FILES=()  # strict policy applies AND kill rate < min
   WARN_FILES=()         # kill rate < min but advisory only
+  # Critical-path files with >=1 surviving consequential mutant. These are a
+  # STRICT FAIL regardless of kill rate or MUTATION_POLICY — a 100%-on-paper
+  # kill rate cannot mask a surviving consequential mutant on a user-money path.
+  CRITICAL_SURVIVOR_FILES=()
   MUTATION_HARD_FAILED=false
   mkdir -p "$MUTATION_REPORTS_DIR"
+
+  # Diff-scoped by default for the PR gate; --mutation-whole-file opts into a
+  # full-file scan (release runs). palace_mutate.py caches diff-only and
+  # whole-file runs under independent keys, so switching modes is safe.
+  MUTATION_SCOPE_ARGS=()
+  if [ "$MUTATION_WHOLE_FILE" = "true" ]; then
+    echo "  Mutation scope: WHOLE FILE (--mutation-whole-file)"
+  else
+    MUTATION_SCOPE_ARGS+=("--diff-only")
+    echo "  Mutation scope: diff-only vs $BASE (default; pass --mutation-whole-file for full-file)"
+  fi
 
   while IFS= read -r swift_file; do
     [ -z "$swift_file" ] && continue
@@ -665,9 +703,12 @@ elif [ -f scripts/palace_mutate.py ] && [ -n "$CHANGED_SWIFT" ]; then
       MUTATE_TEST_ARGS+=("--tests" "$sel")
     done <<< "$TEST_SELECTORS"
 
+    # ${arr[@]+"${arr[@]}"} guards against `set -u` "unbound variable" when the
+    # scope array is empty (whole-file mode) on bash 3.2 (macOS default).
     MUT_OUTPUT=$(python3 scripts/palace_mutate.py \
       --file "$swift_file" \
       "${MUTATE_TEST_ARGS[@]}" \
+      ${MUTATION_SCOPE_ARGS[@]+"${MUTATION_SCOPE_ARGS[@]}"} \
       --report "$REPORT_PATH" \
       --max-mutations 10 2>&1)
     MUT_EXIT=$?
@@ -694,6 +735,49 @@ elif [ -f scripts/palace_mutate.py ] && [ -n "$CHANGED_SWIFT" ]; then
     TOTAL_KILLED=$((TOTAL_KILLED + KILLED))
     TOTAL_MUTATIONS=$((TOTAL_MUTATIONS + FILE_TOTAL))
 
+    # Critical-path survivor override. Read summary.critical_path_survivors from
+    # the per-file JSON report. >0 means a SURVIVED mutant with a consequential
+    # op (cmp/bool/bound/retval/cond) on a user-money path — a STRICT FAIL even
+    # if the kill rate clears the floor. We read from the report (not the printed
+    # line) because the survivor count is a report-only field. Default to 0 when
+    # the key is absent (older cached reports) so this never blocks spuriously.
+    CP_SURVIVORS=0
+    CP_SURVIVOR_LINES=""
+    if [ -f "$REPORT_PATH" ]; then
+      CP_PARSED=$(python3 - "$REPORT_PATH" <<'PYEOF' 2>/dev/null || true
+import json, sys
+try:
+    data = json.load(open(sys.argv[1]))
+except Exception:
+    print("0|")
+    sys.exit(0)
+summary = data.get("summary", {}) or {}
+n = int(summary.get("critical_path_survivors", 0) or 0)
+# Collect the line numbers of surviving consequential mutants for the message.
+# A survivor on a non-assign op is what critical_path_survivors counts; surface
+# every SURVIVED result's line so the reviewer can find them (the report itself
+# is the authority on which were consequential).
+lines = sorted({
+    str((r.get("mutation") or {}).get("line"))
+    for r in (data.get("results") or [])
+    if r.get("status") == "survived"
+    and (r.get("mutation") or {}).get("line") is not None
+})
+print(f"{n}|{','.join(lines)}")
+PYEOF
+)
+      CP_SURVIVORS=$(echo "$CP_PARSED" | cut -d'|' -f1)
+      CP_SURVIVOR_LINES=$(echo "$CP_PARSED" | cut -d'|' -f2)
+      [ -z "$CP_SURVIVORS" ] && CP_SURVIVORS=0
+    fi
+    if [ "${CP_SURVIVORS:-0}" -gt 0 ]; then
+      if [ -n "$CP_SURVIVOR_LINES" ]; then
+        CRITICAL_SURVIVOR_FILES+=("$swift_file (${CP_SURVIVORS} consequential survivor(s) at line(s) ${CP_SURVIVOR_LINES})")
+      else
+        CRITICAL_SURVIVOR_FILES+=("$swift_file (${CP_SURVIVORS} consequential survivor(s))")
+      fi
+    fi
+
     # Per-file policy evaluation against the (possibly overridden) floor.
     if [ "$FILE_TOTAL" -gt 0 ]; then
       FILE_RATE=$((KILLED * 100 / FILE_TOTAL))
@@ -709,15 +793,32 @@ elif [ -f scripts/palace_mutate.py ] && [ -n "$CHANGED_SWIFT" ]; then
 
   if [ "$MUTATION_HARD_FAILED" = "true" ]; then
     : # fail already recorded inside the loop; skip the post-aggregation record
+  elif [ ${#CRITICAL_SURVIVOR_FILES[@]} -gt 0 ]; then
+    # Critical-path survivor override: this takes priority over the kill-rate
+    # decision. A surviving consequential mutant on a user-money path blocks
+    # merge even if the kill rate clears the floor. We still surface any
+    # kill-rate strict failures alongside so the reviewer sees the full picture.
+    DETAIL="${#CRITICAL_SURVIVOR_FILES[@]} critical-path file(s) with surviving consequential mutant(s) — BLOCKS regardless of kill rate: ${CRITICAL_SURVIVOR_FILES[*]}"
+    if [ ${#STRICT_FAIL_FILES[@]} -gt 0 ]; then
+      DETAIL="$DETAIL || also below ${MUTATION_MIN_KILL_RATE}%: ${STRICT_FAIL_FILES[*]}"
+    fi
+    record "mutation" "fail" "$DETAIL"
   elif [ "$TOTAL_MUTATIONS" -eq 0 ]; then
     # Defensive: if zero mutations across ≥3 production files, that's
     # almost certainly a tool misconfiguration, not a genuine no-op diff.
     # Most real production files have at least one comparison/boolean op.
+    #
+    # EXCEPTION: in diff-only mode (the default PR gate), zero mutations across
+    # the diff is legitimate — a PR can change only comments, whitespace, log
+    # lines, or already-uncovered lines. Don't treat that as misconfiguration;
+    # whole-file mode keeps the strict "≥3 files but 0 mutants is suspicious" net.
     PROD_COUNT=$(echo "$CHANGED_SWIFT" | grep -cv '^$' || echo "0")
-    if [ "${PROD_COUNT:-0}" -ge 3 ]; then
+    if [ "${PROD_COUNT:-0}" -ge 3 ] && [ "$MUTATION_WHOLE_FILE" = "true" ]; then
       record "mutation" "fail" "Suspicious: $PROD_COUNT production files changed but 0 mutations generated total — palace_mutate.py likely misconfigured (check REPO_ROOT, file paths, and exit codes)"
-    else
+    elif [ "$MUTATION_WHOLE_FILE" = "true" ]; then
       record "mutation" "pass" "No mutations generated for changed files"
+    else
+      record "mutation" "pass" "No mutations generated for changed lines (diff-only scope)"
     fi
   elif [ ${#STRICT_FAIL_FILES[@]} -gt 0 ]; then
     KILL_RATE=$((TOTAL_KILLED * 100 / TOTAL_MUTATIONS))


### PR DESCRIPTION
## What & why

Reframes Palace's custom Swift mutation tester (`scripts/palace_mutate.py`) from first principles. Mutation cost = **#mutants × cost-per-run**; the biggest wins are *doing less work* and *measuring the right thing*, not just doing the same work faster. A major suite was ~2h, fully serial, on a 24-core box with the 3-sim pool 2/3 idle.

## Levers

- **Coverage-gating (keystone):** captures coverage from the baseline run we already do (`-enableCodeCoverage`), then never runs mutants on lines no test executes (guaranteed survivors). Those uncovered points become a **free coverage-gap report**. Validated end-to-end on Xcode 26.3 — selective on real files (e.g. `AudiobookSessionManager` 20% covered → ~80% of mutants gated out).
- **Per-build flag trimming:** skip SPM resolution / plugin validation / index-store / parallel-testing per `xcodebuild` invocation (env-overridable).
- **Per-mutant incremental cache:** keyed on host-line content + surrounding context (not line number), so editing one method only re-tests changed-line mutants. Whole-file cache kept as the fast path.
- **Critical-path metric:** zero survivors tolerated on critical-path consequential mutants → fail regardless of aggregate kill rate.
- **Diff-scoped by default** for the PR gate (`--mutation-whole-file` for release runs).
- **Equivalent-mutant suppress-list** so known-unkillable survivors stop nagging.
- **Parallel worker pool** (`palace_mutate_parallel.py`): file-level fan-out across isolated worktree + sim + DerivedData workers — *isolation, not batching*, so no result conflation; gated on file count.

## Safety property

Coverage-gating and test-selection are optimizations that **degrade to today's behavior** on any xcresult parse failure (return `None` → mutate every line / run the full class). Worst case is "no speedup," never "wrong verdict" — that's what made this safe on critical quality tooling.

## Verification

- 138 new/updated unit tests + 35 detector pytests green; `bash -n` clean; all modules parse/import.
- Exit-code contract (0/1/2) and the `verify-pr.sh`-greppable summary line preserved; report schema only **adds** keys (back-compatible with old cached reports).
- Coverage parser validated against a real Xcode 26.3 xcresult (selective, path-robust across worktrees).
- End-to-end smoke (`BorrowReducer`, 4 mutants, 100% kill) confirms baseline-with-coverage + flag trimming + cache on real hardware; warm re-run 3m45s → 0.05s.

## Deferred (explicit)

Per-mutant **test-selection is wired but inert**: `tests_for_lines` returns `None` because reliable per-test attribution from an Xcode 26 xcresult isn't solved yet; the engine falls back to the full test class (today's behavior). The seam is in place. See `.forgeos/intent/mutation-testing-world-class.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
