### PR TITLE
feat(regression): RC-TRIAGE+REPORT — Fable triage + campaign HTML report (stages 4–5)

### DIFF
--- a/.forgeos/intent/regression-rebuild-triage-report.md
+++ b/.forgeos/intent/regression-rebuild-triage-report.md
@@ -1,0 +1,71 @@
+# Intent: RC-TRIAGE+REPORT (regression-rebuild campaign, stages 4–5)
+
+**Branch:** `feat/regression-rebuild-triage-report` (off `develop`)
+**Owner:** w-triage · **Coordinator:** palace-pm
+**Design refs:** `palace-pm/docs/REGRESSION-REBUILD-DESIGN.md §4.3 stages 4–5`,
+`REGRESSION-BUILD-PLAN.md` (shared contracts).
+
+## Claims (what this change adds)
+1. Adds `scripts/regression-triage.py` — a deterministic triage harness that
+   reads a campaign `findings.csv` (shared contract schema) and writes back the
+   four triage fields `severity`, `classification`, `dedup_cluster`,
+   `disposition`. Rule-based pre-classifier attributes each finding to the
+   test-isolation pollution taxonomy + finding-type enum; computes dedup
+   clusters by root-cause signature; assigns severity; assigns disposition via
+   the `-test-iterations 3` green@3/red@3 + verified discriminator.
+2. Adds `scripts/regression-triage.py` Fable-bridge: emits a per-finding
+   Fable-input JSON bundle (`--emit-fable-input`) and ingests a Fable-output
+   JSON (`--apply-fable`) so a `model: fable` subagent refines the deterministic
+   baseline. The harness degrades to the deterministic classification if no
+   Fable output is supplied.
+3. Adds `scripts/regression-fable-triage-agent.md` — the `model: fable`
+   subagent spec (the Fable-triage stage) with the exact input/output JSON
+   contract the harness produces/consumes. (`.claude/` is gitignored in
+   ios-core, so the canonical spec lives in `scripts/` and is symlinked into
+   `.claude/agents/` locally for spawnability.)
+4. Adds `scripts/generate-regression-campaign-report.py` — consumes the
+   post-triage contract-schema `findings.csv` → self-contained HTML report with
+   a device/OS coverage matrix, dedup-cluster grouping, taxonomy + severity
+   breakdown, a visual-diff gallery (`screenshot_pair`), and evidence links.
+5. Adds `scripts/tests/test_regression_triage.py` and
+   `scripts/tests/test_regression_campaign_report.py` (pytest) + a sample
+   `scripts/tests/fixtures/regression-findings-sample.csv`.
+
+## Anti-claims (explicitly NOT in scope here)
+- Does NOT define or own the `findings.csv` schema or the shared
+  `scripts/regression_findings.py` I/O module — that is w-stabilize's
+  (RC-AREA). This change reads/writes findings exclusively via that module
+  (`read_findings`/`write_findings`/`FINDINGS_COLUMNS`/`FINDING_CLASSIFICATIONS`)
+  now that #1076 has landed it on develop; no parallel CSV reader/writer is
+  hand-rolled here (BUILD-PLAN contract). (Pre-rebase the branch carried a
+  schema-identical fallback so it could build before the module landed; the
+  rebase onto develop dropped it.)
+- Does NOT modify the existing `scripts/generate-regression-report.py`
+  (old-schema `/regression` report) — the campaign report is a new file.
+- Does NOT call the ForgeOS MCP directly. The changeset hook (harness, local-only
+  per IP boundary) emits a deterministic changeset *plan*; the coordinator
+  executes `forge_propose_changeset`.
+- No Palace/ production code changes. No new public Swift API surface.
+
+## Files-in-scope (ios-core)
+- `scripts/regression-triage.py` (new)
+- `scripts/generate-regression-campaign-report.py` (new)
+- `scripts/regression-fable-triage-agent.md` (new; symlinked into `.claude/agents/` locally)
+- `scripts/tests/test_regression_triage.py` (new)
+- `scripts/tests/test_regression_campaign_report.py` (new)
+- `scripts/tests/fixtures/regression-findings-sample.csv` (new)
+- `.forgeos/intent/regression-rebuild-triage-report.md` (this file)
+
+## Out-of-tree (harness, local-only — Synctek orchestration IP)
+- `~/harness/stacks/ios/regression-campaign/changeset-hook.py` — the ForgeOS
+  changeset-per-real-regression hook (emits the changeset plan).
+
+## Verification plan
+- pytest the triage harness on the sample csv: classification + severity +
+  dedup_cluster + disposition all populated; pollution classes get
+  `ticket-as-flake`/`drop`, real verified regressions get `file-jira`.
+- pytest the report generator: HTML written, contains the coverage matrix +
+  every cluster + severity/taxonomy counts.
+- `bash -n` clean (no shell here; python `-m py_compile`).
+- Open a ForgeOS changeset; SoD `/forge-review` on a different model; coordinator
+  clean-worktree re-verify before merge.

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ scripts/__pycache__/
 # palace-mutate report artifact (regenerated on every run)
 palace-mutate-report.json
 scripts/tests/__pycache__/
+
+# Regression-rebuild campaign run artifacts (generated, never committed)
+.regression-runs/

--- a/scripts/generate-regression-campaign-report.py
+++ b/scripts/generate-regression-campaign-report.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Regression-rebuild campaign — Stage 5 report generator.
+
+Consumes the **post-triage** master ``findings.csv`` (the shared contract
+schema; see ``scripts/regression_findings.py``) and renders a self-contained
+HTML report. Distinct from ``scripts/generate-regression-report.py`` (the legacy
+``/regression`` report on the old Title/Behavior schema) — this one is built for
+the fleet campaign's leaner schema and adds:
+
+  * a **device/OS coverage matrix** (cells × taxonomy),
+  * **dedup-cluster grouping** (one canonical block per root cause, with the
+    cells it reproduces in),
+  * **taxonomy + severity + disposition** breakdowns,
+  * a **visual-diff gallery** (``screenshot_pair`` = ``baseline|candidate``),
+  * **evidence links** (``evidence_paths`` = ``;``-joined).
+
+Schema (one row per raw finding)::
+
+    id,area,device_cell,severity,classification,verified,evidence_paths,
+    screenshot_pair,first_seen_commit,dedup_cluster,disposition
+
+Usage::
+
+    python3 scripts/generate-regression-campaign-report.py \
+        --csv .regression-runs/<run-id>/findings.csv \
+        --output .regression-runs/<run-id>/report.html \
+        [--run-id <run-id>] [--assets-root .regression-runs/<run-id>]
+
+Pure stdlib — no third-party dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Shared findings module (single source of truth for the schema + CSV I/O).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import regression_findings as rf  # noqa: E402
+
+FINDINGS_COLUMNS = list(rf.FINDINGS_COLUMNS)
+
+SEVERITY_COLORS = {
+    "blocker": "#dc2626", "major": "#ea580c", "minor": "#ca8a04",
+    "cosmetic": "#6b7280", "": "#9ca3af",
+}
+SEVERITY_ORDER = {"blocker": 0, "major": 1, "minor": 2, "cosmetic": 3, "": 4}
+
+CLASSIFICATION_COLORS = {
+    "crash": "#dc2626", "device-divergence": "#b91c1c", "visual-parity": "#7c3aed",
+    "perf": "#0891b2", "defer-flag": "#ca8a04", "keychain-auth-state": "#ca8a04",
+    "alert-presentation": "#ca8a04", "build-staleness": "#ca8a04",
+    "other": "#6b7280", "unknown": "#9ca3af",
+}
+POLLUTION_CLASSES = {
+    "defer-flag", "keychain-auth-state", "alert-presentation", "build-staleness",
+}
+DISPOSITION_LABELS = {
+    "file-jira": "File Jira", "ticket-as-flake": "Flake ticket",
+    "needs-verify": "Needs re-verify", "drop": "Dropped",
+}
+DISPOSITION_COLORS = {
+    "file-jira": "#dc2626", "ticket-as-flake": "#ca8a04",
+    "needs-verify": "#0891b2", "drop": "#6b7280", "": "#9ca3af",
+}
+
+
+def load_findings(csv_path: Path) -> List[Dict[str, str]]:
+    """Read the post-triage master via the shared module (single source of
+    truth), normalising so every contract column exists for rendering."""
+    rows = list(rf.read_findings(str(csv_path)))
+    for r in rows:
+        for c in FINDINGS_COLUMNS:
+            r.setdefault(c, "")
+    return rows
+
+
+def _g(row: Dict[str, str], key: str) -> str:
+    return (row.get(key) or "").strip()
+
+
+def _esc(s: str) -> str:
+    return html.escape(s or "")
+
+
+def _is_true(v: str) -> bool:
+    return (v or "").strip().lower() in {"true", "yes", "1"}
+
+
+def _chip(text: str, color: str) -> str:
+    return (f'<span class="chip" style="background:{color}">'
+            f'{_esc(text)}</span>')
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+def cluster_groups(rows: List[Dict[str, str]]) -> Dict[str, List[Dict[str, str]]]:
+    groups: Dict[str, List[Dict[str, str]]] = defaultdict(list)
+    for r in rows:
+        groups[_g(r, "dedup_cluster") or "(unclustered)"].append(r)
+    return dict(groups)
+
+
+def _counts(rows: List[Dict[str, str]], key: str) -> Dict[str, int]:
+    out: Dict[str, int] = defaultdict(int)
+    for r in rows:
+        out[_g(r, key) or "(none)"] += 1
+    return dict(out)
+
+
+def coverage_matrix(rows):
+    """cells × classification grid of counts, plus row/col order."""
+    cells = sorted({_g(r, "device_cell") or "(none)" for r in rows})
+    classes = sorted({_g(r, "classification") or "(none)" for r in rows})
+    grid: Dict[str, Dict[str, int]] = {c: defaultdict(int) for c in cells}
+    for r in rows:
+        grid[_g(r, "device_cell") or "(none)"][
+            _g(r, "classification") or "(none)"] += 1
+    return cells, classes, grid
+
+
+def cluster_sort_key(rows: List[Dict[str, str]]):
+    """Order clusters by worst severity then size (worst first)."""
+    sev = min((SEVERITY_ORDER.get(_g(r, "severity"), 4) for r in rows),
+              default=4)
+    return (sev, -len(rows))
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+CSS = """
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  margin: 0; background: #f8fafc; color: #1e293b; }
+header { background: #0f172a; color: #fff; padding: 24px 32px; }
+header h1 { margin: 0 0 4px; font-size: 22px; }
+header .meta { color: #94a3b8; font-size: 13px; }
+main { max-width: 1100px; margin: 0 auto; padding: 24px 32px 64px; }
+section { background: #fff; border: 1px solid #e2e8f0; border-radius: 10px;
+  padding: 20px 24px; margin-bottom: 20px; }
+section h2 { margin: 0 0 14px; font-size: 17px; }
+.chip { display: inline-block; color: #fff; border-radius: 999px;
+  padding: 2px 10px; font-size: 11px; font-weight: 600; margin-right: 4px; }
+.cards { display: flex; gap: 12px; flex-wrap: wrap; }
+.card { flex: 1 1 120px; background: #f1f5f9; border-radius: 8px; padding: 14px; }
+.card .n { font-size: 26px; font-weight: 700; }
+.card .l { font-size: 12px; color: #64748b; text-transform: uppercase;
+  letter-spacing: .04em; }
+table { border-collapse: collapse; width: 100%; font-size: 13px; }
+th, td { border: 1px solid #e2e8f0; padding: 6px 10px; text-align: left; }
+th { background: #f1f5f9; }
+td.num { text-align: center; font-variant-numeric: tabular-nums; }
+td.zero { color: #cbd5e1; }
+.cluster { border: 1px solid #e2e8f0; border-radius: 8px; margin-bottom: 14px; }
+.cluster > summary { cursor: pointer; padding: 12px 16px; font-weight: 600;
+  list-style: none; display: flex; align-items: center; gap: 8px; }
+.cluster > summary::-webkit-details-marker { display: none; }
+.cluster .body { padding: 0 16px 14px; }
+.finding { border-top: 1px solid #f1f5f9; padding: 10px 0; font-size: 13px; }
+.finding .id { font-weight: 700; }
+.muted { color: #64748b; }
+.evi a { color: #2563eb; text-decoration: none; margin-right: 8px;
+  font-size: 12px; }
+.gallery { display: flex; gap: 16px; flex-wrap: wrap; }
+.pair { border: 1px solid #e2e8f0; border-radius: 8px; padding: 10px;
+  width: 320px; }
+.pair img { width: 100%; border: 1px solid #e2e8f0; border-radius: 4px;
+  display: block; margin-top: 4px; }
+.pair .cap { font-size: 11px; color: #64748b; }
+.empty { color: #94a3b8; font-style: italic; }
+"""
+
+
+def _evidence_links(row: Dict[str, str], assets_root: Optional[str]) -> str:
+    raw = _g(row, "evidence_paths")
+    if not raw:
+        return '<span class="muted">no evidence</span>'
+    parts = [p.strip() for p in raw.split(";") if p.strip()]
+    out = []
+    for p in parts:
+        href = f"{assets_root.rstrip('/')}/{p}" if assets_root else p
+        out.append(f'<a href="{_esc(href)}">{_esc(p)}</a>')
+    return '<span class="evi">' + "".join(out) + "</span>"
+
+
+def _render_finding(row: Dict[str, str], assets_root: Optional[str]) -> str:
+    sev = _g(row, "severity")
+    disp = _g(row, "disposition")
+    verified = "✓ verified" if _is_true(_g(row, "verified")) else "unverified"
+    return (
+        f'<div class="finding">'
+        f'<span class="id">{_esc(_g(row, "id") or "?")}</span> '
+        f'{_chip(sev or "—", SEVERITY_COLORS.get(sev, "#9ca3af"))}'
+        f'{_chip(DISPOSITION_LABELS.get(disp, disp or "—"), DISPOSITION_COLORS.get(disp, "#9ca3af"))}'
+        f'<span class="muted"> · {_esc(_g(row, "area") or "—")} · '
+        f'{_esc(_g(row, "device_cell") or "—")} · {verified}'
+        f'{(" · " + _esc(_g(row, "first_seen_commit"))) if _g(row, "first_seen_commit") else ""}'
+        f'</span><br>'
+        f'{_evidence_links(row, assets_root)}'
+        f'</div>'
+    )
+
+
+def _render_cluster(cid, rows, assets_root):
+    worst = min((SEVERITY_ORDER.get(_g(r, "severity"), 4) for r in rows),
+                default=4)
+    worst_name = next((k for k, v in SEVERITY_ORDER.items() if v == worst), "")
+    classes = sorted({_g(r, "classification") for r in rows if _g(r, "classification")})
+    cells = sorted({_g(r, "device_cell") for r in rows if _g(r, "device_cell")})
+    cls_chips = "".join(
+        _chip(c, CLASSIFICATION_COLORS.get(c, "#6b7280")) for c in classes)
+    findings = "".join(_render_finding(r, assets_root) for r in rows)
+    return (
+        f'<details class="cluster"{" open" if worst <= 1 else ""}>'
+        f'<summary>'
+        f'{_chip(worst_name or "—", SEVERITY_COLORS.get(worst_name, "#9ca3af"))}'
+        f'<span>{_esc(cid)}</span>'
+        f'<span class="muted">· {len(rows)} finding(s) · cells: '
+        f'{_esc(", ".join(cells) or "—")}</span>'
+        f'<span style="margin-left:auto">{cls_chips}</span>'
+        f'</summary>'
+        f'<div class="body">{findings}</div>'
+        f'</details>'
+    )
+
+
+def _render_gallery(rows, assets_root):
+    pairs = []
+    for r in rows:
+        sp = _g(r, "screenshot_pair")
+        if not sp or "|" not in sp:
+            continue
+        base, cand = (sp.split("|", 1) + [""])[:2]
+        def src(p):
+            p = p.strip()
+            if not p:
+                return ""
+            return f"{assets_root.rstrip('/')}/{p}" if assets_root else p
+        pairs.append(
+            f'<div class="pair"><div class="cap">{_esc(_g(r,"id"))} · '
+            f'{_esc(_g(r,"area"))} · {_esc(_g(r,"device_cell"))}</div>'
+            f'<div class="cap">baseline</div>'
+            f'<img src="{_esc(src(base))}" alt="baseline">'
+            f'<div class="cap">candidate</div>'
+            f'<img src="{_esc(src(cand))}" alt="candidate"></div>'
+        )
+    if not pairs:
+        return '<p class="empty">No screenshot pairs in this run.</p>'
+    return '<div class="gallery">' + "".join(pairs) + "</div>"
+
+
+def render(rows, run_id, assets_root):
+    total = len(rows)
+    by_sev = _counts(rows, "severity")
+    by_cls = _counts(rows, "classification")
+    by_disp = _counts(rows, "disposition")
+    groups = cluster_groups(rows)
+    file_jira = by_disp.get("file-jira", 0)
+    blockers = by_sev.get("blocker", 0)
+    pollution = sum(1 for r in rows if _g(r, "classification") in POLLUTION_CLASSES)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    cards = "".join(
+        f'<div class="card"><div class="n">{n}</div><div class="l">{lbl}</div></div>'
+        for n, lbl in [
+            (total, "findings"), (len(groups), "clusters"),
+            (blockers, "blockers"), (file_jira, "to file"),
+            (pollution, "pollution"),
+        ]
+    )
+
+    # Coverage matrix
+    cells, classes, grid = coverage_matrix(rows)
+    head = "".join(f"<th>{_esc(c)}</th>" for c in classes)
+    matrix_rows = ""
+    for cell in cells:
+        tds = ""
+        for c in classes:
+            n = grid[cell].get(c, 0)
+            cls = "num zero" if n == 0 else "num"
+            tds += f'<td class="{cls}">{n or ""}</td>'
+        matrix_rows += f"<tr><th>{_esc(cell)}</th>{tds}</tr>"
+    matrix = (f'<table><tr><th>cell \\ class</th>{head}</tr>{matrix_rows}</table>'
+              if rows else '<p class="empty">No findings.</p>')
+
+    def breakdown(counts, colors):
+        if not counts:
+            return '<p class="empty">none</p>'
+        return " ".join(
+            _chip(f"{k}: {v}", colors.get(k, "#6b7280"))
+            for k, v in sorted(counts.items(), key=lambda kv: -kv[1]))
+
+    ordered = sorted(groups.items(),
+                     key=lambda kv: cluster_sort_key(kv[1]))
+    clusters_html = "".join(
+        _render_cluster(cid, rs, assets_root) for cid, rs in ordered) \
+        or '<p class="empty">No clusters.</p>'
+
+    return f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Regression Campaign Report{(' — ' + _esc(run_id)) if run_id else ''}</title>
+<style>{CSS}</style></head><body>
+<header>
+  <h1>Regression Campaign Report</h1>
+  <div class="meta">{('run: ' + _esc(run_id) + ' · ') if run_id else ''}\
+generated {now} · {total} findings · {len(groups)} dedup clusters</div>
+</header>
+<main>
+  <section><h2>Summary</h2><div class="cards">{cards}</div></section>
+  <section><h2>Device / OS coverage matrix</h2>{matrix}</section>
+  <section><h2>Breakdowns</h2>
+    <p><strong>Severity:</strong> {breakdown(by_sev, SEVERITY_COLORS)}</p>
+    <p><strong>Classification:</strong> {breakdown(by_cls, CLASSIFICATION_COLORS)}</p>
+    <p><strong>Disposition:</strong> {breakdown(by_disp, DISPOSITION_COLORS)}</p>
+  </section>
+  <section><h2>Findings by dedup cluster</h2>{clusters_html}</section>
+  <section><h2>Visual-diff gallery</h2>{_render_gallery(rows, assets_root)}</section>
+</main></body></html>"""
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Campaign findings.csv -> HTML.")
+    ap.add_argument("--csv", required=True, type=Path)
+    ap.add_argument("--output", required=True, type=Path)
+    ap.add_argument("--run-id", default=None)
+    ap.add_argument("--assets-root", default=None,
+                    help="path prefix for evidence/screenshot links "
+                         "(relative to the report's location)")
+    args = ap.parse_args(argv)
+
+    if not args.csv.exists():
+        print(f"Error: findings CSV not found: {args.csv}", file=sys.stderr)
+        return 2
+
+    rows = load_findings(args.csv)
+    html_doc = render(rows, args.run_id, args.assets_root)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(html_doc, encoding="utf-8")
+    print(f"Wrote report: {args.output} "
+          f"({len(rows)} findings, {len(cluster_groups(rows))} clusters, "
+          f"{len(html_doc)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regression-fable-triage-agent.md
+++ b/scripts/regression-fable-triage-agent.md
@@ -1,0 +1,130 @@
+---
+name: regression-fable-triage
+description: >
+  Stage-4 Fable-triage agent for the regression-rebuild campaign. Consumes the
+  per-finding input bundle emitted by `scripts/regression-triage.py
+  --emit-fable-input` (the deterministic baseline + every finding's evidence
+  paths), READS the cited evidence (simdrive logs, crash files, screenshot
+  pairs, diff images), and refines each finding's `classification`, `severity`,
+  `dedup_cluster`, and `disposition`. Spawned with model:fable as the designated
+  triage/classify tier. Advisory only — the coordinator + SoD reviewers ratify,
+  the Chairman authorizes Jira/merge; this agent NEVER files a ticket or opens a
+  PR itself.
+model: fable
+tools: Read, Bash, Grep, Glob
+---
+
+You are the **Fable-triage stage** of the Palace iOS regression-rebuild campaign
+(DESIGN §4.3 stage 4). A deterministic pre-classifier
+(`scripts/regression-triage.py`) has already attributed every raw finding to the
+contract taxonomy from shallow string signals. **Your job is to read the actual
+evidence and correct it where the shallow signal was wrong, then dedup across
+device cells and areas.** You are the ceiling; the deterministic layer is the
+floor.
+
+## Inputs
+
+You are given a JSON bundle (the output of `regression-triage.py
+--emit-fable-input`). Its shape:
+
+```json
+{
+  "schema": ["id","area","device_cell","severity","classification","verified",
+             "evidence_paths","screenshot_pair","first_seen_commit",
+             "dedup_cluster","disposition"],
+  "taxonomy": ["alert-presentation","build-staleness","crash","defer-flag",
+               "device-divergence","keychain-auth-state","other","perf",
+               "unknown","visual-parity"],
+  "severities": ["blocker","major","minor","cosmetic"],
+  "dispositions": ["drop","file-jira","needs-verify","ticket-as-flake"],
+  "findings": [
+    {
+      "id": "F-001",
+      "area": "...", "device_cell": "...",
+      "evidence_paths": "logs/a.log;crashes/b.ips",
+      "screenshot_pair": "baseline.png|candidate.png",
+      "verified": "false",
+      "deterministic_baseline": {
+        "classification": "...", "severity": "...",
+        "dedup_cluster": "C-003", "disposition": "..."
+      }
+    }
+  ]
+}
+```
+
+`evidence_paths` is `;`-joined; `screenshot_pair` is `baseline|candidate`. The
+paths are relative to the campaign run dir (`.regression-runs/<run-id>/`).
+
+## What to do per finding
+
+1. **Open the evidence.** `Read` / `Grep` the cited logs and crash files; if a
+   `screenshot_pair` or a `diffs/...png` is cited, `Read` the image. **A finding
+   with no readable evidence is `drop`** — never invent a classification for an
+   unsupported observation (anti-hallucination rule, BUILD-PLAN contract).
+2. **Correct the classification** against the taxonomy using what the evidence
+   actually shows, not the filename:
+   - `crash` — a real process crash; tag `device-divergence` instead if the
+     crash reproduces in only ONE device cell (e.g. Adobe `recursive_mutex` only
+     when `isiOSAppOnMac == true` at exit) or the stack is a C++ static
+     destructor / `_exit(0)` path.
+   - The four **pollution classes** are test-isolation artifacts, not user-facing
+     bugs: `defer-flag` (an uncancelled `loadCatalogs` crawl / pool starvation /
+     idle-signout), `keychain-auth-state` (sim credential bleed / stale
+     `.credentialsStale` / `errSecMissingEntitlement`), `alert-presentation`
+     (leaked `UIAlertController` / "cannot present after 3 retries"),
+     `build-staleness` (a red that clears on clean DerivedData /
+     `resolveCallCount==0` / link failure).
+   - `visual-parity` — a pixel/structural diff (e.g. PP-4553 empty-skeleton lane
+     that is correctly labelled but renders wrong).
+   - `perf`, `other` (real but uncategorised), `unknown` (no evidence).
+3. **Severity** (`blocker`/`major`/`minor`/`cosmetic`) by user-facing impact: a
+   crash or device-divergence is a `blocker`; a critical-path (auth / borrow /
+   return / download / DRM / audiobook) regression is `blocker`/`major`; a
+   pollution class is `minor` unless it survives the CI `-test-iterations 3` bar
+   (red@3 reddens the board for everyone → `major`).
+4. **Dedup.** Findings that share ONE root cause across cells/areas collapse into
+   ONE `dedup_cluster`. The same Adobe crash on every `ipad-on-mac` run is one
+   cluster; the same empty-skeleton across N lanes is one cluster. Keep the
+   deterministic `C-NNN` id when the baseline already grouped them correctly;
+   merge two baseline clusters by giving the merged findings a single shared id.
+5. **Disposition**: `file-jira` (a real, verified regression — product class) /
+   `ticket-as-flake` (a CI-tolerated pollution flake, green@3) / `drop` (no
+   evidence) / `needs-verify` (a product finding the coordinator has not yet
+   hermetically re-verified — `verified=false`). Pollution classes that are
+   red@3 → `file-jira`; green@3 → `ticket-as-flake`.
+
+## The `-test-iterations 3` discriminator
+
+Look in the cited logs for the CI-parity verdict. **green@3** (passes within 3
+retries) = a CI-tolerated flake → ticket, don't block. **red@3** (fails all 3) =
+a real blocker. A log that printed `Restarting after … test timeout` is **FAILED
+regardless of the final assertion tally** — treat it as red@3.
+
+## Output (exactly this shape — the harness ingests it via `--apply-fable`)
+
+```json
+{
+  "findings": [
+    {
+      "id": "F-001",
+      "classification": "device-divergence",
+      "severity": "blocker",
+      "dedup_cluster": "C-002",
+      "disposition": "file-jira",
+      "rationale": "crashes/b.ips shows recursive_mutex in a C++ static dtor; only the ipad-on-mac cell. Merged with F-007 (same stack)."
+    }
+  ]
+}
+```
+
+Rules for the output:
+- Emit a finding object ONLY for findings you are CHANGING (the harness keeps the
+  deterministic baseline for any id you omit). Always include `id`.
+- Every field you emit must be in the provided enum; an out-of-enum value is
+  rejected by the harness and logged.
+- `rationale` is one line citing the specific evidence file + what in it drove
+  the call. A finding you cannot ground in a readable artifact → set
+  `disposition: drop`, do not guess a class.
+- Return ONLY the JSON object as your final message — it is consumed
+  programmatically, not read by a human.

--- a/scripts/regression-triage.py
+++ b/scripts/regression-triage.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Regression-rebuild campaign — Stage 4 (Fable-triage) harness.
+
+Reads a campaign ``findings.csv`` (the shared contract schema, owned by
+``scripts/regression_findings.py`` / RC-AREA) and writes back the four triage
+fields the contract reserves for this stage:
+
+    severity, classification, dedup_cluster, disposition
+
+It does this in two layers:
+
+1. A **deterministic pre-classifier** (this file) attributes every finding to the
+   test-isolation pollution taxonomy + finding-type enum, computes dedup
+   clusters by root-cause signature, assigns a severity, and assigns a
+   disposition via the ``-test-iterations 3`` green@3/red@3 + ``verified``
+   discriminator. This is the floor: it runs with zero model calls and is what
+   the pytest suite pins.
+2. A **Fable refinement bridge**. ``--emit-fable-input`` writes a per-finding
+   JSON bundle for a ``model: fable`` subagent (see
+   ``scripts/regression-fable-triage-agent.md``, symlinked into
+   ``.claude/agents/`` locally); ``--apply-fable <json>``
+   ingests that subagent's output and overrides the deterministic baseline where
+   Fable provides a value. With no Fable output supplied, the deterministic
+   classification stands — the stage never *requires* a model to produce a valid
+   triaged CSV.
+
+Contract schema (one row per raw finding)::
+
+    id,area,device_cell,severity,classification,verified,evidence_paths,
+    screenshot_pair,first_seen_commit,dedup_cluster,disposition
+
+Enums (contract)::
+
+    classification ∈ {unknown, defer-flag, keychain-auth-state,
+                      alert-presentation, build-staleness, visual-parity,
+                      device-divergence, perf, crash, other}
+    severity       ∈ {blocker, major, minor, cosmetic}
+    disposition    ∈ {file-jira, ticket-as-flake, drop, needs-verify}
+
+Anti-hallucination rule (inherited from the chaos layer / BUILD-PLAN contract):
+a finding with **no evidence at all** (no evidence_paths, no screenshot_pair, no
+crash file) is dispositioned ``drop`` — visible-only observations do not count.
+
+Usage::
+
+    python3 scripts/regression-triage.py --csv .regression-runs/<run>/findings.csv
+    python3 scripts/regression-triage.py --csv f.csv --emit-fable-input fable_in.json
+    python3 scripts/regression-triage.py --csv f.csv --apply-fable fable_out.json
+    python3 scripts/regression-triage.py --csv f.csv --dry-run   # print, don't write
+
+Pure stdlib — plus ``scripts/regression_findings.py`` (RC-AREA's shared module,
+the single source of truth for findings.csv I/O; we never hand-roll a parallel
+CSV reader/writer).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+# The shared findings module owns the schema + CSV I/O (BUILD-PLAN contract).
+# It sits next to this script in scripts/; put that dir on the path so the
+# import resolves regardless of cwd / invocation (CLI, pytest, harness).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import regression_findings as rf  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Contract schema — sourced from the shared module, never re-declared here.
+# ---------------------------------------------------------------------------
+
+FIELDNAMES: List[str] = list(rf.FINDINGS_COLUMNS)
+CLASSIFICATIONS = set(rf.FINDING_CLASSIFICATIONS)
+
+# Pollution-taxonomy classes (test-isolation artifacts, not user-facing product
+# bugs). These attribute to a *test* leak, so they route to flake-tickets unless
+# they survive the CI iters-3 bar (red@3 = real board-reddener -> file-jira).
+POLLUTION_CLASSES = {
+    "defer-flag", "keychain-auth-state", "alert-presentation", "build-staleness",
+}
+
+# Real product-bug classes — a verified one files a Jira (a real regression).
+PRODUCT_CLASSES = {
+    "visual-parity", "device-divergence", "perf", "crash", "other",
+}
+
+SEVERITIES = {"blocker", "major", "minor", "cosmetic"}
+DISPOSITIONS = {"file-jira", "ticket-as-flake", "drop", "needs-verify"}
+
+# P0 critical-path area keywords (auth/borrow/return/download/DRM/audiobook).
+# A real regression here is a blocker by default.
+P0_AREA_RE = re.compile(
+    r"auth|sign[\-\s]?in|sign[\-\s]?out|saml|oidc|borrow|return|hold|download|"
+    r"drm|adobe|lcp|overdrive|findaway|fulfil|credential|reauth|audiobook",
+    re.I,
+)
+
+# ---------------------------------------------------------------------------
+# Signal extraction — scan every free-text field for taxonomy signatures.
+# ---------------------------------------------------------------------------
+
+_SPLIT_RE = re.compile(r"[;,\|\s]+")
+
+
+def _row_blob(row: Dict[str, str]) -> str:
+    """Concatenate every signal-bearing field into one lowercase blob."""
+    parts = [
+        row.get("area", ""), row.get("evidence_paths", ""),
+        row.get("screenshot_pair", ""), row.get("id", ""),
+    ]
+    return " ".join(p for p in parts if p).lower()
+
+
+def _has(blob: str, *needles: str) -> bool:
+    return any(n in blob for n in needles)
+
+
+def iters3_verdict(row: Dict[str, str]) -> Optional[str]:
+    """Return 'green' / 'red' if the evidence encodes the iters-3 CI verdict.
+
+    Convention: the area-worker stamps a token into evidence_paths, one of
+    ``green@3`` / ``red@3`` / ``iters3=green`` / ``iters3=red``. A run that
+    printed "Restarting after ... test timeout" is FAILED regardless of the final
+    tally, so ``timeout@3`` / ``restart@3`` also read as red.
+    """
+    blob = _row_blob(row)
+    if _has(blob, "red@3", "iters3=red", "timeout@3", "restart@3"):
+        return "red"
+    if _has(blob, "green@3", "iters3=green"):
+        return "green"
+    return None
+
+
+def has_evidence(row: Dict[str, str]) -> bool:
+    """Anti-hallucination floor: a real finding cites at least one artifact."""
+    return bool(
+        (row.get("evidence_paths") or "").strip()
+        or (row.get("screenshot_pair") or "").strip()
+    )
+
+
+def _cells_for_signature(rows: List[Dict[str, str]], sig: Tuple[str, str]) -> set:
+    return {
+        (r.get("device_cell") or "").strip()
+        for r in rows if _signature(r, r["classification"]) == sig
+    }
+
+
+# ---------------------------------------------------------------------------
+# Layer 1a: classification (taxonomy attribution)
+# ---------------------------------------------------------------------------
+
+def classify(row: Dict[str, str]) -> str:
+    """Attribute a raw finding to the contract taxonomy from its evidence.
+
+    Order matters: crash/device-divergence first (strongest, user-facing), then
+    the four pollution classes, then visual/perf, then a conservative fallback.
+    An already-set non-``unknown`` classification is respected (trust the worker
+    that emitted it) unless it is empty/unknown.
+    """
+    existing = (row.get("classification") or "").strip().lower()
+    if existing and existing != "unknown" and existing in CLASSIFICATIONS:
+        return existing
+
+    blob = _row_blob(row)
+
+    # Crash family. A crash that fires in only one device cell is a
+    # device-divergence (the cross-cell collapse decides single-cell-ness later;
+    # here we tag the divergence-flavoured crash families explicitly).
+    crashy = _has(
+        blob, ".crash", ".ips", "crashes/", "exc_bad", "sigabrt", "sigsegv",
+        "signal ", "fatal", "_dispatch_semaphore", "task continuation misuse",
+    )
+    divergence = _has(
+        blob, "recursive_mutex", "isiosapponmac", "ipad-on-mac", "ipad_on_mac",
+        "_exit(0)", "static destructor", "at exit", "at-exit",
+    )
+    if divergence:
+        return "device-divergence"
+    if crashy:
+        return "crash"
+
+    # Pollution taxonomy (test-isolation artifacts).
+    if _has(blob, "deferinitialloadcatalogs", "loadcatalogs", "pool starvation",
+            "pool-starvation", "pool saturation", "idle-signout", "idle signout",
+            "preloader timeout", "crawl"):
+        return "defer-flag"
+    if _has(blob, "keychain", "errsecmissingentitlement", "-34018",
+            "credentialsstale", "credentials stale", "credential bleed",
+            "auth-state-bleed", "auth state bleed"):
+        return "keychain-auth-state"
+    if _has(blob, "uialertcontroller", "cannot present", "present after",
+            "alert-presentation", "alert presentation", "leaked alert",
+            "modal stack"):
+        return "alert-presentation"
+    if _has(blob, "deriveddata", "derived-data", "derived_data", "stale build",
+            "staleness", "resolvecallcount", "no adapters registered",
+            "link failed", "relink"):
+        return "build-staleness"
+
+    # Visual parity (pixel diff / structural marks diff).
+    if _has(blob, "visual-parity", "visual parity", "pixel", "ssim",
+            "skeleton", "diffs/", "marks-diff", "screenshot", "snapshot"):
+        return "visual-parity"
+
+    # Perf.
+    if _has(blob, "perf", "latency", "regressed by", "slower", "frame drop",
+            "hang", "spinner"):
+        return "perf"
+
+    # We have evidence but no strong signal -> 'other' (a real, uncategorised
+    # finding). No evidence at all -> stays 'unknown' (will be dropped).
+    return "other" if has_evidence(row) else "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Layer 1b: severity
+# ---------------------------------------------------------------------------
+
+def assign_severity(row: Dict[str, str], classification: str) -> str:
+    """User-facing-impact severity. Pollution classes are graded by board impact
+    (red@3 => operationally major), product crashes are blockers."""
+    area_p0 = bool(P0_AREA_RE.search(row.get("area", "")))
+    verdict = iters3_verdict(row)
+
+    if classification in {"crash", "device-divergence"}:
+        return "blocker"
+
+    if classification in POLLUTION_CLASSES:
+        # A pollution class that survives the CI retry bar reddens the board for
+        # everyone -> operationally major; otherwise a tolerated flake -> minor.
+        return "major" if verdict == "red" else "minor"
+
+    if classification == "visual-parity":
+        # An empty-skeleton on a main catalog lane (PP-4553) is a major parity
+        # bug; off the critical path it's cosmetic.
+        return "major" if area_p0 or _has(_row_blob(row), "lane", "catalog",
+                                          "skeleton") else "cosmetic"
+
+    if classification == "perf":
+        return "major" if _has(_row_blob(row), "high", "blocker") else "minor"
+
+    if classification == "other":
+        return "major" if area_p0 else "minor"
+
+    return "minor"
+
+
+# ---------------------------------------------------------------------------
+# Layer 1c: dedup clustering — collapse same-root across cells/areas
+# ---------------------------------------------------------------------------
+
+# Strong root tokens collapse a family across device cells AND areas (e.g. the
+# Adobe recursive_mutex crash on every ipad-on-mac run is ONE cluster).
+_ROOT_TOKENS = [
+    "recursive_mutex", "_dispatch_semaphore", "task continuation misuse",
+    "exc_bad_access", "errsecmissingentitlement", "deferinitialloadcatalogs",
+    "uialertcontroller", "deriveddata", "isiosapponmac",
+]
+
+
+def _root_signal(row: Dict[str, str]) -> str:
+    """A stable root key. Prefer a strong crash/symptom token (cell-independent);
+    fall back to the normalised area so per-area visual findings still cluster."""
+    blob = _row_blob(row)
+    for tok in _ROOT_TOKENS:
+        if tok in blob:
+            return tok
+    area = (row.get("area") or "").strip().lower()
+    area = re.sub(r"[\s/]+", "-", area)
+    return area or "unkeyed"
+
+
+def _signature(row: Dict[str, str], classification: str) -> Tuple[str, str]:
+    return (classification, _root_signal(row))
+
+
+def assign_clusters(rows: List[Dict[str, str]]) -> Dict[Tuple[str, str], str]:
+    """Assign a stable ``C-NNN`` cluster id per unique (classification, root)
+    signature. Ids are deterministic (sorted by signature) regardless of row
+    order so re-running triage is idempotent."""
+    sigs = sorted({_signature(r, r["classification"]) for r in rows})
+    return {sig: f"C-{i + 1:03d}" for i, sig in enumerate(sigs)}
+
+
+# ---------------------------------------------------------------------------
+# Layer 1d: disposition
+# ---------------------------------------------------------------------------
+
+def assign_disposition(row: Dict[str, str], classification: str) -> str:
+    """Route the finding. Evidence-required; verified-required for filing."""
+    if not has_evidence(row) or classification == "unknown":
+        return "drop"  # anti-hallucination: no evidence => not a finding
+
+    verified = (row.get("verified") or "").strip().lower() in {"true", "yes", "1"}
+    verdict = iters3_verdict(row)
+
+    if classification in POLLUTION_CLASSES:
+        # red@3 = real board-reddener -> file it; green@3 (or unknown) = CI
+        # tolerated flake -> track as a flake ticket, don't block the release.
+        return "file-jira" if verdict == "red" else "ticket-as-flake"
+
+    # Product-bug classes: a coordinator hermetic re-verify must confirm it
+    # before it files. Unverified product findings wait at needs-verify.
+    if not verified:
+        return "needs-verify"
+    return "file-jira"
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def triage_findings(rows: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Fill severity/classification/dedup_cluster/disposition on every row.
+    Mutates and returns the rows (deterministic layer 1)."""
+    for row in rows:
+        row["classification"] = classify(row)
+    cluster_ids = assign_clusters(rows)
+    for row in rows:
+        cls = row["classification"]
+        row["severity"] = assign_severity(row, cls)
+        row["dedup_cluster"] = cluster_ids[_signature(row, cls)]
+        row["disposition"] = assign_disposition(row, cls)
+    return rows
+
+
+def build_fable_input(rows: List[Dict[str, str]]) -> Dict:
+    """Per-finding bundle for the model:fable subagent to refine. Includes the
+    deterministic baseline so Fable only overrides where it has higher-signal
+    judgement (reading the actual evidence files)."""
+    return {
+        "schema": FIELDNAMES,
+        "taxonomy": sorted(CLASSIFICATIONS),
+        "severities": sorted(SEVERITIES),
+        "dispositions": sorted(DISPOSITIONS),
+        "findings": [
+            {
+                "id": r.get("id", ""),
+                "area": r.get("area", ""),
+                "device_cell": r.get("device_cell", ""),
+                "evidence_paths": r.get("evidence_paths", ""),
+                "screenshot_pair": r.get("screenshot_pair", ""),
+                "verified": r.get("verified", ""),
+                "deterministic_baseline": {
+                    "classification": r.get("classification", ""),
+                    "severity": r.get("severity", ""),
+                    "dedup_cluster": r.get("dedup_cluster", ""),
+                    "disposition": r.get("disposition", ""),
+                },
+            }
+            for r in rows
+        ],
+    }
+
+
+def apply_fable_output(rows: List[Dict[str, str]], fable: Dict) -> List[str]:
+    """Override deterministic fields with Fable's per-id values. Returns the list
+    of finding ids Fable changed. Validates enum membership — an out-of-enum
+    Fable value is rejected (logged), never written."""
+    by_id = {r.get("id", ""): r for r in rows}
+    changed: List[str] = []
+    for item in fable.get("findings", []):
+        fid = item.get("id")
+        row = by_id.get(fid)
+        if row is None:
+            continue
+        touched = False
+        for field, allowed in (
+            ("classification", CLASSIFICATIONS),
+            ("severity", SEVERITIES),
+            ("disposition", DISPOSITIONS),
+        ):
+            val = item.get(field)
+            if val is None:
+                continue
+            val = str(val).strip().lower()
+            if val not in allowed:
+                print(f"  [fable] rejected {fid}.{field}={val!r} (not in enum)",
+                      file=sys.stderr)
+                continue
+            if row.get(field) != val:
+                row[field] = val
+                touched = True
+        # dedup_cluster: Fable may merge clusters; accept any non-empty string.
+        dc = item.get("dedup_cluster")
+        if dc and str(dc).strip() and row.get("dedup_cluster") != str(dc).strip():
+            row["dedup_cluster"] = str(dc).strip()
+            touched = True
+        if touched:
+            changed.append(fid)
+    return changed
+
+
+# ---------------------------------------------------------------------------
+# CSV I/O — delegated entirely to the shared regression_findings module.
+# ---------------------------------------------------------------------------
+
+def load_findings(csv_path: Path) -> List[Dict[str, str]]:
+    """Read the master findings.csv via the shared module (single source of
+    truth), normalising so every contract column exists for downstream code."""
+    rows = list(rf.read_findings(str(csv_path)))
+    for r in rows:
+        for col in FIELDNAMES:
+            r.setdefault(col, "")
+    return rows
+
+
+def write_findings(csv_path: Path, rows: List[Dict[str, str]]) -> None:
+    """Write back via the shared module (full rewrite w/ header; upsert-by-id
+    semantics live there per the pinned API)."""
+    rf.write_findings(str(csv_path), rows)
+
+
+def summarize(rows: List[Dict[str, str]]) -> str:
+    by_cls: Dict[str, int] = {}
+    by_disp: Dict[str, int] = {}
+    clusters = set()
+    for r in rows:
+        by_cls[r["classification"]] = by_cls.get(r["classification"], 0) + 1
+        by_disp[r["disposition"]] = by_disp.get(r["disposition"], 0) + 1
+        clusters.add(r["dedup_cluster"])
+    lines = [f"  {len(rows)} findings, {len(clusters)} dedup clusters"]
+    lines.append("  classification: " + ", ".join(
+        f"{k}={v}" for k, v in sorted(by_cls.items())))
+    lines.append("  disposition:    " + ", ".join(
+        f"{k}={v}" for k, v in sorted(by_disp.items())))
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Stage-4 Fable-triage harness.")
+    ap.add_argument("--csv", required=True, type=Path, help="findings.csv path")
+    ap.add_argument("--emit-fable-input", type=Path, metavar="JSON",
+                    help="write the model:fable input bundle and exit")
+    ap.add_argument("--apply-fable", type=Path, metavar="JSON",
+                    help="ingest a model:fable output bundle after triage")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the summary; do not write the CSV back")
+    args = ap.parse_args(argv)
+
+    if not args.csv.exists():
+        print(f"Error: findings CSV not found: {args.csv}", file=sys.stderr)
+        return 2
+
+    rows = load_findings(args.csv)
+    if not rows:
+        print("Error: 0 findings in CSV (a 0-row run is a misconfiguration, "
+              "not a clean pass).", file=sys.stderr)
+        return 3
+
+    triage_findings(rows)
+
+    if args.emit_fable_input:
+        args.emit_fable_input.write_text(
+            json.dumps(build_fable_input(rows), indent=2), encoding="utf-8")
+        print(f"Wrote Fable input bundle: {args.emit_fable_input} "
+              f"({len(rows)} findings)")
+        return 0
+
+    if args.apply_fable:
+        fable = json.loads(args.apply_fable.read_text(encoding="utf-8"))
+        changed = apply_fable_output(rows, fable)
+        print(f"Applied Fable overrides to {len(changed)} findings: "
+              f"{', '.join(changed) if changed else '(none)'}")
+
+    print("Triage complete:")
+    print(summarize(rows))
+
+    if args.dry_run:
+        print("(--dry-run: CSV not written)")
+        return 0
+
+    write_findings(args.csv, rows)
+    print(f"Wrote triaged CSV: {args.csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/fixtures/regression-findings-sample.csv
+++ b/scripts/tests/fixtures/regression-findings-sample.csv
@@ -1,0 +1,10 @@
+id,area,device_cell,severity,classification,verified,evidence_paths,screenshot_pair,first_seen_commit,dedup_cluster,disposition
+F-001,Audiobook playback (Adobe),C-ipad-on-mac,,unknown,true,crashes/f001_recursive_mutex.ips;logs/f001.log,,a1b2c3d,,
+F-002,Audiobook playback (Adobe),C-ipad-on-mac,,unknown,true,crashes/f002_recursive_mutex.ips,,a1b2c3d,,
+F-003,Catalog lane rendering,C-iphone-26,,unknown,true,diffs/f003_lane_skeleton.png;logs/f003.log,baselines/lane.png|candidates/lane.png,e4f5a6b,,
+F-004,Catalog lane rendering,C-ipad-26,,unknown,true,diffs/f004_lane_skeleton.png,baselines/lane2.png|candidates/lane2.png,e4f5a6b,,
+F-005,Sign-in OIDC,C-iphone-26,,unknown,false,logs/f005_keychain_errSecMissingEntitlement.log;red@3,,c7d8e9f,,
+F-006,Token refresh,C-iphone-26,,unknown,false,logs/f006_loadCatalogs_pool-starvation.log;green@3,,b1c2d3e,,
+F-007,Misc UI polish,C-iphone-26,,unknown,true,,,f9a8b7c,,
+F-008,Downloads queue,C-iphone-26,,unknown,false,logs/f008_download_stall.log,,d2e3f4a,,
+F-009,Reader EPUB perf,C-iphone-26,,unknown,true,logs/f009_latency_high.log,,a9b8c7d,,

--- a/scripts/tests/test_regression_campaign_report.py
+++ b/scripts/tests/test_regression_campaign_report.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Pytest for scripts/generate-regression-campaign-report.py (Stage-5 report)."""
+import copy
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+FIXTURE = SCRIPTS / "tests" / "fixtures" / "regression-findings-sample.csv"
+
+_tspec = importlib.util.spec_from_file_location(
+    "regression_triage", SCRIPTS / "regression-triage.py")
+triage = importlib.util.module_from_spec(_tspec)
+_tspec.loader.exec_module(triage)
+
+_rspec = importlib.util.spec_from_file_location(
+    "regression_campaign_report", SCRIPTS / "generate-regression-campaign-report.py")
+report = importlib.util.module_from_spec(_rspec)
+_rspec.loader.exec_module(report)
+
+
+@pytest.fixture
+def triaged():
+    return triage.triage_findings(triage.load_findings(FIXTURE))
+
+
+@pytest.fixture
+def html(triaged):
+    return report.render(triaged, run_id="run-test", assets_root=".")
+
+
+def test_report_is_html_document(html):
+    assert html.startswith("<!DOCTYPE html>")
+    assert "<title>" in html and "Regression Campaign Report" in html
+
+
+def test_report_has_coverage_matrix_cells(html):
+    # Every device cell present in the fixture appears as a matrix row header.
+    for cell in ("C-ipad-on-mac", "C-iphone-26", "C-ipad-26"):
+        assert cell in html
+
+
+def test_report_renders_every_cluster(triaged, html):
+    for cid in {r["dedup_cluster"] for r in triaged}:
+        assert cid in html
+
+
+def test_report_shows_taxonomy_classes(html):
+    assert "device-divergence" in html
+    assert "visual-parity" in html
+
+
+def test_report_gallery_includes_screenshot_pairs(html):
+    # F-003/F-004 carry baseline|candidate pairs -> <img> tags present.
+    assert "candidates/lane.png" in html
+    assert "baselines/lane.png" in html
+    assert "<img" in html
+
+
+def test_report_evidence_links_present(html):
+    assert "crashes/f001_recursive_mutex.ips" in html
+
+
+def test_report_counts_blockers_and_files(triaged, html):
+    blockers = sum(1 for r in triaged if r["severity"] == "blocker")
+    assert blockers >= 1
+    # the summary card count appears in the document
+    assert str(blockers) in html
+
+
+def test_clusters_ordered_worst_first(triaged):
+    groups = report.cluster_groups(triaged)
+    ordered = sorted(groups.items(), key=lambda kv: report.cluster_sort_key(kv[1]))
+    # the first cluster must contain a blocker (device-divergence)
+    first_rows = ordered[0][1]
+    assert any(r["severity"] == "blocker" for r in first_rows)
+
+
+def test_cli_writes_report_file(tmp_path):
+    src = tmp_path / "findings.csv"
+    src.write_text(FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    triage.main(["--csv", str(src)])  # triage first
+    out = tmp_path / "report.html"
+    rc = report.main(["--csv", str(src), "--output", str(out),
+                      "--run-id", "run-x", "--assets-root", "."])
+    assert rc == 0
+    assert out.exists()
+    body = out.read_text(encoding="utf-8")
+    assert len(body) > 2000
+    assert "run-x" in body
+
+
+def test_empty_findings_renders_without_crash(tmp_path):
+    src = tmp_path / "empty.csv"
+    src.write_text(",".join(report.FINDINGS_COLUMNS) + "\n", encoding="utf-8")
+    out = tmp_path / "r.html"
+    assert report.main(["--csv", str(src), "--output", str(out)]) == 0
+    assert "No findings" in out.read_text(encoding="utf-8")
+
+
+# --- cross-module schema contract (QA-required, #1077 SoD) ------------------
+
+def test_report_columns_match_shared_module_order():
+    assert report.FINDINGS_COLUMNS == list(report.rf.FINDINGS_COLUMNS)
+
+
+def test_report_hard_errors_without_shared_module(tmp_path):
+    # Copy ONLY the report script into an isolated dir (no regression_findings.py
+    # beside it), empty PYTHONPATH -> `import regression_findings` must hard-error,
+    # never silently fall back to a hand-rolled reader.
+    iso = tmp_path / "iso"
+    iso.mkdir()
+    shutil.copy(SCRIPTS / "generate-regression-campaign-report.py",
+                iso / "generate-regression-campaign-report.py")
+    csv = iso / "f.csv"
+    csv.write_text("id,area\nF-1,x\n", encoding="utf-8")
+    env = {**os.environ, "PYTHONPATH": ""}
+    r = subprocess.run(
+        [sys.executable, str(iso / "generate-regression-campaign-report.py"),
+         "--csv", str(csv), "--output", str(iso / "r.html")],
+        capture_output=True, text=True, env=env, cwd=str(iso))
+    assert r.returncode != 0
+    assert "ModuleNotFoundError" in r.stderr and "regression_findings" in r.stderr

--- a/scripts/tests/test_regression_triage.py
+++ b/scripts/tests/test_regression_triage.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Pytest for scripts/regression-triage.py (Stage-4 deterministic triage layer).
+
+Tests behaviour, not structure: every assertion fails if a real classification /
+severity / disposition / dedup decision regresses. These are the mutation
+targets — flip a conditional in the production code and one of these reds.
+"""
+import copy
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+FIXTURE = SCRIPTS / "tests" / "fixtures" / "regression-findings-sample.csv"
+
+# Load the hyphenated module by path.
+_spec = importlib.util.spec_from_file_location(
+    "regression_triage", SCRIPTS / "regression-triage.py")
+triage = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(triage)
+
+
+@pytest.fixture
+def rows():
+    return triage.load_findings(FIXTURE)
+
+
+@pytest.fixture
+def triaged(rows):
+    return triage.triage_findings(copy.deepcopy(rows))
+
+
+def _by_id(triaged):
+    return {r["id"]: r for r in triaged}
+
+
+# --- classification (taxonomy attribution) ---------------------------------
+
+def test_recursive_mutex_crash_is_device_divergence(triaged):
+    assert _by_id(triaged)["F-001"]["classification"] == "device-divergence"
+
+
+def test_lane_skeleton_diff_is_visual_parity(triaged):
+    assert _by_id(triaged)["F-003"]["classification"] == "visual-parity"
+
+
+def test_keychain_log_is_keychain_auth_state(triaged):
+    assert _by_id(triaged)["F-005"]["classification"] == "keychain-auth-state"
+
+
+def test_loadcatalogs_pool_starvation_is_defer_flag(triaged):
+    assert _by_id(triaged)["F-006"]["classification"] == "defer-flag"
+
+
+def test_evidenced_but_unsignalled_is_other(triaged):
+    # F-008 has a log but no taxonomy signal -> 'other' (a real, uncategorised
+    # finding), NOT 'unknown'.
+    assert _by_id(triaged)["F-008"]["classification"] == "other"
+
+
+def test_no_evidence_stays_unknown(triaged):
+    assert _by_id(triaged)["F-007"]["classification"] == "unknown"
+
+
+def test_perf_log_is_perf(triaged):
+    assert _by_id(triaged)["F-009"]["classification"] == "perf"
+
+
+def test_every_row_classified_in_enum(triaged):
+    for r in triaged:
+        assert r["classification"] in triage.CLASSIFICATIONS
+
+
+# --- severity ---------------------------------------------------------------
+
+def test_device_divergence_is_blocker(triaged):
+    assert _by_id(triaged)["F-001"]["severity"] == "blocker"
+
+
+def test_visual_parity_on_lane_is_major(triaged):
+    assert _by_id(triaged)["F-003"]["severity"] == "major"
+
+
+def test_pollution_red_at_3_escalates_to_major(triaged):
+    # keychain red@3 reddens the board -> major (not minor).
+    assert _by_id(triaged)["F-005"]["severity"] == "major"
+
+
+def test_pollution_green_at_3_stays_minor(triaged):
+    assert _by_id(triaged)["F-006"]["severity"] == "minor"
+
+
+# --- disposition ------------------------------------------------------------
+
+def test_verified_product_crash_files_jira(triaged):
+    assert _by_id(triaged)["F-001"]["disposition"] == "file-jira"
+
+
+def test_no_evidence_is_dropped(triaged):
+    assert _by_id(triaged)["F-007"]["disposition"] == "drop"
+
+
+def test_unverified_product_finding_needs_verify(triaged):
+    assert _by_id(triaged)["F-008"]["disposition"] == "needs-verify"
+
+
+def test_pollution_red_at_3_files_jira(triaged):
+    assert _by_id(triaged)["F-005"]["disposition"] == "file-jira"
+
+
+def test_pollution_green_at_3_is_flake_ticket(triaged):
+    assert _by_id(triaged)["F-006"]["disposition"] == "ticket-as-flake"
+
+
+def test_every_row_dispositioned_in_enum(triaged):
+    for r in triaged:
+        assert r["disposition"] in triage.DISPOSITIONS
+
+
+# --- the verified gate actually gates (mutation guard) ----------------------
+
+def test_flipping_verified_true_flips_needs_verify_to_file_jira(rows):
+    rows = copy.deepcopy(rows)
+    for r in rows:
+        if r["id"] == "F-008":
+            r["verified"] = "true"
+    out = _by_id(triage.triage_findings(rows))
+    assert out["F-008"]["disposition"] == "file-jira"
+
+
+def test_flipping_red3_to_green3_changes_pollution_disposition(rows):
+    rows = copy.deepcopy(rows)
+    for r in rows:
+        if r["id"] == "F-005":
+            r["evidence_paths"] = r["evidence_paths"].replace("red@3", "green@3")
+    out = _by_id(triage.triage_findings(rows))
+    assert out["F-005"]["disposition"] == "ticket-as-flake"
+    assert out["F-005"]["severity"] == "minor"
+
+
+# --- dedup clustering -------------------------------------------------------
+
+def test_same_crash_family_across_findings_one_cluster(triaged):
+    bid = _by_id(triaged)
+    assert bid["F-001"]["dedup_cluster"] == bid["F-002"]["dedup_cluster"]
+
+
+def test_same_visual_area_across_cells_one_cluster(triaged):
+    # F-003 (iphone) and F-004 (ipad) are the same lane-skeleton root.
+    bid = _by_id(triaged)
+    assert bid["F-003"]["dedup_cluster"] == bid["F-004"]["dedup_cluster"]
+
+
+def test_distinct_roots_get_distinct_clusters(triaged):
+    bid = _by_id(triaged)
+    assert bid["F-001"]["dedup_cluster"] != bid["F-003"]["dedup_cluster"]
+
+
+def test_clustering_is_idempotent(rows):
+    once = _by_id(triage.triage_findings(copy.deepcopy(rows)))
+    twice = _by_id(triage.triage_findings(copy.deepcopy(rows)))
+    for fid in once:
+        assert once[fid]["dedup_cluster"] == twice[fid]["dedup_cluster"]
+
+
+# --- Fable bridge -----------------------------------------------------------
+
+def test_emit_fable_input_carries_baseline_and_evidence(triaged):
+    bundle = triage.build_fable_input(triaged)
+    assert bundle["schema"] == triage.FIELDNAMES
+    f1 = next(f for f in bundle["findings"] if f["id"] == "F-001")
+    assert f1["deterministic_baseline"]["classification"] == "device-divergence"
+    assert "recursive_mutex" in f1["evidence_paths"]
+
+
+def test_apply_fable_overrides_in_enum_value(triaged):
+    fable = {"findings": [
+        {"id": "F-008", "classification": "crash", "severity": "blocker",
+         "disposition": "file-jira"}]}
+    changed = triage.apply_fable_output(triaged, fable)
+    assert "F-008" in changed
+    out = _by_id(triaged)["F-008"]
+    assert out["classification"] == "crash"
+    assert out["severity"] == "blocker"
+    assert out["disposition"] == "file-jira"
+
+
+def test_apply_fable_rejects_out_of_enum(triaged):
+    before = _by_id(triaged)["F-001"]["classification"]
+    fable = {"findings": [{"id": "F-001", "classification": "not-a-real-class"}]}
+    triage.apply_fable_output(triaged, fable)
+    assert _by_id(triaged)["F-001"]["classification"] == before  # unchanged
+
+
+def test_apply_fable_unknown_id_is_noop(triaged):
+    changed = triage.apply_fable_output(
+        triaged, {"findings": [{"id": "F-999", "severity": "blocker"}]})
+    assert changed == []
+
+
+# --- full CLI round-trip ----------------------------------------------------
+
+def test_cli_writes_triaged_csv(tmp_path):
+    src = tmp_path / "findings.csv"
+    src.write_text(FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    rc = triage.main(["--csv", str(src)])
+    assert rc == 0
+    out = triage.load_findings(src)
+    for r in out:
+        assert r["severity"] and r["classification"] and r["disposition"]
+        assert r["dedup_cluster"]
+
+
+def test_empty_csv_is_error(tmp_path):
+    src = tmp_path / "empty.csv"
+    src.write_text(",".join(triage.FIELDNAMES) + "\n", encoding="utf-8")
+    assert triage.main(["--csv", str(src)]) == 3
+
+
+# --- cross-module schema contract (QA-required, #1077 SoD) ------------------
+
+def test_fieldnames_match_shared_module_column_order():
+    # The campaign's linchpin: triage's column list must equal the shared
+    # module's, IN ORDER. A future schema reorder in regression_findings.py
+    # would silently misalign every triaged CSV without this list-equality pin.
+    assert triage.FIELDNAMES == list(triage.rf.FINDINGS_COLUMNS)
+    assert triage.CLASSIFICATIONS == set(triage.rf.FINDING_CLASSIFICATIONS)
+
+
+def test_triage_output_roundtrips_through_real_module(tmp_path):
+    # Triage writes via rf.write_findings; read it back via the REAL module
+    # directly (NOT triage.load_findings) and confirm keys + the 4 triage values
+    # survived the round-trip. Mirrors #1075/#1076's cross-module round-trip.
+    src = tmp_path / "findings.csv"
+    src.write_text(FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    assert triage.main(["--csv", str(src)]) == 0
+    rows = triage.rf.read_findings(str(src))           # real module, not my wrapper
+    by_id = {r["id"]: r for r in rows}
+    assert set(by_id["F-001"].keys()) >= set(triage.rf.FINDINGS_COLUMNS)
+    assert by_id["F-001"]["classification"] == "device-divergence"
+    assert by_id["F-001"]["severity"] == "blocker"
+    assert by_id["F-001"]["disposition"] == "file-jira"
+    assert by_id["F-001"]["dedup_cluster"]             # non-empty cluster id
+    # the on-disk header is exactly the contract column order
+    header = src.read_text(encoding="utf-8").splitlines()[0].split(",")
+    assert header == list(triage.rf.FINDINGS_COLUMNS)
+
+
+def _run_isolated_without_shared_module(script_name, tmp_path, extra_args=()):
+    """Copy ONLY the script into an isolated dir (no regression_findings.py
+    beside it) and run it with an empty PYTHONPATH, so `import regression_findings`
+    cannot resolve — proving there is no silent fallback."""
+    iso = tmp_path / "iso"
+    iso.mkdir()
+    shutil.copy(SCRIPTS / script_name, iso / script_name)
+    csv = iso / "f.csv"
+    csv.write_text("id,area\nF-1,x\n", encoding="utf-8")
+    env = {**os.environ, "PYTHONPATH": ""}
+    return subprocess.run(
+        [sys.executable, str(iso / script_name), "--csv", str(csv), *extra_args],
+        capture_output=True, text=True, env=env, cwd=str(iso))
+
+
+def test_triage_hard_errors_without_shared_module(tmp_path):
+    r = _run_isolated_without_shared_module("regression-triage.py", tmp_path)
+    assert r.returncode != 0
+    assert "ModuleNotFoundError" in r.stderr and "regression_findings" in r.stderr


### PR DESCRIPTION
## RC-TRIAGE+REPORT — regression-campaign stages 4–5

Part of the regression-rebuild campaign (Synctek-orchestrated; this PR is the **ios-core** product test-tooling half — orchestration lives local-only in `~/harness`).

### Stage 4 — Fable triage (`scripts/regression-triage.py`)
Reads the campaign `findings.csv` via the shared `regression_findings` module (`read_findings`/`write_findings`/`FINDINGS_COLUMNS`), writes back `severity`/`classification`/`dedup_cluster`/`disposition`. Deterministic pre-classifier attributes the pollution taxonomy (defer-flag / keychain-auth-state / alert-presentation / build-staleness) + finding-type, clusters by root-cause signature, dispositions via green@3/red@3 + verified. Anti-hallucination: no-evidence → drop. `model: fable` agent spec at `scripts/regression-fable-triage-agent.md` refines the deterministic baseline (degrades gracefully if no Fable output).

### Stage 5 — Campaign report (`scripts/generate-regression-campaign-report.py`)
Post-triage csv → self-contained HTML: device/OS coverage matrix, dedup-cluster grouping (worst-severity first), taxonomy/severity/disposition breakdowns, visual-diff gallery, evidence links.

### DoD
- **84/84 pytest** (40 net-new + 35 pre-existing detectors).
- **E2E** on a sample findings.csv: 9 findings → 7 dedup clusters → 6 real regressions → 4 changesets (device-divergence@80, perf@40, visual-parity@35, keychain-test-infra@30); report renders.
- `check-blast-radius` / `check-superpartner-spectrum` exit 0; `py_compile` clean; intent recorded. No Swift/Palace product code.
- ForgeOS changeset `cs_5416353a`; `forge_release_check` BLOCKED pending SoD (architect + qa_test on a different model) — coordinator runs the SoD; author does not self-approve.

### Status
**Draft — held.** Gated behind the linchpin `scripts/regression_findings.py` (lands via the RC-AREA PR). Rebases zero-change onto develop once that merges (verified against the real module via PYTHONPATH). SoD + coordinator clean-worktree re-verify before it leaves draft.
