### PR TITLE
dev registry: accept an explicit URL in registry debugging

### DIFF
--- a/.forgeos/intent/dev-registry-explicit-url.md
+++ b/.forgeos/intent/dev-registry-explicit-url.md
@@ -1,0 +1,76 @@
+---
+name: dev-registry-explicit-url
+created: 2026-06-26
+author: Maurice Carrier
+branch: feature/dev-registry-explicit-url
+priority: dev-tooling — unblocks QA of registry facets on the complete /libraries feed
+---
+
+# Intent: let the dev-settings registry field target an explicit URL fetched verbatim
+
+## Context
+
+QA needs to validate the new `order` / `availability` facets the registry is
+adding to the complete `/libraries` feed (currently dev-registry-only) before it
+deploys widely. The iOS developer-settings "Library Registry Debugging" field
+could not exercise it: it hardcoded a `/libraries/qa` suffix
+(`TPPConfiguration.customUrl`), and the current app additionally rewrites any base
+to the crawlable endpoint (`LibraryRegistryCrawler.crawlableURL`). So a dev could
+never point the app at a bare `/libraries`.
+
+Grounded surface:
+- `TPPConfiguration.customUrl(settings:)` is the single origin of the custom
+  registry URL; `customUrlHash(settings:)` derives the cache key from it.
+- `AccountsManager.fetchFromNetwork` / `refreshInBackground` invoke the crawler;
+  `fallbackFetchFromNetwork` already performs a verbatim unauthenticated direct
+  GET + cache + load, used today as the crawler-failure fallback.
+- `TPPRegistryDebuggingCell` renders a fixed `https://` prefix + `/libraries/qa`
+  postfix around the input field.
+
+## Claims
+
+- `TPPConfiguration.customUrl(settings:)` uses a full `http(s)://…` entry
+  **verbatim**; a bare host keeps the legacy `https://<host>/libraries/qa`.
+  Empty / whitespace-only input returns `nil` (was: malformed `https:///libraries/qa`).
+- New `TPPConfiguration.customRegistryIsExplicitURL(settings:)` predicate reports
+  whether the configured value is a full URL.
+- `AccountsManager.fetchFromNetwork` and `refreshInBackground` early-return to
+  `fallbackFetchFromNetwork` (verbatim direct GET, no crawlable rewrite) when the
+  custom registry is an explicit URL.
+- `TPPRegistryDebuggingCell` accepts a full URL and hides the `https://` /
+  `/libraries/qa` affix labels when the input looks like a full URL; placeholder
+  updated to "host, or full https:// URL".
+
+## Verification
+
+- Unit: `TPPConfigurationCustomRegistryTests` — 8 tests (bare-host→/libraries/qa,
+  full https/http verbatim, query preserved, whitespace trim, empty→nil,
+  hash-consistency). All green via `-only-testing` spot-check.
+- Runtime (simdrive, iPhone 16 Pro): entered
+  `https://registry.dev.palaceproject.io/libraries` → affixes hid → Set →
+  "Configuration Updated" → Add Library rendered exactly the 1 catalog from the
+  bare feed ("Minotaur Test Library"), confirming the app fetched `/libraries`
+  verbatim (crawlable variant returns 4) and parsed the new facets cleanly.
+- Pre-PR: `scripts/verify-pr.sh --quick` (full scheme) — pending.
+
+## Anti-claims
+
+- Everything is gated behind a custom registry being set. With no custom registry
+  (every production user), `customRegistryIsExplicitURL` is `false` and the
+  crawler path is unchanged — production registry loading is untouched.
+- Does NOT change `LibraryRegistryCrawler.crawlableURL` or the crawler itself.
+- Does NOT change prod/beta URL selection (`prodUrl` / `betaUrl`), the
+  `useBetaLibraries` ("Enable Hidden Libraries") toggle, or any network/auth code.
+- Does NOT alter the registry feed parser (`OPDS2CatalogsFeed`); facet-parse
+  safety is a property of the existing lenient decoder, validated separately.
+
+## Files in scope
+
+- `Palace/AppInfrastructure/TPPConfiguration+SE.swift` — `customUrl`,
+  `customRegistryIsExplicitURL`, `isExplicitURL`, `customUrlHash(settings:)`.
+- `Palace/Accounts/Library/AccountsManager.swift` — explicit-URL early-return in
+  `fetchFromNetwork` + `refreshInBackground`.
+- `Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift` — full-URL
+  input + `updateAffixVisibility`.
+- `PalaceTests/TPPConfigurationCustomRegistryTests.swift` — 8 unit tests.
+- `Palace.xcodeproj/project.pbxproj` — test file registration.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		0B72C5306C699DBCB586DBE7 /* MyBooksDownloadCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317C8F0150303A9AC53BC44F /* MyBooksDownloadCenterTests.swift */; };
 		0B9C4F9CCCF2321228F96954 /* dune_oversubdivided_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 2630448EB64E91E2EADDF594 /* dune_oversubdivided_manifest.json */; };
 		0C26C51E4B1F06A4C02FBB65 /* TPPReauthenticator+Reauthenticating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540375EB4B496BAA15E4F6F4 /* TPPReauthenticator+Reauthenticating.swift */; };
+		0C3DD40B825558E7A86B603F /* TPPConfigurationCustomRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F80A7E0050FBFEDA0FCD075 /* TPPConfigurationCustomRegistryTests.swift */; };
 		0C6A411969E83D1D9A8BD2EA /* BorrowOperationAuthCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CDE8C912B8AD7B20AF282E /* BorrowOperationAuthCoordinatorTests.swift */; };
 		0CE51471A7664B7995B5C8A0 /* AudiobookDataManagerSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7BD91AF3E14990B745A0AA /* AudiobookDataManagerSyncTests.swift */; };
 		0D1F4E6BBD1377B4FD118F80 /* AudiobookPositionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF5D304C32FB1B3732F865C /* AudiobookPositionPolicy.swift */; };
@@ -369,6 +370,7 @@
 		3CCEFB38AC674ECBAA6018BA /* CarPlayTemplateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B6CFD936164F32A7FD6A84 /* CarPlayTemplateManager.swift */; };
 		3CF91B08EF557AF27DD6323F /* TPPUserAccount+TPPUserAccountReadingWriting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA2444F7FCEF34F2D7BE23B /* TPPUserAccount+TPPUserAccountReadingWriting.swift */; };
 		3DDF3224DA8EDA75AA1FA64F /* TPPProblemReportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB1E4A5E6A1E450001D2751 /* TPPProblemReportViewController.swift */; };
+		3DFA32525D80836005DEB6FC /* TPPReaderBlockNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14070A4A26128AE43AC74C6 /* TPPReaderBlockNavigationTests.swift */; };
 		3E3870516DA911431642CD2E /* AccessibilityServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21803F06C0E1741DD2F7973E /* AccessibilityServiceProtocol.swift */; };
 		3EC206476E6C170ECF92ECA8 /* UIView+TPPViewAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581C6B05F79FEB7A95DD4BA5 /* UIView+TPPViewAdditions.swift */; };
 		3F07E84A8D644585AC4214A3 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8D8A0D1A094920B67DC0E2 /* CarPlaySceneDelegate.swift */; };
@@ -489,7 +491,6 @@
 		607C5492BCD1F00E3156DDE6 /* DownloadOnlyOnWiFiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78529336066D2340C7B0FCE0 /* DownloadOnlyOnWiFiTests.swift */; };
 		60A99C600DD9A116635F920A /* AppContainerImageLoaderInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F13FD93A4CE48909066F4AE /* AppContainerImageLoaderInjectionTests.swift */; };
 		611D923EBE0FB1507857F65A /* TPPReaderPositionReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673C54DADAEAD820B2DABB9D /* TPPReaderPositionReportTests.swift */; };
-		3DFA32525D80836005DEB6FC /* TPPReaderBlockNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14070A4A26128AE43AC74C6 /* TPPReaderBlockNavigationTests.swift */; };
 		612E466C3BD31ED26DEDE50C /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF1F7C70AC93BF8E2F22148 /* DebugSettings.swift */; };
 		612FD8DA16387F71EB3CA398 /* HoldsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADE8A45C4B4AAE67143A272 /* HoldsViewModelTests.swift */; };
 		61757D3F95012F8F4340FABB /* TPPAccountAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56509A03466E0531DBC27 /* TPPAccountAuthState.swift */; };
@@ -527,6 +528,7 @@
 		6AC0B57C7401ADE5ECFCD1F2 /* StringHTMLEntitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06784DE00D5161E7071843F0 /* StringHTMLEntitiesTests.swift */; };
 		6AD629A88EADF90A1230E517 /* Account+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7531D0BC80AF1F317534E80 /* Account+State.swift */; };
 		6B4524A7B4E7B404AB95EE4A /* AudiobookSessionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C03DB276DAE8ED383D25A /* AudiobookSessionPresenter.swift */; };
+		6B4686ADB115880CFE56B2B2 /* TPPReaderBlockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */; };
 		6BC5772BEBDDD6ED93E8F6A3 /* OfflineQueueBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C9C7A1029274277B31F57E /* OfflineQueueBadge.swift */; };
 		6BD196ABF46912E87D2F0001 /* MyBooksDownloadCenterEvictionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95095FF0B6661C2AE8B60001 /* MyBooksDownloadCenterEvictionTests.swift */; };
 		6C4729162EE9C5CD63518FC2 /* UnifiedOPDSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FB0D2943B1B29532C05120 /* UnifiedOPDSService.swift */; };
@@ -819,6 +821,7 @@
 		8C9DAEBFC0D1E2F30415263A /* DownloadAuthRetryHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAEBFC0D1E2F304152637AB /* DownloadAuthRetryHandlerTests.swift */; };
 		8C9DAEBFC0D1E2F30415263F /* BookContentResetServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAEBFC0D1E2F30415263750 /* BookContentResetServiceTests.swift */; };
 		8CC26F832370C1DF0000D8E1 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC26F822370C1DF0000D8E1 /* Account.swift */; };
+		8CCB8310199672E1C07F4073 /* TPPReaderBlockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */; };
 		8CD73CE1905CBD7FA883FF6A /* TPPReauthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D5C28E71B1D177EAF1E5F9 /* TPPReauthenticatorTests.swift */; };
 		8CE9C471237F84820072E964 /* TPPBookDetailsProblemDocumentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE9C470237F84820072E964 /* TPPBookDetailsProblemDocumentViewController.swift */; };
 		8DB340CF4268405FAA8954D2 /* SignInModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CCA7049DE640BABC8D20B8 /* SignInModalView.swift */; };
@@ -849,8 +852,6 @@
 		964B6BD847B0E6C061E6CCB2 /* RemoteFeatureFlags+PalaceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272E56401C680E7771557AC3 /* RemoteFeatureFlags+PalaceCatalog.swift */; };
 		967625944F77592C713BFA06 /* NYPLOPDSFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B814E7E38AAEFF18419C6BB /* NYPLOPDSFeedTests.swift */; };
 		97AF6721F64BB54CBB497818 /* TPPReaderPositionReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE49D6CAE9861D0C5EC238 /* TPPReaderPositionReport.swift */; };
-		6B4686ADB115880CFE56B2B2 /* TPPReaderBlockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */; };
-		8CCB8310199672E1C07F4073 /* TPPReaderBlockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */; };
 		97D7098890B79033A5DF0E57 /* SendableSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BD75A5447FB7BD0DA90F57 /* SendableSubject.swift */; };
 		9812F13FF174AC093BB626FF /* BookAvailabilityFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C50D1C0AA0BA1374D31676 /* BookAvailabilityFormatterTests.swift */; };
 		982BDF376B8CC90AD13CC948 /* AudiobookSessionManagerShutdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CAC3762A717783DDE755DD /* AudiobookSessionManagerShutdownTests.swift */; };
@@ -1999,7 +2000,6 @@
 		03F94CCE1DD627AA00CE8F4F /* Accounts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Accounts.json; sourceTree = "<group>"; };
 		03F94CD01DD6288C00CE8F4F /* AccountsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsManager.swift; sourceTree = "<group>"; };
 		03FE49D6CAE9861D0C5EC238 /* TPPReaderPositionReport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderPositionReport.swift; path = ../../Palace/Reader2/BusinessLogic/TPPReaderPositionReport.swift; sourceTree = "<group>"; };
-		17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderBlockNavigation.swift; path = ../../Palace/Reader2/BusinessLogic/TPPReaderBlockNavigation.swift; sourceTree = "<group>"; };
 		040323DBE8E8E5AB1FBC517E /* BackupExclusionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupExclusionMigrationTests.swift; sourceTree = "<group>"; };
 		040827F9F622F17CAA24CCB5 /* AudiobookPositionPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookPositionPolicyTests.swift; sourceTree = "<group>"; };
 		041F2A3B4C5D6E7F8091A2B3 /* DownloadAuthRetryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadAuthRetryHandler.swift; sourceTree = "<group>"; };
@@ -2112,6 +2112,7 @@
 		17BE24E625FABCDE00AE707F /* TPPUserAccountProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPUserAccountProviderMock.swift; sourceTree = "<group>"; };
 		17BE24EC25FB09F000AE707F /* TPPCurrentLibraryAccountProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPCurrentLibraryAccountProviderMock.swift; sourceTree = "<group>"; };
 		17BE24EE25FB114900AE707F /* simplye_authentication_document.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = simplye_authentication_document.json; sourceTree = "<group>"; };
+		17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderBlockNavigation.swift; path = ../../Palace/Reader2/BusinessLogic/TPPReaderBlockNavigation.swift; sourceTree = "<group>"; };
 		17CE5304243C020800315E63 /* TPPUserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPUserAccount.swift; sourceTree = "<group>"; };
 		17CF4EB59391A34A6315985E /* TriageBotKeyAdmin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TriageBotKeyAdmin.swift; sourceTree = "<group>"; };
 		17D08378248E8EEB00092AA9 /* OverdriveProcessor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OverdriveProcessor.framework; path = Carthage/Build/iOS/OverdriveProcessor.framework; sourceTree = "<group>"; };
@@ -2373,6 +2374,7 @@
 		5EBFFFA78FB0357C5C37E4E0 /* TestAppContainerFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestAppContainerFactoryTests.swift; sourceTree = "<group>"; };
 		5F1A2C7B9E8D6A34F0C1B2D5 /* DiskBudgetManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiskBudgetManagerTests.swift; sourceTree = "<group>"; };
 		5F621ADC8194996EB5B5562F /* OPDS2CatalogWiringTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2CatalogWiringTests.swift; sourceTree = "<group>"; };
+		5F80A7E0050FBFEDA0FCD075 /* TPPConfigurationCustomRegistryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPConfigurationCustomRegistryTests.swift; sourceTree = "<group>"; };
 		5FF8D2CE6E794892B5C8C6FD /* ErrorDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDetailViewController.swift; sourceTree = "<group>"; };
 		60385D9D3FD8ED6E19C7608D /* AppContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContainer.swift; sourceTree = "<group>"; };
 		60FB7A3D7F1E7AEABAA4A45E /* Reader2BookmarkContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Reader2BookmarkContractTests.swift; sourceTree = "<group>"; };
@@ -2389,7 +2391,6 @@
 		65C628E6207F3958E194D07C /* BorrowOperationStreamingHTMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BorrowOperationStreamingHTMLTests.swift; sourceTree = "<group>"; };
 		65F03A0005DBD80853C64D12 /* OPDS2PublicationExtendedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2PublicationExtendedTests.swift; sourceTree = "<group>"; };
 		673C54DADAEAD820B2DABB9D /* TPPReaderPositionReportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderPositionReportTests.swift; sourceTree = "<group>"; };
-		D14070A4A26128AE43AC74C6 /* TPPReaderBlockNavigationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderBlockNavigationTests.swift; sourceTree = "<group>"; };
 		673C77C2D01F4E0AB1787C9D /* MyBooksDownloadCenterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterIntegrationTests.swift; sourceTree = "<group>"; };
 		678E47FC2F39F84744921B33 /* DownloadProgressPublisherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadProgressPublisherTests.swift; sourceTree = "<group>"; };
 		67A69DBB718593D67B0150D7 /* LCPPDFAcquisitionPredicateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPDFAcquisitionPredicateTests.swift; sourceTree = "<group>"; };
@@ -2853,6 +2854,7 @@
 		CRWL0013FREF00000001 /* CrossDeviceBookmarkSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrossDeviceBookmarkSyncTests.swift; sourceTree = "<group>"; };
 		D0446DDEE241612C3A2146A6 /* ReaderEditingActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderEditingActions.swift; sourceTree = "<group>"; };
 		D0B0B6008C750B0A082C80D0 /* RecentlyReadingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecentlyReadingService.swift; sourceTree = "<group>"; };
+		D14070A4A26128AE43AC74C6 /* TPPReaderBlockNavigationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderBlockNavigationTests.swift; sourceTree = "<group>"; };
 		D16D32877559BE95F5219281 /* TPPConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPConfiguration.swift; sourceTree = "<group>"; };
 		D17BDDF47AC131191CBB62E6 /* AppContainerAuthCoordinatorWiringTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContainerAuthCoordinatorWiringTests.swift; sourceTree = "<group>"; };
 		D18C9D0E1F2A3B4C5D6E7F80 /* LCPFulfillmentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPFulfillmentHandler.swift; sourceTree = "<group>"; };
@@ -5265,6 +5267,7 @@
 				8A963381EB27A2A8D0EFF8AB /* URLSessionStubbingResetTests.swift */,
 				52E79AEBD6EB68A70141013D /* ReaderStreaming */,
 				1ABC0E40FBEECB22D2E04F66 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift */,
+				5F80A7E0050FBFEDA0FCD075 /* TPPConfigurationCustomRegistryTests.swift */,
 			);
 			path = PalaceTests;
 			sourceTree = "<group>";
@@ -7443,6 +7446,7 @@
 				DD53EDAC28AB285D49FD1848 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift in Sources */,
 				20B17E24C48EC2CCF3A25977 /* BookRegistrySyncReentrancyTests.swift in Sources */,
 				12695B15A63B66C4B42E9B13 /* TPPReaderFootnoteAccessibilityTests.swift in Sources */,
+				0C3DD40B825558E7A86B603F /* TPPConfigurationCustomRegistryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -710,6 +710,14 @@ struct CatalogCacheMetadata: Codable {
     /// 2. Paginate remaining pages in background → update cache when done
     /// Falls back to a direct GET if even the first page fails.
     private func fetchFromNetwork(targetUrl: URL, hash: String) {
+        // A developer-configured explicit registry URL is fetched verbatim via a
+        // direct GET — no crawlable rewrite — so the exact endpoint (e.g. a bare
+        // /libraries feed) is exercised. Gated behind a custom registry being set;
+        // production registry loading still uses the crawler below.
+        if TPPConfiguration.customRegistryIsExplicitURL() {
+            fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
+            return
+        }
         let crawlTask = Task(priority: .userInitiated) { [weak self] in
             guard let self = self else { return }
             Log.debug(#file, "Fetching catalogs via first-page fast path for hash \(hash)")
@@ -809,6 +817,12 @@ struct CatalogCacheMetadata: Codable {
     /// Refreshes catalog data in background using the incremental crawler.
     /// Falls back to a direct GET if the crawlable endpoint fails.
     private func refreshInBackground(targetUrl: URL, hash: String) {
+        // Explicit dev registry URLs bypass the incremental crawler and refresh
+        // via a verbatim direct GET, mirroring fetchFromNetwork.
+        if TPPConfiguration.customRegistryIsExplicitURL() {
+            fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
+            return
+        }
         let refreshTask = Task(priority: .utility) { [weak self] in
             guard let self = self else { return }
             Log.debug(#file, "Starting background refresh (crawl) for catalog hash \(hash)")

--- a/Palace/AppInfrastructure/TPPConfiguration+SE.swift
+++ b/Palace/AppInfrastructure/TPPConfiguration+SE.swift
@@ -19,8 +19,32 @@ extension TPPConfiguration {
     static let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
 
     static func customUrl(settings: TPPSettings = TPPSettings()) -> URL? {
-        guard let server = settings.customLibraryRegistryServer else { return nil }
-        return URL(string: "https://\(server)/libraries/qa")
+        guard let raw = settings.customLibraryRegistryServer?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else { return nil }
+        // A full URL (scheme + path) is fetched verbatim so a developer can
+        // target an exact endpoint — e.g. the bare /libraries feed older clients
+        // parse directly. A bare host preserves the historical
+        // https://<host>/libraries/qa form.
+        if isExplicitURL(raw) {
+            return URL(string: raw)
+        }
+        return URL(string: "https://\(raw)/libraries/qa")
+    }
+
+    /// True when the configured custom registry is a full, explicit URL the
+    /// developer wants fetched verbatim — no /libraries/qa suffix, no crawlable
+    /// rewrite. Lets dev settings target an exact endpoint such as the
+    /// non-crawlable /libraries feed.
+    static func customRegistryIsExplicitURL(settings: TPPSettings = TPPSettings()) -> Bool {
+        guard let raw = settings.customLibraryRegistryServer?
+                .trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
+        return isExplicitURL(raw)
+    }
+
+    private static func isExplicitURL(_ value: String) -> Bool {
+        let lower = value.lowercased()
+        return lower.hasPrefix("https://") || lower.hasPrefix("http://")
     }
 
     /// Checks if registry changed
@@ -35,8 +59,8 @@ extension TPPConfiguration {
         UserDefaults.standard.set(prodUrlHash, forKey: registryHashKey)
     }
 
-    static func customUrlHash() -> String? {
-        customUrl()?.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+    static func customUrlHash(settings: TPPSettings = TPPSettings()) -> String? {
+        customUrl(settings: settings)?.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
     }
 
     /// Converts a base registry URL to the crawlable endpoint URL.

--- a/Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift
+++ b/Palace/Settings/DeveloperSettings/TPPRegistryDebuggingCell.swift
@@ -46,7 +46,7 @@ class TPPRegistryDebuggingCell: UITableViewCell {
         let stackView = UIStackView()
         stackView.axis = .vertical
 
-        inputField.placeholder = "Input custom server"
+        inputField.placeholder = "host, or full https:// URL"
         inputField.text = settings.customLibraryRegistryServer
         inputField.autocapitalizationType = .none
         inputField.autocorrectionType = .no
@@ -121,6 +121,20 @@ class TPPRegistryDebuggingCell: UITableViewCell {
 
         containerStack.autoSetDimension(.height, toSize: 100, relation: .greaterThanOrEqual)
         containerStack.autoPinEdgesToSuperviewMargins()
+
+        updateAffixVisibility(for: inputField.text)
+    }
+
+    /// A full URL is fetched verbatim, so the `https://` / `/libraries/qa`
+    /// hint affixes only make sense for a bare-host entry. Hide them once the
+    /// input looks like a full URL to avoid misrepresenting what will be loaded.
+    private func updateAffixVisibility(for text: String?) {
+        let isFullURL = (text ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .hasPrefix("http")
+        prefixLabel.isHidden = isFullURL
+        postfixLabel.isHidden = isFullURL
     }
 
     @objc private func clear() {
@@ -171,5 +185,6 @@ class TPPRegistryDebuggingCell: UITableViewCell {
 extension TPPRegistryDebuggingCell: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         textField.text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        updateAffixVisibility(for: textField.text)
     }
 }

--- a/PalaceTests/TPPConfigurationCustomRegistryTests.swift
+++ b/PalaceTests/TPPConfigurationCustomRegistryTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import Palace
+
+/// Covers the developer-settings custom registry URL construction
+/// (`TPPConfiguration.customUrl` / `customRegistryIsExplicitURL`).
+///
+/// A bare host preserves the historical `https://<host>/libraries/qa`
+/// behavior; a full URL is used verbatim so a developer can target an
+/// exact endpoint such as the non-crawlable `/libraries` feed that older
+/// clients parse directly.
+final class TPPConfigurationCustomRegistryTests: XCTestCase {
+
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+  private var settings: TPPSettings!
+
+  override func setUp() {
+    super.setUp()
+    suiteName = "TPPConfigurationCustomRegistryTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)
+    settings = TPPSettings(defaults: defaults)
+  }
+
+  override func tearDown() {
+    defaults.removePersistentDomain(forName: suiteName)
+    settings = nil
+    defaults = nil
+    suiteName = nil
+    super.tearDown()
+  }
+
+  // MARK: - customUrl
+
+  func test_customUrl_whenUnset_isNil() {
+    XCTAssertNil(TPPConfiguration.customUrl(settings: settings),
+                 "No custom registry configured should yield no custom URL")
+    XCTAssertFalse(TPPConfiguration.customRegistryIsExplicitURL(settings: settings))
+  }
+
+  func test_customUrl_bareHost_appendsLibrariesQa() {
+    settings.customLibraryRegistryServer = "registry.dev.palaceproject.io"
+    XCTAssertEqual(
+      TPPConfiguration.customUrl(settings: settings)?.absoluteString,
+      "https://registry.dev.palaceproject.io/libraries/qa",
+      "Bare host must preserve the legacy https://<host>/libraries/qa form")
+    XCTAssertFalse(TPPConfiguration.customRegistryIsExplicitURL(settings: settings),
+                   "A bare host is not an explicit URL")
+  }
+
+  func test_customUrl_fullHttpsURL_isUsedVerbatim() {
+    settings.customLibraryRegistryServer = "https://registry.dev.palaceproject.io/libraries"
+    XCTAssertEqual(
+      TPPConfiguration.customUrl(settings: settings)?.absoluteString,
+      "https://registry.dev.palaceproject.io/libraries",
+      "A full https URL must be fetched verbatim — no /qa suffix appended")
+    XCTAssertTrue(TPPConfiguration.customRegistryIsExplicitURL(settings: settings),
+                  "A full URL must be flagged explicit so the crawler is bypassed")
+  }
+
+  func test_customUrl_fullHttpURL_isUsedVerbatim() {
+    settings.customLibraryRegistryServer = "http://localhost:8000/libraries"
+    XCTAssertEqual(
+      TPPConfiguration.customUrl(settings: settings)?.absoluteString,
+      "http://localhost:8000/libraries",
+      "A full http URL (local dev server) must be used verbatim")
+    XCTAssertTrue(TPPConfiguration.customRegistryIsExplicitURL(settings: settings))
+  }
+
+  func test_customUrl_fullURLWithQuery_preservesQuery() {
+    settings.customLibraryRegistryServer = "https://registry.dev.palaceproject.io/libraries?availability=all"
+    XCTAssertEqual(
+      TPPConfiguration.customUrl(settings: settings)?.absoluteString,
+      "https://registry.dev.palaceproject.io/libraries?availability=all",
+      "Query params on an explicit URL must be preserved, not stripped")
+  }
+
+  func test_customUrl_whitespacePaddedHost_isTrimmed() {
+    settings.customLibraryRegistryServer = "  registry.dev.palaceproject.io  "
+    XCTAssertEqual(
+      TPPConfiguration.customUrl(settings: settings)?.absoluteString,
+      "https://registry.dev.palaceproject.io/libraries/qa",
+      "Surrounding whitespace must be trimmed before URL construction")
+  }
+
+  func test_customUrl_emptyOrWhitespaceOnly_isNil() {
+    settings.customLibraryRegistryServer = "   "
+    XCTAssertNil(TPPConfiguration.customUrl(settings: settings),
+                 "Whitespace-only input must not produce a malformed https:///libraries/qa URL")
+    XCTAssertFalse(TPPConfiguration.customRegistryIsExplicitURL(settings: settings))
+  }
+
+  // MARK: - hash consistency
+
+  func test_customUrlHash_matchesHashOfActualFetchURL() {
+    settings.customLibraryRegistryServer = "https://registry.dev.palaceproject.io/libraries"
+    // The cache key must hash the exact URL the app fetches, otherwise the
+    // explicit-URL response is cached under a key the loader never reads.
+    let url = TPPConfiguration.customUrl(settings: settings)!
+    let expected = url.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+    XCTAssertEqual(TPPConfiguration.customUrlHash(settings: settings), expected)
+  }
+}


### PR DESCRIPTION
## Summary

Lets the developer-settings **Library Registry Debugging** field target an explicit registry URL that is fetched **verbatim**, so QA can point the app at the complete `/libraries` feed (e.g. on the dev registry) to exercise the new `order` / `availability` facets.

Previously the field hardcoded a `/libraries/qa` suffix and the app rewrote any base to the crawlable endpoint, so a bare `/libraries` could never be reached from the app.

All behavior is **gated behind a custom registry being set** — with no custom registry (every production user), nothing changes; production registry loading still uses the crawler.

## Changes

- **`TPPConfiguration.customUrl(settings:)`** — a full `http(s)://…` entry is used verbatim; a bare host keeps the legacy `https://<host>/libraries/qa`. Empty/whitespace input now returns `nil` instead of a malformed `https:///libraries/qa`.
- **`TPPConfiguration.customRegistryIsExplicitURL(settings:)`** — new predicate.
- **`AccountsManager`** — `fetchFromNetwork` and `refreshInBackground` fetch an explicit custom URL verbatim via the existing direct-GET path (skip the crawlable rewrite).
- **`TPPRegistryDebuggingCell`** — accepts a full URL; the `https://` / `/libraries/qa` hint affixes auto-hide once the input is a full URL.

## Why no production risk

`customRegistryIsExplicitURL` is `false` for every user who hasn't set a custom registry in developer settings, so both new `AccountsManager` branches are inert on the production path. The crawler, prod/beta URL selection, the "Enable Hidden Libraries" (`useBetaLibraries`) toggle, and the feed parser are all untouched.

## Verification

**Unit** — `TPPConfigurationCustomRegistryTests` (8 tests): bare-host→`/libraries/qa`, full https/http verbatim, query preserved, whitespace trimmed, empty→nil, and cache-key hashes the exact fetched URL.

**Runtime (simdrive, iPhone 16 Pro)** — entered `https://registry.dev.palaceproject.io/libraries`: the affixes hid, Set succeeded, and **Add Library** rendered exactly the one catalog from the bare feed ("Minotaur Test Library"). The crawlable variant returns four — confirming the app fetched `/libraries` verbatim **and parsed the new facets cleanly**.

`scripts/verify-pr.sh --quick`: **22/22 checks PASS — 7334 tests, 0 failures**. Architect + QA reviews approved.

## Scope

iOS dev-tooling only. The product behavior for the `availability` facet ("Enable Hidden Libraries" → `availability=all` vs `production`) is tracked separately.
