### PR TITLE
3.3.0 concurrency crashes: bookmark-sync serialization + saveSync reentrancy-deadlock fix

### DIFF
--- a/.forgeos/intent/3.3.0-concurrency-crash-fixes.md
+++ b/.forgeos/intent/3.3.0-concurrency-crash-fixes.md
@@ -1,0 +1,99 @@
+---
+name: 3.3.0-concurrency-crash-fixes
+created: 2026-06-18
+author: Maurice Carrier
+branch: fleet/palace-3.3.0a
+initiative: TBD (forge MCP pending grant)
+priority: 3.3.0 crash-triage part 1 (concurrency) — critical-path
+memory_refs:
+  - bookmark-sync-concurrency-crash-cluster
+  - savesync-reentrancy-regression-1061
+crashlytics:
+  - abfef568   # TPPNetworkExecutor.executeRequest over-release
+  - 0bbbd8fe   # TPPKeychainCodableVariable.read / TPPUserAccount.credentials race
+  - 8afb1c66   # BookRegistrySync.saveSync reentrancy
+---
+
+# Intent: 3.3.0 concurrency crash fixes (part 1)
+
+## Context
+
+Two independent concurrency crash clusters surfaced in 3.3.0 Crashlytics.
+
+**(a) Bookmark-sync thread-safety — abfef568 / 0bbbd8fe.**
+`AudiobookBookmarkBusinessLogic` keeps three pieces of mutable state that are
+read and written from *three different execution contexts* with no shared
+serialization:
+
+- `deletedBookmarkIds: Set<String>` — inserted on the UI thread
+  (`deleteBookmark`), inserted/removed on URLSession completion threads
+  (`deleteBookmarkByContentMatch`), and read on the serial work queue
+  (`fetchLocalBookmarks`) and completion threads (`updateLocalBookmarks`).
+- `isSyncing: Bool` — written `true` on the work queue (`syncBookmarks`),
+  written `false` on a completion thread (`finalizeSync`).
+- `completionHandlersQueue: [([AudioBookmark]) -> Void]` — appended on the work
+  queue, drained on the main queue (`finalizeSync`).
+
+Concurrent mutation of a Swift `Set`/`Array` corrupts its copy-on-write buffer
+refcount → an over-release that Crashlytics symbolicates wherever the next
+`objc_release` runs in the captured completion-closure chain — i.e. the
+network executor (abfef568). The credentials half (0bbbd8fe) — a torn
+`TPPCredentials` read racing sign-out `write(nil)` — was already fixed in
+PR #1050 by returning `TPPKeychainCodableVariable.read()` from *inside* the
+synchronized block. This change pins that atomicity with a regression test and
+closes the remaining (bookmark-sync) half via serialization.
+
+**(b) saveSync reentrancy — 8afb1c66, regressed by PR #1061 (75088fd1e).**
+PR #1061 wrapped `BookRegistrySync.saveSync` in `diskWriteQueue.sync { ... }`
+**and moved the registry snapshot inside that block**. The snapshot calls
+`store.registrySnapshot()` → `BookRegistryStore.performSync` → `syncQueue.sync`.
+`saveSync` is reached from `BookmarkManager.setLocationSync`'s `onComplete`,
+which runs *inside a `syncQueue` barrier*. So the call chain becomes:
+`syncQueue.barrier` → `saveSync` → `diskWriteQueue.sync` → `registrySnapshot`
+→ `syncQueue.sync` — a `dispatch_sync` back onto a queue the current thread
+already holds → deadlock/hang. #1061 fixed a disk-write race and traded it for
+this reentrancy hang.
+
+Both are critical-path (audiobook playback + registry persistence). Toolkit is
+fragile; cross-vendor audiobook smoke required.
+
+## Claims
+
+- **(a1)** All access to `AudiobookBookmarkBusinessLogic.deletedBookmarkIds`,
+  `isSyncing`, and `completionHandlersQueue` is routed through the class's
+  existing serial `queue` via a reentrancy-safe `onStateQueue` helper
+  (DispatchSpecificKey guard so a call already on `queue` runs inline instead
+  of dead-locking). No field is touched off that serialization domain.
+- **(a2)** `TPPKeychainCodableVariable.read()` remains atomic under concurrent
+  read/`write(nil)` — pinned by a stress regression test (guards the #1050
+  0bbbd8fe fix from silent regression).
+- **(b1)** `BookRegistrySync.saveSync` takes its registry snapshot in the
+  caller's context (as `save(for:)` already does), not inside `diskWriteQueue`,
+  so it never re-enters `BookRegistryStore.syncQueue` from within the disk
+  queue.
+- **(b2)** `saveSync`'s disk write is reentrancy-safe: a `DispatchSpecificKey`
+  guard runs the write inline when already on `diskWriteQueue` instead of a
+  nested `diskWriteQueue.sync` (which would crash). The cross-queue write
+  serialization that #1061 added (no two concurrent `.atomic` replaces to the
+  same URL) is preserved.
+
+## Anti-claims
+
+- Does NOT re-architect `AudiobookBookmarkBusinessLogic` to a full actor /
+  MainActor model — the @objc surface and the existing serial-queue design are
+  preserved; only the unsynchronized field access is closed.
+- Does NOT change bookmark conflict-resolution semantics, the debounce policy,
+  or `BeginningPositionPolicy`.
+- Does NOT change `save(for:)`'s async behavior or the disk-write serialization
+  invariant #1061 introduced — (b) preserves it while removing the deadlock.
+- Does NOT touch `TPPNetworkExecutor`/`TPPNetworkResponder` — abfef568 is a
+  *symptom* surfaced there; the root cause is the bookmark-sync data race.
+- Does NOT add user-facing copy.
+
+## Files in scope
+
+- `Palace/Reader2/Bookmarks/AudiobookBookmarkBusinessLogic.swift`
+- `Palace/Book/Models/BookRegistrySync.swift`
+- `PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift` (new)
+- `PalaceTests/Book/BookRegistrySyncReentrancyTests.swift` (new)
+- `Palace/Packages/PalaceKeychain/Tests/PalaceKeychainTests/TPPKeychainStoredVariableTests.swift` (regression add for a2)

--- a/.forgeos/intent/3.3.0-concurrency-crash-fixes.md
+++ b/.forgeos/intent/3.3.0-concurrency-crash-fixes.md
@@ -99,5 +99,19 @@ fragile; cross-vendor audiobook smoke required.
 - `Palace/Book/Models/BookRegistrySync.swift`
 - `PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift` (new)
 - `PalaceTests/Book/BookRegistrySyncReentrancyTests.swift` (new)
+- `Palace/Packages/PalaceKeychain/Tests/PalaceKeychainTests/TPPKeychainStoredVariableTests.swift`
+  (a2 — adds `testRead_racingSignOutWriteNil_neverTearsCredentials`)
 
-(a2 needs no file — already covered by existing `TPPKeychainStoredVariableTests`.)
+## 0bbbd8fe coverage note (separate root cause from abfef568)
+
+0bbbd8fe is NOT the bookmark-sync data race and is NOT killed by `onStateQueue`.
+It is a keychain-layer torn read: `TPPKeychainCodableVariable.read()` returning
+`cachedValue` from OUTSIDE `transaction.perform` let a background credentials
+read tear a `TPPCredentials` mid sign-out `write(nil)` (EXC_BAD_ACCESS at
+`read:114`). The fix is the atomic read-inside-lock shipped in PR #1050 — already
+in the tree. `syncIsPossibleAndPermitted -> credentials.getter` is reached on the
+bookmark-sync path, but `onStateQueue` does not serialize it; the atomicity is
+what kills the tear. This change PINS that fix with a regression that reproduces
+the exact `read()` vs sign-out `write(nil)` race (6 000 concurrent iterations) —
+the existing sibling test only exercised `write(a/b)` overwrite, not the nil
+clear that 0bbbd8fe actually crashed on.

--- a/.forgeos/intent/3.3.0-concurrency-crash-fixes.md
+++ b/.forgeos/intent/3.3.0-concurrency-crash-fixes.md
@@ -64,9 +64,12 @@ fragile; cross-vendor audiobook smoke required.
   existing serial `queue` via a reentrancy-safe `onStateQueue` helper
   (DispatchSpecificKey guard so a call already on `queue` runs inline instead
   of dead-locking). No field is touched off that serialization domain.
-- **(a2)** `TPPKeychainCodableVariable.read()` remains atomic under concurrent
-  read/`write(nil)` — pinned by a stress regression test (guards the #1050
-  0bbbd8fe fix from silent regression).
+- **(a2)** `TPPKeychainCodableVariable.read()` atomicity (the #1050 0bbbd8fe
+  fix) is ALREADY pinned by existing tests in `TPPKeychainStoredVariableTests`
+  (`testTransactionPerform_returnsValueComputedInsideLock` +
+  `testRead_underConcurrentWritesAndInvalidation_neverTearsValue`). Verified
+  present; no new keychain code or test is required by this changeset — the
+  credentials half of part (a) was shipped in PR #1050 and is regression-guarded.
 - **(b1)** `BookRegistrySync.saveSync` takes its registry snapshot in the
   caller's context (as `save(for:)` already does), not inside `diskWriteQueue`,
   so it never re-enters `BookRegistryStore.syncQueue` from within the disk
@@ -96,4 +99,5 @@ fragile; cross-vendor audiobook smoke required.
 - `Palace/Book/Models/BookRegistrySync.swift`
 - `PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift` (new)
 - `PalaceTests/Book/BookRegistrySyncReentrancyTests.swift` (new)
-- `Palace/Packages/PalaceKeychain/Tests/PalaceKeychainTests/TPPKeychainStoredVariableTests.swift` (regression add for a2)
+
+(a2 needs no file — already covered by existing `TPPKeychainStoredVariableTests`.)

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		1F99EF1C21A34B61A0A0BD18 /* TriageBotCore in Frameworks */ = {isa = PBXBuildFile; productRef = D828BCCE057E56386EB4414B /* TriageBotCore */; };
 		20305375A394FE5768D3D74C /* CatalogRepositoryStaleWhileRevalidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEF7F7CC10FA7EDA2FBD122 /* CatalogRepositoryStaleWhileRevalidateTests.swift */; };
 		2062F7CE28531C0ACDCF5859 /* AccountStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC08BFC96049300E5ADB7AD /* AccountStateMachineTests.swift */; };
+		20B17E24C48EC2CCF3A25977 /* BookRegistrySyncReentrancyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F447D6D0EFBBC91F7CD6C5A4 /* BookRegistrySyncReentrancyTests.swift */; };
 		2126FE2E25C059250095C45C /* ReaderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2126FE2D25C059240095C45C /* ReaderError.swift */; };
 		2126FE3525C059700095C45C /* ReaderModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DF7F9225AF5E1E0090402A /* ReaderModule.swift */; };
 		2126FE3A25C0597E0095C45C /* LibraryServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7B87D25AE1DB9000E8BF3 /* LibraryServiceError.swift */; };
@@ -1180,6 +1181,7 @@
 		DD22AA22BB33CC44DD55EE66 /* DownloadIntegrityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC22AA22BB33CC44DD55EE66 /* DownloadIntegrityTests.swift */; };
 		DD33AA22BB33CC44DD55EE66 /* DownloadFreeSpaceExhaustionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC33AA22BB33CC44DD55EE66 /* DownloadFreeSpaceExhaustionTests.swift */; };
 		DD44AA22BB33CC44DD55EE66 /* DownloadRMSDKHandoffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC44AA22BB33CC44DD55EE66 /* DownloadRMSDKHandoffTests.swift */; };
+		DD53EDAC28AB285D49FD1848 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABC0E40FBEECB22D2E04F66 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift */; };
 		DD6A760B2C7336C887F0B1C7 /* MarksFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080266047BB0E69510152185 /* MarksFixture.swift */; };
 		DD7931BFD5CA3EABC96BC215 /* OpenAccessAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCE659985E97E91217CB739 /* OpenAccessAdapterTests.swift */; };
 		DDBA66D65E63F74D6D2668D5 /* OPDS2IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E38281988A9921BB4B8297 /* OPDS2IntegrationTests.swift */; };
@@ -2108,6 +2110,7 @@
 		1A81964771D1CB9A93ED2EA6 /* TokenRefreshTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenRefreshTests.swift; sourceTree = "<group>"; };
 		1AA20DE46939562EEA2DF764 /* FontFamily.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamily.swift; sourceTree = "<group>"; };
 		1AB1721A59302ABD56C2667E /* ReaderInitialLocationNavigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderInitialLocationNavigator.swift; sourceTree = "<group>"; };
+		1ABC0E40FBEECB22D2E04F66 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookBookmarkBusinessLogicConcurrencyTests.swift; sourceTree = "<group>"; };
 		1ABF38E7BB264BB192202BAC /* DefaultCatalogAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCatalogAPITests.swift; sourceTree = "<group>"; };
 		1B55D09BB1E0EAF8B542077F /* TPPNotifications.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPNotifications.swift; sourceTree = "<group>"; };
 		1BA91B27F363A5BBFB4F5BB0 /* Adapters+Production.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Adapters+Production.swift"; sourceTree = "<group>"; };
@@ -3202,6 +3205,7 @@
 		F30415263748495C6D7E8F90 /* LocalBookContentServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalBookContentServiceTests.swift; sourceTree = "<group>"; };
 		F3456C5272C3572ACAC0A1A1 /* PalaceCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceCheck.swift; sourceTree = "<group>"; };
 		F3E2541AFE374BC6F841E19E /* AppTabHostMiniPlayerIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppTabHostMiniPlayerIntegrationTests.swift; sourceTree = "<group>"; };
+		F447D6D0EFBBC91F7CD6C5A4 /* BookRegistrySyncReentrancyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookRegistrySyncReentrancyTests.swift; sourceTree = "<group>"; };
 		F48995B25FD329E6962BC998 /* MockSyncBackend.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MockSyncBackend.swift; sourceTree = "<group>"; };
 		F4A5B6C7D8E9F0A1B2C3D4E5 /* DownloadTaskLifecycleServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadTaskLifecycleServiceTests.swift; sourceTree = "<group>"; };
 		F4C5D6E7F8091A2B3C4D5E6F /* DownloadQueueOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadQueueOrchestrator.swift; sourceTree = "<group>"; };
@@ -5236,6 +5240,7 @@
 				9C821947A4DF5BDE2F8089DF /* PalaceTestSetupObservationTests.swift */,
 				8A963381EB27A2A8D0EFF8AB /* URLSessionStubbingResetTests.swift */,
 				52E79AEBD6EB68A70141013D /* ReaderStreaming */,
+				1ABC0E40FBEECB22D2E04F66 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift */,
 			);
 			path = PalaceTests;
 			sourceTree = "<group>";
@@ -5394,6 +5399,7 @@
 				25174690C33556366CFFE575 /* TPPBookDRMProtectedTests.swift */,
 				FACAA8E6F45D5A91B3486904 /* TPPBookContentTypeConverterTests.swift */,
 				D9B791C34331187A57984D68 /* BookButtonTypeMetaTests.swift */,
+				F447D6D0EFBBC91F7CD6C5A4 /* BookRegistrySyncReentrancyTests.swift */,
 			);
 			path = Book;
 			sourceTree = "<group>";
@@ -7403,6 +7409,8 @@
 				F58124F59C1F78CADB673820 /* TriageBotKeyAdminTests.swift in Sources */,
 				935B58EA66D6CDC630490B7E /* FindawaySavedVsPlayedTests.swift in Sources */,
 				893C99258D1F416B909E64EE /* AudiobookColdLoadRecoveryTests.swift in Sources */,
+				DD53EDAC28AB285D49FD1848 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift in Sources */,
+				20B17E24C48EC2CCF3A25977 /* BookRegistrySyncReentrancyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Book/Models/BookRegistrySync.swift
+++ b/Palace/Book/Models/BookRegistrySync.swift
@@ -23,6 +23,10 @@ class BookRegistrySync {
   /// Serial queue for disk writes — prevents out-of-order save races where a stale
   /// snapshot could overwrite a newer one if two saves dispatch concurrently.
   private let diskWriteQueue = DispatchQueue(label: "com.palace.registryDiskWrite")
+  /// Identifies execution already inside `diskWriteQueue` so a reentrant
+  /// `saveSync` runs its write inline instead of a nested `diskWriteQueue.sync`
+  /// (which would deadlock). See `saveSync(for:)`.
+  private let diskWriteQueueKey = DispatchSpecificKey<Void>()
 
   var syncUrl: URL?
   var loadingAccount: String?
@@ -43,6 +47,7 @@ class BookRegistrySync {
     self.accountsManager = accountsManager
     self.downloadCenterProvider = downloadCenterProvider
     self.opdsFeedServiceProvider = opdsFeedServiceProvider
+    diskWriteQueue.setSpecific(key: diskWriteQueueKey, value: ())
   }
 
   func registryUrl(for account: String) -> URL? {
@@ -515,18 +520,23 @@ class BookRegistrySync {
   func saveSync(for account: String) {
     guard let registryUrl = registryUrl(for: account) else { return }
 
-    // Route through the SAME serialization domain as `save(for:)`. Previously
-    // this wrote directly on the calling thread, bypassing `diskWriteQueue`, so
-    // a sync save could run its `.atomic` rename-replace concurrently with an
-    // in-flight async write to the same URL — two atomic writes raced and a
-    // stale snapshot could clobber the final one. Running on `diskWriteQueue.sync`
-    // makes the "saveSync blocks until all prior enqueued writes flush" invariant
-    // true by FIFO construction. The snapshot is taken INSIDE the queue so it
-    // reflects state after the prior enqueued writes, not a caller-thread race.
-    diskWriteQueue.sync {
-      let snapshot = store.registrySnapshot()
-      let registryObject = [TPPBookRegistryKey.records.rawValue: snapshot]
+    // Snapshot in the CALLER's context — NOT inside `diskWriteQueue`. `saveSync`
+    // is reached from `BookmarkManager.setLocationSync`'s `onComplete`, which
+    // runs inside a `BookRegistryStore.syncQueue` barrier. Taking the snapshot
+    // inside `diskWriteQueue.sync` re-entered `syncQueue` (`registrySnapshot` →
+    // `performSync` → `syncQueue.sync`) from a thread already holding that
+    // barrier → deadlock (8afb1c66 — the hang #1061 traded for the disk-write
+    // race). The in-memory snapshot is independent of disk-flush ordering, so
+    // reading it here is behavior-equivalent for persistence.
+    let snapshot = store.registrySnapshot()
+    let registryObject = [TPPBookRegistryKey.records.rawValue: snapshot]
 
+    // Serialize the disk write through `diskWriteQueue` so a sync save can't run
+    // its `.atomic` rename-replace concurrently with an in-flight async write to
+    // the same URL (the race #1061 fixed — preserved). Reentrancy-safe: if we are
+    // ALREADY executing on `diskWriteQueue`, run inline — a nested
+    // `diskWriteQueue.sync` would deadlock against itself.
+    let write = {
       do {
         let directoryURL = registryUrl.deletingLastPathComponent()
         if !FileManager.default.fileExists(atPath: directoryURL.path) {
@@ -539,6 +549,12 @@ class BookRegistrySync {
       } catch {
         Log.error(#file, "Error saving book registry synchronously: \(error.localizedDescription)")
       }
+    }
+
+    if DispatchQueue.getSpecific(key: diskWriteQueueKey) != nil {
+      write()
+    } else {
+      diskWriteQueue.sync(execute: write)
     }
   }
 

--- a/Palace/Packages/PalaceKeychain/Tests/PalaceKeychainTests/TPPKeychainStoredVariableTests.swift
+++ b/Palace/Packages/PalaceKeychain/Tests/PalaceKeychainTests/TPPKeychainStoredVariableTests.swift
@@ -199,4 +199,55 @@ final class TPPKeychainStoredVariableTests: XCTestCase {
         XCTAssertTrue(final == a || final == b || final == nil,
                       "final state must be a whole written value or nil, got: \(String(describing: final))")
     }
+
+    /// 0bbbd8fe SPECIFICALLY: a background URLSession continuation reading
+    /// `TPPUserAccount.credentials` while the user signs out (`write(nil)`)
+    /// tore the `TPPCredentials` struct — the exact Crashlytics signature
+    /// (`TPPKeychainCodableVariable.read:114` EXC_BAD_ACCESS). The sibling test
+    /// above mixes only `write(a/b)` (overwrite); this one drives the
+    /// sign-out **`write(nil)`** clear concurrently with reads — the precise
+    /// race that crashed — and asserts every `read()` observes a *whole*
+    /// credential or `nil`, never a torn struct. With the read serialized
+    /// inside `transaction.perform` (#1050) the nil-clear and the read can
+    /// never interleave; a revert to the unsynchronized post-lock
+    /// `return cachedValue` tears (and crashes on retain).
+    func testRead_racingSignOutWriteNil_neverTearsCredentials() throws {
+        try KeychainAvailability.skipIfUnavailable()
+
+        struct Cred: Codable, Equatable, Hashable {
+            let token: String
+            let identifier: String
+        }
+        let key = "signout_cred_\(UUID().uuidString)"
+        let variable = TPPKeychainCodableVariable<Cred>(key: key, accountInfoQueue: testQueue)
+        defer { TPPKeychain.shared.removeObject(forKey: key) }
+
+        let signedIn = Cred(token: "TOKEN-WHOLE-VALUE", identifier: "patron-0001")
+        variable.write(signedIn)
+
+        // Interleave: sign-in writes, sign-out clears (write(nil)), cache
+        // invalidations (force a fresh keychain decode), and reads. A read may
+        // legitimately observe `nil` (after a clear) or the whole credential —
+        // but NEVER a partially-written / torn struct.
+        DispatchQueue.concurrentPerform(iterations: 6_000) { i in
+            switch i % 4 {
+            case 0:
+                variable.write(signedIn)        // sign-in
+            case 1:
+                variable.write(nil)             // sign-out — the 0bbbd8fe write
+            case 2:
+                variable.invalidateCache()      // force fresh decode under contention
+            default:
+                let got = variable.read()
+                if let got {
+                    XCTAssertEqual(got, signedIn,
+                                   "read() returned a torn credential during sign-out: \(got)")
+                }
+            }
+        }
+
+        let final = variable.read()
+        XCTAssertTrue(final == signedIn || final == nil,
+                      "final credential must be whole or cleared, got: \(String(describing: final))")
+    }
 }

--- a/Palace/Reader2/Bookmarks/AudiobookBookmarkBusinessLogic.swift
+++ b/Palace/Reader2/Bookmarks/AudiobookBookmarkBusinessLogic.swift
@@ -16,12 +16,23 @@ import PalaceReadingPosition
     private var registry: TPPBookRegistryProvider
     private var annotationsManager: AnnotationsManager
     private let positionWriter: PositionWriter
-    private var isSyncing: Bool = false
     private let queue = DispatchQueue(label: "com.palace.audiobookBookmarkBusinessLogic")
-    private var debounceTimer: Timer?
+    /// Identifies execution already on `queue` so `onStateQueue` runs inline
+    /// instead of a nested `queue.sync` (which would deadlock).
+    private let queueKey = DispatchSpecificKey<Void>()
     private let debounceInterval: TimeInterval = 1.0
-    private var completionHandlersQueue: [([AudioBookmark]) -> Void] = []
     private var debounceWorkItem: DispatchWorkItem?  // Access only on `queue`
+
+    // MARK: - Serialized sync state
+    // `isSyncing`, `completionHandlersQueue`, and `deletedBookmarkIds` are read
+    // and written from the UI thread, URLSession completion threads, AND the
+    // work `queue`. Concurrent mutation of the Swift Set/Array corrupted its
+    // copy-on-write buffer refcount → an over-release that surfaced in the
+    // captured network-completion closure chain (Crashlytics abfef568). All
+    // access now goes through `onStateQueue` so the serial `queue` is the single
+    // serialization domain for this state.
+    private var isSyncing: Bool = false
+    private var completionHandlersQueue: [([AudioBookmark]) -> Void] = []
     private var deletedBookmarkIds = Set<String>()
 
     @objc convenience init(book: TPPBook) {
@@ -49,6 +60,22 @@ import PalaceReadingPosition
         self.positionWriter = positionWriter ?? RemotePositionWriter(
             network: AudiobookPositionAdapter(annotations: annotationsManager)
         )
+        super.init()
+        queue.setSpecific(key: queueKey, value: ())
+    }
+
+    /// Serializes access to the mutable sync state (`isSyncing`,
+    /// `completionHandlersQueue`, `deletedBookmarkIds`) through the work `queue`.
+    /// Reentrancy-safe: runs inline when already on `queue`, otherwise blocks on
+    /// `queue.sync`. Critical sections must stay O(1)/O(n) — never await network
+    /// inside `work`.
+    @discardableResult
+    private func onStateQueue<T>(_ work: () -> T) -> T {
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            return work()
+        } else {
+            return queue.sync(execute: work)
+        }
     }
 
     // MARK: - Bookmark Management
@@ -227,16 +254,17 @@ import PalaceReadingPosition
         Log.info(#file, "🗑️ Bookmark Details: version=\(bookmark.version), timestamp=\(bookmark.lastSavedTimeStamp ?? "nil"), annotationId=\(bookmark.annotationId.isEmpty ? "UNSYNCED" : bookmark.annotationId), chapter=\(bookmark.chapter ?? "nil"), readingOrderItem=\(bookmark.readingOrderItem ?? "nil")")
 
         // Track this bookmark as deleted (prevents it from coming back from server)
-        if !bookmark.annotationId.isEmpty {
-            deletedBookmarkIds.insert(bookmark.annotationId)
-            Log.info(#file, "🗑️ Tracking deleted annotationId: \(bookmark.annotationId)")
-        }
-
-        // Also track by content hash for bookmarks that might have different annotation IDs
         let contentHash = bookmark.uniqueIdentifier
-        if !contentHash.isEmpty {
-            deletedBookmarkIds.insert("content:\(contentHash)")
-            Log.info(#file, "🗑️ Tracking deleted by content hash: \(contentHash)")
+        onStateQueue {
+            if !bookmark.annotationId.isEmpty {
+                deletedBookmarkIds.insert(bookmark.annotationId)
+                Log.info(#file, "🗑️ Tracking deleted annotationId: \(bookmark.annotationId)")
+            }
+            // Also track by content hash for bookmarks that might have different annotation IDs
+            if !contentHash.isEmpty {
+                deletedBookmarkIds.insert("content:\(contentHash)")
+                Log.info(#file, "🗑️ Tracking deleted by content hash: \(contentHash)")
+            }
         }
 
         var localDeletionSucceeded = false
@@ -273,9 +301,11 @@ import PalaceReadingPosition
         // Temporarily remove from deleted tracking to allow fetching
         let tempAnnotationId = bookmark.annotationId
         let tempContentHash = bookmark.uniqueIdentifier
-        deletedBookmarkIds.remove(tempAnnotationId)
-        if !tempContentHash.isEmpty {
-            deletedBookmarkIds.remove("content:\(tempContentHash)")
+        onStateQueue {
+            deletedBookmarkIds.remove(tempAnnotationId)
+            if !tempContentHash.isEmpty {
+                deletedBookmarkIds.remove("content:\(tempContentHash)")
+            }
         }
 
         fetchServerBookmarks { [weak self] serverBookmarks in
@@ -291,7 +321,7 @@ import PalaceReadingPosition
                 Log.info(#file, "🔍 Server annotationId: \(matchingServerBookmark.annotationId)")
 
                 // Update tracking with correct server annotation ID
-                self.deletedBookmarkIds.insert(matchingServerBookmark.annotationId)
+                self.onStateQueue { self.deletedBookmarkIds.insert(matchingServerBookmark.annotationId) }
 
                 // Delete using the correct server annotation ID
                 self.annotationsManager.deleteBookmark(annotationId: matchingServerBookmark.annotationId) { success in
@@ -305,9 +335,11 @@ import PalaceReadingPosition
             } else {
                 Log.warn(#file, "🔍 ⚠️ No matching bookmark found on server - may have already been deleted")
                 // Re-add to tracking
-                self.deletedBookmarkIds.insert(tempAnnotationId)
-                if !tempContentHash.isEmpty {
-                    self.deletedBookmarkIds.insert("content:\(tempContentHash)")
+                self.onStateQueue {
+                    self.deletedBookmarkIds.insert(tempAnnotationId)
+                    if !tempContentHash.isEmpty {
+                        self.deletedBookmarkIds.insert("content:\(tempContentHash)")
+                    }
                 }
                 DispatchQueue.main.async { completion?(localDeletionSucceeded) }
             }
@@ -317,14 +349,21 @@ import PalaceReadingPosition
     // MARK: - Sync Logic
 
     func syncBookmarks(localBookmarks: [AudioBookmark], completion: (([AudioBookmark]) -> Void)? = nil) {
-        guard !isSyncing else {
-            if let completion {
-                completionHandlersQueue.append(completion)
+        // Atomically test-and-set `isSyncing`. If a sync is already in flight we
+        // enqueue this completion under the same lock that `finalizeSync` drains
+        // — without serialization the append raced the drain (CoW corruption).
+        let shouldStartSync = onStateQueue { () -> Bool in
+            if isSyncing {
+                if let completion {
+                    completionHandlersQueue.append(completion)
+                }
+                return false
             }
-            return
+            isSyncing = true
+            return true
         }
+        guard shouldStartSync else { return }
 
-        isSyncing = true
         Task { [weak self] in
             guard let self else { return }
             await uploadUnsyncedBookmarks(localBookmarks)
@@ -348,11 +387,14 @@ import PalaceReadingPosition
             return localBookmark
         }
 
-        // Filter out bookmarks that user has deleted (belt and suspenders approach)
+        // Filter out bookmarks that user has deleted (belt and suspenders approach).
+        // Snapshot the deleted-id set under the lock so the filter reads a stable
+        // copy instead of racing concurrent inserts/removes on the live Set.
+        let deletedIds = onStateQueue { deletedBookmarkIds }
         let filteredBookmarks = allBookmarks.filter { bookmark in
-            let isDeletedById = deletedBookmarkIds.contains(bookmark.annotationId)
+            let isDeletedById = deletedIds.contains(bookmark.annotationId)
             let contentHash = bookmark.uniqueIdentifier
-            let isDeletedByContent = !contentHash.isEmpty && deletedBookmarkIds.contains("content:\(contentHash)")
+            let isDeletedByContent = !contentHash.isEmpty && deletedIds.contains("content:\(contentHash)")
 
             if isDeletedById || isDeletedByContent {
                 Log.info(#file, "🗑️ Filtering out deleted bookmark from local fetch: \(bookmark.annotationId)")
@@ -436,11 +478,13 @@ import PalaceReadingPosition
             return
         }
 
-        // Filter out bookmarks that user has deleted (even if server still returns them)
+        // Filter out bookmarks that user has deleted (even if server still returns them).
+        // Snapshot under the lock — see `fetchLocalBookmarks`.
+        let deletedIds = onStateQueue { deletedBookmarkIds }
         let filteredRemoteBookmarks = remoteBookmarks.filter { remoteBookmark in
-            let isDeletedById = deletedBookmarkIds.contains(remoteBookmark.annotationId)
+            let isDeletedById = deletedIds.contains(remoteBookmark.annotationId)
             let contentHash = remoteBookmark.uniqueIdentifier
-            let isDeletedByContent = !contentHash.isEmpty && deletedBookmarkIds.contains("content:\(contentHash)")
+            let isDeletedByContent = !contentHash.isEmpty && deletedIds.contains("content:\(contentHash)")
 
             if isDeletedById || isDeletedByContent {
                 Log.info(#file, "🗑️ BLOCKING deleted bookmark from re-appearing: annotationId=\(remoteBookmark.annotationId), timestamp=\(remoteBookmark.lastSavedTimeStamp ?? "nil")")
@@ -494,11 +538,19 @@ import PalaceReadingPosition
     }
 
     private func finalizeSync(with bookmarks: [AudioBookmark], completion: (([AudioBookmark]) -> Void)?) {
-        isSyncing = false
+        // Reset `isSyncing` and drain the queued handlers atomically, then fire
+        // them off-lock on main. Draining inside the lock prevents a handler
+        // enqueued by a concurrent `syncBookmarks` from being lost or
+        // double-invoked while the array is being iterated/cleared.
+        let queuedHandlers: [([AudioBookmark]) -> Void] = onStateQueue {
+            isSyncing = false
+            let drained = completionHandlersQueue
+            completionHandlersQueue.removeAll()
+            return drained
+        }
         DispatchQueue.main.async {
             completion?(bookmarks)
-            self.completionHandlersQueue.forEach { $0(bookmarks) }
-            self.completionHandlersQueue.removeAll()
+            queuedHandlers.forEach { $0(bookmarks) }
         }
     }
 

--- a/PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift
+++ b/PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift
@@ -135,10 +135,13 @@ final class AudiobookBookmarkBusinessLogicConcurrencyTests: XCTestCase {
             }
         }
 
-        // Let any queued fetches settle before tearing down.
-        let settle = expectation(description: "queue settles")
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) { settle.fulfill() }
-        wait(for: [settle], timeout: 5.0)
+        // Let queued main-queue completions land before tearing down.
+        // Deterministic drain (a no-op enqueued behind the prior completions),
+        // not a fixed sleep — the storm already completed synchronously, and
+        // the SUT's async Tasks capture `[weak self]`, so any straggler is a
+        // safe no-op. The crash this guards against (CoW over-release) would
+        // already have fired during the storm above.
+        drainMainQueue()
         XCTAssertNotNil(sut, "SUT survived concurrent delete/fetch without an over-release crash")
     }
 
@@ -151,22 +154,38 @@ final class AudiobookBookmarkBusinessLogicConcurrencyTests: XCTestCase {
         let expectations = (0..<n).map { expectation(description: "sync completion \($0)") }
         let countLock = NSLock()
         var fireCount = [Int: Int]()
+        var fulfilledOnce = Set<Int>()
 
         // When a sync is already in flight, additional callers enqueue their
         // completion in `completionHandlersQueue`, which `finalizeSync` drains.
-        // Without serialization the append raced the drain → a completion could
-        // be lost (timeout) or double-invoked (over-fulfill). Assert each fires
-        // exactly once.
+        // Without serialization the append raced the drain → a CoW-corruption
+        // crash. The fix routes both through the serial `queue`.
+        //
+        // Count fires under the lock and fulfill each expectation AT MOST ONCE:
+        // decoupling the fire-count from the XCTestExpectation API means a stray
+        // double-delivery surfaces as `fireCount > 1` (a clean assertion failure)
+        // instead of an `NSInternalInconsistencyException` from a double
+        // `fulfill()` — which previously crashed the whole test runner under
+        // load and forced a suite restart. The timeout is generous because the
+        // 25 completions fan out through `DispatchQueue.main.async`, which can
+        // back up behind a saturated main queue on a heavily loaded host; a slow
+        // drain must not be misread as a lost completion.
         DispatchQueue.concurrentPerform(iterations: n) { i in
             sut.syncBookmarks(localBookmarks: []) { _ in
-                countLock.lock(); fireCount[i, default: 0] += 1; countLock.unlock()
-                expectations[i].fulfill()
+                countLock.lock()
+                fireCount[i, default: 0] += 1
+                let firstFire = fulfilledOnce.insert(i).inserted
+                countLock.unlock()
+                if firstFire { expectations[i].fulfill() }
             }
         }
 
-        wait(for: expectations, timeout: 15.0)
+        wait(for: expectations, timeout: 60.0) // FLAKE-003-OK: 25-way concurrent sync fan-out via DispatchQueue.main.async; generous ceiling tolerates main-queue saturation under full-suite load (fires in <1s uncontended). Crash-safe via idempotent fulfill.
+        countLock.lock()
+        let counts = fireCount
+        countLock.unlock()
         for i in 0..<n {
-            XCTAssertEqual(fireCount[i], 1, "sync completion \(i) must fire exactly once")
+            XCTAssertEqual(counts[i], 1, "sync completion \(i) must fire exactly once")
         }
     }
 

--- a/PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift
+++ b/PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift
@@ -1,0 +1,209 @@
+//
+//  AudiobookBookmarkBusinessLogicConcurrencyTests.swift
+//  PalaceTests
+//
+//  Regression coverage for the 3.3.0 bookmark-sync thread-safety crash
+//  (Crashlytics abfef568). `AudiobookBookmarkBusinessLogic` kept three pieces
+//  of mutable state — `deletedBookmarkIds` (a Swift Set), `isSyncing`, and
+//  `completionHandlersQueue` — that were read/written from the UI thread,
+//  URLSession completion threads, and the work queue with no shared
+//  serialization. Concurrent mutation of the Set/Array corrupted its
+//  copy-on-write buffer refcount → an over-release surfaced in the captured
+//  network-completion closure chain. The fix routes all of that state through
+//  the class's serial `queue` via `onStateQueue`.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+@testable import PalaceAudiobookToolkit
+
+final class AudiobookBookmarkBusinessLogicConcurrencyTests: XCTestCase {
+
+    // MARK: - Thread-safe mock so concurrency failures are attributable to the SUT
+
+    /// `TPPBookRegistryMock` stores in a plain dictionary with no locking, so a
+    /// concurrent test would otherwise race the *mock* rather than the SUT.
+    /// Guard the methods the bookmark flow touches with one recursive lock; the
+    /// only remaining unsynchronized shared state is then the SUT's own.
+    private final class LockedRegistryMock: TPPBookRegistryMock {
+        private let lock = NSRecursiveLock()
+        private func sync<T>(_ body: () -> T) -> T {
+            lock.lock(); defer { lock.unlock() }; return body()
+        }
+        override func setLocation(_ location: TPPBookLocation?, forIdentifier identifier: String) {
+            sync { super.setLocation(location, forIdentifier: identifier) }
+        }
+        override func location(forIdentifier identifier: String) -> TPPBookLocation? {
+            sync { super.location(forIdentifier: identifier) }
+        }
+        override func genericBookmarksForIdentifier(_ bookIdentifier: String) -> [TPPBookLocation] {
+            sync { super.genericBookmarksForIdentifier(bookIdentifier) }
+        }
+        override func addOrReplaceGenericBookmark(_ location: TPPBookLocation, forIdentifier bookIdentifier: String) {
+            sync { super.addOrReplaceGenericBookmark(location, forIdentifier: bookIdentifier) }
+        }
+        override func deleteGenericBookmark(_ location: TPPBookLocation, forIdentifier bookIdentifier: String) {
+            sync { super.deleteGenericBookmark(location, forIdentifier: bookIdentifier) }
+        }
+        override func replaceGenericBookmark(_ oldLocation: TPPBookLocation, with newLocation: TPPBookLocation, forIdentifier bookIdentifier: String) {
+            sync { super.replaceGenericBookmark(oldLocation, with: newLocation, forIdentifier: bookIdentifier) }
+        }
+    }
+
+    private let bookIdentifier = "fakeAudiobook"
+    private let testID = "TestID"
+    private let manifestJSON: ManifestJSON = .snowcrash
+    private var fakeBook: TPPBook!
+    private var tracks: Tracks!
+
+    override func setUp() {
+        super.setUp()
+        let placeholderUrl = URL(string: "https://test.example.com/book")!
+        let fakeAcquisition = TPPOPDSAcquisition(
+            relation: .generic,
+            type: "application/epub+zip",
+            hrefURL: placeholderUrl,
+            indirectAcquisitions: [TPPOPDSIndirectAcquisition](),
+            availability: TPPOPDSAcquisitionAvailabilityUnlimited()
+        )
+        fakeBook = TPPBook(
+            acquisitions: [fakeAcquisition],
+            authors: [TPPBookAuthor](),
+            categoryStrings: [String](),
+            distributor: "",
+            identifier: bookIdentifier,
+            imageURL: nil,
+            imageThumbnailURL: nil,
+            published: Date(),
+            publisher: "",
+            subtitle: "",
+            summary: "",
+            title: "",
+            updated: Date(),
+            annotationsURL: nil,
+            analyticsURL: nil,
+            alternateURL: nil,
+            relatedWorksURL: nil,
+            previewLink: nil,
+            seriesURL: nil,
+            revokeURL: nil,
+            reportURL: nil,
+            timeTrackingURL: nil,
+            contributors: [:],
+            bookDuration: nil,
+            imageCache: MockImageCache()
+        )
+        let manifest = try! Manifest.from(jsonFileName: manifestJSON.rawValue, bundle: Bundle(for: type(of: self)))
+        tracks = Tracks(manifest: manifest, audiobookID: testID, token: nil)
+    }
+
+    private func makeSUT() -> (AudiobookBookmarkBusinessLogic, LockedRegistryMock, TPPAnnotationMock) {
+        let registry = LockedRegistryMock()
+        registry.addBook(fakeBook, state: .downloadSuccessful)
+        let annotations = TPPAnnotationMock()
+        let sut = AudiobookBookmarkBusinessLogic(
+            book: fakeBook, registry: registry, annotationsManager: annotations
+        )
+        return (sut, registry, annotations)
+    }
+
+    // MARK: - abfef568: concurrent mutation must not corrupt the deleted-id Set
+
+    func testConcurrentDeleteAndFetch_doesNotCrash() {
+        let (sut, _, _) = makeSUT()
+
+        // Writers (deleteBookmark → deletedBookmarkIds.insert) interleaved with
+        // readers (fetchBookmarks → fetchLocalBookmarks snapshots the Set).
+        // Pre-fix, the raw `Set` insert/contains from many threads tore the CoW
+        // buffer and over-released. Survival across 3 CI iterations is the
+        // assertion.
+        let iterations = 400
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            if i % 4 == 0 {
+                sut.fetchBookmarks(for: self.tracks, toc: []) { _ in }
+            } else {
+                let bookmark = AudioBookmark(
+                    type: .locatorAudioBookTime,
+                    annotationId: "",                 // unsynced → no network leg
+                    chapter: "track-\(i % 6)",
+                    time: i
+                )
+                sut.deleteBookmark(at: bookmark) { _ in }
+            }
+        }
+
+        // Let any queued fetches settle before tearing down.
+        let settle = expectation(description: "queue settles")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) { settle.fulfill() }
+        wait(for: [settle], timeout: 5.0)
+        XCTAssertNotNil(sut, "SUT survived concurrent delete/fetch without an over-release crash")
+    }
+
+    // MARK: - isSyncing / completionHandlersQueue: every completion fires once
+
+    func testSyncBookmarks_concurrentCallers_everyCompletionFiresExactlyOnce() {
+        let (sut, _, _) = makeSUT()
+
+        let n = 25
+        let expectations = (0..<n).map { expectation(description: "sync completion \($0)") }
+        let countLock = NSLock()
+        var fireCount = [Int: Int]()
+
+        // When a sync is already in flight, additional callers enqueue their
+        // completion in `completionHandlersQueue`, which `finalizeSync` drains.
+        // Without serialization the append raced the drain → a completion could
+        // be lost (timeout) or double-invoked (over-fulfill). Assert each fires
+        // exactly once.
+        DispatchQueue.concurrentPerform(iterations: n) { i in
+            sut.syncBookmarks(localBookmarks: []) { _ in
+                countLock.lock(); fireCount[i, default: 0] += 1; countLock.unlock()
+                expectations[i].fulfill()
+            }
+        }
+
+        wait(for: expectations, timeout: 15.0)
+        for i in 0..<n {
+            XCTAssertEqual(fireCount[i], 1, "sync completion \(i) must fire exactly once")
+        }
+    }
+
+    // MARK: - Deterministic: a deleted bookmark is filtered from local fetch
+
+    func testDeleteBookmark_thenFetch_filtersDeletedBookmark() {
+        let (sut, registry, _) = makeSUT()
+
+        // Seed one synced bookmark locally.
+        let bookmark = AudioBookmark(
+            type: .locatorAudioBookTime,
+            annotationId: "ann-keepme-then-delete",
+            chapter: "track-1",
+            time: 1234
+        )
+        guard let location = bookmark.toTPPBookLocation() else {
+            return XCTFail("bookmark must convert to a TPPBookLocation")
+        }
+        registry.addOrReplaceGenericBookmark(location, forIdentifier: bookIdentifier)
+
+        // Delete it — this inserts its id into the serialized deleted-id set.
+        let deleted = expectation(description: "delete completes")
+        sut.deleteBookmark(at: bookmark) { _ in deleted.fulfill() }
+        wait(for: [deleted], timeout: 5.0)
+
+        // A subsequent fetch must NOT surface the deleted bookmark.
+        let fetched = expectation(description: "fetch completes")
+        var returned: [TrackPosition] = []
+        sut.fetchBookmarks(for: tracks, toc: []) { positions in
+            returned = positions
+            fetched.fulfill()
+        }
+        wait(for: [fetched], timeout: 5.0)
+
+        XCTAssertFalse(
+            returned.contains { $0.annotationId == "ann-keepme-then-delete" },
+            "Deleted bookmark must be filtered out via the serialized deleted-id set"
+        )
+    }
+}

--- a/PalaceTests/Book/BookRegistrySyncReentrancyTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncReentrancyTests.swift
@@ -1,0 +1,135 @@
+//
+//  BookRegistrySyncReentrancyTests.swift
+//  PalaceTests
+//
+//  Regression coverage for the `saveSync` reentrancy hang (Crashlytics
+//  8afb1c66) introduced by PR #1061. #1061 wrapped `saveSync` in
+//  `diskWriteQueue.sync { ... }` AND moved the registry snapshot inside that
+//  block. `saveSync` is reached from `BookmarkManager.setLocationSync`'s
+//  `onComplete`, which runs inside a `BookRegistryStore.syncQueue` barrier, so
+//  the snapshot's `registrySnapshot() → performSync → syncQueue.sync`
+//  re-entered `syncQueue` from a thread already holding the barrier → deadlock.
+//  The fix snapshots in the caller's context (off `diskWriteQueue`) and makes
+//  the disk write reentrancy-safe.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+final class BookRegistrySyncReentrancyTests: XCTestCase {
+
+    private var store: BookRegistryStore!
+    private var syncManager: BookRegistrySync!
+
+    override func setUp() {
+        super.setUp()
+        store = BookRegistryStore()
+        let appContainer = makeTestAppContainer()
+        syncManager = BookRegistrySync(
+            store: store,
+            accountsManager: appContainer.accountsManager,
+            downloadCenterProvider: { appContainer.downloadCenter },
+            opdsFeedServiceProvider: { appContainer.opdsFeedService }
+        )
+    }
+
+    override func tearDown() {
+        syncManager = nil
+        store = nil
+        super.tearDown()
+    }
+
+    private func makeBook(identifier: String) -> TPPBook {
+        TPPBook(
+            acquisitions: [TPPFake.genericAcquisition],
+            authors: nil, categoryStrings: nil, distributor: nil,
+            identifier: identifier, imageURL: nil, imageThumbnailURL: nil,
+            published: nil, publisher: nil, subtitle: nil, summary: nil,
+            title: "Title \(identifier)", updated: Date(),
+            annotationsURL: nil, analyticsURL: nil, alternateURL: nil,
+            relatedWorksURL: nil, previewLink: nil, seriesURL: nil,
+            revokeURL: nil, reportURL: nil, timeTrackingURL: nil,
+            contributors: nil, bookDuration: nil, imageCache: MockImageCache()
+        )
+    }
+
+    private func isolatedAccount() -> (String, URL) {
+        let account = "brs-reentrancy-\(UUID().uuidString)"
+        let url = syncManager.registryUrl(for: account)!
+        return (account, url)
+    }
+
+    // MARK: - 8afb1c66: saveSync from inside a store barrier must not deadlock
+
+    /// Reproduces the exact production path: `saveSync` invoked from inside a
+    /// `BookRegistryStore.syncQueue` barrier (the same context as
+    /// `BookmarkManager.setLocationSync`'s `onComplete`). Pre-fix this hung; the
+    /// test fails by timeout if the deadlock returns.
+    func testSaveSync_fromInsideRegistryStoreBarrier_doesNotDeadlock() {
+        let (account, url) = isolatedAccount()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let book = makeBook(identifier: "reentrancy-1")
+        store.mutateRegistrySync { $0[book.identifier] = TPPBookRegistryRecord(book: book, state: .downloadSuccessful) }
+
+        let done = expectation(description: "saveSync from barrier returns")
+        DispatchQueue.global(qos: .userInitiated).async {
+            // onComplete runs inside performBarrierSync on syncQueue — the
+            // reentrancy site. saveSync must take its snapshot here (on
+            // syncQueue) and NOT re-enter syncQueue from within diskWriteQueue.
+            self.store.mutateRegistrySync({ registry in
+                registry[book.identifier]?.state = .used
+            }, onComplete: {
+                self.syncManager.saveSync(for: account)
+            })
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 5.0)
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: url.path),
+            "saveSync must persist the registry to disk after running from the store barrier"
+        )
+    }
+
+    // MARK: - saveSync still persists the current snapshot (behavior preserved)
+
+    func testSaveSync_persistsCurrentRegistrySnapshotToDisk() throws {
+        let (account, url) = isolatedAccount()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let book = makeBook(identifier: "persist-1")
+        store.mutateRegistrySync { $0[book.identifier] = TPPBookRegistryRecord(book: book, state: .downloadSuccessful) }
+
+        syncManager.saveSync(for: account)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let data = try Data(contentsOf: url)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let records = try XCTUnwrap(json[TPPBookRegistryKey.records.rawValue] as? [[String: Any]])
+        XCTAssertEqual(records.count, 1, "the one seeded record must be persisted")
+    }
+
+    // MARK: - Concurrent sync saves do not race or deadlock
+
+    func testConcurrentSaveSync_allComplete() {
+        let (account, url) = isolatedAccount()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let book = makeBook(identifier: "concurrent-1")
+        store.mutateRegistrySync { $0[book.identifier] = TPPBookRegistryRecord(book: book, state: .downloadSuccessful) }
+
+        let iterations = 20
+        let done = expectation(description: "all saveSync return")
+        done.expectedFulfillmentCount = iterations
+        DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+            self.syncManager.saveSync(for: account)
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 10.0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+}

--- a/PalaceTests/Book/BookRegistrySyncReentrancyTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncReentrancyTests.swift
@@ -132,4 +132,56 @@ final class BookRegistrySyncReentrancyTests: XCTestCase {
         wait(for: [done], timeout: 10.0)
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
     }
+
+    // MARK: - saveSync serializes its disk write through diskWriteQueue (#1061)
+
+    /// Pins the reentrancy guard at `saveSync`'s tail: when NOT already on
+    /// `diskWriteQueue` (the production path — `saveSync` arrives via the
+    /// `syncQueue` barrier, never via `diskWriteQueue`), the write MUST be
+    /// routed through `diskWriteQueue.sync` so it lands FIFO-last after any
+    /// in-flight async `save(for:)` writes to the same URL. If the guard is
+    /// inverted (the `!=`→`==` mutant), `saveSync` runs its write INLINE,
+    /// bypassing the queue, and the trailing async writes clobber it — exactly
+    /// the disk-write race #1061 closed. Distinguishes the two by record count:
+    /// the async saves persist a 1-record snapshot; `saveSync` persists a
+    /// 2-record snapshot taken after a second book is added. Original ⇒ the
+    /// 2-record snapshot wins (written last); mutant ⇒ a 1-record async write
+    /// clobbers it.
+    func testSaveSync_writeRoutesThroughDiskWriteQueue_landsAfterInFlightAsyncSaves() throws {
+        let (account, url) = isolatedAccount()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        // Snapshot A: a single book. Each async save(for:) captures this at
+        // enqueue time and writes a 1-record registry, posting a notification
+        // when its disk write completes.
+        let book1 = makeBook(identifier: "serialize-1")
+        store.mutateRegistrySync { $0[book1.identifier] = TPPBookRegistryRecord(book: book1, state: .downloadSuccessful) }
+
+        let asyncWrites = 30
+        let drained = expectation(description: "all async save(for:) writes flushed")
+        drained.expectedFulfillmentCount = asyncWrites
+        drained.assertForOverFulfill = false
+        let token = NotificationCenter.default.addObserver(
+            forName: .TPPBookRegistryDidChange, object: nil, queue: nil
+        ) { _ in drained.fulfill() }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        for _ in 0..<asyncWrites { syncManager.save(for: account) }
+
+        // Snapshot B: add a second book, then saveSync. saveSync captures the
+        // 2-record snapshot in caller context and must write it FIFO-last.
+        let book2 = makeBook(identifier: "serialize-2")
+        store.mutateRegistrySync { $0[book2.identifier] = TPPBookRegistryRecord(book: book2, state: .downloadSuccessful) }
+        syncManager.saveSync(for: account)
+
+        wait(for: [drained], timeout: 15.0) // FLAKE-003-OK: waits for 30 async save(for:) disk writes to flush (NotificationCenter drain signal); integration-scoped real-I/O, generous under suite load.
+
+        let data = try Data(contentsOf: url)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let records = try XCTUnwrap(json[TPPBookRegistryKey.records.rawValue] as? [[String: Any]])
+        XCTAssertEqual(
+            records.count, 2,
+            "saveSync must serialize through diskWriteQueue so its 2-record snapshot lands after the in-flight 1-record async writes; an inline (unserialized) write is clobbered by a trailing async save"
+        )
+    }
 }


### PR DESCRIPTION
## 3.3.0 concurrency crash cluster — bookmark-sync + saveSync reentrancy

Fixes two production crashes from the 3.3.0 Crashlytics triage, plus a regression test for a third (already fixed in 3.2.0).

### Crashes
- **`abfef568`** (`TPPNetworkExecutor.executeRequest` over-release, from the audiobook bookmark-sync path) — fixed by serializing `AudiobookBookmarkBusinessLogic`'s racy fields through a reentrancy-safe serial queue (`onStateQueue`, `DispatchSpecificKey` inline guard — the codebase's own `BookRegistryStore.performSync` idiom). Test-and-set + drain-under-lock guarantees every completion fires exactly once.
- **`8afb1c66`** (`BookRegistrySync.saveSync` EXC_BREAKPOINT — a libdispatch reentrant-sync **deadlock**, regression from #1061) — fixed by moving the snapshot to the caller context + a disk-write guard, breaking the `syncQueue → diskWriteQueue → syncQueue` re-entrancy **while preserving #1061's write-serialization**.
- **`0bbbd8fe`** (keychain torn read) — NOT fixed here; already closed by **#1050** in 3.2.0. This adds the missing regression test (concurrent `read()` vs sign-out `write(nil)` + invalidate).

### Governance (ForgeOS `cs_ff3dea64`)
- **Review gate ✅** architect APPROVED (`rev_32cbecab`) — both fixes root-cause-correct, #1061 invariant preserved, `0bbbd8fe` honestly scoped to a test.
- **Testing gate ✅** qa_test APPROVED (`rev_76d7ca6e`) — source-verified: deadlock repro is real (fails-by-timeout), the saveSync mutation-killer is deterministic by construction, the keychain test is the precise tear repro.
- Independent non-author reviewers; `governance_check_sod` = `sod_ok`.
- **Mutation:** `BookRegistrySync` 1/1 = 100%; `AudiobookBookmarkBusinessLogic` 3/3 covered = 100%. Full CI-parity suite green on a dedicated sim (7146 execs, 0 red).

### ⚠️ Pre-merge / release verification (release gate held)
Crash **absence** is a device property — confirm `abfef568` / `8afb1c66` drop in Crashlytics once 3.3.0 has fleet (coordinator telemetry watch).

### Non-blocking follow-ups
- `AudiobookBookmarkBusinessLogic.swift:397/487` — 2 uncovered dedup-filter mutants on the content-hash branch (≥50% floor met at 100%-covered; Reader2 exempt per adr_52261f2a). Suggest a coverage ticket.
- Pre-existing systemic suite pollution (AccountsManager flag-leak class) — separate, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
