### PR TITLE
fix(swift6): Audiobooks → complete-mode concurrency (isolation-only + boxes)

### DIFF
--- a/Palace/Audiobooks/AudiobookLoader.swift
+++ b/Palace/Audiobooks/AudiobookLoader.swift
@@ -224,15 +224,25 @@ final class AudiobookLoader {
         // Structured-concurrency poll (Task.sleep, not recursive GCD) to keep
         // the audiobook open path off GCD per adr_a265ec76, mirroring the
         // sibling poll in AudiobookSessionManager.awaitAudiobookContentLocal.
+        //
+        // The `completion` closure is the caller's non-`@Sendable` callback
+        // (it captures the loader's own `completion`), but the poll runs in a
+        // `@Sendable` `Task`. Wrap it in a carrier box (precedent:
+        // `SendableDecryptCompletion` in LCPAudiobooks) so the completion can
+        // cross into the Task WITHOUT forcing `@Sendable` onto this signature —
+        // which would ripple to the single call site inside
+        // `refreshTokenIfNeeded`. The box fires the wrapped closure exactly
+        // once (success XOR timeout), so the invariant holds.
+        let completionBox = TokenReadyCompletionBox(completion)
         Task {
             let deadline = Date().addingTimeInterval(timeout)
             while true {
                 if !AppContainer.production().accountsManager.currentUserAccount.authTokenHasExpired {
-                    completion(true)
+                    completionBox.fire(true)
                     return
                 }
                 if Date() >= deadline {
-                    completion(false)
+                    completionBox.fire(false)
                     return
                 }
                 try? await Task.sleep(nanoseconds: UInt64(max(0, pollInterval) * 1_000_000_000))
@@ -501,5 +511,25 @@ final class AudiobookLoader {
         ))
 
         return chain
+    }
+}
+
+/// `Sendable` carrier for `awaitTokenReady`'s non-`@Sendable` completion so it
+/// can cross into the poll `Task` without forcing `@Sendable` onto the
+/// `awaitTokenReady` signature (which would ripple to its call site).
+///
+/// - Sendable invariant: `fire(_:)` forwards to the wrapped closure. The poll
+///   loop calls it exactly once (token-ready XOR timeout) from a single Task,
+///   never concurrently. The wrapped closure is otherwise opaque, hence
+///   `@unchecked`. Mirrors `SendableDecryptCompletion` in `LCPAudiobooks`.
+private struct TokenReadyCompletionBox: @unchecked Sendable {
+    private let completion: (Bool) -> Void
+
+    init(_ completion: @escaping (Bool) -> Void) {
+        self.completion = completion
+    }
+
+    func fire(_ becameValid: Bool) {
+        completion(becameValid)
     }
 }

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -2215,7 +2215,15 @@ public final class AudiobookSessionManager: ObservableObject {
 /// exactly once when a bounded await races a timeout against a completion
 /// callback. NSLock-guarded so the (possibly background-thread) sync callback and
 /// the MainActor timeout can race safely without a double-resume trap.
-private final class PositionResolveOnce {
+///
+/// - Sendable invariant: this guard is captured by both the (possibly
+///   off-main) `syncLocation` completion and the `@MainActor` timeout `Task` —
+///   i.e. it deliberately crosses concurrency domains. That is safe because its
+///   only mutable state (`fired`) is read and written EXCLUSIVELY under `lock`,
+///   so the two racing `fire(_:)` calls serialize and exactly one runs `block`.
+///   Hence `@unchecked Sendable` (the lock discipline is the invariant the
+///   compiler cannot see).
+private final class PositionResolveOnce: @unchecked Sendable {
     private let lock = NSLock()
     private var fired = false
     func fire(_ block: () -> Void) {

--- a/Palace/Audiobooks/DPLA/DPLAAudiobooks.swift
+++ b/Palace/Audiobooks/DPLA/DPLAAudiobooks.swift
@@ -44,7 +44,7 @@ class DPLAAudiobooks {
     /// - Parameter error: Error object
     ///
     /// `completion` either returns `keyData` value or an `error`.  `validThrough` date is optional even when `keyData` is not nil.
-    static func drmKey(completion: @escaping (_ keyData: Data?, _ validThrough: Date?, _ error: Error?) -> Void) {
+    static func drmKey(completion: @escaping @Sendable (_ keyData: Data?, _ validThrough: Date?, _ error: Error?) -> Void) {
         let task = URLSession.shared.dataTask(with: DPLAAudiobooks.certificateUrl) { (data, response, error) in
             // In case of an error
             if let error = error {

--- a/Palace/Audiobooks/LCP/LCPAudiobooks.swift
+++ b/Palace/Audiobooks/LCP/LCPAudiobooks.swift
@@ -91,7 +91,7 @@ import PalaceCatalog
         )
     }
 
-    @objc func contentDictionary(completion: @escaping (_ json: NSDictionary?, _ error: NSError?) -> Void) {
+    @objc func contentDictionary(completion: @escaping @Sendable (_ json: NSDictionary?, _ error: NSError?) -> Void) {
         if isReleasedSnapshot() {
             DispatchQueue.main.async {
                 completion(nil, Self.releasedError())
@@ -119,7 +119,7 @@ import PalaceCatalog
         )
     }
 
-    private func loadContentDictionary(completion: @escaping (_ json: NSDictionary?, _ error: NSError?) -> Void) {
+    private func loadContentDictionary(completion: @escaping @Sendable (_ json: NSDictionary?, _ error: NSError?) -> Void) {
         if isReleasedSnapshot() {
             completion(nil, Self.releasedError())
             return

--- a/Palace/Audiobooks/NowPlayingCoordinator.swift
+++ b/Palace/Audiobooks/NowPlayingCoordinator.swift
@@ -51,7 +51,13 @@ public final class NowPlayingCoordinator {
     private var lastUpdateTime: Date = .distantPast
     private var lastIsPlaying: Bool = false
     private var pendingUpdate: Task<Void, Never>?
-    private var foregroundObserver: NSObjectProtocol?
+    /// Foreground-notification observer token. Held in a nonisolated
+    /// `@unchecked Sendable` box so the nonisolated `deinit` can remove it
+    /// WITHOUT reading a `@MainActor`-isolated stored property (which
+    /// `complete` mode rejects, and `MainActor.assumeIsolated` is banned in
+    /// deinit). Mirrors the codebase `ObserverTokenBox` pattern
+    /// (DLNavigator / TPPBookRegistry).
+    private let foregroundObserverBox = ObserverTokenBox()
 
     /// Injectable seam for `UIApplication.shared.applicationState`. Tests
     /// flip this to drive the background / foreground branches without
@@ -101,7 +107,7 @@ public final class NowPlayingCoordinator {
         // dry-stream guard fires without coupling AudiobookSessionManager.
         // Tests drive the guard via `applicationDidBecomeActive()` directly
         // so they don't depend on UIApplication notification timing.
-        foregroundObserver = NotificationCenter.default.addObserver(
+        foregroundObserverBox.token = NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,
             object: nil,
             queue: .main
@@ -113,9 +119,7 @@ public final class NowPlayingCoordinator {
     }
 
     deinit {
-        if let observer = foregroundObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
+        foregroundObserverBox.removeObserver()
         Log.info(#file, "NowPlayingCoordinator deinitialized")
     }
 
@@ -342,5 +346,21 @@ public final class NowPlayingCoordinator {
     /// gating condition.
     func _test_setLastIsPlaying(_ playing: Bool) {
         lastIsPlaying = playing
+    }
+}
+
+/// Nonisolated `Sendable` holder for the foreground-notification observer
+/// token. Mirrors the codebase `ObserverTokenBox` pattern (DLNavigator /
+/// TPPBookRegistry): the `@MainActor`-isolated `NowPlayingCoordinator` cannot
+/// read an isolated stored property from its nonisolated `deinit`, so the
+/// token lives here instead. `token` is written exactly once (right after
+/// `addObserver` returns in `init`) and read only by `removeObserver()` —
+/// write-once-then-read confinement, hence `@unchecked Sendable`.
+private final class ObserverTokenBox: @unchecked Sendable {
+    var token: NSObjectProtocol?
+    func removeObserver() {
+        if let token {
+            NotificationCenter.default.removeObserver(token)
+        }
     }
 }

--- a/Palace/Audiobooks/PlaybackReadinessGate.swift
+++ b/Palace/Audiobooks/PlaybackReadinessGate.swift
@@ -45,7 +45,11 @@
 //
 
 import Foundation
-import PalaceAudiobookToolkit
+// `@preconcurrency`: the toolkit's `Player` / `TrackPosition` are not
+// Sendable-audited upstream, and this file passes a `TrackPosition` across the
+// `await player.play(at:)` boundary and awaits the toolkit player. This is the
+// honest ceiling until the toolkit annotates its types.
+@preconcurrency import PalaceAudiobookToolkit
 import PalaceLogging
 
 // MARK: - PlaybackReadinessError
@@ -353,14 +357,25 @@ internal final class PlayerReadinessProbe: PlaybackReadinessProbing {
         }
 
         pollTimer?.invalidate()
+        // The `Timer.scheduledTimer` block fires on the main runloop, but its
+        // `Timer` argument is not `Sendable`, so it must NOT be captured into
+        // the nested `@MainActor` `Task`. Handle the two invalidation cases
+        // without crossing the non-Sendable `Timer` over the task boundary:
+        //   • dead-self: invalidate synchronously in the outer block (which
+        //     legitimately holds the `timer` argument on the main runloop),
+        //     matching the original leak-guard behavior.
+        //   • ready: invalidate via the stored `pollTimer` (the same timer)
+        //     from inside the `@MainActor` Task.
         let timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] timer in
+            guard self != nil else {
+                timer.invalidate()
+                return
+            }
             Task { @MainActor [weak self] in
-                guard let self = self else {
-                    timer.invalidate()
-                    return
-                }
+                guard let self = self else { return }
                 if self.isLoadedSnapshot() {
-                    timer.invalidate()
+                    self.pollTimer?.invalidate()
+                    self.pollTimer = nil
                     await gate.markReady()
                 }
             }

--- a/Palace/Audiobooks/TPPReturnPromptHelper.swift
+++ b/Palace/Audiobooks/TPPReturnPromptHelper.swift
@@ -3,9 +3,17 @@
 //  Copyright © 2020 NYPL Labs. All rights reserved.
 //
 
+// `@MainActor`: this helper builds `UIAlertController` / `UIAlertAction`
+// instances — main-actor UIKit types — and its actions fire the completion
+// on the main actor via the alert-action handler (itself `@MainActor
+// @Sendable` in the SDK). Isolating the whole helper to the main actor is the
+// correct, isolation-only fix; the completion/handler closures are marked
+// `@Sendable` so they can be captured by the `@MainActor @Sendable`
+// UIAlertAction handler.
+@MainActor
 @objcMembers final class TPPReturnPromptHelper: NSObject {
 
-    static func audiobookPrompt(completion: @escaping (_ returnWasChosen: Bool) -> Void) -> UIAlertController {
+    static func audiobookPrompt(completion: @escaping @MainActor @Sendable (_ returnWasChosen: Bool) -> Void) -> UIAlertController {
         let title = Strings.ReturnPromptHelper.audiobookPromptTitle
         let message = Strings.ReturnPromptHelper.audiobookPromptMessage
         let alert = UIAlertController.init(title: title, message: message, preferredStyle: .alert)
@@ -20,14 +28,14 @@
         return alert
     }
 
-    private static func keepAction(handler: @escaping () -> Void) -> UIAlertAction {
+    private static func keepAction(handler: @escaping @MainActor @Sendable () -> Void) -> UIAlertAction {
         return UIAlertAction(
             title: Strings.ReturnPromptHelper.keepActionAlertTitle,
             style: .cancel,
             handler: { _ in handler() })
     }
 
-    private static func returnAction(handler: @escaping () -> Void) -> UIAlertAction {
+    private static func returnAction(handler: @escaping @MainActor @Sendable () -> Void) -> UIAlertAction {
         return UIAlertAction(
             title: Strings.ReturnPromptHelper.returnActionTitle,
             style: .default,

--- a/Palace/Audiobooks/Tracker/AudiobookDataManager.swift
+++ b/Palace/Audiobooks/Tracker/AudiobookDataManager.swift
@@ -99,7 +99,23 @@ struct AudiobookDataManagerStore: Codable {
     }
 }
 
-class AudiobookDataManager {
+/// - Sendable invariant: `AudiobookDataManager` is captured by the `@Sendable`
+///   closures it schedules onto `syncQueue` (barrier writes + the sync loop),
+///   the `beginBackgroundTask` expiration handler, the `.TPPCurrentAccountDidChange`
+///   observer, and the `networkService.POST` completion. It is safe to share
+///   across those boundaries because:
+///   1. Every stored dependency (`syncTimeInterval`, `syncQueue`, `audiobookLogger`,
+///      `networkService`, `currentAccountIdProvider`) is a `let` — immutable after
+///      `init`.
+///   2. The only mutable persisted state (`store`) is read and written EXCLUSIVELY
+///      through the serial `syncQueue` (`.async`/`.async(flags:.barrier)`/`.sync`),
+///      so there is no unsynchronized shared mutation. `subscriptions` and
+///      `accountChangeObserver` are written once during `init` (before any escape)
+///      and only read afterwards (the observer in `deinit`).
+///   Hence `@unchecked Sendable` rather than a compiler-checked conformance — the
+///   `syncQueue` discipline is the invariant the compiler cannot see, and
+///   `TPPNetworkExecutor` is not Sendable-audited.
+class AudiobookDataManager: @unchecked Sendable {
     private let syncTimeInterval: TimeInterval
     private var subscriptions: Set<AnyCancellable> = []
     /// Serial dispatch queue that owns all writes to `store`. Exposed at
@@ -125,7 +141,7 @@ class AudiobookDataManager {
     ///
     /// See `.forgeos/handoffs/2026-06-05-icarus-cross-host-logout-regression.md`
     /// §2 Bug B for the regression that motivated this guard.
-    private let currentAccountIdProvider: () -> String?
+    private let currentAccountIdProvider: @Sendable () -> String?
     /// Observer token for `.TPPCurrentAccountDidChange` posted by
     /// `AccountsManager.currentAccount.didSet`. Held so the observer is
     /// removed at dealloc; the notification only logs (no queue mutation)
@@ -133,7 +149,7 @@ class AudiobookDataManager {
     private var accountChangeObserver: NSObjectProtocol?
     init(syncTimeInterval: TimeInterval = 60,
          networkService: TPPNetworkExecutor = AppContainer.production().networkExecutor,
-         currentAccountIdProvider: @escaping () -> String? = { AppContainer.production().accountsManager.currentAccountId }) {
+         currentAccountIdProvider: @escaping @Sendable () -> String? = { AppContainer.production().accountsManager.currentAccountId }) {
         self.syncTimeInterval = syncTimeInterval
         self.networkService = networkService
         self.currentAccountIdProvider = currentAccountIdProvider
@@ -193,17 +209,22 @@ class AudiobookDataManager {
     }
 
     func syncValues(_: Date? = nil) {
-        // Request background task to ensure sync completes even if app is backgrounded
-        var backgroundTaskId: UIBackgroundTaskIdentifier = .invalid
-        backgroundTaskId = UIApplication.shared.beginBackgroundTask(withName: "AudiobookTimeSync") {
+        // Request background task to ensure sync completes even if app is
+        // backgrounded. The identifier is shared-mutable across the expiration
+        // handler, the `syncQueue.async` body, and every per-request POST
+        // completion — all of which are `@Sendable` closures. A lock-backed
+        // reference box makes that sharing race-free (and `Sendable`) rather
+        // than capturing a mutable local `var` by reference across the
+        // concurrency boundaries. Behavior is unchanged: begin once, end once.
+        let backgroundTask = BackgroundTaskToken()
+        backgroundTask.set(UIApplication.shared.beginBackgroundTask(withName: "AudiobookTimeSync") {
             // Cleanup handler if time expires
-            UIApplication.shared.endBackgroundTask(backgroundTaskId)
-            backgroundTaskId = .invalid
-        }
+            backgroundTask.end()
+        })
 
         syncQueue.async { [weak self] in
             guard let self = self else {
-                UIApplication.shared.endBackgroundTask(backgroundTaskId)
+                backgroundTask.end()
                 return
             }
 
@@ -244,14 +265,17 @@ class AudiobookDataManager {
             // they produce no completion callback, so counting them would leak
             // the background task until iOS reclaims it.
             let pendingCount = postableLibraryBooks.count
-            var completedCount = 0
-            let countLock = NSLock()
+            // Lock-backed completion counter — mutated from each POST completion
+            // (`@Sendable`) closure. A reference box keeps the shared count
+            // race-free without capturing a mutable local `var` across the
+            // concurrency boundary.
+            let completion = SyncCompletionCounter()
 
             // If no postable entries (queue empty OR every entry is cross-
             // account), end background task immediately so iOS doesn't bill
             // the app for an open background slot that will never close.
             if pendingCount == 0 {
-                UIApplication.shared.endBackgroundTask(backgroundTaskId)
+                backgroundTask.end()
                 return
             }
 
@@ -281,13 +305,8 @@ class AudiobookDataManager {
                     self.networkService.POST(request, useTokenIfAvailable: true) { [weak self] result, response, error in
                         defer {
                             // Track request completion for background task management
-                            countLock.lock()
-                            completedCount += 1
-                            let allComplete = completedCount >= pendingCount
-                            countLock.unlock()
-
-                            if allComplete {
-                                UIApplication.shared.endBackgroundTask(backgroundTaskId)
+                            if completion.increment() >= pendingCount {
+                                backgroundTask.end()
                             }
                         }
 
@@ -356,13 +375,8 @@ class AudiobookDataManager {
                     }
                 } else {
                     // No request made for this book, count as complete
-                    countLock.lock()
-                    completedCount += 1
-                    let allComplete = completedCount >= pendingCount
-                    countLock.unlock()
-
-                    if allComplete {
-                        UIApplication.shared.endBackgroundTask(backgroundTaskId)
+                    if completion.increment() >= pendingCount {
+                        backgroundTask.end()
                     }
                 }
             }
@@ -415,6 +429,57 @@ class AudiobookDataManager {
     private func removeSynchronizedEntries(ids: [String]) {
         store.queue = store.queue.filter { !ids.contains($0.id) }
         saveStore()
+    }
+}
+
+/// Lock-backed holder for the `UIBackgroundTaskIdentifier` used by
+/// `syncValues`. The id is shared-mutable across the `beginBackgroundTask`
+/// expiration handler and every POST-completion `@Sendable` closure; the lock
+/// serializes access and makes the holder `Sendable`.
+///
+/// - Sendable invariant: `id` is only ever read/written under `lock`. `end()`
+///   is idempotent — it ends the task at most once and resets to `.invalid`,
+///   preserving the original code's "begin once, end once" semantics even if
+///   two completion paths race to finish.
+private final class BackgroundTaskToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var id: UIBackgroundTaskIdentifier = .invalid
+
+    func set(_ newId: UIBackgroundTaskIdentifier) {
+        lock.lock()
+        id = newId
+        lock.unlock()
+    }
+
+    func end() {
+        lock.lock()
+        let current = id
+        id = .invalid
+        lock.unlock()
+        if current != .invalid {
+            UIApplication.shared.endBackgroundTask(current)
+        }
+    }
+}
+
+/// Lock-backed completion counter for `syncValues`' per-request POST callbacks.
+/// Replaces the previous `var completedCount` + `NSLock` local pair so the
+/// count can be mutated from `@Sendable` completion closures without capturing
+/// a mutable local `var` across the concurrency boundary.
+///
+/// - Sendable invariant: `count` is only mutated inside `increment()` under
+///   `lock`, which returns the post-increment value atomically.
+private final class SyncCompletionCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    /// Atomically increments and returns the new value.
+    func increment() -> Int {
+        lock.lock()
+        count += 1
+        let value = count
+        lock.unlock()
+        return value
     }
 }
 

--- a/Palace/Audiobooks/Tracker/AudiobookTimeTracker.swift
+++ b/Palace/Audiobooks/Tracker/AudiobookTimeTracker.swift
@@ -12,8 +12,22 @@ import ULID
 import UIKit
 import PalaceAudiobookToolkit
 
+/// - Sendable invariant: instances are captured by the `willTerminateNotification`
+///   observer (`queue: .main`), the `syncQueue.async` body in `receiveValue`, and
+///   the Combine `Timer.publish(on: .main)` sink. Safe to share across those
+///   boundaries because:
+///   1. Every stored dependency (`dataManager`, `libraryId`, `bookId`,
+///      `timeTrackingUrl`, `syncQueue`, `minuteFormatter`, `tick`, `audiobookLogger`)
+///      is a `let` — immutable after `init`.
+///   2. The mutable counters (`duration`, `currentMinute`, `timeEntryId`) are read
+///      and written ONLY through the serial `syncQueue` (`.sync`/`.async`).
+///   3. The playback-lifecycle state (`isPlaying`, `playbackTimer`, `subscriptions`)
+///      is touched only from the `AudiobookPlaybackTrackerDelegate` callbacks and
+///      the main-scheduled Timer sink — i.e. the main runloop — never concurrently.
+///   Hence `@unchecked Sendable`: the `syncQueue`/main-runloop discipline is the
+///   invariant the compiler cannot see, and `DataManager` is not Sendable-audited.
 @objc
-class AudiobookTimeTracker: NSObject, AudiobookPlaybackTrackerDelegate {
+class AudiobookTimeTracker: NSObject, AudiobookPlaybackTrackerDelegate, @unchecked Sendable {
 
     private var subscriptions: Set<AnyCancellable> = []
     private let dataManager: DataManager

--- a/Palace/Audiobooks/Vendors/Adapters+Production.swift
+++ b/Palace/Audiobooks/Vendors/Adapters+Production.swift
@@ -62,7 +62,7 @@ final class ProductionAudiobookFileReader: AudiobookFileReading {
 final class ProductionBearerTokenRefresher: BearerTokenRefreshing {
     func refreshToken(
         from fulfillURL: URL,
-        completion: @escaping (MyBooksSimplifiedBearerToken?) -> Void
+        completion: @escaping @Sendable (MyBooksSimplifiedBearerToken?) -> Void
     ) {
         MyBooksSimplifiedBearerToken.refreshToken(from: fulfillURL, completion: completion)
     }

--- a/Palace/Audiobooks/Vendors/AudiobookVendorAdapter.swift
+++ b/Palace/Audiobooks/Vendors/AudiobookVendorAdapter.swift
@@ -64,3 +64,52 @@ protocol AudiobookVendorAdapter {
         completion: @escaping (Result<(json: [String: Any], decryptor: DRMDecryptor?), AudiobookLoadError>) -> Void
     )
 }
+
+/// `Sendable` carrier for an `AudiobookVendorAdapter` completion.
+///
+/// The `resolveManifest` completion is intentionally NOT `@Sendable` — the
+/// protocol is consumed by `AudiobookLoader` (and its test doubles) whose call
+/// sites pass plain callbacks; marking the protocol `@Sendable` would ripple
+/// through the loader's completion chain and every adapter test mock. But each
+/// adapter must hand the completion across a `Task { @MainActor in }` /
+/// `DispatchQueue.main.async` hop to satisfy the "completion fires on main"
+/// contract. Wrapping it in this box lets it cross that `@Sendable` boundary
+/// without the protocol change. Mirrors `SendableDecryptCompletion`
+/// (LCPAudiobooks) and `TokenReadyCompletionBox` (AudiobookLoader).
+///
+/// - Sendable invariant: `fire(_:)` forwards to the wrapped closure exactly
+///   once per adapter load (the adapters return after each `completion` call),
+///   from a single main-hop continuation — never concurrently. The wrapped
+///   closure is otherwise opaque, hence `@unchecked`.
+struct AudiobookAdapterCompletionBox: @unchecked Sendable {
+    typealias Outcome = Result<(json: [String: Any], decryptor: DRMDecryptor?), AudiobookLoadError>
+    private let completion: (Outcome) -> Void
+
+    init(_ completion: @escaping (Outcome) -> Void) {
+        self.completion = completion
+    }
+
+    func fire(_ outcome: Outcome) {
+        completion(outcome)
+    }
+}
+
+/// `Sendable` carrier for a parsed `[String: Any]` audiobook manifest.
+///
+/// `[String: Any]` is not `Sendable` (it holds `Any` existentials that may be
+/// reference-typed), so it cannot cross a `Task { @MainActor in }` boundary
+/// directly. `LocalFileAdapter` parses the manifest BEFORE its bearer-token
+/// refresh hop and must carry it across into the main-actor completion; this
+/// box makes that crossing explicit.
+///
+/// - Sendable invariant: `value` is set once at init and only read thereafter
+///   — the dictionary is not mutated after boxing, so there is no shared
+///   mutation. The `@unchecked` waiver covers only the `Any`-existential
+///   payload the compiler cannot prove `Sendable`. Adapters that build the
+///   dictionary INSIDE the hop (OpenAccess / BearerToken) don't need this box.
+struct ManifestJSONBox: @unchecked Sendable {
+    let value: [String: Any]
+    init(_ value: [String: Any]) {
+        self.value = value
+    }
+}

--- a/Palace/Audiobooks/Vendors/BearerTokenAdapter.swift
+++ b/Palace/Audiobooks/Vendors/BearerTokenAdapter.swift
@@ -85,34 +85,39 @@ final class BearerTokenAdapter: AudiobookVendorAdapter {
 
         Log.debug(#file, "  📡 Fetching bearer-token wrapper from URL: \(url.absoluteString)")
 
+        // Box the non-`@Sendable` completion so it can cross the network
+        // callback → `Task { @MainActor in }` hops without forcing `@Sendable`
+        // onto the `AudiobookVendorAdapter` protocol. See
+        // `AudiobookAdapterCompletionBox`.
+        let completionBox = AudiobookAdapterCompletionBox(completion)
         network.fetchData(from: url) { [manifestFetcher] data, response, error in
             Task { @MainActor in
                 if let error = error {
                     Log.error(#file, "  ❌ Network error fetching bearer-token wrapper: \(error.localizedDescription)")
-                    completion(.failure(.manifestFetchFailed))
+                    completionBox.fire(.failure(.manifestFetchFailed))
                     return
                 }
                 guard let data = data, !data.isEmpty else {
                     Log.error(#file, "  ❌ No data received from bearer-token fetch")
-                    completion(.failure(.manifestFetchFailed))
+                    completionBox.fire(.failure(.manifestFetchFailed))
                     return
                 }
                 if let httpResponse = response as? HTTPURLResponse,
                    AudiobookLoader.looksLikeHTMLResponse(httpResponse) {
                     Log.error(#file, "  ⚠️ Server returned HTML instead of bearer-token JSON (HTTP \(httpResponse.statusCode))")
-                    completion(.failure(.manifestFetchFailed))
+                    completionBox.fire(.failure(.manifestFetchFailed))
                     return
                 }
 
                 guard let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
                     Log.error(#file, "  ❌ Failed to parse bearer-token data as JSON dictionary")
-                    completion(.failure(.manifestParseFailed))
+                    completionBox.fire(.failure(.manifestParseFailed))
                     return
                 }
 
                 guard let bearerToken = MyBooksSimplifiedBearerToken.simplifiedBearerToken(with: json) else {
                     Log.error(#file, "  ❌ Response did not contain a recognizable bearer-token wrapper")
-                    completion(.failure(.manifestFetchFailed))
+                    completionBox.fire(.failure(.manifestFetchFailed))
                     return
                 }
 
@@ -125,11 +130,11 @@ final class BearerTokenAdapter: AudiobookVendorAdapter {
                     Task { @MainActor in
                         guard let manifestJSON = manifestJSON else {
                             Log.error(#file, "  ❌ Bearer-token second-leg manifest fetch returned nil")
-                            completion(.failure(.manifestFetchFailed))
+                            completionBox.fire(.failure(.manifestFetchFailed))
                             return
                         }
                         Log.debug(#file, "  ✅ Successfully fetched manifest via bearer token")
-                        completion(.success((json: manifestJSON, decryptor: nil)))
+                        completionBox.fire(.success((json: manifestJSON, decryptor: nil)))
                     }
                 }
             }

--- a/Palace/Audiobooks/Vendors/LCPAdapter.swift
+++ b/Palace/Audiobooks/Vendors/LCPAdapter.swift
@@ -75,13 +75,21 @@ final class LCPAdapter: AudiobookVendorAdapter {
         for book: TPPBook,
         completion: @escaping (Result<(json: [String: Any], decryptor: DRMDecryptor?), AudiobookLoadError>) -> Void
     ) {
+        // Box the non-`@Sendable` completion once. The LCP flow hands it across
+        // the `prepareLCPSource` callback, `LCPAudiobooks.contentDictionary`
+        // (whose completion IS `@Sendable`), and the `finishOnMain`
+        // `DispatchQueue.main.async` hop — all `@Sendable` boundaries. Boxing
+        // avoids marking the `AudiobookVendorAdapter` protocol `@Sendable`
+        // (which would ripple to the loader + adapter test mocks). See
+        // `AudiobookAdapterCompletionBox`.
+        let completionBox = AudiobookAdapterCompletionBox(completion)
         prepareLCPSource(for: book) { [weak self] sourceResult in
-            guard let self else { LCPAdapter.finishOnMain(completion, .failure(.cancelled)); return }
+            guard let self else { LCPAdapter.finishOnMain(completionBox, .failure(.cancelled)); return }
             switch sourceResult {
             case .success(let sourceURL):
-                self.loadLCPContent(book: book, lcpSourceURL: sourceURL, completion: completion)
+                self.loadLCPContent(book: book, lcpSourceURL: sourceURL, completionBox: completionBox)
             case .failure(let err):
-                LCPAdapter.finishOnMain(completion, .failure(err))
+                LCPAdapter.finishOnMain(completionBox, .failure(err))
             }
         }
     }
@@ -112,28 +120,28 @@ final class LCPAdapter: AudiobookVendorAdapter {
     private func loadLCPContent(
         book: TPPBook,
         lcpSourceURL: URL,
-        completion: @escaping (Result<(json: [String: Any], decryptor: DRMDecryptor?), AudiobookLoadError>) -> Void
+        completionBox: AudiobookAdapterCompletionBox
     ) {
         guard let lcpAudiobooks = lcpAudiobooksFactory(lcpSourceURL) else {
             Log.error(#file, "Failed to create LCPAudiobooks instance for \(lcpSourceURL.path)")
-            LCPAdapter.finishOnMain(completion, .failure(.lcpInstantiationFailed))
+            LCPAdapter.finishOnMain(completionBox, .failure(.lcpInstantiationFailed))
             return
         }
         if let cached = lcpAudiobooks.cachedContentDictionary() as? [String: Any] {
-            LCPAdapter.finishOnMain(completion, .success((json: cached, decryptor: lcpAudiobooks)))
+            LCPAdapter.finishOnMain(completionBox, .success((json: cached, decryptor: lcpAudiobooks)))
             return
         }
         lcpAudiobooks.contentDictionary { dict, error in
             if let error = error {
                 Log.error(#file, "LCP content dictionary error: \(error.localizedDescription)")
-                LCPAdapter.finishOnMain(completion, .failure(.lcpDecryptionFailed(underlying: error)))
+                LCPAdapter.finishOnMain(completionBox, .failure(.lcpDecryptionFailed(underlying: error)))
                 return
             }
             guard let json = dict as? [String: Any] else {
-                LCPAdapter.finishOnMain(completion, .failure(.lcpDecryptionFailed(underlying: nil)))
+                LCPAdapter.finishOnMain(completionBox, .failure(.lcpDecryptionFailed(underlying: nil)))
                 return
             }
-            LCPAdapter.finishOnMain(completion, .success((json: json, decryptor: lcpAudiobooks)))
+            LCPAdapter.finishOnMain(completionBox, .success((json: json, decryptor: lcpAudiobooks)))
         }
     }
 
@@ -186,13 +194,16 @@ final class LCPAdapter: AudiobookVendorAdapter {
     }
 
     /// Force completion onto the main thread — `AudiobookVendorAdapter`
-    /// contract requires completion fires on main exactly once.
+    /// contract requires completion fires on main exactly once. Takes the
+    /// `Sendable` completion box so the (possibly off-main) callers can hop to
+    /// main via `DispatchQueue.main.async` without capturing the raw
+    /// non-`@Sendable` completion across that boundary.
     private static func finishOnMain(
-        _ completion: @escaping (Result<(json: [String: Any], decryptor: DRMDecryptor?), AudiobookLoadError>) -> Void,
-        _ result: Result<(json: [String: Any], decryptor: DRMDecryptor?), AudiobookLoadError>
+        _ completionBox: AudiobookAdapterCompletionBox,
+        _ result: AudiobookAdapterCompletionBox.Outcome
     ) {
-        if Thread.isMainThread { completion(result) }
-        else { DispatchQueue.main.async { completion(result) } }
+        if Thread.isMainThread { completionBox.fire(result) }
+        else { DispatchQueue.main.async { completionBox.fire(result) } }
     }
 }
 

--- a/Palace/Audiobooks/Vendors/LocalFileAdapter.swift
+++ b/Palace/Audiobooks/Vendors/LocalFileAdapter.swift
@@ -34,7 +34,7 @@ protocol AudiobookFileReading: AnyObject {
 protocol BearerTokenRefreshing {
     func refreshToken(
         from fulfillURL: URL,
-        completion: @escaping (MyBooksSimplifiedBearerToken?) -> Void
+        completion: @escaping @Sendable (MyBooksSimplifiedBearerToken?) -> Void
     )
 }
 
@@ -109,6 +109,14 @@ final class LocalFileAdapter: AudiobookVendorAdapter {
 
         if let fulfillURL = book.bearerTokenFulfillURL {
             Log.debug(#file, "  🔑 Bearer token book - refreshing token before playback")
+            // Box the non-`@Sendable` completion AND the parsed `[String: Any]`
+            // manifest so both can cross the refresh callback →
+            // `Task { @MainActor in }` hop without forcing `@Sendable` onto the
+            // `AudiobookVendorAdapter` protocol. `[String: Any]` is not
+            // `Sendable` (it holds `Any` existentials), so it needs its own
+            // carrier. See `AudiobookAdapterCompletionBox` / `ManifestJSONBox`.
+            let completionBox = AudiobookAdapterCompletionBox(completion)
+            let jsonBox = ManifestJSONBox(json)
             tokenRefresher.refreshToken(from: fulfillURL) { newToken in
                 Task { @MainActor in
                     if let newToken = newToken {
@@ -117,7 +125,7 @@ final class LocalFileAdapter: AudiobookVendorAdapter {
                     } else {
                         Log.warn(#file, "  ⚠️ Bearer token refresh failed - proceeding with existing token")
                     }
-                    completion(.success((json: json, decryptor: nil)))
+                    completionBox.fire(.success((json: jsonBox.value, decryptor: nil)))
                 }
             }
         } else {

--- a/Palace/Audiobooks/Vendors/OpenAccessAdapter.swift
+++ b/Palace/Audiobooks/Vendors/OpenAccessAdapter.swift
@@ -91,29 +91,34 @@ final class OpenAccessAdapter: AudiobookVendorAdapter {
 
         Log.debug(#file, "  📡 Fetching manifest from URL: \(url.absoluteString)")
 
+        // Box the non-`@Sendable` completion so it can cross the network
+        // callback → `Task { @MainActor in }` hop without forcing `@Sendable`
+        // onto the `AudiobookVendorAdapter` protocol (which would ripple to the
+        // loader + every adapter test mock). See `AudiobookAdapterCompletionBox`.
+        let completionBox = AudiobookAdapterCompletionBox(completion)
         network.fetchData(from: url) { [bearerTokenManifestFetcher] data, response, error in
             Task { @MainActor in
                 if let error = error {
                     Log.error(#file, "  ❌ Network error fetching manifest: \(error.localizedDescription)")
-                    completion(.failure(.manifestFetchFailed))
+                    completionBox.fire(.failure(.manifestFetchFailed))
                     return
                 }
                 guard let data = data, !data.isEmpty else {
                     Log.error(#file, "  ❌ No data received from manifest fetch")
-                    completion(.failure(.manifestFetchFailed))
+                    completionBox.fire(.failure(.manifestFetchFailed))
                     return
                 }
                 if let httpResponse = response as? HTTPURLResponse,
                    AudiobookLoader.looksLikeHTMLResponse(httpResponse) {
                     Log.error(#file, "  ⚠️ Server returned HTML instead of JSON - likely a redirect to login or error page (HTTP \(httpResponse.statusCode))")
-                    completion(.failure(.manifestFetchFailed))
+                    completionBox.fire(.failure(.manifestFetchFailed))
                     return
                 }
                 Log.debug(#file, "  ✅ Received \(data.count) bytes of manifest data")
 
                 guard let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
                     Log.error(#file, "  ❌ Failed to parse manifest data as JSON dictionary")
-                    completion(.failure(.manifestParseFailed))
+                    completionBox.fire(.failure(.manifestParseFailed))
                     return
                 }
 
@@ -136,18 +141,18 @@ final class OpenAccessAdapter: AudiobookVendorAdapter {
                         Task { @MainActor in
                             guard let manifestJSON = manifestJSON else {
                                 Log.error(#file, "  ❌ Bearer-token second-leg manifest fetch returned nil")
-                                completion(.failure(.manifestFetchFailed))
+                                completionBox.fire(.failure(.manifestFetchFailed))
                                 return
                             }
                             Log.debug(#file, "  ✅ Successfully fetched manifest via bearer token (open-access fallback)")
-                            completion(.success((json: manifestJSON, decryptor: nil)))
+                            completionBox.fire(.success((json: manifestJSON, decryptor: nil)))
                         }
                     }
                     return
                 }
 
                 Log.debug(#file, "  ✅ Successfully parsed manifest JSON")
-                completion(.success((json: json, decryptor: nil)))
+                completionBox.fire(.success((json: json, decryptor: nil)))
             }
         }
     }

--- a/PalaceTests/Audiobooks/TPPReturnPromptHelperTests.swift
+++ b/PalaceTests/Audiobooks/TPPReturnPromptHelperTests.swift
@@ -10,6 +10,7 @@ import XCTest
 @testable import Palace
 
 /// SRS: AUDIO-006 -- Return prompt displays correctly after audiobook completion
+@MainActor
 final class TPPReturnPromptHelperTests: XCTestCase {
 
     /// SRS: AUDIO-006 -- Return prompt displays correctly after audiobook completion

--- a/PalaceTests/LCP/LCPAudiobooksTests.swift
+++ b/PalaceTests/LCP/LCPAudiobooksTests.swift
@@ -355,18 +355,23 @@ final class LCPAudiobooksTests: XCTestCase {
         audiobook.releaseResources()
 
         let exp = expectation(description: "contentDictionary completes after release")
-        var receivedError: NSError?
-        var receivedDict: NSDictionary?
+        // `contentDictionary`'s completion is `@Sendable` (Swift 6 complete-mode);
+        // capture results in a Sendable carrier box rather than mutable local vars.
+        final class Box: @unchecked Sendable {
+            var dict: NSDictionary?
+            var err: NSError?
+        }
+        let box = Box()
         audiobook.contentDictionary { dict, error in
-            receivedDict = dict
-            receivedError = error
+            box.dict = dict
+            box.err = error
             exp.fulfill()
         }
         wait(for: [exp], timeout: 2.0)
 
-        XCTAssertNil(receivedDict, "contentDictionary must not return a dictionary after release")
-        XCTAssertNotNil(receivedError, "contentDictionary must report an error after release")
-        XCTAssertEqual(receivedError?.domain, "Palace.LCPAudiobooks")
+        XCTAssertNil(box.dict, "contentDictionary must not return a dictionary after release")
+        XCTAssertNotNil(box.err, "contentDictionary must report an error after release")
+        XCTAssertEqual(box.err?.domain, "Palace.LCPAudiobooks")
         #else
         XCTAssertTrue(true, "LCP not enabled - test skipped")
         #endif


### PR DESCRIPTION
## Swift 6 Phase B — Audiobooks (isolation-only + carrier boxes)

Part of **PP-4722** (Phase B critical-module migration). Clears the Audiobooks
module's `complete`-mode strict-concurrency warnings. **No behavior change to
playback / return / DRM.**

### Approach
Isolation-only fixes + the established carrier-box pattern (confining adapter/loader
completions to `Audiobooks/**` instead of a protocol-wide `@Sendable` cascade → zero
adapter-chain test ripple / no 8-mock churn). Documented `@unchecked Sendable` on the
queue/lock-backed managers; `@MainActor @Sendable` on the return-prompt helper;
`ObserverTokenBox` for the `NowPlayingCoordinator` deinit (no `assumeIsolated`-in-deinit).

### Verification
- Compiles in a `complete`-mode DRM `build-for-testing` (app + test target), part of the
  wave-1 union (app **328 → 190**).
- **Two independent SoD reviews APPROVED** (soundness + qa/behavior): traced every lock
  invariant, fire-once on every adapter path (success + error), background-task begin/end
  symmetry, `PlaybackReadinessGate` timing, DRM byte-identical.

### Deferred (wave 2)
~10 residual Audiobooks `complete`-mode warnings (LCPAudiobooks + a few adapter sites
where `@preconcurrency` doesn't kill a `sending` diagnostic) — tracked for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
