### PR TITLE
fix(build-sim-for-simdrive): robust code-sign pre-flight gate

### DIFF
--- a/scripts/build-sim-for-simdrive.sh
+++ b/scripts/build-sim-for-simdrive.sh
@@ -110,7 +110,7 @@ echo "  ✓ BUILD SUCCEEDED → $APP"
 # app (CODE_SIGNING_ALLOWED=NO) launches but -34018s / -1s. Verify there is a
 # code signature before handing it to simdrive.
 say "Pre-flight gate: verifying the app is code-signed"
-if codesign -dv "$APP" 2>&1 | grep -q "Signature=adhoc\|Authority="; then
+if codesign -dvv "$APP" 2>&1 | grep -qiE "signature=adhoc|authority=|\(adhoc\)"; then
   echo "  ✓ signed (keychain + download will work on the sim)"
 else
   die "App is NOT signed — keychain will -34018 and downloads will -1. Rebuild with CODE_SIGNING_ALLOWED=YES."


### PR DESCRIPTION
## What
The `build-sim-for-simdrive.sh` signature pre-flight gate (added in #1104) used `codesign -dv` (single `v`), whose output omits the `Signature=adhoc` line — so it **false-negatived on a perfectly good ad-hoc build** ("App is NOT signed") and aborted before install. Hit live while staging the develop build for PP-4529.

## Fix
Use `codesign -dvv` and match adhoc **or** a real Authority — the CodeDirectory `(adhoc)` flag, `Signature=adhoc`, or `Authority=`. A genuinely-signed build now passes; only an unsigned build (`CODE_SIGNING_ALLOWED=NO`) fails, which is the case the gate is meant to catch.

Verified: the gate now passes on the signed develop build it previously rejected.

Tooling-only; no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)