### PR TITLE
test(stability): reset leaked audiobook-session/presenter statics in _resetForTesting (CarPlay state-bleed)

### DIFF
--- a/.forgeos/intent/fix-carplay-statebleed-reset-audiobook-statics.md
+++ b/.forgeos/intent/fix-carplay-statebleed-reset-audiobook-statics.md
@@ -1,0 +1,68 @@
+---
+name: fix-carplay-statebleed-reset-audiobook-statics
+created: 2026-06-12
+author: claude-opus-4-8 (w-carplay)
+tracking: M0-reconverge — CarPlay state-bleed (last board-green blocker), initiative init_17bfe690
+related_branches: ["fleet/w-carplay-carplay-statebleed (off develop)"]
+---
+
+## Summary
+
+`CarPlayAudiobookBridgePresenterMigrationTests.testCarPlayBridge_dismissBookOnPhone_doesNotKillSession`
+reds the CI board on any shuffle where an upstream test precedes it and leaves the
+shared, never-reset `AppContainer._audiobookSessionPresenter` static in an
+active-session state. The victim's precondition reads that shared static
+(`presenter.hasActiveSession`); the bleed inverts it. On #1071's CI the victim
+failed ALL iters-3 retries (the polluted static persists across retries in the same
+process, so retry does not recover it) → deterministic-red-when-triggered, blocking
+deterministic-green merges of WS-5 / WS-2.
+
+`AppContainer._resetForTesting()` (the DEBUG-only, XCTest-gated test-boundary reset)
+rebuilds `_cached` and now drains the AccountsManager crawl (w-stabilize's #1066
+fix), but it does NOT reset the process-wide audiobook statics
+(`_audiobookSession`, `_audiobookSessionPresenter`, `_playbackBootstrapper`) —
+confirmed they are the only graph members it leaves intact (`_buildCachedAppContainer`
+does not touch them).
+
+Fix (option-C, structural, order-INDEPENDENT — mirrors the accepted crawl-drain
+pattern): reset those three statics to `nil` in `_resetForTesting()` so each test
+class boundary yields a fresh presenter (subscribed to a fresh session, the old
+presenter's leaked subscription torn down on deinit). This neutralizes ANY polluter
+that left the presenter active, without needing to name it — pinning a single
+polluter in a randomized 201-class suite without the failing seed is the wrong tool
+(15 candidate classes ruled out empirically). Approved by palace-pm.
+
+## Claims
+
+- Adds three static resets to `AppContainer._resetForTesting()` (inside the existing
+  `#if DEBUG` + `XCTestConfigurationFilePath` gate → ZERO production/release impact):
+  `_audiobookSession = nil`, `_audiobookSessionPresenter = nil`,
+  `_playbackBootstrapper = nil`.
+- Adds a deterministic red-first test
+  `testResetForTesting_clearsLeakedActiveSessionFromSharedAudiobookPresenter` to
+  `AppContainerResetTests`: pollutes the shared static presenter into an active
+  session via the REAL publisher path (`production().audiobookSession.playbackStatePublisher.send(.playing)`,
+  waited deterministically because delivery is async `.receive(on: DispatchQueue.main)`),
+  calls `_resetForTesting()`, then asserts the next
+  `production().audiobookSessionPresenter` resolution is a fresh presenter with
+  `hasActiveSession == false`. RED before the fix (same static instance, still
+  active); GREEN after. Tests the fix MECHANISM directly — not a behavioral model.
+
+## Anti-claims (out of scope)
+
+- Test-support only. The change lives entirely inside the `#if DEBUG` +
+  XCTest-process-gated `_resetForTesting()` seam — not callable from production/release
+  builds. No production runtime behavior changes.
+- Does NOT name or fix a specific polluter test. The fix is structural and
+  order-independent; it neutralizes any polluter at the class boundary. (The earlier
+  "dispatch backlog" timing model was disproven by its own red-first and discarded.)
+- Does NOT change `AudiobookSessionPresenter`, `AudiobookSessionManager`,
+  `CarPlayAudiobookBridge`, or the CarPlay victim test.
+- Does NOT change `testExecutionOrdering` (stays "random") or any scheme/test-plan
+  config.
+
+## Files in scope
+
+- `Palace/AppInfrastructure/AppContainer.swift` (test-support `_resetForTesting()` only)
+- `PalaceTests/AppInfrastructure/AppContainerResetTests.swift` (red-first test)
+- `.forgeos/intent/fix-carplay-statebleed-reset-audiobook-statics.md` (this file)

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -519,6 +519,27 @@ struct AppContainer {
         // WS-0 follow-up; see AccountsManager.cancelAndDrainBackgroundWork.
         _cached.accountsManager.cancelAndDrainBackgroundWork()
         _cached = Self._buildCachedAppContainer()
+        // Reset the process-wide audiobook session/presenter statics — the only
+        // graph members `_buildCachedAppContainer()` does NOT rebuild. Left
+        // intact, `_audiobookSessionPresenter` carries active-session state (and
+        // its `.receive(on: main)` subscription) across test-class boundaries:
+        // an upstream test that leaves the presenter `.playing` then reds
+        // `CarPlayAudiobookBridgePresenterMigrationTests.testCarPlayBridge_dismissBookOnPhone`
+        // in-suite (its precondition reads the shared `hasActiveSession`). Nil-ing
+        // them here means the next `production()` resolution rebuilds a fresh
+        // presenter subscribed to a fresh session, releasing the polluted one —
+        // order-independent, neutralizing ANY polluter. Same never-reset-static
+        // pattern as the AccountsManager crawl-drain above. M0-reconverge.
+        //
+        // `MainActor.assumeIsolated` because these are `@MainActor`-isolated
+        // statics and `_resetForTesting()` is nonisolated — matching the same
+        // assertion `_buildCachedAppContainer()` (called just above) already
+        // makes. The test-boundary reset always runs on the main thread.
+        MainActor.assumeIsolated {
+            _audiobookSession = nil
+            _audiobookSessionPresenter = nil
+            _playbackBootstrapper = nil
+        }
         // Leave the flag at the test-safe `true` (see step 4 above) — do NOT
         // reset to `false`. The next test class inherits this value before its
         // own setUp runs; `false` here is the root of the cross-test

--- a/PalaceTests/AppInfrastructure/AppContainerResetTests.swift
+++ b/PalaceTests/AppInfrastructure/AppContainerResetTests.swift
@@ -68,6 +68,57 @@ final class AppContainerResetTests: PalaceTestCase {
         )
     }
 
+    /// M0-reconverge — CarPlay state-bleed (the last board-green blocker).
+    ///
+    /// The shared, process-wide `_audiobookSessionPresenter` static is the one
+    /// graph member `_resetForTesting()` historically did NOT reset (the
+    /// AccountsManager crawl-drain and `_cached` rebuild do not touch it). When
+    /// an upstream test leaves it in an active session,
+    /// `CarPlayAudiobookBridgePresenterMigrationTests.testCarPlayBridge_dismissBookOnPhone`
+    /// reads that stale `hasActiveSession` and its precondition inverts in-suite
+    /// (it passes alone). On #1071's CI it failed all iters-3 retries because the
+    /// polluted static persists across retries in the same process.
+    ///
+    /// This pins the structural fix: `_resetForTesting()` must clear the
+    /// audiobook session/presenter statics so the next test class boundary hands
+    /// back a fresh presenter — neutralizing ANY polluter, order-independent.
+    /// It drives the pollution through the REAL publisher path (so it tests the
+    /// fix mechanism, not a model). RED before the static reset (the same polluted
+    /// presenter is handed back, still active); GREEN after.
+    @MainActor
+    func testResetForTesting_clearsLeakedActiveSessionFromSharedAudiobookPresenter() {
+        // Arrange: pollute the shared static presenter into an active session
+        // exactly how an upstream test leaves it dirty — publish `.playing` on
+        // the shared session manager's publisher.
+        let session = AppContainer.production().audiobookSession
+        let pollutedPresenter = AppContainer.production().audiobookSessionPresenter
+        session.playbackStatePublisher.send(.playing(bookId: "polluter"))
+
+        // `hasActiveSession` is delivered async via the presenter's
+        // `.receive(on: DispatchQueue.main)` subscription; pump the run loop
+        // until it lands (CI-safe deterministic wait — never a fixed sleep).
+        let arrangeDeadline = Date().addingTimeInterval(2.0)
+        while !pollutedPresenter.hasActiveSession && Date() < arrangeDeadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.005))
+        }
+        XCTAssertTrue(pollutedPresenter.hasActiveSession,
+                      "ARRANGE: the shared audiobook presenter must be polluted to an active session before the reset")
+
+        // Act: the test-boundary reset that runs between every test class.
+        AppContainer._resetForTesting()
+
+        // Assert: the next resolution hands back a FRESH presenter with no
+        // active session — the leaked active state is gone. Without the static
+        // reset, `production().audiobookSessionPresenter` returns the SAME
+        // polluted instance (still active) and this fails — the CarPlay
+        // state-bleed.
+        let freshPresenter = AppContainer.production().audiobookSessionPresenter
+        XCTAssertFalse(freshPresenter.hasActiveSession,
+                       "_resetForTesting() must clear the shared audiobook presenter's active-session state so it does not bleed into the next test class (CarPlay dismissBookOnPhone precondition state-bleed)")
+        XCTAssertFalse(pollutedPresenter === freshPresenter,
+                       "_resetForTesting() must hand back a fresh presenter instance, not the polluted one")
+    }
+
     /// Reset must produce a cached graph whose AccountsManager was built
     /// with the `deferInitialLoadCatalogsForTesting` flag set to `true`.
     /// The observable consequence: immediately after reset, the new


### PR DESCRIPTION
## What
Closes a test-isolation state-bleed that intermittently reds CI: `CarPlayAudiobookBridgePresenterMigrationTests.testCarPlayBridge_dismissBookOnPhone_doesNotKillSession` fails (its active-session precondition inverts) when an earlier test leaves the shared `@MainActor` audiobook-session/presenter statics in an active state — order-dependent, so it passes alone but reds on shuffles where a polluter precedes it.

## Fix (test-support only; `#if DEBUG` + XCTest-gated → zero production impact)
`AppContainer._resetForTesting()` now nils the three statics it previously left untouched — `_audiobookSession`, `_audiobookSessionPresenter`, `_playbackBootstrapper` — after the existing `cancelAndDrainBackgroundWork` + cached-graph rebuild (additive on #1066, wrapped in `MainActor.assumeIsolated`). The next resolution rebuilds a fresh presenter on a fresh session; the leaked presenter is released and deinits cleanly. **Order-independent** — neutralizes any polluter that left the presenter active (the same structural pattern as #1066's crawl-drain), running at every test-class boundary.

## Evidence
- Red-first: `testResetForTesting_clearsLeakedActiveSessionFromSharedAudiobookPresenter` pollutes the shared static presenter active via the real publisher path → `_resetForTesting()` → asserts fresh+inactive. RED without the fix, GREEN with it (tests the mechanism, not a model).
- `AppContainerResetTests` 5/5 (red-first + 4 existing reset tests unregressed; released-presenter deinit confirmed side-effect-free).
- Wall gates (blast-radius / superpartner / adjacency / test-name-vs-body) exit 0.


🤖 Generated with [Claude Code](https://claude.com/claude-code)