### PR TITLE
fix(hooks): pre-push gate skips on missing-framework build failure (worktree friction)

### DIFF
--- a/scripts/pre-push-test-gate.sh
+++ b/scripts/pre-push-test-gate.sh
@@ -295,6 +295,27 @@ else
     echo "[pre-push-test-gate] Verify locally with 'scripts/verify-pr.sh --quick'; CI remains authoritative." >&2
     exit 0
   fi
+
+  # A build that fails ONLY because Carthage / audiobook binary frameworks are
+  # absent (a worktree that was never `carthage bootstrap`-ed / submodule-init'd,
+  # e.g. a throwaway feature worktree) is an ENVIRONMENT limitation, not a code
+  # failure — the same false-positive class the zero-.swift exemption above
+  # already documents (R2LCPClient.xcframework etc.). The app can't even LINK, so
+  # no test ran; CI (which has the frameworks) is the authoritative gate. Detect
+  # the framework-missing signature AND confirm there is no real Swift/clang
+  # compile error, then treat it as a non-blocking WARN (like the timeout case
+  # above) instead of forcing SKIP_PRE_PUSH_TESTS.
+  _FW_MISSING_RE="no XCFramework found at|Copy Files build phase contains a reference to a missing file"
+  _REAL_ERRORS="$(grep -E ' error:' /tmp/pre-push-test-gate.log 2>/dev/null \
+                  | grep -vE "$_FW_MISSING_RE" || true)"
+  if grep -qE "$_FW_MISSING_RE" /tmp/pre-push-test-gate.log 2>/dev/null && [[ -z "$_REAL_ERRORS" ]]; then
+    echo "" >&2
+    echo "[pre-push-test-gate] BUILD could not LINK: Carthage/audiobook binary frameworks absent." >&2
+    echo "[pre-push-test-gate]   (worktree not 'carthage bootstrap'-ed / submodule-initialised) — NOT a code failure." >&2
+    echo "[pre-push-test-gate]   No test ran; CI has the frameworks and is authoritative — allowing the push." >&2
+    exit 0
+  fi
+
   echo "" >&2
   echo "[pre-push-test-gate] FAIL (exit $rc) — push blocked." >&2
   echo "[pre-push-test-gate] Last 40 lines of /tmp/pre-push-test-gate.log:" >&2


### PR DESCRIPTION
## Problem

The pre-push test gate (`scripts/pre-push-test-gate.sh`) runs targeted `xcodebuild` tests. In a fresh feature **worktree** that was never `carthage bootstrap`-ed / submodule-init'd, the app can't **link** — the build fails on missing binary frameworks (`R2LCPClient`/`AudioEngine` xcframeworks; `PalaceAudiobookToolkit`/`OverdriveProcessor.framework` Copy-Files). That exits 65 → falls through to **BLOCK** → every worktree push had to use `SKIP_PRE_PUSH_TESTS=1` by hand.

## Fix

This is the **same environment-failure class** the gate already handles two other ways: the zero-`.swift` exemption (whose comment literally names the missing-Carthage-framework problem) and the cold-build **timeout → non-blocking WARN**. Add the third:

- Detect a **framework-missing-ONLY** build failure: the framework signature is present (`no XCFramework found at` / `Copy Files build phase contains a reference to a missing file`) **AND** there is no real Swift/clang `error:` line.
- Treat it as a non-blocking **WARN** (like the timeout case) — the app never linked, so no test ran; CI (which has the frameworks) stays authoritative.
- A genuine compile/test failure still produces a real ` error:` → still **BLOCKS**.

## Effect

A plain `git push` from an un-bootstrapped worktree now self-skips the iOS test build instead of blocking — **no `SKIP_PRE_PUSH_TESTS` bypass needed.**

## Verification

`bash -n` clean (also gated by `.github/workflows/tooling-checks.yml`). Observed **live**: it skipped the exact R2LCPClient/audiobook link failure on a feature-worktree push while still blocking real `error:`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)