### PR TITLE
PalaceCatalog → Swift 6 (modernization tent-pole: 66 concurrency warnings → 0)

### DIFF
--- a/.forgeos/intent/palacecatalog-swift6-modernization.md
+++ b/.forgeos/intent/palacecatalog-swift6-modernization.md
@@ -1,0 +1,77 @@
+---
+name: palacecatalog-swift6-modernization
+created: 2026-06-30
+author: claude
+---
+
+# palacecatalog-swift6-modernization
+
+The tent-pole of the Swift 6 modernization fan-out (playbook proven by #1129
+PalaceLogging; modules 2–5 = Keychain/ReadingPosition/TriageBot/Network landed).
+PalaceCatalog is the "center of mass" (#1129 sizing: ~56 warnings) and gates
+PalaceAuth. Design-first; commit on `feat/swift6-palacecatalog`; PR + SoD (it's a
+critical-path-adjacent module — catalog parsing + repository networking).
+
+## Measured scope (2026-06-30, `swift build -Xswiftc -strict-concurrency=complete`)
+
+**66 distinct concurrency-warning locations** (raw 428 incl. duplication +
+~130 non-concurrency style warnings — redundant `public` modifiers, "cast always
+succeeds" — which are OUT of scope, pre-existing, not Swift-6 work). Concentrated
+in 4 hot files:
+
+- `CatalogRepository.swift` — repository + in-memory caches (the heaviest;
+  `#MutableGlobalVariable` static caches/formatters + `#SendableClosureCaptures`
+  in async load paths).
+- `CatalogAPI.swift` — networking layer (closure captures, sending risks).
+- `TPPOPDSAcquisition.swift` — OPDS model (Sendable conformances on
+  structs/enums; non-Sendable associated values).
+- `TPPOpenSearchDescription.swift` — OPDS model (~10).
+- `OPDSParser.swift`, `TPPAsync.swift`, `OPDS2Feed.swift` — a few each.
+
+Dominant categories (raw counts): Sendable conformance (~80), SendableClosure-
+Captures (~78), MutableGlobalVariable (~66), @Sendable-closure data-race (~26),
+SendingRisksDataRace (~12).
+
+## Claims
+
+- **Manifest prep (DONE in this branch):**
+  - Drop phantom `.testTarget(name: "PalaceCatalogTests")` — no `Tests/` dir;
+    tests live in the app's `PalaceTests` target. Broke standalone `swift build`
+    ("overlapping sources"). Same fix as PalaceNetwork #1133.
+  - Bump PalaceCatalog macOS host floor 11 → 13 (PalaceLogging dep needs
+    OSAllocatedUnfairLock; iOS stays 16; host-build only).
+  - Bump **PalaceNetwork** macOS floor 11 → 13 too (latent gap left by #1133 —
+    it depends on PalaceLogging/macOS-13 but declared macOS 11; only bites
+    standalone builds). One-line cross-package fix, required for resolution.
+- **Concurrency (TODO):** fix the 66 by ISOLATION not suppression, per the
+  playbook: `#MutableGlobalVariable` → `OSAllocatedUnfairLock<T>` / `let` /
+  localize; OPDS model types → `Sendable` (most are value types / Codable —
+  largely additive); `#SendableClosureCaptures` → lock or restructure. NEVER
+  `nonisolated(unsafe)`.
+- **Language mode (TODO, last):** bump `swift-tools-version` 5.9 → 6.0 (source
+  target → v6) once warnings are 0 at `complete`.
+
+## Anti-claims
+
+- does NOT use `nonisolated(unsafe)` anywhere (playbook rule).
+- does NOT fix the ~130 pre-existing NON-concurrency style warnings (redundant
+  `public`, always-true casts) — out of scope; separate cleanup if desired.
+- Sendable ripple into consumers (the app target + PalaceAuth) is EXPECTED and
+  tracked — PalaceAuth merges AFTER this (it consumes Catalog types).
+
+## Files in scope
+
+- Palace/Packages/PalaceCatalog/Package.swift (manifest: drop testTarget, floor, later v6)
+- Palace/Packages/PalaceNetwork/Package.swift (macOS floor 13 — resolution fix)
+- Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/CatalogRepository.swift
+- Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/CatalogAPI.swift
+- Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSAcquisition.swift
+- Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOpenSearchDescription.swift
+- Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/{OPDSParser,TPPAsync,OPDS2Feed}.swift
+- (+ Sendable conformances rippling to other OPDS model files as surfaced)
+
+## Verification (TODO on implementation)
+
+`swift build -Xswiftc -strict-concurrency=complete` → 0 concurrency warnings;
+then flip to tools 6.0 and `swift build` (v6 mode) 0/0; full-app iOS CI
+build-and-test green (the cross-module Sendable ripple gate); architect + qa SoD.

--- a/Palace/Packages/PalaceCatalog/Package.swift
+++ b/Palace/Packages/PalaceCatalog/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(

--- a/Palace/Packages/PalaceCatalog/Package.swift
+++ b/Palace/Packages/PalaceCatalog/Package.swift
@@ -5,7 +5,10 @@ let package = Package(
     name: "PalaceCatalog",
     platforms: [
         .iOS(.v16),
-        .macOS(.v11)
+        // macOS host floor 13 to match the PalaceLogging dependency (it needs
+        // OSAllocatedUnfairLock, macOS 13+). Host-build only — the shipping app
+        // is iOS 16. Same floor PalaceLogging/PalaceKeychain established.
+        .macOS(.v13)
     ],
     products: [
         .library(
@@ -21,10 +24,11 @@ let package = Package(
         .target(
             name: "PalaceCatalog",
             dependencies: ["PalaceLogging", "PalaceNetwork"]
-        ),
-        .testTarget(
-            name: "PalaceCatalogTests",
-            dependencies: ["PalaceCatalog"]
         )
+        // No in-package test target: PalaceCatalog's tests live in the app's
+        // `PalaceTests` target (there is no `Tests/` dir here). The phantom
+        // `.testTarget(name: "PalaceCatalogTests")` broke standalone
+        // `swift build`/`swift test` with an "overlapping sources" error — same
+        // manifest bug fixed for PalaceNetwork in #1133.
     ]
 )

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/CatalogAPI.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/CatalogAPI.swift
@@ -11,7 +11,7 @@ public protocol CatalogAPI {
     func fetchSearchEntryPoints(from url: URL) async throws -> [SearchFormatEntry]
 }
 
-public final class DefaultCatalogAPI: CatalogAPI {
+public final class DefaultCatalogAPI: CatalogAPI, Sendable {
     public let client: NetworkClient
     public let parser: OPDSParser
     private let featureFlags: FeatureFlagProvider
@@ -94,28 +94,20 @@ public final class DefaultCatalogAPI: CatalogAPI {
     }
 
     public func search(query: String, searchDescriptorURL: URL) async throws -> CatalogFeed? {
-        return try await withCheckedThrowingContinuation { continuation in
-            TPPOpenSearchDescription.withURL(searchDescriptorURL, networkClient: client) { description in
-                guard let description = description else {
-                    continuation.resume(throwing: NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL, userInfo: [NSLocalizedDescriptionKey: "Could not load OpenSearch description"]))
-                    return
-                }
-
-                guard let searchResultURL = description.opdsURL(forSearchingString: query) else {
-                    continuation.resume(throwing: NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL, userInfo: [NSLocalizedDescriptionKey: "Could not create search URL"]))
-                    return
-                }
-
-                Task {
-                    do {
-                        let searchResults = try await self.fetchFeed(at: searchResultURL)
-                        continuation.resume(returning: searchResults)
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
+        // Straight async/await: `TPPOpenSearchDescription.withURL` is now an
+        // `async` function (was a completion-handler API), so the prior
+        // `withCheckedThrowingContinuation` bridge — which captured `self` and
+        // the continuation in a `@Sendable` closure and is an error under the
+        // Swift 6 language mode — is gone.
+        guard let description = await TPPOpenSearchDescription.withURL(searchDescriptorURL, networkClient: client) else {
+            throw NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL, userInfo: [NSLocalizedDescriptionKey: "Could not load OpenSearch description"])
         }
+
+        guard let searchResultURL = description.opdsURL(forSearchingString: query) else {
+            throw NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL, userInfo: [NSLocalizedDescriptionKey: "Could not create search URL"])
+        }
+
+        return try await fetchFeed(at: searchResultURL)
     }
 
     public func fetchSearchEntryPoints(from url: URL) async throws -> [SearchFormatEntry] {

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/CatalogModels.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/CatalogModels.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct CatalogFeed {
+public struct CatalogFeed: Sendable {
     public let title: String
     public let entries: [CatalogEntry]
     public let opdsFeed: TPPOPDSFeed
@@ -72,7 +72,7 @@ public struct CatalogFeed {
     }
 }
 
-public struct CatalogEntry: Identifiable {
+public struct CatalogEntry: Identifiable, Sendable {
     public let id: String
     public let title: String
     public let authors: [String]
@@ -92,7 +92,7 @@ public struct CatalogEntry: Identifiable {
 
 /// A format entry point shown in the search screen filter row.
 /// Extracted from the groups feed's entry-point facets (e.g. All, eBooks, Audiobooks).
-public struct SearchFormatEntry: Identifiable, Hashable {
+public struct SearchFormatEntry: Identifiable, Hashable, Sendable {
     public let id: String
     public let title: String
 

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/CatalogRepository.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/CatalogRepository.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import PalaceLogging
 #if canImport(UIKit)
 import UIKit
@@ -18,16 +19,25 @@ public protocol CatalogRepositoryProtocol {
     func cachedFeed(for url: URL) -> CatalogFeed?
 }
 
-public final class CatalogRepository: CatalogRepositoryProtocol {
+public final class CatalogRepository: CatalogRepositoryProtocol, @unchecked Sendable {
+    // CONCURRENCY INVARIANT (@unchecked Sendable):
+    // All mutable state lives inside `cache`, an OSAllocatedUnfairLock that
+    // serializes every read and write (the lock replaced the former serial
+    // `catalog.cache.queue` DispatchQueue). No mutable stored property exists
+    // outside that lock. The remaining stored properties are immutable `let`s:
+    // `api` is an internally-thread-safe network client, `now` /
+    // `accountIDProvider` are `@Sendable` closures, and `defaults`
+    // (`UserDefaults`) is documented thread-safe. We retain `@unchecked`
+    // (rather than synthesized `Sendable`) only because the injected
+    // `CatalogAPI` protocol is not yet annotated `Sendable` (owned by a
+    // sibling modernization pass); the lock makes the conformance sound today.
     private let api: CatalogAPI
-    private var memoryCache: [String: CachedFeed] = [:]
-    private let cacheQueue = DispatchQueue(label: "catalog.cache.queue", qos: .userInitiated)
     private static let lastAppLaunchKey = "CatalogRepository.lastAppLaunch"
 
     /// Test seam: injectable "now" provider so unit tests can drive the
     /// stale-while-revalidate clock deterministically without sleeping.
     /// Production callers use the default (`Date.init`).
-    private let now: () -> Date
+    private let now: @Sendable () -> Date
 
     /// Library/account isolation: cache entries are scoped by the current
     /// account UUID so that, if a single repository instance survives a
@@ -35,7 +45,7 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
     /// The bearer token itself is deliberately NOT used as the key — it
     /// rotates (refresh / re-auth) while the library identity is stable.
     /// `nil` is treated as the "anonymous / pre-account" scope.
-    private let accountIDProvider: () -> String?
+    private let accountIDProvider: @Sendable () -> String?
 
     /// `UserDefaults` backing store for the `lastAppLaunchKey` heuristic
     /// (drives `needsBackgroundRefresh` and the 7-day URLCache wipe).
@@ -44,13 +54,23 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
     /// leak across tests. There is NO fallback once injected.
     private let defaults: UserDefaults
 
-    /// Dedicated cache for format entry points, keyed by groups-feed URL.
-    /// Pre-warmed by loadTopLevelCatalog so search can display the format picker immediately
-    /// without an extra network round-trip when the user first opens search.
-    private var formatEntriesCache: [String: [SearchFormatEntry]] = [:]
-
-    /// Track if we need to refresh stale content in background
-    private var needsBackgroundRefresh = false
+    /// Lock-guarded mutable cache state. Replaces the former serial
+    /// `cacheQueue` DispatchQueue — every access goes through
+    /// `cache.withLockUnchecked { … }`. `withLockUnchecked` is used (rather
+    /// than `withLock`) because the guarded model types (`CatalogFeed`,
+    /// `SearchFormatEntry`) are not yet `Sendable`; the lock itself provides
+    /// the synchronization that makes that safe.
+    private struct CacheState {
+        var memoryCache: [String: CachedFeed] = [:]
+        /// Dedicated cache for format entry points, keyed by groups-feed URL.
+        /// Pre-warmed by loadTopLevelCatalog so search can display the format
+        /// picker immediately without an extra network round-trip when the
+        /// user first opens search.
+        var formatEntriesCache: [String: [SearchFormatEntry]] = [:]
+        /// Track if we need to refresh stale content in background.
+        var needsBackgroundRefresh = false
+    }
+    private let cache = OSAllocatedUnfairLock(uncheckedState: CacheState())
 
     private struct CachedFeed {
         let feed: CatalogFeed
@@ -76,7 +96,7 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
     // PUBLIC_INTENT: defaults: arg added by swarm_cd181acd D-cleanup to inject UserDefaults for per-test isolation. Default `.standard` preserves all production callers.
     public init(api: CatalogAPI, defaults: UserDefaults = .standard) {
         self.api = api
-        self.now = Date.init
+        self.now = { Date() }
         self.accountIDProvider = { nil }
         self.defaults = defaults
         self.checkStaleCacheStatus()
@@ -88,9 +108,9 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
     /// the repository sees the *current* account each call — the value
     /// changes when the user switches libraries.
     // PUBLIC_INTENT: defaults: arg added by swarm_cd181acd D-cleanup; same rationale as the no-accountID overload above.
-    public init(api: CatalogAPI, accountID: @escaping () -> String?, defaults: UserDefaults = .standard) {
+    public init(api: CatalogAPI, accountID: @escaping @Sendable () -> String?, defaults: UserDefaults = .standard) {
         self.api = api
-        self.now = Date.init
+        self.now = { Date() }
         self.accountIDProvider = accountID
         self.defaults = defaults
         self.checkStaleCacheStatus()
@@ -102,7 +122,7 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
     /// is `public` only to be reachable from `PalaceTests` (which imports
     /// `PalaceCatalog` without `@testable`).
     // PUBLIC_INTENT: defaults: arg added by swarm_cd181acd D-cleanup; same rationale. Test-only initializer reachable from PalaceTests without @testable.
-    public init(api: CatalogAPI, now: @escaping () -> Date, defaults: UserDefaults = .standard) {
+    public init(api: CatalogAPI, now: @escaping @Sendable () -> Date, defaults: UserDefaults = .standard) {
         self.api = api
         self.now = now
         self.accountIDProvider = { nil }
@@ -115,7 +135,7 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
     /// provider. Used by cache-isolation tests to simulate library switches
     /// deterministically.
     // PUBLIC_INTENT: defaults: arg added by swarm_cd181acd D-cleanup; same rationale. Test-only initializer for cache-isolation tests.
-    public init(api: CatalogAPI, accountID: @escaping () -> String?, now: @escaping () -> Date, defaults: UserDefaults = .standard) {
+    public init(api: CatalogAPI, accountID: @escaping @Sendable () -> String?, now: @escaping @Sendable () -> Date, defaults: UserDefaults = .standard) {
         self.api = api
         self.now = now
         self.accountIDProvider = accountID
@@ -154,11 +174,10 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
     }
 
     @objc private func handleMemoryWarning() {
-        cacheQueue.async { [weak self] in
-            guard let self else { return }
-            Log.info(#file, "Memory warning received — clearing in-memory catalog cache (disk cache preserved)")
-            self.memoryCache.removeAll()
-            self.formatEntriesCache.removeAll()
+        Log.info(#file, "Memory warning received — clearing in-memory catalog cache (disk cache preserved)")
+        cache.withLockUnchecked { state in
+            state.memoryCache.removeAll()
+            state.formatEntriesCache.removeAll()
         }
     }
 
@@ -175,7 +194,7 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
             URLCache.shared.removeAllCachedResponses()
         }
         if daysSinceLastLaunch >= 1 {
-            needsBackgroundRefresh = true
+            cache.withLockUnchecked { $0.needsBackgroundRefresh = true }
         }
 
         defaults.set(currentDate, forKey: Self.lastAppLaunchKey)
@@ -184,11 +203,7 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
     public func loadTopLevelCatalog(at url: URL) async throws -> CatalogFeed? {
         let cacheKey = cacheKey(for: url)
 
-        let cachedEntry = await withCheckedContinuation { [weak self] continuation in
-            cacheQueue.async {
-                continuation.resume(returning: self?.memoryCache[cacheKey])
-            }
-        }
+        let cachedEntry = cache.withLockUnchecked { $0.memoryCache[cacheKey] }
 
         // STALE-WHILE-REVALIDATE PATTERN:
         // 1. Fresh cache (< 10 min) → return immediately
@@ -202,6 +217,7 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
         }
 
         // Stale-while-revalidate: return stale content immediately, refresh in background
+        let needsBackgroundRefresh = cache.withLockUnchecked { $0.needsBackgroundRefresh }
         if let entry = cachedEntry, isStaleButUsable(entry) || needsBackgroundRefresh {
             Log.info(#file, "Returning stale cached catalog feed, refreshing in background: \(url.absoluteString)")
             prewarmFormatEntriesCache(from: entry.feed, cacheKey: cacheKey)
@@ -248,12 +264,8 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
         }
 
         // Cache the result
-        await withCheckedContinuation { continuation in
-            cacheQueue.async {
-                self.memoryCache[cacheKey] = CachedFeed(feed: feed, timestamp: self.now())
-                continuation.resume()
-            }
-        }
+        let cachedFeed = CachedFeed(feed: feed, timestamp: now())
+        cache.withLockUnchecked { $0.memoryCache[cacheKey] = cachedFeed }
         prewarmFormatEntriesCache(from: feed, cacheKey: cacheKey)
 
         Task.detached(priority: .background) {
@@ -272,13 +284,9 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
 
             guard let feed = feed else { return }
 
-            await withCheckedContinuation { continuation in
-                cacheQueue.async {
-                    self.memoryCache[cacheKey] = CachedFeed(feed: feed, timestamp: self.now())
-                    Log.info(#file, "Background refresh completed for: \(url.absoluteString)")
-                    continuation.resume()
-                }
-            }
+            let cachedFeed = CachedFeed(feed: feed, timestamp: now())
+            cache.withLockUnchecked { $0.memoryCache[cacheKey] = cachedFeed }
+            Log.info(#file, "Background refresh completed for: \(url.absoluteString)")
 
             // Preload related facets too
             await preloadRelatedFacets(from: feed)
@@ -295,13 +303,13 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
     private func prewarmFormatEntriesCache(from feed: CatalogFeed, cacheKey: String) {
         let entries = DefaultCatalogAPI.extractSearchEntryPoints(from: feed)
         guard !entries.isEmpty else { return }
-        cacheQueue.async { [weak self] in
-            guard let self, self.formatEntriesCache[cacheKey] == nil else { return }
-            self.formatEntriesCache[cacheKey] = entries
+        cache.withLockUnchecked { state in
+            guard state.formatEntriesCache[cacheKey] == nil else { return }
+            state.formatEntriesCache[cacheKey] = entries
         }
     }
 
-    private func withTimeout<T>(seconds: TimeInterval, operation: @escaping () async throws -> T) async throws -> T {
+    private func withTimeout<T: Sendable>(seconds: TimeInterval, operation: @escaping @Sendable () async throws -> T) async throws -> T {
         try await withThrowingTaskGroup(of: T.self) { group in
             group.addTask {
                 try await operation()
@@ -335,11 +343,7 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
 
         // Check the dedicated format-entries cache first. Pre-warmed by loadTopLevelCatalog
         // so the search format picker has data without an extra network round-trip.
-        let cached = await withCheckedContinuation { (c: CheckedContinuation<[SearchFormatEntry]?, Never>) in
-            cacheQueue.async { [weak self] in
-                c.resume(returning: self?.formatEntriesCache[cacheKey])
-            }
-        }
+        let cached = cache.withLockUnchecked { $0.formatEntriesCache[cacheKey] }
         if let cached, !cached.isEmpty {
             return cached
         }
@@ -347,9 +351,7 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
         // Cache miss — fetch from network and cache for next time.
         let entries = try await api.fetchSearchEntryPoints(from: url)
         if !entries.isEmpty {
-            cacheQueue.async { [weak self] in
-                self?.formatEntriesCache[cacheKey] = entries
-            }
+            cache.withLockUnchecked { $0.formatEntriesCache[cacheKey] = entries }
         }
         return entries
     }
@@ -360,18 +362,15 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
 
     public func invalidateCache(for url: URL) {
         let cacheKey = cacheKey(for: url)
-        cacheQueue.async {
-            self.memoryCache[cacheKey] = nil
-        }
+        cache.withLockUnchecked { $0.memoryCache[cacheKey] = nil }
     }
 
     public func cachedFeed(for url: URL) -> CatalogFeed? {
         let cacheKey = cacheKey(for: url)
-        // Synchronous access — safe because cacheQueue is serial and we
-        // only read. DispatchQueue.sync on a serial queue is deadlock-safe
-        // when called from a different queue (MainActor in our case).
-        return cacheQueue.sync {
-            guard let entry = memoryCache[cacheKey], !isTooOld(entry) else { return nil }
+        // Synchronous, read-only lookup under the cache lock. The unfair lock
+        // holds only briefly, so calling this from the MainActor is safe.
+        return cache.withLockUnchecked { state in
+            guard let entry = state.memoryCache[cacheKey], !isTooOld(entry) else { return nil }
             return entry.feed
         }
     }
@@ -393,21 +392,13 @@ public final class CatalogRepository: CatalogRepositoryProtocol {
                     guard let self else { return }
                     let cacheKey = self.cacheKey(for: url)
 
-                    let isCached = await withCheckedContinuation { continuation in
-                        self.cacheQueue.async {
-                            continuation.resume(returning: self.memoryCache[cacheKey] != nil)
-                        }
-                    }
+                    let isCached = self.cache.withLockUnchecked { $0.memoryCache[cacheKey] != nil }
                     guard !isCached else { return }
 
                     do {
                         if let preloadedFeed = try await self.api.fetchFeed(at: url) {
-                            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-                                self.cacheQueue.async {
-                                    self.memoryCache[cacheKey] = CachedFeed(feed: preloadedFeed, timestamp: self.now())
-                                    c.resume()
-                                }
-                            }
+                            let cachedFeed = CachedFeed(feed: preloadedFeed, timestamp: self.now())
+                            self.cache.withLockUnchecked { $0.memoryCache[cacheKey] = cachedFeed }
                         }
                     } catch {
                         // Silently fail preloading

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/FeatureFlagProvider.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/FeatureFlagProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 /// The protocol intentionally exposes only the flags PalaceCatalog reads.
 /// Adding an unrelated flag here is a smell — extend the protocol only when
 /// the package actually needs the flag.
-public protocol FeatureFlagProvider: AnyObject {
+public protocol FeatureFlagProvider: AnyObject, Sendable {
     /// True when the OPDS 2 catalog format is enabled. Controls the
     /// `Accept` header sent by `DefaultCatalogAPI.fetchFeed(at:)` —
     /// when enabled, OPDS 2 (`application/opds+json`) is preferred over

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDS2AuthenticationDocument.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDS2AuthenticationDocument.swift
@@ -8,24 +8,24 @@
 
 import Foundation
 
-public enum OPDS2LinkRel: String {
+public enum OPDS2LinkRel: String, Sendable {
     case passwordReset = "http://librarysimplified.org/terms/rel/patron-password-reset"
 }
 
-public struct Announcement: Codable {
+public struct Announcement: Codable, Sendable {
     public let id: String
     public let content: String
 }
 
-public struct OPDS2AuthenticationDocument: Codable {
-    public struct Features: Codable {
+public struct OPDS2AuthenticationDocument: Codable, Sendable {
+    public struct Features: Codable, Sendable {
         public let disabled: [String]?
         public let enabled: [String]?
     }
 
-    public struct Authentication: Codable {
-        public struct Inputs: Codable {
-            public struct Input: Codable {
+    public struct Authentication: Codable, Sendable {
+        public struct Inputs: Codable, Sendable {
+            public struct Input: Codable, Sendable {
                 public let barcodeFormat: String?
                 public let maximumLength: UInt?
                 public let keyboard: String // TODO: Use enum instead (or not; it could break if new values are added)
@@ -35,7 +35,7 @@ public struct OPDS2AuthenticationDocument: Codable {
             public let password: Input
         }
 
-        public struct Labels: Codable {
+        public struct Labels: Codable, Sendable {
             public let login: String
             public let password: String
         }

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDS2CatalogsFeed.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDS2CatalogsFeed.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-public struct OPDS2CatalogsFeed: Codable {
-    public struct Metadata: Codable {
+public struct OPDS2CatalogsFeed: Codable, Sendable {
+    public struct Metadata: Codable, Sendable {
         public let adobe_vendor_id: String?
         public let title: String
         /// Total number of items across all pages (from crawlable endpoint)

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDS2Feed.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDS2Feed.swift
@@ -286,22 +286,28 @@ public extension OPDS2Feed {
     static public func makeDecoder() -> JSONDecoder {
         let decoder = JSONDecoder()
 
-        // OPDS 2.0 uses ISO 8601 dates
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
+        // OPDS 2.0 uses ISO 8601 dates. Construct the formatters INSIDE the
+        // `.custom` closure: it is `@Sendable` (capturing a shared mutable
+        // ISO8601DateFormatter would be a data race), and the previous shared
+        // formatter mutated `formatOptions` to drop `.withFractionalSeconds`
+        // and never restored it — so once any non-fractional date was parsed,
+        // every later fractional date silently failed. Per-call formatters are
+        // both race-free and free of that latent ordering bug.
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
             // Try with fractional seconds first
-            if let date = formatter.date(from: dateString) {
+            let fractional = ISO8601DateFormatter()
+            fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = fractional.date(from: dateString) {
                 return date
             }
 
             // Try without fractional seconds
-            formatter.formatOptions = [.withInternetDateTime]
-            if let date = formatter.date(from: dateString) {
+            let plain = ISO8601DateFormatter()
+            plain.formatOptions = [.withInternetDateTime]
+            if let date = plain.date(from: dateString) {
                 return date
             }
 

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDSParser.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/OPDSParser.swift
@@ -1,7 +1,8 @@
 import Foundation
 import PalaceLogging
 
-public final class OPDSParser {
+// Stateless parser (no stored instance state) — safely Sendable.
+public final class OPDSParser: Sendable {
     enum ParserError: Error, LocalizedError, Equatable {
         case invalidXML
         case invalidFeed

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPAsync.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPAsync.swift
@@ -1,6 +1,6 @@
 import Foundation
 
 /// Equivalent to using dispatch_async with the default global priority queue.
-public func TPPAsyncDispatch(_ block: @escaping () -> Void) {
+public func TPPAsyncDispatch(_ block: @escaping @Sendable () -> Void) {
   DispatchQueue.global(qos: .default).async(execute: block)
 }

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSAcquisition.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSAcquisition.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PalaceLogging
 
-@objc public enum TPPOPDSAcquisitionRelation: Int {
+@objc public enum TPPOPDSAcquisitionRelation: Int, Sendable {
   case generic
   case openAccess
   case borrow

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSAcquisition.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSAcquisition.swift
@@ -11,7 +11,7 @@ import PalaceLogging
   case subscribe
 }
 
-public struct TPPOPDSAcquisitionRelationSet: OptionSet {
+public struct TPPOPDSAcquisitionRelationSet: OptionSet, Sendable {
   public let rawValue: UInt
 
   public init(rawValue: UInt) {
@@ -91,13 +91,16 @@ public func NYPLOPDSAcquisitionRelationString(_ relation: TPPOPDSAcquisitionRela
 
 // MARK: - TPPOPDSAcquisition
 
-@objc public class TPPOPDSAcquisition: NSObject {
+// Sendable: `final` + immutable `let` stored properties. `availability` is an
+// existential of the (now Sendable) `TPPOPDSAcquisitionAvailability` protocol,
+// and `indirectAcquisitions` holds the Sendable `TPPOPDSIndirectAcquisition`.
+@objc public final class TPPOPDSAcquisition: NSObject, Sendable {
 
-  @objc public private(set) var relation: TPPOPDSAcquisitionRelation
-  @objc public private(set) var type: String
-  @objc public private(set) var hrefURL: URL
-  @objc public private(set) var indirectAcquisitions: [TPPOPDSIndirectAcquisition]
-  @objc public private(set) var availability: TPPOPDSAcquisitionAvailability
+  @objc public let relation: TPPOPDSAcquisitionRelation
+  @objc public let type: String
+  @objc public let hrefURL: URL
+  @objc public let indirectAcquisitions: [TPPOPDSIndirectAcquisition]
+  @objc public let availability: TPPOPDSAcquisitionAvailability
 
   private static let availabilityKey = "availability"
   private static let hrefURLKey = "href"

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSAcquisitionAvailability.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSAcquisitionAvailability.swift
@@ -4,7 +4,10 @@ public typealias TPPOPDSAcquisitionAvailabilityCopies = UInt
 
 public let TPPOPDSAcquisitionAvailabilityCopiesUnknown: TPPOPDSAcquisitionAvailabilityCopies = UInt.max
 
-@objc public protocol TPPOPDSAcquisitionAvailability: NSObjectProtocol {
+// Refines Sendable so `any TPPOPDSAcquisitionAvailability` existentials are
+// Sendable. All concrete conformers below are `final` NSObject subclasses with
+// immutable `let` stored properties, so each satisfies the checked conformance.
+@objc public protocol TPPOPDSAcquisitionAvailability: NSObjectProtocol, Sendable {
   var since: Date? { get }
   var until: Date? { get }
 
@@ -177,7 +180,7 @@ public func NYPLOPDSAcquisitionAvailabilityDictionaryRepresentation(_ availabili
 
 // MARK: - Concrete availability classes
 
-@objc public class TPPOPDSAcquisitionAvailabilityUnavailable: NSObject, TPPOPDSAcquisitionAvailability {
+@objc public final class TPPOPDSAcquisitionAvailabilityUnavailable: NSObject, TPPOPDSAcquisitionAvailability {
   @objc public let copiesHeld: TPPOPDSAcquisitionAvailabilityCopies
   @objc public let copiesTotal: TPPOPDSAcquisitionAvailabilityCopies
   @objc public let since: Date? = nil
@@ -200,7 +203,7 @@ public func NYPLOPDSAcquisitionAvailabilityDictionaryRepresentation(_ availabili
   }
 }
 
-@objc public class TPPOPDSAcquisitionAvailabilityLimited: NSObject, TPPOPDSAcquisitionAvailability {
+@objc public final class TPPOPDSAcquisitionAvailabilityLimited: NSObject, TPPOPDSAcquisitionAvailability {
   @objc public let copiesAvailable: TPPOPDSAcquisitionAvailabilityCopies
   @objc public let copiesTotal: TPPOPDSAcquisitionAvailabilityCopies
   @objc public let since: Date?
@@ -225,7 +228,7 @@ public func NYPLOPDSAcquisitionAvailabilityDictionaryRepresentation(_ availabili
   }
 }
 
-@objc public class TPPOPDSAcquisitionAvailabilityUnlimited: NSObject, TPPOPDSAcquisitionAvailability {
+@objc public final class TPPOPDSAcquisitionAvailabilityUnlimited: NSObject, TPPOPDSAcquisitionAvailability {
   @objc public let since: Date? = nil
   @objc public let until: Date? = nil
 
@@ -240,7 +243,7 @@ public func NYPLOPDSAcquisitionAvailabilityDictionaryRepresentation(_ availabili
   }
 }
 
-@objc public class TPPOPDSAcquisitionAvailabilityReserved: NSObject, TPPOPDSAcquisitionAvailability {
+@objc public final class TPPOPDSAcquisitionAvailabilityReserved: NSObject, TPPOPDSAcquisitionAvailability {
   @objc public let holdPosition: UInt
   @objc public let copiesTotal: TPPOPDSAcquisitionAvailabilityCopies
   @objc public let since: Date?
@@ -265,7 +268,7 @@ public func NYPLOPDSAcquisitionAvailabilityDictionaryRepresentation(_ availabili
   }
 }
 
-@objc public class TPPOPDSAcquisitionAvailabilityReady: NSObject, TPPOPDSAcquisitionAvailability {
+@objc public final class TPPOPDSAcquisitionAvailabilityReady: NSObject, TPPOPDSAcquisitionAvailability {
   @objc public let since: Date?
   @objc public let until: Date?
 

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSAcquisitionPath.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSAcquisitionPath.swift
@@ -31,11 +31,12 @@ public let ContentTypeStreamingHTML = "text/html;profile=http://librarysimplifie
 
 // MARK: - TPPOPDSAcquisitionPath
 
-@objc public class TPPOPDSAcquisitionPath: NSObject {
+// Sendable: `final` + immutable `let` Sendable value-type stored properties.
+@objc public final class TPPOPDSAcquisitionPath: NSObject, Sendable {
 
-  @objc public private(set) var relation: TPPOPDSAcquisitionRelation
-  @objc public private(set) var types: [String]
-  @objc public private(set) var url: URL
+  @objc public let relation: TPPOPDSAcquisitionRelation
+  @objc public let types: [String]
+  @objc public let url: URL
 
   @objc public init(relation: TPPOPDSAcquisitionRelation, types: [String], url: URL) {
     self.relation = relation

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSCategory.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSCategory.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-@objc public class TPPOPDSCategory: NSObject {
+// Sendable: `final` + immutable `let` Sendable value-type stored properties.
+@objc public final class TPPOPDSCategory: NSObject, Sendable {
 
-  @objc public private(set) var term: String
-  @objc public private(set) var label: String?
-  @objc public private(set) var scheme: URL?
+  @objc public let term: String
+  @objc public let label: String?
+  @objc public let scheme: URL?
 
   @objc public init(term: String, label: String?, scheme: URL?) {
     self.term = term

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSEntry.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSEntry.swift
@@ -1,7 +1,13 @@
 import Foundation
 import PalaceLogging
 
-@objc public class TPPOPDSEntry: NSObject {
+// @unchecked Sendable invariant: every stored property is `private(set)` and is
+// populated only during `init?(xml:)` (directly or via the private `parse*`
+// helpers it invokes); none is mutated after init returns, and the type exposes
+// no public mutators. Instances are therefore effectively immutable once
+// constructed. `@unchecked` (vs checked) is needed only because the properties
+// stay `var` to allow the init-time parse helpers to assign them.
+@objc public final class TPPOPDSEntry: NSObject, @unchecked Sendable {
 
   @objc public private(set) var acquisitions: [TPPOPDSAcquisition] = []
   @objc public private(set) var alternativeHeadline: String?

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSEntryGroupAttributes.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSEntryGroupAttributes.swift
@@ -1,9 +1,10 @@
 import Foundation
 
-@objc public class TPPOPDSEntryGroupAttributes: NSObject {
+// Sendable: `final` + immutable `let` Sendable value-type stored properties.
+@objc public final class TPPOPDSEntryGroupAttributes: NSObject, Sendable {
 
-  @objc public private(set) var href: URL?
-  @objc public private(set) var title: String
+  @objc public let href: URL?
+  @objc public let title: String
 
   @objc public init(href: URL?, title: String) {
     self.title = title

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSFeed.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSFeed.swift
@@ -8,7 +8,14 @@ import PalaceLogging
   case navigation
 }
 
-@objc public class TPPOPDSFeed: NSObject {
+// @unchecked Sendable invariant: every stored property is `private(set)` and is
+// assigned only during `init?(xml:)`; no method mutates an instance afterward.
+// `type` is computed eagerly during init (see `computeType(from:)`) instead of
+// via a post-init lazy cache, so there is no mutable-after-init state to race on.
+// `@unchecked` (vs checked) is required because `licensor` is an `NSDictionary?`,
+// which the compiler cannot prove Sendable; it is an immutable dictionary built
+// locally in init and never re-exposed for mutation.
+@objc public final class TPPOPDSFeed: NSObject, @unchecked Sendable {
 
   @objc public private(set) var entries: [TPPOPDSEntry] = []
   @objc public private(set) var identifier: String?
@@ -18,33 +25,22 @@ import PalaceLogging
   @objc public private(set) var licensor: NSDictionary?
   @objc public private(set) var authorizationIdentifier: String?
 
-  private var _type: TPPOPDSFeedType = .invalid
-  private var typeIsCached = false
+  /// Feed type, derived from `entries`. Computed once during init and never
+  /// mutated afterward (the previous lazy `_type`/`typeIsCached` cache mutated
+  /// on first access, which was not safe for concurrent reads).
+  @objc public private(set) var type: TPPOPDSFeedType = .invalid
 
-  @objc public var type: TPPOPDSFeedType {
-    if typeIsCached { return _type }
-    typeIsCached = true
+  private static func computeType(from entries: [TPPOPDSEntry]) -> TPPOPDSFeedType {
+    guard !entries.isEmpty else { return .acquisitionUngrouped }
 
-    guard !self.entries.isEmpty else {
-      _type = .acquisitionUngrouped
-      return _type
-    }
-
-    let provisionalType = Self.typeImplied(by: entries[0])
-    if provisionalType == .invalid {
-      _type = .invalid
-      return _type
-    }
+    let provisionalType = typeImplied(by: entries[0])
+    if provisionalType == .invalid { return .invalid }
 
     for i in 1..<entries.count {
-      if Self.typeImplied(by: entries[i]) != provisionalType {
-        _type = .invalid
-        return _type
-      }
+      if typeImplied(by: entries[i]) != provisionalType { return .invalid }
     }
 
-    _type = provisionalType
-    return _type
+    return provisionalType
   }
 
   @objc public init?(xml feedXML: TPPXML?) {
@@ -59,6 +55,7 @@ import PalaceLogging
         return nil
       }
       entries = [entry]
+      type = Self.computeType(from: entries)
       return
     }
 
@@ -103,6 +100,7 @@ import PalaceLogging
       parsedEntries.append(entry)
     }
     entries = parsedEntries
+    type = Self.computeType(from: entries)
 
     if let patronXML = feedXML.firstChild(withName: "patron"),
        let attrs = patronXML.attributes as? [String: String],

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSGroup.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSGroup.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-@objc public class TPPOPDSGroup: NSObject {
+// @unchecked Sendable invariant: every stored property is `private(set)` and
+// assigned exactly once in `init`; instances are never mutated afterward.
+// `entries` is typed `[Any]` only for Objective-C bridging — it holds the
+// value-immutable OPDS entry objects, so `@unchecked` is required (the compiler
+// cannot prove `[Any]` Sendable) but the contents are in fact safe to share.
+@objc public final class TPPOPDSGroup: NSObject, @unchecked Sendable {
 
   @objc public private(set) var entries: [Any]
   @objc public private(set) var href: URL

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSIndirectAcquisition.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSIndirectAcquisition.swift
@@ -1,10 +1,12 @@
 import Foundation
 import PalaceLogging
 
-@objc public class TPPOPDSIndirectAcquisition: NSObject {
+// Sendable: `final` + immutable `let` stored properties. `indirectAcquisitions`
+// is an array of this same (now Sendable) value-immutable type.
+@objc public final class TPPOPDSIndirectAcquisition: NSObject, Sendable {
 
-  @objc public private(set) var type: String
-  @objc public private(set) var indirectAcquisitions: [TPPOPDSIndirectAcquisition]
+  @objc public let type: String
+  @objc public let indirectAcquisitions: [TPPOPDSIndirectAcquisition]
 
   private static let typeKey = "type"
   private static let indirectAcquisitionsKey = "indirectAcquisitions"

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSLink.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOPDSLink.swift
@@ -1,7 +1,12 @@
 import Foundation
 import PalaceLogging
 
-@objc public class TPPOPDSLink: NSObject {
+// @unchecked Sendable invariant: every stored property is `private(set)` and
+// assigned exactly once during the failable `init?`; nothing mutates an
+// instance after init. `attributes` is an immutable `NSDictionary` of parsed XML
+// attributes (never an `NSMutableDictionary`, never re-exposed for mutation),
+// which is why this is `@unchecked` rather than a checked conformance.
+@objc public final class TPPOPDSLink: NSObject, @unchecked Sendable {
 
   @objc public private(set) var attributes: NSDictionary = [:]
   @objc public private(set) var href: URL

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOpenSearchDescription.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPOpenSearchDescription.swift
@@ -18,33 +18,39 @@ import PalaceNetwork
   /// `AppContainer.production().networkExecutor`. Callers now pass a
   /// `NetworkClient` explicitly (typically the app target's
   /// `networkExecutor` exposed via `AppContainer`).
+  /// Returns `nil` on any failure (network error, unparseable XML, or XML that
+  /// is not a valid OpenSearch description); failures are logged at the call
+  /// site here rather than surfaced as thrown errors to preserve the prior
+  /// completion-handler contract.
+  ///
+  /// Rewritten from a completion-handler signature to `async` during the Swift 6
+  /// strict-concurrency migration: the old form captured a non-`Sendable`
+  /// `(TPPOpenSearchDescription?) -> Void` closure inside a `Task`, which is an
+  /// error under the Swift 6 language mode. Hopping back to the caller via
+  /// `await` instead of `MainActor.run { completionHandler(...) }` removes the
+  /// `@Sendable` capture entirely.
   public static func withURL(
     _ url: URL,
-    networkClient: NetworkClient,
-    completionHandler: @escaping (TPPOpenSearchDescription?) -> Void
-  ) {
-    Task {
-      do {
-        let request = NetworkRequest(method: .GET, url: url)
-        let response = try await networkClient.send(request)
+    networkClient: NetworkClient
+  ) async -> TPPOpenSearchDescription? {
+    do {
+      let request = NetworkRequest(method: .GET, url: url)
+      let response = try await networkClient.send(request)
 
-        guard let xml = TPPXML.xml(withData: response.data) else {
-          Log.log("TPPOpenSearchDescription: Failed to parse data as XML.")
-          await MainActor.run { completionHandler(nil) }
-          return
-        }
-
-        guard let description = TPPOpenSearchDescription(xml: xml) else {
-          Log.log("TPPOpenSearchDescription: Failed to interpret XML as OpenSearch description document.")
-          await MainActor.run { completionHandler(nil) }
-          return
-        }
-
-        await MainActor.run { completionHandler(description) }
-      } catch {
-        Log.log("TPPOpenSearchDescription: Network error: \(error)")
-        await MainActor.run { completionHandler(nil) }
+      guard let xml = TPPXML.xml(withData: response.data) else {
+        Log.log("TPPOpenSearchDescription: Failed to parse data as XML.")
+        return nil
       }
+
+      guard let description = TPPOpenSearchDescription(xml: xml) else {
+        Log.log("TPPOpenSearchDescription: Failed to interpret XML as OpenSearch description document.")
+        return nil
+      }
+
+      return description
+    } catch {
+      Log.log("TPPOpenSearchDescription: Network error: \(error)")
+      return nil
     }
   }
 

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPProblemDocument.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/TPPProblemDocument.swift
@@ -3,7 +3,11 @@ import Foundation
 /**
  Represents a Problem Document, outlined in https://tools.ietf.org/html/rfc7807
  */
-@objcMembers public class TPPProblemDocument: NSObject, Codable {
+// Sendable: `final` + every stored property is an immutable `let` of a Sendable
+// value type (String?/Int?). The APIs that return mutable shapes
+// (`dictionaryValue`, `stringValue`) are computed and build fresh values per call.
+// NSObject is an allowed superclass for a checked Sendable conformance.
+@objcMembers public final class TPPProblemDocument: NSObject, Codable, Sendable {
     public static let TypeNoActiveLoan =
         "http://librarysimplified.org/terms/problem/no-active-loan"
     public static let TypeLoanAlreadyExists =

--- a/Palace/Packages/PalaceNetwork/Package.swift
+++ b/Palace/Packages/PalaceNetwork/Package.swift
@@ -9,7 +9,10 @@ let package = Package(
     name: "PalaceNetwork",
     platforms: [
         .iOS(.v16),
-        .macOS(.v11)
+        // macOS host floor 13 to match the PalaceLogging dependency
+        // (OSAllocatedUnfairLock, macOS 13+). Host-build only; shipping app is
+        // iOS 16. Latent floor gap from #1133 — only bites standalone builds.
+        .macOS(.v13)
     ],
     products: [.library(name: "PalaceNetwork", targets: ["PalaceNetwork"])],
     dependencies: [

--- a/Palace/Packages/PalaceNetwork/Sources/PalaceNetwork/NetworkClient.swift
+++ b/Palace/Packages/PalaceNetwork/Sources/PalaceNetwork/NetworkClient.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public protocol NetworkClient {
+public protocol NetworkClient: Sendable {
     func send(_ request: NetworkRequest) async throws -> NetworkResponse
 }
 

--- a/PalaceTests/OPDS2/OPDS2FeedTests.swift
+++ b/PalaceTests/OPDS2/OPDS2FeedTests.swift
@@ -299,6 +299,51 @@ final class OPDS2FeedTests: XCTestCase {
         )
     }
 
+    /// Regression for the shared-ISO8601-formatter bug fixed in the Swift 6
+    /// modernization (#1138). ONE decoder decodes two publications: the first
+    /// carries a NON-fractional `updated`, the second a fractional `updated`.
+    /// Array order guarantees the non-fractional date is decoded first. The old
+    /// `makeDecoder` shared a single formatter and dropped `.withFractionalSeconds`
+    /// after the first non-fractional date, never restoring it — so the second
+    /// (fractional) date failed and the whole `from(data:)` THREW. With per-call
+    /// formatters both parse. The single-date tests above cannot exercise this
+    /// cross-field contamination.
+    func testMixedFractionalAndNonFractionalDates_acrossPublications_bothParse() throws {
+        let json = """
+    {
+      "metadata": { "title": "Mixed Dates" },
+      "links": [{"href": "https://example.com/self", "rel": "self"}],
+      "publications": [
+        {
+          "metadata": {"id": "b1", "title": "Non-fractional first", "updated": "2026-01-15T10:30:45Z"},
+          "links": [{"href": "/b1/manifest", "rel": "http://opds-spec.org/acquisition/open-access", "type": "application/epub+zip"}]
+        },
+        {
+          "metadata": {"id": "b2", "title": "Fractional second", "updated": "2026-02-20T08:15:30.500Z"},
+          "links": [{"href": "/b2/manifest", "rel": "http://opds-spec.org/acquisition/open-access", "type": "application/epub+zip"}]
+        }
+      ]
+    }
+    """
+        let data = json.data(using: .utf8)!
+        // Old shared-formatter bug: `from(data:)` throws — pub[1]'s fractional
+        // `updated` fails to parse after pub[0]'s non-fractional `updated`
+        // poisons the shared formatter.
+        let feed = try OPDS2Feed.from(data: data)
+
+        let pubs = try XCTUnwrap(feed.publications)
+        XCTAssertEqual(pubs.count, 2)
+        let firstUpdated = try XCTUnwrap(pubs[0].metadata.updated,
+            "non-fractional `updated` must parse")
+        let secondUpdated = try XCTUnwrap(pubs[1].metadata.updated,
+            "fractional `updated` must parse even after a non-fractional date in the same decode")
+
+        let c1 = Calendar.current.dateComponents([.year, .month, .day], from: firstUpdated)
+        XCTAssertEqual(c1.year, 2026); XCTAssertEqual(c1.month, 1); XCTAssertEqual(c1.day, 15)
+        let c2 = Calendar.current.dateComponents([.year, .month, .day], from: secondUpdated)
+        XCTAssertEqual(c2.year, 2026); XCTAssertEqual(c2.month, 2); XCTAssertEqual(c2.day, 20)
+    }
+
     // MARK: - Format Detection
 
     func testDetectOPDS2FromContentType() {


### PR DESCRIPTION
## What

Brings **PalaceCatalog** (the modernization tent-pole, #1129 sizing's "center of mass") to Swift 6. Measured surface: **66 distinct strict-concurrency warnings → 0** at `.swiftLanguageMode(.v6)`. Follows the #1129 playbook (fix by **isolation**, never `nonisolated(unsafe)`).

## How (3-way swarm + integration)

- **OPDS model layer** — `Sendable` conformances across the model types (value types additive; reference types made `final`+`Sendable` or `@unchecked Sendable` with documented immutable-after-init invariants). Verified no subclasses anywhere.
- **CatalogRepository** — replaced the serial `DispatchQueue` cache with a lock-guarded `CacheState` (`OSAllocatedUnfairLock`), eliminating the `@Sendable` self-captures; `withTimeout<T: Sendable>`.
- **CatalogAPI + TPPOpenSearchDescription** — refactored the completion-handler `withURL` to `async` (removed the `@Sendable` capture entirely); `DefaultCatalogAPI: Sendable`.
- **Seam types** (integration): `TPPOPDSAcquisitionRelation`, `OPDSParser`, `FeatureFlagProvider`, PalaceNetwork's `NetworkClient` → `Sendable`; `TPPAsyncDispatch` param → `@Sendable`.
- **Manifest**: dropped phantom `.testTarget` (no `Tests/` dir; tests live in the app's `PalaceTests`); macOS host floor 11→13 (PalaceLogging dep); same floor bump for PalaceNetwork (latent gap from #1133); `swift-tools-version` 5.9 → 6.0.

## Bonus: two real latent bugs fixed

- `TPPOPDSFeed.type` lazily mutated cached state post-init (unsynchronized) → now computed eagerly at init.
- `OPDS2Feed.makeDecoder` shared an `ISO8601DateFormatter` and dropped `.withFractionalSeconds` **without restoring it** — so after any non-fractional date, every later fractional date silently failed to parse. Now per-call formatters (race-free + order-independent).

## Scope / ripple

- Cross-package: PalaceNetwork `NetworkClient` → `Sendable` (a shared HTTP client should be Sendable; clears the `DefaultCatalogAPI` stored-property warning).
- App-target Sendable ripple (e.g. `FeatureFlagProvider`'s one app conformer) is **warnings only** (app target is Swift 5), tracked for the app-target module.
- **Out of scope:** ~68 pre-existing NON-concurrency style warnings (redundant `public` in public extensions, always-true casts).
- **PalaceAuth** modernizes next and merges after this (Sendable ripple ordering).

## Verification

- `swift build` (v6 language mode): **0 errors, 0 concurrency warnings**.
- App-side ripple greps: no subclasses of now-`final` classes; no app callers of the async-refactored method.
- CI `build-and-test` is the authoritative full-app ripple gate (runs the 13 Catalog test classes with frameworks). SoD architect + qa to follow.

Intent: `palacecatalog-swift6-modernization` (with the full measured breakdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)