### PR TITLE
fix(ci): scope Jira auto-transition to implemented ticket; merge→QA not Done

### DIFF
--- a/.github/workflows/jira-pr-opened.yml
+++ b/.github/workflows/jira-pr-opened.yml
@@ -72,9 +72,13 @@ jobs:
           PR_TITLE: ${{ steps.pr.outputs.title }}
           PR_BRANCH: ${{ steps.pr.outputs.branch }}
         run: |
-          PR_BODY=$(cat /tmp/pr_body.txt 2>/dev/null || true)
-          ALL_TEXT="$PR_TITLE $PR_BODY $PR_BRANCH"
-          
+          # Extract the implemented ticket(s) from PR TITLE + BRANCH only — NOT the
+          # body. The body mentions unrelated tickets (stacked/held/shares-layer);
+          # grepping it moved every mentioned key to Code Review on PR open. Title +
+          # branch are authoritative. (Body is still parsed separately below for the
+          # fix-comment content.) See the 2026-06-22 auto-transition incident.
+          ALL_TEXT="$PR_TITLE $PR_BRANCH"
+
           TICKETS=$(echo "$ALL_TEXT" | grep -oE 'PP-[0-9]+' | sort -u | tr '\n' ' ' || true)
           
           if [ -z "$TICKETS" ]; then

--- a/.github/workflows/jira-update-on-merge.yml
+++ b/.github/workflows/jira-update-on-merge.yml
@@ -28,16 +28,20 @@ jobs:
         id: tickets
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          # Extract ticket numbers from PR title, body, and branch name
-          # NOTE: We pass these via env vars (not direct interpolation)
-          # to prevent shell injection when PR body contains backticks or special chars.
-          
-          # Combine all sources
-          ALL_TEXT="$PR_TITLE $PR_BODY $PR_BRANCH"
-          
+          # Extract the IMPLEMENTED ticket(s) from the PR TITLE and BRANCH only.
+          #
+          # IMPORTANT: We deliberately do NOT scan the PR body. The body routinely
+          # *mentions* other tickets ("Held for next week (NOT in this PR): PP-xxxx",
+          # "Shares a layer with PP-yyyy", "Stacked on PP-zzzz"). Grepping the body
+          # closed/commented every mentioned key on merge — auto-closing tickets that
+          # have no implementing code (see the PP-4527/4529/4531/4533 incident,
+          # 2026-06-22). Title + branch are the authoritative "this PR implements X".
+          #
+          # NOTE: env vars (not direct interpolation) prevent shell injection.
+          ALL_TEXT="$PR_TITLE $PR_BRANCH"
+
           # Extract unique PP-XXXX tickets (silently skip if none found)
           TICKETS=$(echo "$ALL_TEXT" | grep -oE 'PP-[0-9]+' | sort -u | tr '\n' ' ' || true)
           
@@ -83,10 +87,15 @@ jobs:
               echo "⚠️ Failed to add comment to $TICKET"
             }
             
-            # Transition to Done
-            echo "✅ Moving $TICKET to Done..."
-            ./scripts/jira-integration.sh transition "$TICKET" "Done" || {
-              echo "⚠️ Failed to transition $TICKET to Done (may already be done or different workflow)"
+            # Transition to QA/Review — NOT Done.
+            # Merge means "ready for QA", not "verified/done". Closing a ticket is a
+            # human/QA decision after the change is validated (e.g. the device
+            # VoiceOver pass for a11y stories). Auto-closing on merge is what caused
+            # the 2026-06-22 incident where merged-but-unvalidated tickets were
+            # marked Done. The "add-build-info" comment above already says "Ready for QA".
+            echo "🔎 Moving $TICKET to QA/Review..."
+            ./scripts/jira-integration.sh transition "$TICKET" "QA/Review" || {
+              echo "⚠️ Failed to transition $TICKET to QA/Review (may already be there or a different workflow)"
             }
           done
           


### PR DESCRIPTION
## Problem
The Jira automations grepped PP-keys from the PR **body**, so any ticket merely *mentioned* ("Held for next week: PP-xxxx", "stacked on", "shares a layer with") was auto-commented + transitioned on merge/open.

On 2026-06-22, merging #1096 (PP-4529) auto-closed **PP-4527, PP-4531, PP-4533** — PP-4531/4533 had **no implementing code** — and cross-stamped the wrong PR onto each.

## Fix
- **jira-update-on-merge.yml** — extract the implemented ticket from PR **title + branch only** (not body); transition to **QA/Review**, not **Done** (merge = ready-for-QA; closing is a human/QA decision after validation, e.g. the device VoiceOver pass).
- **jira-pr-opened.yml** — same title+branch-only extraction (body still parsed for fix-comment content).

## Follow-up (separate)
A commit-time git hook also comments on every PP-key in the commit message — same class of bug, to be addressed next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)