### PR TITLE
feat(concurrency): PalaceReadingPosition → Swift 6 (module 3, verify-flip)

### DIFF
--- a/Palace/Packages/PalaceReadingPosition/Package.swift
+++ b/Palace/Packages/PalaceReadingPosition/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
     name: "PalaceReadingPosition",
     platforms: [
         .iOS(.v16),
-        .macOS(.v11)
+        .macOS(.v13)
     ],
     products: [
         .library(
@@ -19,11 +19,15 @@ let package = Package(
     targets: [
         .target(
             name: "PalaceReadingPosition",
-            dependencies: ["PalaceLogging"]
+            dependencies: ["PalaceLogging"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .testTarget(
             name: "PalaceReadingPositionTests",
-            dependencies: ["PalaceReadingPosition"]
+            dependencies: ["PalaceReadingPosition"],
+            // Source target is Swift 6 (race-checked); test target stays v5 to
+            // avoid test-infra churn (XCTestCase isn't Sendable). See #1130.
+            swiftSettings: [.swiftLanguageMode(.v5)]
         )
     ]
 )


### PR DESCRIPTION
Already concurrency-clean (actor `PositionSyncService` + Sendable models) — pure verify-and-flip: tools 6.0, source → `.v6`, test → `.v5`. Builds 0/0 at v6.

macOS host floor 11→13 (the PalaceLogging dep needs macOS 13 for `OSAllocatedUnfairLock`) — **host-tooling only; iOS stays 16, app unaffected**. Playbook addendum: PalaceLogging-dependents bump their macOS floor for standalone host builds.

CI full-app build is the gate. 🤖 Generated with [Claude Code](https://claude.com/claude-code)