### PR TITLE
fix(hermeticity): eliminate residual CI hang — O(1) AccountsManager.account() + test-isolation fixes

### DIFF
--- a/.forgeos/intent/hermeticity-leaker-accountdetail-vm.md
+++ b/.forgeos/intent/hermeticity-leaker-accountdetail-vm.md
@@ -1,0 +1,104 @@
+---
+name: hermeticity-leaker-accountdetail-vm
+created: 2026-06-29
+author: claude
+type: bugfix
+---
+
+# hermeticity-leaker-accountdetail-vm
+
+Residual test-hermeticity hang class behind the #1122 flaky-CI block (post-3.2.0
+WS-0 stabilization). NOT the defer-flag class (gated) and NOT pool-starvation
+(probe ruled it out). Roots a main-thread CPU-saturation hang that reds the board
+on unlucky shuffles.
+
+## Claims
+
+<!-- Fix scope is being confirmed with palace-pm before the production-touching
+parts land; the investigation (Reproduction / Root cause) is complete. -->
+
+- removes `MallocStackLogging` + `PrefersMallocStackLoggingLite` from the
+  `Palace.xcscheme` Test action — an accidental Diagnostics-tab leftover that
+  instruments every allocation with a backtrace, the amplifier that turns the
+  O(accounts) account-iteration into a >120s hang (spindump-proven ~50% of the
+  hot-loop leaf time is `stack_logging_lite_malloc`). Test-config only, zero
+  production change.
+- closes the real-network escape: `TPPNetworkExecutor`'s URLSession bypasses
+  `NoNetworkURLProtocol` (which only catches `URLSession.shared`), so
+  `AccountsManager.fallbackDirectRefresh → networkExecutor.GET` hits real
+  `registry.palaceproject.io/libraries` in unit tests (CI log: 67s elapsed,
+  -1001 timeouts) — driving the loadCatalogs churn. [DESIGN PENDING — critical-path]
+- stops the leaked-observer class: an `AccountDetailViewModel` survives its test
+  with active `@MainActor` `.TPPCurrentAccountDidChange` observers that re-run
+  O(~1142-account) `setupTableData` on every account-change post. [DESIGN PENDING]
+
+## Anti-claims
+
+- does NOT change production runtime behaviour of `TPPNetworkExecutor`'s real
+  network path (only test-time protocol registration / session injection).
+- does NOT alter the defer-flag quiescence gate or the crawl-drain fix (#1066).
+- does NOT change `AccountsManager` lock semantics.
+
+## Files in scope
+
+- Palace.xcodeproj/xcshareddata/xcschemes/Palace.xcscheme (MallocStackLogging removal)
+- PalaceTests/NoNetworkURLProtocol.swift / PalaceTests bootstrap (executor session coverage) — TBD
+- Palace/Settings/AccountDetailViewModel.swift (leaked observer) — TBD pending design
+- PalaceTests/ViewModels/AccountDetailViewModelTests.swift (teardown / test AppContainer) — TBD
+
+## Reproduction
+
+REAL artifact = PR #1122 CI run 28384882381 (build-and-test FAILED, 33m). Two
+order-dependent HANGS, persisting across iters-3 retries (NOT retry-masked):
+- `TPPSettingsTests.testUseBetaLibraries_publishesViaCombine` (killed @120s)
+- `CatalogPreloaderTests.testPreloader_PreloadsRecentlyUsedAccounts_UpToLimit` (@60s)
+Decisive: 17 `[WS0-POOL-DIAG]` lines ALL `completed=true` (max 421ms) + 0
+defer-flag breadcrumbs ⟹ neither pool-starvation nor defer-flag class.
+
+Reproduced LOCALLY at iters-1 no-retry, full suite, single-process, random order
+(`scripts/repro.sh` analogue via `harness test -- test-without-building
+-test-timeouts-enabled YES -default-test-execution-time-allowance 120`): a fresh
+shuffle hung `EPUBSearchViewModelTests.testClearSearch_ResetsState` (victim
+varies by shuffle — all victims are async/main-thread-dependent tests).
+`AccountDetailViewModelTests` PASSES in isolation (19 tests / 1.0s) → the hang is
+environment-dependent pollution, not a self-contained bug.
+
+## Root cause
+
+Spindump of the hung test-host (Palace pid 93263, captured live during the
+EPUBSearch hang): the MAIN THREAD is 100%-busy (3654/3654 samples), NOT blocked
+on a lock — a CPU-bound runaway, not a deadlock:
+
+  Main Thread
+   AccountDetailViewModel.setupObservers() sink closure  (AccountDetailViewModel.swift:193)
+    → accountDidChange()                                 (:581)
+     → setupTableData()                                  (:281)
+      → accountInfoSection()                             (:317)
+       → AccountsManager.account(_:) → performRead → accountSetsLock.sync
+        → accountSets.values.first{contains(where:uuid)}.first(where:uuid)  (O(n) over ~1142 bundled accounts)
+         → ~50% leaf time in MallocStackLogging (stack_logging_lite_malloc / thread_stack_pcs)
+
+Mechanism (multi-factor):
+1. A test creates `AccountDetailViewModel` against `AppContainer.production()`
+   (real shared AccountsManager). The VM survives past its test scope (in-flight
+   async init work: `loadInitialData`'s `Task { @MainActor … }` captures self
+   strongly; `ensureAuthenticationDocumentIsLoaded` keeps the chain alive on a
+   slow real-network auth-doc load). Its `.TPPCurrentAccountDidChange` /
+   `.TPPUserAccountDidChange` `@MainActor` observers stay subscribed.
+2. The shared AccountsManager loads the BUNDLED 1142-account snapshot → every
+   `account(uuid)` lookup is O(~1142).
+3. Background churn keeps posting `.TPPCurrentAccountDidChange` / re-running
+   loadCatalogs (104× "Loading catalogs from cache" in the CI run), driven in
+   part by the real-network escape: `TPPNetworkExecutor`'s session is NOT covered
+   by `NoNetworkURLProtocol` (only `URLSession.shared` is), so
+   `fallbackDirectRefresh → networkExecutor.GET` hits real network (60s+ CI
+   timeouts) and retries.
+4. Each churn post re-fires the leaked VM observer → O(1142) main-thread
+   `setupTableData`, AMPLIFIED by scheme-enabled MallocStackLogging → main thread
+   saturated for >120s → whatever async/main test runs next hangs and is killed.
+
+## Verification
+
+<!-- TBD: reproduce hang reliably (baseline), apply fix, show full suite green
+twice at iters-1 with the hang eliminated; spindump no longer shows the
+AccountDetailViewModel observer hot-loop. -->

--- a/.forgeos/intent/hermeticity-leaker-accountdetail-vm.md
+++ b/.forgeos/intent/hermeticity-leaker-accountdetail-vm.md
@@ -99,6 +99,23 @@ Mechanism (multi-factor):
 
 ## Verification
 
-<!-- TBD: reproduce hang reliably (baseline), apply fix, show full suite green
-twice at iters-1 with the hang eliminated; spindump no longer shows the
-AccountDetailViewModel observer hot-loop. -->
+- **Positive control:** full-suite iters-1 reproduced the hang on 2 of 3 baseline
+  shuffles (victims EPUBSearch, CatalogSearch) — two matching spindumps (pids
+  93263, 5771) both showing the AccountDetailViewModel observer → O(~1142)
+  `account()` hot-loop.
+- **#1 + A (landed: a91aaa8db):** full-suite iters-1 **completed with NO timeout
+  twice** (validate1 445s, validate2) — the hang is eliminated; the O(1) index
+  makes a churn-fired observer cost ~nothing. `AccountsManagerAccountIndexTests`
+  5/5 (incl. the reseed desync guard).
+- **GeneralCache race (landed: e09f2098f):** fix A unmasked a pre-existing
+  self-contained async-write race in `GeneralCacheTests`; fixed by polling the
+  written file. Passes in isolation + full suite.
+- **#2 leak — DEFERRED (scope reduction, reported to palace-pm):** the hermetic
+  `AccountDetailViewModelLeakTests` proved the VM does not deallocate — a 4-hop
+  retain cycle through `TPPNetworkResponder.credentialsProvider` (strong `let`),
+  a CRITICAL-PATH fix needing architect + SoD. The hang does NOT depend on it
+  (#1 neutralizes the leaked observer's cost); it is a real production leak to
+  fix at root in a follow-up. Leak-repro test + cycle-break + observer-leak gate
+  land together in the SoD-gated #2.
+- **#3 (TPPNetworkExecutor real-network escape) + observer-leak gate promotion +
+  pool-gate promotion:** scoped follow-ups (design approved; not yet implemented).

--- a/.forgeos/wall-failures/2026-06-29-accountdetail-perf-guard-omitted.md
+++ b/.forgeos/wall-failures/2026-06-29-accountdetail-perf-guard-omitted.md
@@ -1,0 +1,64 @@
+---
+date: 2026-06-29
+source: near-miss
+walls: [implementer, reviewer]
+severity: medium
+wall_status: open
+---
+
+# accountdetail-perf-guard-omitted
+
+## Finding
+
+Independent SoD architect review (rev_f1d31c74) BLOCKED #1 (a91aaa8db, the O(1)
+`AccountsManager.account()` index that fixes the AccountDetailViewModel hang):
+the design doc `docs/architecture/hermeticity-accountdetail-hang-fix-design.md`
+(Fix #1 → "Structural guard") committed to a **complexity-contract test pinning
+that `account()` does not scale with N** — but the shipped tests
+(`AccountsManagerAccountIndexTests`, 5 cases) were all correctness/coherence
+(incl. the desync guard). The desync test guards index COHERENCE, not the O(1)
+COMPLEXITY contract. Since O(1) *is* the hang fix, its core property shipped with
+no recurrence guard: a revert to the old `accountSets.values.first { contains }`
+O(n) scan would pass every test.
+
+## What actually happened
+
+The correctness tests (multi-bucket resolve, reseed desync, boundary, pure
+builder) all genuinely pass and look thorough, which masked the absence of the
+one guard that matters for the fix's PURPOSE. "Lots of green tests" read as
+"well-tested" while the complexity invariant — the whole reason for the change —
+was unguarded. The design had already named the guard; the implementer simply
+did not reconcile the shipped test set against the design's committed guards
+before declaring READY.
+
+## Walls that should have caught it
+
+- **Implementer (TDD/DoD):** the Definition-of-Done self-checks verify tests
+  exist + kill mutants, but mutation was near-zero-surface here (dict + for-in),
+  so the kill-rate signal was empty AND there was no check that the design's
+  *named* guards were actually implemented.
+- **Reviewer:** caught it (SoD architect BLOCK) — so the human/role wall held,
+  but only after READY was declared. The gap is structural: nothing reconciled
+  "design committed guard X" against "diff contains a test for X" earlier.
+
+## Proposed permanent fix
+
+A reconciliation check: when an intent/design doc commits to a named guard test
+(phrases like "guard", "contract test", "recurrence guard", "must FAIL on
+revert", "pin … does not scale"), the diff must contain a test whose name/body
+references that property before promote — analogous to
+`check-contract-reconciliation.py` for "removes X / adds Y" claims, but for
+"design-committed guard ⇒ test present". Grep-able seed: scan the changeset's
+design/intent docs for `recurrence guard|complexity contract|must FAIL|does not
+scale|perf[- ]contract` and require a matching test selector in the diff.
+Until that detector exists, add a DoD self-check line: "for every guard the
+design NAMES, paste the test that implements it." Catches this exact class
+(design-committed-guard-shipped-without-it).
+
+## Application log
+
+- 2026-06-29: filed. Perf-contract guard added in
+  `AccountsManagerAccountIndexTests.testAccount_lookupIsConstantTime_notLinearInAccountCount`
+  (comparative small-vs-large bucket timing; O(n) revert ⇒ ~40× ⇒ fails the 8×
+  ceiling). Clears rev_f1d31c74 requirement #1. Detector (#2) proposed above,
+  not yet implemented — tracked here.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -379,6 +379,7 @@
 		411FE5619F2A1B79454C26ED /* ChaosFaultInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC95BE63D9C7C7AE1EFB8D6B /* ChaosFaultInjectionTests.swift */; };
 		4156D2A2D92766E8268939A4 /* CredentialGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A0B2DA8FB8ABF53C9E32FF /* CredentialGuardTests.swift */; };
 		4172AAE925DEBEDDF9681174 /* TPPLinearView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE97656B54F67282B7B52648 /* TPPLinearView.swift */; };
+		42291E2648C8C7E849A1FEF3 /* AccountsManagerAccountIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D483FA9CC0C0F9A778DED7 /* AccountsManagerAccountIndexTests.swift */; };
 		423525D426442C6249B2F267 /* LCPPDFOpenProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C86F54125C3BD725906F86 /* LCPPDFOpenProgress.swift */; };
 		426EAF683902FAB74F18193A /* OfflineQueueStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A20EB1443A7F62505E2071 /* OfflineQueueStatusView.swift */; };
 		42B90B321C764EAF8456945B /* FacetViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E59F675A3E4419BE1E24BB /* FacetViewModelTests.swift */; };
@@ -2390,6 +2391,7 @@
 		65988BBA901E65AA0905EF43 /* ScopedResetTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScopedResetTests.swift; sourceTree = "<group>"; };
 		65C628E6207F3958E194D07C /* BorrowOperationStreamingHTMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BorrowOperationStreamingHTMLTests.swift; sourceTree = "<group>"; };
 		65F03A0005DBD80853C64D12 /* OPDS2PublicationExtendedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2PublicationExtendedTests.swift; sourceTree = "<group>"; };
+		66D483FA9CC0C0F9A778DED7 /* AccountsManagerAccountIndexTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerAccountIndexTests.swift; sourceTree = "<group>"; };
 		673C54DADAEAD820B2DABB9D /* TPPReaderPositionReportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderPositionReportTests.swift; sourceTree = "<group>"; };
 		673C77C2D01F4E0AB1787C9D /* MyBooksDownloadCenterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterIntegrationTests.swift; sourceTree = "<group>"; };
 		678E47FC2F39F84744921B33 /* DownloadProgressPublisherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadProgressPublisherTests.swift; sourceTree = "<group>"; };
@@ -4000,6 +4002,7 @@
 				8EE910995BD08220089FEBB1 /* AccountDetailsAuthenticationIsBrowserBasedTests.swift */,
 				4C9D88C19C8C537405C71724 /* AccountsManagerCancellationTests.swift */,
 				810C0A1999902FEEE96BD07D /* AccountAuthSurfaceHostsTests.swift */,
+				66D483FA9CC0C0F9A778DED7 /* AccountsManagerAccountIndexTests.swift */,
 			);
 			path = Accounts;
 			sourceTree = "<group>";
@@ -7447,6 +7450,7 @@
 				20B17E24C48EC2CCF3A25977 /* BookRegistrySyncReentrancyTests.swift in Sources */,
 				12695B15A63B66C4B42E9B13 /* TPPReaderFootnoteAccessibilityTests.swift in Sources */,
 				0C3DD40B825558E7A86B603F /* TPPConfigurationCustomRegistryTests.swift in Sources */,
+				42291E2648C8C7E849A1FEF3 /* AccountsManagerAccountIndexTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace.xcodeproj/xcshareddata/xcschemes/Palace.xcscheme
+++ b/Palace.xcodeproj/xcshareddata/xcschemes/Palace.xcscheme
@@ -61,18 +61,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-         <AdditionalOption
-            key = "MallocStackLogging"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
-            key = "PrefersMallocStackLoggingLite"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-      </AdditionalOptions>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -143,6 +143,15 @@ struct CatalogCacheMetadata: Codable {
     private lazy var networkExecutor: TPPNetworkExecutor = AppContainer.production().networkExecutor
     private var accountSet: String
     private var accountSets = [String: [Account]]()
+    /// O(1) `uuid → Account` index derived from `accountSets`, kept in lockstep
+    /// with it under `accountSetsLock`. Lets `account(_:)` resolve a UUID without
+    /// a linear scan over every bucket — the registry snapshot holds ~1142
+    /// accounts, and `account(_:)` is on the main-thread display path for every
+    /// account-change-driven view refresh, so the old `accountSets.values.first {
+    /// $0.contains(where:) }` scan saturated the main thread (the test-suite hang
+    /// class, and a live-app cost on every library switch). MUST only be mutated
+    /// via `mutateAccountSets` so it can never desync from `accountSets`.
+    private var accountByUUID = [String: Account]()
     private let accountSetsLock = DispatchQueue(label: "com.tpp.accountSetsLock", attributes: .concurrent)
 
     private let catalogPreloader = CatalogPreloader()
@@ -320,7 +329,7 @@ struct CatalogCacheMetadata: Codable {
             let accounts = feed.catalogs.map {
                 Account(publication: $0, imageCache: ImageCache.shared)
             }
-            performWrite { self.accountSets[hash] = accounts }
+            mutateAccountSets { $0[hash] = accounts }
             // Account state-machine wiring (3.2.0): Phase 1 — drive every
             // preloaded account into `.basicInfoLoaded`. Display-only
             // consumers (Settings/Libraries) can render the row immediately;
@@ -349,6 +358,33 @@ struct CatalogCacheMetadata: Codable {
         accountSetsLock.async(flags: .barrier) {
             block()
         }
+    }
+
+    /// The ONLY sanctioned way to mutate `accountSets`. Applies `mutate` to the
+    /// dictionary inside the `accountSetsLock` barrier, then rebuilds the
+    /// `accountByUUID` index in the same critical section so the two can never
+    /// desync. Every write site (preload hydrate, network load, the test seams)
+    /// goes through here — adding a new write that bypasses it would silently
+    /// break `account(_:)` lookups, which the index-coherence test guards against.
+    private func mutateAccountSets(_ mutate: @escaping (inout [String: [Account]]) -> Void) {
+        accountSetsLock.async(flags: .barrier) {
+            mutate(&self.accountSets)
+            self.accountByUUID = AccountsManager.buildAccountIndex(self.accountSets)
+        }
+    }
+
+    /// Pure: flatten `accountSets` into a `uuid → Account` index. When a UUID
+    /// appears in more than one bucket (e.g. an account present in both the
+    /// prod and beta registries), the last-enumerated wins — equivalent to the
+    /// nondeterministic "first across `values`" the prior linear scan returned.
+    static func buildAccountIndex(_ sets: [String: [Account]]) -> [String: Account] {
+        var index = [String: Account]()
+        for accounts in sets.values {
+            for account in accounts {
+                index[account.uuid] = account
+            }
+        }
+        return index
     }
 
     // MARK: - Account Retrieval
@@ -454,9 +490,7 @@ struct CatalogCacheMetadata: Codable {
 
     func account(_ uuid: String) -> Account? {
         return performRead {
-            accountSets.values
-                .first { $0.contains(where: { $0.uuid == uuid }) }?
-                .first(where: { $0.uuid == uuid })
+            accountByUUID[uuid]
         }
     }
 
@@ -487,17 +521,17 @@ struct CatalogCacheMetadata: Codable {
     @discardableResult
     func _seedAccountForTesting(_ account: Account) -> () -> Void {
         let seedKey = self.accountSet
-        performWrite {
-            var seeded = self.accountSets[seedKey] ?? []
+        mutateAccountSets {
+            var seeded = $0[seedKey] ?? []
             seeded.removeAll { $0.uuid == account.uuid }
             seeded.append(account)
-            self.accountSets[seedKey] = seeded
+            $0[seedKey] = seeded
         }
         let previousId = defaults.string(forKey: currentAccountIdentifierKey)
         defaults.set(account.uuid, forKey: currentAccountIdentifierKey)
         return {
-            self.performWrite {
-                self.accountSets[seedKey]?.removeAll { $0.uuid == account.uuid }
+            self.mutateAccountSets {
+                $0[seedKey]?.removeAll { $0.uuid == account.uuid }
             }
             if let prev = previousId {
                 self.defaults.set(prev, forKey: currentAccountIdentifierKey)
@@ -1163,9 +1197,7 @@ struct CatalogCacheMetadata: Codable {
                 }
             }
 
-            self.performWrite {
-                self.accountSets[hash] = newAccounts
-            }
+            self.mutateAccountSets { $0[hash] = newAccounts }
 
             // Account state-machine wiring (3.2.0): Phase 1 — drive every
             // freshly-constructed account into its post-load terminal state.
@@ -1295,7 +1327,7 @@ extension AccountsManager {
     /// `account(_ uuid:)` — multi-bucket scenarios are not otherwise
     /// reachable from outside the class.
     func _testSetAccountSet(_ accounts: [Account], forKey key: String) {
-        performWrite { self.accountSets[key] = accounts }
+        mutateAccountSets { $0[key] = accounts }
     }
 
     /// Test-only: cancel the in-flight background `loadCatalogs` Task (if any)

--- a/PalaceTests/Accounts/AccountsManagerAccountIndexTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerAccountIndexTests.swift
@@ -99,4 +99,52 @@ final class AccountsManagerAccountIndexTests: PalaceWiringTestCase {
     func testBuildAccountIndex_emptyInput_isEmpty() {
         XCTAssertTrue(AccountsManager.buildAccountIndex([:]).isEmpty)
     }
+
+    // MARK: - Complexity contract (THE recurrence guard for the hang fix)
+
+    /// `account(_:)` MUST be ~constant-time, independent of the account count —
+    /// that O(1) property is the actual hang fix (a churn-fired observer doing
+    /// account() lookups over the ~1142-account snapshot saturated the main
+    /// thread). A revert to the old `accountSets.values.first { contains(where:) }`
+    /// O(n) scan must FAIL this test.
+    ///
+    /// Comparative, not absolute-timing (machine-independent, CI-safe): the same
+    /// K lookups are timed against a SMALL bucket and a LARGE bucket. Per-call
+    /// `performRead` dispatch overhead is identical for both, so for an O(1) index
+    /// the two times are within a small constant factor; an O(n) scan makes the
+    /// large-bucket time scale with N (≈ large/small ≈ 40×). The 8× ceiling sits
+    /// well above O(1) noise and far below the O(n) blow-up.
+    func testAccount_lookupIsConstantTime_notLinearInAccountCount() {
+        let manager = makeFreshAccountsManager()
+        let small = 50
+        let large = 2000
+        let lookups = 20_000
+
+        func timeLookups(bucketSize: Int) -> TimeInterval {
+            let accounts = (0..<bucketSize).map { stubAccount("scale-\(bucketSize)-\($0)") }
+            manager._testSetAccountSet(accounts, forKey: "scale-\(bucketSize)")
+            // Look up the LAST uuid — worst case for a linear scan (it would scan
+            // the whole bucket every call), best case is identical for the index.
+            let target = "scale-\(bucketSize)-\(bucketSize - 1)"
+            // Warm up, then measure.
+            for _ in 0..<1000 { _ = manager.account(target) }
+            let start = Date()
+            for _ in 0..<lookups { _ = manager.account(target) }
+            return Date().timeIntervalSince(start)
+        }
+
+        let tSmall = timeLookups(bucketSize: small)
+        let tLarge = timeLookups(bucketSize: large)
+
+        XCTAssertEqual(manager.account("scale-\(large)-\(large - 1)")?.uuid,
+                       "scale-\(large)-\(large - 1)",
+                       "sanity: the large-bucket target resolves")
+        XCTAssertLessThan(
+            tLarge, tSmall * 8 + 0.05,
+            "account(_:) must not scale with account count — \(large) accounts took "
+            + "\(tLarge)s vs \(small) accounts \(tSmall)s for \(lookups) lookups. A "
+            + "linear scan would be ~\(large / small)× slower; the O(1) index must "
+            + "stay within a small constant factor. This is the hang-fix recurrence guard."
+        )
+    }
 }

--- a/PalaceTests/Accounts/AccountsManagerAccountIndexTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerAccountIndexTests.swift
@@ -1,0 +1,102 @@
+//
+//  AccountsManagerAccountIndexTests.swift
+//  PalaceTests
+//
+//  Guards the O(1) `uuid → Account` index behind `AccountsManager.account(_:)`
+//  (hermeticity-leaker-accountdetail-vm). The prior implementation linear-scanned
+//  every bucket of `accountSets` on the MAIN thread for every account-change view
+//  refresh; over the ~1142-account registry snapshot that saturated the main
+//  thread (the post-3.2.0 CI hang class) and cost the live app on every library
+//  switch. These tests pin both the correctness of the index AND that it can
+//  never desync from `accountSets` — the desync test is the structural guard:
+//  remove the `accountByUUID = buildAccountIndex(...)` rebuild inside
+//  `mutateAccountSets` and the reseed test fails (stale lookup survives).
+//
+//  Subclasses PalaceWiringTestCase for `makeFreshAccountsManager()` (pins the
+//  defer flag + cancels background work on teardown) and the quiescence floor.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+final class AccountsManagerAccountIndexTests: PalaceWiringTestCase {
+
+    private func stubAccount(_ uuid: String) -> Account {
+        let metadata = OPDS2Publication.Metadata(id: uuid, title: "Stub \(uuid.prefix(6))")
+        let publication = OPDS2Publication(links: [], metadata: metadata, images: nil)
+        return Account(publication: publication, imageCache: ImageCache.shared)
+    }
+
+    // MARK: - Correctness across buckets
+
+    /// `account(_:)` must resolve a UUID that lives in ANY bucket, not only the
+    /// first-enumerated one. Kills a mutation that indexes a single bucket.
+    func testAccount_resolvesUUIDInEitherBucket() {
+        let manager = makeFreshAccountsManager()
+        let prodA = stubAccount("uuid-prod-A")
+        let betaB = stubAccount("uuid-beta-B")
+        manager._testSetAccountSet([prodA], forKey: "prod-hash")
+        manager._testSetAccountSet([betaB], forKey: "beta-hash")
+
+        XCTAssertEqual(manager.account("uuid-prod-A")?.uuid, "uuid-prod-A",
+                       "account(_:) must resolve a UUID from the prod bucket")
+        XCTAssertEqual(manager.account("uuid-beta-B")?.uuid, "uuid-beta-B",
+                       "account(_:) must resolve a UUID from the beta bucket")
+    }
+
+    // MARK: - Desync guard (THE structural guard)
+
+    /// Re-seeding a bucket must rebuild the index: an account removed by the
+    /// reseed must STOP being found, and a newly-added one must START being
+    /// found. If `mutateAccountSets` ever stops rebuilding `accountByUUID`, the
+    /// removed account keeps resolving from the stale index → this fails.
+    func testAccount_reseedRebuildsIndex_removedGoneAddedFound() {
+        let manager = makeFreshAccountsManager()
+        let a = stubAccount("uuid-A")
+        let b = stubAccount("uuid-B")
+        manager._testSetAccountSet([a, b], forKey: "hash")
+        XCTAssertNotNil(manager.account("uuid-A"), "Precondition: A present after first seed")
+
+        // Reseed the SAME bucket without A, with a new C.
+        let c = stubAccount("uuid-C")
+        manager._testSetAccountSet([b, c], forKey: "hash")
+
+        XCTAssertNil(manager.account("uuid-A"),
+                     "A was removed by the reseed — a stale index would still return it")
+        XCTAssertEqual(manager.account("uuid-C")?.uuid, "uuid-C",
+                       "C was added by the reseed and must be found")
+        XCTAssertNotNil(manager.account("uuid-B"), "B survived the reseed")
+    }
+
+    // MARK: - Boundary cases (preserve prior contract)
+
+    func testAccount_unknownUUID_returnsNil() {
+        let manager = makeFreshAccountsManager()
+        manager._testSetAccountSet([stubAccount("uuid-X")], forKey: "hash")
+        XCTAssertNil(manager.account("uuid-does-not-exist"))
+        XCTAssertNil(manager.account(""), "Empty UUID must not resolve")
+    }
+
+    // MARK: - Pure index builder semantics
+
+    /// `buildAccountIndex` maps every account by UUID; on a duplicate UUID across
+    /// buckets the last-enumerated wins (documented equivalent of the prior
+    /// nondeterministic "first across values"). Kills a mutation that drops
+    /// accounts or mis-keys the index.
+    func testBuildAccountIndex_mapsAllAccounts() {
+        let a = stubAccount("u-1")
+        let b = stubAccount("u-2")
+        let index = AccountsManager.buildAccountIndex(["h1": [a], "h2": [b]])
+        XCTAssertEqual(index.count, 2)
+        XCTAssertEqual(index["u-1"]?.uuid, "u-1")
+        XCTAssertEqual(index["u-2"]?.uuid, "u-2")
+        XCTAssertNil(index["missing"])
+    }
+
+    func testBuildAccountIndex_emptyInput_isEmpty() {
+        XCTAssertTrue(AccountsManager.buildAccountIndex([:]).isEmpty)
+    }
+}

--- a/PalaceTests/Utilities/GeneralCacheTests.swift
+++ b/PalaceTests/Utilities/GeneralCacheTests.swift
@@ -232,11 +232,16 @@ final class GeneralCacheTests: XCTestCase {
         let firstURL = diskCache.fileURL(for: firstKey)
         let cacheDir = firstURL.deletingLastPathComponent()
 
-        // Wait for the async barrier write to materialize the cache directory
-        // on disk. Poll the actual signal (directory existence) instead of
-        // sleeping for a fixed wall-clock delay.
+        // Wait for the async barrier write to FULLY materialize — poll the
+        // written FILE, not just the directory. The directory is created before
+        // the file is written, so waiting on directory-existence alone returns
+        // while the file write is still queued; that pending write then races
+        // the `removeItem` below and recreates the directory, flaking the
+        // "directory is gone" precondition. This surfaced once `MallocStackLogging`
+        // (which slowed allocations enough to mask the race) was removed from the
+        // test scheme. Polling the file makes the test timing-independent.
         awaitCondition(timeout: 5.0) {
-            FileManager.default.fileExists(atPath: cacheDir.path)
+            FileManager.default.fileExists(atPath: firstURL.path)
         }
         XCTAssertTrue(FileManager.default.fileExists(atPath: cacheDir.path),
                       "Precondition: cache directory exists after first write")

--- a/docs/architecture/hermeticity-accountdetail-hang-fix-design.md
+++ b/docs/architecture/hermeticity-accountdetail-hang-fix-design.md
@@ -66,10 +66,36 @@ setupViews(); accountDidChange() }` captures `self` STRONGLY (no `[weak self]`),
 and `ensureAuthenticationDocumentIsLoaded`'s chain keeps it alive on a slow
 real-network auth-doc load. Tests create the VM as a local `let`, never torn down.
 
-**Fix (production, Settings — design+review).**
-- `loadInitialData()`: `Task { @MainActor [weak self] in self?... }` (both arms).
-- Audit the other 8 `Task { @MainActor in ... }` sites in the VM for the same
-  strong-self capture (:230,:237,:472,:489,:507,:532 + signInTimeoutTask).
+**UPDATE (2026-06-29) — the leak is a 4-hop RETAIN CYCLE, not just a strong-self Task.**
+A hermetic leak-repro test (`AccountDetailViewModelLeakTests`, seeds an account,
+no keychain gate) proved the VM does NOT deallocate even after the `loadInitialData`
+weak-self fix. Spindump-independent root: the VM constructs
+`TPPNetworkExecutor(credentialsProvider: self, …)` (AccountDetailViewModel.swift:157)
+and hands it to `businessLogic`. The cycle:
+
+  VM → `businessLogic` (strong, :50)
+     → `networker` = the executor (TPPSignInBusinessLogic.swift:83, strong)
+     → `responder` (TPPNetworkExecutor → TPPNetworkResponder, strong)
+     → `credentialsProvider` (TPPNetworkResponder.swift:37, `private let` — STRONG)
+     → **VM**
+
+So every `AccountDetailViewModel` leaks in production (Settings → Account screen),
+taking its account-change observers + a whole network stack with it. `uiDelegate`
+is already `weak` (TPPSignInBusinessLogic.swift:120) and `userInputProvider` is
+weak — `credentialsProvider` is the one strong back-edge.
+
+**Root fix (CRITICAL-PATH — TPPNetworkResponder is the auth-error decision point;
+architect + SoD REQUIRED):** make `TPPNetworkResponder.credentialsProvider` a
+`weak var`. `NYPLBasicAuthCredentialsProvider` must be class-bound to allow weak;
+the existing fallback at TPPNetworkResponder.swift:641 (`credentialsProvider ??
+AppContainer.production().accountsManager.currentUserAccount`) already handles a
+nil provider, so a deallocated transient provider degrades to the singleton —
+which is the correct behavior. Verify no production caller relies on the responder
+RETAINING a transient provider. Plus the `loadInitialData` weak-self cleanup.
+
+**Structural guard:** the hermetic `AccountDetailViewModelLeakTests` dealloc
+assertion (red-first: fails today, passes once the cycle is broken) + promoting
+the NotificationCenter observer-leak detector below.
 
 **Structural guard (the class-closer).** Promote the EXISTING warn-only
 NotificationCenter observer-leak detector. Today `PalaceSingletonResetObserver.

--- a/docs/architecture/hermeticity-accountdetail-hang-fix-design.md
+++ b/docs/architecture/hermeticity-accountdetail-hang-fix-design.md
@@ -1,0 +1,120 @@
+# Design — AccountDetailViewModel hang class (hermeticity leaker hunt)
+
+**Status:** design-for-review (SoD). Investigation complete; see
+`.forgeos/intent/hermeticity-leaker-accountdetail-vm.md` for the real-artifact
+reproduction + spindump root cause.
+**Owner:** test-hermeticity leaker hunt (palace-hermeticity).
+**Approved direction (Chairman, 2026-06-29):** systemic, not the amplifier patch.
+Each layer fixed at its root with a structural guard so the CLASS can't recur.
+
+## The hang (one sentence)
+
+A leaked `AccountDetailViewModel` `@MainActor` account-change observer re-runs an
+O(~1142) `account()` linear scan on the main thread on every
+`.TPPCurrentAccountDidChange` post — the posts driven by a real-network catalog
+refresh churn — saturating the main thread >120s so the next async/main test
+hangs (victim varies by shuffle: TPPSettings / CatalogPreloader / EPUBSearch).
+
+## Fix A — remove MallocStackLogging from the test scheme  [DONE, hygiene]
+
+`Palace.xcscheme` Test action carried `MallocStackLogging` +
+`PrefersMallocStackLoggingLite` (Diagnostics-tab leftover). The spindump shows
+~50% of the hot-loop leaf time is `stack_logging_lite_malloc` / `thread_stack_pcs`.
+Removed both. **Hygiene, not the fix** — it reduces, not eliminates, the hang
+(the O(n) loop + churn remain). Zero production change.
+
+## Fix #1 — O(1) account lookup  [KEYSTONE · critical-path · design+SoD]
+
+**Problem.** `AccountsManager.account(_:)` (AccountsManager.swift:455-461):
+```swift
+accountSets.values.first { $0.contains(where: { $0.uuid == uuid }) }?
+           .first(where: { $0.uuid == uuid })
+```
+O(total accounts) linear scan under `accountSetsLock`, on the MAIN thread for
+every account-change-driven `setupTableData`. With the bundled 1142-account
+snapshot this is the saturation source. **This is the deepest fix: with O(1)
+lookup, even a leaked observer firing costs ~nothing → no main saturation → no
+hang. It is also a live-app perf win (every account switch pays this today).**
+
+**Design.** Maintain a derived index alongside `accountSets`:
+- Add `private var accountByUUID = [String: Account]()` (guarded by the same
+  `accountSetsLock`).
+- Rebuild it inside `performWrite` at EVERY `accountSets` mutation site (5 sites:
+  :323, :491-500 seed, :1167, :1298 test-seam, and removal in :500). A single
+  private `rebuildAccountIndex()` called at the end of each barrier write keeps
+  it impossible to forget.
+- `account(_:)` becomes `performRead { accountByUUID[uuid] }` — O(1).
+
+**Semantics preserved.** Current code returns the first match across
+`accountSets.values` (dict order nondeterministic). In practice a UUID lives in
+exactly one bucket (a given registry hash); the index is uuid→Account. If a UUID
+ever appeared in two buckets, last-rebuilt wins — acceptably equivalent to the
+nondeterministic current behavior. Documented in the index doc-comment.
+
+**Structural guard.** A unit test that seeds N accounts and asserts `account()`
+returns the right Account AND a contract/perf test pinning that `account()` does
+not scale with account count (e.g. lookups on a 1000-account set complete within
+a tight budget) — so a regression back to a linear scan fails. Mutation: flipping
+the index write must fail the lookup test.
+
+## Fix #2 — observer-leak fix + promote the leak detector to a HARD gate
+
+**Problem.** `AccountDetailViewModel` survives its test with active
+`.TPPCurrentAccountDidChange` / `.TPPUserAccountDidChange` `@MainActor` Combine
+observers. Retained because `loadInitialData()`'s `Task { @MainActor in
+setupViews(); accountDidChange() }` captures `self` STRONGLY (no `[weak self]`),
+and `ensureAuthenticationDocumentIsLoaded`'s chain keeps it alive on a slow
+real-network auth-doc load. Tests create the VM as a local `let`, never torn down.
+
+**Fix (production, Settings — design+review).**
+- `loadInitialData()`: `Task { @MainActor [weak self] in self?... }` (both arms).
+- Audit the other 8 `Task { @MainActor in ... }` sites in the VM for the same
+  strong-self capture (:230,:237,:472,:489,:507,:532 + signInTimeoutTask).
+
+**Structural guard (the class-closer).** Promote the EXISTING warn-only
+NotificationCenter observer-leak detector. Today `PalaceSingletonResetObserver.
+testCaseDidFinish` measures `NotificationCenter.default` observer net-adds and
+emits a `runActivity` warning — but `record()` from `testCaseDidFinish` is inert
+(documented). Move the assertion into `PalaceTestCase.tearDownWithError` (the same
+in-lifecycle pattern the defer-flag gate uses), so a test that leaves net
+observer adds FAILS at its own boundary. A leaked VM (its Combine
+`NotificationCenter.publisher` subscriptions count as observer adds) is then
+caught structurally for the WHOLE leak class, not just this VM.
+- Risk: false positives from tests that legitimately add process-lifetime
+  observers. Mitigation: start warn-only-promoted on `PalaceTestCase` adopters,
+  audit a full green run for zero false positives, THEN flip to `XCTFail` (same
+  promotion discipline as the pool gate). Self-test both directions.
+
+## Fix #3 — close the TPPNetworkExecutor real-network escape  [critical-path · design+SoD]
+
+**Problem.** `NoNetworkURLProtocol.enable()` uses `URLProtocol.registerClass`,
+which only covers `URLSession.shared` (e.g. `LibraryRegistryCrawler` — its
+`/libraries/crawlable` requests ARE blocked). But `TPPNetworkExecutor` builds its
+session via `URLSession(configuration:)`, whose `configuration.protocolClasses`
+does NOT include `NoNetworkURLProtocol` → `AccountsManager.fallbackDirectRefresh
+→ networkExecutor.GET` hits real `registry.palaceproject.io/libraries` (CI: 67s
+elapsed, -1001 timeouts) → the loadCatalogs churn engine.
+
+**Design options (for SoD):**
+- (3a) Test-bootstrap: have `PalaceTestSetup` ensure every production
+  `TPPNetworkExecutor` default session config includes `NoNetworkURLProtocol`
+  first in `protocolClasses`. Cleanest if the executor reads a test-injectable
+  default config.
+- (3b) In DEBUG, `TPPNetworkExecutor`'s default `URLSessionConfiguration` prepends
+  any globally-registered test URLProtocols. Small, contained, DEBUG-gated.
+TPPNetworkExecutor already exposes `init(... sessionConfiguration:)` test inits —
+prefer wiring those rather than new production surface.
+
+**Structural guard.** A hermeticity test that drives `TPPNetworkExecutor.GET` to
+a non-stub host and asserts it is BLOCKED (not a real request) — proving no test
+executor can escape to the network. Pairs with a bootstrap assertion.
+
+## Validation plan
+
+1. Positive control: full suite iters-1 reproduces the hang (spindump shows the
+   AccountDetailViewModel observer hot-loop). [1 spindump captured; 2nd in-flight]
+2. After #1 (+A): re-run; spindump no longer shows the hot-loop; suite green.
+3. After #2/#3: full suite **green twice at iters-1** (the DoD bar), plus the
+   promoted observer-leak gate self-tested both directions, zero false positives
+   on a full green run.
+4. CI parity (iters-3) green; mutation on `account()` index + guards ≥ critical-path bar.


### PR DESCRIPTION
## What
Eliminates the **post-3.2.0 residual CI hang** (the `AccountDetailViewModel` main-thread saturation) that's been flaking `build-and-test` on develop (it just blocked #1122), and lands the production O(1142)→O(1) account-lookup win it surfaced.

## Root cause (2 matching spindumps)
A **leaked `AccountDetailViewModel` `@MainActor` account-change observer** re-ran `AccountsManager.account()` — an **O(~1142) linear scan under `accountSetsLock` on the MAIN thread** — on every `.TPPCurrentAccountDidChange` post (driven by real-network catalog churn), saturating the main thread >120s so the next async test hangs (victim varied by shuffle: TPPSettings / CatalogPreloader / EPUBSearch). Two independent spindumps, identical hot-loop.

## Changes
- **#1 keystone — O(1) account lookup** (`a91aaa8db`): `account()` is now an O(1) `accountByUUID` dict read; all 5 `accountSets` write-sites route through one in-lock `mutateAccountSets` barrier that rebuilds the index (desync-proof); `buildAccountIndex` is static/pure. **Also a live-app perf win** — every account switch paid the O(1142) scan before.
- **Fix A (hygiene)** — removed a stray `MallocStackLogging` / `PrefersMallocStackLoggingLite` from the test scheme (Diagnostics leftover, ~50% of hot-loop leaf time). Not the fix; reduces amplification.
- **GeneralCacheTests race fix** (`e09f2098f`) — fix A *unmasked* a pre-existing self-contained race (the test awaited the cache DIR, not the FILE write); fixed to poll the file (timing-independent). A unmasked it; owned here.
- **Perf-contract guard + wall** (`d706c3a28`) — `testAccount_lookupIsConstantTime_notLinearInAccountCount`, **red-first proven** (~33× slower / FAILS on an O(n) revert; passes at O(1) in 0.031s); wall `2026-06-29-accountdetail-perf-guard-omitted.md`.

## DoD evidence
- Hang **ELIMINATED** — full suite iters-1 green **twice** (final1 + final2, no timeout / no spindump; baseline hung ~66%).
- `AccountsManagerAccountIndexTests` **6/6** incl. the desync guard + the O(1) complexity guard.
- `TEST SUCCEEDED`; intent + wall `harness check` ✓.
- Independent architect SoD BLOCK `rev_f1d31c74` (missing perf guard) — **cleared** by `d706c3a28`.

## Notes for the qa reviewer
- Fix A (hygiene) **unmasked** the pre-existing `GeneralCacheTests` race now owned here.
- `#1`'s near-zero mutation surface is real (dict + `for-in` ops `palace_mutate` doesn't mutate) — the perf guard + desync guard are the behavioral protection. We did **not** contort production code to score mutation (that would game the metric for worse code).

## Follow-up (deliberately NOT in this PR)
The hermetic leak-repro uncovered a real **4-hop production retain cycle** (`VM → businessLogic → networkExecutor → TPPNetworkResponder → credentialsProvider` strong-`let`). Tracked for a **design-first, SoD-reviewed follow-up** (`#2` retain-cycle + `#3` network-escape close + observer-leak hard gate). This PR is kept as the clean, validated hang-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)