### PR TITLE
fix(swift6): TPPAlertUtils @MainActor — coordinated caller migration

### DIFF
--- a/Palace/ErrorHandling/TPPAlertUtils.swift
+++ b/Palace/ErrorHandling/TPPAlertUtils.swift
@@ -3,6 +3,15 @@ import UIKit
 import PalaceLogging
 import PalaceCatalog
 
+// swift6: This type exclusively builds, mutates, and presents UIAlertController /
+// UIViewController objects (all @MainActor-isolated in the iOS SDK) and reads
+// UIApplication.shared / UIAccessibility. Isolating the whole type to the main actor
+// is the honest model — there is no genuinely-nonisolated member here. The
+// load-bearing DispatchQueue.main.async re-dispatches (the fe741015 CA-commit-race /
+// HelpSpot 17716 coordinator-wait fixes) are preserved exactly; where a dispatched
+// closure re-enters a @MainActor member, the body is wrapped in
+// MainActor.assumeIsolated — provably safe because the closure runs on the main queue.
+@MainActor
 @objcMembers class TPPAlertUtils: NSObject {
     /**
      Generates an alert view controller. If the `message` is non-nil, it will be
@@ -241,6 +250,7 @@ import PalaceCatalog
         // If a presenter is provided, present from it on main thread
         if let vc = viewController {
             DispatchQueue.main.async {
+              MainActor.assumeIsolated {
                 guard vc.presentedViewController == nil else {
                     Log.warn(#file, "Cannot present alert: view controller already presenting")
                     completion?()
@@ -261,11 +271,13 @@ import PalaceCatalog
                 if let coordinator = vc.transitionCoordinator {
                     coordinator.animate(alongsideTransition: nil) { _ in
                         DispatchQueue.main.async {
+                          MainActor.assumeIsolated {
                             presentFromViewControllerOrNil(alertController: alertController,
                                                            viewController: viewController,
                                                            animated: animated,
                                                            completion: completion,
                                                            retryCount: retryCount)
+                          }
                         }
                     }
                     return
@@ -282,12 +294,14 @@ import PalaceCatalog
                     return
                 }
                 safePresent(alertController, on: vc, animated: animated, completion: completion)
+              }
             }
             return
         }
 
         // SwiftUI-first: present from the app's top-most UIKit controller
         DispatchQueue.main.async {
+          MainActor.assumeIsolated {
             guard let root = (UIApplication.shared.delegate as? TPPAppDelegate)?.topViewController() else {
                 Log.error(#file, "Cannot present alert: no root view controller available")
                 if let msg = alertController.message {
@@ -342,11 +356,13 @@ import PalaceCatalog
             if let coordinator = top.transitionCoordinator {
                 coordinator.animate(alongsideTransition: nil) { _ in
                     DispatchQueue.main.async {
+                      MainActor.assumeIsolated {
                         presentFromViewControllerOrNil(alertController: alertController,
                                                        viewController: viewController,
                                                        animated: animated,
                                                        completion: completion,
                                                        retryCount: retryCount)
+                      }
                     }
                 }
                 return
@@ -407,6 +423,7 @@ import PalaceCatalog
             } else {
                 safePresent(alertController, on: top, animated: animated, completion: completion)
             }
+          }
         }
     }
 
@@ -438,6 +455,7 @@ import PalaceCatalog
         // Exponential backoff: 0.4s, 0.8s, 1.6s
         let delay = 0.4 * pow(2.0, Double(retryCount))
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+          MainActor.assumeIsolated {
             presentFromViewControllerOrNil(
                 alertController: alertController,
                 viewController: viewController,
@@ -445,6 +463,7 @@ import PalaceCatalog
                 completion: completion,
                 retryCount: retryCount + 1
             )
+          }
         }
     }
 

--- a/Palace/ErrorHandling/TPPPresentationUtils.swift
+++ b/Palace/ErrorHandling/TPPPresentationUtils.swift
@@ -88,8 +88,14 @@ class TPPPresentationUtils: NSObject {
             // the in-flight transition to complete, then re-walk to the (possibly
             // new) topmost VC and present there. HelpSpot 17716 follow-up.
             if let coordinator = base.transitionCoordinator {
+                // Box the non-Sendable UIKit payload BEFORE the escaping coordinator
+                // completion so only the @unchecked-Sendable carrier crosses the
+                // closure boundary — `vc`/`completion` themselves never cross. The
+                // box is built, and later read, only on the main actor (both the
+                // coordinator completion and the nested main.async run on main), so
+                // the transfer is data-race-free. Dispatch structure unchanged.
+                let payload = MainActorPresentation(vc, completion)
                 coordinator.animate(alongsideTransition: nil) { _ in
-                    let payload = MainActorPresentation(vc, completion)
                     DispatchQueue.main.async {
                         safelyPresent(payload.viewController, animated: animated, completion: payload.completion)
                     }

--- a/Palace/Reader2/ReaderStackConfiguration/LCP/LCPPassphraseAuthenticationService.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LCP/LCPPassphraseAuthenticationService.swift
@@ -126,32 +126,42 @@ class LCPPassphraseAuthenticationService: LCPAuthenticating {
 
         if settings.enterLCPPassphraseManually {
             return await withCheckedContinuation { continuation in
-                var passphraseField: UITextField?
-                let ac = UIAlertController(title: "Enter LCP Passphrase", message: license.hint, preferredStyle: .alert)
+                // `withCheckedContinuation` runs its body synchronously on the caller's
+                // executor, which for this `nonisolated async` method is the generic
+                // cooperative pool — NOT guaranteed main. A bare `MainActor.assumeIsolated`
+                // would be unsound. Hop the UIKit alert build+present onto main explicitly.
+                // The continuation is captured by the action handlers and resumed there
+                // (on main, from the tapped button), so the resume semantics are preserved.
+                DispatchQueue.main.async {
+                    MainActor.assumeIsolated {
+                        var passphraseField: UITextField?
+                        let ac = UIAlertController(title: "Enter LCP Passphrase", message: license.hint, preferredStyle: .alert)
 
-                let doneAction = UIAlertAction(title: "Done", style: .default) { _ in
-                    continuation.resume(returning: passphraseField?.text)
+                        let doneAction = UIAlertAction(title: "Done", style: .default) { _ in
+                            continuation.resume(returning: passphraseField?.text)
+                        }
+
+                        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in
+                            continuation.resume(returning: nil)
+                        }
+
+                        ac.addAction(doneAction)
+                        ac.addAction(cancelAction)
+
+                        ac.addTextField { textField in
+                            textField.placeholder = "Passphrase"
+                            textField.autocapitalizationType = .none
+                            textField.autocorrectionType = .no
+                            textField.spellCheckingType = .no
+                            textField.keyboardType = .default
+                            textField.returnKeyType = .done
+                            textField.isSecureTextEntry = true
+                            passphraseField = textField
+                        }
+
+                        TPPAlertUtils.presentFromViewControllerOrNil(alertController: ac, viewController: nil, animated: true, completion: nil)
+                    }
                 }
-
-                let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in
-                    continuation.resume(returning: nil)
-                }
-
-                ac.addAction(doneAction)
-                ac.addAction(cancelAction)
-
-                ac.addTextField { textField in
-                    textField.placeholder = "Passphrase"
-                    textField.autocapitalizationType = .none
-                    textField.autocorrectionType = .no
-                    textField.spellCheckingType = .no
-                    textField.keyboardType = .default
-                    textField.returnKeyType = .done
-                    textField.isSecureTextEntry = true
-                    passphraseField = textField
-                }
-
-                TPPAlertUtils.presentFromViewControllerOrNil(alertController: ac, viewController: nil, animated: true, completion: nil)
             }
         } else {
             return await retrievePassphraseFromLoan(for: license, reason: reason, allowUserInteraction: allowUserInteraction, sender: sender)

--- a/Palace/Reader2/UI/TPPBaseReaderViewController.swift
+++ b/Palace/Reader2/UI/TPPBaseReaderViewController.swift
@@ -480,7 +480,7 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
     }
 
     private func addBookmark(at location: TPPBookmarkR3Location) {
-        Task {
+        Task { @MainActor in
             guard let bookmark = await bookmarksBusinessLogic.addBookmark(location) else {
                 let alert = TPPAlertUtils.alert(title: "Bookmarking Error",
                                                 message: "A bookmark could not be created on the current page.")

--- a/Palace/Reader2/UI/TPPReaderPositionsVC.swift
+++ b/Palace/Reader2/UI/TPPReaderPositionsVC.swift
@@ -378,33 +378,37 @@ class TPPReaderPositionsVC: UIViewController, UITableViewDataSource, UITableView
     private func userDidRefreshBookmarks(with refreshControl: UIRefreshControl) {
         delegate?.positionsVC(self, didRequestSyncBookmarksWithCompletion: { [weak self] (success, _) in
             TPPMainThreadRun.asyncIfNeeded {
-                self?.tableView.reloadData()
-                self?.bookmarksRefreshControl?.endRefreshing()
-                if !success {
-                    // Offer retry for bookmark sync failures (likely transient network issue)
-                    let operationId = "bookmark-sync"
-                    let canRetry = self?.retryTracker.canRetry(operationId: operationId) ?? false
+                // asyncIfNeeded runs on main — assert isolation so the now-@MainActor
+                // TPPAlertUtils.alert(...) call below type-checks in Swift 6 complete-mode.
+                MainActor.assumeIsolated {
+                    self?.tableView.reloadData()
+                    self?.bookmarksRefreshControl?.endRefreshing()
+                    if !success {
+                        // Offer retry for bookmark sync failures (likely transient network issue)
+                        let operationId = "bookmark-sync"
+                        let canRetry = self?.retryTracker.canRetry(operationId: operationId) ?? false
 
-                    if canRetry {
-                        let alert = UIAlertController(
-                            title: Strings.MyDownloadCenter.errorSyncingBookmarks,
-                            message: Strings.MyDownloadCenter.bookmarkSyncError,
-                            preferredStyle: .alert
-                        )
-                        alert.addAction(UIAlertAction(title: Strings.MyDownloadCenter.retry, style: .default) { [weak self] _ in
-                            self?.retryTracker.recordRetry(operationId: operationId)
-                            if let rc = self?.bookmarksRefreshControl {
-                                self?.userDidRefreshBookmarks(with: rc)
-                            }
-                        })
-                        alert.addAction(UIAlertAction(title: Strings.Generic.cancel, style: .cancel))
-                        self?.present(alert, animated: true)
-                    } else {
-                        let alert = TPPAlertUtils.alert(
-                            title: Strings.MyDownloadCenter.errorSyncingBookmarks,
-                            message: Strings.MyDownloadCenter.tryAgainLater
-                        )
-                        self?.present(alert, animated: true)
+                        if canRetry {
+                            let alert = UIAlertController(
+                                title: Strings.MyDownloadCenter.errorSyncingBookmarks,
+                                message: Strings.MyDownloadCenter.bookmarkSyncError,
+                                preferredStyle: .alert
+                            )
+                            alert.addAction(UIAlertAction(title: Strings.MyDownloadCenter.retry, style: .default) { [weak self] _ in
+                                self?.retryTracker.recordRetry(operationId: operationId)
+                                if let rc = self?.bookmarksRefreshControl {
+                                    self?.userDidRefreshBookmarks(with: rc)
+                                }
+                            })
+                            alert.addAction(UIAlertAction(title: Strings.Generic.cancel, style: .cancel))
+                            self?.present(alert, animated: true)
+                        } else {
+                            let alert = TPPAlertUtils.alert(
+                                title: Strings.MyDownloadCenter.errorSyncingBookmarks,
+                                message: Strings.MyDownloadCenter.tryAgainLater
+                            )
+                            self?.present(alert, animated: true)
+                        }
                     }
                 }
             }

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
@@ -133,14 +133,19 @@ extension TPPSignInBusinessLogic {
         }
 
         #else
-        if self.bookRegistry.isSyncing {
-            let alert = TPPAlertUtils.alert(
-                title: "SettingsAccountViewControllerCannotLogOutTitle",
-                message: "SettingsAccountViewControllerCannotLogOutMessage")
-            uiDelegate?.present(alert, animated: true, completion: nil)
-            isSignOutInProgress = false
-        } else {
-            completeLogOutProcess()
+        // `performLogOut()` requires the main thread (see doc comment above), so
+        // assert the isolation the now-@MainActor `TPPAlertUtils.alert(...)` call
+        // needs in Swift 6 complete-mode. Matches the sibling `+UI.swift` treatment.
+        MainActor.assumeIsolated {
+            if self.bookRegistry.isSyncing {
+                let alert = TPPAlertUtils.alert(
+                    title: "SettingsAccountViewControllerCannotLogOutTitle",
+                    message: "SettingsAccountViewControllerCannotLogOutMessage")
+                uiDelegate?.present(alert, animated: true, completion: nil)
+                isSignOutInProgress = false
+            } else {
+                completeLogOutProcess()
+            }
         }
         #endif
     }

--- a/PalaceTests/ErrorHandling/AlertUtilsTests.swift
+++ b/PalaceTests/ErrorHandling/AlertUtilsTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AlertUtilsTests: XCTestCase {
 
     // MARK: - Basic Alert Creation

--- a/PalaceTests/ErrorHandling/TPPAlertUtilsTests.swift
+++ b/PalaceTests/ErrorHandling/TPPAlertUtilsTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPAlertUtilsTests: XCTestCase {
 
     // MARK: - Hermetic teardown for alert-presentation tests

--- a/PalaceTests/RegressionGuards/UIAlertCACommitGuardTests.swift
+++ b/PalaceTests/RegressionGuards/UIAlertCACommitGuardTests.swift
@@ -5,6 +5,7 @@ import XCTest
 /// (55 events on Crashlytics post-3.0.0). The fix surface lives in
 /// Palace/ErrorHandling/TPPAlertUtils.swift. See
 /// PalaceTests/RegressionGuards/README.md for the full crash narrative.
+@MainActor
 final class UIAlertCACommitGuardTests: XCTestCase {
 
     /// Window tracked for hermetic teardown so a presentation test cannot leak a


### PR DESCRIPTION
## Swift 6 Phase B — TPPAlertUtils @MainActor (coordinated caller migration)

Part of **PP-4720/PP-4722**. Marks the UIKit-driving `TPPAlertUtils` class `@MainActor`
(~46 `complete`-mode warnings) plus the coordinated caller hops the change forces.
**No behavior change**; the load-bearing CA-commit-race / transition timing
(fe741015, HelpSpot 17716) is preserved **byte-for-byte**.

### Highlights
- 5 already-dispatched `main.async`/`asyncAfter` closures get an inner
  `MainActor.assumeIsolated` (provably on main; zero scheduling change).
- Group-B nonisolated→main caller hops in Reader2 + SignInLogic. The DRM
  `LCPPassphraseAuthenticationService` site uses a **real `DispatchQueue.main.async` hop**
  (its `withCheckedContinuation` body runs off-main, so a bare `assumeIsolated` would crash).
- 3 alert test files → `@MainActor`.

### Verification
- Compiles in a `complete`-mode DRM `build-for-testing` (app + test target), part of the
  wave-1 union (app **328 → 190**).
- **Two independent SoD reviews APPROVED** (assumeIsolated soundness + qa/behavior-regression):
  every `assumeIsolated` on-main; DRM passphrase resume-exactly-once + still presents;
  `UIAlertCACommitGuardTests` regression guard intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
