### PR TITLE
chore(ci): advisory commit-discipline nudges (root-cause + test:source)

### DIFF
--- a/scripts/check-discipline-nudge.py
+++ b/scripts/check-discipline-nudge.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+check-discipline-nudge.py — NON-BLOCKING commit-discipline advisories.
+
+Prints gentle nudges (and ALWAYS exits 0 — never fails a commit) on two
+retrospective-tracked discipline signals that were trending the wrong way:
+
+  1. Root-cause prose: a `fix`-type commit whose body has no "why it broke"
+     line. (Retro: root-cause prose 5.3% of commits, target 30%.)
+  2. Test:source: a `fix`/`feat` commit that changes production source with no
+     accompanying test file. (Retro: test:source 0.74, target >=0.8.)
+
+It is advisory by design — it surfaces the habit at the moment of commit so the
+author can choose to fix it, without ever blocking. Wired into the commit-msg
+hook after the M1 gates.
+
+Usage:
+  check-discipline-nudge.py --commit-msg <file> [--diff <file|->]
+"""
+import argparse
+import os
+import re
+import sys
+
+# Words/phrases that count as a root-cause / "why" explanation in a commit body.
+_ROOT_CAUSE_RE = re.compile(
+    r"\b(because|root[\s-]?cause|caused by|the bug|regression|stems from|"
+    r"due to|root of|the issue was|was that|introduced by|culprit|why:)\b",
+    re.IGNORECASE,
+)
+# Subject is a fix / feature (the commit types that warrant tests + root-cause).
+_FIX_RE = re.compile(r"^\s*(fix|bugfix|hotfix)\b|\bPP-\d+\b.*\b(fix|crash|regression|bug)\b|^\s*\w+:\s*fix", re.IGNORECASE)
+_FEAT_RE = re.compile(r"^\s*(feat|feature)\b", re.IGNORECASE)
+_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$")
+
+
+def _read(path):
+    if not path:
+        return ""
+    if path == "-":
+        return "" if sys.stdin.isatty() else sys.stdin.read()
+    return open(path, errors="ignore").read() if os.path.exists(path) else ""
+
+
+def _changed_files(diff_text):
+    src, tests = 0, 0
+    for line in diff_text.splitlines():
+        m = _FILE_RE.match(line)
+        if not m:
+            continue
+        p = m.group(1).strip()
+        if p == "/dev/null":
+            continue
+        low = p.lower()
+        if not (low.endswith(".swift") or low.endswith(".m") or low.endswith(".mm")):
+            continue
+        if "test" in low:  # PalaceTests/…, *Tests.swift, *Test.swift
+            tests += 1
+        elif p.startswith("Palace/"):
+            src += 1
+    return src, tests
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--commit-msg", default=None)
+    ap.add_argument("--diff", default="-")
+    a = ap.parse_args(argv)
+
+    msg = _read(a.commit_msg)
+    diff = _read(a.diff)
+
+    lines = [l for l in msg.splitlines() if not l.startswith("#")]
+    subject = next((l for l in lines if l.strip()), "")
+    body = "\n".join(lines[1:]) if len(lines) > 1 else ""
+
+    is_fix = bool(_FIX_RE.search(subject))
+    is_feat = bool(_FEAT_RE.search(subject))
+    src, tests = _changed_files(diff)
+
+    nudges = []
+    if is_fix and not _ROOT_CAUSE_RE.search(body):
+        nudges.append(
+            "fix commit without a root-cause line — add one sentence on WHY it "
+            "broke (e.g. \"because …\"). Retro: root-cause prose 5.3%, target 30%.")
+    if (is_fix or is_feat) and src > 0 and tests == 0:
+        nudges.append(
+            f"{src} production source file(s) changed, 0 test files — consider a "
+            f"test or note why none. Retro: test:source 0.74, target ≥0.8.")
+
+    if nudges:
+        sys.stderr.write("\n\033[33m▲ discipline nudge\033[0m (advisory — NOT blocking; commit proceeds):\n")
+        for n in nudges:
+            sys.stderr.write(f"  • {n}\n")
+        sys.stderr.write("\n")
+    return 0  # never block
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -79,6 +79,14 @@ if [[ -n "$(git diff --cached --name-only --diff-filter=AM 2>/dev/null || true)"
   fi
 
   m1_enforce "$M1_FAIL"
+
+  # Discipline nudges — ADVISORY only, never blocks (the script always exits 0;
+  # the `|| true` is belt-and-suspenders). Surfaces retro-tracked habits at
+  # commit time: a fix commit missing a root-cause line, or a fix/feat changing
+  # source with no test. Runs after the M1 gates pass.
+  if [[ -f "$REPO_ROOT_M1/scripts/check-discipline-nudge.py" ]]; then
+    python3 "$REPO_ROOT_M1/scripts/check-discipline-nudge.py" --commit-msg "$MSG_FILE" --diff "$M1_DIFF" 2>&1 || true
+  fi
 fi
 
 HARNESS_HOOK="$HOME/harness/core/hooks/commit-msg-stanza.sh"

--- a/scripts/test_check_discipline_nudge.py
+++ b/scripts/test_check_discipline_nudge.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+test_check_discipline_nudge.py — self-verify check-discipline-nudge.py.
+
+Asserts the advisory nudge: (1) always exits 0 (never blocks), (2) fires on a
+fix commit lacking a root-cause line, (3) fires on a fix/feat source change with
+no test, (4) stays silent when the body has a root-cause AND a test is present,
+(5) stays silent for non-fix/feat (chore/docs) commits.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+
+_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "check-discipline-nudge.py")
+
+_SRC_NO_TEST = "diff --git a/Palace/Foo.swift b/Palace/Foo.swift\n--- a/Palace/Foo.swift\n+++ b/Palace/Foo.swift\n@@\n+x\n"
+_SRC_WITH_TEST = _SRC_NO_TEST + "diff --git a/PalaceTests/FooTests.swift b/PalaceTests/FooTests.swift\n--- a/PalaceTests/FooTests.swift\n+++ b/PalaceTests/FooTests.swift\n@@\n+t\n"
+
+
+def _run(msg, diff):
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as mf:
+        mf.write(msg)
+        msgpath = mf.name
+    try:
+        p = subprocess.run([sys.executable, _SCRIPT, "--commit-msg", msgpath, "--diff", "-"],
+                           input=diff, capture_output=True, text=True)
+        return p.returncode, p.stderr
+    finally:
+        os.unlink(msgpath)
+
+
+def main():
+    fails = []
+
+    rc, err = _run("fix: crash on open\n\nReworked the loader.", _SRC_NO_TEST)
+    if rc != 0: fails.append("fix/no-root-cause should still exit 0")
+    if "root-cause line" not in err: fails.append("fix/no-root-cause should nudge root-cause")
+    if "0 test files" not in err: fails.append("fix/no-test should nudge test:source")
+
+    rc, err = _run("fix: crash on open\n\nThe bug was that the cache tore because of a race; added a guard.", _SRC_WITH_TEST)
+    if rc != 0: fails.append("fix/with-root-cause+test should exit 0")
+    if err.strip(): fails.append("fix/with-root-cause+test should be silent, got: " + err.strip()[:80])
+
+    rc, err = _run("chore: bump deps\n\nRoutine.", _SRC_NO_TEST)
+    if rc != 0: fails.append("chore should exit 0")
+    if err.strip(): fails.append("chore should be silent (not fix/feat), got: " + err.strip()[:80])
+
+    rc, err = _run("feat: add rotor\n\nNew rotor.", _SRC_NO_TEST)
+    if "0 test files" not in err: fails.append("feat/no-test should nudge test:source")
+
+    if fails:
+        print("FAIL: test_check_discipline_nudge.py:")
+        for f in fails:
+            print("  -", f)
+        return 1
+    print("PASS: test_check_discipline_nudge.py (advisory nudge, exit-0, 5 cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why
The performance retrospective surfaced two discipline signals trending the wrong way:
- **Root-cause prose** in commit bodies: **5.3%** (target 30%)
- **Test : source** ratio: **0.74** (target ≥0.8)

These are habit problems best fixed at the moment of commit, not in review.

## What
A **non-blocking** commit-time nudge — it surfaces the habit and *never* gates.
- `scripts/check-discipline-nudge.py` — prints advisories (**always exits 0**) when:
  - a `fix` commit body has no root-cause / "why it broke" line, or
  - a `fix`/`feat` commit changes production source with **no test file**.
  Keyed on commit type, so `chore`/`docs`/`refactor` stay quiet (low noise).
- `scripts/git-hooks/commit-msg` — invokes it after the M1 gates pass, guarded with `|| true`. Purely additive; cannot block a commit.
- `scripts/test_check_discipline_nudge.py` — 5-case self-test (exit-0 always; fires on fix/no-root-cause and fix-or-feat/no-test; silent for chore and a complete fix). **Passes.**

## Safety
No existing gate becomes blocking, no product code, no CI change. The nudge is local commit-time only. (Eating our own dog food: this PR ships a test alongside the script, so its own test:source is met.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)