### PR TITLE
PalaceAuth → Swift 6 (final per-package modernization module)

### DIFF
--- a/.forgeos/intent/palaceauth-swift6-modernization.md
+++ b/.forgeos/intent/palaceauth-swift6-modernization.md
@@ -1,0 +1,65 @@
+---
+name: palaceauth-swift6-modernization
+created: 2026-06-30
+author: claude
+---
+
+# palaceauth-swift6-modernization
+
+Final per-package module of the Swift 6 modernization fan-out (#1129 playbook).
+PalaceAuth is **critical-path** (AuthCoordinator actor, AuthErrorClassifier,
+TokenRequest, the auth-error decision seams) and is gated behind PalaceCatalog
+(consumes its Sendable types) — so this branches off `feat/swift6-palacecatalog`
+and merges after it. PR + architect/qa SoD (critical path).
+
+## Measured scope (2026-06-30, `swift build -Xswiftc -strict-concurrency=complete`)
+
+Only **3** concurrency warnings (#1129 sizing estimated "trivial / 1"). All fixed
+by isolation, never `nonisolated(unsafe)`:
+
+1. `AuthDecisionPayload.iso8601Formatter` (static ISO8601DateFormatter,
+   #MutableGlobalVariable) → localized per-call via `makeISO8601Formatter()`
+   (telemetry path, called once per payload — not hot). Behavior-identical.
+2. `AuthCoordinator.swift:160` Task capture: the actor spawns a `@Sendable`
+   refresh Task capturing `userAccount: TPPUserAccountWriting & TPPUserAccountReading`
+   — the only non-Sendable capture (siblings `Reauthenticating` /
+   `SignInModalPresenting` / `AuthDecisionRecording` were ALREADY `Sendable`).
+   Fixed by adding `Sendable` to `TPPUserAccountReading`/`TPPUserAccountWriting`
+   in AuthCoordinatorSeams.swift — completes the established seam pattern (these
+   deps cross into the refresh Task by design; this is the existing contract
+   made type-honest, not new concurrency).
+3. `TokenRequest.execute(completion:)` Task: `completion` param → `@Sendable`,
+   and `TokenRequest` → `final ... Sendable` (immutable `let`-only storage; no
+   subclasses; self is captured by the Task to drive the async POST).
+
+## Manifest
+
+- macOS host floor 12 → 13 (PalaceLogging dep; host-only; iOS stays 16).
+- `swift-tools-version` 5.9 → 6.0; source target `.swiftLanguageMode(.v6)`, the
+  REAL test target `PalaceAuthTests` stays `.v5` (XCTestCase isn't Sendable) —
+  the Keychain/TriageBot pattern (NOT the dropped-phantom-testTarget pattern,
+  since PalaceAuth has a genuine `Tests/` dir).
+
+## Anti-claims
+
+- does NOT use `nonisolated(unsafe)`.
+- does NOT change AuthCoordinator's refresh logic / AuthErrorClassifier decisions
+  — only Sendable annotations + per-call formatter + closure isolation.
+- App-target Sendable ripple: `TPPUserAccount+TPPUserAccountReadingWriting.swift`
+  conformer gets a Swift-5 Sendable WARNING (not error). Verify TPPUserAccount is
+  genuinely thread-safe (it's already captured into the refresh Task in
+  production) — proper Sendable annotation is the app-target module's job. No app
+  callers of `TokenRequest.execute(completion:)` (grep-clean), so that change has
+  no app ripple.
+
+## Files in scope
+
+- Palace/Packages/PalaceAuth/Package.swift (floor, tools 6.0, source v6 / tests v5)
+- Palace/Packages/PalaceAuth/Sources/PalaceAuth/AuthDecisionPayload.swift (formatter)
+- Palace/Packages/PalaceAuth/Sources/PalaceAuth/AuthCoordinatorSeams.swift (2 protocols → Sendable)
+- Palace/Packages/PalaceAuth/Sources/PalaceAuth/TokenRequest.swift (final+Sendable, @Sendable completion)
+
+## Verification
+
+`swift build` (v6) 0/0; `swift test` (in-package) **110 tests, 0 failures**;
+full-app iOS CI build-and-test is the app-ripple gate; architect + qa SoD.

--- a/Palace/Packages/PalaceAuth/Package.swift
+++ b/Palace/Packages/PalaceAuth/Package.swift
@@ -1,11 +1,14 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
     name: "PalaceAuth",
     platforms: [
         .iOS(.v16),
-        .macOS(.v12)
+        // macOS host floor 13 to match the PalaceLogging dependency
+        // (OSAllocatedUnfairLock, macOS 13+). Host-build only; shipping app is
+        // iOS 16. Same floor the other modernized packages established.
+        .macOS(.v13)
     ],
     products: [
         .library(
@@ -19,13 +22,17 @@ let package = Package(
         .package(path: "../PalaceCatalog")
     ],
     targets: [
+        // Source target → Swift 6 (race-checked). Test target stays v5 to avoid
+        // test-infra churn (XCTestCase isn't Sendable). Same split as #1130.
         .target(
             name: "PalaceAuth",
-            dependencies: ["PalaceLogging", "PalaceNetwork", "PalaceCatalog"]
+            dependencies: ["PalaceLogging", "PalaceNetwork", "PalaceCatalog"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .testTarget(
             name: "PalaceAuthTests",
-            dependencies: ["PalaceAuth"]
+            dependencies: ["PalaceAuth"],
+            swiftSettings: [.swiftLanguageMode(.v5)]
         )
     ]
 )

--- a/Palace/Packages/PalaceAuth/Sources/PalaceAuth/AuthCoordinatorSeams.swift
+++ b/Palace/Packages/PalaceAuth/Sources/PalaceAuth/AuthCoordinatorSeams.swift
@@ -97,7 +97,7 @@ public protocol SignInModalPresenting: AnyObject, Sendable {
 ///
 /// The full ~17-method split is Phase 3 trunk-move scope per
 /// `docs/3.2.0-auth-deps.md` and explicitly out of scope here.
-public protocol TPPUserAccountReading: AnyObject {
+public protocol TPPUserAccountReading: AnyObject, Sendable {
     /// True when there's a stored credential (bearer token, basic pair,
     /// or SAML cookies). Persisted in keychain per library UUID.
     var hasCredentials: Bool { get }
@@ -112,7 +112,7 @@ public protocol TPPUserAccountReading: AnyObject {
 
 /// Narrow write slice of `TPPUserAccount`. The coordinator only writes
 /// the credentials-stale marker before fanning out a refresh attempt.
-public protocol TPPUserAccountWriting: AnyObject {
+public protocol TPPUserAccountWriting: AnyObject, Sendable {
     /// Mark the current credentials as stale so that the next consumer
     /// observes `authState == .credentialsStale` and waits for the
     /// coordinator's re-auth result instead of issuing a fresh request

--- a/Palace/Packages/PalaceAuth/Sources/PalaceAuth/AuthDecisionPayload.swift
+++ b/Palace/Packages/PalaceAuth/Sources/PalaceAuth/AuthDecisionPayload.swift
@@ -150,7 +150,7 @@ public struct AuthDecisionPayload: Sendable, Equatable {
             "decision": decision,
             "call_site": callSite,
             "correlation_id": correlationID.uuidString,
-            "timestamp_iso": Self.iso8601Formatter.string(from: timestamp)
+            "timestamp_iso": Self.makeISO8601Formatter().string(from: timestamp)
         ]
         if let libraryUUID { result["library_uuid"] = libraryUUID }
         if let statusCode { result["status_code"] = String(statusCode) }
@@ -158,11 +158,15 @@ public struct AuthDecisionPayload: Sendable, Equatable {
         return result
     }
 
-    private static let iso8601Formatter: ISO8601DateFormatter = {
+    // Localized per call (playbook: a shared non-Sendable ISO8601DateFormatter
+    // static is a #MutableGlobalVariable under Swift 6; never nonisolated(unsafe)).
+    // Called once per telemetry payload — not a hot path, so per-call allocation
+    // is fine and keeps the formatter provably race-free.
+    private static func makeISO8601Formatter() -> ISO8601DateFormatter {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter
-    }()
+    }
 }
 
 // MARK: - Convenience constructors

--- a/Palace/Packages/PalaceAuth/Sources/PalaceAuth/TokenRequest.swift
+++ b/Palace/Packages/PalaceAuth/Sources/PalaceAuth/TokenRequest.swift
@@ -28,7 +28,10 @@ import PalaceCatalog
     }
 }
 
-@objcMembers public class TokenRequest: NSObject {
+// `Sendable`: immutable value-typed `let` storage only; the Task in
+// `execute(completion:)` captures `self` to drive the async POST. `final` makes
+// the checked conformance sound (no subclasses exist).
+@objcMembers public final class TokenRequest: NSObject, Sendable {
     public let url: URL
     public let username: String
     public let password: String
@@ -189,7 +192,7 @@ import PalaceCatalog
 }
 
 extension TokenRequest {
-    @objc public func execute(completion: @escaping (TokenResponse?, Error?) -> Void) {
+    @objc public func execute(completion: @escaping @Sendable (TokenResponse?, Error?) -> Void) {
         Task {
             let result = await execute()
             switch result {

--- a/Palace/Packages/PalaceAuth/Tests/PalaceAuthTests/AuthDecisionPayloadTests.swift
+++ b/Palace/Packages/PalaceAuth/Tests/PalaceAuthTests/AuthDecisionPayloadTests.swift
@@ -290,7 +290,11 @@ final class AuthDecisionPayloadTests: XCTestCase {
         XCTAssertEqual(fields["step"], "classifier.classified")
         XCTAssertEqual(fields["call_site"], "X/Y")
         XCTAssertEqual(fields["correlation_id"], "00000000-0000-0000-0000-000000000001")
-        XCTAssertNotNil(fields["timestamp_iso"], "timestamp_iso must always be present")
+        // Pin the EXACT ISO-8601 string (not just non-nil) so a regression in
+        // the per-call formatter's formatOptions [.withInternetDateTime,
+        // .withFractionalSeconds] is caught. timeIntervalSince1970: 0 → epoch.
+        XCTAssertEqual(fields["timestamp_iso"], "1970-01-01T00:00:00.000Z",
+            "timestamp must be ISO-8601 internet date-time WITH fractional seconds, in GMT")
     }
 
     func testDashboardFields_emitsAllPresentFields() {


### PR DESCRIPTION
## What

Completes the per-package Swift 6 modernization fan-out. **PalaceAuth** (critical-path: auth/sign-in) — 3 strict-concurrency warnings → 0, flipped to Swift 6 language mode. Gated behind PalaceCatalog (#1138, merged); this consumes its now-Sendable types.

## Fixes (isolation only — never `nonisolated(unsafe)`)

- **`AuthDecisionPayload`** — shared static `ISO8601DateFormatter` (`#MutableGlobalVariable`) → localized per-call `makeISO8601Formatter()`. Telemetry path, behavior-identical (regression test pins the exact `1970-01-01T00:00:00.000Z` output).
- **`AuthCoordinatorSeams`** — `TPPUserAccountReading`/`TPPUserAccountWriting` → `Sendable`, completing the established seam pattern (siblings `Reauthenticating`/`SignInModalPresenting`/`AuthDecisionRecording` were already `Sendable`). The `AuthCoordinator` actor already captured `userAccount` into its `@Sendable` refresh Task in production — this makes an existing data flow type-honest, **not** new concurrency (`AuthCoordinator.swift` has an empty diff).
- **`TokenRequest`** — `final + Sendable` (immutable `let`-only; no subclasses) + `@Sendable` completion param.
- **`Package.swift`** — macOS host floor 12→13 (host-only); tools 6.0; source `.v6`, real test target `PalaceAuthTests` stays `.v5`.

## Verification

- `swift build` (v6): **0 errors / 0 warnings**. `swift test` (in-package): **110 tests, 0 failures**.
- SoD: **architect + qa APPROVE-WITH-NITS**. Architect confirmed no auth-logic change (`AuthCoordinator`/`AuthErrorClassifier` empty diffs) and the Sendable assertion is honest (conformer routes through synchronized `accountInfoQueue`). QA confirmed byte-identical behavior; all test conformers already `@unchecked Sendable` (no breakage).
- CI `build-and-test` is the full-app Sendable-ripple gate.

## Tracked follow-ups (app-target module, non-blocking)

- One Swift-5 Sendable *warning* on the app conformer `CoordinatorUserAccountAdapter` (app target is Swift 5 → warning, not error).
- When the app target flips to v6: scope `TPPUserAccount`'s Sendable conformance (route `signInGeneration`/`notifyAccountChange`/`sessionIdentifier` through the queue — don't blanket `@unchecked`), and add an `execute(completion:)` test.

Intent: `palaceauth-swift6-modernization`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)