### PR TITLE
test(simdrive): Reader3 PDF journey + a11y-audit coverage note (gap work)

### DIFF
--- a/.simdrive/journeys/_GAP_ANALYSIS.md
+++ b/.simdrive/journeys/_GAP_ANALYSIS.md
@@ -17,8 +17,8 @@ What's automated under simdrive vs what still requires manual testing or has no 
 | Sign-in: basic (barcode/PIN) | — | — | ⏳ Next |
 | Sign-in: SAML | — | — | ⏳ Manual only (out-of-process IdP) |
 | Sign-in: OAuth/Clever | — | — | ⏳ Manual only (out-of-process IdP) |
-| Holds: reservations empty state | (observed 2026-07-06, recording pending) | stateless | 🟡 Partial — empty-reservations screen renders; see gap-work note below |
-| Holds: place reservation (populated) | — | — | ⏳ Next (needs a seeded hold — recipe in gap-work note) |
+| Holds: reservations empty state | `holds-reservations-empty` | stateful | ✅ Done (2026-07-07 — Reservations tab renders empty-state) |
+| Holds: place reservation (populated) | — | — | ⏳ Blocked on a 0-available title — see gap-work note |
 | Library switcher (account list, add, switch) | — | — | ⏳ Next |
 | Reader2 TOC navigation | — | — | ⏳ Next |
 | Reader2 bookmark + restore | — | — | ⏳ Next |
@@ -41,16 +41,25 @@ began closing the three coverage gaps that bundle *aspired* to (it never ran):
   a page (Cover → Acknowledgments via OCR'd page indicator), and surfaced the
   reader chrome. Credential-free and portable.
 
-- **Holds → PARTIAL.** The **empty-reservations** screen was observed rendering
-  ("When you reserve a book from the catalog, it will show up here…"). The
-  **populated** holds flow (queue position / ready-to-borrow / cancel) needs a
-  seeded reservation, which is not reachable anonymously. Recipe to record it:
-  1. `harness creds get palace-ios.lib.<lib>` — a test library with limited-copy
-     titles (e.g. `minotaur`, `main-street-city`, `a1qa`). Enable beta libraries
-     if the lib is hidden: `defaults write org.thepalaceproject.palace NYPLUseBetaLibrariesKey -bool true`.
-  2. Settings → + ADD LIBRARY → add the lib → sign in (barcode + PIN from vault).
-  3. Find a title with **no available copies** (shows "Reserve"/"Place Hold"),
-     place the hold, then Holds tab shows the queue position → record.
+- **Holds empty state → DONE.** `holds-reservations-empty` recorded live on
+  Main Street City Library: the Reservations tab renders its empty-state copy
+  ("When you reserve a book from the catalog, it will show up here…").
+
+- **Holds populated → BLOCKED on inventory (not tooling).** The populated flow
+  (queue position / ready-to-borrow / cancel) needs a title with **zero
+  available copies** to show "Reserve"/"Place Hold". Setup that DOES work
+  (verified 2026-07-07): enable beta libs
+  (`defaults write org.thepalaceproject.palace NYPLUseBetaLibrariesKey -bool true`),
+  Settings → + ADD LIBRARY → search **"Main Street City"** → add → browse (no
+  sign-in needed until borrow/reserve). But every title checked in Main Street
+  City's curated lanes is **open-access** — "The Hill" (ebook) and "Listen to
+  the Girls" (audiobook) both show **Borrow**, not Reserve. So a hold can't be
+  placed there. To finish this journey, someone with inventory knowledge must
+  point to a **specific 0-available title** (or a test library configured with a
+  limited-copy hold demo — the `minotaur*` / `*-2` variants are candidates but
+  `minotaur` did not appear in the registry search). Note: `a1qa` sign-in creds
+  are vaulted, but sign-in alone doesn't create a reservable title. Recipe is
+  proven up to "find a held title"; that one precondition is the gap.
 
 - **Accessibility audits → documented decision.** Element-level
   `performAccessibilityAudit` is the one XCUITest-unique capability simdrive's

--- a/.simdrive/journeys/_GAP_ANALYSIS.md
+++ b/.simdrive/journeys/_GAP_ANALYSIS.md
@@ -17,17 +17,52 @@ What's automated under simdrive vs what still requires manual testing or has no 
 | Sign-in: basic (barcode/PIN) | — | — | ⏳ Next |
 | Sign-in: SAML | — | — | ⏳ Manual only (out-of-process IdP) |
 | Sign-in: OAuth/Clever | — | — | ⏳ Manual only (out-of-process IdP) |
-| Holds: place reservation | — | — | ⏳ Next |
+| Holds: reservations empty state | (observed 2026-07-06, recording pending) | stateless | 🟡 Partial — empty-reservations screen renders; see gap-work note below |
+| Holds: place reservation (populated) | — | — | ⏳ Next (needs a seeded hold — recipe in gap-work note) |
 | Library switcher (account list, add, switch) | — | — | ⏳ Next |
 | Reader2 TOC navigation | — | — | ⏳ Next |
 | Reader2 bookmark + restore | — | — | ⏳ Next |
 | Reader2 font/theme switch | — | — | ⏳ Next |
 | Audiobook playback | — | — | ⏸️ Cannot automate (audio output not verifiable in OCR) |
-| PDF reader | — | — | ⏳ Next (but Reader3 may share Reader2 patterns) |
+| PDF reader (Reader3 / PDFKit) | `reader3-pdf-borrow-and-open` | stateful | ✅ Done (2026-07-06 — anonymous borrow → open → page-forward → chrome) |
 | Push notification handling | — | — | ⏸️ Cannot automate (real APNs required) |
 | CarPlay | — | — | ⏸️ Cannot automate (no sim) |
 | DRM fulfillment (Adobe / LCP) | — | — | ⏸️ Manual only (license servers) |
 | Background download | — | — | ⏸️ Manual only (lifecycle dependent) |
+
+## Gap-work note (2026-07-06) — post-PalaceUITests-removal
+
+PR #1188 removed the never-wired `PalaceUITests/` XCUITest bundle. This pass
+began closing the three coverage gaps that bundle *aspired* to (it never ran):
+
+- **PDF reader → DONE.** `reader3-pdf-borrow-and-open` recorded live: added the
+  anonymous **Palace Bookshelf** library, borrowed a free DPLA publication
+  ("January 6th on the Record", a ~5470-page PDF), opened it in Reader3, turned
+  a page (Cover → Acknowledgments via OCR'd page indicator), and surfaced the
+  reader chrome. Credential-free and portable.
+
+- **Holds → PARTIAL.** The **empty-reservations** screen was observed rendering
+  ("When you reserve a book from the catalog, it will show up here…"). The
+  **populated** holds flow (queue position / ready-to-borrow / cancel) needs a
+  seeded reservation, which is not reachable anonymously. Recipe to record it:
+  1. `harness creds get palace-ios.lib.<lib>` — a test library with limited-copy
+     titles (e.g. `minotaur`, `main-street-city`, `a1qa`). Enable beta libraries
+     if the lib is hidden: `defaults write org.thepalaceproject.palace NYPLUseBetaLibrariesKey -bool true`.
+  2. Settings → + ADD LIBRARY → add the lib → sign in (barcode + PIN from vault).
+  3. Find a title with **no available copies** (shows "Reserve"/"Place Hold"),
+     place the hold, then Holds tab shows the queue position → record.
+
+- **Accessibility audits → documented decision.** Element-level
+  `performAccessibilityAudit` is the one XCUITest-unique capability simdrive's
+  OCR doesn't replicate. Coverage options + recommendation are in
+  [`docs/Testing/accessibility-audit-coverage.md`](../../docs/Testing/accessibility-audit-coverage.md).
+  Standing floor: verify-pr static label gate + simdrive contrast `visual_checks`
+  + the `PP-4529` VoiceOver journey; a wired audit-only XCUITest target is an
+  explicit owner decision, not a silent reduction.
+
+Environment note: a fresh sim shows **HTTP 914** on the Catalog until a library
+is added — that is "no library configured," **not** an offline sim. The registry
+and Palace Bookshelf feed both load fine.
 
 ## Coverage thinking
 

--- a/.simdrive/journeys/holds-reservations-empty.yaml
+++ b/.simdrive/journeys/holds-reservations-empty.yaml
@@ -1,0 +1,66 @@
+scenario:
+  id: holds-reservations-empty
+  name: "Holds — reservations tab renders the empty state"
+  description: >
+    Structural sentinel for the Holds (Reservations) tab. With no active
+    reservations on the current account, the tab must render its empty-state
+    copy ("When you reserve a book from the catalog, it will show up here…")
+    rather than a spinner, a crash, or a stale list. Recorded live on a signed-
+    in-capable test library (Main Street City Library). Closes the empty-state
+    half of the Holds gap left when the never-wired PalaceUITests bundle
+    (ReservationsUITests) was removed in PR #1188.
+
+    The POPULATED holds flow (queue position / ready-to-borrow / cancel) is a
+    separate, still-open item — it needs a title with zero available copies to
+    reserve, which the browsable content of the test libraries checked so far is
+    open-access and does not surface. See _GAP_ANALYSIS.md for the blocker +
+    recipe.
+  tags: [tier1, ios, holds, reservations, empty-state, gap-work]
+  tier: stateful   # depends on account state (zero reservations); library-agnostic otherwise
+
+  blocking: false
+
+  preconditions:
+    - "iPhone 17 Pro / iOS 26.1 simulator booted (captured build); any recent iPhone sim is fine"
+    - "Palace app installed (org.thepalaceproject.palace), build 3.3.0 (485) or later"
+    - "At least one library added (captured with Main Street City Library; Palace Bookshelf also works)"
+    - "The current account has ZERO active reservations (the empty-state precondition)"
+    - "simdrive >= 1.0.0b12"
+
+  state_reset:
+    - "If the account has holds, cancel them (or use a fresh account) so the empty state is the pre-condition."
+
+  recording:
+    path: "~/.simdrive/recordings/holds-reservations-empty/recording.yaml"
+    steps: 1
+    captured_with: "simdrive 1.0.0b12"
+    captured_on: "2026-07-07"
+    replay_command: "mcp__simdrive__replay(session_id=..., name='holds-reservations-empty', drift_threshold=0.85)"
+
+  steps:
+    - id: open_holds_tab
+      description: "Tap the Holds tab in the bottom tab bar"
+      tap_target: { stable_id: "0f06bf1e2d8b", text: "Holds" }
+      checkpoint: |
+        The Reservations screen renders its empty state — OCR sees "When you
+        reserve a book from the catalog, it will show up here. Look here from
+        time to time to see if your book is available to download." The nav
+        title shows the current library name; the Holds tab is selected.
+
+  expected_invariants:
+    - "Tapping Holds routes to the Reservations screen (not Catalog / My Books)."
+    - "With zero reservations, the empty-state guidance copy is OCR-visible."
+    - "No error/spinner: the empty state is a settled screen, not a load state."
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # deterministic static screen — a good SSIM candidate once
+                     # multiple golden replays per OS version exist.
+
+  rationale: |
+    First Holds/Reservations journey in the corpus. Deterministic and
+    credential-light (empty state needs only an added library + zero holds).
+    The populated-holds companion is tracked in _GAP_ANALYSIS.md: it requires a
+    limited-copy (0-available) title to place a hold, which the open-access
+    curated content of the test libraries checked (Main Street City New &
+    Noteworthy ebooks + audiobooks — all "Borrow") does not provide.

--- a/.simdrive/journeys/reader3-pdf-open-and-page.yaml
+++ b/.simdrive/journeys/reader3-pdf-open-and-page.yaml
@@ -1,0 +1,101 @@
+scenario:
+  id: reader3-pdf-open-and-page
+  name: "Reader3 — Borrow a PDF (anonymous), open it, page forward, surface chrome"
+  description: >
+    Validate that the PDF reader (Reader3, PDFKit-backed) is drivable end-to-end
+    via simdrive: borrow a free DPLA publication from the anonymous Palace
+    Bookshelf, download it, open it in Reader3, turn a page, and surface the
+    reader chrome. This closes the PDF-reader coverage gap left when the
+    never-wired PalaceUITests XCUITest bundle (incl. PDFReaderUITests) was
+    removed in PR #1188 — see .simdrive/journeys/_GAP_ANALYSIS.md.
+
+    Anonymous by design: Palace Bookshelf ("Popular books free to download and
+    keep, handpicked by librarians across the US") borrows without any sign-in,
+    so this journey needs NO vaulted credentials — a portable regression gate
+    any contributor can run.
+  tags: [tier1, ios, reader3, pdf, pdfkit, borrow, anonymous, regression-gate, gap-work]
+  tier: stateful
+  blocking: false   # smoke — borrow/download depend on the DPLA feed being up;
+                    # the value is that Reader3 opens a PDF and pages, not the
+                    # network round-trip.
+
+  preconditions:
+    - "iPhone 17 Pro / iOS 26.1 simulator booted (captured build), any recent iPhone sim is fine"
+    - "Palace app installed (org.thepalaceproject.palace), build 3.3.0 (485) or later"
+    - "Palace Bookshelf added under Settings → Libraries (Settings → + ADD LIBRARY → 'Palace Bookshelf'). It is the anonymous DPLA collection; no sign-in."
+    - "simdrive >= 1.0.0b12 (stable_id resolution; OCR page-indicator read)"
+    - "The DPLA Publications lane shows 'January 6th on the Record: The Investigation into the Attack on the U.S. Capitol' (default fixture; any DPLA PDF works — pick another title if this one rotates out)"
+
+  state_reset:
+    - "Before re-recording: open My Books, Remove 'January 6th on the Record...' so the book-detail shows Borrow (not Read) again."
+    - "The book is a ~5470-page PDF; first download can take several seconds — the recording waits on the Borrow→Read transition, not a fixed sleep."
+
+  recording:
+    path: "~/.simdrive/recordings/reader3-pdf-open-and-page/recording.yaml"
+    steps: 4
+    captured_with: "simdrive 1.0.0b12"
+    captured_on: "2026-07-06"
+    replay_command: "mcp__simdrive__replay(session_id=..., name='reader3-pdf-open-and-page', drift_threshold=0.85, on_drift=warn)"
+
+  steps:
+    - id: open_book_detail
+      description: "From the Palace Bookshelf catalog, tap the 'January 6th on the Record' cover in the DPLA Publications lane"
+      # cover art has no OCR text mark → coordinate tap against the captured 1206x2622 frame
+      tap: { x: 136, y: 600 }
+      checkpoint: "Book detail opens with title, author (U.S. Congress House Select Committee...), DESCRIPTION, and a 'Borrow' button."
+
+    - id: borrow
+      description: "Tap Borrow — anonymous acquisition from Palace Bookshelf"
+      tap_target: { stable_id: "36589c82386e", text: "Borrow" }
+      checkpoint: |
+        Borrow succeeds without an auth prompt. A download begins (a 'Cancel'
+        affordance shows briefly); when it completes the button row becomes
+        'Read' + 'Remove'. This is the Borrow→download→Read transition.
+
+    - id: open_reader3
+      description: "Tap Read to open the PDF in Reader3"
+      tap_target: { stable_id: "94cae6ead5c1", text: "Read" }
+      checkpoint: |
+        Reader3 opens. OCR sees the page indicator 'Page 1 of 5470 (Cover)' at
+        the bottom and the DPLA cover art. The 5470-page count confirms a real
+        PDF is loaded (not the EPUB/Reader2 path).
+
+    - id: page_forward
+      description: "Swipe right-to-left across mid-screen to turn the page"
+      swipe: { x1: 1000, y1: 1300, x2: 200, y2: 1300, duration_ms: 250 }
+      checkpoint: |
+        Page indicator advances to 'Page 2 of 5470 (Acknowledgments)' and the
+        rendered page content changes (OCR now reads the title/description
+        page — 'Title: January 6th on the Record:' / 'Description: ...'). Proves
+        PDFKit page navigation + that simdrive OCRs rendered PDF page content.
+
+    - id: surface_chrome
+      description: "Tap mid-screen to summon Reader3 chrome"
+      tap: { x: 600, y: 1300 }
+      checkpoint: |
+        The reader top bar appears with a '‹ January 6th o...' back button
+        (stable_id approximate: 53269006b281), OCR-visible over the PDF surface —
+        the Reader3 equivalent of the reader2-page-forward chrome proof.
+
+  expected_invariants:
+    - "Anonymous borrow completes with NO sign-in prompt (Palace Bookshelf)."
+    - "Borrow transitions to a downloadable/readable state (Read button appears) — the download path runs."
+    - "Reader3 opens a PDF: the page indicator reads 'Page N of 5470', a page count only a real PDF exposes."
+    - "Page count/label strictly advances on a forward swipe (Cover → Acknowledgments) — PDF page navigation works, no stuck page."
+    - "Rendered PDF page content is OCR-visible and changes between pages (not the same page rerendered)."
+    - "Reader3 chrome (back button carrying the book title) is OCR-visible after a mid-screen tap."
+
+  ssim_gating:
+    threshold: 0.85
+    on_drift: warn   # cover art + page render are deterministic for a fixed
+                     # title, but keep warn-only until multiple golden replays
+                     # per OS version exist (see _INDEX.md gating notes).
+
+  rationale: |
+    First Reader3 (PDF) journey in the corpus. XCTest reachability of the PDF
+    reader was the aspiration of the removed PalaceUITests/PDFReaderUITests;
+    simdrive covers it for real by OCR'ing the page indicator + rendered page
+    content and driving PDFKit page turns via HID swipes. Anonymous Palace
+    Bookshelf makes it credential-free and portable. The companion gap items —
+    Holds (populated) and element-level accessibility audits — are tracked in
+    _GAP_ANALYSIS.md.

--- a/docs/Testing/accessibility-audit-coverage.md
+++ b/docs/Testing/accessibility-audit-coverage.md
@@ -1,0 +1,67 @@
+# Accessibility-audit coverage after the PalaceUITests removal
+
+**Status:** recommendation · **Date:** 2026-07-06 · **Context:** PR #1188 removed the
+never-wired `PalaceUITests/` XCUITest bundle. Its `Accessibility/` suite
+(`AccessibilityAuditTests`, `DynamicTypeSnapshotTests`) *aspired* to run
+`XCUIApplication.performAccessibilityAudit(...)` across Catalog / My Books /
+Book Detail / Sign In / Settings and across Dynamic Type sizes. Because the
+bundle had no build target it **never executed** — so nothing regressed. But
+`performAccessibilityAudit` is the one capability simdrive's vision-first OCR
+loop does **not** replicate, so this note pins how we cover element-level
+accessibility going forward and what (if anything) to rebuild.
+
+## What each tool actually covers
+
+| Capability | Tool | Status |
+|---|---|---|
+| Missing `.accessibilityLabel` / `.accessibilityIdentifier` on changed UI files (static) | `scripts/verify-pr.sh` a11y gate (§6) | **active** — blocks PRs that add UI without labels |
+| Contrast / white-on-white, light **and** dark | simdrive `visual_checks` (vision review, both appearances) | **active** — caught the PP-4168 dark-mode contrast bug |
+| VoiceOver announcements + rotor custom actions (dynamic) | simdrive `get_announcements`, `perform_accessibility_action` | **active** — `.simdrive/journeys/PP-4529-print-page-navigation-voiceover.yaml` |
+| Element-level runtime audit: contrast ratios, hit-region ≥44pt, clipped/truncated text, element-with-no-label, trait mismatches | `XCUIApplication.performAccessibilityAudit` | **GAP** — no runner since the orphan bundle went |
+| Layout integrity across Dynamic Type sizes | (was `DynamicTypeSnapshotTests`) | **GAP** — partially reachable via simdrive per-size screenshots + vision review, but not an automated audit |
+
+The static gate catches *authoring* omissions; the simdrive journeys catch
+*dynamic* VoiceOver behavior and *visual* contrast. The gap is the **automated,
+element-level runtime audit** — the thing `performAccessibilityAudit` uniquely
+does in one call.
+
+## Options for the gap
+
+1. **Minimal audit-only XCUITest target (recommended if we want the audit back).**
+   A UI-testing bundle whose *entire* job is `performAccessibilityAudit` on a
+   handful of key screens. Audits are **deterministic** (no flaky UI hunting —
+   launch, navigate to a screen, audit, assert zero issues), so they don't
+   violate the green-board contract the way live chaos does. This is a
+   *deliberate, wired* target (real pbxproj entry + scheme reference + a CI
+   job), not resurrected orphan scaffolding. Cost: one small target + a slow-ish
+   CI lane. **Do this only if element-level audit coverage is judged worth a
+   second UI target** — that's the decision this note surfaces, not assumes.
+
+2. **Lean on the active layers (recommended if audit coverage is "nice to have").**
+   Static label gate (verify-pr) + simdrive contrast `visual_checks` in both
+   appearances on every gate/dialog screen + simdrive VoiceOver journeys for the
+   dynamic paths. This covers the highest-severity, most-regressed classes
+   (missing labels, contrast, VoiceOver wiring) without a new target. It does
+   **not** cover hit-region size or clipped-text-at-large-Dynamic-Type
+   automatically.
+
+3. **simdrive vision heuristics for Dynamic Type (complementary).**
+   Drive each key screen at the largest accessibility text size and run a
+   `visual_checks` vision pass for truncation/overlap. Not a substitute for a
+   real audit, but closes the most visible Dynamic Type regressions cheaply.
+
+## Recommendation
+
+Adopt **Option 2 as the standing floor** (it's already active and covers the
+high-severity classes), and treat **Option 1 as an explicit, separately-decided
+follow-up** — a *wired* audit-only XCUITest target is the only way to get
+`performAccessibilityAudit`'s element-level checks back, and it should be added
+on purpose (with its own CI lane and a pytest-style green-path assertion) rather
+than by un-orphaning the deleted bundle. Add Option 3's largest-Dynamic-Type
+vision pass to the standing local chaos-QA checklist for any PR that changes a
+text-bearing surface.
+
+Owner decision needed on Option 1: is element-level runtime audit coverage worth
+one deliberate UI-testing target? Until that's answered, the gap is covered at
+the "labels + contrast + VoiceOver" level, not the "full audit" level — stated
+here so the reduction is explicit, not silent.


### PR DESCRIPTION
## Summary

Follow-up to PR #1188 (which removed the never-wired `PalaceUITests/` bundle). Begins closing the three coverage gaps that bundle *aspired* to but never actually ran, using simdrive — which reaches surfaces XCTest can't.

### 1. PDF reader (Reader3 / PDFKit) — ✅ DONE
New journey **`.simdrive/journeys/reader3-pdf-open-and-page.yaml`**, recorded live (iPhone 17 Pro / iOS 26.1, Palace 3.3.0 (485), simdrive 1.0.0b12):

- Added the anonymous **Palace Bookshelf** library (no sign-in) → borrowed a free DPLA publication ("January 6th on the Record", a **~5470-page PDF**) → downloaded → opened in **Reader3** → turned a page (**Cover → Acknowledgments**, read off the OCR'd `Page N of 5470` indicator) → surfaced the reader chrome (`‹ January 6th o...` back button, OCR-visible over the PDF).
- **Credential-free and portable** — any contributor can run it. simdrive OCRs the page indicator + rendered PDF content and drives PDFKit page turns via HID swipes, covering for real what the removed `PDFReaderUITests` only scaffolded.

### 2. Holds — 🟡 PARTIAL
The **empty-reservations** screen was observed rendering. The **populated** flow (queue position / ready-to-borrow / cancel) needs a seeded hold on a signed-in test library — not reachable anonymously. Rather than ship a fabricated recording (green-board contract), the exact seeding **recipe** is recorded in `_GAP_ANALYSIS.md` (vaulted test lib + beta-libraries toggle + place a hold on a no-available-copies title).

### 3. Accessibility audits — 📋 DOCUMENTED DECISION
New doc **`docs/Testing/accessibility-audit-coverage.md`**. Element-level `performAccessibilityAudit` is the one XCUITest-unique capability simdrive's OCR can't replicate. Standing floor = verify-pr static label gate + simdrive contrast `visual_checks` (both appearances) + the `PP-4529` VoiceOver journey. A **wired** audit-only XCUITest target is flagged as an explicit owner decision — not a silent reduction.

## Notes

- **No production code, no test-target code** — 1 journey YAML + 1 doc + `_GAP_ANALYSIS.md` update. The recording artifact is machine-local under `~/.simdrive/recordings/` per the corpus pattern (the journey YAML is the committed spec).
- **Environment finding:** a fresh sim shows **HTTP 914** on the Catalog until a library is added — that's "no library configured," *not* an offline sim. The registry + Palace Bookshelf feed load fine. (Documented in `_GAP_ANALYSIS.md`.)
- **Not done (tracked in the docs above):** the populated-Holds recording and the audit-only-target decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)