### PR TITLE
Fix CI test pollution: stop AccountsManager background-load flag from leaking false between tests

### DIFF
--- a/.forgeos/intent/fix-test-pollution-accountsmanager-bg-leak.md
+++ b/.forgeos/intent/fix-test-pollution-accountsmanager-bg-leak.md
@@ -1,0 +1,60 @@
+# Intent: fix test pollution — AccountsManager background-load flag leak
+
+## Problem
+
+`AccountsManager.deferInitialLoadCatalogsForTesting` is a process-wide mutable
+static flag that gates whether `AccountsManager.init` spawns its background
+`loadCatalogs` Task. The test-safe value is `true` (no background work);
+`PalaceTestSetup.bootstrap()` pins it `true` at bundle load. Tests that
+genuinely need the background load to fire (`AppContainerResetTests`) opt in by
+setting it `false` in their own setUp.
+
+Two sites leave the flag `false` AFTER they run, leaking the unsafe value
+forward to subsequent test classes:
+
+1. `AppContainer._resetForTesting()` (`AppContainer.swift:505`) — runs after
+   **every** test via `PalaceSingletonResetObserver.testCaseDidFinish`. It sets
+   the flag `false` as its last step.
+2. `AppContainerResetTests.tearDown()` (`AppContainerResetTests.swift:32`) —
+   explicitly sets the flag `false` "so other tests see production semantics."
+
+Once leaked `false`, a later test class that constructs an `AccountsManager`
+(directly or via an incidental `AppContainer.production()`) spawns the
+background registry crawl (1100+ libraries, network, layout). That stray task
+outlives the test and pollutes whatever runs next.
+
+Observed CI failures, all traced to this single leak (none are caused by the
+diffs of the PRs they blocked — #1052, #1053, #1054):
+
+- `AccountsManagerCancellationTests.testCancelBackgroundWork_onOptOutInstance_isSafeNoOp`
+  — opt-out handle non-nil (failed all 3 iterations).
+- `CatalogCacheKeyAndIsolationTests.testInMemoryCache_AfterSystemMemoryWarning…`
+  — "Modifications to the layout engine must not be performed from a background
+  thread" (NSInternalInconsistencyException).
+- `BookReturnCleverReauthTests` — crash/restart → `** TEST FAILED **` with 0
+  reported test failures.
+- `TokenRefreshOnForegroundTests` / `TokenRefreshAndRetryQueueTests` —
+  token/network state bleed.
+
+## Claims
+
+- `AppContainer._resetForTesting()` leaves `deferInitialLoadCatalogsForTesting`
+  in the test-safe state (`true`), not `false`.
+- `AppContainerResetTests.tearDown()` leaves the flag `true`, not `false`.
+- A regression test pins the post-reset invariant: after `_resetForTesting()`
+  the flag is `true`.
+
+## Anti-claims
+
+- No change to production runtime behaviour. The flag is only ever non-default
+  inside an XCTest process (its initializer keys off `XCTestConfigurationFilePath`);
+  `_resetForTesting()` already early-returns outside XCTest.
+- No change to `AccountsManager.init`, `cancelBackgroundWork()`, or the
+  background `loadCatalogs` path itself.
+- Does not touch the three blocked PRs' branches — they rebase on develop after
+  this lands.
+
+## Files in scope
+
+- `Palace/AppInfrastructure/AppContainer.swift`
+- `PalaceTests/AppInfrastructure/AppContainerResetTests.swift`

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -467,10 +467,19 @@ struct AppContainer {
     ///      briefly before observing `Task.isCancelled`.
     ///   3. Atomically reassign `_cached` to a freshly-built AppContainer
     ///      whose AccountsManager observes the opt-out flag.
-    ///   4. Reset the AccountsManager opt-out flag to `false` so production
-    ///      semantics resume if the test bundle is reused in-process or if
-    ///      a later test constructs its own AccountsManager directly and
-    ///      wants the normal background-load behaviour.
+    ///   4. Leave the AccountsManager opt-out flag at the test-safe value
+    ///      `true`. This runs after EVERY test (via the singleton-reset
+    ///      observer), so the flag it leaves behind is what the NEXT test
+    ///      class inherits before its own setUp runs. Leaving it `false`
+    ///      (the prior behaviour) meant any later test that incidentally
+    ///      constructed an `AccountsManager` — directly or via
+    ///      `AppContainer.production()` — spawned the background registry
+    ///      crawl, whose stray Task outlived the test and polluted whatever
+    ///      ran next (layout-off-main crashes, token/network bleed, the
+    ///      `numAccounts` drift). Tests that genuinely need the background
+    ///      load opt IN by setting the flag `false` in their own setUp
+    ///      (`AppContainerResetTests`); the safe default between tests is
+    ///      `true`, matching `PalaceTestSetup.bootstrap()`.
     ///
     /// Residual race window (DOCUMENTED INTENTIONAL):
     /// Step 2's cancellation is cooperative. If the prior AccountsManager's
@@ -502,7 +511,11 @@ struct AppContainer {
         AccountsManager.deferInitialLoadCatalogsForTesting = true
         _cached.accountsManager.cancelBackgroundWork()
         _cached = Self._buildCachedAppContainer()
-        AccountsManager.deferInitialLoadCatalogsForTesting = false
+        // Leave the flag at the test-safe `true` (see step 4 above) — do NOT
+        // reset to `false`. The next test class inherits this value before its
+        // own setUp runs; `false` here is the root of the cross-test
+        // background-crawl pollution.
+        AccountsManager.deferInitialLoadCatalogsForTesting = true
     }
     #endif
 }

--- a/PalaceTests/AppInfrastructure/AppContainerResetTests.swift
+++ b/PalaceTests/AppInfrastructure/AppContainerResetTests.swift
@@ -27,9 +27,12 @@ final class AppContainerResetTests: XCTestCase {
         // this, the test that runs immediately after one of OUR tests
         // observes whatever state THIS test left in `_cached`.
         AppContainer._resetForTesting()
-        // Belt-and-suspenders: ensure the opt-out flag is back to false
-        // so any other test class observing it sees production semantics.
-        AccountsManager.deferInitialLoadCatalogsForTesting = false
+        // Restore the test-safe default (`true`) so the next test class does
+        // not inherit an opt-out-OFF flag and spawn the background catalog
+        // crawl. THIS class opts into background load by setting the flag
+        // `false` in each test that needs it; between classes the safe value
+        // is `true`, matching `PalaceTestSetup.bootstrap()`.
+        AccountsManager.deferInitialLoadCatalogsForTesting = true
         super.tearDown()
     }
 
@@ -92,11 +95,16 @@ final class AppContainerResetTests: XCTestCase {
             "Reset must construct the new AccountsManager with the opt-out flag set so no background loadCatalogs task is spawned"
         )
 
-        // Assert: the flag is back to `false` after reset, so production
-        // semantics resume for any later in-process construction.
-        XCTAssertFalse(
+        // Assert: the flag is left at the test-safe `true` after reset. This
+        // is the pollution-fix invariant — `_resetForTesting()` runs after
+        // EVERY test, so leaving the flag `false` here meant the next test
+        // class inherited opt-out-OFF and spawned the background catalog
+        // crawl on its first incidental `AccountsManager` construction. A
+        // regression that resets the flag to `false` (the prior behaviour)
+        // fails this assertion.
+        XCTAssertTrue(
             AccountsManager.deferInitialLoadCatalogsForTesting,
-            "Reset must restore the opt-out flag to false after rebuilding the graph"
+            "Reset must leave the opt-out flag TRUE so the next test class does not inherit background-crawl semantics"
         )
     }
 
@@ -136,14 +144,13 @@ final class AppContainerResetTests: XCTestCase {
         // network completion.
 
         // (1)-(2) Force a fresh production graph with a real background task
-        // by explicitly clearing the flag BEFORE the rebuild. `_resetForTesting`
-        // restores it to false after rebuilding, but the rebuild itself
-        // uses flag=true, so we need to manually rebuild with flag=false
-        // to get a task-bearing instance.
+        // by explicitly clearing the flag BEFORE the rebuild. The rebuild
+        // inside `_resetForTesting` itself uses flag=true, so we need to
+        // manually rebuild with flag=false to get a task-bearing instance.
         AccountsManager.deferInitialLoadCatalogsForTesting = false
         // Reset first to get a clean slate.
         AppContainer._resetForTesting()
-        // The reset above set the flag back to false at the end, but
+        // The reset above leaves the flag at the test-safe `true`, and
         // `_buildCachedAppContainer` ran with flag=true. So this graph has
         // NO background task. To create a graph WITH a task, we'd need to
         // construct AccountsManager directly outside the reset path — which


### PR DESCRIPTION
## Problem

`AccountsManager.deferInitialLoadCatalogsForTesting` is a process-wide mutable static flag gating whether `AccountsManager.init` spawns its background `loadCatalogs` Task. The test-safe value is `true` (no background work); `PalaceTestSetup.bootstrap()` pins it `true` at bundle load. Tests that genuinely need the background load opt **in** by setting it `false` in their own `setUp`.

Two sites left the flag `false` **after** running, leaking the unsafe value forward to the next test class — which then constructs a real `AccountsManager` and spawns the 1100+-library registry crawl that outlives the test and pollutes whatever runs next:

- `AppContainer._resetForTesting()` — runs after **every** test via the singleton-reset observer; its final line set the flag `false`.
- `AppContainerResetTests.tearDown()` — explicitly set it `false` "for production semantics."

This single leak is the root cause behind the recurring CI flakes that were blocking several open PRs (none of whose own diffs were at fault):

- `AccountsManagerCancellationTests.testCancelBackgroundWork_onOptOutInstance_isSafeNoOp` — opt-out handle non-nil (failed all 3 iterations)
- `CatalogCacheKeyAndIsolationTests` — "Modifications to the layout engine must not be performed from a background thread" crash
- `BookReturnCleverReauthTests` — crash → `** TEST FAILED **` with 0 reported test failures
- `TokenRefreshOnForegroundTests` / `TokenRefreshAndRetryQueueTests` — token/network state bleed

## Fix

Both sites now leave the flag at the test-safe `true`. The safe default *between* tests is OFF (defer = `true`); tests that want background load already opt in explicitly. No production runtime change: the flag is only ever non-default inside an XCTest process (initializer keys off `XCTestConfigurationFilePath`), and `_resetForTesting()` is `#if DEBUG` + early-returns outside XCTest.

Regression: `AppContainerResetTests.testResetForTesting_disablesBackgroundLoadCatalogs` now asserts the flag is `true` post-reset (was asserting `false`). It arranges `flag = false` before the act, so only the production code under test can flip it back — the mutation that reintroduces the leak fails it.

## Verification

- Affected cluster run together (polluter + all known victims): `AppContainerResetTests` + `AccountsManagerCancellationTests` + `CatalogCacheKeyAndIsolationTests` + `TokenRefreshOnForegroundTests` + `TokenRefreshAndRetryQueueTests` + `BookReturnCleverReauthTests` → **41 tests, 0 failures, `** TEST SUCCEEDED **`**.
- Pre-push gate (AppContainer* classes, 180s cap): PASS — 7 classes green.
- Architect + QA reviews: both APPROVED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)