### PR TITLE
fix(regression): perf leak-heuristic distinguishes transient from sustained

### DIFF
--- a/scripts/regression-area-worker.sh
+++ b/scripts/regression-area-worker.sh
@@ -393,6 +393,27 @@ try:
         shutil.rmtree(tmp_rec, ignore_errors=True)
 
     current = sdp.snapshot(udid, app)
+    # LEAK vs TRANSIENT teardown: the immediate post-replay snapshot can catch a ONE-TIME
+    # teardown spike, not a leak. Measured: a1qa sign-out (Adobe-DRM deauthorize) spawns
+    # worker threads 10 -> ~25 -> 10 over ~10s (memory actually DROPS as the catalog
+    # frees) -> the +15-thread transient trips threads>10=HIGH. A LEAK is SUSTAINED. So
+    # if the immediate delta trips HIGH, re-snapshot after a settle and use the SETTLED
+    # values: a transient recedes (no false finding), a real leak persists (stays HIGH).
+    # Both deltas are logged so the decision is auditable, never silently muted.
+    _imm = {"memory_rss_mb": current.get("memory_rss_mb", 0) - baseline.get("memory_rss_mb", 0),
+            "threads": current.get("threads", 0) - baseline.get("threads", 0)}
+    if sdp.severity(_imm) == "high":
+        import time as _time
+        _time.sleep(8)
+        settled = sdp.snapshot(udid, app)
+        _set = {"memory_rss_mb": settled.get("memory_rss_mb", 0) - baseline.get("memory_rss_mb", 0),
+                "threads": settled.get("threads", 0) - baseline.get("threads", 0)}
+        with log_file.open("a") as lf:
+            lf.write("\n[info] perf immediate delta HIGH (threads " + str(_imm["threads"]) +
+                     ", mem " + str(round(_imm["memory_rss_mb"], 1)) + "MB) -> re-measured after 8s settle"
+                     ": threads " + str(_set["threads"]) + ", mem " + str(round(_set["memory_rss_mb"], 1)) +
+                     "MB (transient teardown recedes = not a leak; sustained = stays HIGH)\n")
+        current = settled
     # Scope to crashes since this run started (since_ts) rather than a pre/post
     # count delta — that delta could go negative if the list_crashes window shifts.
     # crashes_since re-applies the run-scoping as a tested pure invariant so a


### PR DESCRIPTION
## Summary
The last smoke blocker. `a1qa-sign-out`'s replay passes clean (2/2 steps, no drift/errors/crashes) but was false-flagged `perf_severity=HIGH` → gating. Root cause (measured): sign-out's Adobe **deauthorize** spins RMSDK teardown worker threads (**+15 transient**), tripping the `threads-delta>10` heuristic — even though **memory drops −48 MB** (catalog frees) and threads recede to baseline (25→10) over ~10s. A transient teardown spike is not a leak.

**Zero `.swift`**, 1 file (`regression-area-worker.sh`, perf-measurement block only).

## Fix
On a HIGH trip, re-snapshot after an ~8s settle and use the **settled** values for severity. Transient teardown recedes → no finding; a sustained leak persists → still HIGH. **Both deltas (immediate + settled) are logged** — auditable, never silently muted (perf stays a real signal). Fan-out-wide: any legit teardown thread-spike (sign-out / audiobook-stop / reader-close) benefits.

## Evidence (live-validated)
- `a1qa-sign-out`: `severity(immediate)=high` (+15 threads) vs `severity(settled)=low` (+1 thread / −49 MB).
- Leak still caught: sustained +80 MB → `severity=high`.

## Coordinator full-suite re-verify (palace-pm, clean worktree onto develop)
Cherry-pick clean onto develop `d1d492421`; **zero `.swift`**; settle-recheck present; `bash -n` clean; **221/221** full `scripts/tests` suite green (whole directory).

**Scope:** perf-measurement block only — no contract/threshold/product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)