### PR TITLE
PP-4533: block-by-block screen-reader navigation — Reader2 a11y

### DIFF
--- a/.forgeos/intent/pp4533-block-by-block-navigation.md
+++ b/.forgeos/intent/pp4533-block-by-block-navigation.md
@@ -1,0 +1,76 @@
+---
+name: pp4533-block-by-block-navigation
+created: 2026-06-23
+author: claude-opus-4-8
+branch: feature/PP-4533-block-navigation
+priority: PP-4533 / Epic PP-833 EPUB Accessibility (DAISY reading-810)
+---
+
+# Intent: block-by-block screen-reader navigation in the iOS reader
+
+## Context
+
+Palace iOS fails DAISY reading-810 ("Block Navigation"): the Reader2 (Readium 3.x)
+reader gives VoiceOver users no way to move through content one logical block at a
+time (paragraph, heading, list item, quote, definition term/description,
+preformatted text, figure caption). Block navigation must operate on the rendered
+spine HTML — the logical blocks live INLINE in the chapter DOM, NOT in the Readium
+manifest — so they are surfaced to VoiceOver by marking the rendered WKWebView DOM
+(see TPPEPUBViewController), not by parsing `publication`. This mirrors the
+just-built PP-4531 footnote pattern.
+
+Grounded surface:
+- `TPPEPUBViewController` already injects JS on chapter render via
+  `epubNavigator.evaluateJavaScript(...)` and, in VoiceOver mode, sets
+  `navigator.view.isAccessibilityElement = false` so VoiceOver traverses the
+  WKWebView DOM directly.
+- `AccessibilityPreferences.customRotorActionsEnabled` (default on) is the
+  established gate for custom rotor actions.
+
+## Claims
+
+- New `TPPReaderBlockNavigation` (pure, Foundation-only): owns the block-element
+  selector (`p, h1..h6, li, blockquote, figcaption, dd, dt, pre, [role="heading"],
+  [role="listitem"]`), a unit-testable `isBlockTag(_:)` classifier, an
+  `annotationJavaScript()` that marks the OUTERMOST matching blocks
+  (`tabindex="-1"` + `data-pp-block="1"`, nested blocks skipped) and returns the
+  marked count, and a `nextBlockJavaScript(forward:)` focus-walk. No UIKit/Readium
+  state; unit-tested in isolation.
+- `annotationJavaScript()` / `nextBlockJavaScript(forward:)` are thin DOM mirrors
+  of the tested selector spec — no duplication of the block-classification rule.
+- Wired into `TPPEPUBViewController`: `annotateBlocksForVoiceOver()` runs on every
+  chapter render (alongside the chapter-change VoiceOver guard), and a
+  `makeBlockRotor()` UIAccessibilityCustomRotor ("Blocks") walks the marked blocks
+  forward/back, gated on `customRotorActionsEnabled`. Additive and idempotent;
+  does not alter reading position.
+
+## Verification
+
+- Unit: `harness test -- -only-testing:PalaceTests/TPPReaderBlockNavigationTests` —
+  all pass (selector/classifier + marking-JS + focus-walk-JS shape).
+- Runtime (pending): device/host-AX VoiceOver pass on the DAISY reading-810
+  fixture — open the "Blocks" rotor, swipe up/down to step block-by-block forward
+  and back. The marked-count is emitted via `Log.info` ("PP-4533 block-nav marked
+  N blocks for VoiceOver") since the injected DOM marks live in the Readium
+  WKWebView web-AX, which host-AX / simdrive cannot inspect on the simulator.
+
+## Files in scope
+
+- `Palace/Reader2/BusinessLogic/TPPReaderBlockNavigation.swift` (new) — pure block selector + classifier + marking/focus-walk JS.
+- `Palace/Reader2/UI/TPPEPUBViewController.swift` — `annotateBlocksForVoiceOver()` + call in `didChangeLocation`, `makeBlockRotor()` + rotor attachment in `configureAccessibilityActions()`.
+- `Palace/Utilities/Localization/Strings.swift` — `blockRotorTitle` ("Blocks").
+- `PalaceTests/Reader2/TPPReaderBlockNavigationTests.swift` (new) — unit tests.
+- `Palace.xcodeproj/project.pbxproj` — register the two new files (Palace, Palace-noDRM, PalaceTests).
+
+## Anti-claims
+
+- Does NOT change reading position — the rotor only moves VoiceOver focus among
+  existing block elements; it never calls `navigator.go(...)`.
+- Does NOT parse blocks from the Readium manifest/`publication` (they are not
+  there) — detection is DOM-only via injected JS.
+- Does NOT add a visible control or settings UI for sighted users — this is
+  screen-reader behavior only, reusing the existing `customRotorActionsEnabled`
+  preference.
+- Does NOT claim the runtime VoiceOver behavior is verified — only the pure
+  selector/classifier and JS shape are unit-tested; the marked-count is via
+  `os_log` and the device/host-AX pass is explicitly pending.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -489,6 +489,7 @@
 		607C5492BCD1F00E3156DDE6 /* DownloadOnlyOnWiFiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78529336066D2340C7B0FCE0 /* DownloadOnlyOnWiFiTests.swift */; };
 		60A99C600DD9A116635F920A /* AppContainerImageLoaderInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F13FD93A4CE48909066F4AE /* AppContainerImageLoaderInjectionTests.swift */; };
 		611D923EBE0FB1507857F65A /* TPPReaderPositionReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673C54DADAEAD820B2DABB9D /* TPPReaderPositionReportTests.swift */; };
+		3DFA32525D80836005DEB6FC /* TPPReaderBlockNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14070A4A26128AE43AC74C6 /* TPPReaderBlockNavigationTests.swift */; };
 		612E466C3BD31ED26DEDE50C /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF1F7C70AC93BF8E2F22148 /* DebugSettings.swift */; };
 		612FD8DA16387F71EB3CA398 /* HoldsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADE8A45C4B4AAE67143A272 /* HoldsViewModelTests.swift */; };
 		61757D3F95012F8F4340FABB /* TPPAccountAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56509A03466E0531DBC27 /* TPPAccountAuthState.swift */; };
@@ -848,6 +849,8 @@
 		964B6BD847B0E6C061E6CCB2 /* RemoteFeatureFlags+PalaceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272E56401C680E7771557AC3 /* RemoteFeatureFlags+PalaceCatalog.swift */; };
 		967625944F77592C713BFA06 /* NYPLOPDSFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B814E7E38AAEFF18419C6BB /* NYPLOPDSFeedTests.swift */; };
 		97AF6721F64BB54CBB497818 /* TPPReaderPositionReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE49D6CAE9861D0C5EC238 /* TPPReaderPositionReport.swift */; };
+		6B4686ADB115880CFE56B2B2 /* TPPReaderBlockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */; };
+		8CCB8310199672E1C07F4073 /* TPPReaderBlockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */; };
 		97D7098890B79033A5DF0E57 /* SendableSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BD75A5447FB7BD0DA90F57 /* SendableSubject.swift */; };
 		9812F13FF174AC093BB626FF /* BookAvailabilityFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C50D1C0AA0BA1374D31676 /* BookAvailabilityFormatterTests.swift */; };
 		982BDF376B8CC90AD13CC948 /* AudiobookSessionManagerShutdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CAC3762A717783DDE755DD /* AudiobookSessionManagerShutdownTests.swift */; };
@@ -1996,6 +1999,7 @@
 		03F94CCE1DD627AA00CE8F4F /* Accounts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Accounts.json; sourceTree = "<group>"; };
 		03F94CD01DD6288C00CE8F4F /* AccountsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsManager.swift; sourceTree = "<group>"; };
 		03FE49D6CAE9861D0C5EC238 /* TPPReaderPositionReport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderPositionReport.swift; path = ../../Palace/Reader2/BusinessLogic/TPPReaderPositionReport.swift; sourceTree = "<group>"; };
+		17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderBlockNavigation.swift; path = ../../Palace/Reader2/BusinessLogic/TPPReaderBlockNavigation.swift; sourceTree = "<group>"; };
 		040323DBE8E8E5AB1FBC517E /* BackupExclusionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupExclusionMigrationTests.swift; sourceTree = "<group>"; };
 		040827F9F622F17CAA24CCB5 /* AudiobookPositionPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookPositionPolicyTests.swift; sourceTree = "<group>"; };
 		041F2A3B4C5D6E7F8091A2B3 /* DownloadAuthRetryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadAuthRetryHandler.swift; sourceTree = "<group>"; };
@@ -2385,6 +2389,7 @@
 		65C628E6207F3958E194D07C /* BorrowOperationStreamingHTMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BorrowOperationStreamingHTMLTests.swift; sourceTree = "<group>"; };
 		65F03A0005DBD80853C64D12 /* OPDS2PublicationExtendedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2PublicationExtendedTests.swift; sourceTree = "<group>"; };
 		673C54DADAEAD820B2DABB9D /* TPPReaderPositionReportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderPositionReportTests.swift; sourceTree = "<group>"; };
+		D14070A4A26128AE43AC74C6 /* TPPReaderBlockNavigationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderBlockNavigationTests.swift; sourceTree = "<group>"; };
 		673C77C2D01F4E0AB1787C9D /* MyBooksDownloadCenterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterIntegrationTests.swift; sourceTree = "<group>"; };
 		678E47FC2F39F84744921B33 /* DownloadProgressPublisherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadProgressPublisherTests.swift; sourceTree = "<group>"; };
 		67A69DBB718593D67B0150D7 /* LCPPDFAcquisitionPredicateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPDFAcquisitionPredicateTests.swift; sourceTree = "<group>"; };
@@ -3886,6 +3891,7 @@
 				9A35DE944F78A26A081622BA /* TPPReaderPageListBusinessLogicTests.swift */,
 				673C54DADAEAD820B2DABB9D /* TPPReaderPositionReportTests.swift */,
 				FD60FEA388441F72F8C8D85C /* TPPReaderFootnoteAccessibilityTests.swift */,
+				D14070A4A26128AE43AC74C6 /* TPPReaderBlockNavigationTests.swift */,
 			);
 			path = Reader2;
 			sourceTree = "<group>";
@@ -5309,6 +5315,7 @@
 				0D848CD4CD0E01B3A2BF67FE /* TPPReaderPageListBusinessLogic.swift */,
 				03FE49D6CAE9861D0C5EC238 /* TPPReaderPositionReport.swift */,
 				E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */,
+				17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */,
 			);
 			name = BusinessLogic;
 			path = BusinessLogic;
@@ -7432,6 +7439,7 @@
 				893C99258D1F416B909E64EE /* AudiobookColdLoadRecoveryTests.swift in Sources */,
 				0824FA7D0F7C1C1EAD93505E /* TPPReaderPageListBusinessLogicTests.swift in Sources */,
 				611D923EBE0FB1507857F65A /* TPPReaderPositionReportTests.swift in Sources */,
+				3DFA32525D80836005DEB6FC /* TPPReaderBlockNavigationTests.swift in Sources */,
 				DD53EDAC28AB285D49FD1848 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift in Sources */,
 				20B17E24C48EC2CCF3A25977 /* BookRegistrySyncReentrancyTests.swift in Sources */,
 				12695B15A63B66C4B42E9B13 /* TPPReaderFootnoteAccessibilityTests.swift in Sources */,
@@ -7982,6 +7990,7 @@
 				F9497743E78564D80AEC155F /* TPPReaderPageListBusinessLogic.swift in Sources */,
 				FAC84E21FA4ECEF263BA02A3 /* TPPReaderPositionReport.swift in Sources */,
 				25959D57AE73A5D30750924D /* TPPReaderFootnoteAccessibility.swift in Sources */,
+				6B4686ADB115880CFE56B2B2 /* TPPReaderBlockNavigation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8532,6 +8541,7 @@
 				C6A457ADC7B74852879349E0 /* TPPReaderPageListBusinessLogic.swift in Sources */,
 				97AF6721F64BB54CBB497818 /* TPPReaderPositionReport.swift in Sources */,
 				5977FE52E5B43328E7773533 /* TPPReaderFootnoteAccessibility.swift in Sources */,
+				8CCB8310199672E1C07F4073 /* TPPReaderBlockNavigation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Reader2/BusinessLogic/TPPReaderBlockNavigation.swift
+++ b/Palace/Reader2/BusinessLogic/TPPReaderBlockNavigation.swift
@@ -1,0 +1,119 @@
+//
+//  TPPReaderBlockNavigation.swift
+//  Palace
+//
+//  PP-4533 — "Support screen-reader block-by-block navigation in the iOS reader"
+//  (DAISY reading-810). VoiceOver users need a way to move through reader content
+//  one logical block at a time (paragraph, heading, list item, quote …) rather
+//  than word-by-word or via the coarse chapter granularity. The logical blocks
+//  live INLINE in the spine HTML — not in the Readium manifest — so they are
+//  surfaced to VoiceOver by marking the rendered DOM (see TPPEPUBViewController),
+//  not by parsing `publication`.
+//
+//  This type is the pure, dependency-free core: it owns the block-element
+//  selector, classifies a tag as a block, and builds the JavaScript that (a)
+//  marks the OUTERMOST matching elements as atomic VoiceOver stops and (b)
+//  focus-walks those stops forward/back. It owns no UIKit/Readium state so it is
+//  unit-testable in isolation; the WKWebView injection that applies these marks
+//  is a thin mirror built by `annotationJavaScript()` (mirrors PP-4531's footnote
+//  core).
+//
+
+import Foundation
+
+enum TPPReaderBlockNavigation {
+
+  /// The CSS selector matching a logical block element. A block is a self-
+  /// contained unit a non-visual reader should be able to step to atomically:
+  /// paragraphs, headings, list items, quotes, definition terms/descriptions,
+  /// preformatted text, figure captions, plus the ARIA equivalents.
+  static let blockSelector =
+    "p, h1, h2, h3, h4, h5, h6, li, blockquote, figcaption, dd, dt, pre, [role=\"heading\"], [role=\"listitem\"]"
+
+  /// The lowercased tag names that constitute a logical block. Exposed (with
+  /// `isBlockTag`) so the selector list is unit-testable without a DOM.
+  static let blockTags: Set<String> = [
+    "p", "h1", "h2", "h3", "h4", "h5", "h6",
+    "li", "blockquote", "figcaption", "dd", "dt", "pre"
+  ]
+
+  /// Whether a bare HTML tag name is a logical block. Case-insensitive. Note:
+  /// the ARIA `role`-based matches (`[role="heading"]` / `[role="listitem"]`)
+  /// are selector-level, not tag-level, so they are not reflected here — this
+  /// classifies the element tag only.
+  static func isBlockTag(_ tag: String?) -> Bool {
+    guard let tag else { return false }
+    return blockTags.contains(tag.lowercased())
+  }
+
+  /// JavaScript that marks the logical block elements in the rendered Readium
+  /// WKWebView so VoiceOver treats each as one atomic stop. It queries the block
+  /// selector, skips NESTED blocks (only the OUTERMOST matching element is marked
+  /// — an `<li>` containing a `<p>` is ONE stop, not two), and sets
+  /// `tabindex="-1"` (so it is focusable for the rotor walk) and
+  /// `data-pp-block="1"` on each. Idempotent: re-running only re-marks.
+  ///
+  /// Returns the count of marked blocks (for logging / verification).
+  static func annotationJavaScript() -> String {
+    let selector = jsString(blockSelector)
+    return """
+    (function() {
+      var SELECTOR = \(selector);
+      var nodes = document.querySelectorAll(SELECTOR);
+      var n = 0;
+      for (var i = 0; i < nodes.length; i++) {
+        var el = nodes[i];
+        // Only mark the OUTERMOST block: skip any element that has an ancestor
+        // already matching the block selector (e.g. a <p> inside an <li>).
+        if (el.parentElement && el.parentElement.closest(SELECTOR)) { continue; }
+        el.setAttribute('tabindex', '-1');
+        el.setAttribute('data-pp-block', '1');
+        n++;
+      }
+      return n;
+    })()
+    """
+  }
+
+  /// JavaScript that moves focus to the next (`forward == true`) or previous
+  /// (`forward == false`) marked block relative to the currently-focused element
+  /// (`document.activeElement`) in document order, and calls `.focus()` on it.
+  ///
+  /// Returns the moved-to element's tag name (string) when it moved, or `null`
+  /// when there is no further block in that direction. The non-null return is the
+  /// signal the rotor uses to advance VoiceOver focus.
+  static func nextBlockJavaScript(forward: Bool) -> String {
+    let forwardLiteral = forward ? "true" : "false"
+    return """
+    (function() {
+      var FORWARD = \(forwardLiteral);
+      var blocks = Array.prototype.slice.call(document.querySelectorAll('[data-pp-block]'));
+      if (blocks.length === 0) { return null; }
+      var active = document.activeElement;
+      // Find the index of the block at or containing the current focus.
+      var current = -1;
+      for (var i = 0; i < blocks.length; i++) {
+        if (blocks[i] === active || blocks[i].contains(active)) { current = i; break; }
+      }
+      var target;
+      if (current === -1) {
+        // No marked block focused yet: start at the first (forward) or last (back).
+        target = FORWARD ? blocks[0] : blocks[blocks.length - 1];
+      } else {
+        var next = FORWARD ? current + 1 : current - 1;
+        if (next < 0 || next >= blocks.length) { return null; }
+        target = blocks[next];
+      }
+      if (!target) { return null; }
+      target.focus();
+      return target.tagName;
+    })()
+    """
+  }
+
+  /// JSON-encode a Swift string into a JS string literal (safe interpolation).
+  private static func jsString(_ s: String) -> String {
+    let data = (try? JSONEncoder().encode(s)) ?? Data()
+    return String(data: data, encoding: .utf8) ?? "\"\""
+  }
+}

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -188,6 +188,18 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
             navigator.view.isAccessibilityElement = false
             navigator.view.accessibilityLabel = nil
             navigator.view.accessibilityCustomActions = [whereAmIAction]
+
+            // Block-by-block navigation rotor (DAISY reading-810, PP-4533): lets a
+            // VoiceOver user step through logical content blocks. Gated on the
+            // app's customRotorActionsEnabled preference (default on); appends to
+            // any existing rotors rather than clobbering.
+            if Self.customRotorActionsEnabled {
+                var rotors = navigator.view.accessibilityCustomRotors ?? []
+                rotors.append(makeBlockRotor())
+                navigator.view.accessibilityCustomRotors = rotors
+            } else {
+                navigator.view.accessibilityCustomRotors = nil
+            }
             return
         }
 
@@ -290,6 +302,87 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
         }
     }
 
+    /// Mark the logical block elements (paragraphs, headings, list items, quotes …)
+    /// in the rendered WKWebView as atomic VoiceOver stops so a non-visual reader
+    /// can step through content one block at a time via the "Blocks" rotor (DAISY
+    /// reading-810, PP-4533). Additive and idempotent; runs after the chapter has
+    /// had a moment to render and bails if the chapter changed again in the
+    /// meantime. Mirrors `annotateFootnotesForVoiceOver()` from PP-4531.
+    private func annotateBlocksForVoiceOver() {
+        let href = lastChapterHREF
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 600_000_000)
+            guard self.lastChapterHREF == href else { return }
+            let result = await self.epubNavigator.evaluateJavaScript(
+                TPPReaderBlockNavigation.annotationJavaScript()
+            )
+            // PP-4533 observability: the injected block marks live in the Readium
+            // WKWebView's web-AX, which host-AX / simdrive CANNOT inspect on the
+            // simulator. Emit the marked-block count + VoiceOver state so the
+            // injection is verifiable end-to-end via log capture (CI / host-AX),
+            // since neither the DOM marks nor VoiceOver focus surface to the host
+            // AX bridge.
+            let value = try? result.get()
+            let n = (value as? Int) ?? (value as? NSNumber)?.intValue ?? -1
+            Log.info(#file, "PP-4533 block-nav marked \(n) blocks for VoiceOver, VoiceOver=\(UIAccessibility.isVoiceOverRunning)")
+        }
+    }
+
+    /// Whether the app's custom-rotor actions are enabled. Read synchronously from
+    /// the persisted `AccessibilityPreferences` (same store `AccessibilityService`
+    /// loads) so the gate is available inside the synchronous accessibility
+    /// configuration path; defaults to the `.default` value (on) when unset.
+    private static var customRotorActionsEnabled: Bool {
+        guard
+          let data = UserDefaults.standard.data(forKey: AccessibilityPreferences.storageKey),
+          let prefs = try? JSONDecoder().decode(AccessibilityPreferences.self, from: data)
+        else {
+          return AccessibilityPreferences.default.customRotorActionsEnabled
+        }
+        return prefs.customRotorActionsEnabled
+    }
+
+    /// A VoiceOver custom rotor that walks the marked logical blocks (see
+    /// `annotateBlocksForVoiceOver()`) forward / back. Each `itemSearchBlock`
+    /// invocation focuses the next / previous `[data-pp-block]` in the DOM and, on
+    /// a move, posts `.layoutChanged` so VoiceOver re-reads from the new focus.
+    /// Returns nil at the chapter's block boundary (DAISY reading-810, PP-4533).
+    private func makeBlockRotor() -> UIAccessibilityCustomRotor {
+        UIAccessibilityCustomRotor(
+            name: Strings.TPPBaseReaderViewController.blockRotorTitle
+        ) { [weak self] predicate in
+            guard let self = self else { return nil }
+            let forward = predicate.searchDirection == .next
+            let result = self.evaluateBlockMove(forward: forward)
+            guard result else { return nil }
+            UIAccessibility.post(notification: .layoutChanged, argument: self.navigator.view)
+            return UIAccessibilityCustomRotorItemResult(
+                targetElement: self.navigator.view,
+                targetRange: nil
+            )
+        }
+    }
+
+    /// Synchronously evaluate the focus-walk JS and report whether focus moved.
+    /// The rotor's `itemSearchBlock` is synchronous, so this blocks briefly on the
+    /// WKWebView evaluation; the JS itself is a cheap DOM walk.
+    private func evaluateBlockMove(forward: Bool) -> Bool {
+        let js = TPPReaderBlockNavigation.nextBlockJavaScript(forward: forward)
+        let semaphore = DispatchSemaphore(value: 0)
+        var moved = false
+        Task { @MainActor in
+            let result = await self.epubNavigator.evaluateJavaScript(js)
+            let value = try? result.get()
+            // Non-null tag name string means it focused a block.
+            if let tag = value as? String, !tag.isEmpty {
+                moved = true
+            }
+            semaphore.signal()
+        }
+        // Bounded wait so a stalled web view never hangs the AX thread.
+        _ = semaphore.wait(timeout: .now() + 1.0)
+        return moved
+    }
     override func voiceOverStatusDidChange() {
         super.voiceOverStatusDidChange()
         configureAccessibilityActions()
@@ -328,6 +421,10 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
         // VoiceOver on every chapter render — manual turns AND Read-All — so a
         // non-visual reader hits semantic note references throughout (PP-4531).
         annotateFootnotesForVoiceOver()
+        // Mark logical content blocks for VoiceOver on every chapter render —
+        // manual turns AND Read-All — so the "Blocks" rotor can step through the
+        // whole chapter (DAISY reading-810, PP-4533).
+        annotateBlocksForVoiceOver()
 
         // For manual page turns only (toolbar buttons, keyboard, edge taps),
         // use JavaScript to focus the first content element so VoiceOver

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -537,6 +537,9 @@ struct Strings {
         static let footnoteReferenceGeneric = NSLocalizedString("Footnote reference", value: "Footnote reference", comment: "VoiceOver label for a footnote reference link with no readable marker")
         static let footnoteContent = NSLocalizedString("Footnote", value: "Footnote", comment: "VoiceOver label prefix announced when focus reaches footnote content")
         static let footnoteBacklink = NSLocalizedString("Back to reference", value: "Back to reference", comment: "VoiceOver label for the footnote return link (doc-backlink) that returns the reader to the reference")
+        // Block-by-block navigation (DAISY reading-810, PP-4533). The title of the
+        // VoiceOver custom rotor that steps through logical content blocks.
+        static let blockRotorTitle = NSLocalizedString("Blocks", value: "Blocks", comment: "VoiceOver rotor title for block-by-block reader navigation")
     }
 
     struct TPPBarCode {

--- a/PalaceTests/Reader2/TPPReaderBlockNavigationTests.swift
+++ b/PalaceTests/Reader2/TPPReaderBlockNavigationTests.swift
@@ -1,0 +1,113 @@
+//
+//  TPPReaderBlockNavigationTests.swift
+//  PalaceTests
+//
+//  PP-4533 (DAISY reading-810) — unit tests for the pure block-navigation core:
+//  the block-element selector / tag classifier and the shape of the DOM-marking
+//  JavaScript. The WKWebView marking + focus-walk JS is a thin mirror of this
+//  spec and is verified at runtime (device VoiceOver / simdrive host-AX), not
+//  here — the runtime DOM effect crosses the host-AX boundary the simulator
+//  cannot inspect.
+//
+
+import XCTest
+@testable import Palace
+
+final class TPPReaderBlockNavigationTests: XCTestCase {
+
+  typealias BN = TPPReaderBlockNavigation
+
+  // MARK: - isBlockTag(_:)
+
+  func testIsBlockTag_paragraph_isTrue() {
+    XCTAssertTrue(BN.isBlockTag("p"))
+  }
+
+  func testIsBlockTag_headings_areTrue() {
+    XCTAssertTrue(BN.isBlockTag("h1"))
+    XCTAssertTrue(BN.isBlockTag("h2"))
+    XCTAssertTrue(BN.isBlockTag("h6"))
+  }
+
+  func testIsBlockTag_listItem_isTrue() {
+    XCTAssertTrue(BN.isBlockTag("li"))
+  }
+
+  func testIsBlockTag_blockquote_isTrue() {
+    XCTAssertTrue(BN.isBlockTag("blockquote"))
+  }
+
+  func testIsBlockTag_definitionAndFigureAndPre_areTrue() {
+    XCTAssertTrue(BN.isBlockTag("dd"))
+    XCTAssertTrue(BN.isBlockTag("dt"))
+    XCTAssertTrue(BN.isBlockTag("figcaption"))
+    XCTAssertTrue(BN.isBlockTag("pre"))
+  }
+
+  func testIsBlockTag_inlineElements_areFalse() {
+    XCTAssertFalse(BN.isBlockTag("span"))
+    XCTAssertFalse(BN.isBlockTag("a"))
+    XCTAssertFalse(BN.isBlockTag("em"))
+  }
+
+  func testIsBlockTag_isCaseInsensitive() {
+    XCTAssertTrue(BN.isBlockTag("P"))
+    XCTAssertTrue(BN.isBlockTag("BlockQuote"))
+  }
+
+  func testIsBlockTag_nilAndUnrelated_areFalse() {
+    XCTAssertFalse(BN.isBlockTag(nil))
+    XCTAssertFalse(BN.isBlockTag(""))
+    XCTAssertFalse(BN.isBlockTag("div"))
+  }
+
+  // MARK: - blockSelector
+
+  func testBlockSelector_containsKeyBlockTags() {
+    let s = BN.blockSelector
+    XCTAssertTrue(s.contains("p"))
+    XCTAssertTrue(s.contains("h1"))
+    XCTAssertTrue(s.contains("li"))
+    XCTAssertTrue(s.contains("blockquote"))
+    XCTAssertTrue(s.contains("[role=\"heading\"]"))
+    XCTAssertTrue(s.contains("[role=\"listitem\"]"))
+  }
+
+  // MARK: - annotationJavaScript()
+
+  func testAnnotationJS_isNonEmptyAndCarriesSelectorMarkerAndCount() {
+    let js = BN.annotationJavaScript()
+    XCTAssertFalse(js.isEmpty)
+    // Mirrors the Swift selector spec and writes the atomic-stop marker.
+    XCTAssertTrue(js.contains("querySelectorAll"))
+    XCTAssertTrue(js.contains("blockquote"))
+    XCTAssertTrue(js.contains("data-pp-block"))
+    XCTAssertTrue(js.contains("tabindex"))
+    // Returns a count for verification logging.
+    XCTAssertTrue(js.contains("return n"))
+  }
+
+  func testAnnotationJS_skipsNestedBlocks() {
+    // Only the OUTERMOST matching element is marked (an <li> wrapping a <p>
+    // is one stop, not two), implemented via an ancestor `closest` check.
+    let js = BN.annotationJavaScript()
+    XCTAssertTrue(js.contains("closest"))
+  }
+
+  // MARK: - nextBlockJavaScript(forward:)
+
+  func testNextBlockJS_forwardAndBackBothFocusAMarkedBlock() {
+    let fwd = BN.nextBlockJavaScript(forward: true)
+    let back = BN.nextBlockJavaScript(forward: false)
+    XCTAssertFalse(fwd.isEmpty)
+    XCTAssertFalse(back.isEmpty)
+    for js in [fwd, back] {
+      XCTAssertTrue(js.contains("data-pp-block"))
+      XCTAssertTrue(js.contains("activeElement"))
+      XCTAssertTrue(js.contains(".focus()"))
+    }
+    // Direction is carried into the DOM walk.
+    XCTAssertTrue(fwd.contains("var FORWARD = true"))
+    XCTAssertTrue(back.contains("var FORWARD = false"))
+  }
+}


### PR DESCRIPTION
## What

Lets a VoiceOver user move through reader content one logical block at a time (paragraph, heading, list item, quote, definition term/description, preformatted text, figure caption) — DAISY reading-810. Mirrors the just-built PP-4531 footnote pattern.

## Mechanism

- **DOM marking JS** (`TPPReaderBlockNavigation.annotationJavaScript()`): on every chapter render, marks the OUTERMOST block elements (`tabindex="-1"` + `data-pp-block="1"`; nested blocks skipped so an `<li>` wrapping a `<p>` is ONE stop) and returns the marked count.
- **"Blocks" rotor** (`makeBlockRotor()`): a `UIAccessibilityCustomRotor` whose `itemSearchBlock` focus-walks the marked `[data-pp-block]` elements forward/back via `nextBlockJavaScript(forward:)`, posting `.layoutChanged` on each move. Attached in VoiceOver mode, gated on the existing `AccessibilityPreferences.customRotorActionsEnabled` (default on).
- Pure, Foundation-only core (`TPPReaderBlockNavigation`) owns the selector + `isBlockTag` classifier + JS builders — no UIKit/Readium state, unit-testable in isolation.

## Verification

- Unit: `harness test -- -only-testing:PalaceTests/TPPReaderBlockNavigationTests` — **Executed 12 tests, 0 failures** (selector/classifier, marking-JS shape, nested-skip, focus-walk-JS). Whole app compiled (Palace + Palace-noDRM + PalaceTests).
- Runtime: the injected DOM marks live in the Readium WKWebView web-AX, which host-AX / simdrive cannot inspect on the simulator, so the marked-count is emitted via `os_log` — `Log.info(... "PP-4533 block-nav marked \(n) blocks for VoiceOver, VoiceOver=...")` — for CI / host-AX log capture; the device VoiceOver pass on the reading-810 fixture is pending.

## Notes

- develop-only (next version bump), additive a11y. No reading-position change; DOM-only detection (blocks are not in the Readium manifest).
- Intent: `.forgeos/intent/pp4533-block-by-block-navigation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)