### PR TITLE
fix(swift6): auth-error network cluster → zero targeted warnings (Phase A.3, slice A)

### DIFF
--- a/Palace/MyBooks/DownloadAuthRetryHandler.swift
+++ b/Palace/MyBooks/DownloadAuthRetryHandler.swift
@@ -41,7 +41,28 @@ protocol DownloadAuthRetryHandlerDelegate: AnyObject {
 /// re-authentication, an auto-borrow, or be passed back to the caller
 /// as a regular alert. Holds no state of its own — every decision is a
 /// fresh read of the current TPPUserAccount.
-final class DownloadAuthRetryHandler {
+///
+/// `@unchecked Sendable` (Swift 6 Wave 1, app-target `targeted` slice): the
+/// handler is captured `[weak self]` by the `@Sendable` retry/clean-up Task
+/// closures below, so it must be `Sendable`. The conformance is honest —
+/// every stored property is immutable-after-init or main-actor-confined:
+///   • `delegate` — `weak var`, wired exactly once on the main actor right
+///     after construction (`MyBooksDownloadCenter` sets it post-`super.init()`)
+///     and read only on the main actor (via `self.delegate` inside
+///     `@MainActor` methods / `MainActor.run` bodies). The non-Sendable
+///     `delegate`/`bookRegistry` are never captured directly by a `@Sendable`
+///     closure — every Task body reaches them through `self`.
+///   • `stateManager` — `let`; its mutable storage is the actor-isolated
+///     `SafeDictionary`/`DownloadCoordinator` it owns.
+///   • `bookRegistry` / `reauthenticator` / `alertPresenter` / `authCoordinator`
+///     / `userAccountProvider` / `currentAccountHostsProvider` — `let`
+///     (immutable after init); `authCoordinator` is an `actor`, the host
+///     provider is `@Sendable`. The non-Sendable ones are touched only on
+///     the main actor.
+///   • `inFlightTasks` — `@MainActor` isolated; every insert/remove runs on
+///     the main actor (see the UUID-keyed retention dance below).
+/// `final`, so the assertion can't be defeated by a subclass.
+final class DownloadAuthRetryHandler: @unchecked Sendable {
 
     weak var delegate: DownloadAuthRetryHandlerDelegate?
 
@@ -89,7 +110,15 @@ final class DownloadAuthRetryHandler {
     /// `@MainActor`-isolated — every site that inserts into or removes
     /// from this set runs on the main actor, matching the
     /// `@MainActor`-isolated entry points of the handler.
-    @MainActor private var inFlightTasks: Set<Task<Void, Never>> = []
+    ///
+    /// Keyed by a per-launch `UUID` token rather than the `Task` handle
+    /// itself: the auto-removal closure captures the token **by value** (a
+    /// `Sendable` value type) instead of the launch-site `var task: Task!`,
+    /// which the Swift-6 `targeted` concurrency check rejects as "`task`
+    /// mutated after capture by sendable closure" (the IUO is assigned after
+    /// the `@Sendable` Task body captures it). Mirrors the proven pattern in
+    /// the sibling `BookReturnService`.
+    @MainActor private var inFlightTasks: [UUID: Task<Void, Never>] = [:]
 
     init(
         stateManager: DownloadStateManager,
@@ -136,7 +165,7 @@ final class DownloadAuthRetryHandler {
     /// after cancellation.
     @MainActor
     func cancelAllInFlightTasks() {
-        for task in inFlightTasks {
+        for task in inFlightTasks.values {
             task.cancel()
         }
         inFlightTasks.removeAll()
@@ -159,14 +188,14 @@ final class DownloadAuthRetryHandler {
     private func launchTrackedTask(
         _ body: @escaping @Sendable () async -> Void
     ) -> Task<Void, Never> {
-        var task: Task<Void, Never>!
-        task = Task { [weak self] in
+        let id = UUID()
+        let task = Task { [weak self] in
             await body()
             await MainActor.run { [weak self] in
-                self?.inFlightTasks.remove(task)
+                self?.inFlightTasks.removeValue(forKey: id)
             }
         }
-        inFlightTasks.insert(task)
+        inFlightTasks[id] = task
         return task
     }
 
@@ -187,14 +216,14 @@ final class DownloadAuthRetryHandler {
     private func scheduleRetainedRetry(
         _ body: @escaping @MainActor (DownloadAuthRetryHandler) -> Void
     ) {
-        var task: Task<Void, Never>!
-        task = Task { @MainActor [weak self] in
+        let id = UUID()
+        let task = Task { @MainActor [weak self] in
             guard let self else { return }
             if Task.isCancelled { return }
             body(self)
-            self.inFlightTasks.remove(task)
+            self.inFlightTasks.removeValue(forKey: id)
         }
-        inFlightTasks.insert(task)
+        inFlightTasks[id] = task
     }
 
     // MARK: - Entry point

--- a/Palace/MyBooks/TokenRefreshInterceptor.swift
+++ b/Palace/MyBooks/TokenRefreshInterceptor.swift
@@ -40,10 +40,16 @@ protocol TokenRefreshInterceptorDelegate: AnyObject {
 /// main-actor-confined:
 ///   • `delegate` — `weak var`, wired exactly once on the main actor right
 ///     after construction (`MyBooksDownloadCenter` sets it post-`super.init()`)
-///     and only ever read on the main actor (inside `@MainActor` methods or
-///     `MainActor.run` bodies). The non-Sendable `delegate`/`bookRegistry`
-///     values are NEVER captured directly by a `@Sendable` closure — they are
-///     re-resolved through `self.delegate` on the main actor at use time.
+///     and read on the main actor at every live retry/clean-up site (inside
+///     `@MainActor` methods or `MainActor.run` bodies). The legacy nonisolated
+///     entry points (`handleProblem`, `handleBorrowInvalidCredentials`) read it
+///     synchronously off-main, but they have no production callers (the live
+///     path is `DownloadAuthRetryHandler.handleAuthFailureIfApplicable`) and are
+///     exercised only by `@MainActor` test classes; `weak var` loads/ARC-zeroing
+///     are runtime-serialized regardless. The crucial invariant: the non-Sendable
+///     `delegate`/`bookRegistry` values are NEVER captured directly by a
+///     `@Sendable` closure — they are re-resolved through `self.delegate` on the
+///     main actor at use time.
 ///   • `reauthenticator` — `let` (immutable after init).
 ///   • `userRetryTracker` / `authCoordinator` / `currentAccountHostsProvider`
 ///     — `let`; `authCoordinator` is an `actor`, the host provider is `@Sendable`.

--- a/Palace/MyBooks/TokenRefreshInterceptor.swift
+++ b/Palace/MyBooks/TokenRefreshInterceptor.swift
@@ -32,7 +32,25 @@ protocol TokenRefreshInterceptorDelegate: AnyObject {
 
 /// Handles 401 detection, token refresh, SAML re-authentication,
 /// and request retry after credential refresh.
-final class TokenRefreshInterceptor {
+///
+/// `@unchecked Sendable` (Swift 6 Wave 1, app-target `targeted` slice): the
+/// interceptor is captured `[weak self]` by the `@Sendable` retry/clean-up
+/// Task closures below, so it must be `Sendable`. The conformance is honest,
+/// not a blanket silence — every stored property is immutable-after-init or
+/// main-actor-confined:
+///   • `delegate` — `weak var`, wired exactly once on the main actor right
+///     after construction (`MyBooksDownloadCenter` sets it post-`super.init()`)
+///     and only ever read on the main actor (inside `@MainActor` methods or
+///     `MainActor.run` bodies). The non-Sendable `delegate`/`bookRegistry`
+///     values are NEVER captured directly by a `@Sendable` closure — they are
+///     re-resolved through `self.delegate` on the main actor at use time.
+///   • `reauthenticator` — `let` (immutable after init).
+///   • `userRetryTracker` / `authCoordinator` / `currentAccountHostsProvider`
+///     — `let`; `authCoordinator` is an `actor`, the host provider is `@Sendable`.
+///   • `hasAttemptedAuthentication` / `isRequestingCredentials` — `@MainActor`
+///     isolated (the only mutable scalar state; serialized by the main actor).
+/// `final`, so the assertion can't be defeated by a subclass.
+final class TokenRefreshInterceptor: @unchecked Sendable {
 
     // MARK: - Properties
 
@@ -41,7 +59,7 @@ final class TokenRefreshInterceptor {
     @MainActor private var hasAttemptedAuthentication = false
     @MainActor private var isRequestingCredentials = false
 
-    var reauthenticator: Reauthenticator
+    let reauthenticator: Reauthenticator
     private let userRetryTracker: UserRetryTracker
 
     /// swarm_66819d80 Module C: auth-refresh coordinator. When non-nil,
@@ -159,7 +177,7 @@ final class TokenRefreshInterceptor {
                             task: task,
                             coordinator: coordinator,
                             reason: isSaml ? .samlSessionExpired : .invalidCredentials,
-                            stateOnSuccess: isSaml ? .SAMLStarted : .downloadNeeded
+                            isSaml: isSaml
                         )
                         return true
                     }
@@ -209,7 +227,7 @@ final class TokenRefreshInterceptor {
                         task: task,
                         coordinator: coordinator,
                         reason: isSaml ? .samlSessionExpired : .invalidCredentials,
-                        stateOnSuccess: isSaml ? .SAMLStarted : .downloadNeeded
+                        isSaml: isSaml
                     )
                     return true
                 }
@@ -263,11 +281,11 @@ final class TokenRefreshInterceptor {
             self.hasAttemptedAuthentication = true
             self.isRequestingCredentials = true
 
-            self.reauthenticator.authenticateIfNeeded(delegate.userAccount, usingExistingCredentials: false) { [weak self, weak delegate] in
-                guard let self = self, let delegate = delegate else { return }
-
+            self.reauthenticator.authenticateIfNeeded(delegate.userAccount, usingExistingCredentials: false) { [weak self] in
                 Task { @MainActor [weak self] in
-                    self?.isRequestingCredentials = false
+                    guard let self else { return }
+                    self.isRequestingCredentials = false
+                    guard let delegate = self.delegate else { return }
 
                     if delegate.userAccount.hasCredentials() == true {
                         delegate.startDownload(for: book, withRequest: nil)
@@ -308,12 +326,11 @@ final class TokenRefreshInterceptor {
         // injected sheet presenter. Single-flight `isRequestingCredentials`
         // dedupe at line 265 still owns the concurrent-401 guard.
         AppContainer.production().signInModalSheetPresenter
-            .presentSignInModalForCurrentAccount { [weak self, weak delegate] in
-            guard let self = self, let delegate = delegate else { return }
-
-            Task { @MainActor [weak self, weak delegate] in
-                guard let self = self, let delegate = delegate else { return }
+            .presentSignInModalForCurrentAccount { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
                 self.isRequestingCredentials = false
+                guard let delegate = self.delegate else { return }
 
                 if delegate.userAccount.hasCredentials() == true {
                     delegate.startDownload(for: book, withRequest: nil)
@@ -342,6 +359,10 @@ final class TokenRefreshInterceptor {
 
             Task { @MainActor [weak self] in
                 guard let self = self, let delegate = self.delegate else { return }
+                // Re-resolve the non-Sendable registry/account through the
+                // main-actor-confined `delegate` rather than capturing them
+                // across the `@Sendable` Task boundary.
+                let bookRegistry = delegate.bookRegistry
 
                 await delegate.stateManager.bookIdentifierToDownloadInfo.remove(book.identifier)
                 await delegate.stateManager.downloadCoordinator.registerCompletion(identifier: book.identifier)
@@ -360,12 +381,13 @@ final class TokenRefreshInterceptor {
 
                 self.isRequestingCredentials = true
 
-                self.reauthenticator.authenticateIfNeeded(userAccount, usingExistingCredentials: false) { [weak self, weak delegate] in
-                    Task { @MainActor in
-                        self?.isRequestingCredentials = false
-                        if delegate?.userAccount.hasCredentials() == true {
+                self.reauthenticator.authenticateIfNeeded(delegate.userAccount, usingExistingCredentials: false) { [weak self] in
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        self.isRequestingCredentials = false
+                        if let delegate = self.delegate, delegate.userAccount.hasCredentials() == true {
                             Log.info(#file, "Sign-in completed, retrying download")
-                            delegate?.startDownload(for: book, withRequest: nil)
+                            delegate.startDownload(for: book, withRequest: nil)
                         }
                     }
                 }
@@ -383,8 +405,15 @@ final class TokenRefreshInterceptor {
             if let coordinator = self.authCoordinator {
                 let isSaml = authDef?.isSaml == true
                 Log.info(#file, "handleProblem: browser-based reauth dispatched through AuthCoordinator (isSaml=\(isSaml))")
-                Task { [weak self, weak delegate] in
-                    guard let delegate = delegate else { return }
+                // `@MainActor` Task so the non-Sendable `delegate`/`bookRegistry`
+                // are re-resolved on the main actor (via `self.delegate`) rather
+                // than captured across the `@Sendable` Task boundary. The
+                // `await` hops to the state-manager actors and the coordinator
+                // actor suspend the main actor without blocking it — same
+                // observable ordering as the prior explicit `MainActor.run`.
+                Task { @MainActor [weak self] in
+                    guard let self, let delegate = self.delegate else { return }
+                    let bookRegistry = delegate.bookRegistry
                     await delegate.stateManager.bookIdentifierToDownloadInfo.remove(book.identifier)
                     await delegate.stateManager.downloadCoordinator.registerCompletion(identifier: book.identifier)
 
@@ -392,20 +421,17 @@ final class TokenRefreshInterceptor {
                         reason: isSaml ? .samlSessionExpired : .invalidCredentials
                     )
 
-                    await MainActor.run {
-                        if isSaml {
-                            bookRegistry.setState(.SAMLStarted, for: book.identifier)
-                        } else {
-                            bookRegistry.setState(.downloadNeeded, for: book.identifier)
-                        }
-                        switch outcome {
-                        case .success:
-                            Log.info(#file, "handleProblem coordinator success — retrying download for \(book.identifier)")
-                            delegate.startDownload(for: book, withRequest: nil)
-                        case .failure(let cancellation):
-                            Log.info(#file, "handleProblem coordinator declined refresh for \(book.identifier) — \(cancellation)")
-                        }
-                        _ = self // retain to make warnings about unused capture happy
+                    if isSaml {
+                        bookRegistry.setState(.SAMLStarted, for: book.identifier)
+                    } else {
+                        bookRegistry.setState(.downloadNeeded, for: book.identifier)
+                    }
+                    switch outcome {
+                    case .success:
+                        Log.info(#file, "handleProblem coordinator success — retrying download for \(book.identifier)")
+                        delegate.startDownload(for: book, withRequest: nil)
+                    case .failure(let cancellation):
+                        Log.info(#file, "handleProblem coordinator declined refresh for \(book.identifier) — \(cancellation)")
                     }
                 }
                 return
@@ -413,16 +439,15 @@ final class TokenRefreshInterceptor {
             if authDef?.isSaml == true {
                 Log.info(#file, "SAML cookies expired - triggering SAML re-auth flow (legacy path)")
 
-                Task { [weak delegate] in
-                    guard let delegate = delegate else { return }
+                Task { @MainActor [weak self] in
+                    guard let self, let delegate = self.delegate else { return }
+                    let bookRegistry = delegate.bookRegistry
                     await delegate.stateManager.bookIdentifierToDownloadInfo.remove(book.identifier)
                     await delegate.stateManager.downloadCoordinator.registerCompletion(identifier: book.identifier)
 
-                    await MainActor.run {
-                        bookRegistry.setState(.SAMLStarted, for: book.identifier)
-                        Log.info(#file, "Cleared download state, retrying with SAML re-auth")
-                        delegate.startDownload(for: book, withRequest: nil)
-                    }
+                    bookRegistry.setState(.SAMLStarted, for: book.identifier)
+                    Log.info(#file, "Cleared download state, retrying with SAML re-auth")
+                    delegate.startDownload(for: book, withRequest: nil)
                 }
             } else {
                 Log.info(#file, "Browser-based auth expired - triggering re-auth via sign-in modal (legacy path)")
@@ -435,12 +460,13 @@ final class TokenRefreshInterceptor {
                     guard !self.isRequestingCredentials else { return }
                     self.isRequestingCredentials = true
 
-                    self.reauthenticator.authenticateIfNeeded(userAccount, usingExistingCredentials: false) { [weak self, weak delegate] in
+                    self.reauthenticator.authenticateIfNeeded(delegate.userAccount, usingExistingCredentials: false) { [weak self] in
                         Task { @MainActor [weak self] in
-                            self?.isRequestingCredentials = false
-                            if delegate?.userAccount.authState == .loggedIn {
+                            guard let self else { return }
+                            self.isRequestingCredentials = false
+                            if let delegate = self.delegate, delegate.userAccount.authState == .loggedIn {
                                 Log.info(#file, "Browser re-auth completed, retrying download")
-                                delegate?.startDownload(for: book, withRequest: nil)
+                                delegate.startDownload(for: book, withRequest: nil)
                             }
                         }
                     }
@@ -463,12 +489,13 @@ final class TokenRefreshInterceptor {
 
                 self.isRequestingCredentials = true
 
-                self.reauthenticator.authenticateIfNeeded(userAccount, usingExistingCredentials: false) { [weak self, weak delegate] in
+                self.reauthenticator.authenticateIfNeeded(delegate.userAccount, usingExistingCredentials: false) { [weak self] in
                     Task { @MainActor [weak self] in
-                        self?.isRequestingCredentials = false
+                        guard let self else { return }
+                        self.isRequestingCredentials = false
 
-                        if delegate?.userAccount.hasCredentials() == true {
-                            delegate?.startDownload(for: book, withRequest: nil)
+                        if let delegate = self.delegate, delegate.userAccount.hasCredentials() == true {
+                            delegate.startDownload(for: book, withRequest: nil)
                         } else {
                             NSLog("Authentication completed but no credentials present, user may have cancelled")
                         }
@@ -492,47 +519,49 @@ final class TokenRefreshInterceptor {
         task: URLSessionTask,
         coordinator: AuthCoordinator,
         reason: ReauthReason,
-        stateOnSuccess: TPPBookState
+        isSaml: Bool
     ) {
-        guard let delegate = delegate else { return }
-        let stateManager = delegate.stateManager
-
-        Task { [weak self, weak delegate] in
+        let taskIdentifier = task.taskIdentifier
+        // `@MainActor` Task so the non-Sendable `delegate` (and the
+        // `TPPBookState` chosen below) are resolved on the main actor via
+        // `self.delegate` rather than captured across the `@Sendable`
+        // boundary. The `await` hops to the state-manager / coordinator
+        // actors suspend the main actor without blocking it — identical
+        // observable ordering to the prior explicit `MainActor.run`.
+        Task { @MainActor [weak self] in
+            guard let self, let delegate = self.delegate else { return }
+            let stateManager = delegate.stateManager
             await stateManager.bookIdentifierToDownloadInfo.remove(book.identifier)
-            await stateManager.taskIdentifierToBook.remove(task.taskIdentifier)
+            await stateManager.taskIdentifierToBook.remove(taskIdentifier)
             await stateManager.downloadCoordinator.registerCompletion(identifier: book.identifier)
 
             let outcome = await coordinator.refreshCredentialsIfNeeded(reason: reason)
 
-            await MainActor.run {
-                guard let delegate = delegate else { return }
-                delegate.bookRegistry.setState(stateOnSuccess, for: book.identifier)
-                switch outcome {
-                case .success:
-                    Log.info(#file, "Coordinator refresh succeeded — retrying download for \(book.identifier)")
-                    delegate.startDownload(for: book, withRequest: nil)
-                case .failure(let cancellation):
-                    Log.info(#file, "Coordinator declined refresh for \(book.identifier) — \(cancellation)")
-                }
-                _ = self // retain to silence unused-capture-of-self
+            guard let delegate = self.delegate else { return }
+            let stateOnSuccess: TPPBookState = isSaml ? .SAMLStarted : .downloadNeeded
+            delegate.bookRegistry.setState(stateOnSuccess, for: book.identifier)
+            switch outcome {
+            case .success:
+                Log.info(#file, "Coordinator refresh succeeded — retrying download for \(book.identifier)")
+                delegate.startDownload(for: book, withRequest: nil)
+            case .failure(let cancellation):
+                Log.info(#file, "Coordinator declined refresh for \(book.identifier) — \(cancellation)")
             }
         }
     }
 
     private func triggerSAMLReauth(for book: TPPBook, task: URLSessionTask) {
-        guard let delegate = delegate else { return }
-        let stateManager = delegate.stateManager
-
-        Task {
+        let taskIdentifier = task.taskIdentifier
+        Task { @MainActor [weak self] in
+            guard let self, let delegate = self.delegate else { return }
+            let stateManager = delegate.stateManager
             await stateManager.bookIdentifierToDownloadInfo.remove(book.identifier)
-            await stateManager.taskIdentifierToBook.remove(task.taskIdentifier)
+            await stateManager.taskIdentifierToBook.remove(taskIdentifier)
             await stateManager.downloadCoordinator.registerCompletion(identifier: book.identifier)
 
-            await MainActor.run {
-                delegate.bookRegistry.setState(.SAMLStarted, for: book.identifier)
-                Log.info(#file, "Cleared failed download, now retrying with SAML re-auth")
-                delegate.startDownload(for: book, withRequest: nil)
-            }
+            delegate.bookRegistry.setState(.SAMLStarted, for: book.identifier)
+            Log.info(#file, "Cleared failed download, now retrying with SAML re-auth")
+            delegate.startDownload(for: book, withRequest: nil)
         }
     }
 
@@ -542,9 +571,9 @@ final class TokenRefreshInterceptor {
         reauthenticator.authenticateIfNeeded(
             delegate.userAccount,
             usingExistingCredentials: false,
-            authenticationCompletion: { [weak delegate] in
-                Task { @MainActor [weak delegate] in
-                    guard let delegate = delegate else { return }
+            authenticationCompletion: { [weak self] in
+                Task { @MainActor [weak self] in
+                    guard let self, let delegate = self.delegate else { return }
                     guard delegate.userAccount.hasCredentials() else {
                         Log.info(#file, "Authentication cancelled, not retrying download for \(book.identifier)")
                         return
@@ -560,37 +589,34 @@ final class TokenRefreshInterceptor {
     /// Unlike SAML which uses a special `.SAMLStarted` book state, browser re-auth
     /// cleans up tracking, resets book state, and presents the sign-in modal.
     private func triggerBrowserReauth(for book: TPPBook, task: URLSessionTask) {
-        guard let delegate = delegate else { return }
-        let stateManager = delegate.stateManager
-
-        Task {
+        let taskIdentifier = task.taskIdentifier
+        Task { @MainActor [weak self] in
+            guard let self, let delegate = self.delegate else { return }
+            let stateManager = delegate.stateManager
             await stateManager.bookIdentifierToDownloadInfo.remove(book.identifier)
-            await stateManager.taskIdentifierToBook.remove(task.taskIdentifier)
+            await stateManager.taskIdentifierToBook.remove(taskIdentifier)
             await stateManager.downloadCoordinator.registerCompletion(identifier: book.identifier)
 
-            await MainActor.run { [weak self, weak delegate] in
-                guard let self = self, let delegate = delegate else { return }
-                delegate.bookRegistry.setState(.downloadNeeded, for: book.identifier)
-                Log.info(#file, "Cleared failed download state, presenting sign-in modal for \(book.identifier)")
+            delegate.bookRegistry.setState(.downloadNeeded, for: book.identifier)
+            Log.info(#file, "Cleared failed download state, presenting sign-in modal for \(book.identifier)")
 
-                self.reauthenticator.authenticateIfNeeded(
-                    delegate.userAccount,
-                    usingExistingCredentials: false,
-                    authenticationCompletion: { [weak delegate] in
-                        Task { @MainActor [weak delegate] in
-                            guard let delegate = delegate else { return }
-                            // Check authState, not just hasCredentials — stale creds still
-                            // return true for hasCredentials() but won't work for downloads
-                            guard delegate.userAccount.authState == .loggedIn else {
-                                Log.info(#file, "Re-auth cancelled or incomplete, not retrying download for \(book.identifier)")
-                                return
-                            }
-                            Log.info(#file, "Re-auth completed, retrying download for \(book.identifier)")
-                            delegate.startDownload(for: book, withRequest: nil)
+            self.reauthenticator.authenticateIfNeeded(
+                delegate.userAccount,
+                usingExistingCredentials: false,
+                authenticationCompletion: { [weak self] in
+                    Task { @MainActor [weak self] in
+                        guard let self, let delegate = self.delegate else { return }
+                        // Check authState, not just hasCredentials — stale creds still
+                        // return true for hasCredentials() but won't work for downloads
+                        guard delegate.userAccount.authState == .loggedIn else {
+                            Log.info(#file, "Re-auth cancelled or incomplete, not retrying download for \(book.identifier)")
+                            return
                         }
+                        Log.info(#file, "Re-auth completed, retrying download for \(book.identifier)")
+                        delegate.startDownload(for: book, withRequest: nil)
                     }
-                )
-            }
+                }
+            )
         }
     }
 
@@ -603,7 +629,6 @@ final class TokenRefreshInterceptor {
     @MainActor
     private func triggerOIDCReauth(for book: TPPBook, task: URLSessionTask) {
         guard let delegate = delegate else { return }
-        let stateManager = delegate.stateManager
         let userAccount = delegate.userAccount
 
         guard let authDef = userAccount.authDefinition,
@@ -641,9 +666,10 @@ final class TokenRefreshInterceptor {
         let session = ASWebAuthenticationSession(
             url: finalURL,
             callbackURLScheme: callbackScheme
-        ) { [weak self, weak delegate] callbackURL, error in
-            Task { @MainActor [weak self, weak delegate] in
-                guard let self = self, let delegate = delegate else { return }
+        ) { [weak self] callbackURL, error in
+            Task { @MainActor [weak self] in
+                guard let self = self, let delegate = self.delegate else { return }
+                let stateManager = delegate.stateManager
 
                 if let error = error as? ASWebAuthenticationSessionError,
                    error.code == .canceledLogin {


### PR DESCRIPTION
## Swift 6 Wave 1 — Phase A.3 critical-path slice A: auth-error network cluster

Part of the app-target Swift 6 strict-concurrency modernization (see `docs/architecture/app-target-swift6-modernization-plan.md`, Phase A.3). Drives the coupled **auth-error decision sites** to zero `targeted` concurrency warnings.

**Files:** `TokenRefreshInterceptor.swift`, `DownloadAuthRetryHandler.swift`
(`TPPNetworkExecutor` / `URLSessionNetworkClient` were already resolved by #1142 — confirmed, no edit.)

**Approach (fix-by-isolation, no `nonisolated(unsafe)`):**
- Both classes → `final class … : @unchecked Sendable` with documented invariants (state immutable-after-init or `@MainActor`-confined; `reauthenticator` `var`→`let`, zero write sites repo-wide).
- `@Sendable` closures restructured to capture only `[weak self]` + Sendable values; collaborators re-resolved through `self` on the main actor.
- `triggerCoordinatorReauth(…, stateOnSuccess: TPPBookState)` → `(…, isSaml: Bool)` so `TPPBookState` is derived on-main instead of captured (private method, both call sites in-file).
- `inFlightTasks` `Set<Task>` → `[UUID: Task]` keyed by per-launch token → kills the "`task` mutated after capture" warning.

**Shared-type changes:** none.
**Tests:** behavior-preserving isolation refactor; existing `TokenRefreshInterceptorAuthCoordinatorTests` / `DownloadAuthRetryHandler*Tests` exercise every restructured seam (SAML + no-loan dispatch, retry-on-success, foreign-host 401 short-circuit per CLAUDE.md host-scoping rule, UUID retention/drain, weak-self post-release).

⚠️ **Critical path (auth) — requires architect + qa SoD.** Not locally buildable (private DRM headers); **CI is the authoritative build + warning-drop gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
