### PR TITLE
fix(swift6): SignInLogic → zero targeted warnings (Phase A.3, slice D)

### DIFF
--- a/.forgeos/intent/swift6-apptarget-signin-targeted.md
+++ b/.forgeos/intent/swift6-apptarget-signin-targeted.md
@@ -1,0 +1,57 @@
+---
+name: swift6-apptarget-signin-targeted
+created: 2026-06-30
+author: Maurice Carrier
+branch: swift6/apptarget-signin
+initiative: Swift 6 app-target Wave 1 — SignInLogic slice (critical-path: auth)
+priority: critical-path
+---
+
+# Intent: Swift 6 `targeted` strict-concurrency — SignInLogic slice
+
+## Context
+
+App-target Wave 1: `SWIFT_STRICT_CONCURRENCY = targeted` is set on develop
+(warnings, `SWIFT_VERSION` stays 5.0). This slice drives the `Palace/SignInLogic/`
+files to zero `targeted` concurrency warnings, fixing by isolation only (never
+`nonisolated(unsafe)`). Auth is a critical path. CI is the build gate (no local
+DRM-app build possible).
+
+## Claims
+
+- Removes the `= SignInModalSheetPresenter.productionDriver` default argument from
+  `SignInModalSheetPresenter`'s designated init (the only `productionDriver`
+  default-arg reference; no caller relied on it — convenience init + all tests
+  pass `driver:` explicitly).
+- Moves the `WKNavigationAction.request` / `WKNavigationResponse.response` reads
+  in `SignInWebViewCoordinator` from the nonisolated delegate body into the
+  existing `Task { @MainActor in }` hop.
+- Makes `TPPReauthenticator` a `final class … @unchecked Sendable` (it now
+  conforms to PalaceAuth's `Sendable`-refined `Reauthenticating`) and serializes
+  its `authenticateCallCount` behind an `OSAllocatedUnfairLock` (replacing the
+  stored `var`). Adds `import os`.
+- Replaces the self-capturing `await MainActor.run { … }` hops in
+  `TPPSignInBusinessLogic.awaitReadyThenRetryLogIn` and
+  `TPPSignInBusinessLogic+CardCreation.startRegularCardCreation` with the file's
+  existing `TPPMainThreadRun.asyncIfNeeded { … }` main-hop; the re-entrancy guard
+  is cleared at the end of the main-thread work on both paths (replaces the
+  `defer`).
+
+## Anti-claims
+
+- Does NOT change any shared/cross-file type (`TPPUserAccount`, `Account`,
+  `TPPBook`, protocols, `TPPNetworkExecutor`, etc.).
+- Does NOT make `TPPSignInBusinessLogic` `@MainActor` (would ripple cross-module
+  into MyBooks/BookDetail/etc.).
+- Does NOT change the foreign-host 401 / `currentAccountHostsProvider` auth-error
+  behavior.
+- Does NOT use `nonisolated(unsafe)` or `MainActor.assumeIsolated`.
+- Does NOT change observable sign-in/reauth behavior — isolation/mechanism only.
+
+## Files in scope
+
+- Palace/SignInLogic/SignInModalSheetPresenter.swift
+- Palace/SignInLogic/SignInWebViewCoordinator.swift
+- Palace/SignInLogic/TPPReauthenticator.swift
+- Palace/SignInLogic/TPPSignInBusinessLogic.swift
+- Palace/SignInLogic/TPPSignInBusinessLogic+CardCreation.swift

--- a/Palace/SignInLogic/SignInModalSheetPresenter.swift
+++ b/Palace/SignInLogic/SignInModalSheetPresenter.swift
@@ -131,10 +131,18 @@ final class SignInModalSheetPresenter: NSObject, SignInModalSheetPresenting, Obs
     /// they guarantee one UIKit presentation per logical flow.
     private var inFlight: Bool = false
 
+    /// - Note: `driver` has no default argument on purpose. `productionDriver`
+    ///   is a `@MainActor`-isolated static, and a default-argument expression is
+    ///   evaluated in a nonisolated context — which trips the `targeted`
+    ///   strict-concurrency diagnostic ("main actor-isolated static property
+    ///   'productionDriver' referenced from nonisolated context"). Production
+    ///   callers reach this through `convenience init(appContainer:)` (which
+    ///   supplies `productionDriver` from a `@MainActor` context); tests always
+    ///   inject an explicit driver. No caller relied on the default.
     init(appContainer: AppContainer,
          currentAccountIDProvider: @escaping () -> String?,
          needsAuthProvider: @escaping (String) -> Bool,
-         driver: @escaping SignInModalPresentationDriver = SignInModalSheetPresenter.productionDriver) {
+         driver: @escaping SignInModalPresentationDriver) {
         self.appContainer = appContainer
         self.currentAccountIDProvider = currentAccountIDProvider
         self.needsAuthProvider = needsAuthProvider

--- a/Palace/SignInLogic/SignInWebViewCoordinator.swift
+++ b/Palace/SignInLogic/SignInWebViewCoordinator.swift
@@ -31,8 +31,14 @@ final class SignInWebViewCoordinator: NSObject, WKNavigationDelegate {
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
-        let request = navigationAction.request
+        // `WKNavigationAction.request` is main actor-isolated; read it inside the
+        // @MainActor hop (capturing `navigationAction`, like `webView` already
+        // is) rather than in this nonisolated delegate body, which would trip the
+        // `targeted` "main actor-isolated property referenced from nonisolated
+        // context" diagnostic. `URLRequest` is a value type, so the deferred read
+        // observes the same request.
         Task { @MainActor in
+            let request = navigationAction.request
             let decision = self.viewModel.decideAction(for: request)
             switch decision {
             case .allow:
@@ -55,8 +61,13 @@ final class SignInWebViewCoordinator: NSObject, WKNavigationDelegate {
         decidePolicyFor navigationResponse: WKNavigationResponse,
         decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
     ) {
-        let mime = navigationResponse.response.mimeType
+        // `WKNavigationResponse.response` is main actor-isolated; read its
+        // `mimeType` inside the @MainActor hop (capturing `navigationResponse`)
+        // rather than in this nonisolated delegate body, which would trip the
+        // `targeted` "main actor-isolated property referenced from nonisolated
+        // context" diagnostic.
         Task { @MainActor in
+            let mime = navigationResponse.response.mimeType
             let decision = self.viewModel.decideResponse(mimeType: mime)
             switch decision {
             case .allow:

--- a/Palace/SignInLogic/TPPReauthenticator.swift
+++ b/Palace/SignInLogic/TPPReauthenticator.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import os
 import PalaceLogging
 
 protocol Reauthenticator: NSObject {
@@ -26,14 +27,31 @@ protocol Reauthenticator: NSObject {
 /// This class takes care of initializing the VC's UI, its business logic,
 /// opening up the VC when needed, and performing the log-in request under
 /// the hood when no user input is needed.
-@objc class TPPReauthenticator: NSObject, Reauthenticator {
+/// `Reauthenticating` (PalaceAuth) refines `Sendable`, so the conformer must be
+/// Sendable-honest. The class is `final` with no un-serialized mutable instance
+/// state: the only instance storage is `authenticateCallCountLock` (an
+/// `OSAllocatedUnfairLock`, itself `Sendable`, which serializes the call
+/// counter); the `_testContainerOverride` seam is a `@MainActor`-isolated
+/// `static` (not instance state). `@unchecked` is required only because the
+/// `NSObject` superclass is not `Sendable` — not because any state is racy.
+//
+// Sendable invariant: the sole mutable instance value (`authenticateCallCount`)
+// is read and written exclusively through `authenticateCallCountLock.withLock`.
+@objc final class TPPReauthenticator: NSObject, Reauthenticator, @unchecked Sendable {
+
+    /// Serializes `authenticateCallCount` so the counter is safe to read from a
+    /// test thread while `authenticateIfNeeded` increments it from the 401-handling
+    /// thread.
+    private let authenticateCallCountLock = OSAllocatedUnfairLock(initialState: 0)
 
     /// Test-observable counter of how many times `authenticateIfNeeded`
     /// has been invoked on this instance. Used by security tests to
     /// verify single-flight behavior at upstream call sites
     /// (e.g. `TokenRefreshInterceptor.isRequestingCredentials` dedupe).
     /// Not used for any production logic.
-    internal private(set) var authenticateCallCount: Int = 0
+    internal var authenticateCallCount: Int {
+        authenticateCallCountLock.withLock { $0 }
+    }
 
     /// Test-only override for the `AppContainer` from which the
     /// `signInModalSheetPresenter` is resolved. Production reads through
@@ -77,7 +95,7 @@ protocol Reauthenticator: NSObject {
     @objc func authenticateIfNeeded(_ user: TPPUserAccount,
                                     usingExistingCredentials: Bool,
                                     authenticationCompletion: (() -> Void)?) {
-        authenticateCallCount += 1
+        authenticateCallCountLock.withLock { $0 += 1 }
         Task { @MainActor in
             Log.info(#file, "TPPReauthenticator: Re-authentication requested, using existing credentials: \(usingExistingCredentials)")
 

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+CardCreation.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+CardCreation.swift
@@ -30,7 +30,13 @@ extension TPPSignInBusinessLogic: CLLocationManagerDelegate {
         }
         Task {
             let details = try? await account.awaitReady()
-            await MainActor.run {
+            // Hop to main via the file's existing `TPPMainThreadRun.asyncIfNeeded`
+            // (a plain, non-`@Sendable` closure) rather than `await MainActor.run
+            // { … self … }`, which captures non-Sendable `self`/`details`/
+            // `completion` in a `@Sendable` body and trips the `targeted`
+            // concurrency diagnostic. This is the last statement in the Task, so
+            // there is no ordering dependency on the hop completing.
+            TPPMainThreadRun.asyncIfNeeded {
                 self.continueRegularCardCreation(with: details, completion: completion)
             }
         }

--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
@@ -684,19 +684,29 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
         guard let account = libraryAccount else { return }
         isAwaitingReadinessForLogIn = true
 
+        // The post-`awaitReady()` work touches main-actor-only state
+        // (`selectedAuthentication`, `logIn`, the `.TPPIsSigningIn` post) on a
+        // class that is NOT `@MainActor`. Hopping back via `await MainActor.run {
+        // … self … }` captures non-Sendable `self` in that `@Sendable` body and
+        // trips the `targeted` "capture of 'self' in @Sendable closure"
+        // diagnostic. Use the file's existing `TPPMainThreadRun.asyncIfNeeded`
+        // main-thread hop (a plain, non-`@Sendable` closure) instead. The
+        // re-entrancy guard (`isAwaitingReadinessForLogIn`) is cleared at the END
+        // of the main-thread work on both paths — preserving the "at most once
+        // per tap" window the `defer` previously provided.
         Task { [weak self] in
-            defer { self?.isAwaitingReadinessForLogIn = false }
             do {
                 _ = try await account.awaitReady()
             } catch {
                 Log.warn(#file, "Sign-in awaited readiness but the auth document did not load: \(error)")
-                await MainActor.run {
+                TPPMainThreadRun.asyncIfNeeded { [weak self] in
                     NotificationCenter.default.post(name: .TPPIsSigningIn, object: false)
+                    self?.isAwaitingReadinessForLogIn = false
                 }
                 return
             }
 
-            await MainActor.run {
+            TPPMainThreadRun.asyncIfNeeded { [weak self] in
                 guard let self else { return }
                 // Details are loaded now; `selectedAuthentication` resolves via
                 // `loadedAccountDetails?.auths`. Re-enter the normal path. If it
@@ -709,6 +719,7 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
                 } else {
                     NotificationCenter.default.post(name: .TPPIsSigningIn, object: false)
                 }
+                self.isAwaitingReadinessForLogIn = false
             }
         }
     }


### PR DESCRIPTION
## Swift 6 Wave 1 — Phase A.3 critical-path slice D: SignInLogic (auth)

Part of the app-target Swift 6 strict-concurrency modernization (`docs/architecture/app-target-swift6-modernization-plan.md`, Phase A.3). Drives SignInLogic to zero `targeted` concurrency warnings.

**Files:** `SignInModalSheetPresenter.swift`, `SignInWebViewCoordinator.swift`, `TPPReauthenticator.swift`, `TPPSignInBusinessLogic.swift` (+`CardCreation`)

**Approach (fix-by-isolation):**
- `SignInModalSheetPresenter`: removed the `= productionDriver` main-actor default arg (all 6 call sites pass `driver:` explicitly — lowest-ripple).
- `SignInWebViewCoordinator`: moved `navigationAction.request` / `navigationResponse.response` reads into the existing `Task { @MainActor in }` (values → same observed data).
- `TPPReauthenticator` → `@objc final class … , @unchecked Sendable`; `authenticateCallCount` serialized behind `OSAllocatedUnfairLock`.
- `TPPSignInBusinessLogic(+CardCreation)`: replaced self-capturing `MainActor.run` hops with the file's existing non-`@Sendable` `TPPMainThreadRun.asyncIfNeeded`.

**Behavior note:** `awaitReadyThenRetryLogIn` — `defer { isAwaitingReadinessForLogIn = false }` moved to end-of-main-thread-work on both paths; preserves the "at most once per tap" window, clears on main consistently with the guard read.

**Shared-type changes:** none. (`TPPUserAccount` ripple in `withCheckedContinuation` is clean under Xcode-26 isolation inheritance; if CI surfaces it, fix is the tracked `TPPUserAccount: @unchecked Sendable` follow-up — not this slice.)
**Tests:** `authenticateCallCount` increment driven by real `TPPReauthenticator` in `AuthFlowSecurityTests`; `.TPPIsSigningIn` paths in existing SignIn suites.

⚠️ **Critical path (auth) — requires architect + qa SoD.** Not locally buildable; **CI is the build + warning-drop gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
