### PR TITLE
fix(swift6): MyBooks presenters → complete-mode concurrency (isolation-only)

### DIFF
--- a/Palace/MyBooks/BorrowErrorPresenter.swift
+++ b/Palace/MyBooks/BorrowErrorPresenter.swift
@@ -19,6 +19,29 @@ import Foundation
 import PalaceCatalog
 import PalaceLogging
 
+// MARK: - Carrier boxes
+
+/// Carrier box that lets the non-Sendable `TPPBook` ride inside a
+/// `@Sendable` closure (the `@MainActor` re-auth Task and the `@Sendable`
+/// retry closures). The book is read-only after construction and the
+/// closures only ever touch it on the main actor, so `@unchecked Sendable`
+/// is sound. Mirrors the carrier-box precedent (`CarPlayImageCompletionBox`,
+/// `ReadiumBookmarkBox`).
+private final class BorrowBookBox: @unchecked Sendable {
+    let book: TPPBook
+    init(_ book: TPPBook) { self.book = book }
+}
+
+/// Carrier box for the non-Sendable `[String: Any]?` problem-error
+/// dictionary so it can cross into the `@MainActor @Sendable` re-auth Task.
+/// Read-only after construction; only decoded (`TPPProblemDocument.from
+/// Dictionary`) on the main actor. `@unchecked Sendable` is sound for the
+/// same read-only-single-consumer reason as `BorrowBookBox`.
+private final class BorrowErrorDictBox: @unchecked Sendable {
+    let error: [String: Any]?
+    init(_ error: [String: Any]?) { self.error = error }
+}
+
 // MARK: - CredentialRequestState
 
 /// Shared flag that gates concurrent sign-in modal presentations across
@@ -49,7 +72,20 @@ protocol BorrowErrorPresenterDelegate: AnyObject {
 /// exists" message, kick a re-auth flow on invalid credentials, present
 /// the generic borrow-failed alert with a retry action, or surface the
 /// problem-document detail in a borrow-failed alert.
-final class BorrowErrorPresenter {
+///
+/// `@unchecked Sendable` invariant (Swift 6 `complete`-mode slice): every
+/// injected collaborator is an immutable `let` (`progressReporter`,
+/// `userRetryTracker`, `reauthenticator`, `userAccountProvider`,
+/// `credentialRequestState` — the last is itself `@unchecked Sendable`). The
+/// only mutable instance storage is the `@MainActor`-isolated
+/// `hasAttemptedAuthentication` latch (read/written solely on the main actor)
+/// and `weak var delegate` (assigned once on the main thread during
+/// `MyBooksDownloadCenter` init, read only from `@MainActor`-hopped
+/// contexts). `@unchecked` is required only so `self` can be captured by the
+/// `@Sendable` alert/reauth closures — not because any state is racy. Mirrors
+/// sibling presenters in this module (`CredentialPromptCoordinator`,
+/// `BookSignInRedirectHandler`, `DownloadAuthRetryHandler`).
+final class BorrowErrorPresenter: @unchecked Sendable {
 
     typealias DisplayStrings = Strings.MyDownloadCenter
 
@@ -96,15 +132,27 @@ final class BorrowErrorPresenter {
         switch errorType {
         case TPPProblemDocument.TypeLoanAlreadyExists:
             let alertMessage = DisplayStrings.loanAlreadyExistsAlertMessage
+            // Snapshot the Sendable identifier so the non-Sendable `book` does
+            // not cross into the `@MainActor @Sendable` closure.
+            let bookId = book.identifier
             runOnMainAsync { [weak self] in
                 self?.progressReporter.publishAndAnnounceError(
-                    DownloadErrorInfo(bookId: book.identifier, title: alertTitle, message: alertMessage, kind: .borrow)
+                    DownloadErrorInfo(bookId: bookId, title: alertTitle, message: alertMessage, kind: .borrow)
                 )
             }
 
         case TPPProblemDocument.TypeInvalidCredentials:
+            // `book` (non-Sendable `TPPBook`) and `error` (`[String: Any]?`,
+            // `Any` is non-Sendable) both need to ride whole into the
+            // `@MainActor @Sendable` re-auth Task. Thread them through
+            // read-only carrier boxes; the boxed values are only touched on
+            // the main actor inside the Task.
+            let bookBox = BorrowBookBox(book)
+            let errorBox = BorrowErrorDictBox(error)
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                let book = bookBox.book
+                let error = errorBox.error
 
                 guard !self.hasAttemptedAuthentication else {
                     self.showAlert(for: book, with: error, alertTitle: alertTitle)
@@ -167,9 +215,14 @@ final class BorrowErrorPresenter {
 
         let retryAction = makeBorrowRetryAction(for: book)
 
+        // Snapshot the Sendable identifier so the non-Sendable `book` does not
+        // cross into the `@MainActor @Sendable` closure. `retryAction` is now
+        // `@Sendable` (see `makeBorrowRetryAction`), so it too is safe to capture.
+        let bookId = book.identifier
+
         runOnMainAsync { [weak self] in
             self?.progressReporter.publishAndAnnounceError(
-                DownloadErrorInfo(bookId: book.identifier, title: alertTitle, message: alertMessage, kind: .borrow, retryAction: retryAction)
+                DownloadErrorInfo(bookId: bookId, title: alertTitle, message: alertMessage, kind: .borrow, retryAction: retryAction)
             )
         }
     }
@@ -178,9 +231,14 @@ final class BorrowErrorPresenter {
         let formattedMessage = String(format: DisplayStrings.borrowFailedMessage, book.title)
         let retryAction = makeBorrowRetryAction(for: book)
 
+        // Snapshot the Sendable identifier so the non-Sendable `book` does not
+        // cross into the `@MainActor @Sendable` closure. `retryAction` is now
+        // `@Sendable` (see `makeBorrowRetryAction`), so it too is safe to capture.
+        let bookId = book.identifier
+
         runOnMainAsync { [weak self] in
             self?.progressReporter.publishAndAnnounceError(
-                DownloadErrorInfo(bookId: book.identifier, title: DisplayStrings.borrowFailed, message: formattedMessage, kind: .borrow, retryAction: retryAction)
+                DownloadErrorInfo(bookId: bookId, title: DisplayStrings.borrowFailed, message: formattedMessage, kind: .borrow, retryAction: retryAction)
             )
         }
     }
@@ -188,13 +246,22 @@ final class BorrowErrorPresenter {
     /// Returns a retry closure that re-attempts the borrow for the given
     /// book when invoked, gated by the per-operation budget on
     /// `userRetryTracker`. Nil means "out of budget, hide the retry button".
-    private func makeBorrowRetryAction(for book: TPPBook) -> (() -> Void)? {
+    ///
+    /// Returns a `@Sendable` closure so it can be captured by the
+    /// `@MainActor @Sendable` alert-publication closures. The closure needs
+    /// the whole non-Sendable `book` to re-drive `startBorrow`, so it is
+    /// threaded through a `BorrowBookBox` carrier: the book is read-only
+    /// inside the closure and the closure is only ever invoked on the main
+    /// actor (from the alert's Retry button), so `@unchecked Sendable` on the
+    /// box is sound.
+    private func makeBorrowRetryAction(for book: TPPBook) -> (@Sendable () -> Void)? {
         let operationId = "borrow-\(book.identifier)"
         guard userRetryTracker.canRetry(operationId: operationId) else { return nil }
+        let bookBox = BorrowBookBox(book)
         return { [weak self] in
             guard let self else { return }
             self.userRetryTracker.recordRetry(operationId: operationId)
-            self.delegate?.startBorrow(for: book, attemptDownload: true, borrowCompletion: nil)
+            self.delegate?.startBorrow(for: bookBox.book, attemptDownload: true, borrowCompletion: nil)
         }
     }
 }

--- a/Palace/MyBooks/DownloadAlertPresenter.swift
+++ b/Palace/MyBooks/DownloadAlertPresenter.swift
@@ -27,6 +27,18 @@ import Foundation
 import PalaceLogging
 import PalaceCatalog
 
+// MARK: - RetryBookBox
+
+/// Carrier box that lets the non-Sendable `TPPBook` ride inside a
+/// `@Sendable` retry closure. The book is read-only after construction and
+/// the closure is only ever invoked on the main actor (from the alert's
+/// Retry button), so `@unchecked Sendable` is sound. Mirrors the
+/// carrier-box precedent (`CarPlayImageCompletionBox`, `ReadiumBookmarkBox`).
+private final class RetryBookBox: @unchecked Sendable {
+    let book: TPPBook
+    init(_ book: TPPBook) { self.book = book }
+}
+
 // MARK: - DownloadAlertPresenterDelegate
 
 /// Surface MBDC needs to expose for the presenter to drive retries and the
@@ -43,7 +55,23 @@ protocol DownloadAlertPresenterDelegate: AnyObject {
 /// download-state cleanup that paired with them on MBDC. No UIKit surface
 /// — the alert is published through `progressReporter.publishAndAnnounce
 /// Error`, which the host SwiftUI sheet observes via Combine.
-final class DownloadAlertPresenter {
+///
+/// `@unchecked Sendable` invariant (Swift 6 `complete`-mode slice): every
+/// injected collaborator is an immutable `let` (`bookRegistry`,
+/// `stateManager`, `progressReporter`, `downloadAnnouncementService`,
+/// `errorActivityTracker`, `userRetryTracker`, `problemDocumentCache`). The
+/// only mutable instance storage is `weak var delegate`, which is assigned
+/// exactly once on the main thread during `MyBooksDownloadCenter` init and
+/// only read from `@MainActor`-hopped or awaited contexts thereafter — never
+/// mutated concurrently. The class does not add
+/// any concurrency of its own beyond hopping alert publication to
+/// `@MainActor` (`runOnMainAsync`) and cleanup to a detached `Task`; both
+/// already run on their own actors. `@unchecked` is required only so `self`
+/// can be captured by those `@Sendable` closures — not because any state is
+/// racy. Mirrors sibling presenters in this module
+/// (`DownloadAuthRetryHandler`, `RightsManagementDispatcher`,
+/// `BookReturnService`, `BookSignInRedirectHandler`).
+final class DownloadAlertPresenter: @unchecked Sendable {
 
     typealias DisplayStrings = Strings.MyDownloadCenter
 
@@ -93,9 +121,14 @@ final class DownloadAlertPresenter {
 
         downloadAnnouncementService.announceDownloadFailed(for: book)
 
+        // Snapshot the Sendable String facets of `book` before the detached
+        // Task so the non-Sendable `TPPBook` does not have to cross the
+        // `@Sendable` boundary. The task only ever reads the identifier/title.
+        let bookId = book.identifier
+        let bookTitle = book.title
         Task { [weak self] in
             await self?.errorActivityTracker.log(
-                "Download failed for '\(book.title)': \(message ?? "unknown reason")",
+                "Download failed for '\(bookTitle)': \(message ?? "unknown reason")",
                 category: .download
             )
             guard let self else { return }
@@ -105,15 +138,15 @@ final class DownloadAlertPresenter {
             // task as in-flight and flip the book to .downloadFailed again
             // (the regression of PP-4114 — same root cause as the
             // success-path leak).
-            await self.stateManager.bookIdentifierToDownloadInfo.remove(book.identifier)
+            await self.stateManager.bookIdentifierToDownloadInfo.remove(bookId)
             let stalePairs = await self.stateManager.taskIdentifierToBook.allPairs()
-            for (taskId, mappedBook) in stalePairs where mappedBook.identifier == book.identifier {
+            for (taskId, mappedBook) in stalePairs where mappedBook.identifier == bookId {
                 await self.stateManager.taskIdentifierToBook.remove(taskId)
             }
-            await self.stateManager.downloadCoordinator.removeCachedDownloadInfo(for: book.identifier)
-            await self.stateManager.downloadCoordinator.registerCompletion(identifier: book.identifier)
+            await self.stateManager.downloadCoordinator.removeCachedDownloadInfo(for: bookId)
+            await self.stateManager.downloadCoordinator.registerCompletion(identifier: bookId)
             let remainingCount = await self.stateManager.downloadCoordinator.activeCount
-            Log.info(#file, "📊 Download failed for '\(book.title)', remaining active: \(remainingCount)")
+            Log.info(#file, "📊 Download failed for '\(bookTitle)', remaining active: \(remainingCount)")
             self.delegate?.schedulePendingStartsIfPossible()
         }
 
@@ -136,10 +169,14 @@ final class DownloadAlertPresenter {
 
         let retryAction = makeRetryAction(for: book)
 
+        // `bookId` (snapshotted above) is the Sendable identifier so the
+        // non-Sendable `book` does not cross into the `@MainActor @Sendable`
+        // closure. `retryAction` is now `@Sendable` (see `makeRetryAction`),
+        // so it too is safe to capture.
         // Publish error and announce via VoiceOver
         runOnMainAsync { [weak self] in
             self?.progressReporter.publishAndAnnounceError(
-                DownloadErrorInfo(bookId: book.identifier,
+                DownloadErrorInfo(bookId: bookId,
                                   title: DisplayStrings.downloadFailed,
                                   message: finalMessage,
                                   kind: .download,
@@ -176,10 +213,15 @@ final class DownloadAlertPresenter {
         // Download failures are generally retryable unless it's a "no active loan" error
         let retryAction = isNoActiveLoan ? nil : makeRetryAction(for: book)
 
+        // Snapshot the Sendable identifier so the non-Sendable `book` does not
+        // cross into the `@MainActor @Sendable` closure. `retryAction` is now
+        // `@Sendable` (see `makeRetryAction`), so it too is safe to capture.
+        let bookId = book.identifier
+
         // Publish error and announce via VoiceOver
         runOnMainAsync { [weak self] in
             self?.progressReporter.publishAndAnnounceError(
-                DownloadErrorInfo(bookId: book.identifier,
+                DownloadErrorInfo(bookId: bookId,
                                   title: DisplayStrings.downloadFailed,
                                   message: finalMessage,
                                   kind: .download,
@@ -195,13 +237,20 @@ final class DownloadAlertPresenter {
     /// (`userRetryTracker`) has been exhausted, so the UI can hide the
     /// retry button instead of letting the user hammer a permanent
     /// failure.
-    private func makeRetryAction(for book: TPPBook) -> (() -> Void)? {
+    // Returns a `@Sendable` closure so it can be captured by the
+    // `@MainActor @Sendable` alert-publication closures. The closure needs the
+    // whole non-Sendable `book` to re-drive `startDownload`, so it is threaded
+    // through a `RetryBookBox` carrier: the book is read-only inside the
+    // closure and the closure is only ever invoked on the main actor (from the
+    // alert's Retry button), so `@unchecked Sendable` on the box is sound.
+    private func makeRetryAction(for book: TPPBook) -> (@Sendable () -> Void)? {
         let operationId = "download-\(book.identifier)"
         guard userRetryTracker.canRetry(operationId: operationId) else { return nil }
+        let bookBox = RetryBookBox(book)
         return { [weak self] in
             guard let self else { return }
             self.userRetryTracker.recordRetry(operationId: operationId)
-            self.delegate?.startDownload(for: book, withRequest: nil)
+            self.delegate?.startDownload(for: bookBox.book, withRequest: nil)
         }
     }
 }

--- a/Palace/MyBooks/MyBooks/BookCell/ButtonView/BookButtonsView.swift
+++ b/Palace/MyBooks/MyBooks/BookCell/ButtonView/BookButtonsView.swift
@@ -185,6 +185,13 @@ enum ButtonSize {
 }
 
 struct HapticFeedback {
+    // `UIImpactFeedbackGenerator` and its `prepare()`/`impactOccurred()`
+    // members are `@MainActor`-isolated UIKit APIs. Under `complete`-mode
+    // strict concurrency a nonisolated `static func` calling them warns.
+    // The sole caller is the SwiftUI `Button(action:)` closure in
+    // `ActionButton.body`, which is already `@MainActor`, so pinning this to
+    // the main actor is the correct isolation and adds no caller ripple.
+    @MainActor
     static func medium() {
         let generator = UIImpactFeedbackGenerator(style: .medium)
         generator.prepare()

--- a/Palace/MyBooks/MyBooks/BookListView.swift
+++ b/Palace/MyBooks/MyBooks/BookListView.swift
@@ -1,5 +1,16 @@
 import SwiftUI
 
+/// Carrier box that lets a read-only `[TPPBook]` snapshot cross into a
+/// `@Sendable` detached prefetch task. `TPPBook` is a non-Sendable
+/// `NSObject`; the boxed array is never mutated after construction and is
+/// consumed by exactly one detached task (read-only thumbnail fetch), so
+/// `@unchecked Sendable` is sound. Mirrors the carrier-box precedent
+/// (`CarPlayImageCompletionBox`, `ReadiumBookmarkBox`).
+private final class PrefetchBooksBox: @unchecked Sendable {
+    let books: [TPPBook]
+    init(_ books: [TPPBook]) { self.books = books }
+}
+
 struct BookListView: View {
     let books: [TPPBook]
     @Binding var isLoading: Bool
@@ -105,8 +116,16 @@ struct BookListView: View {
         // for TPPBookCoverRegistry.shared. Capture the value to avoid touching
         // the SwiftUI Environment from the detached task.
         let imageLoader = appContainer.imageLoader
+        // `TPPBook` is a non-Sendable `NSObject`, so `[TPPBook]` cannot cross
+        // into the `@Sendable` detached task under `complete`-mode strict
+        // concurrency. Wrap the snapshot in a carrier box: the array is a
+        // read-only snapshot handed to a single detached task that only reads
+        // each book to fetch its thumbnail — never mutated, never shared with
+        // another consumer — so `@unchecked Sendable` is sound. (Precedent:
+        // `CarPlayImageCompletionBox`, `ReadiumBookmarkBox`.)
+        let upcomingBooksBox = PrefetchBooksBox(upcomingBooks)
         Task.detached(priority: .utility) {
-            for book in upcomingBooks {
+            for book in upcomingBooksBox.books {
                 _ = await imageLoader.thumbnailImage(for: book)
             }
         }


### PR DESCRIPTION
## Swift 6 Phase B — MyBooks presenters (isolation-only)

Part of **PP-4722** (Phase B critical-module migration). Clears the MyBooks
presenter-layer `complete`-mode strict-concurrency warnings. **No behavior change.**

### Changes
- `BorrowErrorPresenter` / `DownloadAlertPresenter` → `final … @unchecked Sendable`
  (documented invariant: all deps `let`; sole mutable state is the `@MainActor`-
  confined `hasAttemptedAuthentication` + write-once `weak delegate`).
- Snapshot Sendable `bookId`/`bookTitle` before `@Sendable`/`@MainActor` closures;
  carrier boxes (`BorrowBookBox`/`RetryBookBox`/`PrefetchBooksBox`) for non-Sendable
  `TPPBook`/error captures; retry closures `@Sendable`.
- `BookButtonsView`: `HapticFeedback.medium()` → `@MainActor`.

### Verification
- Compiles in a `complete`-mode DRM `build-for-testing` (app + test target), part of
  the wave-1 union that moved the app **328 → 190** distinct `complete`-mode warnings.
- **Two independent SoD reviews APPROVED** (correctness/soundness + qa/behavior lenses):
  traced every `@unchecked Sendable` invariant, confirmed the 3.1.0 placeholder-message
  regression logic untouched, no test ripple, existing regression tests intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
