### PR TITLE
feat(dev-registry): apply availability=all when Hidden Libraries is on (PP-4698)

### DIFF
--- a/.forgeos/intent/pp-4698-registry-availability-all.md
+++ b/.forgeos/intent/pp-4698-registry-availability-all.md
@@ -1,0 +1,56 @@
+---
+name: pp-4698-registry-availability-all
+created: 2026-06-30
+author: claude-opus-4-8
+---
+
+# Intent: PP-4698 — registry debugging menu applies `availability=all` when Hidden Libraries is on
+
+## Problem
+PP-4698 finishes the work explicitly deferred by #1123 (`dev-registry-explicit-url`).
+The "Library Registry Debugging" developer field already accepts a full
+`http(s)://…` URL fetched verbatim (the explicit-URL path bypasses the crawler via
+`fallbackFetchFromNetwork`). What is missing is the *behavior* half of PP-4698:
+when "Enable Hidden Libraries" (`TPPSettings.useBetaLibraries`) is set, the custom
+registry fetch must carry an `availability=all` query parameter so hidden/testing
+libraries are returned.
+
+Today `availability=all` is appended ONLY inside `LibraryRegistryCrawler.crawlableURL`
+and ONLY when the path ends in `/qa`. An explicit custom URL never hits the crawler,
+so toggling "Enable Hidden Libraries" with a custom URL set has no effect on the
+fetched URL. That is the gap.
+
+Per the user decision (2026-06-30) the field stays as-is (#1123's flexible
+full-URL + bare-host + `http://` model is superior to the ticket's literal
+"fixed https" wording and already accepts arbitrary host/path/query).
+
+## Claims
+- `TPPConfiguration.customUrl(settings:)` injects `availability=all` into the
+  returned URL's query **on the explicit-URL branch only**, gated on
+  `settings.useBetaLibraries`. An existing `availability` query value is
+  overwritten to `all`; all other query items are preserved.
+- When `useBetaLibraries` is false, an explicit custom URL is returned exactly as
+  the developer typed it (no `availability` injection, no stripping of any
+  `availability` the developer typed themselves).
+- Because `customUrlHash` derives from `customUrl`, toggling Hidden Libraries with
+  a custom explicit URL set produces a distinct cache bucket and triggers a
+  re-fetch via the existing `.TPPUseBetaDidChange` → `updateAccountSet` path.
+- Tightens `customRegistryIsExplicitURL(settings:)` (deferred SoD item #1 from
+  #1123) to return true only when the explicit string actually parses to a URL,
+  removing the predicate/`customUrl()` divergence on unparseable input.
+
+## Anti-claims
+- Does NOT touch `LibraryRegistryCrawler.crawlableURL` — the bare-host `/qa`
+  legacy path and the non-custom beta/prod registry paths are unchanged, so no
+  double-append of `availability=all` and no change to production registry loading.
+- Does NOT change the registry debugging cell UI / field model (kept flexible per
+  the user decision).
+- Does NOT change `AccountsManager` fetch dispatch (it already consumes `customUrl`
+  / `customUrlHash`; the new query rides through unchanged).
+- Does NOT touch any auth/borrow/return/download/DRM/audiobook critical path.
+
+## Files in scope
+- `Palace/AppInfrastructure/TPPConfiguration+SE.swift`
+- `Palace/Utilities/Networking/URL+Extensions.swift`
+- `PalaceTests/TPPConfigurationCustomRegistryTests.swift`
+- `PalaceTests/Network/URLExtensionsTests.swift`

--- a/Palace/AppInfrastructure/TPPConfiguration+SE.swift
+++ b/Palace/AppInfrastructure/TPPConfiguration+SE.swift
@@ -27,7 +27,16 @@ extension TPPConfiguration {
         // parse directly. A bare host preserves the historical
         // https://<host>/libraries/qa form.
         if isExplicitURL(raw) {
-            return URL(string: raw)
+            guard let url = URL(string: raw) else { return nil }
+            // PP-4698: "Enable Hidden Libraries" (useBetaLibraries) requests the
+            // hidden/testing libraries, expressed as availability=all. On the
+            // explicit-URL branch the crawler is bypassed, so it is applied here
+            // (the bare-host branch below stays on the crawler, which appends
+            // availability=all itself for its /qa path — see
+            // LibraryRegistryCrawler.crawlableURL; injecting it here too would
+            // double-append). With the toggle off the URL is fetched exactly as
+            // typed, including any availability the developer set themselves.
+            return settings.useBetaLibraries ? url.settingQueryItem(name: "availability", value: "all") : url
         }
         return URL(string: "https://\(raw)/libraries/qa")
     }
@@ -36,10 +45,16 @@ extension TPPConfiguration {
     /// developer wants fetched verbatim — no /libraries/qa suffix, no crawlable
     /// rewrite. Lets dev settings target an exact endpoint such as the
     /// non-crawlable /libraries feed.
+    ///
+    /// Only true when the explicit string actually parses to a URL, so it never
+    /// diverges from `customUrl()` (which returns nil for an unparseable
+    /// explicit string) — otherwise the loader would take the explicit-URL fetch
+    /// branch for a URL that does not exist.
     static func customRegistryIsExplicitURL(settings: TPPSettings = TPPSettings()) -> Bool {
         guard let raw = settings.customLibraryRegistryServer?
-                .trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
-        return isExplicitURL(raw)
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              isExplicitURL(raw) else { return false }
+        return URL(string: raw) != nil
     }
 
     private static func isExplicitURL(_ value: String) -> Bool {

--- a/Palace/Utilities/Networking/URL+Extensions.swift
+++ b/Palace/Utilities/Networking/URL+Extensions.swift
@@ -16,4 +16,17 @@ extension URL {
         components.scheme = scheme
         return components.url ?? self
     }
+
+    /// Returns the URL with the given query item set to `value`: any existing
+    /// items with the same `name` are removed and a single `name=value` item is
+    /// appended. All other query items are preserved in order.
+    func settingQueryItem(name: String, value: String) -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return self
+        }
+        var items = (components.queryItems ?? []).filter { $0.name != name }
+        items.append(URLQueryItem(name: name, value: value))
+        components.queryItems = items
+        return components.url ?? self
+    }
 }

--- a/PalaceTests/Network/URLExtensionsTests.swift
+++ b/PalaceTests/Network/URLExtensionsTests.swift
@@ -61,4 +61,55 @@ final class URLExtensionsTests: XCTestCase {
         XCTAssertEqual(result.user, "user")
         XCTAssertEqual(result.password, "pass")
     }
+
+    // MARK: - settingQueryItem Tests
+
+    func testSettingQueryItem_NoExistingQuery_AddsItem() {
+        let url = URL(string: "https://example.com/libraries")!
+        let result = url.settingQueryItem(name: "availability", value: "all")
+
+        XCTAssertEqual(result.absoluteString, "https://example.com/libraries?availability=all")
+    }
+
+    func testSettingQueryItem_PreservesOtherItems_AndOrder() {
+        let url = URL(string: "https://example.com/libraries?order=modified&page=2")!
+        let result = url.settingQueryItem(name: "availability", value: "all")
+
+        let items = URLComponents(url: result, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(items.map(\.name), ["order", "page", "availability"],
+                       "Existing items are preserved in order and the new item is appended last")
+        XCTAssertEqual(items.first { $0.name == "order" }?.value, "modified")
+    }
+
+    func testSettingQueryItem_ReplacesExistingSameName_ExactlyOnce() {
+        let url = URL(string: "https://example.com/libraries?availability=production")!
+        let result = url.settingQueryItem(name: "availability", value: "all")
+
+        let values = (URLComponents(url: result, resolvingAgainstBaseURL: false)?.queryItems ?? [])
+            .filter { $0.name == "availability" }
+            .compactMap(\.value)
+        XCTAssertEqual(values, ["all"],
+                       "The prior value must be replaced, not duplicated — exactly one availability item")
+    }
+
+    func testSettingQueryItem_RemovesAllDuplicatesOfName() {
+        let url = URL(string: "https://example.com/libraries?availability=a&availability=b&keep=1")!
+        let result = url.settingQueryItem(name: "availability", value: "all")
+
+        let items = URLComponents(url: result, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(items.filter { $0.name == "availability" }.count, 1,
+                       "All pre-existing items with the target name are removed before appending one")
+        XCTAssertEqual(items.first { $0.name == "keep" }?.value, "1",
+                       "Unrelated items are untouched")
+    }
+
+    func testSettingQueryItem_PercentEncodesValue() {
+        let url = URL(string: "https://example.com/libraries")!
+        let result = url.settingQueryItem(name: "q", value: "a b&c")
+
+        XCTAssertEqual(URLComponents(url: result, resolvingAgainstBaseURL: false)?
+                        .queryItems?.first { $0.name == "q" }?.value,
+                       "a b&c",
+                       "Round-trips a value containing reserved characters via URLComponents encoding")
+    }
 }

--- a/PalaceTests/TPPConfigurationCustomRegistryTests.swift
+++ b/PalaceTests/TPPConfigurationCustomRegistryTests.swift
@@ -99,4 +99,109 @@ final class TPPConfigurationCustomRegistryTests: XCTestCase {
     let expected = url.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
     XCTAssertEqual(TPPConfiguration.customUrlHash(settings: settings), expected)
   }
+
+  // MARK: - availability=all (Enable Hidden Libraries, PP-4698)
+
+  /// Returns the `availability` query values present on the custom URL, in order.
+  private func availabilityValues() -> [String] {
+    guard let url = TPPConfiguration.customUrl(settings: settings),
+          let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+    else { return [] }
+    return items.filter { $0.name == "availability" }.compactMap { $0.value }
+  }
+
+  private func queryValue(_ name: String) -> String? {
+    guard let url = TPPConfiguration.customUrl(settings: settings),
+          let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+    else { return nil }
+    return items.first { $0.name == name }?.value
+  }
+
+  /// Sets the "Enable Hidden Libraries" flag by writing the backing key on the
+  /// test's ISOLATED defaults suite, rather than via `settings.useBetaLibraries`'s
+  /// setter. The setter posts `.TPPUseBetaDidChange`, which a live shared
+  /// `AccountsManager` observes and turns into a background `loadCatalogs` that
+  /// reads `.standard` and outlives the test — the test-pollution shape CLAUDE.md
+  /// item #2 names. The getter reads this key, so behavior under test is identical
+  /// while the global notification fan-out is avoided.
+  private func setHiddenLibraries(_ on: Bool) {
+    defaults.set(on, forKey: "NYPLUseBetaLibrariesKey")
+  }
+
+  func test_explicitURL_whenHiddenLibrariesOn_appendsAvailabilityAll() {
+    setHiddenLibraries(true)
+    settings.customLibraryRegistryServer = "https://registry.dev.palaceproject.io/libraries"
+    XCTAssertEqual(availabilityValues(), ["all"],
+                   "Enable Hidden Libraries must add availability=all to the explicit registry fetch URL")
+  }
+
+  func test_explicitURL_whenHiddenLibrariesOff_hasNoAvailability() {
+    setHiddenLibraries(false)
+    settings.customLibraryRegistryServer = "https://registry.dev.palaceproject.io/libraries"
+    XCTAssertEqual(TPPConfiguration.customUrl(settings: settings)?.absoluteString,
+                   "https://registry.dev.palaceproject.io/libraries",
+                   "With Hidden Libraries off, the explicit URL is fetched exactly as typed")
+    XCTAssertTrue(availabilityValues().isEmpty)
+  }
+
+  func test_explicitURL_whenHiddenLibrariesOn_preservesOtherQueryItems() {
+    setHiddenLibraries(true)
+    settings.customLibraryRegistryServer = "https://registry.dev.palaceproject.io/libraries?order=modified"
+    XCTAssertEqual(queryValue("order"), "modified",
+                   "Existing query items the developer typed must be preserved")
+    XCTAssertEqual(availabilityValues(), ["all"],
+                   "availability=all is added alongside, not instead of, existing query items")
+  }
+
+  func test_explicitURL_whenHiddenLibrariesOn_overwritesExistingAvailability() {
+    setHiddenLibraries(true)
+    settings.customLibraryRegistryServer = "https://registry.dev.palaceproject.io/libraries?availability=production"
+    XCTAssertEqual(availabilityValues(), ["all"],
+                   "A developer-typed availability=production must be overwritten to all (exactly once) when Hidden Libraries is on")
+  }
+
+  func test_explicitURL_whenHiddenLibrariesOff_leavesTypedAvailabilityUntouched() {
+    setHiddenLibraries(false)
+    settings.customLibraryRegistryServer = "https://registry.dev.palaceproject.io/libraries?availability=production"
+    XCTAssertEqual(availabilityValues(), ["production"],
+                   "With Hidden Libraries off, the app must not rewrite an availability value the developer typed themselves")
+  }
+
+  func test_bareHost_whenHiddenLibrariesOn_isNotRewrittenAtThisLayer() {
+    // A bare host is not an explicit URL: it keeps the legacy
+    // https://<host>/libraries/qa form and gets availability=all from the
+    // crawler (LibraryRegistryCrawler.crawlableURL), NOT from customUrl. This
+    // pins that customUrl does not also inject it, which would double-append.
+    setHiddenLibraries(true)
+    settings.customLibraryRegistryServer = "registry.dev.palaceproject.io"
+    XCTAssertEqual(TPPConfiguration.customUrl(settings: settings)?.absoluteString,
+                   "https://registry.dev.palaceproject.io/libraries/qa",
+                   "Bare host must not get availability=all injected at the customUrl layer")
+    XCTAssertTrue(availabilityValues().isEmpty)
+  }
+
+  func test_hiddenLibrariesToggle_changesCacheHashForExplicitURL() {
+    settings.customLibraryRegistryServer = "https://registry.dev.palaceproject.io/libraries"
+    setHiddenLibraries(false)
+    let hashOff = TPPConfiguration.customUrlHash(settings: settings)
+    setHiddenLibraries(true)
+    let hashOn = TPPConfiguration.customUrlHash(settings: settings)
+    XCTAssertNotNil(hashOff)
+    XCTAssertNotNil(hashOn)
+    XCTAssertNotEqual(hashOff, hashOn,
+                      "Toggling Hidden Libraries must change the cache key so the availability=all feed is fetched, not served from the production-feed cache")
+  }
+
+  // MARK: - explicit-URL predicate parse fidelity (SoD deferred item #1)
+
+  func test_customRegistryIsExplicitURL_unparseableExplicitInput_isFalse() {
+    // Has an http(s):// prefix but does not parse to a URL (unclosed IPv6
+    // literal). The predicate must agree with customUrl() — otherwise
+    // AccountsManager takes the explicit-URL branch for a URL that is nil.
+    settings.customLibraryRegistryServer = "https://["
+    XCTAssertNil(TPPConfiguration.customUrl(settings: settings),
+                 "An unparseable explicit string yields no custom URL")
+    XCTAssertFalse(TPPConfiguration.customRegistryIsExplicitURL(settings: settings),
+                   "customRegistryIsExplicitURL must not claim explicit when customUrl() is nil")
+  }
 }


### PR DESCRIPTION
## PP-4698 — registry debugging menu applies `availability=all` when Hidden Libraries is on

Finishes the behavior half that #1123 explicitly deferred to a separate ticket. The "Library Registry Debugging" developer-settings field already fetches an explicit URL verbatim; the missing piece was the availability facet: **"Enable Hidden Libraries" must add `availability=all` to the custom registry fetch** so hidden/testing libraries are returned.

Previously `availability=all` was appended only by `LibraryRegistryCrawler.crawlableURL` and only for a `/qa` path, so an explicit custom URL (which bypasses the crawler) never got it — toggling Hidden Libraries with a custom URL set did nothing.

### Changes (dev-tooling only; gated behind a custom registry being set)
- **`TPPConfiguration.customUrl`** — on the explicit-URL branch, inject `availability=all` when `settings.useBetaLibraries` is set. Overwrites any developer-typed `availability`, preserves other query items. Toggle off → URL fetched exactly as typed. Bare-host `/qa` is left to the crawler (which already appends it) to avoid a double-append.
- **`TPPConfiguration.customRegistryIsExplicitURL`** — true only when the explicit string actually parses to a URL, removing the predicate/`customUrl()` divergence on unparseable input (SoD-deferred item #1 from #1123).
- **`URL.settingQueryItem(name:value:)`** — reusable helper next to `replacingScheme`.

Because `customUrlHash` derives from `customUrl`, toggling Hidden Libraries with a custom explicit URL re-buckets the cache and re-fetches via the existing `.TPPUseBetaDidChange → updateAccountSet` path.

### Tests
- 8 new cases in `TPPConfigurationCustomRegistryTests` (availability on/off, other-query preservation, overwrite-to-all, off-leaves-typed-value, bare-host-not-rewritten, hash re-bucketing, parse-divergence).
- 5 direct `URL.settingQueryItem` cases in `URLExtensionsTests` (add / preserve-order / replace-once / dedup / percent-encode).
- The Hidden-Libraries flag is set by writing the backing key on the test's **isolated** UserDefaults suite, not via the `useBetaLibraries` setter, so tests don't post `.TPPUseBetaDidChange` and trigger a background `AccountsManager.loadCatalogs` that outlives them (hermeticity per CLAUDE.md test-pollution rule #2).

### Verification
- `verify-pr.sh --quick`: **22/22 checks PASS, 7366 tests / 0 failures**, clean build.
- Mutation: manually proved the parse-divergence mutant (`URL(string:) != nil → == nil`) kills 3 tests; the duplicate-append mutant (dropping `settingQueryItem`'s filter) is killed by the overwrite/dedup tests.
- ForgeOS `cs_a884ec9d`: SoD review **architect ✅ / qa_test ✅ (block→fix→reapprove) / blast_radius ✅**; all gates passed, `can_release: true`.

**Scope:** iOS dev-tooling only. Production registry loading (crawler path) and the non-custom prod/beta selection are unchanged. Per maintainer decision the field model stays flexible (#1123's full-URL + `http://` + bare-host), which already supersets the ticket's literal "fixed https" wording.

**Not done:** simdrive end-to-end visual confirmation (offered as optional follow-up); bare-host custom entries remain always-`/qa` (pre-existing legacy, flagged by architect review as optional future alignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
