### PR TITLE
PP-4632: stop returned audiobook playback (develop)

### DIFF
--- a/.forgeos/intent/pp4632-stop-returned-audiobook.md
+++ b/.forgeos/intent/pp4632-stop-returned-audiobook.md
@@ -1,0 +1,75 @@
+---
+name: pp4632-stop-returned-audiobook
+created: 2026-06-23
+author: Maurice Carrier
+branch: fix/PP-4632-stop-returned-audiobook
+priority: PP-4632 (High) / 3.2.0 RC regression
+---
+
+# Intent: stop the audiobook player when the playing book is returned
+
+## Context
+
+PP-4632 (3.2.0 build 481, High): an audiobook opened in the new player then
+returned **keeps playing** when Play is pressed — the mini-player stays up and
+the returned book plays until a new book is opened.
+
+Root cause: `AudiobookSessionManager` holds the loaded audiobook in memory
+(`currentBook` + manager/audiobook/tracks) and never observes the book registry.
+The return flow (`BookReturnService.returnBook`) deletes local content, purges
+audiobook caches, and transitions the registry to `.unregistered` — but nothing
+tells the in-memory session to stop. The already-loaded tracks keep playing
+(open file handles survive the on-disk deletion). Account-switch teardown is the
+only existing stop-on-removal path (`cleanupActiveContentBeforeAccountSwitch`);
+single-book return was never wired.
+
+Grounded surface:
+- The registry already publishes `bookStatePublisher: AnyPublisher<(String, TPPBookState), Never>`
+  and emits `(id, .unregistered)` on `removeBook` / `updateAndRemoveBook` (the
+  return path). `TPPBookRegistryProvider` (the manager's dependency) exposes it.
+- `AudiobookSessionManager.stopPlayback(dismissPhoneUI:persistFinalPosition:)`
+  already performs the full teardown (pause + unload + release decryptor + nil
+  currentBook + dismiss phone UI).
+
+## Claims
+
+- `AudiobookSessionManager` subscribes to `bookRegistry.bookStatePublisher` in
+  init (`subscribeToBookReturn`, alongside the existing
+  `subscribeToPhoneSideErrorAlerts`, stored in `lifecycleCancellables`).
+- When the change is for the **currently-playing** book and its state is
+  `.unregistered`, it calls
+  `stopPlayback(dismissPhoneUI: true, persistFinalPosition: false)` —
+  `persistFinalPosition: false` so a stale live position is not written back
+  into a possibly re-borrowed registry record (FINDING-D).
+- The decision is a `nonisolated static`
+  `shouldStopPlaybackOnRegistryChange(state:changedIdentifier:currentBookIdentifier:)`
+  (mirrors `networkValidationError`) so it is unit-testable without a live
+  session.
+
+## Verification
+
+- Unit: `AudiobookSessionStateTests` — 4 tests on the pure decision
+  (current+unregistered → true; different book → false; non-unregistered → false;
+  no current book → false). `AudiobookSessionManagerShutdownTests` re-run to
+  confirm init (now wiring the new subscription) + stopPlayback are unaffected.
+- Runtime (device, pending QA on RC 483): borrow audiobook → Listen → minimize →
+  Pause → return from My Books → press Play in the mini-player → player closes and
+  does not resume.
+
+## Files in scope
+
+- `Palace/Audiobooks/AudiobookSessionManager.swift` — `subscribeToBookReturn()` +
+  `handleRegistryStateChange(...)` + `nonisolated static shouldStopPlaybackOnRegistryChange(...)`, called from init.
+- `PalaceTests/Audiobooks/AudiobookSessionStateTests.swift` — 4 decision tests.
+- `Palace.xcodeproj/project.pbxproj` — build 482 → 483 (separate release-chore commit).
+
+## Anti-claims
+
+- Does NOT change the return flow (`BookReturnService`), cache purge, or registry
+  semantics — only adds an observer on the player side.
+- Does NOT stop playback for non-current books or for non-`.unregistered`
+  transitions (download progress, used, etc.).
+- Does NOT alter account-switch teardown (already handled; nils `currentBook`
+  first, so this observer no-ops during it).
+- Does NOT claim runtime device verification — only the pure decision is
+  unit-tested; the on-device return-while-playing pass is pending on RC 483.

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -278,6 +278,7 @@ public final class AudiobookSessionManager: ObservableObject {
         // This manager now owns the full audiobook lifecycle (load → bind → play)
         // directly via AudiobookLoader; no pub/sub handoff is needed.
         subscribeToPhoneSideErrorAlerts()
+        subscribeToBookReturn()
     }
 
     /// AppContainer-friendly initializer. Used by future call sites that
@@ -335,6 +336,49 @@ public final class AudiobookSessionManager: ObservableObject {
                 Self.presentPhoneSideAlert(for: error)
             }
             .store(in: &lifecycleCancellables)
+    }
+
+    /// PP-4632: tear the player down when the CURRENTLY-PLAYING book is returned
+    /// (or otherwise removed → `.unregistered`). The return flow
+    /// (`BookReturnService`) deletes local content + purges caches but cannot
+    /// reach this in-memory session; without this, a returned audiobook keeps
+    /// playing from the already-loaded tracks (open file handles survive the
+    /// file deletion) until a new book is opened. Account-switch teardown is
+    /// handled separately (`cleanupActiveContentBeforeAccountSwitch` nils
+    /// `currentBook` first), so its mass `.unregistered` emissions no-op here.
+    private func subscribeToBookReturn() {
+        bookRegistry.bookStatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] identifier, state in
+                self?.handleRegistryStateChange(identifier: identifier, state: state)
+            }
+            .store(in: &lifecycleCancellables)
+    }
+
+    private func handleRegistryStateChange(identifier: String, state: TPPBookState) {
+        guard Self.shouldStopPlaybackOnRegistryChange(
+            state: state,
+            changedIdentifier: identifier,
+            currentBookIdentifier: currentBook?.identifier
+        ) else { return }
+        Log.info(#file, "📕 Active book \(identifier) was returned/removed from the registry — stopping playback")
+        // persistFinalPosition: false — the book is gone; do not write a stale
+        // live position back into a (possibly re-borrowed) registry record.
+        Task { await stopPlayback(dismissPhoneUI: true, persistFinalPosition: false) }
+    }
+
+    /// Pure decision for `subscribeToBookReturn`: stop only when the book that
+    /// changed is the one currently playing AND it has become `.unregistered`
+    /// (returned / removed / expired). `nonisolated static` so it is unit-
+    /// testable without a live session (mirrors `networkValidationError`).
+    nonisolated static func shouldStopPlaybackOnRegistryChange(
+        state: TPPBookState,
+        changedIdentifier: String,
+        currentBookIdentifier: String?
+    ) -> Bool {
+        state == .unregistered
+            && currentBookIdentifier != nil
+            && currentBookIdentifier == changedIdentifier
     }
 
     static func presentPhoneSideAlert(for error: AudiobookSessionError) {

--- a/PalaceTests/Audiobooks/AudiobookSessionStateTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookSessionStateTests.swift
@@ -240,6 +240,37 @@ final class AudiobookSessionStateTransitionTests: XCTestCase {
         XCTAssertTrue(receivedStates.contains(.idle), "Should publish idle state after stop")
         cancellable.cancel()
     }
+
+    // MARK: - PP-4632: stop playback when the playing book is returned
+
+    /// The currently-playing book becoming `.unregistered` (returned / removed /
+    /// expired) MUST trigger teardown — the exact PP-4632 condition (a returned
+    /// audiobook kept playing because the session never observed the registry).
+    func testShouldStopPlayback_currentBookUnregistered_returnsTrue() {
+        XCTAssertTrue(AudiobookSessionManager.shouldStopPlaybackOnRegistryChange(
+            state: .unregistered, changedIdentifier: "book-1", currentBookIdentifier: "book-1"))
+    }
+
+    /// Returning a DIFFERENT book must NOT stop the active player.
+    func testShouldStopPlayback_differentBookUnregistered_returnsFalse() {
+        XCTAssertFalse(AudiobookSessionManager.shouldStopPlaybackOnRegistryChange(
+            state: .unregistered, changedIdentifier: "other-book", currentBookIdentifier: "book-1"))
+    }
+
+    /// A non-removal state change for the current book (e.g. `.downloadSuccessful`)
+    /// must NOT stop playback — only `.unregistered` (return/expire) does.
+    func testShouldStopPlayback_currentBookNonUnregistered_returnsFalse() {
+        XCTAssertFalse(AudiobookSessionManager.shouldStopPlaybackOnRegistryChange(
+            state: .downloadSuccessful, changedIdentifier: "book-1", currentBookIdentifier: "book-1"))
+    }
+
+    /// Nothing playing → never stop. (During account switch, currentBook is
+    /// already niled by cleanupActiveContentBeforeAccountSwitch, so the mass
+    /// `.unregistered` emissions must no-op here.)
+    func testShouldStopPlayback_noCurrentBook_returnsFalse() {
+        XCTAssertFalse(AudiobookSessionManager.shouldStopPlaybackOnRegistryChange(
+            state: .unregistered, changedIdentifier: "book-1", currentBookIdentifier: nil))
+    }
 }
 
 // MARK: - AudiobookSessionError Tests


### PR DESCRIPTION
## What
A returned audiobook kept playing in the new player. `AudiobookSessionManager` held the loaded audiobook in memory (currentBook + tracks) and never observed the book registry, so the return flow (delete local content + purge caches + registry → `.unregistered`) could not reach the live session — the already-open file handles kept playing until a different book was opened.

## Fix
`AudiobookSessionManager` now subscribes to `bookRegistry.bookStatePublisher` in `init` (`subscribeToBookReturn`). When the **currently-playing** book transitions to `.unregistered`, it calls `stopPlayback(dismissPhoneUI: true, persistFinalPosition: false)` — full teardown, and `false` so a stale live position isn't written back into a possibly re-borrowed record (FINDING-D). The decision is a `nonisolated static` (`shouldStopPlaybackOnRegistryChange`) for unit-testing, mirroring the `networkValidationError` pattern.

## Scope
- **develop only** — per Chairman direction, PP-4632 ships in the next version bump, NOT in 3.2.0 and NOT via a TestFlight RC.
- Cherry-pick of the original fix commit (`5838c0c9a`), fix-only (no build bump).

## Tests
`AudiobookSessionStateTransitionTests` — 22 tests, 0 failures (verified by name on the develop base via the isolated-sim harness):
- `testShouldStopPlayback_currentBookUnregistered_returnsTrue`
- `testShouldStopPlayback_differentBookUnregistered_returnsFalse`
- `testShouldStopPlayback_currentBookNonUnregistered_returnsFalse`
- `testShouldStopPlayback_noCurrentBook_returnsFalse`

Live audiobook return-then-play repro is being validated separately via simdrive.

Intent: `.forgeos/intent/pp4632-stop-returned-audiobook.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)