### PR TITLE
test(carplay): fix migration-test publisher-timing flake (await @Published)

### DIFF
--- a/PalaceTests/CarPlay/CarPlayTests.swift
+++ b/PalaceTests/CarPlay/CarPlayTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import CarPlay
+import Combine
 import MediaPlayer
 @testable import Palace
 @testable import PalaceAudiobookToolkit
@@ -745,8 +746,21 @@ final class CarPlayAudiobookBridgePresenterMigrationTests: XCTestCase {
         // Drive the presenter into an active state via the session's
         // publisher seam — proves the bridge dismiss does NOT touch
         // session state.
+        // Deterministically wait for the presenter's async
+        // `.receive(on: DispatchQueue.main)` playbackStatePublisher sink to
+        // propagate, instead of a fixed 10ms RunLoop pump that flakes under CI
+        // main-queue congestion (the intrinsic race that red'd #1079/#1081).
+        // Subscribe to the `@Published` hasActiveSession BEFORE sending so the
+        // false→true transition cannot be missed.
+        let activePropagated = expectation(description: "presenter observes the active session")
+        var activeCancellable: AnyCancellable? = presenter.$hasActiveSession
+            .first(where: { $0 })
+            .sink { _ in activePropagated.fulfill() }
         session.playbackStatePublisher.send(.playing(bookId: "test-active"))
-        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        wait(for: [activePropagated], timeout: 5.0)
+        activeCancellable?.cancel()
+        activeCancellable = nil
+
         XCTAssertTrue(presenter.hasActiveSession,
                       "PRECONDITION: presenter must report active session before bridge dismiss")
 


### PR DESCRIPTION
## What
Fixes the intrinsic publisher-timing flake in
`CarPlayAudiobookBridgePresenterMigrationTests.testCarPlayBridge_dismissBookOnPhone_doesNotKillSession`
— the test that coin-flipped CI re-runs on #1079 and #1081.

The test drove `presenter.hasActiveSession` active via the session's **async**
`playbackStatePublisher` (delivered on a `.receive(on: DispatchQueue.main)` sink,
`AudiobookSessionPresenter.swift`) then asserted the precondition **synchronously**
behind a fixed `RunLoop.main.run(until: +0.01)` pump. Under CI main-queue
congestion, 10ms is insufficient → `hasActiveSession` not yet propagated →
precondition reds. Fingerprint: fail/fail/pass in-process within ~50ms.

## Fix
Event-driven wait instead of a fixed timer: subscribe to the `@Published`
`$hasActiveSession.first(where: { $0 })` **before** `.send(...)`, then
`wait(for: [expectation], timeout: 5.0)`. Fulfills on actual propagation
(sub-15ms), so the read is deterministic. `import Combine` added. **Test-only —
zero production change.**

## Verification
- **RED-first (deterministic):** with no wait, the precondition fails every run
  (2 failures, value provably not propagated).
- **GREEN after fix:** `-run-tests-until-failure -test-iterations 3` → migration
  class 6/0 (doesNotKillSession 0.013/0.008/0.009s).
- **Safety:** full 9-class CarPlay suite `Executed 43 tests, 0 failures,
  ** TEST SUCCEEDED **` (the `import Combine` change broke nothing).

## Not done
Only this one test's race is fixed. The separate
`TPPSettingsTests.testUseBetaLibraries_postsNotification` 154s near-hang
(quiescence/pool-starvation, test-isolation family) is tracked separately and
out of scope here.
