### PR TITLE
fix(reader2): EPUB reading-resume double-restore — gate is single restore authority

### DIFF
--- a/.forgeos/intent/epub-reading-resume-double-restore.md
+++ b/.forgeos/intent/epub-reading-resume-double-restore.md
@@ -1,0 +1,58 @@
+---
+name: epub-reading-resume-double-restore
+created: 2026-06-14
+author: claude-opus-4-8
+tracking: 3.2.0 regression run — EPUB reading-resume bounce (saved/synced position restore); no dedicated Jira ticket
+related_prs: ["#981 (regressing change — added the post-paint gate but left the constructor restore in place, commit 7612d2312)"]
+---
+
+# Intent — EPUB reading-resume double-restore: single restore authority
+
+3.2.0 must-fix (found by the regression run, confirmed by w-stabilize): restoring
+a real saved/synced reading position bounces the EPUB reader back to My Books (the
+"Sync Reading Position" dialog → Stay/Move → WKWebView WebContent torn down).
+Never-read / page-1 books open fine.
+
+## Root cause (traced in code + reconciled with w-stabilize's behavioral data)
+A saved locator is restored TWICE: (1) the `EPUBNavigatorViewController` constructor
+`initialLocation:` applies it DURING WKWebView first-paint
+(`TPPEPUBViewController.swift:71-75`), and (2) the post-first-paint gate
+`ReaderInitialLocationNavigator.go(to:)` applies it again from `viewDidAppear`
+(`TPPBaseReaderViewController.swift:347`). The constructor restore fires before
+Readium's location-mapping table is populated — the exact failure
+`ReaderInitialLocationNavigator` was built to avoid. For a SERVER-sourced
+cross-device locator that during-first-paint restore can't resolve → "Failed to
+determine navigation direction for scroll" → WebContent teardown → bounce. (A local
+page-N locator survives it, which is why single-device reopen is fine — the
+discriminator is the locator's source/values, the trigger is the during-first-paint
+constructor restore. The sync path adds no separate `go(to:)`; the synced position
+becomes the `initialLocator` via `ReaderService.makeEPUBViewController:577`.)
+
+## Claims (this diff does exactly these)
+1. Makes the post-first-paint gate the SINGLE restore authority:
+   `TPPEPUBViewController.navigatorConstructorInitialLocation(forSavedLocation:)`
+   returns nil, so the navigator constructor never restores; the gate restores once
+   post-paint (after the location-mapping table is populated). Wired at the
+   `EPUBNavigatorViewController(initialLocation:)` call site.
+2. Hardens the gate (`ReaderInitialLocationNavigator`): checks `go(to:)`'s Bool
+   result; on false sets `restoreDidDegradeToStart` + logs "remaining at start
+   (page 1)" — so a future unresolvable locator is a graceful page-1 degradation
+   (the navigator is already at its natural start), observable in prod, NOT a
+   teardown. Adds an `onRestoreAttempt` test hook for deterministic, no-sleep tests.
+3. Extends `TPPBaseReaderViewControllerInitialLocationTests`: the sync-condition
+   exactly-one-restore test (was RED at 2 → now 1), never-read=0, go-false→degrades,
+   go-true→no-degradation.
+
+## Anti-claims
+- Does NOT change the synchronizer, the Sync dialog, `convertToLocator`, the
+  position-save format, or the gate's existing latch/attach/ready semantics.
+- Does NOT attempt to fix any underlying "server-shaped locator fails to resolve"
+  issue (if w-stabilize's re-run lands at page 1 rather than the synced page, that
+  residual is a SEPARATE follow-up — out of scope here; this PR removes the
+  crash/bounce). Likely full restore expected (timing, not shape, per analysis).
+- No build-number bump (release gate intact).
+
+## Files in scope
+- `Palace/Reader2/UI/TPPEPUBViewController.swift`
+- `Palace/Reader2/UI/ReaderInitialLocationNavigator.swift`
+- `PalaceTests/Reader2/TPPBaseReaderViewControllerInitialLocationTests.swift`

--- a/Palace/Reader2/UI/ReaderInitialLocationNavigator.swift
+++ b/Palace/Reader2/UI/ReaderInitialLocationNavigator.swift
@@ -30,6 +30,7 @@
 //
 
 import Foundation
+import PalaceLogging
 import ReadiumNavigator
 import ReadiumShared
 
@@ -59,6 +60,18 @@ final class ReaderInitialLocationNavigator {
     /// can fire multiple times across a VC's lifecycle; we must navigate
     /// to the saved location exactly once on the initial entry.
     private var didNavigate: Bool = false
+
+    /// Set true if the post-first-paint restore `go(to:)` returned false — Readium
+    /// could not resolve the saved/synced locator. Because the EPUB navigator's
+    /// CONSTRUCTOR restore is disabled (`TPPEPUBViewController.navigatorConstructorInitialLocation`
+    /// is always nil), the navigator is already at the publication's natural start,
+    /// so a failed restore is a graceful degradation to page 1 — NOT a WebContent
+    /// teardown / bounce. Observable for diagnostics + tests.
+    private(set) var restoreDidDegradeToStart = false
+
+    /// Test hook: fired (on the main actor) with `go(to:)`'s Bool result once the
+    /// single restore attempt completes. Nil in production.
+    var onRestoreAttempt: ((Bool) -> Void)?
 
     init(initialLocation: Locator?) {
         self.initialLocation = initialLocation
@@ -91,8 +104,19 @@ final class ReaderInitialLocationNavigator {
         }
 
         didNavigate = true
-        Task { @MainActor in
-            await navigator.go(to: location, options: NavigatorGoOptions(animated: false))
+        Task { @MainActor [weak self] in
+            // Single restore authority: the navigator first-paints at its natural
+            // start (constructor restore disabled), then this fires once the
+            // WKWebView is ready (location-mapping table populated). Check the
+            // result: a false return means Readium couldn't resolve the locator —
+            // the reader stays at the natural start (graceful page-1 degradation),
+            // which we record/log rather than silently discard.
+            let restored = await navigator.go(to: location, options: NavigatorGoOptions(animated: false))
+            if !restored {
+                self?.restoreDidDegradeToStart = true
+                Log.warn(#file, "Reader initial-location restore returned false; remaining at start (page 1).")
+            }
+            self?.onRestoreAttempt?(restored)
         }
     }
 }

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -25,6 +25,26 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
     private lazy var keyboardNavigationHandler = KeyboardNavigationHandler(navigable: self)
     private var lastChapterHREF: String?
 
+    /// The location the EPUB navigator's CONSTRUCTOR should restore to.
+    ///
+    /// EXACTLY ONE restore must reach the navigator. The post-first-paint gate
+    /// (`ReaderInitialLocationNavigator`, fed via `super.init(initialLocation:)`)
+    /// is the single restore authority — it `go(to:)`s the saved location once
+    /// the WKWebView has reported first paint (`signalReady()` from
+    /// `viewDidAppear`). If the navigator's `EPUBNavigatorViewController`
+    /// constructor ALSO restores (non-nil `initialLocation:`), the saved location
+    /// is applied during first paint and then AGAIN by the gate mid-layout →
+    /// Readium "Failed to determine navigation direction for scroll" → WebContent
+    /// teardown → the reader bounces back to My Books. (3.2.0 reading-resume
+    /// regression: PR #981 added the gate but left the constructor restore in
+    /// place.) So the constructor restore is always nil — the gate owns restore.
+    static func navigatorConstructorInitialLocation(forSavedLocation savedLocation: Locator?) -> Locator? {
+        // Always nil — the post-first-paint gate is the SINGLE restore authority.
+        // (`savedLocation` is intentionally ignored; the navigator opens at its
+        // natural start and the gate restores once the WKWebView is ready.)
+        nil
+    }
+
     init(publication: Publication,
          book: TPPBook,
          initialLocation: Locator?,
@@ -70,7 +90,7 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
         // server. The `httpServer:` init is deprecated; use the no-server init.
         let navigator = try EPUBNavigatorViewController(
             publication: publication,
-            initialLocation: initialLocation,
+            initialLocation: Self.navigatorConstructorInitialLocation(forSavedLocation: initialLocation),
             config: config
         )
 

--- a/PalaceTests/Reader2/TPPBaseReaderViewControllerInitialLocationTests.swift
+++ b/PalaceTests/Reader2/TPPBaseReaderViewControllerInitialLocationTests.swift
@@ -135,6 +135,108 @@ final class TPPBaseReaderViewControllerInitialLocationTests: XCTestCase {
         XCTAssertEqual(stubNavigator.goCallCount, 1)
     }
 
+    // MARK: - Sync-dialog double-restore (3.2.0 reading-resume regression)
+
+    /// The dialog-driven sync path feeds a SERVER-sourced cross-device locator
+    /// (differs from local) as the reader's `initialLocation`. It restores via the
+    /// SAME two paths as a local reopen: the navigator CONSTRUCTOR's
+    /// `initialLocation:` (applied DURING WKWebView first-paint) AND the post-paint
+    /// gate. A server-shaped locator fails the during-first-paint constructor
+    /// restore → Readium "Failed to determine navigation direction for scroll" →
+    /// WebContent teardown → the reader bounces back to My Books. EXACTLY ONE
+    /// restore must reach the navigator: the post-paint gate is the single restore
+    /// authority; the constructor restore must be nil.
+    func testSyncRestore_serverShapedLocator_exactlyOneRestoreReachesNavigator() async {
+        let serverLocator = makeLocator(href: "/chapter12.xhtml", progression: 0.73)
+
+        // Restore source #1: the navigator constructor's initialLocation input.
+        let constructorRestore =
+            TPPEPUBViewController.navigatorConstructorInitialLocation(forSavedLocation: serverLocator)
+
+        // Restore source #2: the post-paint gate, driven with the recording stub.
+        sut = ReaderInitialLocationNavigator(initialLocation: serverLocator)
+        sut.attach(navigator: stubNavigator)
+        let goCalled = expectation(description: "gate go(to:)")
+        stubNavigator.onGo = { _ in goCalled.fulfill() }
+        sut.signalReady()
+        await fulfillment(of: [goCalled], timeout: 1.0)
+        let gateRestores = stubNavigator.goCallCount
+
+        let totalRestores = (constructorRestore != nil ? 1 : 0) + gateRestores
+        XCTAssertEqual(
+            totalRestores, 1,
+            "EXACTLY ONE restore must reach the navigator (post-paint gate only). A non-nil "
+            + "constructor initialLocation restores a server-shaped locator DURING first-paint "
+            + "→ WebContent teardown → reader bounces. Got \(totalRestores) "
+            + "(constructor=\(constructorRestore != nil), gate=\(gateRestores)).")
+        XCTAssertNil(
+            constructorRestore,
+            "The EPUB navigator constructor must NOT restore — the post-paint gate is the single authority.")
+        XCTAssertEqual(
+            stubNavigator.lastGoLocator?.href.string, serverLocator.href.string,
+            "The gate (sole authority) restores to the saved/synced locator.")
+    }
+
+    /// Never-read book (nil initialLocation): zero restores reach the navigator —
+    /// it opens at its natural start. (Confirms the fix doesn't perturb the
+    /// already-working never-read path.)
+    func testNeverRead_nilLocator_zeroRestoresReachNavigator() async {
+        let constructorRestore =
+            TPPEPUBViewController.navigatorConstructorInitialLocation(forSavedLocation: nil)
+
+        sut = ReaderInitialLocationNavigator(initialLocation: nil)
+        sut.attach(navigator: stubNavigator)
+        sut.signalReady()
+        await Task.yield()
+
+        let totalRestores = (constructorRestore != nil ? 1 : 0) + stubNavigator.goCallCount
+        XCTAssertEqual(totalRestores, 0,
+                       "Never-read book must produce zero navigator restores (opens at natural start).")
+        XCTAssertNil(constructorRestore)
+    }
+
+    /// Failed restore = graceful page-1 degradation, NOT a teardown. When the
+    /// post-paint gate `go(to:)` returns false (Readium can't resolve a
+    /// cross-device server locator), the gate must (a) fire exactly ONE restore
+    /// attempt — no second conflicting `go(to:)` — and (b) record the degradation
+    /// (`restoreDidDegradeToStart`) so the position-loss is observable, while the
+    /// navigator simply remains at its natural start (the constructor restore is
+    /// disabled, so there is nothing to tear down).
+    func testGate_goReturnsFalse_recordsPage1Degradation_noSecondRestore() async {
+        let serverLocator = makeLocator(href: "/unresolvable.xhtml", progression: 0.95)
+        stubNavigator.goResult = false
+        sut = ReaderInitialLocationNavigator(initialLocation: serverLocator)
+        sut.attach(navigator: stubNavigator)
+
+        let restoreDone = expectation(description: "restore attempt completed")
+        sut.onRestoreAttempt = { _ in restoreDone.fulfill() }
+
+        sut.signalReady()
+        await fulfillment(of: [restoreDone], timeout: 1.0)
+
+        XCTAssertEqual(stubNavigator.goCallCount, 1,
+                       "exactly one restore attempt — a failed restore must not fire a second conflicting go(to:)")
+        XCTAssertTrue(sut.restoreDidDegradeToStart,
+                      "the gate must record the page-1 degradation when go(to:) returns false")
+    }
+
+    /// Successful restore must NOT flag degradation.
+    func testGate_goReturnsTrue_doesNotFlagDegradation() async {
+        let locator = makeLocator(href: "/chapter5.xhtml", progression: 0.5)
+        stubNavigator.goResult = true
+        sut = ReaderInitialLocationNavigator(initialLocation: locator)
+        sut.attach(navigator: stubNavigator)
+
+        let restoreDone = expectation(description: "restore attempt completed")
+        sut.onRestoreAttempt = { _ in restoreDone.fulfill() }
+
+        sut.signalReady()
+        await fulfillment(of: [restoreDone], timeout: 1.0)
+
+        XCTAssertFalse(sut.restoreDidDegradeToStart,
+                       "a successful restore must not flag a page-1 degradation")
+    }
+
     // MARK: - Helpers
 
     private func makeLocator(href: String, progression: Double) -> Locator {
@@ -159,11 +261,13 @@ final class StubInitialLocationNavigator: NavigatorGoTo {
     private(set) var goCallCount = 0
     private(set) var lastGoLocator: Locator?
     var onGo: ((Locator) -> Void)?
+    /// Simulate Readium returning false (could not resolve the locator).
+    var goResult = true
 
     func go(to locator: Locator, options: NavigatorGoOptions) async -> Bool {
         goCallCount += 1
         lastGoLocator = locator
         onGo?(locator)
-        return true
+        return goResult
     }
 }


### PR DESCRIPTION
## What
3.2.0 must-fix (found by the regression run): restoring a real **saved/synced** reading position bounced the EPUB reader back to My Books — the "Sync Reading Position" dialog → Stay/Move → the WKWebView's WebContent process was torn down and the reader never rendered. Never-read / page-1 books opened fine; single-device local reopen was fine.

## Root cause
A saved locator was restored **twice**:
1. The `EPUBNavigatorViewController` **constructor** `initialLocation:` applies it **during** WKWebView first-paint (`TPPEPUBViewController.swift:71-75`).
2. The **post-first-paint gate** `ReaderInitialLocationNavigator` applies it again from `viewDidAppear` (`TPPBaseReaderViewController.swift:347`).

The constructor restore fires **before** Readium's location-mapping table is populated — exactly the failure the gate was built to avoid. For a **server-sourced cross-device** locator that during-first-paint restore can't resolve, Readium throws "Failed to determine navigation direction for scroll" → WebContent teardown → bounce. A local page-N locator survives the during-first-paint restore (hence single-device reopen is fine). The sync path adds **no separate `go(to:)`** — the synced position just becomes the `initialLocator` (`ReaderService.makeEPUBViewController:577`).

## Fix
- **`TPPEPUBViewController.navigatorConstructorInitialLocation(forSavedLocation:)` → `nil`**: the navigator never restores at construction; the post-paint gate is the **single restore authority** (fires once the location-mapping table is ready).
- **Gate hardening** (`ReaderInitialLocationNavigator`): check `go(to:)`'s `Bool`; on `false` set `restoreDidDegradeToStart` + log "remaining at start (page 1)". With the constructor restore gone, the navigator is already at its natural start, so a failed restore is a **graceful page-1 degradation** (observable in prod), not a teardown. Plus an `onRestoreAttempt` test hook for deterministic, no-sleep tests.

## Safety
The gate is **unconditionally** wired — `attach` in `viewDidLoad`, `signalReady` in `viewDidAppear` — so every visible reader fires it. `constructor:nil` therefore cannot create a no-restore path.

## Tests — `TPPBaseReaderViewControllerInitialLocationTests` (9, all green)
- `testSyncRestore_serverShapedLocator_exactlyOneRestoreReachesNavigator` — was **RED at 2 restores**, now **1** (constructor nil, gate sole authority).
- `testNeverRead_nilLocator_zeroRestoresReachNavigator` — 0.
- `testGate_goReturnsFalse_recordsPage1Degradation_noSecondRestore` / `...goReturnsTrue_doesNotFlagDegradation` — both gate outcomes.
- + the 5 existing gate tests.

```
Executed 9 tests, with 0 failures (0 unexpected). ** TEST SUCCEEDED **
```

## Scope
No version bump (release gate intact). Does not change the synchronizer / Sync dialog / `convertToLocator` / position-save format. Empirical "bounce gone + lands-at-synced-page vs page-1" confirmation is a follow-up regression re-run; full restore is expected (the failure was timing, not locator shape). If the re-run lands at page 1, the residual "server-shaped locator resolution" is a separate follow-up — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)