### PR TITLE
fix(hermeticity #2): break AccountDetailViewModel retain cycle + leak guard (follow-up to #1127)

### DIFF
--- a/.forgeos/intent/accountdetail-leak-cycle-and-hermetic-network.md
+++ b/.forgeos/intent/accountdetail-leak-cycle-and-hermetic-network.md
@@ -76,6 +76,19 @@ is the one strong back-edge. For #3: `URLProtocol.registerClass`
 builds its own `URLSession(configuration:)` whose `protocolClasses` omits
 NoNetworkURLProtocol.
 
+## Deferred / related (palace-pm decisions, 2026-06-29)
+
+- **Pool-responsiveness gate warn->hard (charter Deliverable A): DEFERRED, keep
+  WARN-ONLY** (decision (ii)). It guards class-4 (pool-starvation), which the
+  real artifact RULED OUT for this hang (17 WS0-POOL-DIAG all completed=true);
+  it already earned its keep AS the diagnostic that ruled pool-starvation out.
+  Promote to hard ONLY after a real false-positive audit, if class-4 ever bites.
+  The observer-leak gate below is the correct guard for the class we fixed.
+- **qa optional follow-ups (fold in if cheap):** (1) pin the dup-UUID
+  cross-bucket tie-break (`buildAccountIndex` last-wins — the one behavior change
+  vs the old nondeterministic scan); (2) keep `AccountsManager.swift` in the
+  pre-release `palace_mutate` run so the 50% floor stays honest.
+
 ## Verification
 
 TBD on implementation: red-first leak-repro fails -> passes when the cycle is

--- a/.forgeos/intent/accountdetail-leak-cycle-and-hermetic-network.md
+++ b/.forgeos/intent/accountdetail-leak-cycle-and-hermetic-network.md
@@ -30,11 +30,17 @@ hang-fix.
   NOT new `#if DEBUG` prod surface) so `AccountsManager.fallbackDirectRefresh ->
   networkExecutor.GET` cannot reach `registry.palaceproject.io` in tests.
 - **structural guards:** (a) hermetic `AccountDetailViewModelLeakTests` dealloc
-  assertion (red-first: fails if the cycle returns); (b) promote the warn-only
-  NotificationCenter observer-leak detector (`PalaceSingletonResetObserver`
-  net-adds) to a HARD gate via `PalaceTestCase.tearDownWithError`, after a
-  zero-false-positive audit on a full green run; (c) a hermeticity test proving
-  no test `TPPNetworkExecutor` escapes to a non-stub host.
+  assertion (red-first: fails if the cycle returns) — **the EFFECTIVE guard**,
+  platform-independent; (b) observer-leak gate via `PalaceTestCase` +
+  `RuntimeQuiescenceAuditor.observerLeakViolations` — implemented WARN-ONLY +
+  self-tested both directions. **NOT promoted to hard:** on the iOS 26 simruntime
+  `NotificationCenter.default.debugDescription` no longer exposes the observer
+  count, so `sampleObserverCount()` returns `nil` and the count-based gate is
+  INERT on the platform we run (the pre-existing `PalaceSingletonResetObserver`
+  runActivity shares this limitation). A hard XCTFail would be inert theater;
+  kept warn-only + nil-skipping so it self-activates if a future runtime restores
+  the API. (c) #3 hermeticity test proving no test `TPPNetworkExecutor` escapes —
+  deferred (non-board-redding; staged).
 
 ## Anti-claims
 

--- a/.forgeos/intent/accountdetail-leak-cycle-and-hermetic-network.md
+++ b/.forgeos/intent/accountdetail-leak-cycle-and-hermetic-network.md
@@ -1,0 +1,84 @@
+---
+name: accountdetail-leak-cycle-and-hermetic-network
+created: 2026-06-29
+author: claude
+type: bugfix
+---
+
+# accountdetail-leak-cycle-and-hermetic-network
+
+Design-first SoD follow-up to `hermeticity-leaker-accountdetail-vm` (the hang fix
+#1 O(1) index + fix A shipped + green-twice on branch
+`fix/test-hermeticity-leaker-hunt`). These are the deeper PROD-weakness roots the
+hang fix neutralized but did not remove. Chairman bar: fix prod at root + test
+hard (red-first), not test-side workarounds. Bundled as ONE SoD-reviewed change
+(palace-pm decision: (b) then (c)). NOT bundled into #1 — #1 stays the clean
+hang-fix.
+
+## Claims
+
+- **#2 — break the AccountDetailViewModel retain cycle (real prod leak).** Make
+  `TPPNetworkResponder.credentialsProvider` `weak` so the cycle
+  VM -> businessLogic -> networker(TPPNetworkExecutor) -> responder ->
+  credentialsProvider(=VM) no longer retains the VM. The nil-fallback at
+  `TPPNetworkResponder.swift:641` (`?? AppContainer.production().accountsManager
+  .currentUserAccount`) already covers a deallocated transient provider.
+  Plus `[weak self]` on `AccountDetailViewModel.loadInitialData`'s init Task.
+- **#3 — close the test real-network escape.** Route the test-time
+  `TPPNetworkExecutor` session through `NoNetworkURLProtocol` via the EXISTING
+  `init(sessionConfiguration:)` seam (palace-pm decision: 3a-via-existing-inits,
+  NOT new `#if DEBUG` prod surface) so `AccountsManager.fallbackDirectRefresh ->
+  networkExecutor.GET` cannot reach `registry.palaceproject.io` in tests.
+- **structural guards:** (a) hermetic `AccountDetailViewModelLeakTests` dealloc
+  assertion (red-first: fails if the cycle returns); (b) promote the warn-only
+  NotificationCenter observer-leak detector (`PalaceSingletonResetObserver`
+  net-adds) to a HARD gate via `PalaceTestCase.tearDownWithError`, after a
+  zero-false-positive audit on a full green run; (c) a hermeticity test proving
+  no test `TPPNetworkExecutor` escapes to a non-stub host.
+
+## Anti-claims
+
+- does NOT change the #1 O(1) index or fix A (already landed).
+- does NOT add `#if DEBUG` to production network code (blast-radius rule; use the
+  existing test-injection init).
+- does NOT change `TPPNetworkResponder`'s auth-error decision logic — only the
+  ownership (`let` -> `weak var`) of `credentialsProvider`, with the existing nil
+  fallback preserved.
+
+## Files in scope
+
+- Palace/Network/TPPNetworkResponder.swift (credentialsProvider weak — CRITICAL-PATH)
+- Palace/Settings/AccountDetailViewModel.swift (loadInitialData [weak self])
+- PalaceTests/ViewModels/AccountDetailViewModelLeakTests.swift (re-add; red-first)
+- PalaceTests/Support/PalaceTestCase.swift + PalaceTests/PalaceTestSetup.swift (observer-leak gate promotion)
+- PalaceTests/NoNetworkURLProtocol.swift / bootstrap + TPPNetworkExecutor test session wiring (#3)
+- PalaceTests/Network/* (executor block-test)
+
+## Reproduction
+
+The hermetic `AccountDetailViewModelLeakTests.testViewModel_deallocatesAfterRelease`
+(written + run 2026-06-29, then held out of #1) asserts the VM deallocates after
+release; it FAILED (weak ref non-nil) even after the loadInitialData weak-self
+change, proving the leak is the 4-hop retain cycle, not just the init Task.
+Real-network escape evidenced in #1122 CI: `registry.palaceproject.io/libraries`
+GET, 67s elapsed, -1001 timeouts (TPPNetworkExecutor session not covered by
+NoNetworkURLProtocol, which only catches URLSession.shared).
+
+## Root cause
+
+`TPPNetworkResponder.swift:37` stores `credentialsProvider` as a strong
+`private let`; the VM passes itself as the provider
+(`AccountDetailViewModel.swift:157`), closing the cycle. `uiDelegate`
+(TPPSignInBusinessLogic.swift:120) and `userInputProvider`
+(TPPUserAccountFrontEndValidation.swift:63) are already weak — credentialsProvider
+is the one strong back-edge. For #3: `URLProtocol.registerClass`
+(NoNetworkURLProtocol.enable) only affects URLSession.shared; TPPNetworkExecutor
+builds its own `URLSession(configuration:)` whose `protocolClasses` omits
+NoNetworkURLProtocol.
+
+## Verification
+
+TBD on implementation: red-first leak-repro fails -> passes when the cycle is
+broken; observer-leak gate self-tested both directions + zero-false-positive
+audit; executor block-test proves no test escapes to the real registry; full
+suite green; architect + qa SoD on the critical-path TPPNetworkResponder change.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -749,6 +749,7 @@
 		76099E9C88874D19A8E1E4F1 /* BookCellModelCacheInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ED6D3F5630D42CFBE6A59A3 /* BookCellModelCacheInvalidationTests.swift */; };
 		766C1BDB436AA9586293ABF7 /* ReadingStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB660AAD998ACFC41771539E /* ReadingStatsStore.swift */; };
 		76A3FDFF52B8F948C2C13A65 /* ReadingStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F8EBC8684EF42942C688A7 /* ReadingStatsService.swift */; };
+		76C676B1C1BF8F2434C03DB9 /* AccountDetailViewModelLeakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACF84E5F5C8C9579E5C61B9 /* AccountDetailViewModelLeakTests.swift */; };
 		76FD3B6DF6B2C07153FBBADE /* TPPBookDetailDownloadFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDA3478B2DF503D6CBD4575 /* TPPBookDetailDownloadFailedView.swift */; };
 		77B0D2A0D5EAB95AFA232581 /* AccessibilityServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2EAE5D772D960178EBD800 /* AccessibilityServiceTests.swift */; };
 		77D37C73FF8E8B1FC7CF6124 /* ReaderInitialLocationNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB1721A59302ABD56C2667E /* ReaderInitialLocationNavigator.swift */; };
@@ -2272,6 +2273,7 @@
 		398C885262F88AA0254CD1C6 /* TPPNetworkResponderAuthCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPNetworkResponderAuthCoordinatorTests.swift; sourceTree = "<group>"; };
 		3A213D524079F39BA952025A /* StreamingReaderPresentationContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingReaderPresentationContractTests.swift; sourceTree = "<group>"; };
 		3A38DEB3619035E1E29DBEA9 /* StreamingReaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingReaderView.swift; sourceTree = "<group>"; };
+		3ACF84E5F5C8C9579E5C61B9 /* AccountDetailViewModelLeakTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountDetailViewModelLeakTests.swift; sourceTree = "<group>"; };
 		3B60ACDE3E15FC832885E932 /* Badge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Badge.swift; sourceTree = "<group>"; };
 		3BB31382B3826FB20CD3BE34 /* URLExtensionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLExtensionTests.swift; sourceTree = "<group>"; };
 		3C0E625DA84AEEFF9840A601 /* LCPAudiobooksTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPAudiobooksTests.swift; sourceTree = "<group>"; };
@@ -3912,6 +3914,7 @@
 				SETVM001T260955EF008E1DC3 /* SettingsViewModelTests.swift */,
 				A1C9CA13B5B94707BFFCB13F /* ViewModelComputedPropertyTests.swift */,
 				6A72A97BA91A0EB66D642A06 /* ActiveSessionsViewModelTests.swift */,
+				3ACF84E5F5C8C9579E5C61B9 /* AccountDetailViewModelLeakTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -7451,6 +7454,7 @@
 				12695B15A63B66C4B42E9B13 /* TPPReaderFootnoteAccessibilityTests.swift in Sources */,
 				0C3DD40B825558E7A86B603F /* TPPConfigurationCustomRegistryTests.swift in Sources */,
 				42291E2648C8C7E849A1FEF3 /* AccountsManagerAccountIndexTests.swift in Sources */,
+				76C676B1C1BF8F2434C03DB9 /* AccountDetailViewModelLeakTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Network/TPPNetworkResponder.swift
+++ b/Palace/Network/TPPNetworkResponder.swift
@@ -34,7 +34,17 @@ class TPPNetworkResponder: NSObject {
     private var tokenRefreshAttempts: Int = 0
     private var taskInfo: [TaskID: TPPNetworkTaskInfo]
     private let useFallbackCaching: Bool
-    private let credentialsProvider: NYPLBasicAuthCredentialsProvider?
+    /// WEAK on purpose: the responder reads the provider ONCE per auth challenge
+    /// (synchronously, with a `?? currentUserAccount` fallback — see
+    /// `urlSession(_:didReceive:...)`), and never retains it beyond a method-local
+    /// `TPPBasicAuth`. A strong reference here closed a retain cycle for any
+    /// provider that also (transitively) owns the executor — the
+    /// `AccountDetailViewModel` case: VM → businessLogic → networkExecutor →
+    /// responder → credentialsProvider(=VM). The only non-nil provider in the app
+    /// is that VM, and it is the ROOT owner of its executor chain, so it is alive
+    /// whenever a challenge fires; every other site passes nil and already relies
+    /// on the fallback. Holding it weakly breaks the leak with no behavior change.
+    private weak var credentialsProvider: NYPLBasicAuthCredentialsProvider?
 
     /// Tracks URLs that have been retried after a 401 to prevent infinite retry loops.
     /// Key is the URL absoluteString, value is the number of retry attempts.

--- a/Palace/Settings/AccountDetailViewModel.swift
+++ b/Palace/Settings/AccountDetailViewModel.swift
@@ -227,10 +227,14 @@ class AccountDetailViewModel: NSObject, ObservableObject {
         isLoadingAuth = true
 
         if businessLogic.libraryAccount?.details != nil {
-            Task { @MainActor in
-                setupViews()
-                accountDidChange()
-                isLoadingAuth = false
+            // [weak self]: this init Task must not keep the view-model alive past
+            // its own scope (defense-in-depth alongside the responder
+            // weak-credentialsProvider cycle break).
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.setupViews()
+                self.accountDidChange()
+                self.isLoadingAuth = false
             }
         } else {
             businessLogic.ensureAuthenticationDocumentIsLoaded { [weak self] success in

--- a/PalaceTests/Accounts/AccountsManagerAccountIndexTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerAccountIndexTests.swift
@@ -100,6 +100,32 @@ final class AccountsManagerAccountIndexTests: PalaceWiringTestCase {
         XCTAssertTrue(AccountsManager.buildAccountIndex([:]).isEmpty)
     }
 
+    /// Tie-break contract for a UUID present in MORE THAN ONE bucket (e.g. an
+    /// account in both the prod and beta registries). The index maps the UUID to
+    /// exactly one entry; WHICH bucket's Account instance wins is unspecified
+    /// (dict-value iteration order) — the same nondeterminism the prior
+    /// `accountSets.values.first { contains }` scan had. What IS pinned: the
+    /// lookup resolves to a non-nil account carrying that exact UUID, never nil
+    /// and never a phantom. This documents the one behavior the O(1) migration
+    /// preserved-but-restated (qa follow-up on #1).
+    func testBuildAccountIndex_duplicateUUIDAcrossBuckets_resolvesToThatUUID() {
+        let dup = "urn:uuid:dup-across-buckets"
+        let prodCopy = stubAccount(dup)
+        let betaCopy = stubAccount(dup)
+        let index = AccountsManager.buildAccountIndex(["prod": [prodCopy], "beta": [betaCopy]])
+
+        XCTAssertEqual(index.count, 1, "a UUID in two buckets collapses to one index entry")
+        XCTAssertEqual(index[dup]?.uuid, dup,
+                       "the entry must carry the duplicated UUID (which instance is unspecified)")
+
+        // Same contract through the live lookup.
+        let manager = makeFreshAccountsManager()
+        manager._testSetAccountSet([prodCopy], forKey: "prod")
+        manager._testSetAccountSet([betaCopy], forKey: "beta")
+        XCTAssertEqual(manager.account(dup)?.uuid, dup,
+                       "account(_:) resolves a cross-bucket duplicate UUID to that UUID, never nil")
+    }
+
     // MARK: - Complexity contract (THE recurrence guard for the hang fix)
 
     /// `account(_:)` MUST be ~constant-time, independent of the account count —

--- a/PalaceTests/MetaTests/RuntimeQuiescenceGateTests.swift
+++ b/PalaceTests/MetaTests/RuntimeQuiescenceGateTests.swift
@@ -118,6 +118,35 @@ final class RuntimeQuiescenceGateTests: PalaceTestCase {
             "A responsive pool MUST NOT flag a violation")
     }
 
+    // MARK: - Observer-leak detector (leaked-observer class) self-tests
+
+    /// Pure detector: net-new observers (>0) MUST flag exactly one violation;
+    /// zero or negative MUST flag none. Proves the detector fires without
+    /// staging a real leak — so promoting `warnOnObserverLeak` to a hard XCTFail
+    /// (after the FP audit) is a one-line change with proven semantics.
+    func testObserverLeakViolations_bothDirections() {
+        XCTAssertEqual(
+            RuntimeQuiescenceAuditor.observerLeakViolations(netObserverAdds: 1).count, 1,
+            "A test that left net-new NotificationCenter observers MUST flag one violation")
+        XCTAssertEqual(
+            RuntimeQuiescenceAuditor.observerLeakViolations(netObserverAdds: 3).count, 1,
+            "Any positive net-add count flags exactly one violation")
+        XCTAssertTrue(
+            RuntimeQuiescenceAuditor.observerLeakViolations(netObserverAdds: 0).isEmpty,
+            "A balanced test (no net adds) MUST NOT trip the gate")
+        XCTAssertTrue(
+            RuntimeQuiescenceAuditor.observerLeakViolations(netObserverAdds: -2).isEmpty,
+            "A test that NET-REMOVED observers MUST NOT trip the gate")
+    }
+
+    /// The violation message must name the remediation paths (injected center /
+    /// remove in tearDown / break the retain cycle) so the failure is actionable.
+    func testObserverLeakViolations_message_isActionable() {
+        let detail = RuntimeQuiescenceAuditor.observerLeakViolations(netObserverAdds: 1).first?.detail ?? ""
+        XCTAssertTrue(detail.contains("tearDown") || detail.contains("retain cycle"),
+                      "Remediation must point at tearDown removal or the retain-cycle break")
+    }
+
     /// Live probe, clean pool: the high-priority probe Task schedules within
     /// budget. Confirms the probe is not a constant-false (which would make the
     /// gate-extension a permanent false-positive).

--- a/PalaceTests/MetaTests/RuntimeQuiescenceGateTests.swift
+++ b/PalaceTests/MetaTests/RuntimeQuiescenceGateTests.swift
@@ -147,6 +147,32 @@ final class RuntimeQuiescenceGateTests: PalaceTestCase {
                       "Remediation must point at tearDown removal or the retain-cycle break")
     }
 
+    /// NON-INERTNESS proof for the live observer-count sampling: a real
+    /// `NotificationCenter.default` observer add must move the sampled count by
+    /// +1. Without this, a `sampleObserverCount()` that always returned a
+    /// constant (or nil) would make the observer-leak gate silently inert — the
+    /// canonical inert-gate trap. If the runtime-private parse is unavailable on
+    /// this host the sample is `nil` and the gate correctly SKIPS (no false
+    /// fail), which this test records via XCTSkip rather than a fake pass.
+    func testSampleObserverCount_reflectsLiveObserverAdd_orSkips() throws {
+        guard let before = PalaceSingletonResetObserver.sampleObserverCount() else {
+            throw XCTSkip("NotificationCenter observer count unavailable on this host — "
+                          + "the warn/gate correctly skips (nil sample ⇒ no violation).")
+        }
+        let token = NotificationCenter.default.addObserver(
+            forName: Notification.Name("WS0-observer-selftest"),
+            object: nil, queue: nil
+        ) { _ in }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let after = PalaceSingletonResetObserver.sampleObserverCount()
+        XCTAssertEqual(
+            after.map { $0 - before }, 1,
+            "sampleObserverCount() must reflect a live observer add (+1) — else the "
+            + "observer-leak gate is inert. Got before=\(before), after=\(String(describing: after))."
+        )
+    }
+
     /// Live probe, clean pool: the high-priority probe Task schedules within
     /// budget. Confirms the probe is not a constant-false (which would make the
     /// gate-extension a permanent false-positive).

--- a/PalaceTests/PalaceTestSetup.swift
+++ b/PalaceTests/PalaceTestSetup.swift
@@ -242,9 +242,10 @@ class PalaceSingletonResetObserver: NSObject, XCTestObservation {
 
     /// Returns the current observer count from `NotificationCenter.default`
     /// when reachable. Best-effort — returns nil if the runtime-private
-    /// API is unavailable. Audit-only — used solely for delta warnings,
-    /// never as a hard assertion.
-    private static func sampleObserverCount() -> Int? {
+    /// API is unavailable. Audit-only — used for delta warnings here and by
+    /// `PalaceTestCase`'s per-test observer-leak gate (warn-only until the
+    /// false-positive audit clears promotion to a hard XCTFail).
+    static func sampleObserverCount() -> Int? {
         // The implementation uses a `debugDescription` parse — the
         // `debugDescription` of NSNotificationCenter contains a line of
         // the form `<NSNotificationCenter: 0x...> observers: <N>` on

--- a/PalaceTests/Support/PalaceTestCase.swift
+++ b/PalaceTests/Support/PalaceTestCase.swift
@@ -36,6 +36,16 @@ import XCTest
 /// Base XCTestCase that asserts runtime quiescence on tearDown. See header.
 class PalaceTestCase: XCTestCase {
 
+    /// Pre-test `NotificationCenter.default` observer count, captured in setUp.
+    /// `nil` when the best-effort sample is unavailable (then the observer-leak
+    /// check is skipped). Subclasses overriding `setUpWithError` MUST call super.
+    private var preObserverCount: Int?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        preObserverCount = PalaceSingletonResetObserver.sampleObserverCount()
+    }
+
     override func tearDownWithError() throws {
         // Call super FIRST. `XCTestCase.tearDownWithError()` invokes the
         // subclass's `tearDown()` (where flag-flippers like
@@ -45,6 +55,28 @@ class PalaceTestCase: XCTestCase {
         // check ran before the restore. Verified by the WS-0 ordering proof.
         try super.tearDownWithError()
         assertRuntimeQuiescent()
+        warnOnObserverLeak()
+    }
+
+    /// WARN-ONLY observer-leak check (leaked-observer class). Emits a
+    /// `[WS0-OBSERVER-DIAG]` breadcrumb if this test left net-new
+    /// `NotificationCenter.default` observers — e.g. a leaked view-model whose
+    /// Combine subscriptions stay alive (the AccountDetailViewModel cycle class,
+    /// now fixed at root; this guards recurrence). NOT yet an `XCTFail`: the
+    /// app-wide count is a best-effort `debugDescription` parse and concurrent
+    /// background observers can add noise, so promotion to a hard gate is gated
+    /// on a zero-false-positive audit across a full green run — the same
+    /// warn→hard discipline as the pool-responsiveness gate. Pure detector
+    /// (`RuntimeQuiescenceAuditor.observerLeakViolations`) is self-tested both
+    /// directions so the flip-to-hard is a one-line change once the audit clears.
+    private func warnOnObserverLeak() {
+        guard let pre = preObserverCount,
+              let post = PalaceSingletonResetObserver.sampleObserverCount() else { return }
+        preObserverCount = nil
+        for violation in RuntimeQuiescenceAuditor.observerLeakViolations(netObserverAdds: post - pre) {
+            NSLog("[WS0-OBSERVER-DIAG] %@ left net observer adds (%d→%d) [%@] — see PalaceTestCase.warnOnObserverLeak (warn-only pending FP audit).",
+                  self.name, pre, post, violation.invariant)
+        }
     }
 
     /// Fail the current test if it left the suite non-quiescent (currently: the

--- a/PalaceTests/Support/PalaceTestCase.swift
+++ b/PalaceTests/Support/PalaceTestCase.swift
@@ -62,13 +62,21 @@ class PalaceTestCase: XCTestCase {
     /// `[WS0-OBSERVER-DIAG]` breadcrumb if this test left net-new
     /// `NotificationCenter.default` observers — e.g. a leaked view-model whose
     /// Combine subscriptions stay alive (the AccountDetailViewModel cycle class,
-    /// now fixed at root; this guards recurrence). NOT yet an `XCTFail`: the
-    /// app-wide count is a best-effort `debugDescription` parse and concurrent
-    /// background observers can add noise, so promotion to a hard gate is gated
-    /// on a zero-false-positive audit across a full green run — the same
-    /// warn→hard discipline as the pool-responsiveness gate. Pure detector
-    /// (`RuntimeQuiescenceAuditor.observerLeakViolations`) is self-tested both
-    /// directions so the flip-to-hard is a one-line change once the audit clears.
+    /// now fixed at root; this guards recurrence).
+    ///
+    /// PLATFORM LIMITATION (measured 2026-06-29, iOS 26 simruntime): the only
+    /// way to count `NotificationCenter.default` observers is parsing its
+    /// `debugDescription`, and on iOS 26 that string no longer exposes an
+    /// `observers: <N>` line — `sampleObserverCount()` returns `nil`, so this
+    /// check (and the pre-existing `PalaceSingletonResetObserver` net-adds
+    /// runActivity, same source) is INERT on the platform we actually run. It is
+    /// kept warn-only + nil-skipping (graceful, self-tested to skip — NOT a fake
+    /// pass) so it lights up automatically if a future runtime restores the API;
+    /// it is deliberately NOT promoted to a hard `XCTFail`, because an inert
+    /// hard-gate is the exact theater the green-board contract forbids. The
+    /// EFFECTIVE structural guard for this leak class is the platform-independent
+    /// dealloc assertion in `AccountDetailViewModelLeakTests` (red→green proven),
+    /// which does not depend on the observer count at all.
     private func warnOnObserverLeak() {
         guard let pre = preObserverCount,
               let post = PalaceSingletonResetObserver.sampleObserverCount() else { return }

--- a/PalaceTests/Support/RuntimeQuiescenceAuditor.swift
+++ b/PalaceTests/Support/RuntimeQuiescenceAuditor.swift
@@ -165,4 +165,43 @@ enum RuntimeQuiescenceAuditor {
             )
         ]
     }
+
+    // MARK: - Observer-leak detector (leaked-observer class — AccountDetailViewModel)
+
+    /// Invariant: a test must not leave NET-NEW `NotificationCenter.default`
+    /// observers behind. A test that adds observers (directly, or via a leaked
+    /// object whose Combine `NotificationCenter.publisher` subscriptions stay
+    /// alive — the AccountDetailViewModel retain-cycle class) leaves them firing
+    /// against later tests; for a VM that does O(n) main-thread work per
+    /// account-change post, that was the suite-hang driver (now fixed at root by
+    /// the credentialsProvider-weak cycle break + the O(1) index, with this gate
+    /// as the structural guard against recurrence).
+    ///
+    /// - Parameter netObserverAdds: post-test minus pre-test observer count for
+    ///   the finishing test (sampled by the caller). Negative/zero ⇒ clean.
+    /// - Returns: a one-element violation when the test left net-new observers.
+    ///
+    /// Pure so the gate's self-test can prove it fires (`netObserverAdds: 1`)
+    /// without staging a real leak. NOTE: the live count is a best-effort
+    /// app-wide `debugDescription` parse, so the caller must treat a `nil`
+    /// sample as "skip" (not a violation) and promotion to a hard XCTFail is
+    /// gated on a zero-false-positive audit (concurrent background observers can
+    /// add noise) — same warn→hard discipline as the pool-responsiveness gate.
+    static func observerLeakViolations(netObserverAdds: Int) -> [Violation] {
+        guard netObserverAdds > 0 else { return [] }
+        return [
+            Violation(
+                invariant: "NotificationCenter.default observers balanced (no net adds)",
+                detail:
+                    "This test left \(netObserverAdds) net-new NotificationCenter."
+                    + "default observer(s) — either it added observers without a "
+                    + "paired remove in tearDown, or it leaked an object (e.g. a "
+                    + "view-model) whose NotificationCenter subscriptions stayed "
+                    + "alive (the AccountDetailViewModel retain-cycle class). Route "
+                    + "observation through an injected NotificationCenter, remove "
+                    + "observers in tearDown, or break the object's retain cycle "
+                    + "(weak back-edge) so it deallocates and cancels its sinks."
+            )
+        ]
+    }
 }

--- a/PalaceTests/ViewModels/AccountDetailViewModelLeakTests.swift
+++ b/PalaceTests/ViewModels/AccountDetailViewModelLeakTests.swift
@@ -24,8 +24,12 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+// Subclasses PalaceTestCase (not bare XCTestCase): it touches shared singletons
+// (`AppContainer.production()`, `ImageCache.shared`) so the TearDownRequiredLint
+// requires a tearDown — inheriting the `*TestCase` base satisfies it AND adds the
+// runtime-quiescence floor, which is apt for a hermeticity test.
 @MainActor
-final class AccountDetailViewModelLeakTests: XCTestCase {
+final class AccountDetailViewModelLeakTests: PalaceTestCase {
 
     private func stubAccount(_ uuid: String) -> Account {
         let metadata = OPDS2Publication.Metadata(id: uuid, title: "Leak Stub \(uuid.prefix(6))")
@@ -34,7 +38,12 @@ final class AccountDetailViewModelLeakTests: XCTestCase {
     }
 
     func testViewModel_deallocatesAfterRelease_noLeakedObservers() async {
-        let manager = AppContainer.production().accountsManager
+        // Hermetic test AppContainer (not .production()) — the retain cycle is
+        // internal to the VM's OWN executor (it constructs
+        // `TPPNetworkExecutor(credentialsProvider: self)`), so a test container
+        // reproduces it identically while keeping the test isolation-lint clean.
+        let appContainer = makeTestAppContainer()
+        let manager = appContainer.accountsManager
         let uuid = "urn:uuid:leak-test-\(UUID().uuidString)"
         // Seed a current account WITHOUT keychain/network so the VM can be
         // constructed hermetically; teardown restores prior state.
@@ -43,7 +52,7 @@ final class AccountDetailViewModelLeakTests: XCTestCase {
 
         weak var weakVM: AccountDetailViewModel?
         do {
-            let viewModel = AccountDetailViewModel(libraryAccountID: uuid, appContainer: .production())
+            let viewModel = AccountDetailViewModel(libraryAccountID: uuid, appContainer: appContainer)
             weakVM = viewModel
             XCTAssertNotNil(weakVM, "Precondition: VM exists while strongly held")
             await Task.yield()   // let the @MainActor init Task run

--- a/PalaceTests/ViewModels/AccountDetailViewModelLeakTests.swift
+++ b/PalaceTests/ViewModels/AccountDetailViewModelLeakTests.swift
@@ -1,0 +1,63 @@
+//
+//  AccountDetailViewModelLeakTests.swift
+//  PalaceTests
+//
+//  Hermetic leak-repro guard for the AccountDetailViewModel retain cycle
+//  (intent: accountdetail-leak-cycle-and-hermetic-network). Deliberately NOT in
+//  AccountDetailViewModelTests: that class is keychain-gated
+//  (KeychainAvailability.skipIfUnavailable) and SKIPS on hosts without the
+//  keychain entitlement (CI sims, -34018), which would silently skip the leak
+//  proof. This class seeds a stub account directly (no keychain, no network) so
+//  the dealloc assertion always runs.
+//
+//  Red→green proof: this test FAILED while the 4-hop cycle was intact —
+//  VM → businessLogic → networkExecutor → TPPNetworkResponder →
+//  credentialsProvider(=VM) — even after the loadInitialData weak-self change
+//  (the cycle dominates). It PASSES once `TPPNetworkResponder.credentialsProvider`
+//  is `weak`, breaking the only strong back-edge so the VM (and its
+//  account-change observers) deallocate after release.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+@MainActor
+final class AccountDetailViewModelLeakTests: XCTestCase {
+
+    private func stubAccount(_ uuid: String) -> Account {
+        let metadata = OPDS2Publication.Metadata(id: uuid, title: "Leak Stub \(uuid.prefix(6))")
+        let publication = OPDS2Publication(links: [], metadata: metadata, images: nil)
+        return Account(publication: publication, imageCache: ImageCache.shared)
+    }
+
+    func testViewModel_deallocatesAfterRelease_noLeakedObservers() async {
+        let manager = AppContainer.production().accountsManager
+        let uuid = "urn:uuid:leak-test-\(UUID().uuidString)"
+        // Seed a current account WITHOUT keychain/network so the VM can be
+        // constructed hermetically; teardown restores prior state.
+        let restore = manager._seedAccountForTesting(stubAccount(uuid))
+        defer { restore() }
+
+        weak var weakVM: AccountDetailViewModel?
+        do {
+            let viewModel = AccountDetailViewModel(libraryAccountID: uuid, appContainer: .production())
+            weakVM = viewModel
+            XCTAssertNotNil(weakVM, "Precondition: VM exists while strongly held")
+            await Task.yield()   // let the @MainActor init Task run
+        }
+        // Drain the main actor so any in-flight @MainActor Task releases its
+        // capture. CI-safe (yield loop, no sleep).
+        for _ in 0..<10 { await Task.yield() }
+
+        XCTAssertNil(
+            weakVM,
+            "AccountDetailViewModel must deallocate after release — the "
+            + "TPPNetworkResponder.credentialsProvider strong back-edge (or an "
+            + "unbalanced observer) would otherwise keep it and its account-change "
+            + "observers alive past its scope"
+        )
+    }
+}


### PR DESCRIPTION
Follow-up to **#1127** (the hang fix). #1127 made the leaked observer cost ~0 (O(1) `account()`), eliminating the *hang*; this PR fixes the underlying **production memory leak** it surfaced.

## The production bug
The hermetic leak-repro (added for #1127's investigation) proved a **4-hop retain cycle**:
`AccountDetailViewModel → businessLogic → networkExecutor → TPPNetworkResponder → credentialsProvider (= the VM)`.
`TPPNetworkResponder.credentialsProvider` was a strong `let` (the auth-error decision point), so **every Settings VM leaked** via the shared network responder — a real, latent prod memory bug, not a test artifact.

## Fix
- **`TPPNetworkResponder.credentialsProvider`: `let → weak`** (critical-path). Blast-radius survey confirmed safe: the protocol is class-bound (`@objc`/`NSObjectProtocol`); the *only* non-nil provider app-wide is the VM itself (root owner of its executor chain, always alive when an auth challenge fires); read once synchronously with a `?? currentUserAccount` fallback; every other call site already passes nil.
- **`AccountDetailViewModel.loadInitialData`: `[weak self]`** on the `Task { @MainActor }` arms.
- **Leak-repro test** (`AccountDetailViewModelLeakTests`) — red→green proven (failed with the cycle, passes now); a platform-independent **dealloc assertion** that is the *effective* structural guard for the leak class.
- **dup-UUID cross-bucket tie-break** test (qa follow-up from #1127).

## Observer-leak gate — honest disposition (please read)
The plan was to promote the warn-only NotificationCenter observer-leak detector to a hard gate. The FP audit showed a full green suite with 0 breadcrumbs — but a **non-inertness self-test proved *why* it's 0**: on the iOS 26 sim runtime, `NotificationCenter.default.debugDescription` no longer exposes the "observers: N" line, so `sampleObserverCount()` returns nil and the count-based gate is **inert on our platform**. Per the green-board contract, an inert hard-gate is theater — so it was **kept warn-only** (nil-skipping, self-tested to auto-activate if a future runtime restores the API). The real guard for this leak class is the platform-independent dealloc test above.

## DoD
- Full suite **GREEN** (FP-audit run); **0 auth/sign-in/SAML/OIDC failures, 0 hangs, 0 spindumps** (the `weak` change is suite-validated safe).
- Lint-clean; rebased onto develop (`--onto`, post-#1127-squash) — diff is **#2-scope only** (10 files, +362/-8).

## Staged separately (NOT in this PR)
`#3` — close the `TPPNetworkExecutor` test-network escape (route the test session through `NoNetworkURLProtocol`). Non-board-redding now that #1 landed; tracked in the intent as its own focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)