### PR TITLE
fix(ci): unbreak chaos-replay workflow — hashFiles() illegal in job-level if

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint configuration.
+# Declares custom self-hosted runner labels so actionlint doesn't flag them as
+# unknown. `palace-ios` is the provisioned macOS chaos-QA / simdrive runner used
+# by chaos-replay-on-pr.yml, chaos-qa-on-demand.yml, and chaos-qa-nightly.yml.
+self-hosted-runner:
+  labels:
+    - palace-ios

--- a/.github/workflows/chaos-replay-on-pr.yml
+++ b/.github/workflows/chaos-replay-on-pr.yml
@@ -35,15 +35,32 @@ jobs:
   replay:
     runs-on: [self-hosted, macos, palace-ios]
     timeout-minutes: 30
-    if: |
-      vars.ENABLE_CHAOS_QA_RUNNER == 'true' &&
-      hashFiles('.simdrive/replays/chaos/**.yaml') != ''
+    # NOTE: `hashFiles()` is NOT permitted in a job-level `if:` — it is only
+    # available inside steps. The previous job-level `hashFiles(...)` guard made
+    # the ENTIRE workflow a startup failure on every push/PR ("workflow file
+    # issue", zero jobs) on every branch. The corpus-presence check now lives in
+    # the "Check chaos corpus" step below; this job-level guard only gates on the
+    # self-hosted runner being provisioned. When the var is unset the job SKIPS
+    # cleanly (run = success) instead of erroring at startup.
+    if: vars.ENABLE_CHAOS_QA_RUNNER == 'true'
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
 
+      - name: Check chaos corpus exists
+        id: corpus
+        run: |
+          # `-e`-safe: the no-match non-zero is consumed by the `if` condition.
+          if compgen -G ".simdrive/replays/chaos/*.yaml" > /dev/null 2>&1; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No curated chaos replays in .simdrive/replays/chaos/ — nothing to verify; skipping."
+          fi
+
       - name: Pick / boot sim
         id: sim
+        if: steps.corpus.outputs.present == 'true'
         run: |
           UDID=$(xcrun simctl list devices iPhone | awk '/Booted/ {print $NF; exit}' | tr -d '()')
           if [[ -z "$UDID" ]]; then
@@ -53,6 +70,7 @@ jobs:
           echo "udid=$UDID" >> "$GITHUB_OUTPUT"
 
       - name: Build candidate
+        if: steps.corpus.outputs.present == 'true'
         run: |
           xcodebuild -project Palace.xcodeproj -scheme Palace \
             -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
@@ -62,6 +80,7 @@ jobs:
 
       - name: Replay each chaos-discovered scenario
         id: replays
+        if: steps.corpus.outputs.present == 'true'
         run: |
           UDID="${{ steps.sim.outputs.udid }}"
           FAIL=0
@@ -87,7 +106,7 @@ jobs:
           [[ "$FAIL" == "0" ]]
 
       - name: Comment summary on PR
-        if: failure()
+        if: failure() && steps.corpus.outputs.present == 'true'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Problem

`chaos-replay-on-pr.yml` has been **failing at startup on every push/PR across every branch** (develop, dependabot, feature branches) — *"This run likely failed because of a workflow file issue"*, zero jobs, `conclusion=failure`. It's a permanent red check on every PR that masks real CI signal (the "red board from pollution" anti-pattern in CLAUDE.md).

## Root cause

`actionlint` pinpoints it:

> calling function `hashFiles` is not allowed here. `hashFiles` is only available in `jobs.<job_id>.steps.*`

The `replay` job's `if:` used `hashFiles('.simdrive/replays/chaos/**.yaml')` — illegal at the **job** level, so GitHub can't evaluate the workflow and fails the whole run before planning any job. Identical on every branch because the file is identical.

## Fix

- Job-level `if:` now gates only on `vars.ENABLE_CHAOS_QA_RUNNER == 'true'` (valid). With the self-hosted runner var unset, the job **skips cleanly** (run = success) instead of erroring at startup.
- The corpus-presence check moved into a new `-e`-safe **"Check chaos corpus"** step; the sim/build/replay/comment steps gate on its output — preserving the original *"run only when runner enabled AND ≥1 replay exists"* semantics.
- Added `.github/actionlint.yaml` declaring the custom `palace-ios` self-hosted label (also clears the warning on `chaos-qa-on-demand`/`nightly`).

## Verification

```
$ actionlint .github/workflows/chaos-replay-on-pr.yml
$ echo $?
0
```

## Scope / follow-up

Workflow + lint config only — no app/test code. **Deferred (own pass):** wire an errors-only `actionlint` gate into `tooling-checks.yml` so this class of startup failure can't land again — the repo currently has 391 pre-existing shellcheck/style findings a strict gate would trip, so it needs its own cleanup first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)