### PR TITLE
EPUBs opening as webview — prefer downloadable format over streaming-HTML (forward-port of RC #1117)

### DIFF
--- a/.forgeos/intent/epub-streaming-html-misroute.md
+++ b/.forgeos/intent/epub-streaming-html-misroute.md
@@ -1,0 +1,45 @@
+---
+name: epub-streaming-html-misroute
+created: 2026-06-25
+author: claude-opus-4-8
+---
+
+## Summary
+
+Production regression (Palace Bookshelf): some EPUB titles — e.g.
+"Multi-National Pulp Industries Within the Global Value Networks:…" — open in
+the in-app WKWebView streaming reader instead of the Readium EPUB reader.
+
+Root cause: PP-4161 (#1034, on release/3.2.0 + develop) added
+`ContentTypeStreamingHTML` to the supported acquisition types. `TPPBook
+.defaultBookContentType` selected `contentTypes.first(where: { $0 != .unsupported })`,
+and `TPPOPDSAcquisitionPath.supportedAcquisitionPaths` preserves the OPDS feed's
+indirect-acquisition order. So an open-access Palace Bookshelf title that
+advertises a "read online" streaming-HTML acquisition BEFORE its `epub+zip`
+now resolves to `.streamingHTML` → `isStreamingHTML == true` → BookService /
+BookDetailViewModel route it to the streaming reader. Before PP-4161 the
+streaming-HTML type was unsupported and skipped, so the EPUB path won — hence
+the regression.
+
+## Claims
+
+- `TPPBook.defaultBookContentType` now selects by a fixed format preference (`.epub`, `.pdf`, `.audiobook`, then `.streamingHTML`) instead of the first supported path, so a downloadable format always beats streaming-HTML regardless of OPDS feed order
+- streaming-HTML is still selected when it is the ONLY supported type (streaming-only books keep opening in the streaming reader)
+- `isStreamingHTML` (derived from `defaultBookContentType`) and all routing that keys off it (BookService, BookDetailViewModel, button set) are corrected by this single change
+- adds `testTPPBook_mixedStreamingAndEpub_streamingFirst_prefersEpub` (regression: streaming-HTML listed first must still resolve to `.epub`)
+- adds `testTPPBook_mixedStreamingAndEpub_epubFirst_prefersEpub` (order-independence guard)
+
+## Anti-claims
+
+- does NOT change behavior for streaming-only books — they still resolve to `.streamingHTML`
+- does NOT alter `supportedAcquisitionPaths`, `supportedSubtypes`, or the OPDS parser; the preference is applied only at `defaultBookContentType`
+- does NOT change the download path's acquisition-URL selection (`MyBooksDownloadCenter` / `pathExtension`); the reported symptom is reader routing, which is driven solely by `defaultBookContentType`
+- does NOT remove streaming-HTML support added by PP-4161
+
+## Files in scope
+
+Production:
+- `Palace/Book/Models/TPPBook.swift` (`defaultBookContentType` preference selection)
+
+Tests:
+- `PalaceTests/Book/TPPBookTests.swift` (two mixed-acquisition regression tests)

--- a/Palace/Book/Models/TPPBook.swift
+++ b/Palace/Book/Models/TPPBook.swift
@@ -649,7 +649,21 @@ public class TPPBook: NSObject, ObservableObject {
             TPPBookContentType.from(mimeType: path.types.last)
         }
 
-        return contentTypes.first(where: { $0 != .unsupported }) ?? .unsupported
+        // Prefer a downloadable format over streaming-HTML, independent of OPDS
+        // feed order. PP-4161 added `.streamingHTML` as a supported acquisition
+        // type; `supportedAcquisitionPaths` preserves the feed's
+        // indirect-acquisition order, so a Palace Bookshelf open-access title
+        // that advertises a "read online" streaming-HTML acquisition BEFORE its
+        // `epub+zip` would otherwise be classified as `.streamingHTML` and open
+        // in the WKWebView shell instead of the EPUB reader. Streaming-HTML is
+        // only the correct choice when no downloadable format is offered, so it
+        // ranks last. (Previously this returned the first non-unsupported type,
+        // which was feed-order-dependent.)
+        let preference: [TPPBookContentType] = [.epub, .pdf, .audiobook, .streamingHTML]
+        for candidate in preference where contentTypes.contains(candidate) {
+            return candidate
+        }
+        return .unsupported
     }
 
     /// PP-3649: Whether this book requires Adobe DRM activation before download.

--- a/PalaceTests/Book/TPPBookTests.swift
+++ b/PalaceTests/Book/TPPBookTests.swift
@@ -512,6 +512,48 @@ final class TPPBookTests: XCTestCase {
         XCTAssertFalse(book.isAudiobook, "Streaming-HTML is not an audiobook")
     }
 
+    /// Regression (Palace Bookshelf "EPUB opens as webview"): when a
+    /// publication offers BOTH a streaming-HTML and an `epub+zip` acquisition,
+    /// the downloadable EPUB must win — regardless of OPDS feed order.
+    /// `supportedAcquisitionPaths` preserves feed order, so a feed listing the
+    /// streaming-HTML acquisition FIRST previously misrouted EPUBs into the
+    /// WKWebView streaming reader (PP-4161 added streaming-HTML support without
+    /// a format preference).
+    func testTPPBook_mixedStreamingAndEpub_streamingFirst_prefersEpub() {
+        let streamingLeaf = TPPOPDSIndirectAcquisition(type: ContentTypeStreamingHTML, indirectAcquisitions: [])
+        let epubLeaf = TPPOPDSIndirectAcquisition(type: ContentTypeEpubZip, indirectAcquisitions: [])
+        let acquisition = TPPOPDSAcquisition(
+            relation: .borrow,
+            type: ContentTypeOPDSPublication,
+            hrefURL: URL(string: "https://example.com/borrow/mixed-streaming-first")!,
+            indirectAcquisitions: [streamingLeaf, epubLeaf], // streaming FIRST — the regression order
+            availability: TPPOPDSAcquisitionAvailabilityUnlimited()
+        )
+        let book = makeBook(acquisitions: [acquisition])
+
+        XCTAssertEqual(book.defaultBookContentType, .epub,
+                       "A book offering both streaming-HTML and epub+zip must open in the EPUB reader even when the feed lists streaming-HTML first")
+        XCTAssertFalse(book.isStreamingHTML,
+                       "A book with a downloadable EPUB must not be treated as streaming-only")
+    }
+
+    /// Order-independence guard: epub listed first must also resolve to .epub
+    /// (proves the fix is preference-based, not merely re-ordered).
+    func testTPPBook_mixedStreamingAndEpub_epubFirst_prefersEpub() {
+        let epubLeaf = TPPOPDSIndirectAcquisition(type: ContentTypeEpubZip, indirectAcquisitions: [])
+        let streamingLeaf = TPPOPDSIndirectAcquisition(type: ContentTypeStreamingHTML, indirectAcquisitions: [])
+        let acquisition = TPPOPDSAcquisition(
+            relation: .borrow,
+            type: ContentTypeOPDSPublication,
+            hrefURL: URL(string: "https://example.com/borrow/mixed-epub-first")!,
+            indirectAcquisitions: [epubLeaf, streamingLeaf],
+            availability: TPPOPDSAcquisitionAvailabilityUnlimited()
+        )
+        let book = makeBook(acquisitions: [acquisition])
+        XCTAssertEqual(book.defaultBookContentType, .epub)
+        XCTAssertFalse(book.isStreamingHTML)
+    }
+
     /// PP-4161: a plain EPUB book must NOT report isStreamingHTML.
     /// Catches a mutant that flipped the predicate to always-true.
     func testTPPBook_isStreamingHTML_epubOnly_returnsFalse() {


### PR DESCRIPTION
Forward-port of the RC fix **#1117** to `develop`.

## Problem
Palace Bookshelf EPUB titles (e.g. *"Multi-National Pulp Industries Within the Global Value Networks:…"*) open in the WKWebView streaming reader instead of the EPUB reader.

## Root cause
PP-4161 (#1034) added `ContentTypeStreamingHTML` as a supported acquisition type. `TPPBook.defaultBookContentType` returned the **first** supported acquisition path, and `supportedAcquisitionPaths` preserves OPDS feed order — so an open-access title advertising a "read online" streaming-HTML acquisition before its `epub+zip` resolved to `.streamingHTML` and routed to the streaming reader.

## Fix
`defaultBookContentType` selects by a fixed format preference (`.epub` › `.pdf` › `.audiobook` › `.streamingHTML`) instead of first-supported. Streaming-only books still resolve to `.streamingHTML`.

## How to verify (QA)
- 95 `TPPBookTests` green via `harness test`, incl. `testTPPBook_mixedStreamingAndEpub_streamingFirst_prefersEpub` / `_epubFirst_prefersEpub`, and the existing streaming-only test still passes.
- Cherry-pick of RC commit `b6307ccfa` (applied clean; `defaultBookContentType` is identical on both branches).

**Scope:** reader-routing only; no change to `supportedAcquisitionPaths`, the OPDS parser, the download path, or PP-4161 streaming support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)