### PR TITLE
app-target Sendable ripple cleanup (Swift 6 Wave 1) + modernization plan

### DIFF
--- a/Palace/Accounts/User/TPPUserAccount+TPPUserAccountReadingWriting.swift
+++ b/Palace/Accounts/User/TPPUserAccount+TPPUserAccountReadingWriting.swift
@@ -27,7 +27,16 @@ import PalaceAuth
 /// Resolves the current user account through `AccountsManager` on every
 /// access so library swaps mid-coordinator-flight are observed (matches
 /// MBDC's existing computed-property semantics for `userAccount`).
-final class CoordinatorUserAccountAdapter: TPPUserAccountReading, TPPUserAccountWriting {
+/// `@unchecked Sendable`: the `TPPUserAccountReading/Writing` protocols are now
+/// `Sendable` (PalaceAuth Swift 6), and this adapter is already captured into
+/// `AuthCoordinator`'s `@Sendable` refresh Task in production. The conformance is
+/// honest: the adapter holds ZERO mutable state — only the immutable
+/// `let accountsManager` — and every method resolves `currentUserAccount`
+/// lazily through that manager, which is already accessed concurrently across
+/// the app. (NB: the architect's N1 — synchronizing `TPPUserAccount`'s
+/// `signInGeneration`/`notifyAccountChange`/`sessionIdentifier` — does not apply
+/// here: `TPPUserAccount` is NOT the conformer; this stateless adapter is.)
+final class CoordinatorUserAccountAdapter: TPPUserAccountReading, TPPUserAccountWriting, @unchecked Sendable {
 
     private let accountsManager: AccountsManager
 

--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -16,7 +16,13 @@ import PalaceLogging
 /// NOTE: This class delegates all Firebase RemoteConfig access to FirebaseManager
 /// to prevent race conditions that cause the "recursive_mutex lock failed" crash.
 /// Do NOT access RemoteConfig directly from this class.
-final class RemoteFeatureFlags {
+/// `@unchecked Sendable`: `FeatureFlagProvider` (the protocol this conforms to in
+/// `RemoteFeatureFlags+PalaceCatalog.swift`) is now `Sendable` (PalaceCatalog
+/// Swift 6). This shared singleton is already accessed app-wide concurrently; the
+/// conformance is honest — its only mutable stored property, `lastFetchTime`, is
+/// accessed exclusively under `lock` (an `NSLock`); every other stored property
+/// is `let`. `final` keeps the assertion subclass-proof.
+final class RemoteFeatureFlags: @unchecked Sendable {
     static let shared = RemoteFeatureFlags()
 
     private var lastFetchTime: Date?

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -83,7 +83,24 @@ private actor TokenRefreshCoordinator {
     }
 }
 
-@objc class TPPNetworkExecutor: NSObject {
+/// `@unchecked Sendable`: lets the executor satisfy the now-`Sendable`
+/// `NetworkClient` boundary (`URLSessionNetworkClient` holds one) and be captured
+/// across concurrency domains as it already is in production. The conformance is
+/// honest, not a blanket silence — every stored property is immutable-after-init
+/// or independently synchronized:
+///   • `transport` / `responder` — `let`; both wrap the shared, thread-safe
+///     `URLSession` and are shared-by-design (the app routes through one executor).
+///   • `tokenCoordinator` — a `private actor` (its `isRefreshing`/`retryQueue`
+///     state is actor-isolated).
+///   • `_accountsManager` — `var`, but assigned ONLY in the DI initializers
+///     (never mutated after construction; nil otherwise → lazy production read).
+///   • `tokenRefreshWatchdogSeconds` — `var` with ZERO mutation sites repo-wide;
+///     effectively constant after init.
+/// NOT `final`: three PalaceTests mocks subclass this for stubbing
+/// (SpyAudiobookNetworkExecutor, MockNetworkExecutorForSync, RecordingExecutorMock).
+/// They add only test-only or lock-guarded state, so they don't defeat the
+/// assertion; `final` would break the test-target build.
+@objc class TPPNetworkExecutor: NSObject, @unchecked Sendable {
     let transport: NetworkTransport
     private let tokenCoordinator = TokenRefreshCoordinator()
 

--- a/docs/architecture/app-target-swift6-modernization-plan.md
+++ b/docs/architecture/app-target-swift6-modernization-plan.md
@@ -1,0 +1,87 @@
+# App-target Swift 6 modernization — scoped plan
+
+<!-- audit-verified -->
+Status: **planned** (per-package modernization complete; this is the final, largest module).
+Author: claude · Drafted 2026-06-30.
+
+PR-state at drafting (verified via `gh pr view` / `git log origin/develop`):
+PalaceCatalog **merged** (commit `e3496d867`); PalaceAuth PR still **OPEN** (CI
+running) — so the Auth-side Sendable ripple below is **pending that merge**, not
+yet present on develop.
+
+## Context
+
+The 7 first-party SPM packages are now Swift 6 (`Logging → Keychain →
+ReadingPosition → TriageBot → Network → Catalog → Auth`; Auth pending its merge).
+The remaining surface is the **`Palace` app target itself** — currently
+`SWIFT_VERSION = 5.0` with **no `SWIFT_STRICT_CONCURRENCY` setting at all** (not
+even `targeted`). This is the "center of mass" + main-target work the #1129 sizing
+always called out as the final heavy lift. It is a multi-wave initiative, not a
+single PR.
+
+## Why incremental (not a big-bang flip)
+
+Flipping `SWIFT_VERSION` to 6.0 directly turns every concurrency warning into a
+hard error at once — for the whole app that is unreviewable and unbisectable.
+The supported path is to ratchet the diagnostic level, fixing each wave to zero
+before tightening:
+
+1. **Wave 0 — measure.** Set `SWIFT_STRICT_CONCURRENCY = targeted` in a branch,
+   build the app for the iOS sim (needs frameworks — run in the main checkout or
+   CI, NOT a fresh worktree), and capture the warning count + categories. This is
+   the first concrete action and the input to sizing the rest.
+2. **Wave 1 — `targeted` → 0.** Fix the `targeted`-level warnings (Sendable on
+   types crossing explicit concurrency boundaries, `@Sendable` closures). Land in
+   reviewable slices by subsystem (Network, MyBooks/Download, Audiobooks,
+   SignInLogic, Reader2, …). Keep `SWIFT_VERSION = 5.0`.
+3. **Wave 2 — `complete` → 0.** Bump to `SWIFT_STRICT_CONCURRENCY = complete`,
+   re-measure, fix the (larger) wave the same way.
+4. **Wave 3 — language mode.** Only once `complete` is clean, set
+   `SWIFT_VERSION = 6.0`. Should be near-zero new errors if waves 1–2 were honest.
+
+Each wave: fix by **isolation, never `nonisolated(unsafe)`** (the #1129 playbook);
+full-app CI `build-and-test` is the gate; critical-path slices (auth, borrow,
+return, download, DRM, audiobooks, migrations) get architect + qa SoD.
+
+## Immediate first slice — the two Sendable ripple follow-ups
+
+These are the warnings the Catalog and Auth package work introduce into the
+Swift-5 app (warnings, not errors). They are the natural Wave-1 starting point
+and are **critical-path**, so they get `/rigorous-fix`:
+
+1. **`TPPNetworkExecutor` (auth-error decision point)** — live now (Catalog
+   merged): `URLSessionNetworkClient: NetworkClient` is now `Sendable`, so the
+   executor it holds should be Sendable. But `TPPNetworkExecutor` has **mutable**
+   state: `private var _accountsManager` (lazy check-then-set) and
+   `var tokenRefreshWatchdogSeconds`. Do NOT slap on a bare `@unchecked Sendable`.
+   Required: confirm/serialize the `_accountsManager` lazy init (it already guards
+   against circular-init deadlock — verify the read/write is safe under
+   concurrency, lock if not); decide whether the watchdog var must be settable
+   post-init (likely test-only — make it injectable-at-init or lock it); THEN
+   `@unchecked Sendable` with a documented invariant. Architect + qa SoD.
+2. **`TPPUserAccount` (credential storage)** — pending the Auth merge: once
+   `TPPUserAccountReading/Writing` land as `Sendable`, the conformer must be
+   Sendable-honest. Architect N1: route `signInGeneration`, `notifyAccountChange`,
+   `sessionIdentifier` (mutated on sign-in/account-change,
+   `TPPUserAccount.swift:134/184/217/413`) through the existing `accountInfoQueue`
+   (the rest of the mutable state already is), THEN `@unchecked Sendable` — do
+   **not** blanket-`@unchecked` over the un-synchronized vars. Also a pre-existing
+   benign TOCTOU in `markCredentialsStale` (architect N2) — fold the fix in if
+   cheap.
+
+Both verified by full-app CI; both critical-path → SoD. Do them together as one
+`/rigorous-fix` PR once the Auth merge lands (so both Sendable changes are on
+develop).
+
+## Other tracked follow-ups (fold into the relevant wave)
+
+- `execute(completion:)` test for `TokenRequest` (qa nit, needs global URLProtocol
+  stubbing) — Wave 1, SignInLogic slice.
+- Refresh stale `cacheQueue` comments in `CatalogRepositoryTests` (qa optional).
+
+## Out of scope here
+
+- Chaos-replay **activation** (admin: `ENABLE_CHAOS_QA_RUNNER` var + self-hosted
+  runner + populate `.simdrive/replays/chaos/`) — tracked separately.
+- ~68 pre-existing non-concurrency style warnings in PalaceCatalog (redundant
+  `public`, always-true casts).


### PR DESCRIPTION
## What

First slice of the **app-target** Swift 6 work (Wave 1): resolves the Swift-5 `Sendable` warnings the Catalog (#1138) and Auth (#1141) package modernization introduced into the app target, by asserting **honest, analysis-backed** `@unchecked Sendable` on the genuinely thread-safe conformers. No logic change.

- **`TPPNetworkExecutor`** (auth-error decision point) → `@unchecked Sendable`. Honest: `transport`/`responder` are `let` URLSession wrappers; `tokenCoordinator` is a `private actor`; `_accountsManager` is assigned only in DI inits; `tokenRefreshWatchdogSeconds` has zero mutation sites repo-wide. **Not `final`** — three PalaceTests mocks subclass it (architect caught this; `final` would break the test target).
- **`CoordinatorUserAccountAdapter`** → `@unchecked Sendable`. Stateless beyond an immutable `let accountsManager`; already captured into `AuthCoordinator`'s `@Sendable` refresh Task in production. (The earlier architect N1 about `TPPUserAccount`'s vars is moot — `TPPUserAccount` isn't the conformer; this adapter is.)
- **`RemoteFeatureFlags`** → `@unchecked Sendable`. Shared singleton; only mutable prop `lastFetchTime` is accessed exclusively under its `NSLock`; all other stored props are `let`.
- `URLSessionNetworkClient` — no change (cascades clean once the executor is Sendable).

Adds `docs/architecture/app-target-swift6-modernization-plan.md` — the wave-based plan (`strict-concurrency` targeted → complete → language mode) for the rest of the app-target flip; these three fixes are its Wave-1 first slice.

## SoD

Independent **architect** review: all three `@unchecked` invariants verified **honest** (no mutable property shared without synchronization). It also caught a `final` build-break on `TPPNetworkExecutor` (test subclasses) — fixed here.

## Verification

App-target files need frameworks to build, so a fresh worktree can't link them locally — **CI `build-and-test` is the authoritative gate** (it builds the app + the test subclasses, confirming the `final` fix and that all three warnings resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)