### PR TITLE
fix(swift6): borrow/return → zero targeted warnings (Phase A.3, slice B)

### DIFF
--- a/.forgeos/intent/swift6-apptarget-borrow-return.md
+++ b/.forgeos/intent/swift6-apptarget-borrow-return.md
@@ -1,0 +1,65 @@
+---
+name: swift6-apptarget-borrow-return
+created: 2026-06-30
+author: Maurice Carrier
+branch: swift6/apptarget-borrow-return
+priority: Swift 6 app-target modernization (Wave 1, targeted strict-concurrency) — borrow/return critical-path slice
+---
+
+# Intent: drive borrow + return flows to zero `targeted` strict-concurrency warnings
+
+## Context
+
+`SWIFT_STRICT_CONCURRENCY = targeted` is set on the Palace app target (warnings,
+not errors; `SWIFT_VERSION` stays 5.0). This slice fixes the borrow + return
+critical-path files by ISOLATION (never `nonisolated(unsafe)`), with no
+control-flow change so the existing `BorrowOperationContractTests` /
+`BookReturnServiceContractTests` ordered-call-order snapshots do not drift.
+
+Baseline warnings (origin/develop):
+- `BorrowOperation.swift` L370,392,413,500,505,530,535 (capture of self) and
+  L456,697,928 (capture of self?) — all `capture of 'self'` in `@Sendable`
+  (`Task` / `MainActor.run` / `withTimeout`) closures.
+- `BookReturnService.swift` L292,302,308,317,340 (capture of self); L294,309,318
+  and L334(x2),471 (capture of non-Sendable `completion`).
+- `BookSignInRedirectHandler.swift` L203 (capture of self?).
+
+## Claims
+
+- `BorrowOperation` conforms to `@unchecked Sendable` with a documented Sendable
+  invariant (all deps `let`; only mutable instance member `weak var delegate` is
+  wired once at owner construction; circuit-breaker state is `static` + NSLock).
+- `BookReturnService` conforms to `@unchecked Sendable` with a documented
+  invariant (`inFlightTasks` guarded by `inFlightLock`; `delegate` wired once).
+- `BookSignInRedirectHandler` conforms to `@unchecked Sendable` with a documented
+  invariant (`delegate` wired once; `credentialRequestState` already
+  `@unchecked Sendable`).
+- `BookReturnService.returnBook(withIdentifier:completion:)` and its private
+  helpers (`handleReturnWithoutRevokeURL`, `handleRevokeError`,
+  `presentReturnFailureAlert`, `performPostReturnSyncThen`) take a `@Sendable`
+  completion so the closure threads through the async return state machine
+  without a non-Sendable capture.
+- `MyBooksDownloadCenter.returnBook(withIdentifier:completion:)` and
+  `BookDetailViewModel.didSelectReturn(for:completion:)` take a matching
+  `@Sendable` completion (1-line additive signature changes — the two
+  cross-file call sites the @Sendable completion ripples into).
+
+## Anti-claims
+
+- No control-flow / call-order change in any borrow or return path; the existing
+  contract-snapshot tests remain valid and are NOT re-recorded.
+- No shared-type change: `TPPBook`, `TPPBookState`, `TPPBookRegistryProvider`,
+  `TPPUserAccount` are NOT modified (TPPBook/CredentialRequestState are already
+  `@unchecked Sendable` on develop).
+- No new functions, enum cases, public API surface, or state machine added.
+
+## Verification
+
+- Cannot build the app target locally (private Adobe DRM headers absent). CI is
+  the build gate per the modernization plan; the orchestrator pushes to CI.
+- Static DoD checks run clean locally: `check-blast-radius.py` (exit 0),
+  `check-superpartner-spectrum.py` (exit 0), `check-adjacency-staleness.py`
+  (exit 0).
+- Changes are pure isolation annotations with zero runtime-behavior change, so
+  no new test is required; the `BorrowOperation` / `BookReturnService` contract
+  snapshots already pin the ordered dependency calls and would fail on drift.

--- a/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
@@ -818,7 +818,11 @@ final class BookDetailViewModel: ObservableObject {
         self.downloadProgress = 0
     }
 
-    func didSelectReturn(for book: TPPBook, completion: (() -> Void)?) {
+    // `completion` is `@Sendable` so the closure handed to
+    // `downloadCenter.returnBook` (which threads it through BookReturnService's
+    // async return state machine) carries no non-Sendable capture. The sole
+    // caller passes an `@MainActor`-isolated closure, so this is additive.
+    func didSelectReturn(for book: TPPBook, completion: (@Sendable () -> Void)?) {
         processingButtons.insert(.returning)
         downloadCenter.returnBook(withIdentifier: book.identifier) { [weak self] in
             guard let self else { return }

--- a/Palace/MyBooks/BookReturnService.swift
+++ b/Palace/MyBooks/BookReturnService.swift
@@ -35,7 +35,24 @@ protocol BookReturnServiceDelegate: AnyObject {
 // MARK: - BookReturnService
 
 /// Coordinates the return-loan flow with the circulation manager.
-final class BookReturnService {
+///
+/// - Sendable invariant: every stored dependency is a `let` bound at init
+///   (`bookRegistry`, `localContentService`, `opdsFeedService`,
+///   `downloadAnnouncementService`, `bookmarkDeletionLog`, `reauthenticator`,
+///   `userRetryTracker`, `userAccountProvider`, `adobeDRMService`,
+///   `authCoordinator`) — the same already-shared services this flow drives
+///   today under Swift-5 mode from `launchTrackedTask` / `MainActor.run`
+///   closures. The mutable instance state is exactly two members, both already
+///   serialized: `inFlightTasks` is guarded by `inFlightLock` (NSLock, see the
+///   property doc), and `weak var delegate` is assigned exactly once during
+///   owner (`MyBooksDownloadCenter`) construction and never reassigned —
+///   weak-reference reads and ARC zeroing are atomic in the Swift runtime, so
+///   it needs no explicit lock. `@unchecked` (rather than a synthesized
+///   conformance) because `delegate`'s protocol existential and the shared
+///   service types are not themselves `Sendable`; this conformance asserts the
+///   serialization contract above and does not change the ordered return
+///   cleanup contract (setProcessing → setState → removeBook → announce).
+final class BookReturnService: @unchecked Sendable {
 
     weak var delegate: BookReturnServiceDelegate?
 
@@ -252,7 +269,7 @@ final class BookReturnService {
 
     // MARK: - returnBook
 
-    func returnBook(withIdentifier identifier: String, completion: (() -> Void)? = nil) {
+    func returnBook(withIdentifier identifier: String, completion: (@Sendable () -> Void)? = nil) {
         guard let book = bookRegistry.book(forIdentifier: identifier) else {
             completion?()
             return
@@ -350,7 +367,7 @@ final class BookReturnService {
     /// Books without a revokeURL skip the OPDS round trip entirely —
     /// just clear local content + bookmarks + remove the book from the
     /// registry, then sync.
-    private func handleReturnWithoutRevokeURL(book: TPPBook, identifier: String, downloaded: Bool, completion: (() -> Void)?) {
+    private func handleReturnWithoutRevokeURL(book: TPPBook, identifier: String, downloaded: Bool, completion: (@Sendable () -> Void)?) {
         if downloaded {
             localContentService.deleteLocalContent(for: identifier)
             delegate?.purgeAllAudiobookCaches(force: true)
@@ -377,7 +394,7 @@ final class BookReturnService {
     /// Failure path branches: parsing-error-as-success, no-active-loan +
     /// loan-term-limit cleanup, invalid-credentials re-auth retry, or
     /// generic alert with retry / remove-from-device / cancel.
-    private func handleRevokeError(_ error: Error, book: TPPBook, identifier: String, downloaded: Bool, completion: (() -> Void)?) {
+    private func handleRevokeError(_ error: Error, book: TPPBook, identifier: String, downloaded: Bool, completion: (@Sendable () -> Void)?) {
         // The OverDrive revoke endpoint returns XML that isn't a
         // valid OPDS feed (e.g., a simple success response). The
         // OPDS parser rejects it → PalaceError.parsing(.opdsFeedInvalid).
@@ -529,7 +546,7 @@ final class BookReturnService {
         book: TPPBook,
         identifier: String,
         downloaded: Bool,
-        completion: (() -> Void)?
+        completion: (@Sendable () -> Void)?
     ) {
         let serverDetail = problemDoc?.detail
             ?? (error as NSError).userInfo["problemDocumentDetail"] as? String
@@ -586,7 +603,7 @@ final class BookReturnService {
     /// Performs a registry sync after a return. On failure, posts
     /// `TPPSyncFailed` so the Reservations tab can show the sync error
     /// banner; completion is always called so the return UI is dismissed.
-    private func performPostReturnSyncThen(completion: @escaping () -> Void) {
+    private func performPostReturnSyncThen(completion: @escaping @Sendable () -> Void) {
         launchTrackedTask { [weak self] in
             do {
                 // Use the injected `bookRegistry` rather than reaching into

--- a/Palace/MyBooks/BookSignInRedirectHandler.swift
+++ b/Palace/MyBooks/BookSignInRedirectHandler.swift
@@ -40,7 +40,19 @@ protocol BookSignInRedirectHandlerDelegate: AnyObject {
 
 /// Drives the cookie-web-view auth redirect flow (SAML + non-SAML
 /// fallback). Bridges back to MBDC for the retry+cancel hooks.
-final class BookSignInRedirectHandler {
+///
+/// - Sendable invariant: every stored dependency is a `let` bound at init
+///   (`bookRegistry`, `stateManager`, `reauthenticator`, `userAccountProvider`,
+///   `credentialRequestState` — the last is itself `@unchecked Sendable`).
+///   The only mutable instance member is `weak var delegate`, assigned exactly
+///   once during owner (`MyBooksDownloadCenter`) construction and never
+///   reassigned; weak-reference reads and ARC zeroing are atomic in the Swift
+///   runtime, so no explicit lock is required. `@unchecked` (rather than a
+///   synthesized conformance) because `delegate`'s protocol existential and the
+///   shared service types are not themselves `Sendable`; this conformance only
+///   formalizes how the SAML redirect flow already executes today under Swift-5
+///   mode (it hops between `Task` and `MainActor.run` closures unchanged).
+final class BookSignInRedirectHandler: @unchecked Sendable {
 
     weak var delegate: BookSignInRedirectHandlerDelegate?
 

--- a/Palace/MyBooks/BorrowOperation.swift
+++ b/Palace/MyBooks/BorrowOperation.swift
@@ -77,7 +77,22 @@ private enum BorrowAuthErrorDecision {
 
 // MARK: - BorrowOperation
 
-final class BorrowOperation {
+/// - Sendable invariant: every stored dependency is a `let` bound at init
+///   (`bookRegistry`, `downloadAnnouncementService`, `errorActivityTracker`,
+///   `debugSettings`, `userRetryTracker`, `userAccountProvider`,
+///   `adobeDRMService`, the four closure-injected seams, `authCoordinator`) —
+///   the same already-shared services this flow drives today under Swift-5
+///   mode from `Task` / `MainActor.run` closures. The only mutable instance
+///   member is `weak var delegate`, assigned exactly once during owner
+///   (`MyBooksDownloadCenter`) construction and never reassigned; weak-reference
+///   reads and ARC zeroing are atomic in the Swift runtime, so no explicit lock
+///   is required. Circuit-breaker state (`borrowReauthAttempted`) is `static`
+///   and serialized by `borrowReauthLock` (NSLock). `@unchecked` (rather than a
+///   synthesized conformance) because `delegate`'s protocol existential and the
+///   shared service types are not themselves `Sendable`; this conformance
+///   asserts the serialization contract above and does not change runtime
+///   behavior — it only formalizes how the flow already executes.
+final class BorrowOperation: @unchecked Sendable {
 
     weak var delegate: BorrowOperationDelegate?
 

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -1230,7 +1230,12 @@ extension MyBooksDownloadCenter {
     // lcpLicenseURL + deleteLocalAudiobookContent moved to LocalBookContentService
     // (private there).
 
-    @objc func returnBook(withIdentifier identifier: String, completion: (() -> Void)? = nil) {
+    // `completion` is `@Sendable` so it can thread through BookReturnService's
+    // async return state machine (`launchTrackedTask` / `MainActor.run` hops)
+    // without a non-Sendable-capture warning. Additive: existing Swift call
+    // sites pass `@MainActor`-isolated `[weak self]` closures (BookDetailViewModel,
+    // BookCellModel), which are already `Sendable`-compatible.
+    @objc func returnBook(withIdentifier identifier: String, completion: (@Sendable () -> Void)? = nil) {
         returnService.returnBook(withIdentifier: identifier, completion: completion)
     }
 

--- a/Palace/MyBooks/MyBooksDownloadCenterProtocol.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenterProtocol.swift
@@ -42,7 +42,7 @@ protocol MyBooksDownloadCenterProviding: AnyObject {
     func deleteLocalContent(for identifier: String, account: String?)
 
     /// Returns the book with the given identifier to the library.
-    func returnBook(withIdentifier identifier: String, completion: (() -> Void)?)
+    func returnBook(withIdentifier identifier: String, completion: (@Sendable () -> Void)?)
 
     // MARK: - Download Info
 


### PR DESCRIPTION
## Swift 6 Wave 1 — Phase A.3 critical-path slice B: borrow + return flows

Part of the app-target Swift 6 strict-concurrency modernization (`docs/architecture/app-target-swift6-modernization-plan.md`, Phase A.3). Drives borrow/return to zero `targeted` concurrency warnings.

**Files:** `BorrowOperation.swift`, `BookReturnService.swift`, `BookSignInRedirectHandler.swift`
**Ripple (on-branch, additive):** `MyBooksDownloadCenter.swift` L1233 + `BookDetailViewModel.swift` L821 — the 2 (and only 2) call sites of `BookReturnService.returnBook`, now `(@Sendable () -> Void)?`.

**Approach (fix-by-isolation):**
- Classes → `final class … : @unchecked Sendable` with documented invariants (deps `let`; only `weak var delegate` mutable, assigned once at construction; `BorrowOperation` circuit breaker is `static`+`NSLock`; `BookReturnService.inFlightTasks` is `inFlightLock`-guarded).
- `completion` params typed `@Sendable` to clear non-Sendable closure captures (preserves "completion runs exactly once on the expected actor").

**Shared-type changes:** none.
**Tests:** pure isolation annotations, zero call-order change. Existing `BorrowOperationContractTests` + `BookReturnServiceContractTests` (ordered-dependency snapshots) are the regression guard — not re-recorded (no drift).

⚠️ **Critical path (borrow/return) — requires architect + qa SoD.** Not locally buildable; **CI is the build + warning-drop gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
