### PR TITLE
feat(rating): app-rating engagement tracking + eligibility (PP-4087, PP-4088)

### DIFF
--- a/.forgeos/intent/pp-4087-4088-app-rating-core.md
+++ b/.forgeos/intent/pp-4087-4088-app-rating-core.md
@@ -1,0 +1,68 @@
+---
+name: pp-4087-4088-app-rating-core
+created: 2026-07-02
+author: claude-opus-4-8
+---
+
+**ADR refs:** extends `adr_059bdb6c` (MVVM + Services + Reducers triad — AppContainer
+as DI root; closure/pure-function reducers). `AppRatingService` is registered via the
+AppContainer lazy-cache pattern and `RatingEligibilityPolicy` is a pure function in the
+reducer spirit. Complies with `adr_204fafdd` (superpartner-spectrum: every new function /
+enum case / state change ships with a matching test). Not a critical-path module per
+`adr_52261f2a` (mutation regex covers auth/borrow/download/DRM/audiobooks/accounts/network;
+AppRating is outside it) — PR 1 deliberately avoids `BorrowOperation` and the audiobook
+seams so it stays off the strict-gate surface; those trigger-wirings land in PR 2.
+
+This is PR 1 of 2 for Epic PP-4086 (App Rating Prompt). It implements the engagement
+tracking (PP-4087) and the eligibility policy (PP-4088). No UI, no StoreKit request, no
+sentiment-gate dialog — those land in PR 2 (PP-4089/4090/4091). PR 1 is mergeable
+standalone: it records engagement signals and can evaluate eligibility, but never presents
+anything.
+
+## Claims
+
+- adds new module group `Palace/AppRating/`
+- adds struct `RatingEngagementState` capturing sessionCount, booksCompleted, lastPromptDate, promptDisplayCount, dismissalCount, optedOut, crashFreeLastSession and a computed isFirstSession
+- adds class `RatingEngagementTracker` in `Palace/AppRating/RatingEngagementTracker.swift` that reads/writes engagement signals through an injected settings store
+- adds struct `RatingConfig` in `Palace/AppRating/RatingConfig.swift` holding the tunable thresholds (minSessions, minBooksCompleted, cooldownDays, lifetimePromptCap) with a hardcoded `.fallback` default
+- adds enum `RatingEligibilityPolicy` with static function `evaluate(state:config:now:) -> Bool` in `Palace/AppRating/RatingEligibilityPolicy.swift` implementing all 7 criteria
+- adds enum `AppRatingTrigger` (`.bookCompleted`, `.borrowSucceeded`) in `Palace/AppRating/AppRatingService.swift`
+- adds class `AppRatingService` (`@MainActor`) in `Palace/AppRating/AppRatingService.swift` exposing `recordSession()`, `recordBookCompleted()`, `recordPromptShown()`, `recordDismissal()`, `recordOptOut()`, and `isEligible(for:) -> Bool` — no presentation logic in PR 1
+- adds engagement-signal keys and computed properties to `TPPSettings` (appRatingSessionCount, appRatingBooksCompleted, appRatingLastPromptDate, appRatingPromptDisplayCount, appRatingDismissalCount, appRatingOptedOut, appRatingCrashFreeLastSession)
+- adds the mirrored properties to `TPPSettingsProviding`
+- adds numeric remote-config accessor `getDoubleValue(forKey:)` to `FirebaseManager`
+- adds `wasLastSessionCrashFree() -> Bool` (Crashlytics-backed, best-effort) to `FirebaseManager`
+- adds `app_rating_*` keys (prompt_enabled master switch + 4 numeric thresholds) to `FirebaseManager.RemoteConfigKey` and their default values
+- adds `isAppRatingPromptEnabled` and `appRatingConfig` accessors to `RemoteFeatureFlags` that source values from remote config with fallback
+- adds lazy-cached `appRatingService` registration to `AppContainer` (+ nil-reset in `_resetForTesting`)
+- adds session-count increment call at `TPPAppDelegate.applicationDidBecomeActive`
+- adds tests `RatingEngagementTrackerTests`, `RatingEligibilityPolicyTests`, `AppRatingServiceTests` under `PalaceTests/AppRating/`
+
+## Anti-claims
+
+- does NOT add any UI, SwiftUI view, dialog, or sheet (deferred to PR 2 / PP-4089)
+- does NOT call `SKStoreReviewController` or request any App Store review (deferred to PR 2 / PP-4090)
+- does NOT add any feedback / mailto path (deferred to PR 2 / PP-4091)
+- does NOT modify `BorrowOperation.swift`, `AudiobookLoader.swift`, `AudiobookSessionManager.swift`, or any `Palace/Reader2/` file — the book-completion / borrow / EPUB triggers wire in PR 2
+- leaves `TPPAppStoreReviewPrompt` untouched — its supersession happens in PR 2
+- does NOT change `TPPBookRegistry` public surface
+- does NOT change `AppContainer`'s init signature or any copy-constructor param list (uses the lazy-cache computed-property pattern, not an eager `let`)
+- does NOT transmit any engagement data off-device (all signals are local UserDefaults)
+
+## Files in scope
+
+- Palace/AppRating/RatingEngagementTracker.swift
+- Palace/AppRating/RatingEligibilityPolicy.swift
+- Palace/AppRating/RatingConfig.swift
+- Palace/AppRating/AppRatingService.swift
+- Palace/Settings/TPPSettings.swift
+- Palace/Settings/TPPSettingsProviding.swift
+- Palace/AppInfrastructure/FirebaseManager.swift
+- Palace/FeatureFlags/RemoteFeatureFlags.swift
+- Palace/AppInfrastructure/AppContainer.swift
+- Palace/AppInfrastructure/TPPAppDelegate.swift
+- PalaceTests/AppRating/RatingEngagementTrackerTests.swift
+- PalaceTests/AppRating/RatingEligibilityPolicyTests.swift
+- PalaceTests/AppRating/AppRatingServiceTests.swift
+- PalaceTests/Mocks/TPPSettingsMock.swift
+- Palace.xcodeproj/project.pbxproj

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		0469ADBAE6CAC0F21823D1E7 /* BadgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59814D0AE9FAF49E9A52426A /* BadgeService.swift */; };
 		048495C6D7E8F90A1B2C3D4E /* DownloadThrottlingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B2C3D4E5F60718293A4B5C /* DownloadThrottlingServiceTests.swift */; };
 		04D627FB804AFA2A05C53C01 /* ResourcePropertiesLengthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50E8682DF2CC80AA981B91C /* ResourcePropertiesLengthTests.swift */; };
+		04E1B61CD5C2DFEEC1687B6F /* RatingEligibilityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E63BC817551861A7A8D75D /* RatingEligibilityPolicy.swift */; };
 		054576899AB2C3D4E5F60829 /* CredentialPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1657899AB2C3D4E5F608291A /* CredentialPromptCoordinator.swift */; };
 		059C1DFA5BF79EEE154645E3 /* LCPSessionOrphaningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C1C5F7FE43056D96C9DE5C /* LCPSessionOrphaningTests.swift */; };
 		05A425DB12A6A7B0F202D793 /* PositionSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683C04EF0CA60F4A118D597A /* PositionSyncServiceTests.swift */; };
@@ -496,6 +497,7 @@
 		5F949B507DBF52145F9905C2 /* PlaybackReadinessGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F714C5D09735CC88BE76576D /* PlaybackReadinessGate.swift */; };
 		6021615DC1CCCE566261E7B5 /* TPPPerAccountIsolationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A5818A6D6FBED89690BA3F /* TPPPerAccountIsolationTests.swift */; };
 		607C5492BCD1F00E3156DDE6 /* DownloadOnlyOnWiFiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78529336066D2340C7B0FCE0 /* DownloadOnlyOnWiFiTests.swift */; };
+		6082A3BC12445EF6992B9AD4 /* RatingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9905AB408890B78E7B723F22 /* RatingConfig.swift */; };
 		60A99C600DD9A116635F920A /* AppContainerImageLoaderInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F13FD93A4CE48909066F4AE /* AppContainerImageLoaderInjectionTests.swift */; };
 		611D923EBE0FB1507857F65A /* TPPReaderPositionReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673C54DADAEAD820B2DABB9D /* TPPReaderPositionReportTests.swift */; };
 		612E466C3BD31ED26DEDE50C /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF1F7C70AC93BF8E2F22148 /* DebugSettings.swift */; };
@@ -767,6 +769,7 @@
 		789D6736FA778CB1B6CF24E1 /* BookFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139A23DAED2B3E9A71A6B408 /* BookFileManager.swift */; };
 		79136EC0FA51B954D0C4DF8D /* Reader2PositionResumeContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9362A84727864E4CE17B46 /* Reader2PositionResumeContractTests.swift */; };
 		792FC867D8830D31B37C0B7B /* CatalogAPIMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D413CEAF86FD23AA8F421AE /* CatalogAPIMock.swift */; };
+		7962E7E9FDC6354CD0BBD9BD /* AppRatingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8634A05347B14A483EBB459D /* AppRatingService.swift */; };
 		79D7234B5BFAE38BC05CBBEA /* Badge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B60ACDE3E15FC832885E932 /* Badge.swift */; };
 		79DF09A8676EA0763C055B65 /* NotificationServiceTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93925AD8656015E0036615C8 /* NotificationServiceTokenTests.swift */; };
 		7B121B8D0C0E39FCB2FE0D9F /* AudiobookTOCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58876626DF4EE60D219F05ED /* AudiobookTOCTests.swift */; };
@@ -814,6 +817,7 @@
 		87A0D209BEFAA71C55C48D47 /* URLSessionConfiguration+MockBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR007 /* URLSessionConfiguration+MockBackend.swift */; };
 		87C254132B0D459592C2B7D6 /* UIApplication+MainScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D50821D42294719B5E6F62C /* UIApplication+MainScene.swift */; };
 		87D45ECE16E00039CE44175E /* AudiobookSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5BAC81314C28A366BF6BB7 /* AudiobookSessionManager.swift */; };
+		886784875A41A7A49C80BFEF /* RatingEngagementTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628AE12E352BCBAEA9346258 /* RatingEngagementTracker.swift */; };
 		88BA8C0DC54BD79F6CF6AFD9 /* ActiveSessionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB928B9E776405C7F436538 /* ActiveSessionsViewModel.swift */; };
 		88EFF2030D2D45419813717D /* ForceResetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1557BA5E024E70AE55ACE2 /* ForceResetTests.swift */; };
 		89288C4DB882DB6F692F1750 /* Reader2BookmarkContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FB7A3D7F1E7AEABAA4A45E /* Reader2BookmarkContractTests.swift */; };
@@ -836,6 +840,7 @@
 		8CCB8310199672E1C07F4073 /* TPPReaderBlockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */; };
 		8CD73CE1905CBD7FA883FF6A /* TPPReauthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D5C28E71B1D177EAF1E5F9 /* TPPReauthenticatorTests.swift */; };
 		8CE9C471237F84820072E964 /* TPPBookDetailsProblemDocumentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE9C470237F84820072E964 /* TPPBookDetailsProblemDocumentViewController.swift */; };
+		8DA4BE9843EAEAD3284D3476 /* RatingEngagementTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628AE12E352BCBAEA9346258 /* RatingEngagementTracker.swift */; };
 		8DB340CF4268405FAA8954D2 /* SignInModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CCA7049DE640BABC8D20B8 /* SignInModalView.swift */; };
 		8DB340D04268405FAA8954D3 /* SignInModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CCA7049DE640BABC8D20B8 /* SignInModalView.swift */; };
 		8E3BAF96E740BE69D854B397 /* PalaceWiringTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D3E99EDF9AFB815A1AEDE68 /* PalaceWiringTestCase.swift */; };
@@ -870,6 +875,7 @@
 		98305B9FFC0E45D2B33B5582 /* TPPSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91FD775116643E6AF6CB27E /* TPPSettingsTests.swift */; };
 		98A18D20D2FA4CAB9B7DACBF /* NotificationTokenRegistrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BBD43B97F3465E8AF2D60C /* NotificationTokenRegistrationTests.swift */; };
 		98DD257D43C93F01180049AA /* ReaderEditingActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94ED05E54513023A79735EA0 /* ReaderEditingActionsTests.swift */; };
+		98E1D5F9C6E1D4088C22EC9F /* RatingEngagementTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD757427072D6596FB42C87F /* RatingEngagementTrackerTests.swift */; };
 		99397E6CF643CA6230966B1E /* NSURLRequest+NYPLURLRequestAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB8CC29A8C5DFB84187D498 /* NSURLRequest+NYPLURLRequestAdditions.swift */; };
 		993DF43B943A29FA04C9E1AF /* BorrowOperationStreamingHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C628E6207F3958E194D07C /* BorrowOperationStreamingHTMLTests.swift */; };
 		99D20F898EFFA152025AF8EF /* LCPPDFAcquisitionPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A69DBB718593D67B0150D7 /* LCPPDFAcquisitionPredicateTests.swift */; };
@@ -929,6 +935,7 @@
 		A6C6D83ED0F20F041062ECF0 /* LCPPDFOpenProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C86F54125C3BD725906F86 /* LCPPDFOpenProgress.swift */; };
 		A6C753810A4D64E933B7B36A /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = SETVM003T260955EF008E1DC3 /* SettingsViewModel.swift */; };
 		A6F47C647E52D22145FB06D2 /* SideloadedBookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94335E63E085BA6718033D06 /* SideloadedBookManager.swift */; };
+		A6FFC495B6F55B158739EE9C /* RatingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9905AB408890B78E7B723F22 /* RatingConfig.swift */; };
 		A7D3A61E77E6B8C0FD9AEA5D /* TypographySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C1C917A6BF4317D7FA6567 /* TypographySettings.swift */; };
 		A7E1CE3367F3C787133E928B /* PalaceCatalog in Frameworks */ = {isa = PBXBuildFile; productRef = 4BDC371B99FCA4E42EEFA3CB /* PalaceCatalog */; };
 		A8131DE3255ED9F6651D1AF6 /* AudioSessionActivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDE63F6732471A2B00D88DC /* AudioSessionActivator.swift */; };
@@ -964,6 +971,7 @@
 		AD0D1E6A0666A62B8483424F /* ChaosHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70819902FBD142EFF56C93D9 /* ChaosHarness.swift */; };
 		AD12AC7147843740E308406E /* TPPBookButtonsStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2767960A51AB8CB4C0607243 /* TPPBookButtonsStateTests.swift */; };
 		AD27B6FD04FB3A7966122D83 /* DownloadAnnouncementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D85D6FFA9CEBA4295D91F15 /* DownloadAnnouncementService.swift */; };
+		AD818A5FF91041A1AEB0A8FA /* RatingEligibilityPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8AB4D59DBD90ED85785F01 /* RatingEligibilityPolicyTests.swift */; };
 		ADC762F8876B7DD97B60178D /* TypographySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C1C917A6BF4317D7FA6567 /* TypographySettings.swift */; };
 		ADCED6A507B7C113E98FAFFC /* AuthFlowSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE020244923A658A8CB9EE39 /* AuthFlowSecurityTests.swift */; };
 		AE0AFD4A8BCD4BCCBD711E9E /* OPDS1ParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE7F15EC8D84FCBBC17832E /* OPDS1ParsingTests.swift */; };
@@ -1043,6 +1051,7 @@
 		BCA6EDA7130EA01205B4AC4B /* XCTestCase+testUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9C0AEAE3241BE40D8F7A14 /* XCTestCase+testUserDefaultsTests.swift */; };
 		BCEBB84F8E655046452697B7 /* ReaderInitialLocationNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB1721A59302ABD56C2667E /* ReaderInitialLocationNavigator.swift */; };
 		BCF3398CEB2C47F09F8ABCFF /* TPPNetworkExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D1A95DE8674E6D83B5A8CA /* TPPNetworkExecutorTests.swift */; };
+		BD6C160472CEFBD15C4F0335 /* RatingEligibilityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E63BC817551861A7A8D75D /* RatingEligibilityPolicy.swift */; };
 		BDDA11B0012345CAFEBABE01 /* BookDetailMetadataHydrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDA22B0012345CAFEBABE02 /* BookDetailMetadataHydrationTests.swift */; };
 		BDDCE7092C8357EC27BDE5D8 /* TPPReaderBookmarksReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4C1C2D6591E2D7439CF24 /* TPPReaderBookmarksReadinessTests.swift */; };
 		BE1400B5FB4C9A7072F82038 /* LocalFileAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4B77CEDF228DC03714AD31 /* LocalFileAdapter.swift */; };
@@ -1172,6 +1181,7 @@
 		D30AD084B4614EFA9C708928 /* TPPCredentialIsolationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16FBDE7626549B79736A665 /* TPPCredentialIsolationE2ETests.swift */; };
 		D3101CC4442E0E2A8E6B9AE2 /* BackgroundDownloadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDB637C01812EEB10919A6E /* BackgroundDownloadHandler.swift */; };
 		D334E57F366D2B71AF9D38F5 /* OPDS2PublicationExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023DFFACC986541965F1560 /* OPDS2PublicationExtended.swift */; };
+		D363615844BC602E2E1FFFBE /* AppRatingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B6CEA300F1440914E64EE8 /* AppRatingServiceTests.swift */; };
 		D3B4C5D6E7F8A9B0C1D2E3F4 /* BorrowOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B2C3D4E5F6A7B8C9D0E1F2 /* BorrowOperation.swift */; };
 		D3E4F5A6B7C8D9E0F1A2B3C4 /* DownloadCompletionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E8F9A0B1C2 /* DownloadCompletionParser.swift */; };
 		D413289F5AAABCA5C1FF5B68 /* MockImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D658439F3483E80A5EAA66A /* MockImageLoader.swift */; };
@@ -1198,6 +1208,7 @@
 		D8323F4CCF51DE6D1961CBDC /* TPPBookAccessibilityLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8468ADD34076BF5935E56B /* TPPBookAccessibilityLabelTests.swift */; };
 		D84A746313A44F09DD90DC0C /* ReadiumPDFReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4494F50352E88455B28AD34E /* ReadiumPDFReaderView.swift */; };
 		D8C46AF7754FE634B2354952 /* TPPUserAccountConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48EA85A0DBA077D1BBAD063 /* TPPUserAccountConcurrencyTests.swift */; };
+		D88A3E4B3868A2FAEC978110 /* AppRatingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8634A05347B14A483EBB459D /* AppRatingService.swift */; };
 		D8E3E2F8DB67110026272CFB /* MockVisualNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75B6896C9742C07208D935E /* MockVisualNavigator.swift */; };
 		D91512129048356CDC3C9542 /* PalaceCheckPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */; };
 		D92D8C0137C4BC9647242D87 /* SignInModalLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA17C81F4AA9F1201A91AC6C /* SignInModalLifecycleTests.swift */; };
@@ -2401,6 +2412,7 @@
 		60FB7A3D7F1E7AEABAA4A45E /* Reader2BookmarkContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Reader2BookmarkContractTests.swift; sourceTree = "<group>"; };
 		61585F7AD2A0D6CDAF2EF098 /* PerformanceMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMonitor.swift; sourceTree = "<group>"; };
 		6264EE86B60659F794A006A0 /* AudiobookVendorAdapterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookVendorAdapterTests.swift; sourceTree = "<group>"; };
+		628AE12E352BCBAEA9346258 /* RatingEngagementTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingEngagementTracker.swift; sourceTree = "<group>"; };
 		62AC10B820071D5968FEFF81 /* PerformanceReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceReportTests.swift; sourceTree = "<group>"; };
 		634E8A7700449B3157A0E943 /* OfflineQueueDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineQueueDetailView.swift; sourceTree = "<group>"; };
 		63880885010BDEA019007D3A /* SingletonResetRegistryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SingletonResetRegistryTests.swift; sourceTree = "<group>"; };
@@ -2609,9 +2621,11 @@
 		84B7A3431B84E8FE00584FB2 /* OFL.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OFL.txt; sourceTree = "<group>"; };
 		84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "OpenDyslexic3-Bold.ttf"; sourceTree = "<group>"; };
 		84B7A3451B84E8FE00584FB2 /* OpenDyslexic3-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "OpenDyslexic3-Regular.ttf"; sourceTree = "<group>"; };
+		84E63BC817551861A7A8D75D /* RatingEligibilityPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingEligibilityPolicy.swift; sourceTree = "<group>"; };
 		84FCD2601B7BA79200BFEDD9 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		8568424DF6517B247D048D5D /* LCPLibraryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPLibraryServiceTests.swift; sourceTree = "<group>"; };
 		85803B918D5A471B9C0B98D0 /* CatalogState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogState.swift; sourceTree = "<group>"; };
+		8634A05347B14A483EBB459D /* AppRatingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppRatingService.swift; sourceTree = "<group>"; };
 		8673802153960A8CA7EAE753 /* AccountsManager+TPPCurrentLibraryAccountProviding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AccountsManager+TPPCurrentLibraryAccountProviding.swift"; sourceTree = "<group>"; };
 		867797B6E90539304E2A80B5 /* AudiobookColdLoadRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookColdLoadRecoveryTests.swift; sourceTree = "<group>"; };
 		867AE0470C91DD0D498E68F4 /* AppContainerAudiobookFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContainerAudiobookFactoryTests.swift; sourceTree = "<group>"; };
@@ -2660,6 +2674,7 @@
 		97FEB8CD861EF1E03044FDDC /* DownloadStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadStateManager.swift; sourceTree = "<group>"; };
 		9842D046008345B881CDC7E7 /* TPPReauthenticatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPReauthenticatorMock.swift; sourceTree = "<group>"; };
 		989EAF4764014D23B7BE358F /* TPPProblemDocumentCacheManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPProblemDocumentCacheManagerTests.swift; sourceTree = "<group>"; };
+		9905AB408890B78E7B723F22 /* RatingConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingConfig.swift; sourceTree = "<group>"; };
 		99895C63131766252D87F554 /* BackupExclusionMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupExclusionMigration.swift; sourceTree = "<group>"; };
 		9A35DE944F78A26A081622BA /* TPPReaderPageListBusinessLogicTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderPageListBusinessLogicTests.swift; sourceTree = "<group>"; };
 		9A399B178C9ECF3F62C62172 /* AccountsManagerIsolationLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerIsolationLintTests.swift; sourceTree = "<group>"; };
@@ -2865,6 +2880,7 @@
 		CD71C8FF18A443133C015DA8 /* KeyboardVoiceOverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyboardVoiceOverTests.swift; sourceTree = "<group>"; };
 		CE97656B54F67282B7B52648 /* TPPLinearView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPLinearView.swift; sourceTree = "<group>"; };
 		CF2D0C6025D50993E6431BDC /* ReaderThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeTests.swift; sourceTree = "<group>"; };
+		CF8AB4D59DBD90ED85785F01 /* RatingEligibilityPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingEligibilityPolicyTests.swift; sourceTree = "<group>"; };
 		COOKIEPERSIST001REF001 /* CookiePersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CookiePersistenceTests.swift; sourceTree = "<group>"; };
 		CPTB00010000FILEREF01 /* CarPlayTemplateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayTemplateBuilder.swift; sourceTree = "<group>"; };
 		CRWL0001FREF00000001 /* CrawlState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrawlState.swift; sourceTree = "<group>"; };
@@ -2944,6 +2960,7 @@
 		E1BBD43B97F3465E8AF2D60C /* NotificationTokenRegistrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationTokenRegistrationTests.swift; sourceTree = "<group>"; };
 		E1F2A3B4C5D6078900000001 /* MyBooksDownloadErrorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadErrorInfo.swift; sourceTree = "<group>"; };
 		E1F2A3B4C5D6E7F8A9B0C1D2 /* RightsManagementDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightsManagementDispatcher.swift; sourceTree = "<group>"; };
+		E2B6CEA300F1440914E64EE8 /* AppRatingServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppRatingServiceTests.swift; sourceTree = "<group>"; };
 		E3465465A1B2C3D4E5F60829 /* OverdriveDownloadHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverdriveDownloadHandler.swift; sourceTree = "<group>"; };
 		E358F2BF99213E34F1B052ED /* OPDS2BookBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2BookBridgeTests.swift; sourceTree = "<group>"; };
 		E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderFootnoteAccessibility.swift; path = ../../Palace/Reader2/BusinessLogic/TPPReaderFootnoteAccessibility.swift; sourceTree = "<group>"; };
@@ -3279,6 +3296,7 @@
 		FC95BE63D9C7C7AE1EFB8D6B /* ChaosFaultInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaosFaultInjectionTests.swift; sourceTree = "<group>"; };
 		FCF5E7D0F712E6F62B28E143 /* LCPPDFOpenProgressTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPDFOpenProgressTests.swift; sourceTree = "<group>"; };
 		FD60FEA388441F72F8C8D85C /* TPPReaderFootnoteAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderFootnoteAccessibilityTests.swift; path = TPPReaderFootnoteAccessibilityTests.swift; sourceTree = "<group>"; };
+		FD757427072D6596FB42C87F /* RatingEngagementTrackerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingEngagementTrackerTests.swift; sourceTree = "<group>"; };
 		FE0CCABB8C99DA55C43F3DA3 /* AdobeDRMHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeDRMHandler.swift; sourceTree = "<group>"; };
 		FE2159403F0FCBE90CFC6858 /* BookImageViewAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImageViewAccessibilityTests.swift; sourceTree = "<group>"; };
 		FE7BD91AF3E14990B745A0AA /* AudiobookDataManagerSyncTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookDataManagerSyncTests.swift; sourceTree = "<group>"; };
@@ -4821,6 +4839,17 @@
 			name = MyBooks;
 			sourceTree = "<group>";
 		};
+		8216AF24139B364FD961D583 /* AppRating */ = {
+			isa = PBXGroup;
+			children = (
+				CF8AB4D59DBD90ED85785F01 /* RatingEligibilityPolicyTests.swift */,
+				FD757427072D6596FB42C87F /* RatingEngagementTrackerTests.swift */,
+				E2B6CEA300F1440914E64EE8 /* AppRatingServiceTests.swift */,
+			);
+			name = AppRating;
+			path = AppRating;
+			sourceTree = "<group>";
+		};
 		839CDA0D0B5BC07729C1E528 /* Debug */ = {
 			isa = PBXGroup;
 			children = (
@@ -4988,6 +5017,18 @@
 			);
 			name = ReaderStreaming;
 			path = ReaderStreaming;
+			sourceTree = "<group>";
+		};
+		A3DE57DDBE9017F448E871F8 /* AppRating */ = {
+			isa = PBXGroup;
+			children = (
+				9905AB408890B78E7B723F22 /* RatingConfig.swift */,
+				84E63BC817551861A7A8D75D /* RatingEligibilityPolicy.swift */,
+				628AE12E352BCBAEA9346258 /* RatingEngagementTracker.swift */,
+				8634A05347B14A483EBB459D /* AppRatingService.swift */,
+			);
+			name = AppRating;
+			path = AppRating;
 			sourceTree = "<group>";
 		};
 		A4E7A9EF8B06FD43D1E1BAD9 /* Telemetry */ = {
@@ -5161,6 +5202,7 @@
 				7FC893466C6A93B65FB0C185 /* MyBooks */,
 				A296C1DE951EE49FBDA9E7B5 /* ReaderStreaming */,
 				F1349B46CEE81FAB9E71DD81 /* Support */,
+				A3DE57DDBE9017F448E871F8 /* AppRating */,
 			);
 			path = Palace;
 			sourceTree = "<group>";
@@ -5318,6 +5360,7 @@
 				1ABC0E40FBEECB22D2E04F66 /* AudiobookBookmarkBusinessLogicConcurrencyTests.swift */,
 				5F80A7E0050FBFEDA0FCD075 /* TPPConfigurationCustomRegistryTests.swift */,
 				4E55AED72A688C44680A7FFA /* FeatureFlags */,
+				8216AF24139B364FD961D583 /* AppRating */,
 			);
 			path = PalaceTests;
 			sourceTree = "<group>";
@@ -7522,6 +7565,9 @@
 				2D32C1D17E592EAF2B61072E /* SideloadImportContractTests.swift in Sources */,
 				6C306D35A8C48C707C25D9C8 /* SideloadedBookManagerTests.swift in Sources */,
 				D8C46AF7754FE634B2354952 /* TPPUserAccountConcurrencyTests.swift in Sources */,
+				AD818A5FF91041A1AEB0A8FA /* RatingEligibilityPolicyTests.swift in Sources */,
+				98E1D5F9C6E1D4088C22EC9F /* RatingEngagementTrackerTests.swift in Sources */,
+				D363615844BC602E2E1FFFBE /* AppRatingServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8071,6 +8117,10 @@
 				2A031F58A8B7EE5BAD71CD9C /* SideloadedBookRegistry.swift in Sources */,
 				B45F11B653AFD64C41129E77 /* SideloadedBookManager.swift in Sources */,
 				B4991867A211185F41CE520E /* SideLoadingView.swift in Sources */,
+				A6FFC495B6F55B158739EE9C /* RatingConfig.swift in Sources */,
+				04E1B61CD5C2DFEEC1687B6F /* RatingEligibilityPolicy.swift in Sources */,
+				886784875A41A7A49C80BFEF /* RatingEngagementTracker.swift in Sources */,
+				7962E7E9FDC6354CD0BBD9BD /* AppRatingService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8623,6 +8673,10 @@
 				16D1246F3608F88A422AE6BA /* SideloadedBookRegistry.swift in Sources */,
 				A6F47C647E52D22145FB06D2 /* SideloadedBookManager.swift in Sources */,
 				0BD8B0C9E2FDB018F9ED98C5 /* SideLoadingView.swift in Sources */,
+				6082A3BC12445EF6992B9AD4 /* RatingConfig.swift in Sources */,
+				BD6C160472CEFBD15C4F0335 /* RatingEligibilityPolicy.swift in Sources */,
+				8DA4BE9843EAEAD3284D3476 /* RatingEngagementTracker.swift in Sources */,
+				D88A3E4B3868A2FAEC978110 /* AppRatingService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -309,11 +309,29 @@ struct AppContainer {
         return bootstrapper
     }
 
+    /// App-rating service (Epic PP-4086). Owns engagement tracking + eligibility
+    /// evaluation; persists through `self.settings` and reads thresholds from
+    /// Remote Config. Lazy + cached like the audiobook services above.
+    @MainActor
+    var appRatingService: AppRatingService {
+        if let cached = AppContainer._appRatingService { return cached }
+        let service = AppRatingService(
+            tracker: RatingEngagementTracker(settings: self.settings),
+            configProvider: { RemoteFeatureFlags.shared.appRatingConfig },
+            promptEnabledProvider: { RemoteFeatureFlags.shared.isAppRatingPromptEnabled },
+            crashFreeProbe: { FirebaseManager.shared.wasLastSessionCrashFree() },
+            now: Date.init
+        )
+        AppContainer._appRatingService = service
+        return service
+    }
+
     @MainActor private static var _bookCellModelCache: BookCellModelCache?
     @MainActor private static var _samplePreviewManager: SamplePreviewManager?
     @MainActor private static var _audiobookSession: AudiobookSessionManager?
     @MainActor private static var _audiobookSessionPresenter: AudiobookSessionPresenter?
     @MainActor private static var _playbackBootstrapper: PlaybackBootstrapper?
+    @MainActor private static var _appRatingService: AppRatingService?
 
     init(
         bookRegistry: TPPBookRegistryProvider,
@@ -630,6 +648,7 @@ struct AppContainer {
             _audiobookSession = nil
             _audiobookSessionPresenter = nil
             _playbackBootstrapper = nil
+            _appRatingService = nil
         }
         // Side-loading (PP-2678): the side-loaded registry is a file-backed
         // shared static cache, so it WOULD bleed manifest state across test

--- a/Palace/AppInfrastructure/FirebaseManager.swift
+++ b/Palace/AppInfrastructure/FirebaseManager.swift
@@ -69,6 +69,12 @@ final class FirebaseManager: @unchecked Sendable {
         case triageBotAIFallbackEnabled = "triage_bot_ai_fallback_enabled"
         case inAppPlaybackNavEnabled = "in_app_playback_nav_enabled"
         case sideLoadingEnabled = "side_loading_enabled"
+        // App-rating prompt (Epic PP-4086). Master switch + tunable thresholds.
+        case appRatingPromptEnabled = "app_rating_prompt_enabled"
+        case appRatingMinSessions = "app_rating_min_sessions"
+        case appRatingMinBooksCompleted = "app_rating_min_books_completed"
+        case appRatingCooldownDays = "app_rating_cooldown_days"
+        case appRatingLifetimePromptCap = "app_rating_lifetime_prompt_cap"
     }
 
     // MARK: - Initialization
@@ -116,7 +122,12 @@ final class FirebaseManager: @unchecked Sendable {
             RemoteConfigKey.triageBotTicketSubmissionEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.triageBotAIFallbackEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.inAppPlaybackNavEnabled.rawValue: NSNumber(value: false),
-            RemoteConfigKey.sideLoadingEnabled.rawValue: NSNumber(value: false)
+            RemoteConfigKey.sideLoadingEnabled.rawValue: NSNumber(value: false),
+            RemoteConfigKey.appRatingPromptEnabled.rawValue: NSNumber(value: true),
+            RemoteConfigKey.appRatingMinSessions.rawValue: NSNumber(value: RatingConfig.fallback.minSessions),
+            RemoteConfigKey.appRatingMinBooksCompleted.rawValue: NSNumber(value: RatingConfig.fallback.minBooksCompleted),
+            RemoteConfigKey.appRatingCooldownDays.rawValue: NSNumber(value: RatingConfig.fallback.cooldownDays),
+            RemoteConfigKey.appRatingLifetimePromptCap.rawValue: NSNumber(value: RatingConfig.fallback.lifetimePromptCap)
         ])
     }
 
@@ -223,9 +234,27 @@ final class FirebaseManager: @unchecked Sendable {
         return remoteConfig.configValue(forKey: key.rawValue).boolValue
     }
 
+    /// Gets a numeric value from remote config (returns 0 when unset and no
+    /// default is registered). Used for the app-rating tunable thresholds.
+    func getDoubleValue(forKey key: RemoteConfigKey) -> Double {
+        remoteConfig.configValue(forKey: key.rawValue).numberValue.doubleValue
+    }
+
     /// Checks if a config value came from the remote server.
     func isRemoteValue(forKey key: RemoteConfigKey) -> Bool {
         remoteConfig.configValue(forKey: key.rawValue).source == .remote
+    }
+
+    /// Best-effort "was the previous app session crash-free?" signal for the
+    /// app-rating eligibility policy (PP-4088). Returns `true` when crash
+    /// reporting is unavailable (non-production or `FEATURE_CRASH_REPORTING`
+    /// off), so an absent signal never blocks an otherwise-eligible patron.
+    func wasLastSessionCrashFree() -> Bool {
+        #if FEATURE_CRASH_REPORTING
+        return !Crashlytics.crashlytics().didCrashDuringPreviousExecution()
+        #else
+        return true
+        #endif
     }
 
     // MARK: - Enhanced Logging

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -304,6 +304,9 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
         // Resume Firebase operations when app becomes active
         FirebaseManager.shared.applicationDidBecomeActive()
 
+        // Record an app-open for the rating-prompt engagement signals (PP-4087).
+        AppContainer.production().appRatingService.recordSession()
+
         // Update feature flag cache after Remote Config is refreshed
         Task {
             // Small delay to let Remote Config fetch complete

--- a/Palace/AppRating/AppRatingService.swift
+++ b/Palace/AppRating/AppRatingService.swift
@@ -1,0 +1,98 @@
+//
+//  AppRatingService.swift
+//  Palace
+//
+//  Orchestrates app-rating engagement tracking + eligibility (Epic PP-4086).
+//  PR 1 scope: recording + eligibility only. Presentation of the sentiment
+//  gate, the StoreKit request, and the feedback path land in PR 2
+//  (PP-4089 / PP-4090 / PP-4091).
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+/// The positive moments that may trigger an eligibility check.
+enum AppRatingTrigger {
+  /// The patron finished reading or listening to a book (primary trigger).
+  case bookCompleted
+  /// The patron successfully borrowed a book (secondary trigger).
+  case borrowSucceeded
+}
+
+/// Central entry point for the app-rating feature. Views and lifecycle hooks
+/// talk to this service rather than to the tracker or policy directly.
+///
+/// `@MainActor` because it is reached from UI lifecycle hooks and (in PR 2)
+/// drives presentation.
+@MainActor
+final class AppRatingService {
+
+  private let tracker: RatingEngagementTracker
+  private let configProvider: () -> RatingConfig
+  private let promptEnabledProvider: () -> Bool
+  private let crashFreeProbe: () -> Bool
+  private let now: () -> Date
+
+  /// - Parameters:
+  ///   - tracker: persists/reads engagement signals.
+  ///   - configProvider: supplies the (remote-tunable) thresholds on demand.
+  ///   - promptEnabledProvider: remote master kill-switch for the whole feature.
+  ///   - crashFreeProbe: best-effort "was the previous session crash-free?"
+  ///     signal, evaluated once per session.
+  ///   - now: injected clock for deterministic cooldown math.
+  init(
+    tracker: RatingEngagementTracker,
+    configProvider: @escaping () -> RatingConfig = { .fallback },
+    promptEnabledProvider: @escaping () -> Bool = { true },
+    crashFreeProbe: @escaping () -> Bool = { true },
+    now: @escaping () -> Date = Date.init
+  ) {
+    self.tracker = tracker
+    self.configProvider = configProvider
+    self.promptEnabledProvider = promptEnabledProvider
+    self.crashFreeProbe = crashFreeProbe
+    self.now = now
+  }
+
+  // MARK: - Recording
+
+  /// Records an app open. Also captures whether the previous session was
+  /// crash-free (best-effort). Call once when the app becomes active.
+  func recordSession() {
+    tracker.recordSession(crashFreeLastSession: crashFreeProbe())
+  }
+
+  /// Records that a book was finished.
+  func recordBookCompleted() {
+    tracker.recordBookCompleted()
+  }
+
+  /// Records that the sentiment gate was shown (stamps cooldown + lifetime cap).
+  func recordPromptShown() {
+    tracker.recordPromptShown(at: now())
+  }
+
+  /// Records that the patron dismissed/declined the gate.
+  func recordDismissal() {
+    tracker.recordDismissal()
+  }
+
+  /// Records that the patron chose "Don't ask again".
+  func recordOptOut() {
+    tracker.recordOptOut()
+  }
+
+  // MARK: - Eligibility
+
+  /// Whether the prompt may be shown for the given trigger right now.
+  /// Returns `false` when the remote master switch is off, regardless of
+  /// engagement state.
+  func isEligible(for trigger: AppRatingTrigger) -> Bool {
+    guard promptEnabledProvider() else { return false }
+    return RatingEligibilityPolicy.evaluate(
+      state: tracker.currentState(),
+      config: configProvider(),
+      now: now()
+    )
+  }
+}

--- a/Palace/AppRating/RatingConfig.swift
+++ b/Palace/AppRating/RatingConfig.swift
@@ -1,0 +1,42 @@
+//
+//  RatingConfig.swift
+//  Palace
+//
+//  Tunable thresholds for the app-rating eligibility policy (PP-4088).
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+/// The tunable thresholds that gate the app-rating prompt. Values are sourced
+/// from Firebase Remote Config at runtime (see `RemoteFeatureFlags.appRatingConfig`)
+/// so they can be re-tuned without an app release; `.fallback` supplies the
+/// recommended defaults when Remote Config is unavailable.
+struct RatingConfig: Equatable {
+
+  /// Minimum number of app sessions before the prompt is eligible.
+  let minSessions: Int
+
+  /// Minimum number of finished books (read or listened) before eligibility.
+  let minBooksCompleted: Int
+
+  /// Days that must elapse after a prompt is shown before it may be shown again.
+  let cooldownDays: Int
+
+  /// Maximum number of times the prompt may ever be displayed to a patron.
+  let lifetimePromptCap: Int
+
+  /// Recommended defaults (PP-4088). Used whenever Remote Config has not
+  /// supplied a value.
+  static let fallback = RatingConfig(
+    minSessions: 5,
+    minBooksCompleted: 1,
+    cooldownDays: 90,
+    lifetimePromptCap: 3
+  )
+
+  /// The cooldown expressed as a `TimeInterval` for date arithmetic.
+  var cooldownInterval: TimeInterval {
+    TimeInterval(cooldownDays) * 86_400
+  }
+}

--- a/Palace/AppRating/RatingEligibilityPolicy.swift
+++ b/Palace/AppRating/RatingEligibilityPolicy.swift
@@ -1,0 +1,52 @@
+//
+//  RatingEligibilityPolicy.swift
+//  Palace
+//
+//  Pure eligibility rules for the app-rating prompt (PP-4088).
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+/// Pure decision function that determines whether a patron is eligible to be
+/// shown the app-rating sentiment gate. Every input is passed explicitly
+/// (state, config, clock) so the policy has no hidden dependencies and is
+/// exhaustively unit- and mutation-testable. It is the single source of truth
+/// for the seven eligibility criteria in PP-4088; callers must not re-implement
+/// any of them.
+enum RatingEligibilityPolicy {
+
+  /// - Parameters:
+  ///   - state: the current engagement snapshot.
+  ///   - config: the (remote-tunable) thresholds.
+  ///   - now: the current time, injected so cooldown math is deterministic.
+  /// - Returns: `true` only when ALL criteria pass.
+  static func evaluate(state: RatingEngagementState, config: RatingConfig, now: Date) -> Bool {
+    // Respect an explicit "Don't ask again" — highest-priority opt-out.
+    guard !state.optedOut else { return false }
+
+    // Never prompt on the first session (onboarding).
+    guard !state.isFirstSession else { return false }
+
+    // Enough usage to have a meaningful opinion.
+    guard state.sessionCount >= config.minSessions else { return false }
+    guard state.booksCompleted >= config.minBooksCompleted else { return false }
+
+    // Don't ask right after a bad (crashing) experience.
+    guard state.crashFreeLastSession else { return false }
+
+    // Respect Apple's spirit of a small lifetime cap.
+    guard state.promptDisplayCount < config.lifetimePromptCap else { return false }
+
+    // Respect the cooldown since the last display. `now >= earliestNext` also
+    // makes a backward clock change fail closed: if the clock is set earlier
+    // than the last prompt, `now` cannot reach `earliestNext`, so the prompt
+    // stays suppressed rather than unlocking.
+    if let lastPromptDate = state.lastPromptDate {
+      let earliestNext = lastPromptDate.addingTimeInterval(config.cooldownInterval)
+      guard now >= earliestNext else { return false }
+    }
+
+    return true
+  }
+}

--- a/Palace/AppRating/RatingEngagementTracker.swift
+++ b/Palace/AppRating/RatingEngagementTracker.swift
@@ -1,0 +1,94 @@
+//
+//  RatingEngagementTracker.swift
+//  Palace
+//
+//  Local, on-device engagement tracking for the app-rating prompt (PP-4087).
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+/// An immutable snapshot of the engagement signals that feed the eligibility
+/// policy. All values are local/on-device; no PII is captured.
+struct RatingEngagementState: Equatable {
+
+  /// Number of times the app has been opened/became active.
+  let sessionCount: Int
+
+  /// Number of books the patron has finished (read or listened to).
+  let booksCompleted: Int
+
+  /// When the sentiment gate was last shown, or `nil` if never.
+  let lastPromptDate: Date?
+
+  /// Lifetime number of times the sentiment gate has been displayed.
+  let promptDisplayCount: Int
+
+  /// Number of times the patron dismissed/declined the sentiment gate.
+  let dismissalCount: Int
+
+  /// Whether the patron selected "Don't ask again".
+  let optedOut: Bool
+
+  /// Whether the most recent previous session ended without a crash.
+  let crashFreeLastSession: Bool
+
+  /// The first session is onboarding; never prompt during it.
+  var isFirstSession: Bool { sessionCount <= 1 }
+}
+
+/// Records and reads the engagement signals used to decide when to show the
+/// app-rating prompt. State is persisted through `TPPSettings`
+/// (`UserDefaults`-backed), so it survives app updates. This type owns the
+/// mutation of those signals; the eligibility decision itself lives in the
+/// pure `RatingEligibilityPolicy`.
+final class RatingEngagementTracker {
+
+  private let settings: TPPSettingsProviding
+
+  init(settings: TPPSettingsProviding) {
+    self.settings = settings
+  }
+
+  /// A snapshot of the current engagement state.
+  func currentState() -> RatingEngagementState {
+    RatingEngagementState(
+      sessionCount: settings.appRatingSessionCount,
+      booksCompleted: settings.appRatingBooksCompleted,
+      lastPromptDate: settings.appRatingLastPromptDate,
+      promptDisplayCount: settings.appRatingPromptDisplayCount,
+      dismissalCount: settings.appRatingDismissalCount,
+      optedOut: settings.appRatingOptedOut,
+      crashFreeLastSession: settings.appRatingCrashFreeLastSession
+    )
+  }
+
+  /// Increments the session count and records whether the previous session was
+  /// crash-free. Called once each time the app becomes active.
+  func recordSession(crashFreeLastSession: Bool) {
+    settings.appRatingSessionCount += 1
+    settings.appRatingCrashFreeLastSession = crashFreeLastSession
+  }
+
+  /// Increments the completed-book count. Called when a book is finished.
+  func recordBookCompleted() {
+    settings.appRatingBooksCompleted += 1
+  }
+
+  /// Records that the sentiment gate was displayed: stamps the date (for the
+  /// cooldown) and increments the lifetime display count (for the cap).
+  func recordPromptShown(at date: Date) {
+    settings.appRatingLastPromptDate = date
+    settings.appRatingPromptDisplayCount += 1
+  }
+
+  /// Records that the patron dismissed/declined the gate.
+  func recordDismissal() {
+    settings.appRatingDismissalCount += 1
+  }
+
+  /// Records that the patron selected "Don't ask again".
+  func recordOptOut() {
+    settings.appRatingOptedOut = true
+  }
+}

--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -68,6 +68,10 @@ final class RemoteFeatureFlags: @unchecked Sendable {
         /// non-DEBUG, so the feature is turned on explicitly by the dev-menu
         /// toggle rather than by build configuration.
         case sideLoadingEnabled = "side_loading_enabled"
+        /// Master kill-switch for the app-rating prompt feature (Epic PP-4086).
+        /// Default ON; set to false in Remote Config to suppress the prompt
+        /// entirely regardless of engagement state.
+        case appRatingPromptEnabled = "app_rating_prompt_enabled"
 
         var defaultValue: Bool {
             switch self {
@@ -76,6 +80,8 @@ final class RemoteFeatureFlags: @unchecked Sendable {
             case .carPlayEnabled:
                 return true
             case .opds2Enabled:
+                return true
+            case .appRatingPromptEnabled:
                 return true
             default:
                 return false
@@ -105,6 +111,8 @@ final class RemoteFeatureFlags: @unchecked Sendable {
                 return .inAppPlaybackNavEnabled
             case .sideLoadingEnabled:
                 return .sideLoadingEnabled
+            case .appRatingPromptEnabled:
+                return .appRatingPromptEnabled
             default:
                 return nil
             }
@@ -382,6 +390,34 @@ final class RemoteFeatureFlags: @unchecked Sendable {
             return override
         }
         return isFeatureEnabled(.sideLoadingEnabled)
+    }
+
+    // MARK: - App Rating (Epic PP-4086)
+
+    /// Master switch for the app-rating prompt. When false, no eligibility
+    /// evaluation should proceed. Default ON.
+    var isAppRatingPromptEnabled: Bool {
+        isFeatureEnabled(.appRatingPromptEnabled)
+    }
+
+    /// The remote-tunable eligibility thresholds. Any threshold missing or
+    /// non-positive in Remote Config falls back to `RatingConfig.fallback`.
+    var appRatingConfig: RatingConfig {
+        RatingConfig(
+            minSessions: positiveIntOrFallback(.appRatingMinSessions, RatingConfig.fallback.minSessions),
+            minBooksCompleted: positiveIntOrFallback(.appRatingMinBooksCompleted, RatingConfig.fallback.minBooksCompleted),
+            cooldownDays: positiveIntOrFallback(.appRatingCooldownDays, RatingConfig.fallback.cooldownDays),
+            lifetimePromptCap: positiveIntOrFallback(.appRatingLifetimePromptCap, RatingConfig.fallback.lifetimePromptCap)
+        )
+    }
+
+    /// Reads a numeric Remote Config value, returning `fallback` when the value
+    /// is absent or non-positive (guards against a mis-set `0` disabling a
+    /// threshold). `minBooksCompleted` is allowed to be as low as 1, never 0,
+    /// so a positive-only guard is correct for every threshold here.
+    private func positiveIntOrFallback(_ key: FirebaseManager.RemoteConfigKey, _ fallback: Int) -> Int {
+        let value = FirebaseManager.shared.getDoubleValue(forKey: key)
+        return value > 0 ? Int(value) : fallback
     }
 
     // MARK: - Device Info for Targeting

--- a/Palace/Settings/TPPSettings.swift
+++ b/Palace/Settings/TPPSettings.swift
@@ -72,6 +72,16 @@ import Combine
     static let showDeveloperSettingsKey = "showDeveloperSettings"
     static let downloadOnlyOnWiFiKey = "TPPSettingsDownloadOnlyOnWiFi"
 
+    // App-rating engagement signals (PP-4087). Local/on-device only; no PII.
+    // Kept on `UserDefaults` so they survive app updates.
+    static private let appRatingSessionCountKey = "TPPAppRatingSessionCount"
+    static private let appRatingBooksCompletedKey = "TPPAppRatingBooksCompleted"
+    static private let appRatingLastPromptDateKey = "TPPAppRatingLastPromptDate"
+    static private let appRatingPromptDisplayCountKey = "TPPAppRatingPromptDisplayCount"
+    static private let appRatingDismissalCountKey = "TPPAppRatingDismissalCount"
+    static private let appRatingOptedOutKey = "TPPAppRatingOptedOut"
+    static private let appRatingCrashFreeLastSessionKey = "TPPAppRatingCrashFreeLastSession"
+
     // Set to nil (the default) if no custom feed should be used.
     var customMainFeedURL: URL? {
         get {
@@ -165,6 +175,55 @@ import Combine
         set {
             defaults.set(newValue, forKey: TPPSettings.downloadOnlyOnWiFiKey)
         }
+    }
+
+    // MARK: - App Rating (PP-4087)
+
+    var appRatingSessionCount: Int {
+        get { defaults.integer(forKey: TPPSettings.appRatingSessionCountKey) }
+        set { defaults.set(newValue, forKey: TPPSettings.appRatingSessionCountKey) }
+    }
+
+    var appRatingBooksCompleted: Int {
+        get { defaults.integer(forKey: TPPSettings.appRatingBooksCompletedKey) }
+        set { defaults.set(newValue, forKey: TPPSettings.appRatingBooksCompletedKey) }
+    }
+
+    var appRatingLastPromptDate: Date? {
+        get { defaults.object(forKey: TPPSettings.appRatingLastPromptDateKey) as? Date }
+        set {
+            if let newValue {
+                defaults.set(newValue, forKey: TPPSettings.appRatingLastPromptDateKey)
+            } else {
+                defaults.removeObject(forKey: TPPSettings.appRatingLastPromptDateKey)
+            }
+        }
+    }
+
+    var appRatingPromptDisplayCount: Int {
+        get { defaults.integer(forKey: TPPSettings.appRatingPromptDisplayCountKey) }
+        set { defaults.set(newValue, forKey: TPPSettings.appRatingPromptDisplayCountKey) }
+    }
+
+    var appRatingDismissalCount: Int {
+        get { defaults.integer(forKey: TPPSettings.appRatingDismissalCountKey) }
+        set { defaults.set(newValue, forKey: TPPSettings.appRatingDismissalCountKey) }
+    }
+
+    var appRatingOptedOut: Bool {
+        get { defaults.bool(forKey: TPPSettings.appRatingOptedOutKey) }
+        set { defaults.set(newValue, forKey: TPPSettings.appRatingOptedOutKey) }
+    }
+
+    /// Defaults to `true` (assume crash-free) when no session has recorded a
+    /// value yet, so a never-crashed patron is not blocked by an absent key.
+    var appRatingCrashFreeLastSession: Bool {
+        get {
+            defaults.object(forKey: TPPSettings.appRatingCrashFreeLastSessionKey) == nil
+                ? true
+                : defaults.bool(forKey: TPPSettings.appRatingCrashFreeLastSessionKey)
+        }
+        set { defaults.set(newValue, forKey: TPPSettings.appRatingCrashFreeLastSessionKey) }
     }
 
 }

--- a/Palace/Settings/TPPSettingsProviding.swift
+++ b/Palace/Settings/TPPSettingsProviding.swift
@@ -69,6 +69,31 @@ import Foundation
     /// When true, content downloads are restricted to Wi-Fi connections only.
     /// Cellular/mobile data downloads are blocked with a user-facing message.
     var downloadOnlyOnWiFi: Bool { get set }
+
+    // MARK: - App Rating (PP-4087)
+    // Local/on-device engagement signals feeding the rating-prompt eligibility
+    // policy. No PII; persisted so they survive app updates.
+
+    /// Number of times the app has been opened/became active.
+    var appRatingSessionCount: Int { get set }
+
+    /// Number of books the patron has finished (read or listened to).
+    var appRatingBooksCompleted: Int { get set }
+
+    /// When the sentiment gate was last shown, or nil if never.
+    var appRatingLastPromptDate: Date? { get set }
+
+    /// Lifetime number of times the sentiment gate has been displayed.
+    var appRatingPromptDisplayCount: Int { get set }
+
+    /// Number of times the patron dismissed/declined the sentiment gate.
+    var appRatingDismissalCount: Int { get set }
+
+    /// Whether the patron selected "Don't ask again".
+    var appRatingOptedOut: Bool { get set }
+
+    /// Whether the most recent previous session ended without a crash.
+    var appRatingCrashFreeLastSession: Bool { get set }
 }
 
 // MARK: - TPPSettings Conformance

--- a/PalaceTests/AppRating/AppRatingServiceTests.swift
+++ b/PalaceTests/AppRating/AppRatingServiceTests.swift
@@ -1,0 +1,122 @@
+//
+//  AppRatingServiceTests.swift
+//  PalaceTests
+//
+//  Tests for AppRatingService (Epic PP-4086, PR 1): recording delegation,
+//  crash-free probe wiring, injected clock, and eligibility gating (master
+//  switch + policy + config).
+//
+
+import XCTest
+@testable import Palace
+
+@MainActor
+final class AppRatingServiceTests: XCTestCase {
+
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+  private var settings: TPPSettings!
+  private let now = Date(timeIntervalSince1970: 1_000_000_000)
+
+  override func setUp() {
+    super.setUp()
+    suiteName = "AppRatingServiceTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)
+    settings = TPPSettings(defaults: defaults)
+  }
+
+  override func tearDown() {
+    defaults.removePersistentDomain(forName: suiteName)
+    settings = nil
+    defaults = nil
+    suiteName = nil
+    super.tearDown()
+  }
+
+  private func makeService(
+    config: RatingConfig = .fallback,
+    promptEnabled: Bool = true,
+    crashFree: Bool = true
+  ) -> AppRatingService {
+    AppRatingService(
+      tracker: RatingEngagementTracker(settings: settings),
+      configProvider: { config },
+      promptEnabledProvider: { promptEnabled },
+      crashFreeProbe: { crashFree },
+      now: { self.now }
+    )
+  }
+
+  /// Writes a fully-eligible engagement state directly into settings.
+  private func seedEligibleState() {
+    settings.appRatingSessionCount = 5
+    settings.appRatingBooksCompleted = 1
+    settings.appRatingPromptDisplayCount = 0
+    settings.appRatingOptedOut = false
+    settings.appRatingCrashFreeLastSession = true
+    settings.appRatingLastPromptDate = nil
+  }
+
+  // MARK: - Recording delegation
+
+  func testRecordSession_incrementsCountAndStoresCrashProbeResult() {
+    let service = makeService(crashFree: false)
+    service.recordSession()
+    XCTAssertEqual(settings.appRatingSessionCount, 1)
+    XCTAssertFalse(settings.appRatingCrashFreeLastSession, "should persist the crash-probe result")
+  }
+
+  func testRecordBookCompleted_incrementsBooksCompleted() {
+    let service = makeService()
+    service.recordBookCompleted()
+    XCTAssertEqual(settings.appRatingBooksCompleted, 1)
+  }
+
+  func testRecordPromptShown_usesInjectedClockAndIncrementsDisplayCount() {
+    let service = makeService()
+    service.recordPromptShown()
+    XCTAssertEqual(settings.appRatingLastPromptDate, now, "should stamp the injected clock time")
+    XCTAssertEqual(settings.appRatingPromptDisplayCount, 1)
+  }
+
+  func testRecordDismissal_incrementsDismissalCount() {
+    let service = makeService()
+    service.recordDismissal()
+    XCTAssertEqual(settings.appRatingDismissalCount, 1)
+  }
+
+  func testRecordOptOut_setsOptedOut() {
+    let service = makeService()
+    service.recordOptOut()
+    XCTAssertTrue(settings.appRatingOptedOut)
+  }
+
+  // MARK: - Eligibility gating
+
+  func testIsEligible_whenEligibleAndSwitchOn_returnsTrue() {
+    seedEligibleState()
+    let service = makeService(promptEnabled: true)
+    XCTAssertTrue(service.isEligible(for: .bookCompleted))
+    XCTAssertTrue(service.isEligible(for: .borrowSucceeded))
+  }
+
+  func testIsEligible_whenMasterSwitchOff_returnsFalseEvenIfOtherwiseEligible() {
+    seedEligibleState()
+    let service = makeService(promptEnabled: false)
+    XCTAssertFalse(service.isEligible(for: .bookCompleted))
+  }
+
+  func testIsEligible_whenPolicyFails_returnsFalse() {
+    seedEligibleState()
+    settings.appRatingOptedOut = true // policy-level disqualifier
+    let service = makeService(promptEnabled: true)
+    XCTAssertFalse(service.isEligible(for: .bookCompleted))
+  }
+
+  func testIsEligible_honorsInjectedConfigThresholds() {
+    seedEligibleState() // sessionCount 5
+    let stricter = RatingConfig(minSessions: 10, minBooksCompleted: 1, cooldownDays: 90, lifetimePromptCap: 3)
+    let service = makeService(config: stricter, promptEnabled: true)
+    XCTAssertFalse(service.isEligible(for: .bookCompleted), "stricter session floor should disqualify")
+  }
+}

--- a/PalaceTests/AppRating/RatingEligibilityPolicyTests.swift
+++ b/PalaceTests/AppRating/RatingEligibilityPolicyTests.swift
@@ -1,0 +1,139 @@
+//
+//  RatingEligibilityPolicyTests.swift
+//  PalaceTests
+//
+//  Exhaustive behavior tests for the app-rating eligibility policy (PP-4088).
+//  Each criterion is exercised individually + at its boundary so a flipped
+//  comparison or negated guard in the policy is caught (mutation coverage).
+//
+
+import XCTest
+@testable import Palace
+
+final class RatingEligibilityPolicyTests: XCTestCase {
+
+  /// Fixed "now" so cooldown math is deterministic.
+  private let now = Date(timeIntervalSince1970: 1_000_000_000)
+  private let config = RatingConfig.fallback // min5, min1, 90d, cap3
+
+  /// A state that passes every criterion. Individual tests mutate one field.
+  private func eligibleState(
+    sessionCount: Int = 5,
+    booksCompleted: Int = 1,
+    lastPromptDate: Date? = nil,
+    promptDisplayCount: Int = 0,
+    dismissalCount: Int = 0,
+    optedOut: Bool = false,
+    crashFreeLastSession: Bool = true
+  ) -> RatingEngagementState {
+    RatingEngagementState(
+      sessionCount: sessionCount,
+      booksCompleted: booksCompleted,
+      lastPromptDate: lastPromptDate,
+      promptDisplayCount: promptDisplayCount,
+      dismissalCount: dismissalCount,
+      optedOut: optedOut,
+      crashFreeLastSession: crashFreeLastSession
+    )
+  }
+
+  private func evaluate(_ state: RatingEngagementState, config: RatingConfig? = nil) -> Bool {
+    RatingEligibilityPolicy.evaluate(state: state, config: config ?? self.config, now: now)
+  }
+
+  func testEvaluate_allCriteriaMet_isEligible() {
+    XCTAssertTrue(evaluate(eligibleState()))
+  }
+
+  // MARK: - Opt out
+
+  func testEvaluate_whenOptedOut_isNotEligible() {
+    XCTAssertFalse(evaluate(eligibleState(optedOut: true)))
+  }
+
+  // MARK: - First session / onboarding
+
+  func testEvaluate_onFirstSession_isNotEligible() {
+    // sessionCount 1 → isFirstSession true, even though it clears minSessions=1.
+    let firstSessionConfig = RatingConfig(minSessions: 1, minBooksCompleted: 1, cooldownDays: 90, lifetimePromptCap: 3)
+    XCTAssertFalse(evaluate(eligibleState(sessionCount: 1), config: firstSessionConfig))
+  }
+
+  // MARK: - Minimum sessions (boundary)
+
+  func testEvaluate_sessionsBelowMinimum_isNotEligible() {
+    XCTAssertFalse(evaluate(eligibleState(sessionCount: 4)))
+  }
+
+  func testEvaluate_sessionsExactlyAtMinimum_isEligible() {
+    XCTAssertTrue(evaluate(eligibleState(sessionCount: 5)))
+  }
+
+  // MARK: - Minimum books completed (boundary)
+
+  func testEvaluate_noBooksCompleted_isNotEligible() {
+    XCTAssertFalse(evaluate(eligibleState(booksCompleted: 0)))
+  }
+
+  func testEvaluate_booksExactlyAtMinimum_isEligible() {
+    XCTAssertTrue(evaluate(eligibleState(booksCompleted: 1)))
+  }
+
+  // MARK: - Crash-free
+
+  func testEvaluate_afterCrashingSession_isNotEligible() {
+    XCTAssertFalse(evaluate(eligibleState(crashFreeLastSession: false)))
+  }
+
+  // MARK: - Lifetime prompt cap (boundary)
+
+  func testEvaluate_displayCountBelowCap_isEligible() {
+    XCTAssertTrue(evaluate(eligibleState(promptDisplayCount: 2)))
+  }
+
+  func testEvaluate_displayCountAtCap_isNotEligible() {
+    XCTAssertFalse(evaluate(eligibleState(promptDisplayCount: 3)))
+  }
+
+  func testEvaluate_displayCountAboveCap_isNotEligible() {
+    XCTAssertFalse(evaluate(eligibleState(promptDisplayCount: 4)))
+  }
+
+  // MARK: - Cooldown (boundary + clock changes)
+
+  func testEvaluate_neverPrompted_ignoresCooldown() {
+    XCTAssertTrue(evaluate(eligibleState(lastPromptDate: nil)))
+  }
+
+  func testEvaluate_withinCooldown_isNotEligible() {
+    // 89 days ago — one day short of the 90-day cooldown.
+    let lastPrompt = now.addingTimeInterval(-89 * 86_400)
+    XCTAssertFalse(evaluate(eligibleState(lastPromptDate: lastPrompt)))
+  }
+
+  func testEvaluate_exactlyAtCooldownBoundary_isEligible() {
+    let lastPrompt = now.addingTimeInterval(-90 * 86_400)
+    XCTAssertTrue(evaluate(eligibleState(lastPromptDate: lastPrompt)))
+  }
+
+  func testEvaluate_wellPastCooldown_isEligible() {
+    let lastPrompt = now.addingTimeInterval(-120 * 86_400)
+    XCTAssertTrue(evaluate(eligibleState(lastPromptDate: lastPrompt)))
+  }
+
+  func testEvaluate_clockMovedBackwardsPastLastPrompt_isNotEligible() {
+    // Device clock set to BEFORE the last prompt (now < lastPromptDate).
+    // Must fail closed — a backward clock change cannot unlock the prompt.
+    let lastPrompt = now.addingTimeInterval(30 * 86_400) // 30 days in the "future"
+    XCTAssertFalse(evaluate(eligibleState(lastPromptDate: lastPrompt)))
+  }
+
+  // MARK: - Config tunability
+
+  func testEvaluate_respectsRemoteThresholds() {
+    // A stricter remote config raises the session floor above the state's count.
+    let stricter = RatingConfig(minSessions: 10, minBooksCompleted: 1, cooldownDays: 90, lifetimePromptCap: 3)
+    XCTAssertFalse(evaluate(eligibleState(sessionCount: 5), config: stricter))
+    XCTAssertTrue(evaluate(eligibleState(sessionCount: 10), config: stricter))
+  }
+}

--- a/PalaceTests/AppRating/RatingEngagementTrackerTests.swift
+++ b/PalaceTests/AppRating/RatingEngagementTrackerTests.swift
@@ -1,0 +1,130 @@
+//
+//  RatingEngagementTrackerTests.swift
+//  PalaceTests
+//
+//  Tests for the app-rating engagement tracker (PP-4087): increment/read
+//  behavior and app-update-surviving persistence through TPPSettings.
+//
+
+import XCTest
+@testable import Palace
+
+final class RatingEngagementTrackerTests: XCTestCase {
+
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+  private var settings: TPPSettings!
+  private var tracker: RatingEngagementTracker!
+
+  override func setUp() {
+    super.setUp()
+    suiteName = "RatingEngagementTrackerTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)
+    settings = TPPSettings(defaults: defaults)
+    tracker = RatingEngagementTracker(settings: settings)
+  }
+
+  override func tearDown() {
+    defaults.removePersistentDomain(forName: suiteName)
+    tracker = nil
+    settings = nil
+    defaults = nil
+    suiteName = nil
+    super.tearDown()
+  }
+
+  // MARK: - Fresh state
+
+  func testCurrentState_freshInstall_hasZeroCountsAndIsFirstSession() {
+    let state = tracker.currentState()
+    XCTAssertEqual(state.sessionCount, 0)
+    XCTAssertEqual(state.booksCompleted, 0)
+    XCTAssertNil(state.lastPromptDate)
+    XCTAssertEqual(state.promptDisplayCount, 0)
+    XCTAssertEqual(state.dismissalCount, 0)
+    XCTAssertFalse(state.optedOut)
+    XCTAssertTrue(state.crashFreeLastSession, "absent crash signal should default to crash-free")
+    XCTAssertTrue(state.isFirstSession)
+  }
+
+  // MARK: - Sessions
+
+  func testRecordSession_incrementsSessionCountAndStoresCrashSignal() {
+    tracker.recordSession(crashFreeLastSession: false)
+    let state = tracker.currentState()
+    XCTAssertEqual(state.sessionCount, 1)
+    XCTAssertFalse(state.crashFreeLastSession)
+  }
+
+  func testRecordSession_calledTwice_accumulatesAndIsNoLongerFirstSession() {
+    tracker.recordSession(crashFreeLastSession: true)
+    tracker.recordSession(crashFreeLastSession: true)
+    let state = tracker.currentState()
+    XCTAssertEqual(state.sessionCount, 2)
+    XCTAssertFalse(state.isFirstSession)
+  }
+
+  func testRecordSession_updatesCrashSignalEachSession() {
+    tracker.recordSession(crashFreeLastSession: false)
+    XCTAssertFalse(tracker.currentState().crashFreeLastSession)
+    tracker.recordSession(crashFreeLastSession: true)
+    XCTAssertTrue(tracker.currentState().crashFreeLastSession)
+  }
+
+  // MARK: - Books
+
+  func testRecordBookCompleted_incrementsCount() {
+    tracker.recordBookCompleted()
+    tracker.recordBookCompleted()
+    XCTAssertEqual(tracker.currentState().booksCompleted, 2)
+  }
+
+  // MARK: - Prompt shown
+
+  func testRecordPromptShown_stampsDateAndIncrementsDisplayCount() {
+    let shownAt = Date(timeIntervalSince1970: 1_234_567_890)
+    tracker.recordPromptShown(at: shownAt)
+    let state = tracker.currentState()
+    XCTAssertEqual(state.lastPromptDate, shownAt)
+    XCTAssertEqual(state.promptDisplayCount, 1)
+
+    let laterShownAt = shownAt.addingTimeInterval(100 * 86_400)
+    tracker.recordPromptShown(at: laterShownAt)
+    let state2 = tracker.currentState()
+    XCTAssertEqual(state2.lastPromptDate, laterShownAt, "most recent display date should win")
+    XCTAssertEqual(state2.promptDisplayCount, 2)
+  }
+
+  // MARK: - Dismissal / opt out
+
+  func testRecordDismissal_incrementsDismissalCount() {
+    tracker.recordDismissal()
+    XCTAssertEqual(tracker.currentState().dismissalCount, 1)
+  }
+
+  func testRecordOptOut_setsOptedOut() {
+    XCTAssertFalse(tracker.currentState().optedOut)
+    tracker.recordOptOut()
+    XCTAssertTrue(tracker.currentState().optedOut)
+  }
+
+  // MARK: - Persistence across "app update"
+
+  func testState_survivesAppUpdate_viaPersistentDefaults() {
+    tracker.recordSession(crashFreeLastSession: true)
+    tracker.recordSession(crashFreeLastSession: true)
+    tracker.recordBookCompleted()
+    tracker.recordPromptShown(at: Date(timeIntervalSince1970: 42))
+
+    // Simulate an app relaunch/update: a brand-new settings+tracker reading the
+    // same persistent UserDefaults must see the previously recorded values.
+    let reloadedSettings = TPPSettings(defaults: UserDefaults(suiteName: suiteName)!)
+    let reloadedTracker = RatingEngagementTracker(settings: reloadedSettings)
+    let state = reloadedTracker.currentState()
+
+    XCTAssertEqual(state.sessionCount, 2, "session count must NOT reset across an app update")
+    XCTAssertEqual(state.booksCompleted, 1)
+    XCTAssertEqual(state.promptDisplayCount, 1)
+    XCTAssertEqual(state.lastPromptDate, Date(timeIntervalSince1970: 42))
+  }
+}

--- a/PalaceTests/Mocks/TPPSettingsMock.swift
+++ b/PalaceTests/Mocks/TPPSettingsMock.swift
@@ -53,6 +53,17 @@ final class TPPSettingsMock: NSObject, TPPSettingsProviding {
     /// Whether downloads are restricted to Wi-Fi only.
     var downloadOnlyOnWiFi: Bool = false
 
+    // MARK: - App Rating (PP-4087)
+
+    var appRatingSessionCount: Int = 0
+    var appRatingBooksCompleted: Int = 0
+    var appRatingLastPromptDate: Date?
+    var appRatingPromptDisplayCount: Int = 0
+    var appRatingDismissalCount: Int = 0
+    var appRatingOptedOut: Bool = false
+    /// Defaults to `true` (assume crash-free), matching `TPPSettings`.
+    var appRatingCrashFreeLastSession: Bool = true
+
     // MARK: - Initialization
 
     override init() {
@@ -114,5 +125,12 @@ final class TPPSettingsMock: NSObject, TPPSettingsProviding {
         appVersion = nil
         customLibraryRegistryServer = nil
         downloadOnlyOnWiFi = false
+        appRatingSessionCount = 0
+        appRatingBooksCompleted = 0
+        appRatingLastPromptDate = nil
+        appRatingPromptDisplayCount = 0
+        appRatingDismissalCount = 0
+        appRatingOptedOut = false
+        appRatingCrashFreeLastSession = true
     }
 }


### PR DESCRIPTION
## Summary

PR 1 of 2 for Epic **PP-4086** (App Rating Prompt). Adds the new `Palace/AppRating/` module — local **engagement tracking (PP-4087)** and the pure **eligibility policy (PP-4088)**. No UI, no StoreKit, no feedback path: this PR records signals and can evaluate eligibility but **never presents anything**, so it is safe to merge on its own.

## What's in scope

- **`RatingEngagementTracker`** — persists session count, books completed, last-prompt date, prompt-display count, dismissal count, opted-out, and crash-free-last-session through `TPPSettings` (survives app updates; local-only, no PII).
- **`RatingEligibilityPolicy.evaluate(state:config:now:)`** — pure function, all 7 criteria (≥5 sessions, ≥1 book, ≥90d cooldown, ≤3 lifetime displays, not opted-out, crash-free, not first session). Fails **closed** on a backward clock change.
- **`RatingConfig`** — thresholds sourced from **Firebase Remote Config** (`RemoteFeatureFlags.appRatingConfig`) with hardcoded `.fallback` defaults, plus an `app_rating_prompt_enabled` master kill-switch.
- **`AppRatingService`** — registered via `AppContainer` lazy-cache; session-count hook in `TPPAppDelegate.applicationDidBecomeActive`.

## Verification

- Build + spot-check tests: **35 tests, 0 failures** (`** TEST SUCCEEDED **`).
- Mutation on `RatingEligibilityPolicy`: **16/16 killed, 100% kill rate**.
- Static gates green: intent-recorded, contract-reconciliation, blast-radius, adjacency, superpartner, test-name-vs-body.
- Pre-push test gate: 11 touched-file test classes green.

## Deferred to PR 2 (PP-4089 / PP-4090 / PP-4091)

Sentiment-gate UI, StoreKit `requestReview`, feedback mailto path, and the book-completion / borrow / EPUB trigger wiring. `recordBookCompleted` / `recordPromptShown` / `recordDismissal` exist and are unit-tested here but are called from production only in PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
