### PR TITLE
chore(release): bump to 3.2.0 (477)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -8705,7 +8705,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 476;
+				CURRENT_PROJECT_VERSION = 477;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8728,7 +8728,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -8763,7 +8763,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 476;
+				CURRENT_PROJECT_VERSION = 477;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8786,7 +8786,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -8951,7 +8951,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 476;
+				CURRENT_PROJECT_VERSION = 477;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -8977,7 +8977,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -9011,7 +9011,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 476;
+				CURRENT_PROJECT_VERSION = 477;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -9038,7 +9038,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "App Store";


### PR DESCRIPTION
## Summary

Version bump for the 3.2.0 release:

- `MARKETING_VERSION` 3.1.0 → **3.2.0**
- `CURRENT_PROJECT_VERSION` 476 → **477**

Applied to the 4 Palace shipping build configs — **Palace** and **Palace-noDRM**, **Debug** and **Release**. The `PalaceUIKit` framework target keeps its independent `1.0` / `1` versioning (intentionally untouched).

## Scope

`Palace.xcodeproj/project.pbxproj` only — 8 lines (4 + 4). No submodule project files changed; no source changes.

## Verification

Post-edit grep on the pushed branch:

```
$ grep -c 'MARKETING_VERSION = 3.2.0;'      → 4
$ grep -c 'CURRENT_PROJECT_VERSION = 477;'  → 4
$ grep -c 'MARKETING_VERSION = 1.0;'        → 2   (PalaceUIKit, unchanged)
$ grep -c 'CURRENT_PROJECT_VERSION = 1;'    → 2   (PalaceUIKit, unchanged)
$ grep -c 'MARKETING_VERSION = 3.1.0;'      → 0
$ grep -c 'CURRENT_PROJECT_VERSION = 476;'  → 0
```

- `plutil -lint Palace.xcodeproj/project.pbxproj` → OK
- `xcodebuild -list -project Palace.xcodeproj` → parses, targets resolve
- A version-string-only change cannot affect compilation; CI on this PR is the authoritative clean-runner build verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)