### PR TITLE
EPUB-as-webview: defaultAcquisition prefers downloadable over streaming (forward-port of RC #1120)

### DIFF
--- a/.forgeos/intent/default-acquisition-prefer-downloadable.md
+++ b/.forgeos/intent/default-acquisition-prefer-downloadable.md
@@ -1,0 +1,45 @@
+---
+name: default-acquisition-prefer-downloadable
+created: 2026-06-25
+author: claude-opus-4-8
+---
+
+## Summary
+
+Follow-up to the EPUB-as-webview regression (RC #1117). #1117 fixed
+`defaultBookContentType`'s OPDS2 indirect-acquisition ordering, but **that did
+not fix the actual reported book** ("Multi-National Pulp Industries…" on Palace
+Bookshelf). Verified against the LIVE OPDS feed
+(`https://dpla.thepalaceproject.org/bookshelf/`): the book is OPDS **1.x** with
+many flat `open-access` links — streaming-media, PDF and EPUB as SEPARATE
+acquisitions, streaming-media FIRST.
+
+`defaultBookContentType` only inspects `defaultAcquisition`, and
+`defaultAcquisition` was `acquisitions.first(where: hasSupportedPath)`. PP-4161
+made streaming-media a *supported* type, so `defaultAcquisition` became the
+first (streaming) link → `.streamingHTML` → WKWebView reader. Confirmed fixed
+end-to-end via simdrive on a signed release/3.2.0+fix build: the book now opens
+in the Readium EPUB reader.
+
+## Claims
+
+- `TPPBook.defaultAcquisition` now ranks supported acquisitions by a fixed format preference (`.epub`, `.pdf`, `.audiobook`, then `.streamingHTML`) and returns the highest-preference one, instead of the first supported in feed order
+- streaming-media is selected only when it is the sole supported acquisition (streaming-only books unaffected)
+- adds private helpers `isSupportedDefaultAcquisition(_:)` and `defaultAcquisitionContentType(_:)` to rank candidates with the default-acquisition relation set
+- because `defaultBookContentType`, `isStreamingHTML`, the Read-button routing (BookService / BookDetailViewModel) and the download URL all derive from `defaultAcquisition`, this corrects both the reader chosen AND the file downloaded
+- adds `testTPPBook_openAccessSeparateLinks_streamingFirst_defaultsToEpub` (the real multi-link shape), `_fallsBackToPDF`, and `_streamingOnly_staysStreaming`
+
+## Anti-claims
+
+- does NOT revert or change #1117's `defaultBookContentType` preference (that still correctly handles the OPDS2 single-acquisition-with-indirects shape)
+- does NOT change behavior for streaming-only books — they still resolve to `.streamingHTML`
+- does NOT alter `supportedAcquisitionPaths`, `supportedSubtypes`, the OPDS parser, or PP-4161 streaming support
+- does NOT change availability/expiration semantics — all open-access links for a work share the same availability, so ranking by format does not affect them
+
+## Files in scope
+
+Production:
+- `Palace/Book/Models/TPPBook.swift` (`defaultAcquisition` preference + two private helpers)
+
+Tests:
+- `PalaceTests/Book/TPPBookTests.swift` (three OPDS1 separate-link regression tests)

--- a/Palace/Book/Models/TPPBook.swift
+++ b/Palace/Book/Models/TPPBook.swift
@@ -512,13 +512,45 @@ public class TPPBook: NSObject, ObservableObject {
     }
 
     @objc var defaultAcquisition: TPPOPDSAcquisition? {
-        acquisitions.first(where: {
-            !TPPOPDSAcquisitionPath.supportedAcquisitionPaths(
-                forAllowedTypes: TPPOPDSAcquisitionPath.supportedTypes(),
-                allowedRelations: TPPOPDSAcquisitionRelationSetDefaultAcquisition,
-                acquisitions: [$0]
-            ).isEmpty
-        })
+        let supported = acquisitions.filter { Self.isSupportedDefaultAcquisition($0) }
+        // Prefer a downloadable format over streaming-HTML when the same work is
+        // offered as separate open-access links. Palace Bookshelf OPDS1 entries
+        // list streaming-media, PDF and EPUB as distinct `open-access` links,
+        // often with streaming-media FIRST. PP-4161 made streaming-media a
+        // *supported* type, so the previous `acquisitions.first(where:supported)`
+        // returned the streaming link → `defaultBookContentType` became
+        // `.streamingHTML` → the book opened in the WKWebView reader and never
+        // downloaded the EPUB/PDF (the reported regression). Streaming-media is
+        // chosen only when no downloadable format is offered.
+        let preference: [TPPBookContentType] = [.epub, .pdf, .audiobook, .streamingHTML]
+        for candidate in preference {
+            if let match = supported.first(where: { Self.defaultAcquisitionContentType($0) == candidate }) {
+                return match
+            }
+        }
+        return supported.first
+    }
+
+    private static func isSupportedDefaultAcquisition(_ acquisition: TPPOPDSAcquisition) -> Bool {
+        !TPPOPDSAcquisitionPath.supportedAcquisitionPaths(
+            forAllowedTypes: TPPOPDSAcquisitionPath.supportedTypes(),
+            allowedRelations: TPPOPDSAcquisitionRelationSetDefaultAcquisition,
+            acquisitions: [acquisition]
+        ).isEmpty
+    }
+
+    /// Content type of a single acquisition, resolved with the default-acquisition
+    /// relation set and the same downloadable-over-streaming preference used by
+    /// `defaultBookContentType`. Used to rank candidate acquisitions.
+    private static func defaultAcquisitionContentType(_ acquisition: TPPOPDSAcquisition) -> TPPBookContentType {
+        let paths = TPPOPDSAcquisitionPath.supportedAcquisitionPaths(
+            forAllowedTypes: TPPOPDSAcquisitionPath.supportedTypes(),
+            allowedRelations: TPPOPDSAcquisitionRelationSetDefaultAcquisition,
+            acquisitions: [acquisition]
+        )
+        let types = paths.compactMap { TPPBookContentType.from(mimeType: $0.types.last) }
+        let preference: [TPPBookContentType] = [.epub, .pdf, .audiobook, .streamingHTML]
+        return preference.first(where: { types.contains($0) }) ?? .unsupported
     }
 
     @objc var sampleAcquisition: TPPOPDSAcquisition? {

--- a/PalaceTests/Book/TPPBookTests.swift
+++ b/PalaceTests/Book/TPPBookTests.swift
@@ -554,6 +554,64 @@ final class TPPBookTests: XCTestCase {
         XCTAssertFalse(book.isStreamingHTML)
     }
 
+    /// Regression for the ACTUAL Palace Bookshelf shape (verified against the
+    /// live OPDS1 feed for "Multi-National Pulp Industries…"): the same
+    /// open-access work is offered as SEPARATE direct links — streaming-media,
+    /// PDF and EPUB — with the streaming-media link FIRST. Unlike the OPDS2
+    /// single-acquisition-with-indirects case above, `defaultBookContentType`
+    /// only inspects `defaultAcquisition`, so the fix has to live in
+    /// `defaultAcquisition` (prefer a downloadable acquisition over streaming).
+    /// Without it, `defaultAcquisition` = the first supported = streaming →
+    /// `.streamingHTML` → WKWebView reader.
+    func testTPPBook_openAccessSeparateLinks_streamingFirst_defaultsToEpub() {
+        let streamingAcq = TPPOPDSAcquisition(
+            relation: .openAccess, type: ContentTypeStreamingHTML,
+            hrefURL: URL(string: "https://example.com/oa/stream")!,
+            indirectAcquisitions: [], availability: TPPOPDSAcquisitionAvailabilityUnlimited())
+        let pdfAcq = TPPOPDSAcquisition(
+            relation: .openAccess, type: ContentTypeOpenAccessPDF,
+            hrefURL: URL(string: "https://example.com/oa/pdf")!,
+            indirectAcquisitions: [], availability: TPPOPDSAcquisitionAvailabilityUnlimited())
+        let epubAcq = TPPOPDSAcquisition(
+            relation: .openAccess, type: ContentTypeEpubZip,
+            hrefURL: URL(string: "https://example.com/oa/epub")!,
+            indirectAcquisitions: [], availability: TPPOPDSAcquisitionAvailabilityUnlimited())
+        // Streaming FIRST — the real feed order.
+        let book = makeBook(acquisitions: [streamingAcq, pdfAcq, epubAcq])
+
+        XCTAssertEqual(book.defaultAcquisition?.type, ContentTypeEpubZip,
+                       "defaultAcquisition must prefer the downloadable EPUB link over the streaming-media link that appears first")
+        XCTAssertEqual(book.defaultBookContentType, .epub,
+                       "Multi-format open-access book must open in the EPUB reader, not the streaming WKWebView")
+        XCTAssertFalse(book.isStreamingHTML)
+    }
+
+    /// And when EPUB is absent, a downloadable PDF must still beat streaming.
+    func testTPPBook_openAccessSeparateLinks_streamingFirst_fallsBackToPDF() {
+        let streamingAcq = TPPOPDSAcquisition(
+            relation: .openAccess, type: ContentTypeStreamingHTML,
+            hrefURL: URL(string: "https://example.com/oa/stream2")!,
+            indirectAcquisitions: [], availability: TPPOPDSAcquisitionAvailabilityUnlimited())
+        let pdfAcq = TPPOPDSAcquisition(
+            relation: .openAccess, type: ContentTypeOpenAccessPDF,
+            hrefURL: URL(string: "https://example.com/oa/pdf2")!,
+            indirectAcquisitions: [], availability: TPPOPDSAcquisitionAvailabilityUnlimited())
+        let book = makeBook(acquisitions: [streamingAcq, pdfAcq])
+        XCTAssertEqual(book.defaultAcquisition?.type, ContentTypeOpenAccessPDF)
+        XCTAssertEqual(book.defaultBookContentType, .pdf)
+    }
+
+    /// Streaming-only must still resolve to streaming (no downloadable format).
+    func testTPPBook_openAccessSeparateLinks_streamingOnly_staysStreaming() {
+        let streamingAcq = TPPOPDSAcquisition(
+            relation: .openAccess, type: ContentTypeStreamingHTML,
+            hrefURL: URL(string: "https://example.com/oa/stream-only")!,
+            indirectAcquisitions: [], availability: TPPOPDSAcquisitionAvailabilityUnlimited())
+        let book = makeBook(acquisitions: [streamingAcq])
+        XCTAssertEqual(book.defaultBookContentType, .streamingHTML)
+        XCTAssertTrue(book.isStreamingHTML)
+    }
+
     /// PP-4161: a plain EPUB book must NOT report isStreamingHTML.
     /// Catches a mutant that flipped the predicate to always-true.
     func testTPPBook_isStreamingHTML_epubOnly_returnsFalse() {


### PR DESCRIPTION
Forward-port of RC **#1120** to develop.

## Problem
Follow-up to #1118 (the develop forward-port of #1117). #1118 fixed `defaultBookContentType`'s OPDS2 indirect ordering but **not** the actual Palace Bookshelf book — which is OPDS 1.x with flat `open-access` links (streaming-media, PDF, EPUB as separate acquisitions, streaming first).

## Fix
`defaultAcquisition` now ranks supported acquisitions by format preference (epub › pdf › audiobook › streamingHTML) instead of first-in-feed-order; streaming chosen only when it's the sole supported acquisition. Corrects the reader, `isStreamingHTML`, the Read routing, and the download URL (all derive from `defaultAcquisition`).

## Verification
- **simdrive (in action)** on a signed build: "Multi-National Pulp Industries…" opens in the **Readium EPUB reader**, not the webview.
- **Unit:** 98 `TPPBookTests` green incl. 3 OPDS1 separate-link tests. Cherry-pick of `911a6db82` (clean).

**Scope:** acquisition/reader selection only; keeps the OPDS2 fix; no change to the OPDS parser or PP-4161 streaming support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)