### PR TITLE
feat(regression): gate-3 fan-out safety — phase2 clean-skip + journey_drm tags

### DIFF
--- a/.simdrive/regression-areas.json
+++ b/.simdrive/regression-areas.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "Area-group manifest for the fleet regression campaign. The canonical SHARD-KEY source: a campaign worker = one (area-group x device-cell). RC-CAMPAIGN reads this to fan workers; scripts/regression-area-worker.sh reads it to resolve which journeys + chaos seeds a shard owns. JSON (not YAML) so the CI tooling-integrity job loads it with stdlib json — no pyyaml dependency. Keys beginning with '_' are documentation and ignored by the loader.",
+  "_doc": "Area-group manifest for the fleet regression campaign. The canonical SHARD-KEY source: a campaign worker = one (area-group x device-cell). RC-CAMPAIGN reads this to fan workers; scripts/regression-area-worker.sh reads it to resolve which journeys + chaos seeds a shard owns. JSON (not YAML) so the CI tooling-integrity job loads it with stdlib json \u2014 no pyyaml dependency. Keys beginning with '_' are documentation and ignored by the loader.",
   "_field_docs": {
     "matrix_ids": "REGRESSION_TEST_MATRIX.md rows this group covers (report coverage matrix; not executed directly).",
     "journeys": ".simdrive/journeys/<id>.yaml ids the area-worker replays. Every id MUST have a journey file on disk (enforced by scripts/tests/test_regression_area_chaos.py).",
@@ -8,15 +8,39 @@
   },
   "version": 1,
   "device_cells": [
-    { "id": "C-iphone-26", "_doc": "iPhone 16 Pro / iOS 26 - baseline parity" },
-    { "id": "C-ipad-26", "_doc": "iPad / iPadOS 26 - iPad layout parity (X1)" },
-    { "id": "C-ios18", "_doc": "iPhone / iOS 18 - back-compat floor (iOS-16 substitute)" },
-    { "id": "C-ipad-on-mac", "_doc": "Designed-for-iPad native - device-divergence crashes" }
+    {
+      "id": "C-iphone-26",
+      "_doc": "iPhone 16 Pro / iOS 26 - baseline parity"
+    },
+    {
+      "id": "C-ipad-26",
+      "_doc": "iPad / iPadOS 26 - iPad layout parity (X1)"
+    },
+    {
+      "id": "C-ios18",
+      "_doc": "iPhone / iOS 18 - back-compat floor (iOS-16 substitute)"
+    },
+    {
+      "id": "C-ipad-on-mac",
+      "_doc": "Designed-for-iPad native - device-divergence crashes"
+    }
   ],
   "area_groups": {
     "auth": {
       "description": "Sign-in / sign-out / session across auth types (A1-A8).",
-      "matrix_ids": ["A1", "A2", "A3", "A3-SAML", "A3-OIDC", "A3-OAuth", "A4", "A5", "A6", "A7", "A8"],
+      "matrix_ids": [
+        "A1",
+        "A2",
+        "A3",
+        "A3-SAML",
+        "A3-OIDC",
+        "A3-OAuth",
+        "A4",
+        "A5",
+        "A6",
+        "A7",
+        "A8"
+      ],
       "journeys": [
         "a1qa-basic-signin",
         "a1qa-sign-out",
@@ -31,7 +55,19 @@
     },
     "circulation": {
       "description": "Borrow / return / hold / download / DRM fulfillment (B1-B9).",
-      "matrix_ids": ["B1", "B2", "B3", "B4", "B5", "B6", "B6-Adobe", "B6-OD", "B7", "B8", "B9"],
+      "matrix_ids": [
+        "B1",
+        "B2",
+        "B3",
+        "B4",
+        "B5",
+        "B6",
+        "B6-Adobe",
+        "B6-OD",
+        "B7",
+        "B8",
+        "B9"
+      ],
       "journeys": [
         "palace-bookshelf-anonymous",
         "book-return-from-mybooks",
@@ -44,7 +80,13 @@
     },
     "reading": {
       "description": "EPUB / PDF / streaming-HTML reader (E1-E2, PP-4161).",
-      "matrix_ids": ["E1", "E1-LCP", "E1-Adobe", "E2", "E2-Hang"],
+      "matrix_ids": [
+        "E1",
+        "E1-LCP",
+        "E1-Adobe",
+        "E2",
+        "E2-Hang"
+      ],
       "journeys": [
         "reader2-back-button",
         "reader2-bookmark-toggle",
@@ -60,18 +102,32 @@
     },
     "audiobook": {
       "description": "Audiobook playback UI: skip / scrub / TOC / download indicator (E3-E8).",
-      "matrix_ids": ["E3-FA", "E3-OD", "E3-LCP", "E3-OA", "E4", "E8"],
+      "matrix_ids": [
+        "E3-FA",
+        "E3-OD",
+        "E3-LCP",
+        "E3-OA",
+        "E4",
+        "E8"
+      ],
       "journeys": [
         "audiobook-download-indicator-stateful",
         "audiobook-scrubber-drag",
         "audiobook-skip-forward",
         "audiobook-toc-seek"
       ],
-      "chaos_seeds": ["cold-launch"]
+      "chaos_seeds": [
+        "cold-launch"
+      ]
     },
     "catalog": {
       "description": "Catalog browse / search / feed-refresh / book-detail (C1-C4, X5).",
-      "matrix_ids": ["C1", "C2", "C3", "X5"],
+      "matrix_ids": [
+        "C1",
+        "C2",
+        "C3",
+        "X5"
+      ],
       "journeys": [
         "catalog-browse-stateless",
         "search-flow-stateful",
@@ -85,12 +141,141 @@
     },
     "ui-nav": {
       "description": "Tab-bar + settings tour - chrome/navigation completeness (U1, X6).",
-      "matrix_ids": ["U1", "X6", "X3"],
+      "matrix_ids": [
+        "U1",
+        "X6",
+        "X3"
+      ],
       "journeys": [
         "tab-bar-tour",
         "settings-tour-stateless"
       ],
-      "chaos_seeds": ["cold-launch"]
+      "chaos_seeds": [
+        "cold-launch"
+      ]
     }
-  }
+  },
+  "journey_drm": {
+    "PP-4161-streaming-html-reader": {
+      "drm_type": "open",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "a1qa-basic-signin": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "a1qa-sign-out": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "audiobook-download-indicator-stateful": {
+      "drm_type": "findaway",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "audiobook-scrubber-drag": {
+      "drm_type": "findaway",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "audiobook-skip-forward": {
+      "drm_type": "findaway",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "audiobook-toc-seek": {
+      "drm_type": "findaway",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "book-detail-stateless": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "book-return-from-mybooks": {
+      "drm_type": "lcp",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "catalog-browse-stateless": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "danny-saml-signin-init": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "feed-refresh-stateless": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "icarus-oidc-signin": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "library-picker-stateless": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "palace-bookshelf-anonymous": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "read-return-from-mybooks-roundtrip": {
+      "drm_type": "lcp",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "reader2-back-button": {
+      "drm_type": "lcp",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "reader2-bookmark-toggle": {
+      "drm_type": "lcp",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "reader2-page-forward": {
+      "drm_type": "lcp",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "reader2-settings-sheet": {
+      "drm_type": "lcp",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "reader2-toc-navigate": {
+      "drm_type": "lcp",
+      "adobe_irreducible": false,
+      "substitutable": true
+    },
+    "search-flow-stateful": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "settings-tour-stateless": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    },
+    "tab-bar-tour": {
+      "drm_type": "none",
+      "adobe_irreducible": false,
+      "substitutable": false
+    }
+  },
+  "_journey_drm_doc": "Per-journey DRM/Adobe routing for the fan-out Phase-A/B filter. PHASE-B iff adobe_irreducible==true (default/absent => false => PHASE-A, unconstrained). All 24 are adobe_irreducible=false: sign-in is activation-free (PP-3649), borrow/read journeys are substitutable to LCP/open, audiobooks are Findaway/OD (never Adobe). Only a future ADEPT-fulfillment or iPad-on-Mac Adobe _exit-crash journey would be adobe_irreducible=true."
 }

--- a/scripts/regression-area-worker.sh
+++ b/scripts/regression-area-worker.sh
@@ -54,6 +54,11 @@ SIM_ID="${HARNESS_SESSION_SIM_UDID:-}"
 KEYCHAIN_RESET=1
 RUN_CHAOS=0
 DRY_RUN=0
+EXCLUDE_DRM=""        # skip journeys whose journey_drm.drm_type == this (Phase-A/B filter)
+ONLY_DRM=""           # run ONLY journeys whose journey_drm.drm_type == this
+DEAUTH_TEARDOWN=0     # accepted now (so the driver flag never errors); the sign-out-to-recycle
+                      # behavior lands with the first adobe_irreducible (Phase-B) journey — none
+                      # exist today, so it would be inert regardless. Live-validated then.
 
 die() { echo "error: $*" >&2; exit 2; }
 
@@ -65,6 +70,9 @@ while [[ $# -gt 0 ]]; do
     --sim-id) SIM_ID="$2"; shift 2 ;;
     --manifest) MANIFEST="$2"; shift 2 ;;
     --no-keychain-reset) KEYCHAIN_RESET=0; shift ;;
+    --exclude-drm) EXCLUDE_DRM="$2"; shift 2 ;;
+    --drm-type) ONLY_DRM="$2"; shift 2 ;;
+    --deauth-on-teardown) DEAUTH_TEARDOWN=1; shift ;;
     --chaos) RUN_CHAOS=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     -h|--help) sed -n '2,/^set -uo/p' "$0" | sed 's/^# \{0,1\}//; /^set -uo/d'; exit 0 ;;
@@ -143,6 +151,32 @@ skip_count=0
 finding_count=0
 
 for journey in "${JOURNEYS[@]}"; do
+  # Stageability gate (MUST be first): a journey that is NOT "ready" (phase2 =
+  # borrow-gated/borrow_and_download-unimplemented, or blocked = creds/OTP) cannot be
+  # staged to its precondition. Skip it CLEANLY here, BEFORE the replay — otherwise the
+  # replay is still attempted, gates on the unmet precondition, and (not being
+  # known-fragile) lands as a GATING false-RED. Clean-skip = no finding = honestly
+  # "not covered (phase2/blocked)", deterministic. (The skipped stage already can't
+  # false-PASS; this also closes the false-RED.)
+  jstatus="$(python3 -c "import sys; sys.path.insert(0,'$SCRIPT_DIR'); from regression_staging import staging_status; print(staging_status('$journey'))" 2>/dev/null || echo unknown)"
+  if [[ "$jstatus" != "ready" ]]; then
+    echo "[SKIP] $journey — not stageable (staging_status=$jstatus: phase2 borrow-gated / blocked)"
+    skip_count=$((skip_count + 1))
+    continue
+  fi
+
+  # Phase-A/B DRM filter (the seam w-mutex's --exclude-drm/--drm-type flags drive):
+  # skip a journey whose journey_drm.drm_type is excluded / not the requested type.
+  # No-op when both flags are empty (the current all-Phase-A matrix).
+  if [[ -n "$EXCLUDE_DRM" || -n "$ONLY_DRM" ]]; then
+    if ! python3 "$FINDINGS" drm-filter "$MANIFEST" "$journey" \
+         --exclude-drm "$EXCLUDE_DRM" --only-drm "$ONLY_DRM" 2>/dev/null; then
+      echo "[SKIP] $journey — drm-filter (exclude='$EXCLUDE_DRM' only='$ONLY_DRM')"
+      skip_count=$((skip_count + 1))
+      continue
+    fi
+  fi
+
   journey_yaml="$JOURNEYS_DIR/$journey.yaml"
   if [[ ! -f "$journey_yaml" ]]; then
     echo "[SKIP] $journey — no journey YAML at $journey_yaml" >&2

--- a/scripts/regression_findings.py
+++ b/scripts/regression_findings.py
@@ -524,6 +524,33 @@ def journeys_for_area(manifest: dict[str, Any], area_group: str) -> list[str]:
     return list(_area(manifest, area_group).get("journeys", []) or [])
 
 
+def drm_for_journey(manifest: dict[str, Any], journey: str) -> dict[str, Any]:
+    """The journey's DRM/Adobe routing tags from the manifest's `journey_drm` map.
+    Absent journey → the Phase-A default ({drm_type:none, adobe_irreducible:false,
+    substitutable:false}) so an untagged journey is never accidentally Phase-B."""
+    jd = (manifest.get("journey_drm") or {}).get(journey) or {}
+    return {
+        "drm_type": jd.get("drm_type", "none"),
+        "adobe_irreducible": bool(jd.get("adobe_irreducible", False)),
+        "substitutable": bool(jd.get("substitutable", False)),
+    }
+
+
+def journey_passes_drm_filter(manifest: dict[str, Any], journey: str,
+                              exclude_drm: str = "", only_drm: str = "") -> bool:
+    """Fan-out Phase-A/B filter (the seam w-mutex's driver flags drive). A journey is
+    SKIPPED iff its drm_type equals `exclude_drm`, or `only_drm` is set and its
+    drm_type differs. Empty filters → always run. Routing to the budget-bounded
+    Phase-B lane is by `adobe_irreducible` (read separately by the --adobe-budget
+    allowlist); this predicate is the --exclude-drm/--drm-type inclusion gate."""
+    dt = drm_for_journey(manifest, journey)["drm_type"]
+    if exclude_drm and dt == exclude_drm:
+        return False
+    if only_drm and dt != only_drm:
+        return False
+    return True
+
+
 def chaos_seeds_for_area(manifest: dict[str, Any], area_group: str) -> list[str]:
     return list(_area(manifest, area_group).get("chaos_seeds", []) or [])
 
@@ -565,7 +592,19 @@ def _cli(argv: list[str]) -> int:
     p_areas = sub.add_parser("areas", help="list area-group names")
     p_areas.add_argument("manifest")
 
+    p_drm = sub.add_parser("drm-filter",
+                           help="exit 0 if journey passes the --exclude-drm/--drm-type filter, 1 if filtered")
+    p_drm.add_argument("manifest")
+    p_drm.add_argument("journey")
+    p_drm.add_argument("--exclude-drm", default="")
+    p_drm.add_argument("--only-drm", default="")
+
     args = p.parse_args(argv)
+
+    if args.cmd == "drm-filter":
+        manifest = load_manifest(args.manifest)
+        return 0 if journey_passes_drm_filter(
+            manifest, args.journey, args.exclude_drm, args.only_drm) else 1
 
     if args.cmd == "init-csv":
         ensure_findings_header(args.csv_path)

--- a/scripts/tests/test_regression_staging.py
+++ b/scripts/tests/test_regression_staging.py
@@ -400,6 +400,38 @@ def test_known_fragile_journeys_are_demoted_but_recognized():
         assert st.staging_status(j) in ("ready", "phase2"), f"{j} must still run"
 
 
+# ── 7. journey_drm Phase-A/B routing (gate-3 fan-out filter seam) ─────────────
+
+def test_drm_for_journey_defaults_to_phase_a_when_untagged():
+    # an untagged journey must default to Phase-A (adobe_irreducible False) — never
+    # accidentally Phase-B
+    m = {"area_groups": {}, "journey_drm": {}}
+    d = rf.drm_for_journey(m, "anything")
+    assert d["adobe_irreducible"] is False and d["drm_type"] == "none"
+
+
+def test_journey_passes_drm_filter_exclude_and_only():
+    m = {"area_groups": {}, "journey_drm": {
+        "adobe-j": {"drm_type": "adobe", "adobe_irreducible": True},
+        "lcp-j": {"drm_type": "lcp", "adobe_irreducible": False}}}
+    assert not rf.journey_passes_drm_filter(m, "adobe-j", exclude_drm="adobe")
+    assert rf.journey_passes_drm_filter(m, "lcp-j", exclude_drm="adobe")
+    assert rf.journey_passes_drm_filter(m, "adobe-j", only_drm="adobe")
+    assert not rf.journey_passes_drm_filter(m, "lcp-j", only_drm="adobe")
+    assert rf.journey_passes_drm_filter(m, "lcp-j")  # no filters → runs
+
+
+def test_current_matrix_is_entirely_phase_a():
+    # gate-3 guard: EVERY tagged journey in the shipped manifest is Phase-A
+    # (adobe_irreducible False). If a future edit flips one to Phase-B it must be
+    # deliberate — this test forces that intent to be explicit.
+    m = rf.load_manifest(_MANIFEST)
+    jd = m.get("journey_drm", {})
+    assert jd, "manifest must carry journey_drm tags"
+    phase_b = [j for j, v in jd.items() if v.get("adobe_irreducible")]
+    assert phase_b == [], f"unexpected Phase-B journeys (need explicit budget): {phase_b}"
+
+
 def test_area_worker_bash_n():
     r = subprocess.run(["bash", "-n", str(_AREA_WORKER)], capture_output=True, text=True)
     assert r.returncode == 0, f"bash -n failed:\n{r.stderr}"


### PR DESCRIPTION
## Summary
Follow-up to #1085. Makes the regression fan-out **safe to fire** and lands the Adobe DRM classifier. **Zero `.swift`** (scripts/`.simdrive` only).

### 1. Stageability gate (the must-fix — prevents false-REDs)
The runner now CLEAN-SKIPS any journey whose `staging_status != "ready"` (phase2 borrow-gated / blocked) **before** the replay (`skip_count++`, no finding). Without this, the 3 phase2-with-recording journeys (`PP-4161-streaming-html-reader`, `book-return-from-mybooks`, `read-return-from-mybooks-roundtrip`) would have replayed against an unmet borrow precondition → `classify_replay` FAIL → a **false gating regression**. Now a fan-out emits **zero findings** for the 13 borrow-gated journeys; only the 9 Phase-A journeys replay.

### 2. journey_drm tags + Adobe budget = 0
`regression-areas.json` tags all 24 journeys with `{drm, adobe_irreducible}`. Every current journey is `adobe_irreducible=false` (every library has a non-Adobe/LCP path) → the current matrix is **100% Phase-A → adobe_budget cost = 0**. Gate-3 forensics (zero activations spent): sign-in doesn't activate (PP-3649 defers to borrow), borrow is idempotent + sign-out deauthorizes (recycles), activation is **per-card** (distinct Adobe user UUID per patron). The only future Phase-B is the iPad-on-Mac Adobe `_exit` crash coverage.

### 3. DRM filter seam (forward-wired, inert now)
Runner honors `--exclude-drm/--drm-type/--deauth-on-teardown`; no-op for the all-Phase-A matrix, ready for the future Adobe Phase-B. Includes a test guarding that the manifest stays 100% Phase-A (a Phase-B flip must be deliberate).

## Coordinator re-verify (palace-pm, clean worktree, cherry-picked onto develop)
- Cherry-pick applies clean onto develop `434ce9602`; **zero `.swift`**.
- Stageability gate confirmed skips phase2 **before** replay (runner L161-164).
- `bash -n` clean; **219/219** `scripts/tests` green (incl. phase2-skip + manifest-stays-Phase-A guards).

## Review notes
`SKIP_CRITICAL_PATH_REVIEW`/`SKIP_PRE_PUSH_TESTS` on push, justified: zero-`.swift` scripts/`.simdrive` diff → iOS `xcodebuild test` gate inapplicable (worktree Carthage env, not the change); relevant `scripts/tests` run independently (219 green).

**Deferred:** `borrow_and_download` (the phase2 borrow→read/listen flow) is NOT implemented here — this only makes the fan-out *safe* for the borrow-gated set by skipping them. Their regression coverage lands in the separate `borrow_and_download` workstream. Resulting fan-out exercises the 9 Phase-A journeys only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)