### PR TITLE
PP-4652: EPUB resume DRM retry — back-merge to develop

### DIFF
--- a/.forgeos/intent/pp-4652-epub-resume-drm-retry.md
+++ b/.forgeos/intent/pp-4652-epub-resume-drm-retry.md
@@ -1,0 +1,43 @@
+---
+name: pp-4652-epub-resume-drm-retry
+created: 2026-06-24
+author: claude-opus-4-8
+---
+
+## Summary
+
+PP-4652 (Blocker, 3.2.0 build 482): an EPUB's last-read position is lost when the
+app is force-quit and reopened — the book reopens to the cover. Reproduces ONLY
+for DRM books (OverDrive / Palace Marketplace via A1QA); open-access EPUBs resume
+fine. Root cause (confirmed by sim log `ReaderInitialLocationNavigator.swift:
+Reader initial-location restore returned false; remaining at start (page 1).`):
+#1084 made the post-paint gate the single restore authority and fired
+`navigator.go(to:)` ONCE at `viewDidAppear`. A DRM/Adobe EPUB decrypts + loads
+its WebContent more slowly, so Readium's location-mapping table is not populated
+yet → the single `go(to:)` no-ops to `false` → #1084's "graceful page-1
+degradation" lands on the cover. The synced server position then surfaces as the
+"Sync Reading Position" dialog, and BOTH Stay and Move end on the cover because
+finalizePresentation routes the (Move-updated) registry position back through the
+same gate.
+
+## Claims
+
+- adds bounded retry to `ReaderInitialLocationNavigator.navigateIfReady()`: retries `navigator.go(to:)` up to `maxRestoreAttempts` (default 12) with `restoreRetryDelayNanos` (default 250ms) between tries, breaking on the first success
+- adds init params `maxRestoreAttempts` + `restoreRetryDelayNanos` (defaulted) to `ReaderInitialLocationNavigator` for deterministic, fast tests
+- records `restoreDidDegradeToStart` only after ALL attempts return false (genuinely unresolvable locator), preserving the observable graceful page-1 degradation
+- updates `Reader initial-location restore returned false` log to include the attempt count
+- adds test double field `goResultSequence` to `StubInitialLocationNavigator` (per-call results, falls back to `goResult`)
+- adds test `testGate_goFalseThenTrue_retriesToSuccess_noDegradation` (PP-4652 regression: transient table-not-ready false→true must restore, not degrade)
+- updates `testGate_goReturnsFalse_*` → `testGate_goPersistentlyFalse_retriesThenRecordsPage1Degradation` (asserts retries are exhausted before degrading)
+
+## Anti-claims
+
+- does NOT re-enable the navigator CONSTRUCTOR restore (`TPPEPUBViewController.navigatorConstructorInitialLocation` stays `nil`) — the post-paint gate remains the single restore authority, so a retried `go(to:)` cannot reintroduce the #1084 double-restore / WebContent teardown bounce
+- does NOT change the SAVE path (`TPPLastReadPositionPoster`/`storeReadPosition`), `convertToLocator`, or the sync conflict rule in `TPPLastReadPositionSynchronizer` — convertToLocator succeeded in the repro (no HREF-resolution failure); the failure was the timing of the gate's go(to:)
+- does NOT alter user-initiated post-load navigation (TOC select, bookmark select, page turns) — those fire after the WebContent is ready, so they are not subject to the not-ready window
+- does NOT touch audiobooks, Android, or CPW
+
+## Files in scope
+
+- Palace/Reader2/UI/ReaderInitialLocationNavigator.swift
+- PalaceTests/Reader2/TPPBaseReaderViewControllerInitialLocationTests.swift

--- a/Palace/Reader2/UI/ReaderInitialLocationNavigator.swift
+++ b/Palace/Reader2/UI/ReaderInitialLocationNavigator.swift
@@ -69,12 +69,29 @@ final class ReaderInitialLocationNavigator {
     /// teardown / bounce. Observable for diagnostics + tests.
     private(set) var restoreDidDegradeToStart = false
 
-    /// Test hook: fired (on the main actor) with `go(to:)`'s Bool result once the
-    /// single restore attempt completes. Nil in production.
+    /// Test hook: fired (on the main actor) with the FINAL `go(to:)` Bool result
+    /// once the restore (incl. retries) completes. Nil in production.
     var onRestoreAttempt: ((Bool) -> Void)?
 
-    init(initialLocation: Locator?) {
+    /// PP-4652: how many times to (re)try `go(to:)` before degrading to page 1,
+    /// and the delay between tries. A DRM/Adobe EPUB decrypts + loads its
+    /// WebContent more slowly than an open-access EPUB, so at `viewDidAppear`
+    /// (when the gate fires) Readium's location-mapping table may not be
+    /// populated yet — the first `go(to:)` then no-ops to `false` and #1084's
+    /// single-shot gate gave up at the cover. Retrying until the table is ready
+    /// restores the real position; the constructor restore stays disabled so a
+    /// retried `go(to:)` cannot double-restore / tear down WebContent.
+    private let maxRestoreAttempts: Int
+    private let restoreRetryDelayNanos: UInt64
+
+    init(
+        initialLocation: Locator?,
+        maxRestoreAttempts: Int = 12,
+        restoreRetryDelayNanos: UInt64 = 250_000_000
+    ) {
         self.initialLocation = initialLocation
+        self.maxRestoreAttempts = max(1, maxRestoreAttempts)
+        self.restoreRetryDelayNanos = restoreRetryDelayNanos
     }
 
     /// Called from the VC's init / viewDidLoad once the navigator is
@@ -105,18 +122,30 @@ final class ReaderInitialLocationNavigator {
 
         didNavigate = true
         Task { @MainActor [weak self] in
+            guard let self else { return }
             // Single restore authority: the navigator first-paints at its natural
-            // start (constructor restore disabled), then this fires once the
-            // WKWebView is ready (location-mapping table populated). Check the
-            // result: a false return means Readium couldn't resolve the locator —
-            // the reader stays at the natural start (graceful page-1 degradation),
-            // which we record/log rather than silently discard.
-            let restored = await navigator.go(to: location, options: NavigatorGoOptions(animated: false))
-            if !restored {
-                self?.restoreDidDegradeToStart = true
-                Log.warn(#file, "Reader initial-location restore returned false; remaining at start (page 1).")
+            // start (constructor restore disabled), then this restores once the
+            // WKWebView's location-mapping table is populated. For a DRM EPUB that
+            // can lag past `viewDidAppear`, so `go(to:)` may no-op to false on the
+            // first try (PP-4652: book reopened to the cover). Retry until it
+            // resolves — each false attempt is a no-op (nothing navigated, nothing
+            // torn down), so retrying restores the real position without
+            // re-introducing the #1084 double-restore. Only a persistently
+            // unresolvable locator (all attempts false) degrades to page 1, which
+            // we record/log rather than silently discard.
+            var restored = false
+            for attempt in 0..<self.maxRestoreAttempts {
+                restored = await navigator.go(to: location, options: NavigatorGoOptions(animated: false))
+                if restored { break }
+                if attempt < self.maxRestoreAttempts - 1, self.restoreRetryDelayNanos > 0 {
+                    try? await Task.sleep(nanoseconds: self.restoreRetryDelayNanos)
+                }
             }
-            self?.onRestoreAttempt?(restored)
+            if !restored {
+                self.restoreDidDegradeToStart = true
+                Log.warn(#file, "Reader initial-location restore returned false after \(self.maxRestoreAttempts) attempt(s); remaining at start (page 1).")
+            }
+            self.onRestoreAttempt?(restored)
         }
     }
 }

--- a/PalaceTests/Reader2/TPPBaseReaderViewControllerInitialLocationTests.swift
+++ b/PalaceTests/Reader2/TPPBaseReaderViewControllerInitialLocationTests.swift
@@ -202,22 +202,62 @@ final class TPPBaseReaderViewControllerInitialLocationTests: XCTestCase {
     /// (`restoreDidDegradeToStart`) so the position-loss is observable, while the
     /// navigator simply remains at its natural start (the constructor restore is
     /// disabled, so there is nothing to tear down).
-    func testGate_goReturnsFalse_recordsPage1Degradation_noSecondRestore() async {
+    func testGate_goPersistentlyFalse_retriesThenRecordsPage1Degradation() async {
+        // A genuinely unresolvable locator: every go(to:) returns false. The gate
+        // retries up to maxRestoreAttempts (the constructor restore is disabled, so
+        // each false attempt is a harmless no-op — no teardown), then records the
+        // page-1 degradation so the position-loss is observable. (delay=0 for speed.)
         let serverLocator = makeLocator(href: "/unresolvable.xhtml", progression: 0.95)
         stubNavigator.goResult = false
-        sut = ReaderInitialLocationNavigator(initialLocation: serverLocator)
+        sut = ReaderInitialLocationNavigator(
+            initialLocation: serverLocator,
+            maxRestoreAttempts: 4,
+            restoreRetryDelayNanos: 0
+        )
         sut.attach(navigator: stubNavigator)
 
         let restoreDone = expectation(description: "restore attempt completed")
         sut.onRestoreAttempt = { _ in restoreDone.fulfill() }
 
         sut.signalReady()
-        await fulfillment(of: [restoreDone], timeout: 1.0)
+        await fulfillment(of: [restoreDone], timeout: 2.0)
 
-        XCTAssertEqual(stubNavigator.goCallCount, 1,
-                       "exactly one restore attempt — a failed restore must not fire a second conflicting go(to:)")
+        XCTAssertEqual(stubNavigator.goCallCount, 4,
+                       "a persistently-false restore must exhaust the bounded retries before degrading")
         XCTAssertTrue(sut.restoreDidDegradeToStart,
-                      "the gate must record the page-1 degradation when go(to:) returns false")
+                      "the gate must record the page-1 degradation when go(to:) never resolves")
+    }
+
+    /// PP-4652 regression: a DRM/Adobe EPUB's WebContent location-mapping table is
+    /// not ready at `viewDidAppear`, so the first go(to:) no-ops to false; once the
+    /// table populates, go(to:) succeeds. The gate MUST retry to the success rather
+    /// than degrade to the cover (the 3.2.0 "last read position lost on reopen" bug),
+    /// and must NOT flag a degradation.
+    func testGate_goFalseThenTrue_retriesToSuccess_noDegradation() async {
+        let savedLocator = makeLocator(href: "/chapter7.xhtml", progression: 0.42)
+        // Not ready twice, then ready.
+        stubNavigator.goResultSequence = [false, false, true]
+        sut = ReaderInitialLocationNavigator(
+            initialLocation: savedLocator,
+            maxRestoreAttempts: 12,
+            restoreRetryDelayNanos: 0
+        )
+        sut.attach(navigator: stubNavigator)
+
+        let restoreDone = expectation(description: "restore attempt completed")
+        var finalResult: Bool?
+        sut.onRestoreAttempt = { result in finalResult = result; restoreDone.fulfill() }
+
+        sut.signalReady()
+        await fulfillment(of: [restoreDone], timeout: 2.0)
+
+        XCTAssertEqual(finalResult, true, "the gate must retry until go(to:) resolves")
+        XCTAssertEqual(stubNavigator.goCallCount, 3,
+                       "go(to:) should be retried until it returns true (2 misses + 1 success)")
+        XCTAssertFalse(sut.restoreDidDegradeToStart,
+                       "a restore that eventually succeeds must NOT flag a page-1 degradation")
+        XCTAssertEqual(stubNavigator.lastGoLocator?.href.string, savedLocator.href.string,
+                       "the gate restores to the saved locator")
     }
 
     /// Successful restore must NOT flag degradation.
@@ -263,11 +303,18 @@ final class StubInitialLocationNavigator: NavigatorGoTo {
     var onGo: ((Locator) -> Void)?
     /// Simulate Readium returning false (could not resolve the locator).
     var goResult = true
+    /// Per-call results, consumed in order; when exhausted, falls back to
+    /// `goResult`. Models the DRM-EPUB case where the location-mapping table is
+    /// not ready for the first call(s) (false) then becomes ready (true).
+    var goResultSequence: [Bool] = []
 
     func go(to locator: Locator, options: NavigatorGoOptions) async -> Bool {
         goCallCount += 1
         lastGoLocator = locator
         onGo?(locator)
+        if !goResultSequence.isEmpty {
+            return goResultSequence.removeFirst()
+        }
         return goResult
     }
 }


### PR DESCRIPTION
Back-merge of the PP-4652 fix (merged to `release/3.2.0` in #1113) to `develop`.

EPUB last-read position was lost on reopen for **DRM books** (OverDrive/Marketplace): #1084's single post-paint `go(to:)` no-ops to false when the DRM WebContent location-mapping table isn't ready at `viewDidAppear`, degrading to the cover. Fix: `ReaderInitialLocationNavigator` retries `go(to:)` (bounded) until it resolves; constructor restore stays nil (no #1084 double-restore). Covers both reopen-resume and Sync→Move (both route through the gate).

Verified: 10/10 gate unit tests on a clean build (incl. new `testGate_goFalseThenTrue_retriesToSuccess_noDegradation`); live re-verified on a clean sim build with an OverDrive DRM EPUB (Move now restores to a content page, not the cover).

Cherry-pick of `d16e86d6` (release/3.2.0). No conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)