### PR TITLE
test(mocks): lock TPPUserAccountMock (LIVE segv-class race) + intent-gate near-miss reporting (R9)

### DIFF
--- a/.forgeos/changesets/fix-useraccount-mock-lock/architect-review.md
+++ b/.forgeos/changesets/fix-useraccount-mock-lock/architect-review.md
@@ -1,0 +1,66 @@
+# Architect Review — fix/useraccount-mock-lock
+
+**Verdict: APPROVED**
+
+Reviewer: independent architect (ForgeOS gates OFF — file-only verdict, no MCP submission)
+Base: origin/develop  •  Commits: 2 (TPPUserAccountMock locking + intent-gate R9 message)
+Scope: PalaceTests/Mocks/TPPUserAccountMock.swift (+225/-84), scripts/check-intent-recorded.py
+(message-only), new pytest, wall-entry note. No production code.
+
+## Scrutiny findings
+
+1. **Lock-ordering (one-directional, no inversion) — PASS.** Confirmed in
+   Palace/Accounts/User/TPPUserAccount.swift: `controlLock` (lines 67–114,
+   incrementSignInGeneration 97–101) is a *leaf* lock used ONLY by the three
+   control accessors (notifyAccountChange, signInGeneration, sessionIdentifier)
+   and the increment helper — none call an overridable member (credentials /
+   authState / hasCredentials). Production `atomicUpdate` (625) and `removeAll`
+   (639) are both OVERRIDDEN by the mock, so their controlLock-adjacent seams
+   never run on the mock. The mock never holds `mockLock` while touching a
+   controlLock member: `removeAll()` releases mockLock, then sets
+   `signInGeneration = 0` sequentially (not nested). No path produces
+   mockLock→controlLock and controlLock→mockLock simultaneously. Inversion is
+   structurally impossible.
+
+2. **Re-entrancy eliminated — PASS.** authState, markCredentialsStale, and
+   credentialSnapshot now derive from `UserAccountAuthHelper.hasCredentials(_:)`
+   on single-acquisition locked snapshots instead of `self.hasCredentials()`
+   (which routes through the overridden `credentials` getter → mockLock, a
+   deadlock/re-entry). Verified the helper (UserAccountAuthState.swift:77–79) is
+   pure — enum switch only, no locking, no overridable calls. markCredentialsStale
+   replicates production's derive-then-guard semantics atomically under one lock;
+   behavior is preserved.
+
+3. **Source compatibility — PASS.** `_credentials` / `_authDefinition` remain
+   public `var` computed properties (get+set, same types), now backed by
+   `__`-prefixed storage under mockLock. ~40 test call sites across
+   PalaceTests set/get these directly; all remain valid (settable var contract
+   unchanged). Direct `_credentials` writes land in `__credentials`, which the
+   overridden `credentials` getter reads — consistent.
+
+4. **atomicUpdate weaker atomicity — PASS (documented, unused).** Block runs
+   outside mockLock (required — setters re-lock individually; holding across
+   would self-deadlock). Weaker than production's whole-block barrier, but grep
+   shows NO external test references atomicUpdateCallCount / atomicUpdateLibraryUUIDs
+   or relies on cross-field atomicity — the only references are inside the mock.
+   Acceptable and clearly documented in the class doc.
+
+5. **R9 script change — PASS (no behavioral drift).** `_near_miss_score` is a
+   new pure helper used ONLY in the already-failing INTENT-MISSING branch;
+   `_has_consecutive_token_match` (the matcher) is untouched. New 3-case pytest
+   pins exit 0 on match-path-unchanged, exit 1 on near-miss, and count-only
+   candidate dump — ran green locally (3 passed).
+
+## Minor (non-blocking) observations
+- `removeAllCallCount`'s computed `private(set)` setter is now effectively dead
+  (removeAll increments `_removeAllCallCount` directly under lock); the getter is
+  the live surface. Harmless.
+
+## Verification posture
+Tests-only change; guard is the check-unsynchronized-sendable-mock.py detector
+(re-covers this mock with the deferral marker removed) plus the author's
+10-iteration soak of the mock-heavy classes (TEST SUCCEEDED, 0 failures). No
+production code, so no mutation gate applies. Appropriate for a mock hardening.
+
+Clean, faithful application of the approved TPPBookRegistryMock recipe to the
+harder subclass case. No concern/fail findings.

--- a/.forgeos/changesets/fix-useraccount-mock-lock/qa-review.md
+++ b/.forgeos/changesets/fix-useraccount-mock-lock/qa-review.md
@@ -1,0 +1,74 @@
+# QA Review — fix/useraccount-mock-lock
+
+**Verdict: APPROVED**
+Reviewer role: qa_test (independent). ForgeOS gates OFF — verdict recorded here, not via forge_submit_review.
+Base: origin/develop  •  HEAD: 33af610c2, f9e56cd84
+Files: PalaceTests/Mocks/TPPUserAccountMock.swift, scripts/check-intent-recorded.py,
+scripts/tests/test_check_intent_recorded_nearmiss.py, .forgeos/wall-failures/2026-07-05-sync-mock-race.md
+
+## Summary
+A lock retrofit of TPPUserAccountMock (segv-class race follow-up to the 2026-07-05 wall entry)
+plus an R9 tooling change to the intent-gate near-miss message. Behavioral semantics for the
+40+/68 consuming test files are preserved (verified mechanically); concurrency safety is
+strengthened; the R9 message change is safe and non-regressing. One warning on R9 pytest
+coverage breadth. No concern/fail findings → APPROVED.
+
+## Findings
+
+### 1. Behavioral compatibility — PASS (coverage)
+Verified equivalence against origin/develop and production TPPUserAccount:
+- **authState derivation preserved.** New `UserAccountAuthHelper.hasCredentials(creds)` on a
+  locked snapshot is EXACTLY what old `hasCredentials()` computed — production TPPUserAccount.swift:343
+  is literally `UserAccountAuthHelper.hasCredentials(credentials)`. loggedOut+credentials → loggedIn
+  semantics identical, now torn-read-free (single lock acquisition, snapshot then pure helper).
+- **markCredentialsStale guard identical.** New derive-under-lock (mock:216-222) replicates old
+  `guard authState == .loggedIn` including the derived-loggedIn case; now TOCTOU-safe vs concurrent
+  markLoggedIn/setAuthToken (strictly stronger, same observable outcome).
+- **setAuthToken atomic.** token + credentials(.token) + .loggedIn all set under one lock (mock:184-191),
+  uses raw `__credentials`. Preserved; old was unlocked.
+- **removeAll clears everything it used to.** git show origin/develop confirms the old removeAll already
+  set signInGeneration=0; new keeps the identical field set + `_removeAllCallCount += 1` under lock, with
+  signInGeneration=0 moved OUTSIDE mockLock (correct — production setter takes controlLock; avoids inversion).
+- **credentialSnapshot** now reads a consistent (creds,state,authDef) snapshot under one lock; authDefinition
+  sourced from that snapshot instead of the locked getter — equivalent, torn-read-free.
+- **Re-entrancy audit clean:** every in-lock access uses raw `__credentials`/`__authDefinition`
+  (mock:186,201,218,234,335,337); the locked `_credentials`/`_authDefinition` wrappers are only touched by
+  the non-locked override accessors. NSLock is non-recursive — no self-deadlock path exists.
+
+### 2. Concurrency evidence — PASS (coverage)
+TPPCredentialConcurrencyTests (TPPCredentialVisibilityTests.swift:693+) drives credentialSnapshot ×100
+concurrent AND refreshCredentialsFromKeychain ×50 concurrent. That covers both the segv-class torn-read
+path and the accountInfoQueue(barrier)→mockLock cross-lock nesting (refresh→hasCredentials()→overridden
+credentials getter→mockLock). Lock order is one-directional (accountInfoQueue→mockLock; controlLock only
+outside mockLock) — no inversion. Because every public member now locks exactly once with no re-entrancy,
+all 68 consumers are safe by construction; the soak proves no deadlock/regression on the heaviest path.
+The other detector-flagged files (AccountsManagerStateMachineWiringTests, TPPAnnotationsTests,
+PalaceTestSetup) do not need separate soaks — correctness is structural, not soak-dependent.
+Detector `check-unsynchronized-sendable-mock.py` now reports this mock CLEAN (deferral marker removed);
+only 3 pre-existing latent notes remain.
+
+### 3. resetShared ordering — PASS (regression)
+New order (fresh instance published under sharedLock, then removeAll on the captured local ref) is STRONGER
+than old: shared assignment is now atomic and removeAll runs on the local ref (no TOCTOU on a second shared
+read). The window where `shared` points at fresh-but-not-yet-removeAll'd is benign — a fresh instance is
+already nil-fields/.loggedOut; removeAll on it only bumps the call count. Concurrent readers see loggedOut
+either way. No weaker-than-old window introduced.
+
+### 4. R9 near-miss pytest — WARNING (coverage)
+The 3 cases pin the fail path (near-miss named + rule), the suppression path (no overlap → count-only,
+no near-miss block), and the match path (rc=0). Together they bracket the matcher: test 3 catches
+under-matching, tests 1&2 catch over-matching; the `s > 0` guard mutant is killed by test 2. Verified:
+`pytest ...nearmiss.py` 3/3 green; legacy `test_check_intent_recorded.py` still PASS (R9 count-only message
+change did not regress the INTENT-MISSING assertion).
+GAP: the fixture uses a SINGLE intent file, so the actual R9 value — ranking the closest of MANY candidates
+and the `scored[:3]` top-3 selection/sort — is never exercised with >1 candidate. A regression in the sort
+key or the top-3 slice among multiple candidates would NOT be caught. Recommend adding a multi-candidate
+case asserting the closest name ranks first. Non-blocking (message-only tooling, not product code).
+
+## Mechanical checks run
+- git show origin/develop:removeAll vs HEAD — field set + signInGeneration=0 identical
+- production TPPUserAccount.swift:343 / UserAccountAuthState.swift:77 — hasCredentials equivalence confirmed
+- grep re-entrancy audit of _/__ credentials access — all in-lock uses raw form
+- pytest test_check_intent_recorded_nearmiss.py — 3 passed
+- python3 scripts/test_check_intent_recorded.py — PASS (no R9 regression)
+- check-unsynchronized-sendable-mock.py — mock no longer flagged

--- a/.forgeos/wall-failures/2026-07-05-sync-mock-race.md
+++ b/.forgeos/wall-failures/2026-07-05-sync-mock-race.md
@@ -73,10 +73,15 @@ Two compounding test-quality failures:
   mock from 50–100 threads (`refreshCredentialsFromKeychain` ×50 concurrent)
   — the same segv class as this entry, active today. 18 unsynchronized vars,
   wide SignInLogic blast radius → **scope-deferred** with marker + this
-  entry as the tracking record. Follow-up is PRIORITIZED: lock it in the
-  next dedicated pass (same recipe as `TPPBookRegistryMock`). Note the
-  file-level deferral marker blinds the detector to this mock entirely —
-  remove the marker in the same PR that adds the lock.
+  entry as the tracking record. **RESOLVED 2026-07-06
+  (fix/useraccount-mock-lock):** locked with the same recipe plus two
+  subclass-specific rules — production-locked members (`signInGeneration` →
+  controlLock) touched only OUTSIDE mockLock (one-directional nesting), and
+  derivations that previously called overridable members (`hasCredentials()`
+  → overridden `credentials`) now use the pure
+  `UserAccountAuthHelper.hasCredentials(_:)` on locked snapshots. The
+  mutable `static shared` (the F-008 race vector) got its own `sharedLock`.
+  Deferral marker removed; detector re-covers this mock.
 - `MockFeatureFlagProvider`, `MockPDFDocumentMetadata`, `MockReachability` —
   latent (no concurrent usage today); detector reports as notes, `--strict`
   escalates.

--- a/PalaceTests/Mocks/TPPUserAccountMock.swift
+++ b/PalaceTests/Mocks/TPPUserAccountMock.swift
@@ -9,23 +9,53 @@
 import Foundation
 @testable import Palace
 
-// unsync-sendable-mock-deferred: 18 unsynchronized vars, wide SignInLogic test
-// blast radius — locking deferred to a follow-up pass (found by
-// scripts/check-unsynchronized-sendable-mock.py during
-// fix/sync-mock-race-segv-bookmark-keys; see the wall entry
-// 2026-07-05-sync-mock-race.md). New unsynchronized @unchecked Sendable
-// mocks are BLOCKED by that detector — do not copy this deferral.
+/// `@unchecked Sendable`: production `TPPUserAccount` is lock-backed
+/// (controlLock, 5a32a8cd2) and consumers may touch accounts across
+/// concurrency domains — `TPPCredentialConcurrencyTests` drives this mock
+/// from 50–100 concurrent threads. The mock HONORS that contract: all
+/// underscore-backed override storage is guarded by a single `mockLock`
+/// (segv-class fix, follow-up to wall entry 2026-07-05-sync-mock-race.md;
+/// same recipe as `TPPBookRegistryMock`).
+///
+/// Locking rules (mirror of the TPPBookRegistryMock review):
+/// - Public members take `mockLock` EXACTLY ONCE; no public member calls
+///   another public/overridable member (or `super`) while holding it —
+///   production getters route through OVERRIDDEN accessors
+///   (`hasCredentials()` → `credentials`), so re-entering would deadlock.
+///   Derivations use pure helpers on locked SNAPSHOTS instead
+///   (`UserAccountAuthHelper.hasCredentials(_:)`).
+/// - Production-locked members (`signInGeneration` → controlLock) are only
+///   touched OUTSIDE `mockLock` — nesting stays one-directional
+///   (production → mock via overridden getters), so no lock-order inversion.
+/// - The mutable `shared` singleton is guarded by `sharedLock` (the F-008
+///   in-flight-observer race on `resetShared` was previously unsynchronized).
+/// - `atomicUpdate` records its call under the lock but runs the block
+///   OUTSIDE it (each setter the block calls locks individually). This is
+///   weaker than production's whole-block atomicity — acceptable for the
+///   mock because tests assert call-recording, not cross-field invariants;
+///   documented here so nobody assumes otherwise.
 class TPPUserAccountMock: TPPUserAccount, @unchecked Sendable {
     /// Test-only fixed library UUID. Per-library isolation semantics are
     /// exercised separately via `TPPMultiLibraryAccountMock` /
     /// `TPPPerAccountIsolationTests`; here a single shared instance is fine.
     static let testLibraryUUID = "test-library-mock"
 
+    private let mockLock = NSLock()
+    private static let sharedLock = NSLock()
+
     /// Counts `removeAll()` invocations so reset tests can assert this
     /// library's credentials were cleared.
-    private(set) var removeAllCallCount = 0
+    private var _removeAllCallCount = 0
+    private(set) var removeAllCallCount: Int {
+        get { mockLock.withLock { _removeAllCallCount } }
+        set { mockLock.withLock { _removeAllCallCount = newValue } }
+    }
 
-    private static var shared = TPPUserAccountMock(libraryUUID: testLibraryUUID)
+    private static var _shared = TPPUserAccountMock(libraryUUID: testLibraryUUID)
+    private static var shared: TPPUserAccountMock {
+        get { sharedLock.withLock { _shared } }
+        set { sharedLock.withLock { _shared = newValue } }
+    }
 
     /// Tests that call `TPPUserAccountMock.sharedAccount(libraryUUID:)` get
     /// the fixed shared mock regardless of UUID — preserves the old behaviour.
@@ -43,100 +73,102 @@ class TPPUserAccountMock: TPPUserAccount, @unchecked Sendable {
 
     // MARK: - Variable redefinitions to avoid keychain
 
-    var _authDefinition: AccountDetails.Authentication?
+    private var __authDefinition: AccountDetails.Authentication?
+    var _authDefinition: AccountDetails.Authentication? {
+        get { mockLock.withLock { __authDefinition } }
+        set { mockLock.withLock { __authDefinition = newValue } }
+    }
     override var authDefinition: AccountDetails.Authentication? {
-        get {
-            return _authDefinition
-        }
-        set {
-            _authDefinition = newValue
-        }
+        get { _authDefinition }
+        set { _authDefinition = newValue }
     }
 
-    var _credentials: TPPCredentials?
+    private var __credentials: TPPCredentials?
+    var _credentials: TPPCredentials? {
+        get { mockLock.withLock { __credentials } }
+        set { mockLock.withLock { __credentials = newValue } }
+    }
     override var credentials: TPPCredentials? {
-        get {
-            return _credentials
-        }
-        set {
-            _credentials = newValue
-        }
+        get { _credentials }
+        set { _credentials = newValue }
     }
 
     private var _authorizationIdentifier: String?
     override var authorizationIdentifier: String? {
-        return _authorizationIdentifier
+        mockLock.withLock { _authorizationIdentifier }
     }
     override func setAuthorizationIdentifier(_ identifier: String) {
-        _authorizationIdentifier = identifier
+        mockLock.withLock { _authorizationIdentifier = identifier }
     }
 
     private var _deviceID: String?
     override var deviceID: String? {
-        return _deviceID
+        mockLock.withLock { _deviceID }
     }
     override func setDeviceID(_ newValue: String) {
-        _deviceID = newValue
+        mockLock.withLock { _deviceID = newValue }
     }
 
     private var _userID: String?
     override var userID: String? {
-        return _userID
+        mockLock.withLock { _userID }
     }
     override func setUserID(_ newValue: String) {
-        _userID = newValue
+        mockLock.withLock { _userID = newValue }
     }
 
     private var _adobeVendor: String?
     override var adobeVendor: String? {
-        return _adobeVendor
+        mockLock.withLock { _adobeVendor }
     }
     override func setAdobeVendor(_ newValue: String) {
-        _adobeVendor = newValue
+        mockLock.withLock { _adobeVendor = newValue }
     }
 
     private var _provider: String?
     override var provider: String? {
-        return _provider
+        mockLock.withLock { _provider }
     }
     override func setProvider(_ newValue: String) {
-        _provider = newValue
+        mockLock.withLock { _provider = newValue }
     }
 
     private var _patron: [String: Any]?
     override var patron: [String: Any]? {
-        return _patron
+        mockLock.withLock { _patron }
     }
     override func setPatron(_ newValue: [String: Any]) {
-        _patron = newValue
+        mockLock.withLock { _patron = newValue }
     }
 
     private var _adobeToken: String?
     override var adobeToken: String? {
-        return _adobeToken
+        mockLock.withLock { _adobeToken }
     }
     override func setAdobeToken(_ newValue: String) {
-        _adobeToken = newValue
+        mockLock.withLock { _adobeToken = newValue }
     }
     override func setAdobeToken(_ token: String, patron: [String: Any]) {
-        _adobeToken = token
-        _patron = patron
+        mockLock.withLock {
+            _adobeToken = token
+            _patron = patron
+        }
     }
 
     private var _licensor: [String: Any]?
     override var licensor: [String: Any]? {
-        return _licensor
+        mockLock.withLock { _licensor }
     }
     override func setLicensor(_ newValue: [String: Any]) {
-        _licensor = newValue
+        mockLock.withLock { _licensor = newValue }
     }
 
     private var _cookies: [HTTPCookie]?
     override var cookies: [HTTPCookie]? {
-        return _cookies
+        mockLock.withLock { _cookies }
     }
     override func setCookies(_ newValue: [HTTPCookie]) {
-        _cookies = newValue
+        mockLock.withLock { _cookies = newValue }
     }
 
     override var legacyAuthToken: String? {
@@ -145,53 +177,69 @@ class TPPUserAccountMock: TPPUserAccount, @unchecked Sendable {
 
     private var _authToken: String?
     override var authToken: String? {
-        return _authToken
+        mockLock.withLock { _authToken }
     }
 
     override func setAuthToken(_ token: String, barcode: String?, pin: String?, expirationDate: Date?) {
-        _authToken = token
-        _credentials = .token(authToken: token, barcode: barcode, pin: pin, expirationDate: expirationDate)
-        // Mirror real TPPUserAccount.setAuthToken: a fresh token clears any
-        // persisted .credentialsStale flag.
-        _authState = .loggedIn
+        mockLock.withLock {
+            _authToken = token
+            __credentials = .token(authToken: token, barcode: barcode, pin: pin, expirationDate: expirationDate)
+            // Mirror real TPPUserAccount.setAuthToken: a fresh token clears any
+            // persisted .credentialsStale flag.
+            _authState = .loggedIn
+        }
     }
 
     // MARK: - Auth State
 
     private var _authState: TPPAccountAuthState = .loggedOut
     override var authState: TPPAccountAuthState {
-        // If we have credentials but state is loggedOut, derive loggedIn state
-        if _authState == .loggedOut && hasCredentials() {
+        // If we have credentials but state is loggedOut, derive loggedIn
+        // state. The derivation uses the PURE helper on a locked snapshot —
+        // calling self.hasCredentials() here would re-enter mockLock via the
+        // overridden `credentials` getter.
+        let (state, creds) = mockLock.withLock { (_authState, __credentials) }
+        if state == .loggedOut && UserAccountAuthHelper.hasCredentials(creds) {
             return .loggedIn
         }
-        return _authState
+        return state
     }
 
     override func setAuthState(_ state: TPPAccountAuthState) {
-        _authState = state
+        mockLock.withLock { _authState = state }
     }
 
     override func markCredentialsStale() {
-        guard authState == .loggedIn else { return }
-        _authState = .credentialsStale
+        // Atomic derive-and-write: the guard and the transition happen under
+        // ONE lock acquisition (a read-then-write through the public members
+        // would TOCTOU-race concurrent markLoggedIn/setAuthToken calls).
+        mockLock.withLock {
+            let derived: TPPAccountAuthState =
+                (_authState == .loggedOut && UserAccountAuthHelper.hasCredentials(__credentials))
+                ? .loggedIn : _authState
+            guard derived == .loggedIn else { return }
+            _authState = .credentialsStale
+        }
     }
 
     override func markLoggedIn() {
-        _authState = .loggedIn
+        mockLock.withLock { _authState = .loggedIn }
     }
 
     override class func credentialSnapshot(for libraryUUID: String?) -> CredentialSnapshot {
         let mock = shared
-        let creds = mock._credentials
-        let hasCreds = mock.hasCredentials()
+        // One lock acquisition for a CONSISTENT snapshot; all derivation on
+        // the snapshot afterwards (helpers are pure).
+        let (creds, state, authDef) = mock.mockLock.withLock {
+            (mock.__credentials, mock._authState, mock.__authDefinition)
+        }
+        let hasCreds = UserAccountAuthHelper.hasCredentials(creds)
         let hasToken: Bool
         if let creds = creds, case .token = creds {
             hasToken = true
         } else {
             hasToken = false
         }
-
-        let state: TPPAccountAuthState = mock._authState
 
         var barcode: String?
         var pin: String?
@@ -220,18 +268,32 @@ class TPPUserAccountMock: TPPUserAccount, @unchecked Sendable {
             barcode: barcode,
             pin: pin,
             authToken: authToken,
-            authDefinition: mock.authDefinition,
+            authDefinition: authDef,
             cookies: nil
         )
     }
 
-    var atomicUpdateCallCount = 0
-    var atomicUpdateLibraryUUIDs: [String?] = []
+    private var _atomicUpdateCallCount = 0
+    var atomicUpdateCallCount: Int {
+        get { mockLock.withLock { _atomicUpdateCallCount } }
+        set { mockLock.withLock { _atomicUpdateCallCount = newValue } }
+    }
+    private var _atomicUpdateLibraryUUIDs: [String?] = []
+    var atomicUpdateLibraryUUIDs: [String?] {
+        get { mockLock.withLock { _atomicUpdateLibraryUUIDs } }
+        set { mockLock.withLock { _atomicUpdateLibraryUUIDs = newValue } }
+    }
 
     override func atomicUpdate(for libraryUUID: String?,
                                 _ block: (TPPUserAccount) -> Void) {
-        atomicUpdateCallCount += 1
-        atomicUpdateLibraryUUIDs.append(libraryUUID)
+        mockLock.withLock {
+            _atomicUpdateCallCount += 1
+            _atomicUpdateLibraryUUIDs.append(libraryUUID)
+        }
+        // Block runs OUTSIDE the lock: it calls back into this mock's locked
+        // setters, and holding mockLock across it would self-deadlock. See
+        // the class doc for the (documented) weaker-than-production
+        // atomicity this implies.
         block(self)
     }
 
@@ -254,26 +316,31 @@ class TPPUserAccountMock: TPPUserAccount, @unchecked Sendable {
     /// also call `businessLogic.userAccount.removeAll()` at the top of the
     /// test body as defense-in-depth.
     static func resetShared() {
-        shared = TPPUserAccountMock(libraryUUID: testLibraryUUID)
-        shared.removeAll()
+        let fresh = TPPUserAccountMock(libraryUUID: testLibraryUUID)
+        shared = fresh
+        fresh.removeAll()
     }
 
     // MARK: - Clean everything up
 
     override func removeAll() {
-        removeAllCallCount += 1
-        _adobeToken = nil
-        _patron = nil
-        _adobeVendor = nil
-        _provider = nil
-        _userID = nil
-        _deviceID = nil
-        _authDefinition = nil
-        _authToken = nil
-        _credentials = nil
-        _cookies = nil
-        _authorizationIdentifier = nil
-        _authState = .loggedOut
+        mockLock.withLock {
+            _removeAllCallCount += 1
+            _adobeToken = nil
+            _patron = nil
+            _adobeVendor = nil
+            _provider = nil
+            _userID = nil
+            _deviceID = nil
+            __authDefinition = nil
+            _authToken = nil
+            __credentials = nil
+            _cookies = nil
+            _authorizationIdentifier = nil
+            _authState = .loggedOut
+        }
+        // Production-locked member (controlLock) — touched OUTSIDE mockLock
+        // so lock nesting stays one-directional (see class doc).
         signInGeneration = 0
     }
 }

--- a/scripts/check-intent-recorded.py
+++ b/scripts/check-intent-recorded.py
@@ -183,6 +183,27 @@ def _tokenize(text: str) -> list[str]:
     return [t.lower() for t in _WORDLIKE_RE.findall(text)]
 
 
+def _near_miss_score(subject: str, name: str) -> tuple[int, int]:
+    """(longest consecutive shared-token run, total shared tokens) between a
+    commit subject and an intent-file name — used ONLY for failure-message
+    ranking (R9: the old message listed 80 candidates without naming the
+    near-miss or the rule, so a semantically-obvious pairing that missed the
+    4-consecutive bar looked like a missing file rather than a naming
+    mismatch)."""
+    subj_tokens = _tokenize(_strip_noise_prefixes(subject))
+    name_tokens = _tokenize(name)
+    shared = len(set(subj_tokens) & set(name_tokens))
+    longest = 0
+    for i in range(len(subj_tokens)):
+        for j in range(len(name_tokens)):
+            k = 0
+            while (i + k < len(subj_tokens) and j + k < len(name_tokens)
+                   and subj_tokens[i + k] == name_tokens[j + k]):
+                k += 1
+            longest = max(longest, k)
+    return (longest, shared)
+
+
 def _has_consecutive_token_match(subject: str, name: str, min_run: int) -> bool:
     """True if `name` shares ≥`min_run` consecutive tokens with `subject`.
 
@@ -394,7 +415,25 @@ def main(argv: list[str]) -> int:
                 print(f"DRY-RUN: would require intent under {intent_dir} "
                       f"matching subject: {subject!r}", file=sys.stderr)
             return 0
-        cand_names = ", ".join(c.name for c in candidates) or "(none)"
+        # R9: rank candidates by near-miss score so the operator sees the
+        # closest names + the matching rule instead of an undifferentiated
+        # 80-file list.
+        scored = sorted(
+            ((c, *_near_miss_score(subject, c.stem)) for c in candidates),
+            key=lambda t: (t[1], t[2]), reverse=True)
+        near = [f"{c.name} (run={r}, shared={s})" for c, r, s in scored[:3] if s > 0]
+        if near:
+            print("INTENT-MISSING: closest candidates (longest consecutive "
+                  "token run / total shared tokens):")
+            for line in near:
+                print(f"  - {line}")
+            print("Matching rule: shared ticket-key + ≥2 consecutive content "
+                  "tokens, OR ≥4 consecutive shared tokens between commit "
+                  "subject and intent-file name. Rename the intent file or "
+                  "reword the subject to satisfy it.")
+        # Full listing replaced by a count now that near-misses are ranked
+        # above (R9) — 80 undifferentiated names buried the signal.
+        cand_names = f"{len(candidates)} file(s) in {intent_dir}/" if candidates else "(none)"
         print(f"INTENT-MISSING: prod LOC added={stats.prod_loc_added} "
               f"≥ threshold={args.threshold_loc}; no intent file in "
               f"{intent_dir} matched subject: {subject!r}. "

--- a/scripts/tests/test_check_intent_recorded_nearmiss.py
+++ b/scripts/tests/test_check_intent_recorded_nearmiss.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+test_check_intent_recorded_nearmiss.py — R9 near-miss reporting on the
+intent-recorded gate.
+
+The 2026-07-05 failure mode: a semantically-obvious subject↔intent pairing
+missed the 4-consecutive-token bar and the error listed 80 undifferentiated
+candidates without naming the near-miss or the rule. These tests pin the
+improved failure message (ranked near-misses + explicit rule + count-only
+candidate line) and that exit codes / the match path are unchanged.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-intent-recorded.py"
+
+INTENT = """---
+name: segv-mock-race-bookmark-keys
+created: 2026-07-05
+author: test
+---
+
+## Summary
+x
+
+## Claims
+- x
+
+## Anti-claims
+- x
+
+## Files in scope
+- x
+"""
+
+# A diff adding >10 prod LOC under Palace/.
+DIFF = "--- a/Palace/Foo.swift\n+++ b/Palace/Foo.swift\n" + "".join(
+    f"+let x{i} = {i}\n" for i in range(15))
+
+
+def _run(tmp: Path, subject: str) -> tuple[int, str]:
+    intent_dir = tmp / "intent"
+    intent_dir.mkdir(exist_ok=True)
+    (intent_dir / "segv-mock-race-bookmark-keys.md").write_text(INTENT)
+    (tmp / "msg.txt").write_text(subject + "\n")
+    (tmp / "diff.txt").write_text(DIFF)
+    result = subprocess.run(
+        ["python3", str(_SCRIPT),
+         "--commit-msg", str(tmp / "msg.txt"),
+         "--diff", str(tmp / "diff.txt"),
+         "--intent-dir", str(intent_dir)],
+        capture_output=True, text=True, cwd=str(_REPO_ROOT), timeout=30,
+    )
+    return result.returncode, result.stdout + result.stderr
+
+
+def test_near_miss_is_named_with_rule(tmp_path):
+    # Shares tokens (mock, race, bookmark, keys) but no 4-consecutive run.
+    rc, out = _run(tmp_path, "fix: mock race cleanup for bookmark keys")
+    assert rc == 1, out
+    assert "closest candidates" in out
+    assert "segv-mock-race-bookmark-keys.md" in out.split("Candidates checked")[0]
+    assert "Matching rule:" in out
+
+
+def test_candidate_dump_is_count_only(tmp_path):
+    rc, out = _run(tmp_path, "feat: zebra quantum unrelated")
+    assert rc == 1, out
+    assert "1 file(s)" in out
+    # No near-miss block when nothing overlaps.
+    assert "closest candidates" not in out
+
+
+def test_match_path_unchanged(tmp_path):
+    rc, out = _run(tmp_path, "fix: segv mock race bookmark keys hardening")
+    assert rc == 0, out
+    assert "OK: intent file" in out

--- a/scripts/tests/test_check_intent_recorded_nearmiss.py
+++ b/scripts/tests/test_check_intent_recorded_nearmiss.py
@@ -75,6 +75,33 @@ def test_candidate_dump_is_count_only(tmp_path):
     assert "closest candidates" not in out
 
 
+def test_ranking_prefers_longer_consecutive_run(tmp_path):
+    """QA finding: the ranking itself (R9's actual point) needs multi-candidate
+    discrimination — the closer name must be listed first."""
+    intent_dir = tmp_path / "intent"
+    intent_dir.mkdir()
+    # Close: shares the consecutive run "mock race" + 4 tokens total.
+    (intent_dir / "mock-race-bookmark-hardening.md").write_text(INTENT)
+    # Distant: one shared token, no run.
+    (intent_dir / "bookmark-unrelated-cleanup.md").write_text(INTENT)
+    (tmp_path / "msg.txt").write_text("fix: mock race guard for bookmark keys\n")
+    (tmp_path / "diff.txt").write_text(DIFF)
+    result = subprocess.run(
+        ["python3", str(_SCRIPT),
+         "--commit-msg", str(tmp_path / "msg.txt"),
+         "--diff", str(tmp_path / "diff.txt"),
+         "--intent-dir", str(intent_dir)],
+        capture_output=True, text=True, cwd=str(_REPO_ROOT), timeout=30,
+    )
+    out = result.stdout + result.stderr
+    assert result.returncode == 1, out
+    close = out.find("mock-race-bookmark-hardening.md")
+    distant = out.find("bookmark-unrelated-cleanup.md")
+    assert close != -1, out
+    assert distant == -1 or close < distant, (
+        f"closer candidate must rank first: {out}")
+
+
 def test_match_path_unchanged(tmp_path):
     rc, out = _run(tmp_path, "fix: segv mock race bookmark keys hardening")
     assert rc == 0, out


### PR DESCRIPTION
## Summary

Two dogfood follow-ups from PR #1178's review cycle. **No production code** — test infrastructure + tooling messages only.

### 1. TPPUserAccountMock locked — closes the LIVE race the blast-radius reviewer found
`TPPCredentialConcurrencyTests` hammers the shared mock from 50–100 threads while the mock carried 18 unsynchronized vars behind `@unchecked Sendable` — the identical class that segfaulted the suite on 2026-07-04 via `TPPBookRegistryMock`. Same locking recipe, plus two subclass-specific rules (the mock extends production `TPPUserAccount`, which has its own `controlLock`):
- **One-directional lock nesting** — production-locked members (`signInGeneration`) touched only outside `mockLock`; architect verified `controlLock` is a leaf lock with no inversion path.
- **No overridable calls under the lock** — derivations (`authState`, `markCredentialsStale`, `credentialSnapshot`) use the pure `UserAccountAuthHelper` on single-acquisition snapshots instead of `hasCredentials()` (which routes through the overridden `credentials` getter → would self-deadlock).
- The mutable `static shared` (the F-008 race vector) gets its own `sharedLock`.
- Deferral marker removed — `check-unsynchronized-sendable-mock.py` re-covers this mock.

### 2. Intent-gate near-miss reporting (dogfood R9)
`INTENT-MISSING` now names the top-3 closest intent files (ranked by longest consecutive shared-token run) plus the explicit matching rule, and trims the 80-file dump to a count. Matcher logic and exit codes unchanged; 4-case pytest added (the gate previously had none), including multi-candidate ranking discrimination per the QA finding.

## Evidence
- **verify-pr --quick: 23/23 PASS**
- Mock-heavy classes (`TPPCredentialConcurrencyTests`, `TPPSignInBusinessLogicSignOutTests`, `SignInModalLifecycleTests`) at `-test-iterations 10` → `** TEST SUCCEEDED **`, 0 failures
- SoD: architect `rev_d2ed9592` APPROVED, qa_test APPROVED (verdicts in `.forgeos/changesets/fix-useraccount-mock-lock/`); QA verified behavioral compatibility mechanically across the 68 consuming test files
- Wall entry `2026-07-05-sync-mock-race.md` updated with the resolution
- Remaining latent mocks (3, no concurrent usage) stay guarded by the blocking detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)