### PR TITLE
feat(triagebot): runtime Anthropic key-paste field in Developer Settings (TestFlight enablement)

### DIFF
--- a/.forgeos/intent/triagebot-anthropic-key-runtime-paste-field.md
+++ b/.forgeos/intent/triagebot-anthropic-key-runtime-paste-field.md
@@ -1,0 +1,48 @@
+---
+name: triagebot-anthropic-key-runtime-paste-field
+created: 2026-06-11
+author: claude-opus-4-8
+tracking: 3.2.0 release hardening — TestFlight enablement for the Triage Bot AI fallback
+related_prs: []
+---
+
+# Intent: runtime Anthropic key-paste field in Developer Settings
+
+## Problem
+The Triage Bot AI fallback reads its Anthropic key from the Keychain
+(`AnthropicKeyStore`). The only path into the Keychain today is
+`bootstrapFromEnvironmentIfNeeded()`, which reads `ANTHROPIC_API_KEY` from the
+Xcode scheme and is `#if DEBUG`-gated. TestFlight is a RELEASE build, so that
+bootstrap is a no-op and there is no other way to load a key — the AI fallback
+cannot be exercised on TestFlight at all. Baking the key into the binary is not
+an option (it ships to every user and is `strings`-extractable).
+
+## Claims
+- Adds a Developer Settings → Triage Bot row "Anthropic API Key" that presents a
+  secure-text alert to paste a key (`TriageBotKeyAdmin.save`, which trims and
+  refuses empty/whitespace) and, when a key is stored, a destructive "Clear Key"
+  action (`TriageBotKeyAdmin.clear`). The row's detail text shows "Stored" / "Not
+  set" via `TriageBotKeyAdmin.hasStoredKey`.
+- `TriageBotKeyAdmin` is a thin, injectable seam over `AnthropicKeyStore`
+  (`AnthropicKeyStoring` protocol) so the trim + empty-rejection + status logic
+  is unit-tested without touching the real Keychain.
+- The field is reachable on TestFlight (engineering sections render under
+  `sandboxReceipt`) and on dev/sim, and hidden on production App Store (real
+  `receipt` on disk) — so production users never reach it and their Keychain
+  stays empty, leaving the AI fallback off. The key lives only in the device
+  Keychain, never in source or the binary.
+
+## Anti-claims
+- No change to `RemoteFeatureFlags` defaults or the DEBUG-on policy: release
+  builds already default the chatbot + audiobook-nav features OFF and Firebase
+  remains the rollout control.
+- No production code path reads the env var in RELEASE; the manual field is the
+  only RELEASE/TestFlight key path and it is gated behind the engineering-tools
+  receipt check and the version-label developer-settings unlock.
+- The Keychain itself is not exercised in tests (errSecMissingEntitlement in the
+  unit host); the injected-store tests pin the admin logic only.
+
+## Files in scope
+- `Palace/Support/TriageBotKeyAdmin.swift` (new)
+- `Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift`
+- `PalaceTests/Support/TriageBotKeyAdminTests.swift` (new)

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -328,8 +328,10 @@
 		30B392104E9FCA6F9CBEEF01 /* ReadingSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0592B4A4D666ED6705BF8093 /* ReadingSessionTracker.swift */; };
 		30BC12FD0338A5885EBA255C /* BookCellModelStreamingHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820FFFB90AD6CB0A124F6420 /* BookCellModelStreamingHTMLTests.swift */; };
 		30E69EFD7A892A1D3D30DCC9 /* PerformanceReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D80DA377151AE41BEF67F7 /* PerformanceReport.swift */; };
+		30FA663F88FFCE7D65BB990C /* TriageBotKeyAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CF4EB59391A34A6315985E /* TriageBotKeyAdmin.swift */; };
 		31648629CEAC60ED194656BA /* TPPBasicAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E5C9EA3B9B15FEF2555CE3 /* TPPBasicAuthTests.swift */; };
 		316543077F31595C2C9C1AFF /* AudiobookSessionManagerPresenterMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CBF74C265D4FA1483F1974 /* AudiobookSessionManagerPresenterMigrationTests.swift */; };
+		317AEF4CF6E747286B2CA086 /* TriageBotKeyAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CF4EB59391A34A6315985E /* TriageBotKeyAdmin.swift */; };
 		32093E834629466F8280138F /* TPPPDFLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BFD0F3410046E6AD2F25B0 /* TPPPDFLocationTests.swift */; };
 		323FEA088C637AA3AAFC0F41 /* LCPAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5248CEFDF1FEDEBE50897394 /* LCPAdapterTests.swift */; };
 		32910EA3300D7728B6FF2268 /* ScopedResetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65988BBA901E65AA0905EF43 /* ScopedResetTests.swift */; };
@@ -1729,6 +1731,7 @@
 		F4565465A1B2C3D4E5F6071A /* OverdriveDownloadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3465465A1B2C3D4E5F60829 /* OverdriveDownloadHandler.swift */; };
 		F516D06B9979F4625E8BD312 /* PalacePDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060B04F768844865F55ED1A1 /* PalacePDFView.swift */; };
 		F54239DDA912F713D8B6695D /* PalaceAudiobookToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E7F9BABE2A8E6811001697DE /* PalaceAudiobookToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F58124F59C1F78CADB673820 /* TriageBotKeyAdminTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E775BA9B323D098F690BE354 /* TriageBotKeyAdminTests.swift */; };
 		F58C276375D206FAC04A20DD /* NYPLADEPT+TPPDRMAuthorizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84756EEE7935063418887357 /* NYPLADEPT+TPPDRMAuthorizing.swift */; };
 		F5A6B7C8D9E0F1A2B3C4D5E6 /* DownloadTaskLifecycleServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A5B6C7D8E9F0A1B2C3D4E5 /* DownloadTaskLifecycleServiceTests.swift */; };
 		F5D05C1A948729F673031D7D /* SingletonResetRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46136706F66E701FB3E45258 /* SingletonResetRegistry.swift */; };
@@ -2090,6 +2093,7 @@
 		17BE24EC25FB09F000AE707F /* TPPCurrentLibraryAccountProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPCurrentLibraryAccountProviderMock.swift; sourceTree = "<group>"; };
 		17BE24EE25FB114900AE707F /* simplye_authentication_document.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = simplye_authentication_document.json; sourceTree = "<group>"; };
 		17CE5304243C020800315E63 /* TPPUserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPUserAccount.swift; sourceTree = "<group>"; };
+		17CF4EB59391A34A6315985E /* TriageBotKeyAdmin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TriageBotKeyAdmin.swift; sourceTree = "<group>"; };
 		17D08378248E8EEB00092AA9 /* OverdriveProcessor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OverdriveProcessor.framework; path = Carthage/Build/iOS/OverdriveProcessor.framework; sourceTree = "<group>"; };
 		17E81F07261522B3001003C2 /* TPPRoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPRoundedButton.swift; sourceTree = "<group>"; };
 		17E81F31261FF758001003C2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -3123,6 +3127,7 @@
 		E759B2052A1BF7AA0041B075 /* PalaceDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PalaceDebug.entitlements; sourceTree = "<group>"; };
 		E75F4A2829C3AB1F006DFBD8 /* TPPPublicationSpeechSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPPublicationSpeechSynthesizer.swift; sourceTree = "<group>"; };
 		E76AD92A296DCB76008ECC61 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		E775BA9B323D098F690BE354 /* TriageBotKeyAdminTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TriageBotKeyAdminTests.swift; sourceTree = "<group>"; };
 		E785BA272B1519C200A12EFA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E7861C482846875D00B3A38A /* TPPPDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPPDFView.swift; sourceTree = "<group>"; };
 		E7861C4A28468AB200B3A38A /* TPPPDFDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPPDFDocumentView.swift; sourceTree = "<group>"; };
@@ -3469,6 +3474,7 @@
 				5EBFFFA78FB0357C5C37E4E0 /* TestAppContainerFactoryTests.swift */,
 				3E793B64D2FB472246D9A244 /* RuntimeQuiescenceAuditor.swift */,
 				DF90048A6DDD9A6025494F1A /* PalaceTestCase.swift */,
+				E775BA9B323D098F690BE354 /* TriageBotKeyAdminTests.swift */,
 			);
 			name = Support;
 			path = Support;
@@ -6162,6 +6168,7 @@
 			children = (
 				F9C1BD2745D8CAF0EC81AEE8 /* TriageBotFactory.swift */,
 				C540202A7A2D7469AEF27B82 /* TriageBotSupportView.swift */,
+				17CF4EB59391A34A6315985E /* TriageBotKeyAdmin.swift */,
 			);
 			name = Support;
 			path = Support;
@@ -7383,6 +7390,7 @@
 				C5A5323E33AA18B96398BA53 /* RuntimeQuiescenceGateTests.swift in Sources */,
 				63F7E41142B47B5051055271 /* RuntimeQuiescenceLintTests.swift in Sources */,
 				36D5376F01972FB0278F2CB9 /* AudioSessionActivatorTests.swift in Sources */,
+				F58124F59C1F78CADB673820 /* TriageBotKeyAdminTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7926,6 +7934,7 @@
 				002A9388476ED8D595661599 /* LibrariesSectionViewModel.swift in Sources */,
 				AA225D8E76E146A5132FEA43 /* LCPKeychainMigration.swift in Sources */,
 				EE7A7C1C1C92278BB0822BE4 /* AudioSessionActivator.swift in Sources */,
+				317AEF4CF6E747286B2CA086 /* TriageBotKeyAdmin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8472,6 +8481,7 @@
 				C4CDA0FAB4E0815ED71715E0 /* LibrariesSectionViewModel.swift in Sources */,
 				5C89F2830C766E791E48CE21 /* LCPKeychainMigration.swift in Sources */,
 				A8131DE3255ED9F6651D1AF6 /* AudioSessionActivator.swift in Sources */,
+				30FA663F88FFCE7D65BB990C /* TriageBotKeyAdmin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -86,6 +86,11 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
     private let triageBotTicketSubmissionCellIdentifier = "triageBotTicketSubmissionCell"
     private let triageBotAIFallbackCellIdentifier = "triageBotAIFallbackCell"
     private let inAppPlaybackNavCellIdentifier = "inAppPlaybackNavCell"
+    private let triageBotAnthropicKeyCellIdentifier = "triageBotAnthropicKeyCell"
+
+    /// Manages the Keychain-backed Anthropic key for the Triage Bot AI
+    /// fallback (paste/clear/status). See `cellForTriageBotAnthropicKey`.
+    private let triageBotKeyAdmin = TriageBotKeyAdmin()
 
     private var pushNotificationsStatus = false
     private let settings: TPPSettings
@@ -148,7 +153,7 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         let sectionType = visibleSections[section]
         switch sectionType {
         case .librarySettings: return 2
-        case .triageBot: return 3  // enabled + ticket submission + AI fallback
+        case .triageBot: return 4  // enabled + ticket submission + AI fallback + Anthropic key
         case .featureFlags: return 1
         case .dataManagement: return 3  // Clear Cached Data + Reset This Library + Full Reset
         case .developerTools: return 2
@@ -192,7 +197,8 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             switch indexPath.row {
             case 0: return cellForTriageBotEnabled()
             case 1: return cellForTriageBotTicketSubmission()
-            default: return cellForTriageBotAIFallback()
+            case 2: return cellForTriageBotAIFallback()
+            default: return cellForTriageBotAnthropicKey()
             }
         case .featureFlags: return cellForInAppPlaybackNav()
         case .libraryRegistryDebugging: return cellForCustomRegsitry()
@@ -372,6 +378,58 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
 
     @objc func triageBotAIFallbackSwitchDidChange(sender: UISwitch) {
         UserDefaults.standard.set(sender.isOn, forKey: RemoteFeatureFlags.triageBotAIFallbackLocalOverrideKey)
+    }
+
+    /// Tappable row to load the Anthropic API key into the device Keychain at
+    /// runtime (so the AI fallback can be exercised on TestFlight without the
+    /// token ever entering source or the binary). `.value1` style so the
+    /// "Stored"/"Not set" status shows on the trailing edge. Tapping presents
+    /// the paste/clear alert in `presentAnthropicKeyEntry()`.
+    private func cellForTriageBotAnthropicKey() -> UITableViewCell {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: triageBotAnthropicKeyCellIdentifier)
+        cell.selectionStyle = .default
+        cell.accessoryType = .disclosureIndicator
+        cell.textLabel?.text = "Anthropic API Key"
+        cell.textLabel?.adjustsFontSizeToFitWidth = true
+        cell.textLabel?.minimumScaleFactor = 0.5
+        cell.detailTextLabel?.text = triageBotKeyAdmin.hasStoredKey ? "Stored" : "Not set"
+        return cell
+    }
+
+    /// Presents a secure-text alert to paste an Anthropic key (and, when one is
+    /// already stored, to clear it). Empty/whitespace pastes are rejected by
+    /// `TriageBotKeyAdmin.save`, so a stray Save can't wipe a working key.
+    private func presentAnthropicKeyEntry() {
+        let hasKey = triageBotKeyAdmin.hasStoredKey
+        let alert = UIAlertController(
+            title: "Anthropic API Key",
+            message: "Paste a key to enable the Triage Bot AI fallback on this device. "
+                + "The key is stored only in this device's Keychain — never in the app "
+                + "binary or source. Production users can't reach this screen, so their "
+                + "AI fallback stays off.",
+            preferredStyle: .alert
+        )
+        alert.addTextField { textField in
+            textField.placeholder = "sk-ant-…"
+            textField.isSecureTextEntry = true
+            textField.autocapitalizationType = .none
+            textField.autocorrectionType = .no
+            textField.spellCheckingType = .no
+        }
+        alert.addAction(UIAlertAction(title: "Save", style: .default) { [weak self, weak alert] _ in
+            guard let self = self else { return }
+            let raw = alert?.textFields?.first?.text ?? ""
+            self.triageBotKeyAdmin.save(raw)
+            self.tableView.reloadData()
+        })
+        if hasKey {
+            alert.addAction(UIAlertAction(title: "Clear Key", style: .destructive) { [weak self] _ in
+                self?.triageBotKeyAdmin.clear()
+                self?.tableView.reloadData()
+            })
+        }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
     }
 
     private func cellForCustomRegsitry() -> UITableViewCell {
@@ -891,7 +949,14 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             }
         #endif
 
-        case .librarySettings, .triageBot, .featureFlags, .libraryRegistryDebugging:
+        case .triageBot:
+            // Rows 0–2 are toggles (handled by their switches); row 3 is the
+            // Anthropic key entry.
+            if indexPath.row == 3 {
+                presentAnthropicKeyEntry()
+            }
+
+        case .librarySettings, .featureFlags, .libraryRegistryDebugging:
             break
         }
     }

--- a/Palace/Support/TriageBotKeyAdmin.swift
+++ b/Palace/Support/TriageBotKeyAdmin.swift
@@ -1,0 +1,61 @@
+//
+//  TriageBotKeyAdmin.swift
+//  Palace
+//
+//  Test-seam wrapper over AnthropicKeyStore for the Developer Settings
+//  "Anthropic API Key" row. The pure logic (trim + empty-rejection + status)
+//  is unit-tested via an injected AnthropicKeyStoring; the real Keychain is
+//  not exercised in tests (errSecMissingEntitlement in the unit host).
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import TriageBotIOS
+
+/// Storage seam so the admin logic can be unit-tested without the real
+/// Keychain. `AnthropicKeyStore` (the production implementation) conforms.
+protocol AnthropicKeyStoring {
+    func read() -> String?
+    @discardableResult func write(_ key: String) -> Bool
+    @discardableResult func delete() -> Bool
+}
+
+extension AnthropicKeyStore: AnthropicKeyStoring {}
+
+/// Drives the Developer Settings "Anthropic API Key" row. Lets a TestFlight
+/// tester load a key onto their own device's Keychain at runtime — so the
+/// Triage Bot AI fallback can be exercised — without the token ever entering
+/// source or the app binary. Production App Store users never reach the row
+/// (engineering sections are hidden there), so their Keychain stays empty and
+/// the fallback stays off.
+struct TriageBotKeyAdmin {
+    private let store: AnthropicKeyStoring
+
+    init(store: AnthropicKeyStoring = AnthropicKeyStore()) {
+        self.store = store
+    }
+
+    /// True when a non-empty key is currently stored.
+    var hasStoredKey: Bool {
+        guard let key = store.read() else { return false }
+        return !key.isEmpty
+    }
+
+    /// Trims the pasted value and stores it only if non-empty. Returns `true`
+    /// iff a key was written. An empty/whitespace-only paste is rejected and
+    /// leaves any existing key untouched (so a fat-fingered empty save can't
+    /// silently wipe a working key).
+    @discardableResult
+    func save(_ raw: String) -> Bool {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return store.write(trimmed)
+    }
+
+    /// Removes the stored key. Returns `true` if a key was present.
+    @discardableResult
+    func clear() -> Bool {
+        store.delete()
+    }
+}

--- a/PalaceTests/Support/TriageBotKeyAdminTests.swift
+++ b/PalaceTests/Support/TriageBotKeyAdminTests.swift
@@ -1,0 +1,86 @@
+//
+//  TriageBotKeyAdminTests.swift
+//  PalaceTests
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class TriageBotKeyAdminTests: XCTestCase {
+
+    /// In-memory stand-in for `AnthropicKeyStore` so the admin logic is tested
+    /// without the real Keychain (errSecMissingEntitlement in the unit host).
+    private final class SpyStore: AnthropicKeyStoring {
+        var stored: String?
+        private(set) var writeArgs: [String] = []
+        private(set) var deleteCount = 0
+
+        func read() -> String? { stored }
+
+        @discardableResult
+        func write(_ key: String) -> Bool {
+            writeArgs.append(key)
+            stored = key
+            return true
+        }
+
+        @discardableResult
+        func delete() -> Bool {
+            deleteCount += 1
+            let had = stored != nil
+            stored = nil
+            return had
+        }
+    }
+
+    func testSave_trimsSurroundingWhitespace_beforeStoring() {
+        let spy = SpyStore()
+        let admin = TriageBotKeyAdmin(store: spy)
+
+        let didSave = admin.save("  sk-ant-abc123  \n")
+
+        XCTAssertTrue(didSave, "a non-empty key must be saved")
+        XCTAssertEqual(spy.writeArgs, ["sk-ant-abc123"],
+                       "save must trim surrounding whitespace/newlines before storing")
+    }
+
+    func testSave_whitespaceOnly_isRejected_andLeavesExistingKeyIntact() {
+        let spy = SpyStore()
+        spy.stored = "existing-key"
+        let admin = TriageBotKeyAdmin(store: spy)
+
+        let didSave = admin.save("   \n\t ")
+
+        XCTAssertFalse(didSave, "a whitespace-only paste must not be stored")
+        XCTAssertTrue(spy.writeArgs.isEmpty, "no write may be issued for an empty paste")
+        XCTAssertEqual(spy.stored, "existing-key",
+                       "rejecting an empty paste must not clobber the existing key")
+    }
+
+    func testHasStoredKey_isFalseForNilOrEmpty_trueForNonEmpty() {
+        let spy = SpyStore()
+        let admin = TriageBotKeyAdmin(store: spy)
+
+        XCTAssertFalse(admin.hasStoredKey, "no key stored → false")
+
+        spy.stored = ""
+        XCTAssertFalse(admin.hasStoredKey, "empty-string key → false (treated as no key)")
+
+        spy.stored = "sk-ant-xyz"
+        XCTAssertTrue(admin.hasStoredKey, "non-empty key → true")
+    }
+
+    func testClear_deletesTheStoredKey() {
+        let spy = SpyStore()
+        spy.stored = "sk-ant-xyz"
+        let admin = TriageBotKeyAdmin(store: spy)
+
+        let didClear = admin.clear()
+
+        XCTAssertTrue(didClear, "clear must report it removed a present key")
+        XCTAssertEqual(spy.deleteCount, 1, "clear must call the store's delete exactly once")
+        XCTAssertNil(spy.stored, "clear must remove the key from the store")
+    }
+}


### PR DESCRIPTION
## Problem

The Triage Bot AI fallback reads its Anthropic key from the Keychain (`AnthropicKeyStore`). The only path into the Keychain was `bootstrapFromEnvironmentIfNeeded()`, which reads `ANTHROPIC_API_KEY` from the Xcode scheme and is **`#if DEBUG`-gated** — so on a RELEASE TestFlight build it is a no-op and there was no other way to load a key. The fallback therefore could **not** be exercised on TestFlight, and baking the key into the binary is not an option (it ships to every user and is `strings`-extractable).

## Change

Adds a **Developer Settings → Triage Bot → "Anthropic API Key"** row:
- Tapping presents a secure-text alert to paste a key (trimmed; empty/whitespace rejected so a stray Save can't wipe a working key) and, when one is stored, a **Clear Key** action.
- The row shows **"Stored" / "Not set"**.

`TriageBotKeyAdmin` is a thin injectable seam over `AnthropicKeyStore` (`AnthropicKeyStoring`) so the trim + empty-rejection + status logic is unit-tested without the real Keychain (which returns `errSecMissingEntitlement` in the unit host).

## Why this is safe for production

- **Token never in source or binary** — it lives only in the device Keychain (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`), typed at runtime through a secure field. No literal, no Info.plist/xcconfig/TPPSecrets entry.
- **Production users can't reach the field** — the Triage Bot section is `audience: .engineering`, and engineering sections are *structurally absent* (not just hidden) on a real App Store install (receipt named `receipt` that exists on disk). `numberOfRows`/`cellForRow`/`didSelect` all index `visibleSections`, so the row doesn't exist in production.
- **TestFlight reachable** — TestFlight carries `sandboxReceipt`, so engineering sections render; you paste the key once on your test device.

## What this does NOT change

No change to `RemoteFeatureFlags` defaults. Release builds already default the chatbot + audiobook-nav features **OFF** (the chatbot's DEBUG-on default only affects local Xcode builds; RELEASE falls through to Firebase, which defaults false). Firebase remains the rollout control. A stored key alone does not flip the AI-fallback override.

## Verification

- 4 unit tests (trim-before-store, whitespace-only-rejected-leaves-existing-key-intact, hasStoredKey nil/empty/non-empty, clear-deletes), 0 failures.
- Mutation (palace_mutate.py, whole-file): **2/2 = 100%**.
- Full Palace scheme **BUILD SUCCEEDED**; new file added to both Palace + Palace-noDRM targets.
- ForgeOS `cs_087fb8c7` — architect + qa_test both APPROVED; review/testing/release gates promoted.

**Scope:** Developer Settings key-entry row + `TriageBotKeyAdmin` seam + 4 tests.
**Not done:** the production server-proxy key path (out of scope; env-var bootstrap + this manual field are dev/TestFlight only). No flag-default change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
