### PR TITLE
fix(ci): M1 contract-reconciliation prefers the staged intent (not a sibling)

### DIFF
--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -59,7 +59,18 @@ if [[ -n "$(git diff --cached --name-only --diff-filter=AM 2>/dev/null || true)"
   M1_INTENT_FLAG=()
   M1_SUBJECT=$(grep -v '^#' "$MSG_FILE" | head -1 | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 ]//g' | awk '{print $1"-"$2}')
   if [[ -n "$M1_SUBJECT" ]] && [[ -d "$REPO_ROOT_M1/.forgeos/intent" ]]; then
-    M1_INTENT_MATCH=$(find "$REPO_ROOT_M1/.forgeos/intent" -maxdepth 1 -name "*${M1_SUBJECT}*.md" -type f 2>/dev/null | head -1)
+    # When several intent files share the subject's ticket tokens (sibling
+    # same-ticket intents from earlier merged work), prefer the one STAGED in
+    # THIS commit — an old sibling's claims must not gate an unrelated diff
+    # (false-positive observed when PP-4527 had two intents). Fall back to the
+    # first match when none is staged.
+    M1_STAGED_INTENT=$(git diff --cached --name-only --diff-filter=AM 2>/dev/null | grep '\.forgeos/intent/.*\.md$' || true)
+    M1_INTENT_MATCH=""
+    for _cand in $(find "$REPO_ROOT_M1/.forgeos/intent" -maxdepth 1 -name "*${M1_SUBJECT}*.md" -type f 2>/dev/null); do
+      _rel="${_cand#"$REPO_ROOT_M1"/}"
+      if printf '%s\n' "$M1_STAGED_INTENT" | grep -qxF "$_rel"; then M1_INTENT_MATCH="$_cand"; break; fi
+    done
+    [[ -z "$M1_INTENT_MATCH" ]] && M1_INTENT_MATCH=$(find "$REPO_ROOT_M1/.forgeos/intent" -maxdepth 1 -name "*${M1_SUBJECT}*.md" -type f 2>/dev/null | head -1)
     [[ -n "$M1_INTENT_MATCH" ]] && M1_INTENT_FLAG=(--intent "$M1_INTENT_MATCH")
   fi
 

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -405,7 +405,14 @@ elif [ -f scripts/check-contract-reconciliation.py ]; then
   CR_INTENT_FLAG=""
   CR_SUBJECT=$(head -1 "$CR_MSG" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 ]//g' | awk '{print $1"-"$2}')
   if [ -n "$CR_SUBJECT" ] && [ -d .forgeos/intent ]; then
-    CR_INTENT_MATCH=$(find .forgeos/intent -maxdepth 1 -name "*${CR_SUBJECT}*.md" -type f 2>/dev/null | head -1)
+    # Prefer an intent file present in THIS branch's diff over an old sibling
+    # that merely shares the ticket tokens — an already-merged same-ticket
+    # intent's claims must not gate this diff. Fall back to first match.
+    CR_INTENT_MATCH=""
+    for _c in $(find .forgeos/intent -maxdepth 1 -name "*${CR_SUBJECT}*.md" -type f 2>/dev/null); do
+      if grep -qF "${_c#./}" "$CR_DIFF" 2>/dev/null; then CR_INTENT_MATCH="$_c"; break; fi
+    done
+    [ -z "$CR_INTENT_MATCH" ] && CR_INTENT_MATCH=$(find .forgeos/intent -maxdepth 1 -name "*${CR_SUBJECT}*.md" -type f 2>/dev/null | head -1)
     [ -n "$CR_INTENT_MATCH" ] && CR_INTENT_FLAG="--intent $CR_INTENT_MATCH"
   fi
   CR_OUT=$(python3 scripts/check-contract-reconciliation.py --diff "$CR_DIFF" --commit-msg "$CR_MSG" $CR_INTENT_FLAG --quiet 2>&1)


### PR DESCRIPTION
## Problem
The M1 commit-msg gate and `verify-pr.sh` resolve the intent file for `check-contract-reconciliation.py` with `find -name "*<ticket>*" | head -1` — which alphabetically picks **any** same-ticket intent. When a ticket has more than one intent file (e.g. the earlier merged `pp4527-where-am-i-position-report` plus the new `pp4527-where-am-i-reachable`), it grabbed the **old merged sibling** and checked *its* claims ("the implementation removes the `navigator.go` call") against an unrelated diff → false-positive that forced a `--no-verify` (hit live on #1109).

## Fix
Disambiguate among multiple matches by **staged-ness**:
- **commit-msg hook** → prefer the intent file *staged in this commit* (`git diff --cached`).
- **verify-pr.sh** → prefer the intent file *present in the branch diff*.
- Fall back to the first match only when none is staged (preserves prior behavior for the single-intent case).

## Scope / safety
CI gate **selection** logic only (two shell hooks) — no change to `check-contract-reconciliation.py` or any product code. Both scripts `bash -n` clean. The matcher itself (first-2-subject-tokens) is unchanged; this only breaks ties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)