### PR TITLE
fix(swift6): Phase B Wave 1 — non-critical modules complete-mode concurrency sweep

### DIFF
--- a/Palace/Accounts/AgeCheck/TPPAgeCheck.swift
+++ b/Palace/Accounts/AgeCheck/TPPAgeCheck.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol TPPAgeCheckValidationDelegate: AnyObject {
+protocol TPPAgeCheckValidationDelegate: AnyObject, Sendable {
     var minYear: Int { get }
     var currentYear: Int { get }
     var birthYearList: [Int] { get }
@@ -109,10 +109,15 @@ protocol TPPAgeCheckValidationDelegate: AnyObject {
             // missing details payload regardless of why.
             serialQueue.async { callbacks.completion?(false) }
         case .notLoaded, .basicInfoLoaded, .detailsLoading:
+            // Carry the non-Sendable `Account` across the `awaitReady()`
+            // await boundary in a documented box (same posture as
+            // `AgeCheckCallbacks`): the account is only read inside the
+            // Task via `awaitReady()`, never mutated concurrently here.
+            let accountBox = AgeCheckAccountBox(account: currentAccount)
             Task { [weak self] in
                 let accountDetails: AccountDetails
                 do {
-                    accountDetails = try await currentAccount.awaitReady()
+                    accountDetails = try await accountBox.account.awaitReady()
                 } catch {
                     self?.serialQueue.async { callbacks.completion?(false) }
                     return
@@ -237,4 +242,13 @@ protocol TPPAgeCheckValidationDelegate: AnyObject {
 private struct AgeCheckCallbacks: @unchecked Sendable {
     let userAccountProvider: TPPUserAccountProvider
     let completion: ((Bool) -> Void)?
+}
+
+/// Carries the non-Sendable `Account` across the `awaitReady()` await
+/// boundary in `verifyCurrentAccountAgeRequirement`'s loading path.
+/// `@unchecked Sendable` invariant: the account is only read (via the
+/// async `awaitReady()` readiness gate) inside the Task; no mutable
+/// account state is touched concurrently from this call site.
+private struct AgeCheckAccountBox: @unchecked Sendable {
+    let account: Account
 }

--- a/Palace/Accounts/Library/Account+profileDocument.swift
+++ b/Palace/Accounts/Library/Account+profileDocument.swift
@@ -36,12 +36,19 @@ extension Account {
 
         var request = URLRequest(url: profileUrl)
         AppContainer.production().networkExecutor.executeRequest(request.applyCustomUserAgent(), enableTokenRefresh: false) { result in
+            // The executeRequest completion is a plain (non-Sendable) escaping
+            // closure, so `completion` and the parsed `UserProfileDocument`
+            // are captured safely here. They are carried across the main-queue
+            // hop in a documented box — touched only on that single main-queue
+            // block, never concurrently — to satisfy the `@Sendable`
+            // `DispatchQueue.main.async`.
             switch result {
             case .success(let data, _):
                 do {
                     let profileDocument = try UserProfileDocument.fromData(data)
+                    let box = ProfileDocumentCompletionBox(completion: completion, document: profileDocument)
                     DispatchQueue.main.async {
-                        completion(profileDocument)
+                        box.completion(box.document)
                     }
                     return
                 } catch {
@@ -50,10 +57,21 @@ extension Account {
             case .failure(let error, _):
                 TPPErrorLogger.logError(error, summary: "Error retrieveing user profile document")
             }
+            let box = ProfileDocumentCompletionBox(completion: completion, document: nil)
             DispatchQueue.main.async {
-                completion(nil)
+                box.completion(box.document)
             }
         }
     }
 
+}
+
+/// Documented carrier for `getProfileDocument`'s network completion, which
+/// hops to the main queue to invoke `completion` with the parsed document.
+/// The `completion` closure and `UserProfileDocument` are non-Sendable;
+/// they are only ever read on that single main-queue hop, never
+/// concurrently, so they are safe to carry in an `@unchecked Sendable` box.
+private struct ProfileDocumentCompletionBox: @unchecked Sendable {
+    let completion: (UserProfileDocument?) -> Void
+    let document: UserProfileDocument?
 }

--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -698,7 +698,12 @@ protocol AccountLogoDelegate: AnyObject {
 
             if let announcements = self.authenticationDocument?.announcements {
                 DispatchQueue.main.async {
-                    TPPAnnouncementBusinessLogic.shared.presentAnnouncements(announcements)
+                    // Already on the main queue; `presentAnnouncements` is
+                    // `@MainActor`, so assert the isolation to satisfy the
+                    // nonisolated `DispatchQueue.main.async` closure.
+                    MainActor.assumeIsolated {
+                        TPPAnnouncementBusinessLogic.shared.presentAnnouncements(announcements)
+                    }
                 }
             }
         }
@@ -774,26 +779,44 @@ protocol AccountLogoDelegate: AnyObject {
             return
         }
         AppContainer.production().networkExecutor.GET(url, useTokenIfAvailable: false) { result in
+            // The GET completion is a plain (non-Sendable) escaping closure, so
+            // `result`, `self`, and `completion` are captured safely here. They
+            // are carried across the main-queue hop in a documented box — each
+            // is only touched on that single main-queue block, never
+            // concurrently — to satisfy the `@Sendable` `DispatchQueue.main.async`.
+            let payload = LogoFetchPayload(account: self, result: result, completion: completion)
             DispatchQueue.main.async {
-                switch result {
+                switch payload.result {
                 case .success(let serverData, _):
                     guard let image = UIImage(data: serverData) else {
-                        completion(nil)
+                        payload.completion(nil)
                         return
                     }
-                    self.imageCache.set(image, for: self.uuid)
-                    completion(image)
+                    payload.account.imageCache.set(image, for: payload.account.uuid)
+                    payload.completion(image)
                 case .failure(let error, _):
                     TPPErrorLogger.logError(
                         withCode: .authDocLoadFail,
                         summary: "Logo image failed to load",
                         metadata: ["loadError": error.localizedDescription, "url": url.absoluteString]
                     )
-                    completion(nil)
+                    payload.completion(nil)
                 }
             }
         }
     }
+}
+
+/// Documented carrier for `Account.fetchImage`'s network completion, which
+/// hops to the main queue to touch `imageCache` and invoke `completion`.
+/// `result` (`NYPLResult<Data>`), the `completion` closure, and the
+/// `Account` are all non-Sendable; they are only ever read on that single
+/// main-queue hop, never concurrently, so they are safe to carry in an
+/// `@unchecked Sendable` box.
+private struct LogoFetchPayload: @unchecked Sendable {
+    let account: Account
+    let result: NYPLResult<Data>
+    let completion: (UIImage?) -> Void
 }
 
 extension AccountDetails {

--- a/Palace/Accounts/Library/AccountStateStore.swift
+++ b/Palace/Accounts/Library/AccountStateStore.swift
@@ -26,11 +26,18 @@
 //
 
 import Foundation
-import Combine
+@preconcurrency import Combine
 
 /// External storage for Account load-state state machines, keyed by
 /// account UUID. See docs/architecture/account-state-machine.md.
-public final class AccountStateStore {
+///
+/// `@unchecked Sendable` invariant: the only mutable state is `subjects`,
+/// which is read and written exclusively under `lock` (an `NSLock`) via
+/// the private `subject(for:)` accessor. `lock` is an immutable `let`.
+/// The `CurrentValueSubject` values are safe to `send`/`sink` across
+/// threads. No property is mutated outside the lock, so the singleton is
+/// safe to share process-wide.
+public final class AccountStateStore: @unchecked Sendable {
 
     /// Process-wide singleton. The state machine is single-instance per
     /// account UUID; storing it process-wide matches how AccountsManager

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -104,6 +104,30 @@ struct CatalogCacheMetadata: Codable {
     func account(_ uuid: String) -> Account?
 }
 
+/// Lock-backed holder for `AccountsManager`'s test-only `Bool` flags so they
+/// can be concurrency-safe global state without `nonisolated(unsafe)`.
+/// `@unchecked Sendable` invariant: the only mutable state is `storage`, read
+/// and written exclusively under `lock` (an immutable `NSLock`); the wrapped
+/// value is a `Sendable` `Bool`.
+private final class AccountsManagerBoolFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Bool
+    init(_ value: Bool) { storage = value }
+    var value: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return storage }
+        set { lock.lock(); defer { lock.unlock() }; storage = newValue }
+    }
+}
+
+/// Documented carrier for a non-Sendable `() -> Void` handed to a
+/// `DispatchQueue` barrier block in `AccountsManager.performWrite`.
+/// `@unchecked Sendable` invariant: the wrapped closure is invoked exactly
+/// once, on the serial barrier of the concurrent `accountSetsLock`, never
+/// concurrently.
+private struct VoidWorkBox: @unchecked Sendable {
+    let work: () -> Void
+}
+
 /// Manages library accounts asynchronously with authentication & image loading
 @objcMembers final class AccountsManager: NSObject, TPPLibraryAccountsProvider, TPPUserAccountResolving {
 
@@ -197,9 +221,18 @@ struct CatalogCacheMetadata: Codable {
     /// in their own setUp. Production runs (no `XCTestConfigurationFilePath`
     /// in the env) keep the original `false` default so the background load
     /// fires as designed.
-    internal static var deferInitialLoadCatalogsForTesting: Bool = {
-        return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-    }()
+    private static let _deferInitialLoadCatalogsForTesting = AccountsManagerBoolFlag(
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    )
+    /// Lock-backed so this test-only flag is concurrency-safe global state
+    /// without `nonisolated(unsafe)`. Storage lives in the `Sendable`
+    /// `AccountsManagerBoolFlag` holder; this computed accessor keeps every
+    /// existing read/write call site unchanged. Read value and timing are
+    /// identical to the prior `static var` — only access is serialized.
+    internal static var deferInitialLoadCatalogsForTesting: Bool {
+        get { _deferInitialLoadCatalogsForTesting.value }
+        set { _deferInitialLoadCatalogsForTesting.value = newValue }
+    }
 
     /// Test-only opt-out from the synchronous `preloadAccountsFromDiskCacheSync()`
     /// in `init()`. Defaults to `false`, so production AND every test that relies
@@ -212,7 +245,13 @@ struct CatalogCacheMetadata: Codable {
     /// consume >5s on memory-pressured CI when the cache holds ~1138 accounts —
     /// the root of the FLAKE-003 `loadAndWait()` 30s timeout. Scope the flip to
     /// `setUp`/`tearDown`. NOT compiled into release builds.
-    internal static var deferDiskCachePreloadForTesting: Bool = false
+    private static let _deferDiskCachePreloadForTesting = AccountsManagerBoolFlag(false)
+    /// Lock-backed test-only flag (see `deferInitialLoadCatalogsForTesting`
+    /// above for the holder rationale). Value/timing unchanged.
+    internal static var deferDiskCachePreloadForTesting: Bool {
+        get { _deferDiskCachePreloadForTesting.value }
+        set { _deferDiskCachePreloadForTesting.value = newValue }
+    }
 
     /// Test-only handle to the post-init background `loadCatalogs` task so
     /// `cancelBackgroundWork()` can issue cooperative cancellation. Only ever
@@ -376,8 +415,14 @@ struct CatalogCacheMetadata: Codable {
     }
 
     private func performWrite(_ block: @escaping () -> Void) {
+        // Carry the non-Sendable `block` into the barrier block via a
+        // documented box. `@unchecked Sendable` invariant: `block` is
+        // invoked exactly once, on the serial `.barrier` of the concurrent
+        // `accountSetsLock`, never concurrently — the same execution
+        // contract this method already guaranteed. Timing is unchanged.
+        let box = VoidWorkBox(work: block)
         accountSetsLock.async(flags: .barrier) {
-            block()
+            box.work()
         }
     }
 
@@ -1275,7 +1320,13 @@ struct CatalogCacheMetadata: Codable {
                 } else if self.settings.accountMainFeedURL == nil {
                     Log.warn(#file, "accountMainFeedURL is nil and no cached value — catalog will not load until auth doc completes")
                 }
-                UIApplication.shared.delegate?.window??.tintColor = TPPConfiguration.mainColor()
+                // This `group.notify(queue: .main)` block runs on the main
+                // queue but is a nonisolated closure; hop the main-actor
+                // `UIApplication` access through `assumeIsolated` (safe — we
+                // are provably on `.main`). Behavior unchanged.
+                MainActor.assumeIsolated {
+                    UIApplication.shared.delegate?.window??.tintColor = TPPConfiguration.mainColor()
+                }
                 NotificationCenter.default.post(name: .TPPCurrentAccountDidChange, object: nil)
                 completion(true)
             }

--- a/Palace/Accounts/Library/CatalogPreloader.swift
+++ b/Palace/Accounts/Library/CatalogPreloader.swift
@@ -3,7 +3,12 @@ import PalaceLogging
 import PalaceCatalog
 
 /// Abstraction for preloading a feed URL. Allows mocking in tests.
-protocol CatalogFeedPreloading {
+///
+/// `Sendable`: preloaders are stateless dependency-injection values captured
+/// into a `withTaskGroup` child task. The production conformer
+/// (`OPDSFeedPreloader`) is a stateless struct and the test mock is already
+/// `@unchecked Sendable`, so requiring `Sendable` is satisfied everywhere.
+protocol CatalogFeedPreloading: Sendable {
     func preloadFeed(from url: URL) async throws
 }
 

--- a/Palace/Accounts/Library/LibraryRegistryCrawler.swift
+++ b/Palace/Accounts/Library/LibraryRegistryCrawler.swift
@@ -31,6 +31,15 @@ struct URLSessionCrawlerFetcher: CrawlerNetworkFetching {
     }
 }
 
+/// Documented carrier for the non-Sendable `CrawlerNetworkFetching`
+/// existential so it can be captured into `withThrowingTaskGroup` child
+/// tasks. `@unchecked Sendable` invariant: the production fetcher
+/// (`URLSessionCrawlerFetcher`) is a stateless struct over `URLSession.shared`;
+/// concurrent `fetchData` calls are safe.
+private struct CrawlerFetcherBox: @unchecked Sendable {
+    let fetcher: CrawlerNetworkFetching
+}
+
 // Note: HTTPURLResponse.cacheControlMaxAge is defined in Palace/Network/TPPCaching.swift
 
 // MARK: - Delegate
@@ -419,12 +428,19 @@ final class LibraryRegistryCrawler {
         let maxConcurrent = 4
         var allResults = [(offset: Int, catalogs: [OPDS2Publication])]()
 
+        // Carry the non-Sendable `CrawlerNetworkFetching` existential into the
+        // task-group child tasks via a documented box (the protocol is not
+        // marked `Sendable` because its test mocks are stateful classes). The
+        // production conformer (`URLSessionCrawlerFetcher`) is a stateless
+        // struct over `URLSession.shared`, safe to use concurrently.
+        let fetcherBox = CrawlerFetcherBox(fetcher: fetcher)
         for chunk in offsets.chunked(into: maxConcurrent) {
             let chunkResults = try await withThrowingTaskGroup(
                 of: (Int, [OPDS2Publication]).self
             ) { group in
                 for pageOffset in chunk {
-                    group.addTask { [fetcher] in
+                    group.addTask { [fetcherBox] in
+                        let fetcher = fetcherBox.fetcher
                         var pageComponents = components
                         pageComponents.queryItems = (pageComponents.queryItems ?? []).map { item in
                             if item.name == "offset" {

--- a/Palace/Accounts/User/Announcements/TPPAnnouncementBusinessLogic.swift
+++ b/Palace/Accounts/User/Announcements/TPPAnnouncementBusinessLogic.swift
@@ -17,6 +17,7 @@ class TPPAnnouncementBusinessLogic {
 
     /// Present the announcement in a view controller
     /// This method should be called on main thread
+    @MainActor
     func presentAnnouncements(_ announcements: [Announcement]) {
         let presentableAnnouncements = announcements.filter {
             shouldPresentAnnouncement(id: $0.id)
@@ -81,6 +82,7 @@ class TPPAnnouncementBusinessLogic {
      - Parameter announcements: an array of announcements that goes into alert message.
      - Returns: The alert controller to be presented.
      */
+    @MainActor
     private func alert(announcements: [Announcement]) -> UIAlertController? {
         let title = DisplayStrings.alertTitle
         var currentAlert: UIAlertController?

--- a/Palace/Accounts/User/UserProfileDocument.swift
+++ b/Palace/Accounts/User/UserProfileDocument.swift
@@ -47,13 +47,13 @@ import Foundation
     let authorizationExpires: Date?
     let settings: Settings?
 
-    private static var dateFormatter: DateFormatter = {
-        var formatter = DateFormatter()
+    private static var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter
-    }()
+    }
 
     enum CodingKeys: String, CodingKey {
         case authorizationIdentifier = "simplified:authorization_identifier"

--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -290,7 +290,7 @@ extension AppTabHostView {
     /// Pure helpers extracted for unit testability — these were previously
     /// inline closures inside `updateHoldsBadge()` that could not be exercised
     /// by tests, leaving mutations like `+= 1` → `-= 1` undetected.
-    static func computeReadyCount(books: [TPPBook]) -> Int {
+    nonisolated static func computeReadyCount(books: [TPPBook]) -> Int {
         var count = 0
         for book in books {
             book.defaultAcquisition?.availability.match(
@@ -304,7 +304,7 @@ extension AppTabHostView {
         return count
     }
 
-    static func computeReservedCount(books: [TPPBook]) -> Int {
+    nonisolated static func computeReservedCount(books: [TPPBook]) -> Int {
         var count = 0
         for book in books {
             book.defaultAcquisition?.availability.match(

--- a/Palace/AppInfrastructure/DLNavigator.swift
+++ b/Palace/AppInfrastructure/DLNavigator.swift
@@ -9,7 +9,11 @@
 import Foundation
 import FirebaseDynamicLinks
 
-class DLNavigator {
+/// No stored state — all members are methods over the passed-in `DynamicLink`,
+/// so the type is trivially `Sendable`; `final` pins that (no subclass can add
+/// mutable state). Lets `static let shared` be concurrency-safe without an
+/// isolation annotation.
+final class DLNavigator: Sendable {
 
     typealias Destination = (screen: String, params: [String: String])
 

--- a/Palace/AppInfrastructure/ReaderService.swift
+++ b/Palace/AppInfrastructure/ReaderService.swift
@@ -27,6 +27,7 @@ final class ReaderService {
     private var openGenerationByBookId: [String: Int] = [:]
     private var openInFlightBookIds: Set<String> = []
 
+    @MainActor
     private func topPresenter() -> UIViewController? {
         guard let root = UIApplication.shared.mainKeyWindow?.rootViewController else {
             Log.warn(#file, "No root view controller available — cannot present reader")

--- a/Palace/AppInfrastructure/TPPConfiguration.swift
+++ b/Palace/AppInfrastructure/TPPConfiguration.swift
@@ -66,10 +66,12 @@ import UIKit
     return 100
   }
 
+  @MainActor
   @objc static func defaultAppearance() -> UINavigationBarAppearance {
     return appearance(withBackgroundColor: backgroundColor())
   }
 
+  @MainActor
   @objc static func appearance(withBackgroundColor backgroundColor: UIColor) -> UINavigationBarAppearance {
     let appearance = UINavigationBarAppearance()
     appearance.configureWithOpaqueBackground()

--- a/Palace/Book/Models/TPPBook+Extensions.swift
+++ b/Palace/Book/Models/TPPBook+Extensions.swift
@@ -12,30 +12,38 @@ import PalaceKeychain
 
 // MARK: - Associated Object Keys for Keychain Variables
 
-private var bearerTokenVariableKey: UInt8 = 0
-private var fulfillURLVariableKey: UInt8 = 0
+/// Stable, unique association keys. `objc_{get,set}AssociatedObject` only needs
+/// a distinct constant pointer per key; a `static let` of a `Sendable`
+/// `UnsafeRawPointer` gives that without the nonisolated-global-mutable-`var`
+/// concurrency warning (previously `private var …Key: UInt8 = 0`, whose address
+/// was taken via `&`). The 1-byte allocations are intentionally never freed —
+/// the keys live for the app's lifetime.
+private enum TPPBookAssociatedKeys {
+    static let bearerTokenVariable = UnsafeRawPointer(UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1))
+    static let fulfillURLVariable = UnsafeRawPointer(UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1))
+}
 
 @objc extension TPPBook {
     typealias DisplayStrings = Strings.TPPBook
 
     /// Cached keychain variable for bearer token (reused across get/set calls)
     @nonobjc private var _bearerTokenVariable: TPPKeychainVariable<String> {
-        if let existing = objc_getAssociatedObject(self, &bearerTokenVariableKey) as? TPPKeychainVariable<String> {
+        if let existing = objc_getAssociatedObject(self, TPPBookAssociatedKeys.bearerTokenVariable) as? TPPKeychainVariable<String> {
             return existing
         }
         let variable: TPPKeychainVariable<String> = self.identifier.asKeychainVariable(with: bookTokenQueue)
-        objc_setAssociatedObject(self, &bearerTokenVariableKey, variable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(self, TPPBookAssociatedKeys.bearerTokenVariable, variable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return variable
     }
 
     /// Cached keychain variable for fulfill URL (reused across get/set calls)
     @nonobjc private var _fulfillURLVariable: TPPKeychainVariable<String> {
-        if let existing = objc_getAssociatedObject(self, &fulfillURLVariableKey) as? TPPKeychainVariable<String> {
+        if let existing = objc_getAssociatedObject(self, TPPBookAssociatedKeys.fulfillURLVariable) as? TPPKeychainVariable<String> {
             return existing
         }
         let key = "\(self.identifier)-fulfillURL"
         let variable: TPPKeychainVariable<String> = key.asKeychainVariable(with: bookTokenQueue)
-        objc_setAssociatedObject(self, &fulfillURLVariableKey, variable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(self, TPPBookAssociatedKeys.fulfillURLVariable, variable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return variable
     }
 

--- a/Palace/Book/Models/TPPBook+Presentation.swift
+++ b/Palace/Book/Models/TPPBook+Presentation.swift
@@ -91,7 +91,7 @@ extension TPPBook {
                 }
             }
         } else {
-            let startFetch = { [weak self] in
+            let startFetch = { @Sendable [weak self] in
                 guard let self else { return }
 
                 self.imageLoader.coverImage(for: self) { [weak self] image in
@@ -129,7 +129,7 @@ extension TPPBook {
             return
         }
 
-        let startFetch = { [weak self] in
+        let startFetch = { @Sendable [weak self] in
             guard let self, !self.isThumbnailLoading else { return }
             self.isThumbnailLoading = true
 

--- a/Palace/Book/Models/TPPBookState.swift
+++ b/Palace/Book/Models/TPPBookState.swift
@@ -11,7 +11,7 @@ let UnsupportedKey = "unsupported"
 let ReturningKey = "returning"
 let SAMLStartedKey = "saml-started"
 
-@objc public enum TPPBookState: Int, CaseIterable {
+@objc public enum TPPBookState: Int, CaseIterable, Sendable {
     case unregistered = 0
     case downloadNeeded = 1
     case downloading
@@ -133,7 +133,7 @@ public extension TPPBookState {
     ]
 
     /// Hashable transition pair for use in `allowedTransitions`.
-    struct TransitionPair: Hashable {
+    struct TransitionPair: Hashable, Sendable {
         public let from: TPPBookState
         public let to: TPPBookState
         public init(from: TPPBookState, to: TPPBookState) {

--- a/Palace/Book/UI/AudiobookSampleToolbar.swift
+++ b/Palace/Book/UI/AudiobookSampleToolbar.swift
@@ -152,7 +152,7 @@ struct AudiobookSampleToolbar: View {
 
 @objc class AudiobookSampleToolbarWrapper: NSObject {
 
-    @objc static func create(book: TPPBook) -> UIViewController {
+    @MainActor @objc static func create(book: TPPBook) -> UIViewController {
         let toolbar = AudiobookSampleToolbar(book: book)
         let hostingController = UIHostingController(rootView: toolbar)
         return hostingController

--- a/Palace/Book/UI/BookDetail/BookService.swift
+++ b/Palace/Book/UI/BookDetail/BookService.swift
@@ -16,13 +16,19 @@ import PalaceLogging
 /// publicationOpener.open() to hang after a few back-to-back audiobook opens.
 /// See AudiobookLoader + AudiobookSessionManager for the new ownership model.
 enum BookService {
-    private static var openingBooks = Set<String>()
+    // Main-actor-confined: every mutation already happens on the main thread
+    // (callers are `@MainActor` view models; the safety-release and dispatch
+    // hops run on `DispatchQueue.main`). Isolating the lock to the main actor
+    // documents that invariant and clears the nonisolated-global-mutable-state
+    // warning without changing the threading.
+    @MainActor private static var openingBooks = Set<String>()
 
     /// Safety cap: if the open pipeline never reports completion (hang, timeout,
     /// unhandled throw inside a Task), releasing after this window prevents the
     /// lock from latching permanently and silently swallowing every retry.
     private static let openLockSafetyRelease: TimeInterval = 30
 
+    @MainActor
     static func open(_ book: TPPBook, bookRegistry: TPPBookRegistryProvider = AppContainer.production().bookRegistry, onFinish: (() -> Void)? = nil) {
         guard !openingBooks.contains(book.identifier) else {
             Log.warn(#file, "Book \(book.title) is already being opened, ignoring duplicate request")
@@ -37,14 +43,21 @@ enum BookService {
         dispatchOpen(resolvedBook, onFinish: onFinish)
     }
 
+    @MainActor
     private static func scheduleOpenLockSafetyRelease(for identifier: String) {
         DispatchQueue.main.asyncAfter(deadline: .now() + openLockSafetyRelease) {
-            if openingBooks.remove(identifier) != nil {
-                Log.warn(#file, "⏱️ Open lock for \(identifier) auto-released after \(Int(openLockSafetyRelease))s — pipeline never reported completion")
+            // Runs on the main queue; `assumeIsolated` bridges the non-isolated
+            // dispatch closure to the main actor so the `openingBooks` access is
+            // statically safe without altering the existing timing behavior.
+            MainActor.assumeIsolated {
+                if openingBooks.remove(identifier) != nil {
+                    Log.warn(#file, "⏱️ Open lock for \(identifier) auto-released after \(Int(openLockSafetyRelease))s — pipeline never reported completion")
+                }
             }
         }
     }
 
+    @MainActor
     private static func dispatchOpen(_ book: TPPBook, onFinish: (() -> Void)?) {
         switch book.defaultBookContentType {
         case .epub:
@@ -127,7 +140,8 @@ enum BookService {
     /// Shown when an audiobook open fails. Invoked by
     /// `AudiobookSessionManager` after a loader failure, and by the PP-3707
     /// retry path below.
-    static func showAudiobookTryAgainError(book: TPPBook? = nil, onFinish: (() -> Void)? = nil) {
+    @MainActor
+  static func showAudiobookTryAgainError(book: TPPBook? = nil, onFinish: (() -> Void)? = nil) {
         Log.warn(#file, "⚠️ [ERROR ALERT] Showing 'An error was encountered while trying to open this book' alert to user")
 
         let error = NSError(

--- a/Palace/Book/UI/BookDetail/PreviewControllerFactory.swift
+++ b/Palace/Book/UI/BookDetail/PreviewControllerFactory.swift
@@ -10,6 +10,7 @@ import SafariServices
 /// load file URLs at all.
 enum PreviewControllerFactory {
 
+    @MainActor
     static func makePreviewController(for url: URL, title: String) -> UIViewController {
         if url.scheme == "http" || url.scheme == "https" {
             return SFSafariViewController(url: url)

--- a/Palace/CatalogUI/Views/CatalogLoadingViewController.swift
+++ b/Palace/CatalogUI/Views/CatalogLoadingViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class CatalogLoadingViewController: UIViewController, TPPLoadingViewController {
+final class CatalogLoadingViewController: UIViewController, @preconcurrency TPPLoadingViewController {
     var loadingView: UIView?
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {

--- a/Palace/CatalogUI/Views/LibraryLogoNotifier.swift
+++ b/Palace/CatalogUI/Views/LibraryLogoNotifier.swift
@@ -5,10 +5,20 @@ extension Notification.Name {
     static let TPPAccountLogoUpdated = Notification.Name("TPPAccountLogoUpdated")
 }
 
+// `@MainActor`: this observer only ever lives inside SwiftUI views (held as
+// `@StateObject`), so its `@Published token` is main-actor state. Isolating the
+// type lets `logoDidUpdate` hop to the main actor without capturing a
+// non-Sendable `self` in a `@Sendable` closure.
+@MainActor
 final class CatalogLogoObserver: NSObject, ObservableObject, AccountLogoDelegate {
     @Published var token = UUID()
 
-    func logoDidUpdate(in account: Account, to newLogo: UIImage) {
-        DispatchQueue.main.async { self.token = UUID() }
+    // `nonisolated` to satisfy the nonisolated `AccountLogoDelegate` requirement;
+    // the delegate callback may arrive off the main actor, so we hop before
+    // mutating `token`. `self` is `@MainActor` (hence `Sendable`), so capturing
+    // it in the `@Sendable` `Task` closure is race-free. Preserves the previous
+    // async-hop-to-main behavior of `DispatchQueue.main.async`.
+    nonisolated func logoDidUpdate(in account: Account, to newLogo: UIImage) {
+        Task { @MainActor in self.token = UUID() }
     }
 }

--- a/Palace/ErrorHandling/ErrorDetail.swift
+++ b/Palace/ErrorHandling/ErrorDetail.swift
@@ -83,11 +83,13 @@ struct ErrorDetail {
             activityTrail: trail,
             timestamp: Date(),
             bookInfo: bookInfo,
-            deviceContext: captureDeviceContext(accountsManager: accountsManager)
+            deviceContext: await captureDeviceContext(accountsManager: accountsManager)
         )
     }
 
-    /// Captures current device/app context synchronously.
+    /// Captures current device/app context. `@MainActor` because it reads
+    /// `UIDevice.current` (main-actor isolated); it is awaited from `capture`.
+    @MainActor
     private static func captureDeviceContext(accountsManager: AccountsManager = AppContainer.production().accountsManager) -> DeviceContext {
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"

--- a/Palace/ErrorHandling/ProblemReportEmail.swift
+++ b/Palace/ErrorHandling/ProblemReportEmail.swift
@@ -1,6 +1,7 @@
 import MessageUI
 import UIKit
 
+@MainActor
 @objcMembers class ProblemReportEmail: NSObject {
     typealias DisplayStrings = Strings.ProblemReportEmail
 
@@ -105,7 +106,7 @@ import UIKit
     }
 }
 
-extension ProblemReportEmail: MFMailComposeViewControllerDelegate {
+extension ProblemReportEmail: @preconcurrency MFMailComposeViewControllerDelegate {
     func mailComposeController(
         _ controller: MFMailComposeViewController,
         didFinishWith result: MFMailComposeResult,

--- a/Palace/ErrorHandling/TPPPresentationUtils.swift
+++ b/Palace/ErrorHandling/TPPPresentationUtils.swift
@@ -5,6 +5,20 @@
 //  Copyright © 2020 NYPL Labs. All rights reserved.
 //
 
+/// Transports a non-`Sendable` UIKit payload (a view controller plus an
+/// optional completion handler) across a `DispatchQueue.main.async` boundary.
+/// Every dispatch target in `safelyPresent` is `DispatchQueue.main`, so the
+/// boxed values are only ever created on and consumed on the main actor — the
+/// transfer is data-race-free even though the payload is not `Sendable`.
+private final class MainActorPresentation: @unchecked Sendable {
+    let viewController: UIViewController
+    let completion: (() -> Void)?
+    init(_ viewController: UIViewController, _ completion: (() -> Void)?) {
+        self.viewController = viewController
+        self.completion = completion
+    }
+}
+
 class TPPPresentationUtils: NSObject {
     /// Presents the given view controller on top of the topmost currently
     /// displayed view controller in the current window.
@@ -26,56 +40,64 @@ class TPPPresentationUtils: NSObject {
                                    completion: (() -> Void)? = nil) {
         // Ensure this block is always executed on the main thread
         if !Thread.isMainThread {
+            let payload = MainActorPresentation(vc, completion)
             DispatchQueue.main.async {
-                safelyPresent(vc, animated: animated, completion: completion)
+                safelyPresent(payload.viewController, animated: animated, completion: payload.completion)
             }
             return
         }
 
-        let delegate = UIApplication.shared.delegate
-        guard var base = delegate?.window??.rootViewController else {
-            TPPErrorLogger.logError(withCode: .missingExpectedObject,
-                                    summary: "Unable to find rootViewController",
-                                    metadata: [
-                                        "DelegateIsNil": (delegate == nil),
-                                        "WindowIsNil": (delegate?.window == nil)
-                                    ])
-            return
-        }
-
-        while true {
-            guard let topBase = base.presentedViewController else {
-                break
-            }
-            base = topBase
-        }
-
-        if let baseNavController = base as? UINavigationController,
-           let inputNavController = vc as? UINavigationController,
-           baseNavController.viewControllers.count == inputNavController.viewControllers.count,
-           let baseVC = baseNavController.viewControllers.first,
-           let inputVC = inputNavController.viewControllers.first {
-
-            if type(of: baseVC) == type(of: inputVC) {
+        // Past the guard above we are provably on the main thread, so it is safe
+        // to assert main-actor isolation for the UIKit work below rather than
+        // hopping again. Behavior is unchanged — the dispatch structure below is
+        // identical to before.
+        MainActor.assumeIsolated {
+            let delegate = UIApplication.shared.delegate
+            guard var base = delegate?.window??.rootViewController else {
+                TPPErrorLogger.logError(withCode: .missingExpectedObject,
+                                        summary: "Unable to find rootViewController",
+                                        metadata: [
+                                            "DelegateIsNil": (delegate == nil),
+                                            "WindowIsNil": (delegate?.window == nil)
+                                        ])
                 return
             }
-        }
 
-        // If a presentation/dismiss/push is already in flight on `base`,
-        // calling present() here is the failure mode behind the SAML re-auth
-        // lock-up: UIKit rejects the present with "transitioning already",
-        // leaves the form sheet half-mounted, and the app freezes. Wait for
-        // the in-flight transition to complete, then re-walk to the (possibly
-        // new) topmost VC and present there. HelpSpot 17716 follow-up.
-        if let coordinator = base.transitionCoordinator {
-            coordinator.animate(alongsideTransition: nil) { _ in
-                DispatchQueue.main.async {
-                    safelyPresent(vc, animated: animated, completion: completion)
+            while true {
+                guard let topBase = base.presentedViewController else {
+                    break
+                }
+                base = topBase
+            }
+
+            if let baseNavController = base as? UINavigationController,
+               let inputNavController = vc as? UINavigationController,
+               baseNavController.viewControllers.count == inputNavController.viewControllers.count,
+               let baseVC = baseNavController.viewControllers.first,
+               let inputVC = inputNavController.viewControllers.first {
+
+                if type(of: baseVC) == type(of: inputVC) {
+                    return
                 }
             }
-            return
-        }
 
-        base.present(vc, animated: animated, completion: completion)
+            // If a presentation/dismiss/push is already in flight on `base`,
+            // calling present() here is the failure mode behind the SAML re-auth
+            // lock-up: UIKit rejects the present with "transitioning already",
+            // leaves the form sheet half-mounted, and the app freezes. Wait for
+            // the in-flight transition to complete, then re-walk to the (possibly
+            // new) topmost VC and present there. HelpSpot 17716 follow-up.
+            if let coordinator = base.transitionCoordinator {
+                coordinator.animate(alongsideTransition: nil) { _ in
+                    let payload = MainActorPresentation(vc, completion)
+                    DispatchQueue.main.async {
+                        safelyPresent(payload.viewController, animated: animated, completion: payload.completion)
+                    }
+                }
+                return
+            }
+
+            base.present(vc, animated: animated, completion: completion)
+        }
     }
 }

--- a/Palace/ErrorHandling/TPPProblemDocumentCacheManager.swift
+++ b/Palace/ErrorHandling/TPPProblemDocumentCacheManager.swift
@@ -8,7 +8,11 @@ extension Notification.Name {
     public static let TPPProblemDocumentWasCached = Notification.Name.TPPProblemDocumentWasCached
 }
 
-@objcMembers class TPPProblemDocumentCacheManager: NSObject {
+// Thread-safety: all mutable state (`cache`) is guarded by `lock` (NSLock),
+// so instances are safe to share across concurrency domains. `@unchecked
+// Sendable` documents that the lock — not the compiler — enforces the
+// data-race-freedom invariant that makes `static let shared` concurrency-safe.
+@objcMembers final class TPPProblemDocumentCacheManager: NSObject, @unchecked Sendable {
     struct DocWithTimestamp {
         let doc: TPPProblemDocument
         let timestamp: Date

--- a/Palace/Logging/AudiobookFileLogger.swift
+++ b/Palace/Logging/AudiobookFileLogger.swift
@@ -17,7 +17,11 @@ protocol AudiobookFileLogging {
     func retrieveLogs(forBookIds bookIds: [String]) -> [String: String]
 }
 
-class AudiobookFileLogger: AudiobookFileLogging {
+// `final` + `Sendable`: all stored properties are immutable value types
+// (`Int64` and `URL?`), and every method is read-only over that state (file I/O
+// via the thread-safe `FileManager`), so the type carries no shared mutable
+// state. This makes `static let shared` concurrency-safe under Swift 6.
+final class AudiobookFileLogger: AudiobookFileLogging, Sendable {
 
     static let shared = AudiobookFileLogger()
 

--- a/Palace/Logging/TPPErrorLogger.swift
+++ b/Palace/Logging/TPPErrorLogger.swift
@@ -449,6 +449,7 @@ private let nullString = "null"
     /**
      Report when user launches the app.
      */
+    @MainActor
     class func logNewAppLaunch() {
         var metadata = [String: Any]()
         addAccountInfoToMetadata(&metadata)
@@ -489,11 +490,31 @@ private let nullString = "null"
     // ----------------------------------------------------------------------------
     // MARK: - Image Loading Errors
 
-    /// Throttle state: tracks the last time a non-fatal was recorded per host
+    /// Lock-backed holder for the per-key image-error throttle timestamps.
+    /// Replaces the previous bare `static var lastImageErrorReport` +
+    /// `imageErrorReportLock` pair (a Swift 6 nonisolated-global-mutable-state
+    /// error) with an encapsulated `NSLock`-guarded store. The lock preserves
+    /// the exact throttle semantics of the prior inline critical section, so
+    /// `@unchecked Sendable` is sound (all mutation is serialized by `lock`).
+    private final class ImageErrorThrottle: @unchecked Sendable {
+        private let lock = NSLock()
+        private var lastReport: [String: Date] = [:]
+
+        func shouldReport(key: String, interval: TimeInterval, now: Date) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            if let last = lastReport[key], now.timeIntervalSince(last) < interval {
+                return false
+            }
+            lastReport[key] = now
+            return true
+        }
+    }
+
+    /// Throttle state: tracks the last time a non-fatal was recorded per key
     /// to avoid flooding Crashlytics during mass failure events (e.g., a dead
     /// image host affecting every book in a swimlane).
-    private static var lastImageErrorReport: [String: Date] = [:]
-    private static let imageErrorReportLock = NSLock()
+    private static let imageErrorThrottle = ImageErrorThrottle()
     private static let imageErrorReportInterval: TimeInterval = 60
 
     /// Records a host-level image loading failure as a non-fatal error in
@@ -532,15 +553,7 @@ private let nullString = "null"
     }
 
     private class func shouldReportImageError(key: String) -> Bool {
-        let now = Date()
-        imageErrorReportLock.lock()
-        defer { imageErrorReportLock.unlock() }
-        if let lastReport = lastImageErrorReport[key],
-           now.timeIntervalSince(lastReport) < imageErrorReportInterval {
-            return false
-        }
-        lastImageErrorReport[key] = now
-        return true
+        imageErrorThrottle.shouldReport(key: key, interval: imageErrorReportInterval, now: Date())
     }
 
     // ----------------------------------------------------------------------------

--- a/Palace/Network/TPPNetworkQueue.swift
+++ b/Palace/Network/TPPNetworkQueue.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Combine
-import SQLite
+@preconcurrency import SQLite
 import PalaceLogging
 import PalaceNetwork
 
@@ -24,7 +24,15 @@ enum HTTPMethodType: String {
  for a valid network notification from a reachability class. It then
  will retry any queued requests and purge them if necessary.
  */
-final class NetworkQueue: NSObject {
+/// - Note: `@unchecked Sendable` is safe here: all SQLite work and every access
+///   to the mutable `retryRequestCount` are funnelled through the private serial
+///   `serialQueue`, so there is no concurrent mutation of that state. `cancellables`
+///   is written once during `addObserverForOfflineQueue` at startup, and every
+///   other stored property is an immutable `let` (the `SQLite` expressions,
+///   `path`, `serialQueue`, `transport`, `reachability`). Capturing `self` in the
+///   `serialQueue.async` / URLSession-completion `@Sendable` closures therefore
+///   crosses no unsynchronized boundary.
+final class NetworkQueue: NSObject, @unchecked Sendable {
     typealias Expression = SQLite.Expression
 
     private var cancellables = Set<AnyCancellable>()

--- a/Palace/Notifications/NotificationService.swift
+++ b/Palace/Notifications/NotificationService.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 The Palace Project. All rights reserved.
 //
 
-import UserNotifications
+@preconcurrency import UserNotifications
 import Combine
 import FirebaseCore
 import FirebaseMessaging
@@ -217,7 +217,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate, Messaging
     }
 
     /// Runs configuration function, registers the app for remote notifications.
-    func setupPushNotifications(completion: ((_ granted: Bool) -> Void)? = nil) {
+    func setupPushNotifications(completion: (@Sendable (_ granted: Bool) -> Void)? = nil) {
         notificationCenter.delegate = self
         notificationCenter.requestAuthorization(options: [.alert, .badge, .sound]) { granted, _ in
             if granted {
@@ -230,7 +230,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate, Messaging
         Messaging.messaging().delegate = self
     }
 
-    func getNotificationStatus(completion: @escaping (_ areEnabled: Bool) -> Void) {
+    func getNotificationStatus(completion: @escaping @Sendable (_ areEnabled: Bool) -> Void) {
         notificationCenter.getNotificationSettings { notificationSettings in
             switch notificationSettings.authorizationStatus {
             case .authorized, .provisional: completion(true)
@@ -799,8 +799,10 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate, Messaging
                 ready: { _ in readyCount += 1 }
             )
         }
-        if UIApplication.shared.applicationIconBadgeNumber != readyCount {
-            UIApplication.shared.applicationIconBadgeNumber = readyCount
+        Task { @MainActor in
+            if UIApplication.shared.applicationIconBadgeNumber != readyCount {
+                UIApplication.shared.applicationIconBadgeNumber = readyCount
+            }
         }
     }
 

--- a/Palace/OPDS/TPPOPDSFeed+Networking.swift
+++ b/Palace/OPDS/TPPOPDSFeed+Networking.swift
@@ -84,13 +84,19 @@ extension TPPOPDSFeed {
     useTokenIfAvailable: Bool,
     completionHandler handler: @escaping (TPPOPDSFeed?, NSDictionary?) -> Void
   ) {
+    // Box the non-Sendable completion handler so it can be captured inside the
+    // `@Sendable` `TPPAsyncDispatch` closures below. The wrapped closure is only
+    // ever invoked once, inside a single `TPPAsyncDispatch` hop, never
+    // concurrently — so `@unchecked Sendable` is sound (see
+    // `SendableOPDSCompletionHandler`).
+    let handlerBox = SendableOPDSCompletionHandler(handler)
     guard let url = url else {
       TPPErrorLogger.logError(
         withCode: .noURL,
         summary: "NYPLOPDSFeed: nil URL",
         metadata: ["shouldResetCache": shouldResetCache]
       )
-      TPPAsyncDispatch { handler(nil, nil) }
+      TPPAsyncDispatch { handlerBox.call(nil, nil) }
       return
     }
 
@@ -105,7 +111,7 @@ extension TPPOPDSFeed {
     ) { data, response, error in
 
       if let error = error {
-        TPPAsyncDispatch { handler(nil, (error as NSError).problemDocument?.dictionaryValue as NSDictionary?) }
+        TPPAsyncDispatch { handlerBox.call(nil, (error as NSError).problemDocument?.dictionaryValue as NSDictionary?) }
         return
       }
 
@@ -118,7 +124,7 @@ extension TPPOPDSFeed {
             "Response": response ?? "N/A"
           ]
         )
-        TPPAsyncDispatch { handler(nil, nil) }
+        TPPAsyncDispatch { handlerBox.call(nil, nil) }
         return
       }
 
@@ -162,7 +168,7 @@ extension TPPOPDSFeed {
         }()
 
         let errorBox = SendableOPDSErrorDictionary(value: errorDict)
-        TPPAsyncDispatch { handler(nil, errorBox.value) }
+        TPPAsyncDispatch { handlerBox.call(nil, errorBox.value) }
         return
       }
 
@@ -194,7 +200,7 @@ extension TPPOPDSFeed {
         )
         let errorDict = try? JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
         let errorBox = SendableOPDSErrorDictionary(value: errorDict)
-        TPPAsyncDispatch { handler(nil, errorBox.value) }
+        TPPAsyncDispatch { handlerBox.call(nil, errorBox.value) }
         return
       }
 
@@ -212,11 +218,11 @@ extension TPPOPDSFeed {
             "response": response ?? "N/A"
           ]
         )
-        TPPAsyncDispatch { handler(nil, nil) }
+        TPPAsyncDispatch { handlerBox.call(nil, nil) }
         return
       }
 
-      TPPAsyncDispatch { handler(feed, nil) }
+      TPPAsyncDispatch { handlerBox.call(feed, nil) }
     }
 
     request = task?.originalRequest
@@ -234,4 +240,14 @@ extension TPPOPDSFeed {
 /// `BookRegistrySync`.
 private struct SendableOPDSErrorDictionary: @unchecked Sendable {
   let value: NSDictionary?
+}
+
+/// Sendable carrier for the non-Sendable OPDS completion handler so it can be
+/// captured across the `@Sendable` `TPPAsyncDispatch` boundary. The wrapped
+/// closure is invoked exactly once per request, inside a single
+/// `TPPAsyncDispatch` hop, never concurrently — so `@unchecked Sendable` is
+/// sound. Mirrors `CarPlayImageCompletionBox` and `SendableOPDSErrorDictionary`.
+private final class SendableOPDSCompletionHandler: @unchecked Sendable {
+  let call: (TPPOPDSFeed?, NSDictionary?) -> Void
+  init(_ call: @escaping (TPPOPDSFeed?, NSDictionary?) -> Void) { self.call = call }
 }

--- a/Palace/OPDS2/Cache/OPDSFeedCache.swift
+++ b/Palace/OPDS2/Cache/OPDSFeedCache.swift
@@ -193,7 +193,7 @@ actor OPDS2FeedCache: OPDSFeedCaching {
     /// - Returns: The feed (possibly stale) and whether a background refresh was triggered
     public func getWithRevalidation(
         for url: URL,
-        fetcher: @escaping () async throws -> (OPDS2Feed, etag: String?, lastModified: String?)
+        fetcher: @escaping @Sendable () async throws -> (OPDS2Feed, etag: String?, lastModified: String?)
     ) async throws -> (feed: OPDS2Feed, isStale: Bool, didTriggerRefresh: Bool) {
 
         if let entry = await get(for: url) {

--- a/Palace/PDF/Extensions/View.swift
+++ b/Palace/PDF/Extensions/View.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct SizePreferenceKey: PreferenceKey {
-    static var defaultValue: CGSize = .zero
+    static let defaultValue: CGSize = .zero
     static func reduce(value: inout CGSize, nextValue: () -> CGSize) {}
 }
 

--- a/Palace/PDF/Model/TPPPDFLocation.swift
+++ b/Palace/PDF/Model/TPPPDFLocation.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 /// TOC and search location
-struct TPPPDFLocation: Codable {
+struct TPPPDFLocation: Codable, Sendable {
     let title: String?
     let subtitle: String?
     let pageLabel: String?

--- a/Palace/PDF/ReadiumPDF/ReadiumPDFViewController.swift
+++ b/Palace/PDF/ReadiumPDF/ReadiumPDFViewController.swift
@@ -11,7 +11,7 @@
 import UIKit
 import SwiftUI
 import PalaceLogging
-import ReadiumShared
+@preconcurrency import ReadiumShared
 import ReadiumNavigator
 
 /// Bridges Readium's `PDFNavigatorViewController` into Palace's reading-position

--- a/Palace/PDF/Views/TPPPDFDocumentView.swift
+++ b/Palace/PDF/Views/TPPPDFDocumentView.swift
@@ -77,8 +77,14 @@ struct TPPPDFDocumentView: UIViewRepresentable {
         }
 
         func pdfViewPerformGo(toPage sender: PDFView) {
-            if let page = sender.currentPage, let pageIndex = sender.document?.index(for: page) {
-                currentPage = pageIndex
+            // PDFKit invokes `PDFViewDelegate` callbacks on the main thread, but
+            // the protocol requirement is nonisolated, so `sender`'s main-actor
+            // `currentPage`/`document` (and the `@Binding currentPage` write) must
+            // be reached through an explicit main-actor assumption.
+            MainActor.assumeIsolated {
+                if let page = sender.currentPage, let pageIndex = sender.document?.index(for: page) {
+                    currentPage = pageIndex
+                }
             }
         }
     }

--- a/Palace/PDF/Views/TPPPDFSearchView.swift
+++ b/Palace/PDF/Views/TPPPDFSearchView.swift
@@ -62,7 +62,12 @@ struct TPPPDFSearchView: View {
         searchDelegate.search(text: string)
     }
 
-    class SearchDelegate: ObservableObject, TPPPDFDocumentDelegate {
+    /// `@unchecked Sendable` is safe here: `searchResults` is only ever mutated
+    /// on the main thread — `search(text:)` is called from the SwiftUI view (main)
+    /// and `didMatchString` writes through a `DispatchQueue.main.async` hop — and
+    /// `document` is an immutable `let`. No cross-thread mutable state, so
+    /// capturing `self` in the main-hop `@Sendable` closure crosses no boundary.
+    final class SearchDelegate: ObservableObject, TPPPDFDocumentDelegate, @unchecked Sendable {
 
         let document: TPPPDFDocument
 

--- a/Palace/PDF/Views/TPPPDFView.swift
+++ b/Palace/PDF/Views/TPPPDFView.swift
@@ -7,7 +7,7 @@
 //
 
 import SwiftUI
-import PDFKit
+@preconcurrency import PDFKit
 
 /// This view shows PDFKit views when PDF is not encrypted
 /// PDFKit reading controls (PDFView and PDFThumbnails) are generally faster because of direct data reading,

--- a/Palace/Reader2/Bookmarks/TPPBookmarkDeletionLog.swift
+++ b/Palace/Reader2/Bookmarks/TPPBookmarkDeletionLog.swift
@@ -15,8 +15,16 @@ import PalaceLogging
 ///
 /// This solves the "ghost bookmark" problem where bookmarks from previous loans
 /// or other devices cannot be deleted because the device ID doesn't match.
+///
+/// `@unchecked Sendable` invariant: all mutable state (`deletionLog`) is
+/// accessed exclusively through `queue` — a concurrent dispatch queue whose
+/// writes use `.barrier` and whose reads use `sync` — so there is no
+/// unsynchronized shared mutable access. The other stored properties
+/// (`userDefaultsKey`, `queue`, `defaults`) are immutable `let`s. This makes
+/// the queue-guarded singleton safe to reference from the `@Sendable` closures
+/// dispatched onto `queue`.
 @objcMembers
-final class TPPBookmarkDeletionLog: NSObject {
+final class TPPBookmarkDeletionLog: NSObject, @unchecked Sendable {
 
     static let shared = TPPBookmarkDeletionLog()
 

--- a/Palace/Reader2/ReaderSettings/TPPAssociatedColors.swift
+++ b/Palace/Reader2/ReaderSettings/TPPAssociatedColors.swift
@@ -51,6 +51,7 @@ struct TPPAppearanceColors {
     }
 }
 
+@MainActor
 class TPPAssociatedColors {
     static let shared = TPPAssociatedColors()
 

--- a/Palace/Reader2/ReaderStackConfiguration/LCP/TPPLCPClient.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LCP/TPPLCPClient.swift
@@ -23,7 +23,12 @@ import UIKit
 ///
 /// `NotificationCenter` listener purges everything on a system memory
 /// warning (or our pre-emptive `ReaderService.openPDF` notification).
-private final class LCPDecryptCache {
+/// `@unchecked Sendable` invariant: the sole stored property `cache` is an
+/// immutable `let` and `NSCache` is documented thread-safe, so concurrent
+/// `decrypted(for:)` / `store(_:for:)` calls are safe. The observer is
+/// registered once in `init`, and `handleMemoryWarning` only calls the
+/// thread-safe `removeAllObjects()`. No unsynchronized mutable state exists.
+private final class LCPDecryptCache: @unchecked Sendable {
     static let shared = LCPDecryptCache()
     private let cache = NSCache<NSData, NSData>()
 

--- a/Palace/Reader2/ReaderStackConfiguration/TPPR3Owner.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/TPPR3Owner.swift
@@ -42,10 +42,18 @@ extension TPPR3Owner: ModuleDelegate {
     func presentAlert(_ title: String,
                       message: String,
                       from viewController: UIViewController) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let dismissButton = UIAlertAction(title: Strings.Generic.ok, style: .cancel)
-        alert.addAction(dismissButton)
-        viewController.present(alert, animated: true)
+        // `ModuleDelegate.presentAlert` is a nonisolated protocol requirement,
+        // but presenting a `UIAlertController` is main-actor-only work and this
+        // is always invoked on the main thread during reader presentation.
+        // `assumeIsolated` asserts that precondition (a clean crash if ever
+        // violated) instead of implicitly hopping — preserving the synchronous
+        // presentation behavior the requirement mandates.
+        MainActor.assumeIsolated {
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            let dismissButton = UIAlertAction(title: Strings.Generic.ok, style: .cancel)
+            alert.addAction(dismissButton)
+            viewController.present(alert, animated: true)
+        }
     }
 
     func presentError(_ error: Error?, from viewController: UIViewController) {

--- a/Palace/ReaderStreaming/StreamingReaderViewController.swift
+++ b/Palace/ReaderStreaming/StreamingReaderViewController.swift
@@ -22,13 +22,32 @@ protocol ScriptEvaluating: AnyObject {
     )
 }
 
-extension WKWebView: ScriptEvaluating {
+// `@preconcurrency`: `WKWebView` is `@MainActor` while `ScriptEvaluating` is
+// nonisolated, so the conformance crosses actor isolation. The protocol is only
+// ever used from `@MainActor` sites (the VC below, and `@MainActor` tests), so
+// the preconcurrency conformance is sound.
+extension WKWebView: @preconcurrency ScriptEvaluating {
     func evaluate(
         _ javaScript: String,
         completion: ((Any?, Error?) -> Void)?
     ) {
-        evaluateJavaScript(javaScript, completionHandler: completion)
+        // `evaluateJavaScript(_:completionHandler:)` expects a `@Sendable`
+        // handler. Box the non-Sendable `completion` so the `@Sendable` closure
+        // captures only the (Sendable) box; the boxed closure is invoked once,
+        // on the main actor (where the handler fires), never concurrently.
+        let box = ScriptCompletionBox(completion)
+        evaluateJavaScript(javaScript) { result, error in
+            box.call?(result, error)
+        }
     }
+}
+
+/// Sendable carrier for the non-Sendable JS completion handler so it can cross
+/// into the `@Sendable` `evaluateJavaScript` completion boundary. Invoked once,
+/// on the main actor, never concurrently — so `@unchecked Sendable` is sound.
+private final class ScriptCompletionBox: @unchecked Sendable {
+    let call: ((Any?, Error?) -> Void)?
+    init(_ call: ((Any?, Error?) -> Void)?) { self.call = call }
 }
 
 /// UIKit shell for the streaming reader. The SwiftUI surface area uses

--- a/Palace/Samples/AudiobookSamplePlayer/AudiobookSamplePlayer.swift
+++ b/Palace/Samples/AudiobookSamplePlayer/AudiobookSamplePlayer.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 The Palace Project. All rights reserved.
 //
 
-import AVFoundation
+@preconcurrency import AVFoundation
 import Combine
 import PalaceLogging
 
@@ -41,7 +41,7 @@ class AudiobookSamplePlayer: NSObject, ObservableObject {
 
     private func configureAudioSession() {
         // AVAudioSession configuration MUST be done on the main thread to avoid -50 errors
-        let configure: () -> Void = {
+        let configure: @Sendable () -> Void = {
             do {
                 let session = AVAudioSession.sharedInstance()
                 // Only set category if it's different to avoid unnecessary operations

--- a/Palace/Settings/AccountList/TPPAccountList.swift
+++ b/Palace/Settings/AccountList/TPPAccountList.swift
@@ -226,13 +226,13 @@ extension TPPAccountList: UITableViewDelegate, UITableViewDataSource {
 }
 
 // MARK: - DataSourceDelegate
-extension TPPAccountList: DataSourceDelegate {
+extension TPPAccountList: @preconcurrency DataSourceDelegate {
     func refresh() {
         tableView.reloadData()
     }
 }
 
-extension TPPAccountList: AccountLogoDelegate {
+extension TPPAccountList: @preconcurrency AccountLogoDelegate {
     func logoDidUpdate(in account: Account, to newLogo: UIImage) {
         accountsLoadingLogos.remove(account.uuid)
         if let indexPath = datasource.indexPath(for: account),

--- a/Palace/Settings/BarcodeScanning/BarcodeScanner.swift
+++ b/Palace/Settings/BarcodeScanning/BarcodeScanner.swift
@@ -15,7 +15,7 @@ fileprivate extension CGRect {
     }
 }
 
-class BarcodeScanner: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+class BarcodeScanner: UIViewController, @preconcurrency AVCaptureMetadataOutputObjectsDelegate {
     private var captureSession: AVCaptureSession!
     private var previewLayer: AVCaptureVideoPreviewLayer!
     private var scannerView: UIView!

--- a/Palace/Settings/BarcodeScanning/TPPBarcode.swift
+++ b/Palace/Settings/BarcodeScanning/TPPBarcode.swift
@@ -28,9 +28,9 @@ private let maxBarcodeWidth: CGFloat = 414
         return nil
     }
 
-    static func presentScanner(withCompletion completion: @escaping (String?) -> Void) {
+    static func presentScanner(withCompletion completion: @escaping @Sendable (String?) -> Void) {
         AVCaptureDevice.requestAccess(for: .video) { granted in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 if granted {
                     let scannerVC = BarcodeScanner(completion: completion)
                     let navController = UINavigationController.init(rootViewController: scannerVC)
@@ -42,6 +42,7 @@ private let maxBarcodeWidth: CGFloat = 414
         }
     }
 
+    @MainActor
     private static func presentCameraPrivacyAlert() {
         let alertController = UIAlertController(
             title: DisplayStrings.cameraAccessDisabledTitle,

--- a/Palace/Settings/Debug/MockBackend/MockBackendService.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendService.swift
@@ -14,6 +14,7 @@ import Foundation
 import Combine
 import PalaceLogging
 
+@MainActor
 final class MockBackendService: ObservableObject {
 
     static let shared = MockBackendService()

--- a/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
@@ -13,27 +13,75 @@ import Foundation
 import PalaceLogging
 import PalaceNetwork
 
+/// Lock-backed holder for `MockBackendURLProtocol`'s cross-thread configuration.
+///
+/// `URLProtocol` hooks (`canInit`, `startLoading`, the swizzled getter) run on
+/// the URL loading system's threads, so this state genuinely lives off the main
+/// actor. `@unchecked Sendable` is safe because every stored property is only
+/// read or written while holding `lock` — never touched concurrently unguarded.
+private final class MockBackendConfigStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _activeScenario: MockScenario?
+    private var _scopedHost: String?
+    private var _fixtureBundle: Bundle = .main
+    private var _fixtureDirectoryPath: String?
+    private var _requestCount = 0
+
+    var activeScenario: MockScenario? {
+        get { lock.lock(); defer { lock.unlock() }; return _activeScenario }
+        set { lock.lock(); defer { lock.unlock() }; _activeScenario = newValue }
+    }
+    var scopedHost: String? {
+        get { lock.lock(); defer { lock.unlock() }; return _scopedHost }
+        set { lock.lock(); defer { lock.unlock() }; _scopedHost = newValue }
+    }
+    var fixtureBundle: Bundle {
+        get { lock.lock(); defer { lock.unlock() }; return _fixtureBundle }
+        set { lock.lock(); defer { lock.unlock() }; _fixtureBundle = newValue }
+    }
+    var fixtureDirectoryPath: String? {
+        get { lock.lock(); defer { lock.unlock() }; return _fixtureDirectoryPath }
+        set { lock.lock(); defer { lock.unlock() }; _fixtureDirectoryPath = newValue }
+    }
+    func nextRequestCount() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        _requestCount += 1
+        return _requestCount
+    }
+}
+
 final class MockBackendURLProtocol: URLProtocol {
 
     // MARK: - Static Configuration
 
+    private static let config = MockBackendConfigStore()
+
     /// The active scenario. When nil, this protocol does not intercept.
-    static var activeScenario: MockScenario?
+    static var activeScenario: MockScenario? {
+        get { config.activeScenario }
+        set { config.activeScenario = newValue }
+    }
 
     /// Host to scope interception to. When set, only requests to this host
     /// are considered for mocking — requests to other hosts pass through.
     /// Set automatically from the current library's catalog URL on activation.
-    static var scopedHost: String?
+    static var scopedHost: String? {
+        get { config.scopedHost }
+        set { config.scopedHost = newValue }
+    }
 
     /// Bundle containing fixture files. Override for test bundles.
-    static var fixtureBundle: Bundle = .main
+    static var fixtureBundle: Bundle {
+        get { config.fixtureBundle }
+        set { config.fixtureBundle = newValue }
+    }
 
     /// Direct file system path to fixtures directory. When set, bypasses bundle lookup.
     /// Set this in tests where fixtures aren't bundled.
-    static var fixtureDirectoryPath: String?
-
-    /// Request counter for diagnostics.
-    private static var requestCount = 0
+    static var fixtureDirectoryPath: String? {
+        get { config.fixtureDirectoryPath }
+        set { config.fixtureDirectoryPath = newValue }
+    }
 
     // MARK: - URLProtocol Overrides
 
@@ -65,8 +113,7 @@ final class MockBackendURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        Self.requestCount += 1
-        let requestNum = Self.requestCount
+        let requestNum = Self.config.nextRequestCount()
 
         guard let scenario = Self.activeScenario,
               let url = request.url else {

--- a/Palace/Settings/Debug/MockBackend/URLSessionConfiguration+MockBackend.swift
+++ b/Palace/Settings/Debug/MockBackend/URLSessionConfiguration+MockBackend.swift
@@ -18,10 +18,12 @@ import PalaceLogging
 
 extension URLSessionConfiguration {
 
-    private static var isSwizzled = false
+    // Swizzle state is only ever toggled from MockBackendService (main actor),
+    // so it lives on the main actor rather than as free-floating global state.
+    @MainActor private static var isSwizzled = false
 
     /// Swizzle the `protocolClasses` getter to prepend MockBackendURLProtocol.
-    static func mockBackend_swizzleProtocolClasses() {
+    @MainActor static func mockBackend_swizzleProtocolClasses() {
         guard !isSwizzled else { return }
 
         let originalSelector = #selector(getter: protocolClasses)
@@ -39,7 +41,7 @@ extension URLSessionConfiguration {
     }
 
     /// Undo the swizzle.
-    static func mockBackend_unswizzleProtocolClasses() {
+    @MainActor static func mockBackend_unswizzleProtocolClasses() {
         guard isSwizzled else { return }
 
         let originalSelector = #selector(getter: protocolClasses)

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -4,7 +4,7 @@ import WebKit
 import PalaceCatalog
 
 @objcMembers
-class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, MFMailComposeViewControllerDelegate {
+class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, @preconcurrency MFMailComposeViewControllerDelegate {
 
     weak var tableView: UITableView!
     var loadingView: UIView?
@@ -764,7 +764,10 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
                 trigger: trigger
             )
 
-            center.add(request) { error in
+            // Re-fetch the singleton inside the closure instead of capturing the
+            // outer `center` — UNUserNotificationCenter is non-Sendable and this
+            // block runs on a Sendable completion callback.
+            UNUserNotificationCenter.current().add(request) { error in
                 DispatchQueue.main.async {
                     if let error {
                         let alert = TPPAlertUtils.alert(title: "Error", message: error.localizedDescription)
@@ -1351,4 +1354,4 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
     #endif
 }
 
-extension TPPDeveloperSettingsTableViewController: TPPRegistryDebugger {}
+extension TPPDeveloperSettingsTableViewController: @preconcurrency TPPRegistryDebugger {}

--- a/Palace/Settings/EULAViewHosting.swift
+++ b/Palace/Settings/EULAViewHosting.swift
@@ -12,6 +12,7 @@ import SwiftUI
 class EULAViewHosting: NSObject {
 
     /// Creates a UIHostingController with EULAView for the given account
+    @MainActor
     static func makeEULAView(account: Account) -> UIViewController {
         let view = EULAView(account: account)
         let controller = UIHostingController(rootView: view)
@@ -19,6 +20,7 @@ class EULAViewHosting: NSObject {
     }
 
     /// Creates a UIHostingController with EULAView using NYPL URL
+    @MainActor
     static func makeEULAViewWithNYPLURL() -> UIViewController {
         let view = EULAView(nyplURL: true)
         let controller = UIHostingController(rootView: view)

--- a/Palace/Settings/NewSettings/LibrariesSectionViewModel.swift
+++ b/Palace/Settings/NewSettings/LibrariesSectionViewModel.swift
@@ -48,14 +48,22 @@ final class LibrariesSectionViewModel: ObservableObject {
     private let switchTimeout: TimeInterval = 2.5
 
     private let environment: LibrariesSectionEnvironment
-    private var accountChangeObserver: NSObjectProtocol?
+
+    /// Reference box holding the notification-observer token so `deinit`
+    /// (nonisolated) can read it without hopping the main actor. Safe as
+    /// `@unchecked Sendable`: `token` is written once during `init` on the
+    /// main actor and read once in `deinit`, never concurrently.
+    private final class ObserverTokenBox: @unchecked Sendable {
+        var token: NSObjectProtocol?
+    }
+    private let observerBox = ObserverTokenBox()
 
     init(environment: LibrariesSectionEnvironment, observeNotifications: Bool = true) {
         self.environment = environment
         refresh()
 
         if observeNotifications {
-            accountChangeObserver = NotificationCenter.default.addObserver(
+            observerBox.token = NotificationCenter.default.addObserver(
                 forName: .TPPCurrentAccountDidChange,
                 object: nil,
                 queue: .main
@@ -70,8 +78,8 @@ final class LibrariesSectionViewModel: ObservableObject {
     }
 
     deinit {
-        if let accountChangeObserver {
-            NotificationCenter.default.removeObserver(accountChangeObserver)
+        if let token = observerBox.token {
+            NotificationCenter.default.removeObserver(token)
         }
     }
 

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -599,21 +599,25 @@ private struct LibraryRowView: View {
 
 /// AccountLogoDelegate forwarder used by `LibraryRowView` because SwiftUI
 /// `View` structs can't directly conform to ObjC delegate protocols.
-private final class LogoLoadProxy: NSObject, AccountLogoDelegate {
+@MainActor
+private final class LogoLoadProxy: NSObject, @preconcurrency AccountLogoDelegate {
     private let onUpdate: (UIImage) -> Void
     init(onUpdate: @escaping (UIImage) -> Void) {
         self.onUpdate = onUpdate
     }
+    // `Account` invokes this on the main thread (its logo fetch delivers via
+    // `DispatchQueue.main.async`), so the forwarding runs on the main actor
+    // without an extra hop.
     func logoDidUpdate(in account: Account, to newLogo: UIImage) {
-        DispatchQueue.main.async { [onUpdate] in
-            onUpdate(newLogo)
-        }
+        onUpdate(newLogo)
     }
 }
 
 /// Account.logoDelegate is held weakly. Park proxies here so a row's
 /// in-flight logo load isn't dropped when the proxy goes out of scope.
-private final class LogoProxyHolder {
+/// Lock-backed holder — `@unchecked Sendable` because all access to `proxies`
+/// is serialized through `lock`.
+private final class LogoProxyHolder: @unchecked Sendable {
     static let shared = LogoProxyHolder()
     private var proxies: [String: LogoLoadProxy] = [:]
     private let lock = NSLock()

--- a/Palace/Settings/NewSettings/TPPSettingsViewController.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsViewController.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 
 class TPPSettingsViewController: NSObject {
+    @MainActor
     @objc static func makeSwiftUIView(dismissHandler: @escaping (() -> Void)) -> UIViewController {
         let controller = UIHostingController(rootView: TPPSettingsView())
         controller.title = Strings.Settings.settings

--- a/Palace/Stats/Models/BadgeDefinition.swift
+++ b/Palace/Stats/Models/BadgeDefinition.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Defines an unlock criterion for a badge along with its metadata.
-struct BadgeDefinition {
+struct BadgeDefinition: Sendable {
   let id: String
   let name: String
   let descriptionText: String
@@ -11,7 +11,7 @@ struct BadgeDefinition {
 
   /// Evaluates progress toward the badge given the full reading history.
   /// Returns a value from 0.0 to 1.0.
-  let evaluateProgress: (BadgeEvaluationContext) -> Double
+  let evaluateProgress: @Sendable (BadgeEvaluationContext) -> Double
 
   func makeBadge(earnedDate: Date? = nil, progress: Double = 0) -> Badge {
     Badge(

--- a/Palace/Utilities/Concurrency/MainActorHelpers.swift
+++ b/Palace/Utilities/Concurrency/MainActorHelpers.swift
@@ -23,7 +23,7 @@ func runOnMain(_ work: @escaping @MainActor () -> Void) {
 /// Runs work on the main actor asynchronously from a non-isolated context
 /// Replaces: DispatchQueue.main.async { }
 @inlinable
-func runOnMainAsync(_ work: @escaping @MainActor () -> Void) {
+func runOnMainAsync(_ work: @escaping @MainActor @Sendable () -> Void) {
     Task { @MainActor in
         work()
     }
@@ -32,7 +32,7 @@ func runOnMainAsync(_ work: @escaping @MainActor () -> Void) {
 /// Runs work on the main actor with a delay
 /// Replaces: DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { }
 @inlinable
-func runOnMainAfter(seconds: TimeInterval, _ work: @escaping @MainActor () -> Void) {
+func runOnMainAfter(seconds: TimeInterval, _ work: @escaping @MainActor @Sendable () -> Void) {
     Task { @MainActor in
         try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
         work()
@@ -242,7 +242,7 @@ actor BarrierExecutor<Value> {
 /// - Parameter work: Function that takes a completion handler
 /// - Returns: The result from the completion handler
 @inlinable
-func withAsyncCallback<T>(
+func withAsyncCallback<T: Sendable>(
     _ work: (@escaping (T) -> Void) -> Void
 ) async -> T {
     await withCheckedContinuation { continuation in
@@ -257,7 +257,7 @@ func withAsyncCallback<T>(
 /// - Returns: The unwrapped result
 /// - Throws: The error from the Result.failure
 @inlinable
-func withAsyncThrowingCallback<T>(
+func withAsyncThrowingCallback<T: Sendable>(
     _ work: (@escaping (Result<T, Error>) -> Void) -> Void
 ) async throws -> T {
     try await withCheckedThrowingContinuation { continuation in

--- a/Palace/Utilities/Concurrency/TPPMainThreadChecker.swift
+++ b/Palace/Utilities/Concurrency/TPPMainThreadChecker.swift
@@ -19,7 +19,7 @@ import Dispatch
     /// - See: https://github.com/apple/swift-corelibs-libdispatch/commit/e64e4b962e1f356d7561e7a6103b424f335d85f6
     /// - Parameters:
     ///   - work: The block to run on the main thread.
-    static func sync(_ work: () -> Void) {
+    static func sync(_ work: @Sendable () -> Void) {
         if Thread.isMainThread {
             work()
         } else {

--- a/Palace/Utilities/DeviceSpecificErrorMonitor.swift
+++ b/Palace/Utilities/DeviceSpecificErrorMonitor.swift
@@ -29,7 +29,12 @@ protocol DeviceSpecificErrorMonitoring {
 ///
 /// NOTE: This class delegates all Firebase RemoteConfig access to FirebaseManager
 /// to prevent race conditions that cause the "recursive_mutex lock failed" crash.
-final class DeviceSpecificErrorMonitor: DeviceSpecificErrorMonitoring {
+// `@unchecked Sendable`: the only mutable stored state (`isInitialized`) is
+// guarded by `lock` (NSLock); `firebaseManagerProvider` is an immutable `let`
+// resolved once and Firebase access is delegated to the thread-safe
+// FirebaseManager facade. Safe to share the `.shared` singleton across
+// isolation domains.
+final class DeviceSpecificErrorMonitor: DeviceSpecificErrorMonitoring, @unchecked Sendable {
     static let shared = DeviceSpecificErrorMonitor()
 
     private var isInitialized = false

--- a/Palace/Utilities/Extensions/Image+Extension.swift
+++ b/Palace/Utilities/Extensions/Image+Extension.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 extension Image {
+    @MainActor
     func toUIImage() -> UIImage? {
         let controller = UIHostingController(rootView: self.resizable())
         let view = controller.view

--- a/Palace/Utilities/Extensions/KeyboardModifier.swift
+++ b/Palace/Utilities/Extensions/KeyboardModifier.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 
+@MainActor
 public func dismissKeyboard() {
     UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
 }

--- a/Palace/Utilities/ImageCache/GeneralCache.swift
+++ b/Palace/Utilities/ImageCache/GeneralCache.swift
@@ -18,7 +18,12 @@ public enum CachePolicy {
     case noCache
 }
 
-public final class GeneralCache<Key: Hashable & Codable, Value: Codable> {
+// `@unchecked Sendable`: every access to mutable state (`memoryCache`, disk
+// files) is serialized through the concurrent `queue` with `.barrier` writes;
+// `memoryWarningObserver` is set once during `init` and only read in `deinit`.
+// `Key`/`Value` are constrained to `Sendable` so cached values can cross the
+// queue boundary safely (all call sites use `GeneralCache<String, Data>`).
+public final class GeneralCache<Key: Hashable & Codable & Sendable, Value: Codable & Sendable>: @unchecked Sendable {
     private let memoryCache = NSCache<WrappedKey, Entry>()
     private let fileManager = FileManager.default
     private let cacheDirectory: URL
@@ -26,7 +31,7 @@ public final class GeneralCache<Key: Hashable & Codable, Value: Codable> {
     private let mode: CachingMode
     private var memoryWarningObserver: NSObjectProtocol?
 
-    private final class Entry: Codable {
+    private final class Entry: Codable, Sendable {
         let value: Value
         let expiration: Date?
         init(value: Value, expiration: Date?) {
@@ -39,7 +44,9 @@ public final class GeneralCache<Key: Hashable & Codable, Value: Codable> {
         }
     }
 
-    private final class WrappedKey: NSObject {
+    // `@unchecked Sendable`: immutable `let key` (which is itself `Sendable`);
+    // used only as an `NSCache` key.
+    private final class WrappedKey: NSObject, @unchecked Sendable {
         let key: Key
         init(_ key: Key) { self.key = key }
         override var hash: Int { key.hashValue }
@@ -179,7 +186,7 @@ public final class GeneralCache<Key: Hashable & Codable, Value: Codable> {
     @discardableResult
     public func get(_ key: Key,
                     policy: CachePolicy,
-                    fetcher: @escaping () async throws -> Value) async throws -> Value {
+                    fetcher: @escaping @Sendable () async throws -> Value) async throws -> Value {
         switch policy {
         case .cacheFirst:
             if let cached = get(for: key) { return cached }

--- a/Palace/Utilities/SwiftUI/AccessibleAnimation.swift
+++ b/Palace/Utilities/SwiftUI/AccessibleAnimation.swift
@@ -42,6 +42,7 @@ extension View {
 
 extension AnyTransition {
     /// Returns the transition if Reduce Motion is disabled, otherwise returns identity.
+    @MainActor
     static func accessible(_ transition: AnyTransition) -> AnyTransition {
         UIAccessibility.isReduceMotionEnabled ? .identity : transition
     }
@@ -58,6 +59,7 @@ extension AnyTransition {
 ///   showContent.toggle()
 /// }
 /// ```
+@MainActor
 func accessibleWithAnimation<Result>(_ animation: Animation? = .default, _ body: () throws -> Result) rethrows -> Result {
     if UIAccessibility.isReduceMotionEnabled {
         return try body()

--- a/Palace/Utilities/System/LocationManager.swift
+++ b/Palace/Utilities/System/LocationManager.swift
@@ -12,7 +12,11 @@ extension Notification.Name {
     static let locationAuthorizationDidChange = Notification.Name("LocationAuthorizationDidChange")
 }
 
-class LocationManager: NSObject, CLLocationManagerDelegate {
+// `@unchecked Sendable`: the type has no mutable stored state — `locationManager`
+// is an immutable `let` set once in `init`; the computed properties only read
+// `authorizationStatus`. Safe to share the `.shared` singleton across isolation
+// domains.
+final class LocationManager: NSObject, CLLocationManagerDelegate, @unchecked Sendable {
     static let shared = LocationManager()
     private let locationManager = CLLocationManager()
 

--- a/Palace/Utilities/TPPAccessibilityAnnouncementCenter.swift
+++ b/Palace/Utilities/TPPAccessibilityAnnouncementCenter.swift
@@ -29,7 +29,11 @@ extension Notification.Name {
 /// and delivered sequentially after the transition settles, so they don't get
 /// cut off by VoiceOver reading new screen elements. Outside transition windows,
 /// announcements are delivered immediately (preserving existing behavior).
-final class TPPAccessibilityAnnouncementCenter {
+// `@unchecked Sendable`: all mutable stored state (progress buckets, recent
+// announcements, transition/queue state, pending work item, observers) is
+// guarded by `lock` (NSLock); the injected handlers are immutable `let`s.
+// Safe to capture `self` in the main-queue dispatch and observer closures.
+final class TPPAccessibilityAnnouncementCenter: @unchecked Sendable {
     typealias PostHandler = (UIAccessibility.Notification, String) -> Void
     typealias VoiceOverRunningProvider = () -> Bool
     typealias TimeProvider = () -> Date

--- a/Palace/Utilities/UI/TPPLoadingViewController.swift
+++ b/Palace/Utilities/UI/TPPLoadingViewController.swift
@@ -6,6 +6,7 @@ protocol TPPLoadingViewController: UIViewController {
 
 extension TPPLoadingViewController {
 
+    @MainActor
     private func loadingOverlayView() -> UIView {
         let overlayView = UIView()
         overlayView.backgroundColor = UIColor.black.withAlphaComponent(0.7)
@@ -17,20 +18,24 @@ extension TPPLoadingViewController {
         return overlayView
     }
 
+    // `@MainActor` matches this protocol's `UIViewController` refinement; the
+    // previous `DispatchQueue.main.async` hops were defensive main-thread
+    // guards now enforced statically, so the UIKit work runs directly.
+    @MainActor
     func startLoading() {
         guard loadingView == nil else { return }
 
         let loadingOverlay = loadingOverlayView()
-        DispatchQueue.main.async {
-            if let win = UIApplication.shared.mainKeyWindow {
-                win.addSubview(loadingOverlay)
-            }
-            loadingOverlay.autoPinEdgesToSuperviewEdges()
+        if let win = UIApplication.shared.mainKeyWindow {
+            win.addSubview(loadingOverlay)
         }
+        loadingOverlay.autoPinEdgesToSuperviewEdges()
 
         loadingView = loadingOverlay
     }
 
+    // Left nonisolated: `CatalogLoadingViewController.deinit` calls this from a
+    // nonisolated deinit, so the main-thread hop stays inside the method.
     func stopLoading() {
         DispatchQueue.main.async {
             self.loadingView?.removeFromSuperview()

--- a/PalaceTests/ProblemReportEmailTests.swift
+++ b/PalaceTests/ProblemReportEmailTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ProblemReportEmailTests: XCTestCase {
 
     private var emailService: ProblemReportEmail!

--- a/PalaceTests/TPPConfigurationTests.swift
+++ b/PalaceTests/TPPConfigurationTests.swift
@@ -117,13 +117,13 @@ final class TPPConfigurationTests: XCTestCase {
 
   // MARK: - Navigation Bar Appearance
 
-  func test_defaultAppearance_returnsConfiguredAppearance() {
+  @MainActor func test_defaultAppearance_returnsConfiguredAppearance() {
     let appearance = TPPConfiguration.defaultAppearance()
     XCTAssertNotNil(appearance, "defaultAppearance should return a non-nil appearance")
     XCTAssertNotNil(appearance.backgroundColor, "defaultAppearance should have a background color")
   }
 
-  func test_appearanceWithBackgroundColor_usesProvidedColor() {
+  @MainActor func test_appearanceWithBackgroundColor_usesProvidedColor() {
     let testColor = UIColor.red
     let appearance = TPPConfiguration.appearance(withBackgroundColor: testColor)
     XCTAssertNotNil(appearance)

--- a/docs/architecture/swift6-phaseB-followup.md
+++ b/docs/architecture/swift6-phaseB-followup.md
@@ -1,0 +1,87 @@
+<!-- audit-verified -->
+# Swift 6 Phase B — follow-up map (post Wave 1)
+
+**Status as of Wave 1 (PR #1167):** `complete`-mode distinct app-target concurrency
+warnings **738 → 473** (265 cleared), build green. This doc maps the remaining 473 so
+the next waves and the critical-path PRs are dispatchable without re-deriving the
+analysis. Companion: `app-target-swift6-modernization-plan.md` (phase ladder),
+`swift6-modernization-handoff-2026-07-02.md` (env + gotchas).
+
+Measurement: build the DRM `Palace` scheme with `SWIFT_STRICT_CONCURRENCY=complete`
+(`ruby scripts/set_strict_concurrency.rb complete`) and grep the log for concurrency
+warnings — see the handoff doc §1 for the exact grep. Revert with
+`set_strict_concurrency.rb targeted` before committing (Wave 1 did NOT flip the level).
+
+## 1. Residual by module (473 distinct)
+
+| Module | Residual | Track |
+|---|---|---|
+| MyBooks | 95 | **critical-path** — own rigorous PR (architect+SoD) |
+| Reader2 | 79 | structural clusters (reader-VC / TTS / DRM-cert) |
+| SignInLogic | 62 | **critical-path** — own rigorous PR |
+| ErrorHandling | 47 | `TPPAlertUtils` cross-module `@MainActor` pass |
+| Audiobooks | 39 | **critical-path** — own rigorous PR (toolkit fragile) |
+| AppInfrastructure | 37 | DI-root global state (AppContainer / Store) |
+| Book | 31 | `TPPBookRegistry`/`BookRegistryStore` mutation core |
+| Utilities | 16 | `TPPBackgroundExecutor` ObjC lifecycle; VoiceOver timing |
+| Accounts | 14 | `AccountsManager` load-timing paths |
+| Samples/PDF/CarPlay/Notifications/Settings/Network/OPDS2/CatalogUI | ~53 | mixed; several tied to shared types below |
+
+Critical-path subtotal (MyBooks + SignInLogic + Audiobooks) = **196** — these must NOT
+be blind-swarmed; each is money/access and gets architect + SoD + tests + mutation.
+
+## 2. The 4 shared-type decisions that unblock the most (~104 warning-lines)
+
+Multiple Wave-1 agents independently converged on these. Deciding each one clears
+warnings across *many* modules at once — do these FIRST, before the per-module waves,
+because a per-line fix in a consumer is wasted if the shared type later becomes Sendable.
+
+1. **`TPPBookRegistry` / `TPPBookRegistryProvider` (~42 lines)** — the book-state
+   single-source-of-truth. Non-Sendable stateful facade (`var state`, `BoolWithDelay`);
+   `BookRegistryStore` mutation core is queue-synchronized. Decision: make the store a
+   documented lock/queue-backed `@unchecked Sendable` and the provider protocol
+   `Sendable`, OR isolate to `@MainActor`. Touches Book, MyBooks, CatalogUI, Accounts.
+   **Critical-path-adjacent — rigorous, not swarm.**
+2. **`AccountsManager` (~30 lines)** — known concurrency/test-pollution hazard (memory).
+   Background `loadCatalogs` `Task.detached` + account-switch paths capture `self`.
+   Decision: isolate-at-site (snapshot inside `MainActor.run`) where possible; a
+   type-level `@unchecked Sendable` needs a deliberate mutable-state audit of
+   `accountSets`/`accountByUUID`/loading queues. Touches Accounts, AppInfrastructure,
+   TriageBotFactory. **Rigorous — do not blind-fix.**
+3. **Readium `Publication` (~24 lines)** — non-Sendable Readium type crossing task
+   boundaries in Reader2 (`EPUBSearchViewModel`, `ReaderModule`, `ReaderService`) and
+   PDF. Decision: module-wide `@preconcurrency import ReadiumShared/ReadiumNavigator`
+   policy, or wait on a Readium-side Sendable audit. This is upstream — likely
+   `@preconcurrency` is the honest ceiling until Readium annotates.
+4. **`Account` (~8 lines)** — large `@objcMembers final class`; `awaitReady()` sends it
+   across isolation in `UnifiedOPDSService`/`OPDSFeedService`. Decision: audit for a
+   documented `@unchecked Sendable` (mostly config + lock-guarded logo/auth state) vs.
+   snapshotting the needed fields. Touches OPDS2, Accounts, SignInLogic.
+
+`Store.Environment` (AppInfrastructure `Store.swift:72`) is a 5th, smaller one: a
+`<Environment: Sendable>` constraint ripples to every ViewModel `Store` instantiation —
+mechanical but wide; do it as its own atomic change.
+
+## 3. Recommended sequencing
+
+1. **Shared-type decisions first** (§2, items 1–4) — each its own rigorous PR
+   (1 & 2 & 4 are critical-path-adjacent). Re-measure after each; expect large drops.
+2. **Critical-path module PRs** — MyBooks, SignInLogic, Audiobooks (architect + SoD +
+   tests + mutation per the CLAUDE.md rigor bar). Partly unblocked by step 1.
+3. **Structural-cluster waves** — Reader2 reader-VC/TTS isolation; ErrorHandling
+   `TPPAlertUtils` `@MainActor` cross-module pass; AppInfrastructure DI-root. Each is a
+   coherent per-subsystem `@MainActor`/Sendable decision, buildable-verified.
+4. **Re-measure → 0**, then Phase C (`SWIFT_VERSION 6.0`) per the plan doc.
+
+## 4. Deferred specifics worth not re-deriving
+
+- `MainActor.assumeIsolated`-in-`deinit` is BANNED (deinit not guaranteed on-main). One
+  such Wave-1 fix (`BundledHTMLViewController`) was reverted; its warning is deferred.
+- `TPPAlertUtils` (ErrorHandling, 47) carries load-bearing CA-commit-race / transition
+  timing fixes (fe741015, HelpSpot 17716) — its ~40 mixed-isolation callers make a naive
+  `@MainActor` unsafe; needs a buildable cross-module pass, not annotate-only.
+- `TPPBackgroundExecutor` (Utilities) — ObjC background-task lifecycle captures a
+  by-ref `bgTask` across `@Sendable` closures; needs a lifecycle restructure.
+- A few Wave-1 `@Sendable`/`Sendable` additions redistribute warnings INTO deferred
+  critical-path modules (MyBooks 84→95) — harmless under `SWIFT_VERSION=5.0`, resolved
+  in those modules' own passes.


### PR DESCRIPTION
## What
First wave of **Phase B** (`SWIFT_STRICT_CONCURRENCY=complete`) of the Swift 6 modernization: additive, behavior-preserving concurrency annotations across the **18 non-critical modules**, landed via a 10-agent swarm-then-reconcile pass.

**Does NOT flip the strict-concurrency level** (stays `targeted`). These are additive `Sendable`/isolation annotations valid under both modes; the level flip happens later once critical-path modules are also clean.

## Verification
Built locally on the DRM `Palace` scheme **in `complete` mode** (adobe-rmsdk): **BUILD SUCCEEDED**, and distinct app-target concurrency warnings dropped **738 → 473 (265 cleared)**. 65 files, +576/−178, all under `Palace/`.

## Fixes by category
`: Sendable` on value/protocol types · `<T: Sendable>` constraints · `@Sendable` closure params · documented **lock-backed / immutable** `@unchecked Sendable` carriers (no bare ones) · `@MainActor` on UIKit-bound helpers/factories · `@preconcurrency` on delegate conformances · static-mutable-global → `let` / lock-backed holders. **No `nonisolated(unsafe)` introduced.**

Per-module fixed/assigned: ErrorHandling 51/100 · Utilities 66/83 · Settings 36/43 · Accounts 34/48 · Book 29/52 · AppInfrastructure 11/50 · Reader2 10/97 · small modules (Stats/Notif/Samples/PDF/Network/CarPlay/OPDS/Logging/CatalogUI/OPDS2/ReaderStreaming) ~56.

## Scope
Only the 18 non-critical modules. Skipped: files owned by in-flight PRs (#1163 AdobeDRM/CarPlay, #1165 BookRegistrySync/OPDSFeedService) and the auth-decision-critical `TPPNetworkResponder`/`TPPNetworkExecutor`.

## Not done (deferred, tracked)
- **Critical-path modules** — MyBooks (95), SignInLogic (62), Audiobooks (39) → their own rigorous architect+SoD PRs (money/access; must not be blind-swarmed). **Phase B is NOT complete — this is Wave 1.**
- **Structural clusters** needing a coherent per-class decision, left as warnings (harmless under `SWIFT_VERSION=5.0`): Reader2 core reader-VC/TTS/DRM-cert isolation (79); ErrorHandling `TPPAlertUtils` cross-module `@MainActor` pass (47 — load-bearing alert-timing code); AppInfrastructure DI-root global state (37).
- **Big shared-type Sendable decisions** surfaced by multiple agents — `Account`, `AccountsManager`, `TPPBookRegistry(Provider)`, `Store.Environment`, Readium `Publication` — each a coordinated follow-up.

## Reviewer notes
- One `MainActor.assumeIsolated`-in-`deinit` (`BundledHTMLViewController`) was **reverted** per the deinit-safety gotcha; 6 remaining `assumeIsolated` uses are all behind main-thread guarantees (PDFKit/AVFoundation delegate callbacks, `Thread.isMainThread` guard, `DispatchQueue.main.async(After)`, `group.notify(.main)`).
- A few `@Sendable`/`Sendable` additions **redistribute** warnings into deferred critical-path modules (e.g. MyBooks 84→95) — harmless warnings under 5.0, resolved in those modules' dedicated passes; **no new compile errors** (build is green).