### PR TITLE
PP-4531: footnote VoiceOver (doc-noteref/footnote/backlink) — Reader2 a11y

### DIFF
--- a/.forgeos/intent/pp4531-footnote-voiceover.md
+++ b/.forgeos/intent/pp4531-footnote-voiceover.md
@@ -1,0 +1,70 @@
+---
+name: pp4531-footnote-voiceover
+created: 2026-06-22
+author: Maurice Carrier
+branch: feature/PP-4531-footnote-voiceover
+priority: PP-4531 / Sprint 77 / Epic PP-833 EPUB Accessibility (DAISY reading-420)
+---
+
+# Intent: footnote handling with VoiceOver in the iOS reader
+
+## Context
+
+Palace iOS fails DAISY reading-420 ("Footnote Reading"): the Reader2 (Readium 3.x)
+reader does not surface EPUB footnote semantics to VoiceOver, so a non-visual
+reader has no reliable way to recognize a footnote reference, reach the note, and
+return to the reference. EPUBs mark the reference with `epub:type="doc-noteref"`,
+the note with `doc-footnote` (or `doc-endnote` / `doc-rearnote`), and the return
+link with `doc-backlink`.
+
+Grounded surface:
+- Footnote refs/notes are inline `<a>` elements in the spine HTML — NOT in the
+  Readium manifest — so they are reached via the rendered WKWebView DOM, not via
+  `publication`. (This is why the page-list manifest approach from PP-4529 does
+  not apply here.)
+- `TPPEPUBViewController` already injects JS on chapter render via
+  `epubNavigator.evaluateJavaScript(...)` (the chapter-load focus JS in
+  `didChangeLocation`), and in VoiceOver mode sets `navigator.view.isAccessibilityElement = false`
+  so VoiceOver traverses the WKWebView DOM directly.
+
+## Claims
+
+- New `TPPReaderFootnoteAccessibility` (pure, Foundation-only): classifies an
+  element's `epub:type`/ARIA `role` into `.reference`/`.note`/`.backlink` and
+  composes the VoiceOver label (e.g. "Footnote 3", "Footnote", "Back to
+  reference"). Unit-testable in isolation (16 tests: role parsing + label
+  composition), no UIKit/Readium state.
+- `annotationJavaScript()` is a thin DOM mirror of the tested label rule; it sets
+  `aria-label` on the inline footnote elements so VoiceOver speaks the role +
+  marker. No duplication of the label logic's spec.
+- Wired into `TPPEPUBViewController.didChangeLocation` (VoiceOver-only, every
+  chapter render), additive and idempotent; does not alter reading position.
+
+## Verification
+
+- Unit: `xcodebuild test -only-testing:PalaceTests/TPPReaderFootnoteAccessibilityTests` — 16/16 pass.
+- Runtime (pending): device/host-AX VoiceOver pass on the DAISY "Fundamental
+  Accessibility Tests: Non-Visual Reading" (reading-420) fixture — focus a
+  reference → announced as a footnote reference; activate → note reachable +
+  announced; backlink → returns to the reference.
+
+## Files in scope
+
+- `Palace/Reader2/BusinessLogic/TPPReaderFootnoteAccessibility.swift` (new) — pure role classifier + label composer + annotation JS.
+- `Palace/Reader2/UI/TPPEPUBViewController.swift` — `annotateFootnotesForVoiceOver()` + call in `didChangeLocation`.
+- `Palace/Utilities/Localization/Strings.swift` — 4 footnote VoiceOver labels.
+- `PalaceTests/Reader2/TPPReaderFootnoteAccessibilityTests.swift` (new) — 16 unit tests.
+- `Palace.xcodeproj/project.pbxproj` — register the two new files (Palace, Palace-noDRM, PalaceTests).
+
+## Anti-claims
+
+- Does NOT change reading position or move VoiceOver focus — the annotation only
+  sets `aria-label`s on existing elements; navigation/return is the EPUB's own
+  in-content links.
+- Does NOT parse footnotes from the Readium manifest/`publication` (they are not
+  there) — detection is DOM-only via injected JS.
+- Does NOT change how footnotes are authored/marked up in the EPUB.
+- Does NOT add a visible popover/inline-note treatment for sighted users
+  (separate story); this is screen-reader behavior only.
+- Does NOT claim the runtime VoiceOver behavior is verified — only the pure
+  label/role logic is unit-tested; the device/host-AX pass is explicitly pending.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		121E8B66B8634CD720E7C524 /* CatalogRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA39820CBA75D6BA9B763E2 /* CatalogRepositoryTests.swift */; };
 		1246CC54E04F756C2913D438 /* LCPPDFDiskExtractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F470EA0E88BDCE56E27B86 /* LCPPDFDiskExtractTests.swift */; };
 		1266D86E87E4AA575EB966BD /* BookmarkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EFBB61877EFCAB44897E93 /* BookmarkManager.swift */; };
+		12695B15A63B66C4B42E9B13 /* TPPReaderFootnoteAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD60FEA388441F72F8C8D85C /* TPPReaderFootnoteAccessibilityTests.swift */; };
 		134F3EF0E81145878D455EFF /* UserRetryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43040747774740399559510F /* UserRetryTracker.swift */; };
 		137A5C5FCEB1C3E9F22B6A99 /* TPPPDFModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3D078322CEC4B660EC470F /* TPPPDFModelTests.swift */; };
 		1387B2F9424A9B052E3B353F /* TPPLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C7D04F855F2DA251329CDD /* TPPLocalization.swift */; };
@@ -273,6 +274,7 @@
 		24C1F145C0A0FB6B336CE9E3 /* OfflineQueueServiceExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF2F2922050A267096B9D57 /* OfflineQueueServiceExtendedTests.swift */; };
 		25011A2221163A21257C73C8 /* BookReturnServiceContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D24086CF8BC2C596888CDA /* BookReturnServiceContractTests.swift */; };
 		2509AED42CD6FC9523E9901D /* BookButtonTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4FCC8401ACF8D4FD8CAFFE2 /* BookButtonTypeTests.swift */; };
+		25959D57AE73A5D30750924D /* TPPReaderFootnoteAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */; };
 		25DF742278BA71BEE5EBAD27 /* TokenResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A325872EF1D517D66C0FA15F /* TokenResponseTests.swift */; };
 		262789F2A1A164B79D0138AB /* TriageBotIOS in Frameworks */ = {isa = PBXBuildFile; productRef = B848F3B79F55EEDD9B820E1F /* TriageBotIOS */; };
 		2637485A6B7C8D9E0F102132 /* LCPFulfillmentHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37485A6B7C8D9E0F10213243 /* LCPFulfillmentHandlerTests.swift */; };
@@ -452,6 +454,7 @@
 		5944697470D242E08CB939D5 /* AccountsManagerCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D598423237C04DE7B3834ABC /* AccountsManagerCacheTests.swift */; };
 		595B6A6AAC779FEBBCA7B897 /* MockCredentialsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C493684B84FF9EDBEBCD104 /* MockCredentialsProvider.swift */; };
 		596F8091A2B3C4D5E6F70718 /* BookReturnService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7081A2B3C4D5E6F7081929 /* BookReturnService.swift */; };
+		5977FE52E5B43328E7773533 /* TPPReaderFootnoteAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */; };
 		5A6C30A999D9E0264FD78074 /* ActiveSessionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A72A97BA91A0EB66D642A06 /* ActiveSessionsViewModelTests.swift */; };
 		5AD42A9111A49CFDF0AC22B1 /* AdobeRightsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E62D6F6D6313094B90E80E5 /* AdobeRightsParser.swift */; };
 		5AEA9E011B947419009F71DB /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503EA1993F91E009FB788 /* libc++.dylib */; };
@@ -2908,6 +2911,7 @@
 		E1F2A3B4C5D6E7F8A9B0C1D2 /* RightsManagementDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightsManagementDispatcher.swift; sourceTree = "<group>"; };
 		E3465465A1B2C3D4E5F60829 /* OverdriveDownloadHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverdriveDownloadHandler.swift; sourceTree = "<group>"; };
 		E358F2BF99213E34F1B052ED /* OPDS2BookBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2BookBridgeTests.swift; sourceTree = "<group>"; };
+		E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderFootnoteAccessibility.swift; path = ../../Palace/Reader2/BusinessLogic/TPPReaderFootnoteAccessibility.swift; sourceTree = "<group>"; };
 		E3C9C7A1029274277B31F57E /* OfflineQueueBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineQueueBadge.swift; sourceTree = "<group>"; };
 		E3FF91DFB962417EA742080A /* RetryClassificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryClassificationTests.swift; sourceTree = "<group>"; };
 		E48AE22D7C0BC6134885E9F0 /* TPPProcessInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPProcessInfo.swift; sourceTree = "<group>"; };
@@ -3242,6 +3246,7 @@
 		FC465C72310C5054118CBBEA /* UserAccountValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserAccountValidationTests.swift; sourceTree = "<group>"; };
 		FC95BE63D9C7C7AE1EFB8D6B /* ChaosFaultInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaosFaultInjectionTests.swift; sourceTree = "<group>"; };
 		FCF5E7D0F712E6F62B28E143 /* LCPPDFOpenProgressTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPDFOpenProgressTests.swift; sourceTree = "<group>"; };
+		FD60FEA388441F72F8C8D85C /* TPPReaderFootnoteAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderFootnoteAccessibilityTests.swift; path = TPPReaderFootnoteAccessibilityTests.swift; sourceTree = "<group>"; };
 		FE0CCABB8C99DA55C43F3DA3 /* AdobeDRMHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeDRMHandler.swift; sourceTree = "<group>"; };
 		FE2159403F0FCBE90CFC6858 /* BookImageViewAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImageViewAccessibilityTests.swift; sourceTree = "<group>"; };
 		FE7BD91AF3E14990B745A0AA /* AudiobookDataManagerSyncTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookDataManagerSyncTests.swift; sourceTree = "<group>"; };
@@ -3880,6 +3885,7 @@
 				6F78C5D7DB880A6C70921339 /* TPPBaseReaderViewControllerInitialLocationTests.swift */,
 				9A35DE944F78A26A081622BA /* TPPReaderPageListBusinessLogicTests.swift */,
 				673C54DADAEAD820B2DABB9D /* TPPReaderPositionReportTests.swift */,
+				FD60FEA388441F72F8C8D85C /* TPPReaderFootnoteAccessibilityTests.swift */,
 			);
 			path = Reader2;
 			sourceTree = "<group>";
@@ -5302,6 +5308,7 @@
 				B3FBCE9F366E7A29724332D4 /* EPUBPositionAdapter.swift */,
 				0D848CD4CD0E01B3A2BF67FE /* TPPReaderPageListBusinessLogic.swift */,
 				03FE49D6CAE9861D0C5EC238 /* TPPReaderPositionReport.swift */,
+				E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */,
 			);
 			name = BusinessLogic;
 			path = BusinessLogic;
@@ -7427,6 +7434,7 @@
 				611D923EBE0FB1507857F65A /* TPPReaderPositionReportTests.swift in Sources */,
 				DD53EDAC28AB285D49FD1848 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift in Sources */,
 				20B17E24C48EC2CCF3A25977 /* BookRegistrySyncReentrancyTests.swift in Sources */,
+				12695B15A63B66C4B42E9B13 /* TPPReaderFootnoteAccessibilityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7973,6 +7981,7 @@
 				317AEF4CF6E747286B2CA086 /* TriageBotKeyAdmin.swift in Sources */,
 				F9497743E78564D80AEC155F /* TPPReaderPageListBusinessLogic.swift in Sources */,
 				FAC84E21FA4ECEF263BA02A3 /* TPPReaderPositionReport.swift in Sources */,
+				25959D57AE73A5D30750924D /* TPPReaderFootnoteAccessibility.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8522,6 +8531,7 @@
 				30FA663F88FFCE7D65BB990C /* TriageBotKeyAdmin.swift in Sources */,
 				C6A457ADC7B74852879349E0 /* TPPReaderPageListBusinessLogic.swift in Sources */,
 				97AF6721F64BB54CBB497818 /* TPPReaderPositionReport.swift in Sources */,
+				5977FE52E5B43328E7773533 /* TPPReaderFootnoteAccessibility.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Reader2/BusinessLogic/TPPReaderFootnoteAccessibility.swift
+++ b/Palace/Reader2/BusinessLogic/TPPReaderFootnoteAccessibility.swift
@@ -1,0 +1,132 @@
+//
+//  TPPReaderFootnoteAccessibility.swift
+//  Palace
+//
+//  PP-4531 — "Properly handle footnotes with VoiceOver in the iOS reader" (DAISY
+//  reading-420). EPUBs mark a footnote reference with `epub:type="doc-noteref"`,
+//  the note with `doc-footnote` (or `doc-endnote` / `doc-rearnote`), and the
+//  return link with `doc-backlink`. These live INLINE in the spine HTML — not in
+//  the Readium manifest — so they are surfaced to VoiceOver by annotating the
+//  rendered DOM (see TPPEPUBViewController), not by parsing `publication`.
+//
+//  This type is the pure, dependency-free core: it classifies an element's
+//  `epub:type` / ARIA `role` into a footnote Role and composes the VoiceOver
+//  label for that role. It owns no UIKit/Readium state so it is unit-testable in
+//  isolation; the WKWebView injection that applies these labels is a thin mirror
+//  built by `annotationJavaScript()`.
+//
+
+import Foundation
+
+enum TPPReaderFootnoteAccessibility {
+
+  /// The footnote role a DOM element plays, derived from its `epub:type`
+  /// (preferred) or ARIA `role`.
+  enum Role: Equatable {
+    /// An inline reference TO a note (`doc-noteref`). Activating it navigates to
+    /// the note.
+    case reference
+    /// The note content itself (`doc-footnote` / `doc-endnote` / `doc-rearnote`).
+    case note
+    /// The return link back to the reference (`doc-backlink`).
+    case backlink
+  }
+
+  /// Classify a footnote role from a (possibly space-separated, possibly
+  /// `doc-`-prefixed) `epub:type` or ARIA `role` token list. Returns nil when no
+  /// footnote-related token is present.
+  ///
+  /// EPUB `epub:type` and the matching DAISY ARIA `role` values share the same
+  /// `doc-*` vocabulary, so one classifier serves both. Matching is
+  /// case-insensitive and tolerant of the optional `doc-` prefix.
+  static func role(forEPUBType epubType: String?) -> Role? {
+    guard let epubType else { return nil }
+    let tokens = epubType
+      .lowercased()
+      .split { $0 == " " || $0 == "\t" || $0 == "\n" }
+      .map { $0.hasPrefix("doc-") ? String($0.dropFirst(4)) : String($0) }
+    let set = Set(tokens)
+    // Reference is checked first: a single element is never both a ref and a note.
+    if set.contains("noteref") { return .reference }
+    if set.contains("backlink") { return .backlink }
+    if set.contains("footnote") || set.contains("endnote") || set.contains("rearnote") {
+      return .note
+    }
+    return nil
+  }
+
+  /// The VoiceOver label for a footnote element.
+  ///
+  /// - `reference`: a marker (e.g. "3", "*", "a") yields `Footnote 3`; an empty
+  ///   or whitespace-only marker yields the generic `Footnote reference`.
+  ///   VoiceOver appends "link" itself because the element is an `<a>`.
+  /// - `note`: `Footnote` (announced as focus reaches the note content).
+  /// - `backlink`: `Back to reference`.
+  static func accessibilityLabel(role: Role, marker: String?) -> String {
+    switch role {
+    case .reference:
+      let trimmed = (marker ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+      if trimmed.isEmpty {
+        return Strings.TPPBaseReaderViewController.footnoteReferenceGeneric
+      }
+      return String(format: Strings.TPPBaseReaderViewController.footnoteReferenceNumbered, trimmed)
+    case .note:
+      return Strings.TPPBaseReaderViewController.footnoteContent
+    case .backlink:
+      return Strings.TPPBaseReaderViewController.footnoteBacklink
+    }
+  }
+
+  /// JavaScript that annotates inline footnote elements in the rendered Readium
+  /// WKWebView with `aria-label`s, so VoiceOver speaks the role + marker. It is a
+  /// thin mirror of `accessibilityLabel(role:marker:)` — the Swift composer is
+  /// the spec (and is unit-tested); this applies the same rule in the DOM, where
+  /// the per-element marker text is known. Idempotent: re-running only re-labels.
+  ///
+  /// Returns the element count it labelled (for logging / verification).
+  static func annotationJavaScript() -> String {
+    // Localized label templates passed into the DOM so wording stays centralized.
+    let numbered = jsString(Strings.TPPBaseReaderViewController.footnoteReferenceNumbered)
+    let generic = jsString(Strings.TPPBaseReaderViewController.footnoteReferenceGeneric)
+    let note = jsString(Strings.TPPBaseReaderViewController.footnoteContent)
+    let backlink = jsString(Strings.TPPBaseReaderViewController.footnoteBacklink)
+    return """
+    (function() {
+      var NUMBERED = \(numbered), GENERIC = \(generic), NOTE = \(note), BACKLINK = \(backlink);
+      function roleOf(el) {
+        var t = ((el.getAttribute('epub:type') || el.getAttribute('role') || '')).toLowerCase();
+        if (!t) return null;
+        var toks = t.split(/\\s+/).map(function(x){ return x.indexOf('doc-') === 0 ? x.slice(4) : x; });
+        if (toks.indexOf('noteref') >= 0) return 'reference';
+        if (toks.indexOf('backlink') >= 0) return 'backlink';
+        if (toks.indexOf('footnote') >= 0 || toks.indexOf('endnote') >= 0 || toks.indexOf('rearnote') >= 0) return 'note';
+        return null;
+      }
+      var nodes = document.querySelectorAll('[epub\\\\:type],[role]');
+      var n = 0;
+      for (var i = 0; i < nodes.length; i++) {
+        var el = nodes[i], r = roleOf(el);
+        if (!r) continue;
+        var label;
+        if (r === 'reference') {
+          var marker = (el.textContent || '').trim();
+          label = marker ? NUMBERED.replace('%@', marker) : GENERIC;
+        } else if (r === 'note') {
+          label = NOTE;
+        } else {
+          label = BACKLINK;
+        }
+        el.setAttribute('aria-label', label);
+        n++;
+      }
+      return n;
+    })()
+    """
+  }
+
+  /// JSON-encode a Swift string into a JS string literal (safe interpolation).
+  private static func jsString(_ s: String) -> String {
+    let data = (try? JSONEncoder().encode(s)) ?? Data()
+    return String(data: data, encoding: .utf8) ?? "\"\""
+  }
+}

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import ReadiumShared
 import ReadiumNavigator
 import GameController
+import PalaceLogging
 
 class TPPEPUBViewController: TPPBaseReaderViewController {
     /// Tap handling is performed by Readium's input observer system:
@@ -274,9 +275,18 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 600_000_000)
             guard self.lastChapterHREF == href else { return }
-            await self.epubNavigator.evaluateJavaScript(
+            let result = await self.epubNavigator.evaluateJavaScript(
                 TPPReaderFootnoteAccessibility.annotationJavaScript()
             )
+            // PP-4531 observability: the injected aria-labels live in the Readium
+            // WKWebView's web-AX, which host-AX / simdrive CANNOT inspect on the
+            // simulator (verified 2026-06-23). Emit a log of the labelled-element
+            // count + the VoiceOver state so the injection is verifiable
+            // end-to-end via log capture (CI / host-AX), since neither the DOM
+            // labels nor VoiceOver focus-speech surface to the host AX bridge.
+            let value = try? result.get()
+            let labelled = (value as? Int) ?? (value as? NSNumber)?.intValue ?? -1
+            Log.info(#file, "PP-4531 injected aria-labels on \(labelled) noteref/footnote/backlink elements, VoiceOver=\(UIAccessibility.isVoiceOverRunning)")
         }
     }
 

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -263,6 +263,23 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
         }
     }
 
+    /// Annotate inline EPUB footnote elements (`doc-noteref` / `doc-footnote` /
+    /// `doc-backlink`) in the rendered WKWebView with VoiceOver `aria-label`s so a
+    /// non-visual reader knows a link is a note reference, hears the note, and can
+    /// return to the reference (DAISY reading-420, PP-4531). Additive and
+    /// idempotent; runs after the chapter has had a moment to render and bails if
+    /// the chapter changed again in the meantime.
+    private func annotateFootnotesForVoiceOver() {
+        let href = lastChapterHREF
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 600_000_000)
+            guard self.lastChapterHREF == href else { return }
+            await self.epubNavigator.evaluateJavaScript(
+                TPPReaderFootnoteAccessibility.annotationJavaScript()
+            )
+        }
+    }
+
     override func voiceOverStatusDidChange() {
         super.voiceOverStatusDidChange()
         configureAccessibilityActions()
@@ -296,6 +313,11 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
         // so VoiceOver's "Read All" continues into the new chapter.
         let status = locator.title.flatMap { $0.isEmpty ? nil : $0 } ?? "Page changed"
         UIAccessibility.post(notification: .pageScrolled, argument: status)
+
+        // Label inline footnotes (doc-noteref/doc-footnote/doc-backlink) for
+        // VoiceOver on every chapter render — manual turns AND Read-All — so a
+        // non-visual reader hits semantic note references throughout (PP-4531).
+        annotateFootnotesForVoiceOver()
 
         // For manual page turns only (toolbar buttons, keyboard, edge taps),
         // use JavaScript to focus the first content element so VoiceOver

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -530,6 +530,13 @@ struct Strings {
         static let whereAmI = NSLocalizedString("Where am I?", value: "Where am I?", comment: "VoiceOver custom action that announces the patron's current reading position without moving focus")
         static let percentRead = NSLocalizedString("%d%% read", value: "%d%% read", comment: "VoiceOver position component stating how far through the book the patron is, e.g. `45% read`")
         static let positionUnavailable = NSLocalizedString("Current position unavailable", value: "Current position unavailable", comment: "VoiceOver announcement when the current reading position cannot be determined")
+        // Footnotes (DAISY reading-420, PP-4531). VoiceOver speaks these labels on
+        // the inline EPUB elements so a non-visual reader knows a link is a note
+        // reference, hears the note, and can return to the reference.
+        static let footnoteReferenceNumbered = NSLocalizedString("Footnote %@", value: "Footnote %@", comment: "VoiceOver label for an inline footnote reference link with a marker, e.g. `Footnote 3`. VoiceOver appends `link` itself.")
+        static let footnoteReferenceGeneric = NSLocalizedString("Footnote reference", value: "Footnote reference", comment: "VoiceOver label for a footnote reference link with no readable marker")
+        static let footnoteContent = NSLocalizedString("Footnote", value: "Footnote", comment: "VoiceOver label prefix announced when focus reaches footnote content")
+        static let footnoteBacklink = NSLocalizedString("Back to reference", value: "Back to reference", comment: "VoiceOver label for the footnote return link (doc-backlink) that returns the reader to the reference")
     }
 
     struct TPPBarCode {

--- a/PalaceTests/Reader2/TPPReaderFootnoteAccessibilityTests.swift
+++ b/PalaceTests/Reader2/TPPReaderFootnoteAccessibilityTests.swift
@@ -1,0 +1,106 @@
+//
+//  TPPReaderFootnoteAccessibilityTests.swift
+//  PalaceTests
+//
+//  PP-4531 (DAISY reading-420) — unit tests for the pure footnote-accessibility
+//  core: epub:type/role classification and VoiceOver label composition. The
+//  WKWebView annotation JS is a thin mirror of this spec and is verified at
+//  runtime (device VoiceOver / simdrive host-AX), not here.
+//
+
+import XCTest
+@testable import Palace
+
+final class TPPReaderFootnoteAccessibilityTests: XCTestCase {
+
+  typealias FA = TPPReaderFootnoteAccessibility
+
+  // MARK: - role(forEPUBType:)
+
+  func testRole_noteref_isReference() {
+    XCTAssertEqual(FA.role(forEPUBType: "doc-noteref"), .reference)
+  }
+
+  func testRole_footnote_isNote() {
+    XCTAssertEqual(FA.role(forEPUBType: "doc-footnote"), .note)
+  }
+
+  func testRole_endnoteAndRearnote_areNote() {
+    XCTAssertEqual(FA.role(forEPUBType: "doc-endnote"), .note)
+    XCTAssertEqual(FA.role(forEPUBType: "doc-rearnote"), .note)
+  }
+
+  func testRole_backlink_isBacklink() {
+    XCTAssertEqual(FA.role(forEPUBType: "doc-backlink"), .backlink)
+  }
+
+  func testRole_toleratesMissingDocPrefix() {
+    XCTAssertEqual(FA.role(forEPUBType: "noteref"), .reference)
+    XCTAssertEqual(FA.role(forEPUBType: "backlink"), .backlink)
+  }
+
+  func testRole_isCaseInsensitive() {
+    XCTAssertEqual(FA.role(forEPUBType: "DOC-NOTEREF"), .reference)
+    XCTAssertEqual(FA.role(forEPUBType: "Doc-Footnote"), .note)
+  }
+
+  func testRole_multiTokenList_picksReferenceFirst() {
+    // ARIA/epub:type can carry several space-separated tokens.
+    XCTAssertEqual(FA.role(forEPUBType: "doc-noteref annotation"), .reference)
+  }
+
+  func testRole_ariaRoleVocabularyShared() {
+    // The DAISY ARIA role vocabulary uses the same doc-* tokens.
+    XCTAssertEqual(FA.role(forEPUBType: "doc-backlink"), .backlink)
+  }
+
+  func testRole_nilAndEmptyAndUnrelated_areNil() {
+    XCTAssertNil(FA.role(forEPUBType: nil))
+    XCTAssertNil(FA.role(forEPUBType: ""))
+    XCTAssertNil(FA.role(forEPUBType: "doc-chapter"))
+    XCTAssertNil(FA.role(forEPUBType: "section"))
+  }
+
+  // MARK: - accessibilityLabel(role:marker:)
+
+  func testLabel_referenceWithMarker_includesMarker() {
+    XCTAssertEqual(FA.accessibilityLabel(role: .reference, marker: "3"), "Footnote 3")
+  }
+
+  func testLabel_referenceWithNonNumericMarker_includesMarker() {
+    XCTAssertEqual(FA.accessibilityLabel(role: .reference, marker: "*"), "Footnote *")
+    XCTAssertEqual(FA.accessibilityLabel(role: .reference, marker: "a"), "Footnote a")
+  }
+
+  func testLabel_referenceTrimsMarker() {
+    XCTAssertEqual(FA.accessibilityLabel(role: .reference, marker: "  12\n"), "Footnote 12")
+  }
+
+  func testLabel_referenceWithEmptyOrWhitespaceMarker_isGeneric() {
+    XCTAssertEqual(FA.accessibilityLabel(role: .reference, marker: nil), "Footnote reference")
+    XCTAssertEqual(FA.accessibilityLabel(role: .reference, marker: ""), "Footnote reference")
+    XCTAssertEqual(FA.accessibilityLabel(role: .reference, marker: "   "), "Footnote reference")
+  }
+
+  func testLabel_note_isFootnote() {
+    XCTAssertEqual(FA.accessibilityLabel(role: .note, marker: nil), "Footnote")
+  }
+
+  func testLabel_backlink_isBackToReference() {
+    XCTAssertEqual(FA.accessibilityLabel(role: .backlink, marker: nil), "Back to reference")
+  }
+
+  // MARK: - annotationJavaScript()
+
+  func testAnnotationJS_isNonEmptyAndCarriesLabelsAndSelectors() {
+    let js = FA.annotationJavaScript()
+    XCTAssertFalse(js.isEmpty)
+    // Mirrors the Swift rule: detects the doc-* tokens and writes aria-label.
+    XCTAssertTrue(js.contains("noteref"))
+    XCTAssertTrue(js.contains("backlink"))
+    XCTAssertTrue(js.contains("aria-label"))
+    // Localized templates are interpolated into the DOM walker.
+    XCTAssertTrue(js.contains("Footnote"))
+    XCTAssertTrue(js.contains("Back to reference"))
+  }
+}


### PR DESCRIPTION
## What
Properly handles footnotes with VoiceOver in the iOS reader (DAISY reading-420). EPUBs mark a footnote reference (`epub:type="doc-noteref"`), the note (`doc-footnote`/`doc-endnote`/`doc-rearnote`), and the return link (`doc-backlink`) **inline in the spine HTML** — not in the Readium manifest — so we surface them to VoiceOver by annotating the rendered DOM with `aria-label`s.

- `TPPReaderFootnoteAccessibility.swift` — pure, dependency-free core: classifies an element's `epub:type`/ARIA `role` into a footnote Role and composes the VoiceOver label; plus the JS that mirrors that rule onto the DOM (idempotent; returns the labelled-element count).
- `TPPEPUBViewController.swift` — injects the annotation JS after each chapter renders (VoiceOver-gated, settle-delay + stale-chapter guard).
- Localized strings for the footnote labels.

## Observability (added this round)
The injected labels live in the Readium **WKWebView** web-AX, which host-AX/simdrive **cannot inspect** on the simulator (verified live), and the `.announcement` observer doesn't carry VoiceOver focus-speech. So the feature had no simulator-observable signal. Added one feature-gated `Log.info` after injection — `"PP-4531 injected aria-labels on N noteref/footnote/backlink elements, VoiceOver=<bool>"` (subsystem `org.thepalaceproject.palace`) — so it's verifiable end-to-end via log capture (CI / host-AX). Additive logging only.

## Validation
- **Unit:** `TPPReaderFootnoteAccessibilityTests` — **16/16 pass** (role classification + label composition + JS shape), verified on the develop base via the isolated-sim harness.
- **simdrive (live):** fixture DOM + test design confirmed — the test EPUB has 2× `doc-noteref` / 2× `doc-footnote` / 1× `doc-backlink` with **zero** static labels, so injection is net-new and unambiguous. Runtime injection isn't host-AX-observable (WKWebView boundary) → the new `os_log` is the validation path; simdrive's next run asserts it.

## Scope
**develop only** (next version bump). Jira PP-4531 moves on merge.

Intent: `.forgeos/intent/pp4531-footnote-voiceover.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)