### PR TITLE
fix(swift6): app-target targeted concurrency → 0 (Phase A complete) — AdobeDRM + CarPlay

### DIFF
--- a/Palace/CarPlay/CarPlaySceneDelegate.swift
+++ b/Palace/CarPlay/CarPlaySceneDelegate.swift
@@ -42,6 +42,12 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
 
         AppContainer.production().playbackBootstrapper.ensureInitializedForCarPlay()
 
+        // Defensive: if a prior manager is somehow still held (a second
+        // didConnect without an intervening didDisconnect), tear it down first
+        // so its Now Playing observer registration is removed on the main actor
+        // before we drop the reference — otherwise it would dangle on the shared
+        // CPNowPlayingTemplate.
+        templateManager?.tearDown()
         self.templateManager = CarPlayTemplateManager(interfaceController: interfaceController)
 
         // Set up the root template
@@ -60,6 +66,11 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         Log.info(#file, "🚗 CarPlay disconnected")
 
         cancellables.removeAll()
+        // Remove the Now Playing observer on the main actor BEFORE releasing the
+        // manager. This replaces the former deinit-time removal (unrepresentable
+        // under Swift 6 strict concurrency) and makes removal deterministic
+        // regardless of when the manager actually deallocs.
+        templateManager?.tearDown()
         templateManager = nil
         self.interfaceController = nil
 

--- a/Palace/CarPlay/CarPlayTemplateManager.swift
+++ b/Palace/CarPlay/CarPlayTemplateManager.swift
@@ -85,17 +85,35 @@ final class CarPlayTemplateManager: NSObject {
         setupPlayerBridgeBindings()
     }
 
-    deinit {
-        // Remove ourselves as observer from the Now Playing template to prevent crashes
-        // during CarPlay disconnect/reconnect cycles
-        if hasConfiguredNowPlaying, let nowPlayingTemplate = nowPlayingTemplate {
-            // strict-concurrency flags this call: `CPNowPlayingTemplate.remove(_:)`
-            // is main-actor-isolated but deinit is nonisolated. LEFT AS-IS for now —
-            // `MainActor.assumeIsolated` would risk a fatalError (deinit isn't
-            // guaranteed to run on main). Deferred to the CarPlay critical-path slice.
-            nowPlayingTemplate.remove(self)
-            Log.debug(#file, "CarPlay: Removed Now Playing observer during deinit")
-        }
+    // MARK: - Teardown
+
+    /// Removes our `CPNowPlayingTemplate.shared` observer registration before
+    /// this object is released. The shared Now Playing template outlives every
+    /// `CarPlayTemplateManager`; if we dealloc while still registered, the
+    /// singleton holds a dangling observer and the next disconnect/reconnect
+    /// cycle crashes (the reason the removal is load-bearing).
+    ///
+    /// This USED to live in `deinit`, but under Swift 6 strict concurrency the
+    /// call is unrepresentable there: `CPNowPlayingTemplate.remove(_:)` is
+    /// main-actor-isolated while `deinit` is nonisolated, and the banned
+    /// `MainActor.assumeIsolated` would risk a `fatalError` because `deinit`
+    /// isn't guaranteed to run on the main thread. Instead the owning
+    /// `CarPlaySceneDelegate` calls this from its `@MainActor` disconnect path
+    /// (and defensively before replacing the manager on reconnect), so removal
+    /// happens at a deterministic point on the main actor BEFORE dealloc.
+    ///
+    /// Idempotent: clears `hasConfiguredNowPlaying` and drops the template
+    /// reference so a second call (e.g. teardown-then-dealloc) is a no-op.
+    // no-superpartner: CPInterfaceController / CPNowPlayingTemplate.shared are
+    // non-injectable CarPlay singletons — the teardown removal cannot be spied
+    // without a seam refactor, so no unit test is feasible for this method (the
+    // pre-refactor deinit was equally untestable; this is not a coverage regression).
+    func tearDown() {
+        guard hasConfiguredNowPlaying, let nowPlayingTemplate else { return }
+        nowPlayingTemplate.remove(self)
+        self.nowPlayingTemplate = nil
+        hasConfiguredNowPlaying = false
+        Log.debug(#file, "CarPlay: Removed Now Playing observer during teardown")
     }
 
     // MARK: - Public Methods

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
@@ -244,7 +244,17 @@ public actor DRMDataResource: Resource {
         return fullData
     }
 
-    public func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    // `nonisolated`: the `Streamable.stream(range:consume:)` requirement declares
+    // `consume` as a plain `@escaping (Data) -> Void` (NOT `@Sendable`), so the
+    // witness cannot strengthen it to `@Sendable` — function parameters are
+    // contravariant and Readium passes a non-Sendable closure. Marking the witness
+    // `nonisolated` removes the actor-isolation boundary the closure would otherwise
+    // be *sent* across (the Swift 6 error), keeping the closure in the caller's
+    // domain. Decryption is unchanged: the actual decrypt + cache still happens on
+    // the actor inside the isolated `read(range:)` helper we `await` below; only the
+    // `consume` callback now runs in this nonisolated async context, which is where
+    // the Streamable contract expects callers to accumulate chunks anyway.
+    public nonisolated func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
         do {
             let chunk = try await read(range: range)
             consume(chunk)


### PR DESCRIPTION
## What
Clears the **final 2 residual app-target `targeted` warnings**, completing **Phase A (app-target → 0)** of the Swift 6 modernization.

Verified locally on the DRM `Palace` scheme (adobe-rmsdk): baseline **2 → 0**, BUILD SUCCEEDED.

## P1 — `AdobeDRMContentProtection.swift` (DRM decryption · critical-path)
`DRMDataResource.stream(range:consume:)` marked `nonisolated`. Readium's `Streamable` requirement declares `consume` as a plain **non-`@Sendable`** `@escaping (Data)->Void`, so the actor-isolated witness required *sending* a non-Sendable closure across the actor boundary (Swift 6 error). A witness can't strengthen the param to `@Sendable` (function-param **contravariance**), and boxing would launder a real hazard — so `nonisolated` is the honest minimal fix: the closure stays in the caller's domain while decrypt + the `_decryptedData` cache stay actor-serialized behind the awaited `read(range:)`. **Decryption output is byte-for-byte identical.**

## P2 — `CarPlayTemplateManager.swift` / `CarPlaySceneDelegate.swift` (CarPlay lifecycle)
Deleted the `deinit` that called main-actor-isolated `CPNowPlayingTemplate.remove(self)` from a nonisolated context. Moved the **load-bearing** removal into an idempotent `@MainActor func tearDown()`, wired from `CarPlaySceneDelegate` at both drop sites (before `templateManager=nil` in `didDisconnect`; defensively before reassignment in `didConnect`). Every load-bearing release path now removes the observer on the main actor **before dealloc**; the one uncovered path (feature-flag-disabled early return) is provably benign (`hasConfiguredNowPlaying==false` → no-op). No `MainActor.assumeIsolated`, no self-capturing `Task` in `deinit`.

## SoD reviews (in-session, ForgeOS off)
Independent adversarial architect/QA reviewers — **both APPROVE**:
- **P1 APPROVE:** `nonisolated` body touches no isolated state synchronously; `decryptedData()` cache read→write has no intervening `await` (atomic on the actor executor); delivery ordering byte-identical; contravariance rationale ruling out `@Sendable` confirmed correct; no ripples (single construction site; callers invoke via `await` on the `Resource` existential).
- **P2 APPROVE:** enumerated every `templateManager` create/reassign/nil site — all load-bearing drops covered by a main-actor `tearDown()` before release; idempotency verified against the `add`/flag invariant; both call sites `@MainActor` (UIResponder); old `deinit` did nothing but the removal.

## Test coverage
`tearDown()` carries a `// no-superpartner:` marker — `CPInterfaceController`/`CPNowPlayingTemplate.shared` are non-injectable, so the removal can't be spied without a seam refactor (the pre-refactor `deinit` was equally untestable — not a coverage regression). `DRMDataResource` has no unit tests today; a DRM decrypt-provider seam for a behavioral regression test is a flagged **non-blocking** follow-up.

## Scope
- **Scope:** the two remaining app-target `targeted` warnings only.
- **Not done:** submodule (~5 warnings, Phase D) and the Phase B `complete`-mode sweep are separate efforts.

Part of the Swift 6 modernization fan-out (P1+P2 of P1–P5).