### PR TITLE
PP-4542: audiobook cold-load fixes (token race + download-gate + frozen-flow)

### DIFF
--- a/.forgeos/intent/pp-4542-cold-load-auto-reopen-recovery.md
+++ b/.forgeos/intent/pp-4542-cold-load-auto-reopen-recovery.md
@@ -1,0 +1,68 @@
+---
+name: pp-4542-cold-load-auto-reopen-recovery
+created: 2026-06-16
+author: Maurice Carrier
+branch: fix/pp4542-audiobook-coldload
+ticket: PP-4542
+priority: 3.2.0 regression (critical-path, audiobook playback)
+---
+
+# Intent: cold-load auto-reopen guard for LCP audiobook first-open failure
+
+## Context
+
+Suite-missed 3.2.0 regression (Chairman repro'd on device; reproduced in
+simdrive 2026-06-16 on "Valley of the Moms", Main Street City Library). First
+cold-open of an LCP audiobook (fresh borrow → download → immediate first open)
+fails with the "Audiobook Unavailable" alert and recovers only on a manual
+re-tap. Root cause: the LCP-encrypted package isn't fully materialized when
+playback begins, so `LCPResourceLoaderDelegate` reads a byte-range past the
+archive's available extent and Readium 3.9.0 (PP-4340, ReadiumZIPFoundation
+3.0.1) surfaces `Archive.ArchiveError.rangeOutOfBounds` — where pre-3.2.0
+Readium tolerated the short read. The loader forwarded the hard error to the
+AVPlayerItem (`AVFoundationErrorDomain -11800`), and `handleManagerState`'s
+`.playbackFailed` cold-load branch turned it into a permanent alert.
+
+Primary fix is in the toolkit (retry the transient range read). This app-side
+change is the belt-and-suspenders guard for cold-load failures the toolkit
+retry doesn't absorb, mirroring the bounded OverDrive re-fulfill recovery
+([[ws3-overdrive-expired-url-refulfill]]).
+
+Critical-path (audiobook playback). Toolkit-coupled — submodule pin moves in
+lockstep.
+
+## Claims
+
+- Adds a pure boundary predicate
+  `shouldAutoReopenOnColdLoadFailure(hasEverStartedPlayback:hasCurrentBook:alreadyAttempted:)`
+  returning true iff playback NEVER started this session (a genuine cold load),
+  there is a current book to reopen, and a reopen has not already been attempted
+  for this book this session.
+- Adds a cold-load auto-reopen branch in `.playbackFailed` (PARALLEL to, and
+  after, the SAML and OverDrive branches): on the first cold-load failure,
+  silently `openAudiobook(book, startPlaying: true)` ONCE before publishing any
+  error or surfacing the alert. Bounded by `coldLoadReopenAttemptedBookIds`
+  (reset on a fresh user-initiated open).
+- A mid-playback failure (`hasEverStartedPlayback == true`) does NOT silently
+  reopen — it falls through to the existing error/alert path unchanged.
+- A persistent cold-load failure (second attempt) surfaces the existing
+  "Audiobook Unavailable" alert instead of looping.
+- Bumps the `ios-audiobooktoolkit` submodule pin to carry the toolkit-side
+  resource-loader retry fix.
+
+## Anti-claims
+
+- Does NOT retry on warm/mid-playback failures or when there is no current book.
+- Does NOT loop: bounded to one auto-reopen per book per session.
+- Does NOT add or change user-facing copy (reuses the existing
+  "Audiobook Unavailable" alert on exhaustion).
+- Does NOT change the SAML-reauth or OverDrive re-fulfill branches, nor other
+  vendors' playback paths.
+
+## Files in scope
+
+- `Palace/Audiobooks/AudiobookSessionManager.swift` (predicate + cold-load
+  auto-reopen branch + `coldLoadReopenAttemptedBookIds` bound/reset)
+- `ios-audiobooktoolkit` (submodule pin → toolkit resource-loader retry)
+- Tests: `PalaceTests/Audiobook/AudiobookColdLoadRecoveryTests.swift`
+- Toolkit tests: `PalaceAudiobookToolkitTests/LCPResourceLoaderColdLoadRetryTests.swift`

--- a/.forgeos/intent/pp-4542-review-awaittokenready-off-gcd.md
+++ b/.forgeos/intent/pp-4542-review-awaittokenready-off-gcd.md
@@ -1,0 +1,48 @@
+---
+name: PP-4542 review remediation awaitTokenReady off GCD
+created: 2026-06-17
+author: claude-opus-4-8
+---
+
+## Summary
+
+Remediation of the two independent-reviewer BLOCK verdicts on the PP-4542
+audiobook cold-load PR (#1094): the architect flagged that
+`AudiobookLoader.awaitTokenReady` reintroduced GCD on the audiobook critical
+path (recursive `DispatchQueue.global().asyncAfter`) in contradiction of
+`adr_a265ec76`, while its sibling `awaitAudiobookContentLocal` already polls
+correctly with `Task.sleep`; and both reviewers flagged the open-time
+remote-vs-local decision `preferRemotePosition` as shipped without unit
+coverage on a critical-path FR. Neither found a correctness defect.
+
+## Claims
+
+- rewrites `AudiobookLoader.awaitTokenReady` from a recursive
+  `DispatchQueue.global(qos:).asyncAfter` poll to a `Task` + `Task.sleep`
+  loop, keeping the audiobook open path off GCD per `adr_a265ec76`
+- preserves the existing `awaitTokenReady` API and semantics exactly: same
+  `nonisolated static` signature, same `completion: (Bool) -> Void`, same
+  bounded `timeout`/`pollInterval`, same re-read of `currentUserAccount`
+  each tick, same terminate-on-token-valid / terminate-on-deadline behaviour
+- adds a 7-case table test for `AudiobookSessionManager.preferRemotePosition`
+  (the strict `> 5.0s` remote-newer rule, plus the no-local / unparseable-local
+  / unparseable-remote / remote-older branches and the exact-5s boundary)
+- documents (comment-only) why the upfront `#if LCP` download gate and the
+  reactive `.playbackFailed` download gate are mutually exclusive and cannot
+  stack to 360s
+
+## Anti-claims
+
+- does NOT change `awaitTokenReady`'s observable behaviour — it is a
+  GCD→structured-concurrency swap of the poll mechanism only
+- does NOT change `preferRemotePosition` itself (test-only addition)
+- does NOT change any control flow on the open/restore path; the
+  `AudiobookSessionManager` edit is a clarifying comment, no executable change
+- does NOT touch the audiobook toolkit submodule, DRM, or network code
+
+## Files in scope
+
+- Palace/Audiobooks/AudiobookLoader.swift
+- Palace/Audiobooks/AudiobookSessionManager.swift (comment only)
+- PalaceTests/Audiobooks/AudiobookPositionRestoreTests.swift
+- .forgeos/intent/pp-4542-review-awaittokenready-off-gcd.md (NEW)

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -797,6 +797,7 @@
 		88EFF2030D2D45419813717D /* ForceResetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1557BA5E024E70AE55ACE2 /* ForceResetTests.swift */; };
 		89288C4DB882DB6F692F1750 /* Reader2BookmarkContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FB7A3D7F1E7AEABAA4A45E /* Reader2BookmarkContractTests.swift */; };
 		89382FCA6DC82E0D3906130A /* PalaceReadingPosition in Frameworks */ = {isa = PBXBuildFile; productRef = 5F61B627DDE72CE091C181D5 /* PalaceReadingPosition */; };
+		893C99258D1F416B909E64EE /* AudiobookColdLoadRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 867797B6E90539304E2A80B5 /* AudiobookColdLoadRecoveryTests.swift */; };
 		894A8D661F91D50152D41952 /* PositionSyncBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BA6F84CC20612B8D4969FE /* PositionSyncBanner.swift */; };
 		89952B99496C6D204701B8A0 /* ReadingSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0592B4A4D666ED6705BF8093 /* ReadingSessionTracker.swift */; };
 		89BF1555E007747A08BAB214 /* AuthDecisionEventEmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0F3324CC2B636469DBEE8A /* AuthDecisionEventEmissionTests.swift */; };
@@ -2568,6 +2569,7 @@
 		8568424DF6517B247D048D5D /* LCPLibraryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPLibraryServiceTests.swift; sourceTree = "<group>"; };
 		85803B918D5A471B9C0B98D0 /* CatalogState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogState.swift; sourceTree = "<group>"; };
 		8673802153960A8CA7EAE753 /* AccountsManager+TPPCurrentLibraryAccountProviding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AccountsManager+TPPCurrentLibraryAccountProviding.swift"; sourceTree = "<group>"; };
+		867797B6E90539304E2A80B5 /* AudiobookColdLoadRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookColdLoadRecoveryTests.swift; sourceTree = "<group>"; };
 		867AE0470C91DD0D498E68F4 /* AppContainerAudiobookFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContainerAudiobookFactoryTests.swift; sourceTree = "<group>"; };
 		87F6DEC8A63194712483BB6B /* TPPSettings+UniversalLinksProviding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "TPPSettings+UniversalLinksProviding.swift"; sourceTree = "<group>"; };
 		8A2EAE5D772D960178EBD800 /* AccessibilityServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityServiceTests.swift; sourceTree = "<group>"; };
@@ -3829,6 +3831,7 @@
 				7EA3C09A7973CF58C57F23C0 /* AudiobookLoaderOPDSShapeMatrixTests.swift */,
 				73D1CD4CDD735A3008ACCD5F /* AudiobookBookmarkBusinessLogicPositionWriteTests.swift */,
 				F774A40BD0FCA32D809EFDA7 /* FindawaySavedVsPlayedTests.swift */,
+				867797B6E90539304E2A80B5 /* AudiobookColdLoadRecoveryTests.swift */,
 			);
 			path = Audiobook;
 			sourceTree = "<group>";
@@ -7399,6 +7402,7 @@
 				36D5376F01972FB0278F2CB9 /* AudioSessionActivatorTests.swift in Sources */,
 				F58124F59C1F78CADB673820 /* TriageBotKeyAdminTests.swift in Sources */,
 				935B58EA66D6CDC630490B7E /* FindawaySavedVsPlayedTests.swift in Sources */,
+				893C99258D1F416B909E64EE /* AudiobookColdLoadRecoveryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/NavigationCoordinator.swift
+++ b/Palace/AppInfrastructure/NavigationCoordinator.swift
@@ -165,6 +165,25 @@ final class NavigationCoordinator: ObservableObject {
         Log.debug(#file, "📍 NavigationCoordinator.pop() - After pop count: \(path.count)")
     }
 
+    /// Pops ONLY when the audiobook player is actually the top route.
+    ///
+    /// PP-4542: opening a new audiobook while a previous session is still bound
+    /// tears that session down via `stopPlayback(dismissPhoneUI: true)` →
+    /// `dismissPlayerOnPhone` → pop. But if the previous player's screen was
+    /// already gone (the user navigated back, then opened a different title),
+    /// an unconditional `pop()` removes the WRONG thing — the *new* book's
+    /// detail — dumping the user onto the catalog. With the download-gate that
+    /// gap lasts the entire download. Guarding on `isTopRouteAudio` makes the
+    /// teardown a no-op when there's no player on top to dismiss, so the new
+    /// book's detail stays put until the real player is pushed.
+    func popIfTopRouteAudio() {
+        guard isTopRouteAudio else {
+            Log.debug(#file, "📍 popIfTopRouteAudio — top route is not the audio player; skipping pop")
+            return
+        }
+        pop()
+    }
+
     func popToRoot() {
         guard !path.isEmpty else { return }
         isTopRouteAudio = false

--- a/Palace/Audiobooks/AudiobookLoader.swift
+++ b/Palace/Audiobooks/AudiobookLoader.swift
@@ -221,19 +221,23 @@ final class AudiobookLoader {
         pollInterval: TimeInterval = 0.15,
         completion: @escaping (Bool) -> Void
     ) {
-        let deadline = Date().addingTimeInterval(timeout)
-        func poll() {
-            if !AppContainer.production().accountsManager.currentUserAccount.authTokenHasExpired {
-                completion(true)
-                return
+        // Structured-concurrency poll (Task.sleep, not recursive GCD) to keep
+        // the audiobook open path off GCD per adr_a265ec76, mirroring the
+        // sibling poll in AudiobookSessionManager.awaitAudiobookContentLocal.
+        Task {
+            let deadline = Date().addingTimeInterval(timeout)
+            while true {
+                if !AppContainer.production().accountsManager.currentUserAccount.authTokenHasExpired {
+                    completion(true)
+                    return
+                }
+                if Date() >= deadline {
+                    completion(false)
+                    return
+                }
+                try? await Task.sleep(nanoseconds: UInt64(max(0, pollInterval) * 1_000_000_000))
             }
-            if Date() >= deadline {
-                completion(false)
-                return
-            }
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + pollInterval, execute: poll)
         }
-        poll()
     }
 
     private func logAccountDiagnostics(userAccount: TPPUserAccount, book: TPPBook) {

--- a/Palace/Audiobooks/AudiobookLoader.swift
+++ b/Palace/Audiobooks/AudiobookLoader.swift
@@ -169,10 +169,71 @@ final class AudiobookLoader {
                 Log.info(#file, "✅ Token refresh successful - proceeding to open audiobook")
                 completion(.success(()))
             case .failure(let error, _):
+                // PP-4542: the open requested a token but another refresh
+                // (almost always the proactive launch refresh of a near-expiry
+                // token) already held the single-flight slot, so
+                // refreshTokenAndResume(task: nil) returned "Token refresh in
+                // progress" *immediately* instead of queueing+retrying the way
+                // the URLSession-task path does. That hard failure was the
+                // dominant field cause of "Audiobook failed to open — please try
+                // again" (Crashlytics issue 27f5746…: ~45k events / 8.2k users,
+                // since 2.0.4). It is purely a timing race — tap an audiobook in
+                // the first second after launch and it dead-ends. Don't fail:
+                // AWAIT the in-flight refresh and proceed the instant it
+                // populates a valid token.
+                if Self.isRefreshInProgressError(error) {
+                    Log.info(#file, "⏳ A token refresh is already in progress — awaiting it before opening audiobook")
+                    Self.awaitTokenReady { becameValid in
+                        if becameValid {
+                            Log.info(#file, "✅ In-flight token refresh completed — proceeding to open audiobook")
+                            completion(.success(()))
+                        } else {
+                            Log.error(#file, "❌ Timed out awaiting in-flight token refresh")
+                            completion(.failure(.tokenRefreshFailed(underlying: error)))
+                        }
+                    }
+                    return
+                }
                 Log.error(#file, "❌ Token refresh failed: \(error.localizedDescription)")
                 completion(.failure(.tokenRefreshFailed(underlying: error)))
             }
         }
+    }
+
+    /// True when `error` is the "Token refresh in progress" signal from
+    /// `TPPNetworkExecutor.refreshTokenAndResume(task:)` — i.e. another refresh
+    /// already owns the single-flight slot. Matched on the message (not the
+    /// code) because `invalidCredentials` is overloaded for several token
+    /// failures; only this one is safe to wait on.
+    nonisolated static func isRefreshInProgressError(_ error: Error) -> Bool {
+        (error as NSError).localizedDescription.localizedCaseInsensitiveContains("token refresh in progress")
+    }
+
+    /// Polls the *current* account's token state until a concurrently-running
+    /// refresh populates a valid (unexpired) token, or `timeout` elapses.
+    /// Re-reads `currentUserAccount` each tick so a mid-flight account-object
+    /// swap can't strand us on a stale instance. Bounded so a failed/stuck
+    /// in-flight refresh can't hang the open forever — on timeout the caller
+    /// surfaces the original error (same as the pre-fix behaviour, just after
+    /// giving the in-flight refresh a chance).
+    nonisolated static func awaitTokenReady(
+        timeout: TimeInterval = 10.0,
+        pollInterval: TimeInterval = 0.15,
+        completion: @escaping (Bool) -> Void
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        func poll() {
+            if !AppContainer.production().accountsManager.currentUserAccount.authTokenHasExpired {
+                completion(true)
+                return
+            }
+            if Date() >= deadline {
+                completion(false)
+                return
+            }
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + pollInterval, execute: poll)
+        }
+        poll()
     }
 
     private func logAccountDiagnostics(userAccount: TPPUserAccount, book: TPPBook) {

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -397,6 +397,14 @@ public final class AudiobookSessionManager: ObservableObject {
     /// ONCE per playback session and never loops on the shared handler.
     private var overdriveRefulfillAttemptedBookIds = Set<String>()
 
+    /// PP-4542: per-session bound on the cold-load auto-reopen recovery. A book
+    /// id is inserted when its automatic re-open fires and removed when the user
+    /// initiates a fresh open — so a cold-load failure auto-reopens at most ONCE
+    /// per playback session and a genuinely persistent failure surfaces the
+    /// "Audiobook Unavailable" alert instead of looping. Visibility is internal
+    /// (not private) so the cold-load recovery test can assert the bound.
+    var coldLoadReopenAttemptedBookIds = Set<String>()
+
     /// Loader factory — recovery seam (WS-3). The default closure is
     /// byte-equivalent to the inline `AudiobookLoader(forceRefulfill:)` it
     /// replaces, so production behavior is unchanged. `private(set)` so only
@@ -423,6 +431,7 @@ public final class AudiobookSessionManager: ObservableObject {
         // (forceRefulfill) must NOT reset it, or the bound never holds.
         if !forceRefulfill {
             overdriveRefulfillAttemptedBookIds.remove(book.identifier)
+            coldLoadReopenAttemptedBookIds.remove(book.identifier)
         }
 
         if case .loading(let loadingId) = state, loadingId == book.identifier {
@@ -1566,6 +1575,26 @@ public final class AudiobookSessionManager: ObservableObject {
         return status == 410
     }
 
+    /// PP-4542: decides whether a `.playbackFailed` should trigger ONE silent
+    /// auto-reopen before surfacing the "Audiobook Unavailable" alert. Pure so
+    /// the per-session bound is unit-pinned without driving the auth-gated open
+    /// flow. Distributor-agnostic on purpose: the regression (Readium 3.9.0
+    /// rangeOutOfBounds on a not-yet-materialized LCP package) is a cold-load
+    /// race that any first-open can hit, and a reopen demonstrably recovers it.
+    /// - `hasEverStartedPlayback == false`: only a COLD-load failure (playback
+    ///   never started this session) is a candidate; a mid-playback failure is a
+    ///   different surface and must NOT silently reopen.
+    /// - `hasCurrentBook`: there must be a book to reopen.
+    /// - `alreadyAttempted == false`: bounded to one reopen per book per session
+    ///   so a genuinely persistent failure reaches the alert instead of looping.
+    static func shouldAutoReopenOnColdLoadFailure(
+        hasEverStartedPlayback: Bool,
+        hasCurrentBook: Bool,
+        alreadyAttempted: Bool
+    ) -> Bool {
+        !hasEverStartedPlayback && hasCurrentBook && !alreadyAttempted
+    }
+
     /// Extracts an HTTP status code from a playback error. The toolkit's network
     /// layer stamps `userInfo["httpStatusCode"]` on download/streaming failures
     /// (`OpenAccessDownloadTask`); we also walk one level of the
@@ -1811,19 +1840,44 @@ public final class AudiobookSessionManager: ObservableObject {
             }
 #endif
 
+            // PP-4542: cold-load auto-recovery. A first cold open of an LCP
+            // audiobook can fail transiently because the encrypted package
+            // isn't fully materialized yet — the toolkit's resource loader
+            // reads a byte-range past the not-yet-complete ZIP and surfaces
+            // ReadiumZIPFoundation rangeOutOfBounds (a Readium 3.9.0 / PP-4340
+            // regression). Re-opening succeeds once the data has landed, which
+            // is exactly what users discover by re-tapping. Do ONE re-open
+            // automatically before surfacing any error. Bounded to one attempt
+            // per book per session (mirrors the OverDrive refulfill guard) so a
+            // genuinely persistent failure can't loop and still reaches the
+            // alert below. The toolkit-side retry (LCPResourceLoaderDelegate) is
+            // the primary fix; this is the belt-and-suspenders guard for
+            // cold-load failures it doesn't absorb.
+            if Self.shouldAutoReopenOnColdLoadFailure(
+                   hasEverStartedPlayback: hasEverStartedPlayback,
+                   hasCurrentBook: currentBook != nil,
+                   alreadyAttempted: coldLoadReopenAttemptedBookIds.contains(bookId)
+               ), let book = currentBook {
+                coldLoadReopenAttemptedBookIds.insert(bookId)
+                Log.info(#file, "Cold-load failure detected — attempting one automatic re-open before surfacing alert")
+                Task { [weak self] in
+                    guard let self else { return }
+                    guard self.currentBook?.identifier == book.identifier else { return }
+                    _ = await self.openAudiobook(book, startPlaying: true)
+                }
+                return
+            }
+
             errorPublisher.send(.unknown("Playback failed"))
 
-            // Cold-load failure: playback never started for this session, so
-            // the player UI is just a stuck slider showing 0:00 over a dead
-            // AVPlayerItem. Dismiss the player and surface an honest "not
-            // playable right now" alert — NOT a retry offer, since these
-            // failures are typically persistent (distributor auth issues,
-            // yanked content, etc.) and a retry button would just invite
-            // rage-tapping for no outcome. If the problem was truly
-            // transient the user can re-tap the book themselves; that's
-            // natural UX, not a fake recovery affordance.
+            // Cold-load failure that persisted past the one silent auto-reopen
+            // above (or a failure after playback had already started): dismiss
+            // the player and surface an honest "not playable right now" alert.
+            // NOT a retry offer — we already retried once silently; a button
+            // would just invite rage-tapping for no outcome. The user can re-tap
+            // the book themselves; that's natural UX, not a fake affordance.
             if !hasEverStartedPlayback, currentBook != nil {
-                Log.info(#file, "Cold-load failure detected — dismissing player UI and showing unavailable alert")
+                Log.info(#file, "Cold-load failure persisted after auto re-open — dismissing player UI and showing unavailable alert")
                 Task { [weak self] in
                     guard let self else { return }
                     // Cold-load failure path: the player never started, so

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -405,6 +405,17 @@ public final class AudiobookSessionManager: ObservableObject {
     /// (not private) so the cold-load recovery test can assert the bound.
     var coldLoadReopenAttemptedBookIds = Set<String>()
 
+    /// PP-4542 (A): book ids currently parked in the "awaiting content download"
+    /// recovery (a fresh-borrow streaming failure whose `.lcpa` hasn't landed
+    /// yet). The streaming player emits a *storm* of `.playbackFailed` events for
+    /// a single failed open; without this guard, the first failure enters the
+    /// await branch but the next one — now seeing `alreadyAttempted == true` —
+    /// falls straight through to the "Unavailable" alert, defeating the wait.
+    /// While a book id is in this set, further `.playbackFailed` events for it
+    /// are swallowed until the await resolves (content lands → reopen, or times
+    /// out → alert). Internal so the recovery test can assert the guard.
+    var awaitingContentDownloadBookIds = Set<String>()
+
     /// Loader factory — recovery seam (WS-3). The default closure is
     /// byte-equivalent to the inline `AudiobookLoader(forceRefulfill:)` it
     /// replaces, so production behavior is unchanged. `private(set)` so only
@@ -418,8 +429,8 @@ public final class AudiobookSessionManager: ObservableObject {
     ///   instead of replaying the expired on-disk manifest. Internal (not part of
     ///   the public `AudiobookSessionManaging` surface); the public 2-param
     ///   witness above delegates here, and the in-class recovery branch calls it.
-    func openAudiobook(_ book: TPPBook, startPlaying: Bool, forceRefulfill: Bool) async -> Result<Void, AudiobookSessionError> {
-        Log.info(#file, "Opening audiobook: '\(book.title)' (id: \(book.identifier))\(forceRefulfill ? " [re-fulfill]" : "")")
+    func openAudiobook(_ book: TPPBook, startPlaying: Bool, forceRefulfill: Bool, isColdLoadRecovery: Bool = false) async -> Result<Void, AudiobookSessionError> {
+        Log.info(#file, "Opening audiobook: '\(book.title)' (id: \(book.identifier))\(forceRefulfill ? " [re-fulfill]" : "")\(isColdLoadRecovery ? " [cold-load recovery]" : "")")
         // Polish-phase (in-app-nav-polish-2026-06-01): record wall-clock
         // open time so the Continue Reading row's sort surfaces the real
         // last-touched book even when the audiobook position-save flow
@@ -431,7 +442,13 @@ public final class AudiobookSessionManager: ObservableObject {
         // (forceRefulfill) must NOT reset it, or the bound never holds.
         if !forceRefulfill {
             overdriveRefulfillAttemptedBookIds.remove(book.identifier)
-            coldLoadReopenAttemptedBookIds.remove(book.identifier)
+            // The cold-load recovery re-open must NOT reset its own bound, or the
+            // one-shot guard never holds and a persistently-failing book loops
+            // (re-open → fail → re-open …). Mirrors the OverDrive forceRefulfill
+            // guard. PP-4542.
+            if !isColdLoadRecovery {
+                coldLoadReopenAttemptedBookIds.remove(book.identifier)
+            }
         }
 
         if case .loading(let loadingId) = state, loadingId == book.identifier {
@@ -468,6 +485,49 @@ public final class AudiobookSessionManager: ObservableObject {
         currentBook = book
         hasEverStartedPlayback = false
         playbackStatePublisher.send(state)
+
+#if LCP
+        // PP-4542 (gate): a freshly-borrowed LCP audiobook is marked
+        // download-successful the instant its tiny .lcpl license lands, but the
+        // real .lcpa content is still downloading in the background. Opening now
+        // would route through the streaming path — and LCP streaming-from-
+        // license is BROKEN under Readium 3.9.0: the remote read returns 0 bytes
+        // with nil length, so AVPlayer dead-ends in CoreMedia -12873 → -11849
+        // "Operation Stopped" (the 3.2.0-only "Audiobook Unavailable"; confirmed
+        // via instrumented repro). The content download is already in flight, so
+        // instead of attempting the broken stream we HOLD the loading state and
+        // open from the local package the moment it lands — the reliable path.
+        // Skipped for cold-load recovery re-opens (content is already local by
+        // then). Generation/identity re-checked after the wait so a newer open
+        // supersedes us cleanly.
+        if !isColdLoadRecovery,
+           LCPAudiobooks.canOpenBook(book),
+           !Self.audiobookContentIsLocal(book.identifier) {
+            Log.info(#file, "LCP audiobook content still downloading — awaiting local package before opening (PP-4542 gate)")
+            let landed = await Self.awaitAudiobookContentLocal(book.identifier)
+            // A newer open (user tapped a different book) would have replaced
+            // currentBook + the .loading state; bail if so.
+            guard currentBook?.identifier == book.identifier,
+                  case .loading(let lid) = state, lid == book.identifier else {
+                Log.info(#file, "PP-4542 gate: a newer open superseded \(book.identifier) while awaiting content — bailing")
+                return .failure(.alreadyLoading)
+            }
+            if !landed {
+                Log.info(#file, "PP-4542 gate: content did not finish downloading within the wait window — surfacing unavailable")
+                await dismissAndPresentColdLoadUnavailable()
+                return .failure(.unknown("Audiobook content is still downloading"))
+            }
+            Log.info(#file, "PP-4542 gate: content landed — opening '\(book.title)' from local package")
+        }
+#endif
+
+        // PP-4542 follow-up: activate the audio session NOW, while the book
+        // loads, so it's live by the time the toolkit issues the first play().
+        // Cold launch defers session activation (it ran only on CarPlay connect /
+        // foreground re-entry), so a plain first open issued play() against an
+        // inactive session → AVError -11849 ("Operation Stopped") → slow start via
+        // auto-reopen. Pre-existing (also on 3.1.0); this removes the slow start.
+        AppContainer.production().playbackBootstrapper.ensureAudioSessionActiveForPlayback()
 
         loadGeneration &+= 1
         let generation = loadGeneration
@@ -824,7 +884,11 @@ public final class AudiobookSessionManager: ObservableObject {
             audiobookSessionPresenterProvider().clearActiveSession()
         } else if let coordinator = navigationCoordinatorHubProvider().coordinator {
             coordinator.removeAudioModel(forBookId: bookId)
-            coordinator.pop()
+            // PP-4542: only pop if the audio player is actually on top. A stale
+            // unconditional pop here removed the NEW book's detail when tearing
+            // down a previous session whose player had already been navigated
+            // away — dumping the user on the catalog for the whole download-gate.
+            coordinator.popIfTopRouteAudio()
         }
     }
 
@@ -998,20 +1062,50 @@ public final class AudiobookSessionManager: ObservableObject {
     }
 
     private func startPlaybackAndSyncPosition(for book: TPPBook, loaded: LoadedAudiobook) {
-        let shouldRestore = shouldRestoreBookmarkPosition(for: book)
-        let localPosition = shouldRestore ? getValidLocalPosition(book: book, audiobook: loaded.audiobook) : nil
-
-        let initialPosition: TrackPosition
-        if let local = localPosition {
-            Log.debug(#file, "Starting playback with local position: track=\(local.track.key), timestamp=\(local.timestamp)")
-            initialPosition = local
-        } else if let firstTrack = loaded.audiobook.tableOfContents.allTracks.first {
-            Log.debug(#file, "Starting '\(book.title)' from beginning - no saved position")
-            initialPosition = TrackPosition(track: firstTrack, timestamp: 0.0, tracks: loaded.audiobook.tableOfContents.tracks)
-        } else {
+        guard let firstTrack = loaded.audiobook.tableOfContents.allTracks.first else {
             Log.error(#file, "No tracks available in audiobook")
             return
         }
+        let shouldRestore = shouldRestoreBookmarkPosition(for: book)
+        let localPosition = shouldRestore ? getValidLocalPosition(book: book, audiobook: loaded.audiobook) : nil
+        let beginning = TrackPosition(
+            track: firstTrack,
+            timestamp: 0.0,
+            tracks: loaded.audiobook.tableOfContents.tracks
+        )
+        let bookId = book.identifier
+
+        // PP-4542 launch-smoothing: resolve the position to OPEN at — preferring a
+        // newer REMOTE bookmark over the local one — BEFORE issuing the first
+        // play, so playback opens directly at the right spot. Previously play
+        // started at the local/0 position immediately and the async server-bookmark
+        // sync then seeked to the remote position a beat later, which the user saw
+        // as the playhead "jumping around" before settling. The remote lookup is
+        // bounded (`remotePositionResolveTimeout`) so a slow/again backend can't
+        // stall open — on timeout we open at the local/beginning position
+        // (bookmarks normally return in ~0.5s, so the timeout is a rare safety
+        // valve, not the common path).
+        Task { @MainActor in
+            guard self.currentBook?.identifier == bookId else { return }
+            let initialPosition = await self.resolveInitialPosition(
+                for: book,
+                audiobook: loaded.audiobook,
+                localPosition: localPosition,
+                fallback: localPosition ?? beginning
+            )
+            guard self.currentBook?.identifier == bookId else { return }
+            self.issueFirstPlay(for: book, loaded: loaded, initialPosition: initialPosition)
+        }
+    }
+
+    /// Issues the first `play(at:)` for a freshly-loaded audiobook at the
+    /// already-resolved `initialPosition` (see the resolve step in
+    /// `startPlaybackAndSyncPosition`). Extracted so the position resolve can run
+    /// — and be awaited — BEFORE play, without disturbing the F-011 readiness-gate
+    /// / LCP-bypass wiring below.
+    @MainActor
+    private func issueFirstPlay(for book: TPPBook, loaded: LoadedAudiobook, initialPosition: TrackPosition) {
+        Log.debug(#file, "Opening '\(book.title)' at: track=\(initialPosition.track.key), timestamp=\(initialPosition.timestamp)")
 
         // F-011 fix (PR #990 toolkit overhaul regression): await the
         // toolkit's player-coordinator-ready signal BEFORE issuing the
@@ -1078,70 +1172,86 @@ public final class AudiobookSessionManager: ObservableObject {
             }
         }
 
-        let audiobookRef = loaded.audiobook
-        let playbackModelRef = loaded.playbackModel
-        // `syncLocation(for:)` lives on the concrete TPPBookRegistry as an
-        // extension; the provider protocol doesn't expose it. Cast at the
-        // call site so the rest of this file talks to the protocol.
-        // syncLocation(for:) lives on the concrete TPPBookRegistry as an
-        // extension; the provider protocol doesn't expose it. If the injected
-        // bookRegistry isn't the concrete app-scoped instance, skip the
-        // remote-bookmark lookup rather than fall through to a singleton —
-        // tests pass mocks here on purpose.
-        guard let concreteRegistry = bookRegistry as? TPPBookRegistry else {
-            // No-op: progress-syncing requires the production registry. In a
-            // mock-injected test, the local position alone is the best signal.
-            return
-        }
-        concreteRegistry.syncLocation(for: book) { [weak self, weak playbackModel = playbackModelRef, localPosition] (remoteBookmark: AudioBookmark?) in
-            guard let remoteBookmark = remoteBookmark,
-                  let remote = TrackPosition(
-                    audioBookmark: remoteBookmark,
-                    toc: audiobookRef.tableOfContents.toc,
-                    tracks: audiobookRef.tableOfContents.tracks
-                  ) else {
-                Log.debug(#file, "No remote position found - continuing with local position")
-                return
-            }
-            let formatter = ISO8601DateFormatter()
-            let localSaveDate = localPosition.flatMap { formatter.date(from: $0.lastSavedTimeStamp) }
-            let remoteSaveDate = formatter.date(from: remote.lastSavedTimeStamp)
-            guard let remoteDate = remoteSaveDate else { return }
-            let shouldUseRemote: Bool
-            if let localDate = localSaveDate {
-                shouldUseRemote = remoteDate.timeIntervalSince(localDate) > 5.0
-            } else {
-                shouldUseRemote = true
-            }
-            guard shouldUseRemote else {
-                Log.debug(#file, "Local position is current - keeping local position")
-                return
-            }
-            Log.info(#file, "📡 Remote position is newer - seeking to remote: track=\(remote.track.key), timestamp=\(remote.timestamp)")
-            Task { @MainActor in
-                // Route through session manager so we seek the CURRENT manager,
-                // not a stale one if the user switched books mid-sync.
-                guard let self = self,
-                      let currentMgr = self.manager,
-                      self.currentBook?.identifier == bookId else {
-                    return
-                }
-                playbackModel?.currentLocation = remote
-                // Toolkit T1 migration: player.play(at:) is now `async throws`.
-                Task { @MainActor in
-                    do {
-                        try await currentMgr.audiobook.player.play(at: remote)
-                    } catch {
-                        Log.error(#file, "Failed to seek to remote position: \(error)")
-                    }
-                }
-            }
-        }
-
         Task { @MainActor [weak playbackModel = loaded.playbackModel] in
             try? await Task.sleep(nanoseconds: 3_500_000_000)
             playbackModel?.persistLocation()
         }
+    }
+
+    // MARK: - Position resolve before play (PP-4542)
+
+    /// PP-4542: maximum time to wait for the server-synced position before
+    /// opening at the local/beginning position, so a slow backend can't stall
+    /// audiobook open. Audiobook bookmarks normally return in ~0.5s; this is the
+    /// rare-slow-case safety valve.
+    static let remotePositionResolveTimeout: TimeInterval = 2.5
+
+    /// Resolves the position to OPEN at: awaits the remote bookmark (bounded) and
+    /// prefers it over the local position only when meaningfully newer (the same
+    /// >5s rule the prior post-play seek used), otherwise returns `fallback`
+    /// (local-or-beginning). Running this BEFORE the first play is what removes
+    /// the "jump" — the player opens directly at the resolved spot.
+    @MainActor
+    private func resolveInitialPosition(
+        for book: TPPBook,
+        audiobook: Audiobook,
+        localPosition: TrackPosition?,
+        fallback: TrackPosition
+    ) async -> TrackPosition {
+        guard let remote = await awaitRemotePosition(
+            for: book,
+            audiobook: audiobook,
+            timeout: Self.remotePositionResolveTimeout
+        ) else {
+            Log.debug(#file, "No remote position resolved before play — opening at local position")
+            return fallback
+        }
+        guard Self.preferRemotePosition(local: localPosition, remote: remote) else {
+            Log.debug(#file, "Local position is current — opening at local position")
+            return fallback
+        }
+        Log.info(#file, "📡 Opening at remote position (newer than local): track=\(remote.track.key), timestamp=\(remote.timestamp)")
+        return remote
+    }
+
+    /// Bounded await of the server-synced position. Resolves to the remote
+    /// `TrackPosition` if the bookmark sync returns one within `timeout`, else
+    /// `nil` (slow/again backend or no remote bookmark). Single-resume guarded so
+    /// the timeout and the sync callback race safely. No-ops to `nil` for a
+    /// mock-injected registry (tests), so the local position alone drives open.
+    @MainActor
+    private func awaitRemotePosition(
+        for book: TPPBook,
+        audiobook: Audiobook,
+        timeout: TimeInterval
+    ) async -> TrackPosition? {
+        guard let concreteRegistry = bookRegistry as? TPPBookRegistry else { return nil }
+        let toc = audiobook.tableOfContents
+        return await withCheckedContinuation { (cont: CheckedContinuation<TrackPosition?, Never>) in
+            let once = PositionResolveOnce()
+            concreteRegistry.syncLocation(for: book) { (remoteBookmark: AudioBookmark?) in
+                let position = remoteBookmark.flatMap {
+                    TrackPosition(audioBookmark: $0, toc: toc.toc, tracks: toc.tracks)
+                }
+                once.fire { cont.resume(returning: position) }
+            }
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: UInt64(max(0, timeout) * 1_000_000_000))
+                once.fire { cont.resume(returning: nil) }
+            }
+        }
+    }
+
+    /// True iff `remote` should be preferred over `local` — i.e. the remote save
+    /// is >5s newer (no local ⇒ prefer remote). Pure/static so it's unit-pinnable.
+    static func preferRemotePosition(local: TrackPosition?, remote: TrackPosition) -> Bool {
+        let formatter = ISO8601DateFormatter()
+        guard let remoteDate = formatter.date(from: remote.lastSavedTimeStamp) else { return false }
+        guard let local = local,
+              let localDate = formatter.date(from: local.lastSavedTimeStamp) else {
+            return true
+        }
+        return remoteDate.timeIntervalSince(localDate) > 5.0
     }
 
     // MARK: - Readiness gate wiring (F-011)
@@ -1610,6 +1720,52 @@ public final class AudiobookSessionManager: ObservableObject {
     }
 #endif
 
+    /// True once the LCP audiobook's full content package is on disk. The `.lcpa`
+    /// is moved into place atomically on download completion
+    /// (BackgroundDownloadHandler.replaceBook), so file existence == content
+    /// complete — the same signal `LCPAdapter.prepareLCPSource` uses to prefer
+    /// the reliable local path over streaming.
+    static func audiobookContentIsLocal(_ bookId: String) -> Bool {
+        guard let url = AppContainer.production().downloadCenter.fileUrl(for: bookId) else { return false }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    /// Awaits a freshly-borrowed audiobook's content download landing on disk by
+    /// polling existence of the local package. The download is already in flight
+    /// (it auto-starts on borrow), so this is a *wait*, not a trigger. Bounded so
+    /// a stalled/failed download can't hold the loading state forever; on timeout
+    /// the caller surfaces the unavailable alert (i.e. no worse than today, just
+    /// after giving the in-flight download a chance to finish).
+    static func awaitAudiobookContentLocal(
+        _ bookId: String,
+        timeout: TimeInterval = 180,
+        pollInterval: TimeInterval = 0.5
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if audiobookContentIsLocal(bookId) { return true }
+            try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+        }
+        return audiobookContentIsLocal(bookId)
+    }
+
+    /// Dismisses the player UI and shows the honest "couldn't play right now"
+    /// alert used by the cold-load failure paths. Factored so the immediate
+    /// failure path and the PP-4542 await-local-content timeout path present an
+    /// identical experience.
+    private func dismissAndPresentColdLoadUnavailable() async {
+        // Cold-load failure path: the player never started, so there is no
+        // meaningful "live position" to persist.
+        await self.stopPlayback(dismissPhoneUI: true, persistFinalPosition: false)
+        await MainActor.run {
+            let alert = TPPAlertUtils.alert(
+                title: NSLocalizedString("Audiobook Unavailable", comment: "Title when a cold-load playback failure dismisses the player"),
+                message: NSLocalizedString("This audiobook couldn't be played right now. The content may be temporarily unavailable — please try again later or contact your library.", comment: "Message when a cold-load playback failure dismisses the player")
+            )
+            TPPAlertUtils.presentFromViewControllerOrNil(alertController: alert, viewController: nil, animated: true, completion: nil)
+        }
+    }
+
     private func validateRequirements(for book: TPPBook) async -> AudiobookSessionError? {
         if !(await isUserAuthenticated()) {
             return .notAuthenticated
@@ -1767,6 +1923,18 @@ public final class AudiobookSessionManager: ObservableObject {
             playbackStatePublisher.send(state)
 
         case .playbackFailed(let position, let error):
+            // PP-4542 (A): if we're already parked awaiting this book's content
+            // download (a fresh-borrow streaming failure), swallow the streaming
+            // player's follow-on failure storm. Without this, a second
+            // `.playbackFailed` slips past the auto-reopen guard (alreadyAttempted
+            // is now true) and dead-ends to the "Unavailable" alert while the
+            // await is still in flight — which is exactly what defeated the wait
+            // in the field repro.
+            if awaitingContentDownloadBookIds.contains(bookId) {
+                Log.info(#file, "Ignoring follow-on playback failure for \(bookId) — already awaiting content download (PP-4542)")
+                return
+            }
+
             Log.error(#file, "Playback failed at position: \(String(describing: position))")
             isPlaying = false
             state = .error(bookId: bookId, message: "Playback failed")
@@ -1859,11 +2027,51 @@ public final class AudiobookSessionManager: ObservableObject {
                    alreadyAttempted: coldLoadReopenAttemptedBookIds.contains(bookId)
                ), let book = currentBook {
                 coldLoadReopenAttemptedBookIds.insert(bookId)
+
+                // PP-4542 (A): the freshly-borrowed LCP audiobook case. A book is
+                // marked download-successful the instant the tiny .lcpl license
+                // lands, but the full .lcpa content keeps downloading in the
+                // background and only lands atomically on completion. Until then,
+                // the open *streams* — and streaming a fresh borrow is unreliable
+                // (the 3.2.0-only "Audiobook Unavailable"; root cause tracked as
+                // B). Re-opening the SAME not-ready stream a few ms later just
+                // fails again, even though simply waiting for the in-flight
+                // download would play perfectly from the local path (exactly what
+                // users discover by re-tapping later). So when the content isn't
+                // on disk yet, hold a loading state and re-open from the reliable
+                // local path the moment the download lands — instead of dead-
+                // ending to the alert.
+                if !Self.audiobookContentIsLocal(book.identifier) {
+                    Log.info(#file, "Cold-load failure while content still downloading — awaiting local content before re-opening (PP-4542)")
+                    // Park this book so the streaming player's follow-on failure
+                    // storm is swallowed (see the guard at the top of this case)
+                    // instead of racing past us to the "Unavailable" alert.
+                    awaitingContentDownloadBookIds.insert(book.identifier)
+                    state = .loading(bookId: book.identifier)
+                    playbackStatePublisher.send(state)
+                    Task { [weak self] in
+                        guard let self else { return }
+                        let becameLocal = await Self.awaitAudiobookContentLocal(book.identifier)
+                        // The wait is over — stop swallowing failures for this book
+                        // so the re-open's own success/failure drives the UI.
+                        self.awaitingContentDownloadBookIds.remove(book.identifier)
+                        guard self.currentBook?.identifier == book.identifier else { return }
+                        if becameLocal {
+                            Log.info(#file, "Content download landed — re-opening audiobook from local path")
+                            _ = await self.openAudiobook(book, startPlaying: true, forceRefulfill: false, isColdLoadRecovery: true)
+                        } else {
+                            Log.info(#file, "Content download did not land within wait window — surfacing unavailable alert")
+                            await self.dismissAndPresentColdLoadUnavailable()
+                        }
+                    }
+                    return
+                }
+
                 Log.info(#file, "Cold-load failure detected — attempting one automatic re-open before surfacing alert")
                 Task { [weak self] in
                     guard let self else { return }
                     guard self.currentBook?.identifier == book.identifier else { return }
-                    _ = await self.openAudiobook(book, startPlaying: true)
+                    _ = await self.openAudiobook(book, startPlaying: true, forceRefulfill: false, isColdLoadRecovery: true)
                 }
                 return
             }
@@ -1880,16 +2088,7 @@ public final class AudiobookSessionManager: ObservableObject {
                 Log.info(#file, "Cold-load failure persisted after auto re-open — dismissing player UI and showing unavailable alert")
                 Task { [weak self] in
                     guard let self else { return }
-                    // Cold-load failure path: the player never started, so
-                    // there is no meaningful "live position" to persist.
-                    await self.stopPlayback(dismissPhoneUI: true, persistFinalPosition: false)
-                    await MainActor.run {
-                        let alert = TPPAlertUtils.alert(
-                            title: NSLocalizedString("Audiobook Unavailable", comment: "Title when a cold-load playback failure dismisses the player"),
-                            message: NSLocalizedString("This audiobook couldn't be played right now. The content may be temporarily unavailable — please try again later or contact your library.", comment: "Message when a cold-load playback failure dismisses the player")
-                        )
-                        TPPAlertUtils.presentFromViewControllerOrNil(alertController: alert, viewController: nil, animated: true, completion: nil)
-                    }
+                    await self.dismissAndPresentColdLoadUnavailable()
                 }
             }
 
@@ -1959,5 +2158,24 @@ public final class AudiobookSessionManager: ObservableObject {
             isPlaying: isPlaying,
             playbackRate: audiobook.player.playbackRate
         )
+    }
+}
+
+/// One-shot resume guard (PP-4542): ensures a `CheckedContinuation` is resumed
+/// exactly once when a bounded await races a timeout against a completion
+/// callback. NSLock-guarded so the (possibly background-thread) sync callback and
+/// the MainActor timeout can race safely without a double-resume trap.
+private final class PositionResolveOnce {
+    private let lock = NSLock()
+    private var fired = false
+    func fire(_ block: () -> Void) {
+        lock.lock()
+        if fired {
+            lock.unlock()
+            return
+        }
+        fired = true
+        lock.unlock()
+        block()
     }
 }

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -2041,6 +2041,12 @@ public final class AudiobookSessionManager: ObservableObject {
                 // on disk yet, hold a loading state and re-open from the reliable
                 // local path the moment the download lands — instead of dead-
                 // ending to the alert.
+                // Cannot stack with the upfront `#if LCP` gate in openAudiobook:
+                // that gate fires BEFORE any playback attempt and `return`s on
+                // timeout (no loader.load → no streaming → no .playbackFailed),
+                // and on success the content is local so the guard below is
+                // false. This reactive wait therefore only covers non-LCP books
+                // downloading mid-open — a single 180s window, never 180+180.
                 if !Self.audiobookContentIsLocal(book.identifier) {
                     Log.info(#file, "Cold-load failure while content still downloading — awaiting local content before re-opening (PP-4542)")
                     // Park this book so the streaming player's follow-on failure

--- a/Palace/Audiobooks/PlaybackBootstrapper.swift
+++ b/Palace/Audiobooks/PlaybackBootstrapper.swift
@@ -204,6 +204,29 @@ public final class PlaybackBootstrapper {
         Log.debug(#file, "🚀 PlaybackBootstrapper ready for CarPlay")
     }
 
+    /// Ensure the audio session is configured AND active before a normal (phone)
+    /// audiobook open issues `play()`.
+    ///
+    /// At cold launch `configureAudioSession()` can fail with OSStatus -50 ("no
+    /// scenes yet"), and `setActive(true)` previously ran ONLY on CarPlay connect
+    /// (`ensureInitializedForCarPlay`) or foreground re-entry — never on a plain
+    /// first open. So the first `play()` of a freshly-opened audiobook was issued
+    /// against an INACTIVE session and failed with AVError -11849 ("Operation
+    /// Stopped"), recovering only on a retry/auto-reopen — the "slow to start"
+    /// symptom (pre-existing; also reproduces on 3.1.0, so not a 3.2.0
+    /// regression). By open time the scenes ARE connected, so re-running the
+    /// category setup now succeeds, and we activate with the same bounded retry
+    /// used for CarPlay. Idempotent and safe to call on every open; the activator
+    /// skips activation when other audio is already playing. Fire-and-forget so
+    /// the synchronous open path is never blocked by the backoff.
+    // PUBLIC_INTENT: lifecycle entry point on the public PlaybackBootstrapper, matching the sibling `public` ensureInitialized()/ensureInitializedForCarPlay() bootstrap surface.
+    public func ensureAudioSessionActiveForPlayback() {
+        configureAudioSession()
+        Task { @MainActor [weak self] in
+            await self?.activateAudioSessionWithRetry()
+        }
+    }
+
     // MARK: - Audio Session
 
     private func configureAudioSession() {

--- a/PalaceTests/Audiobook/AudiobookColdLoadRecoveryTests.swift
+++ b/PalaceTests/Audiobook/AudiobookColdLoadRecoveryTests.swift
@@ -1,0 +1,50 @@
+//
+//  AudiobookColdLoadRecoveryTests.swift
+//  PalaceTests
+//
+//  Regression coverage for PP-4542: the LCP audiobook first-cold-open
+//  "Audiobook Unavailable" failure. The toolkit-side fix
+//  (LCPResourceLoaderDelegate cold-load retry) is the primary repair; this
+//  pins the APP-side belt-and-suspenders guard — a bounded one-shot silent
+//  auto-reopen on a cold-load `.playbackFailed` before the alert is shown.
+//
+//  Like the OverDrive re-fulfill guard, the full handleManagerState ->
+//  openAudiobook wiring is auth-gated and proven by SoD review + device/sim
+//  validation; here we pin the pure decision predicate (the per-session bound
+//  and the cold-vs-warm distinction) so the recovery semantics can't drift.
+//
+
+import XCTest
+@testable import Palace
+
+@MainActor
+final class AudiobookColdLoadRecoveryTests: XCTestCase {
+
+    // Cold load (playback never started), a book to reopen, first failure → reopen.
+    func testColdLoad_firstFailure_triggersAutoReopen() {
+        XCTAssertTrue(AudiobookSessionManager.shouldAutoReopenOnColdLoadFailure(
+            hasEverStartedPlayback: false, hasCurrentBook: true, alreadyAttempted: false),
+            "A first cold-load failure with a current book must silently auto-reopen once — the regression (rangeOutOfBounds on a not-yet-materialized LCP package) recovers on reopen")
+    }
+
+    // Warm failure: playback already started this session → NOT a cold-load reopen.
+    func testWarmFailure_afterPlaybackStarted_doesNotAutoReopen() {
+        XCTAssertFalse(AudiobookSessionManager.shouldAutoReopenOnColdLoadFailure(
+            hasEverStartedPlayback: true, hasCurrentBook: true, alreadyAttempted: false),
+            "A failure AFTER playback has started is not a cold-load race — silently reopening would interrupt a real session and mask a genuine mid-playback error")
+    }
+
+    // No current book → nothing to reopen.
+    func testNoCurrentBook_doesNotAutoReopen() {
+        XCTAssertFalse(AudiobookSessionManager.shouldAutoReopenOnColdLoadFailure(
+            hasEverStartedPlayback: false, hasCurrentBook: false, alreadyAttempted: false),
+            "Without a current book there is nothing to reopen")
+    }
+
+    // Bounded: a second cold-load failure in the same session must surface the alert, not loop.
+    func testSecondFailure_alreadyAttempted_surfacesAlertNotLoop() {
+        XCTAssertFalse(AudiobookSessionManager.shouldAutoReopenOnColdLoadFailure(
+            hasEverStartedPlayback: false, hasCurrentBook: true, alreadyAttempted: true),
+            "Bounded to one reopen per book per session — a persistent cold-load failure must reach the 'Audiobook Unavailable' alert instead of looping the auto-reopen")
+    }
+}

--- a/PalaceTests/Audiobook/AudiobookLoaderOPDSShapeMatrixTests.swift
+++ b/PalaceTests/Audiobook/AudiobookLoaderOPDSShapeMatrixTests.swift
@@ -397,4 +397,36 @@ final class AudiobookLoaderOPDSShapeMatrixTests: XCTestCase {
         XCTAssertEqual(spies.openAccess.resolveCallCount, 1,
                        "With auth state cleared, the loader's token gate passes and the adapter chain routes (no longer skipped)")
     }
+
+    // MARK: - PP-4542: token-refresh-in-progress classifier
+
+    /// The audiobook open's pre-fetch token refresh returns a "Token refresh in
+    /// progress" error when another refresh (typically the proactive launch
+    /// refresh) already holds the single-flight slot. `AudiobookLoader` must
+    /// recognize THAT specific error — and only it — so it awaits the in-flight
+    /// refresh instead of hard-failing the open with "Audiobook failed to open —
+    /// please try again" (the dominant field cause, ~8k users / Crashlytics
+    /// 27f5746…). Matched on the message, not the (overloaded) code.
+    func testRefreshInProgressClassifier_matchesOnlyTheInProgressError() {
+        let inProgress = NSError(
+            domain: "org.thepalaceproject.palace", code: 301,
+            userInfo: [NSLocalizedDescriptionKey: "Token refresh in progress"]
+        )
+        XCTAssertTrue(AudiobookLoader.isRefreshInProgressError(inProgress),
+                      "the in-progress race must be recognized so the open awaits it")
+
+        // Same family, different message (missing credentials) must NOT match —
+        // only the in-progress race is safe to wait on; everything else fails.
+        let missingCreds = NSError(
+            domain: "org.thepalaceproject.palace", code: 401,
+            userInfo: [NSLocalizedDescriptionKey: "Cannot request token with empty credentials"]
+        )
+        XCTAssertFalse(AudiobookLoader.isRefreshInProgressError(missingCreds))
+
+        let unrelated = NSError(
+            domain: "NSURLErrorDomain", code: -1009,
+            userInfo: [NSLocalizedDescriptionKey: "The Internet connection appears to be offline."]
+        )
+        XCTAssertFalse(AudiobookLoader.isRefreshInProgressError(unrelated))
+    }
 }

--- a/PalaceTests/Audiobooks/AudiobookPositionRestoreTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookPositionRestoreTests.swift
@@ -319,4 +319,72 @@ final class AudiobookPositionRestoreTests: XCTestCase {
         let pub = OPDS2Publication(links: [], metadata: metadata, images: nil)
         return Account(publication: pub, imageCache: MockImageCache())
     }
+
+    // MARK: - preferRemotePosition (the >5s remote-vs-local rule)
+    //
+    // PP-4542: the open path was reworked so remote-position resolution gates
+    // the FIRST play (was a post-play seek). The decision of whether to honor
+    // the remote save over the local one funnels through the pure static
+    // `AudiobookSessionManager.preferRemotePosition(local:remote:)` — "prefer
+    // remote iff it was saved >5s newer; no/unparseable local ⇒ prefer remote;
+    // unparseable remote ⇒ keep local." This static changed open-time behavior
+    // on a critical-path FR but shipped unpinned (flagged in review). The table
+    // below kills every branch + the 5.0 boundary literal.
+    //
+    // Production parses with a default `ISO8601DateFormatter` (whole-second
+    // precision — no `.withFractionalSeconds`), so all fixtures use whole
+    // seconds; sub-second deltas wouldn't round-trip the parser.
+
+    private func makePosition(savedAt: String, trackIndex: Int = 0) -> TrackPosition {
+        var position = TrackPosition(track: tracks.tracks[trackIndex], timestamp: 0, tracks: tracks)
+        position.lastSavedTimeStamp = savedAt
+        return position
+    }
+
+    func testPreferRemote_unparseableRemoteTimestamp_keepsLocal() {
+        // Remote save we can't date → can't prove it's newer → keep local.
+        let local = makePosition(savedAt: "2026-01-01T00:00:00Z")
+        let remote = makePosition(savedAt: "garbage-not-a-date")
+        XCTAssertFalse(AudiobookSessionManager.preferRemotePosition(local: local, remote: remote))
+    }
+
+    func testPreferRemote_noLocalPosition_prefersRemote() {
+        // Nothing local to lose → take the remote save.
+        let remote = makePosition(savedAt: "2026-01-01T00:00:00Z")
+        XCTAssertTrue(AudiobookSessionManager.preferRemotePosition(local: nil, remote: remote))
+    }
+
+    func testPreferRemote_unparseableLocalTimestamp_prefersRemote() {
+        // Local exists but its timestamp is corrupt → trust the dateable remote.
+        let local = makePosition(savedAt: "not-iso8601")
+        let remote = makePosition(savedAt: "2026-01-01T00:00:00Z")
+        XCTAssertTrue(AudiobookSessionManager.preferRemotePosition(local: local, remote: remote))
+    }
+
+    func testPreferRemote_remoteNewerByMoreThan5s_prefersRemote() {
+        let local = makePosition(savedAt: "2026-01-01T00:00:00Z")
+        let remote = makePosition(savedAt: "2026-01-01T00:00:06Z") // +6s
+        XCTAssertTrue(AudiobookSessionManager.preferRemotePosition(local: local, remote: remote))
+    }
+
+    func testPreferRemote_remoteNewerByExactly5s_keepsLocal() {
+        // Boundary: rule is strict `> 5.0`, so exactly 5s does NOT prefer remote.
+        // Kills a `>` → `>=` mutation of the threshold comparison.
+        let local = makePosition(savedAt: "2026-01-01T00:00:00Z")
+        let remote = makePosition(savedAt: "2026-01-01T00:00:05Z") // +5s exactly
+        XCTAssertFalse(AudiobookSessionManager.preferRemotePosition(local: local, remote: remote))
+    }
+
+    func testPreferRemote_remoteNewerByLessThan5s_keepsLocal() {
+        let local = makePosition(savedAt: "2026-01-01T00:00:00Z")
+        let remote = makePosition(savedAt: "2026-01-01T00:00:03Z") // +3s
+        XCTAssertFalse(AudiobookSessionManager.preferRemotePosition(local: local, remote: remote))
+    }
+
+    func testPreferRemote_remoteOlderThanLocal_keepsLocal() {
+        // Negative delta → never prefer remote (kills an `abs()`/sign mutation).
+        let local = makePosition(savedAt: "2026-01-01T00:00:10Z")
+        let remote = makePosition(savedAt: "2026-01-01T00:00:00Z") // -10s
+        XCTAssertFalse(AudiobookSessionManager.preferRemotePosition(local: local, remote: remote))
+    }
 }


### PR DESCRIPTION
## PP-4542 — Audiobook cold-load fixes (token race + download-gate + frozen-flow)

Fixes the cluster of 3.2.0 "Audiobook Unavailable" / "Audiobook failed to open — please try again" field reports. Three independent app-side fixes plus the toolkit submodule re-pin (toolkit side: ThePalaceProject/ios-audiobooktoolkit#185).

### 1. Token-refresh-in-progress race — `AudiobookLoader`
Tapping an audiobook in the first ~second after launch races the proactive launch token refresh. The open's `refreshTokenAndResume(task: nil)` returns **"Token refresh in progress"** *immediately* (the no-task path doesn't queue+retry the way the URLSession-task path does), so the open hard-failed. This is the **dominant field cause** — Crashlytics `27f5746…`, ~45k events / **8.2k users** since 2.0.4.

**Fix:** classify that specific error (`isRefreshInProgressError`, matched on message not the overloaded code) and **await** the in-flight refresh (`awaitTokenReady`, bounded 10s, re-reads `currentUserAccount` each tick) before proceeding, instead of failing. On timeout we surface the original error — same as before, just after giving the in-flight refresh a chance.

### 2. Download-gated cold-load reopen — `AudiobookSessionManager`
Fresh-borrow LCP audiobooks route through Readium **streaming** until the `.lcpa` content lands (it's moved into place atomically only on download completion). Streaming-from-license is broken under the Readium **3.9.0** bump (#1042 / PP-4340) and is an upstream/backend concern (the LCP CDN must support HTTP HEAD + Range — Readium [#810](https://github.com/readium/swift-toolkit/issues/810), "by design").

**Fix (RC workaround):** on open of a not-yet-local LCP audiobook, park it (`awaitingContentDownloadBookIds`), await content (`awaitAudiobookContentLocal`, 180s poll), then reopen from the reliable **local** path. The streaming player emits a *storm* of `.playbackFailed` for one failed open — we swallow follow-on failures for a parked book so they can't defeat the wait. On timeout, surface "Unavailable" rather than hanging.

### 3. Frozen-flow teardown — `NavigationCoordinator.popIfTopRouteAudio`
Opening a new audiobook while a previous session was still bound ran an **unconditional `pop()`** in teardown (`stopPlayback(dismissPhoneUI:)` → `dismissPlayerOnPhone`). If the previous player's screen was already gone, that pop removed the **new** book's detail — dumping the user onto the catalog while playback loaded (the whole download, with the gate). New `popIfTopRouteAudio()` guards on `isTopRouteAudio`, making teardown a no-op when there's no player on top to dismiss, so the new book's detail stays put until the real player is pushed.

### Also
- `PlaybackBootstrapper.ensureAudioSessionActiveForPlayback()` — activate the audio session on a normal (phone) first open, not just on CarPlay connect; fixes the pre-existing AVError **-11849** "slow to start" (also reproduces on 3.1.0 — not a 3.2.0 regression).
- Toolkit submodule re-pinned `→ 2166a6f8` (rangeOutOfBounds clamp + deinit `AVAudioSession` teardown — see ThePalaceProject/ios-audiobooktoolkit#185).
- Regression test: `testRefreshInProgressClassifier_matchesOnlyTheInProgressError`.

### Verification
- Token-race + gate verified on simulator (gate awaits ~22–52s, then plays in a single attempt — no -11849 / no "Unavailable" storm); frozen-flow fix confirmed on a physical device (new book's detail no longer dismissed mid-load).
- Pre-push targeted suite: 11 audiobook/nav/bootstrapper test classes green.

### Not done
Does **not** fix LCP streaming-from-license itself — that needs upstream Readium / backend-CDN HEAD+Range support (#810). The download-gate is the RC cure. The token-race fix targets only the "refresh in progress" race; other token failures (missing/invalid creds) still fail the open as before.

Depends on: ThePalaceProject/ios-audiobooktoolkit#185 (submodule pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
