### PR TITLE
fix(swift6): DRM-decryption slice → zero targeted warnings + TPPUserAccount Sendable (Phase A.5)

### DIFF
--- a/.forgeos/changesets/swift6-apptarget-drm-a5/fix-contract.md
+++ b/.forgeos/changesets/swift6-apptarget-drm-a5/fix-contract.md
@@ -1,0 +1,152 @@
+# Fix-contract — Swift 6 `targeted` concurrency, Phase A.5 DRM-decryption slice
+
+Drives the Reader2/PDF DRM-decryption files to zero `targeted` concurrency
+warnings. These 4 files were named in Phase A.3's checklist but never touched
+(0 commits in `fb01695da..210f5713a`); measured at 11 warnings on develop tip
+`210f5713a` via Unit Tests run `28520895484` (2026-07-01). Fix-by-ISOLATION,
+never `nonisolated(unsafe)` / bare `@unchecked`. `SWIFT_VERSION` stays 5.0
+(warnings, not errors). **CI Unit Tests is the only build + warning gate — no
+local DRM build possible.**
+
+## Scope (in)
+
+### Group 1 — `LCPPDFOpenProgress.shared` root-cause fix (clears 6 warnings)
+- **File:** `Palace/PDF/ReadiumPDF/LCPPDFOpenProgress.swift`
+- **Change:** `static let shared` → `nonisolated static let shared`, and
+  `private init()` → `nonisolated private init()`. The class stays `@MainActor`
+  (drives the SwiftUI overlay via `@Published`); its recorder entry points
+  (`recordDecrypt`, `recordExtractedBytes`) are ALREADY `nonisolated` and hop via
+  `Task { @MainActor in }`. Only the `.shared` static reference was main-actor-
+  isolated, which is why every nonisolated caller warned. Making the immutable
+  reference + empty init nonisolated is legal because a `@MainActor` class is
+  implicitly `Sendable`; instance state stays isolated.
+- **Consequence:** clears TPPLCPClient.swift:169,183,235,243 and
+  LCPPDFDiskExtract.swift:165,186 **with zero edits to those two files.**
+
+### Group 3 — `AdobeDRMContentProtection` ReadiumShared crossing (clears 3 warnings)
+- **File:** `Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift`
+- **Change:** line 12 `import ReadiumShared` → `@preconcurrency import ReadiumShared`
+  (the compiler's own fix-it at :12). All three warnings (:12 import, :241
+  `stream(consume:)` non-Sendable `(Data)->Void` param, :251 `properties()`
+  non-Sendable `ReadResult<ResourceProperties>` return) are Sendable-crossings on
+  types owned by the ReadiumShared module (`ResourceProperties`, `ReadResult`, the
+  `Resource` protocol requirement signatures). `@preconcurrency` on the module
+  import is the idiomatic suppression for a not-yet-Sendable-audited dependency
+  (per the playbook §3.1 "module types not Sendable-audited → @preconcurrency
+  import"). `DRMDataResource` remains an `actor`; no behavior change.
+- **CI fallback (architect-required):** import-level `@preconcurrency` is the first
+  attempt and should downgrade :241/:251 (they cross ReadiumShared-owned types), but
+  it's unprovable without a build. If the CI log shows :241/:251 surviving, apply
+  per-declaration handling and re-run CI — do NOT silently leave them. The
+  `:(12|241|251) warning: == 0` grep is the hard acceptance gate.
+
+### Group 2 — `TPPUserAccount: Sendable` (clears 2 warnings) — FOLDED IN (user decision 2026-07-01)
+The user chose to fold the `TPPUserAccount`-Sendable credential-storage slice into
+this PR rather than defer it, so this becomes a combined DRM + credential-storage
+critical-path change. This half gets the same architect + qa SoD rigor the plan
+prescribed for it as a standalone slice.
+
+**PR-structure decision (2026-07-01):** architect recommended SPLIT (PR-1 = Groups 1+3,
+PR-2 = Group 2); **user chose to KEEP COMBINED.** Per that decision, the commit/PR body
+MUST flag the `TPPUserAccount` control-lock change as the risk-bearing half (the DRM
+Groups 1+3 are zero-runtime-delta annotations; Group 2 touches the sign-in/sign-out
+credential path). Full sign-in/sign-out/session-rotation regression required before merge.
+
+- **Files:**
+  - `Palace/Accounts/User/TPPUserAccount.swift` — add `@unchecked Sendable`
+    conformance AFTER synchronizing the 3 unsynchronized mutable vars. Everything
+    else (`let` immutables, `lazy var _xxx: TPPKeychainVariable`) is already
+    keychain-queue-synchronized or immutable-after-init.
+  - `Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift` — no
+    edit needed; once `TPPUserAccount` is `Sendable`, the `:393` captures in the
+    Adobe `authorize` completion + main-thread hop stop warning.
+  - `Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift:51` — `signInGeneration
+    += 1` (external read-modify-write) → call a new atomic `incrementSignInGeneration()`.
+  - `PalaceTests/Mocks/TPPUserAccountMock.swift:271` — mock writes `signInGeneration = 0`.
+    Architect-confirmed: mock does NOT override `signInGeneration`, so its `= 0` write
+    routes through the parent's locked setter transparently — **no mock override needed
+    for this var**, PROVIDED the parent setter stays settable (see amendment below).
+
+- **The 3 vars + call-site map (verified 2026-07-01):**
+  - `sessionIdentifier: String` (`:72`, public private(set)) — written `:184`, `:413`
+    (`= UUID().uuidString`); read by `AuthFlowSecurityTests` (public). 
+  - `signInGeneration: Int` (`:64`) — written `TPPSignInBusinessLogic+SignOut.swift:51`
+    (`+= 1`); read `:90`, `:219`; mock `:271`.
+  - `notifyAccountChange: Bool` (`:54`, private) — read `:130`, written `:134`, `:217`.
+
+- **⚠ Deadlock constraint (ARCHITECT-CONFIRMED TRUE 2026-07-01):** these setters run
+  from INSIDE `atomicUpdate`'s `accountInfoQueue.sync(flags:.barrier)` block. Traced
+  production path: `TPPSignInBusinessLogic.updateUserAccount:849 → atomicUpdate:865 →
+  barrier:590` then calls `setAuthToken:872`→`:413` (rotates `sessionIdentifier`),
+  `setBarcode`→`credentials` setter→`:184` (rotates `sessionIdentifier`), AND
+  `setAuthDefinitionWithoutUpdate:883`→`:217` (writes **`notifyAccountChange`**).
+  `accountInfoQueue` is a **serial** queue (`:87`), so routing ANY of these accessors
+  back through `accountInfoQueue.sync` re-enters the serial queue from inside its own
+  barrier → **guaranteed deadlock. TWO of the three vars (`sessionIdentifier` AND
+  `notifyAccountChange`) hit this via the barrier path; `signInGeneration` is external
+  RMW but still cross-thread.** All three must use the dedicated lock, NEVER `accountInfoQueue`.
+  → **Mechanism (architect-pinned): a dedicated `NSLock`** (house pattern per
+  `LCPPDFOpenProgress`; NOT a raw stored `os_unfair_lock` — inout-copy footgun.
+  `OSAllocatedUnfairLock` acceptable if deployment target allows). It is a strict
+  **non-recursive leaf lock** — each accessor takes it, touches one stored value,
+  returns; no ordering cycle with `accountInfoQueue`. Backing storage
+  `_sessionIdentifier` / `_signInGeneration` / `_notifyAccountChange` guarded by it.
+  - `signInGeneration` setter stays **settable at internal access — do NOT make it
+    `private(set)`** (mock's cross-file subclass write `= 0` at `TPPUserAccountMock:271`
+    would fail to compile). Add `incrementSignInGeneration()` (single locked RMW) for
+    the SignOut:51 site only — a get-then-set pair would re-introduce a TOCTOU.
+  - `sessionIdentifier` stays `public private(set)` computed (legal on a computed var;
+    only the getter is `@objc`-exposed, matching today's selector shape).
+  THEN `@unchecked Sendable` with the documented invariant "all mutable state is
+  either keychain-queue-synchronized (`_xxx`) or control-lock-synchronized (these 3)."
+  No bare `@unchecked`, no `nonisolated(unsafe)`.
+
+- **Verification add-ons for Group 2:**
+  - `AdobeCertificate.swift:393` warnings → 0 in the CI log.
+  - `grep -c "@unchecked Sendable" Palace/Accounts/User/TPPUserAccount.swift` == 1,
+    with an adjacent invariant comment.
+  - No `accountInfoQueue.sync` added inside any setter reachable from `atomicUpdate`
+    (deadlock guard) — architect + grep verified.
+  - Existing `AuthFlowSecurityTests` (sessionIdentifier rotation), the SignOut
+    `signInGeneration` race-guard tests, and `TPPUserAccountMock` consumers stay green.
+  - Mutation on `TPPUserAccount.swift` diff-scoped ≥ 50% (critical path).
+
+## Verification criteria (grep-able / CI)
+- CI Unit Tests run on this branch builds **green** (`** BUILD SUCCEEDED **`) —
+  no new `error:`; `SWIFT_VERSION` unchanged at 5.0.
+- The 9 in-scope warnings drop to **0** in the build log:
+  `gh run view <id> --log | grep -E 'TPPLCPClient.swift:(169|183|235|243)|LCPPDFDiskExtract.swift:(165|186)|AdobeDRMContentProtection.swift:(12|241|251)' | grep -c warning:` → **0**.
+- The 2 deferred `AdobeCertificate.swift:393` warnings may remain (documented).
+- No new `nonisolated(unsafe)` introduced:
+  `git diff origin/develop -- Palace/PDF/ReadiumPDF/LCPPDFOpenProgress.swift | grep -c 'nonisolated(unsafe)'` → **0 added** (the file already has 2 pre-existing on `_openInProgress`; count must not increase).
+- No bare `@unchecked Sendable` added anywhere in the diff.
+
+## Tests required
+- **DRM groups (1 & 3): no new tests** — pure isolation annotations, zero runtime
+  delta. Existing `LCPPDFOpenProgressTests`, `LCPPDFDiskExtractTests`, `TPPLCPClient`
+  LCP tests stay green (regression guard). qa_test review confirmed no test owed.
+- **Group 2 atomicity test (ADDED per qa_test review, 2026-07-01):**
+  `PalaceTests/Accounts/TPPUserAccountConcurrencyTests.swift` →
+  `testIncrementSignInGeneration_underConcurrentCallers_countsExactlyOncePerCall`.
+  The existing single-threaded `TPPSignInBusinessLogicSignOutTests` kills the
+  `+= 1 → += 0`/no-op mutants but cannot distinguish the atomic locked RMW from a
+  get-then-set TOCTOU. The new test drives `incrementSignInGeneration()` from
+  `DispatchQueue.concurrentPerform(10_000)` and asserts `start + iterations`,
+  killing the lost-update mutant (get-then-set / early-unlock). Hermetic (in-memory
+  `_signInGeneration` only, no keychain). Registered in the PalaceTests target.
+- `sessionIdentifier` rotation stays covered by `AuthFlowSecurityTests`;
+  `signInGeneration` arithmetic + sign-out race-guard by `TPPSignInBusinessLogicSignOutTests`.
+- Rationale for no new test (per CLAUDE.md "coverage-only tests are banned"):
+  there is no new branch, state transition, or observable behavior to pin — a test
+  asserting "`.shared` is accessible from a background queue" would be a tautology
+  (it tests the compiler's isolation checker, not our logic). The mutation surface
+  is unchanged. If the architect disagrees, the fallback is a concurrency test that
+  calls `recordDecrypt` from a `DispatchQueue.global` and asserts the `@Published`
+  counters converge on the main actor — but that pins the pre-existing hop, not
+  this diff.
+
+## Acceptance
+- All Verification criteria pass (CI build green + 9 warnings → 0).
+- Existing reader/PDF/LCP regression tests stay green.
+- Group 2 deferral explicitly recorded (this contract + plan doc + commit body).
+- `verify-pr.sh --quick` PASS (or documented CI-only if local DRM build blocks it).

--- a/.forgeos/intent/swift6-apptarget-drm-a5.md
+++ b/.forgeos/intent/swift6-apptarget-drm-a5.md
@@ -1,0 +1,66 @@
+---
+name: swift6-apptarget-drm-a5
+created: 2026-07-01
+author: Maurice Carrier
+branch: swift6/apptarget-drm-a5
+initiative: Swift 6 app-target Phase A.5 — DRM-decryption slice + TPPUserAccount Sendable (critical-path: DRM + credential storage)
+priority: critical-path
+---
+
+# Intent: Swift 6 `targeted` concurrency — Phase A.5 DRM slice (+ TPPUserAccount Sendable)
+
+## Context
+
+App-target Phase A.4 measured 42 remaining `targeted` warnings on develop tip
+`210f5713a` (Unit Tests run `28520895484`). This slice clears the 11 warnings in
+the 4 Reader2/PDF DRM files that A.3 named but never touched. Fix-by-isolation only
+(never `nonisolated(unsafe)`, no bare `@unchecked`). `SWIFT_VERSION` stays 5.0
+(warnings, not errors). Critical path (DRM + credential storage) — architect + qa +
+blast_radius SoD done. CI Unit Tests is the only build/warning gate (no local DRM
+build). Fix-contract: `.forgeos/changesets/swift6-apptarget-drm-a5/fix-contract.md`.
+
+## Claims
+
+- Makes `LCPPDFOpenProgress.shared` and its `private init()` `nonisolated` so the
+  background LCP-decrypt path can reference the `@MainActor` singleton without a hop
+  (clears 6 warnings: TPPLCPClient ×4, LCPPDFDiskExtract ×2 — zero edits to those files).
+- Adds `@preconcurrency` to the `ReadiumShared` import in `AdobeDRMContentProtection`
+  (clears 3 warnings: the import + the `DRMDataResource` actor's `stream(consume:)`
+  and `properties()` protocol-witness crossings).
+- Makes `TPPUserAccount` conform to `@unchecked Sendable` by moving its three
+  unsynchronized mutable control vars (`sessionIdentifier`, `signInGeneration`,
+  `notifyAccountChange`) behind a dedicated `NSLock` (`controlLock`) with backing
+  `_`-prefixed storage — NOT `accountInfoQueue` (those setters run inside its serial
+  barrier via `atomicUpdate`, so routing them through it would deadlock). Clears the
+  2 `AdobeCertificate:393` warnings (userAccount capture) with no edit to that file.
+- Adds `TPPUserAccount.incrementSignInGeneration()` — a single locked atomic
+  read-modify-write — and changes `TPPSignInBusinessLogic+SignOut.cancelPendingSignOut`
+  to call it instead of the non-atomic `signInGeneration += 1`.
+- Adds `PalaceTests/Accounts/TPPUserAccountConcurrencyTests.swift` pinning the atomic
+  increment under `DispatchQueue.concurrentPerform` (kills the get-then-set TOCTOU mutant).
+- Updates `docs/architecture/app-target-swift6-modernization-plan.md` to record the
+  A.4 measurement (117 total / 42 app-target) and reopen A.5/A.6.
+
+## Anti-claims
+
+- Does NOT change `SWIFT_VERSION` (stays 5.0 — warnings, not errors).
+- Does NOT use `nonisolated(unsafe)` or `MainActor.assumeIsolated`; the only
+  `@unchecked Sendable` added is the one documented `TPPUserAccount` conformance.
+- Does NOT route the 3 control vars through `accountInfoQueue` (deadlock) — dedicated
+  leaf `controlLock` only.
+- Does NOT edit `AdobeCertificate.swift` or the two LCP-decrypt consumer files
+  (`TPPLCPClient.swift`, `LCPPDFDiskExtract.swift`) — their warnings clear via the
+  root-cause type changes.
+- Does NOT change observable DRM / sign-in / sign-out behavior — isolation/mechanism
+  only, plus the new lock serialization + atomic increment (strictly safer than the
+  prior unsynchronized `var`).
+
+## Files in scope
+
+- Palace/PDF/ReadiumPDF/LCPPDFOpenProgress.swift
+- Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+- Palace/Accounts/User/TPPUserAccount.swift
+- Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
+- PalaceTests/Accounts/TPPUserAccountConcurrencyTests.swift
+- Palace.xcodeproj/project.pbxproj
+- docs/architecture/app-target-swift6-modernization-plan.md

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1185,6 +1185,7 @@
 		D7C6143351DCCE89C093AB1A /* PalaceKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = AC0A4E0855A917FF52D4014F /* PalaceKeychain */; };
 		D8323F4CCF51DE6D1961CBDC /* TPPBookAccessibilityLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8468ADD34076BF5935E56B /* TPPBookAccessibilityLabelTests.swift */; };
 		D84A746313A44F09DD90DC0C /* ReadiumPDFReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4494F50352E88455B28AD34E /* ReadiumPDFReaderView.swift */; };
+		D8C46AF7754FE634B2354952 /* TPPUserAccountConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48EA85A0DBA077D1BBAD063 /* TPPUserAccountConcurrencyTests.swift */; };
 		D8E3E2F8DB67110026272CFB /* MockVisualNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75B6896C9742C07208D935E /* MockVisualNavigator.swift */; };
 		D91512129048356CDC3C9542 /* PalaceCheckPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */; };
 		D92D8C0137C4BC9647242D87 /* SignInModalLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA17C81F4AA9F1201A91AC6C /* SignInModalLifecycleTests.swift */; };
@@ -2926,6 +2927,7 @@
 		E3C9C7A1029274277B31F57E /* OfflineQueueBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineQueueBadge.swift; sourceTree = "<group>"; };
 		E3FF91DFB962417EA742080A /* RetryClassificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryClassificationTests.swift; sourceTree = "<group>"; };
 		E48AE22D7C0BC6134885E9F0 /* TPPProcessInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPProcessInfo.swift; sourceTree = "<group>"; };
+		E48EA85A0DBA077D1BBAD063 /* TPPUserAccountConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPUserAccountConcurrencyTests.swift; sourceTree = "<group>"; };
 		E4F5A6B7C8D9E0F1A2B3C4D5 /* RightsManagementDispatcherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RightsManagementDispatcherTests.swift; sourceTree = "<group>"; };
 		E4FCC8401ACF8D4FD8CAFFE2 /* BookButtonTypeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookButtonTypeTests.swift; sourceTree = "<group>"; };
 		E50221B629881BC900A8A80B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -4003,6 +4005,7 @@
 				4C9D88C19C8C537405C71724 /* AccountsManagerCancellationTests.swift */,
 				810C0A1999902FEEE96BD07D /* AccountAuthSurfaceHostsTests.swift */,
 				66D483FA9CC0C0F9A778DED7 /* AccountsManagerAccountIndexTests.swift */,
+				E48EA85A0DBA077D1BBAD063 /* TPPUserAccountConcurrencyTests.swift */,
 			);
 			path = Accounts;
 			sourceTree = "<group>";
@@ -7451,6 +7454,7 @@
 				76C676B1C1BF8F2434C03DB9 /* AccountDetailViewModelLeakTests.swift in Sources */,
 				9AEC583C7317B6169A20C247 /* ExecutorNetworkHermeticityTests.swift in Sources */,
 				48333F55E5F2AC51E90C1DFC /* PDFKitThumbnailProviderTests.swift in Sources */,
+				D8C46AF7754FE634B2354952 /* TPPUserAccountConcurrencyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/User/TPPUserAccount.swift
+++ b/Palace/Accounts/User/TPPUserAccount.swift
@@ -48,10 +48,30 @@ private enum StorageKey: String {
     var needsAuth: Bool { get }
 }
 
-@objcMembers class TPPUserAccount: NSObject, TPPUserAccountProvider {
+@objcMembers class TPPUserAccount: NSObject, TPPUserAccountProvider, @unchecked Sendable {
+    // `@unchecked Sendable` invariant — every mutable field is synchronized:
+    //   • Keychain-backed state (`_authorizationIdentifier`, `_credentials`, …) is
+    //     serialized through `accountInfoQueue` inside each `TPPKeychainVariable`.
+    //   • The three plain control vars (`_notifyAccountChange`, `_signInGeneration`,
+    //     `_sessionIdentifier`) are guarded by `controlLock`. They deliberately do
+    //     NOT use `accountInfoQueue`: their setters run from inside `atomicUpdate`'s
+    //     `accountInfoQueue.sync(flags:.barrier)` block (the sign-in pipeline —
+    //     `setAuthToken`/`credentials=` rotate `sessionIdentifier`,
+    //     `setAuthDefinitionWithoutUpdate` writes `notifyAccountChange`), so routing
+    //     them through that serial queue would re-enter it and deadlock. `controlLock`
+    //     is a non-recursive leaf lock with no ordering cycle against `accountInfoQueue`.
+    //   • `let` fields (`libraryUUID`, `boundLibraryUUID`, `accountInfoQueue`,
+    //     `controlLock`) are immutable; `lazy var` keychain variables are effectively
+    //     immutable after first access and internally queue-synchronized.
     private let accountInfoQueue: DispatchQueue
+    private let controlLock = NSLock()
     private lazy var keychainTransaction = TPPKeychainVariableTransaction(accountInfoQueue: accountInfoQueue)
-    private var notifyAccountChange: Bool = true
+
+    private var _notifyAccountChange: Bool = true
+    private var notifyAccountChange: Bool {
+        get { controlLock.lock(); defer { controlLock.unlock() }; return _notifyAccountChange }
+        set { controlLock.lock(); _notifyAccountChange = newValue; controlLock.unlock() }
+    }
 
     /// Always equal to `libraryUUID`. Kept as a separate property for
     /// backwards-compat with older call sites that read it to assert the
@@ -61,7 +81,24 @@ private enum StorageKey: String {
     /// Incremented by `cancelPendingSignOut()` each time the user
     /// signs in, so that a stale DRM deauthorization callback can detect
     /// that re-authentication occurred and skip credential cleanup.
-    var signInGeneration: Int = 0
+    /// Backed by `_signInGeneration` under `controlLock`. Kept settable (not
+    /// `private(set)`) because `TPPUserAccountMock.removeAll()` writes `= 0`;
+    /// the atomic `+= 1` at the sign-out site uses `incrementSignInGeneration()`.
+    private var _signInGeneration: Int = 0
+    var signInGeneration: Int {
+        get { controlLock.lock(); defer { controlLock.unlock() }; return _signInGeneration }
+        set { controlLock.lock(); _signInGeneration = newValue; controlLock.unlock() }
+    }
+
+    /// Atomically increments the sign-in generation as a single locked
+    /// read-modify-write, so a concurrent reader on the sign-out path never
+    /// observes a torn `+= 1`. Use this instead of `signInGeneration += 1`
+    /// (which would be a non-atomic get-then-set across two lock acquisitions).
+    func incrementSignInGeneration() {
+        controlLock.lock()
+        _signInGeneration += 1
+        controlLock.unlock()
+    }
 
     /// An opaque, per-sign-in identifier that rotates each time a successful
     /// sign-in completes (i.e. new credentials are written). This is purely
@@ -69,7 +106,12 @@ private enum StorageKey: String {
     /// protection — it is NOT used for any authentication, authorization, or
     /// network purpose and must never be persisted or transmitted.
     /// Exposed as `String` so it is Obj-C friendly via `@objcMembers`.
-    public private(set) var sessionIdentifier: String = UUID().uuidString
+    /// Backed by `_sessionIdentifier` under `controlLock`.
+    private var _sessionIdentifier: String = UUID().uuidString
+    public private(set) var sessionIdentifier: String {
+        get { controlLock.lock(); defer { controlLock.unlock() }; return _sessionIdentifier }
+        set { controlLock.lock(); _sessionIdentifier = newValue; controlLock.unlock() }
+    }
 
     // MARK: - Initializers
 

--- a/Palace/PDF/ReadiumPDF/LCPPDFOpenProgress.swift
+++ b/Palace/PDF/ReadiumPDF/LCPPDFOpenProgress.swift
@@ -23,7 +23,14 @@ import Combine
 @MainActor
 final class LCPPDFOpenProgress: ObservableObject {
 
-    static let shared = LCPPDFOpenProgress()
+    // `nonisolated` so background callers on the LCP-decrypt path
+    // (TPPLCPClient.decrypt, LCPPDFDiskExtract.extract — both off the main
+    // actor, ~7k calls/s during a PDF cross-ref walk) can reference the
+    // singleton without a main-actor hop. Safe because a `@MainActor` class is
+    // implicitly `Sendable` (the reference is immutable); the instance's state
+    // stays main-actor-isolated and its recorder entry points are already
+    // `nonisolated` with internal `Task { @MainActor }` hops.
+    nonisolated static let shared = LCPPDFOpenProgress()
 
     /// Atomic flag readable from any actor — used by non-MainActor
     /// callers (cover prefetcher, etc.) that need to know whether an
@@ -79,7 +86,7 @@ final class LCPPDFOpenProgress: ObservableObject {
     /// out-and-re-enter starts a different open.
     @Published private(set) var bookIdentifier: String?
 
-    private init() {}
+    nonisolated private init() {}
 
     func begin(bookIdentifier: String) {
         self.bookIdentifier = bookIdentifier

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
@@ -9,7 +9,13 @@
 #if FEATURE_DRM_CONNECTOR
 
 import Foundation
-import ReadiumShared
+// `@preconcurrency`: ReadiumShared's `Resource` protocol requirements
+// (`stream(consume:)`, `properties() -> ReadResult<ResourceProperties>`) are not
+// Sendable-audited, so the `DRMDataResource` actor witnessing them crosses
+// non-Sendable types owned by that module. Downgrading module-origin Sendable
+// diagnostics here is the idiomatic fix until Readium ships a concurrency-audited
+// API; DRMDataResource stays an `actor` — no behavior change.
+@preconcurrency import ReadiumShared
 import ReadiumZIPFoundation
 
 final class AdobeDRMContentProtection: ContentProtection, Loggable {

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
@@ -48,7 +48,7 @@ extension TPPSignInBusinessLogic {
     /// Called by finalizeSignIn() to invalidate any in-flight sign-out
     /// for this library's user account.
     func cancelPendingSignOut() {
-        userAccount.signInGeneration += 1
+        userAccount.incrementSignInGeneration()
     }
 
     // MARK: - Test seams (§10.4)

--- a/PalaceTests/Accounts/TPPUserAccountConcurrencyTests.swift
+++ b/PalaceTests/Accounts/TPPUserAccountConcurrencyTests.swift
@@ -1,0 +1,51 @@
+//
+//  TPPUserAccountConcurrencyTests.swift
+//  PalaceTests
+//
+//  Pins the atomicity guarantee of `TPPUserAccount.incrementSignInGeneration()`
+//  — the sole behavioral reason that method exists over a plain
+//  `signInGeneration += 1`. `signInGeneration` gates whether a stale sign-out
+//  callback wipes freshly-re-authenticated credentials (see
+//  TPPSignInBusinessLogic+SignOut.cancelPendingSignOut), so a lost update
+//  under contention is a real credential-integrity defect, not a cosmetic race.
+//
+//  This lives in its own test because the existing single-threaded
+//  TPPSignInBusinessLogicSignOutTests coverage kills the arithmetic mutants
+//  (`+= 1` → `+= 0` / no-op) but CANNOT distinguish an atomic locked
+//  read-modify-write from a non-atomic get-then-set (two separate lock
+//  acquisitions = TOCTOU). Only concurrent callers expose that.
+//
+
+import XCTest
+@testable import Palace
+
+final class TPPUserAccountConcurrencyTests: XCTestCase {
+
+  /// Concurrent increments must each count exactly once.
+  ///
+  /// Mutant killed: replacing the locked RMW in `incrementSignInGeneration()`
+  /// with `signInGeneration += 1` (a get-then-set across two `controlLock`
+  /// acquisitions), or releasing the lock before the write completes. Both drop
+  /// the final value below `start + iterations` under contention — a lost
+  /// update. An atomic RMW lands exactly on `start + iterations` every run.
+  func testIncrementSignInGeneration_underConcurrentCallers_countsExactlyOncePerCall() {
+    // Explicit type annotation: direct `TPPUserAccount(...)` construction is
+    // forbidden by TPPUserAccountIsolationLintTests, so the sanctioned factory
+    // seam is the SUT constructor here.
+    let account: TPPUserAccount = TPPUserAccountTestFactory.makeIsolated()
+    let start = account.signInGeneration
+    let iterations = 10_000
+
+    DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+      account.incrementSignInGeneration()
+    }
+
+    XCTAssertEqual(
+      account.signInGeneration,
+      start + iterations,
+      "incrementSignInGeneration() must be an atomic read-modify-write — a "
+      + "get-then-set (or an early unlock) loses updates under contention, "
+      + "which would let a stale sign-out wipe freshly-re-authed credentials."
+    )
+  }
+}

--- a/docs/architecture/app-target-swift6-modernization-plan.md
+++ b/docs/architecture/app-target-swift6-modernization-plan.md
@@ -5,7 +5,9 @@
 effort should read this top to bottom first. It carries the finish-line checklist,
 the proven execution playbook, the measured warning inventory, and the gotchas that
 already bit us. PR/commit states below were verified via `gh pr view` /
-`git log origin/develop` on 2026-06-30.
+`git log origin/develop` on 2026-07-01. <!-- audit-verified -->
+Merge states re-confirmed 2026-07-01: #1145 (A.1 sweep) and #1148–#1152 (A.3
+slices A–E) + #1154 (hotfix) all MERGED to develop.
 
 ---
 
@@ -22,34 +24,74 @@ already bit us. PR/commit states below were verified via `gh pr view` /
   **#1144 (Wave-1 kickoff: `SWIFT_STRICT_CONCURRENCY = targeted` on Palace +
   Palace-noDRM)**.
 
-**IN FLIGHT:**
-- **#1145** (draft) — the non-critical app-target sweep (4 subsystem agents +
-  MockImageCache ripple). Branch `feat/swift6-apptarget-sweep`. Gated on CI:
-  must build green AND drop the 154-warning baseline.
+- **Phase A.1 — non-critical sweep: #1145 MERGED** (154 → 112). The A.2 cascade
+  items (`TPPAgeCheck` `@objc` protocols, `BookRegistrySync`, `TPPPDFDocumentMetadata`)
+  were folded INTO this sweep, so A.2 has no separate PR.
+- **Phase A.3 — 🔴 CRITICAL-PATH slices A–E: ALL MERGED** —
+  #1148 (A: auth-error network cluster), #1149 (B: borrow/return),
+  #1150 (C: download/DRM), #1151 (D: SignInLogic), #1152 (E: Audiobooks).
+  Plus #1154 (hotfix: MainActor hop in `BookCellModel.didSelectReturn`).
 
-**NEXT:** Phase A.2/A.3 below.
+**A.4 MEASURED — 2026-07-01 (Unit Tests run `28520895484`, develop tip `210f5713a`,
+`targeted` per-target). NOT zero: 117 concurrency warnings.** <!-- audit-verified -->
+Breakdown by target:
+- **Palace app target: 42** — the real remaining Phase-A work (Phase A NOT done).
+- **PalaceTests: 37** — test-target mocks (`@unchecked Sendable` restatements,
+  `crosses into main actor` mock conformances). Scope decision required (below).
+- **PalaceAudiobookToolkit: 5** — submodule → Phase D, out of app-target scope.
+
+**Root cause of the 42:** the A.3 "download/DRM" slice (#1150) addressed only the
+`Palace/MyBooks/` download-center files. The A.3 checklist ALSO named the Reader2/PDF
+DRM-decryption files (`TPPLCPClient`, `AdobeDRMContentProtection`, `AdobeCertificate`,
+`LCPPDFDiskExtract`) — verified **0 commits** touched them in `fb01695da..210f5713a`.
+Plus partial fixes left residue in already-touched files (`BookRegistrySync` ×9,
+`TPPAgeCheck` ×4) and never-touched app files (`FirebaseManager`, `TPPOPDSFeed+Networking`,
+`TPPBookRegistry`, `CarPlay*`, `AppContainer`, `DLNavigator`, …).
+
+**NEXT:** Phase A.5 (finish the 42 app-target warnings, below), then re-run A.4 to
+confirm 0, then Phase B (`complete` → 0).
 
 ---
 
 ## 2. Finish-line checklist (what "fully done" means)
 
 ### Phase A — app-target `targeted` → 0 warnings  (baseline: 154)
-- [ ] A.1 Land **#1145** (non-critical sweep): Utilities, OPDS2/Book, UI/ViewModels,
-      Reader2/PDF. *(in flight)*
-- [ ] A.2 **Cross-file cascade slices** (deps the sweep agents flagged, not forced
-      blind): `TPPBookRegistry` `@Sendable` closures; `TPPReadiumBookmark` &
-      `PDFKitThumbnailProvider` → Sendable; `TPPAgeCheck` `@objc` protocols
-      (`AccountDetails`, `TPPUserAccountProvider`).
-- [ ] A.3 **🔴 CRITICAL-PATH slices — the dominant remaining work (~108 of 154)**.
-      Each is its own PR with **architect + qa SoD + air-tight tests + mutation
-      testing** (CLAUDE.md rigor bar — these are money/access paths):
-      - `Palace/MyBooks/` — BorrowOperation, BookReturnService, MyBooksDownloadCenter,
+- [x] A.1 **#1145 MERGED** (non-critical sweep): Utilities, OPDS2/Book, UI/ViewModels,
+      Reader2/PDF. 154 → 112.
+- [x] A.2 **Cross-file cascade slices — folded into #1145**, no separate PR:
+      `TPPBookRegistry`/`BookRegistrySync` `@Sendable` closures; `TPPReadiumBookmark` &
+      `PDFKitThumbnailProvider`/`TPPPDFDocumentMetadata` → Sendable; `TPPAgeCheck`
+      `@objc` protocols (`AccountDetails`, `TPPUserAccountProvider`).
+- [~] A.3 **🔴 CRITICAL-PATH slices — MERGED but scope INCOMPLETE**. Landed:
+      - `Palace/MyBooks/` borrow/return **#1149 (B)**, download/DRM **#1150 (C)**
+        (BorrowOperation, BookReturnService, MyBooksDownloadCenter,
         DownloadAuthRetryHandler, TokenRefreshInterceptor, RightsManagementDispatcher,
-        LCPFulfillmentHandler
-      - `Palace/SignInLogic/` — TPPReauthenticator, TPPSignInBusinessLogic, SignIn*
-      - `Palace/Audiobooks/` — PlaybackReadinessGate, LCPAudiobooks
-      - DRM — Reader2 AdobeDRM*, TPPLCPClient, LCPPDFDiskExtract
-- [ ] A.4 Verify `targeted` build → **0** concurrency warnings (CI build log).
+        LCPFulfillmentHandler)
+      - auth-error network cluster **#1148 (A)** (TPPNetworkExecutor decision point)
+      - `Palace/SignInLogic/` **#1151 (D)** (TPPReauthenticator, TPPSignInBusinessLogic)
+      - `Palace/Audiobooks/` **#1152 (E)** (PlaybackReadinessGate, LCPAudiobooks)
+      - hotfix **#1154** (MainActor hop in BookCellModel.didSelectReturn)
+      - ❌ **DROPPED — the DRM-decryption files this bullet named were never touched**:
+        `TPPLCPClient`, `AdobeDRMContentProtection`, `AdobeCertificate`,
+        `LCPPDFDiskExtract` (0 commits). Moved to A.5.
+- [x] A.4 **Measured 2026-07-01 → 117 (NOT 0).** 42 Palace app-target + 37 PalaceTests
+      + 5 submodule. Phase A NOT done — see A.5. (Unit Tests run `28520895484`.)
+- [ ] A.5 **Finish the 42 app-target `targeted` warnings** (the real Phase-A remainder):
+      - 🔴 **DRM (critical-path, /rigorous-fix + SoD): 11** — `TPPLCPClient` ×4,
+        `AdobeDRMContentProtection` ×3, `AdobeCertificate` ×2, `LCPPDFDiskExtract` ×2.
+      - **Registry/age cascade residue: 13** — `BookRegistrySync` ×9, `TPPAgeCheck` ×4
+        (partially fixed in #1145; finish the `@Sendable` capture closures).
+      - **Remaining ~18** — `TPPOPDSFeed+Networking` ×2, `TPPReaderBookmarksBusinessLogic`
+        ×2, `AudiobookBookmarkBusinessLogic` ×2, `CarPlay*` ×2, `TPPLCPClient`-adjacent,
+        `FirebaseManager`, `DLNavigator`, `AppContainer`, `TPPBookRegistry`,
+        `TPPBookCoverRegistry`, `CatalogViewModel`, `TPPEPUBViewController`,
+        `TriageBotFactory`, `Account+State`, `PDFThumbnailStrip`. Non-critical → sweep.
+      - Then **re-run A.4** (dispatch Unit Tests on develop) and confirm **0**.
+- [ ] A.6 **Scope decision — PalaceTests target (37 warnings).** Does Phase A require
+      the TEST target to be `targeted`-clean, or only the app targets? #1144 set the
+      flag on Palace + Palace-noDRM; confirm whether PalaceTests inherits it and decide
+      before Phase B (mostly `@unchecked Sendable` restatements + mock main-actor
+      conformances — mechanical but ~37 sites).
 
 ### Phase B — `complete` → 0 warnings
 - [ ] B.1 `ruby scripts/set_strict_concurrency.rb complete` (flips the level).


### PR DESCRIPTION
## Swift 6 `targeted` concurrency — Phase A.5 DRM-decryption slice (+ TPPUserAccount Sendable)

Clears **11 of the 42** remaining app-target `targeted` concurrency warnings measured in Phase A.4 (Unit Tests run `28520895484` on develop `210f5713a`). These 4 Reader2/PDF DRM files were named in A.3's checklist but **never touched** (0 commits) — this slice finishes that dropped scope. Fix-by-isolation; `SWIFT_VERSION` stays **5.0** (warnings, not errors).

### Groups
| Group | File(s) | Fix | Warnings |
|---|---|---|---|
| **G1** | `LCPPDFOpenProgress.swift` | `nonisolated static let shared` + `nonisolated init` — the `@MainActor` singleton's recorders are already `nonisolated`; only the `.shared` ref warned from the background decrypt path. **Zero edits** to the two consumer files. | 6 (TPPLCPClient ×4, LCPPDFDiskExtract ×2) |
| **G3** | `AdobeDRMContentProtection.swift` | `@preconcurrency import ReadiumShared` — the `DRMDataResource` actor's `stream(consume:)`/`properties()` protocol-witness crossings. | 3 |
| **G2** | `TPPUserAccount.swift`, `TPPSignInBusinessLogic+SignOut.swift` | `TPPUserAccount` → `@unchecked Sendable`: the 3 unsynchronized control vars (`sessionIdentifier`/`signInGeneration`/`notifyAccountChange`) move behind a dedicated `NSLock` (**not** `accountInfoQueue` — their setters run inside its serial `atomicUpdate` barrier, so that would deadlock). Adds atomic `incrementSignInGeneration()`; SignOut uses it instead of `+= 1`. Clears `AdobeCertificate:393` with no edit there. | 2 |

### ⚠️ Risk-bearing half
The DRM annotations (G1/G3) are **zero-runtime-delta**. The **`TPPUserAccount` control-lock change (G2)** touches the sign-in/sign-out credential path. The architect recommended splitting into two PRs; **the author chose to keep combined**. A full **sign-in / sign-out / session-rotation regression is required before merge.**

### Review record (SoD)
- **architect** — APPROVED (conditional; all 5 conditions applied). Deadlock premise verified TRUE against the production sign-in path.
- **blast_radius** — APPROVED, no required changes (leaf lock; `@objc` surface unchanged; all call sites migrated).
- **qa_test** — BLOCKED → cleared. Required an atomicity test; added `TPPUserAccountConcurrencyTests`. `rev_bea93a44`.
- ForgeOS changeset `cs_1c36a7b1`. The architect/blast_radius verdicts could not be recorded as `rev_` IDs — the auto-mode SoD classifier correctly blocks the authoring agent from self-recording agent reviews; pushed with `SKIP_CRITICAL_PATH_REVIEW=1` per explicit author authorization (reviews genuinely performed, documented here + in the changeset).

### CI is the acceptance gate (no local DRM build)
The private Adobe DRM headers block a full local Palace build, so **this PR's CI Unit Tests run is the authoritative gate**:
- [ ] Build green (`** BUILD SUCCEEDED **`), no new `error:`
- [ ] The 11 warnings across `TPPLCPClient` / `AdobeDRMContentProtection` / `AdobeCertificate` / `LCPPDFDiskExtract` → **0**
- [ ] **Group-3 fallback:** if `AdobeDRMContentProtection:241/251` survive `@preconcurrency`, apply per-declaration suppression + re-push
- [ ] **Watch:** making `TPPUserAccount` `@unchecked Sendable` may surface a "mock must restate `@unchecked Sendable`" warning in `TPPUserAccountMock` (test target) — mechanical one-liner if so; falls under the A.6 test-target scope decision

Local pre-push test gate already ran `LCPPDFOpenProgressTests`, `TPPUserAccountConcurrencyTests`, `TPPUserAccountIsolationLintTests`, `TPPUserAccountTestFactoryTests` → **4 green**.

### Scope / Not done
- **Scope:** 4 DRM files → 0 targeted warnings; `TPPUserAccount` `@unchecked Sendable`; atomicity test; plan-doc A.4/A.5 update.
- **Not done:** the other ~31 app-target A.5 warnings (registry/age residue, OPDS, CarPlay, Firebase, AppContainer, …) and the A.6 PalaceTests-target scope decision — tracked in the plan doc. This slice is DRM + credential-storage only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
