### PR TITLE
fix(hooks): untrack self-referential scripts/hooks symlink (breaks governance hooks on checkout)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,11 @@ docs/spec/
 !.specterqa/DOGFOOD_NOTES.md
 scripts/sim-test/
 
+# Per-machine git/PreToolUse hook symlinks (created by the local dev setup;
+# must NOT be tracked — a tracked symlink here previously pointed at its own
+# path and broke every governance hook with ELOOP on checkout).
+/scripts/hooks
+
 # Backup pbxproj variants
 *.pbxproj.swift-only
 *.pbxproj.bak

--- a/scripts/hooks
+++ b/scripts/hooks
@@ -1,1 +1,0 @@
-/Users/mauricework/PalaceProject/ios-core/scripts/hooks


### PR DESCRIPTION
## What

`scripts/hooks` was committed as a symlink pointing at its **own absolute path** (`scripts/hooks -> /Users/.../ios-core/scripts/hooks`, mode `120000`). From the main checkout that's a self-loop, so every `git checkout` / branch-switch restores it and any governance hook resolving `scripts/hooks/<hook>.sh` dies with `ELOOP` ("Too many levels of symbolic links").

**Impact:** pre-commit / pre-push / session-start / audit hooks silently stop running after any branch switch — commits and pushes go ungated until someone notices. This was observed live: a concurrent session's branch switch broke all hooks mid-work.

## Fix

`scripts/hooks` is a per-machine dev-setup artifact (each developer's local install populates it with symlinks into their own tooling) — it should never have been tracked. This:
- `git rm --cached scripts/hooks` (untrack the broken symlink)
- adds `/scripts/hooks` to `.gitignore` so it stays local-only

After this lands, a checkout no longer restores a broken symlink; each machine's local setup populates `scripts/hooks` itself.

## Verification

- 1 tracked symlink removed + 1 `.gitignore` line. No code, no behavior change to tracked files.
- From a worktree, the local `scripts/hooks` continues to resolve to the developer's real hook directory (hooks keep working); only the tracked self-loop is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
