### PR TITLE
fix(regression): normalize requires.sim.ios_version (cross-minor fan-out fix)

### DIFF
--- a/scripts/regression-area-worker.sh
+++ b/scripts/regression-area-worker.sh
@@ -248,6 +248,7 @@ try:
     from regression_findings import (crashes_since, classify_replay,
                                      normalized_requires_device,
                                      normalized_requires_version_match,
+                                     normalized_requires_ios_version,
                                      normalized_text_subset_required)
 
     # Per-journey STAGING (#21 — the campaign-runnability fix): drive the sim to
@@ -298,22 +299,44 @@ try:
             return None
         return None
 
+    def _current_ios_version(u):
+        # the runtime key encodes the version, e.g. ...SimRuntime.iOS-26-2 -> "26.2"
+        try:
+            import re as _re
+            import subprocess
+            out = subprocess.run(["xcrun", "simctl", "list", "devices", "-j"],
+                                 capture_output=True, text=True, timeout=20)
+            for _rt, devs in json.loads(out.stdout).get("devices", {}).items():
+                for d in devs:
+                    if d.get("udid", "").upper() == u.upper():
+                        mm = _re.search(r"iOS-(\d+)-(\d+)", _rt)
+                        return (mm.group(1) + "." + mm.group(2)) if mm else None
+        except Exception:
+            return None
+        return None
+
     try:
         import yaml as _yaml
         rec_dir = Path.home() / ".simdrive" / "recordings" / journey_name
         data = _yaml.safe_load((rec_dir / "recording.yaml").read_text())
         _req = ((data or {}).get("requires") or {})
         rec_dev = ((_req.get("sim") or {}).get("device"))
+        rec_ios = ((_req.get("sim") or {}).get("ios_version"))
         rec_vm = ((_req.get("app") or {}).get("version_match"))
         rec_ts = (((_req.get("initial_state") or {}).get("text_subset_required")) or [])
         new_dev = normalized_requires_device(rec_dev or "", _current_device_name(udid) or "")
         new_vm = normalized_requires_version_match(rec_vm)
+        # iOS VERSION: requires.sim.ios_version is HARD-checked, so a 26.0-captured
+        # recording halts on a 26.2 candidate sim. Rewrite to the current sim version
+        # (predicate ios_versions left intact). The device/text_subset/screen contract
+        # is STILL enforced; a real regression HALTs.
+        new_ios = normalized_requires_ios_version(rec_ios, _current_ios_version(udid))
         # OCR ARTIFACTS (#21 corpus hardening): logo/glyph tokens (e.g. the A1QA logo
         # -> 'ga'/'al'/'qa') OCR variably run-to-run and cause non-deterministic
         # 0-execute = matrix-wide FALSE REDS. Strip them at replay time, keeping the
         # stable real-text tokens (never below a 3-token floor).
         new_ts = normalized_text_subset_required(rec_ts)
-        if new_dev or new_vm or new_ts is not None:
+        if new_dev or new_vm or new_ios or new_ts is not None:
             cell = os.environ.get("DEVICE_CELL", "cell")
             tmp_name = journey_name + "__rcnorm__" + cell
             tmp_rec = Path.home() / ".simdrive" / "recordings" / tmp_name
@@ -325,6 +348,9 @@ try:
             if new_dev:
                 d2["requires"]["sim"]["device"] = new_dev
                 note.append("device " + str(rec_dev) + " -> " + str(new_dev) + " (clone-suffix)")
+            if new_ios:
+                d2["requires"].setdefault("sim", {})["ios_version"] = new_ios
+                note.append("ios_version " + str(rec_ios) + " -> " + str(new_ios) + " (cross-os)")
             if new_vm:
                 d2["requires"].setdefault("app", {})["version_match"] = new_vm
                 note.append("version_match " + str(rec_vm or "minor") + " -> any (cross-build)")

--- a/scripts/regression_findings.py
+++ b/scripts/regression_findings.py
@@ -346,7 +346,9 @@ def strip_device_suffix(device: str) -> str:
     `iPad Pro (12.9-inch)` recording would not match a fleet
     `iPad Pro (12.9-inch) (pool-3)` sim, spuriously FAILing the iPad cell.
     Matching only the clone tag fixes that AND stays FAIL-safe — an unrecognized
-    suffix is left intact, so it errs toward a real mismatch (never a false-pass).
+    suffix is left intact, so it errs toward a real mismatch (never a false-MATCH
+    that masks a device divergence). A hand-named smoke sim must therefore use a
+    RECOGNIZED clone tag (fleet-N / _allocate_sim), not an arbitrary label.
 
     `iPhone 16 Pro (pool-3)` → `iPhone 16 Pro`;
     `iPad Pro (12.9-inch) (fleet-2)` → `iPad Pro (12.9-inch)`;
@@ -406,6 +408,28 @@ def normalized_requires_version_match(current_match: str | None) -> str | None:
     if (current_match or "minor") == "any":
         return None
     return "any"
+
+
+def normalized_requires_ios_version(recorded_ios: str | None,
+                                    current_ios: str | None) -> str | None:
+    """Cross-OS-version normalize (the rc-smoke residual): the recorder HARD-checks
+    `requires.sim.ios_version`, so a 26.0-captured recording HALTs (state_contract_
+    mismatch) on a 26.2 candidate sim — defeating the point of replaying OLD recordings
+    against a NEW build/sim. Rewrite the recording's ios_version to the CURRENT sim's
+    so the literal check passes; the load-bearing contract (text_subset/screen/
+    foreground + device modulo clone-suffix) is STILL enforced, so a real regression
+    still HALTs. A PREDICATE ios_version (e.g. '>=26.0') is left intact — the recorder
+    evaluates it. Returns the current ios_version when a rewrite is needed, else None
+    (already matches, predicate, or no current). Same Optional shape as the device /
+    version-match normalizers so the worker wires it identically."""
+    if not current_ios or not recorded_ios:
+        return None
+    rec = str(recorded_ios)
+    if any(c in rec for c in "<>="):     # predicate — leave for the recorder to evaluate
+        return None
+    if rec == str(current_ios):
+        return None
+    return str(current_ios)
 
 
 # Curated denylist of the A1QA library LOGO glyph fragments — the stacked "a1/qa"

--- a/scripts/tests/test_regression_staging.py
+++ b/scripts/tests/test_regression_staging.py
@@ -72,6 +72,26 @@ def test_version_normalize_is_independent_of_device_normalize():
     assert rf.normalized_requires_device("iPad Pro", "iPhone 16 Pro") is None  # cross-model still halts
 
 
+def test_device_strip_is_fail_safe_only_pool_fleet_unrecognized_kept():
+    # FAIL-SAFE (anti-false-MATCH): strip ONLY the recognized pool/fleet clone tags;
+    # an UNRECOGNIZED suffix is LEFT INTACT so it can never mask a real device mismatch
+    # (a hand-named smoke sim must use fleet-N / _allocate_sim, not an arbitrary label).
+    assert rf.strip_device_suffix("iPhone 16 Pro (pool-3)") == "iPhone 16 Pro"
+    assert rf.strip_device_suffix("iPhone 16 Pro (fleet-2)") == "iPhone 16 Pro"
+    assert rf.strip_device_suffix("iPhone 16 Pro (custom)") == "iPhone 16 Pro (custom)"   # unrecognized — KEPT
+    assert rf.strip_device_suffix("iPad Pro (12.9-inch)") == "iPad Pro (12.9-inch)"        # model — kept
+    assert rf.strip_device_suffix("iPad Pro (12.9-inch) (fleet-2)") == "iPad Pro (12.9-inch)"
+
+
+def test_ios_version_normalize_relaxes_cross_minor_keeps_predicate():
+    # the rc-smoke residual: a 26.0-captured recording must replay on a 26.2 sim
+    assert rf.normalized_requires_ios_version("26.0", "26.2") == "26.2"
+    assert rf.normalized_requires_ios_version("26.2", "26.2") is None       # already matches
+    assert rf.normalized_requires_ios_version(">=26.0", "26.2") is None      # predicate — recorder evaluates
+    assert rf.normalized_requires_ios_version(None, "26.2") is None
+    assert rf.normalized_requires_ios_version("26.0", None) is None
+
+
 # ── 1b. OCR-artifact text_subset normalize (corpus hardening) ─────────────────
 
 def test_text_subset_strips_a1qa_logo_ocr_artifacts():


### PR DESCRIPTION
## Summary
The smoke fan-out blocker. The runner relaxed `requires.sim.device` + `app.version_match` but **never `requires.sim.ios_version`** — which the recorder hard-checks. A 26.0-captured recording → `state_contract_mismatch` (0-executed) on any 26.2 fleet sim → **the whole matrix would 0-execute on cross-minor-iOS candidates.** The 9/9 order-independence gate masked it because the gate sim (141BD227) *is* iOS 26.0 (the capture version). The C-iphone-26 smoke on a fresh 26.2 sim caught it **before** the 24-worker fan-out.

**Zero `.swift`** (scripts/ + tests only).

## Fix
- `normalized_requires_ios_version()` rewrites the recording's `ios_version` to the current sim's, **predicate forms (`>=26.0`) preserved**; wired into the worker temp-copy alongside the existing device/version_match normalize.
- **Lock-test** added: `strip_device_suffix` leaves an *unrecognized* suffix intact (fail-safe — never masks a device mismatch).

## What this PR does NOT do (and why)
An earlier cut also broadened `strip_device_suffix` to strip *any* suffix — **rejected and reverted**: it broke the device fail-safe (an unrecognized suffix must stay intact so a real device mismatch surfaces rather than being masked). The smoke-sim device issue is handled **driver-side** by using recognized `(fleet-N)` sim names (`_allocate_sim`), not by weakening the normalize. The real fan-out is unaffected (fleet sims are already whitelist-recognized).

## Coordinator full-suite re-verify (palace-pm, clean worktree, cherry-picked onto develop)
- Cherry-pick clean onto develop `3c2f7b28d`; **zero `.swift`**.
- `normalized_requires_ios_version` present + wired; `strip("(custom)")` → `"iPhone 16 Pro (custom)"` (fail-safe intact).
- `bash -n` clean; **221/221** full `scripts/tests` suite green (incl. the device fail-safe assertion + the new lock-test). *(An earlier cut's per-file test count missed a sibling-file failure — this was caught by running the full directory; lesson noted.)*

## Review notes
`SKIP_CRITICAL_PATH_REVIEW`/`SKIP_PRE_PUSH_TESTS` on push, justified: zero-`.swift` scripts diff → iOS `xcodebuild test` gate inapplicable; relevant `scripts/tests` run independently (221 green).

**Scope:** `ios_version` normalize only. Recordings untouched (temp-copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)