### PR TITLE
fix: bound Firebase remote-config fetch so fetchIfNeeded can't hang

### DIFF
--- a/.forgeos/intent/fix-remote-config-fetch-timeout.md
+++ b/.forgeos/intent/fix-remote-config-fetch-timeout.md
@@ -1,0 +1,43 @@
+---
+name: fix-remote-config-fetch-timeout-firebase-unbounded-await
+created: 2026-06-10
+author: claude-opus-4-8
+tracking: unblocks PR #1053 (per-test timeout) — last hard hang after the #1061 foundational fix
+related_prs: []
+---
+
+# Intent: bound the remote-config fetch so it can't hang the caller
+
+## Problem
+`FirebaseManager.fetchAndActivateRemoteConfig()` does `try await
+remoteConfig.fetchAndActivate()` with no upper bound. Firebase's
+`fetchAndActivate()` can stall indefinitely when the network is dead/slow, or —
+in unit tests — when Firebase is not configured, leaving the `await` suspended
+forever. `RemoteFeatureFlags.shared.fetchIfNeeded()` awaits this, so
+`RemoteFeatureFlagsTests.testFetchIfNeeded_doesNotCrash` intermittently hung
+>2min and was killed by PR #1053's per-test timeout (the last hard hang after
+the #1061 awaitReady-leak fix cleared the pool-starvation class). A real user on
+a dead network would likewise hang the flag fetch.
+
+## Claims
+- `fetchAndActivateRemoteConfig()` wraps the fetch in `Self.withTimeout(seconds:
+  Configuration.fetchTimeoutSeconds /* 10 */)`; on timeout it logs and returns
+  `false` (proceeds with cached/default config).
+- `withTimeout` is a generic `static` helper (races the operation against a
+  `Task.sleep`, cancels the loser, throws `RemoteConfigFetchTimeout` on timeout),
+  made `internal` so tests can pin it deterministically.
+- Two deterministic tests: `testWithTimeout_boundsAHangingOperation` (a 10s
+  inner hang is bounded under 2s and throws the timeout) and
+  `testWithTimeout_returnsResultOfFastOperation` (a fast op returns its value, no
+  false timeout).
+
+## Anti-claims
+- No XCTSkip / no relaxed test timeout / no test-environment special-casing — the
+  bound is a real PRODUCTION robustness improvement that also resolves the test
+  hang.
+- No change to the flag values returned, the rate-limiting, or the `isFetching`
+  single-flight guard.
+
+## Files in scope
+- `Palace/AppInfrastructure/FirebaseManager.swift`
+- `PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift`

--- a/Palace/AppInfrastructure/FirebaseManager.swift
+++ b/Palace/AppInfrastructure/FirebaseManager.swift
@@ -29,6 +29,10 @@ final class FirebaseManager {
         static let minimumFetchIntervalDebug: TimeInterval = 60 // 1 minute
         static let minimumFetchIntervalRelease: TimeInterval = 3600 // 1 hour
         static let deviceIdentifierKey = "TPPDeviceIdentifier"
+        /// Hard upper bound on a single remote-config fetch+activate so it can
+        /// never hang the caller (dead network in production; unconfigured
+        /// Firebase in unit tests). Generous vs. a healthy fetch (~1-3s).
+        static let fetchTimeoutSeconds: Double = 10
     }
 
     // MARK: - Immutable State (thread-safe by design)
@@ -132,7 +136,16 @@ final class FirebaseManager {
         }
 
         do {
-            let status = try await remoteConfig.fetchAndActivate()
+            // Bound the fetch so it can never hang indefinitely. Firebase's
+            // `fetchAndActivate()` can stall when the network is dead/slow or
+            // (in unit tests) when Firebase is not configured — leaving the
+            // `await` suspended forever. A real user on a dead network must not
+            // have flag-fetch hang the caller, and the unit-test
+            // `testFetchIfNeeded_doesNotCrash` must not hang the suite. On
+            // timeout we proceed with cached/default config (return false).
+            let status = try await Self.withTimeout(seconds: Configuration.fetchTimeoutSeconds) {
+                try await self.remoteConfig.fetchAndActivate()
+            }
 
             switch status {
             case .successFetchedFromRemote:
@@ -147,9 +160,40 @@ final class FirebaseManager {
             @unknown default:
                 return false
             }
+        } catch is RemoteConfigFetchTimeout {
+            Log.error(#file, "Remote config fetch timed out — proceeding with cached/default values")
+            return false
         } catch {
             Log.error(#file, "Failed to fetch remote config: \(error.localizedDescription)")
             return false
+        }
+    }
+
+    /// Sentinel thrown by `withTimeout` when the wrapped operation exceeds the bound.
+    struct RemoteConfigFetchTimeout: Error {}
+
+    /// Runs `operation`, racing it against a timeout. If the timeout wins, the
+    /// operation's task is cancelled and `RemoteConfigFetchTimeout` is thrown.
+    /// (The underlying Firebase call may not honour cancellation; the orphaned
+    /// fetch completes harmlessly in the background while the caller proceeds.)
+    ///
+    /// `internal` (not `private`) so the tests can pin the bound-a-hang
+    /// behaviour deterministically (see `RemoteFeatureFlagsTests`).
+    static func withTimeout<T: Sendable>(
+        seconds: Double,
+        _ operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await operation() }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw RemoteConfigFetchTimeout()
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw RemoteConfigFetchTimeout()
+            }
+            return result
         }
     }
 

--- a/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
+++ b/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
@@ -134,4 +134,38 @@ final class RemoteFeatureFlagsTests: XCTestCase {
         XCTAssertEqual(flagsBefore, flagsAfter,
                        "fetchIfNeeded() must not change flag values in a test environment without Firebase")
     }
+
+    // MARK: - FirebaseManager.withTimeout (bounds the remote-config fetch hang)
+
+    /// `withTimeout` must bound an operation that would otherwise hang
+    /// indefinitely — this is what stops `fetchIfNeeded()` from hanging the
+    /// caller (dead network in production / unconfigured Firebase in tests).
+    /// A regression that removed the timeout race would let this run for the
+    /// full inner 10s "hang" (or forever), so the elapsed-time assertion fails.
+    func testWithTimeout_boundsAHangingOperation() async {
+        let start = Date()
+        do {
+            _ = try await FirebaseManager.withTimeout(seconds: 0.2) { () async throws -> Bool in
+                // Simulate a fetch that never completes within the bound.
+                try await Task.sleep(nanoseconds: 10_000_000_000) // 10s
+                return true
+            }
+            XCTFail("withTimeout must throw when the operation exceeds the bound")
+        } catch is FirebaseManager.RemoteConfigFetchTimeout {
+            let elapsed = Date().timeIntervalSince(start)
+            XCTAssertLessThan(elapsed, 2.0,
+                              "withTimeout(0.2s) must bound a hanging operation well under the inner 10s, got \(elapsed)s")
+        } catch {
+            XCTFail("Expected RemoteConfigFetchTimeout, got \(type(of: error)): \(error)")
+        }
+    }
+
+    /// A fast operation must return its value, NOT be falsely timed out —
+    /// kills a mutant that always throws / always loses the race.
+    func testWithTimeout_returnsResultOfFastOperation() async throws {
+        let value = try await FirebaseManager.withTimeout(seconds: 5.0) { () async throws -> Int in
+            42
+        }
+        XCTAssertEqual(value, 42, "withTimeout must return the operation's result when it completes within the bound")
+    }
 }


### PR DESCRIPTION
## Problem

`FirebaseManager.fetchAndActivateRemoteConfig()` awaited `remoteConfig.fetchAndActivate()` with **no upper bound**. Firebase's `fetchAndActivate()` can stall indefinitely on a dead/slow network — and in unit tests, with Firebase unconfigured, the `await` can suspend forever. `RemoteFeatureFlags.shared.fetchIfNeeded()` awaits it, so `RemoteFeatureFlagsTests.testFetchIfNeeded_doesNotCrash` intermittently hung >2 min and was killed by the per-test timeout. A real user on a dead network would likewise hang the flag fetch.

This was the last latent unbounded-await hang surfacing after the foundational test-pollution fixes (#1056/#1057/#1058/#1061) cleared the cooperative-thread-pool starvation class.

## Fix

Wrap the fetch in `Self.withTimeout(seconds: 10)`. On timeout, log and return `false` (proceed with cached/default config — same semantics as the pre-existing generic-catch path). `withTimeout` is a generic `static` helper that races the operation against a `Task.sleep`, cancels the loser via `defer { group.cancelAll() }`, and throws `RemoteConfigFetchTimeout`.

This is a **real production robustness improvement** — the flag fetch can no longer hang the caller — not a test-environment special-case or skip. No change to flag values, rate-limiting, or the `isFetching` single-flight guard.

## Tests (deterministic)

- `testWithTimeout_boundsAHangingOperation` — a 10s inner hang bounded under 2s, throws the timeout. Kills the no-timeout mutant.
- `testWithTimeout_returnsResultOfFastOperation` — a fast op returns its value, no false timeout. Kills the always-throw / sleep-always-wins mutant.
- `testFetchIfNeeded_doesNotCrash` remains the integration regression guard (hung >2 min before; bounded now).

`RemoteFeatureFlagsTests` → 11 tests, 0 failures, TEST SUCCEEDED.

## Verification

- ForgeOS changeset `cs_e41aee64` — architect + qa_test both APPROVED; review/testing/release gates promoted.
- Architect: task-group race + `defer{cancelAll}` correct, no child leak / self-hang, orphaned fetch harmless, `isFetching` cleared by outer defer, 10s bound has no double-counting with `RemoteConfigSettings.fetchTimeout`.
- QA: no masking — real production bound, no XCTSkip / relaxed timeout / `isRunningTests` branch; both new tests mutation-meaningful.

**Scope:** production fetch bound + `withTimeout` helper + 2 deterministic tests.
**Not done:** `RemoteFeatureFlags`/`FirebaseManager` remain `.shared` singletons (a full DI refactor to isolate Firebase from tests is out of scope; `testFetchIfNeeded` still exercises the real, now-bounded fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
