### PR TITLE
Fix intermittent book-return crash: track in-flight Tasks by UUID, not a racy IUO

### DIFF
--- a/.forgeos/intent/fix-bookreturn-inflight-task-iuo-race.md
+++ b/.forgeos/intent/fix-bookreturn-inflight-task-iuo-race.md
@@ -1,0 +1,55 @@
+---
+name: fix-bookreturn-inflight-task-iuo-race
+created: 2026-06-10
+author: claude-opus-4-8
+tracking: (none — latent crash surfaced by CI flake-hunt on PR #1053)
+related_prs: []
+---
+
+# Intent: fix BookReturnService in-flight-task IUO data race (return-path crash)
+
+## Problem
+
+`BookReturnService` tracks fire-and-forget Tasks for cancellation in
+`inFlightTasks`. Both `launchTrackedTask` and `launchTrackedMainActorTask` used:
+
+```swift
+var task: Task<Void, Never>!
+task = Task { [weak self] in
+    await body()
+    self.inFlightTasks.remove(task)   // <-- reads the IUO from inside the body
+}
+inFlightTasks.insert(task)
+```
+
+The Task body runs on a **different executor** than the launch site that
+assigns `task`. The read of the `var task` IUO inside the body is an
+**unsynchronized cross-thread read**: under CPU load the assignment is not yet
+visible to the body's thread, so the implicit unwrap finds nil and traps —
+`Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional
+value` at the `inFlightTasks.remove(task)` line. Intermittent (race-window-
+dependent), and it crashed `BookReturnServiceContractTests.test_returnBook_authError_triggersReauth`
+on CI on the legacy reauth path. The same crash can hit a real user returning a
+book while a reauthentication is in flight.
+
+## Claims
+
+- `inFlightTasks` becomes `[UUID: Task<Void, Never>]`, keyed by a per-launch
+  `UUID` token.
+- Both launch helpers capture the **value-typed** `UUID` (Sendable) in the
+  auto-removal closure and remove by key — the closure no longer references the
+  launch-site `task` handle, eliminating the cross-thread IUO read. `task` is
+  now a plain `let`.
+- `cancelAllInFlightTasks`, `inFlightTaskCount`, and
+  `inFlightTasksSnapshotForTesting()` preserve their existing behavior /
+  signatures (snapshot still returns `Set<Task<Void, Never>>`).
+
+## Anti-claims
+
+- No change to the return flow, reauth path, cancellation contract, or the
+  set of Tasks that get tracked/cancelled. Pure data-structure + capture change.
+- No public API change (`inFlightTasksSnapshotForTesting` still returns a Set).
+
+## Files in scope
+
+- `Palace/MyBooks/BookReturnService.swift`

--- a/Palace/MyBooks/BookReturnService.swift
+++ b/Palace/MyBooks/BookReturnService.swift
@@ -87,7 +87,16 @@ final class BookReturnService {
     /// (MBDC) and the Task bodies straddle the cooperative pool and the
     /// main actor. NSLock is the lowest-blast-radius primitive that
     /// keeps both safe.
-    private var inFlightTasks: Set<Task<Void, Never>> = []
+    /// Keyed by a per-launch `UUID` token rather than the `Task` handle
+    /// itself. The auto-removal closure captures the token **by value**
+    /// (a `Sendable` value type), so it never reads the launch-site `task`
+    /// variable from inside the Task body. The prior `var task: Task!` +
+    /// `inFlightTasks.remove(task)` pattern was an unsynchronized cross-thread
+    /// read of the IUO: the body runs on a different executor than the one
+    /// assigning `task`, so under load the write was not yet visible and the
+    /// implicit unwrap crashed ("nil while implicitly unwrapping") — an
+    /// intermittent fatal on the book-return reauth path.
+    private var inFlightTasks: [UUID: Task<Void, Never>] = [:]
     private let inFlightLock = NSLock()
 
     #if FEATURE_DRM_CONNECTOR
@@ -166,9 +175,9 @@ final class BookReturnService {
     /// already-started Tasks unwind without re-entering registry
     /// mutations after cancellation.
     func cancelAllInFlightTasks() {
-        let snapshot: Set<Task<Void, Never>>
+        let snapshot: [Task<Void, Never>]
         inFlightLock.lock()
-        snapshot = inFlightTasks
+        snapshot = Array(inFlightTasks.values)
         inFlightTasks.removeAll()
         inFlightLock.unlock()
         for task in snapshot {
@@ -192,7 +201,7 @@ final class BookReturnService {
     internal func inFlightTasksSnapshotForTesting() -> Set<Task<Void, Never>> {
         inFlightLock.lock()
         defer { inFlightLock.unlock() }
-        return inFlightTasks
+        return Set(inFlightTasks.values)
     }
 
     /// Wraps a fire-and-forget Task in the retention + auto-removal
@@ -204,16 +213,16 @@ final class BookReturnService {
     private func launchTrackedTask(
         _ body: @escaping @Sendable () async -> Void
     ) -> Task<Void, Never> {
-        var task: Task<Void, Never>!
-        task = Task { [weak self] in
+        let id = UUID()
+        let task = Task { [weak self] in
             await body()
             guard let self else { return }
             self.inFlightLock.lock()
-            self.inFlightTasks.remove(task)
+            self.inFlightTasks.removeValue(forKey: id)
             self.inFlightLock.unlock()
         }
         inFlightLock.lock()
-        inFlightTasks.insert(task)
+        inFlightTasks[id] = task
         inFlightLock.unlock()
         return task
     }
@@ -227,16 +236,16 @@ final class BookReturnService {
     private func launchTrackedMainActorTask(
         _ body: @escaping @MainActor () async -> Void
     ) -> Task<Void, Never> {
-        var task: Task<Void, Never>!
-        task = Task { @MainActor [weak self] in
+        let id = UUID()
+        let task = Task { @MainActor [weak self] in
             await body()
             guard let self else { return }
             self.inFlightLock.lock()
-            self.inFlightTasks.remove(task)
+            self.inFlightTasks.removeValue(forKey: id)
             self.inFlightLock.unlock()
         }
         inFlightLock.lock()
-        inFlightTasks.insert(task)
+        inFlightTasks[id] = task
         inFlightLock.unlock()
         return task
     }


### PR DESCRIPTION
## Problem

`BookReturnService` tracks fire-and-forget Tasks for cancellation. Both `launchTrackedTask` and `launchTrackedMainActorTask` used:

```swift
var task: Task<Void, Never>!
task = Task { [weak self] in
    await body()
    self.inFlightTasks.remove(task)   // reads the IUO from inside the body
}
inFlightTasks.insert(task)
```

The Task body runs on a **different executor** than the launch site that assigns `task`, so the read of the `var task` IUO inside the body is an **unsynchronized cross-thread read**. Under CPU load the assignment isn't yet visible to the body's thread, the implicit unwrap finds nil, and the process traps:

```
Palace/MyBooks/BookReturnService.swift: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value
```

It surfaced on CI crashing `BookReturnServiceContractTests.test_returnBook_authError_triggersReauth` on the legacy reauth path — and the same crash can hit a **real user returning a book while a reauthentication is in flight**. (Found while getting the CI flake-hunt PRs green; this was the last blocker for #1053.)

## Fix

Key `inFlightTasks` on a per-launch **`UUID` token** (`[UUID: Task<Void, Never>]`). Both launch helpers capture the **value-typed** `UUID` (Sendable, safe to capture cross-thread) in the auto-removal closure and evict the entry via its key — the closure never reads the launch-site `task` handle. `task` is now a plain `let`. No change to the return flow, reauth path, cancellation contract, or the set of tracked/cancelled Tasks; `inFlightTasksSnapshotForTesting()` still returns `Set<Task<Void, Never>>`.

## Verification

- `BookReturnServiceContractTests` + `BookReturnServiceTests` + `DownloadAuthRetryHandlerTests` → **31 tests, 0 failures, TEST SUCCEEDED**.
- Pre-push gate (3 BookReturnService classes): PASS.
- Mutation (`palace_mutate.py --diff-only`): 0/0 mutation points on changed lines — pure type/structure refactor (Set→Dict + capture change), no mutable logic; behaviour pinned by the contract tests.
- ForgeOS SoD: architect + QA reviews both APPROVED (critical-path rigor bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)