### PR TITLE
feat(rating): sentiment gate UI, StoreKit request, feedback path + triggers (PP-4089, PP-4090, PP-4091)

### DIFF
--- a/.forgeos/intent/pp-4089-4090-4091-app-rating-ui.md
+++ b/.forgeos/intent/pp-4089-4090-4091-app-rating-ui.md
@@ -1,0 +1,68 @@
+---
+name: pp-4089-4090-4091-app-rating-ui
+created: 2026-07-02
+author: claude-opus-4-8
+---
+
+**ADR refs:** extends `adr_059bdb6c` (MVVM + Services + Reducers — AppContainer DI
+root; the routing logic is a pure, testable seam on `AppRatingService`). Complies
+with `adr_204fafdd` (superpartner-spectrum) and `adr_3e2c6a3c` (present-during-
+transition: the gate is an in-`ZStack` overlay, not a `present()` racing a
+transition coordinator). Touches critical paths `Palace/MyBooks/BorrowOperation.swift`
+and `Palace/Audiobooks/AudiobookLoader.swift` (both in `adr_52261f2a`'s strict
+mutation regex) — trigger hooks there are single-line insertions gated on the
+new service; the risk-bearing decision logic stays in the testable service.
+
+PR 2 of 2 for Epic PP-4086. Adds the sentiment-gate UI (PP-4089), native StoreKit
+request (PP-4090), and feedback path (PP-4091), plus the three positive-moment
+triggers and a Developer Settings force-eligibility/reset hook (enables QA PP-4092
+and the simdrive suite PP-4716). Stacked on the PR 1 branch.
+
+## Claims
+
+- adds SwiftUI `SentimentGateView` in `Palace/AppRating/SentimentGateView.swift` — the "Are you enjoying The Palace Project?" card + the "share feedback?" follow-up, VoiceOver + Dynamic Type + Dark Mode
+- adds `RatingPromptPresenter` (`@MainActor ObservableObject`) in `Palace/AppRating/RatingPromptPresenter.swift` with a published `step: RatingPromptStep?` and the routing methods `handleTrigger(_:)`, `respondPositive()`, `respondNegative()`, `confirmFeedback()`, `declineFeedback()`, `respondAskLater()`, `dismiss()`
+- adds protocol `ReviewRequesting` and `RatingReviewRequester` (SKStoreReviewController wrapper) in `Palace/AppRating/RatingReviewRequester.swift`
+- adds protocol `FeedbackPresenting` and `RatingFeedbackPresenter` (reuses `ProblemReportEmail`, support@thepalaceproject.org, mailto fallback) in `Palace/AppRating/RatingFeedbackPresenter.swift`
+- adds `resetEngagementState()` to `AppRatingService` and a force-eligible bypass in `isEligible(for:)`
+- adds `reset()` to `RatingEngagementTracker`
+- adds `appRatingForceEligibleLocalOverrideKey` + `isAppRatingForceEligible` to `RemoteFeatureFlags`
+- adds `ratingPromptPresenter` lazy-cache registration to `AppContainer` and wires the force-eligible provider into `appRatingService`
+- adds a sentiment-gate overlay layer to `AppTabHostView`'s root `ZStack`
+- adds a "Force rating-prompt eligible" toggle row and a "Reset rating state" action row to `TPPDeveloperSettingsTableViewController`
+- migrates all four `TPPAppStoreReviewPrompt.presentIfAvailable()` end-of-book call sites (both branches of `presentEndOfBookAlert` in `BookAvailabilityFormatter.swift` and `BookDetailViewModel.swift`) to route through `AppRatingService` via `noteBookCompleted()`. This also covers the audiobook completion path, since `AudiobookLoader`'s `playbackCompletionHandler` calls `BookDetailViewModel.presentEndOfBookAlert` — no direct `AudiobookLoader` edit is needed.
+- adds a borrow-succeeded trigger after `announceBorrowSucceeded` in `BorrowOperation.swift`
+- adds an EPUB end-of-book (`totalProgression >= 0.99`) trigger in `TPPEPUBViewController.swift`
+- adds tests under `PalaceTests/AppRating/` for routing, requester, feedback, presenter, and trigger eligibility
+
+## Anti-claims
+
+- does NOT change `RatingEligibilityPolicy` — the PR 1 policy is reused unchanged
+- does NOT present the gate via `.fullScreenCover` or a `present()` racing a transition coordinator (uses an in-`ZStack` overlay)
+- does NOT add XCTest image-snapshot tests — visual regression is covered by the simdrive suite (PP-4716); the XCTest layer stays deterministic behavior/routing tests
+- does NOT offer any incentive for a rating and presents NO custom star-rating UI (only the system prompt) — §5.6.1
+- does NOT change `TPPBookRegistry` public surface
+- does NOT modify the borrow/download state machine in `BorrowOperation` beyond the single post-success trigger call
+- does NOT delete `TPPAppStoreReviewPrompt` (left in place; its call sites are re-routed)
+
+## Files in scope
+
+- Palace/AppRating/SentimentGateView.swift
+- Palace/AppRating/RatingPromptPresenter.swift
+- Palace/AppRating/RatingReviewRequester.swift
+- Palace/AppRating/RatingFeedbackPresenter.swift
+- Palace/AppRating/AppRatingService.swift
+- Palace/AppRating/RatingEngagementTracker.swift
+- Palace/FeatureFlags/RemoteFeatureFlags.swift
+- Palace/AppInfrastructure/AppContainer.swift
+- Palace/AppInfrastructure/AppTabHostView.swift
+- Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+- Palace/Book/UI/BookDetail/BookAvailabilityFormatter.swift
+- Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+- Palace/MyBooks/BorrowOperation.swift
+- Palace/Reader2/UI/TPPEPUBViewController.swift
+- Palace/Utilities/Localization/Strings.swift
+- PalaceTests/AppRating/RatingPromptPresenterTests.swift
+- PalaceTests/AppRating/RatingFeedbackPresenterTests.swift
+- PalaceTests/AppRating/AppRatingServiceOverrideTests.swift
+- Palace.xcodeproj/project.pbxproj

--- a/.forgeos/wall-failures/2026-07-02-pr1167-arch1.md
+++ b/.forgeos/wall-failures/2026-07-02-pr1167-arch1.md
@@ -1,0 +1,107 @@
+---
+date: 2026-07-02
+pr: "#1167"
+source: reviewer-block
+reviewer_ids: []
+changeset_id: ""
+wall: reviewer
+walls: [contract, reviewer]
+severity: high
+wall_status: proposed
+applied_in: ""
+detector_script: "scripts/check-partial-replace-all.py"
+detector_status: queued
+no-detector: ""
+name: wall-failures-2026-07-02-pr1167-arch1
+type: evolving
+status: active
+created: 2026-07-02
+last_refresh: 2026-07-02
+freshness_window: 365d
+owners: [general]
+description: Partial replace_all left 2 of 4 identical call sites unmigrated; a dissatisfied patron on a non-returnable book still hit the raw App Store prompt
+---
+
+# Partial `replace_all` — 2 of 4 identical call sites migrated, claimed as 4
+
+## Finding (verbatim from reviewer / architect)
+
+> BLOCK — incomplete supersession (2 of 4 sites migrated). Both `presentEndOfBookAlert`
+> functions have two branches. The commit migrated only the `if paths.count > 0`
+> branch in each file; the `else` (non-returnable book) branch still calls the old
+> prompt directly: `BookAvailabilityFormatter.swift:92`, `BookDetailViewModel.swift:1231`.
+> Concrete failure: a patron who is *not* enjoying the app finishes a non-returnable
+> book → `SKStoreReviewController` native prompt fires immediately, with no sentiment
+> gate and no "Not really → feedback" diversion. The commit body claims "supersedes
+> the 4 call sites"; only 2 of 4 are migrated.
+
+## What actually happened
+
+The migration replaced `TPPAppStoreReviewPrompt.presentIfAvailable()` with a gated
+call via an Edit using `replace_all: true`. But the two occurrences in each file sit
+at **different indentation** (one nested inside a closure at 16 spaces, one in the
+`else` branch at 12 spaces). The Edit's `old_string` carried the 16-space indentation,
+so `replace_all` matched and replaced only the 16-space occurrences — and reported
+"All occurrences were successfully replaced," which was true *for that exact string*.
+The 12-space `else`-branch sites survived. The commit body and intent both asserted
+"all four" / "the four call sites," so the count read as complete. Build was green
+(the leftover sites still compile — they call a still-existing class), and no test
+covered the non-returnable end-of-book path, so nothing flagged the gap. Only the
+architect's manual `HEAD~1` diff count (4 sites before, 2 replaced) caught it.
+
+## Walls that should have caught it (and why they didn't)
+
+- **contract-reconciliation**: the reconciler parses "migrates the four X call sites"
+  but has no mechanism to *count* the remaining calls to `X` in the tree. It checks
+  that a migration verb + symbol appears in the diff, not that the migration is
+  exhaustive. A "migrate all N" claim with N-2 done reconciles as satisfied.
+- **build / verify-pr**: leftover calls to a still-existing symbol compile cleanly —
+  a partial migration is never a compile error.
+- **TDD / mutation**: no test exercised the `else` (non-returnable, `paths.count == 0`)
+  branch of `presentEndOfBookAlert`, so the surviving old-prompt path was invisible to
+  the suite. Mutation ran on the new files, not on the re-routed legacy call sites.
+- **reviewer**: worked — the architect caught it by diffing against `HEAD~1` and
+  counting. But that is a human count, not a structural guarantee.
+
+## Proposed permanent fix
+
+`scripts/check-partial-replace-all.py` (queued): for each file in the staged diff,
+detect an **identical removed call expression that still has a surviving identical
+occurrence in the same file** — i.e. the diff deletes `Foo.bar(...)` on one line but
+a textually-identical `Foo.bar(...)` remains post-diff in that file. Flag it as a
+likely incomplete `replace_all`. Escape hatch `// no-partial-replace: <reason>` on the
+surviving line for the legitimate "these two calls are intentionally different" case.
+
+Complementary contract clause (applies now, no script): a commit/intent claim of the
+grammar "migrates/supersedes/removes **all** N <symbol> call sites" must be backed by
+`grep -rn '<symbol>' <prod-tree>` returning only the symbol's own definition. Add to
+CLAUDE.md Definition of Done #8 (contract reconciliation): *"An 'all N call sites'
+claim requires a post-migration grep showing zero surviving call sites; paste the
+grep."* This is what the architect did by hand.
+
+## Detector script
+
+**Script:** `scripts/check-partial-replace-all.py`
+**Tests:** `scripts/tests/test_check_partial_replace_all.py`
+**Wired into:** `scripts/verify-pr.sh` + pre-commit hook (queued for follow-up PR).
+
+**What it catches (one paragraph):** a diff hunk that deletes a call expression
+`Ident.method(` (or `Ident(`) from a file while a byte-identical call expression
+survives elsewhere in the same file's post-image. That shape is the fingerprint of an
+indentation-scoped `replace_all` that missed siblings, or a hand edit that changed one
+of N identical sites. Canonical fix: migrate the survivors too, or annotate the
+survivor with `// no-partial-replace:` explaining why it is intentionally not migrated.
+
+**Severity:** high — the escaped instance routed dissatisfied patrons straight to the
+App Store, defeating the feature's core §5.6.1-adjacent purpose on a live path.
+
+## Application log
+
+- 2026-07-02 — BLOCK fix (migrate the 2 `else`-branch sites) applied in the amended
+  PR-2 commit; intent reconciled (removed stale `AudiobookLoader.swift` claim).
+- detector `scripts/check-partial-replace-all.py` queued as a follow-up.
+
+## Related entries
+
+- `2026-05-27-pr1018-*` — the Module-C scope-reduction cluster (completeness claim not
+  reconciling against the diff). Same root class: "claimed done, partially done."

--- a/.forgeos/wall-failures/2026-07-02-pr1168-darkmode-contrast.md
+++ b/.forgeos/wall-failures/2026-07-02-pr1168-darkmode-contrast.md
@@ -1,0 +1,110 @@
+---
+date: 2026-07-02
+pr: "#1168"
+source: near-miss
+reviewer_ids: []
+changeset_id: ""
+wall: verify-pr
+walls: [TDD, verify-pr]
+severity: medium
+wall_status: proposed
+applied_in: ""
+detector_script: ""
+detector_status: no-detector
+no-detector: |
+  Contrast/legibility is a rendered-pixel property, not a static-diff property.
+  A grep/AST check cannot know that `.accentColor` resolves to ~white in this
+  app's dark mode, nor that the resulting fill collides with a `.white` label.
+  The correct gate is a vision review of the actual screenshot in the simdrive
+  loop (added to the flow fixture) plus per-appearance visual baselines — not a
+  source-scanning script.
+name: wall-failures-2026-07-02-pr1168-darkmode-contrast
+type: evolving
+status: active
+created: 2026-07-02
+last_refresh: 2026-07-02
+freshness_window: 365d
+owners: [general]
+description: OCR text-presence assertions passed on a white-on-white dark-mode button; the human-invisible label was caught only by a manual look
+---
+
+# Dark-mode white-on-white button — OCR passed, the label was invisible
+
+## Finding (verbatim from user)
+
+> "are you seeing the button color issue on dark mode?"
+
+The sentiment gate's primary "Yes, I love it!" button rendered as a solid white
+pill with white text in **dark mode** — the label was completely invisible to a
+human. My simdrive validation had reported the gate "renders correctly with all
+3 buttons" because the OCR `observe` marks read "Yes, I love it!" as present.
+
+## What actually happened
+
+`SentimentGateView.primaryButton` used `.background(Color.accentColor)` +
+`.foregroundColor(.white)`. In the Palace app, `Color.accentColor` resolves to
+~white in dark mode (the brand green/blue lives in named color assets, not the
+SwiftUI accent). So the fill was white and the label was white → invisible.
+
+The simdrive OCR pass (`observe` with Set-of-Mark) reads text from the rendered
+glyphs regardless of their contrast against the background — the glyphs ARE
+drawn, just in the same color as the fill. So `contains_text: ["Yes, I love
+it!"]` passed. I reported the run green off the OCR marks WITHOUT looking at the
+actual screenshot pixels. The bug was invisible to text assertions and only
+surfaced when the user (and then I) looked at the image.
+
+Fix: primary button now uses the fixed brand navy `Color.palaceBlueBase`
+(identical in both appearances) + white text; secondary/tertiary use semantic
+`.primary`/`.secondary`. Verified legible in BOTH light and dark via a vision
+review of the rendered screenshots.
+
+## Walls that should have caught it (and why they didn't)
+
+- **TDD**: the XCTest layer is deliberately behavior/routing only — SwiftUI
+  color rendering is not unit-tested (and image-snapshot XCTest is banned here
+  as flaky per CLAUDE.md). So no unit test could catch a contrast bug.
+- **verify-pr / simdrive**: the simdrive flow asserted OCR **text presence**,
+  which is contrast-blind. The flow had no visual/legibility check and no
+  per-appearance baseline, so a white-on-white render passed. The reporting
+  step compounded it: "renders correctly" was claimed off OCR marks, not a look
+  at the pixels.
+
+## Proposed permanent fix
+
+Two-part, both landed/queued:
+
+1. **Mandatory visual check in every simdrive gate flow (landed).** The
+   `app-rating-sentiment-gate.yaml` fixture now carries a `visual_checks:` block
+   requiring a vision review of the rendered screenshot for label legibility
+   (NOT white-on-white / same-color-on-same-color), run in BOTH appearances.
+   Standing rule for authoring any simdrive UI flow: *OCR text presence is
+   necessary but not sufficient — every screen with rendered UI gets a vision
+   review of the actual image, and any flow that renders themed UI runs in both
+   light and dark.*
+
+2. **Per-appearance visual baselines (queued for PP-4716).** Capture
+   `.simdrive/fixtures/baselines/<version>/app-rating-sentiment-gate/<step>.png`
+   for light AND dark once the corrected build ships, and gate regressions via
+   SSIM `replay`. A baseline comparison catches a future white-on-white
+   regression structurally (the pixels change), where OCR cannot.
+
+## No detector — justification
+
+See frontmatter `no-detector`. Contrast is a rendered-pixel property; no static
+source scan can encode "this color pair collides at runtime in this appearance."
+The gate is the vision-in-the-loop review + per-appearance baselines, both in
+the simdrive layer, not a `scripts/check-*.py`.
+
+## Application log
+
+- 2026-07-02 — button-color fix + fixture `visual_checks` applied on PR #1168
+  (branch feature/PP-4089-4090-4091-app-rating-ui). Verified legible in light +
+  dark via screenshot vision review.
+- Per-appearance baselines tracked in PP-4716.
+
+## Related entries
+
+- `2026-07-02-pr1167-arch1.md` — same PR family; that one was "claimed done,
+  partially done" (partial replace_all). This one is "claimed verified,
+  verified-by-the-wrong-signal" (OCR presence instead of visual legibility).
+  Both are reporting-off-an-insufficient-signal failures.

--- a/.simdrive/fixtures/flows/app-rating-sentiment-gate.yaml
+++ b/.simdrive/fixtures/flows/app-rating-sentiment-gate.yaml
@@ -1,0 +1,99 @@
+name: app-rating-sentiment-gate
+description: |
+  Drive the app-rating sentiment gate (Epic PP-4086) via the Developer Settings
+  test hook, and verify both routing branches. Exercises:
+  - PP-4089 (sentiment gate appears with correct copy + 3 buttons)
+  - PP-4090 (positive → native App Store rating prompt renders — system prompt,
+    no custom star UI)
+  - PP-4091 (negative → feedback path to support address, NEVER the App Store)
+  - The force-eligible + trigger + reset debug hooks in Developer Settings.
+
+  PREREQUISITE (set before launch, mirrors QA setup):
+    defaults write org.thepalaceproject.palace showDeveloperSettings -bool true
+    defaults write org.thepalaceproject.palace \
+      RemoteFeatureFlags.appRatingForceEligibleOverride -bool true
+
+  Validated live 2026-07-02 (iOS 26 sim, DEBUG). NOTE: the native
+  SKStoreReviewController prompt DID render in the simulator here — contrary to
+  the original PP-4092 assumption. simdrive can therefore assert the system
+  prompt *appears*; only the actual App Store submission stays production-only.
+
+steps:
+  - id: 01-settings
+    action: "tap text='Settings' (tab bar)"
+    expects:
+      contains_text: ["Settings", "TESTING", "Testing"]
+      tab_bar: ["Catalog", "My Books", "Holds", "Settings"]
+
+  - id: 02-developer-settings
+    action: "tap text='Testing'"
+    expects:
+      title: "Testing"
+      contains_text: ["FEATURE FLAGS", "Force Rating Prompt Eligible", "Trigger Rating Prompt Now", "Reset Rating State"]
+
+  - id: 03-trigger-gate
+    action: "tap text='Trigger Rating Prompt Now'"
+    expects:
+      contains_text: ["Are you enjoying The", "Palace Project?", "Yes, I love it!", "Not really", "Ask me later"]
+
+  # --- Negative branch: never reaches the App Store ---
+  - id: 04-not-really
+    action: "tap text='Not really'"
+    expects:
+      contains_text: ["We're sorry to hear that", "share feedback", "Share feedback", "No thanks"]
+      no_text: ["Yes, I love it!"]
+
+  - id: 05-share-feedback
+    action: "tap text='Share feedback'"
+    expects:
+      # On a sim with no Mail account, ProblemReportEmail's canSendMail() fallback
+      # surfaces the support address. On a device WITH Mail, this is the composer.
+      contains_text: ["support@thepalaceproject.org"]
+      no_text: ["App Store", "Tap a star"]   # negative path must NEVER offer a rating
+
+  - id: 06-dismiss-feedback-fallback
+    action: "tap text='OK'"
+    expects:
+      title: "Testing"
+
+  # --- Positive branch: native App Store prompt ---
+  - id: 07-retrigger
+    action: "tap text='Trigger Rating Prompt Now'"
+    expects:
+      contains_text: ["Are you enjoying The", "Yes, I love it!"]
+
+  - id: 08-yes-native-prompt
+    action: "tap text='Yes, I love it!'"
+    expects:
+      # System StoreKit prompt (renders in sim under DEBUG). Stars + "Not Now".
+      contains_text: ["Enjoying Palace", "Tap a star to rate it on the App Store", "Not Now"]
+
+  - id: 09-dismiss-native
+    action: "tap text='Not Now'"
+    expects:
+      title: "Testing"
+      no_text: ["Tap a star", "Are you enjoying"]
+
+mutation_targets:
+  - file: Palace/AppRating/RatingPromptPresenter.swift
+    lines: [80, 90, 97, 105, 114, 121]
+    rationale: |
+      The routing guards. If handleTrigger's eligibility guard is flipped, the
+      gate would appear (step 03) even when ineligible. If respondNegative's
+      routing is flipped, step 04 would reach the App Store instead of feedback —
+      the invariant this flow exists to protect. If respondPositive is flipped,
+      step 08's native prompt never appears.
+  - file: Palace/AppRating/AppRatingService.swift
+    lines: []
+    rationale: |
+      isEligible's force-eligible short-circuit. If broken, step 03 never shows
+      the gate (force override is the only thing making a fresh install eligible).
+  - file: Palace/Book/UI/BookDetail/BookAvailabilityFormatter.swift
+    lines: [88, 92]
+  - file: Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+    lines: [1227, 1231]
+    rationale: |
+      The 4 supersession sites (both branches). A partial migration here (the
+      arch1 wall-failure) would route a dissatisfied patron on a non-returnable
+      book straight to the raw App Store prompt with no sentiment gate — the exact
+      regression steps 03–05 guard.

--- a/.simdrive/fixtures/flows/app-rating-sentiment-gate.yaml
+++ b/.simdrive/fixtures/flows/app-rating-sentiment-gate.yaml
@@ -35,6 +35,14 @@ steps:
     action: "tap text='Trigger Rating Prompt Now'"
     expects:
       contains_text: ["Are you enjoying The", "Palace Project?", "Yes, I love it!", "Not really", "Ask me later"]
+    # MANDATORY visual check — OCR text presence is NOT enough. A prior bug
+    # rendered the "Yes, I love it!" primary button white-on-white in dark mode:
+    # OCR still read the label (invisible to a human) so text assertions passed.
+    # Every gate step must include a vision review of the rendered screenshot.
+    visual_checks:
+      - "The 'Yes, I love it!' primary button label is legible against its fill (NOT white-on-white / same-color-on-same-color)."
+      - "All three buttons ('Yes, I love it!', 'Not really', 'Ask me later') have visible, readable labels."
+      - "Run in BOTH light and dark appearance (simctl ui <udid> appearance {light,dark}); the check must pass in both."
 
   # --- Negative branch: never reaches the App Store ---
   - id: 04-not-really

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		06A3D1FBD9EAD882D6F86181 /* OPDSFeedCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A97CD1F92B404EA664C6968 /* OPDSFeedCacheTests.swift */; };
 		0725F3E330D15C718C170C94 /* PalaceCatalog in Frameworks */ = {isa = PBXBuildFile; productRef = 7081635582F472450D1A1B85 /* PalaceCatalog */; };
 		07A5AAEF6F9B32DC06C0C3E8 /* AudiobookPlaytimesLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D899B519469E743D48FFACC /* AudiobookPlaytimesLifecycleTests.swift */; };
+		07CF93264C7911AB3EE1550B /* RatingReviewRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F892EAF356E802A7E33A657 /* RatingReviewRequester.swift */; };
 		08089BE4DD377F0F13D14F15 /* FirebaseCrashlyticsBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74362E9DDB10D6F6B404D57 /* FirebaseCrashlyticsBridge.swift */; };
 		0824D44E24B8DFE400C85A7E /* NSString+JSONParse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0824D44D24B8DFE400C85A7E /* NSString+JSONParse.swift */; };
 		0824FA7D0F7C1C1EAD93505E /* TPPReaderPageListBusinessLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A35DE944F78A26A081622BA /* TPPReaderPageListBusinessLogicTests.swift */; };
@@ -84,6 +85,7 @@
 		0E35934574903B31826A7BD3 /* NSURLRequest+NYPLURLRequestAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB8CC29A8C5DFB84187D498 /* NSURLRequest+NYPLURLRequestAdditions.swift */; };
 		0E7C38A8706867B15E679AE4 /* OfflineActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1922D2BAB150025B12F0B341 /* OfflineActionTests.swift */; };
 		0E9BC8790B4478C9BDD28A09 /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C78FDF4D5C0DE3F151FAE5 /* AccessibilityPreferences.swift */; };
+		0F8EFC60E22A72D8D0C7BE61 /* SentimentGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8071F10244E560346A8D3030 /* SentimentGateView.swift */; };
 		10AE92560E641525607F4CE3 /* UIFont+TPPSystemFontOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CD20B0A844EE53B3370192 /* UIFont+TPPSystemFontOverride.swift */; };
 		10B89E606AFEA9DCA89F038E /* TPPBookDetailDownloadFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDA3478B2DF503D6CBD4575 /* TPPBookDetailDownloadFailedView.swift */; };
 		10BDB9803CA69D9968DD25B0 /* StreakView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1D8E96BB21CEA1AB690046 /* StreakView.swift */; };
@@ -113,6 +115,7 @@
 		15E780E11F3F16BC3348D0DB /* BundledRegistrySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E0A5661D94D658E8CDD19F /* BundledRegistrySnapshot.swift */; };
 		15F5D99EB5B18B23BC88B2C8 /* LCPPDFDiskExtract.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2E5B460F60157DE72566D7 /* LCPPDFDiskExtract.swift */; };
 		161DDED234AF46D984276897 /* EmailAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B222C03630C4B2984C38A28 /* EmailAddressTests.swift */; };
+		165C30CC09A69EA31390E6B5 /* RatingReviewRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F892EAF356E802A7E33A657 /* RatingReviewRequester.swift */; };
 		1698C14BA6720F592D8A0834 /* TestAppContainerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F955BD354E7BE3DEFB5B74 /* TestAppContainerFactory.swift */; };
 		16D1246F3608F88A422AE6BA /* SideloadedBookRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F96D2A6AAB3B6C802BDBFCF /* SideloadedBookRegistry.swift */; };
 		16E9A34D3D9D5833B73139CF /* iPadOnMacRMSDKGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20222DD2B8B50BD8CDF984D /* iPadOnMacRMSDKGuardTests.swift */; };
@@ -293,6 +296,7 @@
 		2778A5578F0A472E80098431 /* CarPlayTemplateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B6CFD936164F32A7FD6A84 /* CarPlayTemplateManager.swift */; };
 		2829574961502365B6E6808C /* CoverageGapTests3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913F56D4F2AA03D69839AB40 /* CoverageGapTests3.swift */; };
 		2852B3BF49CF7C61548AD428 /* ErrorLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821943DED462B52FCCF8555A /* ErrorLogging.swift */; };
+		2884699FF9E46A68BEACB258 /* AppRatingServiceOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703200C275C44EC99D42144B /* AppRatingServiceOverrideTests.swift */; };
 		28A0F230E614A06EC16E4213 /* ReadingSessionTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973B633FA62911CD52ED9CB9 /* ReadingSessionTrackerTests.swift */; };
 		28BF883FC0815B62204E2D84 /* OfflineQueueStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A20EB1443A7F62505E2071 /* OfflineQueueStatusView.swift */; };
 		28C3A73CCDA85DD1F28457ED /* AccountsManager+TPPCurrentLibraryAccountProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8673802153960A8CA7EAE753 /* AccountsManager+TPPCurrentLibraryAccountProviding.swift */; };
@@ -776,6 +780,7 @@
 		7B8192A3B4C5D6E7F8091A2B /* BookReturnService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7081A2B3C4D5E6F7081929 /* BookReturnService.swift */; };
 		7B8D9E0F102132435465A1B2 /* BookSignInRedirectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9E0F102132435465A1B2C3 /* BookSignInRedirectHandler.swift */; };
 		7BAD9E66404EC74E86FF4FA9 /* KeyboardNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144BB5C0F2D1B2C0C398BD98 /* KeyboardNavigationHandler.swift */; };
+		7BAE3385DABC17BFFA6BA157 /* RatingPromptPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B60466B2029331616A708B4 /* RatingPromptPresenter.swift */; };
 		7BAEB06552C5C127312C948A /* RuntimeQuiescenceAuditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E793B64D2FB472246D9A244 /* RuntimeQuiescenceAuditor.swift */; };
 		7BF32AE422DD08A70AEE7374 /* PDFKitThumbnailProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44129BCB71E3F6C8F5CE54A4 /* PDFKitThumbnailProvider.swift */; };
 		7C412CCF4234E353860E7FAD /* KeyboardNavigationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1020FD76B5E7EA7D89A58124 /* KeyboardNavigationHandlerTests.swift */; };
@@ -803,6 +808,7 @@
 		83E2CD8FDAA5E6D546BB3276 /* PalaceNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = 2848F02E421F52EA61A35E60 /* PalaceNetwork */; };
 		83E697CE284149F399B8DDD5 /* NetworkClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9942FC82D3E4CC990D870D3 /* NetworkClientMock.swift */; };
 		842AC113654DBB5517F8B000 /* AppTabHostMiniPlayerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E2541AFE374BC6F841E19E /* AppTabHostMiniPlayerIntegrationTests.swift */; };
+		84B09C70B9117792D1D92339 /* RatingPromptPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD7869524EB1DD2F9D6A4D4 /* RatingPromptPresenterTests.swift */; };
 		84B7A3461B84E8FE00584FB2 /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3431B84E8FE00584FB2 /* OFL.txt */; };
 		84B7A3471B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */; };
 		84B7A3481B84E8FE00584FB2 /* OpenDyslexic3-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3451B84E8FE00584FB2 /* OpenDyslexic3-Regular.ttf */; };
@@ -811,6 +817,7 @@
 		8587EB0A7355DFD5E73FC4C8 /* AppLaunchTrackerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6CA6FD20109963823CABD1 /* AppLaunchTrackerExtendedTests.swift */; };
 		85CA12FDD8CAF6227F7040FD /* FindawayChapterStatusGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EABA877790A16435BFD9CC8 /* FindawayChapterStatusGuardTests.swift */; };
 		85E8F8673C54D7999841467A /* LocalFileAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17D1419EA3F2F6BDA0D4B81 /* LocalFileAdapterTests.swift */; };
+		8616DDACA8979FE873AF66C5 /* RatingPromptPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B60466B2029331616A708B4 /* RatingPromptPresenter.swift */; };
 		86BB2A9E88846B9C858D1F5F /* SpyAudiobookSessionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794351D0F625F9610414FA23 /* SpyAudiobookSessionPresenter.swift */; };
 		8753EC265A5DF6362FFF71B9 /* ReadingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B28BFC973E94C02E7E117D /* ReadingSession.swift */; };
 		877C7FD52A41DF842E473359 /* TPPBookmarkDeletionLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0452B249AF7C21DDAACD5C58 /* TPPBookmarkDeletionLog.swift */; };
@@ -936,6 +943,7 @@
 		A6C753810A4D64E933B7B36A /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = SETVM003T260955EF008E1DC3 /* SettingsViewModel.swift */; };
 		A6F47C647E52D22145FB06D2 /* SideloadedBookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94335E63E085BA6718033D06 /* SideloadedBookManager.swift */; };
 		A6FFC495B6F55B158739EE9C /* RatingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9905AB408890B78E7B723F22 /* RatingConfig.swift */; };
+		A725B03CF6619B2EE7F8B26C /* RatingFeedbackPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3640FC284C2E096253CAB7E4 /* RatingFeedbackPresenterTests.swift */; };
 		A7D3A61E77E6B8C0FD9AEA5D /* TypographySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C1C917A6BF4317D7FA6567 /* TypographySettings.swift */; };
 		A7E1CE3367F3C787133E928B /* PalaceCatalog in Frameworks */ = {isa = PBXBuildFile; productRef = 4BDC371B99FCA4E42EEFA3CB /* PalaceCatalog */; };
 		A8131DE3255ED9F6651D1AF6 /* AudioSessionActivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDE63F6732471A2B00D88DC /* AudioSessionActivator.swift */; };
@@ -1052,6 +1060,7 @@
 		BCEBB84F8E655046452697B7 /* ReaderInitialLocationNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB1721A59302ABD56C2667E /* ReaderInitialLocationNavigator.swift */; };
 		BCF3398CEB2C47F09F8ABCFF /* TPPNetworkExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D1A95DE8674E6D83B5A8CA /* TPPNetworkExecutorTests.swift */; };
 		BD6C160472CEFBD15C4F0335 /* RatingEligibilityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E63BC817551861A7A8D75D /* RatingEligibilityPolicy.swift */; };
+		BD71BAF794F984B4C6A3DB66 /* RatingFeedbackPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440B8B1CCFD6A6D539D6AB83 /* RatingFeedbackPresenter.swift */; };
 		BDDA11B0012345CAFEBABE01 /* BookDetailMetadataHydrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDA22B0012345CAFEBABE02 /* BookDetailMetadataHydrationTests.swift */; };
 		BDDCE7092C8357EC27BDE5D8 /* TPPReaderBookmarksReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4C1C2D6591E2D7439CF24 /* TPPReaderBookmarksReadinessTests.swift */; };
 		BE1400B5FB4C9A7072F82038 /* LocalFileAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4B77CEDF228DC03714AD31 /* LocalFileAdapter.swift */; };
@@ -1139,6 +1148,7 @@
 		CDE41C3AEC1783FB1D454686 /* CrossFormatMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFD104EE843356CD66327E6 /* CrossFormatMappingTests.swift */; };
 		CDEC308487806981D7C85FB9 /* SignInModalPresenter+SignInModalPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12CC78F892CA5C26671BE206 /* SignInModalPresenter+SignInModalPresenting.swift */; };
 		CE6ADDAE5A5A4796C2017A19 /* PDFReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A586098465213BD58E11860 /* PDFReaderTests.swift */; };
+		CE7DF18FE79F2222F4EBC5DC /* SentimentGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8071F10244E560346A8D3030 /* SentimentGateView.swift */; };
 		CE9909A4CDA78EEE1B7B1936 /* PlaybackRateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CC0A3CFA3E9E20C65B5C01 /* PlaybackRateTests.swift */; };
 		CECCBCC321A54AC1970A9E15 /* TPPBookRegistryRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E22186CA3D046EA9541D1FE /* TPPBookRegistryRecordTests.swift */; };
 		CF16C9CEFF972B187420D537 /* DownloadAnnouncementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCF14A6A237EADD5978E148 /* DownloadAnnouncementServiceTests.swift */; };
@@ -1184,6 +1194,7 @@
 		D363615844BC602E2E1FFFBE /* AppRatingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B6CEA300F1440914E64EE8 /* AppRatingServiceTests.swift */; };
 		D3B4C5D6E7F8A9B0C1D2E3F4 /* BorrowOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B2C3D4E5F6A7B8C9D0E1F2 /* BorrowOperation.swift */; };
 		D3E4F5A6B7C8D9E0F1A2B3C4 /* DownloadCompletionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E8F9A0B1C2 /* DownloadCompletionParser.swift */; };
+		D3F8580D266C275F7707B35E /* RatingFeedbackPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440B8B1CCFD6A6D539D6AB83 /* RatingFeedbackPresenter.swift */; };
 		D413289F5AAABCA5C1FF5B68 /* MockImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D658439F3483E80A5EAA66A /* MockImageLoader.swift */; };
 		D47EC2412CEC04D24BF6D1C5 /* BookRegistrySync.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEB9F995C87FE2C71DFA9BC /* BookRegistrySync.swift */; };
 		D4E5F6071839405162738495 /* MockSAMLAuthContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F60718394051627384 /* MockSAMLAuthContext.swift */; };
@@ -2059,6 +2070,7 @@
 		09CAC3762A717783DDE755DD /* AudiobookSessionManagerShutdownTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookSessionManagerShutdownTests.swift; sourceTree = "<group>"; };
 		09CF38F572AE4A88961FCA46 /* AudiobookIssueFixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookIssueFixTests.swift; sourceTree = "<group>"; };
 		0ABB253AB7CB4183943EBA6A /* AccountStateStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountStateStore.swift; sourceTree = "<group>"; };
+		0B60466B2029331616A708B4 /* RatingPromptPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingPromptPresenter.swift; sourceTree = "<group>"; };
 		0B9A4E1085F59AB6E4E0AD4C /* SupportSectionDecisionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SupportSectionDecisionTests.swift; sourceTree = "<group>"; };
 		0C33E4BDBC27454AB30FAF96 /* AlertModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertModelTests.swift; sourceTree = "<group>"; };
 		0CD8A9D1E84E9CA99C5DA03D /* ExecutorNetworkHermeticityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExecutorNetworkHermeticityTests.swift; sourceTree = "<group>"; };
@@ -2287,6 +2299,7 @@
 		34BD75A5447FB7BD0DA90F57 /* SendableSubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SendableSubject.swift; sourceTree = "<group>"; };
 		3572DBB51B1244AE18879435 /* MyBooksDownloadCenterExtendedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterExtendedTests.swift; sourceTree = "<group>"; };
 		3592F6473F87F4D7C96FB483 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
+		3640FC284C2E096253CAB7E4 /* RatingFeedbackPresenterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingFeedbackPresenterTests.swift; sourceTree = "<group>"; };
 		3648221A70384B06A0AB23B6 /* BookButtonMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookButtonMapperTests.swift; sourceTree = "<group>"; };
 		37485A6B7C8D9E0F10213243 /* LCPFulfillmentHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPFulfillmentHandlerTests.swift; sourceTree = "<group>"; };
 		374C5D6E7F8091A2B3C4D5E6 /* LocalBookContentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalBookContentService.swift; sourceTree = "<group>"; };
@@ -2320,6 +2333,7 @@
 		42F178DBC9EBCF7C7FA70BEC /* FocusIndicationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FocusIndicationTests.swift; sourceTree = "<group>"; };
 		43040747774740399559510F /* UserRetryTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRetryTracker.swift; sourceTree = "<group>"; };
 		43D3F34D468B2BB51C86A5BA /* AudiobookPositionAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookPositionAdapter.swift; sourceTree = "<group>"; };
+		440B8B1CCFD6A6D539D6AB83 /* RatingFeedbackPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingFeedbackPresenter.swift; sourceTree = "<group>"; };
 		44129BCB71E3F6C8F5CE54A4 /* PDFKitThumbnailProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFKitThumbnailProvider.swift; sourceTree = "<group>"; };
 		4494F50352E88455B28AD34E /* ReadiumPDFReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumPDFReaderView.swift; sourceTree = "<group>"; };
 		44B9D77A2797816A93F9D35B /* PDFAccessibilityToolbarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFAccessibilityToolbarTests.swift; sourceTree = "<group>"; };
@@ -2354,6 +2368,7 @@
 		4EF2F2922050A267096B9D57 /* OfflineQueueServiceExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineQueueServiceExtendedTests.swift; sourceTree = "<group>"; };
 		4F512B3D5A11D22D6AC2CEC7 /* StreamingReaderProgressStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingReaderProgressStoreTests.swift; sourceTree = "<group>"; };
 		4F5F04553ABBB927952EB31B /* TPPSignInBusinessLogicStateMachineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPSignInBusinessLogicStateMachineTests.swift; sourceTree = "<group>"; };
+		4F892EAF356E802A7E33A657 /* RatingReviewRequester.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingReviewRequester.swift; sourceTree = "<group>"; };
 		4F8D8A0D1A094920B67DC0E2 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
 		4F901D7BCF798BFF0E528D6D /* NSURL+NYPLURLAdditions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSURL+NYPLURLAdditions.swift"; sourceTree = "<group>"; };
 		500A72CE85F5DBA5FC681080 /* AudiobookTrackerExtendedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookTrackerExtendedTests.swift; sourceTree = "<group>"; };
@@ -2454,6 +2469,7 @@
 		6EBF1AB49179CABFF759380B /* AppHealthViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHealthViewModelTests.swift; sourceTree = "<group>"; };
 		6F78C5D7DB880A6C70921339 /* TPPBaseReaderViewControllerInitialLocationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBaseReaderViewControllerInitialLocationTests.swift; sourceTree = "<group>"; };
 		6F826CF3A1D6633781419179 /* ManifestFetchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManifestFetchTests.swift; sourceTree = "<group>"; };
+		703200C275C44EC99D42144B /* AppRatingServiceOverrideTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppRatingServiceOverrideTests.swift; sourceTree = "<group>"; };
 		706130D4BA8B4FE88304EC9C /* TPPLastReadPositionSynchronizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPLastReadPositionSynchronizerTests.swift; sourceTree = "<group>"; };
 		70819902FBD142EFF56C93D9 /* ChaosHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaosHarness.swift; sourceTree = "<group>"; };
 		7096661E3AAF4B878E1F49DC /* RDServicesStubs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RDServicesStubs.h; sourceTree = "<group>"; };
@@ -2597,6 +2613,7 @@
 		7B2C3D4E5F6A7B8C9D0E1F2A /* DownloadAlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadAlertPresenter.swift; sourceTree = "<group>"; };
 		7B8D9E0F102132435465A1B9 /* BookSignInRedirectHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookSignInRedirectHandlerTests.swift; sourceTree = "<group>"; };
 		7BA4D17463BADFD0DEBC53FA /* ReadingStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStats.swift; sourceTree = "<group>"; };
+		7BD7869524EB1DD2F9D6A4D4 /* RatingPromptPresenterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingPromptPresenterTests.swift; sourceTree = "<group>"; };
 		7BFD7CCC67838590BD9E203D /* FuzzRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzRunner.swift; sourceTree = "<group>"; };
 		7CBC313C7F61C891527F159B /* PerformanceMonitorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMonitorProtocol.swift; sourceTree = "<group>"; };
 		7DD56A046E056AE23C0ACBFA /* LCPKeychainMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPKeychainMigrationTests.swift; sourceTree = "<group>"; };
@@ -2606,6 +2623,7 @@
 		7EFC5BB5B5F0627FFE2FDFA6 /* ContinueRowSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContinueRowSection.swift; sourceTree = "<group>"; };
 		7F31B83CAB15F0245AEEE83C /* NetworkRetryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkRetryTests.swift; sourceTree = "<group>"; };
 		7FB83837FEBD5C6790EBB743 /* AudiobookLoaderFinalizeBuildTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookLoaderFinalizeBuildTests.swift; sourceTree = "<group>"; };
+		8071F10244E560346A8D3030 /* SentimentGateView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SentimentGateView.swift; sourceTree = "<group>"; };
 		807EEB2577D3B011EA278AB8 /* FloatTPPAdditionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FloatTPPAdditionsTests.swift; sourceTree = "<group>"; };
 		8095146D959C854EDE502449 /* OfflineAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineAction.swift; sourceTree = "<group>"; };
 		80D24086CF8BC2C596888CDA /* BookReturnServiceContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookReturnServiceContractTests.swift; sourceTree = "<group>"; };
@@ -4845,6 +4863,9 @@
 				CF8AB4D59DBD90ED85785F01 /* RatingEligibilityPolicyTests.swift */,
 				FD757427072D6596FB42C87F /* RatingEngagementTrackerTests.swift */,
 				E2B6CEA300F1440914E64EE8 /* AppRatingServiceTests.swift */,
+				7BD7869524EB1DD2F9D6A4D4 /* RatingPromptPresenterTests.swift */,
+				703200C275C44EC99D42144B /* AppRatingServiceOverrideTests.swift */,
+				3640FC284C2E096253CAB7E4 /* RatingFeedbackPresenterTests.swift */,
 			);
 			name = AppRating;
 			path = AppRating;
@@ -5026,6 +5047,10 @@
 				84E63BC817551861A7A8D75D /* RatingEligibilityPolicy.swift */,
 				628AE12E352BCBAEA9346258 /* RatingEngagementTracker.swift */,
 				8634A05347B14A483EBB459D /* AppRatingService.swift */,
+				8071F10244E560346A8D3030 /* SentimentGateView.swift */,
+				0B60466B2029331616A708B4 /* RatingPromptPresenter.swift */,
+				4F892EAF356E802A7E33A657 /* RatingReviewRequester.swift */,
+				440B8B1CCFD6A6D539D6AB83 /* RatingFeedbackPresenter.swift */,
 			);
 			name = AppRating;
 			path = AppRating;
@@ -7568,6 +7593,9 @@
 				AD818A5FF91041A1AEB0A8FA /* RatingEligibilityPolicyTests.swift in Sources */,
 				98E1D5F9C6E1D4088C22EC9F /* RatingEngagementTrackerTests.swift in Sources */,
 				D363615844BC602E2E1FFFBE /* AppRatingServiceTests.swift in Sources */,
+				84B09C70B9117792D1D92339 /* RatingPromptPresenterTests.swift in Sources */,
+				2884699FF9E46A68BEACB258 /* AppRatingServiceOverrideTests.swift in Sources */,
+				A725B03CF6619B2EE7F8B26C /* RatingFeedbackPresenterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8121,6 +8149,10 @@
 				04E1B61CD5C2DFEEC1687B6F /* RatingEligibilityPolicy.swift in Sources */,
 				886784875A41A7A49C80BFEF /* RatingEngagementTracker.swift in Sources */,
 				7962E7E9FDC6354CD0BBD9BD /* AppRatingService.swift in Sources */,
+				CE7DF18FE79F2222F4EBC5DC /* SentimentGateView.swift in Sources */,
+				7BAE3385DABC17BFFA6BA157 /* RatingPromptPresenter.swift in Sources */,
+				07CF93264C7911AB3EE1550B /* RatingReviewRequester.swift in Sources */,
+				BD71BAF794F984B4C6A3DB66 /* RatingFeedbackPresenter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8677,6 +8709,10 @@
 				BD6C160472CEFBD15C4F0335 /* RatingEligibilityPolicy.swift in Sources */,
 				8DA4BE9843EAEAD3284D3476 /* RatingEngagementTracker.swift in Sources */,
 				D88A3E4B3868A2FAEC978110 /* AppRatingService.swift in Sources */,
+				0F8EFC60E22A72D8D0C7BE61 /* SentimentGateView.swift in Sources */,
+				8616DDACA8979FE873AF66C5 /* RatingPromptPresenter.swift in Sources */,
+				165C30CC09A69EA31390E6B5 /* RatingReviewRequester.swift in Sources */,
+				D3F8580D266C275F7707B35E /* RatingFeedbackPresenter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -341,11 +341,27 @@ struct AppContainer {
             tracker: RatingEngagementTracker(settings: self.settings),
             configProvider: { RemoteFeatureFlags.shared.appRatingConfig },
             promptEnabledProvider: { RemoteFeatureFlags.shared.isAppRatingPromptEnabled },
+            forceEligibleProvider: { RemoteFeatureFlags.shared.isAppRatingForceEligible },
             crashFreeProbe: { FirebaseManager.shared.wasLastSessionCrashFree() },
             now: Date.init
         )
         AppContainer._appRatingService = service
         return service
+    }
+
+    /// Root-level presenter driving the app-rating sentiment gate (PP-4089).
+    /// Observed by the overlay in `AppTabHostView`; lazy + cached like the
+    /// audiobook presenter above.
+    @MainActor
+    var ratingPromptPresenter: RatingPromptPresenter {
+        if let cached = AppContainer._ratingPromptPresenter { return cached }
+        let presenter = RatingPromptPresenter(
+            service: self.appRatingService,
+            reviewRequester: RatingReviewRequester(),
+            feedbackPresenter: RatingFeedbackPresenter()
+        )
+        AppContainer._ratingPromptPresenter = presenter
+        return presenter
     }
 
     @MainActor private static var _bookCellModelCache: BookCellModelCache?
@@ -354,6 +370,7 @@ struct AppContainer {
     @MainActor private static var _audiobookSessionPresenter: AudiobookSessionPresenter?
     @MainActor private static var _playbackBootstrapper: PlaybackBootstrapper?
     @MainActor private static var _appRatingService: AppRatingService?
+    @MainActor private static var _ratingPromptPresenter: RatingPromptPresenter?
 
     init(
         bookRegistry: TPPBookRegistryProvider,
@@ -671,6 +688,7 @@ struct AppContainer {
             _audiobookSessionPresenter = nil
             _playbackBootstrapper = nil
             _appRatingService = nil
+            _ratingPromptPresenter = nil
         }
         // Side-loading (PP-2678): the side-loaded registry is a file-backed
         // shared static cache, so it WOULD bleed manifest state across test

--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -33,6 +33,11 @@ struct AppTabHostView: View {
     /// own `@ObservedObject`) re-renders when the presenter publishes.
     @ObservedObject private var audiobookSessionPresenter: AudiobookSessionPresenter
 
+    /// Drives the app-rating sentiment gate overlay (PP-4089). Process-cached
+    /// on the AppContainer so the trigger sites (book completion / borrow) and
+    /// this overlay share one instance.
+    @ObservedObject private var ratingPromptPresenter: RatingPromptPresenter
+
     /// Subscribes to the developer-settings local override so the view
     /// re-renders the moment the dev toggle flips. The actual gating
     /// decision delegates to `RemoteFeatureFlags.shared
@@ -58,6 +63,7 @@ struct AppTabHostView: View {
         // AppContainer so this read returns the same instance the mini-
         // player + manager + CarPlay bridge all use.
         self._audiobookSessionPresenter = ObservedObject(initialValue: appContainer.audiobookSessionPresenter)
+        self._ratingPromptPresenter = ObservedObject(initialValue: appContainer.ratingPromptPresenter)
         let client = URLSessionNetworkClient()
         let parser = OPDSParser()
         let api = DefaultCatalogAPI(client: client, parser: parser, featureFlags: RemoteFeatureFlags.shared)
@@ -138,6 +144,7 @@ struct AppTabHostView: View {
         ZStack(alignment: .bottom) {
             tabViewContent
             persistentFullPlayerOverlay
+            SentimentGateView(presenter: ratingPromptPresenter)
         }
     }
 

--- a/Palace/AppRating/AppRatingService.swift
+++ b/Palace/AppRating/AppRatingService.swift
@@ -30,6 +30,7 @@ final class AppRatingService {
   private let tracker: RatingEngagementTracker
   private let configProvider: () -> RatingConfig
   private let promptEnabledProvider: () -> Bool
+  private let forceEligibleProvider: () -> Bool
   private let crashFreeProbe: () -> Bool
   private let now: () -> Date
 
@@ -37,6 +38,9 @@ final class AppRatingService {
   ///   - tracker: persists/reads engagement signals.
   ///   - configProvider: supplies the (remote-tunable) thresholds on demand.
   ///   - promptEnabledProvider: remote master kill-switch for the whole feature.
+  ///   - forceEligibleProvider: QA/simdrive override that forces eligibility so
+  ///     the gate can be triggered on demand (bypasses thresholds, cooldown, and
+  ///     the master switch). Defaults to off.
   ///   - crashFreeProbe: best-effort "was the previous session crash-free?"
   ///     signal, evaluated once per session.
   ///   - now: injected clock for deterministic cooldown math.
@@ -44,12 +48,14 @@ final class AppRatingService {
     tracker: RatingEngagementTracker,
     configProvider: @escaping () -> RatingConfig = { .fallback },
     promptEnabledProvider: @escaping () -> Bool = { true },
+    forceEligibleProvider: @escaping () -> Bool = { false },
     crashFreeProbe: @escaping () -> Bool = { true },
     now: @escaping () -> Date = Date.init
   ) {
     self.tracker = tracker
     self.configProvider = configProvider
     self.promptEnabledProvider = promptEnabledProvider
+    self.forceEligibleProvider = forceEligibleProvider
     self.crashFreeProbe = crashFreeProbe
     self.now = now
   }
@@ -82,12 +88,19 @@ final class AppRatingService {
     tracker.recordOptOut()
   }
 
+  /// Clears all engagement signals (QA/simdrive "Reset rating state" action).
+  func resetEngagementState() {
+    tracker.reset()
+  }
+
   // MARK: - Eligibility
 
   /// Whether the prompt may be shown for the given trigger right now.
-  /// Returns `false` when the remote master switch is off, regardless of
-  /// engagement state.
+  /// The force-eligible override (QA/simdrive) short-circuits to `true`.
+  /// Otherwise returns `false` when the remote master switch is off, regardless
+  /// of engagement state.
   func isEligible(for trigger: AppRatingTrigger) -> Bool {
+    if forceEligibleProvider() { return true }
     guard promptEnabledProvider() else { return false }
     return RatingEligibilityPolicy.evaluate(
       state: tracker.currentState(),

--- a/Palace/AppRating/RatingEngagementTracker.swift
+++ b/Palace/AppRating/RatingEngagementTracker.swift
@@ -91,4 +91,16 @@ final class RatingEngagementTracker {
   func recordOptOut() {
     settings.appRatingOptedOut = true
   }
+
+  /// Clears every engagement signal back to a fresh-install state. Used by the
+  /// QA/simdrive "Reset rating state" action so the flow can be re-exercised.
+  func reset() {
+    settings.appRatingSessionCount = 0
+    settings.appRatingBooksCompleted = 0
+    settings.appRatingLastPromptDate = nil
+    settings.appRatingPromptDisplayCount = 0
+    settings.appRatingDismissalCount = 0
+    settings.appRatingOptedOut = false
+    settings.appRatingCrashFreeLastSession = true
+  }
 }

--- a/Palace/AppRating/RatingFeedbackPresenter.swift
+++ b/Palace/AppRating/RatingFeedbackPresenter.swift
@@ -1,0 +1,71 @@
+//
+//  RatingFeedbackPresenter.swift
+//  Palace
+//
+//  Feedback path for dissatisfied patrons (PP-4091). Routes a "Not really"
+//  response to a pre-composed support email — never to the App Store.
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// Abstraction over the feedback path so routing can be unit-tested with a spy.
+@MainActor
+protocol FeedbackPresenting {
+  /// Presents the feedback mechanism (pre-composed support email). Never routes
+  /// to the App Store.
+  func presentFeedback()
+}
+
+/// Production `FeedbackPresenting` that opens a pre-filled mail composer to the
+/// support address, reusing `ProblemReportEmail`. When no Mail account is
+/// configured (`!canSendMail()`), `ProblemReportEmail` itself shows a fallback
+/// alert with the address, so the patron is never left with a dead button.
+@MainActor
+final class RatingFeedbackPresenter: FeedbackPresenting {
+
+  private let supportEmail: String
+  private let composer: ProblemReportEmail
+  private let topViewControllerProvider: @MainActor () -> UIViewController?
+
+  init(
+    supportEmail: String = SupportSectionDecision.generalFallbackEmail,
+    composer: ProblemReportEmail = .sharedInstance,
+    topViewControllerProvider: @escaping @MainActor () -> UIViewController? = {
+      RatingFeedbackPresenter.topViewController()
+    }
+  ) {
+    self.supportEmail = supportEmail
+    self.composer = composer
+    self.topViewControllerProvider = topViewControllerProvider
+  }
+
+  func presentFeedback() {
+    guard let presenter = topViewControllerProvider() else { return }
+    composer.beginComposing(
+      to: supportEmail,
+      presentingViewController: presenter,
+      body: Self.feedbackBody
+    )
+  }
+
+  /// A minimal, PII-free lead-in the patron can edit before sending.
+  private static let feedbackBody = "\n\nWhat could we do better in The Palace Project?\n"
+
+  /// Resolves the top-most presented view controller in the active foreground
+  /// window scene, so the composer presents above whatever is on screen.
+  static func topViewController() -> UIViewController? {
+    let keyWindow = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .first(where: { $0.activationState == .foregroundActive })?
+      .windows
+      .first(where: { $0.isKeyWindow })
+
+    var top = keyWindow?.rootViewController
+    while let presented = top?.presentedViewController {
+      top = presented
+    }
+    return top
+  }
+}

--- a/Palace/AppRating/RatingPromptPresenter.swift
+++ b/Palace/AppRating/RatingPromptPresenter.swift
@@ -1,0 +1,136 @@
+//
+//  RatingPromptPresenter.swift
+//  Palace
+//
+//  Drives the sentiment-gate overlay (PP-4089) and routes the patron's
+//  response to the native review request (PP-4090) or the feedback path
+//  (PP-4091). Owns the published UI state; delegates recording/eligibility to
+//  AppRatingService and the terminal actions to injected protocols so the
+//  routing is fully unit-testable.
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+/// Which step of the rating flow is currently on screen. `nil` = nothing shown.
+enum RatingPromptStep: Equatable {
+  /// "Are you enjoying The Palace Project?" — Yes / Not really / Ask me later.
+  case sentiment
+  /// "We're sorry to hear that. Would you like to share feedback?" follow-up.
+  case feedbackFollowup
+}
+
+@MainActor
+final class RatingPromptPresenter: ObservableObject {
+
+  /// The overlay observes this; setting it non-nil shows the gate, nil hides it.
+  @Published private(set) var step: RatingPromptStep?
+
+  private let service: AppRatingService
+  private let reviewRequester: ReviewRequesting
+  private let feedbackPresenter: FeedbackPresenting
+  private let triggerDelayNanoseconds: UInt64
+
+  /// - Parameter triggerDelayNanoseconds: the "brief delay" before the gate
+  ///   appears after a positive moment (PP-4088, ~2s), so it doesn't feel
+  ///   jarring. Injected as 0 in tests that drive `handleTrigger` directly.
+  init(
+    service: AppRatingService,
+    reviewRequester: ReviewRequesting,
+    feedbackPresenter: FeedbackPresenting,
+    triggerDelayNanoseconds: UInt64 = 2_000_000_000
+  ) {
+    self.service = service
+    self.reviewRequester = reviewRequester
+    self.feedbackPresenter = feedbackPresenter
+    self.triggerDelayNanoseconds = triggerDelayNanoseconds
+  }
+
+  // MARK: - Positive-moment entry points
+
+  /// A book was finished. Counts the completion (an eligibility input) then
+  /// schedules the sentiment gate after the brief delay.
+  func noteBookCompleted() {
+    service.recordBookCompleted()
+    scheduleTrigger(.bookCompleted)
+  }
+
+  /// A borrow succeeded. Schedules the sentiment gate after the brief delay.
+  func noteBorrowSucceeded() {
+    scheduleTrigger(.borrowSucceeded)
+  }
+
+  private func scheduleTrigger(_ trigger: AppRatingTrigger) {
+    Task { @MainActor in
+      if triggerDelayNanoseconds > 0 {
+        try? await Task.sleep(nanoseconds: triggerDelayNanoseconds)
+      }
+      handleTrigger(trigger)
+    }
+  }
+
+  // MARK: - Trigger
+
+  /// Shows the sentiment gate only when the patron is eligible, and records the
+  /// display (stamping the cooldown + lifetime cap) as it appears. A gate
+  /// already on screen is never replaced. The testable seam driven directly by
+  /// unit tests.
+  func handleTrigger(_ trigger: AppRatingTrigger) {
+    guard step == nil else { return }
+    guard service.isEligible(for: trigger) else { return }
+    service.recordPromptShown()
+    step = .sentiment
+  }
+
+  // MARK: - Sentiment responses
+
+  /// "Yes, I love it!" — request the native App Store prompt and dismiss.
+  func respondPositive() {
+    guard step == .sentiment else { return }
+    reviewRequester.requestReview()
+    step = nil
+  }
+
+  /// "Not really" — record the dissatisfaction and offer the feedback path.
+  func respondNegative() {
+    guard step == .sentiment else { return }
+    service.recordDismissal()
+    step = .feedbackFollowup
+  }
+
+  /// "Ask me later" (or an outside/back dismissal of the sentiment step). The
+  /// cooldown was already reset when the gate was shown, so this just hides it.
+  func respondAskLater() {
+    guard step == .sentiment else { return }
+    step = nil
+  }
+
+  // MARK: - Feedback follow-up responses
+
+  /// The patron opted to share feedback — open the feedback path (never the
+  /// App Store) and dismiss.
+  func confirmFeedback() {
+    guard step == .feedbackFollowup else { return }
+    feedbackPresenter.presentFeedback()
+    step = nil
+  }
+
+  /// The patron declined to share feedback — just dismiss.
+  func declineFeedback() {
+    guard step == .feedbackFollowup else { return }
+    step = nil
+  }
+
+  // MARK: - Dismissal
+
+  /// A tap-outside / back gesture. Treated as "Ask me later" on the sentiment
+  /// step and as "decline" on the follow-up step.
+  func dismiss() {
+    switch step {
+    case .sentiment: respondAskLater()
+    case .feedbackFollowup: declineFeedback()
+    case nil: break
+    }
+  }
+}

--- a/Palace/AppRating/RatingReviewRequester.swift
+++ b/Palace/AppRating/RatingReviewRequester.swift
@@ -1,0 +1,42 @@
+//
+//  RatingReviewRequester.swift
+//  Palace
+//
+//  Native App Store review request (PP-4090). Thin wrapper over StoreKit's
+//  system prompt — no custom UI, no incentive (App Store Guideline §5.6.1).
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import StoreKit
+import UIKit
+
+/// Abstraction over the system review prompt so routing can be unit-tested
+/// with a spy (the real `SKStoreReviewController` call is untestable — the
+/// prompt only appears in TestFlight/production and is iOS-rate-limited).
+@MainActor
+protocol ReviewRequesting {
+  /// Requests the native App Store rating prompt. Display is not guaranteed;
+  /// iOS may decline, in which case the patron experience continues normally.
+  func requestReview()
+}
+
+/// Production `ReviewRequesting` that invokes the system prompt in the active
+/// foreground window scene.
+@MainActor
+final class RatingReviewRequester: ReviewRequesting {
+  // no-superpartner: SKStoreReviewController.requestReview only surfaces in
+  // TestFlight/production and is iOS-rate-limited — unobservable in a unit test.
+  // The routing that reaches this call is covered via the ReviewRequesting spy
+  // (RatingPromptPresenterTests); the real prompt is exercised by simdrive/manual
+  // QA (PP-4716 / PP-4092).
+  func requestReview() {
+    guard let scene = UIApplication.shared.connectedScenes
+      .compactMap({ $0 as? UIWindowScene })
+      .first(where: { $0.activationState == .foregroundActive })
+    else {
+      return
+    }
+    SKStoreReviewController.requestReview(in: scene)
+  }
+}

--- a/Palace/AppRating/SentimentGateView.swift
+++ b/Palace/AppRating/SentimentGateView.swift
@@ -74,7 +74,15 @@ struct SentimentGateView: View {
     .accessibilityAddTraits(.isModal)
   }
 
-  // MARK: - Button styles (Dynamic Type + Dark Mode via semantic colors)
+  // MARK: - Button styles
+  //
+  // Colors are chosen to guarantee contrast in BOTH light and dark mode. We do
+  // NOT use `Color.accentColor` here: in this app it resolves to ~white in dark
+  // mode, which made the filled primary button render white-on-white (invisible
+  // label). The primary uses the fixed brand navy (`palaceBlueBase`, identical
+  // in both appearances) with white text; the secondary/tertiary use the
+  // semantic label colors (`.primary`/`.secondary`) which always contrast with
+  // the card's `secondarySystemBackground`.
 
   private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {
     Button(action: action) {
@@ -82,7 +90,7 @@ struct SentimentGateView: View {
         .fontWeight(.semibold)
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
-        .background(Color.accentColor)
+        .background(Color.palaceBlueBase)
         .foregroundColor(.white)
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
@@ -95,9 +103,9 @@ struct SentimentGateView: View {
         .padding(.vertical, 12)
         .overlay(
           RoundedRectangle(cornerRadius: 10, style: .continuous)
-            .stroke(Color.accentColor, lineWidth: 1)
+            .stroke(Color.primary, lineWidth: 1)
         )
-        .foregroundColor(.accentColor)
+        .foregroundColor(.primary)
     }
   }
 

--- a/Palace/AppRating/SentimentGateView.swift
+++ b/Palace/AppRating/SentimentGateView.swift
@@ -1,0 +1,112 @@
+//
+//  SentimentGateView.swift
+//  Palace
+//
+//  The app-rating sentiment gate (PP-4089): a lightweight, dismissible card
+//  shown after a positive moment. Yes → native review (PP-4090); Not really →
+//  feedback follow-up (PP-4091); Ask me later / tap-outside → defer.
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import SwiftUI
+
+/// A root-level overlay that renders the rating flow when the presenter has an
+/// active `step`, and nothing otherwise. Designed to be placed as a sibling
+/// layer in `AppTabHostView`'s root `ZStack` so it survives tab switches.
+struct SentimentGateView: View {
+  @ObservedObject var presenter: RatingPromptPresenter
+
+  private typealias L = Strings.AppRating
+
+  var body: some View {
+    ZStack {
+      if let step = presenter.step {
+        // Dimmed, tap-to-dismiss backdrop.
+        Color.black.opacity(0.4)
+          .ignoresSafeArea()
+          .onTapGesture { presenter.dismiss() }
+          .accessibilityLabel(Text(L.askLater))
+          .accessibilityAction { presenter.dismiss() }
+
+        card(for: step)
+          .transition(.opacity.combined(with: .scale(scale: 0.96)))
+      }
+    }
+    .animation(.easeInOut(duration: 0.25), value: presenter.step)
+  }
+
+  @ViewBuilder
+  private func card(for step: RatingPromptStep) -> some View {
+    VStack(spacing: 20) {
+      switch step {
+      case .sentiment:
+        Text(L.sentimentTitle)
+          .font(.headline)
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+
+        VStack(spacing: 12) {
+          primaryButton(L.positive) { presenter.respondPositive() }
+          secondaryButton(L.negative) { presenter.respondNegative() }
+          tertiaryButton(L.askLater) { presenter.respondAskLater() }
+        }
+
+      case .feedbackFollowup:
+        Text(L.feedbackTitle)
+          .font(.headline)
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+
+        VStack(spacing: 12) {
+          primaryButton(L.feedbackConfirm) { presenter.confirmFeedback() }
+          tertiaryButton(L.feedbackDecline) { presenter.declineFeedback() }
+        }
+      }
+    }
+    .padding(24)
+    .frame(maxWidth: 340)
+    .background(
+      RoundedRectangle(cornerRadius: 16, style: .continuous)
+        .fill(Color(.secondarySystemBackground))
+    )
+    .padding(32)
+    .accessibilityElement(children: .contain)
+    .accessibilityAddTraits(.isModal)
+  }
+
+  // MARK: - Button styles (Dynamic Type + Dark Mode via semantic colors)
+
+  private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      Text(title)
+        .fontWeight(.semibold)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .background(Color.accentColor)
+        .foregroundColor(.white)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+  }
+
+  private func secondaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      Text(title)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .overlay(
+          RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .stroke(Color.accentColor, lineWidth: 1)
+        )
+        .foregroundColor(.accentColor)
+    }
+  }
+
+  private func tertiaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      Text(title)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+        .foregroundColor(.secondary)
+    }
+  }
+}

--- a/Palace/Book/UI/BookDetail/BookAvailabilityFormatter.swift
+++ b/Palace/Book/UI/BookDetail/BookAvailabilityFormatter.swift
@@ -85,11 +85,11 @@ final class BookAvailabilityFormatter {
                     AppContainer.production().navigationCoordinatorHub.coordinator?.pop()
                     AppContainer.production().downloadCenter.returnBook(withIdentifier: book.identifier)
                 }
-                TPPAppStoreReviewPrompt.presentIfAvailable()
+                Task { @MainActor in AppContainer.production().ratingPromptPresenter.noteBookCompleted() }
             }
             TPPAlertUtils.presentFromViewControllerOrNil(alertController: alert, viewController: nil, animated: true, completion: nil)
         } else {
-            TPPAppStoreReviewPrompt.presentIfAvailable()
+            Task { @MainActor in AppContainer.production().ratingPromptPresenter.noteBookCompleted() }
         }
     }
 }

--- a/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
@@ -1224,11 +1224,11 @@ extension BookDetailViewModel {
                     AppContainer.production().navigationCoordinatorHub.coordinator?.pop()
                     downloadCenter.returnBook(withIdentifier: book.identifier)
                 }
-                TPPAppStoreReviewPrompt.presentIfAvailable()
+                Task { @MainActor in AppContainer.production().ratingPromptPresenter.noteBookCompleted() }
             }
             TPPAlertUtils.presentFromViewControllerOrNil(alertController: alert, viewController: nil, animated: true, completion: nil)
         } else {
-            TPPAppStoreReviewPrompt.presentIfAvailable()
+            Task { @MainActor in AppContainer.production().ratingPromptPresenter.noteBookCompleted() }
         }
     }
 

--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -400,6 +400,18 @@ final class RemoteFeatureFlags: @unchecked Sendable {
         isFeatureEnabled(.appRatingPromptEnabled)
     }
 
+    /// UserDefaults override that lets QA / simdrive force the rating prompt to
+    /// be eligible without meeting the real thresholds or waiting out the
+    /// cooldown. Settable from `TPPDeveloperSettingsTableViewController`. Mirrors
+    /// the `triageBotLocalOverrideKey` pattern.
+    static let appRatingForceEligibleLocalOverrideKey = "RemoteFeatureFlags.appRatingForceEligibleOverride"
+
+    /// Whether the rating prompt is force-eligible for QA/simdrive. Defaults to
+    /// false; no remote flag — this is a local debug override only.
+    var isAppRatingForceEligible: Bool {
+      defaults.object(forKey: Self.appRatingForceEligibleLocalOverrideKey) as? Bool ?? false
+    }
+
     /// The remote-tunable eligibility thresholds. Any threshold missing or
     /// non-positive in Remote Config falls back to `RatingConfig.fallback`.
     var appRatingConfig: RatingConfig {

--- a/Palace/MyBooks/BorrowOperation.swift
+++ b/Palace/MyBooks/BorrowOperation.swift
@@ -458,6 +458,10 @@ final class BorrowOperation: @unchecked Sendable {
 
             downloadAnnouncementService.announceBorrowSucceeded(for: borrowedBook)
 
+            // App-rating secondary trigger (PP-4088): a successful borrow is a
+            // positive moment. The gate is shown only if the patron is eligible.
+            Task { @MainActor in AppContainer.production().ratingPromptPresenter.noteBorrowSucceeded() }
+
             // F-014: condition was inverted (`!= .downloadNeeded`), skipping
             // auto-download on the most common post-borrow state and stranding
             // the user on a manual Download tap. The borrow→download chain is

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -26,6 +26,11 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
     private lazy var keyboardNavigationHandler = KeyboardNavigationHandler(navigable: self)
     private var lastChapterHREF: String?
 
+    /// App-rating (PP-4088): guards the end-of-book completion trigger so it
+    /// fires at most once per reader session, even as locator changes keep
+    /// arriving while the patron lingers on the final page.
+    private var didFireRatingCompletion = false
+
     /// The location the EPUB navigator's CONSTRUCTOR should restore to.
     ///
     /// EXACTLY ONE restore must reach the navigator. The post-first-paint gate
@@ -432,6 +437,15 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
         let wasManual = manualNavigationPending
         manualNavigationPending = false
         lastChapterHREF = newHREF
+
+        // App-rating primary trigger (PP-4088): reaching the end of the book is
+        // a positive moment. Fire once; the gate appears only if eligible.
+        if !didFireRatingCompletion,
+           let progression = locator.locations.totalProgression,
+           progression >= 0.99 {
+          didFireRatingCompletion = true
+          AppContainer.production().ratingPromptPresenter.noteBookCompleted()
+        }
 
         guard UIAccessibility.isVoiceOverRunning, isChapterChange else { return }
 

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -87,6 +87,7 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
     private let triageBotAIFallbackCellIdentifier = "triageBotAIFallbackCell"
     private let inAppPlaybackNavCellIdentifier = "inAppPlaybackNavCell"
     private let appRatingForceEligibleCellIdentifier = "appRatingForceEligibleCell"
+    private let appRatingTriggerCellIdentifier = "appRatingTriggerCell"
     private let appRatingResetCellIdentifier = "appRatingResetCell"
     private let triageBotAnthropicKeyCellIdentifier = "triageBotAnthropicKeyCell"
 
@@ -147,6 +148,7 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: triageBotAIFallbackCellIdentifier)
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: inAppPlaybackNavCellIdentifier)
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: appRatingForceEligibleCellIdentifier)
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: appRatingTriggerCellIdentifier)
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: appRatingResetCellIdentifier)
     }
 
@@ -158,7 +160,7 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         switch sectionType {
         case .librarySettings: return 2
         case .triageBot: return 4  // enabled + ticket submission + AI fallback + Anthropic key
-        case .featureFlags: return 3  // in-app playback nav + force-rating-eligible + reset-rating-state
+        case .featureFlags: return 4  // in-app playback nav + force-eligible + trigger-now + reset-rating-state
         case .dataManagement: return 3  // Clear Cached Data + Reset This Library + Full Reset
         case .developerTools: return 2
         case .pushNotificationTesting: return 3
@@ -208,6 +210,7 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             switch indexPath.row {
             case 0: return cellForInAppPlaybackNav()
             case 1: return cellForAppRatingForceEligible()
+            case 2: return cellForAppRatingTrigger()
             default: return cellForAppRatingReset()
             }
         case .libraryRegistryDebugging: return cellForCustomRegsitry()
@@ -492,6 +495,19 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
 
     @objc func appRatingForceEligibleSwitchDidChange(sender: UISwitch) {
         UserDefaults.standard.set(sender.isOn, forKey: RemoteFeatureFlags.appRatingForceEligibleLocalOverrideKey)
+    }
+
+    /// Tap-to-run action that fires the app-rating book-completed trigger
+    /// immediately (bypassing the ~2s delay and a real book completion), so the
+    /// sentiment gate can be driven deterministically by QA/simdrive. Shows only
+    /// when eligible — pair with "Force Rating Prompt Eligible".
+    private func cellForAppRatingTrigger() -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: appRatingTriggerCellIdentifier) else {
+            fatalError("Failed to dequeue cell with identifier \(appRatingTriggerCellIdentifier)")
+        }
+        cell.textLabel?.text = "Trigger Rating Prompt Now"
+        cell.textLabel?.textColor = .systemBlue
+        return cell
     }
 
     /// Tap-to-run action that clears all app-rating engagement state so the flow
@@ -1002,9 +1018,12 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             }
 
         case .featureFlags:
-            // Row 0/1 are toggles (handled by their switches); row 2 resets
-            // the app-rating engagement state.
+            // Row 0/1 are toggles (handled by their switches). Row 2 fires the
+            // rating trigger immediately; row 3 resets the engagement state.
             if indexPath.row == 2 {
+                tableView.deselectRow(at: indexPath, animated: true)
+                AppContainer.production().ratingPromptPresenter.handleTrigger(.bookCompleted)
+            } else if indexPath.row == 3 {
                 AppContainer.production().appRatingService.resetEngagementState()
                 tableView.deselectRow(at: indexPath, animated: true)
                 let confirm = TPPAlertUtils.alert(title: "Rating State Reset",

--- a/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
+++ b/Palace/Settings/DeveloperSettings/TPPDeveloperSettingsTableViewController.swift
@@ -86,6 +86,8 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
     private let triageBotTicketSubmissionCellIdentifier = "triageBotTicketSubmissionCell"
     private let triageBotAIFallbackCellIdentifier = "triageBotAIFallbackCell"
     private let inAppPlaybackNavCellIdentifier = "inAppPlaybackNavCell"
+    private let appRatingForceEligibleCellIdentifier = "appRatingForceEligibleCell"
+    private let appRatingResetCellIdentifier = "appRatingResetCell"
     private let triageBotAnthropicKeyCellIdentifier = "triageBotAnthropicKeyCell"
 
     /// Manages the Keychain-backed Anthropic key for the Triage Bot AI
@@ -144,6 +146,8 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: triageBotTicketSubmissionCellIdentifier)
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: triageBotAIFallbackCellIdentifier)
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: inAppPlaybackNavCellIdentifier)
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: appRatingForceEligibleCellIdentifier)
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: appRatingResetCellIdentifier)
     }
 
     // MARK: - UITableViewDataSource
@@ -154,7 +158,7 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
         switch sectionType {
         case .librarySettings: return 2
         case .triageBot: return 4  // enabled + ticket submission + AI fallback + Anthropic key
-        case .featureFlags: return 1
+        case .featureFlags: return 3  // in-app playback nav + force-rating-eligible + reset-rating-state
         case .dataManagement: return 3  // Clear Cached Data + Reset This Library + Full Reset
         case .developerTools: return 2
         case .pushNotificationTesting: return 3
@@ -200,7 +204,12 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
             case 2: return cellForTriageBotAIFallback()
             default: return cellForTriageBotAnthropicKey()
             }
-        case .featureFlags: return cellForInAppPlaybackNav()
+        case .featureFlags:
+            switch indexPath.row {
+            case 0: return cellForInAppPlaybackNav()
+            case 1: return cellForAppRatingForceEligible()
+            default: return cellForAppRatingReset()
+            }
         case .libraryRegistryDebugging: return cellForCustomRegsitry()
         case .dataManagement:
             switch indexPath.row {
@@ -461,6 +470,39 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
 
     @objc func inAppPlaybackNavSwitchDidChange(sender: UISwitch) {
         UserDefaults.standard.set(sender.isOn, forKey: RemoteFeatureFlags.inAppPlaybackNavLocalOverrideKey)
+    }
+
+    /// QA/simdrive override that forces the app-rating prompt eligible so the
+    /// sentiment gate can be triggered on demand (bypasses thresholds/cooldown).
+    /// Writes `RemoteFeatureFlags.appRatingForceEligibleLocalOverrideKey`.
+    private func cellForAppRatingForceEligible() -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: appRatingForceEligibleCellIdentifier) else {
+            fatalError("Failed to dequeue cell with identifier \(appRatingForceEligibleCellIdentifier)")
+        }
+        cell.selectionStyle = .none
+        cell.textLabel?.text = "Force Rating Prompt Eligible"
+        cell.textLabel?.adjustsFontSizeToFitWidth = true
+        cell.textLabel?.minimumScaleFactor = 0.5
+        cell.accessoryView = createSwitch(
+            isOn: RemoteFeatureFlags.shared.isAppRatingForceEligible,
+            action: #selector(appRatingForceEligibleSwitchDidChange)
+        )
+        return cell
+    }
+
+    @objc func appRatingForceEligibleSwitchDidChange(sender: UISwitch) {
+        UserDefaults.standard.set(sender.isOn, forKey: RemoteFeatureFlags.appRatingForceEligibleLocalOverrideKey)
+    }
+
+    /// Tap-to-run action that clears all app-rating engagement state so the flow
+    /// can be re-exercised from a fresh-install baseline (QA/simdrive).
+    private func cellForAppRatingReset() -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: appRatingResetCellIdentifier) else {
+            fatalError("Failed to dequeue cell with identifier \(appRatingResetCellIdentifier)")
+        }
+        cell.textLabel?.text = "Reset Rating State"
+        cell.textLabel?.textColor = .systemRed
+        return cell
     }
 
     private func cellForClearCache() -> UITableViewCell {
@@ -959,7 +1001,18 @@ class TPPDeveloperSettingsTableViewController: UIViewController, UITableViewDele
                 presentAnthropicKeyEntry()
             }
 
-        case .librarySettings, .featureFlags, .libraryRegistryDebugging:
+        case .featureFlags:
+            // Row 0/1 are toggles (handled by their switches); row 2 resets
+            // the app-rating engagement state.
+            if indexPath.row == 2 {
+                AppContainer.production().appRatingService.resetEngagementState()
+                tableView.deselectRow(at: indexPath, animated: true)
+                let confirm = TPPAlertUtils.alert(title: "Rating State Reset",
+                                                  message: "All app-rating engagement signals have been cleared.")
+                TPPAlertUtils.presentFromViewControllerOrNil(alertController: confirm, viewController: self, animated: true, completion: nil)
+            }
+
+        case .librarySettings, .libraryRegistryDebugging:
             break
         }
     }

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -845,4 +845,39 @@ struct Strings {
             comment: "Button title in the streaming reader's offline / failed state — re-evaluates reachability and retries the load."
         )
     }
+
+    // Epic PP-4086: the app-rating sentiment gate. A lightweight pre-prompt
+    // asks how the patron feels before the native App Store review prompt;
+    // a positive answer routes to the system prompt, a negative one to a
+    // feedback email, and "Ask me later" defers.
+    struct AppRating {
+        static let sentimentTitle = NSLocalizedString(
+            "Are you enjoying The Palace Project?",
+            comment: "Title of the app-rating sentiment gate shown after a positive moment (finishing a book or borrowing)."
+        )
+        static let positive = NSLocalizedString(
+            "Yes, I love it!",
+            comment: "Sentiment-gate button; a positive response that leads to the native App Store rating prompt."
+        )
+        static let negative = NSLocalizedString(
+            "Not really",
+            comment: "Sentiment-gate button; a negative response that leads to a feedback option instead of the App Store."
+        )
+        static let askLater = NSLocalizedString(
+            "Ask me later",
+            comment: "Sentiment-gate button; defers the prompt and resets the cooldown."
+        )
+        static let feedbackTitle = NSLocalizedString(
+            "We're sorry to hear that. Would you like to share feedback?",
+            comment: "Follow-up shown after a negative sentiment-gate response, offering to open a feedback email."
+        )
+        static let feedbackConfirm = NSLocalizedString(
+            "Share feedback",
+            comment: "Feedback follow-up button; opens a pre-composed support email."
+        )
+        static let feedbackDecline = NSLocalizedString(
+            "No thanks",
+            comment: "Feedback follow-up button; dismisses without opening the feedback email."
+        )
+    }
 }

--- a/PalaceTests/AppRating/AppRatingServiceOverrideTests.swift
+++ b/PalaceTests/AppRating/AppRatingServiceOverrideTests.swift
@@ -1,0 +1,71 @@
+//
+//  AppRatingServiceOverrideTests.swift
+//  PalaceTests
+//
+//  Tests for the PR-2 additions to AppRatingService: the force-eligible
+//  override (QA/simdrive) and resetEngagementState.
+//
+
+import XCTest
+@testable import Palace
+
+@MainActor
+final class AppRatingServiceOverrideTests: XCTestCase {
+
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+  private var settings: TPPSettings!
+
+  override func setUp() {
+    super.setUp()
+    suiteName = "AppRatingServiceOverrideTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)
+    settings = TPPSettings(defaults: defaults)
+  }
+
+  override func tearDown() {
+    defaults.removePersistentDomain(forName: suiteName)
+    settings = nil; defaults = nil; suiteName = nil
+    super.tearDown()
+  }
+
+  private func makeService(forceEligible: Bool, promptEnabled: Bool = true) -> AppRatingService {
+    AppRatingService(
+      tracker: RatingEngagementTracker(settings: settings),
+      promptEnabledProvider: { promptEnabled },
+      forceEligibleProvider: { forceEligible }
+    )
+  }
+
+  func testForceEligible_bypassesIneligibleStateAndMasterSwitch() {
+    // Fresh install (session 0, no books) AND master switch off — normally
+    // doubly ineligible. Force override must still report eligible.
+    let service = makeService(forceEligible: true, promptEnabled: false)
+    XCTAssertTrue(service.isEligible(for: .bookCompleted))
+  }
+
+  func testWithoutForce_ineligibleStateStaysIneligible() {
+    let service = makeService(forceEligible: false, promptEnabled: true)
+    XCTAssertFalse(service.isEligible(for: .bookCompleted), "fresh install must not be eligible without the override")
+  }
+
+  func testResetEngagementState_clearsAllSignals() {
+    settings.appRatingSessionCount = 9
+    settings.appRatingBooksCompleted = 4
+    settings.appRatingPromptDisplayCount = 2
+    settings.appRatingDismissalCount = 3
+    settings.appRatingOptedOut = true
+    settings.appRatingLastPromptDate = Date(timeIntervalSince1970: 1000)
+    settings.appRatingCrashFreeLastSession = false
+
+    makeService(forceEligible: false).resetEngagementState()
+
+    XCTAssertEqual(settings.appRatingSessionCount, 0)
+    XCTAssertEqual(settings.appRatingBooksCompleted, 0)
+    XCTAssertEqual(settings.appRatingPromptDisplayCount, 0)
+    XCTAssertEqual(settings.appRatingDismissalCount, 0)
+    XCTAssertFalse(settings.appRatingOptedOut)
+    XCTAssertNil(settings.appRatingLastPromptDate)
+    XCTAssertTrue(settings.appRatingCrashFreeLastSession, "reset restores the crash-free default of true")
+  }
+}

--- a/PalaceTests/AppRating/RatingFeedbackPresenterTests.swift
+++ b/PalaceTests/AppRating/RatingFeedbackPresenterTests.swift
@@ -1,0 +1,76 @@
+//
+//  RatingFeedbackPresenterTests.swift
+//  PalaceTests
+//
+//  Tests for the feedback path (PP-4091): it composes to the support address
+//  from the resolved top view controller, and no-ops safely when there is no
+//  presenter — never routing to the App Store.
+//
+
+import XCTest
+import UIKit
+@testable import Palace
+
+@MainActor
+final class RatingFeedbackPresenterTests: XCTestCase {
+
+  /// Spy over ProblemReportEmail's composing call. ProblemReportEmail is a
+  /// concrete singleton, so we subclass to intercept the reused entry point.
+  private final class SpyComposer: ProblemReportEmail {
+    private(set) var toAddress: String?
+    private(set) var presentingVC: UIViewController?
+    private(set) var callCount = 0
+    override func beginComposing(to emailAddress: String, presentingViewController: UIViewController, body: String) {
+      callCount += 1
+      toAddress = emailAddress
+      presentingVC = presentingViewController
+    }
+  }
+
+  func testPresentFeedback_composesToSupportFromTopViewController() {
+    let spy = SpyComposer()
+    let host = UIViewController()
+    let presenter = RatingFeedbackPresenter(
+      supportEmail: "support@example.org",
+      composer: spy,
+      topViewControllerProvider: { host }
+    )
+
+    presenter.presentFeedback()
+
+    XCTAssertEqual(spy.callCount, 1)
+    XCTAssertEqual(spy.toAddress, "support@example.org")
+    XCTAssertTrue(spy.presentingVC === host)
+  }
+
+  func testPresentFeedback_withNoTopViewController_isSafeNoOp() {
+    let spy = SpyComposer()
+    let presenter = RatingFeedbackPresenter(
+      supportEmail: "support@example.org",
+      composer: spy,
+      topViewControllerProvider: { nil }
+    )
+
+    presenter.presentFeedback()
+
+    XCTAssertEqual(spy.callCount, 0, "no presenter → must not attempt to compose")
+  }
+
+  func testDefaultInit_wiresComposerToPalaceSupportAddress() {
+    // Exercises the PRODUCTION default supportEmail wiring (not just the
+    // constant): a default-constructed presenter must compose to the palace
+    // support address. Injects only the composer + a stub top-VC so the real
+    // default `supportEmail` is used.
+    let spy = SpyComposer()
+    let host = UIViewController()
+    let presenter = RatingFeedbackPresenter(
+      composer: spy,
+      topViewControllerProvider: { host }
+    )
+
+    presenter.presentFeedback()
+
+    XCTAssertEqual(spy.toAddress, "support@thepalaceproject.org",
+                   "default presenter must route feedback to the configured palace support address")
+  }
+}

--- a/PalaceTests/AppRating/RatingPromptPresenterTests.swift
+++ b/PalaceTests/AppRating/RatingPromptPresenterTests.swift
@@ -1,0 +1,213 @@
+//
+//  RatingPromptPresenterTests.swift
+//  PalaceTests
+//
+//  Routing tests for the sentiment-gate flow (PP-4089/4090/4091): trigger
+//  gating, the three sentiment responses, the feedback follow-up, and
+//  tap-outside dismissal — all driven through the production seam with spy
+//  requester/feedback so each terminal action is asserted.
+//
+
+import XCTest
+@testable import Palace
+
+@MainActor
+final class RatingPromptPresenterTests: XCTestCase {
+
+  private final class SpyReviewRequester: ReviewRequesting {
+    private(set) var requestCount = 0
+    func requestReview() { requestCount += 1 }
+  }
+
+  private final class SpyFeedbackPresenter: FeedbackPresenting {
+    private(set) var presentCount = 0
+    func presentFeedback() { presentCount += 1 }
+  }
+
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+  private var settings: TPPSettings!
+  private var requester: SpyReviewRequester!
+  private var feedback: SpyFeedbackPresenter!
+
+  override func setUp() {
+    super.setUp()
+    suiteName = "RatingPromptPresenterTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)
+    settings = TPPSettings(defaults: defaults)
+    requester = SpyReviewRequester()
+    feedback = SpyFeedbackPresenter()
+  }
+
+  override func tearDown() {
+    defaults.removePersistentDomain(forName: suiteName)
+    settings = nil; defaults = nil; suiteName = nil
+    requester = nil; feedback = nil
+    super.tearDown()
+  }
+
+  /// Builds a presenter whose service is either forced-eligible or forced-
+  /// ineligible, so trigger behavior is deterministic without seeding state.
+  /// The trigger delay defaults to 0 so the scheduled gate resolves promptly
+  /// in the async combiner tests.
+  private func makePresenter(eligible: Bool) -> RatingPromptPresenter {
+    let service = AppRatingService(
+      tracker: RatingEngagementTracker(settings: settings),
+      promptEnabledProvider: { true },
+      forceEligibleProvider: { eligible }
+    )
+    return RatingPromptPresenter(
+      service: service,
+      reviewRequester: requester,
+      feedbackPresenter: feedback,
+      triggerDelayNanoseconds: 0
+    )
+  }
+
+  /// Spins the main run loop until `condition` holds or a short budget elapses,
+  /// so the `scheduleTrigger` Task (delay 0) has a chance to run.
+  private func waitUntil(_ condition: @escaping () -> Bool) async {
+    for _ in 0..<50 {
+      if condition() { return }
+      await Task.yield()
+    }
+  }
+
+  // MARK: - Trigger gating
+
+  func testHandleTrigger_whenEligible_showsSentimentAndStampsDisplay() {
+    let presenter = makePresenter(eligible: true)
+    presenter.handleTrigger(.bookCompleted)
+    XCTAssertEqual(presenter.step, .sentiment)
+    XCTAssertEqual(settings.appRatingPromptDisplayCount, 1, "showing the gate must stamp the lifetime cap")
+    XCTAssertNotNil(settings.appRatingLastPromptDate, "showing the gate must reset the cooldown")
+  }
+
+  func testHandleTrigger_whenIneligible_showsNothing() {
+    let presenter = makePresenter(eligible: false)
+    presenter.handleTrigger(.bookCompleted)
+    XCTAssertNil(presenter.step)
+    XCTAssertEqual(settings.appRatingPromptDisplayCount, 0)
+  }
+
+  func testHandleTrigger_whenAlreadyShowing_doesNotReshowOrRestamp() {
+    let presenter = makePresenter(eligible: true)
+    presenter.handleTrigger(.bookCompleted)
+    presenter.handleTrigger(.borrowSucceeded)
+    XCTAssertEqual(presenter.step, .sentiment)
+    XCTAssertEqual(settings.appRatingPromptDisplayCount, 1, "a second trigger must not re-stamp while the gate is up")
+  }
+
+  // MARK: - Positive-moment combiners (record + scheduled gate)
+
+  func testNoteBookCompleted_recordsCompletionThenSchedulesGate() async {
+    let presenter = makePresenter(eligible: true)
+    presenter.noteBookCompleted()
+    XCTAssertEqual(settings.appRatingBooksCompleted, 1, "completion is recorded synchronously")
+    await waitUntil { presenter.step == .sentiment }
+    XCTAssertEqual(presenter.step, .sentiment, "the scheduled trigger shows the gate when eligible")
+  }
+
+  func testNoteBorrowSucceeded_schedulesGateWithoutRecordingCompletion() async {
+    let presenter = makePresenter(eligible: true)
+    presenter.noteBorrowSucceeded()
+    XCTAssertEqual(settings.appRatingBooksCompleted, 0, "a borrow is not a book completion")
+    await waitUntil { presenter.step == .sentiment }
+    XCTAssertEqual(presenter.step, .sentiment)
+  }
+
+  func testNoteBookCompleted_whenIneligible_recordsButShowsNoGate() async {
+    let presenter = makePresenter(eligible: false)
+    presenter.noteBookCompleted()
+    XCTAssertEqual(settings.appRatingBooksCompleted, 1)
+    await waitUntil { presenter.step != nil }
+    XCTAssertNil(presenter.step, "ineligible → the scheduled trigger must not show the gate")
+  }
+
+  // MARK: - Sentiment responses
+
+  func testRespondPositive_requestsReviewAndDismisses() {
+    let presenter = makePresenter(eligible: true)
+    presenter.handleTrigger(.bookCompleted)
+    presenter.respondPositive()
+    XCTAssertEqual(requester.requestCount, 1)
+    XCTAssertEqual(feedback.presentCount, 0, "positive path must never open feedback")
+    XCTAssertNil(presenter.step)
+  }
+
+  func testRespondNegative_recordsDismissalAndShowsFeedbackFollowup() {
+    let presenter = makePresenter(eligible: true)
+    presenter.handleTrigger(.bookCompleted)
+    presenter.respondNegative()
+    XCTAssertEqual(presenter.step, .feedbackFollowup)
+    XCTAssertEqual(settings.appRatingDismissalCount, 1)
+    XCTAssertEqual(requester.requestCount, 0, "negative path must never request App Store review")
+  }
+
+  func testRespondAskLater_dismissesWithoutActionOrDismissalCount() {
+    let presenter = makePresenter(eligible: true)
+    presenter.handleTrigger(.bookCompleted)
+    presenter.respondAskLater()
+    XCTAssertNil(presenter.step)
+    XCTAssertEqual(requester.requestCount, 0)
+    XCTAssertEqual(feedback.presentCount, 0)
+    XCTAssertEqual(settings.appRatingDismissalCount, 0, "ask-later is not a dismissal-count event")
+  }
+
+  // MARK: - Feedback follow-up
+
+  func testConfirmFeedback_presentsFeedbackNotAppStore() {
+    let presenter = makePresenter(eligible: true)
+    presenter.handleTrigger(.bookCompleted)
+    presenter.respondNegative()
+    presenter.confirmFeedback()
+    XCTAssertEqual(feedback.presentCount, 1)
+    XCTAssertEqual(requester.requestCount, 0, "feedback path must never route to the App Store")
+    XCTAssertNil(presenter.step)
+  }
+
+  func testDeclineFeedback_dismissesWithoutPresenting() {
+    let presenter = makePresenter(eligible: true)
+    presenter.handleTrigger(.bookCompleted)
+    presenter.respondNegative()
+    presenter.declineFeedback()
+    XCTAssertEqual(feedback.presentCount, 0)
+    XCTAssertNil(presenter.step)
+  }
+
+  // MARK: - Tap-outside dismissal
+
+  func testDismiss_onSentiment_behavesAsAskLater() {
+    let presenter = makePresenter(eligible: true)
+    presenter.handleTrigger(.bookCompleted)
+    presenter.dismiss()
+    XCTAssertNil(presenter.step)
+    XCTAssertEqual(settings.appRatingDismissalCount, 0)
+  }
+
+  func testDismiss_onFeedbackFollowup_behavesAsDecline() {
+    let presenter = makePresenter(eligible: true)
+    presenter.handleTrigger(.bookCompleted)
+    presenter.respondNegative()   // → feedbackFollowup, dismissalCount now 1
+    presenter.dismiss()
+    XCTAssertNil(presenter.step)
+    XCTAssertEqual(feedback.presentCount, 0, "dismissing the follow-up must not open feedback")
+  }
+
+  // MARK: - Response guards (wrong-step calls are no-ops)
+
+  func testRespondPositive_whenNothingShown_isNoOp() {
+    let presenter = makePresenter(eligible: true)
+    presenter.respondPositive()
+    XCTAssertEqual(requester.requestCount, 0)
+    XCTAssertNil(presenter.step)
+  }
+
+  func testConfirmFeedback_onSentimentStep_isNoOp() {
+    let presenter = makePresenter(eligible: true)
+    presenter.handleTrigger(.bookCompleted)   // step == .sentiment
+    presenter.confirmFeedback()               // wrong step
+    XCTAssertEqual(feedback.presentCount, 0)
+    XCTAssertEqual(presenter.step, .sentiment, "confirmFeedback on the sentiment step must not change state")
+  }
+}


### PR DESCRIPTION
## Summary

**App Rating Prompt — UI, routing & triggers** (Epic **PP-4086**): sentiment-gate dialog (**PP-4089**), native StoreKit request (**PP-4090**), feedback path (**PP-4091**), the three positive-moment triggers, and the QA/simdrive debug hooks.

> Supersedes #1168 (auto-closed when its stacked base branch was deleted after PR1 #1166 merged). Rebased directly onto `develop`; contains only the UI/trigger work — PR1's engagement/eligibility core already landed via #1166.

## What's in scope
- **`SentimentGateView` (PP-4089)** — dismissible root overlay; Yes / Not really / Ask me later; VoiceOver + Dynamic Type + Dark Mode. (Dark-mode white-on-white primary button caught via simdrive + fixed → brand navy.)
- **`RatingPromptPresenter`** — routing brain; unit-tested via spies (100% mutation on covered guards).
- **`RatingReviewRequester` (PP-4090)** — `SKStoreReviewController`; supersedes all 4 old `TPPAppStoreReviewPrompt` end-of-book sites.
- **`RatingFeedbackPresenter` (PP-4091)** — pre-composed mailto to support@thepalaceproject.org; never routes to the App Store.
- **Triggers** — audiobook + return end-of-book, borrow success, EPUB completion (`totalProgression >= 0.99`).
- **Developer Settings** — Force Rating Prompt Eligible / Trigger Rating Prompt Now / Reset Rating State (QA + simdrive hooks) + `.simdrive/fixtures/flows/app-rating-sentiment-gate.yaml`.

## Verification
- Architect + QA SoD review passed (architect BLOCK on a partial supersession → fixed).
- Full build clean + 73 AppRating/config tests green (post-rebase onto latest develop).
- Routing mutation 100% (covered guards); simdrive live-validated both routing branches + both appearances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
