### PR TITLE
fix(swift6): Reader2 non-critical structural residual (bookmark/annotation sync)

### DIFF
--- a/Palace/Reader2/Bookmarks/AudiobookBookmarkBusinessLogic.swift
+++ b/Palace/Reader2/Bookmarks/AudiobookBookmarkBusinessLogic.swift
@@ -32,7 +32,10 @@ import PalaceReadingPosition
     // access now goes through `onStateQueue` so the serial `queue` is the single
     // serialization domain for this state.
     private var isSyncing: Bool = false
-    private var completionHandlersQueue: [([AudioBookmark]) -> Void] = []
+    // Boxed so the drained handlers can be captured by the `@Sendable`
+    // `DispatchQueue.main.async` closure in `finalizeSync` without crossing a
+    // non-Sendable boundary (each element wraps a `([AudioBookmark]) -> Void`).
+    private var completionHandlersQueue: [AudioBookmarkListCompletionBox] = []
     private var deletedBookmarkIds = Set<String>()
 
     @objc convenience init(book: TPPBook) {
@@ -111,13 +114,24 @@ import PalaceReadingPosition
             device: AnnotationDevice.currentID()
         )
 
+        // Swift 6 `complete`: box the non-Sendable `String?` completion closure
+        // and the non-Sendable `AudioBookmark` (a Palace-owned mutable class) so
+        // the `@Sendable` `Task` below captures Sendable carriers. INVARIANT: the
+        // boxed `audioBookmark` is created here and handed off exclusively to
+        // this single `Task` — the synchronous prefix above finishes touching it
+        // before the Task is enqueued, and no other task aliases it — so the
+        // `annotationId` mutation inside the Task is race-free.
+        let completionBox = StringCompletionBox(completion)
+        let audioBookmarkBox = AudioBookmarkBox(audioBookmark)
+
         Task { [weak self] in
             guard let self else { return }
+            let audioBookmark = audioBookmarkBox.bookmark
             do {
                 guard let serverID = try await self.positionWriter.save(snapshot) else {
                     // Throttled or queued — local position is already saved,
                     // and the writer will flush later. Nothing else to do here.
-                    completion?(nil)
+                    completionBox.call?(nil)
                     return
                 }
 
@@ -137,7 +151,7 @@ import PalaceReadingPosition
                         Log.warn(#file, "⚠️ Race condition detected: Local position is newer. Keeping local.")
                         Log.warn(#file, "  Sent: track=\(sentTrackKey), time=\(sentPlaybackTime), timestamp=\(sentTimestamp)")
                         Log.warn(#file, "  Current local: track=\(currentBookmark.chapter ?? "?"), timestamp=\(currentLocalTimestamp)")
-                        completion?(serverID)
+                        completionBox.call?(serverID)
                         return
                     }
 
@@ -157,7 +171,7 @@ import PalaceReadingPosition
                             Log.warn(#file, "⚠️ Prevented 'beginning' position from overwriting progress!")
                             Log.warn(#file, "  Attempting to save: track 0, time \(sentPlaybackTime)")
                             Log.warn(#file, "  Current position: track \(currentTrackIndex)")
-                            completion?(serverID)
+                            completionBox.call?(serverID)
                             return
                         }
                     }
@@ -169,10 +183,10 @@ import PalaceReadingPosition
 
                 self.registry.setLocation(audioBookmark.toTPPBookLocation(), forIdentifier: self.book.identifier)
                 Log.debug(#file, "☁️ Synced position to server: track=\(sentTrackKey), annotationId=\(audioBookmark.annotationId)")
-                completion?(serverID)
+                completionBox.call?(serverID)
             } catch {
                 Log.warn(#file, "⚠️ Server sync failed, but local position was already saved: \(error)")
-                completion?(nil)
+                completionBox.call?(nil)
             }
         }
     }
@@ -214,6 +228,16 @@ import PalaceReadingPosition
     }
 
     public func fetchBookmarks(for tracks: Tracks, toc: [Chapter], completion: @escaping ([TrackPosition]) -> Void) {
+        // Swift 6 `complete`: box the non-Sendable `completion` closure so the
+        // `@Sendable` work-`queue` closure (and the nested `syncBookmarks`
+        // handler + `DispatchQueue.main.async`) capture a Sendable carrier
+        // rather than the raw closure. `AudioBookmark` is a Palace-owned
+        // mutable class (not covered by `@preconcurrency import
+        // PalaceAudiobookToolkit`), so the `[AudioBookmark]` snapshots that
+        // flow through the sync handler are boxed the same way. INVARIANT: the
+        // boxed completion is only ever invoked on the main queue (the
+        // `DispatchQueue.main.async` below). Mirrors `ReadiumBookmarkBox`.
+        let completionBox = TrackPositionListCompletionBox(completion)
         queue.async { [weak self] in
             guard let self else { return }
 
@@ -244,7 +268,7 @@ import PalaceReadingPosition
                 }
 
                 DispatchQueue.main.async {
-                    completion(trackPositions)
+                    completionBox.call(trackPositions)
                 }
             }
         }
@@ -256,6 +280,15 @@ import PalaceReadingPosition
     }
 
     public func deleteBookmark(at bookmark: AudioBookmark, completion: ((Bool) -> Void)? = nil) {
+        // Swift 6 `complete`: box the non-Sendable `Bool` completion closure so
+        // the `@Sendable` `DispatchQueue.main.async` blocks (here and threaded
+        // into `deleteBookmarkByContentMatch`) capture a Sendable carrier.
+        // INVARIANT: the boxed completion is only ever invoked on the main queue.
+        let completionBox = BoolCompletionBox(completion)
+        deleteBookmark(at: bookmark, completion: completionBox)
+    }
+
+    private func deleteBookmark(at bookmark: AudioBookmark, completion: BoolCompletionBox) {
         Log.info(#file, "🗑️ DELETE BOOKMARK REQUEST for book: \(self.book.identifier)")
         Log.info(#file, "🗑️ Bookmark Details: version=\(bookmark.version), timestamp=\(bookmark.lastSavedTimeStamp ?? "nil"), annotationId=\(bookmark.annotationId.isEmpty ? "UNSYNCED" : bookmark.annotationId), chapter=\(bookmark.chapter ?? "nil"), readingOrderItem=\(bookmark.readingOrderItem ?? "nil")")
 
@@ -284,7 +317,7 @@ import PalaceReadingPosition
 
         guard !bookmark.isUnsynced else {
             Log.info(#file, "🗑️ Bookmark was unsynced (local only), deletion complete")
-            DispatchQueue.main.async { completion?(localDeletionSucceeded) }
+            DispatchQueue.main.async { completion.call?(localDeletionSucceeded) }
             return
         }
 
@@ -293,7 +326,7 @@ import PalaceReadingPosition
         annotationsManager.deleteBookmark(annotationId: bookmark.annotationId) { [weak self] serverSuccess in
             if serverSuccess {
                 Log.info(#file, "🗑️ ✅ Server deletion successful for annotationId: \(bookmark.annotationId)")
-                DispatchQueue.main.async { completion?(localDeletionSucceeded) }
+                DispatchQueue.main.async { completion.call?(localDeletionSucceeded) }
             } else {
                 Log.warn(#file, "🗑️ ⚠️ Direct server deletion failed - attempting content-based match")
                 self?.deleteBookmarkByContentMatch(bookmark, localDeletionSucceeded: localDeletionSucceeded, completion: completion)
@@ -301,7 +334,7 @@ import PalaceReadingPosition
         }
     }
 
-    private func deleteBookmarkByContentMatch(_ bookmark: AudioBookmark, localDeletionSucceeded: Bool, completion: ((Bool) -> Void)?) {
+    private func deleteBookmarkByContentMatch(_ bookmark: AudioBookmark, localDeletionSucceeded: Bool, completion: BoolCompletionBox) {
         Log.info(#file, "🔍 CONTENT-BASED DELETE: Fetching server bookmarks to find match")
 
         // Temporarily remove from deleted tracking to allow fetching
@@ -316,7 +349,7 @@ import PalaceReadingPosition
 
         fetchServerBookmarks { [weak self] serverBookmarks in
             guard let self = self else {
-                DispatchQueue.main.async { completion?(localDeletionSucceeded) }
+                DispatchQueue.main.async { completion.call?(localDeletionSucceeded) }
                 return
             }
 
@@ -336,7 +369,7 @@ import PalaceReadingPosition
                     } else {
                         Log.error(#file, "🔍 ❌ Content-matched deletion also failed - blocking bookmark from reappearing anyway")
                     }
-                    DispatchQueue.main.async { completion?(localDeletionSucceeded) }
+                    DispatchQueue.main.async { completion.call?(localDeletionSucceeded) }
                 }
             } else {
                 Log.warn(#file, "🔍 ⚠️ No matching bookmark found on server - may have already been deleted")
@@ -347,7 +380,7 @@ import PalaceReadingPosition
                         self.deletedBookmarkIds.insert("content:\(tempContentHash)")
                     }
                 }
-                DispatchQueue.main.async { completion?(localDeletionSucceeded) }
+                DispatchQueue.main.async { completion.call?(localDeletionSucceeded) }
             }
         }
     }
@@ -355,13 +388,24 @@ import PalaceReadingPosition
     // MARK: - Sync Logic
 
     func syncBookmarks(localBookmarks: [AudioBookmark], completion: (([AudioBookmark]) -> Void)? = nil) {
+        // Swift 6 `complete`: box the non-Sendable `[AudioBookmark]` input and
+        // the non-Sendable `completion` closure so the `@Sendable` `Task` below
+        // captures Sendable carriers instead of the raw values. `AudioBookmark`
+        // is a Palace-owned mutable class and must NOT be made `: Sendable` (9
+        // mutable `var`s) — see `AudioBookmarkListBox` / `ReadiumBookmarkBox`
+        // precedent. The serial work `queue` remains the single serialization
+        // domain (see the `isSyncing`/`completionHandlersQueue` note above), so
+        // boxing is safe: the boxed values are only ever touched on `queue` or
+        // the main queue, never concurrently.
+        let localBox = AudioBookmarkListBox(localBookmarks)
+        let completionBox = AudioBookmarkListCompletionBox(completion)
         // Atomically test-and-set `isSyncing`. If a sync is already in flight we
         // enqueue this completion under the same lock that `finalizeSync` drains
         // — without serialization the append raced the drain (CoW corruption).
         let shouldStartSync = onStateQueue { () -> Bool in
             if isSyncing {
-                if let completion {
-                    completionHandlersQueue.append(completion)
+                if completionBox.call != nil {
+                    completionHandlersQueue.append(completionBox)
                 }
                 return false
             }
@@ -372,13 +416,13 @@ import PalaceReadingPosition
 
         Task { [weak self] in
             guard let self else { return }
-            await uploadUnsyncedBookmarks(localBookmarks)
+            await uploadUnsyncedBookmarks(localBox.bookmarks)
 
             fetchServerBookmarks { [weak self] remoteBookmarks in
                 guard let strongSelf = self else { return }
 
                 strongSelf.updateLocalBookmarks(with: remoteBookmarks) { updatedBookmarks in
-                    strongSelf.finalizeSync(with: updatedBookmarks, completion: completion)
+                    strongSelf.finalizeSync(with: updatedBookmarks, completion: completionBox)
                 }
             }
         }
@@ -543,20 +587,24 @@ import PalaceReadingPosition
         }
     }
 
-    private func finalizeSync(with bookmarks: [AudioBookmark], completion: (([AudioBookmark]) -> Void)?) {
+    private func finalizeSync(with bookmarks: [AudioBookmark], completion: AudioBookmarkListCompletionBox?) {
+        // Swift 6 `complete`: box the `[AudioBookmark]` result so it — and the
+        // already-boxed queued handlers — cross the `@Sendable`
+        // `DispatchQueue.main.async` boundary as Sendable carriers.
+        let bookmarksBox = AudioBookmarkListBox(bookmarks)
         // Reset `isSyncing` and drain the queued handlers atomically, then fire
         // them off-lock on main. Draining inside the lock prevents a handler
         // enqueued by a concurrent `syncBookmarks` from being lost or
         // double-invoked while the array is being iterated/cleared.
-        let queuedHandlers: [([AudioBookmark]) -> Void] = onStateQueue {
+        let queuedHandlers: [AudioBookmarkListCompletionBox] = onStateQueue {
             isSyncing = false
             let drained = completionHandlersQueue
             completionHandlersQueue.removeAll()
             return drained
         }
         DispatchQueue.main.async {
-            completion?(bookmarks)
-            queuedHandlers.forEach { $0(bookmarks) }
+            completion?.call?(bookmarksBox.bookmarks)
+            queuedHandlers.forEach { $0.call?(bookmarksBox.bookmarks) }
         }
     }
 
@@ -648,4 +696,69 @@ extension AudiobookBookmarkBusinessLogic: AudiobookBookmarkDelegate {}
 private final class TrackPositionCompletionBox: @unchecked Sendable {
     let call: ((TrackPosition?) -> Void)?
     init(_ call: ((TrackPosition?) -> Void)?) { self.call = call }
+}
+
+// MARK: - Sendable carriers for the bookmark-sync @Sendable-closure captures
+
+/// Sendable carrier for a non-Sendable `[TrackPosition]` completion closure
+/// captured by the `@Sendable` work-`queue` / `DispatchQueue.main.async` chain
+/// in `fetchBookmarks`. INVARIANT — invoked only on the main queue.
+/// Mirrors `TrackPositionCompletionBox` / `ReadiumBookmarkBox`.
+private final class TrackPositionListCompletionBox: @unchecked Sendable {
+    let call: ([TrackPosition]) -> Void
+    init(_ call: @escaping ([TrackPosition]) -> Void) { self.call = call }
+}
+
+/// Sendable carrier for a non-Sendable `[AudioBookmark]` completion closure
+/// captured by the `@Sendable` `Task` in `syncBookmarks` and the
+/// `DispatchQueue.main.async` drain in `finalizeSync`. `AudioBookmark` is a
+/// Palace-owned mutable class (9 mutable `var`s) that must NOT be made
+/// `: Sendable` — boxing the closure is the correct ceiling, mirroring
+/// `ReadiumBookmarkBox` (Decision 3). INVARIANT — the boxed closure is only
+/// ever invoked on the main queue (the `finalizeSync` drain). The serial work
+/// `queue` remains the single serialization domain for the sync state, so no
+/// two invocations race.
+private final class AudioBookmarkListCompletionBox: @unchecked Sendable {
+    let call: (([AudioBookmark]) -> Void)?
+    init(_ call: (([AudioBookmark]) -> Void)?) { self.call = call }
+}
+
+/// Sendable carrier for a non-Sendable `[AudioBookmark]` value crossing a
+/// `@Sendable` `Task` / `DispatchQueue.main.async` boundary (the sync input in
+/// `syncBookmarks`, the result in `finalizeSync`). The wrapped array and its
+/// `AudioBookmark` elements are only ever produced, merged, and consumed on the
+/// serial work `queue` or the main queue — never mutated concurrently across
+/// the box — so `@unchecked Sendable` waives no real race.
+private final class AudioBookmarkListBox: @unchecked Sendable {
+    let bookmarks: [AudioBookmark]
+    init(_ bookmarks: [AudioBookmark]) { self.bookmarks = bookmarks }
+}
+
+/// Sendable carrier for a single non-Sendable `AudioBookmark` handed off to the
+/// `@Sendable` `Task` in `saveListeningPosition`. INVARIANT — the wrapped
+/// bookmark is created immediately before the Task and owned exclusively by it;
+/// the synchronous prefix finishes touching it before the Task is enqueued and
+/// no other task aliases it, so the in-Task `annotationId` mutation is race-free.
+private final class AudioBookmarkBox: @unchecked Sendable {
+    let bookmark: AudioBookmark
+    init(_ bookmark: AudioBookmark) { self.bookmark = bookmark }
+}
+
+/// Sendable carrier for a non-Sendable `String?` completion closure captured by
+/// the `@Sendable` `Task` in `saveListeningPosition`. INVARIANT — invoked only
+/// inside that single Task (server-sync terminal paths). Mirrors
+/// `TrackPositionCompletionBox`.
+private final class StringCompletionBox: @unchecked Sendable {
+    let call: ((String?) -> Void)?
+    init(_ call: ((String?) -> Void)?) { self.call = call }
+}
+
+/// Sendable carrier for a non-Sendable `Bool` completion closure captured by the
+/// `@Sendable` `DispatchQueue.main.async` blocks in `deleteBookmark` /
+/// `deleteBookmarkByContentMatch`. INVARIANT — invoked only on the main queue,
+/// exactly once per delete request (the terminal paths are mutually exclusive).
+/// Mirrors `TrackPositionCompletionBox`.
+private final class BoolCompletionBox: @unchecked Sendable {
+    let call: ((Bool) -> Void)?
+    init(_ call: ((Bool) -> Void)?) { self.call = call }
 }

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -141,18 +141,24 @@ protocol AnnotationsManager {
             return nil
         }
 
-        let bookmarks = await withCheckedContinuation { continuation in
+        // Swift 6 `complete`: `Bookmark` is a Palace-owned non-Sendable protocol
+        // (`protocol Bookmark: NSObject {}`), so a `[Bookmark]?` cannot cross the
+        // `CheckedContinuation.resume(returning:)` Sendable boundary. Box the
+        // single first bookmark we actually need. INVARIANT: the boxed value is
+        // produced once inside the `getServerBookmarks` completion and read once
+        // after the continuation resumes — no concurrent access.
+        let firstBox: BookmarkBox = await withCheckedContinuation { continuation in
             var didResume = false
 
             getServerBookmarks(forBook: book, atURL: url, motivation: .readingProgress) { bookmarks in
                 guard !didResume else { return }
                 didResume = true
 
-                continuation.resume(returning: bookmarks)
+                continuation.resume(returning: BookmarkBox(bookmarks?.first))
             }
         }
 
-        return bookmarks?.first
+        return firstBox.bookmark
     }
 
     static func postListeningPosition(forBook bookID: String, selectorValue: String, completion: ((_ response: AnnotationResponse?) -> Void)? = nil) {
@@ -573,23 +579,33 @@ protocol AnnotationsManager {
 
         Log.debug(#file, "Begin task of uploading local bookmarks, count: \(bookmarks.count).")
         let uploadGroup = DispatchGroup()
-        var bookmarksFailedToUpdate = [TPPReadiumBookmark]()
-        var bookmarksUpdated = [TPPReadiumBookmark]()
+        // Swift 6 `complete`: `TPPReadiumBookmark` is a Palace-owned non-Sendable
+        // class, so the mutable `[TPPReadiumBookmark]` accumulators and the
+        // per-upload `localBookmark` cannot be captured by the `@Sendable`
+        // `DispatchQueue.main.async` / `uploadGroup.notify` closures as raw
+        // values. Box the accumulators and the completion in a carrier whose
+        // INVARIANT is that every mutation and every read happens on the main
+        // queue: each upload's `append` runs inside `DispatchQueue.main.async`,
+        // and the terminal read runs inside `notify(queue: DispatchQueue.main)`.
+        // DispatchGroup serializes the two so no read races an in-flight append.
+        let accumulator = BookmarkUploadAccumulatorBox(completion: completion)
 
         for localBookmark in bookmarks {
             guard localBookmark.annotationId == nil else { continue }
 
+            let bookmarkBox = ReadiumBookmarkBox(localBookmark)
             uploadGroup.enter()
             postBookmark(localBookmark, forBookID: bookID) { response in
                 DispatchQueue.main.async {
                     defer { uploadGroup.leave() }
 
+                    let localBookmark = bookmarkBox.bookmark
                     if let serverId = response?.serverId {
                         localBookmark.annotationId = serverId
-                        bookmarksUpdated.append(localBookmark)
+                        accumulator.updated.append(localBookmark)
                     } else {
                         Log.error(#file, "Local Bookmark not uploaded: \(localBookmark)")
-                        bookmarksFailedToUpdate.append(localBookmark)
+                        accumulator.failed.append(localBookmark)
                     }
                 }
             }
@@ -597,7 +613,7 @@ protocol AnnotationsManager {
 
         uploadGroup.notify(queue: DispatchQueue.main) {
             Log.debug(#file, "Finished task of uploading local bookmarks.")
-            completion(bookmarksUpdated, bookmarksFailedToUpdate)
+            accumulator.completion(accumulator.updated, accumulator.failed)
         }
     }
     // MARK: -
@@ -664,5 +680,45 @@ protocol AnnotationsManager {
         let parameterData = try? JSONSerialization.data(withJSONObject: parameters, options: [.prettyPrinted])
         let headers = executor.request(for: url).allHTTPHeaderFields
         AppContainer.production().networkQueue.addRequest(libraryID, bookID, url, .POST, parameterData, headers)
+    }
+}
+
+// MARK: - Sendable carriers for the annotation-sync @Sendable-closure captures
+
+/// Sendable carrier for a single non-Sendable `Bookmark?` crossing the
+/// `CheckedContinuation.resume(returning:)` Sendable boundary in
+/// `syncReadingPosition`. `Bookmark` is a Palace-owned protocol
+/// (`protocol Bookmark: NSObject {}`) and cannot be made `Sendable`.
+/// INVARIANT — produced once in the `getServerBookmarks` completion, read once
+/// after the continuation resumes.
+private final class BookmarkBox: @unchecked Sendable {
+    let bookmark: Bookmark?
+    init(_ bookmark: Bookmark?) { self.bookmark = bookmark }
+}
+
+/// Sendable carrier for a single non-Sendable `TPPReadiumBookmark` handed to the
+/// `@Sendable` `DispatchQueue.main.async` upload-completion in
+/// `uploadLocalBookmarks`. `TPPReadiumBookmark` is a Palace-owned mutable class
+/// (must not be made `Sendable`). INVARIANT — the boxed bookmark's
+/// `annotationId` is mutated only on the main queue inside that completion.
+/// Mirrors `ReadiumBookmarkBox` in `TPPReaderBookmarksBusinessLogic`.
+private final class ReadiumBookmarkBox: @unchecked Sendable {
+    let bookmark: TPPReadiumBookmark
+    init(_ bookmark: TPPReadiumBookmark) { self.bookmark = bookmark }
+}
+
+/// Sendable carrier for the mutable `[TPPReadiumBookmark]` accumulators and the
+/// non-Sendable completion in `uploadLocalBookmarks`. INVARIANT — `updated` and
+/// `failed` are appended to only inside per-upload `DispatchQueue.main.async`
+/// blocks and read only inside the `uploadGroup.notify(queue:
+/// DispatchQueue.main)` terminal; all access is main-queue-confined and the
+/// DispatchGroup serializes the terminal read after every append, so
+/// `@unchecked Sendable` waives no real race.
+private final class BookmarkUploadAccumulatorBox: @unchecked Sendable {
+    var updated: [TPPReadiumBookmark] = []
+    var failed: [TPPReadiumBookmark] = []
+    let completion: ([TPPReadiumBookmark], [TPPReadiumBookmark]) -> Void
+    init(completion: @escaping ([TPPReadiumBookmark], [TPPReadiumBookmark]) -> Void) {
+        self.completion = completion
     }
 }

--- a/Palace/Reader2/BusinessLogic/TPPLastReadPositionSynchronizer.swift
+++ b/Palace/Reader2/BusinessLogic/TPPLastReadPositionSynchronizer.swift
@@ -58,10 +58,18 @@ final class TPPLastReadPositionSynchronizer: @unchecked Sendable {
               book: TPPBook,
               drmDeviceID: String?,
               completion: @escaping () -> Void) {
+        // Swift 6 `complete`: box the non-Sendable `() -> Void` completion so the
+        // `@Sendable` `Task` captures a Sendable carrier. We box rather than mark
+        // the param `@Sendable` because the `ReaderModule` caller closure
+        // captures non-Sendable main-actor values (`formatModule`,
+        // `navigationController`); `@Sendable` would ripple onto that call site.
+        // INVARIANT — the boxed closure runs only on the main thread (via
+        // `TPPMainThreadRun.asyncIfNeeded`).
+        let completionBox = VoidCompletionBox(completion)
         Task {
             await sync(for: publication, book: book, drmDeviceID: drmDeviceID)
             TPPMainThreadRun.asyncIfNeeded {
-                completion()
+                completionBox.call()
             }
         }
     }
@@ -123,9 +131,12 @@ final class TPPLastReadPositionSynchronizer: @unchecked Sendable {
                                         publication: Publication,
                                         book: TPPBook,
                                         completion: @escaping () -> Void) {
+        // Swift 6 `complete`: box the non-Sendable `() -> Void` completion for the
+        // `@Sendable` `Task` capture, matching `sync(for:book:drmDeviceID:completion:)`.
+        let completionBox = VoidCompletionBox(completion)
         Task {
             await presentNavigationAlert(for: serverLocator, publication: publication, book: book)
-            completion()
+            completionBox.call()
         }
     }
 
@@ -195,4 +206,15 @@ final class TPPLastReadPositionSynchronizer: @unchecked Sendable {
             }
         }
     }
+}
+
+/// Sendable carrier for a non-Sendable `() -> Void` completion closure captured
+/// by the `@Sendable` `Task`s in `TPPLastReadPositionSynchronizer`. Boxing
+/// avoids rippling `@Sendable` onto the `sync(...completion:)` signature, whose
+/// `ReaderModule` caller closure captures non-Sendable main-actor values.
+/// INVARIANT — the boxed closure runs only on the main thread (via
+/// `TPPMainThreadRun.asyncIfNeeded` / the alert-action continuation).
+private final class VoidCompletionBox: @unchecked Sendable {
+    let call: () -> Void
+    init(_ call: @escaping () -> Void) { self.call = call }
 }

--- a/Palace/Reader2/BusinessLogic/TPPReaderTOCBusinessLogic.swift
+++ b/Palace/Reader2/BusinessLogic/TPPReaderTOCBusinessLogic.swift
@@ -7,7 +7,11 @@
 //
 
 import Foundation
-import ReadiumShared
+// Swift 6 `complete`: `Publication`, `Link`, and `Locator` are non-Sendable
+// Readium types captured by the `@Sendable` `Task` in `init` (and returned from
+// the `async` locator helpers). `@preconcurrency` is the honest ceiling until
+// Readium annotates these Sendable — matches the sibling Reader2 files.
+@preconcurrency import ReadiumShared
 
 typealias TPPReaderTOCLink = (level: Int, link: Link)
 

--- a/Palace/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Palace/Reader2/ReaderPresentation/ReaderModule.swift
@@ -115,6 +115,19 @@ final class ReaderModule: ReaderModuleAPI, @unchecked Sendable {
                               formatModule: ReaderFormatModule,
                               in navigationController: UINavigationController,
                               forSample: Bool = false) {
+        // Swift 6 `complete`: the `Task.detached` closure is `@Sendable`, but
+        // `formatModule` (a non-Sendable `ReaderFormatModule` existential) and
+        // `navigationController` (a main-actor `UINavigationController`) are only
+        // ever *used* on the main actor — `makeReaderViewController` is
+        // `@MainActor`, and the nav controller is touched exclusively inside the
+        // `MainActor.run` blocks. Box them so the detached task captures a
+        // Sendable carrier rather than the raw main-actor values. INVARIANT: the
+        // boxed values are dereferenced only on the main actor. Mirrors the
+        // module's own `@unchecked Sendable` conformance rationale above.
+        let presentationBox = ReaderPresentationBox(
+            formatModule: formatModule,
+            navigationController: navigationController
+        )
         Task.detached { [weak self] in
             guard let self else { return }
 
@@ -122,7 +135,7 @@ final class ReaderModule: ReaderModuleAPI, @unchecked Sendable {
                 let lastSavedLocation = self.bookRegistry.location(forIdentifier: book.identifier)
                 let initialLocator = await lastSavedLocation?.convertToLocator(publication: publication)
 
-                let readerVC = try await formatModule.makeReaderViewController(
+                let readerVC = try await presentationBox.formatModule.makeReaderViewController(
                     for: publication,
                     book: book,
                     initialLocation: initialLocator,
@@ -130,6 +143,7 @@ final class ReaderModule: ReaderModuleAPI, @unchecked Sendable {
                 )
 
                 await MainActor.run {
+                    let navigationController = presentationBox.navigationController
                     let backItem = UIBarButtonItem()
                     backItem.title = Strings.Generic.back
                     readerVC.navigationItem.backBarButtonItem = backItem
@@ -141,9 +155,23 @@ final class ReaderModule: ReaderModuleAPI, @unchecked Sendable {
 
             } catch {
                 await MainActor.run {
-                    self.delegate?.presentError(error, from: navigationController)
+                    self.delegate?.presentError(error, from: presentationBox.navigationController)
                 }
             }
         }
+    }
+}
+
+/// Sendable carrier for the main-actor-confined `formatModule` +
+/// `navigationController` captured by the `@Sendable` `Task.detached` in
+/// `ReaderModule.finalizePresentation`. INVARIANT — both stored values are only
+/// dereferenced on the main actor: `makeReaderViewController` is `@MainActor`,
+/// and `navigationController` is touched only inside `MainActor.run`.
+private final class ReaderPresentationBox: @unchecked Sendable {
+    let formatModule: ReaderFormatModule
+    let navigationController: UINavigationController
+    init(formatModule: ReaderFormatModule, navigationController: UINavigationController) {
+        self.formatModule = formatModule
+        self.navigationController = navigationController
     }
 }

--- a/Palace/Reader2/Typography/FontManager.swift
+++ b/Palace/Reader2/Typography/FontManager.swift
@@ -11,11 +11,20 @@ import PalaceLogging
 
 /// Manages registration of custom fonts (e.g. OpenDyslexic) and checks font availability.
 /// Call `registerCustomFonts()` at app launch to ensure bundled fonts are available.
-final class FontManager {
+///
+/// Swift 6 `complete`: `@unchecked Sendable` makes the `static let shared`
+/// singleton concurrency-safe. The only mutable state is `hasRegistered`, a
+/// launch-once guard flipped exclusively from `registerCustomFonts()`, which is
+/// called once at app launch on the main thread. Availability reads
+/// (`isFontAvailable`, `availableFamilies`) are pure CoreText/UIFont lookups
+/// with no shared mutable state. INVARIANT — `hasRegistered` is written only on
+/// the main thread during launch, so no data race is waived.
+final class FontManager: @unchecked Sendable {
 
     static let shared = FontManager()
 
     /// Tracks whether fonts have already been registered this session.
+    /// Written only from `registerCustomFonts()` on the main thread at launch.
     private var hasRegistered = false
 
     private init() {}


### PR DESCRIPTION
## What
Clears ~43 of the ~49 non-critical `complete`-mode warnings in Reader2's bookmark/annotation sync, reader-presentation, and typography — using documented `@unchecked Sendable` carrier boxes (matching the existing `ReadiumBookmarkBox`/`ImageCompletionBox` precedent). Additive; **no bookmark-sync logic or ordering changed**. Part of PP-4720.

## Changes
- **`AudiobookBookmarkBusinessLogic`** (the big one, ~29): 6 carrier boxes threaded through the completion-heavy save/fetch/sync/delete paths. The serial `queue` stays the single serialization domain; `isSyncing` test-and-set, `completionHandlersQueue` enqueue/atomic-drain, `deletedBookmarkIds` filtering, and timestamp conflict-resolution are byte-for-byte unchanged. **Boxes relocate the capture, not the execution** — bookmarks still upload/download and remain findable.
- **`TPPAnnotations`**: boxed the `Bookmark?` crossing `CheckedContinuation.resume` + the mutable `[TPPReadiumBookmark]` accumulators/completion in `uploadLocalBookmarks`.
- **`ReaderModule`** / **`TPPLastReadPositionSynchronizer`**: boxed main-actor-confined values crossing `Task.detached`/`Task`.
- **`TPPReaderTOCBusinessLogic`**: `@preconcurrency import ReadiumShared`.
- **`FontManager`**: documented `@unchecked Sendable` (launch-once/main-thread singleton).

No `nonisolated(unsafe)`, no bare `@unchecked Sendable`, no `assumeIsolated` in a `deinit`. `AudioBookmark` is a mutable `@objc` class — deliberately boxed, **not** marked Sendable.

## Verification
Local DRM `build-for-testing` (`complete` mode), app + tests: **0 errors**.

## Scope / not done
- **Scope:** Reader2 bookmark/annotation/presentation/typography residual only.
- **Not done:** (1) the **DRM/LCP critical-path files** (`AdobeCertificate`, `AdobeDRMContentProtection`, `LCP*`) are **skipped** — separate rigorous slice. (2) 2 reader-VC sites deferred: `TPPEPUBViewController`'s keyboard-chord handler + VoiceOver block-rotor semaphore bridge, and `TPPBaseReaderViewController`'s 2 residual Readium-type crossings — a fix there risks input/AX timing. (3) Readium / PalaceAudiobookToolkit types stay at the `@preconcurrency` ceiling until those libraries annotate `Sendable` upstream.