### PR TITLE
PalaceTriageBot: Swift 6 language-mode flip (leaf modernization)

### DIFF
--- a/Palace/Packages/PalaceTriageBot/Package.swift
+++ b/Palace/Packages/PalaceTriageBot/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
@@ -31,25 +31,32 @@ let package = Package(
         )
     ],
     targets: [
+        // Source targets → Swift 6 mode (race-checked). Test targets → v5 to
+        // avoid test-infra churn (XCTestCase isn't Sendable). See #1130.
         .target(
             name: "TriageBotCore",
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .target(
             name: "TriageBotIOS",
-            dependencies: ["TriageBotCore"]
+            dependencies: ["TriageBotCore"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .target(
             name: "TriageBotUI",
-            dependencies: ["TriageBotCore", "TriageBotIOS"]
+            dependencies: ["TriageBotCore", "TriageBotIOS"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .testTarget(
             name: "TriageBotCoreTests",
-            dependencies: ["TriageBotCore"]
+            dependencies: ["TriageBotCore"],
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .testTarget(
             name: "TriageBotUITests",
-            dependencies: ["TriageBotUI"]
+            dependencies: ["TriageBotUI"],
+            swiftSettings: [.swiftLanguageMode(.v5)]
         )
     ]
 )


### PR DESCRIPTION
## What

Flips **PalaceTriageBot** to Swift 6: `swift-tools-version` 5.9 → 6.0 and `.swiftLanguageMode(.v6)` on all 3 source targets (`TriageBotCore`, `TriageBotIOS`, `TriageBotUI`). Test targets stay `.v5` (XCTestCase isn't `Sendable`).

## Why this is a pure verify-and-flip

Module was already **0-warning** under the strict-concurrency sizing sweep, so no source changes were needed. Standalone `swift build` is green (35/35 units, 0 concurrency warnings). It has **no PalaceLogging dependency**, so unlike the other leaves it needs **no macOS-13 floor bump**.

## Tier

Last of the **leaf tier** of the modernization fan-out:
- PalaceLogging #1129 ✅
- PalaceKeychain #1130 ✅
- PalaceReadingPosition #1131
- **PalaceTriageBot (this)**

Next tier is core/critical-path (PalaceNetwork, in SoD review) → then PalaceCatalog + the main `Palace` target.

## Test

`swift build` → `Build complete!`, 0 errors, 0 concurrency warnings across all targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)