### PR TITLE
fix(swift6): download/DRM → zero targeted warnings (Phase A.3, slice C)

### DIFF
--- a/Palace/MyBooks/LCPFulfillmentHandler.swift
+++ b/Palace/MyBooks/LCPFulfillmentHandler.swift
@@ -38,7 +38,14 @@ protocol LCPFulfillmentHandlerDelegate: AnyObject {
 /// through the shared DownloadProgressReporter and reports failures
 /// through the shared DownloadAlertPresenter so the UI sees a single,
 /// coherent download error stream regardless of which DRM produced it.
-final class LCPFulfillmentHandler {
+// @unchecked Sendable invariant: every stored dependency is a `let`
+// (immutable after init). The only mutable member is `weak var delegate`,
+// which is wired exactly once by MyBooksDownloadCenter during its own
+// construction on the main thread and thereafter only read from inside the
+// fulfillment/progress callbacks' `MainActor.run` hops. No stored value is
+// mutated after init, so the handler is safe to share across the LCP
+// fulfillment-task / progress-callback concurrency boundaries.
+final class LCPFulfillmentHandler: @unchecked Sendable {
 
     weak var delegate: LCPFulfillmentHandlerDelegate?
 

--- a/Palace/MyBooks/LCPFulfillmentHandler.swift
+++ b/Palace/MyBooks/LCPFulfillmentHandler.swift
@@ -41,9 +41,11 @@ protocol LCPFulfillmentHandlerDelegate: AnyObject {
 // @unchecked Sendable invariant: every stored dependency is a `let`
 // (immutable after init). The only mutable member is `weak var delegate`,
 // which is wired exactly once by MyBooksDownloadCenter during its own
-// construction on the main thread and thereafter only read from inside the
-// fulfillment/progress callbacks' `MainActor.run` hops. No stored value is
-// mutated after init, so the handler is safe to share across the LCP
+// construction on the main thread and never reassigned. It is read from the
+// fulfillment/progress callbacks' `MainActor.run` hops and from nonisolated
+// callback bodies, but `weak var` loads / ARC-zeroing are runtime-serialized
+// via the side-table lock, so reading it off-main is memory-safe. No stored
+// value is mutated after init, so the handler is safe to share across the LCP
 // fulfillment-task / progress-callback concurrency boundaries.
 final class LCPFulfillmentHandler: @unchecked Sendable {
 

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -958,10 +958,16 @@ import OverdriveProcessor
             // represent an in-progress URLSession task warrant the failure
             // transition; everything else (e.g. .downloadSuccessful, .used)
             // must be left alone.
-            let registry = self.bookRegistry
-            let booksToFail: [TPPBook] = await MainActor.run {
-                activePairs.compactMap { (_, book) -> TPPBook? in
-                    let state = registry.state(for: book.identifier)
+            // Read each book's registry state on the main actor. We capture
+            // `self` (already-clean across this file's MainActor hops — see the
+            // failDownloadWithAlert loop below) rather than the `bookRegistry`
+            // existential: `TPPBookRegistryProvider` is a shared, non-Sendable
+            // protocol that must NOT be made Sendable, and capturing it directly
+            // trips the strict-concurrency Sendable-capture check.
+            let booksToFail: [TPPBook] = await MainActor.run { [weak self] in
+                guard let self else { return [] }
+                return activePairs.compactMap { (_, book) -> TPPBook? in
+                    let state = self.bookRegistry.state(for: book.identifier)
                     return (state == .downloading || state == .SAMLStarted) ? book : nil
                 }
             }

--- a/Palace/MyBooks/RightsManagementDispatcher.swift
+++ b/Palace/MyBooks/RightsManagementDispatcher.swift
@@ -61,10 +61,12 @@ struct RightsManagementDispatchResult {
 // @unchecked Sendable invariant: every stored dependency is a `let`
 // (immutable after init). The only mutable member is `weak var delegate`,
 // which is wired exactly once by MyBooksDownloadCenter during its own
-// construction (`self.rightsDispatcher.delegate = self`) on the main thread
-// and thereafter only read from inside `MainActor.run` hops. No stored value
-// is mutated after init, so the class is safe to share across the Adobe
-// fulfillment Task's concurrency boundary.
+// construction (`self.rightsDispatcher.delegate = self`) on the main thread and
+// never reassigned. It is read from both `MainActor.run` hops and the
+// nonisolated `dispatch(...)` body, but `weak var` loads / ARC-zeroing are
+// runtime-serialized via the side-table lock, so reading it off-main is
+// memory-safe. No stored value is mutated after init, so the class is safe to
+// share across the Adobe fulfillment Task's concurrency boundary.
 final class RightsManagementDispatcher: @unchecked Sendable {
 
     weak var delegate: RightsManagementDispatcherDelegate?

--- a/Palace/MyBooks/RightsManagementDispatcher.swift
+++ b/Palace/MyBooks/RightsManagementDispatcher.swift
@@ -58,7 +58,14 @@ struct RightsManagementDispatchResult {
 
 // MARK: - RightsManagementDispatcher
 
-final class RightsManagementDispatcher {
+// @unchecked Sendable invariant: every stored dependency is a `let`
+// (immutable after init). The only mutable member is `weak var delegate`,
+// which is wired exactly once by MyBooksDownloadCenter during its own
+// construction (`self.rightsDispatcher.delegate = self`) on the main thread
+// and thereafter only read from inside `MainActor.run` hops. No stored value
+// is mutated after init, so the class is safe to share across the Adobe
+// fulfillment Task's concurrency boundary.
+final class RightsManagementDispatcher: @unchecked Sendable {
 
     weak var delegate: RightsManagementDispatcherDelegate?
 
@@ -136,10 +143,15 @@ final class RightsManagementDispatcher {
                     guard let self else { return }
                     do {
                         try await self.adobeDRMService.ensureDeviceActivated()
+                        // Read the Sendable credential values off the (shared,
+                        // non-Sendable) TPPUserAccount up front so the MainActor
+                        // hop captures only `String?`s, not the account object.
                         let ua = self.userAccountProvider()
-                        Log.info(#file, "Adobe DRM activated — fulfilling ACSM for '\(book.title)' with userID: \(ua.userID ?? "nil")")
+                        let userID = ua.userID
+                        let deviceID = ua.deviceID
+                        Log.info(#file, "Adobe DRM activated — fulfilling ACSM for '\(book.title)' with userID: \(userID ?? "nil")")
                         await MainActor.run {
-                            self.adobeDRMService.fulfill(withACSMData: acsmData, tag: book.identifier, userID: ua.userID, deviceID: ua.deviceID)
+                            self.adobeDRMService.fulfill(withACSMData: acsmData, tag: book.identifier, userID: userID, deviceID: deviceID)
                         }
                     } catch {
                         Log.error(#file, "Adobe DRM activation failed for '\(book.title)': \(error.localizedDescription)")


### PR DESCRIPTION
## Swift 6 Wave 1 — Phase A.3 critical-path slice C: download + DRM fulfillment

Part of the app-target Swift 6 strict-concurrency modernization (`docs/architecture/app-target-swift6-modernization-plan.md`, Phase A.3). Drives download/DRM to zero `targeted` concurrency warnings.

**Files:** `MyBooksDownloadCenter.swift` (L964 region only), `RightsManagementDispatcher.swift`, `LCPFulfillmentHandler.swift`

**Approach (fix-by-isolation):**
- `RightsManagementDispatcher` + `LCPFulfillmentHandler` → `final class … : @unchecked Sendable` (deps `let`; only `weak var delegate` mutable, wired once on main).
- `MyBooksDownloadCenter` capture of `registry` narrowed to `[weak self]` reading `self.bookRegistry.state(for:)` inside (mirrors the adjacent already-clean loop).
- `capture of ua (TPPUserAccount)` narrowed by reading `userID`/`deviceID` into locals before the MainActor hop — `TPPUserAccount` untouched.

**Shared-type changes:** none.
**Tests:** touched seams pinned by existing `MyBooksDownloadCenterOfflineTests` (reachability-drop filter) + `RightsManagementDispatcherTests`.

**Note:** also edits `MyBooksDownloadCenter.swift` (different region, L964) from slice B (#PR-B, L1233) — far apart, sequential landing is clean.

⚠️ **Critical path (download/DRM) — requires architect + qa SoD.** Not locally buildable; **CI is the build + warning-drop gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
