### PR TITLE
PP-4518: adopt 0.5x–3.0x audiobook speed range (toolkit bump + tests)

### DIFF
--- a/PalaceTests/PlaybackRateTests.swift
+++ b/PalaceTests/PlaybackRateTests.swift
@@ -18,9 +18,14 @@ class PlaybackRateTests: XCTestCase {
     XCTAssertEqual(PlaybackRate.convert(rate: .oneAndAQuarterTime), 1.25, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .oneAndAHalfTime),   1.50, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .doubleTime),         2.00, accuracy: 0.001)
+    // PP-4518: 3.0× is the new ceiling.
+    XCTAssertEqual(PlaybackRate.convert(rate: .tripleTime),         3.00, accuracy: 0.001)
   }
 
   func testConvert_IntermediateCases_ReturnCorrectMultipliers() {
+    // PP-4518 extends the rail down to 0.5× and up to 3.0×.
+    XCTAssertEqual(PlaybackRate.convert(rate: .p050), 0.50, accuracy: 0.001)
+    XCTAssertEqual(PlaybackRate.convert(rate: .p065), 0.65, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .p080), 0.80, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .p095), 0.95, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .p110), 1.10, accuracy: 0.001)
@@ -28,71 +33,95 @@ class PlaybackRateTests: XCTestCase {
     XCTAssertEqual(PlaybackRate.convert(rate: .p145), 1.45, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .p175), 1.75, accuracy: 0.001)
     XCTAssertEqual(PlaybackRate.convert(rate: .p195), 1.95, accuracy: 0.001)
+    XCTAssertEqual(PlaybackRate.convert(rate: .p205), 2.05, accuracy: 0.001)
+    XCTAssertEqual(PlaybackRate.convert(rate: .p250), 2.50, accuracy: 0.001)
+    XCTAssertEqual(PlaybackRate.convert(rate: .p275), 2.75, accuracy: 0.001)
+    XCTAssertEqual(PlaybackRate.convert(rate: .p295), 2.95, accuracy: 0.001)
   }
 
   // MARK: - presets
 
-  /// PP-4358 locks the user-facing preset ladder to exactly five rates
-  /// [0.75×, 1.0×, 1.2×, 1.5×, 2.0×]. Pinning the *order* and the
-  /// *exact* enum cases together kills mutants that:
+  /// PP-4518 product direction: the user-facing preset chips are even 0.5×
+  /// steps across the full rail — [0.5×, 1.0×, 1.5×, 2.0×, 2.5×, 3.0×]. Pinning
+  /// the *order* and the *exact* enum cases together kills mutants that:
   ///   - shuffle the order
   ///   - drop/add a preset
-  ///   - swap 1.2× for 1.25× (the design-review change vs PP-4233 prototype)
+  ///   - reintroduce the old 0.75×/1.2× chips
   ///   - substitute an intermediate `.p###` step for a named rate (or vice versa)
-  func testPresets_isExactly_0p75_1p0_1p2_1p5_2p0_inAscendingOrder() {
+  func testPresets_isExactly_0p5_1p0_1p5_2p0_2p5_3p0_inAscendingOrder() {
     let expected: [PlaybackRate] = [
-      .threeQuartersTime, .normalTime, .p120, .oneAndAHalfTime, .doubleTime,
+      .p050, .normalTime, .oneAndAHalfTime, .doubleTime, .p250, .tripleTime,
     ]
     XCTAssertEqual(PlaybackRate.presets, expected,
-                   "PP-4358 acceptance: presets must be exactly [0.75×, 1.0×, 1.2×, 1.5×, 2.0×] in ascending order")
+                   "PP-4518 acceptance: presets must be exactly [0.5×, 1.0×, 1.5×, 2.0×, 2.5×, 3.0×] in ascending order")
   }
 
   /// Independent assertion of the multipliers — separate from enum-case identity —
-  /// so a mutant that re-numbers a case's raw value still trips this test.
-  func testPresets_MultipliersAreExactly_0p75_1p0_1p2_1p5_2p0() {
-    let expected: [Float] = [0.75, 1.0, 1.2, 1.5, 2.0]
+  /// so a mutant that re-numbers a case's raw value still trips this test. Also
+  /// asserts the chips are an evenly-spaced 0.5× ladder (each gap == 0.5).
+  func testPresets_MultipliersAreEven0p5StepsFrom0p5To3p0() {
+    let expected: [Float] = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0]
     let actual = PlaybackRate.presets.map { PlaybackRate.convert(rate: $0) }
-    XCTAssertEqual(actual.count, expected.count, "PP-4358 presets must be exactly 5 multipliers")
+    XCTAssertEqual(actual.count, expected.count, "PP-4518 presets must be exactly 6 multipliers")
     for (index, (actualMultiplier, expectedMultiplier)) in zip(actual, expected).enumerated() {
       XCTAssertEqual(actualMultiplier, expectedMultiplier, accuracy: 0.001,
-                     "PP-4358 preset[\(index)] multiplier must be \(expectedMultiplier)×, got \(actualMultiplier)×")
+                     "PP-4518 preset[\(index)] multiplier must be \(expectedMultiplier)×, got \(actualMultiplier)×")
+    }
+    for i in 1..<actual.count {
+      XCTAssertEqual(actual[i] - actual[i - 1], 0.5, accuracy: 0.001,
+                     "PP-4518 chips must be evenly 0.5× apart; gap \(i - 1)→\(i) was \(actual[i] - actual[i - 1])")
     }
   }
 
-  func testPresets_ContainsAllNamedRates() {
-    XCTAssertTrue(PlaybackRate.presets.contains(.threeQuartersTime))
-    XCTAssertTrue(PlaybackRate.presets.contains(.normalTime))
-    XCTAssertTrue(PlaybackRate.presets.contains(.p120))
-    XCTAssertTrue(PlaybackRate.presets.contains(.oneAndAHalfTime))
-    XCTAssertTrue(PlaybackRate.presets.contains(.doubleTime))
+  /// PP-4518 acceptance: the slow-down chip is 0.5× and there are TWO chips
+  /// above 2.0× (2.5× and 3.0×).
+  func testPresets_SlowChipIs0p5_AndTwoChipsExceed2x() {
+    XCTAssertEqual(PlaybackRate.presets.first, .p050,
+                   "Slowest chip must be 0.5× under the even-0.5 ladder")
+    let above2x = PlaybackRate.presets.filter { PlaybackRate.convert(rate: $0) > 2.0 }
+    XCTAssertEqual(above2x, [.p250, .tripleTime],
+                   "Exactly 2.5× and 3.0× must exceed 2.0× in the preset row")
   }
 
-  /// The earlier prototype shipped 1.25× as the third preset; design review
-  /// changed it to 1.2×. Lock this so a regression that re-introduces 1.25×
-  /// to the preset row fails immediately.
-  func testPresets_DoesNotContain1p25x() {
-    XCTAssertFalse(PlaybackRate.presets.contains(.oneAndAQuarterTime),
-                   "1.25× must not appear in the preset row — design approved 1.2× (.p120)")
+  /// 0.75× and 1.2× are dropped from the quick-select CHIPS per product
+  /// direction, but they remain valid enum cases reachable on the 0.05-step
+  /// slider (so accessibility slow-down at 0.75× still works and historic
+  /// UserDefaults raw 75/120 still decode).
+  func testPresets_DropOld0p75And1p2Chips_ButCasesStillReachable() {
+    XCTAssertFalse(PlaybackRate.presets.contains(.threeQuartersTime),
+                   "0.75× is no longer a quick-select chip")
+    XCTAssertFalse(PlaybackRate.presets.contains(.p120),
+                   "1.2× is no longer a quick-select chip")
+    // Still reachable on the slider rail.
+    XCTAssertEqual(PlaybackRate.nearest(to: 0.75), .threeQuartersTime,
+                   "0.75× must remain reachable via the slider for accessibility slow-down")
+    XCTAssertEqual(PlaybackRate.nearest(to: 1.20), .p120,
+                   "1.2× must remain reachable via the slider")
+    // Historic persistence still decodes.
+    XCTAssertEqual(PlaybackRate(rawValue: 75), .threeQuartersTime)
+    XCTAssertEqual(PlaybackRate(rawValue: 120), .p120)
   }
 
-  func testPresets_DoesNotContainIntermediateCases() {
+  func testPresets_DoesNotContainOtherIntermediateCases() {
     XCTAssertFalse(PlaybackRate.presets.contains(.p080))
     XCTAssertFalse(PlaybackRate.presets.contains(.p110))
     XCTAssertFalse(PlaybackRate.presets.contains(.p175))
+    XCTAssertFalse(PlaybackRate.presets.contains(.oneAndAQuarterTime),
+                   "1.25× is not a chip")
   }
 
   // MARK: - steps
 
-  /// `steps` is the full slider rail: 26 values from 0.75 to 2.00 in 0.05
+  /// `steps` is the full slider rail: 51 values from 0.50 to 3.00 in 0.05
   /// increments, sorted ascending. Lock the bounds, count, sortedness, AND
   /// the uniform 0.05 gap in one body so a mutant that drops a step,
   /// shuffles the order, or changes the increment fails on a single test.
-  func testSteps_isMonotonicLadderFromThreeQuartersToDoubleIn0Point05Increments() {
+  func testSteps_isMonotonicLadderFromHalfToTripleIn0Point05Increments() {
     let steps = PlaybackRate.steps
-    XCTAssertEqual(steps.count, 26,
-                   "0.75→2.00 in 0.05 increments must be 26 distinct values")
-    XCTAssertEqual(steps.first, .threeQuartersTime, "Lower bound is 0.75×")
-    XCTAssertEqual(steps.last,  .doubleTime,        "Upper bound is 2.00×")
+    XCTAssertEqual(steps.count, 51,
+                   "0.50→3.00 in 0.05 increments must be 51 distinct values")
+    XCTAssertEqual(steps.first, .p050,       "Lower bound is 0.50×")
+    XCTAssertEqual(steps.last,  .tripleTime, "Upper bound is 3.00×")
 
     let raws = steps.map(\.rawValue)
     XCTAssertEqual(raws, raws.sorted(),
@@ -111,14 +140,18 @@ class PlaybackRateTests: XCTestCase {
     XCTAssertEqual(PlaybackRate.nearest(to: 1.25), .oneAndAQuarterTime)
     XCTAssertEqual(PlaybackRate.nearest(to: 1.50), .oneAndAHalfTime)
     XCTAssertEqual(PlaybackRate.nearest(to: 2.00), .doubleTime)
+    XCTAssertEqual(PlaybackRate.nearest(to: 3.00), .tripleTime)
   }
 
   func testNearest_ExactIntermediateValues_ReturnExactCase() {
+    XCTAssertEqual(PlaybackRate.nearest(to: 0.50), .p050)
     XCTAssertEqual(PlaybackRate.nearest(to: 0.80), .p080)
     XCTAssertEqual(PlaybackRate.nearest(to: 0.95), .p095)
     XCTAssertEqual(PlaybackRate.nearest(to: 1.10), .p110)
     XCTAssertEqual(PlaybackRate.nearest(to: 1.45), .p145)
     XCTAssertEqual(PlaybackRate.nearest(to: 1.95), .p195)
+    XCTAssertEqual(PlaybackRate.nearest(to: 2.50), .p250)
+    XCTAssertEqual(PlaybackRate.nearest(to: 2.75), .p275)
   }
 
   func testNearest_ValueBetweenSteps_SnapsToNearest() {
@@ -132,30 +165,50 @@ class PlaybackRateTests: XCTestCase {
     // 1.22 is closer to 1.20 (distance 0.02) than to 1.25 (distance 0.03)
     XCTAssertEqual(PlaybackRate.nearest(to: 1.22), .p120)
 
-    // 1.98 is closer to 2.00 than to 1.95
-    XCTAssertEqual(PlaybackRate.nearest(to: 1.98), .doubleTime)
+    // 2.97 is closer to 2.95 than to 3.00
+    XCTAssertEqual(PlaybackRate.nearest(to: 2.97), .p295)
+
+    // 2.99 is closer to 3.00 than to 2.95
+    XCTAssertEqual(PlaybackRate.nearest(to: 2.99), .tripleTime)
   }
 
   /// `nearest(to:)` clamps out-of-range values to the bounds — sub-minimum
-  /// snaps to the slowest preset, super-maximum snaps to the fastest.
+  /// snaps to the slowest step (0.5×), super-maximum snaps to the fastest (3.0×).
   /// Pin both clamping branches at multiple values per side so a mutant
   /// that flips one boundary fails immediately.
   func testNearest_clampsOutOfRangeValuesToBounds() {
-    // Sub-minimum
-    XCTAssertEqual(PlaybackRate.nearest(to: 0.10), .threeQuartersTime)
-    XCTAssertEqual(PlaybackRate.nearest(to: 0.50), .threeQuartersTime)
-    XCTAssertEqual(PlaybackRate.nearest(to: 0.74), .threeQuartersTime,
+    // Sub-minimum → 0.50×
+    XCTAssertEqual(PlaybackRate.nearest(to: 0.10), .p050)
+    XCTAssertEqual(PlaybackRate.nearest(to: 0.49), .p050,
                    "Just under the minimum must still snap to the minimum, not interpolate")
 
-    // Super-maximum
-    XCTAssertEqual(PlaybackRate.nearest(to: 2.01), .doubleTime,
+    // Super-maximum → 3.00×
+    XCTAssertEqual(PlaybackRate.nearest(to: 3.01), .tripleTime,
                    "Just over the maximum must still snap to the maximum")
-    XCTAssertEqual(PlaybackRate.nearest(to: 5.0),  .doubleTime)
-    XCTAssertEqual(PlaybackRate.nearest(to: 9.99), .doubleTime)
+    XCTAssertEqual(PlaybackRate.nearest(to: 5.0),  .tripleTime)
+    XCTAssertEqual(PlaybackRate.nearest(to: 9.99), .tripleTime)
 
     // Negative input should not crash and must clamp to the minimum.
-    XCTAssertEqual(PlaybackRate.nearest(to: -1.0), .threeQuartersTime,
+    XCTAssertEqual(PlaybackRate.nearest(to: -1.0), .p050,
                    "Negative input must be clamped, not crash on arithmetic")
+  }
+
+  // MARK: - persistence round-trip (rawValue ↔ case)
+
+  /// Selected speed persists across app restart as the rawValue Int under the
+  /// `playback_rate` UserDefaults key (see Player.savePlaybackRate / fetchPlaybackRate).
+  /// The round-trip must hold for the new boundary + above-2.0× cases so a
+  /// stored 3.0× restores as 3.0×, not a clamped 2.0×.
+  func testRawValueRoundTrip_BoundaryAndAbove2xCases() {
+    let cases: [(PlaybackRate, Int)] = [
+      (.p050, 50), (.threeQuartersTime, 75), (.normalTime, 100),
+      (.doubleTime, 200), (.p250, 250), (.p275, 275), (.tripleTime, 300),
+    ]
+    for (rate, raw) in cases {
+      XCTAssertEqual(rate.rawValue, raw, "\(rate) must serialize to raw \(raw)")
+      XCTAssertEqual(PlaybackRate(rawValue: raw), rate,
+                     "raw \(raw) must restore to \(rate) across app restart")
+    }
   }
 
   // MARK: - HumanReadablePlaybackRate.formatMultiplier
@@ -163,6 +216,7 @@ class PlaybackRateTests: XCTestCase {
   func testFormatMultiplier_WholeNumber_ShowsOneDecimalPlace() {
     XCTAssertEqual(HumanReadablePlaybackRate.formatMultiplier(1.0), "1.0×")
     XCTAssertEqual(HumanReadablePlaybackRate.formatMultiplier(2.0), "2.0×")
+    XCTAssertEqual(HumanReadablePlaybackRate.formatMultiplier(3.0), "3.0×")
   }
 
   func testFormatMultiplier_OneDecimalPlace_ShowsOneDecimalPlace() {
@@ -174,6 +228,9 @@ class PlaybackRateTests: XCTestCase {
     XCTAssertEqual(HumanReadablePlaybackRate.formatMultiplier(1.25), "1.25×")
     XCTAssertEqual(HumanReadablePlaybackRate.formatMultiplier(1.95), "1.95×")
     XCTAssertEqual(HumanReadablePlaybackRate.formatMultiplier(0.85), "0.85×")
+    // PP-4518: above-2.0× labels, e.g. "2.75×".
+    XCTAssertEqual(HumanReadablePlaybackRate.formatMultiplier(2.75), "2.75×")
+    XCTAssertEqual(HumanReadablePlaybackRate.formatMultiplier(2.05), "2.05×")
   }
 
   /// Every step in the slider rail produces a label that ends with the
@@ -187,5 +244,16 @@ class PlaybackRateTests: XCTestCase {
       XCTAssertTrue(label.hasSuffix("×"),
                     "Label '\(label)' for \(rate) must END with × — the multiply sign is the trailing unit, not a prefix")
     }
+  }
+
+  /// PP-4518: the fastest rate's spoken VoiceOver description must identify it as
+  /// the fastest (and 2.0× must no longer claim to be the fastest).
+  func testAccessibleDescription_FastestIsNowTripleTime_Not2x() {
+    let tripleDesc = HumanReadablePlaybackRate(rate: .tripleTime).accessibleDescription.lowercased()
+    XCTAssertTrue(tripleDesc.contains("fastest"),
+                  "3.0× must announce itself as the fastest speed for VoiceOver users")
+    let doubleDesc = HumanReadablePlaybackRate(rate: .doubleTime).accessibleDescription.lowercased()
+    XCTAssertFalse(doubleDesc.contains("fastest"),
+                   "2.0× is no longer the fastest — its description must not claim 'fastest'")
   }
 }


### PR DESCRIPTION
## Summary

Adopts **PP-4518** in the app: bumps the `ios-audiobooktoolkit` submodule to the merged toolkit (ThePalaceProject/ios-audiobooktoolkit#187, `main` @ `abe0be1e`) and adds the covering tests. This is what lands the **0.5×–3.0×** audiobook playback speed range in Palace.

ios-core consumes the change purely via the submodule pointer — **0 production Swift LOC here**; the logic lives in the toolkit PR.

## What the toolkit change does (for reviewers)

- `PlaybackRate` extended to 0.5×–3.0× in 0.05 steps; preset chips → even-0.5 ladder `[0.5, 1.0, 1.5, 2.0, 2.5, 3.0]` (0.75×/1.25× remain valid cases + slider-reachable; dropping the 0.75× chip is Android-aligned and maintainer-confirmed).
- Slider rail widened to 0.5–3.0; VoiceOver "Fastest" moved to 3.0×.
- **Pitch fix:** multi-file composition paths in `OpenAccessPlayer`/`LCPStreamingPlayer` now set `audioTimePitchAlgorithm = .timeDomain` (were vari-speeding/raising pitch above ~1×).
- `FindawayPlayer` rate getters hardened from force-unwrap → `nearest(to:)`.

## Tests

`PalaceTests/PlaybackRateTests.swift` — new ladder + even-0.5 spacing, two chips >2.0×, clamp at 0.5/3.0, rawValue persistence round-trip across restart, `2.75x`/`3.0x` formatting, VoiceOver Fastest = 3.0×. Toolkit-local run: 18/18.

## Verification

- Toolkit build green; PlaybackRateTests 18/18.
- Preset chips validated locally by the maintainer.
- **Full ios-core CI on this PR (build + suite + audiobook cross-vendor smoke) is the merge gate.**

## Follow-up

Live in-app speed-sheet simdrive walkthrough tracked as a follow-up QA pass (was blocked locally by audiobook test content/creds; chips validated locally).

Depends on: ThePalaceProject/ios-audiobooktoolkit#187 (merged).
