### PR TITLE
feat(regression): device/OS matrix cells + CarPlay cold-launch test seam

### DIFF
--- a/.forgeos/intent/carplay-cold-launch-gate-seam.md
+++ b/.forgeos/intent/carplay-cold-launch-gate-seam.md
@@ -1,0 +1,67 @@
+---
+name: carplay-cold-launch-gate-seam
+created: 2026-06-12
+author: claude-opus-4-8
+tracking: regression-rebuild device-cells (HC-DEVICE-CELLS) — C-carplay cell
+---
+
+## Summary
+
+The C-carplay regression cell (headless XCTest, per the CarPlay feasibility
+verdict — CarPlay cannot be interactively driven on a sim) needs a real test of
+the CarPlay cold-launch device-divergence gate. Today that gate is only
+FLUFF-tested. This change extracts a pure decision seam so the behavior is
+unit-testable, replaces the banned tautology test with a real round-trip
+behavior test, and adds the scenario-1 statebleed round-trip test. Worktree
+`feat/regression-rebuild-device-cells` off `origin/develop@51d21177c`.
+
+## Claims
+
+1. **Extract a pure cold-launch gate seam.** `CarPlayTemplateManager` decides
+   whether to show the "open Palace on your phone" alert based on
+   `SceneDelegate.hasMainSceneConnected` — when only CarPlay has connected
+   (cold start from the car, main phone scene not connected), iOS limits
+   background execution so playback won't work reliably, so the gate shows the
+   alert instead of attempting playback. That decision is currently inline in
+   the `private func handleBookSelection` (needs a `CPInterfaceController`, no
+   public init → not headlessly testable). Extract it to a pure
+   `static func shouldShowOpenAppAlert(mainSceneConnected: Bool) -> Bool` and
+   wire the single call site to consult it. No behavior change — pure refactor
+   that makes the device-divergence gate testable.
+
+2. **Replace the fluff test with a real behavior test.**
+   `testSceneDelegate_HasMainSceneConnected_Flag` is a banned tautology
+   (`XCTAssertTrue(flag == true || flag == false)` + `XCTAssertNotNil(flag)`).
+   Replace it 1:1 with round-trip behavior tests asserting both branches of the
+   new seam (`mainSceneConnected: false → true (show alert)`,
+   `mainSceneConnected: true → false (proceed)`).
+
+3. **Add the scenario-1 statebleed round-trip test.** Prove `AppContainer
+   ._resetForTesting()` (the #1072 fix) rebuilds fresh audiobook session
+   statics, driven through the PRODUCTION seam
+   (`AppContainer.production().audiobookSession / audiobookSessionPresenter /
+   playbackBootstrapper`), not direct static writes: resolve the cached
+   instances, call the reset, re-resolve, assert the instances are NOT identical
+   (the reset released the prior — potentially CarPlay-presenter-polluted —
+   instances). This is the canonical write→reset→re-enter round-trip.
+
+## Anti-claims
+
+- I am NOT changing the cold-launch gate's behavior — the seam returns exactly
+  `!mainSceneConnected`, identical to the inline check it replaces.
+- I am NOT touching the async auth/downloaded/offline gates below it, the
+  playback path, or `SceneDelegate.hasMainSceneConnected` itself.
+- I am NOT adding a test that requires a `CPInterfaceController` mock or asserts
+  the private `handleBookSelection` directly (the seam is the testable unit; the
+  single call site is verified by the diff).
+- I am NOT modifying `AppContainer._resetForTesting()` — only testing its
+  existing contract.
+
+## Files in scope
+
+- `Palace/CarPlay/CarPlayTemplateManager.swift` — add the pure seam + wire the
+  one call site.
+- `PalaceTests/CarPlay/CarPlayTests.swift` — replace the fluff test (2 seam
+  tests) + add the statebleed round-trip test.
+- (device-cells tooling under `scripts/` + `docs/regression-suite/` ship in the
+  same PR but are covered by the workstream, not this intent.)

--- a/Palace/CarPlay/CarPlayTemplateManager.swift
+++ b/Palace/CarPlay/CarPlayTemplateManager.swift
@@ -28,6 +28,20 @@ final class CarPlayTemplateManager: NSObject {
         static let artworkSize = CGSize(width: 90, height: 90)
     }
 
+    // MARK: - Cold-launch gate
+
+    /// Whether CarPlay should show the "open Palace on your phone" alert instead
+    /// of attempting playback. True when the main phone scene has not connected
+    /// (cold start from CarPlay only): iOS limits background execution in that
+    /// state so playback won't work reliably.
+    ///
+    /// Extracted as a pure decision so this device-divergence gate is unit
+    /// testable without a `CPInterfaceController`. Consumed at the single call
+    /// site in `handleBookSelection`.
+    static func shouldShowOpenAppAlert(mainSceneConnected: Bool) -> Bool {
+        !mainSceneConnected
+    }
+
     // MARK: - Properties
 
     private weak var interfaceController: CPInterfaceController?
@@ -266,7 +280,7 @@ final class CarPlayTemplateManager: NSObject {
         let mainSceneConnected = SceneDelegate.hasMainSceneConnected
         Log.info(#file, "CarPlay: Main scene connected: \(mainSceneConnected)")
 
-        if !mainSceneConnected {
+        if Self.shouldShowOpenAppAlert(mainSceneConnected: mainSceneConnected) {
             Log.info(#file, "CarPlay: Main scene not connected - showing open app alert")
             showOpenAppAlert()
             return

--- a/PalaceTests/CarPlay/CarPlayTests.swift
+++ b/PalaceTests/CarPlay/CarPlayTests.swift
@@ -273,6 +273,21 @@ class CarPlayIntegrationTests: XCTestCase {
 @MainActor
 class CarPlayOpenAppAlertTests: XCTestCase {
 
+    // Bracket the class with the AppContainer test-boundary reset so the
+    // statebleed round-trip below starts from a known-clean graph (the
+    // resolve→reset→re-resolve non-identity assertion only proves the reset
+    // rebuilt the statics if the arrange step isn't pre-polluted by a prior
+    // test) and this class doesn't leak rebuilt statics into the next.
+    override func setUp() {
+        super.setUp()
+        AppContainer._resetForTesting()
+    }
+
+    override func tearDown() {
+        AppContainer._resetForTesting()
+        super.tearDown()
+    }
+
     func testCarPlay_OpenAppStrings_AreConfigured() {
         // Assert that Open App strings are not empty
         // The alert uses message variants (message, messageShort, messageShortest)

--- a/PalaceTests/CarPlay/CarPlayTests.swift
+++ b/PalaceTests/CarPlay/CarPlayTests.swift
@@ -360,17 +360,17 @@ class CarPlayOpenAppAlertTests: XCTestCase {
     @MainActor
     func testStatebleed_resetForTesting_rebuildsFreshAudiobookStatics() {
         // Arrange — resolve (and thereby cache) the audiobook statics.
-        let session1 = AppContainer.production().audiobookSession as AnyObject
-        let presenter1 = AppContainer.production().audiobookSessionPresenter
-        let bootstrapper1 = AppContainer.production().playbackBootstrapper
+        let session1 = AppContainer.production().audiobookSession as AnyObject // MIGRATED-DEFERRED: swarm_47883816 — production() resolution IS the test contract (asserting _resetForTesting rebuilds the audiobook statics; no DI seam observes the static cache)
+        let presenter1 = AppContainer.production().audiobookSessionPresenter // MIGRATED-DEFERRED: swarm_47883816 — production() resolution IS the test contract (asserting _resetForTesting rebuilds the audiobook statics; no DI seam observes the static cache)
+        let bootstrapper1 = AppContainer.production().playbackBootstrapper // MIGRATED-DEFERRED: swarm_47883816 — production() resolution IS the test contract (asserting _resetForTesting rebuilds the audiobook statics; no DI seam observes the static cache)
 
         // Act — the test-boundary reset.
         AppContainer._resetForTesting()
 
         // Assert — re-resolving yields FRESH instances; the polluted ones are gone.
-        let session2 = AppContainer.production().audiobookSession as AnyObject
-        let presenter2 = AppContainer.production().audiobookSessionPresenter
-        let bootstrapper2 = AppContainer.production().playbackBootstrapper
+        let session2 = AppContainer.production().audiobookSession as AnyObject // MIGRATED-DEFERRED: swarm_47883816 — production() resolution IS the test contract (asserting _resetForTesting rebuilds the audiobook statics; no DI seam observes the static cache)
+        let presenter2 = AppContainer.production().audiobookSessionPresenter // MIGRATED-DEFERRED: swarm_47883816 — production() resolution IS the test contract (asserting _resetForTesting rebuilds the audiobook statics; no DI seam observes the static cache)
+        let bootstrapper2 = AppContainer.production().playbackBootstrapper // MIGRATED-DEFERRED: swarm_47883816 — production() resolution IS the test contract (asserting _resetForTesting rebuilds the audiobook statics; no DI seam observes the static cache)
 
         XCTAssertFalse(session1 === session2,
                        "reset must rebuild a fresh audiobook session")

--- a/PalaceTests/CarPlay/CarPlayTests.swift
+++ b/PalaceTests/CarPlay/CarPlayTests.swift
@@ -310,17 +310,59 @@ class CarPlayOpenAppAlertTests: XCTestCase {
         )
     }
 
-    func testSceneDelegate_HasMainSceneConnected_Flag() {
-        // Verify the flag exists and is accessible
-        // This flag is used to determine when to show the "Open App" alert
-        let flagValue = SceneDelegate.hasMainSceneConnected
+    // MARK: - Cold-launch gate (device-divergence)
 
-        // The flag should be a Bool and accessible without crashing
-        XCTAssertTrue(flagValue == true || flagValue == false,
-                      "hasMainSceneConnected flag should be a valid Bool")
-        // In test environment, no CarPlay scene is connected, so flag should be false
-        // (unless another test has already set it)
-        XCTAssertNotNil(flagValue, "hasMainSceneConnected should have a value")
+    /// When the main phone scene has NOT connected (CarPlay-only cold start),
+    /// the gate must show the "open Palace on your phone" alert — iOS limits
+    /// background execution so playback won't work reliably. Behavior test on
+    /// the extracted seam (replaces the prior tautology that only asserted the
+    /// flag was a Bool).
+    func testShouldShowOpenAppAlert_whenMainSceneNotConnected_isTrue() {
+        XCTAssertTrue(
+            CarPlayTemplateManager.shouldShowOpenAppAlert(mainSceneConnected: false),
+            "CarPlay-only cold start must gate playback behind the open-app alert"
+        )
+    }
+
+    /// When the main phone scene HAS connected, the gate must NOT short-circuit
+    /// to the alert — playback selection proceeds to the auth/download checks.
+    func testShouldShowOpenAppAlert_whenMainSceneConnected_isFalse() {
+        XCTAssertFalse(
+            CarPlayTemplateManager.shouldShowOpenAppAlert(mainSceneConnected: true),
+            "with the phone scene connected, selection must proceed past the gate"
+        )
+    }
+
+    // MARK: - Statebleed reset (CarPlay presenter pollution, #1072)
+
+    /// The audiobook session / presenter / bootstrapper are process-wide statics
+    /// that `_buildCachedAppContainer()` does NOT rebuild, so a prior test that
+    /// leaves the presenter mid-session can bleed `hasActiveSession` into a later
+    /// CarPlay test. `AppContainer._resetForTesting()` (the #1072 fix) nils them
+    /// so the next resolution rebuilds fresh. Drive the cycle through the
+    /// PRODUCTION seam (`production().audiobook*`), not direct static writes, and
+    /// assert the reset releases the prior instances (write → reset → re-enter).
+    @MainActor
+    func testStatebleed_resetForTesting_rebuildsFreshAudiobookStatics() {
+        // Arrange — resolve (and thereby cache) the audiobook statics.
+        let session1 = AppContainer.production().audiobookSession as AnyObject
+        let presenter1 = AppContainer.production().audiobookSessionPresenter
+        let bootstrapper1 = AppContainer.production().playbackBootstrapper
+
+        // Act — the test-boundary reset.
+        AppContainer._resetForTesting()
+
+        // Assert — re-resolving yields FRESH instances; the polluted ones are gone.
+        let session2 = AppContainer.production().audiobookSession as AnyObject
+        let presenter2 = AppContainer.production().audiobookSessionPresenter
+        let bootstrapper2 = AppContainer.production().playbackBootstrapper
+
+        XCTAssertFalse(session1 === session2,
+                       "reset must rebuild a fresh audiobook session")
+        XCTAssertFalse(presenter1 === presenter2,
+                       "reset must rebuild a fresh presenter (CarPlay statebleed fix)")
+        XCTAssertFalse(bootstrapper1 === bootstrapper2,
+                       "reset must rebuild a fresh playback bootstrapper")
     }
 }
 

--- a/docs/regression-suite/CARPLAY-FEASIBILITY.md
+++ b/docs/regression-suite/CARPLAY-FEASIBILITY.md
@@ -1,0 +1,85 @@
+# CarPlay regression-cell feasibility + design (C-carplay)
+
+> Verdict from the regression-rebuild device-cells workstream (HC-DEVICE-CELLS),
+> 2026-06-12. Decides how the CarPlay surface is covered in the cross-device
+> matrix. **Bottom line: CarPlay cannot be interactively driven on a simulator;
+> C-carplay is a headless-XCTest cell, not a simdrive-journey cell.**
+
+## 1. The question
+
+Can simdrive (or XCUITest) drive the Simulator's CarPlay external display
+(Simulator.app → I/O → External Displays → CarPlay) so the regression campaign
+can fan area-workers across CarPlay like it does the iPhone/iPad cells?
+
+## 2. Verdict — by capability (each backed by what was actually run)
+
+| Capability | Feasible? | Evidence |
+|---|---|---|
+| **Activate** the CarPlay external display | Only via Simulator.app **private API / GUI menu** — NOT `simctl` | `xcrun simctl help` has no carplay/external-display subcommand. `strings Simulator` exposes `enableCarPlay:error:`, `-[DeviceCoordinator configureExternalDisplay:]`, `setExternalDisplayMode:forDevice:`, `carplayScreenWithSize:scale:`, and the log "Enabled CarPlay UI. CarPlay should be running." The `SimulatorExternalDisplay` default (=2114 globally in DevicePreferences) persists the mode but isn't a clean per-device on-switch. |
+| **Observe / screenshot** the CarPlay display | Yes, but **gated on activation** | `xcrun simctl io <udid> screenshot --display external` exists; run with no CarPlay active → `Timeout waiting for screen surfaces`. So visual capture only works *after* the fragile activation above. |
+| **Drive / tap** the CarPlay UI | **No** (the real blocker) | `simctl io` = screenshot/record/enumerate only, no touch injection. simdrive HID targets the device **internal-display** coordinate space, not the external CarPlay `NSWindow`/scene. XCUITest has **no public CarPlay API** — `XCUIApplication` attaches to the main foreground scene; the `CPTemplateApplicationScene` head-unit is not queryable/tappable. You cannot script "tap a book in the CarPlay list → assert playback." |
+| **Headless logic testing** of CarPlay templates/scene | **Yes — and already present** | `PalaceTests/CarPlay/` drives `CarPlayAudiobookBridge`, `CarPlayTemplateManager`/`Builder`, `CarPlayImageProvider`, and the scene-delegate readiness gate via `CPInterfaceController` with no sim CarPlay window. This is where the automated regression signal lives. |
+
+This **upgrades** the original design doc's blanket "CarPlay stays manual/XCTest"
+(REGRESSION-REBUILD-DESIGN.md §4.2): there is a concrete, already-existing
+headless automation surface that is the cell's primary signal.
+
+## 3. C-carplay cell design (v1 = headless-only)
+
+- **PRIMARY (automated, CI):** the headless `PalaceTests/CarPlay` XCTest suite,
+  run on the C-iphone-26 base sim and converted to findings.
+  - Runner: `scripts/regression-carplay-cell.sh`
+  - Failures → findings: `scripts/regression_xcresult_findings.py` (own shard
+    `<run>/findings/C-carplay__carplay.csv`, pinned schema; a crashed test →
+    `classification=crash, severity=blocker`, an assertion failure → `other/major`).
+  - The cell does **not** fan out simdrive area-workers.
+- **SECONDARY (DEFERRED — fast-follow):** automated *visual capture* of an
+  activated CarPlay display for the visual-diff gallery. See §4.
+- **TERTIARY (manual):** true head-unit tap-through that no automated path
+  covers. See §5.
+
+## 4. DEFERRED — SECONDARY visual-capture PoC (fast-follow, not built)
+
+Not built for v1 (fragile, GUI/private-API-coupled, low ROI). If the visual-diff
+stage later wants CarPlay frames, the path is:
+
+1. **Activate** the CarPlay external display on a booted sim — either
+   - AppleScript UI-script the menu *I/O → External Displays → CarPlay*
+     (needs Accessibility permission + the device window focused), or
+   - a tiny CoreSimulator/Simulator helper calling the private
+     `setExternalDisplayMode:forDevice:` / `enableCarPlay:` path.
+2. **Capture** with `xcrun simctl io <udid> screenshot --display external`
+   (the external framebuffer enumerates as `Display class: 1` once active).
+3. Feed the PNG into the masked-SSIM visual-diff stage as a CarPlay baseline.
+
+Treat as **best-effort, non-gating** — the activation step is the fragile part.
+
+## 5. TERTIARY — manual CarPlay interaction checklist (honest gap)
+
+Behaviors no sim/XCUITest path can drive — run on a real head unit or the
+Simulator CarPlay window before a release:
+
+- [ ] CarPlay connects → Palace library tab appears with downloaded audiobooks.
+- [ ] Tap a downloaded audiobook → Now Playing dash UI appears, playback starts.
+- [ ] Cold-launch from CarPlay (phone app not foregrounded) → the **"open Palace
+      on your phone" alert** shows instead of a silent failure (the
+      `hasMainSceneConnected==false` gate — see §6).
+- [ ] Tap a NOT-downloaded book → "download required" alert.
+- [ ] Tap a book on a library that requires auth, not signed in → "auth
+      required" alert (not a bare 401).
+- [ ] Now-Playing transport controls (play/pause, skip ±, chapter list) and the
+      lock-screen / Siri controls reflect playback state.
+- [ ] Disconnect/reconnect CarPlay mid-playback → state restored, no crash.
+
+## 6. Known test gap (tracked) — the cold-launch open-app gate
+
+`CarPlayTemplateManager.handleBookSelection` shows the open-app alert when
+`SceneDelegate.hasMainSceneConnected == false` (CarPlay-only cold start). This
+**device-divergence behavior is not headlessly unit-tested** — the existing
+`testSceneDelegate_HasMainSceneConnected_Flag` only asserts the flag is a Bool
+(a tautology), and the real decision is `private` + needs a `CPInterfaceController`
+(no public init) + reads a static flag. Closing it cleanly needs a small
+production seam extraction (a pure `shouldShowOpenAppAlert(mainSceneConnected:)`
+decision) so the behavior — not the flag — can be asserted, plus a round-trip
+test (`false → alert`, `true → proceeds`). Tracked as a C-carplay fast-follow;
+until then it is a §5 manual checklist item.

--- a/scripts/regression-carplay-cell.sh
+++ b/scripts/regression-carplay-cell.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# regression-carplay-cell.sh — the C-carplay regression cell.
+#
+# CarPlay cannot be interactively driven on a simulator (separate scene/window,
+# no public touch injection — see docs/regression/CARPLAY-FEASIBILITY.md). So
+# this cell's regression signal is the HEADLESS PalaceTests/CarPlay XCTest suite,
+# run on the baseline iPhone sim. Test failures become findings via
+# regression_xcresult_findings.py (own shard, pinned schema).
+#
+# Usage:
+#   scripts/regression-carplay-cell.sh [--sim-id <UDID>] [--run-dir <dir>]
+#       [--classes "CarPlayTests,CarPlayAuthHelperReadinessTests,..."]
+#       [--first-seen-commit <sha>]
+#
+# Exit code:
+#   0  — cell ran; CarPlay suite all-green (PASS), OR cell skipped (preflight)
+#   1  — at least one CarPlay test failed (findings emitted; FAIL)
+#   2  — config / build error
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+SIM_ID="${HARNESS_SESSION_SIM_UDID:-}"
+RUN_DIR=""
+CLASSES="CarPlayTests,CarPlayIntegrationTests,CarPlayOpenAppAlertTests,CarPlayLibraryRefreshTests,CarPlayNowPlayingTemplateTests,CarPlayChapterListTests,CarPlayPlaybackErrorTests,CarPlayAudiobookBridgePresenterMigrationTests,CarPlayAuthHelperReadinessTests"
+FIRST_SEEN_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo '')"
+DEVICE_CELL="C-carplay"
+AREA="carplay"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sim-id) SIM_ID="$2"; shift 2 ;;
+    --run-dir) RUN_DIR="$2"; shift 2 ;;
+    --classes) CLASSES="$2"; shift 2 ;;
+    --first-seen-commit) FIRST_SEEN_COMMIT="$2"; shift 2 ;;
+    --area) AREA="$2"; shift 2 ;;
+    -h|--help) sed -n '2,/^set -uo/p' "$0" | sed 's/^# \{0,1\}//; /^set -uo/d'; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+ts="$(date +%Y%m%d-%H%M%S)"
+[ -z "$RUN_DIR" ] && RUN_DIR=".regression-runs/carplay-$ts"
+mkdir -p "$RUN_DIR/logs" "$RUN_DIR/findings"
+LOG="$RUN_DIR/logs/carplay-$ts.log"
+XCRESULT="$RUN_DIR/logs/carplay-$ts.xcresult"
+
+log() { echo "$@" | tee -a "$LOG"; }
+
+log "=== C-carplay cell (headless XCTest) ==="
+log "classes: $CLASSES"
+
+# Resolve the destination from the preflight (C-iphone-26 base) if no sim given.
+if [ -z "$SIM_ID" ]; then
+  DEST="$(python3 "$SCRIPT_DIR/regression_matrix_preflight.py" --cell C-carplay --json 2>/dev/null \
+          | python3 -c 'import json,sys; c=json.load(sys.stdin)["cells"][0]; print(c["destination"] if c["status"]=="ready" else "")' 2>/dev/null)"
+  if [ -z "$DEST" ]; then
+    log "SKIP: C-carplay base sim not ready (preflight)."
+    exit 0
+  fi
+else
+  DEST="platform=iOS Simulator,id=$SIM_ID"
+fi
+log "destination: $DEST"
+
+# Build the -only-testing args from the class list.
+ONLY=()
+IFS=',' read -ra CLS <<< "$CLASSES"
+for c in "${CLS[@]}"; do ONLY+=("-only-testing:PalaceTests/$c"); done
+
+log "Running CarPlay suite..."
+xcodebuild test \
+  -project Palace.xcodeproj -scheme Palace \
+  -destination "$DEST" \
+  "${ONLY[@]}" \
+  -resultBundlePath "$XCRESULT" \
+  >>"$LOG" 2>&1
+BUILD_RC=$?
+
+if [ ! -d "$XCRESULT" ]; then
+  log "ERROR: no result bundle produced (build/test setup failure, rc=$BUILD_RC) — see $LOG"
+  exit 2
+fi
+
+# Parse failures → findings (own shard). Exit 1 if any failure.
+python3 "$SCRIPT_DIR/regression_xcresult_findings.py" \
+  --xcresult "$XCRESULT" \
+  --device-cell "$DEVICE_CELL" --area "$AREA" \
+  --run-dir "$RUN_DIR" --first-seen-commit "$FIRST_SEEN_COMMIT" \
+  --json | tee "$RUN_DIR/logs/carplay-findings-$ts.json"
+PARSE_RC=${PIPESTATUS[0]}
+
+if [ "$PARSE_RC" = "1" ]; then
+  log "VERDICT: FAIL — CarPlay regression(s) found. Findings emitted to $RUN_DIR/findings/."
+  exit 1
+fi
+log "VERDICT: PASS — CarPlay headless suite all-green."
+exit 0

--- a/scripts/regression-ipad-on-mac.sh
+++ b/scripts/regression-ipad-on-mac.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# regression-ipad-on-mac.sh — the C-ipad-on-mac regression cell.
+#
+# Runs the "Designed for iPad" Palace build NATIVELY on this Apple-Silicon Mac
+# (ProcessInfo.isiOSAppOnMac == true — the configuration that produces the WS-4
+# Adobe RMSDK recursive_mutex-at-exit crash; it cannot be reproduced in a sim),
+# brackets an interaction window, then harvests + classifies the crash reports
+# the run leaves behind for the WS-4 signature. This is the automated form of
+# docs/architecture/ws4-mac-validation-runbook.md CHECK 2.
+#
+# simdrive cannot drive a Mac-native app (HID injection differs natively), so the
+# Path-A / Path-B interaction is operator-driven (or a future XCUITest-mac
+# co-driver). The deterministic, automatable core — launch bracketing + crash
+# harvest + WS-4 classification + findings emission — is what this script owns.
+#
+# Usage:
+#   scripts/regression-ipad-on-mac.sh --prebuilt <Palace.app> [opts]
+#   scripts/regression-ipad-on-mac.sh --build [opts]            # build here first
+#
+# Options:
+#   --prebuilt <App.app>   use this Designed-for-iPad .app (skip build)
+#   --build                build the Designed-for-iPad product in this worktree
+#   --run-dir <dir>        artifact dir (default .regression-runs/ipad-on-mac-<ts>)
+#   --mode manual|path-a|path-b   interaction mode (default manual)
+#   --interaction-timeout N seconds to allow interaction before harvest (default 180)
+#   --process <name>       crash-report process match (default Palace)
+#   --bundle-id <id>       app bundle id (default org.thepalaceproject.palace)
+#   --first-seen-commit <sha>  carried into the finding (default: git HEAD)
+#   -h|--help
+#
+# Exit code:
+#   0  — cell ran AND no WS-4 signature found (PASS), OR cell skipped (non-arm64)
+#   1  — WS-4 signature found at exit (FAIL — regression; finding emitted)
+#   2  — config error (no app, build failed)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+PREBUILT=""
+DO_BUILD=0
+RUN_DIR=""
+MODE="manual"
+INTERACTION_TIMEOUT=180
+PROCESS="Palace"
+BUNDLE_ID="org.thepalaceproject.palace"
+FIRST_SEEN_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo '')"
+DEVICE_CELL="C-ipad-on-mac"
+AREA="audiobook-drm-exit"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prebuilt) PREBUILT="$2"; shift 2 ;;
+    --build) DO_BUILD=1; shift ;;
+    --run-dir) RUN_DIR="$2"; shift 2 ;;
+    --mode) MODE="$2"; shift 2 ;;
+    --interaction-timeout) INTERACTION_TIMEOUT="$2"; shift 2 ;;
+    --process) PROCESS="$2"; shift 2 ;;
+    --bundle-id) BUNDLE_ID="$2"; shift 2 ;;
+    --first-seen-commit) FIRST_SEEN_COMMIT="$2"; shift 2 ;;
+    --area) AREA="$2"; shift 2 ;;
+    -h|--help) sed -n '2,/^set -uo/p' "$0" | sed 's/^# \{0,1\}//; /^set -uo/d'; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+ts="$(date +%Y%m%d-%H%M%S)"
+[ -z "$RUN_DIR" ] && RUN_DIR=".regression-runs/ipad-on-mac-$ts"
+mkdir -p "$RUN_DIR/logs" "$RUN_DIR/crashes" "$RUN_DIR/findings"
+SCAN_LOG="$RUN_DIR/logs/ipad-on-mac-$ts.log"
+
+log() { echo "$@" | tee -a "$SCAN_LOG"; }
+
+log "=== C-ipad-on-mac cell ==="
+log "run-dir: $RUN_DIR"
+log "commit:  $FIRST_SEEN_COMMIT"
+
+# 1. Arch gate (skip-with-warning per BUILD-PLAN — never a hard fail).
+PREFLIGHT="$SCRIPT_DIR/regression_matrix_preflight.py"
+if [ -x "$PREFLIGHT" ] || [ -f "$PREFLIGHT" ]; then
+  status="$(python3 "$PREFLIGHT" --cell "$DEVICE_CELL" --json 2>/dev/null \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["cells"][0]["status"])' 2>/dev/null)"
+  if [ "$status" = "skip" ]; then
+    log "SKIP: preflight reports C-ipad-on-mac not ready on this host (non-arm64)."
+    exit 0
+  fi
+fi
+
+# 2. Resolve the app bundle.
+if [ "$DO_BUILD" = "1" ]; then
+  DD="$RUN_DIR/dd"
+  log "Building Designed-for-iPad product (platform=macOS,variant=Designed for iPad)..."
+  xcodebuild -project Palace.xcodeproj -scheme Palace \
+    -destination 'platform=macOS,variant=Designed for iPad' \
+    -derivedDataPath "$DD" -configuration Debug \
+    build CODE_SIGNING_ALLOWED=NO >>"$SCAN_LOG" 2>&1
+  if [ $? -ne 0 ]; then
+    log "ERROR: build failed — see $SCAN_LOG"
+    exit 2
+  fi
+  PREBUILT="$(/usr/bin/find "$DD/Build/Products" -maxdepth 2 -name 'Palace.app' -type d | head -1)"
+fi
+
+if [ -z "$PREBUILT" ] || [ ! -d "$PREBUILT" ]; then
+  log "ERROR: no app bundle. Pass --prebuilt <Palace.app> or --build."
+  exit 2
+fi
+log "app: $PREBUILT"
+
+# 3. Bracket: record the launch instant; only crash reports newer than this count.
+SINCE="$(python3 -c 'import time; print(time.time())')"
+log "launch-since epoch: $SINCE"
+
+# 4. Launch the app natively on macOS.
+log "Launching Mac-native (isiOSAppOnMac path)..."
+open "$PREBUILT" >>"$SCAN_LOG" 2>&1
+sleep 3
+if pgrep -f "$PROCESS" >/dev/null 2>&1; then
+  log "launched: process '$PROCESS' is running."
+else
+  log "WARN: process '$PROCESS' not detected after launch (may be sandboxed/renamed)."
+fi
+
+# 5. Interaction window — drive Path A / Path B per the runbook.
+cat >>"$SCAN_LOG" <<EOF
+--- interaction protocol (ws4-mac-validation-runbook.md CHECK 2) ---
+Path A (normal): read an Adobe-DRM EPUB page, then Cmd-Q.
+Path B (forced): reopen the book, send app to BACKGROUND (the atexit installs
+  at applicationDidEnterBackground because didUseAdobeDRMThisSession is set),
+  then trigger FinalTerminationWatchdog / a forced exit() — NOT kill -9.
+Assert (both): no recursive_mutex fault, no new Crashlytics 9a91840677.
+EOF
+
+case "$MODE" in
+  manual)
+    log "MODE=manual: drive the Adobe-DRM open → background → forced-exit per the"
+    log "protocol above. Harvest runs after ${INTERACTION_TIMEOUT}s (or when the app exits)."
+    waited=0
+    while [ "$waited" -lt "$INTERACTION_TIMEOUT" ]; do
+      pgrep -f "$PROCESS" >/dev/null 2>&1 || { log "app exited at ${waited}s"; break; }
+      sleep 5; waited=$((waited+5))
+    done
+    ;;
+  path-a)
+    log "MODE=path-a: backgrounding then quitting via AppleScript (best-effort)."
+    osascript -e "tell application \"$PROCESS\" to quit" >>"$SCAN_LOG" 2>&1 || true
+    sleep 5
+    ;;
+  path-b)
+    log "MODE=path-b: backgrounding via Finder activate, then forced exit."
+    osascript -e 'tell application "Finder" to activate' >>"$SCAN_LOG" 2>&1 || true
+    sleep 3
+    # Forced exit that still runs atexit handlers: SIGTERM is caught by the app's
+    # termination path; kill -9 would bypass atexit and prove nothing, so it is
+    # NOT used. (True watchdog-exit fidelity needs the in-app trigger; documented.)
+    pkill -TERM -f "$PROCESS" >>"$SCAN_LOG" 2>&1 || true
+    sleep 3
+    ;;
+  *) log "Unknown --mode $MODE"; exit 2 ;;
+esac
+
+# 6 + 7. Harvest crash reports since launch, classify for WS-4, emit finding.
+log "Harvesting crash reports since launch..."
+python3 "$SCRIPT_DIR/regression_crash_harvest.py" \
+  --process "$PROCESS" --since "$SINCE" \
+  --device-cell "$DEVICE_CELL" --area "$AREA" \
+  --run-dir "$RUN_DIR" --first-seen-commit "$FIRST_SEEN_COMMIT" \
+  --scan-log "$SCAN_LOG" --json | tee "$RUN_DIR/logs/harvest-$ts.json"
+HARVEST_RC=${PIPESTATUS[0]}
+
+# Copy any matched crash reports into the run's crashes/ for evidence retention.
+python3 - "$RUN_DIR/logs/harvest-$ts.json" "$RUN_DIR/crashes" <<'PY' >>"$SCAN_LOG" 2>&1 || true
+import json, shutil, sys, pathlib
+data = json.load(open(sys.argv[1])); dest = pathlib.Path(sys.argv[2])
+for c in data.get("crashes", []):
+    p = pathlib.Path(c["path"])
+    if p.exists():
+        shutil.copy2(p, dest / p.name)
+PY
+
+if [ "$HARVEST_RC" = "1" ]; then
+  log "VERDICT: FAIL — WS-4 recursive_mutex signature present at exit. Finding emitted."
+  exit 1
+fi
+log "VERDICT: PASS — no WS-4 signature; the _exit(0) remediation held this run."
+exit 0

--- a/scripts/regression_crash_harvest.py
+++ b/scripts/regression_crash_harvest.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""regression_crash_harvest.py — harvest + classify macOS crash reports for the
+iPad-on-Mac (C-ipad-on-mac) regression cell, with first-class detection of the
+WS-4 Adobe RMSDK `recursive_mutex`-at-exit signature.
+
+Context (docs/architecture/ws4-mac-validation-runbook.md): the "Designed for
+iPad" build run natively on Apple Silicon (`isiOSAppOnMac == true`) crashed at
+process exit in Adobe RMSDK's C++ static `recursive_mutex` destructor (294
+Crashlytics events, issue 9a91840677). PR #1067 installs `atexit { _exit(0) }`
+at `applicationDidEnterBackground` so the process exits before that destructor
+runs. This module is the automated detector that decides, from the crash reports
+a run leaves behind, whether that remediation HELD (no signature → PASS) or
+REGRESSED (signature present → FAIL).
+
+The crash-report scan + WS-4 classification is pure and deterministic; it is the
+unit-tested core. The orchestration (build / launch / drive the app) lives in
+scripts/regression-ipad-on-mac.sh.
+
+Crash reports: `~/Library/Logs/DiagnosticReports/*.ips` (modern JSON format).
+Each .ips is a one-line JSON header followed by a JSON payload; we classify on
+the raw text so the detector is robust to schema drift.
+
+Findings: conforms to the pinned regression_findings schema (FINDINGS_COLUMNS).
+On the pinned module's absence (isolated worktree) we fall back to an inline
+writer that emits the identical CSV — so this is integration-ready AND
+self-contained.
+
+Usage:
+  regression_crash_harvest.py --process Palace --since <epoch> \
+      --device-cell C-ipad-on-mac --area audiobook-drm-exit \
+      --run-dir .regression-runs/<id> [--reports-dir <dir>] \
+      [--first-seen-commit <sha>] [--json]
+
+Exit code:
+  0  — scan ran; NO WS-4 signature found (PASS — remediation holds)
+  1  — at least one WS-4 signature found (FAIL — regression; finding emitted)
+  2  — config error
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_REPORTS_DIR = os.path.expanduser("~/Library/Logs/DiagnosticReports")
+
+# The WS-4 signature set (ws4-mac-validation-runbook.md CHECK 2 assertions).
+# A crash matching ANY of these, in a report for our process, is the regression.
+WS4_SIGNATURES = [
+    # The literal fault the static-destructor bug produces.
+    re.compile(r"recursive_mutex lock failed", re.I),
+    re.compile(r"recursive_mutex", re.I),
+    # The Crashlytics issue id for this crash family.
+    re.compile(r"9a91840677", re.I),
+]
+
+# Adobe / RMSDK frame markers — a SIGABRT/EXC_CRASH carrying one of these in a
+# stack frame is the same family even if the literal "recursive_mutex" string
+# was elided. Used only to upgrade an abort that also names Adobe.
+ADOBE_FRAME_MARKERS = [
+    re.compile(r"\bdp::", ),
+    re.compile(r"librmsdk", re.I),
+    re.compile(r"\badept\b", re.I),
+    re.compile(r"NYPLADEPT", ),
+    re.compile(r"RMServices", re.I),
+]
+
+ABORT_MARKERS = [
+    re.compile(r"EXC_CRASH \(SIGABRT\)", re.I),
+    re.compile(r"\bSIGABRT\b"),
+    re.compile(r"EXC_BAD_ACCESS", re.I),
+]
+
+
+def _process_name_of(text: str) -> str:
+    """Best-effort extract the crashed process name from an .ips report."""
+    # Modern .ips header is the first line: {"app_name":"Palace", "procName":...}
+    first = text.lstrip().split("\n", 1)[0]
+    try:
+        hdr = json.loads(first)
+        for key in ("procName", "app_name", "process", "bundleID", "coalitionName"):
+            if hdr.get(key):
+                return str(hdr[key])
+    except (json.JSONDecodeError, AttributeError):
+        pass
+    m = re.search(r'"procName"\s*:\s*"([^"]+)"', text)
+    if m:
+        return m.group(1)
+    m = re.search(r"^Process:\s+([^\[\s]+)", text, re.M)  # legacy .crash format
+    return m.group(1) if m else ""
+
+
+def classify_crash_text(text: str) -> dict:
+    """Pure classifier. Returns whether the crash text is the WS-4 signature and
+    which markers matched. No I/O."""
+    matched = [sig.pattern for sig in WS4_SIGNATURES if sig.search(text)]
+    is_ws4 = bool(matched)
+
+    # Upgrade path: an abort that also names an Adobe/RMSDK frame is the same
+    # family even without the literal mutex string.
+    if not is_ws4:
+        has_abort = any(m.search(text) for m in ABORT_MARKERS)
+        has_adobe = any(m.search(text) for m in ADOBE_FRAME_MARKERS)
+        if has_abort and has_adobe:
+            is_ws4 = True
+            matched = ["abort+adobe-frame"]
+
+    exc = ""
+    m = re.search(r'"exceptionType"\s*:\s*"([^"]+)"', text) or \
+        re.search(r"Exception Type:\s+(\S+)", text)
+    if m:
+        exc = m.group(1)
+
+    return {
+        "is_ws4": is_ws4,
+        "matched_signatures": matched,
+        "exception_type": exc,
+    }
+
+
+def harvest(process: str, since_epoch: float, reports_dir: str) -> list[dict]:
+    """Scan reports_dir for crash reports newer than since_epoch whose process
+    matches `process`. Returns a parsed classification per matching report."""
+    d = Path(reports_dir)
+    if not d.is_dir():
+        return []
+    out = []
+    for path in sorted(d.glob("*.ips")) + sorted(d.glob("*.crash")):
+        try:
+            if path.stat().st_mtime < since_epoch:
+                continue
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        proc = _process_name_of(text)
+        # Match the target process by case-insensitive substring (covers
+        # "Palace", "Palace-noDRM", bundle ids).
+        if process.lower() not in proc.lower() and process.lower() not in text[:2000].lower():
+            continue
+        cls = classify_crash_text(text)
+        out.append({
+            "path": str(path),
+            "process": proc,
+            "mtime": path.stat().st_mtime,
+            **cls,
+        })
+    return out
+
+
+def _emit_findings(run_dir: str, device_cell: str, area: str,
+                   crashes: list[dict], first_seen_commit: str,
+                   scan_log: Optional[str]) -> Optional[str]:
+    """Write one finding per WS-4 crash into this cell's own shard, conforming to
+    the pinned regression_findings schema. Returns the shard path, or None when
+    there is nothing to emit."""
+    ws4 = [c for c in crashes if c["is_ws4"]]
+    if not ws4:
+        return None
+
+    shard = Path(run_dir) / "findings" / f"{device_cell}__{area}.csv"
+    rows = []
+    for i, c in enumerate(ws4):
+        evidence = [c["path"]]
+        if scan_log:
+            evidence.append(scan_log)
+        rows.append({
+            "id": f"{device_cell}-ws4-{i+1}",
+            "area": area,
+            "device_cell": device_cell,
+            "severity": "blocker",  # the WS-4 crash family is a release blocker
+            "classification": "device-divergence",
+            "verified": "false",
+            "evidence_paths": ";".join(evidence),
+            "screenshot_pair": "",
+            "first_seen_commit": first_seen_commit,
+            "dedup_cluster": "ws4-adobe-recursive-mutex",
+            "disposition": "",
+        })
+
+    # Prefer the pinned module; fall back to an inline writer (identical CSV).
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import regression_findings as rf  # type: ignore
+        rf.append_findings(str(shard), rows)
+    except Exception:
+        _inline_append(shard, rows)
+    return str(shard)
+
+
+_COLUMNS = [
+    "id", "area", "device_cell", "severity", "classification", "verified",
+    "evidence_paths", "screenshot_pair", "first_seen_commit", "dedup_cluster",
+    "disposition",
+]
+
+
+def _inline_append(shard: Path, rows: list[dict]) -> None:
+    import csv
+    shard.parent.mkdir(parents=True, exist_ok=True)
+    new = not shard.exists() or shard.stat().st_size == 0
+    with shard.open("a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=_COLUMNS)
+        if new:
+            w.writeheader()
+        for row in rows:
+            w.writerow({c: row.get(c, "") for c in _COLUMNS})
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="iPad-on-Mac crash harvest (WS-4)")
+    ap.add_argument("--process", default="Palace")
+    ap.add_argument("--since", type=float, required=True,
+                    help="epoch seconds; only reports newer than this are scanned")
+    ap.add_argument("--device-cell", default="C-ipad-on-mac")
+    ap.add_argument("--area", default="audiobook-drm-exit")
+    ap.add_argument("--run-dir", default=".regression-runs/adhoc")
+    ap.add_argument("--reports-dir", default=DEFAULT_REPORTS_DIR)
+    ap.add_argument("--first-seen-commit", default="")
+    ap.add_argument("--scan-log", default="", help="path to the run's scan log (evidence)")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    crashes = harvest(args.process, args.since, args.reports_dir)
+    ws4 = [c for c in crashes if c["is_ws4"]]
+    shard = _emit_findings(
+        args.run_dir, args.device_cell, args.area, crashes,
+        args.first_seen_commit, args.scan_log or None,
+    )
+
+    result = {
+        "device_cell": args.device_cell,
+        "area": args.area,
+        "process": args.process,
+        "scanned_since": args.since,
+        "reports_matched": len(crashes),
+        "ws4_signature_hits": len(ws4),
+        "verdict": "FAIL" if ws4 else "PASS",
+        "findings_shard": shard,
+        "crashes": crashes,
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"=== iPad-on-Mac crash harvest ({args.device_cell}) ===")
+        print(f"process={args.process}  reports_matched={len(crashes)}  "
+              f"ws4_hits={len(ws4)}")
+        for c in crashes:
+            tag = "WS-4" if c["is_ws4"] else "----"
+            print(f"  [{tag}] {Path(c['path']).name}  "
+                  f"exc={c['exception_type'] or '?'}  "
+                  f"sig={','.join(c['matched_signatures']) or '-'}")
+        print(f"\nVERDICT: {result['verdict']}"
+              + (f"  (finding → {shard})" if shard else "  (WS-4 remediation holds)"))
+
+    return 1 if ws4 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/regression_matrix_preflight.py
+++ b/scripts/regression_matrix_preflight.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""regression_matrix_preflight.py — gate the regression device/OS matrix.
+
+For each matrix cell, check that its required simulator runtime + device type
+(or, for the Mac-native cell, the host architecture) is present on THIS machine.
+A cell whose requirement is missing is reported `skip` with a reason — it never
+fails the campaign (skip-with-warning per the BUILD-PLAN). Cells that are ready
+get a concrete, resolved `xcodebuild` destination string the campaign driver and
+per-cell harnesses consume verbatim.
+
+Matrix cells (REGRESSION-BUILD-PLAN.md §host-constraint resolutions):
+  C-iphone-26    iPhone 16 Pro / newest iOS 26.x sim        baseline parity
+  C-ipad-26      iPad / newest iPadOS 26.x sim              iPad layout parity
+  C-ios18        iPhone 16 Pro / iOS 18.0 (floor)           back-compat (iOS-16
+                                                            unavailable on Xcode 26
+                                                            → 18.0 substitute)
+  C-ipad-on-mac  Designed-for-iPad build, Mac-native        device-divergence
+                 (isiOSAppOnMac==true), Apple-Silicon host  crashes (WS-4 Adobe)
+  C-carplay      headless XCTest cell (no interactive sim   CarPlay regression
+                 drive — see CARPLAY-FEASIBILITY verdict)   (template/scene logic)
+
+Usage:
+  scripts/regression_matrix_preflight.py                 # table, all cells
+  scripts/regression_matrix_preflight.py --json          # machine-readable JSON
+  scripts/regression_matrix_preflight.py --cell C-ios18  # one cell
+  scripts/regression_matrix_preflight.py --out <file>    # write JSON to file
+  scripts/regression_matrix_preflight.py --ready-only    # exit 1 if ANY cell skipped
+
+Exit code:
+  0  — preflight ran; every requested cell is either ready or skip-with-warning
+  1  — --ready-only was set AND at least one cell is skipped
+  2  — config error (simctl unavailable / unparseable)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import re
+import subprocess
+import sys
+from typing import Optional
+
+# --- Cell contract -----------------------------------------------------------
+# kind:
+#   "sim"            — a booted simulator of (device_type, runtime). Gated on both.
+#   "mac-native"     — the Designed-for-iPad binary run natively on the Mac host
+#                      (isiOSAppOnMac==true). Gated on Apple-Silicon arch.
+#   "headless-xctest"— a test bundle exercising headless logic (CarPlay). Gated on
+#                      the base iPhone sim runtime only (the bundle runs there).
+#
+# runtime_pref: how to resolve the concrete runtime from what's installed.
+#   ("major", N)   — newest installed iOS N.x  (e.g. newest 26.x)
+#   ("exact", "X.Y") with floor fallback to the lowest installed same-major.
+CELLS = [
+    {
+        "cell": "C-iphone-26",
+        "kind": "sim",
+        "device_type": "iPhone 16 Pro",
+        "runtime_pref": ("major", 26),
+        "signal": "baseline parity (today's coverage)",
+    },
+    {
+        "cell": "C-ipad-26",
+        "kind": "sim",
+        # any iPad device type; resolved to the first installed match below.
+        "device_type": "iPad",
+        "runtime_pref": ("major", 26),
+        "signal": "iPad layout parity (X1)",
+    },
+    {
+        "cell": "C-ios18",
+        "kind": "sim",
+        "device_type": "iPhone 16 Pro",
+        # iOS-16 is unavailable on Xcode 26; 18.0 is the back-compat floor.
+        "runtime_pref": ("exact", "18.0"),
+        "signal": "back-compat / deprecated-API divergence (iOS-16 floor substitute)",
+    },
+    {
+        "cell": "C-ipad-on-mac",
+        "kind": "mac-native",
+        "device_type": None,
+        "runtime_pref": None,
+        "signal": "device-divergence crashes (Adobe recursive_mutex-at-exit, WS-4)",
+    },
+    {
+        "cell": "C-carplay",
+        "kind": "headless-xctest",
+        # CarPlay headless bundle runs on the baseline iPhone sim.
+        "device_type": "iPhone 16 Pro",
+        "runtime_pref": ("major", 26),
+        "signal": "CarPlay template/scene regression (headless — see verdict)",
+    },
+]
+
+
+def _simctl_json(*args: str) -> dict:
+    out = subprocess.run(
+        ["xcrun", "simctl", "list", "-j", *args],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(out.stdout)
+
+
+def load_environment() -> dict:
+    """Snapshot installed runtimes + device types once."""
+    try:
+        runtimes_raw = _simctl_json("runtimes")["runtimes"]
+        devicetypes_raw = _simctl_json("devicetypes")["devicetypes"]
+    except (subprocess.CalledProcessError, KeyError, json.JSONDecodeError) as exc:
+        print(f"ERROR: could not query simctl: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    runtimes = []
+    for rt in runtimes_raw:
+        # Only usable iOS runtimes.
+        if rt.get("platform") != "iOS" and "iOS" not in rt.get("name", ""):
+            continue
+        if not rt.get("isAvailable", rt.get("availability", "") == "(available)"):
+            continue
+        ver = rt.get("version", "")
+        m = re.match(r"(\d+)\.(\d+)", ver)
+        if not m:
+            continue
+        runtimes.append({
+            "name": rt.get("name", ""),
+            "version": ver,
+            "major": int(m.group(1)),
+            "minor": int(m.group(2)),
+            "identifier": rt.get("identifier", ""),
+        })
+
+    devicetypes = [
+        {"name": dt.get("name", ""), "identifier": dt.get("identifier", "")}
+        for dt in devicetypes_raw
+    ]
+    return {"runtimes": runtimes, "devicetypes": devicetypes}
+
+
+def resolve_runtime(pref, runtimes) -> Optional[dict]:
+    """Resolve a runtime_pref against installed runtimes; None if unsatisfiable."""
+    if pref is None:
+        return None
+    kind, val = pref
+    if kind == "major":
+        candidates = [r for r in runtimes if r["major"] == val]
+        # newest minor wins
+        return max(candidates, key=lambda r: r["minor"], default=None)
+    if kind == "exact":
+        major = int(val.split(".")[0])
+        exact = [r for r in runtimes if r["version"] == val]
+        if exact:
+            return exact[0]
+        # floor fallback: lowest installed runtime of the same major
+        same_major = [r for r in runtimes if r["major"] == major]
+        return min(same_major, key=lambda r: r["minor"], default=None)
+    return None
+
+
+def resolve_device_type(name, devicetypes) -> Optional[dict]:
+    """Exact-name match, else first device type whose name starts with `name`."""
+    if name is None:
+        return None
+    exact = [d for d in devicetypes if d["name"] == name]
+    if exact:
+        return exact[0]
+    prefix = [d for d in devicetypes if d["name"].startswith(name)]
+    return prefix[0] if prefix else None
+
+
+def destination_for(cell_kind, device_type, runtime) -> Optional[str]:
+    """xcodebuild -destination string for a ready cell."""
+    if cell_kind == "mac-native":
+        # Designed-for-iPad app run natively on Apple Silicon.
+        return "platform=macOS,variant=Designed for iPad"
+    if cell_kind in ("sim", "headless-xctest") and device_type and runtime:
+        return (
+            f"platform=iOS Simulator,name={device_type['name']},"
+            f"OS={runtime['version']}"
+        )
+    return None
+
+
+def evaluate_cell(cfg, env) -> dict:
+    cell = cfg["cell"]
+    kind = cfg["kind"]
+    result = {
+        "cell": cell,
+        "kind": kind,
+        "signal": cfg["signal"],
+        "status": "ready",
+        "reason": "",
+        "device_type": None,
+        "runtime": None,
+        "destination": None,
+    }
+
+    if kind == "mac-native":
+        is_apple_silicon = platform.machine() == "arm64"
+        if not is_apple_silicon:
+            result["status"] = "skip"
+            result["reason"] = (
+                f"host arch is {platform.machine()}, not arm64 — Designed-for-iPad "
+                "native run requires an Apple-Silicon Mac"
+            )
+            return result
+        result["reason"] = (
+            "Apple-Silicon host; runs Designed-for-iPad binary natively "
+            "(isiOSAppOnMac==true) + crash-log harvest at exit"
+        )
+        result["destination"] = destination_for(kind, None, None)
+        return result
+
+    # sim / headless-xctest cells: need a device type + runtime
+    rt = resolve_runtime(cfg["runtime_pref"], env["runtimes"])
+    dt = resolve_device_type(cfg["device_type"], env["devicetypes"])
+
+    if rt is None:
+        result["status"] = "skip"
+        pref = cfg["runtime_pref"]
+        want = f"{pref[1]}.x" if pref[0] == "major" else pref[1]
+        result["reason"] = f"no installed iOS {want} runtime"
+        return result
+    if dt is None:
+        result["status"] = "skip"
+        result["reason"] = f"no installed '{cfg['device_type']}' device type"
+        return result
+
+    result["device_type"] = dt["name"]
+    result["runtime"] = rt["version"]
+    result["destination"] = destination_for(kind, dt, rt)
+
+    # Floor-substitution note for the iOS-18 cell.
+    if cfg["runtime_pref"][0] == "exact" and rt["version"] != cfg["runtime_pref"][1]:
+        result["reason"] = (
+            f"requested iOS {cfg['runtime_pref'][1]} absent; using floor "
+            f"iOS {rt['version']}"
+        )
+    elif kind == "headless-xctest":
+        result["reason"] = (
+            "headless XCTest cell — CarPlay logic exercised via test bundle, "
+            "no interactive CarPlay-display drive (per feasibility verdict)"
+        )
+    else:
+        result["reason"] = "runtime + device type present"
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Regression device/OS matrix preflight")
+    ap.add_argument("--json", action="store_true", help="emit JSON to stdout")
+    ap.add_argument("--cell", help="preflight a single cell by name")
+    ap.add_argument("--out", help="write JSON report to this file")
+    ap.add_argument("--ready-only", action="store_true",
+                    help="exit 1 if any requested cell is skipped")
+    args = ap.parse_args()
+
+    env = load_environment()
+
+    cells = CELLS
+    if args.cell:
+        cells = [c for c in CELLS if c["cell"] == args.cell]
+        if not cells:
+            print(f"ERROR: unknown cell '{args.cell}'. Known: "
+                  f"{', '.join(c['cell'] for c in CELLS)}", file=sys.stderr)
+            return 2
+
+    results = [evaluate_cell(c, env) for c in cells]
+    report = {
+        "host": {
+            "arch": platform.machine(),
+            "model": platform.platform(),
+        },
+        "cells": results,
+        "ready": [r["cell"] for r in results if r["status"] == "ready"],
+        "skipped": [r["cell"] for r in results if r["status"] == "skip"],
+    }
+
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump(report, fh, indent=2)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print("=== regression matrix preflight ===")
+        print(f"host: {platform.machine()}\n")
+        width = max(len(r["cell"]) for r in results)
+        for r in results:
+            badge = "READY" if r["status"] == "ready" else "SKIP "
+            dest = r["destination"] or "—"
+            print(f"  [{badge}] {r['cell']:<{width}}  {dest}")
+            print(f"          {r['reason']}")
+        print(f"\nready:   {', '.join(report['ready']) or '(none)'}")
+        print(f"skipped: {', '.join(report['skipped']) or '(none)'}")
+
+    if args.ready_only and report["skipped"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/regression_xcresult_findings.py
+++ b/scripts/regression_xcresult_findings.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""regression_xcresult_findings.py — turn an xcresult's test failures into
+findings.csv rows for a headless XCTest regression cell (e.g. C-carplay).
+
+The C-carplay cell (per the CarPlay feasibility verdict) is NOT a simdrive
+journey cell — CarPlay can't be interactively driven on a sim. Its regression
+signal is the headless `PalaceTests/CarPlay` XCTest suite. This module reads the
+result bundle that suite produces and emits one finding per failed test into the
+cell's own shard, conforming to the pinned regression_findings schema.
+
+Source of truth: `xcrun xcresulttool get test-results summary --format json`,
+whose `testFailures[]` array gives, per failure:
+    { failureText, targetName, testIdentifierString ("Suite/testMethod()"),
+      testName }
+`failureText` discriminates a crash ("Test crashed with signal trap.") from an
+assertion ("XCTAssertNotNil failed") — so a CarPlay regression that *crashes*
+(the high-severity case) is classified `crash`; an assertion failure is `other`.
+(Cross-cell `device-divergence` is assigned later by Fable-triage when the same
+failure reproduces across cells — a single cell does not self-assign it.)
+
+Usage:
+  regression_xcresult_findings.py --xcresult <bundle> \
+      --device-cell C-carplay --area carplay \
+      --run-dir .regression-runs/<id> [--first-seen-commit <sha>] [--json]
+  # or feed a pre-extracted summary JSON (testing / offline):
+  regression_xcresult_findings.py --summary-json <file> ...
+
+Exit code:
+  0  — parsed; no test failures (cell PASS)
+  1  — at least one failure (findings emitted; cell FAIL)
+  2  — config error (no xcresult / xcresulttool error)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# failureText markers that mean the test CRASHED (vs. a plain assertion).
+_CRASH_MARKERS = re.compile(
+    r"crash|signal|trap|fatal error|EXC_|SIGABRT|SIGSEGV|SIGTRAP|"
+    r"terminating with uncaught", re.I,
+)
+
+_COLUMNS = [
+    "id", "area", "device_cell", "severity", "classification", "verified",
+    "evidence_paths", "screenshot_pair", "first_seen_commit", "dedup_cluster",
+    "disposition",
+]
+
+
+def classify_failure(failure_text: str) -> str:
+    """A crashed test → 'crash'; any other failure → 'other'."""
+    return "crash" if _CRASH_MARKERS.search(failure_text or "") else "other"
+
+
+def parse_failures(summary: dict) -> list[dict]:
+    """Extract normalized failures from a `test-results summary` JSON object."""
+    out = []
+    for f in summary.get("testFailures", []) or []:
+        ident = f.get("testIdentifierString", "") or ""
+        suite, _, method = ident.partition("/")
+        text = f.get("failureText", "") or ""
+        out.append({
+            "suite": suite,
+            "test": method or f.get("testName", ""),
+            "identifier": ident,
+            "failure_text": text,
+            "target": f.get("targetName", ""),
+            "classification": classify_failure(text),
+        })
+    return out
+
+
+def build_rows(failures: list[dict], device_cell: str, area: str,
+               evidence: str, first_seen_commit: str) -> list[dict]:
+    rows = []
+    for i, f in enumerate(failures):
+        is_crash = f["classification"] == "crash"
+        rows.append({
+            "id": f"{device_cell}-{area}-{i+1}",
+            "area": area,
+            "device_cell": device_cell,
+            # a crashing CarPlay test is a blocker; an assertion failure major.
+            "severity": "blocker" if is_crash else "major",
+            "classification": f["classification"],
+            "verified": "false",
+            "evidence_paths": evidence,
+            "screenshot_pair": "",
+            "first_seen_commit": first_seen_commit,
+            "dedup_cluster": "",
+            "disposition": "",
+            # not schema columns, but handy in --json output:
+            "_identifier": f["identifier"],
+            "_failure_text": f["failure_text"],
+        })
+    return rows
+
+
+def emit_findings(run_dir: str, device_cell: str, area: str,
+                  rows: list[dict]) -> str | None:
+    if not rows:
+        return None
+    shard = Path(run_dir) / "findings" / f"{device_cell}__{area}.csv"
+    schema_rows = [{c: r.get(c, "") for c in _COLUMNS} for r in rows]
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import regression_findings as rf  # type: ignore
+        rf.append_findings(str(shard), schema_rows)
+    except Exception:
+        _inline_append(shard, schema_rows)
+    return str(shard)
+
+
+def _inline_append(shard: Path, rows: list[dict]) -> None:
+    import csv
+    shard.parent.mkdir(parents=True, exist_ok=True)
+    new = not shard.exists() or shard.stat().st_size == 0
+    with shard.open("a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=_COLUMNS)
+        if new:
+            w.writeheader()
+        for row in rows:
+            w.writerow({c: row.get(c, "") for c in _COLUMNS})
+
+
+def _summary_from_xcresult(xcresult: str) -> dict:
+    res = subprocess.run(
+        ["xcrun", "xcresulttool", "get", "test-results", "summary",
+         "--path", xcresult, "--format", "json"],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0:
+        print(f"ERROR: xcresulttool failed: {res.stderr.strip()}", file=sys.stderr)
+        sys.exit(2)
+    return json.loads(res.stdout)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="xcresult failures → findings")
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--xcresult", help="path to the .xcresult bundle")
+    src.add_argument("--summary-json", help="pre-extracted summary JSON (offline/testing)")
+    ap.add_argument("--device-cell", default="C-carplay")
+    ap.add_argument("--area", default="carplay")
+    ap.add_argument("--run-dir", default=".regression-runs/adhoc")
+    ap.add_argument("--first-seen-commit", default="")
+    ap.add_argument("--evidence", default="", help="evidence path override (default: the xcresult)")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    if args.summary_json:
+        summary = json.loads(Path(args.summary_json).read_text())
+        evidence = args.evidence or args.summary_json
+    else:
+        summary = _summary_from_xcresult(args.xcresult)
+        evidence = args.evidence or args.xcresult
+
+    failures = parse_failures(summary)
+    rows = build_rows(failures, args.device_cell, args.area, evidence,
+                      args.first_seen_commit)
+    shard = emit_findings(args.run_dir, args.device_cell, args.area, rows)
+
+    result = {
+        "device_cell": args.device_cell,
+        "area": args.area,
+        "total_tests": summary.get("totalTestCount"),
+        "failed": len(failures),
+        "crashes": sum(1 for f in failures if f["classification"] == "crash"),
+        "verdict": "FAIL" if failures else "PASS",
+        "findings_shard": shard,
+        "failures": [
+            {"identifier": f["identifier"], "classification": f["classification"],
+             "failure_text": f["failure_text"]} for f in failures
+        ],
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"=== {args.device_cell} headless XCTest cell ===")
+        print(f"tests={summary.get('totalTestCount')}  failed={len(failures)}  "
+              f"crashes={result['crashes']}")
+        for f in failures:
+            print(f"  [{f['classification']}] {f['identifier']} — {f['failure_text'][:70]}")
+        print(f"\nVERDICT: {result['verdict']}"
+              + (f"  (findings → {shard})" if shard else ""))
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_regression_crash_harvest.py
+++ b/scripts/tests/test_regression_crash_harvest.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+test_regression_crash_harvest.py — pytest harness for
+scripts/regression_crash_harvest.py (the C-ipad-on-mac WS-4 crash detector).
+
+Asserts the deterministic core:
+  - classify_crash_text recognises the WS-4 recursive_mutex signature, the
+    Crashlytics 9a91840677 id, and the abort+Adobe-frame upgrade path;
+  - clean / unrelated crashes are NOT misclassified as WS-4;
+  - harvest() matches only our process and only reports newer than `since`;
+  - a WS-4 hit emits a finding into the cell's own shard with the pinned
+    schema (classification=device-divergence, blocker), and PASS emits none.
+
+Fixtures are synthesised in tmp_path — no dependency on the host's real
+DiagnosticReports.
+"""
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "regression_crash_harvest", _SCRIPTS / "regression_crash_harvest.py"
+)
+harvest_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(harvest_mod)
+
+
+def _ips(app="Palace", exc="EXC_CRASH", body=""):
+    """Build a minimal modern .ips text: JSON header line + payload."""
+    header = json.dumps({"app_name": app, "procName": app})
+    payload = json.dumps({"exceptionType": exc, "body": body})
+    return header + "\n" + payload
+
+
+WS4_RECURSIVE_MUTEX = _ips(
+    body="terminating with uncaught exception ... recursive_mutex lock failed: "
+         "Invalid argument in dp::DPCriticalSection")
+WS4_CRASHLYTICS_ID = _ips(body="Crashlytics issue 9a91840677 fatal at exit")
+ABORT_ADOBE_FRAME = _ips(
+    exc="EXC_CRASH (SIGABRT)",
+    body="Thread 0 Crashed:\n0 librmsdk  dp::SomeAdeptCall()\n1 libc abort")
+PALACE_NON_WS4 = _ips(
+    exc="EXC_BAD_ACCESS",
+    body="Thread 0 Crashed:\n0 Palace  Swift.Optional.unsafelyUnwrapped")
+OTHER_PROCESS = _ips(app="Mail", body="recursive_mutex lock failed")  # not ours
+
+
+# --- pure classifier ---------------------------------------------------------
+
+def test_classify_recursive_mutex_is_ws4():
+    r = harvest_mod.classify_crash_text(WS4_RECURSIVE_MUTEX)
+    assert r["is_ws4"] is True
+    assert any("recursive_mutex" in s for s in r["matched_signatures"])
+
+
+def test_classify_crashlytics_id_is_ws4():
+    assert harvest_mod.classify_crash_text(WS4_CRASHLYTICS_ID)["is_ws4"] is True
+
+
+def test_classify_abort_plus_adobe_frame_upgrades_to_ws4():
+    r = harvest_mod.classify_crash_text(ABORT_ADOBE_FRAME)
+    assert r["is_ws4"] is True
+    assert r["matched_signatures"] == ["abort+adobe-frame"]
+
+
+def test_classify_palace_non_ws4_is_not_ws4():
+    r = harvest_mod.classify_crash_text(PALACE_NON_WS4)
+    assert r["is_ws4"] is False
+    assert r["matched_signatures"] == []
+
+
+def test_classify_plain_abort_without_adobe_is_not_ws4():
+    plain = _ips(exc="EXC_CRASH (SIGABRT)", body="0 Foundation -[NSArray objectAtIndex]")
+    assert harvest_mod.classify_crash_text(plain)["is_ws4"] is False
+
+
+# --- harvest scoping ---------------------------------------------------------
+
+def _write(dirpath: Path, name: str, text: str, mtime: float | None = None):
+    p = dirpath / name
+    p.write_text(text)
+    if mtime is not None:
+        import os
+        os.utime(p, (mtime, mtime))
+    return p
+
+
+def test_harvest_matches_only_our_process(tmp_path):
+    rd = tmp_path / "reports"; rd.mkdir()
+    _write(rd, "a.ips", WS4_RECURSIVE_MUTEX)
+    _write(rd, "b.ips", OTHER_PROCESS)
+    got = harvest_mod.harvest("Palace", since_epoch=0, reports_dir=str(rd))
+    procs = {c["process"] for c in got}
+    assert "Palace" in procs and "Mail" not in procs
+    assert len(got) == 1 and got[0]["is_ws4"] is True
+
+
+def test_harvest_ignores_reports_older_than_since(tmp_path):
+    rd = tmp_path / "reports"; rd.mkdir()
+    now = time.time()
+    _write(rd, "old.ips", WS4_RECURSIVE_MUTEX, mtime=now - 600)
+    _write(rd, "new.ips", WS4_RECURSIVE_MUTEX, mtime=now)
+    got = harvest_mod.harvest("Palace", since_epoch=now - 60, reports_dir=str(rd))
+    assert len(got) == 1
+    assert Path(got[0]["path"]).name == "new.ips"
+
+
+def test_harvest_missing_dir_returns_empty(tmp_path):
+    assert harvest_mod.harvest("Palace", 0, str(tmp_path / "nope")) == []
+
+
+# --- findings emission (own shard, pinned schema) ----------------------------
+
+_EXPECTED_COLUMNS = [
+    "id", "area", "device_cell", "severity", "classification", "verified",
+    "evidence_paths", "screenshot_pair", "first_seen_commit", "dedup_cluster",
+    "disposition",
+]
+
+
+def test_ws4_hit_emits_finding_into_own_shard(tmp_path):
+    rd = tmp_path / "reports"; rd.mkdir()
+    _write(rd, "crash.ips", WS4_RECURSIVE_MUTEX)
+    run_dir = tmp_path / "run"
+    crashes = harvest_mod.harvest("Palace", 0, str(rd))
+    shard = harvest_mod._emit_findings(
+        str(run_dir), "C-ipad-on-mac", "audiobook-drm-exit", crashes,
+        first_seen_commit="deadbee", scan_log=str(tmp_path / "scan.log"),
+    )
+    assert shard is not None
+    sp = Path(shard)
+    assert sp.name == "C-ipad-on-mac__audiobook-drm-exit.csv"  # own shard naming
+    rows = list(csv.DictReader(sp.open()))
+    assert len(rows) == 1
+    row = rows[0]
+    assert list(row.keys()) == _EXPECTED_COLUMNS          # pinned schema/order
+    assert row["classification"] == "device-divergence"
+    assert row["severity"] == "blocker"
+    assert row["verified"] == "false"
+    assert row["dedup_cluster"] == "ws4-adobe-recursive-mutex"
+    assert "crash.ips" in row["evidence_paths"]
+    assert row["first_seen_commit"] == "deadbee"
+
+
+def test_pass_emits_no_finding(tmp_path):
+    rd = tmp_path / "reports"; rd.mkdir()
+    _write(rd, "ok.ips", PALACE_NON_WS4)  # matches process, not WS-4
+    run_dir = tmp_path / "run"
+    crashes = harvest_mod.harvest("Palace", 0, str(rd))
+    shard = harvest_mod._emit_findings(
+        str(run_dir), "C-ipad-on-mac", "audiobook-drm-exit", crashes,
+        first_seen_commit="", scan_log=None,
+    )
+    assert shard is None
+    assert not (run_dir / "findings").exists() or \
+        not list((run_dir / "findings").glob("*.csv"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/scripts/tests/test_regression_matrix_preflight.py
+++ b/scripts/tests/test_regression_matrix_preflight.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+test_regression_matrix_preflight.py — pytest harness for
+scripts/regression_matrix_preflight.py.
+
+The preflight gates each regression-matrix cell on installed runtimes / device
+types / host arch. Its core contract (REGRESSION-BUILD-PLAN.md) is
+**skip-with-warning, never fail** when a requirement is missing, plus an
+iOS-18.0 *floor* substitution for the unavailable iOS-16 cell.
+
+These tests drive `evaluate_cell` / `resolve_runtime` / `resolve_device_type`
+against SYNTHETIC environments (no dependency on what's installed on the runner),
+so they assert the gating logic deterministically in CI.
+"""
+from __future__ import annotations
+
+import importlib.util
+import platform
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "regression_matrix_preflight", _SCRIPTS / "regression_matrix_preflight.py"
+)
+preflight = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(preflight)
+
+
+def _rt(version):
+    major, minor = (int(x) for x in version.split("."))
+    return {"name": f"iOS {version}", "version": version, "major": major,
+            "minor": minor, "identifier": f"id{version.replace('.', '')}"}
+
+
+def _dt(name):
+    return {"name": name, "identifier": "dt-" + name.replace(" ", "-")}
+
+
+IPHONE = _dt("iPhone 16 Pro")
+IPAD = _dt("iPad Pro 11-inch (M4)")
+
+
+def _cell(name):
+    return next(c for c in preflight.CELLS if c["cell"] == name)
+
+
+# --- runtime resolution ------------------------------------------------------
+
+def test_major_pref_picks_newest_minor():
+    rts = [_rt("26.0"), _rt("26.2"), _rt("26.1")]
+    got = preflight.resolve_runtime(("major", 26), rts)
+    assert got["version"] == "26.2"
+
+
+def test_exact_pref_prefers_exact_match():
+    rts = [_rt("18.0"), _rt("18.2")]
+    got = preflight.resolve_runtime(("exact", "18.0"), rts)
+    assert got["version"] == "18.0"
+
+
+def test_exact_pref_floor_fallback_to_lowest_same_major():
+    # 18.0 absent → floor to the LOWEST installed 18.x (18.2 here, the only one).
+    rts = [_rt("18.2"), _rt("18.4"), _rt("26.2")]
+    got = preflight.resolve_runtime(("exact", "18.0"), rts)
+    assert got["version"] == "18.2"
+
+
+def test_runtime_pref_unsatisfiable_returns_none():
+    rts = [_rt("26.2")]
+    assert preflight.resolve_runtime(("exact", "18.0"), rts) is None
+    assert preflight.resolve_runtime(("major", 18), rts) is None
+
+
+# --- device-type resolution --------------------------------------------------
+
+def test_device_type_exact_then_prefix():
+    dts = [IPHONE, IPAD]
+    assert preflight.resolve_device_type("iPhone 16 Pro", dts)["name"] == "iPhone 16 Pro"
+    # "iPad" is a prefix match against the installed iPad Pro
+    assert preflight.resolve_device_type("iPad", dts)["name"].startswith("iPad")
+    assert preflight.resolve_device_type("Apple Watch", dts) is None
+
+
+# --- cell evaluation: ready ---------------------------------------------------
+
+def test_iphone26_ready_with_destination():
+    env = {"runtimes": [_rt("26.2")], "devicetypes": [IPHONE]}
+    r = preflight.evaluate_cell(_cell("C-iphone-26"), env)
+    assert r["status"] == "ready"
+    assert r["runtime"] == "26.2"
+    assert r["destination"] == "platform=iOS Simulator,name=iPhone 16 Pro,OS=26.2"
+
+
+def test_ios18_floor_substitution_is_ready_with_note():
+    # 18.0 absent, 18.2 present → ready on the floor, with a substitution reason.
+    env = {"runtimes": [_rt("18.2"), _rt("26.2")], "devicetypes": [IPHONE]}
+    r = preflight.evaluate_cell(_cell("C-ios18"), env)
+    assert r["status"] == "ready"
+    assert r["runtime"] == "18.2"
+    assert "floor" in r["reason"]
+
+
+def test_carplay_is_headless_with_destination():
+    env = {"runtimes": [_rt("26.2")], "devicetypes": [IPHONE]}
+    r = preflight.evaluate_cell(_cell("C-carplay"), env)
+    assert r["status"] == "ready"
+    assert r["kind"] == "headless-xctest"
+    assert "headless" in r["reason"].lower()
+
+
+# --- cell evaluation: skip-with-warning (the contract) -----------------------
+
+def test_ios18_skips_when_no_18x_runtime():
+    env = {"runtimes": [_rt("26.2")], "devicetypes": [IPHONE]}
+    r = preflight.evaluate_cell(_cell("C-ios18"), env)
+    assert r["status"] == "skip"
+    assert "18.0" in r["reason"]
+    assert r["destination"] is None
+
+
+def test_ipad_skips_when_no_ipad_device_type():
+    env = {"runtimes": [_rt("26.2")], "devicetypes": [IPHONE]}
+    r = preflight.evaluate_cell(_cell("C-ipad-26"), env)
+    assert r["status"] == "skip"
+    assert "iPad" in r["reason"]
+
+
+def test_mac_native_skips_on_non_apple_silicon(monkeypatch):
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    env = {"runtimes": [_rt("26.2")], "devicetypes": [IPHONE, IPAD]}
+    r = preflight.evaluate_cell(_cell("C-ipad-on-mac"), env)
+    assert r["status"] == "skip"
+    assert "arm64" in r["reason"]
+
+
+def test_mac_native_ready_on_apple_silicon(monkeypatch):
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+    env = {"runtimes": [], "devicetypes": []}  # mac-native needs neither
+    r = preflight.evaluate_cell(_cell("C-ipad-on-mac"), env)
+    assert r["status"] == "ready"
+    assert r["destination"] == "platform=macOS,variant=Designed for iPad"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/scripts/tests/test_regression_xcresult_findings.py
+++ b/scripts/tests/test_regression_xcresult_findings.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+test_regression_xcresult_findings.py — pytest for
+scripts/regression_xcresult_findings.py (the headless-XCTest-cell findings
+parser used by C-carplay).
+
+Asserts:
+  - crash-vs-assertion classification from xcresult `failureText`;
+  - testFailures[] → normalized (suite, test, identifier);
+  - PASS (no failures) emits no shard;
+  - failures emit own-shard rows in the pinned schema, with crash→blocker and
+    assertion→major severity.
+
+Fixtures mirror the REAL `xcresulttool get test-results summary --format json`
+shape: a top-level dict with `totalTestCount` and a `testFailures` list of
+{failureText, targetName, testIdentifierString, testName}.
+"""
+from __future__ import annotations
+
+import csv
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "regression_xcresult_findings", _SCRIPTS / "regression_xcresult_findings.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _failure(ident, text, target="PalaceTests"):
+    suite, _, method = ident.partition("/")
+    return {
+        "failureText": text,
+        "targetName": target,
+        "testIdentifierString": ident,
+        "testName": method,
+    }
+
+
+CRASH = _failure("CarPlayTests/testCarPlay_OpensBook()", "Test crashed with signal trap.")
+ASSERT = _failure("CarPlayTests/testCarPlay_LibraryName()", "XCTAssertEqual failed: (\"a\") is not equal to (\"b\")")
+FATAL = _failure("CarPlayTests/testBridge_x()", "Fatal error: Unexpectedly found nil")
+
+
+# --- classification ----------------------------------------------------------
+
+@pytest.mark.parametrize("text,expected", [
+    ("Test crashed with signal trap.", "crash"),
+    ("Fatal error: Unexpectedly found nil", "crash"),
+    ("Thread 1: EXC_BAD_ACCESS", "crash"),
+    ("terminating with uncaught exception", "crash"),
+    ("XCTAssertNotNil failed", "other"),
+    ("XCTAssertEqual failed", "other"),
+    ("", "other"),
+])
+def test_classify_failure(text, expected):
+    assert mod.classify_failure(text) == expected
+
+
+# --- parse -------------------------------------------------------------------
+
+def test_parse_failures_splits_suite_and_method():
+    summary = {"totalTestCount": 40, "testFailures": [CRASH, ASSERT]}
+    got = mod.parse_failures(summary)
+    assert len(got) == 2
+    assert got[0]["suite"] == "CarPlayTests"
+    assert got[0]["test"] == "testCarPlay_OpensBook()"
+    assert got[0]["classification"] == "crash"
+    assert got[1]["classification"] == "other"
+
+
+def test_parse_no_failures_is_empty():
+    assert mod.parse_failures({"totalTestCount": 40, "testFailures": []}) == []
+    assert mod.parse_failures({"totalTestCount": 40}) == []  # key absent
+
+
+# --- rows + severity ---------------------------------------------------------
+
+def test_build_rows_severity_by_class():
+    failures = mod.parse_failures({"testFailures": [CRASH, ASSERT, FATAL]})
+    rows = mod.build_rows(failures, "C-carplay", "carplay", "x.xcresult", "abc123")
+    sev = {r["classification"]: r["severity"] for r in rows}
+    assert sev["crash"] == "blocker"
+    assert sev["other"] == "major"
+    assert all(r["device_cell"] == "C-carplay" for r in rows)
+    assert all(r["evidence_paths"] == "x.xcresult" for r in rows)
+
+
+# --- emission (own shard, pinned schema) -------------------------------------
+
+_EXPECTED_COLUMNS = [
+    "id", "area", "device_cell", "severity", "classification", "verified",
+    "evidence_paths", "screenshot_pair", "first_seen_commit", "dedup_cluster",
+    "disposition",
+]
+
+
+def test_emit_writes_own_shard_with_schema(tmp_path):
+    failures = mod.parse_failures({"testFailures": [CRASH, ASSERT]})
+    rows = mod.build_rows(failures, "C-carplay", "carplay", "x.xcresult", "abc")
+    shard = mod.emit_findings(str(tmp_path / "run"), "C-carplay", "carplay", rows)
+    assert Path(shard).name == "C-carplay__carplay.csv"
+    out = list(csv.DictReader(Path(shard).open()))
+    assert len(out) == 2
+    assert list(out[0].keys()) == _EXPECTED_COLUMNS  # schema/order conformance
+    assert out[0]["classification"] == "crash"
+    assert out[0]["severity"] == "blocker"
+
+
+def test_pass_emits_no_shard(tmp_path):
+    shard = mod.emit_findings(str(tmp_path / "run"), "C-carplay", "carplay", [])
+    assert shard is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What

Adds the regression-campaign **device/OS matrix cell tooling** and a small
**CarPlay cold-launch test seam** so the CarPlay-only-cold-start device-divergence
path is unit-testable.

### Cell tooling (`scripts/`, product test tooling)
- **`regression_matrix_preflight.py`** — gates each matrix cell on installed
  runtimes / device types / host arch. Skip-with-warning (never fails the
  campaign); uses iOS 18.0 as the floor for the iOS-16 cell (unavailable on
  Xcode 26); emits an `xcodebuild -destination` per ready cell + JSON for the
  campaign driver.
- **`regression-ipad-on-mac.sh` + `regression_crash_harvest.py`** — the
  `C-ipad-on-mac` cell: runs the Designed-for-iPad build natively
  (`isiOSAppOnMac == true`) and harvests/classifies exit crash logs for the
  Adobe RMSDK `recursive_mutex`-at-exit signature (the automated form of the
  Mac validation CHECK 2 for the iPad-on-Mac exit crash).
- **`regression-carplay-cell.sh` + `regression_xcresult_findings.py`** — the
  `C-carplay` cell: CarPlay cannot be driven interactively on a simulator, so its
  signal is the headless `PalaceTests/CarPlay` XCTest suite (all 9 classes); test
  failures become findings.
- All emit findings to the campaign `findings.csv` schema, each cell to its own
  shard. 34 pytest tests across the three modules.
- `docs/regression-suite/CARPLAY-FEASIBILITY.md` documents the feasibility
  verdict, the deferred visual-capture path, and the manual interaction checklist.

### Production — CarPlay cold-launch gate
- Extract a pure
  `CarPlayTemplateManager.shouldShowOpenAppAlert(mainSceneConnected:)` from
  `handleBookSelection` so the gate that shows the "open Palace on your phone"
  alert on a CarPlay-only cold start is unit-testable without a
  `CPInterfaceController`. **Behavior-identical** (returns `!mainSceneConnected`).
- Replace the tautology `testSceneDelegate_HasMainSceneConnected_Flag` with real
  both-branch behavior tests, and add a statebleed round-trip test proving
  `AppContainer._resetForTesting()` rebuilds fresh audiobook session statics via
  the production seam.

## Verification
- **Full CarPlay suite (9 classes) green:** `Executed 43 tests, with 0 failures`,
  `** TEST SUCCEEDED **`, no restart/timeout (iPhone 16 Pro sim).
- New tests execute + pass: `testShouldShowOpenAppAlert_whenMainSceneNotConnected_isTrue`,
  `testShouldShowOpenAppAlert_whenMainSceneConnected_isFalse`,
  `testStatebleed_resetForTesting_rebuildsFreshAudiobookStatics`.
- Tooling pytest: `34 passed` (preflight + crash-harvest + xcresult-findings),
  validated against a real xcresult and synthetic crash fixtures.
- Mechanical gates: blast-radius=0, superpartner=0, test-name-vs-body=0,
  adjacency=0.

## Not done (deferred / honest gaps)
- C-carplay **visual-capture PoC** (Simulator-private-API activation + screenshot)
  — documented fast-follow, not built.
- True **head-unit tap-through** — manual checklist item; no automatable path.
- iPad-on-Mac **live CHECK 2** (Adobe-EPUB → background → forced-exit) is
  operator/Mac-session-driven; this ships the launch-bracket + harvest +
  classification core, not a live result.
