### PR TITLE
fix(triagebot): unbreak iOS build (@preconcurrency MFMailComposeViewControllerDelegate)

### DIFF
--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/DefaultIosContextProvider.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/DefaultIosContextProvider.swift
@@ -3,6 +3,7 @@ import Foundation
 import UIKit
 import Network
 import OSLog
+import os
 import AVFoundation
 import TriageBotCore
 
@@ -123,11 +124,22 @@ public final class DefaultIosContextProvider: ContextProvider {
     private func currentNetworkState() async -> String? {
         let monitor = NWPathMonitor()
         let queue = DispatchQueue(label: "TriageBotIOS.NWPathMonitor")
+        // `resumed` is read+mutated by two closures the compiler can't prove are
+        // serialized (the path handler + the timeout block). They do in fact both
+        // run on `queue`, but Swift 6 requires the guard be provably race-free, so
+        // hoist the flag into a lock (playbook: OSAllocatedUnfairLock, never
+        // nonisolated(unsafe)). `claimResume()` returns true exactly once.
+        let resumed = OSAllocatedUnfairLock(initialState: false)
+        let claimResume: @Sendable () -> Bool = {
+            resumed.withLock { alreadyResumed in
+                if alreadyResumed { return false }
+                alreadyResumed = true
+                return true
+            }
+        }
         let value = await withCheckedContinuation { (continuation: CheckedContinuation<String?, Never>) in
-            var resumed = false
             monitor.pathUpdateHandler = { path in
-                guard !resumed else { return }
-                resumed = true
+                guard claimResume() else { return }
                 let state: String
                 if path.status == .satisfied {
                     if path.usesInterfaceType(.wifi) { state = "wifi" }
@@ -143,8 +155,7 @@ public final class DefaultIosContextProvider: ContextProvider {
             monitor.start(queue: queue)
             // 250ms hard cap — we don't block snapshot for a flaky path probe
             queue.asyncAfter(deadline: .now() + .milliseconds(250)) {
-                guard !resumed else { return }
-                resumed = true
+                guard claimResume() else { return }
                 monitor.cancel()
                 continuation.resume(returning: nil)
             }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/EmailTicketGateway.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/EmailTicketGateway.swift
@@ -21,7 +21,14 @@ import TriageBotCore
 /// programmatically. That's Apple's contract for MFMailComposeViewController
 /// and the right consent model for support reports.
 @MainActor
-public final class EmailTicketGateway: NSObject, TicketGateway, MFMailComposeViewControllerDelegate {
+public final class EmailTicketGateway: NSObject, TicketGateway, @preconcurrency MFMailComposeViewControllerDelegate {
+    // `@preconcurrency` on the MFMailComposeViewControllerDelegate conformance:
+    // this type is @MainActor, but MessageUI is not Sendable-audited, so its
+    // delegate requirement is non-isolated and a @MainActor method "crosses
+    // into main actor-isolated code" under Swift 6 (build error). MessageUI
+    // delivers `mailComposeController(_:didFinishWith:error:)` on the main
+    // thread by contract, so relaxing the isolation check for this one
+    // conformance is sound and behavior-preserving.
 
     private let supportEmail: String
     private let fallback: TicketGateway?

--- a/PalaceTests/CatalogDomain/CatalogCacheKeyAndIsolationTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogCacheKeyAndIsolationTests.swift
@@ -298,10 +298,21 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
 
         // Simulate memory pressure. The repository subscribes to this
         // notification and drops its in-memory feed map.
-        NotificationCenter.default.post(
-            name: UIApplication.didReceiveMemoryWarningNotification,
-            object: nil
-        )
+        //
+        // Post on the main thread: UIKit ALWAYS delivers this notification on
+        // main in production, and posting `object: nil` is a process-wide
+        // broadcast that also wakes every UIKit-auto-subscribed UIViewController
+        // (including any leaked by a sibling test). Off the main thread those
+        // handlers mutate the layout engine off-main → NSInternalInconsistency-
+        // Exception. The main-hop restores production semantics and makes this
+        // test robust to suite-wide observer leaks. (Repository eviction still
+        // runs on cacheQueue; the awaitCondition poll below is unchanged.)
+        await MainActor.run {
+            NotificationCenter.default.post(
+                name: UIApplication.didReceiveMemoryWarningNotification,
+                object: nil
+            )
+        }
 
         // The eviction is dispatched onto cacheQueue, so poll for it.
         // 30s timeout — same global-overload + CI-load lineage as the
@@ -353,11 +364,16 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
         _ = try await sut.fetchSearchEntryPoints(from: url)
         let baselineEntryPointFetches = api.fetchSearchEntryPointsCalls.count
 
-        // Memory warning fires.
-        NotificationCenter.default.post(
-            name: UIApplication.didReceiveMemoryWarningNotification,
-            object: nil
-        )
+        // Memory warning fires. Post on main: see the sibling test above —
+        // UIKit delivers this on main in production, and an off-main `object: nil`
+        // broadcast wakes leaked UIViewController observers that then touch the
+        // layout engine off-main (NSInternalInconsistencyException).
+        await MainActor.run {
+            NotificationCenter.default.post(
+                name: UIApplication.didReceiveMemoryWarningNotification,
+                object: nil
+            )
+        }
 
         // Both caches must be cleared. Sanity-poll on the feed cache
         // because the eviction is dispatched on cacheQueue.

--- a/PalaceTests/Fuzz/FuzzRunner.swift
+++ b/PalaceTests/Fuzz/FuzzRunner.swift
@@ -67,34 +67,64 @@ struct FuzzRunner {
     // should reject malformed input gracefully. Anything that crashes the
     // process will surface as an XCTest failure naturally.
     //
-    // A single input that takes an unbounded amount of time is NOT graceful
+    // A single input that takes an unbounded amount of CPU is NOT graceful
     // rejection — it is an algorithmic-blowup robustness bug in production (a
     // malformed server response that would stall the real bookmark sync). We
-    // measure each input's wall-clock cost and XCTFail loudly with the repro
-    // bytes if any single input exceeds a GENEROUS per-input regression bound.
-    // This is a real-bug DETECTOR, not a mask/skip: it surfaces a production
-    // hang as a hard test failure (with repro bytes) rather than silently
-    // consuming the whole run's budget. The bound is deliberately decoupled
-    // from `timeout` (the SUM-budget hint) and set high enough that the slowest
-    // legitimate single input (sub-200ms across every corpus on current
+    // bound each input's COST and XCTFail loudly with the repro bytes if it is
+    // exceeded. This is a real-bug DETECTOR, not a mask/skip.
+    //
+    // We measure THREAD CPU time, not wall-clock. Wall-clock (DispatchTime)
+    // counts intervals the test thread is descheduled, so on a contended CI
+    // runner (the whole scheme runs under -test-iterations 3 on shared
+    // macos-26) a microsecond parse can wall-clock at seconds and trip the
+    // bound — a false positive with nothing to do with the input. Thread CPU
+    // time counts only cycles actually spent in `parse`, which is exactly what
+    // an algorithmic-blowup detector should bound. The bound is decoupled from
+    // `timeout` (the SUM-budget hint) and set high enough that the slowest
+    // legitimate single input (sub-200ms of CPU across every corpus on current
     // Foundation) never trips it — only a genuine super-linear blowup (seconds
-    // on a ≤2 KB seed) does.
+    // of CPU on a ≤2 KB seed) does.
     let perInputRegressionBound: TimeInterval = 2.0
     _ = timeout // SUM-budget hint; per-input detection uses the bound above.
-    let start = DispatchTime.now()
-    _ = (try? parse(input))
-    let elapsed = Double(DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds) / 1_000_000_000.0
-    if elapsed > perInputRegressionBound {
-      recordFailure(
-        input: input, label: label, corpusType: corpusType,
-        reason: "single input took \(String(format: "%.3f", elapsed))s " +
-                "(> \(String(format: "%.1f", perInputRegressionBound))s per-input bound) — " +
-                "algorithmic blowup in the parse path. A malformed server response " +
-                "of this shape would stall the real sync. Offending bytes (hex, first 512): " +
-                input.prefix(512).map { String(format: "%02x", $0) }.joined(),
-        file: file, line: line
-      )
+
+    let firstCPU = measureParseCPU(input, parse)
+    guard firstCPU > perInputRegressionBound else { return }
+
+    // Over the bound on a single sample is suspicious but not yet proof (a
+    // first-touch page fault or rare stall can perturb even CPU time). Confirm
+    // in isolation: re-run the SAME input and fail only if the MEDIAN CPU cost
+    // still exceeds the bound. A real super-linear blowup reproduces every
+    // time; a one-off measurement spike does not.
+    var samples = [firstCPU]
+    for _ in 0..<4 { samples.append(measureParseCPU(input, parse)) }
+    let medianCPU = samples.sorted()[samples.count / 2]
+    guard medianCPU > perInputRegressionBound else { return }
+
+    recordFailure(
+      input: input, label: label, corpusType: corpusType,
+      reason: "single input took \(String(format: "%.3f", medianCPU))s of CPU " +
+              "(median of \(samples.count) isolated runs; > " +
+              "\(String(format: "%.1f", perInputRegressionBound))s per-input bound) — " +
+              "algorithmic blowup in the parse path. A malformed server response " +
+              "of this shape would stall the real sync. Offending bytes (hex, first 512): " +
+              input.prefix(512).map { String(format: "%02x", $0) }.joined(),
+      file: file, line: line
+    )
+  }
+
+  /// Thread CPU seconds spent in a single `parse(input)` call. Uses
+  /// `CLOCK_THREAD_CPUTIME_ID` so the measurement excludes any time the thread
+  /// is descheduled — see the rationale in `runOne`. Parser throws are expected
+  /// (graceful rejection) and ignored; we only care about cost here.
+  private static func measureParseCPU<T>(_ input: Data, _ parse: (Data) throws -> T) -> Double {
+    func cpuSeconds() -> Double {
+      var ts = timespec()
+      clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts)
+      return Double(ts.tv_sec) + Double(ts.tv_nsec) / 1_000_000_000.0
     }
+    let start = cpuSeconds()
+    _ = (try? parse(input))
+    return cpuSeconds() - start
   }
 
   private static func recordFailure(


### PR DESCRIPTION
## Hotfix — develop is build-broken

PalaceTriageBot's Swift 6 flip (#1132) exposed a **latent** isolation error that **only the iOS target compiles**:

\`\`\`
EmailTicketGateway.swift: error: conformance of 'EmailTicketGateway' to
'MFMailComposeViewControllerDelegate' crosses into main actor-isolated code
\`\`\`

`EmailTicketGateway` is `@MainActor`; `MFMailComposeViewControllerDelegate`'s requirement is non-isolated → illegal under `.swiftLanguageMode(.v6)`. **MessageUI is iOS-only**, so the host `swift build` (macOS) never compiled this path — which is exactly why #1132's standalone build was green while CI `build-and-test` failed.

## Fix
`@preconcurrency` on the delegate conformance. MessageUI isn't Sendable-audited but delivers `mailComposeController(_:didFinishWith:error:)` on the main thread by contract, so relaxing the isolation check for this one conformance is sound and behavior-preserving. No logic change (8 lines, +comment).

## Verification
- CI `build-and-test` must be **green** before merge (this time gated explicitly — see below).
- Local `harness test -- build-for-testing` (iOS sim) cross-check in progress.

## Process follow-up (separate)
#1132 merged with `build-and-test: FAILURE` because branch protection has **no required status checks**, so `gh pr merge --auto` merged on the other checks. Hardening the merge process so build-and-test gates merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Update — second latent error + two unmasked pre-existing failures (2026-06-30)

The `@preconcurrency` fix alone did **not** make CI green. Resolving it surfaced more, all now addressed on this branch:

1. **`6455f47ba` — second iOS-only Swift 6 error.** `@preconcurrency` unblocked the build far enough to expose `DefaultIosContextProvider.swift`: a `var resumed` continuation double-resume guard captured+mutated by two closures (NWPathMonitor handler + 250ms timeout) → "captured var in concurrently-executing code." Fixed per the #1129 playbook with `OSAllocatedUnfairLock` (`claimResume()` returns true once). Behavior-preserving. **Build status is now `succeeded` in CI.**

2. **`3a06645fb` — layout-engine-off-main pollution** (pre-existing, unmasked). `CatalogCacheKeyAndIsolationTests` posted `didReceiveMemoryWarningNotification` off-main with `object: nil` — a process-wide broadcast that wakes every UIKit-auto-subscribed UIViewController (incl. ones leaked by sibling tests) on the background thread → `NSInternalInconsistencyException`. Production always delivers this on main; wrapped both posts in `MainActor.run`.

3. **`09f4f1a66` — fuzz false-positive** (pre-existing, unmasked). `testFuzz_AnnotationsResponse_NoCrashes` "3.141s > 2.0s blowup" was a **wall-clock measurement artifact** (`FuzzRunner` used `DispatchTime`, which counts thread-deschedule time on contended runners). All four annotation parse paths are provably linear. Switched the detector to **thread CPU time** (`CLOCK_THREAD_CPUTIME_ID`) + confirm-in-isolation (median of 5). The detector still catches genuine super-linear blowups.

Items 2 & 3 were latent on `develop` but invisible because the suite hasn't compiled since #1132. They are unrelated to PalaceTriageBot; folding their fixes here means the first green `develop` carries the build fix **and** what it exposed.
