### PR TITLE
fix(carplay): WS-2 — bounded async retry for AVAudioSession activation on cold launch (.playerNotReady)

### DIFF
--- a/.forgeos/intent/WS-2-PR-BODY.md
+++ b/.forgeos/intent/WS-2-PR-BODY.md
@@ -1,0 +1,61 @@
+[DO NOT MERGE] fix(carplay): async bounded-retry audio-session activation (.playerNotReady crash)
+
+## What / Why
+WS-2 (3.2.0 M1 crash triage, initiative init_17bfe690). Closes the Crashlytics
+`d45f5aa9` CarPlay OpenAccess `.playerNotReady` crash, deferred from PR #1050.
+
+On a CarPlay **cold launch** `PlaybackBootstrapper.activateAudioSession()` issued a
+single `AVAudioSession.setActive(true)`. A transient refusal (OSStatus `561015905`,
+or `-50` paramErr in the early-launch window) left the session inactive; the
+toolkit's `OpenAccessPlayer` then observed `AVQueuePlayer.status == .failed` →
+`playerIsReady = .failed` → `attemptToPlay` default branch
+(`handlePlaybackError(.playerNotReady)`, OpenAccessPlayer.swift:254) when CarPlay
+issued play. Nobody retried the transient: Palace's old code AND the toolkit's own
+`setupAudioSession` (recoverable set `{-50, 560557684}`) both did a single
+non-retried `setActive`.
+
+## Change (app-side only — no toolkit submodule change)
+- New internal `AudioSessionActivator` (`Palace/Audiobooks/AudioSessionActivator.swift`):
+  bounded async retry-with-backoff. Pure `isRetriable(errorCode:)` (transient set =
+  `561015905`, `-50`, `cannotStartPlaying`, `cannotInterruptOthers`; everything else
+  fails fast) + pure exponential `backoff(forAttempt:base:cap:)`. Bounded
+  `1...maxAttempts` (no infinite retry); no sleep after the final attempt; injected
+  `sleep`/`setActive`/`isOtherAudioPlaying` seams for deterministic CI-safe tests.
+- `PlaybackBootstrapper.activateAudioSession` → async `activateAudioSessionWithRetry`,
+  invoked from `Task { @MainActor }` in `ensureInitializedForCarPlay` so the bounded
+  backoff never blocks the synchronous CarPlay `didConnect` path (~1s block the
+  deferral flagged).
+
+## Scope / residual (honest)
+- Closes the **dominant transient cold-launch race** that is `d45f5aa9`. Not a hard
+  happens-before barrier on the play path (a true barrier = gate the play path on
+  session-active, an AudiobookSessionManager change beyond WS-2's pinned seam →
+  follow-up). Exhaustion degrades gracefully: logs + returns, never issues play, so
+  it cannot itself trigger `.playerNotReady`; re-fires on each CarPlay reconnect.
+- Residual persistent-denial tail = the toolkit HYBRID half (add `561015905` to the
+  toolkit recoverable set / make `attemptToPlay` degrade-not-crash) — tracked as a
+  toolkit follow-up, out of WS-2 scope.
+- `561015905` transient-vs-persistent is UNVERIFIED in-process — folds into the
+  device/simdrive CarPlay-cold-launch validation pass (same as WS-4/WS-5).
+
+## DoD evidence
+- TDD red-first: `PalaceTests/Audiobooks/AudioSessionActivatorTests.swift` (8 tests).
+- Focused: AudioSessionActivatorTests **8/8 pass** (** TEST SUCCEEDED **, sim 35FA2B33).
+- Mutation: `AudioSessionActivator.swift` **1/1 = 100% kill**, 0 survivors, 0
+  critical-path survivors. `PlaybackBootstrapper.swift` diff-only 0/2 points on
+  changed lines (thin wiring; logic delegated to the activator).
+- `verify-pr.sh --quick`: **21/22 PASS** — build, mutation, audiobook cross-vendor
+  smoke (4/4: LCP/Bearer/OpenAccess/LocalFile), accessibility, blast-radius,
+  superpartner, contract-reconciliation, adjacency, intent-recorded, test-name-vs-body,
+  all phase-3.5 detectors, coverage floors. The 1 fail = `unit_tests` 2/7157:
+  `OPDSFeedServiceStateMachineTests.testFetchLoansFeed_blocksUntilLoaded_thenFetches`
+  — a timing-sensitive OPDS2 readiness test (unrelated module), **passed in isolation
+  twice** (verify-pr's own 17:00 re-run + an independent re-run, 5/5). Confirmed
+  contention flake (verify-pr ran concurrently with the pool-4 M0 confirm); not WS-2.
+- ForgeOS: changeset `cs_1a4e3f20` (init_17bfe690); evidence `ev_f86fa86d`,
+  `ev_07b9b4c3`. `forge_release_check`: can_release=false, pending [review, testing,
+  release], 0 failed gates.
+
+## Merge gate
+Pending: Chairman check-off + palace-pm SoD /forge-review (different model) +
+palace-pm independent re-verify + M0. DO NOT MERGE.

--- a/.forgeos/intent/WS-2-PR-BODY.md
+++ b/.forgeos/intent/WS-2-PR-BODY.md
@@ -38,6 +38,20 @@ non-retried `setActive`.
 - `561015905` transient-vs-persistent is UNVERIFIED in-process — folds into the
   device/simdrive CarPlay-cold-launch validation pass (same as WS-4/WS-5).
 
+### Deferred to the device-validation / structural-barrier revision (SoD non-blocking findings)
+- **(architect W1)** Re-check `isOtherAudioPlaying()` inside the retry loop when the
+  error is `cannotInterruptOthers`, so the bounded budget isn't spent on a durable
+  "another app owns audio" denial. Pairs with the structural barrier.
+- **(architect W2)** Add an `isActivating` flag / `activationTask` to skip a duplicate
+  in-flight activation on a rapid (<350ms) double CarPlay `didConnect`. Low practical
+  risk today (MainActor-isolated; a duplicate `setActive` is a no-op), but cleaner
+  alongside the play-path session-active barrier.
+- **(qa W1 — tooling, flagged to devops)** `palace_mutate.py` has no return-value
+  mutator for an implicit `return contains(...)`, so `isRetriable` has no formal
+  mutation-kill entry; its behavior is pinned by two integration tests
+  (`testIsRetriable_transientActivationCodes_areRetriable` /
+  `_terminalCodes_areNotRetriable`) instead. Tooling limitation, not a coverage gap.
+
 ## DoD evidence
 - TDD red-first: `PalaceTests/Audiobooks/AudioSessionActivatorTests.swift` (8 tests).
 - Focused: AudioSessionActivatorTests **8/8 pass** (** TEST SUCCEEDED **, sim 35FA2B33).

--- a/.forgeos/intent/fix-carplay-playernotready-async-activation.md
+++ b/.forgeos/intent/fix-carplay-playernotready-async-activation.md
@@ -1,0 +1,97 @@
+---
+name: fix-carplay-playernotready-async-activation
+created: 2026-06-11
+author: claude-opus-4-8 (w-carplay)
+tracking: WS-2 (3.2.0 M1 crash triage follow-up, initiative init_17bfe690 — no dedicated Jira ticket)
+related_prs: ["#1050 (3.2.0 crash triage that deferred this — changeset cs_e1abd9f4)"]
+crashlytics: ["d45f5aa9 (CarPlay OpenAccess .playerNotReady)"]
+---
+
+## Summary
+
+PR #1050 (3.2.0 pre-regression crash triage) confirmed but **deferred** the CarPlay
+OpenAccess `.playerNotReady` crash (Crashlytics `d45f5aa9`) to a reviewed follow-up.
+This is that follow-up.
+
+Root cause (app-side seam pinned in `.forgeos/intent/3.2.0-crash-triage.md`): during a
+CarPlay **cold launch**, `PlaybackBootstrapper.ensureInitializedForCarPlay()` calls
+`activateAudioSession()`, which issues a single `AVAudioSession.setActive(true)`. On a
+cold CarPlay connect the audio session can transiently refuse activation (observed
+error code `561015905`, plus `-50 paramErr` in the very-early-launch window). The
+current code swallows that single failure and logs it — leaving the audio session
+**not active**. The toolkit's `OpenAccessPlayer` then reports `playerIsReady != .readyToPlay`
+when CarPlay issues the play command, hits `attemptToPlay`'s default branch
+(`handlePlaybackError(.playerNotReady)` at `OpenAccessPlayer.swift:254`), and the
+resulting failure surfaces the `.playerNotReady` crash on the CarPlay path.
+
+The pinned fix is an **async bounded retry with backoff** on the activation: retry
+`setActive` a small number of times with exponential backoff so the session has time to
+become active before the play command is issued — and it MUST be async because
+`activateAudioSession()` runs on the MainActor during CarPlay cold launch, so a
+synchronous retry/sleep would block main for up to ~1s.
+
+The retry/backoff/classification logic is extracted into a pure, injectable, deterministic
+unit — `AudioSessionActivator` — so the bounded loop, the transient-vs-terminal error
+predicate, and the backoff schedule are all unit-testable with no real `AVAudioSession`
+and no real sleeps (CI-safe). `PlaybackBootstrapper` wires the real `AVAudioSession` +
+`Task.sleep` into it and invokes it from a `Task { @MainActor }` so the synchronous
+CarPlay `didConnect` path is never blocked.
+
+## Claims
+
+- Adds `Palace/Audiobooks/AudioSessionActivator.swift` — a new **internal** struct
+  `AudioSessionActivator` encapsulating bounded async retry of audio-session activation.
+  No new public API surface.
+- `AudioSessionActivator.activate() async -> Outcome` runs a **bounded** loop
+  (`1...maxAttempts`, default 3 — no unbounded loop): on success returns
+  `.activated(attempts:)`; on a retriable error sleeps the backoff and retries; on a
+  non-retriable error returns `.failed` immediately; when other audio is playing returns
+  `.skippedOtherAudioPlaying` without activating.
+- Adds pure static helper `AudioSessionActivator.isRetriable(errorCode:) -> Bool` —
+  true for the transient activation codes (`561015905` observed in `d45f5aa9`, `-50`
+  paramErr, `AVAudioSession.ErrorCode.cannotStartPlaying`/`.cannotInterruptOthers`
+  rawValues), false otherwise (genuine/terminal errors fail fast — never retried).
+- Adds pure static helper `AudioSessionActivator.backoff(forAttempt:base:cap:) -> TimeInterval`
+  — exponential `base * 2^(attempt-1)` clamped to `cap`.
+- The loop does **not** sleep after the final attempt (no wasted backoff before failing).
+- `PlaybackBootstrapper.activateAudioSession()` is replaced by an async
+  `activateAudioSessionWithRetry()` that builds an `AudioSessionActivator` from the real
+  `AVAudioSession.sharedInstance()` (`isOtherAudioPlaying`, `setActive`) + `Task.sleep`
+  for backoff, and logs the outcome.
+- `PlaybackBootstrapper.ensureInitializedForCarPlay()` invokes the async activation via
+  `Task { @MainActor [weak self] in await self?.activateAudioSessionWithRetry() }` so the
+  synchronous `CPTemplateApplicationScene.didConnect` path is not blocked (the ~1s
+  main-thread block the deferral flagged).
+- Adds `PalaceTests/Audiobooks/AudioSessionActivatorTests.swift` — red-first tests:
+  first-try success (1 attempt, setActive once), transient-then-success (retries with
+  backoff, sleep called per retry), persistent-transient bounded at maxAttempts
+  (setActive == maxAttempts, sleep == maxAttempts-1), non-retriable fails immediately
+  (setActive once, sleep never), other-audio-playing skip (setActive never), plus pure
+  `isRetriable` classification and `backoff` schedule tests.
+- Registers both new files in the `Palace` + `Palace-noDRM` (production) and `PalaceTests`
+  (test) targets via `scripts/pbxproj_add_swift.rb`.
+
+## Anti-claims (out of scope)
+
+- Does NOT modify the `ios-audiobooktoolkit` submodule. The HYBRID toolkit option (adding
+  `561015905` to the toolkit's recoverable set in `OpenAccessPlayer`) is a separate
+  submodule pass; this changeset is app-side only.
+- Does NOT change the `MPRemoteCommandCenter` command handlers, the play/pause/skip
+  routing, or `handlePlay`/`handlePause`/etc. semantics.
+- Does NOT change the F-011 first-open `PlaybackReadinessGate` path
+  (`openAudiobook` → `awaitReadinessAndIssueFirstPlay`); that gate already guards the
+  first `play(at:)`. This changeset closes the distinct audio-session-not-active seam.
+- Does NOT touch `CarPlayAudiobookBridge`, `CarPlayTemplateManager`, or the
+  `AudiobookSessionManager` play/openAudiobook paths.
+- Does NOT change `configureAudioSession()` (category/mode setup) or the public
+  signatures of `ensureInitialized()` / `ensureInitializedForCarPlay()`.
+- Does NOT address the OverDrive expired-URL or LCP-load deferrals (separate WS items).
+- No new user-facing copy.
+
+## Files in scope
+
+- `Palace/Audiobooks/AudioSessionActivator.swift` (new)
+- `Palace/Audiobooks/PlaybackBootstrapper.swift` (modified — `activateAudioSession` →
+  async retry; `ensureInitializedForCarPlay` invocation site)
+- `PalaceTests/Audiobooks/AudioSessionActivatorTests.swift` (new)
+- `Palace.xcodeproj/project.pbxproj` (new-file registration, via helper)

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 		364459D0B4CBC9DACC5C6C2F /* AccessibilityServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21803F06C0E1741DD2F7973E /* AccessibilityServiceProtocol.swift */; };
 		36650A19392D0CF505DA037D /* TPPMigrationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3391CCE50BC961BC7A5726 /* TPPMigrationManagerTests.swift */; };
 		366C7E46CBA55744BEE438CD /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153576DF8AE3801A58DE3F75 /* DateExtensionTests.swift */; };
+		36D5376F01972FB0278F2CB9 /* AudioSessionActivatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22962DCAAE51DD5C78AFB85B /* AudioSessionActivatorTests.swift */; };
 		36F5308F6729B23EA8F5180F /* TPPIndeterminateProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F8E5B987D7324D570F67D0 /* TPPIndeterminateProgressView.swift */; };
 		36FD0974914BA5944F65C95F /* ContractSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73668D395F71A962A961AB94 /* ContractSnapshot.swift */; };
 		37C8D50A955D44CABEA546D0 /* AudiobookFileLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA14F5C3F5544F838599F895 /* AudiobookFileLoggerTests.swift */; };
@@ -900,6 +901,7 @@
 		A6C753810A4D64E933B7B36A /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = SETVM003T260955EF008E1DC3 /* SettingsViewModel.swift */; };
 		A7D3A61E77E6B8C0FD9AEA5D /* TypographySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C1C917A6BF4317D7FA6567 /* TypographySettings.swift */; };
 		A7E1CE3367F3C787133E928B /* PalaceCatalog in Frameworks */ = {isa = PBXBuildFile; productRef = 4BDC371B99FCA4E42EEFA3CB /* PalaceCatalog */; };
+		A8131DE3255ED9F6651D1AF6 /* AudioSessionActivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDE63F6732471A2B00D88DC /* AudioSessionActivator.swift */; };
 		A823D811192BABA400B55DE2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A823D810192BABA400B55DE2 /* Foundation.framework */; };
 		A823D813192BABA400B55DE2 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A823D812192BABA400B55DE2 /* CoreGraphics.framework */; };
 		A823D815192BABA400B55DE2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A823D814192BABA400B55DE2 /* UIKit.framework */; };
@@ -1695,6 +1697,7 @@
 		EDABAC96498D2F204A963521 /* PerformanceMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A934FABA62A6E51A6928F0DD /* PerformanceMonitorTests.swift */; };
 		EE31E6EB491AED36D48F37E5 /* OPDS2PublicationExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F03A0005DBD80853C64D12 /* OPDS2PublicationExtendedTests.swift */; };
 		EE62CB8A78482228B1365D4E /* PlaybackBootstrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7460F23BAEC7FED016069 /* PlaybackBootstrapper.swift */; };
+		EE7A7C1C1C92278BB0822BE4 /* AudioSessionActivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDE63F6732471A2B00D88DC /* AudioSessionActivator.swift */; };
 		EEEE66239B26A72D3043149B /* AuthCoordinatorTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D2803422C2006E33C1BC3E /* AuthCoordinatorTelemetryTests.swift */; };
 		EF45FA58251EA725B1A9EC42 /* ImageLoaderImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16897C4A4AB0AFFDE25449BF /* ImageLoaderImpl.swift */; };
 		F00D000000000000000F5501 /* MyBooksDownloadSessionInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00D000000000000000F5502 /* MyBooksDownloadSessionInvalidationTests.swift */; };
@@ -2173,6 +2176,7 @@
 		21F238C724991A2A004DC0B1 /* AdobeDRMLibraryService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdobeDRMLibraryService.swift; sourceTree = "<group>"; };
 		21F4BF3926BC62D4000CF592 /* AdobeCertificate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeCertificate.swift; sourceTree = "<group>"; };
 		21F634E426D828CF00C8BE87 /* ReadiumLCP.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ReadiumLCP.xcframework; path = Carthage/Build/ReadiumLCP.xcframework; sourceTree = "<group>"; };
+		22962DCAAE51DD5C78AFB85B /* AudioSessionActivatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioSessionActivatorTests.swift; sourceTree = "<group>"; };
 		22C9565C8C9D4F8F6DA585CE /* LCPBotanCRLGuardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPBotanCRLGuardTests.swift; sourceTree = "<group>"; };
 		22D5C28E71B1D177EAF1E5F9 /* TPPReauthenticatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReauthenticatorTests.swift; sourceTree = "<group>"; };
 		23421B886CD7122945915B93 /* TPPOPDSGroupTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPOPDSGroupTests.swift; sourceTree = "<group>"; };
@@ -2286,6 +2290,7 @@
 		4CD86C00D774B74F80D5B713 /* OPDS2FeedParsingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2FeedParsingTests.swift; sourceTree = "<group>"; };
 		4DA71264EE431E238A3B66ED /* AudiobookPlaybackTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookPlaybackTests.swift; sourceTree = "<group>"; };
 		4DCF14A6A237EADD5978E148 /* DownloadAnnouncementServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadAnnouncementServiceTests.swift; sourceTree = "<group>"; };
+		4DDE63F6732471A2B00D88DC /* AudioSessionActivator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioSessionActivator.swift; sourceTree = "<group>"; };
 		4E6709F729264A8D0DFE7431 /* TPPPDFAccessibilityToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPPDFAccessibilityToolbar.swift; sourceTree = "<group>"; };
 		4EF041C7CEA6592C3141FA49 /* AuthErrorProblemDocSeamTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthErrorProblemDocSeamTests.swift; sourceTree = "<group>"; };
 		4EF195BFDD71F9F64A017579 /* TearDownRequiredLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TearDownRequiredLintTests.swift; sourceTree = "<group>"; };
@@ -3673,6 +3678,7 @@
 				CD8B92D1772840882A596D73 /* Vendors */,
 				F714C5D09735CC88BE76576D /* PlaybackReadinessGate.swift */,
 				260C03DB276DAE8ED383D25A /* AudiobookSessionPresenter.swift */,
+				4DDE63F6732471A2B00D88DC /* AudioSessionActivator.swift */,
 			);
 			path = Audiobooks;
 			sourceTree = "<group>";
@@ -4676,6 +4682,7 @@
 				787DCAF97FD5E190363EC3CA /* AudiobookSessionManagerFlagGatePresentationTests.swift */,
 				8D899B519469E743D48FFACC /* AudiobookPlaytimesLifecycleTests.swift */,
 				7409BB4778BF1736365594FB /* AudiobookPositionRestoreTests.swift */,
+				22962DCAAE51DD5C78AFB85B /* AudioSessionActivatorTests.swift */,
 			);
 			path = Audiobooks;
 			sourceTree = "<group>";
@@ -7375,6 +7382,7 @@
 				1821A08D1697605DF91F7831 /* PalaceTestCase.swift in Sources */,
 				C5A5323E33AA18B96398BA53 /* RuntimeQuiescenceGateTests.swift in Sources */,
 				63F7E41142B47B5051055271 /* RuntimeQuiescenceLintTests.swift in Sources */,
+				36D5376F01972FB0278F2CB9 /* AudioSessionActivatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7917,6 +7925,7 @@
 				1841AF92E817CC9D4A6CE829 /* Reachability+StreamingReader.swift in Sources */,
 				002A9388476ED8D595661599 /* LibrariesSectionViewModel.swift in Sources */,
 				AA225D8E76E146A5132FEA43 /* LCPKeychainMigration.swift in Sources */,
+				EE7A7C1C1C92278BB0822BE4 /* AudioSessionActivator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8462,6 +8471,7 @@
 				DF3CA61B57101027DA63290B /* Reachability+StreamingReader.swift in Sources */,
 				C4CDA0FAB4E0815ED71715E0 /* LibrariesSectionViewModel.swift in Sources */,
 				5C89F2830C766E791E48CE21 /* LCPKeychainMigration.swift in Sources */,
+				A8131DE3255ED9F6651D1AF6 /* AudioSessionActivator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Audiobooks/AudioSessionActivator.swift
+++ b/Palace/Audiobooks/AudioSessionActivator.swift
@@ -1,0 +1,169 @@
+//
+//  AudioSessionActivator.swift
+//  Palace
+//
+//  WS-2 — CarPlay OpenAccess `.playerNotReady` crash (Crashlytics d45f5aa9).
+//
+//  WHAT THIS FIXES:
+//  During a CarPlay cold launch, `PlaybackBootstrapper.activateAudioSession()`
+//  issued a single `AVAudioSession.setActive(true)`. On a cold CarPlay connect
+//  the audio session can transiently refuse activation (observed OSStatus
+//  561015905, plus `-50` paramErr in the very-early-launch window). The old
+//  code swallowed that single failure and logged it — leaving the session
+//  inactive. The toolkit's `OpenAccessPlayer` then reports
+//  `playerIsReady != .readyToPlay` when CarPlay issues the play command, takes
+//  the default branch of `attemptToPlay` (`handlePlaybackError(.playerNotReady)`
+//  at `OpenAccessPlayer.swift:254`), and the `.playerNotReady` failure surfaces
+//  the CarPlay crash.
+//
+//  THE FIX (app-side, NO submodule changes):
+//  Retry the activation a bounded number of times with exponential backoff so
+//  the session has time to become active before the play command is issued.
+//  The retry MUST be async because activation runs on the MainActor during
+//  CarPlay cold launch — a synchronous retry/sleep would block main for up to
+//  ~1s (see `.forgeos/intent/3.2.0-crash-triage.md`). `AudioSessionActivator`
+//  is the pure, injectable unit so the bounded loop, the transient-vs-terminal
+//  classification, and the backoff schedule are unit-testable with no real
+//  `AVAudioSession` and no real sleeps. `PlaybackBootstrapper` wires the real
+//  session + `Task.sleep` and invokes it from a `Task { @MainActor }`.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import AVFoundation
+import Foundation
+
+// MARK: - AudioSessionActivator
+
+/// Bounded, async retry-with-backoff for activating the audio session.
+///
+/// The activation primitives are injected as closures so the retry loop is
+/// testable without a real `AVAudioSession`: production binds the closures to
+/// `AVAudioSession.sharedInstance()` + `Task.sleep`; tests bind recording
+/// stubs that fail a scripted number of times before succeeding.
+///
+/// Internal — no consumer outside the audiobook playback bootstrap needs it,
+/// so it adds no public API surface.
+struct AudioSessionActivator {
+
+    // MARK: - Outcome
+
+    /// Terminal result of an activation attempt sequence.
+    enum Outcome: Equatable {
+        /// Activation succeeded; `attempts` is the number of `setActive`
+        /// calls it took (1 = first try).
+        case activated(attempts: Int)
+        /// Skipped because another app was already playing audio — Palace
+        /// should not steal the session in that case.
+        case skippedOtherAudioPlaying
+        /// Activation never succeeded; `attempts` is how many were made and
+        /// `lastErrorCode` is the final activation error's OSStatus.
+        case failed(attempts: Int, lastErrorCode: Int)
+    }
+
+    // MARK: - Configuration
+
+    /// Maximum number of `setActive` attempts. Bounded — there is no
+    /// unbounded retry. Default 3.
+    let maxAttempts: Int
+    /// Base backoff in seconds for the first retry; grows exponentially.
+    let baseBackoff: TimeInterval
+    /// Upper clamp on a single backoff interval, so a few retries never sum
+    /// to a perceptible stall.
+    let backoffCap: TimeInterval
+
+    // MARK: - Injected seams
+
+    /// Whether another app currently owns audio playback.
+    let isOtherAudioPlaying: () -> Bool
+    /// Performs the activation; throws on refusal.
+    let setActive: () throws -> Void
+    /// Suspends for the supplied number of seconds (the backoff).
+    let sleep: (TimeInterval) async -> Void
+
+    init(
+        maxAttempts: Int = 3,
+        baseBackoff: TimeInterval = 0.05,
+        backoffCap: TimeInterval = 0.5,
+        isOtherAudioPlaying: @escaping () -> Bool,
+        setActive: @escaping () throws -> Void,
+        sleep: @escaping (TimeInterval) async -> Void
+    ) {
+        self.maxAttempts = maxAttempts
+        self.baseBackoff = baseBackoff
+        self.backoffCap = backoffCap
+        self.isOtherAudioPlaying = isOtherAudioPlaying
+        self.setActive = setActive
+        self.sleep = sleep
+    }
+
+    // MARK: - Pure classification / scheduling
+
+    /// OSStatus codes that warrant a retry — transient activation refusals
+    /// seen during a CarPlay cold launch. Anything else is treated as
+    /// terminal and is NOT retried (fail fast).
+    ///
+    /// - `561015905` — observed in Crashlytics d45f5aa9 for this crash.
+    /// - `-50` (paramErr) — early-launch window before scenes connect.
+    /// - `cannotStartPlaying` / `cannotInterruptOthers` — the AVAudioSession
+    ///   activation-contention codes.
+    private static let retriableCodes: Set<Int> = [
+        561015905,
+        -50,
+        Int(AVAudioSession.ErrorCode.cannotStartPlaying.rawValue),
+        Int(AVAudioSession.ErrorCode.cannotInterruptOthers.rawValue)
+    ]
+
+    /// Pure predicate: should an activation failure with this OSStatus be
+    /// retried? Static + pure so it is mutation-testable in isolation.
+    static func isRetriable(errorCode: Int) -> Bool {
+        retriableCodes.contains(errorCode)
+    }
+
+    /// Pure backoff schedule: exponential (`base * 2^(attempt-1)`) clamped to
+    /// `cap`. `attempt` is 1-based (the first retry uses attempt 1).
+    static func backoff(forAttempt attempt: Int, base: TimeInterval, cap: TimeInterval) -> TimeInterval {
+        let exponent = max(0, attempt - 1)
+        let raw = base * pow(2.0, Double(exponent))
+        return min(raw, cap)
+    }
+
+    // MARK: - Activation loop
+
+    /// Runs the bounded activation loop. `@MainActor` because
+    /// `AVAudioSession` activation must happen on the main thread (see the
+    /// `AudiobookSamplePlayer` -50 note); production drives this from a
+    /// `Task { @MainActor }` so the synchronous CarPlay `didConnect` path is
+    /// never blocked.
+    @MainActor
+    func activate() async -> Outcome {
+        if isOtherAudioPlaying() {
+            return .skippedOtherAudioPlaying
+        }
+
+        var lastErrorCode = 0
+        for attempt in 1...max(1, maxAttempts) {
+            do {
+                try setActive()
+                return .activated(attempts: attempt)
+            } catch {
+                let code = (error as NSError).code
+                lastErrorCode = code
+
+                // Terminal error → fail fast, no backoff, no further attempts.
+                guard Self.isRetriable(errorCode: code) else {
+                    return .failed(attempts: attempt, lastErrorCode: code)
+                }
+
+                // Bounded: never sleep after the final attempt.
+                if attempt == max(1, maxAttempts) {
+                    break
+                }
+
+                await sleep(Self.backoff(forAttempt: attempt, base: baseBackoff, cap: backoffCap))
+            }
+        }
+
+        return .failed(attempts: max(1, maxAttempts), lastErrorCode: lastErrorCode)
+    }
+}

--- a/Palace/Audiobooks/PlaybackBootstrapper.swift
+++ b/Palace/Audiobooks/PlaybackBootstrapper.swift
@@ -240,7 +240,7 @@ public final class PlaybackBootstrapper {
     /// `.playerNotReady` (Crashlytics d45f5aa9). The retry gives the session
     /// time to become active before play is issued. Async so the bounded
     /// backoff never blocks the MainActor `didConnect` path.
-    func activateAudioSessionWithRetry() async {
+    private func activateAudioSessionWithRetry() async {
         let session = AVAudioSession.sharedInstance()
         let activator = AudioSessionActivator(
             isOtherAudioPlaying: { session.isOtherAudioPlaying },

--- a/Palace/Audiobooks/PlaybackBootstrapper.swift
+++ b/Palace/Audiobooks/PlaybackBootstrapper.swift
@@ -189,8 +189,14 @@ public final class PlaybackBootstrapper {
         // Full initialization if not done yet
         ensureInitialized()
 
-        // Re-activate audio session in case it was deactivated
-        activateAudioSession()
+        // Re-activate audio session in case it was deactivated. Runs as a
+        // detached MainActor task so the synchronous CarPlay `didConnect`
+        // path is NOT blocked by the bounded retry/backoff — the deferral in
+        // `.forgeos/intent/3.2.0-crash-triage.md` flagged a ~1s main-thread
+        // block if this retried synchronously. WS-2 / Crashlytics d45f5aa9.
+        Task { @MainActor [weak self] in
+            await self?.activateAudioSessionWithRetry()
+        }
 
         // Re-apply command configuration to ensure correctness after reconnect
         configureCommandSettings()
@@ -225,16 +231,33 @@ public final class PlaybackBootstrapper {
         }
     }
 
-    private func activateAudioSession() {
+    /// Activates the audio session with a bounded async retry/backoff.
+    ///
+    /// CarPlay cold launch can transiently refuse activation (observed
+    /// OSStatus 561015905, plus `-50` in the very-early window). Before WS-2
+    /// a single refusal left the session inactive, so the toolkit's
+    /// OpenAccessPlayer reported not-ready and the CarPlay play command hit
+    /// `.playerNotReady` (Crashlytics d45f5aa9). The retry gives the session
+    /// time to become active before play is issued. Async so the bounded
+    /// backoff never blocks the MainActor `didConnect` path.
+    func activateAudioSessionWithRetry() async {
         let session = AVAudioSession.sharedInstance()
-
-        do {
-            if !session.isOtherAudioPlaying {
-                try session.setActive(true)
-                Log.debug(#file, "🔊 Audio session activated")
+        let activator = AudioSessionActivator(
+            isOtherAudioPlaying: { session.isOtherAudioPlaying },
+            setActive: { try session.setActive(true) },
+            sleep: { seconds in
+                let nanos = UInt64(max(0, seconds) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: nanos)
             }
-        } catch {
-            Log.error(#file, "🔊 Failed to activate audio session: \(error)")
+        )
+
+        switch await activator.activate() {
+        case .activated(let attempts):
+            Log.debug(#file, "🔊 Audio session activated (attempts: \(attempts))")
+        case .skippedOtherAudioPlaying:
+            Log.debug(#file, "🔊 Audio session activation skipped — other audio playing")
+        case .failed(let attempts, let code):
+            Log.error(#file, "🔊 Failed to activate audio session after \(attempts) attempts (last OSStatus \(code))")
         }
     }
 

--- a/PalaceTests/Audiobooks/AudioSessionActivatorTests.swift
+++ b/PalaceTests/Audiobooks/AudioSessionActivatorTests.swift
@@ -1,0 +1,183 @@
+//
+//  AudioSessionActivatorTests.swift
+//  PalaceTests
+//
+//  WS-2 — CarPlay OpenAccess `.playerNotReady` crash (Crashlytics d45f5aa9).
+//
+//  Red-first tests for the bounded async retry-with-backoff that activates
+//  the audio session during a CarPlay cold launch. The crash happens when a
+//  single `AVAudioSession.setActive` refusal leaves the session inactive, so
+//  the toolkit's OpenAccessPlayer reports not-ready and the CarPlay play
+//  command hits `.playerNotReady`. `AudioSessionActivator` retries the
+//  activation a bounded number of times before giving up, so the session has
+//  time to become active before the play command is issued.
+//
+//  These tests drive the activator with injected closures (no real
+//  AVAudioSession, no real sleeps) so every branch — first-try success,
+//  transient-then-success, persistent-transient bounded at the cap,
+//  non-retriable fail-fast, and the other-audio-playing skip — is exercised
+//  deterministically and CI-safe.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import AVFoundation
+import XCTest
+@testable import Palace
+
+@MainActor
+final class AudioSessionActivatorTests: XCTestCase {
+
+    /// Records calls made by the activator so each test can assert how many
+    /// `setActive` attempts and `sleep` backoffs happened, and with what
+    /// backoff durations.
+    private final class Recorder {
+        var setActiveCalls = 0
+        var sleepDurations: [TimeInterval] = []
+    }
+
+    /// Builds an activator whose `setActive` throws the supplied errors (one
+    /// per call, in order) and then succeeds once the error list is
+    /// exhausted. A `nil` element means "succeed on this call".
+    private func makeActivator(
+        recorder: Recorder,
+        maxAttempts: Int = 3,
+        baseBackoff: TimeInterval = 0.05,
+        backoffCap: TimeInterval = 0.5,
+        otherAudioPlaying: Bool = false,
+        failures: [NSError?]
+    ) -> AudioSessionActivator {
+        AudioSessionActivator(
+            maxAttempts: maxAttempts,
+            baseBackoff: baseBackoff,
+            backoffCap: backoffCap,
+            isOtherAudioPlaying: { otherAudioPlaying },
+            setActive: {
+                let index = recorder.setActiveCalls
+                recorder.setActiveCalls += 1
+                if index < failures.count, let error = failures[index] {
+                    throw error
+                }
+                // No error queued for this call → activation succeeded.
+            },
+            sleep: { duration in
+                recorder.sleepDurations.append(duration)
+            }
+        )
+    }
+
+    /// A retriable (transient) activation error — the code observed in
+    /// Crashlytics d45f5aa9.
+    private func transientError() -> NSError {
+        NSError(domain: NSOSStatusErrorDomain, code: 561015905, userInfo: nil)
+    }
+
+    /// A terminal/non-retriable error the activator should NOT retry.
+    private func terminalError() -> NSError {
+        NSError(domain: NSOSStatusErrorDomain, code: 2003329396, userInfo: nil)
+    }
+
+    // MARK: - activate() outcomes
+
+    func testActivate_succeedsFirstTry_returnsActivatedOneAttempt_noSleep() async {
+        let recorder = Recorder()
+        let activator = makeActivator(recorder: recorder, failures: [])
+
+        let outcome = await activator.activate()
+
+        XCTAssertEqual(outcome, .activated(attempts: 1))
+        XCTAssertEqual(recorder.setActiveCalls, 1, "should activate exactly once on first-try success")
+        XCTAssertTrue(recorder.sleepDurations.isEmpty, "no backoff sleep when activation succeeds immediately")
+    }
+
+    func testActivate_transientThenSuccess_retriesWithBackoff() async {
+        let recorder = Recorder()
+        // Fail twice (transient), succeed on the third attempt.
+        let activator = makeActivator(
+            recorder: recorder,
+            failures: [transientError(), transientError()]
+        )
+
+        let outcome = await activator.activate()
+
+        XCTAssertEqual(outcome, .activated(attempts: 3))
+        XCTAssertEqual(recorder.setActiveCalls, 3, "two transient failures then a success = 3 attempts")
+        // One backoff per retry (after attempt 1 and attempt 2); none after the success.
+        XCTAssertEqual(recorder.sleepDurations.count, 2, "one backoff sleep per retry")
+        // Exponential growth: attempt-2 backoff > attempt-1 backoff.
+        XCTAssertEqual(recorder.sleepDurations[0], 0.05, accuracy: 0.0001)
+        XCTAssertEqual(recorder.sleepDurations[1], 0.10, accuracy: 0.0001)
+    }
+
+    func testActivate_persistentTransient_isBoundedAtMaxAttempts() async {
+        let recorder = Recorder()
+        // Always throws transient — must stop at maxAttempts, never loop forever.
+        let activator = makeActivator(
+            recorder: recorder,
+            maxAttempts: 4,
+            failures: Array(repeating: transientError(), count: 10)
+        )
+
+        let outcome = await activator.activate()
+
+        XCTAssertEqual(outcome, .failed(attempts: 4, lastErrorCode: 561015905))
+        XCTAssertEqual(recorder.setActiveCalls, 4, "bounded at maxAttempts")
+        XCTAssertEqual(recorder.sleepDurations.count, 3, "no backoff sleep after the final (failing) attempt")
+    }
+
+    func testActivate_nonRetriableError_failsImmediately_noRetry_noSleep() async {
+        let recorder = Recorder()
+        let activator = makeActivator(
+            recorder: recorder,
+            failures: [terminalError(), transientError(), transientError()]
+        )
+
+        let outcome = await activator.activate()
+
+        XCTAssertEqual(outcome, .failed(attempts: 1, lastErrorCode: 2003329396))
+        XCTAssertEqual(recorder.setActiveCalls, 1, "terminal error must not be retried")
+        XCTAssertTrue(recorder.sleepDurations.isEmpty, "no backoff before a fail-fast terminal error")
+    }
+
+    func testActivate_otherAudioPlaying_skipsWithoutActivating() async {
+        let recorder = Recorder()
+        let activator = makeActivator(
+            recorder: recorder,
+            otherAudioPlaying: true,
+            failures: []
+        )
+
+        let outcome = await activator.activate()
+
+        XCTAssertEqual(outcome, .skippedOtherAudioPlaying)
+        XCTAssertEqual(recorder.setActiveCalls, 0, "must not activate while other audio is playing")
+        XCTAssertTrue(recorder.sleepDurations.isEmpty)
+    }
+
+    // MARK: - isRetriable (pure)
+
+    func testIsRetriable_transientActivationCodes_areRetriable() {
+        XCTAssertTrue(AudioSessionActivator.isRetriable(errorCode: 561015905),
+                      "the d45f5aa9 Crashlytics code must be retriable")
+        XCTAssertTrue(AudioSessionActivator.isRetriable(errorCode: -50),
+                      "paramErr (-50) in the early-launch window must be retriable")
+        XCTAssertTrue(AudioSessionActivator.isRetriable(errorCode: Int(AVAudioSession.ErrorCode.cannotStartPlaying.rawValue)))
+        XCTAssertTrue(AudioSessionActivator.isRetriable(errorCode: Int(AVAudioSession.ErrorCode.cannotInterruptOthers.rawValue)))
+    }
+
+    func testIsRetriable_terminalCodes_areNotRetriable() {
+        XCTAssertFalse(AudioSessionActivator.isRetriable(errorCode: 2003329396),
+                       "an unrelated/terminal OSStatus must not be retried")
+        XCTAssertFalse(AudioSessionActivator.isRetriable(errorCode: 0))
+    }
+
+    // MARK: - backoff (pure)
+
+    func testBackoff_isExponential_andClampedToCap() {
+        XCTAssertEqual(AudioSessionActivator.backoff(forAttempt: 1, base: 0.05, cap: 0.5), 0.05, accuracy: 0.0001)
+        XCTAssertEqual(AudioSessionActivator.backoff(forAttempt: 2, base: 0.05, cap: 0.5), 0.10, accuracy: 0.0001)
+        XCTAssertEqual(AudioSessionActivator.backoff(forAttempt: 3, base: 0.05, cap: 0.5), 0.20, accuracy: 0.0001)
+        // attempt 5 would be 0.05 * 16 = 0.8 > cap → clamped.
+        XCTAssertEqual(AudioSessionActivator.backoff(forAttempt: 5, base: 0.05, cap: 0.5), 0.50, accuracy: 0.0001)
+    }
+}

--- a/PalaceTests/Audiobooks/AudioSessionActivatorTests.swift
+++ b/PalaceTests/Audiobooks/AudioSessionActivatorTests.swift
@@ -123,6 +123,13 @@ final class AudioSessionActivatorTests: XCTestCase {
         XCTAssertEqual(outcome, .failed(attempts: 4, lastErrorCode: 561015905))
         XCTAssertEqual(recorder.setActiveCalls, 4, "bounded at maxAttempts")
         XCTAssertEqual(recorder.sleepDurations.count, 3, "no backoff sleep after the final (failing) attempt")
+        // Self-contain the schedule: backoffs after attempts 1, 2, 3 are the
+        // exponential series 0.05 * 2^(n-1), none clamped (all < cap 0.5).
+        let expectedBackoffs: [TimeInterval] = [0.05, 0.10, 0.20]
+        for (index, expected) in expectedBackoffs.enumerated() {
+            XCTAssertEqual(recorder.sleepDurations[index], expected, accuracy: 0.0001,
+                           "backoff for retry \(index + 1) should be \(expected)s")
+        }
     }
 
     func testActivate_nonRetriableError_failsImmediately_noRetry_noSleep() async {


### PR DESCRIPTION
## What
Fixes the CarPlay OpenAccess `.playerNotReady` crash (Crashlytics `d45f5aa9`). On CarPlay cold launch, `PlaybackBootstrapper.activateAudioSession`'s single `AVAudioSession.setActive(true)` can transiently fail (OSStatus 561015905 / -50), leaving the session inactive → `OpenAccessPlayer` reports not-ready → the CarPlay play command hits `.playerNotReady`.

## Fix (app-side; no toolkit submodule change)
New `AudioSessionActivator` — a bounded async retry with exponential backoff (pure `isRetriable` + a bounded `1...maxAttempts` loop, no infinite retry), invoked off the MainActor `didConnect` path. `PlaybackBootstrapper.activateAudioSession` → `activateAudioSessionWithRetry`. Conservative retriable set ({561015905, -50, `cannotStartPlaying`, `cannotInterruptOthers`}); everything else fails fast; on exhaustion it logs and returns without issuing play (so exhaustion cannot itself trigger `.playerNotReady`); each CarPlay reconnect re-fires activation (idempotent).

## Tests
- `AudioSessionActivatorTests` 8/8 (first-try, transient-then-success with backoff assertions, persistent bounded-at-max, non-retriable fail-fast, other-audio skip, pure `isRetriable`, pure backoff).
- Mutation 100% (1/1) on `AudioSessionActivator`; `PlaybackBootstrapper` wiring has no killable logic.
- verify-pr.sh --quick: cross-vendor audiobook smoke 4/4 (LCP / Bearer / OpenAccess / LocalFile), wall gates, all detectors green. One unrelated failure (`OPDSFeedServiceStateMachineTests`, a timing-sensitive OPDS module test) passed in isolation twice — a machine-contention flake, not this change.

## Scope / residual
Closes the dominant cold-launch transient-denial race that is `d45f5aa9`. A genuinely persistent activation denial would still surface via the toolkit's `attemptToPlay` — hardening that (adding 561015905 to the toolkit recoverable set) is a separate toolkit follow-up. CarPlay cold-launch behavior is device-validation scope.


🤖 Generated with [Claude Code](https://claude.com/claude-code)