### PR TITLE
test(hermeticity): register ImageCache._resetForTesting — stop suspended-queue leak flaking the suite

### DIFF
--- a/Palace/Utilities/ImageCache/ImageCacheType.swift
+++ b/Palace/Utilities/ImageCache/ImageCacheType.swift
@@ -299,6 +299,23 @@ public final class ImageCache: ImageCacheType {
         dataCache.clear()
     }
 
+    /// Test-only: restore the shared `processingQueue` to its running state.
+    ///
+    /// `ImageCacheContinuationTests` is the only test that suspends this
+    /// singleton's queue (suspend → enqueue → cancelAllOperations → resume) to
+    /// exercise the getAsync cancellation path. If that test ever aborts while
+    /// the queue is suspended, the global queue stays suspended and every later
+    /// `ImageCache.shared.getAsync` hangs to timeout — surfacing as a different
+    /// flaky victim each run (the test-isolation-family signature). Registering
+    /// this with `SingletonResetRegistry` makes the queue restore after EVERY
+    /// test via the finished-test observer, independent of that one test's
+    /// tearDown. `internal` (not `#if DEBUG`) matches the
+    /// `AppContainer._resetForTesting` convention and the blast-radius gate.
+    internal func _resetForTesting() {
+        processingQueue.cancelAllOperations()
+        processingQueue.isSuspended = false
+    }
+
     /// Evict decoded in-memory images without touching the compressed disk
     /// cache. The disk cache retains JPEG data, so the next fetchCoverImage
     /// call promotes from disk (~5ms) instead of hitting the network.

--- a/PalaceTests/PalaceTestSetup.swift
+++ b/PalaceTests/PalaceTestSetup.swift
@@ -121,6 +121,14 @@ class PalaceTestSetup: NSObject {
         registry.register("URLSession._resetStubbedSession") {
             URLSession._resetStubbedSession()
         }
+
+        // Restore ImageCache.shared's processing queue after every test.
+        // ImageCacheContinuationTests suspends the shared queue; without this
+        // fallback a mid-suspend abort would leave it suspended and hang every
+        // later getAsync — a whole-suite test-isolation hazard.
+        registry.register("ImageCache._resetForTesting") {
+            ImageCache.shared._resetForTesting()
+        }
     }
 }
 


### PR DESCRIPTION
## Flaky-suite hardening (test-isolation family), Step 1

Full-suite CI intermittently reds **different** tests run-to-run because a singleton's global state leaks across tests. Investigation found the "missing tearDown" problem was already solved by prior work (`TearDownRequiredLint` + base TestCases + `SingletonResetRegistry`); the one remaining **whole-suite** gap is `ImageCache.shared`.

`ImageCacheContinuationTests` is the only test that **suspends** `ImageCache.shared.processingQueue`. It restores the queue in its own `tearDown`, but `ImageCache` had **no `_resetForTesting`** registered as a fallback. If that test aborts mid-suspend, the global queue stays suspended → every later `ImageCache.shared.getAsync` hangs to timeout → a different flaky victim each run.

## Change
- `ImageCache._resetForTesting()` (internal): `processingQueue.cancelAllOperations()` + `isSuspended = false`.
- Registered with `SingletonResetRegistry`, so the queue restores after **every** test via the finished-test observer — independent of any single test's tearDown.

Matches the `AppContainer._resetForTesting` convention (plain `internal`, not `#if DEBUG`).

## Verify
- 12 tests green via `harness test` (`ImageCacheContinuationTests` + `ImageLoaderTests`); resetter runs after each test via the observer with no crash.

**Scope:** restores only the processing queue (the hang hazard); does not clear cached image data. No production behavior change — reset is test-only.

Follow-ups (not here): promote the pool-responsiveness probe to an enforced gate after a clean warn-only sweep; use `find-test-polluter.sh` to name the Task-leak polluter behind the `TPPLastReadPositionSynchronizer` concurrency timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)