### PR TITLE
fix(tests): FLAKE-003 de-flake — defer AccountsManager disk-cache preload in BookRegistry suites

### DIFF
--- a/PalaceTests/BookRegistry/TPPBookRegistryAtomicWriteTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryAtomicWriteTests.swift
@@ -42,6 +42,14 @@ class TPPBookRegistryAtomicWriteTests: PalaceWiringTestCase {
         try super.setUpWithError()
         account = "test-atomic-\(UUID().uuidString)"
         store = BookRegistryStore()
+        // FLAKE-003 fix: this suite constructs an AccountsManager purely as a
+        // BookRegistrySync dependency and never reads its account sets, so skip
+        // the on-disk cached-account preload — the >5s (~1138-account) load that
+        // was the root of the intermittent BookRegistry-test timeouts on
+        // memory-pressured CI. Reset in tearDown to keep the flip scoped.
+        #if DEBUG
+        AccountsManager.deferDiskCachePreloadForTesting = true
+        #endif
         accountsManager = makeFreshAccountsManager()
         sync = BookRegistrySync(
             store: store,
@@ -59,6 +67,9 @@ class TPPBookRegistryAtomicWriteTests: PalaceWiringTestCase {
         store = nil
         sync = nil
         accountsManager = nil
+        #if DEBUG
+        AccountsManager.deferDiskCachePreloadForTesting = false
+        #endif
         try super.tearDownWithError()
     }
 

--- a/PalaceTests/BookRegistry/TPPBookRegistryDependencyTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryDependencyTests.swift
@@ -33,6 +33,27 @@ import XCTest
 
 class TPPBookRegistryDependencyTests: PalaceWiringTestCase {
 
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // FLAKE-003 fix: this suite constructs an AccountsManager purely as a
+        // TPPBookRegistry dependency and never reads its account sets — the init
+        // contracts here rely on there being NO current account (the no-op
+        // mutation path). Skip the on-disk cached-account preload — the >5s
+        // (~1138-account) load that was the root of the intermittent
+        // BookRegistry-test timeouts on memory-pressured CI. Reset in tearDown
+        // to keep the flip scoped.
+        #if DEBUG
+        AccountsManager.deferDiskCachePreloadForTesting = true
+        #endif
+    }
+
+    override func tearDownWithError() throws {
+        #if DEBUG
+        AccountsManager.deferDiskCachePreloadForTesting = false
+        #endif
+        try super.tearDownWithError()
+    }
+
     // MARK: - Init contract
 
     /// The new init MUST take AccountsManager explicitly. If someone re-adds

--- a/PalaceTests/BookRegistry/TPPBookRegistryLargeCorpusTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryLargeCorpusTests.swift
@@ -40,6 +40,14 @@ class TPPBookRegistryLargeCorpusTests: PalaceWiringTestCase {
         try super.setUpWithError()
         account = "test-large-corpus-\(UUID().uuidString)"
         store = BookRegistryStore()
+        // FLAKE-003 fix: this suite constructs an AccountsManager purely as a
+        // BookRegistrySync dependency and never reads its account sets, so skip
+        // the on-disk cached-account preload — the >5s (~1138-account) load that
+        // was the root of the intermittent BookRegistry-test timeouts on
+        // memory-pressured CI. Reset in tearDown to keep the flip scoped.
+        #if DEBUG
+        AccountsManager.deferDiskCachePreloadForTesting = true
+        #endif
         accountsManager = makeFreshAccountsManager()
         sync = BookRegistrySync(
             store: store,
@@ -57,6 +65,9 @@ class TPPBookRegistryLargeCorpusTests: PalaceWiringTestCase {
         store = nil
         sync = nil
         accountsManager = nil
+        #if DEBUG
+        AccountsManager.deferDiskCachePreloadForTesting = false
+        #endif
         try super.tearDownWithError()
     }
 

--- a/PalaceTests/BookRegistry/TPPBookRegistryPersistenceTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryPersistenceTests.swift
@@ -47,6 +47,14 @@ class TPPBookRegistryPersistenceTests: PalaceWiringTestCase {
         try super.setUpWithError()
         account = "test-persistence-\(UUID().uuidString)"
         store = BookRegistryStore()
+        // FLAKE-003 fix: this suite constructs an AccountsManager purely as a
+        // BookRegistrySync dependency and never reads its account sets, so skip
+        // the on-disk cached-account preload — the >5s (~1138-account) load that
+        // was the root of the intermittent persistence-test timeouts on
+        // memory-pressured CI. Reset in tearDown to keep the flip scoped.
+        #if DEBUG
+        AccountsManager.deferDiskCachePreloadForTesting = true
+        #endif
         accountsManager = makeFreshAccountsManager()
         // Lazy-resolved providers — never invoked unless we save records in a
         // file-tracking state (.downloading/.downloadSuccessful/.used/...). All
@@ -69,6 +77,9 @@ class TPPBookRegistryPersistenceTests: PalaceWiringTestCase {
         store = nil
         sync = nil
         accountsManager = nil
+        #if DEBUG
+        AccountsManager.deferDiskCachePreloadForTesting = false
+        #endif
         try super.tearDownWithError()
     }
 


### PR DESCRIPTION
## What
Extends the #1159 `AccountsManager.deferDiskCachePreloadForTesting` fix to the BookRegistry test suites that construct an `AccountsManager` purely as a `BookRegistrySync`/`TPPBookRegistry` dependency and never read its account sets.

## Why
`AccountsManager.init` synchronously preloads ~1138 cached accounts from disk (>5s on memory-pressured CI) — the **FLAKE-003** root that intermittently timed out BookRegistry tests (and blocked #1160's first CI run).

**Key finding:** `makeFreshAccountsManager()` already pins `deferInitialLoadCatalogsForTesting` (the *background* `loadCatalogs`) but **not** the synchronous disk-cache preload — so these suites still paid the full >5s cost. This PR closes that gap.

## Changes (test-only)
Flag set in `setUp`, reset to `false` in `tearDown` (inside `#if DEBUG`, matching #1159 exactly):
- `TPPBookRegistryPersistenceTests` (named in the handoff as still flaking)
- `TPPBookRegistryLargeCorpusTests`
- `TPPBookRegistryAtomicWriteTests`
- `TPPBookRegistryDependencyTests`

**Conservatively skipped** (read account sets — flag would break assertions): `AccountsManagerAccountIndexTests`, `AccountsManagerStateMachineWiringTests`, `AccountsManagerCancellationTests`, `AccountSwitchLifecycleTests`, and the meta/lint suites.

**Flagged for human judgment** (construct AccountsManager but use `userAccount(for:)`/`currentAccountId` — likely `accountSets`-independent, but critical-path integration tests where a broken assertion is costly): `SignInToReadFlowIntegrationTests`, `BorrowAndDownloadIntegrationTests`, `ColdStartResumeIntegrationTests`, `SideloadImportContractTests`, `SideloadedBookManagerTests`, `BookFileManagerSideloadResolutionTests`.

## Verification
Local DRM `build-for-testing` (adobe-rmsdk): app + all test targets compile, 0 targeted warnings, **TEST BUILD SUCCEEDED**. No production change.

Part of the Swift 6 modernization fan-out (P3 of P1–P5).