### PR TITLE
feat(sideload): test-only side loading — registry, manager, catalog lane (PP-2677/2678/2679)

### DIFF
--- a/.forgeos/intent/sideloading.md
+++ b/.forgeos/intent/sideloading.md
@@ -1,3 +1,9 @@
+---
+name: PP-2677 side-loading manager settings catalog lane registry sync-exemption feature flag
+created: 2026-07-01
+author: swarm_495a88d9
+---
+
 # Intent — Side Loading (PP-2677 / PP-2678 / PP-2679)
 
 Swarm: swarm_495a88d9 · Branch: feature/PP-2677-sideloading · Date: 2026-07-01

--- a/.forgeos/intent/sideloading.md
+++ b/.forgeos/intent/sideloading.md
@@ -1,0 +1,28 @@
+# Intent — Side Loading (PP-2677 / PP-2678 / PP-2679)
+
+Swarm: swarm_495a88d9 · Branch: feature/PP-2677-sideloading · Date: 2026-07-01
+Ground truth: docs/architecture/sideloading-plan.md · Contracts: .forgeos/swarms/swarm_495a88d9/contracts/
+
+## Claims (what this change WILL do)
+- Add a `SideloadedBookRegistry` — a dedicated, local-only JSON manifest of sideloaded books (PP-2678) with add/remove/rename/update/allBooks/identifiers.
+- Add a `SideloadedBookManager` (PP-2677) that imports a local EPUB/PDF/audiobook file: classify → mint an open-access `TPPBook` → copy the file to a fixed-account `BookFileManager` path → register in both the sideloaded registry and the main `TPPBookRegistry` as `.downloadSuccessful` → add the id to a sync-exemption set; plus a flag-gated Settings screen and launch rehydration.
+- Exempt sideloaded book ids from `BookRegistrySync` reconciliation so server sync does not evict them or delete their files.
+- Make `BookFileManager` resolve sideloaded book files against a fixed `sideloadContentAccountID` (= primary account) so they survive library switches.
+- Add a `RemoteFeatureFlags.sideLoadingEnabled` flag (Firebase default + DEBUG-on + dev-menu local override) gating the whole feature.
+- Inject a "Side Loaded" `CatalogLaneModel` at every `toCatalogContent()` site in `CatalogViewModel` via a single choke-point helper (PP-2679), flag-gated.
+
+## Anti-claims (what this change will NOT do)
+- Will NOT sync sideloaded books to any server or OPDS feed (local-only).
+- Will NOT alter the borrow / download / DRM-fulfillment pipelines for catalog books.
+- Will NOT change server-sync behavior for non-sideloaded books (exemption is scoped to the sideloaded id set only).
+- Will NOT hide sideloaded books from the My Books shelf (accepted side effect of registry reuse).
+- Will NOT bypass the `didSelectRead` auth gate (accepted limitation for auth-required libraries when signed out).
+
+## Files in scope
+- NEW: Palace/MyBooks/Sideload/SideloadedBookRegistry.swift, SideloadedBookManager.swift (+ tests)
+- MODIFY: Palace/Book/Models/BookRegistrySync.swift (sync exemption), Palace/MyBooks/BookFileManager.swift (account-stable resolution), Palace/Book/Models/TPPBookRegistry.swift (provider threading)
+- MODIFY: Palace/FeatureFlags/RemoteFeatureFlags.swift (+ FirebaseManager)
+- MODIFY: Palace/CatalogUI/ViewModels/CatalogViewModel.swift, CatalogState.swift (lane injection)
+- MODIFY: Palace/Settings/TPPSettings.swift, Settings/NewSettings/TPPSettingsView.swift (Settings entry)
+- MODIFY: Palace/AppInfrastructure/AppContainer.swift (2 additive properties), TPPAppDelegate.swift (rehydration in load(completion:))
+- MODIFY: Palace.xcodeproj/project.pbxproj (via scripts/pbxproj_add_swift.rb only)

--- a/.forgeos/swarms/swarm_495a88d9/architect-review.md
+++ b/.forgeos/swarms/swarm_495a88d9/architect-review.md
@@ -1,0 +1,193 @@
+# Architect review — swarm_495a88d9 (Side Loading, PP-2677/2678/2679)
+
+**Reviewer:** architect-reviewer
+**Date:** 2026-07-01
+**Worktree:** ios-core-sideloading @ feature/PP-2677-sideloading
+**Method:** ran the cited greps/reads against the real tree — did not take contracts at their word.
+
+## VERDICT: **BLOCKED** → **RESOLVED** (contracts updated 2026-07-01; see Resolution section at bottom)
+
+The plan and the A/B module contracts are accurate and implementable. **Two concrete
+correctness defects are baked into contracts C and D** (findings 1 & 2), plus two
+real hazards (3 & 4) and one caveat (5). Findings 1–2 will cause the implementer to
+ship a lane that vanishes on facet navigation (AC5) and a rehydration wired against a
+misidentified sync site. All are cheap **contract** fixes — the architecture (locked
+decisions, exemption-at-reconciliation-core, AppContainer additive pattern) is sound.
+
+---
+
+## Findings
+
+### FINDING 1 — [HIGH / BLOCKING] Module D undercounts the `toCatalogContent()` call sites — lane vanishes on facet cache-hit
+The D contract says inject "at the toCatalogContent() call sites in load()(:166) /
+applyFacet(:308) / applyEntryPoint(:362,:381)" — **4 sites**. There are **5**:
+
+| line | method | branch |
+|------|--------|--------|
+| 166 | `load()` | — |
+| **283** | `applyFacet()` | **cache-HIT (synchronous fast path)** — MISSED by contract |
+| 308 | `applyFacet()` | cache-MISS |
+| 362 | `applyEntryPoint()` | cached |
+| 381 | `applyEntryPoint()` | fetched |
+
+`:283` and `:308` are **mutually exclusive branches** (verified: `:281 if let cachedFeed = repository.cachedFeed(for: href)` returns at `:294`; `:308` is the else/network path). An implementer following the contract literally patches only `:308`, so **every facet applied from cache (the common path) drops the Side Loaded lane** — a silent AC5 regression that unit tests keyed to `load()` won't catch.
+**Fix:** contract must enumerate all 5 sites (or refactor to a single choke point — e.g. push the `prepending:` injection into a wrapper all five call). Add a test case: "applyFacet cache-hit still shows the Side Loaded lane."
+
+### FINDING 2 — [HIGH / BLOCKING] Module C's rehydration anchor `TPPAppDelegate:218` is NOT a launch sync
+The C contract + plan R2 say "wire rehydrateAtLaunch between the registry `load()`
+(`:200`) and the first launch `sync {}` (`:218`)." Verified: **`:218` is inside
+`handleAppRefresh(task:)` (starts `:214`) — the BGAppRefresh background handler**, not
+the launch path. `load()` at `:200` is inside `applicationDidFinishLaunching` (`:35`),
+which contains **no `sync()` at all**. The real first runtime syncs are
+`applicationDidBecomeActive` **`:330`** (fires on cold-launch foreground) and
+`AppTabHostView.swift` **`:260`** (catalog appear). The contract's grep gate
+("rehydration on a line between :200 and :218") is semantically meaningless — it would
+pass for a call placed anywhere textually before line 218, including the wrong method.
+An implementer who opens `:218` to place the call "before the first sync" lands in the
+background-refresh handler and is misled.
+**Fix:** anchor rehydration explicitly inside `applicationDidFinishLaunching`
+immediately after `load()` (`:200`), and rewrite the verification to assert it appears
+in `applicationDidFinishLaunching` (not "before :218"). Note the exemption itself
+protects persistence regardless of ordering (it reads `SideloadedBookRegistry` live),
+so worst case of getting this wrong is "book absent until rehydration runs," not data
+loss — but the wiring is still wrong as written.
+
+### FINDING 3 — [MEDIUM] `load()` is async; synchronous rehydrate-right-after may be clobbered
+`bookRegistry.load()` (`:200`) is explicitly asynchronous — the in-code comment
+(`:195-200`) states "load() returns immediately — the disk I/O is dispatched onto the
+store's own queue … queues the state transition to .loaded." `rehydrateAtLaunch()`
+calls `TPPBookRegistry.addBook`. Calling it synchronously right after `load()` returns
+risks the addBook running while the registry is `.unloaded/.loading`, then being
+overwritten when the disk snapshot lands and transitions to `.loaded`.
+**Fix:** contract C must specify rehydration hooks into `load()`'s completion / the
+`.loaded` transition (or prove `addBook` during `.loading` survives the snapshot merge).
+This is the actual R2 race, not the sync-ordering framing in the current contract.
+
+### FINDING 4 — [MEDIUM] File path is account-scoped; sideloaded books are account-agnostic
+Reader resolves `book.url` → `AppContainer…downloadCenter.fileUrl(for: identifier)`
+(`TPPBook+Additions.swift:15-16`) → `fileUrl(for: identifier, account: accountsManager.currentAccountId)`
+(`BookFileManager.swift:55-64`) → `fileUrl(for: book, account:)` builds
+`<dir(for: account)>/content/<sha256(id)>.<ext>` (`:69-73`). The path is **scoped to
+`currentAccountId`**. C's contract says copy to `fileUrl(for: book, account:)` but never
+pins the account. If the copy account ≠ the current account at read time, the reader
+resolves a different directory and gets nil → open fails. And because
+`SideloadedBookRegistry` is deliberately local-only/account-agnostic, **switching
+libraries changes `currentAccountId` and makes the sideloaded file unresolvable** — a
+real limitation not listed in the plan's risks.
+**Fix:** contract C must pin the copy to `accountsManager.currentAccountId` (matching
+read time) and document the cross-account limitation, or store under a fixed sideload
+pseudo-account and confirm the reader path resolves it.
+
+### FINDING 5 — [LOW / document] `didSelectRead` runs `ensureAuthAndExecute` — an auth gate the "sufficient, no edits" claim omits
+`didSelectRead` (`:844`) wraps the open in `ensureAuthAndExecute` (`:711`), which
+presents a sign-in modal when `account.needsAuth && !account.hasCredentials()` or
+`authState == .credentialsStale`. Opening a sideloaded open-access book **while signed
+out on an auth-required library shows sign-in, not the reader**. The contract's
+"reader-open sufficiency: no availability/download-record/OPDS gate" is technically
+true (this is an auth gate, not those), but the blanket "SUFFICIENT with NO other
+production edits" glosses over it. Acceptable for the signed-in DRM-test use case;
+should be documented so the E2E tester signs in first.
+
+---
+
+## Verified CORRECT (no action)
+
+**Module A (accurate + robust):**
+- `BookRegistrySync.swift`: `recordsToDelete = Set(registry.keys)` at **:406** ✓;
+  eviction `registry.removeValue` at **:481** ✓; on-disk delete
+  `downloadCenter.deleteLocalContent` at **:497** ✓. Adding
+  `recordsToDelete.subtract(sideloadedIDsProvider())` after `:406` exempts BOTH the
+  un-registration and the file delete, and sits **before** the `shouldSkipBulkDeletion`
+  guards (`:455-469`) as required. ✓
+- init at **:64-75** with the lazy `downloadCenterProvider` precedent (`:43`, `:67`) —
+  the proposed `sideloadedIDsProvider` default mirrors it exactly. ✓
+- Both `BookRegistrySync(` construction sites in `TPPBookRegistry.swift` at **:212**
+  and **:242** ✓ (note :242 is the `fileprivate init(account:)` used by
+  `with(account:perform:)` — it also gets the exemption via the default, good).
+- `@unchecked Sendable` + documented invariant at `:9-31`; storing the provider as
+  `let` preserves it. ✓
+- **Exemption is centralized at the reconciliation core**, so ALL sync() callers are
+  covered by one subtract. Verified sync() fan-in: `AppTabHostView:260`,
+  `TPPAppDelegate:218/:330`, `HoldsViewModel:255/:273`, `TPPSignInBusinessLogic:892`,
+  `OverdriveDownloadHandler:120`, `MyBooksViewModel:204/:219`, `NotificationService:625`,
+  `BookReturnService:616` — all funnel through `BookRegistrySync.sync()`. The plan's R2
+  worry about "other launch sync sites" is moot for the exemption (only matters for
+  rehydration, see finding 2/3).
+- **Off-limits eviction list is complete.** `TokenRefreshInterceptor.swift` and
+  `DownloadAuthRetryHandler.swift` exist but do **not** evict/reconcile (no
+  `deleteLocalContent`/`recordsToDelete`). Other `deleteLocalContent` sites
+  (`BookReturnService`, `MyBooksViewModel:143`, `BookContentResetService`,
+  `TPPBookRegistryAsync:118`, `ReaderService:505`) are **user-initiated** deletes, not
+  automatic reconciliation — correctly out of exemption scope.
+- **Critical regression test is writable.** `sync()` fetches its feed via
+  `opdsFeedService.fetchFeed(from: loansUrl, …)` (`:382`); spy seams exist
+  (`downloadCenterProvider` for recording `deleteLocalContent`, `opdsFeedServiceProvider`
+  for feed injection, `BookRegistryStore` for seeding a `.downloadSuccessful` book).
+  Existing `PalaceTests/Book/BookRegistrySyncTests.swift` demonstrates the spy
+  construction AND the non-trivial `loansUrl`/`awaitReady` account setup the regression
+  test will need to replicate. **Implementer note:** the loans-feed injection requires
+  an account whose `details.loansUrl` resolves (see the anonymous-library setup at
+  `BookRegistrySyncTests:448-561`) or `sync()` bails before reconciliation.
+
+**Module B (all line refs accurate):** `isTriageBotEnabled` DEBUG-on at **:249-258**,
+`inAppPlaybackNavLocalOverrideKey` at **:320**, `managerKey` at **:76** (inAppPlaybackNav
+arm :94-95), `RemoteConfigKey` enum at **:55** (inAppPlaybackNav :65),
+`setDefaultValues()` at **:102** (entry :112). Contract correctly notes
+`inAppPlaybackNavEnabled` lacks DEBUG-on and to borrow it from `isTriageBotEnabled`. ✓
+
+**AppContainer wiring:** `bookOpenTracker` lazy-cache precedent at **:230-236** (contract
+said :229-236 — accurate); `_resetForTesting()` at **:546** (contract cited :584-588 —
+**stale by ~40 lines**, minor; the method exists). SideloadedBookRegistry is a
+file-backed shared static cache, so it **must** be nil'd in `_resetForTesting` to avoid
+cross-test-class pollution — treat the contract's "ONLY IF" as "YES." ✓
+
+**Dependency graph accurate:** D reads `appContainer.sideloadedBookRegistry.allBooks` at
+the sole `CatalogViewModel(` construction site `AppTabHostView.swift:74-79` and does
+**NOT** modify `AppContainer.swift` — confirmed. So C∥D collide on AppContainer via C
+only; the A→C staging is the sole AppContainer ordering constraint. `CatalogViewModel.init`
+at **:53-66** uses closure injection (`topLevelURLProvider`) — the proposed
+`sideloadedLaneBooksProvider` mirrors it. `CatalogLaneModel` at **:417**. ✓
+
+**Reader-open EPUB/PDF (biggest assumption — verified at the seam):**
+`BookButtonMapper.swift:48-49` maps `.downloadSuccessful` from registry state alone;
+`BookService.open` (`:26`) EPUB→`readerService.openEPUB`, non-LCP PDF→
+`downloadCenter.fileUrl(for: book.identifier)`→`TPPPDFDocument(url:)`; no OPDS refetch /
+availability / download-record gate; `#if FEATURE_DRM_CONNECTOR` (`:848`) is skipped for
+a no-credentials open-access book. Confirmed **modulo findings 4 (account scoping) and 5
+(auth gate)** — those are the two seams the "no edits" claim glosses.
+
+---
+
+## Instructions for implementers (once contracts are fixed)
+- **D:** patch all 5 `toCatalogContent()` sites (or a single choke point) + add the
+  facet-cache-hit lane test.
+- **C:** anchor rehydration in `applicationDidFinishLaunching` after `load()`, hooking
+  the async-load completion (finding 3); pin the file copy to `currentAccountId`
+  (finding 4); document the auth-gate + cross-account caveats (findings 4/5).
+- **A:** reset `_sideloadedBookRegistry` in `_resetForTesting`; regression test needs
+  a `loansUrl`-resolving account (see BookRegistrySyncTests pattern).
+
+---
+
+## Resolution (architect-directed contract edits, 2026-07-01)
+
+Each finding → the exact contract edit that resolves it. No code was written; all
+fixes are in the contracts / plan / manifest so implementers cannot land the defect.
+
+| # | Sev | Resolution | Where |
+|---|-----|-----------|-------|
+| 1 | HIGH/BLOCK | Contract D now enumerates all **5** `toCatalogContent()` sites (166/283/308/362/381) and **mandates a single choke-point helper** `withSideloadedLane(_:)` that every site routes through. Added grep gates: exactly one `toCatalogContent(` in CatalogViewModel, zero bare `.toCatalogContent()`, `withSideloadedLane(` ≥ 5. Added test case 5 (applyFacet cache-HIT drives the VM, not just the pure fn). | `contracts/D-SideloadedLane.md` (Design + Test contract + Verification); `manifest.yaml` D prompt + AC5 |
+| 2 | HIGH/BLOCK | Contract C rehydration anchor corrected: `:218` is `handleAppRefresh` (background), NOT launch. Re-anchored to `applicationDidFinishLaunching` / `setupBookRegistryAndNotifications()`. Grep gate rewritten to assert the call is in that method and NOT in `handleAppRefresh`. | `contracts/C-Manager-and-Settings.md` (Launch rehydration + Verification); `manifest.yaml` C prompt |
+| 3 | MED | Rehydration mechanism pinned to the **`bookRegistry.load(completion:)` callback** (load is async; a synchronous rehydrate is clobbered by the disk snapshot). Grep gate asserts `load(` on that path passes a trailing closure. R2 in plan.md rewritten to this race. | `contracts/C` (Launch rehydration); `plan.md` R2 |
+| 4 | MED | New **Component 4** in contract A: `BookFileManager` gains account-stable read resolution — sideloaded ids resolve against a fixed `sideloadContentAccountID` (= `AccountsManager.TPPAccountUUIDs[0]`, no-subpath dir) regardless of `currentAccountId`. `BookFileManager.swift` + a resolution test added to A's scope. Contract C's import pins the **write** to the same constant. New R6 in plan.md; new AC5b. | `contracts/A` (Component 4 + scope + test + greps); `contracts/C` (import step 3); `plan.md` R6; `manifest.yaml` A scope/prompt + C prompt + AC5b |
+| 5 | LOW | Documented as **accepted limitation (option a)** in contract C + plan.md: `didSelectRead` → `ensureAuthAndExecute` shows sign-in when signed out on an auth-required library; not engineered around (shared critical-path auth gate); E2E signs in first. New R7. | `contracts/C` (Reader-open sufficiency); `plan.md` reader-open caveats + R7 |
+
+Plus the two "verified correct" nits folded in: A now nils `_sideloadedBookRegistry`
+in `_resetForTesting` (REQUIRED, not "only if"), and A's regression-test note cites
+the `BookRegistrySyncTests:448-561` loansUrl-resolving account setup.
+
+**Intended verdict after these edits: APPROVED for dispatch.** The two correctness
+defects (1, 2) are structurally gated (choke-point grep + method-anchored grep), the
+two hazards (3, 4) have concrete mechanisms pinned in the contracts, and the caveat
+(5) is an explicit accept. Re-review only the C/D diffs against these gates at
+integrate.

--- a/.forgeos/swarms/swarm_495a88d9/contracts/A-Registry-and-SyncExemption.md
+++ b/.forgeos/swarms/swarm_495a88d9/contracts/A-Registry-and-SyncExemption.md
@@ -1,0 +1,184 @@
+# Module A — SideloadedBookRegistry + Sync-Exemption + AppContainer wiring
+
+**Swarm:** swarm_495a88d9 (side-loading)
+**Risk:** `critical_path` — touches `BookRegistrySync` reconciliation (the code that
+deletes local books + on-disk files). Requires architect + SoD (blast_radius)
+review regardless of LOC. See CLAUDE.md "Risk-driven rigor bar" + "Auth-error /
+critical-path" canon.
+**Depends on:** none (foundation). Modules C and D depend on THIS.
+**Tickets:** PP-2678 (registry) + the critical sync-exemption from the plan.
+
+## Why A bundles registry + sync-exemption + AppContainer construction
+The sync-exemption set is *driven by* `SideloadedBookRegistry.identifiers`, and the
+provider that feeds `BookRegistrySync` reads it via `AppContainer`. These three
+edits are one atomic seam — splitting them yields a half-wired exemption that the
+next `sync()` defeats (the exact load-bearing hazard in the plan). One contract,
+one critical-path implementer.
+
+## Component 1 — `SideloadedBookRegistry` (PP-2678, NEW)
+Dedicated local-only persistence, separate manifest from `registry.json`.
+- **Storage:** own JSON manifest. Recommend **Application Support** (consistent
+  with `registry.json`, backup-excluded) — treat the ticket's "Documents folder"
+  wording as illustrative (plan open item; confirm in transcript). Path helper:
+  mirror `BookRegistrySync.registryUrl(for:)` style but a distinct filename, e.g.
+  `sideloaded/sideloaded.json`. Local-only, NOT account-scoped-synced.
+- **Model:** persists each sideloaded `TPPBook` via `book.dictionaryRepresentation()`
+  round-trip + the original imported filename (per-entry). Re-hydrate with the
+  matching `TPPBook(dictionary:)` initializer.
+- **API (exact):**
+  - `func add(book: TPPBook, fileURL: URL)`  (records book + original filename)
+  - `func remove(identifier: String)`
+  - `func rename(identifier: String, to newTitle: String)`
+  - `func update(book: TPPBook)`
+  - `var allBooks: [TPPBook]` (drives the lane, Module D)
+  - `var identifiers: Set<String>` (drives the sync-exemption set — MUST be a
+    cheap synchronous read; it is called inside `BookRegistrySync.sync()`)
+- **Concurrency:** MUST be thread-safe and `Sendable` (internal `NSLock` +
+  `@unchecked Sendable` with a documented invariant, per module-3 playbook —
+  do NOT use `nonisolated(unsafe)`). `identifiers` is read from the main-actor
+  sync-reconciliation path AND from the manager's import path (Module C), so it
+  cannot be `@MainActor`-only. Persist synchronously on mutation, or serialize
+  writes on an internal queue; a corrupt/empty/missing manifest must load as an
+  empty registry (no crash).
+
+## Component 2 — Sync-exemption in `BookRegistrySync` (CRITICAL)
+- Add init param to `BookRegistrySync.init` (`BookRegistrySync.swift:64-75`):
+  `sideloadedIDsProvider: @escaping () -> Set<String> = { AppContainer.production().sideloadedBookRegistry.identifiers }`.
+  Store it as a `let` (immutable — preserves the `@unchecked Sendable` invariant
+  documented at `:11-30`; do NOT add a mutable var). Mirror the existing lazy
+  `downloadCenterProvider` precedent (`:43`, `:215`) — resolving `AppContainer`
+  lazily avoids the launch-time dispatch_once cycle.
+- In `sync()` reconciliation, immediately after
+  `var recordsToDelete = Set<String>(registry.keys)` (**`BookRegistrySync.swift:406`**),
+  add: `recordsToDelete.subtract(sideloadedIDsProvider())`.
+  This exempts sideloaded ids from BOTH the `registry.removeValue` un-registration
+  (`:480-481`) AND the `deleteLocalContent` on-disk delete (`:496-497`).
+- Thread the provider through **both** `TPPBookRegistry` inits that construct a
+  `BookRegistrySync` (`TPPBookRegistry.swift:212` and `:242`). Passing the default
+  is acceptable, but pass it EXPLICITLY at both sites for clarity + so the
+  contract-reconciliation gate sees the wiring.
+
+## Component 3 — AppContainer exposure (ADDITIVE ONLY)
+- Add a lazy-cached computed property `sideloadedBookRegistry: SideloadedBookRegistry`
+  to `AppContainer`, backed by a `private static var _sideloadedBookRegistry`,
+  mirroring the `bookOpenTracker` cache pattern (`AppContainer.swift:229-236`).
+- **DO NOT** touch the big `init(...)` (`:283-325`), `_buildCachedAppContainer()`
+  return statement (`:469-494`), or the two `with*Presenter` copy methods
+  (`:106`, `:158`). The property is additive so Module C's later append and the
+  orchestrator's final reconcile stay conflict-free.
+- **`_resetForTesting()` reset (REQUIRED, not optional).** `SideloadedBookRegistry`
+  is a file-backed shared static cache, so it WILL bleed manifest state across test
+  classes. Add `_sideloadedBookRegistry = nil` to `_resetForTesting()` (method at
+  `AppContainer.swift:546`; nil the static in the same style as the audiobook
+  statics reset — the exact line is ~`:585-587`, re-locate it, the earlier `:584-588`
+  cite was ~40 lines stale). The architect review confirmed this is a YES, not an
+  "only if."
+
+## Component 4 — Account-stable file resolution in `BookFileManager` (REQUIRED)
+`BookFileManager.fileUrl` is scoped to `currentAccountId`
+(`fileUrl(for identifier:)` → `fileUrl(for: identifier, account: currentAccountId)`
+→ `directory(for: account)/content/<sha256(id)>.<ext>`). The reader resolves a
+book via `TPPBook.url` → `downloadCenter.fileUrl(for: identifier)` →
+`bookFileManager.fileUrl(for: identifier)` (`MyBooksDownloadCenter.swift:1625-1631`).
+`SideloadedBookRegistry` is deliberately **account-agnostic**, so if a sideloaded
+file is written under one library's content dir and the user switches libraries,
+`currentAccountId` changes and the read resolves the WRONG directory → nil → open
+fails. This is a real cross-account defect, not a nicety.
+
+**Resolution (pin both write and read to ONE fixed account):**
+- Expose a single constant for the sideload content account:
+  `static let sideloadContentAccountID = AccountsManager.TPPAccountUUIDs[0]`
+  (the primary/no-subpath account — `TPPBookContentMetadataFilesHelper.directory(for:)`
+  at `:32` appends NO sub-path for `TPPAccountUUIDs[0]`, giving the stable
+  `<AppSupport>/<bundleID>/content/` dir). Put the constant on `SideloadedBookRegistry`
+  (or `BookFileManager`) so BOTH Module A (read) and Module C (write) reference the
+  SAME value — do NOT let the two sides pick the account independently.
+- In `BookFileManager.fileUrl(for identifier:, account:)` (`:59`), before resolving,
+  if `identifier` is sideloaded (∈ `AppContainer.production().sideloadedBookRegistry.identifiers`
+  — the same lazy provider pattern, evaluated at read time, no init cycle),
+  substitute `account = <sideloadContentAccountID>`. This is the single READ choke
+  point every `fileUrl(for: identifier)` overload funnels through, so it fixes the
+  reader path without touching `MyBooksDownloadCenter`.
+- Module C's import writes via `fileUrl(for: book, account: <sideloadContentAccountID>)`
+  (explicit account overload `:69` — no interception needed on the write side because
+  C passes the account directly). C consumes the constant from A.
+
+## Files IN scope
+- `Palace/MyBooks/Sideload/SideloadedBookRegistry.swift` (NEW)
+- `Palace/Book/Models/BookRegistrySync.swift` (modify — provider param + subtract at :406)
+- `Palace/Book/Models/TPPBookRegistry.swift` (modify — pass provider at :212 & :242 ONLY)
+- `Palace/AppInfrastructure/AppContainer.swift` (modify — ADD lazy-cached property + static cache + `_resetForTesting` nil ONLY; see Component 3 boundaries)
+- `Palace/MyBooks/BookFileManager.swift` (modify — account-stable read resolution for sideloaded ids + the `sideloadContentAccountID` constant; Component 4)
+- `PalaceTests/MyBooks/Sideload/SideloadedBookRegistryTests.swift` (NEW)
+- `PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift` (NEW — critical regression)
+- `PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift` (NEW — account-stable resolution)
+- New Swift files added to BOTH targets via `ruby scripts/pbxproj_add_swift.rb`
+  (NEVER hand-edit `project.pbxproj`). Test files auto-route to `PalaceTests`.
+
+## Files OFF-LIMITS
+- `Palace/FeatureFlags/RemoteFeatureFlags.swift`, `FirebaseManager.swift` (Module B).
+- `Palace/MyBooks/Sideload/SideloadedBookManager.swift` + all Settings files (Module C).
+- `Palace/CatalogUI/*` (Module D).
+- AppContainer big `init` / `_buildCachedAppContainer` return / `with*Presenter`
+  copies — additive-only (Component 3).
+- The reconciliation guards `shouldSkipBulkDeletion` / large-deletion warn logic
+  (`:449-467`) — do not alter; the `subtract` goes at :406, before those.
+
+## Test contract
+1. `SideloadedBookRegistryTests` — construct `SideloadedBookRegistry(...)` with an
+   injected temp directory (add a directory-override init seam like
+   `BookFileManager`'s `directoryProvider`). Prove:
+   - Manifest round-trip: add 2 books → reload a fresh instance → `allBooks`
+     identical (identifiers, titles, original filenames).
+   - `add` then `remove` → `identifiers` no longer contains it.
+   - `rename` changes the persisted title; reload confirms.
+   - `identifiers` reflects current membership after add/remove.
+   - Edge cases: duplicate add (same id) does not double-insert; missing/corrupt/
+     empty manifest file loads as empty (no throw/crash); unsupported/garbage JSON
+     tolerated.
+2. `BookRegistrySyncSideloadExemptionTests` — **THE critical regression.**
+   Construct `BookRegistrySync(store:accountsManager:downloadCenterProvider:opdsFeedServiceProvider:sideloadedIDsProvider:)`
+   directly with spy dependencies. Seed the store with a `.downloadSuccessful`
+   book whose id is "sideloaded-1". Drive `sync()` with a stubbed loans feed that
+   does NOT contain "sideloaded-1", and `sideloadedIDsProvider` returning
+   `["sideloaded-1"]`. Assert:
+   - After sync, "sideloaded-1" is STILL in the registry with `.downloadSuccessful`.
+   - The spy `downloadCenter.deleteLocalContent` was NOT called for it.
+   - Control case (same test class, second method): with an EMPTY exemption set,
+     the same book IS evicted + `deleteLocalContent` IS called — proving the
+     exemption is what saved it, not some other guard (mutation-grade contrast).
+3. `BookFileManagerSideloadResolutionTests` — construct `BookFileManager` with a
+   `directoryProvider` temp override and a stubbed `sideloadedBookRegistry`
+   identifier set. Prove: a sideloaded id resolves to the FIXED
+   `sideloadContentAccountID` directory **even when `accountsManager.currentAccountId`
+   is a different library** (set currentAccountId to a non-primary account, assert
+   the resolved path is the primary/no-subpath content dir). Contrast: a
+   non-sideloaded id still resolves against `currentAccountId` (no behavior change
+   for normal books).
+
+## Verification criteria (grep-able, per acceptance criterion)
+- SUT instantiation (DoD #1):
+  - `grep -c "SideloadedBookRegistry(" PalaceTests/MyBooks/Sideload/SideloadedBookRegistryTests.swift` ≥ 2
+  - `grep -c "BookRegistrySync(" PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift` ≥ 1
+- Exemption present in production: `grep -c "recordsToDelete.subtract" Palace/Book/Models/BookRegistrySync.swift` == 1
+- Provider param present: `grep -c "sideloadedIDsProvider" Palace/Book/Models/BookRegistrySync.swift` ≥ 2 (param + use)
+  and `grep -c "sideloadedIDsProvider" Palace/Book/Models/TPPBookRegistry.swift` == 2 (both inits)
+- AppContainer additive only: `git diff Palace/AppInfrastructure/AppContainer.swift` must NOT touch lines inside `init(` param list or the `_buildCachedAppContainer` `return AppContainer(` block; confirm with a review of the hunk ranges. (The `_resetForTesting` nil is the one exception — a single added line in that method.)
+- Account-stable resolution present: `grep -c "sideloadContentAccountID" Palace/MyBooks/BookFileManager.swift` ≥ 1 and `grep -c "sideloadedBookRegistry" Palace/MyBooks/BookFileManager.swift` ≥ 1 (the membership check).
+- Resolution test proves cross-account stability: `grep -c "BookFileManager(" PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift` ≥ 1, and the test sets `currentAccountId` to a non-primary account and asserts the primary/no-subpath dir (multi-step body).
+- Multi-step / contrast body (DoD #3): the exemption regression test class has
+  BOTH the "survives with exemption" and "evicted without exemption" methods —
+  `grep -c "func test" PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift` ≥ 2, and grep the file for both `deleteLocalContent` assertion directions (called / not-called).
+- Wiring-coverage (DoD #7): line-coverage report shows the exemption test hits
+  `BookRegistrySync.swift:406` and the `deleteLocalContent` branch at `:496-497`.
+- **Mutation (DoD #5, MANDATORY critical path):**
+  `python3 scripts/palace_mutate.py --file Palace/Book/Models/BookRegistrySync.swift --tests PalaceTests/BookRegistrySyncSideloadExemptionTests --diff-only`
+  → **100% kill on the touched lines** (the `subtract` line and provider use; the
+  contrast test must kill the "subtract removed" mutant). Also run
+  `--file Palace/MyBooks/Sideload/SideloadedBookRegistry.swift --tests PalaceTests/SideloadedBookRegistryTests --diff-only` ≥ 50%.
+- `check-blast-radius.py --quiet` exit 0 (new AppContainer property is not a
+  test-only init param; provider default is not a discarded result).
+- `check-contract-reconciliation.py --commit-msg <file>` exit 0 for the "adds
+  SideloadedBookRegistry / adds sync exemption" claims.
+- `check-superpartner-spectrum.py --quiet` exit 0.
+- Build clean (both targets); `scripts/verify-pr.sh --quick` PASS.

--- a/.forgeos/swarms/swarm_495a88d9/contracts/B-FeatureFlag.md
+++ b/.forgeos/swarms/swarm_495a88d9/contracts/B-FeatureFlag.md
@@ -1,0 +1,73 @@
+# Module B — FeatureFlag (sideLoadingEnabled gate)
+
+**Swarm:** swarm_495a88d9 (side-loading)
+**Risk:** standard
+**Depends on:** none (foundational — A/C/D consume the flag)
+**Ticket:** PP-2679 ("test mode" gate), PP-2677
+
+## Purpose
+Add ONE remote feature flag, `sideLoadingEnabled`, that gates every side-loading
+surface (Settings entry, catalog lane). Mirrors the `inAppPlaybackNavEnabled`
+wiring pattern **but with the DEBUG-on precedence of `isTriageBotEnabled`**
+(per locked decision #2: "Firebase remote default + local override, DEBUG-on").
+
+This module owns the flag exclusively. Modules C (Settings + Manager) and D
+(Lane) call `RemoteFeatureFlags.shared.isSideLoadingEnabled` (production) or an
+injected `RemoteFeatureFlags` instance (tests) — they do NOT add flag plumbing.
+
+## Public surface added
+- `RemoteFeatureFlags.FeatureFlag.sideLoadingEnabled = "side_loading_enabled"`
+  (new enum case).
+- `RemoteFeatureFlags.FeatureFlag.managerKey` — add mapping
+  `.sideLoadingEnabled → .sideLoadingEnabled`.
+- `RemoteFeatureFlags.FeatureFlag.defaultValue` — `.sideLoadingEnabled` returns
+  `false` (falls into the `default` arm; no edit needed unless you special-case).
+- `static let sideLoadingLocalOverrideKey = "RemoteFeatureFlags.sideLoadingLocalOverride"`.
+- `var isSideLoadingEnabled: Bool` — computed accessor. Precedence EXACTLY:
+  1. UserDefaults local override (`defaults.object(forKey: Self.sideLoadingLocalOverrideKey) as? Bool`)
+  2. `#if DEBUG` → `true`
+  3. `isFeatureEnabled(.sideLoadingEnabled)` (Firebase)
+- `FirebaseManager.RemoteConfigKey.sideLoadingEnabled = "side_loading_enabled"`
+  (new enum case) + a default entry `NSNumber(value: false)` in
+  `setDefaultValues()`.
+
+## Files IN scope
+- `Palace/FeatureFlags/RemoteFeatureFlags.swift` (modify — add case, managerKey
+  arm, override key, accessor). Model on `isTriageBotEnabled` (:249-258) for the
+  DEBUG-on precedence and `inAppPlaybackNavLocalOverrideKey` (:320) for naming.
+- `Palace/AppInfrastructure/FirebaseManager.swift` (modify — add
+  `RemoteConfigKey.sideLoadingEnabled` at :65-ish and its `setDefaults` entry at
+  :112-ish). REQUIRED for remote gating to resolve; without it `managerKey`
+  returns nil and the flag silently falls back to `defaultValue`.
+- `PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift` (NEW).
+
+## Files OFF-LIMITS
+- Any `Palace/MyBooks/Sideload/*` (Modules A/C).
+- `Palace/CatalogUI/*` (Module D).
+- `Palace/AppInfrastructure/AppContainer.swift` (Modules A/C + orchestrator).
+- Do NOT remove or renumber existing FeatureFlag / RemoteConfigKey cases.
+
+## Test contract
+`RemoteFeatureFlagsSideLoadingTests` MUST construct
+`RemoteFeatureFlags(defaults: UserDefaults(suiteName:)!)` (never `.shared`) and
+prove:
+1. `isSideLoadingEnabled` returns the local override when set to `true`, and to
+   `false` (both directions — not just the on case).
+2. Local override takes precedence over the DEBUG/Firebase fallback (set override
+   `false`, assert `false` even though DEBUG would return `true`).
+3. With no override set, DEBUG builds return `true` (guard the assertion in
+   `#if DEBUG` so the release config test still compiles/passes).
+Use a fresh suite per test; `removePersistentDomain(forName:)` in tearDown.
+
+## Verification criteria (grep-able)
+- SUT instantiation: `grep -c "RemoteFeatureFlags(" PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift` ≥ 2.
+- Flag case present: `grep -c 'case sideLoadingEnabled = "side_loading_enabled"' Palace/FeatureFlags/RemoteFeatureFlags.swift` == 1.
+- RemoteConfigKey present: `grep -c 'case sideLoadingEnabled = "side_loading_enabled"' Palace/AppInfrastructure/FirebaseManager.swift` == 1.
+- setDefaults entry: `grep -c 'RemoteConfigKey.sideLoadingEnabled.rawValue' Palace/AppInfrastructure/FirebaseManager.swift` ≥ 1.
+- Override-precedence test body actually sets override to BOTH values:
+  `grep -c 'sideLoadingLocalOverride' PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift` ≥ 1
+  AND the test asserts `false` outcome (multi-step-body check #3): grep the test
+  for both `set(true` and `set(false` (or equivalent) on the override key.
+- `check-superpartner-spectrum.py --quiet` exit 0 (new accessor `isSideLoadingEnabled`
+  and enum case must have a referencing test).
+- Build clean; `scripts/verify-pr.sh --quick` PASS.

--- a/.forgeos/swarms/swarm_495a88d9/contracts/C-Manager-and-Settings.md
+++ b/.forgeos/swarms/swarm_495a88d9/contracts/C-Manager-and-Settings.md
@@ -1,0 +1,206 @@
+# Module C — SideloadedBookManager + Settings + launch rehydration
+
+**Swarm:** swarm_495a88d9 (side-loading)
+**Risk:** `critical_path` — mints synthetic `TPPBook`s and registers them into the
+main `TPPBookRegistry`; a mis-registration interacts with the sync-exemption and
+DRM stack. Architect + SoD (blast_radius) review required.
+**Depends on:** A (`SideloadedBookRegistry`, `TPPBookRegistry.addBook`,
+`AppContainer.sideloadedBookRegistry`), B (`RemoteFeatureFlags.isSideLoadingEnabled`).
+**Ticket:** PP-2677.
+
+## Component 1 — `SideloadedBookManager` (NEW)
+`Palace/MyBooks/Sideload/SideloadedBookManager.swift`.
+
+### Import (`import(fileURL: URL) throws / async throws`)
+1. **Classify** by extension/MIME → `TPPBookContentType.from(mimeType:)`
+   (`TPPContentType.swift:20`). Must resolve to `.epub` / `.pdf` / `.audiobook`;
+   reject `.unsupported` with a surfaced error (do NOT register).
+2. **Mint an open-access `TPPBook`** via the designated init (`TPPBook.swift:122`):
+   - generated `identifier` (e.g. `"sideload-" + UUID`; the sha256 of this drives
+     the on-disk path).
+   - exactly ONE `TPPOPDSAcquisition` whose **MIME matches the content type** so
+     both `defaultBookContentType` (`TPPBook.swift:669`) AND
+     `BookFileManager.pathExtension` (`BookFileManager.swift:123`) resolve
+     correctly (LCP audiobook → `.lcpa`, LCP PDF → `.zip`, else `.epub`). This MIME
+     is load-bearing — a wrong MIME → `.unsupported` → the reader shows
+     `presentUnsupportedItemError` and never opens.
+   - DRM-free / open-access (no `revokeURL`, no bearer token, no `needsAuth`
+     acquisition), `imageCache: ImageCache.shared`, `title` from the filename.
+3. **Copy the file** to
+   `BookFileManager.fileUrl(for: book, account: SideloadedBookRegistry.sideloadContentAccountID)`
+   (explicit-account overload `BookFileManager.swift:69`) — the sha256-hashed path.
+   **Pin the account to the fixed `sideloadContentAccountID` constant defined by
+   Module A** (= `AccountsManager.TPPAccountUUIDs[0]`, the primary/no-subpath dir),
+   NOT `currentAccountId`. Sideloaded books are account-agnostic; writing under the
+   current library would make the file unresolvable after a library switch. Module
+   A owns the matching READ-side resolution (BookFileManager substitutes this same
+   fixed account for sideloaded ids), so write and read agree. Consume A's constant
+   — do NOT hardcode a second copy of the account value here.
+4. **Register:** `SideloadedBookRegistry.add(book:fileURL:)` (dedicated manifest —
+   truth) **and** `TPPBookRegistry.addBook(book, state: .downloadSuccessful)`
+   (`TPPBookRegistry.swift:387`; state is the 3rd arg).
+   - NOTE: the sync-exemption is **automatically** satisfied by adding to
+     `SideloadedBookRegistry` — Module A's provider reads `identifiers` live at
+     sync time. There is NO separate `syncExemption.insert` call; adding to the
+     registry IS the exemption. Do not invent a second exemption store.
+
+### Remove (`remove(identifier:)`)
+Reverse: delete the on-disk file, `SideloadedBookRegistry.remove(identifier:)`,
+`TPPBookRegistry.removeBook(forIdentifier:)` (`:417`).
+
+### Launch rehydration (`rehydrateAtLaunch()`)
+Read `SideloadedBookRegistry.allBooks`; for each not already present in the main
+registry, `TPPBookRegistry.addBook(book, state: .downloadSuccessful)`. Idempotent
+(running twice does not duplicate).
+
+**Anchor (CORRECTED — the original `:218` cite was wrong).** The rehydration is
+wired inside `applicationDidFinishLaunching`, specifically in
+`setupBookRegistryAndNotifications()` where `bookRegistry.load()` is called
+(`TPPAppDelegate.swift:200`). **`TPPAppDelegate.swift:218` is NOT a launch sync — it
+is inside `handleAppRefresh(task:)`, the BGAppRefresh background handler.** The real
+first runtime syncs are `applicationDidBecomeActive` (`:330`) and
+`AppTabHostView.swift:260` (catalog appear) — both come AFTER
+`applicationDidFinishLaunching`.
+
+**Mechanism (CORRECTED — must hook the async load completion, finding 3).**
+`bookRegistry.load()` is asynchronous — the comment at `:196-199` states "load()
+returns immediately — the disk I/O is dispatched onto the store's own queue." A
+synchronous `rehydrateAtLaunch()` right after `load()` returns would run while the
+registry is still `.loading`/`.unloaded` and be clobbered when the disk snapshot
+lands and transitions to `.loaded`. Therefore rehydration MUST run in the
+`load(completion:)` callback (`TPPBookRegistry.load(account:completion:)` at `:269`):
+
+```swift
+AppContainer.production().bookRegistry.load {
+    AppContainer.production().sideloadedBookManager.rehydrateAtLaunch()
+}
+```
+
+Hop to main if `rehydrateAtLaunch` touches main-only state (`addBook` is itself
+store-queue-safe). The exemption protects persistence regardless of ordering (it
+reads the persisted `SideloadedBookRegistry` live), so worst case of a wiring
+mistake is "book absent until rehydration runs," not data loss — but wire it
+correctly per the above.
+
+## Component 2 — Settings UI (gated by the flag)
+- `Palace/Settings/NewSettings/TPPSettingsView.swift` (modify): add a
+  `sideLoadingSection` to the `List` (`:104-108`), rendered ONLY when
+  `RemoteFeatureFlags.shared.isSideLoadingEnabled` (inline flag read matches the
+  existing `:276` usage). Use the `row(title:index:selection:destination:)` helper
+  (`:424-434`) with a fresh unique `index` (e.g. 11) and `NavigationLink` →
+  `SideLoadingView`.
+- `Palace/Settings/NewSettings/SideLoadingView.swift` (NEW): the screen — a
+  file-import affordance (SwiftUI `.fileImporter(isPresented:allowedContentTypes:
+  onCompletion:)` — there is NO existing `UIDocumentPicker` pattern in the repo, so
+  build from scratch; `allowedContentTypes` = epub/pdf/audiobook UTTypes) + a
+  "manage" list of imported books (title, delete). Back it with a small
+  `SideLoadingViewModel` (`@MainActor ObservableObject`, may live in the same file
+  or a sibling) that calls `SideloadedBookManager`. Obtain the manager via
+  `AppContainer.production().sideloadedBookManager` (the settings view already
+  reads services this way, e.g. `:277`, `:395`) OR construct the VM in
+  `TPPSettingsView.init()` mirroring the `librariesVM` `@StateObject` template
+  (`:27`,`:35`). No `TPPSettings` key is needed — visibility is gated by the
+  RemoteFeatureFlag, not a `TPPSettings` toggle.
+
+## Component 3 — AppContainer exposure (ADDITIVE, appends after Module A)
+Add a lazy-cached computed property `sideloadedBookManager: SideloadedBookManager`
++ `private static var _sideloadedBookManager`, mirroring `bookOpenTracker`
+(`AppContainer.swift:229-236`). It resolves `self.sideloadedBookRegistry` (from
+Module A) + `self.bookRegistry` + `self.downloadCenter` + a `BookFileManager`.
+DO NOT touch the big `init`, `_buildCachedAppContainer` return, or `with*Presenter`
+copies. Append your property AFTER Module A's `sideloadedBookRegistry` property so
+the orchestrator's AppContainer reconcile is a clean concatenation.
+
+## Files IN scope
+- `Palace/MyBooks/Sideload/SideloadedBookManager.swift` (NEW)
+- `Palace/Settings/NewSettings/SideLoadingView.swift` (NEW; VM may be a 2nd NEW file)
+- `Palace/Settings/NewSettings/TPPSettingsView.swift` (modify — add gated section)
+- `Palace/AppInfrastructure/AppContainer.swift` (modify — ADD `sideloadedBookManager` property ONLY)
+- `Palace/AppInfrastructure/TPPAppDelegate.swift` (modify — rehydration call ONLY, inside the `bookRegistry.load(completion:)` callback in `applicationDidFinishLaunching`/`setupBookRegistryAndNotifications` per the CORRECTED anchor above; do NOT place it in `handleAppRefresh` / near :218)
+- `PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift` (NEW)
+- `PalaceTests/Contract/SideloadImportContractTests.swift` (NEW — import-pipeline snapshot)
+- New Swift files → BOTH targets via `ruby scripts/pbxproj_add_swift.rb` (NEVER hand-edit pbxproj).
+
+## Files OFF-LIMITS
+- `SideloadedBookRegistry.swift`, `BookRegistrySync.swift`, `TPPBookRegistry.swift`
+  (Module A — consume their surfaces, do not modify).
+- `RemoteFeatureFlags.swift` / `FirebaseManager.swift` (Module B — read `isSideLoadingEnabled`).
+- `CatalogUI/*`, `AppTabHostView.swift` (Module D).
+- `BookFileManager.swift` (consume `fileUrl`/`pathExtension`; do not modify).
+- AppContainer big `init` / `_buildCachedAppContainer` return / `with*Presenter`.
+
+## Reader-open sufficiency (confirmed — no extra production edits)
+Tracing confirms: for EPUB (Reader2) and PDF (Reader3), a book registered
+`.downloadSuccessful` with the file at `BookFileManager.fileUrl` opens with NO
+other production changes — the reader resolves `book.url` →
+`downloadCenter.fileUrl(for:identifier)` → sha256 path (`TPPBook+Additions.swift:15`,
+`BookFileManager.swift:59-73`); no download-record / OPDS-refetch / availability
+gate. The `#if FEATURE_DRM_CONNECTOR` Adobe gate (`BookDetailViewModel.swift:848`)
+is skipped for a no-credentials open-access book. **Module C's construction
+obligations are:** (a) correct acquisition MIME; (b) for audiobooks, the copied
+file MUST be a valid **manifest JSON** (the `LocalFileAdapter` parses it —
+`Vendors/LocalFileAdapter.swift:73-80`), and remote track playback still needs the
+network at play time; and (c) pin file placement to the fixed
+`sideloadContentAccountID` (import step 3 — else a library switch makes the file
+unresolvable).
+
+**Accepted limitation (DECISION — document, do NOT engineer around; finding 5):**
+`didSelectRead` (`BookDetailViewModel.swift:844`) wraps the open in
+`ensureAuthAndExecute` (`:711`), which presents a sign-in modal when
+`account.needsAuth && !account.hasCredentials()` (or `authState == .credentialsStale`).
+Opening a sideloaded book **while signed out on an auth-required library shows
+sign-in, not the reader.** This is an auth gate (not an availability/download/OPDS
+gate), so the EPUB/PDF "no other production edits" claim holds for the intended
+signed-in DRM-test use case. **Decision: accept (option a)** — do NOT route
+sideloaded opens around the shared critical-path auth gate for a test feature.
+E2E testers sign in first; note this in the simdrive flow.
+
+## Test contract
+1. `SideloadedBookManagerTests` — construct `SideloadedBookManager(...)` with
+   injected spies (fake `SideloadedBookRegistry` w/ temp dir, spy
+   `TPPBookRegistryProvider`, a `BookFileManager` with a `directoryProvider`
+   temp override, a fake file source). Prove:
+   - Import EPUB MIME → minted book `defaultBookContentType == .epub`, file copied
+     to the expected sha256 path, `SideloadedBookRegistry.identifiers` contains id,
+     `TPPBookRegistry.addBook` called with `state: .downloadSuccessful`.
+   - Import PDF and audiobook MIME → correct `defaultBookContentType`.
+   - Unsupported MIME/extension → throws / returns error, NEITHER registry mutated
+     (edge case).
+   - Duplicate import (same content) → no double-register (dedup).
+   - `remove` → file deleted + both registries cleared.
+   - `rehydrateAtLaunch` → each persisted book re-added to the main registry as
+     `.downloadSuccessful`; idempotent (running twice doesn't duplicate).
+   - Missing-file / copy-failure error path → no partial registration.
+2. `SideloadImportContractTests` (contract-snapshot, `PalaceTests/Contract/`) —
+   record the ordered call sequence of a successful import:
+   `classify → copyFile → sideloadRegistry.add → bookRegistry.addBook(.downloadSuccessful)`.
+   Follow the `CallLog` + `ContractSnapshot.assert` pattern (CLAUDE.md
+   "Contract-snapshot tests"). A reorder / dropped call drifts the snapshot.
+
+## Verification criteria (grep-able)
+- SUT instantiation (DoD #1):
+  - `grep -c "SideloadedBookManager(" PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift` ≥ 1
+  - `python3 scripts/check-test-name-vs-body.py PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift` → exit 0
+- `.downloadSuccessful` wiring present: `grep -c "downloadSuccessful" Palace/MyBooks/Sideload/SideloadedBookManager.swift` ≥ 1 (import + rehydration).
+- Rehydration wired in the correct method + via load completion:
+  `grep -n "rehydrateAtLaunch" Palace/AppInfrastructure/TPPAppDelegate.swift` must
+  land inside `setupBookRegistryAndNotifications()` (the `applicationDidFinishLaunching`
+  path), inside the `bookRegistry.load { ... }` completion closure — NOT inside
+  `handleAppRefresh` and NOT a bare fire-and-forget after `load()`. Verify: the
+  rehydration call's line is between the `func setupBookRegistryAndNotifications`
+  declaration and its closing brace, AND the `load(` on that path passes a trailing
+  closure (`grep -A2 "bookRegistry.load" TPPAppDelegate.swift` shows `{`, not `load()`).
+- Fixed-account write: `grep -c "sideloadContentAccountID" Palace/MyBooks/Sideload/SideloadedBookManager.swift` ≥ 1 (import copy pins the account); the manager must NOT call `fileUrl(for:book:account: currentAccountId)` for sideloaded copies.
+- Flag-gated settings: `grep -c "isSideLoadingEnabled" Palace/Settings/NewSettings/TPPSettingsView.swift` ≥ 1.
+- Multi-step body (DoD #3): `rehydrate`/`twice`/`again` tests actually drive the
+  step twice — grep the rehydration test for two `rehydrateAtLaunch()` calls (idempotency).
+- Contract-snapshot exists: `ls PalaceTests/Contract/__Snapshots__/SideloadImportContractTests/` non-empty after first record run; committed baseline present.
+- **Mutation (DoD #5, MANDATORY):**
+  `python3 scripts/palace_mutate.py --file Palace/MyBooks/Sideload/SideloadedBookManager.swift --tests PalaceTests/SideloadedBookManagerTests --diff-only` → ≥ 50% (aim 100% on classify + register + rehydrate branches; critical path).
+- `check-contract-reconciliation.py --commit-msg <file>` exit 0 for the
+  "adds SideloadedBookManager / mints open-access book / rehydrates at launch" claims.
+- `check-blast-radius.py --quiet` exit 0 (AppContainer property not a test-only init param).
+- `check-superpartner-spectrum.py --quiet` exit 0.
+- Build clean (both targets, incl. Palace-noDRM); `scripts/verify-pr.sh --quick` PASS.
+- (Release-path) simdrive E2E per plan step 5: enable flag → import LCP 2.x test
+  EPUB (PP-2580) → lane → open in reader → renders. Record a chaos-replay.

--- a/.forgeos/swarms/swarm_495a88d9/contracts/D-SideloadedLane.md
+++ b/.forgeos/swarms/swarm_495a88d9/contracts/D-SideloadedLane.md
@@ -1,0 +1,113 @@
+# Module D — SideloadedLane (catalog)
+
+**Swarm:** swarm_495a88d9 (side-loading)
+**Risk:** standard
+**Depends on:** A (`AppContainer.sideloadedBookRegistry.allBooks`), B (flag).
+**Ticket:** PP-2679.
+
+## Purpose
+Surface a "Side Loaded" lane at the top of the catalog when the feature flag is on
+and there is ≥1 sideloaded book. The lane must appear **even when the base feed is
+ungrouped or empty** (locked requirement — the DRM test use-case has no OPDS feed).
+
+## Design (confirmed seams)
+- Lane model: `CatalogLaneModel(title:, books:, moreURL: nil)`
+  (`CatalogViewModel.swift:417-430`). No `moreURL` → no "more" affordance.
+- **Injection point:** `MappedCatalog.toCatalogContent()`
+  (`CatalogState.swift:129-149`) — the single conversion every load / facet /
+  entry-point path funnels through. Add a parameter:
+  `func toCatalogContent(prepending extraLanes: [CatalogLaneModel] = []) -> CatalogContent`.
+  When `extraLanes` is non-empty, force the `.grouped` case:
+  - base `.grouped(lanes)` → `.grouped(extraLanes + lanes)`
+  - base `.ungrouped(books)` → `.grouped(extraLanes + [wrap(books)])` (wrap the
+    ungrouped books in one `CatalogLaneModel` so nothing is lost) OR keep them as
+    a trailing ungrouped-equivalent lane — pick one and document; must not drop books.
+  - base `.empty` → `.grouped(extraLanes)`.
+- **Provider injection into CatalogViewModel:** add ONE init param
+  `sideloadedLaneBooksProvider: @escaping () -> [TPPBook] = { [] }`
+  (`CatalogViewModel.swift:53-66`, mirrors the existing `topLevelURLProvider`
+  closure-injection style). Keep the flag OUT of CatalogViewModel — the provider
+  returns `[]` when the flag is off (the gate lives at the construction site).
+- **SINGLE CHOKE POINT (REQUIRED — do NOT patch call sites individually).** There
+  are **FIVE** `toCatalogContent()` call sites, not four:
+
+  | line | method | branch |
+  |------|--------|--------|
+  | 166 | `load()` | — |
+  | **283** | `applyFacet()` | **cache-HIT synchronous fast path** (the common facet path) |
+  | 308 | `applyFacet()` | cache-MISS network path |
+  | 362 | `applyEntryPoint()` | repo-cache hit |
+  | 381 | `applyEntryPoint()` | fetched |
+
+  `:283` and `:308` are mutually exclusive; patching only `:308` drops the lane on
+  every facet applied from cache — a silent AC5 regression. To make the site count
+  stop being a landmine, factor the injection into ONE private helper and route
+  **every** site through it:
+
+  ```swift
+  @MainActor
+  private func withSideloadedLane(_ mapped: MappedCatalog) -> CatalogContent {
+    let books = sideloadedLaneBooksProvider()
+    let lanes = books.isEmpty ? [] : [CatalogLaneModel(title: <"Side Loaded">, books: books, moreURL: nil)]
+    return mapped.toCatalogContent(prepending: lanes)
+  }
+  ```
+
+  Replace all five: sites 166/283/308 → `withSideloadedLane(mapped)`; sites
+  362/381 → `withSideloadedLane(Self.mapFeed(feed, bookRegistry: bookRegistry))`.
+  After the refactor there must be **exactly one** `toCatalogContent(` call in
+  `CatalogViewModel.swift` (inside the helper); zero bare
+  `.toCatalogContent()` calls remain.
+- **Construction site (the only caller):** `AppTabHostView.swift:74-79`. Pass:
+  `sideloadedLaneBooksProvider: { RemoteFeatureFlags.shared.isSideLoadingEnabled ? appContainer.sideloadedBookRegistry.allBooks : [] }`.
+- Renderer: **zero changes.** `CatalogContentView.swift:104-132` iterates any
+  `.grouped` lane automatically.
+
+## Files IN scope
+- `Palace/CatalogUI/ViewModels/CatalogViewModel.swift` (modify — init param +
+  build lane at the `toCatalogContent()` call sites)
+- `Palace/CatalogUI/ViewModels/CatalogState.swift` (modify — `toCatalogContent(prepending:)`)
+- `Palace/AppInfrastructure/AppTabHostView.swift` (modify — pass provider into
+  CatalogViewModel init at :74-79 ONLY; do NOT touch the `.sync()` region at :260)
+- `PalaceTests/CatalogUI/SideloadedLaneTests.swift` (NEW) — plus/or extend an
+  existing `CatalogState`/`CatalogViewModel` test file (document which).
+- Lane title string via `Strings`/`DisplayStrings` if that's the house style;
+  otherwise a literal is acceptable for a test-only feature (document choice).
+
+## Files OFF-LIMITS
+- `Palace/MyBooks/Sideload/*` (A/C), `RemoteFeatureFlags.swift`/`FirebaseManager.swift` (B),
+  `AppContainer.swift` (A/C + orchestrator), `TPPSettingsView.swift` (C).
+- `CatalogContentView.swift` (no render change needed — if you think you need one,
+  STOP and flag it).
+
+## Test contract
+Prefer testing `toCatalogContent(prepending:)` and the provider→lane logic
+directly (pure, no network):
+1. Flag/provider ON + non-empty registry → returned `CatalogContent.feed` is
+   `.grouped` and its first lane is the Side Loaded lane with the expected books.
+2. Provider returns `[]` → content is IDENTICAL to the no-injection baseline
+   (lane ABSENT) — assert the `.grouped`/`.ungrouped`/`.empty` shape is unchanged.
+3. **Ungrouped base feed + provider non-empty → result is `.grouped`, Side Loaded
+   lane present, AND the original ungrouped books are still reachable** (not dropped).
+4. **Empty base feed + provider non-empty → `.grouped([sideloadedLane])`** (lane
+   shows with no base feed — the core DRM-test requirement).
+5. **`applyFacet` cache-HIT still shows the Side Loaded lane** (finding 1). Drive
+   `applyFacet(_:)` on a `CatalogViewModel` whose `repository.cachedFeed(for:)`
+   returns a stub feed (forcing the synchronous `:283` path) with a non-empty
+   provider; assert the resulting `state.content.feed` is `.grouped` with the Side
+   Loaded lane present. This is the case a per-site patch would miss — it must
+   exercise the VM path, not just `toCatalogContent(prepending:)` directly.
+
+## Verification criteria (grep-able)
+- SUT instantiation: the test constructs the SUT it names — for
+  `CatalogViewModel`-named methods, `grep -c "CatalogViewModel(" PalaceTests/CatalogUI/SideloadedLaneTests.swift` ≥ 1; for `toCatalogContent`-level tests, the body calls `.toCatalogContent(`.
+  Run `python3 scripts/check-test-name-vs-body.py PalaceTests/CatalogUI/SideloadedLaneTests.swift` → exit 0.
+- Injection present: `grep -c "prepending" Palace/CatalogUI/ViewModels/CatalogState.swift` ≥ 1.
+- **Choke-point enforced (finding 1 landmine guard):**
+  `grep -c "toCatalogContent(" Palace/CatalogUI/ViewModels/CatalogViewModel.swift` == 1 (only inside the helper) AND `grep -c "\.toCatalogContent()" Palace/CatalogUI/ViewModels/CatalogViewModel.swift` == 0 (no un-injected bare calls remain) AND `grep -c "withSideloadedLane(" Palace/CatalogUI/ViewModels/CatalogViewModel.swift` ≥ 5 (helper called at every former site). This assertion fails loudly if any of the 5 sites is left un-injected.
+- Provider wired at construction: `grep -c "sideloadedLaneBooksProvider" Palace/AppInfrastructure/AppTabHostView.swift` == 1 and `grep -c "isSideLoadingEnabled" Palace/AppInfrastructure/AppTabHostView.swift` == 1.
+- The 5 cases each exist as a named test (multi-step body check #3):
+  `grep -c "func test" PalaceTests/CatalogUI/SideloadedLaneTests.swift` ≥ 5, covering grouped / ungrouped / empty / absent / **facet-cache-hit**. The cache-hit test constructs `CatalogViewModel(` and drives `applyFacet` (not just `toCatalogContent`).
+- Mutation: `python3 scripts/palace_mutate.py --file Palace/CatalogUI/ViewModels/CatalogState.swift --tests PalaceTests/SideloadedLaneTests --diff-only` ≥ 50% (kill the "force-grouped removed" and "extraLanes dropped" mutants).
+- `check-superpartner-spectrum.py --quiet` exit 0.
+- Build clean (both targets); `scripts/verify-pr.sh --quick` PASS.

--- a/.forgeos/swarms/swarm_495a88d9/manifest.yaml
+++ b/.forgeos/swarms/swarm_495a88d9/manifest.yaml
@@ -1,0 +1,89 @@
+swarm_id: swarm_495a88d9
+task: "Side loading (test-only) — PP-2678 SideloadedBookRegistry + PP-2677 SideloadedBookManager/Settings + PP-2679 SideloadedLane, plus the critical BookRegistrySync sync-exemption, AppContainer wiring, and a RemoteFeatureFlags gate. Locked decisions in docs/architecture/sideloading-plan.md."
+created_at: "2026-07-01"
+status: triaged
+base_ref: origin/develop
+branch: feature/PP-2677-sideloading
+worktree: /Users/mauricework/PalaceProject/ios-core-sideloading
+
+parallelism:
+  wave_1: [A-Registry-and-SyncExemption, B-FeatureFlag]   # parallel, zero shared files
+  wave_2: [C-Manager-and-Settings, D-SideloadedLane]      # parallel after A+B land
+  integrate: "orchestrator reconciles AppContainer.swift + Palace.xcodeproj/project.pbxproj, then verify-pr.sh --quick + /forge-review (architect + blast_radius on A and C)"
+
+collision_points:
+  - file: Palace/AppInfrastructure/AppContainer.swift
+    touched_by: [A-Registry-and-SyncExemption, C-Manager-and-Settings]
+    resolution: "ADDITIVE ONLY — both add lazy-cached computed properties (bookOpenTracker style). Neither touches the big init / _buildCachedAppContainer return / with*Presenter copies. A is primary author; C appends after A. ORCHESTRATOR owns final composition at integrate."
+  - file: Palace.xcodeproj/project.pbxproj
+    touched_by: [A-Registry-and-SyncExemption, C-Manager-and-Settings]
+    resolution: "Every module uses `ruby scripts/pbxproj_add_swift.rb` (idempotent, both targets) for its own files — NEVER hand-edit. Orchestrator re-runs / reconciles at integrate."
+
+modules:
+  - name: A-Registry-and-SyncExemption
+    risk: critical_path
+    depends_on: []
+    contract_path: .forgeos/swarms/swarm_495a88d9/contracts/A-Registry-and-SyncExemption.md
+    files_scope:
+      - "Palace/MyBooks/Sideload/SideloadedBookRegistry.swift (NEW — dedicated local manifest; add/remove/rename/update/allBooks/identifiers; Sendable+lock)"
+      - "Palace/Book/Models/BookRegistrySync.swift (modify — add sideloadedIDsProvider init param + `recordsToDelete.subtract(sideloadedIDsProvider())` at :406)"
+      - "Palace/Book/Models/TPPBookRegistry.swift (modify — pass provider at the two BookRegistrySync() sites :212 and :242 ONLY)"
+      - "Palace/AppInfrastructure/AppContainer.swift (modify — ADD lazy-cached `sideloadedBookRegistry` property + static cache + nil it in _resetForTesting; additive region only)"
+      - "Palace/MyBooks/BookFileManager.swift (modify — account-stable read resolution for sideloaded ids + the `sideloadContentAccountID` constant; architect finding 4)"
+      - "PalaceTests/MyBooks/Sideload/SideloadedBookRegistryTests.swift (NEW)"
+      - "PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift (NEW — critical regression + no-exemption contrast)"
+      - "PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift (NEW — cross-account-stable resolution)"
+    implementer_prompt: "Implement the side-load registry foundation + the CRITICAL sync-exemption. (1) NEW SideloadedBookRegistry: own JSON manifest under Application Support (NOT registry.json), persists TPPBooks via dictionaryRepresentation() round-trip + original filenames; API add(book:fileURL:)/remove(identifier:)/rename(identifier:to:)/update(book:)/allBooks/identifiers; thread-safe Sendable via internal NSLock + @unchecked Sendable with a documented invariant (NOT nonisolated(unsafe)); corrupt/empty/missing manifest loads empty (no crash); inject a temp-directory override init seam for tests. Also expose `static let sideloadContentAccountID = AccountsManager.TPPAccountUUIDs[0]` (the primary/no-subpath content dir) so write (C) and read (A) share one account. (2) BookRegistrySync: add `sideloadedIDsProvider: @escaping () -> Set<String> = { AppContainer.production().sideloadedBookRegistry.identifiers }` (store as immutable let — preserves the @unchecked Sendable invariant), and add `recordsToDelete.subtract(sideloadedIDsProvider())` IMMEDIATELY after `var recordsToDelete = Set<String>(registry.keys)` at :406. Mirror the existing lazy downloadCenterProvider precedent. (3) Thread the provider through both TPPBookRegistry inits (:212,:242). (4) AppContainer: ADD a lazy-cached `sideloadedBookRegistry` property mirroring bookOpenTracker (:230-236) AND nil `_sideloadedBookRegistry` in _resetForTesting (:546; it is a file-backed shared cache that bleeds across test classes — REQUIRED) — DO NOT otherwise touch the big init, _buildCachedAppContainer return, or with*Presenter copies. (5) FINDING 4 — account-stable resolution: in BookFileManager.fileUrl(for identifier:, account:) (:59), if the id is sideloaded (member of AppContainer.production().sideloadedBookRegistry.identifiers, read lazily at call time), substitute account = sideloadContentAccountID BEFORE resolving. This is the single read choke point that TPPBook.url -> downloadCenter.fileUrl(for:identifier) funnels through, so a sideloaded book opens from ANY library. TDD: write the exemption regression test FIRST — constructs BookRegistrySync directly with spies, seeds a .downloadSuccessful book absent from the loans feed, asserts (with exemption) survival + deleteLocalContent NOT called, AND a contrast method (empty exemption) proving eviction + deleteLocalContent IS called. Also test BookFileManager cross-account resolution (sideloaded id resolves to the primary/no-subpath dir even when currentAccountId is a different library; non-sideloaded id unchanged). Note: the exemption regression needs a loansUrl-resolving account (replicate the anonymous-library setup in PalaceTests/Book/BookRegistrySyncTests.swift:448-561) or sync() bails before reconciliation. 100% diff-scoped mutation on the touched BookRegistrySync lines is MANDATORY. Add new files to BOTH targets via scripts/pbxproj_add_swift.rb. CRITICAL PATH — expect architect + blast_radius review. OFF-LIMITS: RemoteFeatureFlags/FirebaseManager (B), SideloadedBookManager/Settings (C), CatalogUI (D), the AppContainer big init region."
+
+  - name: B-FeatureFlag
+    risk: standard
+    depends_on: []
+    contract_path: .forgeos/swarms/swarm_495a88d9/contracts/B-FeatureFlag.md
+    files_scope:
+      - "Palace/FeatureFlags/RemoteFeatureFlags.swift (modify — FeatureFlag.sideLoadingEnabled case + managerKey arm + local-override key + isSideLoadingEnabled accessor, DEBUG-on precedence)"
+      - "Palace/AppInfrastructure/FirebaseManager.swift (modify — RemoteConfigKey.sideLoadingEnabled case + setDefaults false entry)"
+      - "PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift (NEW)"
+    implementer_prompt: "Add ONE remote feature flag `sideLoadingEnabled` (\"side_loading_enabled\") that gates all side-loading surfaces. In RemoteFeatureFlags.swift add the FeatureFlag case, its managerKey mapping, a `sideLoadingLocalOverrideKey`, and a computed `isSideLoadingEnabled` whose precedence is EXACTLY: (1) UserDefaults local override, (2) #if DEBUG -> true, (3) isFeatureEnabled(.sideLoadingEnabled) — model on isTriageBotEnabled (:249-258) for DEBUG-on and inAppPlaybackNavLocalOverrideKey (:320) for naming. In FirebaseManager.swift add RemoteConfigKey.sideLoadingEnabled + its NSNumber(false) setDefaults entry (required for remote resolution). TDD: RemoteFeatureFlagsSideLoadingTests constructs RemoteFeatureFlags(defaults: UserDefaults(suiteName:)!) — NEVER .shared — and proves override precedence in BOTH directions (true and false) and that a false override beats the DEBUG-on fallback. Fresh suite per test; removePersistentDomain in tearDown. Do NOT remove/renumber existing cases. OFF-LIMITS: everything outside the two production files + your test file."
+
+  - name: C-Manager-and-Settings
+    risk: critical_path
+    depends_on: [A-Registry-and-SyncExemption, B-FeatureFlag]
+    contract_path: .forgeos/swarms/swarm_495a88d9/contracts/C-Manager-and-Settings.md
+    files_scope:
+      - "Palace/MyBooks/Sideload/SideloadedBookManager.swift (NEW — import/remove/rehydrateAtLaunch)"
+      - "Palace/Settings/NewSettings/SideLoadingView.swift (NEW — .fileImporter + manage list + SideLoadingViewModel)"
+      - "Palace/Settings/NewSettings/TPPSettingsView.swift (modify — add flag-gated sideLoadingSection via row() helper)"
+      - "Palace/AppInfrastructure/AppContainer.swift (modify — ADD lazy-cached `sideloadedBookManager` property; append after A)"
+      - "Palace/AppInfrastructure/TPPAppDelegate.swift (modify — call rehydrateAtLaunch between :200 load() and :218 sync())"
+      - "PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift (NEW)"
+      - "PalaceTests/Contract/SideloadImportContractTests.swift (NEW — import-pipeline snapshot)"
+    implementer_prompt: "Implement the side-load orchestration + Settings UI (depends on Module A's SideloadedBookRegistry/AppContainer.sideloadedBookRegistry/sideloadContentAccountID + Module B's isSideLoadingEnabled — build against their contracts, rebase onto merged A+B before final verify). SideloadedBookManager.import(fileURL): classify by ext/MIME -> TPPBookContentType.from (reject .unsupported), mint an open-access DRM-free TPPBook (generated id, ONE TPPOPDSAcquisition whose MIME matches the type so defaultBookContentType AND BookFileManager.pathExtension resolve, imageCache: ImageCache.shared), copy file to BookFileManager.fileUrl(for: book, account: SideloadedBookRegistry.sideloadContentAccountID) — FINDING 4: pin the account to A's fixed constant, NOT currentAccountId, or a library switch orphans the file — then SideloadedBookRegistry.add(book:fileURL:) + TPPBookRegistry.addBook(book, state: .downloadSuccessful). The exemption is AUTO-satisfied by adding to SideloadedBookRegistry (Module A's provider reads identifiers live) — do NOT build a second exemption store. remove() reverses (file + both registries). rehydrateAtLaunch() re-adds persisted books to the main registry as .downloadSuccessful, idempotent. FINDING 2+3: wire it in applicationDidFinishLaunching via setupBookRegistryAndNotifications() INSIDE the bookRegistry.load { ... } completion closure (load() is async — a synchronous rehydrate after it is clobbered by the disk snapshot). Do NOT anchor at TPPAppDelegate:218 — that is handleAppRefresh (background), not launch. Settings: add a flag-gated section to TPPSettingsView (RemoteFeatureFlags.shared.isSideLoadingEnabled, row() helper index 11 -> NavigationLink to a NEW SideLoadingView with SwiftUI .fileImporter — no existing UIDocumentPicker pattern in repo — and a manage/delete list backed by a small @MainActor SideLoadingViewModel). AppContainer: ADD a lazy-cached sideloadedBookManager property (bookOpenTracker style) appended after A's property; DO NOT touch the big init. Reader-open needs NO other production edits for EPUB/PDF (confirmed) — your obligations are the correct acquisition MIME and, for audiobooks, copying a valid manifest JSON. TDD with spies (temp-dir registry, spy TPPBookRegistryProvider, BookFileManager directoryProvider override); cover unsupported-type/duplicate/remove/missing-file/rehydration-idempotent edges. Add a Contract-snapshot pinning the ordered import calls (classify->copyFile->sideloadRegistry.add->bookRegistry.addBook(.downloadSuccessful)). Mutation >=50% diff-scoped (aim 100% on classify+register+rehydrate). CRITICAL PATH — architect + blast_radius review. New files -> both targets via scripts/pbxproj_add_swift.rb. OFF-LIMITS: SideloadedBookRegistry/BookRegistrySync/TPPBookRegistry/BookFileManager (A / consume-only), RemoteFeatureFlags/FirebaseManager (B), CatalogUI/AppTabHostView (D), the AppContainer big init region."
+
+  - name: D-SideloadedLane
+    risk: standard
+    depends_on: [A-Registry-and-SyncExemption, B-FeatureFlag]
+    contract_path: .forgeos/swarms/swarm_495a88d9/contracts/D-SideloadedLane.md
+    files_scope:
+      - "Palace/CatalogUI/ViewModels/CatalogState.swift (modify — toCatalogContent(prepending:) that force-groups extra lanes)"
+      - "Palace/CatalogUI/ViewModels/CatalogViewModel.swift (modify — sideloadedLaneBooksProvider init param + build lane at the toCatalogContent() call sites)"
+      - "Palace/AppInfrastructure/AppTabHostView.swift (modify — pass provider into CatalogViewModel init at :74-79)"
+      - "PalaceTests/CatalogUI/SideloadedLaneTests.swift (NEW)"
+    implementer_prompt: "Inject a 'Side Loaded' catalog lane (depends on Module A's AppContainer.sideloadedBookRegistry.allBooks + Module B's isSideLoadingEnabled — build against contracts, rebase before final verify). Add `func toCatalogContent(prepending extraLanes: [CatalogLaneModel] = [])` in CatalogState.swift (:129-149): when extraLanes non-empty, force the .grouped case — base .grouped -> extraLanes+lanes; base .ungrouped(books) -> .grouped(extraLanes + [wrap(books)]) (do NOT drop books); base .empty -> .grouped(extraLanes). Add `sideloadedLaneBooksProvider: @escaping () -> [TPPBook] = { [] }` to CatalogViewModel.init (:53-66, mirrors topLevelURLProvider). FINDING 1: there are FIVE toCatalogContent() call sites (166, 283 [applyFacet cache-HIT — the common path, MISSED by the original 4-site list], 308 [cache-MISS], 362, 381) — patching only some drops the lane on facet cache-hit (silent AC5 regression). Factor injection into ONE private helper `withSideloadedLane(_ mapped:) -> CatalogContent` that returns `mapped.toCatalogContent(prepending: laneOrEmpty())`, and route ALL FIVE sites through it (166/283/308 -> withSideloadedLane(mapped); 362/381 -> withSideloadedLane(Self.mapFeed(feed, bookRegistry:))). After refactor there must be exactly ONE toCatalogContent( call in CatalogViewModel (inside the helper) and zero bare .toCatalogContent(). Keep the flag OUT of CatalogViewModel — the provider returns [] when off. At the sole construction site AppTabHostView.swift:74-79 pass `sideloadedLaneBooksProvider: { RemoteFeatureFlags.shared.isSideLoadingEnabled ? appContainer.sideloadedBookRegistry.allBooks : [] }`. CatalogLaneModel(title:books:moreURL:isLoading:) at :417; renderer needs ZERO changes (CatalogContentView iterates .grouped lanes). TDD: test toCatalogContent(prepending:) + provider->lane logic covering 5 cases — grouped / ungrouped(books preserved) / empty(lane still shows) / absent(identical baseline) / applyFacet-cache-HIT(drive the VM's applyFacet with a stubbed cachedFeed + non-empty provider, assert the lane appears — the case a per-site patch misses). Mutation >=50% (kill force-grouped-removed + extraLanes-dropped mutants). OFF-LIMITS: MyBooks/Sideload (A/C), RemoteFeatureFlags/FirebaseManager (B), AppContainer.swift (A/C), TPPSettingsView (C), CatalogContentView (no render change)."
+
+acceptance_criteria:
+  - "AC1 PP-2678: SideloadedBookRegistry persists/round-trips its own manifest; add/remove/rename/update + edge cases tested."
+  - "AC2 sync-exemption: sync() with a loans feed lacking a sideloaded id leaves the book + file intact; 100% mutation on touched BookRegistrySync lines."
+  - "AC3 PP-2677: import classifies, mints open-access TPPBook, copies file, registers in both registries; remove reverses; rehydration before first sync; import pipeline contract-snapshotted."
+  - "AC4 PP-2677: flag-gated Settings 'Side Loading' screen (file picker + manage list)."
+  - "AC5 PP-2679: flag on + >=1 book -> lane present incl. ungrouped/empty base feed AND the applyFacet cache-HIT path; off/empty -> absent. (All 5 toCatalogContent sites routed through one choke point.)"
+  - "AC5b (finding 4): a sideloaded book opens after a library switch — file placement + read resolution pinned to the fixed sideloadContentAccountID."
+  - "AC6 gate: isSideLoadingEnabled precedence local-override > DEBUG-on > Firebase."
+  - "AC7: sideloaded EPUB/PDF/audiobook opens in the real reader; LCP 2.x test EPUB (PP-2580) opens end-to-end (simdrive E2E + chaos-replay)."
+  - "Global DoD 11-check; build clean both targets; verify-pr.sh --quick PASS; architect + blast_radius review on A and C."
+
+dont_touch:
+  - "Palace/AppInfrastructure/AppContainer.swift big init(...) / _buildCachedAppContainer return / with*Presenter copies — orchestrator-reconciled additive region only"
+  - "Palace.xcodeproj/project.pbxproj — via scripts/pbxproj_add_swift.rb only, never hand-edit"
+  - "BookRegistrySync reconciliation guards (shouldSkipBulkDeletion / large-deletion warn, :449-467)"
+  - "Existing RemoteFeatureFlags / FirebaseManager.RemoteConfigKey cases (no removal/renumber)"
+  - "CatalogContentView render path (no change needed for the lane)"

--- a/.forgeos/swarms/swarm_495a88d9/plan.md
+++ b/.forgeos/swarms/swarm_495a88d9/plan.md
@@ -1,0 +1,158 @@
+# Swarm plan — swarm_495a88d9 — Side Loading (PP-2677 / PP-2678 / PP-2679)
+
+**Branch:** feature/PP-2677-sideloading (worktree `ios-core-sideloading`)
+**Base:** develop
+**Created:** 2026-07-01
+**Ground truth:** `docs/architecture/sideloading-plan.md` (LOCKED decisions — not re-litigated here)
+
+## Goal
+A **test-only** capability: import a local EPUB / PDF / audiobook file, have it
+appear in a dedicated catalog lane, and open in the real reader + DRM stack with
+no OPDS feed involved. Primary use: exercising DRM profiles (LCP 2.x, PP-2580)
+end-to-end in the shipping reader.
+
+Locked approach (plan doc): reuse the main `TPPBookRegistry` by registering
+sideloaded books as `.downloadSuccessful` + a **sync exemption**, gated behind a
+`RemoteFeatureFlags` flag with a DEBUG-on local override.
+
+## Modules
+
+| Module | Risk | Depends on | Owns |
+|--------|------|-----------|------|
+| **B — FeatureFlag** | standard | — | `RemoteFeatureFlags` + `FirebaseManager` flag `sideLoadingEnabled` |
+| **A — Registry + Sync-Exemption** | **critical_path** | — | `SideloadedBookRegistry` (PP-2678), `BookRegistrySync` exemption, `TPPBookRegistry` provider threading, AppContainer `sideloadedBookRegistry` property |
+| **C — Manager + Settings** | critical_path | A, B | `SideloadedBookManager` (PP-2677), Settings "Side Loading" screen, launch rehydration, AppContainer `sideloadedBookManager` property |
+| **D — SideloadedLane** | standard | A, B | Catalog lane injection (PP-2679) in `CatalogViewModel`/`CatalogState`/`AppTabHostView` |
+
+Contracts: `.forgeos/swarms/swarm_495a88d9/contracts/{B-FeatureFlag,A-Registry-and-SyncExemption,C-Manager-and-Settings,D-SideloadedLane}.md`.
+
+## Parallelism / dependency plan
+`SideloadedBookRegistry` (A) is the foundation everything consumes; the flag (B)
+is foundational and independent. C and D both consume A + B.
+
+```
+Wave 1 (parallel):   A (registry + sync-exemption)   ||   B (feature flag)
+Wave 2 (parallel):   C (manager + settings)          ||   D (catalog lane)
+Integrate:           orchestrator reconciles AppContainer + project.pbxproj, then verify-pr + forge-review
+```
+
+- **A ∥ B** run fully in parallel — zero shared files.
+- **C ∥ D** run in parallel after A+B land — C touches MyBooks/Settings/AppDelegate,
+  D touches CatalogUI/AppTabHostView. Their only shared file is `AppContainer.swift`
+  (C appends a property; D does not touch AppContainer — D reads via the property A
+  added). So C ∥ D is clean; the AppContainer collision is A↔C, resolved by staging
+  (C lands after A) + orchestrator reconcile.
+- C and D can begin against A's **contract** (stable public surface) before A's code
+  fully merges, but must rebase onto merged A before final verify.
+
+## Real integration collision points (explicit ownership)
+1. **`Palace/AppInfrastructure/AppContainer.swift`** — touched by A (adds
+   `sideloadedBookRegistry` lazy-cached property) and C (adds `sideloadedBookManager`
+   lazy-cached property + is where rehydration is composed). Both edits are
+   **additive** lazy-cached computed properties in the `bookOpenTracker`-style
+   region — NEITHER touches the big `init`, `_buildCachedAppContainer` return, or
+   the `with*Presenter` copies. **Orchestrator owns final AppContainer composition
+   at integrate time**; A is primary author of the property region, C appends.
+2. **`Palace.xcodeproj/project.pbxproj`** — new files from A (2 prod) and C (2-3
+   prod) + test files from all. **Every module MUST use
+   `ruby scripts/pbxproj_add_swift.rb [--targets Palace,Palace-noDRM] FILE...`
+   — NEVER hand-edit.** The helper is idempotent; orchestrator re-runs / reconciles
+   pbxproj at integrate to absorb both modules' additions cleanly.
+
+## Reader-open call-graph confirmation (task item 4)
+Traced: catalog lane tap → `BookDetailViewModel` button state for `.downloadSuccessful`
+→ Read/Listen action → `MyBooksDownloadCenter.fileUrl` / `BookFileManager.fileUrl(for:account:)`
+→ reader.
+
+**Verdict: SUFFICIENT for EPUB + PDF with NO other production edits.** Registering
+a book `.downloadSuccessful` and placing the correct file at
+`BookFileManager.fileUrl` opens it:
+- `BookButtonMapper.swift:48` maps `.downloadSuccessful` → Read/Listen from
+  registry state alone (no availability/download-record/network gate).
+- The reader resolves `book.url` → `downloadCenter.fileUrl(for:identifier)` →
+  `BookFileManager.fileUrl` sha256 path (`TPPBook+Additions.swift:15`,
+  `BookFileManager.swift:59-73`) — no download-record lookup, no OPDS re-fetch, no
+  acquisition-availability check.
+- The `#if FEATURE_DRM_CONNECTOR` Adobe gate (`BookDetailViewModel.swift:848`) is
+  skipped for a no-credentials open-access book.
+- **Caveat (architect finding 5):** `didSelectRead` still runs the `ensureAuthAndExecute`
+  AUTH gate (`:711`) — a signed-out user on an auth-required library sees sign-in
+  first. Accepted (R7); not an availability/download/OPDS gate.
+- **Caveat (architect finding 4):** file placement + read resolution are pinned to a
+  fixed account so a library switch cannot orphan the file (R6, Modules A+C).
+
+**No hidden production gap** — but two *construction requirements* fall to Module C
+(already in its scope, not new files):
+1. The minted `TPPBook`'s single acquisition MIME MUST classify via
+   `TPPBookContentType.from` to epub/pdf/audiobook, else `defaultBookContentType`
+   → `.unsupported` → `presentUnsupportedItemError` and it never opens.
+2. **Audiobook caveat:** the copied file must be a valid **manifest JSON** (parsed
+   by `LocalFileAdapter`, `Vendors/LocalFileAdapter.swift:73-80`); remote-track
+   playback still needs the network at play time. Also, audiobook open runs
+   `validateRequirements` which requires credentials only for auth-required
+   accounts — a synthetic open-access book passes. Acceptable for a test feature.
+
+## Risks
+- **R1 (load-bearing):** the main registry `sync()` evicts + deletes any book not in
+  the loans feed (`BookRegistrySync.swift:406,480-497`). Sideloaded books MUST be
+  exempted or the next sync destroys them. Owned by Module A; guarded by the
+  critical regression test + 100% mutation on the touched lines.
+- **R2 (rehydration ordering + async load — architect finding 2/3):** the exemption
+  set is driven by `SideloadedBookRegistry.identifiers` (persisted independently,
+  read lazily at sync time), so persistence is safe regardless of ordering. But
+  rehydration into the MAIN registry (so books open + appear) must (a) be anchored in
+  `applicationDidFinishLaunching` / `setupBookRegistryAndNotifications()` — NOT the
+  `handleAppRefresh` background handler that the original `:218` cite pointed at — and
+  (b) run in the **`bookRegistry.load(completion:)` callback**, because `load()` is
+  async and a synchronous rehydrate afterward is clobbered when the disk snapshot
+  lands and transitions to `.loaded`. The real first runtime syncs
+  (`applicationDidBecomeActive:330`, `AppTabHostView:260`) both follow launch and are
+  guarded by the registry loading state. Owned by Module C.
+- **R6 (cross-account file scoping — architect finding 4):** `BookFileManager.fileUrl`
+  is scoped to `currentAccountId`, but sideloaded books are account-agnostic. Both
+  the write (Module C import) AND the read resolution (Module A, in `BookFileManager`)
+  are pinned to ONE fixed `sideloadContentAccountID` (= `AccountsManager.TPPAccountUUIDs[0]`,
+  the primary/no-subpath content dir), so a library switch cannot orphan the file.
+  Module A owns the read-side override; C consumes the shared constant for the copy.
+- **R7 (auth gate — architect finding 5, ACCEPTED):** `didSelectRead` runs
+  `ensureAuthAndExecute`, so opening a sideloaded book while signed out on an
+  auth-required library shows sign-in, not the reader. Accepted for this test feature
+  (signed-in DRM-test use case works); NOT engineered around (shared critical-path
+  auth gate). E2E testers sign in first.
+- **R3 (AppContainer / pbxproj collisions):** mitigated by additive-only property
+  edits + orchestrator reconcile (above).
+- **R4 (My Books visibility):** decision #1 makes sideloaded books appear on the My
+  Books shelf. Accepted for a test feature (plan open item); not in scope to filter.
+- **R5 (DRM path for LCP 2.x):** the whole point. `BookFileManager.pathExtension`
+  (`:123`) chooses `.lcpa`/`.zip`/`.epub` from the book's acquisition chain — Module
+  C's minted `TPPBook` acquisition MIME must be correct so the file lands at the
+  extension the LCP extract pass expects. Verified via simdrive E2E (plan step 5).
+
+## Acceptance criteria (from the three tickets + plan Verification)
+- AC1 (PP-2678): `SideloadedBookRegistry` persists/round-trips sideloaded books in
+  its own manifest; add/remove/rename/update + edge cases covered by tests.
+- AC2 (sync-exemption): a `sync()` whose loans feed lacks a sideloaded id leaves the
+  book + its file intact (critical regression test, 100% mutation on touched lines).
+- AC3 (PP-2677): import a file → classify by type → mint open-access `TPPBook` →
+  copy to `BookFileManager.fileUrl` → register in both registries → exemption set
+  updated; remove reverses; launch rehydration re-registers before first sync.
+  Import pipeline pinned by a contract-snapshot.
+- AC4 (PP-2677): Settings "Side Loading" screen (file picker + manage list), gated
+  by the flag.
+- AC5 (PP-2679): flag on + ≥1 sideloaded book → lane present (incl. ungrouped/empty
+  base feed); flag off or empty registry → lane absent.
+- AC6 (gate): `RemoteFeatureFlags.isSideLoadingEnabled` — local override > DEBUG-on
+  > Firebase.
+- AC7: opening a sideloaded book renders in the real reader (EPUB/PDF/audiobook);
+  LCP 2.x test EPUB opens end-to-end (simdrive E2E + chaos-replay recording).
+- Global DoD: 11-check battery, build clean both targets, `verify-pr.sh --quick`
+  PASS, architect + SoD (blast_radius) review on A and C (critical path).
+
+## Integration & review
+1. Land A + B (wave 1), rebuild pbxproj, verify each in isolation.
+2. Land C + D (wave 2) rebased on A+B.
+3. Orchestrator reconciles `AppContainer.swift` + `project.pbxproj`.
+4. `scripts/verify-pr.sh --quick` full-suite parity.
+5. `/forge-review` — architect + blast_radius reviewers focused on the
+   sync-exemption (A) and the import/rehydration wiring (C).
+6. simdrive E2E per plan step 5; record a chaos-replay.

--- a/.forgeos/swarms/swarm_495a88d9/transcripts/A.md
+++ b/.forgeos/swarms/swarm_495a88d9/transcripts/A.md
@@ -1,0 +1,107 @@
+# Module A — SideloadedBookRegistry + Sync-Exemption + AppContainer wiring — READY
+
+**Swarm:** swarm_495a88d9  **Worktree:** `ios-core-sl-A` (branch `swarm/495a88d9-A`)
+**Risk:** critical_path (registry sync + DRM-adjacent).
+
+## Summary
+
+- New `SideloadedBookRegistry` (PP-2678): dedicated local-only JSON manifest under
+  Application Support (`<AppSupport>/<bundleID>/sideloaded/sideloaded.json`),
+  `@unchecked Sendable` + `NSLock`, synchronous persist-on-mutation. API:
+  `add/remove/rename/update/allBooks/identifiers` (+ `originalFilename(for:)`).
+  Corrupt/empty/missing/garbage-record manifests all load as empty (no crash).
+- Sync-exemption (the load-bearing change): `BookRegistrySync` gained a
+  `sideloadedIDsProvider: () -> Set<String>` init param (default lazily reads
+  `AppContainer.production().sideloadedBookRegistry.identifiers`, mirroring the
+  `downloadCenterProvider` cycle-avoidance precedent) and, immediately after
+  `var recordsToDelete = Set<String>(registry.keys)`, `recordsToDelete.subtract(sideloadedIDsProvider())`.
+  This exempts sideloaded ids from BOTH the un-registration AND the on-disk delete.
+- `TPPBookRegistry`: provider threaded EXPLICITLY through both `BookRegistrySync`
+  construction sites (`init(accountsManager:imageLoader:)` and the account-scoped
+  `init`).
+- `AppContainer`: additive-only `sideloadedBookRegistry` lazy-cached computed
+  property + `private static var _sideloadedBookRegistry` (bookOpenTracker-style),
+  and `_sideloadedBookRegistry = nil` added to `_resetForTesting()`. The big
+  `init`, `_buildCachedAppContainer()` return, and `with*Presenter` copies were
+  NOT touched.
+- `BookFileManager` (Component 4): account-stable read resolution. Added a
+  `sideloadedIdentifiersProvider` seam (production default = the lazy AppContainer
+  provider) and, at the single read choke point `fileUrl(for identifier:account:)`,
+  substitute `SideloadedBookRegistry.sideloadContentAccountID` for sideloaded ids
+  so a library switch can't orphan the file. The shared constant
+  `SideloadedBookRegistry.sideloadContentAccountID = AccountsManager.TPPAccountUUIDs[0]`
+  lives on `SideloadedBookRegistry` — **Module C must consume THIS constant for its
+  import write** (do not pick the account independently).
+
+## Files added
+- `Palace/MyBooks/Sideload/SideloadedBookRegistry.swift` (prod → Palace + Palace-noDRM)
+- `PalaceTests/MyBooks/Sideload/SideloadedBookRegistryTests.swift`
+- `PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift`
+- `PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift`
+All registered via `ruby scripts/pbxproj_add_swift.rb` (added=4 skipped=0 failed=0).
+
+## Files modified
+- `Palace/Book/Models/BookRegistrySync.swift` (provider param + subtract line)
+- `Palace/Book/Models/TPPBookRegistry.swift` (provider at both inits)
+- `Palace/AppInfrastructure/AppContainer.swift` (additive property + static + reset nil)
+- `Palace/MyBooks/BookFileManager.swift` (Component 4 resolution + provider seam)
+
+## Key test names
+- Exemption (critical): `test_sync_withSideloadedIdExempt_preservesBookAndSkipsOnDiskDelete`
+  (drives full production `sync()` — awaitReady gate + HTTP-stubbed loans feed +
+  real reconciliation barrier + spy `LocalBookContentService` recording deletes;
+  same-run non-exempt book IS evicted+deleted, proving reconciliation ran) and the
+  contrast `test_sync_withEmptyExemption_evictsTheSameBook_andDeletesItsContent`.
+- Resolution: `test_sideloadedId_resolvesToFixedAccount_evenWhenCurrentAccountDiffers`
+  (+ explicit-account variant + non-sideloaded contrast).
+- Registry: round-trip, add/remove/rename/update, duplicate-add, missing/corrupt/
+  empty/garbage manifest.
+
+## Gaps for the integrator
+- **AppContainer collision (A↔C):** A authored the `sideloadedBookRegistry` property
+  region; C appends `sideloadedBookManager`. Both additive, neither touches init /
+  builder return / presenter copies. Orchestrator owns final composition.
+- **pbxproj:** 4 files added to both targets via the helper; re-run/reconcile at integrate.
+- **Constant ownership:** `SideloadedBookRegistry.sideloadContentAccountID` is the
+  single source of truth for the pinned account — Module C's import copy must call
+  `bookFileManager.fileUrl(for: book, account: SideloadedBookRegistry.sideloadContentAccountID)`.
+- **Full both-target build / verify-pr.sh --quick:** NOT run here (time). The Palace
+  app target compiled clean; new code is DRM-agnostic so Palace-noDRM is expected
+  clean, but the integrator should run the full both-target build + verify-pr at integrate.
+- **Mutation --diff-only:** `palace_mutate.py --diff-only` computes `git diff base..HEAD`,
+  which is empty for uncommitted working-tree changes (I must not commit). I verified
+  the touched lines via manual single-mutant kills instead (see DoD #5). At integrate,
+  after the changes are committed, `palace_mutate.py --file … --diff-only` will work
+  normally.
+
+## DoD evidence
+
+1. **SUT instantiation** — `grep -c 'SideloadedBookRegistry(' …SideloadedBookRegistryTests.swift` = 2;
+   `grep -c 'BookRegistrySync(' …BookRegistrySyncSideloadExemptionTests.swift` = 1;
+   `grep -c 'BookFileManager(' …BookFileManagerSideloadResolutionTests.swift` = 1. All ≥ required.
+   Contract greps: `recordsToDelete.subtract`=1, `sideloadedIDsProvider` in BookRegistrySync=4 /
+   in TPPBookRegistry=2, `sideloadContentAccountID` in BookFileManager=2, `sideloadedBookRegistry`
+   in BookFileManager=1, `func test` in exemption class=2.
+2. **Multi-step bodies** — exemption class has both survives/evicted methods with opposite
+   `deleteLocalContent` assertion directions; resolution "…evenWhenCurrentAccountDiffers" sets
+   a non-primary currentAccountId then asserts the fixed dir.
+3. **check-test-name-vs-body.py** — exit 0 on all three new test files.
+4. **Tests green** — `Executed 17 tests, with 0 failures` (12 registry + 3 resolution + 2 exemption).
+   Regression: existing `BookRegistrySyncTests`+`Reentrancy`+`Readiness` = `Executed 31 tests,
+   with 1 test skipped and 0 failures` (skip is a pre-existing keychain gate).
+   xcresult: `/tmp/harness-palace-ios-…/Logs/Test/Test-Palace-2026.07.01_10-35-34--0400.xcresult`.
+5. **Mutation (manual single-mutant kills, critical path):**
+   - `BookRegistrySync` subtract line → replaced with `_ = sideloadedIDsProvider()`:
+     `test_sync_withSideloadedIdExempt` FAILED (mutant killed); control still passed. Restored. → 100% on touched line.
+   - `BookFileManager` substitution → `? account : account`: both resolution tests FAILED
+     (killed); non-sideloaded contrast passed. Restored.
+   - `SideloadedBookRegistry` add duplicate-guard flip `== nil` → `!= nil`: 10/12 tests FAILED
+     (killed). Restored.
+   (Restores verified by grep; final all-green re-run confirmed.)
+6. **Build** — Palace app target compiled clean (test target builds + runs green).
+7. **Wiring coverage** — exemption tests drive real `sync()` to `.synced` and the spy records
+   the on-disk delete for the non-exempt book, i.e. the `:496-497` delete branch executed.
+8. **Contract reconciliation** — deferred to integrate (needs commit-msg file; no commit made).
+9. **check-blast-radius.py --quiet** — exit 0.
+10. **check-adjacency-staleness.py --quiet** — exit 0.
+11. **check-superpartner-spectrum.py --quiet** — exit 0.

--- a/.forgeos/swarms/swarm_495a88d9/transcripts/B.md
+++ b/.forgeos/swarms/swarm_495a88d9/transcripts/B.md
@@ -1,0 +1,79 @@
+# Module B — FeatureFlag (sideLoadingEnabled) — READY
+
+**Swarm:** swarm_495a88d9 · **Branch:** swarm/495a88d9-B · **Worktree:** `ios-core-sl-B`
+
+## Summary
+Added the `sideLoadingEnabled` remote feature flag with DEBUG-on local-override
+precedence (mirrors `isTriageBotEnabled` per locked decision #2). All flag
+plumbing only — no Settings UI, no lane (owned by C/D). Contract fully satisfied.
+
+## Files changed
+- `Palace/FeatureFlags/RemoteFeatureFlags.swift` (modify)
+  - `FeatureFlag.sideLoadingEnabled = "side_loading_enabled"` (new case)
+  - `managerKey` arm `.sideLoadingEnabled → .sideLoadingEnabled`
+  - `static let sideLoadingLocalOverrideKey = "RemoteFeatureFlags.sideLoadingLocalOverride"`
+  - `var isSideLoadingEnabled: Bool` — precedence: local override > `#if DEBUG` true > `isFeatureEnabled(.sideLoadingEnabled)` (Firebase)
+  - `defaultValue` unchanged (falls into `default` arm → false, as contract specifies)
+- `Palace/AppInfrastructure/FirebaseManager.swift` (modify)
+  - `RemoteConfigKey.sideLoadingEnabled = "side_loading_enabled"` (new case)
+  - `setDefaultValues()` entry `RemoteConfigKey.sideLoadingEnabled.rawValue: NSNumber(value: false)`
+- `PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift` (NEW, registered via `pbxproj_add_swift.rb`)
+- `Palace.xcodeproj/project.pbxproj` (test file entry, via helper — not hand-edited)
+
+## Tests (5, all behavior/precedence — no default-value fluff)
+1. `testIsSideLoadingEnabled_whenLocalOverrideTrue_returnsTrue`
+2. `testIsSideLoadingEnabled_whenLocalOverrideFalse_returnsFalse_overridingDebugDefault` — precedence proof (override beats DEBUG-on)
+3. `testIsSideLoadingEnabled_overrideRoundTrip_true_false_true` — round-trip through the production seam
+4. `testIsSideLoadingEnabled_noOverride_followsSameDebugOnPrecedenceAsTriageBot` — DEBUG-on parity (see gotcha below)
+5. `testSideLoadingFeatureFlag_mapsToRemoteConfigKey` — managerKey wiring (release path resolves to Remote Config, not silent default)
+
+## KEY GOTCHA for the orchestrator / other modules
+The **PalaceTests target does NOT define `DEBUG`** in its compilation conditions
+(`SWIFT_ACTIVE_COMPILATION_CONDITIONS = LCP FEATURE_OVERDRIVE`), while the
+**Palace module DOES** under Debug config (`DEBUG SIMPLYE FEATURE_DRM_CONNECTOR …`).
+The contract's suggested "guard the assertion in `#if DEBUG`" approach is WRONG
+for this repo: a test-side `#if DEBUG` always compiles the release branch and
+diverges from the production `isSideLoadingEnabled` value (which was compiled WITH
+DEBUG). My initial contract-literal test failed for exactly this reason. Fixed by
+asserting **parity with `isTriageBotEnabled`** — both accessors are compiled in the
+production module under identical flags and share the DEBUG-on precedence, so they
+resolve identically with no override regardless of build config, and the assertion
+fails if the `#if DEBUG return true` arm is dropped from `isSideLoadingEnabled`.
+Modules C/D writing any DEBUG-dependent test should use the same parity pattern,
+not a test-side `#if DEBUG`.
+
+## DoD evidence
+1. **SUT instantiation:** `grep -c "RemoteFeatureFlags(" …SideLoadingTests.swift` = **5** (≥2 required).
+2. **Build clean:** `** BUILD SUCCEEDED **` (Palace scheme, iPhone 16 Pro).
+3. **Test run:** `Executed 5 tests, with 0 failures` — `** TEST SUCCEEDED **`.
+   xcresult: `/tmp/harness-palace-ios-141BD227-…/Logs/Test/Test-Palace-2026.07.01_10-22-45--0400.xcresult`
+4. **Mutation** (`palace_mutate.py`, whole-file with coverage-gating; `--diff-only`
+   sees nothing because changes are uncommitted per swarm rules):
+   - **killed 2, survived 1, uncovered 14 → 66.7% covered kill rate (≥50%).**
+   - My accessor's only mutation point, **L377 `#if DEBUG return true` → KILLED**.
+     So **added-line (diff-scoped) kill rate = 100%**.
+   - The lone survivor is **L120 `default: return false`** in `defaultValue` —
+     pre-existing shared line. The contract explicitly bans testing it
+     ("asserting a flag's default value … is fluff; test the RESOLUTION
+     precedence instead"), and `sideLoadingEnabled` has a non-nil `managerKey`
+     so its `defaultValue` is never consulted in resolution anyway. Not killed
+     by design.
+5. **check-test-name-vs-body.py:** `0 fake-wiring tests found` — exit 0.
+6. **Scope-coverage audit:** all contract "Public surface added" items present
+   (verified via the contract's grep-able criteria — all pass). No off-limits
+   files touched. No dev-menu UI (contract assigns flag plumbing only).
+7. **check-blast-radius.py --quiet:** exit 0.
+8. **check-superpartner-spectrum.py --quiet:** exit 0.
+
+## Grep-able contract criteria (all pass)
+- `RemoteFeatureFlags(` in test = 5 (≥2) ✓
+- `case sideLoadingEnabled = "side_loading_enabled"` in RemoteFeatureFlags.swift = 1 ✓
+- `case sideLoadingEnabled = "side_loading_enabled"` in FirebaseManager.swift = 1 ✓
+- `RemoteConfigKey.sideLoadingEnabled.rawValue` in FirebaseManager.swift = 1 (≥1) ✓
+- test sets override `set(true` ×3 and `set(false` ×2 ✓
+- superpartner exit 0 ✓
+
+## Gaps / deferred
+None. Full contract scope landed. Did NOT commit/push (per swarm rules — left in
+working tree for orchestrator integration). `verify-pr.sh --quick` (full-suite
+parity) deferred to the orchestrator integrate step per the plan.

--- a/.forgeos/swarms/swarm_495a88d9/transcripts/C.md
+++ b/.forgeos/swarms/swarm_495a88d9/transcripts/C.md
@@ -1,0 +1,146 @@
+# Module C — SideloadedBookManager + Settings + launch rehydration — READY
+
+**Swarm:** swarm_495a88d9 · **Branch:** swarm/495a88d9-C · **Worktree:** `ios-core-sl-C`
+**Risk:** critical_path (mints synthetic `TPPBook`s into the main registry). **Ticket:** PP-2677.
+**Built on:** Wave 1 (A registry + sync-exemption + BookFileManager Component 4; B `isSideLoadingEnabled`).
+
+## Summary
+
+- **NEW `SideloadedBookManager`** (`Palace/MyBooks/Sideload/`): import → classify (ext→MIME→
+  `TPPBookContentType.from`, rejecting unsupported before any write) → mint an OPEN-ACCESS
+  `TPPBook` (single acquisition, correct MIME, `relation: .openAccess`, unlimited availability,
+  no revoke/bearer/needs-auth) → copy the file to the FIXED-account `BookFileManager.fileUrl`
+  path → register in BOTH `SideloadedBookRegistry` (truth = the sync-exemption) AND the main
+  `TPPBookRegistry` as `.downloadSuccessful`. `remove()` reverses all three; `rehydrateAtLaunch()`
+  re-registers persisted books into the main registry, idempotently.
+- **Fixed-account write:** the import copy pins to
+  `SideloadedBookRegistry.sideloadContentAccountID` (Module A's constant) — NOT `currentAccountId`
+  — so it agrees with A's read-side resolution and a library switch can't orphan the file.
+- **Dedup:** the identifier is content-derived (`"sideload-" + sha256(fileBytes)`), so a re-import
+  of the same file yields the same id → overwrites in place instead of duplicating.
+- **Settings "Side Loading" screen** (`SideLoadingView` + `SideLoadingViewModel`): SwiftUI
+  `.fileImporter` (epub/pdf/json UTTypes, security-scoped access handled) + a manage/delete list.
+  Gated by `RemoteFeatureFlags.shared.isSideLoadingEnabled` at the `TPPSettingsView` call site.
+- **AppContainer:** additive lazy-cached `sideloadedBookManager` property + static + `_resetForTesting` nil.
+- **Launch rehydration** wired inside `setupBookRegistryAndNotifications()` in the
+  `bookRegistry.load { … }` completion (CORRECTED anchor).
+
+## Files added
+- `Palace/MyBooks/Sideload/SideloadedBookManager.swift` (prod → Palace + Palace-noDRM)
+- `Palace/Settings/NewSettings/SideLoadingView.swift` (prod → Palace + Palace-noDRM)
+- `PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift`
+- `PalaceTests/Contract/SideloadImportContractTests.swift`
+- `PalaceTests/Contract/__Snapshots__/SideloadImportContractTests/importEpub.json` (recorded baseline — commit it)
+All 4 source files registered via `ruby scripts/pbxproj_add_swift.rb` (added=4 skipped=0 failed=0).
+
+## Files modified
+- `Palace/Settings/NewSettings/TPPSettingsView.swift` (gated `sideLoadingSection` + `@AppStorage` override read)
+- `Palace/AppInfrastructure/AppContainer.swift` (additive property + static + reset nil)
+- `Palace/AppInfrastructure/TPPAppDelegate.swift` (rehydration in the load completion)
+
+## FOR THE INTEGRATOR — exact reconcile points
+
+### AppContainer additive lines (append after Module A's `_sideloadedBookRegistry`)
+```swift
+var sideloadedBookManager: SideloadedBookManager {
+    if let cached = AppContainer._sideloadedBookManager { return cached }
+    let manager = SideloadedBookManager(
+        bookRegistry: self.bookRegistry,
+        sideloadedRegistry: self.sideloadedBookRegistry,
+        bookFileManager: BookFileManager()
+    )
+    AppContainer._sideloadedBookManager = manager
+    return manager
+}
+private static var _sideloadedBookManager: SideloadedBookManager?
+```
+And in `_resetForTesting()`, right after A's `_sideloadedBookRegistry = nil`:
+```swift
+_sideloadedBookManager = nil
+```
+NEITHER the big `init`, `_buildCachedAppContainer()` return, nor `with*Presenter` copies are touched.
+
+### TPPAppDelegate rehydration hookpoint (`setupBookRegistryAndNotifications`, replaced the bare `load()`)
+```swift
+if let loadableRegistry = AppContainer.production().bookRegistry as? TPPBookRegistry {
+    loadableRegistry.load {
+        AppContainer.production().sideloadedBookManager.rehydrateAtLaunch()
+    }
+} else {
+    AppContainer.production().bookRegistry.load()
+}
+```
+NOTE: the `AppContainer.bookRegistry` property is typed `TPPBookRegistryProvider`, whose surface
+has only `load()` (no completion). `load(completion:)` lives on the concrete `TPPBookRegistry`
+(off-limits to edit), hence the `as? TPPBookRegistry` cast. Production always resolves to the
+concrete type; the `else` keeps the original behaviour if that ever changes. (The contract's
+`grep "bookRegistry.load"` convenience matches `loadableRegistry.load {` in spirit — the local is
+`loadableRegistry`, not `bookRegistry`, because of the cast.)
+
+### Protocol seam introduced (no Module-A file touched)
+`SideloadedBookManager.swift` declares `protocol SideloadedBookRegistering` and
+`extension SideloadedBookRegistry: SideloadedBookRegistering {}` — the conformance is a one-liner
+extension in C's own file, so A's `SideloadedBookRegistry.swift` is untouched. The manager depends
+on this protocol (spyable). It also declares `SideloadContentClassifier` + `SideloadFileManaging`
+seams with `Default*` production impls.
+
+### pbxproj
+4 source files added to the correct targets via the helper (prod→both, tests→PalaceTests).
+Re-run / reconcile at integrate.
+
+## DoD evidence
+1. **SUT instantiation:** `grep -c "SideloadedBookManager(" …SideloadedBookManagerTests.swift` = 1 (≥1). ✓
+2. **Multi-step bodies:** idempotency test drives `rehydrateAtLaunch()` twice (grep count = 3 incl. helper);
+   remove-fallback + remove tests each do stage→act→assert. ✓
+3. **Build:** `** BUILD SUCCEEDED **` (Palace scheme, `generic/platform=iOS Simulator`).
+4. **Tests:** 12 tests, 0 failures (11 manager + 1 contract). First green run
+   `Executed 11 tests, with 0 failures` (before the remove-fallback test); the 12-test set then
+   passed as the mutation **baseline: PASS in 17.1s**. `** TEST SUCCEEDED **`.
+   xcresult: `/tmp/harness-palace-ios-BFB9B169-…/Logs/Test/Test-Palace-2026.07.01_11-20-27--0400.xcresult`.
+5. **Mutation (critical path, whole-file, `--no-cache`):** 3 points, **killed 3, survived 0,
+   kill rate 100.0%** (baseline PASS). L122 classifier unsupported-guard KILLED; L259 remove()
+   fallback-lookup comparison KILLED (added fallback test); L290 rehydrate existence-guard KILLED
+   (idempotency test).
+6. **check-test-name-vs-body.py:** exit 0 on both test files. ✓
+7. **Scope-coverage audit:** table below.
+8. **check-blast-radius.py --quiet:** exit 0. ✓
+9. **check-adjacency-staleness.py --quiet:** exit 0. ✓
+10. **check-superpartner-spectrum.py --quiet:** exit 0. ✓
+
+## Grep-able contract criteria (all pass)
+- `SideloadedBookManager(` in test = 1 (≥1) ✓
+- `downloadSuccessful` in manager = 5 (≥1) ✓
+- `sideloadContentAccountID` in manager = 3 (≥1) ✓
+- `isSideLoadingEnabled` in TPPSettingsView = 2 (≥1) ✓
+- `rehydrateAtLaunch` in TPPAppDelegate lands inside `setupBookRegistryAndNotifications` in the
+  `load { … }` completion (lines 209-210) ✓
+- contract snapshot baseline present: `__Snapshots__/SideloadImportContractTests/importEpub.json`
+  records `classify → copyFile → sideloadRegistry.add → bookRegistry.addBook(state=download-successful)` ✓
+
+## Scope-coverage audit
+| Contract item | Status |
+|---|---|
+| `SideloadedBookManager.import` (classify/mint/copy/register both) | DONE |
+| fixed-account write (`sideloadContentAccountID`) | DONE + test |
+| dedup (content-hash id) | DONE + test |
+| unsupported + copy-failure error paths (no partial write) | DONE + tests |
+| `remove()` reverses file + both registries | DONE + 2 tests (incl. fallback lookup) |
+| `rehydrateAtLaunch()` idempotent | DONE + 2 tests |
+| Settings "Side Loading" screen, flag-gated | DONE |
+| AppContainer `sideloadedBookManager` (additive) | DONE |
+| TPPAppDelegate rehydration in load completion | DONE |
+| Contract-snapshot on import pipeline | DONE (baseline recorded) |
+| EPUB + PDF + audiobook support | DONE (classification tests per type) |
+
+## Gaps / deferred (for the integrator)
+- **Both-target build + verify-pr.sh --quick:** only the `Palace` scheme was built here (time). New
+  files carry NO `#if LCP`/`#if FEATURE_DRM_CONNECTOR`, so Palace-noDRM is expected clean, but the
+  integrator should run the full both-target build + `verify-pr.sh --quick` at integrate (matches A).
+- **Contract snapshot recording:** the baseline JSON was recorded (first-run auto-record; the env
+  var doesn't propagate through `harness test` to the sim, so it took the first-run record-and-fail
+  branch and wrote the file). It is present in the working tree and re-runs PASS. Commit it.
+- **simdrive E2E (plan step 5):** deferred to the release-path pass (enable flag → import LCP 2.x
+  EPUB → lane → open → renders + chaos-replay). Not run in this implementer pass.
+- **Accepted limitation (R7):** opening a sideloaded book while signed-out on an auth-required
+  library shows sign-in first (shared critical-path auth gate) — accepted per contract, not
+  engineered around.

--- a/.forgeos/swarms/swarm_495a88d9/transcripts/D.md
+++ b/.forgeos/swarms/swarm_495a88d9/transcripts/D.md
@@ -1,0 +1,115 @@
+# Module D — SideloadedLane (catalog) — Implementer transcript
+
+**Swarm:** swarm_495a88d9 · **Ticket:** PP-2679 · **Branch:** swarm/495a88d9-D
+**Worktree:** `/Users/mauricework/PalaceProject/ios-core-sl-D`
+
+## Summary
+
+Injected a flag-gated "Side Loaded" lane at the top of the catalog, present only
+when the sideloaded registry is non-empty, surviving every catalog conversion
+path — including the `applyFacet` cache-HIT synchronous fast path (:283) that a
+per-site patch would silently drop.
+
+All injection routes through ONE choke-point helper
+`CatalogViewModel.withSideloadedLane(_:)`, so the lane can never vanish on a
+single path. The five former `toCatalogContent()` call sites (166/283/308/362/381)
+now call the helper; exactly one `toCatalogContent(` call remains in the file
+(inside the helper).
+
+## DI wiring (how the registry + flag reach the VM)
+
+- **Provider seam:** `CatalogViewModel` gained ONE init param
+  `sideloadedLaneBooksProvider: @escaping () -> [TPPBook] = { [] }`. The flag is
+  kept OUT of the VM — the provider returns `[]` when side-loading is off.
+- **Construction site (only caller):** `AppTabHostView.swift` init passes:
+  ```swift
+  sideloadedLaneBooksProvider: {
+      RemoteFeatureFlags.shared.isSideLoadingEnabled
+          ? appContainer.sideloadedBookRegistry.allBooks
+          : []
+  }
+  ```
+  The flag gate lives here; the registry is read via the existing Wave-1
+  `AppContainer.sideloadedBookRegistry` property (READ-only — AppContainer.swift
+  was NOT edited).
+- **Bridge:** `MappedCatalog.toCatalogContent(prepending:)` forces `.grouped`
+  when `extraLanes` is non-empty so the lane shows even for `.ungrouped`/`.empty`
+  base feeds. Ungrouped base books are wrapped into a single trailing lane (feed
+  title as header) so nothing is dropped — documented choice per contract.
+
+## Files changed
+
+- `Palace/CatalogUI/ViewModels/CatalogState.swift` — `toCatalogContent(prepending:)`.
+- `Palace/CatalogUI/ViewModels/CatalogViewModel.swift` — init param, `withSideloadedLane(_:)` helper, 5 call sites routed through it.
+- `Palace/AppInfrastructure/AppTabHostView.swift` — provider passed at the CatalogViewModel init (:74 region), flag-gated. (`.sync()` region untouched.)
+- `PalaceTests/CatalogUI/SideloadedLaneTests.swift` — NEW (registered in pbxproj → PalaceTests target).
+
+**NOT edited:** AppContainer.swift, RemoteFeatureFlags.swift, SideloadedBookRegistry.swift, CatalogContentView.swift (renderer needed zero changes).
+
+## Tests (PalaceTests/CatalogUI/SideloadedLaneTests.swift)
+
+`SideloadedLaneBridgeTests` (pure toCatalogContent(prepending:)):
+- grouped base + provider → Side Loaded lane FIRST, base lanes retained
+- ungrouped base + provider → forces `.grouped`, original books not dropped
+- empty base + provider → `.grouped([sideloadedLane])`
+- provider empty for grouped/ungrouped/empty base → baseline shape unchanged (lane ABSENT)
+
+`SideloadedLaneViewModelTests` (VM wiring, constructs `CatalogViewModel(`):
+- load + non-empty provider → lane prepended at top
+- load + empty provider → no Side Loaded lane (flag-off / empty-registry analog)
+- **applyFacet cache-HIT (:283)** → drives the synchronous cache branch (repo
+  load count unchanged = no network; scrollGeneration incremented = branch ran)
+  and asserts the Side Loaded lane is still first.
+
+## Definition of Done — evidence
+
+1. **SUT instantiation:** `grep -c "CatalogViewModel(" SideloadedLaneTests.swift` = 1; `grep -c "toCatalogContent(" SideloadedLaneTests.swift` = 8. PASS.
+2. **Choke-point greps (CatalogViewModel.swift):**
+   - `grep -c "toCatalogContent("` = **1** (want 1 — only in helper)
+   - `grep -c "\.toCatalogContent()"` = **0** (want 0)
+   - `grep -c "withSideloadedLane("` = **7** (want ≥5: def + 5 sites + doc-ref)
+   - AppTabHostView: `sideloadedLaneBooksProvider` = 1, `isSideLoadingEnabled` = 1.
+3. **Build:** `** BUILD SUCCEEDED **` (Palace scheme, generic iOS Simulator).
+4. **Tests:** `** TEST SUCCEEDED **` — `Executed 9 tests, with 0 failures`
+   (SideloadedLaneBridgeTests: 6, SideloadedLaneViewModelTests: 3).
+   xcresult: `/tmp/harness-palace-ios-141BD227-6E9A-4409-8D99-2D4FE818238D-d87edc89-dd/Logs/Test/Test-Palace-2026.07.01_11-11-47--0400.xcresult`
+5. **Mutation (CatalogState.swift):** the engine discovers only 4 mutation points
+   in the file, ALL on PRE-EXISTING lines (39/40 `isApplyingFacet`, 111/121
+   selector `==`) — it generates NO mutants for my changed lines because
+   `toCatalogContent(prepending:)` is expressed with `.isEmpty` / `!` / array-`+`
+   constructs the engine doesn't mutate. Whole-file kill rate is therefore 0/4
+   (all 4 UNCOVERED — they belong to code my SUT doesn't exercise), and
+   `--diff-only` reports "0 mutation points on changed lines". Not a coverage gap
+   in my tests — an engine-operator gap on the changed shape.
+
+   **Manual single-mutant proof (per contract's "single-mutant manual since no
+   commit" allowance):** injected `if extraLanes.isEmpty || true` to gut the lane
+   injection (extraLanes dropped / force-grouped removed), rebuilt, ran
+   `SideloadedLaneBridgeTests` → **mutant KILLED**: `Executed 6 tests, with 5
+   failures` — the 3 "present" tests (grouped/ungrouped/empty base) all failed on
+   the exact assertions (lane-first, force-grouped, keeps-original-books) while
+   the 3 baseline "absent" tests correctly still passed. Mutant reverted; file
+   confirmed clean (`grep MANUAL-MUTANT` = 0). Kill rate on the touched behavior
+   = 100% (mutant caught by 3 tests / 5 assertions).
+6. **check-test-name-vs-body.py:** exit 0 ("0 fake-wiring tests found").
+7. **check-blast-radius.py --quiet:** exit 0.
+8. **check-superpartner-spectrum.py --quiet:** exit 0.
+9. **Scope-coverage audit:** all contract items landed — bridge param, helper,
+   5 sites, provider wiring, 5+ named tests incl. facet-cache-hit. No deferrals.
+
+## Note for integrator
+
+`--diff-only` mutation could not scope because changes are uncommitted (git diff
+vs origin/develop saw 0 changed lines in the working tree for this tool). After
+the orchestrator commits, re-running `palace_mutate.py --file CatalogState.swift
+--tests PalaceTests/SideloadedLaneBridgeTests --diff-only` will still find 0
+mutants on the changed lines (engine-operator gap on `.isEmpty`/`!`/`+`), which
+is expected — the manual single-mutant proof above is the authoritative evidence
+that the tests catch the injection defect. Also note: palace_mutate's shared
+DerivedData had a stale precompiled-header (modulemap mtime) that failed the
+first baseline; cleared `PrecompiledHeaders` + `GeneratedModuleMaps-iphonesimulator`
+under `Palace-cjpueeer...` DerivedData to recover (not a code issue).
+
+## Gaps / BLOCKED
+
+None.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		15F5D99EB5B18B23BC88B2C8 /* LCPPDFDiskExtract.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2E5B460F60157DE72566D7 /* LCPPDFDiskExtract.swift */; };
 		161DDED234AF46D984276897 /* EmailAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B222C03630C4B2984C38A28 /* EmailAddressTests.swift */; };
 		1698C14BA6720F592D8A0834 /* TestAppContainerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F955BD354E7BE3DEFB5B74 /* TestAppContainerFactory.swift */; };
+		16D1246F3608F88A422AE6BA /* SideloadedBookRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F96D2A6AAB3B6C802BDBFCF /* SideloadedBookRegistry.swift */; };
 		16E9A34D3D9D5833B73139CF /* iPadOnMacRMSDKGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20222DD2B8B50BD8CDF984D /* iPadOnMacRMSDKGuardTests.swift */; };
 		17071065242A923400E2648F /* TPPSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17071060242A923400E2648F /* TPPSecrets.swift */; };
 		171966A924170819007BB87E /* TPPBookState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171966A824170819007BB87E /* TPPBookState.swift */; };
@@ -265,6 +266,7 @@
 		2328B4483544EAC500B592B6 /* UserAccountValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC465C72310C5054118CBBEA /* UserAccountValidationTests.swift */; };
 		233349692EA7423D97E70B5F /* SEMigrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE116B1078F648DCB8A52598 /* SEMigrationsTests.swift */; };
 		237B6705CA505A8CE33EAE6D /* TPPDeferredAdobeActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557641B8197B528D886F32DB /* TPPDeferredAdobeActivationTests.swift */; };
+		23C9A2139AFE09942ED9010E /* BookRegistrySyncSideloadExemptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5645B2E3AB447845108FC02C /* BookRegistrySyncSideloadExemptionTests.swift */; };
 		23D8F00859E95DCB9305146B /* AudiobookLoaderOPDSShapeMatrixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA3C09A7973CF58C57F23C0 /* AudiobookLoaderOPDSShapeMatrixTests.swift */; };
 		24627E54AF34930D7ACEB030 /* BookCellModelCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DCAEB765B50E04217F0CB7 /* BookCellModelCache.swift */; };
 		246ED064D298281426FEF8D5 /* KeyboardNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144BB5C0F2D1B2C0C398BD98 /* KeyboardNavigationHandler.swift */; };
@@ -297,6 +299,7 @@
 		29BB24C5E49A9781F6F16EC5 /* ReadiumPDFTOCCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AC116D83FA0E5E94E26508B /* ReadiumPDFTOCCache.swift */; };
 		29D8F99A3730BCAD7334FB9D /* BookListViewAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3E4B69D4B62EDE3F7B9288 /* BookListViewAccessibilityTests.swift */; };
 		29EA3A64D577CE0995849D12 /* ReadiumPDFTOCCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AC116D83FA0E5E94E26508B /* ReadiumPDFTOCCache.swift */; };
+		2A031F58A8B7EE5BAD71CD9C /* SideloadedBookRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F96D2A6AAB3B6C802BDBFCF /* SideloadedBookRegistry.swift */; };
 		2A34C74881B37E0DE564B774 /* PalaceCatalog in Frameworks */ = {isa = PBXBuildFile; productRef = 7AA8A6B3C2C375EC4328722F /* PalaceCatalog */; };
 		2A71783008E7BB879EFB5029 /* NSURL+NYPLURLAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F901D7BCF798BFF0E528D6D /* NSURL+NYPLURLAdditions.swift */; };
 		2A74794DA3EC5581988D5187 /* AppContainerResetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B06750CB65241FF2701518 /* AppContainerResetTests.swift */; };
@@ -329,6 +332,7 @@
 		2F9602AFA9104EA7960516E9 /* AccountDetailSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D6A9F2703AA4DE2B0D5D35C /* AccountDetailSkeletonView.swift */; };
 		2F987E6CCC6642EAADAFC965 /* ViewModelComputedPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C9CA13B5B94707BFFCB13F /* ViewModelComputedPropertyTests.swift */; };
 		2FFD02C9E4694723CB61B853 /* DataBase64Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5E734D2FB5E1FABA1C8A1F /* DataBase64Tests.swift */; };
+		3066D90425C628B819529D35 /* SideloadedBookRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C133FD45251FA7A771EC43A /* SideloadedBookRegistryTests.swift */; };
 		30B392104E9FCA6F9CBEEF01 /* ReadingSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0592B4A4D666ED6705BF8093 /* ReadingSessionTracker.swift */; };
 		30BC12FD0338A5885EBA255C /* BookCellModelStreamingHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820FFFB90AD6CB0A124F6420 /* BookCellModelStreamingHTMLTests.swift */; };
 		30E69EFD7A892A1D3D30DCC9 /* PerformanceReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D80DA377151AE41BEF67F7 /* PerformanceReport.swift */; };
@@ -1145,6 +1149,7 @@
 		CRWL0012BTST00000001 /* CrawlerFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0012FREF00000001 /* CrawlerFallbackTests.swift */; };
 		CRWL0013BTST00000001 /* CrossDeviceBookmarkSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0013FREF00000001 /* CrossDeviceBookmarkSyncTests.swift */; };
 		D0D6599222C5D48C2F478674 /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A5376E7114F302CCBD1497 /* ArrayExtensionsTests.swift */; };
+		D157A0BD33F950C02A51E540 /* BookFileManagerSideloadResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C15702663E81BBC13C0077 /* BookFileManagerSideloadResolutionTests.swift */; };
 		D1662F093947D3C2F76B25D1 /* ReaderTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F994F35E532ACAA0F6C45035 /* ReaderTheme.swift */; };
 		D17D94E13F0041A895571384 /* TPPBookBearerTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF737E48E0644508688E443 /* TPPBookBearerTokenTests.swift */; };
 		D19CE930C954410A845200318 /* RDServicesStubs.m in Sources */ = {isa = PBXBuildFile; fileRef = 75305888F6A941DDA9EEE592 /* RDServicesStubs.m */; };
@@ -1189,6 +1194,7 @@
 		D91512129048356CDC3C9542 /* PalaceCheckPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */; };
 		D92D8C0137C4BC9647242D87 /* SignInModalLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA17C81F4AA9F1201A91AC6C /* SignInModalLifecycleTests.swift */; };
 		D987D93E00D55416261ED333 /* TPPBook+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C1093BDA93392F7DEF0D31 /* TPPBook+Accessibility.swift */; };
+		DAB0BEB25C0820964D148327 /* RemoteFeatureFlagsSideLoadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB471B469C9CDB15F2F2ABA /* RemoteFeatureFlagsSideLoadingTests.swift */; };
 		DB12A83E17C9B20180711EB8 /* URLRequestNYPLAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B163B18C48334A913B2CCA /* URLRequestNYPLAdditionsTests.swift */; };
 		DC6436C6EA2D2F98393B59AF /* BorrowOperationTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFCCBD649C2E3E305E047A65 /* BorrowOperationTimeoutTests.swift */; };
 		DCAFDA3FE1357BBDC9BA7575 /* ImageLoaderImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16897C4A4AB0AFFDE25449BF /* ImageLoaderImpl.swift */; };
@@ -2044,6 +2050,7 @@
 		0D848CD4CD0E01B3A2BF67FE /* TPPReaderPageListBusinessLogic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderPageListBusinessLogic.swift; path = ../../Palace/Reader2/BusinessLogic/TPPReaderPageListBusinessLogic.swift; sourceTree = "<group>"; };
 		0D99051FE5305ABE13531F76 /* FontPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontPickerView.swift; sourceTree = "<group>"; };
 		0F4A943502B7E2966FF50B0D /* AudiobookFullPlayerCoverContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookFullPlayerCoverContainer.swift; sourceTree = "<group>"; };
+		0FB471B469C9CDB15F2F2ABA /* RemoteFeatureFlagsSideLoadingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagsSideLoadingTests.swift; sourceTree = "<group>"; };
 		1020FD76B5E7EA7D89A58124 /* KeyboardNavigationHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyboardNavigationHandlerTests.swift; sourceTree = "<group>"; };
 		11068C53196DD37900E8A94B /* TPPNull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPNull.h; sourceTree = "<group>"; };
 		11068C54196DD37900E8A94B /* TPPNull.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPNull.m; sourceTree = "<group>"; };
@@ -2343,6 +2350,7 @@
 		5550F79A349D3D7ADE48B5E1 /* TPPBookRegistryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookRegistryTests.swift; sourceTree = "<group>"; };
 		557641B8197B528D886F32DB /* TPPDeferredAdobeActivationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPDeferredAdobeActivationTests.swift; sourceTree = "<group>"; };
 		55ABB7E13EF5B68C8635A58F /* BadgesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgesViewModel.swift; sourceTree = "<group>"; };
+		5645B2E3AB447845108FC02C /* BookRegistrySyncSideloadExemptionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookRegistrySyncSideloadExemptionTests.swift; sourceTree = "<group>"; };
 		56F8E5B987D7324D570F67D0 /* TPPIndeterminateProgressView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPIndeterminateProgressView.swift; sourceTree = "<group>"; };
 		581C6B05F79FEB7A95DD4BA5 /* UIView+TPPViewAdditions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+TPPViewAdditions.swift"; sourceTree = "<group>"; };
 		58876626DF4EE60D219F05ED /* AudiobookTOCTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookTOCTests.swift; sourceTree = "<group>"; };
@@ -2359,6 +2367,7 @@
 		5A8468ADD34076BF5935E56B /* TPPBookAccessibilityLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookAccessibilityLabelTests.swift; sourceTree = "<group>"; };
 		5B500DE51F6502CF4983A267 /* AudiobookMiniPlayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookMiniPlayerView.swift; sourceTree = "<group>"; };
 		5BC9F70101B8AD9FAFF88F0E /* AppLaunchTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchTracker.swift; sourceTree = "<group>"; };
+		5C133FD45251FA7A771EC43A /* SideloadedBookRegistryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadedBookRegistryTests.swift; sourceTree = "<group>"; };
 		5CEA3369458249AC6239C383 /* AppContainerIsolationLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContainerIsolationLintTests.swift; sourceTree = "<group>"; };
 		5D1B142922CC179F0006C964 /* TPPAlertUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAlertUtils.swift; sourceTree = "<group>"; };
 		5D3A28CB22D3DA850042B3BD /* UserProfileDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileDocument.swift; sourceTree = "<group>"; };
@@ -2392,6 +2401,7 @@
 		65988BBA901E65AA0905EF43 /* ScopedResetTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScopedResetTests.swift; sourceTree = "<group>"; };
 		65C628E6207F3958E194D07C /* BorrowOperationStreamingHTMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BorrowOperationStreamingHTMLTests.swift; sourceTree = "<group>"; };
 		65F03A0005DBD80853C64D12 /* OPDS2PublicationExtendedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2PublicationExtendedTests.swift; sourceTree = "<group>"; };
+		66C15702663E81BBC13C0077 /* BookFileManagerSideloadResolutionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookFileManagerSideloadResolutionTests.swift; sourceTree = "<group>"; };
 		66D483FA9CC0C0F9A778DED7 /* AccountsManagerAccountIndexTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerAccountIndexTests.swift; sourceTree = "<group>"; };
 		673C54DADAEAD820B2DABB9D /* TPPReaderPositionReportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderPositionReportTests.swift; sourceTree = "<group>"; };
 		673C77C2D01F4E0AB1787C9D /* MyBooksDownloadCenterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterIntegrationTests.swift; sourceTree = "<group>"; };
@@ -2615,6 +2625,7 @@
 		8E3B7D396BC507BA4B029CF5 /* OpenAccessAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenAccessAdapter.swift; sourceTree = "<group>"; };
 		8ED6D3F5630D42CFBE6A59A3 /* BookCellModelCacheInvalidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCellModelCacheInvalidationTests.swift; sourceTree = "<group>"; };
 		8EE910995BD08220089FEBB1 /* AccountDetailsAuthenticationIsBrowserBasedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountDetailsAuthenticationIsBrowserBasedTests.swift; sourceTree = "<group>"; };
+		8F96D2A6AAB3B6C802BDBFCF /* SideloadedBookRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadedBookRegistry.swift; sourceTree = "<group>"; };
 		8FB5684FAB210E6557DD37E7 /* BookCellModelCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BookCellModelCacheTests.swift; path = Performance/BookCellModelCacheTests.swift; sourceTree = "<group>"; };
 		903ECDDBC7F04668AAD303C9 /* ErrorDetailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDetailTests.swift; sourceTree = "<group>"; };
 		903F56D4F2AA03D69839AB3F /* CoverageGapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverageGapTests.swift; sourceTree = "<group>"; };
@@ -3925,6 +3936,15 @@
 			path = Chaos;
 			sourceTree = "<group>";
 		};
+		4E55AED72A688C44680A7FFA /* FeatureFlags */ = {
+			isa = PBXGroup;
+			children = (
+				0FB471B469C9CDB15F2F2ABA /* RemoteFeatureFlagsSideLoadingTests.swift */,
+			);
+			name = FeatureFlags;
+			path = FeatureFlags;
+			sourceTree = "<group>";
+		};
 		52452B48CF3C52B395874F52 /* LCP */ = {
 			isa = PBXGroup;
 			children = (
@@ -4337,6 +4357,7 @@
 				DF0FE8362E5FDFD0DB180577 /* TPPMyBooksDownloadInfo.swift */,
 				D0B0B6008C750B0A082C80D0 /* RecentlyReadingService.swift */,
 				C54010275AF91385B8410DF1 /* BookOpenTracker.swift */,
+				9E34D2A160AA6DF18246B0B9 /* Sideload */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -4912,6 +4933,15 @@
 			path = Reader;
 			sourceTree = "<group>";
 		};
+		9E34D2A160AA6DF18246B0B9 /* Sideload */ = {
+			isa = PBXGroup;
+			children = (
+				8F96D2A6AAB3B6C802BDBFCF /* SideloadedBookRegistry.swift */,
+			);
+			name = Sideload;
+			path = Sideload;
+			sourceTree = "<group>";
+		};
 		9F58D0747C340882892B31C5 /* OPDS2 */ = {
 			isa = PBXGroup;
 			children = (
@@ -5270,6 +5300,7 @@
 				52E79AEBD6EB68A70141013D /* ReaderStreaming */,
 				1ABC0E40FBEECB22D2E04F66 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift */,
 				5F80A7E0050FBFEDA0FCD075 /* TPPConfigurationCustomRegistryTests.swift */,
+				4E55AED72A688C44680A7FFA /* FeatureFlags */,
 			);
 			path = PalaceTests;
 			sourceTree = "<group>";
@@ -5433,6 +5464,7 @@
 				FACAA8E6F45D5A91B3486904 /* TPPBookContentTypeConverterTests.swift */,
 				D9B791C34331187A57984D68 /* BookButtonTypeMetaTests.swift */,
 				F447D6D0EFBBC91F7CD6C5A4 /* BookRegistrySyncReentrancyTests.swift */,
+				5645B2E3AB447845108FC02C /* BookRegistrySyncSideloadExemptionTests.swift */,
 			);
 			path = Book;
 			sourceTree = "<group>";
@@ -5537,6 +5569,8 @@
 				1E8B9BFBB791BB1A85E46685 /* DefaultRecentlyReadingServiceTests.swift */,
 				820FFFB90AD6CB0A124F6420 /* BookCellModelStreamingHTMLTests.swift */,
 				65C628E6207F3958E194D07C /* BorrowOperationStreamingHTMLTests.swift */,
+				66C15702663E81BBC13C0077 /* BookFileManagerSideloadResolutionTests.swift */,
+				C357A9EDEB4B9A3F57AD944D /* Sideload */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -5574,6 +5608,15 @@
 				CE669450263E1799207AA2ED /* Views */,
 			);
 			path = Stats;
+			sourceTree = "<group>";
+		};
+		C357A9EDEB4B9A3F57AD944D /* Sideload */ = {
+			isa = PBXGroup;
+			children = (
+				5C133FD45251FA7A771EC43A /* SideloadedBookRegistryTests.swift */,
+			);
+			name = Sideload;
+			path = Sideload;
 			sourceTree = "<group>";
 		};
 		C37B1C9E3DE9890FC24DFCD7 /* ImageLoading */ = {
@@ -7451,6 +7494,10 @@
 				76C676B1C1BF8F2434C03DB9 /* AccountDetailViewModelLeakTests.swift in Sources */,
 				9AEC583C7317B6169A20C247 /* ExecutorNetworkHermeticityTests.swift in Sources */,
 				48333F55E5F2AC51E90C1DFC /* PDFKitThumbnailProviderTests.swift in Sources */,
+				23C9A2139AFE09942ED9010E /* BookRegistrySyncSideloadExemptionTests.swift in Sources */,
+				D157A0BD33F950C02A51E540 /* BookFileManagerSideloadResolutionTests.swift in Sources */,
+				DAB0BEB25C0820964D148327 /* RemoteFeatureFlagsSideLoadingTests.swift in Sources */,
+				3066D90425C628B819529D35 /* SideloadedBookRegistryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7997,6 +8044,7 @@
 				6B4686ADB115880CFE56B2B2 /* TPPReaderBlockNavigation.swift in Sources */,
 				548BDFB27A52C3D705F51AF9 /* PDFKitThumbnailProvider.swift in Sources */,
 				BA273F316B533C5D83693DBD /* PDFThumbnailStrip.swift in Sources */,
+				2A031F58A8B7EE5BAD71CD9C /* SideloadedBookRegistry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8546,6 +8594,7 @@
 				8CCB8310199672E1C07F4073 /* TPPReaderBlockNavigation.swift in Sources */,
 				7BF32AE422DD08A70AEE7374 /* PDFKitThumbnailProvider.swift in Sources */,
 				6BC7E24CA90EF069C73A11ED /* PDFThumbnailStrip.swift in Sources */,
+				16D1246F3608F88A422AE6BA /* SideloadedBookRegistry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		0B55EFB324FAF34D779EB878 /* StreamingReaderPresentationContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A213D524079F39BA952025A /* StreamingReaderPresentationContractTests.swift */; };
 		0B72C5306C699DBCB586DBE7 /* MyBooksDownloadCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317C8F0150303A9AC53BC44F /* MyBooksDownloadCenterTests.swift */; };
 		0B9C4F9CCCF2321228F96954 /* dune_oversubdivided_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 2630448EB64E91E2EADDF594 /* dune_oversubdivided_manifest.json */; };
+		0BD8B0C9E2FDB018F9ED98C5 /* SideLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F833987DFE38DF4D313424 /* SideLoadingView.swift */; };
 		0C26C51E4B1F06A4C02FBB65 /* TPPReauthenticator+Reauthenticating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540375EB4B496BAA15E4F6F4 /* TPPReauthenticator+Reauthenticating.swift */; };
 		0C3DD40B825558E7A86B603F /* TPPConfigurationCustomRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F80A7E0050FBFEDA0FCD075 /* TPPConfigurationCustomRegistryTests.swift */; };
 		0C6A411969E83D1D9A8BD2EA /* BorrowOperationAuthCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CDE8C912B8AD7B20AF282E /* BorrowOperationAuthCoordinatorTests.swift */; };
@@ -315,6 +316,7 @@
 		2D2B47841D08F8E2007F7764 /* UpdateCheckUpToDate.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D2B47691D08F264007F7764 /* UpdateCheckUpToDate.json */; };
 		2D2B478E1D08FDF5007F7764 /* UpdateCheckNeedsUpdate.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D2B478A1D08FC78007F7764 /* UpdateCheckNeedsUpdate.json */; };
 		2D2B478F1D08FDF5007F7764 /* UpdateCheckUnknown.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D2B47891D08FC78007F7764 /* UpdateCheckUnknown.json */; };
+		2D32C1D17E592EAF2B61072E /* SideloadImportContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39FED88A010E48C748A3410B /* SideloadImportContractTests.swift */; };
 		2D4379FE1C46FDB600AE1AD5 /* ReaderClientCert.sig in Resources */ = {isa = PBXBuildFile; fileRef = 085D31FB1BE7BE86007F7672 /* ReaderClientCert.sig */; };
 		2D54C989CCCF423FB7F8DE04 /* BorrowErrorMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170AEC7A489A485A87793078 /* BorrowErrorMessageTests.swift */; };
 		2D574446496E48530BA40807 /* BackgroundDownloadHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE511C614AE46DCC9A9B642A /* BackgroundDownloadHandlerTests.swift */; };
@@ -515,6 +517,7 @@
 		653FFE80382CFE2981E25461 /* TriageBotFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C1BD2745D8CAF0EC81AEE8 /* TriageBotFactory.swift */; };
 		6552DA0826AB41E985E7B17A /* CatalogRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DDE892E38D34061A2DBE2F2 /* CatalogRepositoryMock.swift */; };
 		65C9C378EE67A7B2D1D12B08 /* MyBooksDownloadCenterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420E95312BFA6C62C6CA835D /* MyBooksDownloadCenterProtocol.swift */; };
+		65FFEE7138ABC534BDC38DAE /* SideloadedLaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D99F654723B202B64BEDFD /* SideloadedLaneTests.swift */; };
 		66AE9D42FA4F53E26C31747C /* ReadingStreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6CA6654994D77041AE0F79 /* ReadingStreak.swift */; };
 		676F638471BA390A373B329B /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF1F7C70AC93BF8E2F22148 /* DebugSettings.swift */; };
 		67D8EFBDE46E7BA527E46953 /* EmbeddedScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR005 /* EmbeddedScenarios.swift */; };
@@ -537,6 +540,7 @@
 		6BC5772BEBDDD6ED93E8F6A3 /* OfflineQueueBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C9C7A1029274277B31F57E /* OfflineQueueBadge.swift */; };
 		6BC7E24CA90EF069C73A11ED /* PDFThumbnailStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15FCA49C708DFACA3FD66B6 /* PDFThumbnailStrip.swift */; };
 		6BD196ABF46912E87D2F0001 /* MyBooksDownloadCenterEvictionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95095FF0B6661C2AE8B60001 /* MyBooksDownloadCenterEvictionTests.swift */; };
+		6C306D35A8C48C707C25D9C8 /* SideloadedBookManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C9773F1E6CD48C6CA4ACAC /* SideloadedBookManagerTests.swift */; };
 		6C4729162EE9C5CD63518FC2 /* UnifiedOPDSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FB0D2943B1B29532C05120 /* UnifiedOPDSService.swift */; };
 		6D1A2EAA9359F95A03E24924 /* TriageBotUI in Frameworks */ = {isa = PBXBuildFile; productRef = EC7C8BCB15CB04F41C93E21B /* TriageBotUI */; };
 		6D31B0C0854BA3F8E14FA904 /* NotificationSyncThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF4B6BD211B2BF0AEA436A7 /* NotificationSyncThrottleTests.swift */; };
@@ -924,6 +928,7 @@
 		A6B46B564D17521FD9892D70 /* TypographyPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A78DE6D235AA54DC8F02DA /* TypographyPreset.swift */; };
 		A6C6D83ED0F20F041062ECF0 /* LCPPDFOpenProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C86F54125C3BD725906F86 /* LCPPDFOpenProgress.swift */; };
 		A6C753810A4D64E933B7B36A /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = SETVM003T260955EF008E1DC3 /* SettingsViewModel.swift */; };
+		A6F47C647E52D22145FB06D2 /* SideloadedBookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94335E63E085BA6718033D06 /* SideloadedBookManager.swift */; };
 		A7D3A61E77E6B8C0FD9AEA5D /* TypographySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C1C917A6BF4317D7FA6567 /* TypographySettings.swift */; };
 		A7E1CE3367F3C787133E928B /* PalaceCatalog in Frameworks */ = {isa = PBXBuildFile; productRef = 4BDC371B99FCA4E42EEFA3CB /* PalaceCatalog */; };
 		A8131DE3255ED9F6651D1AF6 /* AudioSessionActivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDE63F6732471A2B00D88DC /* AudioSessionActivator.swift */; };
@@ -997,8 +1002,10 @@
 		B3BKAUT002F260300000001 /* TPPBookAuthorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BKAUT001F260300000001 /* TPPBookAuthorTests.swift */; };
 		B3BKLOC002F260300000001 /* TPPBookLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BKLOC001F260300000001 /* TPPBookLocationTests.swift */; };
 		B3CA81E4A64B45269F4DD741 /* SpyAuthDecisionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0832A22CC1EC07844CD4AA /* SpyAuthDecisionRecorder.swift */; };
+		B45F11B653AFD64C41129E77 /* SideloadedBookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94335E63E085BA6718033D06 /* SideloadedBookManager.swift */; };
 		B4716E7BCDCDDE571C374086 /* PlaybackReadinessGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F714C5D09735CC88BE76576D /* PlaybackReadinessGate.swift */; };
 		B4892856507B70F7C04ADD43 /* TPPJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52226B7262C85C91578DB3A7 /* TPPJSON.swift */; };
+		B4991867A211185F41CE520E /* SideLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F833987DFE38DF4D313424 /* SideLoadingView.swift */; };
 		B4CONC001BF000000000001 /* MainActorHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CONC001FR000000000001 /* MainActorHelpersTests.swift */; };
 		B4CONC002BF000000000001 /* TPPMainThreadCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CONC002FR000000000001 /* TPPMainThreadCheckerTests.swift */; };
 		B4NETW001BF000000000001 /* URLExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4NETW001FR000000000001 /* URLExtensionsTests.swift */; };
@@ -2276,6 +2283,8 @@
 		38BB1056721E445D90C72FFF /* TPPLastReadPositionPosterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPLastReadPositionPosterTests.swift; sourceTree = "<group>"; };
 		38D1A95DE8674E6D83B5A8CA /* TPPNetworkExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPNetworkExecutorTests.swift; sourceTree = "<group>"; };
 		398C885262F88AA0254CD1C6 /* TPPNetworkResponderAuthCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPNetworkResponderAuthCoordinatorTests.swift; sourceTree = "<group>"; };
+		39F833987DFE38DF4D313424 /* SideLoadingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideLoadingView.swift; sourceTree = "<group>"; };
+		39FED88A010E48C748A3410B /* SideloadImportContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadImportContractTests.swift; sourceTree = "<group>"; };
 		3A213D524079F39BA952025A /* StreamingReaderPresentationContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingReaderPresentationContractTests.swift; sourceTree = "<group>"; };
 		3A38DEB3619035E1E29DBEA9 /* StreamingReaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingReaderView.swift; sourceTree = "<group>"; };
 		3ACF84E5F5C8C9579E5C61B9 /* AccountDetailViewModelLeakTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountDetailViewModelLeakTests.swift; sourceTree = "<group>"; };
@@ -2636,11 +2645,13 @@
 		9363B8BAFC71462390D7DD31 /* AudiobookLoadFailureSAMLReauthTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookLoadFailureSAMLReauthTests.swift; sourceTree = "<group>"; };
 		93925AD8656015E0036615C8 /* NotificationServiceTokenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationServiceTokenTests.swift; sourceTree = "<group>"; };
 		93D2803422C2006E33C1BC3E /* AuthCoordinatorTelemetryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthCoordinatorTelemetryTests.swift; sourceTree = "<group>"; };
+		94335E63E085BA6718033D06 /* SideloadedBookManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadedBookManager.swift; sourceTree = "<group>"; };
 		94ED05E54513023A79735EA0 /* ReaderEditingActionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderEditingActionsTests.swift; sourceTree = "<group>"; };
 		95095FF0B6661C2AE8B60001 /* MyBooksDownloadCenterEvictionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterEvictionTests.swift; sourceTree = "<group>"; };
 		95524DFA311D1BE65A9F5FF3 /* ThemePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemePickerView.swift; sourceTree = "<group>"; };
 		958964493F9D85E5FCFAAAE2 /* BorrowOperationContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BorrowOperationContractTests.swift; sourceTree = "<group>"; };
 		95C7D04F855F2DA251329CDD /* TPPLocalization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPLocalization.swift; sourceTree = "<group>"; };
+		96C9773F1E6CD48C6CA4ACAC /* SideloadedBookManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadedBookManagerTests.swift; sourceTree = "<group>"; };
 		96D27685071B8A1E07185FD0 /* LCPAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPAdapter.swift; sourceTree = "<group>"; };
 		973B633FA62911CD52ED9CB9 /* ReadingSessionTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSessionTrackerTests.swift; sourceTree = "<group>"; };
 		978A163EF2834D9087A9CDEB /* UserRetryTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRetryTrackerTests.swift; sourceTree = "<group>"; };
@@ -2688,6 +2699,7 @@
 		A4B5C6D7E8F9A0B1C2D3E4F5 /* DownloadCancellationHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadCancellationHandlerTests.swift; sourceTree = "<group>"; };
 		A556E4218D9D8BDC19019BFA /* TPPBookTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookTests.swift; sourceTree = "<group>"; };
 		A5A6C8FEE9804D8B9B969537 /* CatalogLaneRowViewAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogLaneRowViewAccessibilityTests.swift; sourceTree = "<group>"; };
+		A6D99F654723B202B64BEDFD /* SideloadedLaneTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadedLaneTests.swift; sourceTree = "<group>"; };
 		A7531D0BC80AF1F317534E80 /* Account+State.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Account+State.swift"; sourceTree = "<group>"; };
 		A77E63314ED6F70CC68C0DA0 /* AudiobookAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookAccessibilityTests.swift; sourceTree = "<group>"; };
 		A7E31E236C9F4875AEF5B087 /* AccountsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsManagerTests.swift; sourceTree = "<group>"; };
@@ -3662,6 +3674,7 @@
 				9BFF70FF762C60CE8CD8D811 /* CatalogSearchViewModelTests.swift */,
 				4057C151D980D26B04B8FC53 /* ContinueRowSectionTests.swift */,
 				B0B284DD9A4739D34937C4D0 /* CatalogViewContinueRowsIntegrationTests.swift */,
+				A6D99F654723B202B64BEDFD /* SideloadedLaneTests.swift */,
 			);
 			path = CatalogUI;
 			sourceTree = "<group>";
@@ -4937,6 +4950,7 @@
 			isa = PBXGroup;
 			children = (
 				8F96D2A6AAB3B6C802BDBFCF /* SideloadedBookRegistry.swift */,
+				94335E63E085BA6718033D06 /* SideloadedBookManager.swift */,
 			);
 			name = Sideload;
 			path = Sideload;
@@ -5372,6 +5386,7 @@
 				60FB7A3D7F1E7AEABAA4A45E /* Reader2BookmarkContractTests.swift */,
 				FA9362A84727864E4CE17B46 /* Reader2PositionResumeContractTests.swift */,
 				3A213D524079F39BA952025A /* StreamingReaderPresentationContractTests.swift */,
+				39FED88A010E48C748A3410B /* SideloadImportContractTests.swift */,
 			);
 			name = Contract;
 			path = Contract;
@@ -5614,6 +5629,7 @@
 			isa = PBXGroup;
 			children = (
 				5C133FD45251FA7A771EC43A /* SideloadedBookRegistryTests.swift */,
+				96C9773F1E6CD48C6CA4ACAC /* SideloadedBookManagerTests.swift */,
 			);
 			name = Sideload;
 			path = Sideload;
@@ -5979,6 +5995,7 @@
 				E5B2B8DC2759552F00150ED4 /* TPPSettingsViewController.swift */,
 				SETVM003T260955EF008E1DC3 /* SettingsViewModel.swift */,
 				BD8A6CD8712B3CCDDF937A39 /* LibrariesSectionViewModel.swift */,
+				39F833987DFE38DF4D313424 /* SideLoadingView.swift */,
 			);
 			path = NewSettings;
 			sourceTree = "<group>";
@@ -7498,6 +7515,9 @@
 				D157A0BD33F950C02A51E540 /* BookFileManagerSideloadResolutionTests.swift in Sources */,
 				DAB0BEB25C0820964D148327 /* RemoteFeatureFlagsSideLoadingTests.swift in Sources */,
 				3066D90425C628B819529D35 /* SideloadedBookRegistryTests.swift in Sources */,
+				65FFEE7138ABC534BDC38DAE /* SideloadedLaneTests.swift in Sources */,
+				2D32C1D17E592EAF2B61072E /* SideloadImportContractTests.swift in Sources */,
+				6C306D35A8C48C707C25D9C8 /* SideloadedBookManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8045,6 +8065,8 @@
 				548BDFB27A52C3D705F51AF9 /* PDFKitThumbnailProvider.swift in Sources */,
 				BA273F316B533C5D83693DBD /* PDFThumbnailStrip.swift in Sources */,
 				2A031F58A8B7EE5BAD71CD9C /* SideloadedBookRegistry.swift in Sources */,
+				B45F11B653AFD64C41129E77 /* SideloadedBookManager.swift in Sources */,
+				B4991867A211185F41CE520E /* SideLoadingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8595,6 +8617,8 @@
 				7BF32AE422DD08A70AEE7374 /* PDFKitThumbnailProvider.swift in Sources */,
 				6BC7E24CA90EF069C73A11ED /* PDFThumbnailStrip.swift in Sources */,
 				16D1246F3608F88A422AE6BA /* SideloadedBookRegistry.swift in Sources */,
+				A6F47C647E52D22145FB06D2 /* SideloadedBookManager.swift in Sources */,
+				0BD8B0C9E2FDB018F9ED98C5 /* SideLoadingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -249,6 +249,27 @@ struct AppContainer {
     }
     private static var _sideloadedBookRegistry: SideloadedBookRegistry?
 
+    /// Side-loading (PP-2677) — orchestrates the import/remove/rehydrate flow on
+    /// top of `sideloadedBookRegistry`. Consumes the side-loaded registry (truth
+    /// store + sync-exemption), the main `bookRegistry` (so the reader sees the
+    /// book as `.downloadSuccessful`), and a `BookFileManager` for the fixed-
+    /// account file path. Lazy + cached the same way `sideloadedBookRegistry` is;
+    /// `_resetForTesting()` nils it so a stale manager doesn't outlive the
+    /// registry it was wired to. Additive property only — the big `init`,
+    /// `_buildCachedAppContainer()` return, and `with*Presenter` copies are NOT
+    /// touched (Module A owns this property region; Module C appends here).
+    var sideloadedBookManager: SideloadedBookManager {
+        if let cached = AppContainer._sideloadedBookManager { return cached }
+        let manager = SideloadedBookManager(
+            bookRegistry: self.bookRegistry,
+            sideloadedRegistry: self.sideloadedBookRegistry,
+            bookFileManager: BookFileManager()
+        )
+        AppContainer._sideloadedBookManager = manager
+        return manager
+    }
+    private static var _sideloadedBookManager: SideloadedBookManager?
+
     /// Process-wide audiobook session presenter — the root-level
     /// SwiftUI-observable bridge between the manager's published state and
     /// the mini-player + full-screen-cover surfaces Module D wires into
@@ -607,6 +628,10 @@ struct AppContainer {
         // Not `@MainActor`-isolated (its `identifiers` is read off-main), so
         // reset outside the `assumeIsolated` block.
         _sideloadedBookRegistry = nil
+        // Side-loading (PP-2677): the manager caches a reference to the
+        // side-loaded registry above, so nil it in lockstep — a stale manager
+        // would keep pointing at the reset registry across test classes.
+        _sideloadedBookManager = nil
         // Leave the flag at the test-safe `true` (see step 4 above) — do NOT
         // reset to `false`. The next test class inherits this value before its
         // own setUp runs; `false` here is the root of the cross-test

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -235,6 +235,20 @@ struct AppContainer {
     }
     @MainActor private static var _bookOpenTracker: BookOpenTracking?
 
+    /// Side-loading (PP-2678) — process-wide registry of side-loaded books.
+    /// Source of truth for the sync-exemption set (consumed by
+    /// `BookRegistrySync.sync()` via a lazy provider) and the side-loaded
+    /// catalog lane (Module D). File-backed shared cache, lazy + cached the
+    /// same way `bookOpenTracker` is; `_resetForTesting()` nils it so its
+    /// on-disk manifest state does not bleed across test classes.
+    var sideloadedBookRegistry: SideloadedBookRegistry {
+        if let cached = AppContainer._sideloadedBookRegistry { return cached }
+        let registry = SideloadedBookRegistry()
+        AppContainer._sideloadedBookRegistry = registry
+        return registry
+    }
+    private static var _sideloadedBookRegistry: SideloadedBookRegistry?
+
     /// Process-wide audiobook session presenter — the root-level
     /// SwiftUI-observable bridge between the manager's published state and
     /// the mini-player + full-screen-cover surfaces Module D wires into
@@ -586,6 +600,13 @@ struct AppContainer {
             _audiobookSessionPresenter = nil
             _playbackBootstrapper = nil
         }
+        // Side-loading (PP-2678): the side-loaded registry is a file-backed
+        // shared static cache, so it WOULD bleed manifest state across test
+        // classes if left intact. Nil it here so the next `production()`
+        // resolution rebuilds a fresh instance reading the current manifest.
+        // Not `@MainActor`-isolated (its `identifiers` is read off-main), so
+        // reset outside the `assumeIsolated` block.
+        _sideloadedBookRegistry = nil
         // Leave the flag at the test-safe `true` (see step 4 above) — do NOT
         // reset to `false`. The next test class inherits this value before its
         // own setUp runs; `false` here is the root of the cross-test

--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -75,7 +75,17 @@ struct AppTabHostView: View {
             repository: repository,
             topLevelURLProvider: { appContainer.settings.accountMainFeedURL },
             bookRegistry: appContainer.bookRegistry,
-            imageCache: appContainer.imageCache
+            imageCache: appContainer.imageCache,
+            // Module D (swarm_495a88d9 / PP-2679): the "Side Loaded" catalog lane.
+            // The flag gate lives HERE (not in the VM) — the provider returns []
+            // when side-loading is off, so the VM never sees the flag and the lane
+            // simply doesn't appear. Read lazily so registry/flag changes take
+            // effect on the next catalog conversion.
+            sideloadedLaneBooksProvider: {
+                RemoteFeatureFlags.shared.isSideLoadingEnabled
+                    ? appContainer.sideloadedBookRegistry.allBooks
+                    : []
+            }
         ))
         _myBooksViewModel = StateObject(wrappedValue: MyBooksViewModel(appContainer: appContainer))
         // Module B (swarm_0b7616e7) composition root for the Continue

--- a/Palace/AppInfrastructure/FirebaseManager.swift
+++ b/Palace/AppInfrastructure/FirebaseManager.swift
@@ -63,6 +63,7 @@ final class FirebaseManager {
         case triageBotTicketSubmissionEnabled = "triage_bot_ticket_submission_enabled"
         case triageBotAIFallbackEnabled = "triage_bot_ai_fallback_enabled"
         case inAppPlaybackNavEnabled = "in_app_playback_nav_enabled"
+        case sideLoadingEnabled = "side_loading_enabled"
     }
 
     // MARK: - Initialization
@@ -109,7 +110,8 @@ final class FirebaseManager {
             RemoteConfigKey.triageBotEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.triageBotTicketSubmissionEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.triageBotAIFallbackEnabled.rawValue: NSNumber(value: false),
-            RemoteConfigKey.inAppPlaybackNavEnabled.rawValue: NSNumber(value: false)
+            RemoteConfigKey.inAppPlaybackNavEnabled.rawValue: NSNumber(value: false),
+            RemoteConfigKey.sideLoadingEnabled.rawValue: NSNumber(value: false)
         ])
     }
 

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -197,7 +197,21 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
         // store's own queue — but it primes the `loadingAccount` guard and
         // queues the state transition to .loaded. Any sync() that races it is
         // caught by the .unloaded/.loading guard in BookRegistrySync.sync.
-        AppContainer.production().bookRegistry.load()
+        // PP-2677 side-loading: re-register persisted side-loaded books into the
+        // MAIN registry so they open in the reader and appear on the shelf. This
+        // MUST run in the `load(completion:)` callback — `load()` is async and a
+        // rehydrate that ran before the disk snapshot landed would be clobbered
+        // when the store transitions to `.loaded`. `load(completion:)` lives on
+        // the concrete `TPPBookRegistry`, not the `TPPBookRegistryProvider`
+        // surface, hence the cast; production always resolves to the concrete
+        // type. The fallback keeps the original behaviour if that ever changes.
+        if let loadableRegistry = AppContainer.production().bookRegistry as? TPPBookRegistry {
+            loadableRegistry.load {
+                AppContainer.production().sideloadedBookManager.rehydrateAtLaunch()
+            }
+        } else {
+            AppContainer.production().bookRegistry.load()
+        }
 
         NotificationService.shared.setupPushNotifications()
     }

--- a/Palace/Book/Models/BookRegistrySync.swift
+++ b/Palace/Book/Models/BookRegistrySync.swift
@@ -42,6 +42,16 @@ final class BookRegistrySync: @unchecked Sendable {
   /// `AppContainer.production().downloadCenter` has settled.
   private let downloadCenterProvider: () -> MyBooksDownloadCenter
   private let opdsFeedServiceProvider: () -> OPDSFeedService
+  /// Identifiers of side-loaded books, resolved lazily on each `sync()`.
+  /// Side-loaded books are registered `.downloadSuccessful` but never appear
+  /// in the loans feed, so without this exemption `sync()`'s reconciliation
+  /// would un-register them AND delete their on-disk file every sync (the
+  /// load-bearing hazard in `docs/architecture/sideloading-plan.md`).
+  /// Immutable `let` (preserves the `@unchecked Sendable` invariant above);
+  /// resolved lazily via `AppContainer.production()` mirroring
+  /// `downloadCenterProvider` so construction inside `TPPBookRegistry.init`
+  /// does not re-enter the still-resolving `AppContainer._cached`.
+  private let sideloadedIDsProvider: () -> Set<String>
   private let registryFolderName = "registry"
   private let registryFileName = "registry.json"
   /// Serial queue for disk writes — prevents out-of-order save races where a stale
@@ -65,12 +75,14 @@ final class BookRegistrySync: @unchecked Sendable {
     store: BookRegistryStore,
     accountsManager: AccountsManager,
     downloadCenterProvider: @escaping () -> MyBooksDownloadCenter,
-    opdsFeedServiceProvider: @escaping () -> OPDSFeedService
+    opdsFeedServiceProvider: @escaping () -> OPDSFeedService,
+    sideloadedIDsProvider: @escaping () -> Set<String> = { AppContainer.production().sideloadedBookRegistry.identifiers }
   ) {
     self.store = store
     self.accountsManager = accountsManager
     self.downloadCenterProvider = downloadCenterProvider
     self.opdsFeedServiceProvider = opdsFeedServiceProvider
+    self.sideloadedIDsProvider = sideloadedIDsProvider
     diskWriteQueue.setSpecific(key: diskWriteQueueKey, value: ())
   }
 
@@ -404,6 +416,10 @@ final class BookRegistrySync: @unchecked Sendable {
         var booksToDeleteLocally: [TPPBook] = []
         self.store.mutateRegistrySync { registry in
           var recordsToDelete = Set<String>(registry.keys)
+          // Side-loaded books never appear in the loans feed. Exempt them so
+          // reconciliation neither un-registers them (:480-481) nor deletes
+          // their on-disk content (:496-497). See sideloading-plan.md R1.
+          recordsToDelete.subtract(sideloadedIDsProvider())
           for entry in feed.entries {
             guard let opdsEntry = entry as? TPPOPDSEntry,
                   let book = TPPBook(entry: opdsEntry)

--- a/Palace/Book/Models/TPPBookRegistry.swift
+++ b/Palace/Book/Models/TPPBookRegistry.swift
@@ -213,7 +213,10 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
             store: store,
             accountsManager: accountsManager,
             downloadCenterProvider: { AppContainer.production().downloadCenter },
-            opdsFeedServiceProvider: { AppContainer.production().opdsFeedService }
+            opdsFeedServiceProvider: { AppContainer.production().opdsFeedService },
+            // Side-loaded books are exempt from loans-feed reconciliation.
+            // Provider resolved lazily (same AppContainer-cycle avoidance).
+            sideloadedIDsProvider: { AppContainer.production().sideloadedBookRegistry.identifiers }
         )
         self.store = store
         self.syncEngine = sync
@@ -243,7 +246,10 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
             store: store,
             accountsManager: accountsManager,
             downloadCenterProvider: { AppContainer.production().downloadCenter },
-            opdsFeedServiceProvider: { AppContainer.production().opdsFeedService }
+            opdsFeedServiceProvider: { AppContainer.production().opdsFeedService },
+            // Side-loaded books are exempt from loans-feed reconciliation.
+            // Provider resolved lazily (same AppContainer-cycle avoidance).
+            sideloadedIDsProvider: { AppContainer.production().sideloadedBookRegistry.identifiers }
         )
         self.store = store
         self.syncEngine = sync

--- a/Palace/CatalogUI/ViewModels/CatalogState.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogState.swift
@@ -22,14 +22,21 @@ enum CatalogState {
   /// remain visible above the skeleton.
   case switchingEntryPoint(CatalogSelectors)
 
-  /// Unrecoverable error during initial load (no content to fall back to).
-  case error(String)
+  /// Unrecoverable error during initial load (no catalog content to fall back
+  /// to). Carries the "Side Loaded" lane rows (F-1) so the view can surface
+  /// imported books ALONGSIDE the feed-error message rather than hiding them
+  /// behind the failure. `sideloadedLanes` is empty whenever side-loading is
+  /// off or the registry is empty — the view then renders the plain error,
+  /// byte-identical to the pre-F-1 behavior.
+  case error(String, sideloadedLanes: [CatalogLaneModel])
 
   /// The initial load failed because the device has no connectivity. Distinct
   /// from `.error` so the view can direct the patron to their downloaded books
   /// instead of offering a Reload that cannot succeed offline. Reload happens
-  /// automatically when connectivity returns (see `CatalogViewModel`).
-  case offline
+  /// automatically when connectivity returns (see `CatalogViewModel`). Carries
+  /// the "Side Loaded" lane rows (F-1) for the same reason `.error` does; empty
+  /// when side-loading contributes no books (behavior unchanged).
+  case offline(sideloadedLanes: [CatalogLaneModel])
 }
 
 // MARK: - Computed Helpers
@@ -51,6 +58,17 @@ extension CatalogState {
   /// Extract title for navigation bar, if available.
   var title: String? {
     content?.title
+  }
+
+  /// The "Side Loaded" lane rows carried by an `.error` / `.offline` state
+  /// (F-1). Empty for every other state, and empty on `.error` / `.offline`
+  /// whenever side-loading contributes no books — so a flag-off catalog failure
+  /// exposes no lanes, exactly as before.
+  var sideloadedLanes: [CatalogLaneModel] {
+    switch self {
+    case .error(_, let lanes), .offline(let lanes): return lanes
+    default: return []
+    }
   }
 
   /// All books across all lanes/ungrouped, for search.

--- a/Palace/CatalogUI/ViewModels/CatalogState.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogState.swift
@@ -127,14 +127,33 @@ extension CatalogSelectors {
 // MARK: - MappedCatalog Bridge
 
 extension CatalogViewModel.MappedCatalog {
-  func toCatalogContent() -> CatalogContent {
+  /// Convert the mapped feed to displayable `CatalogContent`, optionally
+  /// prepending extra lanes (e.g. the "Side Loaded" lane — Module D / PP-2679).
+  ///
+  /// When `extraLanes` is non-empty the result is FORCED to `.grouped` so the
+  /// injected lanes appear even when the base feed is ungrouped or empty — the
+  /// DRM side-loading test use-case has no OPDS feed at all, so the lane must
+  /// survive the `.empty`/`.ungrouped` shapes. To avoid dropping books, an
+  /// ungrouped base feed is wrapped into a single trailing lane (its header is
+  /// the feed title) rather than discarded.
+  func toCatalogContent(prepending extraLanes: [CatalogLaneModel] = []) -> CatalogContent {
     let feed: CatalogFeedContent
-    if !lanes.isEmpty {
-      feed = .grouped(lanes)
-    } else if !ungroupedBooks.isEmpty {
-      feed = .ungrouped(ungroupedBooks)
+    if extraLanes.isEmpty {
+      if !lanes.isEmpty {
+        feed = .grouped(lanes)
+      } else if !ungroupedBooks.isEmpty {
+        feed = .ungrouped(ungroupedBooks)
+      } else {
+        feed = .empty
+      }
     } else {
-      feed = .empty
+      if !lanes.isEmpty {
+        feed = .grouped(extraLanes + lanes)
+      } else if !ungroupedBooks.isEmpty {
+        feed = .grouped(extraLanes + [CatalogLaneModel(title: title, books: ungroupedBooks, moreURL: nil)])
+      } else {
+        feed = .grouped(extraLanes)
+      }
     }
 
     return CatalogContent(

--- a/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
@@ -21,6 +21,12 @@ final class CatalogViewModel: ObservableObject {
   private let bookRegistry: TPPBookRegistryProvider
   private let imageCache: ImageCacheType
   private let reachability: Reachability
+  /// Supplies the books for the "Side Loaded" catalog lane (Module D / PP-2679).
+  /// Returns `[]` when side-loading is off — the feature-flag gate lives at the
+  /// construction site (`AppTabHostView`), keeping the flag out of the VM. When
+  /// this returns ≥1 book, `withSideloadedLane(_:)` prepends a lane on every
+  /// catalog conversion path.
+  private let sideloadedLaneBooksProvider: () -> [TPPBook]
   private var cancellables = Set<AnyCancellable>()
 
   // MARK: - Public accessors for search
@@ -55,14 +61,36 @@ final class CatalogViewModel: ObservableObject {
     topLevelURLProvider: @escaping () -> URL?,
     bookRegistry: TPPBookRegistryProvider,
     imageCache: ImageCacheType,
+    sideloadedLaneBooksProvider: @escaping () -> [TPPBook] = { [] },
     reachability: Reachability = AppContainer.production().reachability
   ) {
     self.repository = repository
     self.topLevelURLProvider = topLevelURLProvider
     self.bookRegistry = bookRegistry
     self.imageCache = imageCache
+    self.sideloadedLaneBooksProvider = sideloadedLaneBooksProvider
     self.reachability = reachability
     observeConnectivity()
+  }
+
+  /// Literal (not localized) side-loaded lane title. Side-loading is a
+  /// DEBUG/test-only feature gated behind `isSideLoadingEnabled` (default OFF in
+  /// production), so per the Module D contract a literal is acceptable here.
+  private static let sideloadedLaneTitle = "Side Loaded"
+
+  /// SINGLE CHOKE POINT for injecting the "Side Loaded" lane into every catalog
+  /// conversion (PP-2679). EVERY former catalog-content call site routes
+  /// through here so the lane can never silently vanish on one path — in
+  /// particular the `applyFacet` cache-HIT fast path, which a per-site patch
+  /// would miss. The lane is present iff `sideloadedLaneBooksProvider()` returns
+  /// ≥1 book; when it returns `[]` the result is identical to the un-injected
+  /// baseline shape.
+  private func withSideloadedLane(_ mapped: MappedCatalog) -> CatalogContent {
+    let books = sideloadedLaneBooksProvider()
+    let lanes = books.isEmpty
+      ? []
+      : [CatalogLaneModel(title: Self.sideloadedLaneTitle, books: books, moreURL: nil)]
+    return mapped.toCatalogContent(prepending: lanes)
   }
 
   deinit {
@@ -163,7 +191,7 @@ final class CatalogViewModel: ObservableObject {
 
         guard !Task.isCancelled else { return }
 
-        let content = mapped.toCatalogContent()
+        let content = self.withSideloadedLane(mapped)
         self.state = .loaded(content)
         self.lastLoadedURL = url
         // Store under both the top-level URL and the active entry point href,
@@ -280,7 +308,7 @@ final class CatalogViewModel: ObservableObject {
     // Try synchronous cache check — instant swap, no opacity fade
     if let cachedFeed = repository.cachedFeed(for: href) {
       let mapped = Self.mapFeed(cachedFeed, bookRegistry: bookRegistry)
-      let newContent = mapped.toCatalogContent()
+      let newContent = withSideloadedLane(mapped)
       state = .loaded(CatalogContent(
         title: newContent.title,
         feed: newContent.feed,
@@ -305,7 +333,7 @@ final class CatalogViewModel: ObservableObject {
     do {
       if let feed = try await repository.loadTopLevelCatalog(at: href) {
         let mapped = Self.mapFeed(feed, bookRegistry: bookRegistry)
-        state = .loaded(mapped.toCatalogContent())
+        state = .loaded(withSideloadedLane(mapped))
         scrollGeneration &+= 1
       } else {
         state = .loaded(currentContent)
@@ -359,7 +387,7 @@ final class CatalogViewModel: ObservableObject {
 
     // Try repository cache — feed data exists but views need creation
     if let cachedFeed = repository.cachedFeed(for: href) {
-      let base = Self.mapFeed(cachedFeed, bookRegistry: bookRegistry).toCatalogContent()
+      let base = withSideloadedLane(Self.mapFeed(cachedFeed, bookRegistry: bookRegistry))
       let newContent = CatalogContent(
         title: base.title, feed: base.feed,
         selectors: CatalogSelectors(entryPoints: optimisticSelectors.entryPoints, facetGroups: base.selectors.facetGroups)
@@ -378,7 +406,7 @@ final class CatalogViewModel: ObservableObject {
 
     do {
       if let feed = try await repository.loadTopLevelCatalog(at: href) {
-        let base = Self.mapFeed(feed, bookRegistry: bookRegistry).toCatalogContent()
+        let base = withSideloadedLane(Self.mapFeed(feed, bookRegistry: bookRegistry))
         let newContent = CatalogContent(
           title: base.title, feed: base.feed,
           selectors: CatalogSelectors(entryPoints: optimisticSelectors.entryPoints, facetGroups: base.selectors.facetGroups)

--- a/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
@@ -86,11 +86,19 @@ final class CatalogViewModel: ObservableObject {
   /// ≥1 book; when it returns `[]` the result is identical to the un-injected
   /// baseline shape.
   private func withSideloadedLane(_ mapped: MappedCatalog) -> CatalogContent {
+    mapped.toCatalogContent(prepending: sideloadedLanes())
+  }
+
+  /// The "Side Loaded" lane rows for the current provider snapshot — empty when
+  /// side-loading is off or the registry has no books. Shared by the success
+  /// path (`withSideloadedLane`) and the failure path (`loadFailureState`, F-1)
+  /// so both surface exactly the same lane, and neither shows one when the
+  /// provider is empty.
+  private func sideloadedLanes() -> [CatalogLaneModel] {
     let books = sideloadedLaneBooksProvider()
-    let lanes = books.isEmpty
+    return books.isEmpty
       ? []
       : [CatalogLaneModel(title: Self.sideloadedLaneTitle, books: books, moreURL: nil)]
-    return mapped.toCatalogContent(prepending: lanes)
   }
 
   deinit {
@@ -138,7 +146,15 @@ final class CatalogViewModel: ObservableObject {
   /// generic error state (genuine online failure). Keeps the offline-vs-error
   /// decision in one place so both the nil-feed and thrown-error paths agree.
   private func loadFailureState(message: String) -> CatalogState {
-    reachability.isConnectedToNetwork() ? .error(message) : .offline
+    // F-1: attach the Side Loaded lane so imported books stay reachable even
+    // when the catalog feed fails. The feed error is still surfaced (the view
+    // renders the error/offline banner above the lane). When side-loading
+    // contributes no lane the states carry `[]`, so the plain error/offline
+    // presentation is byte-identical to the pre-F-1 behavior.
+    let lanes = sideloadedLanes()
+    return reachability.isConnectedToNetwork()
+      ? .error(message, sideloadedLanes: lanes)
+      : .offline(sideloadedLanes: lanes)
   }
 
   // MARK: - Public API

--- a/Palace/CatalogUI/Views/CatalogView.swift
+++ b/Palace/CatalogUI/Views/CatalogView.swift
@@ -153,11 +153,11 @@ private extension CatalogView {
             skeletonList
                 .accessibilityIdentifier(AccessibilityID.Catalog.loadingIndicator)
 
-        case .error(let message):
-            errorView(message: message)
+        case .error(let message, let sideloadedLanes):
+            errorView(message: message, sideloadedLanes: sideloadedLanes)
 
-        case .offline:
-            offlineView
+        case .offline(let sideloadedLanes):
+            offlineView(sideloadedLanes: sideloadedLanes)
 
         case .loaded(let catalogContent), .applyingFacet(let catalogContent):
             CatalogContentView(
@@ -194,7 +194,14 @@ private extension CatalogView {
         }
     }
 
-    private func errorView(message: String) -> some View {
+    private func errorView(message: String, sideloadedLanes: [CatalogLaneModel]) -> some View {
+        failureView(sideloadedLanes: sideloadedLanes) { errorBanner(message: message) }
+    }
+
+    /// The feed-error banner (headline + message + Reload). Extracted from
+    /// `errorView` so it can render either full-screen-centered (no side-loaded
+    /// books) or as a header above the Side Loaded lane (F-1).
+    private func errorBanner(message: String) -> some View {
         VStack(spacing: 16) {
             Text(Strings.Generic.error)
                 .font(.headline)
@@ -221,8 +228,6 @@ private extension CatalogView {
                 .cornerRadius(8)
             })
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
     }
 
     /// Offline state (PP-4578): shown when the catalog load fails because the
@@ -230,7 +235,14 @@ private extension CatalogView {
     /// (which cannot succeed offline) and instead points the patron to their
     /// downloaded books. The catalog reloads automatically when connectivity
     /// returns (handled in `CatalogViewModel`).
-    private var offlineView: some View {
+    private func offlineView(sideloadedLanes: [CatalogLaneModel]) -> some View {
+        failureView(sideloadedLanes: sideloadedLanes) { offlineBanner }
+    }
+
+    /// The offline banner (wifi.slash + message + Go-to-My-Books). Extracted so
+    /// it can render either full-screen-centered or above the Side Loaded lane
+    /// (F-1), mirroring `errorBanner`.
+    private var offlineBanner: some View {
         VStack(spacing: 16) {
             Image(systemName: "wifi.slash")
                 .font(.largeTitle)
@@ -258,9 +270,47 @@ private extension CatalogView {
             })
             .accessibilityIdentifier(AccessibilityID.Catalog.goToMyBooksButton)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
         .accessibilityIdentifier(AccessibilityID.Catalog.offlineStateView)
+    }
+
+    /// F-1 composition seam. When there are no side-loaded lanes the banner
+    /// fills the screen exactly as it did before F-1 (byte-identical layout).
+    /// When the Side Loaded lane is present, the banner becomes a header above
+    /// the lane inside a scroll view — the feed failure stays visible AND the
+    /// imported books remain reachable.
+    @ViewBuilder
+    private func failureView<Banner: View>(
+        sideloadedLanes: [CatalogLaneModel],
+        @ViewBuilder banner: () -> Banner
+    ) -> some View {
+        if sideloadedLanes.isEmpty {
+            banner()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    banner()
+                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal)
+                        .padding(.top, 8)
+
+                    ForEach(sideloadedLanes) { lane in
+                        CatalogLaneRowView(
+                            title: lane.title,
+                            books: lane.books,
+                            moreURL: lane.moreURL,
+                            onSelect: presentBookDetail,
+                            onMoreTapped: { title, url in
+                                coordinator.push(.catalogLaneMore(title: title, url: url))
+                            },
+                            showHeader: true
+                        )
+                    }
+                }
+                .padding(.vertical, 17)
+            }
+        }
     }
 
     func presentBookDetail(_ book: TPPBook) {

--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -365,19 +365,21 @@ final class RemoteFeatureFlags: @unchecked Sendable {
     /// building from Xcode gets the feature automatically. TestFlight and App
     /// Store builds respect the Firebase Remote Config flag (default off).
     ///
-    /// Override precedence (mirrors `isTriageBotEnabled`):
-    ///   1. UserDefaults local override (QA / staged demos)
-    ///   2. DEBUG build → true
-    ///   3. Firebase Remote Config
+    /// Side loading is a test-only capability enabled via the Testing settings
+    /// menu (per PP-2581), so it is OFF by default and turned on explicitly by a
+    /// tester/QA rather than auto-enabled by build configuration. A build-time
+    /// `#if DEBUG` gate would only enable it in local Xcode debug builds anyway
+    /// (TestFlight/Release are non-DEBUG), so it would not reach the QA builds
+    /// that actually need it — the dev-menu local override does.
+    ///
+    /// Override precedence:
+    ///   1. UserDefaults local override (dev-menu toggle / QA / staged demos)
+    ///   2. Firebase Remote Config (default `false`)
     var isSideLoadingEnabled: Bool {
         if let override = defaults.object(forKey: Self.sideLoadingLocalOverrideKey) as? Bool {
             return override
         }
-        #if DEBUG
-        return true
-        #else
         return isFeatureEnabled(.sideLoadingEnabled)
-        #endif
     }
 
     // MARK: - Device Info for Targeting

--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -58,6 +58,14 @@ final class RemoteFeatureFlags: @unchecked Sendable {
         /// `AudiobookSessionPresenter`. Default OFF — the feature is
         /// opt-in via the developer settings toggle until broad rollout.
         case inAppPlaybackNavEnabled = "in_app_playback_nav_enabled"
+        /// Gates every side-loading surface (swarm_495a88d9 — PP-2677 /
+        /// PP-2678 / PP-2679): the Settings "Side Loading" import screen and
+        /// the catalog side-loaded lane. Test-only capability for exercising
+        /// the real reader + DRM stack against local files with no OPDS feed.
+        /// Default OFF in production; DEBUG-on via `isSideLoadingEnabled` so
+        /// engineers building from Xcode get it automatically (mirrors the
+        /// triage-bot precedence per locked decision #2).
+        case sideLoadingEnabled = "side_loading_enabled"
 
         var defaultValue: Bool {
             switch self {
@@ -93,6 +101,8 @@ final class RemoteFeatureFlags: @unchecked Sendable {
                 return .triageBotAIFallbackEnabled
             case .inAppPlaybackNavEnabled:
                 return .inAppPlaybackNavEnabled
+            case .sideLoadingEnabled:
+                return .sideLoadingEnabled
             default:
                 return nil
             }
@@ -337,6 +347,37 @@ final class RemoteFeatureFlags: @unchecked Sendable {
             return override
         }
         return isFeatureEnabled(.inAppPlaybackNavEnabled)
+    }
+
+    /// UserDefaults override that lets QA / a developer force side loading on
+    /// or off without a Firebase round-trip. Settable from
+    /// `TPPDeveloperSettingsTableViewController`. Falls through to the
+    /// DEBUG default / Remote Config flag when nil. Mirrors the
+    /// `triageBotLocalOverrideKey` naming pattern.
+    static let sideLoadingLocalOverrideKey = "RemoteFeatureFlags.sideLoadingLocalOverride"
+
+    /// Whether the side-loading capability is enabled: the Settings "Side
+    /// Loading" import screen and the catalog side-loaded lane. A test-only
+    /// feature for exercising the real reader + DRM stack against local files
+    /// with no OPDS feed (swarm_495a88d9 — PP-2677 / PP-2678 / PP-2679).
+    ///
+    /// Defaults OFF in production, but ON in DEBUG builds so an engineer
+    /// building from Xcode gets the feature automatically. TestFlight and App
+    /// Store builds respect the Firebase Remote Config flag (default off).
+    ///
+    /// Override precedence (mirrors `isTriageBotEnabled`):
+    ///   1. UserDefaults local override (QA / staged demos)
+    ///   2. DEBUG build → true
+    ///   3. Firebase Remote Config
+    var isSideLoadingEnabled: Bool {
+        if let override = defaults.object(forKey: Self.sideLoadingLocalOverrideKey) as? Bool {
+            return override
+        }
+        #if DEBUG
+        return true
+        #else
+        return isFeatureEnabled(.sideLoadingEnabled)
+        #endif
     }
 
     // MARK: - Device Info for Targeting

--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -62,9 +62,11 @@ final class RemoteFeatureFlags: @unchecked Sendable {
         /// PP-2678 / PP-2679): the Settings "Side Loading" import screen and
         /// the catalog side-loaded lane. Test-only capability for exercising
         /// the real reader + DRM stack against local files with no OPDS feed.
-        /// Default OFF in production; DEBUG-on via `isSideLoadingEnabled` so
-        /// engineers building from Xcode get it automatically (mirrors the
-        /// triage-bot precedence per locked decision #2).
+        /// Default OFF; enabled via `isSideLoadingEnabled` whose precedence is
+        /// UserDefaults local override (dev-menu toggle) > Firebase remote
+        /// (default false). No DEBUG auto-enable — QA/TestFlight builds are
+        /// non-DEBUG, so the feature is turned on explicitly by the dev-menu
+        /// toggle rather than by build configuration.
         case sideLoadingEnabled = "side_loading_enabled"
 
         var defaultValue: Bool {
@@ -361,9 +363,9 @@ final class RemoteFeatureFlags: @unchecked Sendable {
     /// feature for exercising the real reader + DRM stack against local files
     /// with no OPDS feed (swarm_495a88d9 — PP-2677 / PP-2678 / PP-2679).
     ///
-    /// Defaults OFF in production, but ON in DEBUG builds so an engineer
-    /// building from Xcode gets the feature automatically. TestFlight and App
-    /// Store builds respect the Firebase Remote Config flag (default off).
+    /// Defaults OFF in production. There is NO DEBUG auto-enable; the feature
+    /// is turned on explicitly via the dev-menu local override, otherwise it
+    /// falls through to the Firebase Remote Config flag (default off).
     ///
     /// Side loading is a test-only capability enabled via the Testing settings
     /// menu (per PP-2581), so it is OFF by default and turned on explicitly by a

--- a/Palace/MyBooks/BookFileManager.swift
+++ b/Palace/MyBooks/BookFileManager.swift
@@ -79,7 +79,17 @@ class BookFileManager {
         // choke point every `fileUrl(for: identifier)` overload funnels
         // through, so the reader path is fixed without touching
         // MyBooksDownloadCenter.
-        let resolvedAccount = sideloadedIdentifiersProvider().contains(identifier)
+        //
+        // Perf: this method resolves EVERY book-file URL app-wide, so gate the
+        // provider call (NSLock + Set copy) behind the cheap "sideload-" prefix
+        // check. Side-loaded ids are minted with that prefix
+        // (`SideloadedBookManager.contentIdentifier`), so a normal id skips the
+        // lock entirely. The provider membership check is retained for
+        // prefixed ids as defense in depth (an id could carry the prefix
+        // without being registered). Coupling: this prefix MUST match the one
+        // `SideloadedBookManager.contentIdentifier` mints.
+        let resolvedAccount = (identifier.hasPrefix("sideload-")
+            && sideloadedIdentifiersProvider().contains(identifier))
             ? SideloadedBookRegistry.sideloadContentAccountID
             : account
         return fileUrl(for: book, account: resolvedAccount)

--- a/Palace/MyBooks/BookFileManager.swift
+++ b/Palace/MyBooks/BookFileManager.swift
@@ -34,17 +34,27 @@ class BookFileManager {
     /// depending on a real per-account App Support directory. Semantics
     /// match the existing production return: nil means "no directory".
     private let directoryProvider: ((String?) -> URL?)?
+    /// Identifiers of side-loaded books, resolved on each read. Side-loaded
+    /// content is account-agnostic and is written under one fixed account
+    /// (`SideloadedBookRegistry.sideloadContentAccountID`); this provider lets
+    /// `fileUrl(for:account:)` pin a side-loaded id to that account so a
+    /// library switch cannot orphan its file. Production resolves it lazily
+    /// through `AppContainer` (same cycle-avoidance pattern as elsewhere);
+    /// tests inject a fixed set. See sideloading-plan.md R6.
+    private let sideloadedIdentifiersProvider: () -> Set<String>
 
     init(
         bookRegistry: TPPBookRegistryProvider = AppContainer.production().bookRegistry,
         accountsManager: AccountsManager = AppContainer.production().accountsManager,
         fileManager: FileManager = .default,
-        directoryProvider: ((String?) -> URL?)? = nil
+        directoryProvider: ((String?) -> URL?)? = nil,
+        sideloadedIdentifiersProvider: @escaping () -> Set<String> = { AppContainer.production().sideloadedBookRegistry.identifiers }
     ) {
         self.bookRegistry = bookRegistry
         self.accountsManager = accountsManager
         self.fileManager = fileManager
         self.directoryProvider = directoryProvider
+        self.sideloadedIdentifiersProvider = sideloadedIdentifiersProvider
     }
 
     // MARK: - File URL
@@ -60,7 +70,19 @@ class BookFileManager {
         guard let book = bookRegistry.book(forIdentifier: identifier) else {
             return nil
         }
-        return fileUrl(for: book, account: account)
+        // Component 4 (sideloading-plan.md R6): side-loaded books are
+        // account-agnostic — their file is written under one fixed account.
+        // If `currentAccount` (or the caller-supplied account) differs, the
+        // per-account path would resolve the wrong directory → nil → the
+        // reader can't open the book after a library switch. Pin the read to
+        // the same fixed account the import wrote to. This is the single read
+        // choke point every `fileUrl(for: identifier)` overload funnels
+        // through, so the reader path is fixed without touching
+        // MyBooksDownloadCenter.
+        let resolvedAccount = sideloadedIdentifiersProvider().contains(identifier)
+            ? SideloadedBookRegistry.sideloadContentAccountID
+            : account
+        return fileUrl(for: book, account: resolvedAccount)
     }
 
     /// Returns the file URL for a book, accepting the book directly instead

--- a/Palace/MyBooks/Sideload/SideloadedBookManager.swift
+++ b/Palace/MyBooks/Sideload/SideloadedBookManager.swift
@@ -48,7 +48,7 @@ import PalaceLogging
 protocol SideloadedBookRegistering: AnyObject {
   var allBooks: [TPPBook] { get }
   var identifiers: Set<String> { get }
-  func add(book: TPPBook, fileURL: URL)
+  func add(book: TPPBook, fileURL: URL) throws
   func remove(identifier: String)
 }
 
@@ -84,6 +84,10 @@ enum SideloadImportError: Error, Equatable, CustomStringConvertible {
   case unreadableFile(URL)
   /// `BookFileManager` could not resolve a destination path.
   case destinationUnavailable
+  /// The side-load manifest could not be persisted; the import was aborted
+  /// before registering into the main registry to avoid a book that the
+  /// sync-exemption set won't cover (which would be silently evicted).
+  case persistenceFailed
 
   var description: String {
     switch self {
@@ -93,6 +97,8 @@ enum SideloadImportError: Error, Equatable, CustomStringConvertible {
       return "Could not read side-load file at \(url.lastPathComponent)."
     case .destinationUnavailable:
       return "Could not resolve a destination for the side-loaded file."
+    case .persistenceFailed:
+      return "Could not save the side-loaded book; the import was cancelled."
     }
   }
 }
@@ -236,7 +242,19 @@ final class SideloadedBookManager: @unchecked Sendable {
     // Truth store first (this IS the sync-exemption — Module A reads
     // `identifiers` live at sync time), then the main registry so the reader
     // and My Books see it as a completed download.
-    sideloadedRegistry.add(book: book, fileURL: fileURL)
+    //
+    // If the manifest does NOT persist, ABORT before touching the main
+    // registry: a book in the main registry but absent from the side-load
+    // manifest is not in the sync-exemption set, so the next `sync()` would
+    // evict it and delete its file (silent data loss). Roll back the copied
+    // file so a failed import leaves no orphan on disk.
+    do {
+      try sideloadedRegistry.add(book: book, fileURL: fileURL)
+    } catch {
+      try? fileManaging.removeFile(at: destination)
+      Log.error(#file, "Side-load import: manifest persist failed, aborting before main-registry write: \(error.localizedDescription)")
+      throw SideloadImportError.persistenceFailed
+    }
     bookRegistry.addBook(
       book,
       location: nil,

--- a/Palace/MyBooks/Sideload/SideloadedBookManager.swift
+++ b/Palace/MyBooks/Sideload/SideloadedBookManager.swift
@@ -50,6 +50,10 @@ protocol SideloadedBookRegistering: AnyObject {
   var identifiers: Set<String> { get }
   func add(book: TPPBook, fileURL: URL) throws
   func remove(identifier: String)
+  /// The original imported filename for a side-loaded book, if known. Surfaced
+  /// in the Settings manage-list caption (UI-2) so a row shows the file the
+  /// tester imported instead of the opaque content-hash identifier.
+  func originalFilename(for identifier: String) -> String?
 }
 
 extension SideloadedBookRegistry: SideloadedBookRegistering {}
@@ -197,6 +201,12 @@ final class SideloadedBookManager: @unchecked Sendable {
   /// and (indirectly) the side-loaded catalog lane.
   var allBooks: [TPPBook] {
     sideloadedRegistry.allBooks
+  }
+
+  /// The original imported filename for a side-loaded book (UI-2). Returns nil
+  /// for an unknown identifier; callers fall back to the book title.
+  func originalFilename(for identifier: String) -> String? {
+    sideloadedRegistry.originalFilename(for: identifier)
   }
 
   // MARK: Import

--- a/Palace/MyBooks/Sideload/SideloadedBookManager.swift
+++ b/Palace/MyBooks/Sideload/SideloadedBookManager.swift
@@ -1,0 +1,363 @@
+//
+//  SideloadedBookManager.swift
+//  Palace
+//
+//  Orchestrates the side-loading import flow (PP-2677).
+//
+//  Side-loading is a test-only capability (see
+//  `docs/architecture/sideloading-plan.md`): a user imports a local
+//  EPUB / PDF / audiobook file from Settings and it is registered into the
+//  main `TPPBookRegistry` as `.downloadSuccessful` so the real reader + DRM
+//  stack opens it with no OPDS feed involved.
+//
+//  This manager is the *behaviour* on top of `SideloadedBookRegistry` (the
+//  truth store, Module A). It:
+//    1. classifies the file by extension → MIME → `TPPBookContentType`,
+//       rejecting unsupported types before anything is written;
+//    2. mints a synthetic OPEN-ACCESS `TPPBook` whose single acquisition MIME
+//       matches the content type (so `defaultBookContentType` resolves and the
+//       reader opens it instead of showing `presentUnsupportedItemError`);
+//    3. copies the file to the FIXED-account content path
+//       (`SideloadedBookRegistry.sideloadContentAccountID`) — the SAME account
+//       `BookFileManager` (Module A, Component 4) substitutes on the read side,
+//       so a library switch cannot orphan the file;
+//    4. registers the book into BOTH the side-loaded registry (truth) AND the
+//       main registry as `.downloadSuccessful`. Adding to the side-loaded
+//       registry IS the sync-exemption (Module A reads its `identifiers` live
+//       at sync time) — there is no separate exemption store.
+//
+//  `remove` reverses all three. `rehydrateAtLaunch` re-registers the persisted
+//  side-loaded books into the main registry after a cold launch (the main
+//  registry does not persist side-loaded-ness).
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import CryptoKit
+import PalaceCatalog
+import PalaceLogging
+
+// MARK: - Seams
+
+/// The behavioural slice of `SideloadedBookRegistry` this manager depends on.
+/// Declared here (not on Module A's type) so the manager can be unit- and
+/// contract-tested against a spy without touching the off-limits registry file.
+/// `SideloadedBookRegistry` already satisfies every requirement; the conformance
+/// is declared below.
+protocol SideloadedBookRegistering: AnyObject {
+  var allBooks: [TPPBook] { get }
+  var identifiers: Set<String> { get }
+  func add(book: TPPBook, fileURL: URL)
+  func remove(identifier: String)
+}
+
+extension SideloadedBookRegistry: SideloadedBookRegistering {}
+
+/// Result of classifying an import candidate.
+struct SideloadClassification: Equatable {
+  let contentType: TPPBookContentType
+  /// The acquisition MIME to mint the synthetic book with. Must round-trip
+  /// through `TPPBookContentType.from(mimeType:)` back to `contentType`.
+  let mimeType: String
+}
+
+/// Classifies an import candidate by file type. A seam so the contract test can
+/// record the classify step and the unit test can force error paths.
+protocol SideloadContentClassifier {
+  func classify(fileURL: URL) throws -> SideloadClassification
+}
+
+/// The file operations the import/remove flow needs. A seam so tests can record
+/// the copy step (contract snapshot) and drive copy failures.
+protocol SideloadFileManaging {
+  func copyFile(from source: URL, to destination: URL) throws
+  func removeFile(at url: URL) throws
+}
+
+// MARK: - Errors
+
+enum SideloadImportError: Error, Equatable, CustomStringConvertible {
+  /// The file extension / MIME did not resolve to EPUB, PDF or audiobook.
+  case unsupportedFileType(String)
+  /// The source file could not be read (missing / unreadable).
+  case unreadableFile(URL)
+  /// `BookFileManager` could not resolve a destination path.
+  case destinationUnavailable
+
+  var description: String {
+    switch self {
+    case let .unsupportedFileType(ext):
+      return "Unsupported side-load file type: \"\(ext)\". Supported: EPUB, PDF, audiobook manifest."
+    case let .unreadableFile(url):
+      return "Could not read side-load file at \(url.lastPathComponent)."
+    case .destinationUnavailable:
+      return "Could not resolve a destination for the side-loaded file."
+    }
+  }
+}
+
+// MARK: - Default seam implementations
+
+/// Extension → MIME classification. LCP-encrypted EPUBs are still `.epub`
+/// files; audiobooks import as their manifest JSON.
+struct DefaultSideloadContentClassifier: SideloadContentClassifier {
+  func classify(fileURL: URL) throws -> SideloadClassification {
+    let ext = fileURL.pathExtension.lowercased()
+    let mimeType: String
+    switch ext {
+    case "epub":
+      mimeType = ContentTypeEpubZip
+    case "pdf":
+      mimeType = ContentTypeOpenAccessPDF
+    case "json", "audiobook":
+      mimeType = ContentTypeOpenAccessAudiobook
+    default:
+      throw SideloadImportError.unsupportedFileType(ext.isEmpty ? "<none>" : ext)
+    }
+    // Defend against a mapping drift: the minted MIME MUST classify back to a
+    // supported content type, else the reader would show the unsupported-item
+    // error after import.
+    let contentType = TPPBookContentType.from(mimeType: mimeType)
+    guard contentType != .unsupported else {
+      throw SideloadImportError.unsupportedFileType(ext)
+    }
+    return SideloadClassification(contentType: contentType, mimeType: mimeType)
+  }
+}
+
+/// `FileManager`-backed file operations. Creates the destination's parent
+/// directory (the test `directoryProvider` path does not create it) and
+/// overwrites an existing file so a re-import of the same content is idempotent.
+struct DefaultSideloadFileManaging: SideloadFileManaging {
+  let fileManager: FileManager
+
+  init(fileManager: FileManager = .default) {
+    self.fileManager = fileManager
+  }
+
+  func copyFile(from source: URL, to destination: URL) throws {
+    let directory = destination.deletingLastPathComponent()
+    if !fileManager.fileExists(atPath: directory.path) {
+      try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+    if fileManager.fileExists(atPath: destination.path) {
+      try fileManager.removeItem(at: destination)
+    }
+    try fileManager.copyItem(at: source, to: destination)
+  }
+
+  func removeFile(at url: URL) throws {
+    guard fileManager.fileExists(atPath: url.path) else { return }
+    try fileManager.removeItem(at: url)
+  }
+}
+
+// MARK: - SideloadedBookManager
+
+/// Concurrency: `@unchecked Sendable`. All stored dependencies are immutable
+/// `let`s and are themselves internally synchronised (the registries are
+/// lock/queue-backed; `BookFileManager` is effectively stateless path logic).
+/// The manager holds no mutable state of its own. It is cached in an
+/// `AppContainer` static the same way `SideloadedBookRegistry` is, and its
+/// `rehydrateAtLaunch()` runs off the main actor from the registry-load
+/// completion — so it cannot be `@MainActor`-only.
+final class SideloadedBookManager: @unchecked Sendable {
+
+  private let bookRegistry: TPPBookRegistryProvider
+  private let sideloadedRegistry: SideloadedBookRegistering
+  private let bookFileManager: BookFileManager
+  private let classifier: SideloadContentClassifier
+  private let fileManaging: SideloadFileManaging
+  private let imageCache: ImageCacheType
+
+  init(
+    bookRegistry: TPPBookRegistryProvider,
+    sideloadedRegistry: SideloadedBookRegistering,
+    bookFileManager: BookFileManager,
+    classifier: SideloadContentClassifier = DefaultSideloadContentClassifier(),
+    fileManaging: SideloadFileManaging = DefaultSideloadFileManaging(),
+    imageCache: ImageCacheType = ImageCache.shared
+  ) {
+    self.bookRegistry = bookRegistry
+    self.sideloadedRegistry = sideloadedRegistry
+    self.bookFileManager = bookFileManager
+    self.classifier = classifier
+    self.fileManaging = fileManaging
+    self.imageCache = imageCache
+  }
+
+  /// Every side-loaded book, in import order. Drives the Settings manage-list
+  /// and (indirectly) the side-loaded catalog lane.
+  var allBooks: [TPPBook] {
+    sideloadedRegistry.allBooks
+  }
+
+  // MARK: Import
+
+  /// Import a local file as a side-loaded book. Returns the minted `TPPBook`.
+  ///
+  /// The identifier is derived from the file's CONTENT (sha256), so importing
+  /// the same file twice yields the same identifier — the second import
+  /// overwrites in place rather than creating a duplicate lane entry (dedup).
+  ///
+  /// Ordered effects (pinned by `SideloadImportContractTests`):
+  /// classify → copyFile → sideloadedRegistry.add → bookRegistry.addBook.
+  @discardableResult
+  func `import`(fileURL: URL) throws -> TPPBook {
+    let classification = try classifier.classify(fileURL: fileURL)
+
+    let identifier = try Self.contentIdentifier(for: fileURL)
+    let title = fileURL.deletingPathExtension().lastPathComponent
+    let book = Self.mintOpenAccessBook(
+      identifier: identifier,
+      title: title.isEmpty ? "Side-loaded book" : title,
+      mimeType: classification.mimeType,
+      imageCache: imageCache
+    )
+
+    // Pin the write to the FIXED side-load account (NOT currentAccountId) so
+    // the file remains resolvable after a library switch. Module A's read-side
+    // resolution substitutes the same account for side-loaded ids.
+    guard let destination = bookFileManager.fileUrl(
+      for: book,
+      account: SideloadedBookRegistry.sideloadContentAccountID
+    ) else {
+      throw SideloadImportError.destinationUnavailable
+    }
+
+    do {
+      try fileManaging.copyFile(from: fileURL, to: destination)
+    } catch {
+      Log.error(#file, "Side-load import: file copy failed: \(error.localizedDescription)")
+      throw error
+    }
+
+    // Truth store first (this IS the sync-exemption — Module A reads
+    // `identifiers` live at sync time), then the main registry so the reader
+    // and My Books see it as a completed download.
+    sideloadedRegistry.add(book: book, fileURL: fileURL)
+    bookRegistry.addBook(
+      book,
+      location: nil,
+      state: .downloadSuccessful,
+      fulfillmentId: nil,
+      readiumBookmarks: nil,
+      genericBookmarks: nil
+    )
+
+    Log.info(#file, "Side-loaded \(classification.contentType) book imported: \(identifier)")
+    return book
+  }
+
+  // MARK: Remove
+
+  /// Forget a side-loaded book: delete its on-disk file, then remove it from
+  /// the side-loaded registry AND the main registry. No-op for an unknown id.
+  func remove(identifier: String) {
+    let book = bookRegistry.book(forIdentifier: identifier)
+      ?? sideloadedRegistry.allBooks.first { $0.identifier == identifier }
+
+    if let book,
+       let fileURL = bookFileManager.fileUrl(
+        for: book,
+        account: SideloadedBookRegistry.sideloadContentAccountID
+       ) {
+      do {
+        try fileManaging.removeFile(at: fileURL)
+      } catch {
+        Log.warn(#file, "Side-load remove: could not delete file \(fileURL.lastPathComponent): \(error.localizedDescription)")
+      }
+    }
+
+    sideloadedRegistry.remove(identifier: identifier)
+    bookRegistry.removeBook(forIdentifier: identifier)
+  }
+
+  // MARK: Launch rehydration
+
+  /// Re-register every persisted side-loaded book into the MAIN registry as
+  /// `.downloadSuccessful`. The main registry does not persist side-loaded-ness,
+  /// so a cold launch loses these entries until this runs. Idempotent: a book
+  /// already present in the main registry is skipped, so running twice does not
+  /// duplicate or reset state.
+  ///
+  /// MUST be driven from the `bookRegistry.load(completion:)` callback (see
+  /// `TPPAppDelegate.setupBookRegistryAndNotifications`): `load()` is async and
+  /// a rehydrate that ran before the disk snapshot landed would be clobbered.
+  func rehydrateAtLaunch() {
+    for book in sideloadedRegistry.allBooks
+    where bookRegistry.book(forIdentifier: book.identifier) == nil {
+      bookRegistry.addBook(
+        book,
+        location: nil,
+        state: .downloadSuccessful,
+        fulfillmentId: nil,
+        readiumBookmarks: nil,
+        genericBookmarks: nil
+      )
+    }
+  }
+
+  // MARK: Minting
+
+  /// A stable, content-derived identifier. The sha256 of THIS string is what
+  /// `BookFileManager` uses for the on-disk path; deriving the id from content
+  /// is what makes a re-import of the same file dedup.
+  static func contentIdentifier(for fileURL: URL) throws -> String {
+    let data: Data
+    do {
+      data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+    } catch {
+      throw SideloadImportError.unreadableFile(fileURL)
+    }
+    let digest = SHA256.hash(data: data)
+    let hex = digest.map { String(format: "%02x", $0) }.joined()
+    return "sideload-\(hex)"
+  }
+
+  /// Mints a synthetic OPEN-ACCESS `TPPBook` with exactly one acquisition whose
+  /// MIME is `mimeType` — DRM-free (no revoke URL, no bearer token, no
+  /// needs-auth acquisition), unlimited availability, no cover.
+  static func mintOpenAccessBook(
+    identifier: String,
+    title: String,
+    mimeType: String,
+    imageCache: ImageCacheType
+  ) -> TPPBook {
+    let acquisition = TPPOPDSAcquisition(
+      relation: .openAccess,
+      type: mimeType,
+      hrefURL: URL(string: "palace-sideload://\(identifier)") ?? URL(fileURLWithPath: "/"),
+      indirectAcquisitions: [],
+      availability: TPPOPDSAcquisitionAvailabilityUnlimited()
+    )
+    return TPPBook(
+      acquisitions: [acquisition],
+      authors: nil,
+      categoryStrings: nil,
+      distributor: nil,
+      identifier: identifier,
+      imageURL: nil,
+      imageThumbnailURL: nil,
+      published: nil,
+      publisher: nil,
+      subtitle: nil,
+      summary: nil,
+      title: title,
+      updated: Date(),
+      annotationsURL: nil,
+      analyticsURL: nil,
+      alternateURL: nil,
+      relatedWorksURL: nil,
+      previewLink: nil,
+      seriesURL: nil,
+      revokeURL: nil,
+      reportURL: nil,
+      timeTrackingURL: nil,
+      contributors: nil,
+      bookDuration: nil,
+      imageCache: imageCache
+    )
+  }
+}

--- a/Palace/MyBooks/Sideload/SideloadedBookRegistry.swift
+++ b/Palace/MyBooks/Sideload/SideloadedBookRegistry.swift
@@ -131,43 +131,79 @@ final class SideloadedBookRegistry: @unchecked Sendable {
   /// Record (or overwrite) a side-loaded book plus the file it was imported
   /// from. A repeat `add` for the same identifier updates in place — it does
   /// not create a duplicate lane entry.
-  func add(book: TPPBook, fileURL: URL) {
+  /// Record (or overwrite) a side-loaded book plus its imported file, then
+  /// persist. THROWS if the manifest write fails, rolling the in-memory
+  /// mutation back first so the failure is atomic — the caller (import) can
+  /// then abort before registering into the main registry. A repeat `add` for
+  /// the same identifier updates in place; it does not create a duplicate.
+  func add(book: TPPBook, fileURL: URL) throws {
     lock.lock()
     defer { lock.unlock() }
-    if entriesByIdentifier[book.identifier] == nil {
+    let previousEntry = entriesByIdentifier[book.identifier]
+    let wasPresent = previousEntry != nil
+    if !wasPresent {
       order.append(book.identifier)
     }
     entriesByIdentifier[book.identifier] = Entry(
       book: book,
       originalFilename: fileURL.lastPathComponent
     )
-    persistLocked()
+    do {
+      try persistLocked()
+    } catch {
+      // Roll the mutation back so a persist failure leaves the registry
+      // exactly as it was — the add is all-or-nothing.
+      if wasPresent {
+        entriesByIdentifier[book.identifier] = previousEntry
+      } else {
+        entriesByIdentifier[book.identifier] = nil
+        order.removeAll { $0 == book.identifier }
+      }
+      throw error
+    }
   }
 
-  /// Forget a side-loaded book. No-op if the identifier is unknown.
+  /// Forget a side-loaded book. No-op if the identifier is unknown. Persist is
+  /// best-effort: a failed remove-persist leaves a stale manifest entry (the
+  /// book reappears next launch pointing at a deleted file), which is a
+  /// self-healing nuisance, not the silent data loss `add` guards against — so
+  /// this path logs (inside `persistLocked`) and swallows rather than throws.
   func remove(identifier: String) {
     lock.lock()
     defer { lock.unlock() }
     guard entriesByIdentifier[identifier] != nil else { return }
     entriesByIdentifier[identifier] = nil
     order.removeAll { $0 == identifier }
-    persistLocked()
+    try? persistLocked()
   }
 
-  /// Rename a side-loaded book's display title in place. No-op if unknown.
+  /// Rename a side-loaded book's display title. No-op if unknown. Replaces the
+  /// stored `TPPBook` with a copy carrying the new title rather than mutating
+  /// the shared instance in place: that same `TPPBook` reference was handed to
+  /// the main `TPPBookRegistry` at import, so an in-place `title` write could
+  /// race main-registry / Catalog readers (only this registry's lock guards
+  /// the write). Persist is best-effort (see `remove`).
   func rename(identifier: String, to newTitle: String) {
     lock.lock()
     defer { lock.unlock() }
     guard let entry = entriesByIdentifier[identifier] else { return }
-    // `TPPBook.title` is a mutable `var`; the book is a reference type, so
-    // mutating the stored instance's title is the rename.
-    entry.book.title = newTitle
-    persistLocked()
+    // `bookWithMetadata(from:)` returns a fresh, distinct `TPPBook` (a full
+    // copy of `entry.book`). Mutating THAT copy's title is safe — it is not the
+    // instance the main registry holds — whereas mutating `entry.book.title`
+    // directly would race the shared reference.
+    let renamed = entry.book.bookWithMetadata(from: entry.book)
+    renamed.title = newTitle
+    entriesByIdentifier[identifier] = Entry(
+      book: renamed,
+      originalFilename: entry.originalFilename
+    )
+    try? persistLocked()
   }
 
   /// Replace the persisted book for an identifier (e.g. after re-minting
   /// metadata) while preserving the original imported filename. No-op if the
-  /// identifier is unknown — `update` never inserts.
+  /// identifier is unknown — `update` never inserts. Persist is best-effort
+  /// (see `remove`).
   func update(book: TPPBook) {
     lock.lock()
     defer { lock.unlock() }
@@ -176,12 +212,20 @@ final class SideloadedBookRegistry: @unchecked Sendable {
       book: book,
       originalFilename: existing.originalFilename
     )
-    persistLocked()
+    try? persistLocked()
   }
 
   // MARK: - Persistence (lock held by caller)
 
-  private func persistLocked() {
+  /// Writes the manifest to disk. Throws on any write failure so callers on
+  /// the atomicity-critical import path (`add`) can abort loudly instead of
+  /// silently proceeding to register a book the manifest doesn't record — a
+  /// book present in the main registry but absent from the side-load manifest
+  /// is not in the sync-exemption set and would be evicted (silent data loss).
+  /// The nil-`manifestURL` degraded mode (no Application Support path) is NOT a
+  /// write failure: it is the documented in-memory-only fallback, so it returns
+  /// without throwing.
+  private func persistLocked() throws {
     guard let manifestURL else {
       Log.warn(#file, "SideloadedBookRegistry: no manifest URL — side-loaded state will not persist")
       return
@@ -204,6 +248,7 @@ final class SideloadedBookRegistry: @unchecked Sendable {
       try data.write(to: manifestURL, options: .atomic)
     } catch {
       Log.error(#file, "SideloadedBookRegistry: failed to persist manifest: \(error.localizedDescription)")
+      throw error
     }
   }
 

--- a/Palace/MyBooks/Sideload/SideloadedBookRegistry.swift
+++ b/Palace/MyBooks/Sideload/SideloadedBookRegistry.swift
@@ -1,0 +1,237 @@
+//
+//  SideloadedBookRegistry.swift
+//  Palace
+//
+//  Dedicated, local-only persistence for side-loaded books (PP-2678).
+//
+//  Side-loading is a test-only capability (see
+//  `docs/architecture/sideloading-plan.md`): a user imports a local
+//  EPUB / PDF / audiobook file and it is registered into the main
+//  `TPPBookRegistry` as `.downloadSuccessful` so the real reader + DRM
+//  stack opens it with no OPDS feed involved.
+//
+//  This registry is the *source of truth* for "what is side-loaded". It
+//  serves two consumers:
+//    1. The main registry's server `sync()` reconciliation subtracts
+//       `identifiers` from its delete set so a loans feed that (of course)
+//       never lists a side-loaded book does not evict it + delete its file.
+//       This read happens INSIDE `BookRegistrySync.sync()` on the main
+//       actor, so it MUST be a cheap synchronous read.
+//    2. The side-loaded catalog lane (Module D) renders `allBooks`.
+//
+//  Persistence is a private JSON manifest, separate from `registry.json`,
+//  under Application Support (backup-excluded, consistent with the main
+//  registry — the ticket's "Documents folder" wording is illustrative; see
+//  the plan's persistence-location open item). It is NOT account-scoped or
+//  server-synced: side-loaded content is account-agnostic.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import PalaceLogging
+
+/// Local-only registry of side-loaded books.
+///
+/// Concurrency: `@unchecked Sendable`. INVARIANT — every access to the two
+/// mutable stores (`entriesByIdentifier`, `order`) is serialised through
+/// `lock`; the manifest is (re)written synchronously while the lock is held,
+/// so a reader never observes a half-applied mutation and two writers never
+/// race the file. `fileManager` and `manifestURL` are immutable `let`s. This
+/// follows the module-3 playbook (prefer `NSLock` + documented invariant over
+/// `nonisolated(unsafe)`). `identifiers`/`allBooks` are read from BOTH the
+/// main-actor sync path and the (off-main) import path, so the type cannot be
+/// `@MainActor`-only.
+final class SideloadedBookRegistry: @unchecked Sendable {
+
+  /// Fixed account the side-loaded content directory is pinned to. Side-loaded
+  /// books are account-agnostic, but `BookFileManager.fileUrl` resolves a
+  /// per-account path. Pinning BOTH the write (Module C's import copy) AND the
+  /// read (`BookFileManager` Component 4) to this one account means a library
+  /// switch cannot orphan a side-loaded file. `TPPAccountUUIDs[0]` is the
+  /// primary/no-subpath account — `TPPBookContentMetadataFilesHelper.directory`
+  /// appends no sub-path for it, giving the stable
+  /// `<AppSupport>/<bundleID>/content/` directory. Both sides consume THIS
+  /// constant so they can never pick the account independently.
+  static let sideloadContentAccountID = AccountsManager.TPPAccountUUIDs[0]
+
+  /// One persisted side-loaded book: the `TPPBook` plus the original imported
+  /// filename (surfaced in the manage-list UI, Module C).
+  private struct Entry {
+    let book: TPPBook
+    let originalFilename: String
+  }
+
+  private let lock = NSLock()
+  private let fileManager: FileManager
+  /// Manifest file URL. Optional because directory resolution can fail (no
+  /// Application Support path / missing bundle id) — in that degraded state
+  /// the registry works in-memory and simply cannot persist.
+  private let manifestURL: URL?
+
+  private var entriesByIdentifier: [String: Entry] = [:]
+  /// Insertion order of identifiers, so `allBooks` is stable across reloads.
+  private var order: [String] = []
+
+  // MARK: - JSON keys
+
+  private enum ManifestKey {
+    static let books = "books"
+    static let book = "book"
+    static let filename = "filename"
+  }
+
+  // MARK: - Init
+
+  /// - Parameters:
+  ///   - fileManager: injectable for tests; production uses `.default`.
+  ///   - manifestDirectory: test seam. When non-nil, the manifest lives at
+  ///     `<manifestDirectory>/sideloaded.json`; when nil (production) it
+  ///     resolves under Application Support at
+  ///     `<AppSupport>/<bundleID>/sideloaded/sideloaded.json`.
+  init(fileManager: FileManager = .default, manifestDirectory: URL? = nil) {
+    self.fileManager = fileManager
+    if let manifestDirectory {
+      self.manifestURL = manifestDirectory.appendingPathComponent("sideloaded.json")
+    } else {
+      self.manifestURL = TPPBookContentMetadataFilesHelper
+        .directory(for: Self.sideloadContentAccountID)?
+        .appendingPathComponent("sideloaded")
+        .appendingPathComponent("sideloaded.json")
+    }
+    loadFromDisk()
+  }
+
+  // MARK: - Public read surface
+
+  /// Identifiers of every side-loaded book. Cheap synchronous read — this is
+  /// what `BookRegistrySync.sync()` subtracts from its delete set.
+  var identifiers: Set<String> {
+    lock.lock()
+    defer { lock.unlock() }
+    return Set(entriesByIdentifier.keys)
+  }
+
+  /// Every side-loaded book, in import order. Drives the side-loaded lane.
+  var allBooks: [TPPBook] {
+    lock.lock()
+    defer { lock.unlock() }
+    return order.compactMap { entriesByIdentifier[$0]?.book }
+  }
+
+  /// Original imported filename for a side-loaded book, if known.
+  func originalFilename(for identifier: String) -> String? {
+    lock.lock()
+    defer { lock.unlock() }
+    return entriesByIdentifier[identifier]?.originalFilename
+  }
+
+  // MARK: - Public mutation surface
+
+  /// Record (or overwrite) a side-loaded book plus the file it was imported
+  /// from. A repeat `add` for the same identifier updates in place — it does
+  /// not create a duplicate lane entry.
+  func add(book: TPPBook, fileURL: URL) {
+    lock.lock()
+    defer { lock.unlock() }
+    if entriesByIdentifier[book.identifier] == nil {
+      order.append(book.identifier)
+    }
+    entriesByIdentifier[book.identifier] = Entry(
+      book: book,
+      originalFilename: fileURL.lastPathComponent
+    )
+    persistLocked()
+  }
+
+  /// Forget a side-loaded book. No-op if the identifier is unknown.
+  func remove(identifier: String) {
+    lock.lock()
+    defer { lock.unlock() }
+    guard entriesByIdentifier[identifier] != nil else { return }
+    entriesByIdentifier[identifier] = nil
+    order.removeAll { $0 == identifier }
+    persistLocked()
+  }
+
+  /// Rename a side-loaded book's display title in place. No-op if unknown.
+  func rename(identifier: String, to newTitle: String) {
+    lock.lock()
+    defer { lock.unlock() }
+    guard let entry = entriesByIdentifier[identifier] else { return }
+    // `TPPBook.title` is a mutable `var`; the book is a reference type, so
+    // mutating the stored instance's title is the rename.
+    entry.book.title = newTitle
+    persistLocked()
+  }
+
+  /// Replace the persisted book for an identifier (e.g. after re-minting
+  /// metadata) while preserving the original imported filename. No-op if the
+  /// identifier is unknown — `update` never inserts.
+  func update(book: TPPBook) {
+    lock.lock()
+    defer { lock.unlock() }
+    guard let existing = entriesByIdentifier[book.identifier] else { return }
+    entriesByIdentifier[book.identifier] = Entry(
+      book: book,
+      originalFilename: existing.originalFilename
+    )
+    persistLocked()
+  }
+
+  // MARK: - Persistence (lock held by caller)
+
+  private func persistLocked() {
+    guard let manifestURL else {
+      Log.warn(#file, "SideloadedBookRegistry: no manifest URL — side-loaded state will not persist")
+      return
+    }
+    let records: [[String: Any]] = order.compactMap { identifier in
+      guard let entry = entriesByIdentifier[identifier] else { return nil }
+      return [
+        ManifestKey.book: entry.book.dictionaryRepresentation(),
+        ManifestKey.filename: entry.originalFilename
+      ]
+    }
+    let manifest: [String: Any] = [ManifestKey.books: records]
+    do {
+      let directoryURL = manifestURL.deletingLastPathComponent()
+      if !fileManager.fileExists(atPath: directoryURL.path) {
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+      }
+      directoryURL.excludeFromBackup()
+      let data = try JSONSerialization.data(withJSONObject: manifest, options: .fragmentsAllowed)
+      try data.write(to: manifestURL, options: .atomic)
+    } catch {
+      Log.error(#file, "SideloadedBookRegistry: failed to persist manifest: \(error.localizedDescription)")
+    }
+  }
+
+  private func loadFromDisk() {
+    guard let manifestURL,
+          fileManager.fileExists(atPath: manifestURL.path),
+          let data = try? Data(contentsOf: manifestURL),
+          let json = try? JSONSerialization.jsonObject(with: data),
+          let dict = json as? [String: Any],
+          let records = dict[ManifestKey.books] as? [[String: Any]]
+    else {
+      // Missing / corrupt / empty / wrong-shape manifest: start empty. Never
+      // throw — a bad manifest must not crash launch.
+      return
+    }
+
+    for record in records {
+      guard let bookDict = record[ManifestKey.book] as? [String: Any],
+            let book = TPPBook(dictionary: bookDict)
+      else {
+        Log.warn(#file, "SideloadedBookRegistry: dropping unreadable manifest record")
+        continue
+      }
+      let filename = record[ManifestKey.filename] as? String ?? ""
+      if entriesByIdentifier[book.identifier] == nil {
+        order.append(book.identifier)
+      }
+      entriesByIdentifier[book.identifier] = Entry(book: book, originalFilename: filename)
+    }
+  }
+}

--- a/Palace/Settings/NewSettings/SideLoadingView.swift
+++ b/Palace/Settings/NewSettings/SideLoadingView.swift
@@ -1,0 +1,152 @@
+//
+//  SideLoadingView.swift
+//  Palace
+//
+//  Settings "Side Loading" screen (PP-2677). A test-only affordance, gated by
+//  `RemoteFeatureFlags.isSideLoadingEnabled` at the call site in
+//  `TPPSettingsView`. Lets a tester import a local EPUB / PDF / audiobook
+//  manifest file and manage (delete) the imported set. Importing registers the
+//  book so it opens in the real reader + DRM stack with no OPDS feed.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+// MARK: - View model
+
+/// Drives `SideLoadingView`. Thin layer over `SideloadedBookManager`.
+@MainActor
+final class SideLoadingViewModel: ObservableObject {
+
+  /// The imported books, newest state re-read from the manager after every
+  /// mutation so the manage-list stays in sync.
+  @Published private(set) var books: [TPPBook] = []
+  /// Non-nil while an import error alert should be shown.
+  @Published var errorMessage: String?
+  @Published var isImporterPresented = false
+
+  private let manager: SideloadedBookManager
+
+  init(manager: SideloadedBookManager) {
+    self.manager = manager
+    refresh()
+  }
+
+  func refresh() {
+    books = manager.allBooks
+  }
+
+  /// Handle the `.fileImporter` result. Security-scoped access is required for
+  /// files the document picker returns from outside the app sandbox.
+  func handleImport(result: Result<[URL], Error>) {
+    switch result {
+    case let .success(urls):
+      guard let url = urls.first else { return }
+      let needsScopedAccess = url.startAccessingSecurityScopedResource()
+      defer { if needsScopedAccess { url.stopAccessingSecurityScopedResource() } }
+      do {
+        _ = try manager.import(fileURL: url)
+        refresh()
+      } catch {
+        errorMessage = "\(error)"
+      }
+    case let .failure(error):
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  func delete(_ book: TPPBook) {
+    manager.remove(identifier: book.identifier)
+    refresh()
+  }
+
+  func delete(at offsets: IndexSet) {
+    for index in offsets {
+      guard books.indices.contains(index) else { continue }
+      manager.remove(identifier: books[index].identifier)
+    }
+    refresh()
+  }
+
+  /// The content types the picker accepts. Audiobooks import as a manifest
+  /// JSON (`.json`); EPUB and PDF have first-class UTTypes.
+  var allowedContentTypes: [UTType] {
+    var types: [UTType] = [.pdf, .json]
+    if let epub = UTType(filenameExtension: "epub") {
+      types.insert(epub, at: 0)
+    }
+    return types
+  }
+}
+
+// MARK: - View
+
+struct SideLoadingView: View {
+  @StateObject private var viewModel: SideLoadingViewModel
+
+  init(manager: SideloadedBookManager) {
+    _viewModel = StateObject(wrappedValue: SideLoadingViewModel(manager: manager))
+  }
+
+  var body: some View {
+    List {
+      Section(footer: Text("Import a local EPUB, PDF, or audiobook manifest to open it in the reader without a catalog feed. For testing only.")) {
+        Button {
+          viewModel.isImporterPresented = true
+        } label: {
+          Label("Import File…", systemImage: "square.and.arrow.down")
+        }
+        .accessibilityIdentifier("settings.sideloading.import")
+      }
+
+      if viewModel.books.isEmpty {
+        Section {
+          Text("No side-loaded books yet.")
+            .foregroundColor(.secondary)
+        }
+      } else {
+        Section(header: Text("Imported")) {
+          ForEach(viewModel.books, id: \.identifier) { book in
+            VStack(alignment: .leading, spacing: 2) {
+              Text(book.title)
+              Text(book.identifier)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+            }
+            .swipeActions {
+              Button(role: .destructive) {
+                viewModel.delete(book)
+              } label: {
+                Label("Delete", systemImage: "trash")
+              }
+            }
+          }
+          .onDelete(perform: viewModel.delete(at:))
+        }
+      }
+    }
+    .navigationTitle("Side Loading")
+    .fileImporter(
+      isPresented: $viewModel.isImporterPresented,
+      allowedContentTypes: viewModel.allowedContentTypes,
+      allowsMultipleSelection: false
+    ) { result in
+      viewModel.handleImport(result: result)
+    }
+    .alert(
+      "Import Failed",
+      isPresented: Binding(
+        get: { viewModel.errorMessage != nil },
+        set: { if !$0 { viewModel.errorMessage = nil } }
+      )
+    ) {
+      Button("OK", role: .cancel) { viewModel.errorMessage = nil }
+    } message: {
+      Text(viewModel.errorMessage ?? "")
+    }
+    .onAppear { viewModel.refresh() }
+  }
+}

--- a/Palace/Settings/NewSettings/SideLoadingView.swift
+++ b/Palace/Settings/NewSettings/SideLoadingView.swift
@@ -70,6 +70,13 @@ final class SideLoadingViewModel: ObservableObject {
     refresh()
   }
 
+  /// The caption shown under a book's title in the manage-list (UI-2): the
+  /// original imported filename, falling back to the book title when the
+  /// filename is unknown. Never the opaque `sideload-<sha256>` identifier.
+  func caption(for book: TPPBook) -> String {
+    manager.originalFilename(for: book.identifier) ?? book.title
+  }
+
   /// The content types the picker accepts. Audiobooks import as a manifest
   /// JSON (`.json`); EPUB and PDF have first-class UTTypes.
   var allowedContentTypes: [UTType] {
@@ -92,7 +99,10 @@ struct SideLoadingView: View {
 
   var body: some View {
     List {
-      Section(footer: Text("Import a local EPUB, PDF, or audiobook manifest to open it in the reader without a catalog feed. For testing only.")) {
+      Section(
+        header: Text("Import"),
+        footer: Text("Import a local EPUB, PDF, or audiobook manifest to open it in the reader without a catalog feed. For testing only.")
+      ) {
         Button {
           viewModel.isImporterPresented = true
         } label: {
@@ -103,15 +113,16 @@ struct SideLoadingView: View {
 
       if viewModel.books.isEmpty {
         Section {
-          Text("No side-loaded books yet.")
-            .foregroundColor(.secondary)
+          emptyState
+            .frame(maxWidth: .infinity)
+            .listRowBackground(Color.clear)
         }
       } else {
         Section(header: Text("Imported")) {
           ForEach(viewModel.books, id: \.identifier) { book in
             VStack(alignment: .leading, spacing: 2) {
               Text(book.title)
-              Text(book.identifier)
+              Text(viewModel.caption(for: book))
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .lineLimit(1)
@@ -128,6 +139,7 @@ struct SideLoadingView: View {
         }
       }
     }
+    .listStyle(GroupedListStyle())
     .navigationTitle("Side Loading")
     .fileImporter(
       isPresented: $viewModel.isImporterPresented,
@@ -148,5 +160,34 @@ struct SideLoadingView: View {
       Text(viewModel.errorMessage ?? "")
     }
     .onAppear { viewModel.refresh() }
+  }
+
+  /// UI-1: a real empty state instead of a `Text` that reads as a disabled row.
+  /// `ContentUnavailableView` is iOS 17+, so iOS 16 gets an equivalent centered
+  /// VStack (deployment target is iOS 16.0 — do not raise it).
+  @ViewBuilder
+  private var emptyState: some View {
+    let title = "No Imported Books"
+    let description = "Tap \"Import File…\" above to add an EPUB, PDF, or audiobook."
+    if #available(iOS 17.0, *) {
+      ContentUnavailableView(
+        title,
+        systemImage: "arrow.down.doc",
+        description: Text(description)
+      )
+    } else {
+      VStack(spacing: 12) {
+        Image(systemName: "arrow.down.doc")
+          .font(.largeTitle)
+          .foregroundColor(.secondary)
+        Text(title)
+          .font(.headline)
+        Text(description)
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+          .multilineTextAlignment(.center)
+      }
+      .padding(.vertical, 24)
+    }
   }
 }

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -23,9 +23,10 @@ struct TPPSettingsView: View {
     @AppStorage("RemoteFeatureFlags.triageBotLocalOverride") private var triageBotLocalOverride: Bool = false
     /// Subscribes to the side-loading local override so the "Side Loading"
     /// section appears/disappears the moment the dev-menu toggle flips.
-    /// Effective gating still folds in DEBUG-default-on + Firebase via
+    /// Effective gating still runs through
     /// `RemoteFeatureFlags.shared.isSideLoadingEnabled` (read in
-    /// `sideLoadingSection`); this @AppStorage read registers the observation.
+    /// `sideLoadingSection`), whose precedence is local override > Firebase
+    /// remote (default off); this @AppStorage read registers the observation.
     @AppStorage(RemoteFeatureFlags.sideLoadingLocalOverrideKey) private var sideLoadingLocalOverride: Bool = false
     @State private var selectedView: Int? = 0
     @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
@@ -335,8 +336,8 @@ struct TPPSettingsView: View {
     /// `SideLoadingView` and is resolved lazily at navigation time.
     @ViewBuilder private var sideLoadingSection: some View {
         // Register the @AppStorage observation so the section shows/hides the
-        // instant the dev-menu override flips; effective value still folds in
-        // DEBUG-default-on + Firebase below.
+        // instant the dev-menu override flips; effective value still runs
+        // through isSideLoadingEnabled (local override > Firebase remote) below.
         let _ = sideLoadingLocalOverride
         if RemoteFeatureFlags.shared.isSideLoadingEnabled {
             Section(header: Text("Side Loading")) {

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -21,6 +21,12 @@ struct TPPSettingsView: View {
     /// DEBUG-default-on and Firebase fallback). The @AppStorage read in
     /// `supportSection` registers the SwiftUI observation.
     @AppStorage("RemoteFeatureFlags.triageBotLocalOverride") private var triageBotLocalOverride: Bool = false
+    /// Subscribes to the side-loading local override so the "Side Loading"
+    /// section appears/disappears the moment the dev-menu toggle flips.
+    /// Effective gating still folds in DEBUG-default-on + Firebase via
+    /// `RemoteFeatureFlags.shared.isSideLoadingEnabled` (read in
+    /// `sideLoadingSection`); this @AppStorage read registers the observation.
+    @AppStorage(RemoteFeatureFlags.sideLoadingLocalOverrideKey) private var sideLoadingLocalOverride: Bool = false
     @State private var selectedView: Int? = 0
     @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
     @State private var switchPromptAccount: Account? = nil
@@ -104,6 +110,7 @@ struct TPPSettingsView: View {
             librariesSection
             downloadsSection
             supportSection
+            sideLoadingSection
             infoSection
             developerSettingsSection
         }
@@ -320,6 +327,26 @@ struct TPPSettingsView: View {
             current = presented
         }
         return current
+    }
+
+    /// PP-2677 side-loading: a test-only entry to the Side Loading screen,
+    /// rendered ONLY when the feature flag is on. Row visibility depends on the
+    /// cheap flag read; the import/manage machinery lives inside
+    /// `SideLoadingView` and is resolved lazily at navigation time.
+    @ViewBuilder private var sideLoadingSection: some View {
+        // Register the @AppStorage observation so the section shows/hides the
+        // instant the dev-menu override flips; effective value still folds in
+        // DEBUG-default-on + Firebase below.
+        let _ = sideLoadingLocalOverride
+        if RemoteFeatureFlags.shared.isSideLoadingEnabled {
+            Section(header: Text("Side Loading")) {
+                let destination = SideLoadingView(
+                    manager: AppContainer.production().sideloadedBookManager
+                ).anyView()
+                row(title: "Side Loading", index: 11, selection: self.$selectedView, destination: destination)
+                    .accessibilityIdentifier("settings.row.sideLoading")
+            }
+        }
     }
 
     @ViewBuilder private var infoSection: some View {

--- a/PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift
@@ -171,7 +171,7 @@ final class BookRegistrySyncSideloadExemptionTests: XCTestCase {
     accountsManager.currentAccount?._setState(.detailsLoaded(details))
 
     // Credentials on the instance sync() reads via sharedAccount → production.
-    let prodUserAccount = AppContainer.production().accountsManager.userAccount(for: fixtureId)
+    let prodUserAccount = AppContainer.production().accountsManager.userAccount(for: fixtureId) // MIGRATED-DEFERRED: SUT BookRegistrySync.sync() reads credentials via the production shared account, so credentials must be seeded on the production user account (swarm_495a88d9)
     prodUserAccount.setAuthToken("sideload-token", barcode: "bc", pin: "1234",
                                  expirationDate: Date().addingTimeInterval(3600))
 
@@ -186,7 +186,7 @@ final class BookRegistrySyncSideloadExemptionTests: XCTestCase {
       store: store,
       accountsManager: accountsManager,
       downloadCenterProvider: { [downloadCenter] in downloadCenter! },
-      opdsFeedServiceProvider: { AppContainer.production().opdsFeedService },
+      opdsFeedServiceProvider: { OPDSFeedService() },
       sideloadedIDsProvider: { sideloadedIDs }
     )
   }

--- a/PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift
@@ -1,0 +1,253 @@
+//
+//  BookRegistrySyncSideloadExemptionTests.swift
+//  PalaceTests
+//
+//  THE critical sync-exemption regression (sideloading-plan.md R1).
+//
+//  The main registry's server `sync()` evicts any book NOT in the loans feed
+//  and deletes its on-disk content. Side-loaded books are registered
+//  `.downloadSuccessful` but of course never appear in the loans feed, so
+//  without the `recordsToDelete.subtract(sideloadedIDsProvider())` exemption
+//  the next sync silently destroys them.
+//
+//  These tests drive the FULL production `sync()` path — real account
+//  readiness gate, a stubbed loans-feed HTTP response, the real reconciliation
+//  barrier, and a spy download center recording on-disk deletes — with a
+//  mutation-grade contrast: the SAME scenario with an EMPTY exemption set must
+//  evict the same book (proving the exemption, not some other guard, is what
+//  saved it — so removing the `subtract` line fails the first test).
+//
+//  Keychain-gated (credentials must be writable for sync() to reach the feed
+//  fetch) — an environment-capability guard, NOT a host-sign-in-state dodge:
+//  the fixture UUID is unique so credential state is deterministic.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+final class BookRegistrySyncSideloadExemptionTests: XCTestCase {
+
+  private let loansURLString = "https://sideload-exemption-test.example.com/loans"
+
+  private var store: BookRegistryStore!
+  private var accountsManager: AccountsManager!
+  private var spyContentService: SpyLocalContentService!
+  private var downloadCenter: MyBooksDownloadCenter!
+  private var savedProtocolClasses: [AnyClass]!
+
+  // MARK: - Spy
+
+  /// Records the on-disk delete calls sync() makes for evicted books without
+  /// touching the filesystem. `MyBooksDownloadCenter.deleteLocalContent`
+  /// delegates to `localContentService`, which (unlike the extension method on
+  /// the download center) is overridable — so this is the correct seam.
+  final class SpyLocalContentService: LocalBookContentService {
+    private(set) var deletedBookIds: [String] = []
+    override func deleteLocalContent(forBook book: TPPBook, account: String? = nil) {
+      deletedBookIds.append(book.identifier)
+    }
+    override func deleteLocalContent(for identifier: String, account: String? = nil) {
+      deletedBookIds.append(identifier)
+    }
+  }
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+
+    // Route the SHARED network executor (used by TPPOPDSFeed.withURL inside
+    // the loans fetch) through the HTTP stub so we control the loans feed.
+    savedProtocolClasses = AppContainer.testExecutorProtocolClasses
+    AppContainer.testExecutorProtocolClasses = [HTTPStubURLProtocol.self, NoNetworkURLProtocol.self]
+    AppContainer._rebuildCachedForTestProtocols()
+
+    HTTPStubURLProtocol.register { [loansURLString] request in
+      guard request.url?.absoluteString.contains("/loans") == true else { return nil }
+      return HTTPStubURLProtocol.StubbedResponse(
+        statusCode: 200,
+        headers: ["Content-Type": "application/atom+xml"],
+        body: Data(Self.loansFeedXML.utf8)
+      )
+    }
+
+    let appContainer = makeTestAppContainer()
+    accountsManager = appContainer.accountsManager
+    store = BookRegistryStore()
+    spyContentService = SpyLocalContentService(bookRegistry: TPPBookRegistryMock())
+    downloadCenter = MyBooksDownloadCenter(
+      bookRegistry: TPPBookRegistryMock(),
+      localContentService: spyContentService
+    )
+  }
+
+  override func tearDownWithError() throws {
+    HTTPStubURLProtocol.removeAllHandlers()
+    AppContainer.testExecutorProtocolClasses = savedProtocolClasses
+    AppContainer._rebuildCachedForTestProtocols()
+    savedProtocolClasses = nil
+    downloadCenter = nil
+    spyContentService = nil
+    store = nil
+    accountsManager = nil
+    try super.tearDownWithError()
+  }
+
+  // MARK: - Loans feed fixture (one entry, none of our seeded ids)
+
+  private static let loansFeedXML = """
+  <?xml version="1.0" encoding="utf-8"?>
+  <feed xmlns="http://www.w3.org/2005/Atom">
+    <title type="text">Loans</title>
+    <id>urn:test:loans</id>
+    <updated>2026-07-01T00:00:00Z</updated>
+    <entry>
+      <title type="text">Feed Only Book</title>
+      <id>feed-only-book</id>
+      <updated>2026-07-01T00:00:00Z</updated>
+      <link href="http://example.com/x.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access" />
+    </entry>
+  </feed>
+  """
+
+  // MARK: - Helpers
+
+  private func makeBook(identifier: String, title: String) -> TPPBook {
+    TPPBook(
+      acquisitions: [TPPFake.genericAcquisition],
+      authors: nil, categoryStrings: nil, distributor: nil,
+      identifier: identifier,
+      imageURL: nil, imageThumbnailURL: nil, published: nil, publisher: nil,
+      subtitle: nil, summary: nil, title: title, updated: Date(),
+      annotationsURL: nil, analyticsURL: nil, alternateURL: nil,
+      relatedWorksURL: nil, previewLink: nil, seriesURL: nil,
+      revokeURL: nil, reportURL: nil, timeTrackingURL: nil,
+      contributors: nil, bookDuration: nil, imageCache: MockImageCache()
+    )
+  }
+
+  private func seedStore(_ books: [(String, String)]) {
+    let done = expectation(description: "seeded")
+    done.expectedFulfillmentCount = books.count
+    for (id, title) in books {
+      store.addBook(makeBook(identifier: id, title: title), state: .downloadSuccessful) { _ in done.fulfill() }
+    }
+    wait(for: [done], timeout: 3.0)
+    drainMainQueue()
+  }
+
+  /// Seeds a fresh-UUID fixture account as currentAccount, with an auth
+  /// document whose shelf link is the stubbed loans URL, and stored
+  /// credentials on the production-stack user account sync() consults.
+  /// Returns the uuid and a cleanup closure (defer-call it).
+  private func seedReadyCredentialedAccount() throws -> (uuid: String, cleanup: () -> Void) {
+    try KeychainAvailability.skipIfUnavailable()
+
+    let fixtureId = "sideload-exempt-\(UUID().uuidString)"
+    let pub = OPDS2Publication(
+      links: [OPDS2Link(href: "https://example.com/catalog", rel: "http://opds-spec.org/catalog")],
+      metadata: OPDS2Publication.Metadata(id: fixtureId, title: "Sideload Exemption Fixture"),
+      images: nil
+    )
+    let fixture = Account(publication: pub, imageCache: MockImageCache())
+    let seedCleanup = accountsManager._seedAccountForTesting(fixture)
+
+    // Auth document with a shelf link → details.loansUrl == our stubbed URL.
+    let json: [String: Any] = [
+      "id": "urn:uuid:\(fixtureId)",
+      "title": "Sideload Exemption Fixture",
+      "links": [["href": loansURLString, "rel": "http://opds-spec.org/shelf"]],
+      "authentication": [[
+        "type": "http://opds-spec.org/auth/basic",
+        "inputs": ["login": ["keyboard": "Default"], "password": ["keyboard": "Default"]],
+        "labels": ["login": "Login", "password": "Password"]
+      ]],
+      "features": ["enabled": [], "disabled": []]
+    ]
+    let data = try JSONSerialization.data(withJSONObject: json)
+    let doc = try OPDS2AuthenticationDocument.fromData(data)
+    let details = AccountDetails(authenticationDocument: doc, uuid: fixtureId)
+    accountsManager.currentAccount?._setState(.detailsLoaded(details))
+
+    // Credentials on the instance sync() reads via sharedAccount → production.
+    let prodUserAccount = AppContainer.production().accountsManager.userAccount(for: fixtureId)
+    prodUserAccount.setAuthToken("sideload-token", barcode: "bc", pin: "1234",
+                                 expirationDate: Date().addingTimeInterval(3600))
+
+    return (fixtureId, {
+      prodUserAccount.removeAll()
+      seedCleanup()
+    })
+  }
+
+  private func makeSyncManager(sideloadedIDs: Set<String>) -> BookRegistrySync {
+    BookRegistrySync(
+      store: store,
+      accountsManager: accountsManager,
+      downloadCenterProvider: { [downloadCenter] in downloadCenter! },
+      opdsFeedServiceProvider: { AppContainer.production().opdsFeedService },
+      sideloadedIDsProvider: { sideloadedIDs }
+    )
+  }
+
+  private func runSync(_ syncManager: BookRegistrySync) {
+    let exp = expectation(description: "sync completed")
+    var received: [TPPBookRegistry.RegistryState] = []
+    syncManager.sync(
+      currentState: .loaded,
+      setState: { received.append($0) },
+      completion: { _, _ in exp.fulfill() }
+    )
+    wait(for: [exp], timeout: 10.0)
+    drainMainQueue()
+    XCTAssertEqual(received.last, .synced,
+                   "sync() must reach reconciliation (.synced); got \(received)")
+  }
+
+  // MARK: - Tests
+
+  func test_sync_withSideloadedIdExempt_preservesBookAndSkipsOnDiskDelete() throws {
+    let (_, cleanup) = try seedReadyCredentialedAccount()
+    defer { cleanup() }
+
+    // Two downloaded books: one side-loaded (exempt), one normal (not in feed).
+    seedStore([("sideloaded-1", "Side-loaded"), ("normal-1", "Normal")])
+
+    let syncManager = makeSyncManager(sideloadedIDs: ["sideloaded-1"])
+    runSync(syncManager)
+
+    // The side-loaded book survives with its downloaded state...
+    XCTAssertEqual(store.state(for: "sideloaded-1"), .downloadSuccessful,
+                   "Exempt side-loaded book must survive a loans-feed sync that omits it")
+    XCTAssertFalse(spyContentService.deletedBookIds.contains("sideloaded-1"),
+                   "Exempt side-loaded book's on-disk content must NOT be deleted")
+
+    // ...while the non-exempt book in the SAME run IS evicted + deleted,
+    // proving reconciliation actually ran (so the survival above is the
+    // exemption at work, not a short-circuited sync).
+    XCTAssertNil(store.book(forIdentifier: "normal-1"),
+                 "A non-exempt downloaded book absent from the feed must be evicted")
+    XCTAssertTrue(spyContentService.deletedBookIds.contains("normal-1"),
+                  "The evicted normal book's on-disk content must be deleted")
+  }
+
+  func test_sync_withEmptyExemption_evictsTheSameBook_andDeletesItsContent() throws {
+    // Mutation-grade contrast: identical scenario, EMPTY exemption set. Now the
+    // "side-loaded" book is unprotected and MUST be evicted + deleted — this is
+    // what proves the previous test's survival is caused by the exemption
+    // subtract, and kills the "subtract removed" mutant.
+    let (_, cleanup) = try seedReadyCredentialedAccount()
+    defer { cleanup() }
+
+    seedStore([("sideloaded-1", "Side-loaded"), ("normal-1", "Normal")])
+
+    let syncManager = makeSyncManager(sideloadedIDs: [])
+    runSync(syncManager)
+
+    XCTAssertNil(store.book(forIdentifier: "sideloaded-1"),
+                 "With no exemption, the book absent from the feed must be evicted")
+    XCTAssertTrue(spyContentService.deletedBookIds.contains("sideloaded-1"),
+                  "With no exemption, the book's on-disk content must be deleted")
+  }
+}

--- a/PalaceTests/CatalogUI/CatalogViewModelTests.swift
+++ b/PalaceTests/CatalogUI/CatalogViewModelTests.swift
@@ -20,9 +20,10 @@ final class CatalogStateTests: XCTestCase {
     }
 
     func testState_Error_HasNoContent() {
-        let state = CatalogState.error("Network failed")
+        let state = CatalogState.error("Network failed", sideloadedLanes: [])
         XCTAssertNil(state.content)
         XCTAssertTrue(state.allBooks.isEmpty)
+        XCTAssertTrue(state.sideloadedLanes.isEmpty)
     }
 
     func testState_Loaded_ExposesContent() {

--- a/PalaceTests/CatalogUI/SideloadedLaneTests.swift
+++ b/PalaceTests/CatalogUI/SideloadedLaneTests.swift
@@ -180,7 +180,7 @@ final class SideloadedLaneViewModelTests: XCTestCase {
     CatalogViewModel(
       repository: repository,
       topLevelURLProvider: { [feedURL] in feedURL },
-      bookRegistry: AppContainer.production().bookRegistry,
+      bookRegistry: TPPBookRegistryMock(),
       imageCache: ImageCache.shared,
       sideloadedLaneBooksProvider: provider,
       reachability: MockReachability(initiallyConnected: true)

--- a/PalaceTests/CatalogUI/SideloadedLaneTests.swift
+++ b/PalaceTests/CatalogUI/SideloadedLaneTests.swift
@@ -1,0 +1,267 @@
+//
+//  SideloadedLaneTests.swift
+//  PalaceTests
+//
+//  Module D (swarm_495a88d9 / PP-2679): the "Side Loaded" catalog lane.
+//
+//  Covers two layers:
+//   1. The pure `MappedCatalog.toCatalogContent(prepending:)` bridge — proves the
+//      injected lanes force `.grouped` for every base-feed shape (grouped /
+//      ungrouped / empty) and that an empty prepend list is identical to the
+//      un-injected baseline (lane ABSENT).
+//   2. The `CatalogViewModel` wiring — proves the single choke-point helper
+//      `withSideloadedLane(_:)` runs on the load path AND, critically, on the
+//      `applyFacet` cache-HIT synchronous fast path (:283) that a per-site patch
+//      would silently miss.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import Combine
+@testable import Palace
+@testable import PalaceCatalog
+
+// MARK: - Pure bridge: toCatalogContent(prepending:)
+
+final class SideloadedLaneBridgeTests: XCTestCase {
+
+  private func mapped(
+    lanes: [CatalogLaneModel] = [],
+    ungrouped: [TPPBook] = [],
+    title: String = "Base"
+  ) -> CatalogViewModel.MappedCatalog {
+    CatalogViewModel.MappedCatalog(
+      title: title, entries: [], lanes: lanes, ungroupedBooks: ungrouped,
+      facetGroups: [], entryPoints: []
+    )
+  }
+
+  private func sideloadedLane(_ books: [TPPBook]) -> [CatalogLaneModel] {
+    [CatalogLaneModel(title: "Side Loaded", books: books, moreURL: nil)]
+  }
+
+  private func lanes(from content: CatalogContent) -> [CatalogLaneModel]? {
+    if case .grouped(let l) = content.feed { return l }
+    return nil
+  }
+
+  // MARK: present (provider non-empty)
+
+  func testPrepending_groupedBase_sideloadedLaneIsFirst_baseLanesRetained() {
+    let sideBook = TPPBookMocker.snapshotEPUB()
+    let baseBook = TPPBookMocker.snapshotAudiobook()
+    let base = mapped(lanes: [CatalogLaneModel(title: "Popular", books: [baseBook], moreURL: nil)])
+
+    let content = base.toCatalogContent(prepending: sideloadedLane([sideBook]))
+
+    guard let lanes = lanes(from: content) else { return XCTFail("Expected .grouped") }
+    XCTAssertEqual(lanes.count, 2, "Side Loaded lane + base lane")
+    XCTAssertEqual(lanes.first?.title, "Side Loaded")
+    XCTAssertEqual(lanes.first?.books.map(\.identifier), [sideBook.identifier])
+    XCTAssertEqual(lanes.last?.title, "Popular", "Base lane must be preserved after the injected lane")
+    XCTAssertEqual(lanes.last?.books.map(\.identifier), [baseBook.identifier])
+  }
+
+  func testPrepending_ungroupedBase_forcesGrouped_keepsOriginalBooks() {
+    let sideBook = TPPBookMocker.snapshotEPUB()
+    let baseBook = TPPBookMocker.snapshotAudiobook()
+    let base = mapped(ungrouped: [baseBook])
+
+    let content = base.toCatalogContent(prepending: sideloadedLane([sideBook]))
+
+    guard let lanes = lanes(from: content) else {
+      return XCTFail("Ungrouped base + injected lane must force .grouped")
+    }
+    XCTAssertEqual(lanes.first?.title, "Side Loaded")
+    XCTAssertEqual(lanes.first?.books.map(\.identifier), [sideBook.identifier])
+    // The ungrouped books must NOT be dropped — they are wrapped into a lane.
+    let allBooks = lanes.flatMap { $0.books.map(\.identifier) }
+    XCTAssertTrue(allBooks.contains(baseBook.identifier),
+                  "Original ungrouped books must survive the force-to-grouped conversion")
+  }
+
+  func testPrepending_emptyBase_groupedWithOnlySideloadedLane() {
+    let sideBook = TPPBookMocker.snapshotEPUB()
+    let base = mapped() // empty base feed — the DRM side-loading use-case
+
+    let content = base.toCatalogContent(prepending: sideloadedLane([sideBook]))
+
+    guard let lanes = lanes(from: content) else {
+      return XCTFail("Empty base + injected lane must force .grouped")
+    }
+    XCTAssertEqual(lanes.count, 1)
+    XCTAssertEqual(lanes.first?.title, "Side Loaded")
+    XCTAssertEqual(lanes.first?.books.map(\.identifier), [sideBook.identifier])
+  }
+
+  // MARK: absent (provider empty → baseline shape unchanged)
+
+  func testPrependingEmpty_groupedBase_shapeUnchanged() {
+    let base = mapped(lanes: [CatalogLaneModel(title: "Popular", books: [], moreURL: nil)])
+    let content = base.toCatalogContent(prepending: [])
+    guard case .grouped(let l) = content.feed else { return XCTFail("Expected .grouped") }
+    XCTAssertEqual(l.count, 1)
+    XCTAssertEqual(l.first?.title, "Popular", "No injected lane when the prepend list is empty")
+  }
+
+  func testPrependingEmpty_ungroupedBase_shapeUnchanged() {
+    let base = mapped(ungrouped: [TPPBookMocker.snapshotEPUB()])
+    let content = base.toCatalogContent(prepending: [])
+    guard case .ungrouped(let books) = content.feed else {
+      return XCTFail("Empty prepend must leave an ungrouped feed ungrouped")
+    }
+    XCTAssertEqual(books.count, 1)
+  }
+
+  func testPrependingEmpty_emptyBase_shapeUnchanged() {
+    let base = mapped()
+    let content = base.toCatalogContent(prepending: [])
+    guard case .empty = content.feed else {
+      return XCTFail("Empty prepend must leave an empty feed empty (lane ABSENT)")
+    }
+  }
+}
+
+// MARK: - VM wiring: withSideloadedLane choke point
+
+@MainActor
+final class SideloadedLaneViewModelTests: XCTestCase {
+
+  private var repository: CatalogRepositoryTestMock!
+  private var cancellables: Set<AnyCancellable>!
+  private let feedURL = URL(string: "https://example.com/catalog")!
+  private let facetURL = URL(string: "https://example.com/facet")!
+
+  override func setUp() {
+    super.setUp()
+    repository = CatalogRepositoryTestMock()
+    cancellables = []
+  }
+
+  override func tearDown() {
+    repository = nil
+    cancellables = nil
+    super.tearDown()
+  }
+
+  // MARK: OPDS2 stub-feed helpers
+
+  private func makePublication(id: String) -> OPDS2Publication {
+    OPDS2Publication(
+      links: [
+        OPDS2Link(
+          href: "https://example.com/borrow/\(id)",
+          type: "application/epub+zip",
+          rel: "http://opds-spec.org/acquisition/borrow"
+        )
+      ],
+      metadata: OPDS2Publication.Metadata(id: id, title: "Title \(id)"),
+      images: nil
+    )
+  }
+
+  private func groupedFeed(laneTitle: String, pubID: String) -> CatalogFeed {
+    let feed = OPDS2Feed(
+      metadata: OPDS2FeedMetadata(title: "Feed"),
+      groups: [
+        OPDS2Group(
+          metadata: OPDS2GroupMetadata(title: laneTitle),
+          links: nil,
+          publications: [makePublication(id: pubID)],
+          navigation: nil
+        )
+      ]
+    )
+    return CatalogFeed(opds2Feed: feed)
+  }
+
+  private func makeViewModel(provider: @escaping () -> [TPPBook]) -> CatalogViewModel {
+    CatalogViewModel(
+      repository: repository,
+      topLevelURLProvider: { [feedURL] in feedURL },
+      bookRegistry: AppContainer.production().bookRegistry,
+      imageCache: ImageCache.shared,
+      sideloadedLaneBooksProvider: provider,
+      reachability: MockReachability(initiallyConnected: true)
+    )
+  }
+
+  private func awaitLoaded(_ vm: CatalogViewModel) async {
+    let exp = XCTestExpectation(description: "loaded")
+    vm.$state.sink { if case .loaded = $0 { exp.fulfill() } }.store(in: &cancellables)
+    await vm.load()
+    await fulfillment(of: [exp], timeout: 5.0)
+  }
+
+  private func groupedLanes(_ vm: CatalogViewModel) -> [CatalogLaneModel]? {
+    guard case .grouped(let lanes) = vm.state.content?.feed else { return nil }
+    return lanes
+  }
+
+  // MARK: - load path (flag ON analog: provider non-empty)
+
+  func testLoad_providerNonEmpty_prependsSideloadedLaneAtTop() async {
+    let sideBook = TPPBookMocker.snapshotEPUB()
+    repository.loadTopLevelCatalogResult = groupedFeed(laneTitle: "Popular", pubID: "base-1")
+    let vm = makeViewModel(provider: { [sideBook] })
+
+    await awaitLoaded(vm)
+
+    guard let lanes = groupedLanes(vm) else {
+      return XCTFail("Expected grouped content with the injected lane, got \(vm.state)")
+    }
+    XCTAssertEqual(lanes.first?.title, "Side Loaded")
+    XCTAssertEqual(lanes.first?.books.map(\.identifier), [sideBook.identifier])
+  }
+
+  func testLoad_providerEmpty_noSideloadedLane() async {
+    repository.loadTopLevelCatalogResult = groupedFeed(laneTitle: "Popular", pubID: "base-1")
+    let vm = makeViewModel(provider: { [] })
+
+    await awaitLoaded(vm)
+
+    let titles: [String] = {
+      switch vm.state.content?.feed {
+      case .grouped(let lanes): return lanes.map(\.title)
+      default: return []
+      }
+    }()
+    XCTAssertFalse(titles.contains("Side Loaded"),
+                   "Empty provider (flag off / empty registry) must not inject a lane")
+  }
+
+  // MARK: - applyFacet cache-HIT path (:283) — the finding-1 landmine
+
+  /// Drives the synchronous cache-HIT branch of `applyFacet` (repository has a
+  /// cached feed) with a non-empty provider and asserts the Side Loaded lane
+  /// still appears. A per-site patch that only touched the cache-MISS path would
+  /// fail here. Proven-cache-hit via: repository load count unchanged (no
+  /// network) AND scrollGeneration incremented by the cache-hit branch.
+  func testApplyFacet_cacheHit_stillShowsSideloadedLane() async {
+    let sideBook = TPPBookMocker.snapshotPDF()
+    repository.loadTopLevelCatalogResult = groupedFeed(laneTitle: "Popular", pubID: "base-1")
+    let vm = makeViewModel(provider: { [sideBook] })
+
+    // Establish a .loaded state so applyFacet has current content to work from.
+    await awaitLoaded(vm)
+    let loadCallsBeforeFacet = repository.loadTopLevelCatalogCallCount
+    let scrollBeforeFacet = vm.scrollGeneration
+
+    // Arm the synchronous cache-HIT fast path (:283).
+    repository.cachedFeedResult = groupedFeed(laneTitle: "Filtered", pubID: "facet-1")
+    await vm.applyFacet(CatalogFilter(id: "f1", title: "Fiction", href: facetURL, active: false))
+
+    XCTAssertEqual(repository.loadTopLevelCatalogCallCount, loadCallsBeforeFacet,
+                   "Cache HIT must not hit the network")
+    XCTAssertGreaterThan(vm.scrollGeneration, scrollBeforeFacet,
+                         "The synchronous cache-HIT branch must have run")
+
+    guard let lanes = groupedLanes(vm) else {
+      return XCTFail("Cache-HIT applyFacet must still produce a grouped feed with the lane, got \(vm.state)")
+    }
+    XCTAssertEqual(lanes.first?.title, "Side Loaded",
+                   "Side Loaded lane must survive the applyFacet cache-HIT fast path")
+    XCTAssertEqual(lanes.first?.books.map(\.identifier), [sideBook.identifier])
+  }
+}

--- a/PalaceTests/CatalogUI/SideloadedLaneTests.swift
+++ b/PalaceTests/CatalogUI/SideloadedLaneTests.swift
@@ -176,20 +176,38 @@ final class SideloadedLaneViewModelTests: XCTestCase {
     return CatalogFeed(opds2Feed: feed)
   }
 
-  private func makeViewModel(provider: @escaping () -> [TPPBook]) -> CatalogViewModel {
+  private func makeViewModel(
+    provider: @escaping () -> [TPPBook],
+    connected: Bool = true
+  ) -> CatalogViewModel {
     CatalogViewModel(
       repository: repository,
       topLevelURLProvider: { [feedURL] in feedURL },
       bookRegistry: TPPBookRegistryMock(),
       imageCache: ImageCache.shared,
       sideloadedLaneBooksProvider: provider,
-      reachability: MockReachability(initiallyConnected: true)
+      reachability: MockReachability(initiallyConnected: connected)
     )
   }
 
   private func awaitLoaded(_ vm: CatalogViewModel) async {
     let exp = XCTestExpectation(description: "loaded")
     vm.$state.sink { if case .loaded = $0 { exp.fulfill() } }.store(in: &cancellables)
+    await vm.load()
+    await fulfillment(of: [exp], timeout: 5.0)
+  }
+
+  /// Drive `load()` to a terminal failure state (`.error` or `.offline`,
+  /// depending on the injected reachability) and wait for it to land. The load
+  /// task is spawned but not awaited by `load()`, so we sink on `$state`.
+  private func awaitFailure(_ vm: CatalogViewModel) async {
+    let exp = XCTestExpectation(description: "failure")
+    vm.$state.sink {
+      switch $0 {
+      case .error, .offline: exp.fulfill()
+      default: break
+      }
+    }.store(in: &cancellables)
     await vm.load()
     await fulfillment(of: [exp], timeout: 5.0)
   }
@@ -263,5 +281,75 @@ final class SideloadedLaneViewModelTests: XCTestCase {
     XCTAssertEqual(lanes.first?.title, "Side Loaded",
                    "Side Loaded lane must survive the applyFacet cache-HIT fast path")
     XCTAssertEqual(lanes.first?.books.map(\.identifier), [sideBook.identifier])
+  }
+
+  // MARK: - F-1: feed-failure path still surfaces the Side Loaded lane
+
+  /// Feed error while CONNECTED with a non-empty provider: the VM must land in
+  /// `.error` (feed failure surfaced) AND carry the Side Loaded lane so the
+  /// imported books stay reachable. Driven through the real `load()` failure
+  /// path (`loadFailureState`), not by hand-constructing state.
+  func testLoadFailure_connected_nonEmptyProvider_exposesErrorAndSideloadedLane() async {
+    let sideBook = TPPBookMocker.snapshotEPUB()
+    repository.loadTopLevelCatalogError = NSError(domain: "test", code: 500)
+    let vm = makeViewModel(provider: { [sideBook] }, connected: true)
+
+    await awaitFailure(vm)
+
+    guard case .error = vm.state else {
+      return XCTFail("Connected feed failure must surface as .error, got \(vm.state)")
+    }
+    let lanes = vm.state.sideloadedLanes
+    XCTAssertEqual(lanes.first?.title, "Side Loaded",
+                   "The Side Loaded lane must ride alongside the feed error")
+    XCTAssertEqual(lanes.first?.books.map(\.identifier), [sideBook.identifier])
+  }
+
+  /// Feed error while CONNECTED with an EMPTY provider: behavior unchanged — the
+  /// state is `.error` and carries NO lanes (byte-identical to pre-F-1).
+  func testLoadFailure_connected_emptyProvider_exposesErrorOnly_noLane() async {
+    repository.loadTopLevelCatalogError = NSError(domain: "test", code: 500)
+    let vm = makeViewModel(provider: { [] }, connected: true)
+
+    await awaitFailure(vm)
+
+    guard case .error = vm.state else {
+      return XCTFail("Connected feed failure must surface as .error, got \(vm.state)")
+    }
+    XCTAssertTrue(vm.state.sideloadedLanes.isEmpty,
+                  "Empty provider must not inject a lane on the error path (unchanged behavior)")
+  }
+
+  /// Feed failure while OFFLINE with a non-empty provider: state is `.offline`
+  /// (connectivity error surfaced) AND carries the Side Loaded lane.
+  func testLoadFailure_offline_nonEmptyProvider_exposesOfflineAndSideloadedLane() async {
+    let sideBook = TPPBookMocker.snapshotPDF()
+    repository.loadTopLevelCatalogError = NSError(domain: "test", code: -1009)
+    let vm = makeViewModel(provider: { [sideBook] }, connected: false)
+
+    await awaitFailure(vm)
+
+    guard case .offline = vm.state else {
+      return XCTFail("Failure with no connectivity must surface as .offline, got \(vm.state)")
+    }
+    let lanes = vm.state.sideloadedLanes
+    XCTAssertEqual(lanes.first?.title, "Side Loaded",
+                   "The Side Loaded lane must ride alongside the offline banner")
+    XCTAssertEqual(lanes.first?.books.map(\.identifier), [sideBook.identifier])
+  }
+
+  /// Feed failure while OFFLINE with an EMPTY provider: `.offline` with no
+  /// lanes — unchanged behavior.
+  func testLoadFailure_offline_emptyProvider_exposesOfflineOnly_noLane() async {
+    repository.loadTopLevelCatalogError = NSError(domain: "test", code: -1009)
+    let vm = makeViewModel(provider: { [] }, connected: false)
+
+    await awaitFailure(vm)
+
+    guard case .offline = vm.state else {
+      return XCTFail("Failure with no connectivity must surface as .offline, got \(vm.state)")
+    }
+    XCTAssertTrue(vm.state.sideloadedLanes.isEmpty,
+                  "Empty provider must not inject a lane on the offline path (unchanged behavior)")
   }
 }

--- a/PalaceTests/Contract/SideloadImportContractTests.swift
+++ b/PalaceTests/Contract/SideloadImportContractTests.swift
@@ -1,0 +1,135 @@
+//
+//  SideloadImportContractTests.swift
+//  PalaceTests
+//
+//  Contract-snapshot for the side-loading import pipeline (PP-2677). Pins the
+//  ORDERED sequence of dependency calls a successful import makes:
+//
+//      classify → copyFile → sideloadRegistry.add → bookRegistry.addBook
+//
+//  A reorder, a dropped call, or a changed state argument drifts the snapshot
+//  and fails loudly. See PalaceTests/Contract/README.md for the pattern.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class SideloadImportContractTests: XCTestCase {
+
+  private var tempRoot: URL!
+  private var contentRoot: URL!
+  private var manifestDir: URL!
+  private var sourceDir: URL!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    tempRoot = FileManager.default.temporaryDirectory
+      .appendingPathComponent("SideloadContractTests-\(UUID().uuidString)")
+    contentRoot = tempRoot.appendingPathComponent("content")
+    manifestDir = tempRoot.appendingPathComponent("manifest")
+    sourceDir = tempRoot.appendingPathComponent("incoming")
+    for dir in [contentRoot, manifestDir, sourceDir] {
+      try FileManager.default.createDirectory(at: dir!, withIntermediateDirectories: true)
+    }
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(at: tempRoot)
+    tempRoot = nil
+    try super.tearDownWithError()
+  }
+
+  func testImportPipeline_recordsOrderedDependencyCalls() throws {
+    let log = CallLog()
+
+    let recordingRegistry = RecordingBookRegistry(log: log)
+    let recordingSideloaded = RecordingSideloadedRegistry(
+      inner: SideloadedBookRegistry(manifestDirectory: manifestDir),
+      log: log
+    )
+    let isolatedDefaults = UserDefaults(suiteName: "SideloadContract-\(UUID().uuidString)") ?? .standard
+    let bookFileManager = BookFileManager(
+      bookRegistry: recordingRegistry,
+      accountsManager: AccountsManager(defaults: isolatedDefaults),
+      fileManager: .default,
+      directoryProvider: { [contentRoot] account in contentRoot!.appendingPathComponent("acct-\(account ?? "nil")") },
+      sideloadedIdentifiersProvider: { [] }
+    )
+
+    let manager = SideloadedBookManager(
+      bookRegistry: recordingRegistry,
+      sideloadedRegistry: recordingSideloaded,
+      bookFileManager: bookFileManager,
+      classifier: RecordingClassifier(inner: DefaultSideloadContentClassifier(), log: log),
+      fileManaging: RecordingFileManaging(log: log),
+      imageCache: MockImageCache()
+    )
+
+    // Fixed content ⇒ deterministic; but only stable args are recorded anyway.
+    let source = sourceDir.appendingPathComponent("contract-fixture.epub")
+    try Data("palace-sideload-contract-fixture".utf8).write(to: source)
+
+    _ = try manager.import(fileURL: source)
+
+    ContractSnapshot.assert(log, named: "importEpub")
+  }
+}
+
+// MARK: - Recording spies (record stable args only, so the snapshot is deterministic)
+
+private final class RecordingClassifier: SideloadContentClassifier {
+  private let inner: SideloadContentClassifier
+  private let log: CallLog
+  init(inner: SideloadContentClassifier, log: CallLog) { self.inner = inner; self.log = log }
+  func classify(fileURL: URL) throws -> SideloadClassification {
+    let result = try inner.classify(fileURL: fileURL)
+    log.record("classify", args: ["contentType": "\(result.contentType)", "mimeType": result.mimeType])
+    return result
+  }
+}
+
+private final class RecordingFileManaging: SideloadFileManaging {
+  private let log: CallLog
+  init(log: CallLog) { self.log = log }
+  func copyFile(from source: URL, to destination: URL) throws {
+    log.record("copyFile", args: ["ext": destination.pathExtension])
+  }
+  func removeFile(at url: URL) throws {
+    log.record("removeFile")
+  }
+}
+
+private final class RecordingSideloadedRegistry: SideloadedBookRegistering {
+  private let inner: SideloadedBookRegistry
+  private let log: CallLog
+  init(inner: SideloadedBookRegistry, log: CallLog) { self.inner = inner; self.log = log }
+  var allBooks: [TPPBook] { inner.allBooks }
+  var identifiers: Set<String> { inner.identifiers }
+  func add(book: TPPBook, fileURL: URL) {
+    log.record("sideloadRegistry.add", args: ["contentType": "\(book.defaultBookContentType)"])
+    inner.add(book: book, fileURL: fileURL)
+  }
+  func remove(identifier: String) {
+    log.record("sideloadRegistry.remove")
+    inner.remove(identifier: identifier)
+  }
+}
+
+private final class RecordingBookRegistry: TPPBookRegistryMock {
+  private let log: CallLog
+  init(log: CallLog) { self.log = log; super.init() }
+  override func addBook(
+    _ book: TPPBook,
+    location: TPPBookLocation?,
+    state: TPPBookState,
+    fulfillmentId: String?,
+    readiumBookmarks: [TPPReadiumBookmark]?,
+    genericBookmarks: [TPPBookLocation]?
+  ) {
+    log.record("bookRegistry.addBook", args: ["state": state.stringValue()])
+    super.addBook(book, location: location, state: state, fulfillmentId: fulfillmentId,
+                  readiumBookmarks: readiumBookmarks, genericBookmarks: genericBookmarks)
+  }
+}

--- a/PalaceTests/Contract/SideloadImportContractTests.swift
+++ b/PalaceTests/Contract/SideloadImportContractTests.swift
@@ -115,6 +115,9 @@ private final class RecordingSideloadedRegistry: SideloadedBookRegistering {
     log.record("sideloadRegistry.remove")
     inner.remove(identifier: identifier)
   }
+  func originalFilename(for identifier: String) -> String? {
+    inner.originalFilename(for: identifier)
+  }
 }
 
 private final class RecordingBookRegistry: TPPBookRegistryMock {

--- a/PalaceTests/Contract/SideloadImportContractTests.swift
+++ b/PalaceTests/Contract/SideloadImportContractTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 @testable import Palace
 
-final class SideloadImportContractTests: XCTestCase {
+final class SideloadImportContractTests: PalaceWiringTestCase {
 
   private var tempRoot: URL!
   private var contentRoot: URL!
@@ -52,7 +52,7 @@ final class SideloadImportContractTests: XCTestCase {
     let isolatedDefaults = UserDefaults(suiteName: "SideloadContract-\(UUID().uuidString)") ?? .standard
     let bookFileManager = BookFileManager(
       bookRegistry: recordingRegistry,
-      accountsManager: AccountsManager(defaults: isolatedDefaults),
+      accountsManager: makeFreshAccountsManager(defaults: isolatedDefaults),
       fileManager: .default,
       directoryProvider: { [contentRoot] account in contentRoot!.appendingPathComponent("acct-\(account ?? "nil")") },
       sideloadedIdentifiersProvider: { [] }

--- a/PalaceTests/Contract/SideloadImportContractTests.swift
+++ b/PalaceTests/Contract/SideloadImportContractTests.swift
@@ -107,9 +107,9 @@ private final class RecordingSideloadedRegistry: SideloadedBookRegistering {
   init(inner: SideloadedBookRegistry, log: CallLog) { self.inner = inner; self.log = log }
   var allBooks: [TPPBook] { inner.allBooks }
   var identifiers: Set<String> { inner.identifiers }
-  func add(book: TPPBook, fileURL: URL) {
+  func add(book: TPPBook, fileURL: URL) throws {
     log.record("sideloadRegistry.add", args: ["contentType": "\(book.defaultBookContentType)"])
-    inner.add(book: book, fileURL: fileURL)
+    try inner.add(book: book, fileURL: fileURL)
   }
   func remove(identifier: String) {
     log.record("sideloadRegistry.remove")

--- a/PalaceTests/Contract/__Snapshots__/SideloadImportContractTests/importEpub.json
+++ b/PalaceTests/Contract/__Snapshots__/SideloadImportContractTests/importEpub.json
@@ -1,0 +1,27 @@
+[
+  {
+    "args" : {
+      "contentType" : "TPPBookContentType(rawValue: 0)",
+      "mimeType" : "application\/epub+zip"
+    },
+    "method" : "classify"
+  },
+  {
+    "args" : {
+      "ext" : "epub"
+    },
+    "method" : "copyFile"
+  },
+  {
+    "args" : {
+      "contentType" : "TPPBookContentType(rawValue: 0)"
+    },
+    "method" : "sideloadRegistry.add"
+  },
+  {
+    "args" : {
+      "state" : "download-successful"
+    },
+    "method" : "bookRegistry.addBook"
+  }
+]

--- a/PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift
+++ b/PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift
@@ -13,8 +13,8 @@ import XCTest
 ///
 /// These tests pin the RESOLUTION PRECEDENCE, not the default value:
 ///   1. UserDefaults local override (either direction) wins.
-///   2. No override → DEBUG builds resolve `true`.
-///   3. No override, release build → Firebase Remote Config (default `false`).
+///   2. No override → Firebase Remote Config (default `false`) — side loading is
+///      a test-only feature, OFF by default, enabled via the dev-menu toggle.
 ///
 /// Every test constructs a fresh `RemoteFeatureFlags(defaults:)` with a
 /// per-suite `UserDefaults` so override-key state never leaks — `.shared` is
@@ -79,32 +79,26 @@ final class RemoteFeatureFlagsSideLoadingTests: XCTestCase {
         XCTAssertTrue(sut.isSideLoadingEnabled, "override flipped back to true → true")
     }
 
-    // MARK: - No override → DEBUG-on precedence
+    // MARK: - No override → defers to Remote Config
 
-    /// With NO override present, `isSideLoadingEnabled` must follow the exact
-    /// same DEBUG-on precedence as the canonical `isTriageBotEnabled`
-    /// (override > `#if DEBUG` true > Firebase — locked decision #2).
+    /// With NO local override present, `isSideLoadingEnabled` must defer to
+    /// Firebase Remote Config (`isFeatureEnabled(.sideLoadingEnabled)`) rather
+    /// than a build-time `#if DEBUG` default. Side loading is a test-only feature
+    /// that is OFF by default and enabled via the dev-menu toggle, so the
+    /// no-override path is exactly the Remote Config value.
     ///
-    /// This is asserted via parity with `isTriageBotEnabled` rather than a
-    /// test-side `#if DEBUG`, because the PalaceTests target does NOT define
-    /// `DEBUG` even when the Palace module (where both accessors are compiled)
-    /// does — a test-side `#if DEBUG` would always take the release branch and
-    /// diverge from the production value. Both accessors here are evaluated in
-    /// the production module under the same compilation flags, so with no
-    /// override on either key they must resolve identically regardless of build
-    /// configuration. If the `#if DEBUG return true` arm is dropped from
-    /// `isSideLoadingEnabled`, a DEBUG-config production build makes
-    /// `isTriageBotEnabled` true while `isSideLoadingEnabled` falls to the
-    /// Firebase default (false) — and this assertion fails.
-    func testIsSideLoadingEnabled_noOverride_followsSameDebugOnPrecedenceAsTriageBot() {
+    /// This pins that the accessor's fallback is the Remote Config seam (so
+    /// remote gating actually works) and that no override silently forces it on.
+    /// The override-drop / precedence-inversion mutants are killed by the
+    /// override-direction tests above (override=true must return true even though
+    /// the Remote Config default is false).
+    func testIsSideLoadingEnabled_noOverride_defersToRemoteConfig() {
         let sut = RemoteFeatureFlags(defaults: defaults)
         XCTAssertNil(defaults.object(forKey: RemoteFeatureFlags.sideLoadingLocalOverrideKey),
                      "Precondition: fresh suite must have no side-loading override")
-        XCTAssertNil(defaults.object(forKey: RemoteFeatureFlags.triageBotLocalOverrideKey),
-                     "Precondition: fresh suite must have no triage-bot override")
 
-        XCTAssertEqual(sut.isSideLoadingEnabled, sut.isTriageBotEnabled,
-                       "With no local override, isSideLoadingEnabled must follow the same DEBUG-on precedence as isTriageBotEnabled")
+        XCTAssertEqual(sut.isSideLoadingEnabled, sut.isFeatureEnabled(.sideLoadingEnabled),
+                       "With no local override, isSideLoadingEnabled must defer to Remote Config (isFeatureEnabled)")
     }
 
     // MARK: - Flag / RemoteConfig wiring

--- a/PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift
+++ b/PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift
@@ -1,0 +1,121 @@
+//
+//  RemoteFeatureFlagsSideLoadingTests.swift
+//  PalaceTests
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+/// Behavior specs for the `sideLoadingEnabled` feature-flag resolution
+/// (swarm_495a88d9, Module B — PP-2679 / PP-2677).
+///
+/// These tests pin the RESOLUTION PRECEDENCE, not the default value:
+///   1. UserDefaults local override (either direction) wins.
+///   2. No override → DEBUG builds resolve `true`.
+///   3. No override, release build → Firebase Remote Config (default `false`).
+///
+/// Every test constructs a fresh `RemoteFeatureFlags(defaults:)` with a
+/// per-suite `UserDefaults` so override-key state never leaks — `.shared` is
+/// never touched.
+final class RemoteFeatureFlagsSideLoadingTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "RemoteFeatureFlagsSideLoadingTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - Local override precedence (both directions)
+
+    /// Override set to `true` → accessor returns `true`. If the accessor
+    /// ignored the override and read only the DEBUG/Firebase fallback, this
+    /// would still pass in DEBUG — which is why the `false` case below is the
+    /// load-bearing assertion. This one pins the on-direction of the override.
+    func testIsSideLoadingEnabled_whenLocalOverrideTrue_returnsTrue() {
+        let sut = RemoteFeatureFlags(defaults: defaults)
+        defaults.set(true, forKey: RemoteFeatureFlags.sideLoadingLocalOverrideKey)
+
+        XCTAssertTrue(sut.isSideLoadingEnabled,
+                      "A local override of true must resolve isSideLoadingEnabled to true")
+    }
+
+    /// Override set to `false` → accessor returns `false` EVEN IN DEBUG, where
+    /// the fallback would otherwise return `true`. This is the precedence
+    /// proof: it fails if the override check is dropped or the precedence is
+    /// inverted (fallback consulted before the override).
+    func testIsSideLoadingEnabled_whenLocalOverrideFalse_returnsFalse_overridingDebugDefault() {
+        let sut = RemoteFeatureFlags(defaults: defaults)
+        defaults.set(false, forKey: RemoteFeatureFlags.sideLoadingLocalOverrideKey)
+
+        XCTAssertFalse(sut.isSideLoadingEnabled,
+                       "A local override of false must win over the DEBUG-on / Firebase fallback")
+    }
+
+    /// Full round-trip through the single production seam: true → false → true.
+    /// Proves the accessor re-reads the override on every call (no cached
+    /// first-read) and that both write directions are honored via the same key.
+    func testIsSideLoadingEnabled_overrideRoundTrip_true_false_true() {
+        let sut = RemoteFeatureFlags(defaults: defaults)
+
+        defaults.set(true, forKey: RemoteFeatureFlags.sideLoadingLocalOverrideKey)
+        XCTAssertTrue(sut.isSideLoadingEnabled, "override=true → true")
+
+        defaults.set(false, forKey: RemoteFeatureFlags.sideLoadingLocalOverrideKey)
+        XCTAssertFalse(sut.isSideLoadingEnabled, "override flipped to false → false")
+
+        defaults.set(true, forKey: RemoteFeatureFlags.sideLoadingLocalOverrideKey)
+        XCTAssertTrue(sut.isSideLoadingEnabled, "override flipped back to true → true")
+    }
+
+    // MARK: - No override → DEBUG-on precedence
+
+    /// With NO override present, `isSideLoadingEnabled` must follow the exact
+    /// same DEBUG-on precedence as the canonical `isTriageBotEnabled`
+    /// (override > `#if DEBUG` true > Firebase — locked decision #2).
+    ///
+    /// This is asserted via parity with `isTriageBotEnabled` rather than a
+    /// test-side `#if DEBUG`, because the PalaceTests target does NOT define
+    /// `DEBUG` even when the Palace module (where both accessors are compiled)
+    /// does — a test-side `#if DEBUG` would always take the release branch and
+    /// diverge from the production value. Both accessors here are evaluated in
+    /// the production module under the same compilation flags, so with no
+    /// override on either key they must resolve identically regardless of build
+    /// configuration. If the `#if DEBUG return true` arm is dropped from
+    /// `isSideLoadingEnabled`, a DEBUG-config production build makes
+    /// `isTriageBotEnabled` true while `isSideLoadingEnabled` falls to the
+    /// Firebase default (false) — and this assertion fails.
+    func testIsSideLoadingEnabled_noOverride_followsSameDebugOnPrecedenceAsTriageBot() {
+        let sut = RemoteFeatureFlags(defaults: defaults)
+        XCTAssertNil(defaults.object(forKey: RemoteFeatureFlags.sideLoadingLocalOverrideKey),
+                     "Precondition: fresh suite must have no side-loading override")
+        XCTAssertNil(defaults.object(forKey: RemoteFeatureFlags.triageBotLocalOverrideKey),
+                     "Precondition: fresh suite must have no triage-bot override")
+
+        XCTAssertEqual(sut.isSideLoadingEnabled, sut.isTriageBotEnabled,
+                       "With no local override, isSideLoadingEnabled must follow the same DEBUG-on precedence as isTriageBotEnabled")
+    }
+
+    // MARK: - Flag / RemoteConfig wiring
+
+    /// The FeatureFlag case must map to a FirebaseManager RemoteConfigKey so the
+    /// release-path (`isFeatureEnabled`) actually consults Remote Config instead
+    /// of silently falling through to `defaultValue`. A nil managerKey would
+    /// break remote gating — this pins the mapping exists.
+    func testSideLoadingFeatureFlag_mapsToRemoteConfigKey() {
+        XCTAssertEqual(RemoteFeatureFlags.FeatureFlag.sideLoadingEnabled.managerKey,
+                       .sideLoadingEnabled,
+                       "sideLoadingEnabled FeatureFlag must map to the sideLoadingEnabled RemoteConfigKey")
+    }
+}

--- a/PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift
+++ b/PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift
@@ -1,0 +1,140 @@
+//
+//  BookFileManagerSideloadResolutionTests.swift
+//  PalaceTests
+//
+//  Component 4 (sideloading-plan.md R6): a side-loaded book's file is written
+//  under one fixed account (`SideloadedBookRegistry.sideloadContentAccountID`)
+//  because side-loaded content is account-agnostic. `BookFileManager.fileUrl`
+//  must therefore resolve a side-loaded id to that FIXED account's directory
+//  even when the current library (or a caller-supplied account) differs — else
+//  a library switch orphans the file and the reader can't open it.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class BookFileManagerSideloadResolutionTests: XCTestCase {
+
+  private var tempDirectory: URL!
+  private var defaultsSuiteName: String!
+  private var customDefaults: UserDefaults!
+
+  /// A library that is NOT the fixed side-load account, so we can prove the
+  /// resolution ignores it for side-loaded ids.
+  private let nonPrimaryAccount = "urn:uuid:deadbeef-0000-4000-8000-nonprimarylib"
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    tempDirectory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("BFMSideloadTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+
+    defaultsSuiteName = "BFMSideloadTests-\(UUID().uuidString)"
+    customDefaults = UserDefaults(suiteName: defaultsSuiteName)
+    // Drive currentAccountId to a NON-primary library.
+    customDefaults.set(nonPrimaryAccount, forKey: currentAccountIdentifierKey)
+
+    XCTAssertNotEqual(nonPrimaryAccount, SideloadedBookRegistry.sideloadContentAccountID,
+                      "Precondition: the current account must differ from the fixed side-load account")
+  }
+
+  override func tearDownWithError() throws {
+    customDefaults.removePersistentDomain(forName: defaultsSuiteName)
+    customDefaults = nil
+    defaultsSuiteName = nil
+    try? FileManager.default.removeItem(at: tempDirectory)
+    tempDirectory = nil
+    try super.tearDownWithError()
+  }
+
+  // MARK: - Helpers
+
+  private func makeBook(identifier: String) -> TPPBook {
+    TPPBook(
+      acquisitions: [TPPFake.genericAcquisition],
+      authors: nil, categoryStrings: nil, distributor: nil,
+      identifier: identifier,
+      imageURL: nil, imageThumbnailURL: nil, published: nil, publisher: nil,
+      subtitle: nil, summary: nil, title: "Title \(identifier)", updated: Date(),
+      annotationsURL: nil, analyticsURL: nil, alternateURL: nil,
+      relatedWorksURL: nil, previewLink: nil, seriesURL: nil,
+      revokeURL: nil, reportURL: nil, timeTrackingURL: nil,
+      contributors: nil, bookDuration: nil, imageCache: MockImageCache()
+    )
+  }
+
+  /// Builds a BookFileManager whose content directory is a per-account temp
+  /// folder (so the resolved path reveals WHICH account was used), a registry
+  /// with the two seeded books, and a fixed side-loaded id set.
+  private func makeFileManager(sideloadedIDs: Set<String>) -> BookFileManager {
+    let registry = TPPBookRegistryMock()
+    registry.addBook(makeBook(identifier: "sl-1"), state: .downloadSuccessful)
+    registry.addBook(makeBook(identifier: "normal-1"), state: .downloadSuccessful)
+
+    let accountsManager = AccountsManager(defaults: customDefaults)
+    let dir = tempDirectory!
+
+    return BookFileManager(
+      bookRegistry: registry,
+      accountsManager: accountsManager,
+      fileManager: .default,
+      directoryProvider: { account in
+        dir.appendingPathComponent("acct-\(account ?? "nil")")
+      },
+      sideloadedIdentifiersProvider: { sideloadedIDs }
+    )
+  }
+
+  // MARK: - Tests
+
+  func test_sideloadedId_resolvesToFixedAccount_evenWhenExplicitAccountDiffers() {
+    let bfm = makeFileManager(sideloadedIDs: ["sl-1"])
+
+    // Caller passes the NON-primary account; the side-load substitution must
+    // override it with the fixed account.
+    let url = bfm.fileUrl(for: "sl-1", account: nonPrimaryAccount)
+
+    let path = try? XCTUnwrap(url).path
+    XCTAssertNotNil(path)
+    XCTAssertTrue(path?.contains("acct-\(SideloadedBookRegistry.sideloadContentAccountID)") ?? false,
+                  "Side-loaded id must resolve under the fixed side-load account, got: \(path ?? "nil")")
+    XCTAssertFalse(path?.contains("acct-\(nonPrimaryAccount)") ?? true,
+                   "Side-loaded id must NOT resolve under the caller-supplied non-primary account")
+  }
+
+  func test_sideloadedId_resolvesToFixedAccount_evenWhenCurrentAccountDiffers() {
+    // Multi-step: currentAccountId is a non-primary library (set in setUp),
+    // then resolve via the no-account overload (which reads currentAccountId),
+    // and assert the FIXED account directory — proving a library switch cannot
+    // orphan the side-loaded file.
+    let bfm = makeFileManager(sideloadedIDs: ["sl-1"])
+
+    let url = bfm.fileUrl(for: "sl-1")
+
+    let path = try? XCTUnwrap(url).path
+    XCTAssertTrue(path?.contains("acct-\(SideloadedBookRegistry.sideloadContentAccountID)") ?? false,
+                  "With current account = non-primary, side-loaded id must still resolve under the fixed account, got: \(path ?? "nil")")
+    XCTAssertFalse(path?.contains("acct-\(nonPrimaryAccount)") ?? true)
+  }
+
+  func test_nonSideloadedId_resolvesAgainstCurrentAccount_unchanged() {
+    // Contrast: a normal book is NOT side-loaded, so it must resolve against
+    // the current/caller account exactly as before (no behavior change).
+    let bfm = makeFileManager(sideloadedIDs: ["sl-1"])
+
+    let explicitURL = bfm.fileUrl(for: "normal-1", account: nonPrimaryAccount)
+    let explicitPath = try? XCTUnwrap(explicitURL).path
+    XCTAssertTrue(explicitPath?.contains("acct-\(nonPrimaryAccount)") ?? false,
+                  "A non-side-loaded id must resolve under the passed account, got: \(explicitPath ?? "nil")")
+    XCTAssertFalse(explicitPath?.contains("acct-\(SideloadedBookRegistry.sideloadContentAccountID)") ?? true,
+                   "A non-side-loaded id must NOT be pinned to the fixed side-load account")
+
+    // And via the current-account overload.
+    let currentURL = bfm.fileUrl(for: "normal-1")
+    let currentPath = try? XCTUnwrap(currentURL).path
+    XCTAssertTrue(currentPath?.contains("acct-\(nonPrimaryAccount)") ?? false,
+                  "A non-side-loaded id must resolve under currentAccountId")
+  }
+}

--- a/PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift
+++ b/PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift
@@ -70,8 +70,11 @@ final class BookFileManagerSideloadResolutionTests: PalaceWiringTestCase {
   /// with the two seeded books, and a fixed side-loaded id set.
   private func makeFileManager(sideloadedIDs: Set<String>) -> BookFileManager {
     let registry = TPPBookRegistryMock()
-    registry.addBook(makeBook(identifier: "sl-1"), state: .downloadSuccessful)
+    registry.addBook(makeBook(identifier: "sideload-1"), state: .downloadSuccessful)
     registry.addBook(makeBook(identifier: "normal-1"), state: .downloadSuccessful)
+    // Carries the "sideload-" prefix but is NOT in the provider set — for the
+    // defense-in-depth case: prefix alone must not pin to the fixed account.
+    registry.addBook(makeBook(identifier: "sideload-ghost"), state: .downloadSuccessful)
 
     let accountsManager = makeFreshAccountsManager(defaults: customDefaults)
     let dir = tempDirectory!
@@ -90,11 +93,11 @@ final class BookFileManagerSideloadResolutionTests: PalaceWiringTestCase {
   // MARK: - Tests
 
   func test_sideloadedId_resolvesToFixedAccount_evenWhenExplicitAccountDiffers() {
-    let bfm = makeFileManager(sideloadedIDs: ["sl-1"])
+    let bfm = makeFileManager(sideloadedIDs: ["sideload-1"])
 
     // Caller passes the NON-primary account; the side-load substitution must
     // override it with the fixed account.
-    let url = bfm.fileUrl(for: "sl-1", account: nonPrimaryAccount)
+    let url = bfm.fileUrl(for: "sideload-1", account: nonPrimaryAccount)
 
     let path = try? XCTUnwrap(url).path
     XCTAssertNotNil(path)
@@ -109,9 +112,9 @@ final class BookFileManagerSideloadResolutionTests: PalaceWiringTestCase {
     // then resolve via the no-account overload (which reads currentAccountId),
     // and assert the FIXED account directory — proving a library switch cannot
     // orphan the side-loaded file.
-    let bfm = makeFileManager(sideloadedIDs: ["sl-1"])
+    let bfm = makeFileManager(sideloadedIDs: ["sideload-1"])
 
-    let url = bfm.fileUrl(for: "sl-1")
+    let url = bfm.fileUrl(for: "sideload-1")
 
     let path = try? XCTUnwrap(url).path
     XCTAssertTrue(path?.contains("acct-\(SideloadedBookRegistry.sideloadContentAccountID)") ?? false,
@@ -122,7 +125,7 @@ final class BookFileManagerSideloadResolutionTests: PalaceWiringTestCase {
   func test_nonSideloadedId_resolvesAgainstCurrentAccount_unchanged() {
     // Contrast: a normal book is NOT side-loaded, so it must resolve against
     // the current/caller account exactly as before (no behavior change).
-    let bfm = makeFileManager(sideloadedIDs: ["sl-1"])
+    let bfm = makeFileManager(sideloadedIDs: ["sideload-1"])
 
     let explicitURL = bfm.fileUrl(for: "normal-1", account: nonPrimaryAccount)
     let explicitPath = try? XCTUnwrap(explicitURL).path
@@ -136,5 +139,22 @@ final class BookFileManagerSideloadResolutionTests: PalaceWiringTestCase {
     let currentPath = try? XCTUnwrap(currentURL).path
     XCTAssertTrue(currentPath?.contains("acct-\(nonPrimaryAccount)") ?? false,
                   "A non-side-loaded id must resolve under currentAccountId")
+  }
+
+  func test_sideloadPrefixedId_notInProvider_resolvesAgainstAccount_defenseInDepth() {
+    // An id can carry the "sideload-" prefix yet not be registered in the
+    // provider set. The prefix is only a cheap gate for the lock+set lookup;
+    // membership in the provider is still authoritative. Such an id must NOT be
+    // pinned to the fixed side-load account — it resolves against the caller's
+    // account like any normal id.
+    let bfm = makeFileManager(sideloadedIDs: ["sideload-1"])
+
+    let url = bfm.fileUrl(for: "sideload-ghost", account: nonPrimaryAccount)
+
+    let path = try? XCTUnwrap(url).path
+    XCTAssertTrue(path?.contains("acct-\(nonPrimaryAccount)") ?? false,
+                  "A prefixed id absent from the provider must resolve under the passed account, got: \(path ?? "nil")")
+    XCTAssertFalse(path?.contains("acct-\(SideloadedBookRegistry.sideloadContentAccountID)") ?? true,
+                   "Prefix alone must not pin to the fixed side-load account — provider membership is authoritative")
   }
 }

--- a/PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift
+++ b/PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift
@@ -15,7 +15,7 @@
 import XCTest
 @testable import Palace
 
-final class BookFileManagerSideloadResolutionTests: XCTestCase {
+final class BookFileManagerSideloadResolutionTests: PalaceWiringTestCase {
 
   private var tempDirectory: URL!
   private var defaultsSuiteName: String!
@@ -73,7 +73,7 @@ final class BookFileManagerSideloadResolutionTests: XCTestCase {
     registry.addBook(makeBook(identifier: "sl-1"), state: .downloadSuccessful)
     registry.addBook(makeBook(identifier: "normal-1"), state: .downloadSuccessful)
 
-    let accountsManager = AccountsManager(defaults: customDefaults)
+    let accountsManager = makeFreshAccountsManager(defaults: customDefaults)
     let dir = tempDirectory!
 
     return BookFileManager(

--- a/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
+++ b/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
@@ -1,0 +1,326 @@
+//
+//  SideloadedBookManagerTests.swift
+//  PalaceTests
+//
+//  Behaviour coverage for the side-loading import/remove/rehydrate flow
+//  (PP-2677). Drives the real `SideloadedBookManager` against a temp-dir
+//  `SideloadedBookRegistry`, a `TPPBookRegistryMock`, and a `BookFileManager`
+//  with a temp `directoryProvider` — no singletons, no network.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class SideloadedBookManagerTests: XCTestCase {
+
+  private var tempRoot: URL!
+  private var contentRoot: URL!
+  private var manifestDir: URL!
+  private var importSourceDir: URL!
+  private var defaultsSuiteName: String!
+  private var customDefaults: UserDefaults!
+
+  /// A library that is NOT the fixed side-load account — proves the import
+  /// pins the write to the fixed account regardless of the current library.
+  private let nonPrimaryAccount = "urn:uuid:deadbeef-1111-4000-8000-notprimarylib"
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    tempRoot = FileManager.default.temporaryDirectory
+      .appendingPathComponent("SideloadMgrTests-\(UUID().uuidString)")
+    contentRoot = tempRoot.appendingPathComponent("content")
+    manifestDir = tempRoot.appendingPathComponent("manifest")
+    importSourceDir = tempRoot.appendingPathComponent("incoming")
+    for dir in [contentRoot, manifestDir, importSourceDir] {
+      try FileManager.default.createDirectory(at: dir!, withIntermediateDirectories: true)
+    }
+
+    defaultsSuiteName = "SideloadMgrTests-\(UUID().uuidString)"
+    customDefaults = UserDefaults(suiteName: defaultsSuiteName)
+    customDefaults.set(nonPrimaryAccount, forKey: currentAccountIdentifierKey)
+
+    XCTAssertNotEqual(nonPrimaryAccount, SideloadedBookRegistry.sideloadContentAccountID,
+                      "Precondition: current account must differ from the fixed side-load account")
+  }
+
+  override func tearDownWithError() throws {
+    customDefaults.removePersistentDomain(forName: defaultsSuiteName)
+    customDefaults = nil
+    defaultsSuiteName = nil
+    try? FileManager.default.removeItem(at: tempRoot)
+    tempRoot = nil
+    try super.tearDownWithError()
+  }
+
+  // MARK: - Fixtures / builders
+
+  private func writeFixture(ext: String, contents: String = UUID().uuidString) throws -> URL {
+    let url = importSourceDir.appendingPathComponent("\(UUID().uuidString).\(ext)")
+    try Data(contents.utf8).write(to: url)
+    return url
+  }
+
+  private func makeBookFileManager(registry: TPPBookRegistryProvider) -> BookFileManager {
+    let accountsManager = AccountsManager(defaults: customDefaults)
+    let root = contentRoot!
+    return BookFileManager(
+      bookRegistry: registry,
+      accountsManager: accountsManager,
+      fileManager: .default,
+      directoryProvider: { account in root.appendingPathComponent("acct-\(account ?? "nil")") },
+      sideloadedIdentifiersProvider: { [] }
+    )
+  }
+
+  private func makeManager(
+    registry: TPPBookRegistryProvider,
+    sideloaded: SideloadedBookRegistry,
+    fileManaging: SideloadFileManaging = DefaultSideloadFileManaging()
+  ) -> SideloadedBookManager {
+    SideloadedBookManager(
+      bookRegistry: registry,
+      sideloadedRegistry: sideloaded,
+      bookFileManager: makeBookFileManager(registry: registry),
+      classifier: DefaultSideloadContentClassifier(),
+      fileManaging: fileManaging,
+      imageCache: MockImageCache()
+    )
+  }
+
+  // MARK: - Classification
+
+  func testImport_epubFile_mintsEpubOpenAccessBook_andRegistersDownloadSuccessful() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+    let source = try writeFixture(ext: "epub")
+
+    let book = try manager.import(fileURL: source)
+
+    XCTAssertEqual(book.defaultBookContentType, .epub)
+    XCTAssertTrue(sideloaded.identifiers.contains(book.identifier), "truth store must record the id")
+    XCTAssertEqual(registry.state(for: book.identifier), .downloadSuccessful,
+                   "main registry must record .downloadSuccessful so the reader opens it")
+    XCTAssertNotNil(registry.book(forIdentifier: book.identifier))
+  }
+
+  func testImport_pdfFile_mintsPdfContentType() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+
+    let book = try manager.import(fileURL: try writeFixture(ext: "pdf"))
+
+    XCTAssertEqual(book.defaultBookContentType, .pdf)
+    XCTAssertEqual(registry.state(for: book.identifier), .downloadSuccessful)
+  }
+
+  func testImport_audiobookManifest_mintsAudiobookContentType() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+
+    let book = try manager.import(fileURL: try writeFixture(ext: "json", contents: "{\"metadata\":{}}"))
+
+    XCTAssertEqual(book.defaultBookContentType, .audiobook)
+  }
+
+  // MARK: - Fixed-account write
+
+  func testImport_copiesFileToFixedAccountPath_notCurrentAccount() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+    let source = try writeFixture(ext: "epub")
+
+    let book = try manager.import(fileURL: source)
+
+    let fixedAccount = SideloadedBookRegistry.sideloadContentAccountID
+    let expectedDir = contentRoot.appendingPathComponent("acct-\(fixedAccount)")
+    let expected = expectedDir
+      .appendingPathComponent(book.identifier.sha256())
+      .appendingPathExtension("epub")
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: expected.path),
+                  "file must be copied to the fixed-account sha256 path, expected: \(expected.path)")
+    let currentAccountDir = contentRoot.appendingPathComponent("acct-\(nonPrimaryAccount)")
+    XCTAssertFalse(FileManager.default.fileExists(atPath: currentAccountDir.path),
+                   "file must NOT be written under the current (non-primary) account")
+  }
+
+  // MARK: - Dedup
+
+  func testImport_sameContentTwice_doesNotDuplicate() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+    let source = try writeFixture(ext: "epub", contents: "identical-bytes")
+
+    let first = try manager.import(fileURL: source)
+    let second = try manager.import(fileURL: source)
+
+    XCTAssertEqual(first.identifier, second.identifier,
+                   "same content ⇒ same content-derived identifier")
+    XCTAssertEqual(sideloaded.identifiers.count, 1, "re-import must not create a duplicate entry")
+    XCTAssertEqual(sideloaded.allBooks.count, 1)
+  }
+
+  // MARK: - Error paths
+
+  func testImport_unsupportedType_throws_andMutatesNeitherRegistry() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+    let source = try writeFixture(ext: "txt")
+
+    XCTAssertThrowsError(try manager.import(fileURL: source)) { error in
+      guard case SideloadImportError.unsupportedFileType = error else {
+        return XCTFail("expected unsupportedFileType, got \(error)")
+      }
+    }
+    XCTAssertTrue(sideloaded.identifiers.isEmpty, "no partial write to the truth store")
+    XCTAssertTrue(registry.registry.isEmpty, "no partial write to the main registry")
+  }
+
+  func testImport_copyFailure_throws_andMutatesNeitherRegistry() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded, fileManaging: FailingFileManaging())
+    let source = try writeFixture(ext: "epub")
+
+    XCTAssertThrowsError(try manager.import(fileURL: source))
+    XCTAssertTrue(sideloaded.identifiers.isEmpty,
+                  "a copy failure must abort before any registry mutation")
+    XCTAssertTrue(registry.registry.isEmpty)
+  }
+
+  // MARK: - Remove
+
+  func testRemove_deletesFile_andClearsBothRegistries() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+    let book = try manager.import(fileURL: try writeFixture(ext: "epub"))
+
+    let expected = contentRoot
+      .appendingPathComponent("acct-\(SideloadedBookRegistry.sideloadContentAccountID)")
+      .appendingPathComponent(book.identifier.sha256())
+      .appendingPathExtension("epub")
+    XCTAssertTrue(FileManager.default.fileExists(atPath: expected.path), "precondition: file exists")
+
+    manager.remove(identifier: book.identifier)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: expected.path), "file must be deleted")
+    XCTAssertFalse(sideloaded.identifiers.contains(book.identifier), "truth store must be cleared")
+    XCTAssertNil(registry.book(forIdentifier: book.identifier), "main registry must be cleared")
+  }
+
+  func testRemove_bookPresentOnlyInSideloadedRegistry_deletesFileViaFallbackLookup() throws {
+    // Main registry is EMPTY, so `remove` must resolve the book through the
+    // side-loaded-registry fallback to find + delete its on-disk file.
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let bfm = makeBookFileManager(registry: registry)
+    let manager = SideloadedBookManager(
+      bookRegistry: registry,
+      sideloadedRegistry: sideloaded,
+      bookFileManager: bfm,
+      imageCache: MockImageCache()
+    )
+
+    let book = SideloadedBookManager.mintOpenAccessBook(
+      identifier: "sideload-fallback-1",
+      title: "Fallback",
+      mimeType: "application/epub+zip",
+      imageCache: MockImageCache()
+    )
+    sideloaded.add(book: book, fileURL: URL(fileURLWithPath: "/tmp/z.epub"))
+
+    let fileURL = try XCTUnwrap(bfm.fileUrl(for: book, account: SideloadedBookRegistry.sideloadContentAccountID))
+    try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data("x".utf8).write(to: fileURL)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path), "precondition: file staged")
+    XCTAssertNil(registry.book(forIdentifier: book.identifier), "precondition: NOT in the main registry")
+
+    manager.remove(identifier: book.identifier)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path),
+                   "fallback lookup must resolve the book and delete its file")
+    XCTAssertFalse(sideloaded.identifiers.contains(book.identifier))
+  }
+
+  // MARK: - Launch rehydration
+
+  func testRehydrateAtLaunch_reRegistersPersistedBooks_intoMainRegistry_asDownloadSuccessful() throws {
+    // Persist a side-loaded book directly (simulates surviving a cold launch),
+    // with an EMPTY main registry (the main registry loses side-loaded-ness).
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let book = SideloadedBookManager.mintOpenAccessBook(
+      identifier: "sideload-rehydrate-1",
+      title: "Rehydrated",
+      mimeType: "application/epub+zip",
+      imageCache: MockImageCache()
+    )
+    sideloaded.add(book: book, fileURL: URL(fileURLWithPath: "/tmp/x.epub"))
+
+    let registry = TPPBookRegistryMock()
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+    XCTAssertNil(registry.book(forIdentifier: book.identifier), "precondition: main registry empty")
+
+    manager.rehydrateAtLaunch()
+
+    XCTAssertNotNil(registry.book(forIdentifier: book.identifier), "book must be re-registered")
+    XCTAssertEqual(registry.state(for: book.identifier), .downloadSuccessful)
+  }
+
+  func testRehydrateAtLaunch_runTwice_isIdempotent_doesNotReAddPresentBook() throws {
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let book = SideloadedBookManager.mintOpenAccessBook(
+      identifier: "sideload-rehydrate-2",
+      title: "Rehydrated Twice",
+      mimeType: "application/epub+zip",
+      imageCache: MockImageCache()
+    )
+    sideloaded.add(book: book, fileURL: URL(fileURLWithPath: "/tmp/y.epub"))
+
+    let registry = CountingBookRegistryMock()
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+
+    manager.rehydrateAtLaunch()
+    manager.rehydrateAtLaunch()
+
+    XCTAssertEqual(registry.addBookCallCount, 1,
+                   "second rehydrate must skip the already-present book (idempotent)")
+    XCTAssertEqual(registry.state(for: book.identifier), .downloadSuccessful)
+  }
+}
+
+// MARK: - Test doubles
+
+/// A file-managing seam that fails every copy, to drive the copy-failure path.
+private struct FailingFileManaging: SideloadFileManaging {
+  struct Boom: Error {}
+  func copyFile(from source: URL, to destination: URL) throws { throw Boom() }
+  func removeFile(at url: URL) throws {}
+}
+
+/// Counts `addBook` calls so the idempotency test can prove the second
+/// rehydrate does NOT re-add an already-present book (kills the existence-guard
+/// mutant, which a keyed-dict registry alone can't observe).
+private final class CountingBookRegistryMock: TPPBookRegistryMock {
+  private(set) var addBookCallCount = 0
+  override func addBook(
+    _ book: TPPBook,
+    location: TPPBookLocation?,
+    state: TPPBookState,
+    fulfillmentId: String?,
+    readiumBookmarks: [TPPReadiumBookmark]?,
+    genericBookmarks: [TPPBookLocation]?
+  ) {
+    addBookCallCount += 1
+    super.addBook(book, location: location, state: state, fulfillmentId: fulfillmentId,
+                  readiumBookmarks: readiumBookmarks, genericBookmarks: genericBookmarks)
+  }
+}

--- a/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
+++ b/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
@@ -268,6 +268,58 @@ final class SideloadedBookManagerTests: PalaceWiringTestCase {
                   "the book must NOT reach the main registry when the manifest didn't persist")
   }
 
+  // MARK: - Original filename surfacing (UI-2)
+
+  func testOriginalFilename_afterImport_returnsImportedFilename() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+    // A fixed, recognizable source filename (not the sha256 identifier).
+    let source = importSourceDir.appendingPathComponent("My Great Novel.epub")
+    try Data(UUID().uuidString.utf8).write(to: source)
+
+    let book = try manager.import(fileURL: source)
+
+    XCTAssertEqual(manager.originalFilename(for: book.identifier), "My Great Novel.epub",
+                   "manager must surface the imported filename, not the content-hash id")
+    XCTAssertNotEqual(manager.originalFilename(for: book.identifier), book.identifier)
+  }
+
+  func testOriginalFilename_unknownIdentifier_returnsNil() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+
+    XCTAssertNil(manager.originalFilename(for: "sideload-nonexistent"),
+                 "an unknown identifier must have no filename")
+  }
+
+  @MainActor
+  func testCaption_importedBook_isFilename_unknownBook_fallsBackToTitle() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+    let source = importSourceDir.appendingPathComponent("Report.pdf")
+    try Data(UUID().uuidString.utf8).write(to: source)
+    let imported = try manager.import(fileURL: source)
+
+    let viewModel = SideLoadingViewModel(manager: manager)
+
+    XCTAssertEqual(viewModel.caption(for: imported), "Report.pdf",
+                   "caption for an imported book must show its filename")
+
+    // A book the manager has never seen → caption falls back to the title,
+    // never the raw identifier.
+    let unknown = SideloadedBookManager.mintOpenAccessBook(
+      identifier: "sideload-unknown-1",
+      title: "Untracked Title",
+      mimeType: "application/epub+zip",
+      imageCache: MockImageCache()
+    )
+    XCTAssertEqual(viewModel.caption(for: unknown), "Untracked Title",
+                   "caption must fall back to the book title when no filename is known")
+  }
+
   // MARK: - Remove
 
   func testRemove_deletesFile_andClearsBothRegistries() throws {

--- a/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
+++ b/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
@@ -13,7 +13,7 @@
 import XCTest
 @testable import Palace
 
-final class SideloadedBookManagerTests: XCTestCase {
+final class SideloadedBookManagerTests: PalaceWiringTestCase {
 
   private var tempRoot: URL!
   private var contentRoot: URL!
@@ -63,7 +63,7 @@ final class SideloadedBookManagerTests: XCTestCase {
   }
 
   private func makeBookFileManager(registry: TPPBookRegistryProvider) -> BookFileManager {
-    let accountsManager = AccountsManager(defaults: customDefaults)
+    let accountsManager = makeFreshAccountsManager(defaults: customDefaults)
     let root = contentRoot!
     return BookFileManager(
       bookRegistry: registry,

--- a/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
+++ b/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
@@ -196,6 +196,78 @@ final class SideloadedBookManagerTests: PalaceWiringTestCase {
     XCTAssertTrue(registry.registry.isEmpty)
   }
 
+  func testImport_unreadableSourceFile_throwsUnreadableFile_andMutatesNeitherRegistry() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+    // Supported extension so classification passes, but no file on disk — the
+    // content-hash read in `contentIdentifier` fails → `.unreadableFile`.
+    let missing = importSourceDir.appendingPathComponent("\(UUID().uuidString).epub")
+    XCTAssertFalse(FileManager.default.fileExists(atPath: missing.path), "precondition: file absent")
+
+    XCTAssertThrowsError(try manager.import(fileURL: missing)) { error in
+      guard case SideloadImportError.unreadableFile = error else {
+        return XCTFail("expected unreadableFile, got \(error)")
+      }
+    }
+    XCTAssertTrue(sideloaded.identifiers.isEmpty, "no write to the truth store")
+    XCTAssertTrue(registry.registry.isEmpty, "no write to the main registry")
+  }
+
+  func testImport_destinationUnavailable_throwsDestinationUnavailable_andMutatesNeitherRegistry() throws {
+    let registry = TPPBookRegistryMock()
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: manifestDir)
+    let accountsManager = makeFreshAccountsManager(defaults: customDefaults)
+    // A directoryProvider that returns nil makes `fileUrl(for:account:)` nil,
+    // so the import cannot resolve a copy destination → `.destinationUnavailable`.
+    let bfm = BookFileManager(
+      bookRegistry: registry,
+      accountsManager: accountsManager,
+      fileManager: .default,
+      directoryProvider: { _ in nil },
+      sideloadedIdentifiersProvider: { [] }
+    )
+    let manager = SideloadedBookManager(
+      bookRegistry: registry,
+      sideloadedRegistry: sideloaded,
+      bookFileManager: bfm,
+      imageCache: MockImageCache()
+    )
+    let source = try writeFixture(ext: "pdf")
+
+    XCTAssertThrowsError(try manager.import(fileURL: source)) { error in
+      guard case SideloadImportError.destinationUnavailable = error else {
+        return XCTFail("expected destinationUnavailable, got \(error)")
+      }
+    }
+    XCTAssertTrue(sideloaded.identifiers.isEmpty, "no write to the truth store")
+    XCTAssertTrue(registry.registry.isEmpty, "no write to the main registry")
+  }
+
+  func testImport_manifestPersistFails_throwsPersistenceFailed_andDoesNotRegisterInMainRegistry() throws {
+    let registry = TPPBookRegistryMock()
+    // Make the manifest unwritable: nest its directory under a regular FILE, so
+    // the `createDirectory` inside `persistLocked` fails → the manifest write
+    // throws → `add` rolls back and rethrows → `import` must abort BEFORE the
+    // main-registry write (else the book would be evicted on the next sync).
+    let blocker = tempRoot.appendingPathComponent("blocker-\(UUID().uuidString)")
+    try Data("x".utf8).write(to: blocker)
+    let unwritableManifestDir = blocker.appendingPathComponent("nested")
+    let sideloaded = SideloadedBookRegistry(manifestDirectory: unwritableManifestDir)
+    let manager = makeManager(registry: registry, sideloaded: sideloaded)
+    let source = try writeFixture(ext: "epub")
+
+    XCTAssertThrowsError(try manager.import(fileURL: source)) { error in
+      guard case SideloadImportError.persistenceFailed = error else {
+        return XCTFail("expected persistenceFailed, got \(error)")
+      }
+    }
+    XCTAssertTrue(sideloaded.identifiers.isEmpty,
+                  "a manifest-persist failure must roll the truth store back (atomic add)")
+    XCTAssertTrue(registry.registry.isEmpty,
+                  "the book must NOT reach the main registry when the manifest didn't persist")
+  }
+
   // MARK: - Remove
 
   func testRemove_deletesFile_andClearsBothRegistries() throws {
@@ -236,7 +308,7 @@ final class SideloadedBookManagerTests: PalaceWiringTestCase {
       mimeType: "application/epub+zip",
       imageCache: MockImageCache()
     )
-    sideloaded.add(book: book, fileURL: URL(fileURLWithPath: "/tmp/z.epub"))
+    try sideloaded.add(book: book, fileURL: URL(fileURLWithPath: "/tmp/z.epub"))
 
     let fileURL = try XCTUnwrap(bfm.fileUrl(for: book, account: SideloadedBookRegistry.sideloadContentAccountID))
     try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -263,7 +335,7 @@ final class SideloadedBookManagerTests: PalaceWiringTestCase {
       mimeType: "application/epub+zip",
       imageCache: MockImageCache()
     )
-    sideloaded.add(book: book, fileURL: URL(fileURLWithPath: "/tmp/x.epub"))
+    try sideloaded.add(book: book, fileURL: URL(fileURLWithPath: "/tmp/x.epub"))
 
     let registry = TPPBookRegistryMock()
     let manager = makeManager(registry: registry, sideloaded: sideloaded)
@@ -283,7 +355,7 @@ final class SideloadedBookManagerTests: PalaceWiringTestCase {
       mimeType: "application/epub+zip",
       imageCache: MockImageCache()
     )
-    sideloaded.add(book: book, fileURL: URL(fileURLWithPath: "/tmp/y.epub"))
+    try sideloaded.add(book: book, fileURL: URL(fileURLWithPath: "/tmp/y.epub"))
 
     let registry = CountingBookRegistryMock()
     let manager = makeManager(registry: registry, sideloaded: sideloaded)

--- a/PalaceTests/MyBooks/Sideload/SideloadedBookRegistryTests.swift
+++ b/PalaceTests/MyBooks/Sideload/SideloadedBookRegistryTests.swift
@@ -1,0 +1,237 @@
+//
+//  SideloadedBookRegistryTests.swift
+//  PalaceTests
+//
+//  Behavioural tests for the local-only side-loaded book registry (PP-2678):
+//  manifest round-trip, add/remove/rename/update, and the corrupt/empty/
+//  missing-manifest and duplicate-add edge cases.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class SideloadedBookRegistryTests: XCTestCase {
+
+  private var tempDirectory: URL!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    tempDirectory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("SideloadedBookRegistryTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(at: tempDirectory)
+    tempDirectory = nil
+    try super.tearDownWithError()
+  }
+
+  // MARK: - Helpers
+
+  private func makeRegistry() -> SideloadedBookRegistry {
+    SideloadedBookRegistry(fileManager: .default, manifestDirectory: tempDirectory)
+  }
+
+  private func makeBook(identifier: String, title: String) -> TPPBook {
+    TPPBook(
+      acquisitions: [TPPFake.genericAcquisition],
+      authors: nil,
+      categoryStrings: nil,
+      distributor: nil,
+      identifier: identifier,
+      imageURL: nil,
+      imageThumbnailURL: nil,
+      published: nil,
+      publisher: nil,
+      subtitle: nil,
+      summary: nil,
+      title: title,
+      updated: Date(),
+      annotationsURL: nil,
+      analyticsURL: nil,
+      alternateURL: nil,
+      relatedWorksURL: nil,
+      previewLink: nil,
+      seriesURL: nil,
+      revokeURL: nil,
+      reportURL: nil,
+      timeTrackingURL: nil,
+      contributors: nil,
+      bookDuration: nil,
+      imageCache: MockImageCache()
+    )
+  }
+
+  private func fileURL(named name: String) -> URL {
+    tempDirectory.appendingPathComponent(name)
+  }
+
+  private var manifestPath: String {
+    tempDirectory.appendingPathComponent("sideloaded.json").path
+  }
+
+  // MARK: - Manifest round-trip
+
+  func test_add_persistsAcrossReload_preservingIdentifiersTitlesAndFilenames() {
+    let registry = makeRegistry()
+    registry.add(book: makeBook(identifier: "sl-1", title: "First"),
+                 fileURL: fileURL(named: "first.epub"))
+    registry.add(book: makeBook(identifier: "sl-2", title: "Second"),
+                 fileURL: fileURL(named: "second.pdf"))
+
+    // Fresh instance reads the same on-disk manifest.
+    let reloaded = makeRegistry()
+
+    XCTAssertEqual(reloaded.allBooks.map(\.identifier), ["sl-1", "sl-2"],
+                   "Reload must preserve books and their import order")
+    XCTAssertEqual(reloaded.allBooks.map(\.title), ["First", "Second"],
+                   "Reload must preserve titles")
+    XCTAssertEqual(reloaded.originalFilename(for: "sl-1"), "first.epub")
+    XCTAssertEqual(reloaded.originalFilename(for: "sl-2"), "second.pdf")
+    XCTAssertEqual(reloaded.identifiers, ["sl-1", "sl-2"])
+  }
+
+  // MARK: - add / remove
+
+  func test_remove_dropsBookFromIdentifiersAndPersists() {
+    let registry = makeRegistry()
+    registry.add(book: makeBook(identifier: "sl-1", title: "First"),
+                 fileURL: fileURL(named: "first.epub"))
+    registry.add(book: makeBook(identifier: "sl-2", title: "Second"),
+                 fileURL: fileURL(named: "second.epub"))
+
+    registry.remove(identifier: "sl-1")
+
+    XCTAssertEqual(registry.identifiers, ["sl-2"],
+                   "remove must drop the id from the in-memory set")
+    // Persisted: a fresh instance must not resurrect the removed book.
+    XCTAssertEqual(makeRegistry().identifiers, ["sl-2"],
+                   "remove must persist — reload must not resurrect the book")
+  }
+
+  func test_remove_unknownIdentifier_isNoOp() {
+    let registry = makeRegistry()
+    registry.add(book: makeBook(identifier: "sl-1", title: "First"),
+                 fileURL: fileURL(named: "first.epub"))
+
+    registry.remove(identifier: "does-not-exist")
+
+    XCTAssertEqual(registry.identifiers, ["sl-1"])
+  }
+
+  // MARK: - rename
+
+  func test_rename_changesPersistedTitle_survivesReload() {
+    let registry = makeRegistry()
+    registry.add(book: makeBook(identifier: "sl-1", title: "Old Title"),
+                 fileURL: fileURL(named: "first.epub"))
+
+    registry.rename(identifier: "sl-1", to: "New Title")
+
+    XCTAssertEqual(registry.allBooks.first?.title, "New Title",
+                   "rename must mutate the in-memory title")
+    XCTAssertEqual(makeRegistry().allBooks.first?.title, "New Title",
+                   "rename must persist the new title across reload")
+  }
+
+  func test_rename_unknownIdentifier_isNoOp() {
+    let registry = makeRegistry()
+    registry.add(book: makeBook(identifier: "sl-1", title: "Old Title"),
+                 fileURL: fileURL(named: "first.epub"))
+
+    registry.rename(identifier: "ghost", to: "Should Not Apply")
+
+    XCTAssertEqual(registry.allBooks.first?.title, "Old Title")
+  }
+
+  // MARK: - update
+
+  func test_update_replacesBookButPreservesOriginalFilename() {
+    let registry = makeRegistry()
+    registry.add(book: makeBook(identifier: "sl-1", title: "Before"),
+                 fileURL: fileURL(named: "import-source.epub"))
+
+    registry.update(book: makeBook(identifier: "sl-1", title: "After"))
+
+    XCTAssertEqual(registry.allBooks.first?.title, "After",
+                   "update must replace the stored book")
+    XCTAssertEqual(registry.originalFilename(for: "sl-1"), "import-source.epub",
+                   "update must preserve the original imported filename")
+  }
+
+  func test_update_unknownIdentifier_doesNotInsert() {
+    let registry = makeRegistry()
+
+    registry.update(book: makeBook(identifier: "sl-1", title: "Ghost"))
+
+    XCTAssertTrue(registry.identifiers.isEmpty,
+                  "update must never insert an unknown book")
+  }
+
+  // MARK: - Edge cases
+
+  func test_addDuplicateIdentifier_doesNotDoubleInsert_andUpdatesInPlace() {
+    let registry = makeRegistry()
+    registry.add(book: makeBook(identifier: "sl-1", title: "First Import"),
+                 fileURL: fileURL(named: "a.epub"))
+    registry.add(book: makeBook(identifier: "sl-1", title: "Re-Import"),
+                 fileURL: fileURL(named: "b.epub"))
+
+    XCTAssertEqual(registry.allBooks.count, 1,
+                   "Re-adding the same id must not create a duplicate lane entry")
+    XCTAssertEqual(registry.allBooks.first?.title, "Re-Import")
+    XCTAssertEqual(registry.originalFilename(for: "sl-1"), "b.epub",
+                   "Re-add must overwrite the stored filename")
+  }
+
+  func test_missingManifest_loadsAsEmpty() {
+    // No file has been written to tempDirectory.
+    XCTAssertFalse(FileManager.default.fileExists(atPath: manifestPath))
+    // Direct instantiation (not via the helper) to document the construction seam.
+    let registry = SideloadedBookRegistry(fileManager: .default, manifestDirectory: tempDirectory)
+    XCTAssertTrue(registry.identifiers.isEmpty)
+    XCTAssertTrue(registry.allBooks.isEmpty)
+  }
+
+  func test_corruptManifest_loadsAsEmpty_withoutCrashing() throws {
+    try Data("{ this is not valid json".utf8)
+      .write(to: tempDirectory.appendingPathComponent("sideloaded.json"))
+
+    let registry = makeRegistry()
+
+    XCTAssertTrue(registry.identifiers.isEmpty,
+                  "A corrupt manifest must load as an empty registry, not crash")
+    // And the registry must still be usable afterward.
+    registry.add(book: makeBook(identifier: "sl-1", title: "Recovered"),
+                 fileURL: fileURL(named: "r.epub"))
+    XCTAssertEqual(registry.identifiers, ["sl-1"])
+  }
+
+  func test_emptyManifestFile_loadsAsEmpty() throws {
+    try Data().write(to: tempDirectory.appendingPathComponent("sideloaded.json"))
+    let registry = makeRegistry()
+    XCTAssertTrue(registry.identifiers.isEmpty)
+  }
+
+  func test_manifestWithGarbageRecord_skipsUnreadableEntry_keepsValidOnes() throws {
+    // Hand-write a manifest: one valid book record + one record whose "book"
+    // dict is missing the required id/title (TPPBook(dictionary:) → nil).
+    let valid = makeBook(identifier: "sl-good", title: "Good")
+    let manifest: [String: Any] = [
+      "books": [
+        ["book": valid.dictionaryRepresentation(), "filename": "good.epub"],
+        ["book": ["title": "no id here"], "filename": "bad.epub"]
+      ]
+    ]
+    let data = try JSONSerialization.data(withJSONObject: manifest)
+    try data.write(to: tempDirectory.appendingPathComponent("sideloaded.json"))
+
+    let registry = makeRegistry()
+
+    XCTAssertEqual(registry.identifiers, ["sl-good"],
+                   "Garbage records must be skipped while valid ones survive")
+  }
+}

--- a/PalaceTests/MyBooks/Sideload/SideloadedBookRegistryTests.swift
+++ b/PalaceTests/MyBooks/Sideload/SideloadedBookRegistryTests.swift
@@ -75,11 +75,11 @@ final class SideloadedBookRegistryTests: XCTestCase {
 
   // MARK: - Manifest round-trip
 
-  func test_add_persistsAcrossReload_preservingIdentifiersTitlesAndFilenames() {
+  func test_add_persistsAcrossReload_preservingIdentifiersTitlesAndFilenames() throws {
     let registry = makeRegistry()
-    registry.add(book: makeBook(identifier: "sl-1", title: "First"),
+    try registry.add(book: makeBook(identifier: "sl-1", title: "First"),
                  fileURL: fileURL(named: "first.epub"))
-    registry.add(book: makeBook(identifier: "sl-2", title: "Second"),
+    try registry.add(book: makeBook(identifier: "sl-2", title: "Second"),
                  fileURL: fileURL(named: "second.pdf"))
 
     // Fresh instance reads the same on-disk manifest.
@@ -96,11 +96,11 @@ final class SideloadedBookRegistryTests: XCTestCase {
 
   // MARK: - add / remove
 
-  func test_remove_dropsBookFromIdentifiersAndPersists() {
+  func test_remove_dropsBookFromIdentifiersAndPersists() throws {
     let registry = makeRegistry()
-    registry.add(book: makeBook(identifier: "sl-1", title: "First"),
+    try registry.add(book: makeBook(identifier: "sl-1", title: "First"),
                  fileURL: fileURL(named: "first.epub"))
-    registry.add(book: makeBook(identifier: "sl-2", title: "Second"),
+    try registry.add(book: makeBook(identifier: "sl-2", title: "Second"),
                  fileURL: fileURL(named: "second.epub"))
 
     registry.remove(identifier: "sl-1")
@@ -112,9 +112,9 @@ final class SideloadedBookRegistryTests: XCTestCase {
                    "remove must persist — reload must not resurrect the book")
   }
 
-  func test_remove_unknownIdentifier_isNoOp() {
+  func test_remove_unknownIdentifier_isNoOp() throws {
     let registry = makeRegistry()
-    registry.add(book: makeBook(identifier: "sl-1", title: "First"),
+    try registry.add(book: makeBook(identifier: "sl-1", title: "First"),
                  fileURL: fileURL(named: "first.epub"))
 
     registry.remove(identifier: "does-not-exist")
@@ -124,9 +124,9 @@ final class SideloadedBookRegistryTests: XCTestCase {
 
   // MARK: - rename
 
-  func test_rename_changesPersistedTitle_survivesReload() {
+  func test_rename_changesPersistedTitle_survivesReload() throws {
     let registry = makeRegistry()
-    registry.add(book: makeBook(identifier: "sl-1", title: "Old Title"),
+    try registry.add(book: makeBook(identifier: "sl-1", title: "Old Title"),
                  fileURL: fileURL(named: "first.epub"))
 
     registry.rename(identifier: "sl-1", to: "New Title")
@@ -137,9 +137,27 @@ final class SideloadedBookRegistryTests: XCTestCase {
                    "rename must persist the new title across reload")
   }
 
-  func test_rename_unknownIdentifier_isNoOp() {
+  func test_rename_doesNotMutateSharedBookInstance_replacesWithCopy() throws {
+    // The same `TPPBook` reference is handed to the main registry at import, so
+    // rename must NOT mutate it in place (that would race main-registry /
+    // Catalog readers) — it must replace the stored entry with a copy.
     let registry = makeRegistry()
-    registry.add(book: makeBook(identifier: "sl-1", title: "Old Title"),
+    let original = makeBook(identifier: "sl-1", title: "Original")
+    try registry.add(book: original, fileURL: fileURL(named: "first.epub"))
+
+    registry.rename(identifier: "sl-1", to: "Renamed")
+
+    XCTAssertEqual(original.title, "Original",
+                   "rename must not mutate the shared TPPBook instance — it must replace with a copy")
+    XCTAssertEqual(registry.allBooks.first?.title, "Renamed",
+                   "the registry read API must reflect the new title")
+    XCTAssertFalse(registry.allBooks.first === original,
+                   "the stored book must be a distinct instance from the shared original")
+  }
+
+  func test_rename_unknownIdentifier_isNoOp() throws {
+    let registry = makeRegistry()
+    try registry.add(book: makeBook(identifier: "sl-1", title: "Old Title"),
                  fileURL: fileURL(named: "first.epub"))
 
     registry.rename(identifier: "ghost", to: "Should Not Apply")
@@ -149,9 +167,9 @@ final class SideloadedBookRegistryTests: XCTestCase {
 
   // MARK: - update
 
-  func test_update_replacesBookButPreservesOriginalFilename() {
+  func test_update_replacesBookButPreservesOriginalFilename() throws {
     let registry = makeRegistry()
-    registry.add(book: makeBook(identifier: "sl-1", title: "Before"),
+    try registry.add(book: makeBook(identifier: "sl-1", title: "Before"),
                  fileURL: fileURL(named: "import-source.epub"))
 
     registry.update(book: makeBook(identifier: "sl-1", title: "After"))
@@ -171,13 +189,33 @@ final class SideloadedBookRegistryTests: XCTestCase {
                   "update must never insert an unknown book")
   }
 
+  // MARK: - Persist-failure atomicity
+
+  func test_add_whenManifestWriteFails_throws_andRollsBackInMemory() throws {
+    // Nest the manifest directory under a regular FILE so `createDirectory`
+    // inside `persistLocked` fails → the write throws. `add` must surface the
+    // error AND leave the registry exactly as it was (all-or-nothing).
+    let blocker = tempDirectory.appendingPathComponent("blocker")
+    try Data("x".utf8).write(to: blocker)
+    let unwritableDir = blocker.appendingPathComponent("nested")
+    let registry = SideloadedBookRegistry(fileManager: .default, manifestDirectory: unwritableDir)
+
+    XCTAssertThrowsError(try registry.add(book: makeBook(identifier: "sl-1", title: "Doomed"),
+                                          fileURL: fileURL(named: "x.epub")),
+                         "a manifest write failure must propagate out of add")
+    XCTAssertTrue(registry.identifiers.isEmpty,
+                  "a failed add must roll back — no partial in-memory entry")
+    XCTAssertTrue(registry.allBooks.isEmpty,
+                  "a failed add must not leave a dangling order entry")
+  }
+
   // MARK: - Edge cases
 
-  func test_addDuplicateIdentifier_doesNotDoubleInsert_andUpdatesInPlace() {
+  func test_addDuplicateIdentifier_doesNotDoubleInsert_andUpdatesInPlace() throws {
     let registry = makeRegistry()
-    registry.add(book: makeBook(identifier: "sl-1", title: "First Import"),
+    try registry.add(book: makeBook(identifier: "sl-1", title: "First Import"),
                  fileURL: fileURL(named: "a.epub"))
-    registry.add(book: makeBook(identifier: "sl-1", title: "Re-Import"),
+    try registry.add(book: makeBook(identifier: "sl-1", title: "Re-Import"),
                  fileURL: fileURL(named: "b.epub"))
 
     XCTAssertEqual(registry.allBooks.count, 1,
@@ -205,7 +243,7 @@ final class SideloadedBookRegistryTests: XCTestCase {
     XCTAssertTrue(registry.identifiers.isEmpty,
                   "A corrupt manifest must load as an empty registry, not crash")
     // And the registry must still be usable afterward.
-    registry.add(book: makeBook(identifier: "sl-1", title: "Recovered"),
+    try registry.add(book: makeBook(identifier: "sl-1", title: "Recovered"),
                  fileURL: fileURL(named: "r.epub"))
     XCTAssertEqual(registry.identifiers, ["sl-1"])
   }

--- a/docs/architecture/sideloading-plan.md
+++ b/docs/architecture/sideloading-plan.md
@@ -1,0 +1,149 @@
+<!-- audit-verified: PP-2677/2678/2679/2581/2580 fetched via jira_get_issue on 2026-07-01 -->
+# Side Loading — Architecture & Implementation Plan
+
+Covers **PP-2677** (side-load manager + settings), **PP-2678** (side-load registry),
+**PP-2679** (side-loaded catalog lane). Parent investigation: **PP-2581**
+("investigate side loading … most likely a test feature only exposed via the
+Testing settings menu"), motivated by **PP-2580** (test LCP 2.x profiles by
+loading an encrypted EPUB without a real OPDS feed).
+
+## Goal
+
+A **test-only** capability: import a local EPUB / PDF / audiobook file and have it
+appear in a dedicated catalog lane and open in the real reader + DRM stack, with no
+OPDS feed involved. Primary purpose is exercising DRM profiles (e.g. LCP 2.x)
+end-to-end in the shipping reader.
+
+## Locked decisions (2026-07-01)
+
+1. **Registry model:** reuse the main `TPPBookRegistry` (register sideloaded books
+   as `.downloadSuccessful`) **+ sync exemption**, rather than a fully independent
+   open path. Reuses the entire mature reader/file/DRM/LCP stack unchanged.
+   Accepted side effect: sideloaded books also appear on the My Books shelf.
+2. **Gating:** a `RemoteFeatureFlags` flag with a dev-menu local override
+   (mirrors `inAppPlaybackNavEnabled`) — Firebase remote default + local override,
+   DEBUG-on. This is the "test mode" in PP-2679.
+3. **Content types:** EPUB + PDF + audiobook from the start (infra handles all
+   three uniformly via `TPPBookContentType`).
+
+## Load-bearing constraint
+
+The main registry's server `sync()` **evicts any book not in the loans feed and
+deletes its on-disk file** — `BookRegistrySync.swift:406` seeds
+`recordsToDelete = Set(registry.keys)`, removes feed entries, then at `:480-497`
+un-registers the remainder and calls `deleteLocalContent` for `.downloadSuccessful`
+ones. Therefore sideloaded books **must** be exempted from reconciliation, or the
+next sync silently destroys them. This is the reason for decision #1's exemption set.
+
+## Components
+
+### PP-2678 — `SideloadedBookRegistry` (dedicated persistence, local-only)
+- Own JSON manifest, separate from `registry.json`; holds sideloaded `TPPBook`s
+  (via `dictionaryRepresentation()` round-trip) + original filenames. No server sync.
+- API: `add(book:fileURL:)`, `remove(identifier:)`, `rename(identifier:to:)`,
+  `update(book:)`, `allBooks`, `identifiers` (drives the sync-exemption set).
+- Source of truth for "what is sideloaded" → feeds both the exemption set and the lane.
+
+### PP-2677 — `SideloadedBookManager` (orchestration + settings)
+- **Import:** file URL (from `UIDocumentPicker` in Settings) → classify via
+  MIME/extension → `TPPBookContentType.from(...)` → mint synthetic **open-access**
+  `TPPBook` (generated id, one `TPPOPDSAcquisition` with correct MIME,
+  `imageCache: ImageCache.shared`, DRM-free) → copy file to
+  `BookFileManager.fileUrl(for: book, account:)` → register into
+  `SideloadedBookRegistry` **and** `TPPBookRegistry.addBook(.downloadSuccessful)` →
+  `syncExemption.insert(id)`.
+- **Remove:** reverse (file + both registries + exemption).
+- **Launch rehydration:** read manifest, re-register each into main registry +
+  exemption set (main registry does not persist sideloaded-ness).
+- **Settings UI:** "Side Loading" entry (picker + manage list) via the
+  `TPPSettings` key + `@AppStorage` pattern (`TPPSettingsView.downloadsSection` template),
+  gated by the feature flag.
+
+### Sync exemption (surgical, CRITICAL PATH)
+- In `BookRegistrySync` reconciliation: `recordsToDelete.subtract(sideloadedIDs)`.
+- Inject the id set from `SideloadedBookRegistry` via `AppContainer`.
+- Highest-risk change → architect + SoD review required.
+
+### PP-2679 — `SideloadedLane`
+- Inject `CatalogLaneModel(title:, books: sideloadedRegistry.allBooks, moreURL: nil)`
+  into the catalog lanes, gated by the feature flag.
+- Seam: `CatalogViewModel.load()` / `MappedCatalog.toCatalogContent()`
+  (`CatalogUI/ViewModels/CatalogState.swift:129`).
+- Handle `.grouped` / `.ungrouped` / `.empty` so the lane shows even when the base
+  feed isn't grouped.
+
+## Data flow
+
+```
+Settings "Side Loading" → UIDocumentPicker → file URL
+  → SideloadedBookManager.import(fileURL)
+      → classify (MIME/ext → TPPBookContentType)
+      → mint open-access TPPBook (sha256(id) drives file path)
+      → copy file → BookFileManager content dir
+      → SideloadedBookRegistry.add          (dedicated manifest — truth)
+      → TPPBookRegistry.addBook(.downloadSuccessful)  (so reader works)
+      → syncExemption.insert(id)
+  → CatalogViewModel injects SideloadedLane (flag-gated)
+  → tap book → BookDetailViewModel sees .downloadSuccessful → "Read"
+  → reader resolves file via downloadCenter.fileUrl(id) → opens (LCP handled by existing stack)
+```
+
+## Key files
+- New: `Palace/MyBooks/Sideload/SideloadedBookRegistry.swift`, `SideloadedBookManager.swift`
+- `Palace/Book/Models/BookRegistrySync.swift` — sync exemption (critical)
+- `Palace/Settings/TPPSettings.swift` + `Settings/NewSettings/TPPSettingsView.swift`
+- `Palace/CatalogUI/ViewModels/CatalogViewModel.swift` / `CatalogState.swift`
+- `Palace/FeatureFlags/RemoteFeatureFlags.swift` — new flag + local override
+- `Palace/AppInfrastructure/AppContainer.swift` — wire services + inject exemption set
+
+## Reference seams (from architecture map)
+- `TPPBook` designated init: `Palace/Book/Models/TPPBook.swift:122`; content type via
+  `defaultBookContentType` (`:669`), MIME→type `TPPBookContentType.from(mimeType:)`
+  (`Palace/Book/Models/TPPContentType.swift:20`).
+- `TPPBookRegistry.addBook(...)` `:387`; `setState` `:464`.
+- File path resolver `BookFileManager.fileUrl(for:account:)`
+  (`Palace/MyBooks/BookFileManager.swift:69`); content dir `:82`; extension `:123`.
+- Registry persistence `BookRegistrySync.swift` (registry.json under Application Support).
+- Lane model `CatalogLaneModel` (`CatalogUI/ViewModels/CatalogViewModel.swift:417`);
+  feed→lanes `mapFeed` `:444`; render `CatalogContentView.swift:104`.
+- Settings toggle pattern `TPPSettingsView.swift:244`; keys `TPPSettings.swift:62-73`.
+- Feature-flag template `RemoteFeatureFlags.inAppPlaybackNavEnabled` `:54` +
+  local-override switch `:462`.
+
+## Verification
+
+1. **Unit (TDD, mandated by all three tickets):**
+   - `SideloadedBookRegistry`: manifest round-trip (persist→reload→identical),
+     add/remove/rename/update, edge cases (duplicate import, missing file, corrupt/
+     empty manifest, unsupported type).
+   - `SideloadedBookManager`: classification per type (EPUB/PDF/audiobook MIME →
+     correct `defaultBookContentType`), open-access minting, dedup, error paths,
+     exemption-set maintenance, launch rehydration.
+   - **Sync-exemption regression (critical):** drive `sync()` with a loans feed
+     lacking the sideloaded id → assert book + file survive.
+   - Lane injection: flag on + non-empty registry → lane present; flag off → absent;
+     empty/ungrouped base feed → lane still present.
+2. **Contract-snapshot** for the import pipeline (ordered calls: classify → copyFile →
+   registry.addBook → sideloadRegistry.add → exemption.insert).
+3. **Mutation** (`palace_mutate.py --diff-only`) on manager + registry, ≥50%
+   (critical-path files → 100% on touched lines).
+4. **Build + `scripts/verify-pr.sh --quick`** (full-suite parity).
+5. **simdrive E2E:** enable in Settings → import the LCP 2.x test EPUB (PP-2580) →
+   see lane → open in reader → renders. Record a replay for the chaos-replay corpus.
+6. **DoD 11-check battery** before READY.
+
+## Orchestration
+Spans ≥2 modules (Book/registry, MyBooks, Settings, CatalogUI) **and** touches a
+critical path (registry sync + DRM) → implement via **`/swarm`** with architect +
+SoD review focused on the sync-exemption change.
+
+## Open items / risks
+- **My Books visibility:** decision #1 makes sideloaded books appear on the My Books
+  shelf. Acceptable for a test feature; revisit if noise is a problem (could filter
+  by exemption-id membership).
+- **Persistence location:** ticket says "Documents folder"; the app's registry lives
+  under Application Support. Recommend Application Support (consistent, backup-excluded)
+  and treat the ticket wording as illustrative — confirm during implementation.
+- **Sync-exemption ordering:** rehydration must populate the exemption set *before*
+  the first `sync()` after launch, or a race could still evict. Wire rehydration into
+  `AppContainer` startup ahead of the sync trigger.


### PR DESCRIPTION
Implements the test-only **side loading** capability across the three tickets — import a local EPUB/PDF/audiobook and have it appear in a dedicated catalog lane and open in the real reader + DRM stack, with no OPDS feed. Motivated by PP-2581/PP-2580 (exercise DRM profiles like LCP 2.x without a feed). Built via swarm `swarm_495a88d9` (architect triage → 4 parallel implementers → integrate → SoD review).

Architecture + decisions: `docs/architecture/sideloading-plan.md`. Contracts/transcripts: `.forgeos/swarms/swarm_495a88d9/`.

## What's included
- **PP-2678 — `SideloadedBookRegistry`**: dedicated local-only JSON manifest (own store, not `registry.json`); add/remove/rename/update/allBooks/identifiers; atomic add with rollback on persist failure.
- **Sync-exemption (critical path)**: `BookRegistrySync` reconciliation exempts sideloaded ids (`recordsToDelete.subtract(...)`) via a lazy provider, so server sync no longer evicts sideloaded books or deletes their files. Account-stable resolution in `BookFileManager` (`sideloadContentAccountID`) so files survive library switches.
- **PP-2677 — `SideloadedBookManager` + Settings**: import flow (classify → mint open-access `TPPBook` → copy to fixed-account path → register in both registries + exemption set), launch rehydration inside `bookRegistry.load{}` completion, and a flag-gated Settings "Side Loading" screen.
- **PP-2679 — catalog lane**: single `withSideloadedLane(_:)` choke-point routes all 5 `toCatalogContent()` sites (incl. the facet cache-hit fast path); shows for grouped/ungrouped/empty base feeds.
- **Gating**: `RemoteFeatureFlags.sideLoadingEnabled` — off by default, enabled via the dev-menu local override (test-only).

## Verification
- Full suite `** TEST SUCCEEDED **`, 0 failures; ~43 new sideload tests (registry round-trip + edge cases, the **critical sync-exemption regression + eviction contrast**, account-stable resolution, import atomicity, rename copy-not-mutate, flag precedence, lane bridge incl. facet cache-hit, import contract-snapshot).
- **Mutation 100%** on the touched critical-path lines of `BookRegistrySync`, `SideloadedBookManager`, `BookFileManager`.
- Phase 4.5 skeptic pass green (choke-point greps, rehydration anchor, check-test-name-vs-body, blast-radius, contract-reconciliation, intent-recorded, superpartner, adjacency).
- **Independent SoD review**: architect + blast-radius reviewers both APPROVED (normal book paths provably unaffected — flag-off catalog is byte-identical; `sideload-<sha256>` id prefix prevents cross-contamination). Their non-blocking findings (import atomicity, `rename` race, `fileUrl` hot-path short-circuit, doc cleanup, 2 error-case tests) were applied.

## Accepted limitations
- Sideloaded books also appear on the My Books shelf (side effect of registry reuse).
- On an auth-required library while signed out, opening prompts sign-in (shared `didSelectRead` gate) — E2E signs in first.

## Follow-up
- simdrive import→lane→open E2E with the LCP 2.x test EPUB (running post-merge-readiness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)