### PR TITLE
Fix: clone-tag-only device strip (unblocks iPad cell) + classify_replay halt test

### DIFF
--- a/scripts/regression_findings.py
+++ b/scripts/regression_findings.py
@@ -336,14 +336,24 @@ def classify_replay(replay_result: dict) -> dict:
 
 
 def strip_device_suffix(device: str) -> str:
-    """Strip a trailing clone-suffix parenthetical from a sim device name.
+    """Strip a trailing CoreSimulator clone tag ((pool-N)/(fleet-N)) from a sim
+    device name.
 
-    Fleet/pool sims are named `iPhone 16 Pro (pool-3)` / `(fleet-5)` — the
-    parenthetical is a CoreSimulator clone tag, not a different device model.
-    `iPhone 16 Pro (pool-3)` → `iPhone 16 Pro`.
+    ONLY the fleet/pool clone tag is removed — a MODEL parenthetical such as
+    `iPad Pro (12.9-inch)` is preserved, because it is part of the device
+    identity. Stripping only the LAST paren (the old behavior) conflated
+    `iPad Pro (12.9-inch)` with `iPad Pro` and broke iPad normalization: a base
+    `iPad Pro (12.9-inch)` recording would not match a fleet
+    `iPad Pro (12.9-inch) (pool-3)` sim, spuriously FAILing the iPad cell.
+    Matching only the clone tag fixes that AND stays FAIL-safe — an unrecognized
+    suffix is left intact, so it errs toward a real mismatch (never a false-pass).
+
+    `iPhone 16 Pro (pool-3)` → `iPhone 16 Pro`;
+    `iPad Pro (12.9-inch) (fleet-2)` → `iPad Pro (12.9-inch)`;
+    `iPad Pro (12.9-inch)` → `iPad Pro (12.9-inch)` (model paren kept).
     """
     import re
-    return re.sub(r"\s*\([^)]*\)\s*$", "", device or "").strip()
+    return re.sub(r"\s*\((?:pool|fleet)-[^)]*\)\s*$", "", device or "").strip()
 
 
 def device_matches_modulo_suffix(expected: str, actual: str) -> bool:

--- a/scripts/tests/test_regression_area_chaos.py
+++ b/scripts/tests/test_regression_area_chaos.py
@@ -306,6 +306,18 @@ def test_classify_replay_state_contract_halt_is_fail_not_pass():
     assert "0/11" in v["reason"]
 
 
+def test_classify_replay_halt_reason_with_ok_true_is_fail():
+    # Isolate the `or halt_reason` clause: a halt_reason set with ok=True (e.g. a
+    # mid-run marks-count-drift halt) must still FAIL even though some steps ran.
+    r = {"ok": True, "halted_at": 3, "halt_reason": "marks_count_drift",
+         "steps_planned": 5,
+         "steps": [{"executed": True}, {"executed": True}, {"executed": True}]}
+    v = rf.classify_replay(r)
+    assert v["status"] == "fail"
+    assert "marks_count_drift" in v["reason"]
+    assert "3/5" in v["reason"]
+
+
 def test_classify_replay_incomplete_is_fail():
     r = {"ok": True, "steps_planned": 11,
          "steps": [{"executed": True}] * 5}   # only 5 of 11 ran
@@ -360,6 +372,26 @@ def test_strip_device_suffix():
     assert rf.strip_device_suffix("iPhone 16 Pro (fleet-5)") == "iPhone 16 Pro"
     assert rf.strip_device_suffix("iPhone 16 Pro") == "iPhone 16 Pro"
     assert rf.strip_device_suffix("") == ""
+
+
+def test_strip_device_suffix_preserves_model_paren_strips_only_clone_tag():
+    # Only the (pool-N)/(fleet-N) clone tag is removed; a MODEL paren is kept,
+    # so iPad recordings normalize correctly on fleet iPad sims (the C-ipad cell).
+    assert rf.strip_device_suffix("iPad Pro (12.9-inch) (pool-3)") == "iPad Pro (12.9-inch)"
+    assert rf.strip_device_suffix("iPad Pro (12.9-inch) (fleet-2)") == "iPad Pro (12.9-inch)"
+    assert rf.strip_device_suffix("iPad Pro (12.9-inch)") == "iPad Pro (12.9-inch)"
+    # an unrecognized suffix is left intact (FAIL-safe — never masks a mismatch)
+    assert rf.strip_device_suffix("iPhone 16 Pro (custom)") == "iPhone 16 Pro (custom)"
+
+
+def test_normalized_requires_device_ipad_model_paren_normalizes_on_fleet():
+    # base iPad recording vs fleet iPad sim → same model → rewrite to current
+    assert rf.normalized_requires_device(
+        "iPad Pro (12.9-inch)", "iPad Pro (12.9-inch) (pool-3)"
+    ) == "iPad Pro (12.9-inch)" + " (pool-3)"
+    # different iPad model paren → genuinely different device → None (FAIL)
+    assert rf.normalized_requires_device(
+        "iPad Pro (12.9-inch)", "iPad Pro (11-inch) (pool-3)") is None
 
 
 def test_device_matches_modulo_suffix():


### PR DESCRIPTION
Fast-follow to the two non-blocking SoD notes on #1080 (merged).

**1. `strip_device_suffix` strips only the `(pool-N)/(fleet-N)` clone tag, preserving model parens.** The prior "strip last paren" conflated `iPad Pro (12.9-inch)` with `iPad Pro`, so a base `iPad Pro (12.9-inch)` recording would not normalize against a fleet `iPad Pro (12.9-inch) (pool-3)` sim — the **C-ipad-26 cell would spuriously FAIL** every state-dependent journey. Clone-tag-only matching fixes it and stays FAIL-safe (unrecognized suffix → left intact → real mismatch, never a false-pass). iPhone behavior unchanged.

**2. `classify_replay` test for `halt_reason` set with `ok=True`** — isolates the `or halt_reason` clause from the `ok=False` path; a mid-run halt with some steps executed must still FAIL.

52 unit tests (3 new). bash -n clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)