### PR TITLE
chore(hooks): auto-assign agent-created PRs to Maurice Carrier

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -123,6 +123,12 @@
             "command": "bash scripts/hooks/post-pr-retro.sh",
             "timeout": 5,
             "statusMessage": "Checking for post-PR retro..."
+          },
+          {
+            "type": "command",
+            "command": "input=$(cat); echo \"$input\" | jq -r '.tool_input.command // empty' 2>/dev/null | grep -q 'gh pr create' || exit 0; url=$(echo \"$input\" | grep -oE 'https://github\\.com/[^\"[:space:]]+/pull/[0-9]+' | head -1); [ -n \"$url\" ] && gh pr edit \"$url\" --add-assignee mauricecarrier7 >/dev/null 2>&1; exit 0",
+            "timeout": 20,
+            "statusMessage": "Auto-assigning new PR to Maurice Carrier..."
           }
         ]
       }


### PR DESCRIPTION
## What

Adds a `PostToolUse(Bash)` hook to `.claude/settings.json` that, after a `gh pr create`, extracts the new PR's URL from the command output and runs `gh pr edit <url> --add-assignee mauricecarrier7`.

## Why

Belt-and-suspenders for the existing org-level auto-assignment, so every agent-created PR is reliably assigned to the maintainer.

## Behavior

- **No-op** for any command that isn't `gh pr create` (guarded on the command string), and won't misfire on `gh pr view`/`gh pr list` URLs.
- **Never blocks** — always `exit 0`, output suppressed. On a contributor without assign permission, the `gh pr edit` simply no-ops.

Verified via pipe-test: assigns on `gh pr create` (extracts the `/pull/N` URL), no-ops on `gh pr view 1134` and unrelated commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)