### PR TITLE
fix(swift6): MyBooks auth/token → complete-mode concurrency (isolation-only)

### DIFF
--- a/Palace/MyBooks/CredentialPromptCoordinator.swift
+++ b/Palace/MyBooks/CredentialPromptCoordinator.swift
@@ -28,7 +28,30 @@ protocol CredentialPromptCoordinatorDelegate: AnyObject {
 // MARK: - CredentialPromptCoordinator
 
 /// Coordinates the per-borrow credential-prompt flow.
-final class CredentialPromptCoordinator {
+///
+/// `@unchecked Sendable` (Swift 6 `complete`-mode): `requestCredentialsAndStartDownload`
+/// captures `[weak self]` into a `@Sendable Task { @MainActor … }`, so the
+/// coordinator must be `Sendable`. The conformance is honest — every stored
+/// member is immutable-after-init or main-actor-confined:
+///   • `delegate` — `weak var`, wired once during owner (`MyBooksDownloadCenter`)
+///     construction and read only on the main actor (via `self.delegate` inside
+///     the `@MainActor` Task bodies). Never captured directly across the
+///     `@Sendable` boundary — it is re-resolved through `self`.
+///   • `stateManager` — `let`; its mutable storage is the actor-isolated
+///     `DownloadCoordinator`/`SafeDictionary` it owns.
+///   • `userAccountProvider` — `let` closure, invoked only inside the
+///     `@MainActor` Task body.
+///   • `credentialRequestState` — `let`; itself `@unchecked Sendable`
+///     (its `isRequestingCredentials` bool is main-actor-confined by
+///     convention — every access in this coordinator is inside a
+///     `Task { @MainActor }` body; the confinement is not compiler-enforced,
+///     tracked for a follow-up `@MainActor` annotation on the property).
+///   • `presentSignInModal` / `isAdobeDRMExpired` / `presentAdobeExpiredAlert`
+///     — `let` closures; the two UI-presenting ones are `@MainActor`-typed and
+///     are only ever invoked from the `@MainActor` Task body, so no closure
+///     value crosses an isolation boundary in a racy way.
+/// `final`, so the invariant can't be defeated by a subclass.
+final class CredentialPromptCoordinator: @unchecked Sendable {
 
     weak var delegate: CredentialPromptCoordinatorDelegate?
 

--- a/Palace/MyBooks/MyBooksDownloadInfo.swift
+++ b/Palace/MyBooks/MyBooksDownloadInfo.swift
@@ -9,7 +9,15 @@
 import Foundation
 import UIKit
 
-@objc class MyBooksDownloadInfo: NSObject {
+// `@unchecked Sendable` (Swift 6 complete-mode): stored in the actor-isolated
+// SafeDictionary download-info tracking and returned across that actor
+// boundary. `downloadTask` (URLSessionDownloadTask) is @unchecked Sendable in
+// the SDK; `bearerToken` is now Sendable (see RIPPLE 2). The value is a
+// per-download record produced once and read on the main actor / mutated via
+// the copy-returning `withDownloadProgress` / `withRightsManagement` helpers
+// (which build a fresh instance) rather than in-place from multiple isolation
+// domains. `final` to keep the invariant.
+@objc final class MyBooksDownloadInfo: NSObject, @unchecked Sendable {
 
     @objc enum MyBooksDownloadRightsManagement: Int {
         case unknown

--- a/Palace/MyBooks/MyBooksSimplifiedBearerToken.swift
+++ b/Palace/MyBooks/MyBooksSimplifiedBearerToken.swift
@@ -9,7 +9,17 @@
 import Foundation
 import PalaceLogging
 
-class MyBooksSimplifiedBearerToken {
+/// `@unchecked Sendable` (Swift 6 `complete`-mode): the token is handed to
+/// `refreshToken`'s completion from inside `URLSession`'s `@Sendable` dataTask
+/// closure, and is stored across the actor-isolated download-info tracking, so
+/// it must be `Sendable`. The stored properties are `var` for the two-phase
+/// construction the refresh path uses (build via the `simplifiedBearerToken`
+/// factory, then set `fulfillURL` before handing the token to the caller — see
+/// `refreshToken`). After that hand-off the token is treated as a value carrier
+/// and is not concurrently mutated: each fetch produces a fresh instance and
+/// publishes it exactly once. `final`, so the invariant can't be defeated by a
+/// subclass (no subclasses exist today).
+final class MyBooksSimplifiedBearerToken: @unchecked Sendable {
     var accessToken: String
     var expiration: Date
     var location: URL
@@ -46,7 +56,7 @@ class MyBooksSimplifiedBearerToken {
     /// - Parameters:
     ///   - fulfillURL: The CM fulfill URL that returns bearer token JSON.
     ///   - completion: Called with the new token on success, or nil on failure.
-    static func refreshToken(from fulfillURL: URL, completion: @escaping (MyBooksSimplifiedBearerToken?) -> Void) {
+    static func refreshToken(from fulfillURL: URL, completion: @escaping @Sendable (MyBooksSimplifiedBearerToken?) -> Void) {
         var request = URLRequest(url: fulfillURL)
         request.cachePolicy = .reloadIgnoringLocalCacheData
 

--- a/Palace/MyBooks/TokenRefreshInterceptor.swift
+++ b/Palace/MyBooks/TokenRefreshInterceptor.swift
@@ -271,11 +271,16 @@ final class TokenRefreshInterceptor: @unchecked Sendable {
 
     /// Handles invalid credentials error during borrow.
     func handleBorrowInvalidCredentials(for book: TPPBook, error: [String: Any]?) {
+        // Convert the non-Sendable `[String: Any]` payload to the `Sendable`
+        // `TPPProblemDocument` BEFORE the `Task { @MainActor }` hop so the raw
+        // dictionary never crosses the isolation boundary (Swift 6
+        // `complete`-mode). `nil` error → `nil` document (no detail to show).
+        let problemDoc = error.map { TPPProblemDocument.fromDictionary($0) }
         Task { @MainActor [weak self] in
             guard let self = self, let delegate = self.delegate else { return }
 
             guard !self.hasAttemptedAuthentication else {
-                self.showBorrowAlert(for: book, with: error)
+                self.showBorrowAlert(for: book, problemDoc: problemDoc)
                 return
             }
 
@@ -735,16 +740,24 @@ final class TokenRefreshInterceptor: @unchecked Sendable {
         session.start()
     }
 
-    private func showBorrowAlert(for book: TPPBook, with error: [String: Any]?) {
+    /// `@MainActor` (Swift 6 `complete`-mode): the sole caller
+    /// (`handleBorrowInvalidCredentials`) already dispatches on the main actor,
+    /// so hoisting the isolation here lets the body touch the non-Sendable
+    /// `delegate` / `delegate.progressReporter` and build the non-Sendable
+    /// `retryAction` closure without any of them crossing an isolation
+    /// boundary. The prior `runOnMainAsync` hop is now redundant — the
+    /// announce runs synchronously on the main actor we're already on. The
+    /// `error` payload is pre-converted to the `Sendable` `TPPProblemDocument`
+    /// by the caller so no `[String: Any]` dictionary crosses the caller's
+    /// `Task { @MainActor }` boundary.
+    @MainActor
+    private func showBorrowAlert(for book: TPPBook, problemDoc: TPPProblemDocument?) {
         guard let delegate = delegate else { return }
         let alertTitle = Strings.MyDownloadCenter.borrowFailed
         var alertMessage = String(format: Strings.MyDownloadCenter.borrowFailedMessage, book.title)
 
-        if let error = error {
-            let problemDoc = TPPProblemDocument.fromDictionary(error)
-            if let detail = problemDoc.detail {
-                alertMessage = "\(alertMessage)\n\n\(detail)"
-            }
+        if let detail = problemDoc?.detail {
+            alertMessage = "\(alertMessage)\n\n\(detail)"
         }
 
         let retryAction: (() -> Void)? = {
@@ -756,11 +769,9 @@ final class TokenRefreshInterceptor: @unchecked Sendable {
             }
         }()
 
-        runOnMainAsync {
-            delegate.progressReporter.publishAndAnnounceError(
-                DownloadErrorInfo(bookId: book.identifier, title: alertTitle, message: alertMessage, retryAction: retryAction)
-            )
-        }
+        delegate.progressReporter.publishAndAnnounceError(
+            DownloadErrorInfo(bookId: book.identifier, title: alertTitle, message: alertMessage, retryAction: retryAction)
+        )
     }
 }
 

--- a/Palace/MyBooks/UserRetryTracker.swift
+++ b/Palace/MyBooks/UserRetryTracker.swift
@@ -10,7 +10,16 @@ import Foundation
 /// Tracks user-initiated retry attempts per operation to enforce a retry limit.
 /// Prevents users from endlessly retrying failed operations while still
 /// allowing a reasonable number of attempts for transient errors.
-final class UserRetryTracker {
+///
+/// `@unchecked Sendable` (Swift 6 `complete`-mode): the shared singleton is
+/// captured by value into retry-alert closures and read from arbitrary
+/// re-auth completion queues, so it must be `Sendable`. The conformance is
+/// honest — the only mutable state (`retries`) is *always* mutated under
+/// `lock` (`canRetry`, `recordRetry`, `clearRetries`, and the private
+/// `cleanupStaleEntries` each take `lock.lock()`/`defer unlock`). The
+/// remaining stored members (`maxRetries`, `resetInterval`) are immutable
+/// `let`s. `final`, so the lock invariant can't be defeated by a subclass.
+final class UserRetryTracker: @unchecked Sendable {
     static let shared = UserRetryTracker()
 
     private struct RetryInfo {


### PR DESCRIPTION
## Swift 6 Phase B — MyBooks auth/token (isolation-only)

Part of **PP-4722** (Phase B critical-module migration). **AUTH critical-path.**
Clears the MyBooks auth/token `complete`-mode strict-concurrency warnings. **No
behavior change**; the 401/credential-stale decision + auth-surface-host scoping
(CLAUDE.md) are provably untouched — the decision path lives outside this diff.

### Changes
- `UserRetryTracker` / `CredentialPromptCoordinator` / `MyBooksSimplifiedBearerToken`
  → documented `@unchecked Sendable` (lock-guarded / write-before-publish / main-actor-
  confined invariants; retry counting byte-identical).
- `TokenRefreshInterceptor`: snapshot the error dict to a **checked-Sendable**
  `TPPProblemDocument` before the `@MainActor` Task; private `showBorrowAlert` →
  `@MainActor` (removes a redundant same-actor hop).
- `MyBooksDownloadInfo` → `@objc final @unchecked Sendable` (widening-only; clears 10
  non-Sendable `.remove`-across-actor sites + cascades to download-machinery counts).

### Verification
- Compiles in a `complete`-mode DRM `build-for-testing` on top of merged develop
  (app + test target), part of the **328 → 134** measurement.
- **Two independent SoD reviews APPROVED** (auth soundness + qa/behavior): every lock
  invariant traced, `MyBooksDownloadInfo` has zero in-place mutation, auth-decision
  path byte-equivalent, retry counting/token delivery unchanged.

### Deferred (follow-ups, non-blocking)
`@MainActor` annotation on `CredentialRequestState.isRequestingCredentials` to
compiler-enforce the documented convention; a spy test asserting the second-attempt
borrow alert fires (pre-existing coverage gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
