### PR TITLE
fix(audiobook): Findaway concurrency crash + skip stutter/flicker (toolkit bump)

### DIFF
--- a/scripts/pre-push-test-gate.sh
+++ b/scripts/pre-push-test-gate.sh
@@ -217,9 +217,9 @@ if run_with_timeout "$TIMEOUT_SECS" \
      xcodebuild \
      -project Palace.xcodeproj \
      -scheme Palace \
-     "${DEST_ARGS[@]}" \
-     "${DERIVED_ARGS[@]}" \
-     "${ONLY_TESTING_ARGS[@]}" \
+     ${DEST_ARGS[@]+"${DEST_ARGS[@]}"} \
+     ${DERIVED_ARGS[@]+"${DERIVED_ARGS[@]}"} \
+     ${ONLY_TESTING_ARGS[@]+"${ONLY_TESTING_ARGS[@]}"} \
      test \
      -quiet >/tmp/pre-push-test-gate.log 2>&1; then
   echo "[pre-push-test-gate] PASS — ${#CLASSES[@]} class(es) green." >&2


### PR DESCRIPTION
## Summary

Two commits:

1. **Bump `PalaceAudiobookToolkit`** to pick up the Findaway audiobook fixes in ThePalaceProject/ios-audiobooktoolkit#183:
   - **Open crash** (`EXC_BREAKPOINT` in `_dispatch_semaphore_dispose.cold.1`) — concurrent access of Findaway's non-thread-safe download engine from per-chapter task queues, now serialized through a single gate.
   - **Skip stutter + "must tap play"** — same-chapter skips were misrouted to a full reload off the transient `isPlaying`; now keyed off user play-intent.
   - **Rapid-skip position/title/play-button flicker** — the in-app player model held transient buffer→resume values; now holds the skip target through the settle window.
2. **Fix the pre-push test gate** (`scripts/pre-push-test-gate.sh`) — it crashed expanding empty xcodebuild arg arrays under `set -u` on macOS bash 3.2 (`DERIVED_ARGS[@]: unbound variable`), aborting pushes from a main checkout. Guarded with the bash-3.2-safe `${arr[@]+"${arr[@]}"}` form.

## Testing

- Toolkit: 20/20 unit tests green; verified on device (crash gone, skips smooth, no must-tap-play, no flicker).
- Hook fix: `bash -n` passes; verified old form errors / new form expands cleanly under /bin/bash 3.2.57.

## ⚠️ Merge ordering

This points the submodule at the **branch** commit of #183. Once #183 squash-merges, its SHA changes — **re-bump this pointer to the merged `main` SHA before merging this PR**, or the gitlink will be orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
