### PR TITLE
feat(concurrency): PalaceKeychain → Swift 6 (modernization module 2)

### DIFF
--- a/Palace/Packages/PalaceKeychain/Package.swift
+++ b/Palace/Packages/PalaceKeychain/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
@@ -19,11 +19,17 @@ let package = Package(
     targets: [
         .target(
             name: "PalaceKeychain",
-            dependencies: ["PalaceLogging"]
+            dependencies: ["PalaceLogging"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .testTarget(
             name: "PalaceKeychainTests",
-            dependencies: ["PalaceKeychain"]
+            dependencies: ["PalaceKeychain"],
+            // Source target is Swift 6 (race-checked); the test target stays v5
+            // to avoid test-infrastructure churn (XCTestCase isn't Sendable, so
+            // v6 flags benign `self`-sends in async tests). Production code — the
+            // point of the migration — is fully v6.
+            swiftSettings: [.swiftLanguageMode(.v5)]
         )
     ]
 )

--- a/Palace/Packages/PalaceKeychain/Sources/PalaceKeychain/TPPKeychain.swift
+++ b/Palace/Packages/PalaceKeychain/Sources/PalaceKeychain/TPPKeychain.swift
@@ -3,7 +3,11 @@ import Security
 import PalaceLogging
 
 /// This class is capable of working with values serializable by NSKeyedArchiver.
-public final class TPPKeychain {
+///
+/// `Sendable`: stateless (no stored mutable properties) — every method operates
+/// on function-local dictionaries and the thread-safe `SecItem*` keychain APIs.
+/// The shared singleton is therefore data-race-safe under Swift 6.
+public final class TPPKeychain: Sendable {
 
   public static let sharedKeychain: TPPKeychain = {
     let keychain = TPPKeychain()


### PR DESCRIPTION
Second leaf module of the strict-Swift-Concurrency modernization (after PalaceLogging #1129).

## What
PalaceKeychain's single own warning was `TPPKeychain.sharedKeychain` (`#MutableGlobalVariable`). `TPPKeychain` is a **stateless final class** (no stored mutable properties — every method uses function-local dictionaries + the thread-safe `SecItem*` APIs), so the fix is a clean **one-line `: Sendable`** — no `@unchecked`, and *additive* (no consumer ripple, no public symbol removed).

`Package.swift` → tools 6.0; **source target `.swiftLanguageMode(.v6)`** (race-checked), **0 errors / 0 concurrency warnings**.

## Playbook refinement (banked here)
The **test target is pinned to `.v5`**, not v6. Flipping test targets to v6 flags benign non-`Sendable` `self`-sends in async `XCTestCase` tests — test-infrastructure noise, not production safety. So: **race-check production code (source → v6); leave test targets at v5** to keep the fan-out fast. (PalaceLogging's tests happened to be v6-clean; this is the general rule going forward.)

## Verification
Source builds clean at v6 locally. Test target is v5 with **unchanged test code** (its original state). CI's full-app `build-and-test` is the authoritative gate (same as #1129).

## Notes
- Only pre-existing `NSKeyedArchiver` deprecation warnings remain — unrelated to concurrency, out of scope.
- Depends on PalaceLogging (still Swift-5 on develop until #1129 merges) — no conflict; the `Log` API is stable; rebases clean after #1129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)