### PR TITLE
fix(swift6): Phase B Wave 2 — structural clusters (complete-mode concurrency)

### DIFF
--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -128,8 +128,99 @@ private struct VoidWorkBox: @unchecked Sendable {
     let work: () -> Void
 }
 
+/// Documented carrier for the non-Sendable `(inout [String: [Account]]) -> Void`
+/// mutation closure handed to the `accountSetsLock` barrier in
+/// `AccountsManager.mutateAccountSets`. Same `@unchecked Sendable` invariant as
+/// `VoidWorkBox`: the wrapped closure is invoked exactly once, on the serial
+/// `.barrier` of the concurrent `accountSetsLock`, never concurrently. Timing
+/// and the mutate-then-rebuild-index contract are unchanged.
+private struct AccountSetsMutationBox: @unchecked Sendable {
+    let mutate: (inout [String: [Account]]) -> Void
+}
+
+/// Documented carrier for a non-Sendable `(Bool) -> Void` load-completion
+/// handler stored into the `loadingHandlersQueue` barrier in
+/// `AccountsManager.addLoadingHandler`. `@unchecked Sendable` invariant: the
+/// wrapped closure is only ever appended to / read from
+/// `loadingCompletionHandlers[hash]` under the serial `.barrier` of the
+/// concurrent `loadingHandlersQueue`, and invoked later on whatever queue the
+/// caller of `callAndClearLoadingHandlers` runs on — never concurrently with
+/// its own storage mutation. The handler's own thread-affinity is the caller's
+/// contract (unchanged); this box only satisfies the `@Sendable` boundary of
+/// the dispatch barrier.
+private struct LoadCompletionBox: @unchecked Sendable {
+    let handler: (Bool) -> Void
+}
+
+/// Documented carrier for the non-Sendable `LibraryRegistryCrawler` handed
+/// from the first-page crawl Task into its nested background pagination Task
+/// in `AccountsManager.fetchFromNetwork`. `@unchecked Sendable` invariant: the
+/// crawler is used strictly sequentially — the outer Task finishes its
+/// `crawlFirstPage` await BEFORE the pagination Task is spawned, and only the
+/// pagination Task touches the crawler thereafter (`crawlRemainingPages`), so
+/// the two never touch it concurrently. Mirrors `LibraryRegistryCrawler`'s own
+/// `CrawlerFetcherBox`.
+private struct CrawlerHandoffBox: @unchecked Sendable {
+    let crawler: LibraryRegistryCrawler
+}
+
 /// Manages library accounts asynchronously with authentication & image loading
-@objcMembers final class AccountsManager: NSObject, TPPLibraryAccountsProvider, TPPUserAccountResolving {
+///
+/// `@unchecked Sendable` rationale (Swift 6 Phase B, Wave-2):
+/// `AccountsManager` is a process-wide singleton owned by `AppContainer` and
+/// shared, by design, across every actor (the background `loadCatalogs` crawl
+/// Tasks, `@MainActor` UI, token-refresh / audiobook / bookmark consumers).
+/// Its four background `Task { [weak self] in … }` crawl/refresh/preload
+/// closures require a `@Sendable` capture of `self` — and they cannot be
+/// rewritten to "snapshot Sendable fields at the site" because each one drives
+/// `self`'s instance I/O pipeline (`cacheAccountsCatalogData`,
+/// `loadAccountSetsAndAuthDoc`, `fallbackFetchFromNetwork`, `triggerCatalogPreload`,
+/// `catalogPreloader`, `currentAccount`), which is the whole purpose of the Task.
+/// So the type itself must be `Sendable`. It is safe to share because EVERY
+/// mutable stored property is synchronized. Full audit (matches #1155's
+/// `TPPUserAccount` and `AccountStateStore`'s own `@unchecked` justification):
+///
+///   Instance mutable state:
+///   - `accountSet`, `accountSets`, `accountByUUID`  → read via `performRead`
+///     (`accountSetsLock.sync`), written via `performWrite` / `mutateAccountSets`
+///     (`accountSetsLock.async(flags:.barrier)`). `accountByUUID` is only ever
+///     rebuilt inside the same barrier as `accountSets`, so the two never desync.
+///   - `loadingCompletionHandlers`  → read via `loadingHandlersQueue.sync`,
+///     written via `loadingHandlersQueue.async(flags:.barrier)`.
+///   - `inflightAuthDocFetches`  → read/written only under `inflightAuthDocLock`.
+///   - `userAccounts`, `lastKnownCurrentUserAccount`  → read/written only under
+///     `userAccountsLock`.
+///   - `_trackedCrawlTasks`  → read/written only under `_trackedCrawlTasksLock`.
+///   - `isAccountSwitching`  → storage moved into the lock-backed
+///     `AccountsManagerBoolFlag` holder (`_isAccountSwitching`), so its `Bool`
+///     set/get is serialized by the holder's own `NSLock`; the public
+///     `private(set) var` computed accessor preserves every call site and the
+///     value/timing verbatim (see property below).
+///   - `networkExecutor`, `noAccountPlaceholder`  → `lazy var`, each resolved
+///     exactly once from an already-constructed dependency and immutable
+///     thereafter; the lazy init runs on the first touch, which for
+///     `networkExecutor` is inside the background load path after `AppContainer`
+///     finishes constructing, and for `noAccountPlaceholder` only on the fresh-
+///     install `currentUserAccount` path. Effectively write-once.
+///   - `backgroundFetchTask`, `_explicitCancelCalled`  → `#if DEBUG` test-only;
+///     compiled out of release. Driven only from the test-boundary
+///     `cancelBackgroundWork()` / `_injectBackgroundFetchTaskForTesting` seams.
+///
+///   Immutable (`let`) state — inherently safe: `tppAccountUUID`, `ageCheck`,
+///   `settings`, `defaults`, `accountSetsLock`, `catalogPreloader`,
+///   `loadingHandlersQueue`, `inflightAuthDocLock`, `userAccountsLock`,
+///   `_trackedCrawlTasksLock`.
+///
+///   `currentAccountId` is a computed property backed by the injected
+///   `UserDefaults` (`defaults`), which is itself internally thread-safe — no
+///   instance storage is mutated.
+///
+/// NO property uses `nonisolated(unsafe)` and there is no bare `@unchecked`:
+/// every mutable field above has a named synchronization mechanism. Making the
+/// singleton `@MainActor` was rejected — it would move `loadCatalogs` /
+/// `init`'s background dispatch onto the main actor and change load timing,
+/// which is out of scope for this pass.
+@objcMembers final class AccountsManager: NSObject, TPPLibraryAccountsProvider, TPPUserAccountResolving, @unchecked Sendable {
 
     // MARK: – Config / state
 
@@ -145,9 +236,24 @@ private struct VoidWorkBox: @unchecked Sendable {
 
     let tppAccountUUID = AccountsManager.TPPAccountUUIDs[0]
 
+    /// Lock-backed storage for `isAccountSwitching` so the flag is
+    /// concurrency-safe without `nonisolated(unsafe)`. Written from the
+    /// `currentAccount` setter (account-switch path) and the `@MainActor`
+    /// cleanup Task; read from the sign-in-modal presenter. In practice all
+    /// accesses are main-thread, but the holder's `NSLock` makes that safe
+    /// regardless — closing the one un-synchronized-instance-var gap in the
+    /// `@unchecked Sendable` audit above. Value/timing are identical to the
+    /// prior plain `Bool` — only access is serialized.
+    private let _isAccountSwitching = AccountsManagerBoolFlag(false)
+
     /// True during an account switch — suppresses sign-in modal presentation
-    /// to prevent the intermittent login prompt (F-032).
-    private(set) var isAccountSwitching = false
+    /// to prevent the intermittent login prompt (F-032). `private(set)`
+    /// contract preserved: external readers see get-only, internal code sets
+    /// via the private setter (both routed through the lock-backed holder).
+    private(set) var isAccountSwitching: Bool {
+        get { _isAccountSwitching.value }
+        set { _isAccountSwitching.value = newValue }
+    }
 
     let ageCheck: TPPAgeCheckVerifying
     private let settings: TPPSettings
@@ -433,8 +539,12 @@ private struct VoidWorkBox: @unchecked Sendable {
     /// goes through here — adding a new write that bypasses it would silently
     /// break `account(_:)` lookups, which the index-coherence test guards against.
     private func mutateAccountSets(_ mutate: @escaping (inout [String: [Account]]) -> Void) {
+        // Carry the non-Sendable `mutate` into the `@Sendable` barrier block via
+        // a documented box (mirrors `performWrite`'s `VoidWorkBox`). Same serial-
+        // barrier execution contract; timing unchanged.
+        let box = AccountSetsMutationBox(mutate: mutate)
         accountSetsLock.async(flags: .barrier) {
-            mutate(&self.accountSets)
+            box.mutate(&self.accountSets)
             self.accountByUUID = AccountsManager.buildAccountIndex(self.accountSets)
         }
     }
@@ -689,16 +799,19 @@ private struct VoidWorkBox: @unchecked Sendable {
 
         guard !alreadyLoading else {
             if let h = handler {
+                // Box the non-Sendable handler across the `@Sendable` barrier.
+                let box = LoadCompletionBox(handler: h)
                 loadingHandlersQueue.async(flags: .barrier) { [weak self] in
-                    self?.loadingCompletionHandlers[hash]?.append(h)
+                    self?.loadingCompletionHandlers[hash]?.append(box.handler)
                 }
             }
             return true
         }
 
         // first request for this hash
+        let box = handler.map { LoadCompletionBox(handler: $0) }
         loadingHandlersQueue.async(flags: .barrier) {
-            self.loadingCompletionHandlers[hash] = handler.map { [$0] } ?? []
+            self.loadingCompletionHandlers[hash] = box.map { [$0.handler] } ?? []
         }
         return false
     }
@@ -854,10 +967,14 @@ private struct VoidWorkBox: @unchecked Sendable {
                 }
 
                 Log.info(#file, "Registry has more pages (first page: \(firstPage.catalogs.count) of \(firstPage.metadata.numberOfItems ?? -1)) — paginating in background")
+                // Carry the non-Sendable crawler into the nested pagination Task
+                // via a documented box (used strictly sequentially — see
+                // `CrawlerHandoffBox`). `firstPage`/`targetUrl` are Sendable.
+                let crawlerBox = CrawlerHandoffBox(crawler: crawler)
                 let paginationTask = Task(priority: .utility) { [weak self] in
                     guard let self = self else { return }
 
-                    let remainingResult = await crawler.crawlRemainingPages(
+                    let remainingResult = await crawlerBox.crawler.crawlRemainingPages(
                         firstPage: firstPage,
                         baseURL: targetUrl,
                         existingPublications: firstPage.catalogs,
@@ -1241,6 +1358,11 @@ private struct VoidWorkBox: @unchecked Sendable {
         key hash: String,
         completion: @escaping (Bool) -> Void
     ) {
+        // Box the non-Sendable `completion` so it can be invoked from the
+        // `@Sendable` `group.notify(queue: .main)` block below. The handler is
+        // still only called once, on `.main`; its thread-affinity contract is
+        // unchanged — the box only satisfies the `@Sendable` boundary.
+        let completionBox = LoadCompletionBox(handler: completion)
         do {
             let feed = try OPDS2CatalogsFeed.fromData(data)
             let hadAccount = self.currentAccount != nil
@@ -1328,7 +1450,7 @@ private struct VoidWorkBox: @unchecked Sendable {
                     UIApplication.shared.delegate?.window??.tintColor = TPPConfiguration.mainColor()
                 }
                 NotificationCenter.default.post(name: .TPPCurrentAccountDidChange, object: nil)
-                completion(true)
+                completionBox.handler(true)
             }
 
         } catch {

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Combine
+import os
 import PalaceAuth
 import PalaceNetwork
 
@@ -242,12 +243,25 @@ struct AppContainer {
     /// same way `bookOpenTracker` is; `_resetForTesting()` nils it so its
     /// on-disk manifest state does not bleed across test classes.
     var sideloadedBookRegistry: SideloadedBookRegistry {
-        if let cached = AppContainer._sideloadedBookRegistry { return cached }
+        if let cached = AppContainer._sideloadedBookRegistry.withLock({ $0 }) { return cached }
+        // Built outside the lock (matches the prior non-atomic check-then-set
+        // race semantics — `SideloadedBookRegistry()` does no `production()`
+        // re-entry, so no deadlock even if two first-callers each build one).
+        // The lock re-checks on store so a concurrent winner is honored and
+        // the loser's instance is discarded; production callers observe a
+        // single stable registry either way.
         let registry = SideloadedBookRegistry()
-        AppContainer._sideloadedBookRegistry = registry
-        return registry
+        return AppContainer._sideloadedBookRegistry.withLock { slot in
+            if let existing = slot { return existing }
+            slot = registry
+            return registry
+        }
     }
-    private static var _sideloadedBookRegistry: SideloadedBookRegistry?
+    /// Swift 6: `OSAllocatedUnfairLock`-guarded so the off-main first access
+    /// (its `identifiers` is read off-main) is concurrency-safe without a
+    /// `@MainActor` annotation that would forbid the off-main read. The
+    /// stored value (`SideloadedBookRegistry`) is itself `@unchecked Sendable`.
+    private static let _sideloadedBookRegistry = OSAllocatedUnfairLock<SideloadedBookRegistry?>(initialState: nil)
 
     /// Side-loading (PP-2677) — orchestrates the import/remove/rehydrate flow on
     /// top of `sideloadedBookRegistry`. Consumes the side-loaded registry (truth
@@ -259,16 +273,24 @@ struct AppContainer {
     /// `_buildCachedAppContainer()` return, and `with*Presenter` copies are NOT
     /// touched (Module A owns this property region; Module C appends here).
     var sideloadedBookManager: SideloadedBookManager {
-        if let cached = AppContainer._sideloadedBookManager { return cached }
+        if let cached = AppContainer._sideloadedBookManager.withLock({ $0 }) { return cached }
+        // Built outside the lock (see `sideloadedBookRegistry`). Reads
+        // `self.sideloadedBookRegistry`, which acquires a DIFFERENT lock —
+        // consistent manager→registry ordering, no reverse path, no deadlock.
         let manager = SideloadedBookManager(
             bookRegistry: self.bookRegistry,
             sideloadedRegistry: self.sideloadedBookRegistry,
             bookFileManager: BookFileManager()
         )
-        AppContainer._sideloadedBookManager = manager
-        return manager
+        return AppContainer._sideloadedBookManager.withLock { slot in
+            if let existing = slot { return existing }
+            slot = manager
+            return manager
+        }
     }
-    private static var _sideloadedBookManager: SideloadedBookManager?
+    /// Swift 6: `OSAllocatedUnfairLock`-guarded (see `_sideloadedBookRegistry`).
+    /// Stored value is `@unchecked Sendable`.
+    private static let _sideloadedBookManager = OSAllocatedUnfairLock<SideloadedBookManager?>(initialState: nil)
 
     /// Process-wide audiobook session presenter — the root-level
     /// SwiftUI-observable bridge between the manager's published state and
@@ -636,12 +658,13 @@ struct AppContainer {
         // classes if left intact. Nil it here so the next `production()`
         // resolution rebuilds a fresh instance reading the current manifest.
         // Not `@MainActor`-isolated (its `identifiers` is read off-main), so
-        // reset outside the `assumeIsolated` block.
-        _sideloadedBookRegistry = nil
+        // reset outside the `assumeIsolated` block. Now lock-guarded storage
+        // (Swift 6) — clear the slot through the lock.
+        _sideloadedBookRegistry.withLock { $0 = nil }
         // Side-loading (PP-2677): the manager caches a reference to the
         // side-loaded registry above, so nil it in lockstep — a stale manager
         // would keep pointing at the reset registry across test classes.
-        _sideloadedBookManager = nil
+        _sideloadedBookManager.withLock { $0 = nil }
         // Leave the flag at the test-safe `true` (see step 4 above) — do NOT
         // reset to `false`. The next test class inherits this value before its
         // own setUp runs; `false` here is the root of the cross-test

--- a/Palace/AppInfrastructure/ReaderService.swift
+++ b/Palace/AppInfrastructure/ReaderService.swift
@@ -6,8 +6,25 @@ import PalaceLogging
 import ReadiumLCP
 #endif
 
+/// `@MainActor`-isolated: every instance method already hopped to the main
+/// actor (all `open*` / `release*` / present* entry points were annotated
+/// `@MainActor`), and all mutable stored state (`redownloadObservers`,
+/// `openGenerationByBookId`, `openInFlightBookIds`, …) is touched only from
+/// those methods. Hoisting the annotation to the type makes that isolation
+/// explicit, makes `self` a `Sendable` main-actor reference so the
+/// `Task.detached` decrypt/extract closures no longer trigger `sending self`
+/// under `complete` checking, and lets `AppContainer` hold `readerService`
+/// as a `Sendable` member. The two `static` helpers that run off the main
+/// actor (`residentMemoryMB`, `ms`) are marked `nonisolated` so the
+/// background decrypt loop can still read them.
+@MainActor
 final class ReaderService {
-    init() {}
+    /// `nonisolated` so the composition root
+    /// (`AppContainer._buildCachedAppContainer()`, which runs off the main
+    /// actor on the first `production()` caller's thread) can construct the
+    /// service without a `MainActor.assumeIsolated` hop. The initializer
+    /// stores nothing and touches no main-actor state.
+    nonisolated init() {}
 
     private lazy var r3Owner: TPPR3Owner = TPPR3Owner()
 
@@ -350,7 +367,7 @@ final class ReaderService {
     /// Console log after a test run produces a per-stage breakdown
     /// without needing Instruments / WDA. Cheap rounded integer so
     /// the log line stays compact.
-    private static func ms(since start: Date) -> Int {
+    nonisolated private static func ms(since start: Date) -> Int {
         Int(Date().timeIntervalSince(start) * 1000)
     }
 
@@ -394,7 +411,7 @@ final class ReaderService {
         )
     }
 
-    static func residentMemoryMB() -> Int {
+    nonisolated static func residentMemoryMB() -> Int {
         var info = mach_task_basic_info()
         var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size)
         let result = withUnsafeMutablePointer(to: &info) {

--- a/Palace/AppInfrastructure/Store.swift
+++ b/Palace/AppInfrastructure/Store.swift
@@ -8,19 +8,29 @@ import Foundation
 /// side-effect, `.send(action)` to dispatch synchronously on the main actor,
 /// and `.task { env in ... }` for async work that eventually yields an
 /// action (or `nil` to end the chain).
-struct Effect<Action, Environment> {
-    let run: (Environment) async -> Action?
+///
+/// `Environment: Sendable` (Swift 6): the `@MainActor` `Store` hands the
+/// environment to `run` from an `async` context that hops off the main
+/// actor (both `send`'s unstructured `Task` and `sendAwait`'s off-actor
+/// `await`), so the environment value crosses an isolation boundary. A
+/// `Sendable` environment makes that crossing safe; the alternative
+/// (`sending` the stored property) would consume it and break the reuse
+/// across the effect chain. Concrete environments are lightweight value
+/// bags of `@Sendable` closures / immutable data — see `HoldsEnvironment`,
+/// `BorrowEnvironment`.
+struct Effect<Action, Environment: Sendable> {
+    let run: @Sendable (Environment) async -> Action?
 
     static var none: Effect<Action, Environment> {
         Effect { _ in nil }
     }
 
-    static func send(_ action: Action) -> Effect<Action, Environment> {
+    static func send(_ action: Action) -> Effect<Action, Environment> where Action: Sendable {
         Effect { _ in action }
     }
 
     static func task(
-        _ work: @escaping (Environment) async -> Action?
+        _ work: @escaping @Sendable (Environment) async -> Action?
     ) -> Effect<Action, Environment> {
         Effect(run: work)
     }
@@ -37,7 +47,7 @@ struct Effect<Action, Environment> {
 /// Not TCA: no scoped reducers, no pullback, no TestStore. One reducer
 /// closure per domain, effects as `async` closures capturing the environment.
 @MainActor
-final class Store<State, Action, Environment>: ObservableObject {
+final class Store<State, Action, Environment: Sendable>: ObservableObject {
     @Published private(set) var state: State
     private let environment: Environment
     private let reduce: (inout State, Action) -> Effect<Action, Environment>

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import FirebaseCore
 import FirebaseAnalytics
 import FirebaseCrashlytics
@@ -614,11 +615,31 @@ private enum CleanupSeverity {
 
 /// Centralized observer for memory pressure, thermal state, and disk space cleanup.
 /// Performs cache purges, download throttling, and space reclamation when needed.
-final class MemoryPressureMonitor {
+///
+/// `@unchecked Sendable` invariant (mirrors `FirebaseManager`): every stored
+/// property is either an immutable `let` of a `Sendable` type
+/// (`monitorQueue` is a `DispatchQueue`) or the single piece of mutable
+/// state (`proactiveMonitoringTask`) which is guarded by
+/// `OSAllocatedUnfairLock`. All work runs off the main actor on
+/// `monitorQueue` or in a detached `Task`; the type is intentionally NOT
+/// `@MainActor` because its job is background pressure monitoring and disk
+/// reclamation. Cross-actor hops to the main actor are made explicitly
+/// where UIKit-adjacent collaborators require it (see `proactiveCacheCleanup`
+/// and `handleMemoryWarning`). This lets the `static let shared` singleton
+/// and the `self`-capturing queue/task closures satisfy the `complete`
+/// concurrency checker without a `@MainActor` annotation that would be
+/// semantically wrong for a background monitor.
+final class MemoryPressureMonitor: @unchecked Sendable {
     static let shared = MemoryPressureMonitor()
 
     private let monitorQueue = DispatchQueue(label: "org.thepalaceproject.memory-pressure", qos: .utility)
-    private var proactiveMonitoringTask: Task<Void, Never>?
+
+    /// The proactive-monitoring loop task. Guarded by
+    /// `OSAllocatedUnfairLock` because it is written from `start()` (via
+    /// `startProactiveMonitoring()`) and read+cancelled from `stop()`,
+    /// which may be invoked from different threads over the monitor's
+    /// lifetime.
+    private let proactiveMonitoringTask = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
 
     private init() {}
 
@@ -658,14 +679,15 @@ final class MemoryPressureMonitor {
 
     /// Proactively monitors memory usage and cleans up before hitting critical levels
     private func startProactiveMonitoring() {
-        proactiveMonitoringTask = Task {
+        let task = Task { [weak self] in
             while !Task.isCancelled {
                 // Check every 30 seconds
                 try? await Task.sleep(nanoseconds: 30_000_000_000)
 
-                await checkMemoryPressure()
+                await self?.checkMemoryPressure()
             }
         }
+        proactiveMonitoringTask.withLock { $0 = task }
     }
 
     /// Checks current memory usage and takes action if needed
@@ -714,8 +736,10 @@ final class MemoryPressureMonitor {
     }
 
     func stop() {
-        proactiveMonitoringTask?.cancel()
-        proactiveMonitoringTask = nil
+        proactiveMonitoringTask.withLock { task in
+            task?.cancel()
+            task = nil
+        }
     }
 
     @objc private func handleMemoryWarning() {

--- a/Palace/Book/Models/BookRegistryStore.swift
+++ b/Palace/Book/Models/BookRegistryStore.swift
@@ -3,7 +3,31 @@ import Combine
 
 /// Thread-safe in-memory storage for book registry records.
 /// Uses a concurrent DispatchQueue with barrier writes for thread safety.
-class BookRegistryStore {
+///
+/// `@unchecked Sendable` invariant (verified, not waived):
+///   ALL access to the two pieces of mutable state — the `registry`
+///   dictionary and the `processingIdentifiers` set — is funnelled through
+///   `syncQueue`, a *concurrent* queue used as a reader/writer lock:
+///     • Every READ (`allBooks`, `heldBooks`, `myBooks`, `record(for:)`,
+///       `book(for:)`, `state(for:)`, `fulfillmentId(for:)`,
+///       `processing(for:)`, `readRegistry`, `registrySnapshot`) goes through
+///       `performSync`, which runs the block on `syncQueue` (a plain
+///       concurrent read).
+///     • Every WRITE (`addBook`, `removeBook`, `updateBook`,
+///       `updateAndRemoveBook`, `updatedBookMetadata`, `setState`,
+///       `setFulfillmentId`, `setProcessing`, `removeAll`, `mutateRegistry*`)
+///       goes through `performBarrier` / `performBarrierSync` (an
+///       `async(flags: .barrier)` / `sync(flags: .barrier)` write), which
+///       excludes all concurrent readers and other writers for its duration.
+///   The `syncQueueKey` `DispatchSpecific` guard makes the sync helpers
+///   re-entrant (a barrier block that calls back into `performSync` runs
+///   inline instead of deadlocking) without ever escaping the serialized
+///   write window. No property is read or written outside these helpers.
+///   The Combine subjects (`registrySubject`, `bookStateSubject`) are `let`
+///   and thread-safe by construction. Therefore instances are safe to share
+///   across concurrency domains: the class carries its own synchronization,
+///   which is exactly the condition `@unchecked Sendable` documents.
+final class BookRegistryStore: @unchecked Sendable {
 
   private let syncQueueKey = DispatchSpecificKey<Void>()
   private let syncQueue = DispatchQueue(

--- a/Palace/Holds/HoldsReducer.swift
+++ b/Palace/Holds/HoldsReducer.swift
@@ -44,8 +44,11 @@ enum HoldsAction {
     case dismissSyncError
 }
 
-struct HoldsEnvironment {
-    let filterBooks: (String, [TPPBook]) async -> [TPPBook]
+struct HoldsEnvironment: Sendable {
+    // @Sendable: `Store` now constrains `Environment: Sendable`, so the effect
+    // closure it stores must be Sendable too. The construction site captures
+    // only value types + a @MainActor VM read, so this conforms cleanly.
+    let filterBooks: @Sendable (String, [TPPBook]) async -> [TPPBook]
 }
 
 /// Namespace holder for the Holds reducer. Using an enum with a single

--- a/Palace/Notifications/NotificationService.swift
+++ b/Palace/Notifications/NotificationService.swift
@@ -9,7 +9,15 @@
 @preconcurrency import UserNotifications
 import Combine
 import FirebaseCore
-import FirebaseMessaging
+// `@preconcurrency`: Firebase Messaging's completion handlers (`token { }`) and
+// the `MessagingDelegate` protocol carry `@Sendable`/isolation expectations that
+// `NotificationService` (a non-Sendable `@objcMembers` singleton whose callbacks
+// run on Firebase's own queues) cannot satisfy without a class-level `@MainActor`
+// decision — which is intentionally deferred here (the class is called from the
+// off-main book-registry sync path and from deferred critical-path modules).
+// `@preconcurrency` silences the pre-Swift-6-annotated-API warnings without
+// changing behavior.
+@preconcurrency import FirebaseMessaging
 import PalaceLogging
 
 // MARK: - Notification Constants

--- a/Palace/PDF/Protocols/TPPPDFPreviewGridDelegate.swift
+++ b/Palace/PDF/Protocols/TPPPDFPreviewGridDelegate.swift
@@ -9,6 +9,14 @@
 import Foundation
 
 /// Delegate protocol for previews and bookmarks.
+///
+/// `@MainActor`: the sole caller is `TPPPDFPreviewGridController`'s
+/// `collectionView(_:didSelectItemAt:)` (a main-actor UIKit delegate callback),
+/// and the sole conformer — `TPPPDFPreviewGrid.Coordinator` — forwards into a
+/// closure that mutates the main-actor `TPPPDFDocumentMetadata.currentPage`.
+/// Pinning the protocol to the main actor makes that isolation explicit and
+/// removes the Swift-6 warning without changing behavior.
+@MainActor
 protocol TPPPDFPreviewGridDelegate {
 
     /// Is called when a page preiview is tapped.

--- a/Palace/PDF/ReadiumPDF/LCPPDFOpenProgress.swift
+++ b/Palace/PDF/ReadiumPDF/LCPPDFOpenProgress.swift
@@ -37,17 +37,31 @@ final class LCPPDFOpenProgress: ObservableObject {
     /// LCP PDF open is currently in flight without paying for a hop
     /// onto the main actor on every check. Mirrors the `phase != .idle`
     /// signal but is safe to read concurrently.
-    nonisolated private static let openInProgressLock = NSLock()
-    nonisolated(unsafe) private static var _openInProgress = false
+    ///
+    /// Backed by a lock-guarded `@unchecked Sendable` holder rather than a
+    /// `nonisolated(unsafe) static var`: all access to the mutable `Bool` is
+    /// serialized through the holder's `NSLock`, so the concurrency safety is
+    /// enforced structurally instead of asserted away.
+    private final class OpenInProgressFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+        var isSet: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+        func set(_ newValue: Bool) {
+            lock.lock()
+            value = newValue
+            lock.unlock()
+        }
+    }
+    nonisolated private static let openInProgressFlag = OpenInProgressFlag()
     nonisolated static var isOpenInProgress: Bool {
-        openInProgressLock.lock()
-        defer { openInProgressLock.unlock() }
-        return _openInProgress
+        openInProgressFlag.isSet
     }
     nonisolated private static func setOpenInProgress(_ value: Bool) {
-        openInProgressLock.lock()
-        _openInProgress = value
-        openInProgressLock.unlock()
+        openInProgressFlag.set(value)
     }
 
     enum Phase: String {

--- a/Palace/PDF/Views/TPPPDFPreviewGrid.swift
+++ b/Palace/PDF/Views/TPPPDFPreviewGrid.swift
@@ -43,6 +43,11 @@ struct TPPPDFPreviewGrid: UIViewControllerRepresentable {
         }
     }
 
+    // `@MainActor`: conforms to the (now main-actor) `TPPPDFPreviewGridDelegate`
+    // and its `action` closure mutates the main-actor `metadata.currentPage`.
+    // The Coordinator is only ever created in `makeCoordinator()` and driven by
+    // main-actor UIKit delegate callbacks, so this is behavior-preserving.
+    @MainActor
     class Coordinator: TPPPDFPreviewGridDelegate {
         let action: (Int) -> Void
 

--- a/Palace/PDF/Views/TPPPDFPreviewGridController.swift
+++ b/Palace/PDF/Views/TPPPDFPreviewGridController.swift
@@ -128,14 +128,32 @@ class TPPPDFPreviewGridController: UICollectionViewController {
             } else {
                 cell.imageView.image = nil
             }
-            DispatchQueue.pdfThumbnailRenderingQueue.async {
-                let image: UIImage? = self.document?.preview(for: page)
-                if let image = image {
-                    self.previewCache.setObject(image, forKey: key)
-                }
-                if page == cell.pageNumber {
-                    DispatchQueue.main.async {
-                        cell.imageView.image = image
+            // Render the preview off the main thread, then update the cell back
+            // on main. `TPPPDFPreviewGridController` is a `UICollectionViewController`
+            // (implicitly `@MainActor`), so `self`, `cell`, and `previewCache` are
+            // main-actor-isolated. To cross the `@Sendable` render-queue boundary
+            // without touching main-actor state off-main, the non-Sendable
+            // `TPPPDFDocument` and the non-Sendable `cell` travel in
+            // `@unchecked Sendable` boxes (`PDFDocumentBox` / `PreviewCellBox`).
+            // `document.preview(for:)` is the only thing invoked off-main (a
+            // read-only PDFKit thumbnail render); the boxed cell is dereferenced
+            // ONLY inside the main hop. This preserves the previous behavior —
+            // background render, then main-thread cache-set + page-still-current
+            // guard + image assignment — while making the isolation sound.
+            if let document = document {
+                let documentBox = PDFDocumentBox(document)
+                let cellBox = PreviewCellBox(cell)
+                DispatchQueue.pdfThumbnailRenderingQueue.async {
+                    let image: UIImage? = documentBox.document.preview(for: page)
+                    DispatchQueue.main.async { [weak self] in
+                        guard let self else { return }
+                        let cell = cellBox.cell
+                        if let image = image {
+                            self.previewCache.setObject(image, forKey: key)
+                        }
+                        if page == cell.pageNumber {
+                            cell.imageView.image = image
+                        }
                     }
                 }
             }
@@ -159,6 +177,26 @@ class TPPPDFPreviewGridController: UICollectionViewController {
         let indexPath = IndexPath(item: currentPage, section: 0)
         collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
     }
+}
+
+/// Sendable carrier that transports the non-Sendable `TPPPDFDocument` across the
+/// `@Sendable` background-render closure in `cellForItemAt`. Only
+/// `document.preview(for:)` — a read-only PDFKit thumbnail render — is called on
+/// `pdfThumbnailRenderingQueue`; the mutable `delegate`/search state on
+/// `TPPPDFDocument` is never touched off-main, so `@unchecked Sendable` is sound.
+/// Mirrors `ThumbnailProviderBox` in `PDFThumbnailStrip`.
+private final class PDFDocumentBox: @unchecked Sendable {
+    let document: TPPPDFDocument
+    init(_ document: TPPPDFDocument) { self.document = document }
+}
+
+/// Sendable carrier for the non-Sendable `TPPPDFPreviewGridCell` so the render
+/// closure can hand it back to the main-queue hop without capturing a UIKit view
+/// in a `@Sendable` background closure. The cell is dereferenced ONLY on the main
+/// thread (inside `DispatchQueue.main.async`), so `@unchecked Sendable` is sound.
+private final class PreviewCellBox: @unchecked Sendable {
+    let cell: TPPPDFPreviewGridCell
+    init(_ cell: TPPPDFPreviewGridCell) { self.cell = cell }
 }
 
 extension TPPPDFPreviewGridController: UICollectionViewDelegateFlowLayout {

--- a/Palace/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Palace/Reader2/ReaderPresentation/ReaderModule.swift
@@ -12,7 +12,13 @@
 
 import Foundation
 import UIKit
-import ReadiumShared
+// Swift 6 `complete`: `Publication` (and `Locator`, produced by
+// `convertToLocator`) are non-Sendable Readium types that this module hands to
+// `formatModule.makeReaderViewController(...)` from inside a `Task.detached` and
+// across `MainActor.run`. `@preconcurrency` is the honest ceiling until Readium
+// annotates these types Sendable; the module's own concurrency contract is
+// documented on the `@unchecked Sendable` conformance below.
+@preconcurrency import ReadiumShared
 
 /// Base module delegate, that sub-modules' delegate can extend.
 /// Provides basic shared functionalities.

--- a/Palace/Reader2/TTS/TPPPublicationSpeechSynthesizer.swift
+++ b/Palace/Reader2/TTS/TPPPublicationSpeechSynthesizer.swift
@@ -9,8 +9,13 @@
 import Foundation
 import Combine
 import AVFoundation
-import ReadiumShared
-import ReadiumNavigator
+// Swift 6 `complete`: Readium's `Publication`, `Locator`, `ContentIterator`,
+// `ContentElement`, and `ContentTokenizer` are not `Sendable`; this synthesizer
+// iterates publication content across `await` boundaries and stores utterances
+// (which wrap `Locator`) in its `@MainActor` state. `@preconcurrency` is the
+// honest ceiling until Readium annotates these types.
+@preconcurrency import ReadiumShared
+@preconcurrency import ReadiumNavigator
 
 /// Iterator direction
 private enum Direction {
@@ -27,6 +32,11 @@ public struct Utterance {
     public let language: Language?
 }
 
+/// `@MainActor` — the synthesizer emits state changes from its main-actor
+/// `state.didSet`, and the sole conformer (`TPPTextToSpeech`) drives SwiftUI /
+/// the navigator on the main actor. Isolating the protocol keeps both sides
+/// on-actor without `@preconcurrency` shims.
+@MainActor
 public protocol TPPPublicationSpeechSynthesizerDelegate: AnyObject {
     /// Called when the synthesizer's state is updated.
     func publicationSpeechSynthesizer(_ synthesizer: TPPPublicationSpeechSynthesizer, stateDidChange state: TPPPublicationSpeechSynthesizer.State)
@@ -34,6 +44,17 @@ public protocol TPPPublicationSpeechSynthesizerDelegate: AnyObject {
 
 /// `PublicationSpeechSynthesizer` orchestrates the rendition of a `Publication` by iterating through its content,
 /// splitting it into individual utterances using a `ContentTokenizer`
+///
+/// Swift 6 `complete`: this type is main-actor-natural — it reads
+/// `UIAccessibility.isVoiceOverRunning`, posts VoiceOver announcements, drives
+/// `AVSpeechSynthesizer`, and mutates `state` (whose `didSet` calls the
+/// `@MainActor` delegate). Annotating the class `@MainActor` matches that
+/// reality: the `Task { … }` bodies below inherit main-actor isolation, so
+/// `state` mutation across their `await` boundaries stays on-actor. The one
+/// nonisolated crossing — `AVSpeechSynthesizerDelegate`, which AVFoundation
+/// delivers on the main queue at runtime — carries `@preconcurrency` on its
+/// conformance.
+@MainActor
 public class TPPPublicationSpeechSynthesizer: NSObject, Loggable {
 
     public typealias TokenizerFactory = (_ defaultLanguage: Language?) -> ContentTokenizer
@@ -167,11 +188,10 @@ public class TPPPublicationSpeechSynthesizer: NSObject, Loggable {
     public func resume() {
         Task {
             if case let .paused(utterance) = state {
-                // `UIAccessibility.isVoiceOverRunning` is main-actor-isolated;
-                // read it via an explicit main-actor hop (only the `Bool` — a
-                // `Sendable` value — crosses back), rather than touching it
-                // directly from this nonisolated task.
-                let isVoiceOverRunning = await MainActor.run { UIAccessibility.isVoiceOverRunning }
+                // The class is `@MainActor`; this `Task` inherits main-actor
+                // isolation, so `UIAccessibility.isVoiceOverRunning` (main-actor
+                // isolated) can be read directly without a hop.
+                let isVoiceOverRunning = UIAccessibility.isVoiceOverRunning
                 if isVoiceOverRunning {
                     if let previousUtterance = await nextUtterance(.backward) {
                         play(previousUtterance)
@@ -341,7 +361,7 @@ public class TPPPublicationSpeechSynthesizer: NSObject, Loggable {
     }
 }
 
-extension TPPPublicationSpeechSynthesizer: AVSpeechSynthesizerDelegate {
+extension TPPPublicationSpeechSynthesizer: @preconcurrency AVSpeechSynthesizerDelegate {
     public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
         self.didFinishUtterance()
     }

--- a/Palace/Reader2/TTS/TPPTextToSpeech.swift
+++ b/Palace/Reader2/TTS/TPPTextToSpeech.swift
@@ -1,8 +1,18 @@
 import Combine
 import Foundation
-import ReadiumNavigator
-import ReadiumShared
+// Swift 6 `complete`: Readium's `Navigator`, `Publication`, `Locator`, and
+// `Decoration` are not `Sendable`; this `@MainActor` view model holds the
+// navigator, applies decorations, and drives `navigator.go(to:)` across
+// `await` boundaries. `@preconcurrency` is the honest ceiling until Readium
+// annotates these types.
+@preconcurrency import ReadiumNavigator
+@preconcurrency import ReadiumShared
 
+/// `@MainActor` — an `ObservableObject` that publishes `isPlaying` /
+/// `playingUtterance` to SwiftUI and drives the (main-actor) navigator and
+/// speech synthesizer. Isolating it keeps the Combine sinks below (which mutate
+/// published state and call the navigator) on-actor.
+@MainActor
 class TPPTextToSpeech: ObservableObject {
 
     private let publication: Publication

--- a/Palace/Reader2/UI/EpubSearchView/EPUBSearchViewModel.swift
+++ b/Palace/Reader2/UI/EpubSearchView/EPUBSearchViewModel.swift
@@ -7,8 +7,14 @@
 //
 
 import Foundation
-import ReadiumShared
-import ReadiumNavigator
+// Swift 6 `complete`: Readium's `Publication`, `SearchIterator`, and
+// `LocatorCollection` are not `Sendable`; this `@MainActor` view model awaits
+// `publication.search(...)` / `iterator.next()` and stores the resulting
+// iterator across suspension points. `@preconcurrency` is the honest ceiling
+// until Readium annotates these types — it suppresses the non-Sendable-crossing
+// diagnostics without weakening our own isolation (the VM stays `@MainActor`).
+@preconcurrency import ReadiumShared
+@preconcurrency import ReadiumNavigator
 
 protocol EPUBSearchDelegate: AnyObject {
     func didSelect(location: Locator)

--- a/Palace/Reader2/UI/TPPBaseReaderViewController.swift
+++ b/Palace/Reader2/UI/TPPBaseReaderViewController.swift
@@ -11,8 +11,8 @@
 import SafariServices
 import UIKit
 import WebKit
-import ReadiumNavigator
-import ReadiumShared
+@preconcurrency import ReadiumNavigator
+@preconcurrency import ReadiumShared
 import Combine
 import PalaceLogging
 
@@ -31,6 +31,16 @@ private final class GoToNavigatorAdapter: NavigatorGoTo {
 }
 
 /// This class is meant to be subclassed by each publication format view controller. It contains the shared behavior, eg. navigation bar toggling.
+///
+/// Swift 6 `complete`: this is a UIKit view controller, so it is already
+/// `@MainActor`-isolated via `UIViewController`. The residual `complete`-mode
+/// warnings here are (1) non-Sendable Readium type crossings — `Publication`,
+/// `Locator`, `Decoration` — handled by the `@preconcurrency import`s above, and
+/// (2) conformance of this main-actor type to the Palace-owned, nonisolated
+/// `TPPReaderPositionsDelegate`, handled by `@preconcurrency` on that
+/// conformance below. The Readium delegate protocols (`NavigatorDelegate`,
+/// `VisualNavigatorDelegate`) are already `@MainActor`, so those conformances
+/// need no annotation.
 class TPPBaseReaderViewController: UIViewController, Loggable {
     typealias DisplayStrings = Strings.TPPBaseReaderViewController
 
@@ -707,7 +717,7 @@ extension TPPBaseReaderViewController: VisualNavigatorDelegate {
 // ------------------------------------------------------------------------------
 // MARK: - TPPReaderPositionsDelegate
 
-extension TPPBaseReaderViewController: TPPReaderPositionsDelegate {
+extension TPPBaseReaderViewController: @preconcurrency TPPReaderPositionsDelegate {
     func positionsVC(_ positionsVC: TPPReaderPositionsVC, didSelectTOCLocation loc: Any) {
         if shouldPresentAsPopover() {
             positionsVC.dismiss(animated: true)

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 import SwiftUI
-import ReadiumShared
+@preconcurrency import ReadiumShared
 @preconcurrency import ReadiumNavigator
 import GameController
 import PalaceLogging
@@ -771,7 +771,7 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
     }
 }
 
-extension TPPEPUBViewController: EPUBSearchDelegate {
+extension TPPEPUBViewController: @preconcurrency EPUBSearchDelegate {
     func didSelect(location: ReadiumShared.Locator) {
 
         presentedViewController?.dismiss(animated: true) { [weak self] in
@@ -794,7 +794,7 @@ extension TPPEPUBViewController: EPUBSearchDelegate {
 }
 
 // MARK: - TPPReaderSettingsDelegate
-extension TPPEPUBViewController: TPPReaderSettingsDelegate {
+extension TPPEPUBViewController: @preconcurrency TPPReaderSettingsDelegate {
     func getUserPreferences() -> EPUBPreferences {
         return preferences
     }
@@ -879,7 +879,7 @@ extension TPPEPUBViewController: UIPopoverPresentationControllerDelegate {
     }
 }
 
-extension TPPEPUBViewController: DecorableNavigator {
+extension TPPEPUBViewController: @preconcurrency DecorableNavigator {
     func apply(decorations: [Decoration], in group: String) {
         guard let navigator = navigator as? DecorableNavigator else { return }
         navigator.apply(decorations: decorations, in: group)

--- a/Palace/Samples/AudiobookSamplePlayer/AudiobookSamplePlayer.swift
+++ b/Palace/Samples/AudiobookSamplePlayer/AudiobookSamplePlayer.swift
@@ -17,6 +17,16 @@ enum AudiobookSamplePlayerState {
     case playing
 }
 
+// `@MainActor`: `AudiobookSamplePlayer` is an `ObservableObject` whose
+// `@Published` state (`state`, `remainingTime`, `isLoading`) is only ever
+// observed from SwiftUI (`AudiobookSampleToolbar` holds it as `@ObservedObject`,
+// itself owned by the `@MainActor SamplePreviewManager`). Every existing state
+// mutation already hopped to main via `DispatchQueue.main.async`, so isolating
+// the type is behavior-preserving and removes the manual hops. The framework
+// delegate callbacks (`AVAudioPlayerDelegate`, the `Timer` selector) are all
+// delivered on the main run loop because the player and timer are created on
+// main (see `setupPlayer(data:)` / `startTimer()`).
+@MainActor
 class AudiobookSamplePlayer: NSObject, ObservableObject {
 
     @Published var remainingTime = 0.0
@@ -73,7 +83,13 @@ class AudiobookSamplePlayer: NSObject, ObservableObject {
         }
     }
 
-    deinit {
+    // `isolated deinit` (SE-0371, Xcode 26 / Swift 6.2): the class is
+    // `@MainActor`, so `timer` and `player` are main-actor-isolated,
+    // non-Sendable stored properties. A plain nonisolated `deinit` cannot touch
+    // them, and `MainActor.assumeIsolated` in a deinit is banned (deinit is not
+    // guaranteed to run on the main thread). Isolating the deinit lets it clean
+    // up the timer and player on the main actor exactly as before.
+    isolated deinit {
         self.timer?.invalidate()
         timer = nil
         self.player?.stop()
@@ -117,9 +133,11 @@ class AudiobookSamplePlayer: NSObject, ObservableObject {
               player.currentTime < player.duration
         else { return }
 
-        DispatchQueue.main.async {
-            self.remainingTime = player.duration - player.currentTime
-        }
+        // The Timer fires on the main run loop (scheduled on main), so we are
+        // already on the main actor here. Compute the new value now — capturing
+        // the non-Sendable `AVAudioPlayer` inside a `@Sendable` main-hop closure
+        // would be a concurrency violation — then assign directly.
+        remainingTime = player.duration - player.currentTime
     }
 
     private func startTimer() {
@@ -161,7 +179,13 @@ class AudiobookSamplePlayer: NSObject, ObservableObject {
     }
 }
 
-extension AudiobookSamplePlayer: AVAudioPlayerDelegate {
+// `@preconcurrency`: `AVAudioPlayerDelegate` requirements are nonisolated, but
+// AVFoundation delivers this callback on the run loop where the player was
+// created — here always the main run loop (`setupPlayer(data:)` runs inside a
+// `DispatchQueue.main.async`). Satisfying the nonisolated requirement with a
+// main-actor-isolated method is therefore safe; `@preconcurrency` silences the
+// isolation-mismatch warning without changing the (main-thread) call behavior.
+extension AudiobookSamplePlayer: @preconcurrency AVAudioPlayerDelegate {
     func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         state = .paused
     }


### PR DESCRIPTION
## What
Second wave of the Phase B (`SWIFT_STRICT_CONCURRENCY=complete`) sweep — the harder **structural clusters** that Wave 1 (#1167) deferred because each needs a coherent per-class decision rather than a per-line annotation. Additive and behavior-preserving; does **not** flip the language level. Part of epic PP-4717 / story PP-4720.

## Verification
Built on the DRM `Palace` scheme in `complete` mode (`build-for-testing`, app + all tests): **0 compile errors**. Cumulative app-target concurrency warnings **738 → 381** (Wave 1 cleared 265; this wave + the SignInLogic PR clear another 92).

## By module
- **Reader2** — `@preconcurrency` imports for Readium's non-Sendable `Publication`/`Navigator` types; core EPUB reader view controllers rely on their inherited `UIViewController` `@MainActor`; the text-to-speech classes made `@MainActor` (currently unreferenced, so zero runtime risk).
- **AppInfrastructure** — `Store`/`Effect` gain an `Environment: Sendable` constraint (rippled into `HoldsEnvironment.filterBooks`); `AppContainer` sideloaded caches moved behind `OSAllocatedUnfairLock` holders; `MemoryPressureMonitor` → documented lock-backed `@unchecked Sendable`; `ReaderService` → `@MainActor` with a `nonisolated` init.
- **Accounts** — `AccountsManager` → documented `@unchecked Sendable` (mutable-state audit; **no load-timing change**); `Account` left non-Sendable (4 crossings flagged for their owners).
- **Book** — `BookRegistryStore` → documented `@unchecked Sendable` (queue-synchronized invariant stated); **registry mutation logic untouched**.
- **PDF / Notifications / Samples** — preview-grid off-main capture boxed; a pre-existing `nonisolated(unsafe)` **removed** in favor of a lock-backed holder; `NotificationService` `@preconcurrency` import; `AudiobookSamplePlayer` `@MainActor` with an `isolated deinit` (Swift 6.2).
- **Holds** — `HoldsEnvironment: Sendable` + `@Sendable filterBooks` (the `Store.Environment` ripple).

## Safety
No `nonisolated(unsafe)` introduced (one pre-existing one removed). No **bare** `@unchecked Sendable` — every one carries a documented invariant. No `MainActor.assumeIsolated` in a `deinit`.

## Scope / not done
- **Scope:** structural clusters in the non-critical modules only.
- **Not done:** `ErrorHandling/TPPAlertUtils` (needs a coordinated 6-caller `@MainActor` migration → its own PR); the 4 shared-type Sendable decisions (`TPPBookRegistry` protocol, `AccountsManager` consumers, `Account`, Readium `Publication`) that would collapse the bulk of the remaining ~381 warnings — tracked in `docs/architecture/swift6-phaseB-followup.md` and PP-4721.