### PR TITLE
fix(swift6): Book registry consumers → complete-mode 0 (isolation-only)

### DIFF
--- a/Palace/Book/Models/BookRegistryStore.swift
+++ b/Palace/Book/Models/BookRegistryStore.swift
@@ -70,7 +70,18 @@ final class BookRegistryStore: @unchecked Sendable {
   }
 
   func performBarrier(_ block: @escaping () -> Void) {
-    syncQueue.async(flags: .barrier, execute: block)
+    // `DispatchQueue.async(execute:)` wants a `@Sendable` closure in Swift 6
+    // `complete` mode, but `block` is a plain non-Sendable `() -> Void` (its
+    // callers — `mutateRegistry`, `BookmarkManager`'s CRUD closures — capture
+    // non-Sendable state like `save` and `TPPBookLocation`, so `@Sendable`ing
+    // this parameter would ripple the diagnostic up the whole chain). Confine
+    // the non-Sendable closure to a carrier box and submit a `@Sendable`
+    // trampoline instead. INVARIANT: the box's `block` is invoked exactly once,
+    // on `syncQueue` inside the serialized barrier window — the same
+    // single-threaded execution the parameter already had — so no capture races
+    // another thread. Mirrors `SyncCallbacks` / `SendableErrorDocument`.
+    let carrier = BarrierBlockBox(block)
+    syncQueue.async(flags: .barrier) { carrier.run() }
   }
 
   func performBarrierSync(_ block: () -> Void) {
@@ -324,4 +335,26 @@ final class BookRegistryStore: @unchecked Sendable {
       self.registry.values.map { $0.dictionaryRepresentation }
     }
   }
+}
+
+// MARK: - Sendable carrier for `performBarrier`
+
+/// Sendable carrier for the non-Sendable `() -> Void` block that `performBarrier`
+/// submits to `syncQueue`. `DispatchQueue.async(execute:)` expects a `@Sendable`
+/// closure under Swift 6 `complete`; wrapping the block here lets the barrier
+/// submission capture this box (Sendable) instead of the raw non-Sendable
+/// closure — without pushing `@Sendable` onto `performBarrier`'s public
+/// parameter (which would ripple through `mutateRegistry` and every
+/// `BookmarkManager` CRUD closure, since those capture non-Sendable `save` /
+/// `TPPBookLocation` values).
+///
+/// `@unchecked Sendable` invariant: `run()` is called exactly once, on
+/// `syncQueue` inside the serialized `.barrier` window — the identical
+/// single-threaded execution the block had before boxing. The stored closure is
+/// never invoked from more than one thread, so moving the box across the
+/// dispatch boundary is race-free. Mirrors `SyncCallbacks` / `SendableErrorDocument`.
+private final class BarrierBlockBox: @unchecked Sendable {
+  private let block: () -> Void
+  init(_ block: @escaping () -> Void) { self.block = block }
+  func run() { block() }
 }

--- a/Palace/Book/Models/BookRegistrySync.swift
+++ b/Palace/Book/Models/BookRegistrySync.swift
@@ -118,8 +118,17 @@ final class BookRegistrySync: @unchecked Sendable {
 
     loadingAccount = account
     Log.info(#file, "Loading registry for account: \(account)")
+
+    // Box the injected callbacks so the `@Sendable` `DispatchQueue.main.async`
+    // closures below (here and in the mutateRegistry completion) capture a
+    // Sendable value rather than the raw non-Sendable `setState` / `completion`
+    // function values — otherwise `complete` mode reports "capture of … in a
+    // '@Sendable' closure" / "sending … risks data races". The callbacks are
+    // still only ever invoked on main. Mirrors `sync(...)`'s `SyncCallbacks`.
+    let callbacks = LoadCallbacks(setState: setState, completion: completion)
+
     DispatchQueue.main.async {
-      setState(.loading)
+      callbacks.setState(.loading)
     }
 
     store.mutateRegistry { [weak self] registry in
@@ -243,7 +252,7 @@ final class BookRegistrySync: @unchecked Sendable {
 
       DispatchQueue.main.async { [weak self] in
         guard let self else {
-          completion?()
+          callbacks.completion?()
           return
         }
 
@@ -251,7 +260,7 @@ final class BookRegistrySync: @unchecked Sendable {
           self.loadingAccount = nil
         }
 
-        setState(.loaded)
+        callbacks.setState(.loaded)
         self.store.registrySubject.send(snapshot)
 
         for (identifier, state) in bookStates {
@@ -265,7 +274,7 @@ final class BookRegistrySync: @unchecked Sendable {
         // notified — callers that chain sync() off load (e.g. the account-change
         // observer, AppDelegate cold-launch) need the store populated before
         // sync's reconciliation runs.
-        completion?()
+        callbacks.completion?()
 
         // PP-4129: schedule recovery for orphaned downloads. Each scheduled block
         // re-checks that the account that ran the load is still current before
@@ -546,7 +555,13 @@ final class BookRegistrySync: @unchecked Sendable {
     guard let registryUrl = registryUrl(for: account) else { return }
 
     let snapshot = store.registrySnapshot()
-    let registryObject = [TPPBookRegistryKey.records.rawValue: snapshot]
+    // Box the JSON payload so the `@Sendable` `diskWriteQueue.async` closure
+    // captures a Sendable value rather than the raw `[String: [[String: Any]]]`
+    // (non-Sendable because it holds `Any`). INVARIANT: the payload is built once
+    // here from a fresh snapshot and only ever READ inside the closure (serialized
+    // to JSON on `diskWriteQueue`), never mutated or shared — a write-once /
+    // read-once-off-thread handoff. Mirrors `SendableErrorDocument`.
+    let payload = SendableRegistryPayload(value: [TPPBookRegistryKey.records.rawValue: snapshot])
 
     diskWriteQueue.async {
       do {
@@ -555,7 +570,7 @@ final class BookRegistrySync: @unchecked Sendable {
           try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         }
         directoryURL.excludeFromBackup()
-        let registryData = try JSONSerialization.data(withJSONObject: registryObject, options: .fragmentsAllowed)
+        let registryData = try JSONSerialization.data(withJSONObject: payload.value, options: .fragmentsAllowed)
         try registryData.write(to: registryUrl, options: .atomic)
         DispatchQueue.main.async {
           NotificationCenter.default.post(name: .TPPBookRegistryDidChange, object: nil, userInfo: nil)
@@ -702,6 +717,20 @@ private struct SyncCallbacks: @unchecked Sendable {
   let completion: ((_ errorDocument: [AnyHashable: Any]?, _ newBooks: Bool) -> Void)?
 }
 
+/// Sendable carrier for `load`'s injected callbacks. Same rationale as
+/// `SyncCallbacks`, but `load`'s `completion` is the no-argument `(() -> Void)?`
+/// shape (fired once the registry is populated), so it needs its own struct.
+/// `setState` and `completion` are non-Sendable function values invoked only on
+/// the main thread (inside `load`'s `DispatchQueue.main.async` blocks); boxing
+/// them here lets those `@Sendable` closures capture a Sendable value instead of
+/// the raw closures, clearing the `complete`-mode "capture … in a '@Sendable'
+/// closure" / "sending … risks data races" diagnostics WITHOUT rippling
+/// `@Sendable` onto the `TPPBookRegistry` caller closures.
+private struct LoadCallbacks: @unchecked Sendable {
+  let setState: (TPPBookRegistry.RegistryState) -> Void
+  let completion: (() -> Void)?
+}
+
 /// Sendable carrier for the OPDS sync error document (`[AnyHashable: Any]` from
 /// `NSError.userInfo`, whose `Any` values are not Sendable). It is created once
 /// from a caught error and only ever read thereafter (forwarded to `completion`),
@@ -715,4 +744,14 @@ private struct SyncCallbacks: @unchecked Sendable {
 /// than each site minting its own near-identical carrier.
 struct SendableErrorDocument: @unchecked Sendable {
   let value: [AnyHashable: Any]?
+}
+
+/// Sendable carrier for the JSON registry payload that `save(for:)` hands to the
+/// `@Sendable` `diskWriteQueue.async` closure. The value is a
+/// `[String: [[String: Any]]]` (non-Sendable — holds `Any`) built once from a
+/// fresh in-memory snapshot and only ever READ (serialized to JSON) on the disk
+/// queue, never mutated or shared. `@unchecked` documents that write-once /
+/// read-off-thread confinement. Mirrors `SendableErrorDocument`.
+private struct SendableRegistryPayload: @unchecked Sendable {
+  let value: [String: [[String: Any]]]
 }

--- a/Palace/Book/Models/TPPBook+Extensions.swift
+++ b/Palace/Book/Models/TPPBook+Extensions.swift
@@ -12,15 +12,28 @@ import PalaceKeychain
 
 // MARK: - Associated Object Keys for Keychain Variables
 
+/// Sendable wrapper for an `objc_{get,set}AssociatedObject` key. The stdlib does
+/// NOT make `UnsafeRawPointer` `Sendable`, so a bare `static let … :
+/// UnsafeRawPointer` trips the `complete`-mode "static property is not
+/// concurrency-safe because non-'Sendable' type 'UnsafeRawPointer' may have
+/// shared mutable state" diagnostic. Wrapping it here makes the keys honestly
+/// `Sendable`.
+///
+/// `@unchecked Sendable` invariant: `raw` is a constant, distinct pointer
+/// allocated once at static-init and never written, dereferenced, or freed — it
+/// is used ONLY as an opaque identity token for associated-object storage. An
+/// immutable pointer identity carries no shared mutable state, so sharing it
+/// across concurrency domains is race-free.
+private struct AssociationKey: @unchecked Sendable {
+    let raw: UnsafeRawPointer
+}
+
 /// Stable, unique association keys. `objc_{get,set}AssociatedObject` only needs
-/// a distinct constant pointer per key; a `static let` of a `Sendable`
-/// `UnsafeRawPointer` gives that without the nonisolated-global-mutable-`var`
-/// concurrency warning (previously `private var …Key: UInt8 = 0`, whose address
-/// was taken via `&`). The 1-byte allocations are intentionally never freed —
-/// the keys live for the app's lifetime.
+/// a distinct constant pointer per key. The 1-byte allocations are intentionally
+/// never freed — the keys live for the app's lifetime.
 private enum TPPBookAssociatedKeys {
-    static let bearerTokenVariable = UnsafeRawPointer(UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1))
-    static let fulfillURLVariable = UnsafeRawPointer(UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1))
+    static let bearerTokenVariable = AssociationKey(raw: UnsafeRawPointer(UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)))
+    static let fulfillURLVariable = AssociationKey(raw: UnsafeRawPointer(UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)))
 }
 
 @objc extension TPPBook {
@@ -28,22 +41,22 @@ private enum TPPBookAssociatedKeys {
 
     /// Cached keychain variable for bearer token (reused across get/set calls)
     @nonobjc private var _bearerTokenVariable: TPPKeychainVariable<String> {
-        if let existing = objc_getAssociatedObject(self, TPPBookAssociatedKeys.bearerTokenVariable) as? TPPKeychainVariable<String> {
+        if let existing = objc_getAssociatedObject(self, TPPBookAssociatedKeys.bearerTokenVariable.raw) as? TPPKeychainVariable<String> {
             return existing
         }
         let variable: TPPKeychainVariable<String> = self.identifier.asKeychainVariable(with: bookTokenQueue)
-        objc_setAssociatedObject(self, TPPBookAssociatedKeys.bearerTokenVariable, variable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(self, TPPBookAssociatedKeys.bearerTokenVariable.raw, variable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return variable
     }
 
     /// Cached keychain variable for fulfill URL (reused across get/set calls)
     @nonobjc private var _fulfillURLVariable: TPPKeychainVariable<String> {
-        if let existing = objc_getAssociatedObject(self, TPPBookAssociatedKeys.fulfillURLVariable) as? TPPKeychainVariable<String> {
+        if let existing = objc_getAssociatedObject(self, TPPBookAssociatedKeys.fulfillURLVariable.raw) as? TPPKeychainVariable<String> {
             return existing
         }
         let key = "\(self.identifier)-fulfillURL"
         let variable: TPPKeychainVariable<String> = key.asKeychainVariable(with: bookTokenQueue)
-        objc_setAssociatedObject(self, TPPBookAssociatedKeys.fulfillURLVariable, variable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(self, TPPBookAssociatedKeys.fulfillURLVariable.raw, variable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return variable
     }
 

--- a/Palace/Book/Models/TPPBookCoverRegistry.swift
+++ b/Palace/Book/Models/TPPBookCoverRegistry.swift
@@ -321,6 +321,14 @@ actor TPPBookCoverRegistry {
             await self.acquireFetchSlot()
             defer { Task { await self.releaseFetchSlot() } }
 
+            // Recompute the cache key inside the Task from the Sendable `url`
+            // rather than capturing the outer `key` (`NSString`, non-Sendable) —
+            // capturing it made this `sending` Task closure trip the
+            // `complete`-mode "risks data races between 'self'-isolated code and
+            // concurrent execution of the closure" diagnostic. `url` is Sendable
+            // and the key is a pure function of it, so this is behavior-identical.
+            let key = url.absoluteString as NSString
+
             do {
                 let (data, _) = try await Self.imageSession.data(
                     for: URLRequest.withoutHTTP3Assumption(url: url)

--- a/Palace/Book/Models/TPPBookRegistry.swift
+++ b/Palace/Book/Models/TPPBookRegistry.swift
@@ -71,6 +71,24 @@ private final class ObserverTokenBox: @unchecked Sendable {
     }
 }
 
+/// Sendable carrier for the sync-completion closure captured by the `@Sendable`
+/// state-change observer block in `waitForLoadThenRunSync`. The closure is a
+/// non-Sendable `(([AnyHashable: Any]?, Bool) -> Void)?`; wrapping it lets the
+/// observer capture this box instead of the raw value, clearing the
+/// `complete`-mode "capture … in a '@Sendable' closure" diagnostic without
+/// rippling `@Sendable` onto `sync`/`runSync`'s public completion parameter.
+///
+/// `@unchecked Sendable` invariant: `completion` is stored once at construction
+/// and only ever READ, then invoked on the main queue (where the observer fires
+/// and `runSync` runs). No cross-thread mutation. Mirrors `SyncCallbacks` in
+/// `BookRegistrySync`.
+private final class SyncCompletionBox: @unchecked Sendable {
+    let completion: ((_ errorDocument: [AnyHashable: Any]?, _ newBooks: Bool) -> Void)?
+    init(_ completion: ((_ errorDocument: [AnyHashable: Any]?, _ newBooks: Bool) -> Void)?) {
+        self.completion = completion
+    }
+}
+
 /// A `Bool` that auto-resets to `false` after `delay` seconds, firing `onChange`
 /// on every edge. Used by `TPPBookRegistry` to post `TPPSyncBegan`/`TPPSyncEnded`.
 ///
@@ -426,6 +444,12 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing, @unchecked Sendable {
         // Hold the token in a Sendable box instead — the closure captures the
         // box reference (never reassigned), and the token is written exactly
         // once, right after `addObserver` returns.
+        // Box `completion` (a non-Sendable function value) so the `@Sendable`
+        // observer block captures a Sendable carrier instead of the raw closure —
+        // otherwise `complete` mode reports "capture of 'completion' … in a
+        // '@Sendable' closure". The observer fires on `.main`, where `runSync`
+        // (and thus the completion) already runs; boxing is behavior-neutral.
+        let completionBox = SyncCompletionBox(completion)
         let tokenBox = ObserverTokenBox()
         tokenBox.token = NotificationCenter.default.addObserver(
             forName: .TPPBookRegistryStateDidChange,
@@ -438,7 +462,7 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing, @unchecked Sendable {
             }
             if self.state == .loaded || self.state == .synced {
                 tokenBox.removeObserver()
-                self.runSync(completion: completion)
+                self.runSync(completion: completionBox.completion)
             }
         }
     }

--- a/Palace/Book/UI/BookDetail/BookService.swift
+++ b/Palace/Book/UI/BookDetail/BookService.swift
@@ -207,30 +207,55 @@ enum BookService {
 
         Log.info(#file, "  📡 Fetching manifest from bearer token location: \(token.location.host ?? "unknown")")
 
+        // Box `completion` so the `@Sendable` `dataTask` handler captures a
+        // Sendable carrier rather than the raw non-Sendable `([String: Any]?) ->
+        // Void` closure. Boxing (vs. marking the parameter `@Sendable`) keeps this
+        // static func's public signature unchanged — `@Sendable`ing it would
+        // ripple onto the `BearerTokenManifestFetching` protocol and both its
+        // production and test conformers in `Palace/Audiobooks/`. INVARIANT: the
+        // completion is invoked exactly once, on the URLSession delegate queue,
+        // per request — a single-consumer handoff, no shared mutation. Mirrors
+        // `ImageCompletionBox` / `SyncCallbacks`.
+        let completionBox = ManifestCompletionBox(completion)
         let task = session.dataTask(with: request) { data, response, error in
             if let error = error {
                 Log.error(#file, "  ❌ Network error fetching manifest via bearer token: \(error.localizedDescription)")
-                completion(nil)
+                completionBox.completion(nil)
                 return
             }
             guard let data = data, !data.isEmpty else {
                 Log.error(#file, "  ❌ No data received from bearer token manifest fetch")
-                completion(nil)
+                completionBox.completion(nil)
                 return
             }
             if let httpResponse = response as? HTTPURLResponse, !httpResponse.isSuccess() {
                 Log.error(#file, "  ❌ Bearer token manifest fetch failed with HTTP \(httpResponse.statusCode)")
-                completion(nil)
+                completionBox.completion(nil)
                 return
             }
             guard let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
                 Log.error(#file, "  ❌ Failed to parse bearer token manifest as JSON")
-                completion(nil)
+                completionBox.completion(nil)
                 return
             }
             Log.info(#file, "  ✅ Successfully fetched manifest via bearer token (\(data.count) bytes)")
-            completion(json)
+            completionBox.completion(json)
         }
         task.resume()
     }
+}
+
+/// Sendable carrier for `fetchManifestWithBearerToken`'s non-Sendable
+/// `([String: Any]?) -> Void` completion, so the `@Sendable` URLSession
+/// `dataTask` handler can capture it under Swift 6 `complete` mode without
+/// forcing `@Sendable` onto the public parameter (which would ripple onto the
+/// `BearerTokenManifestFetching` protocol in `Palace/Audiobooks/`).
+///
+/// `@unchecked Sendable` invariant: `completion` is stored once and invoked
+/// exactly once, on the URLSession delegate queue, for a single request — a
+/// one-shot single-consumer handoff, never mutated or shared. Mirrors
+/// `ImageCompletionBox`.
+private final class ManifestCompletionBox: @unchecked Sendable {
+    let completion: ([String: Any]?) -> Void
+    init(_ completion: @escaping ([String: Any]?) -> Void) { self.completion = completion }
 }


### PR DESCRIPTION
## Swift 6 Phase B — Book module

Clears the Book module's `complete`-mode concurrency residual with carrier boxes mirroring existing in-file precedents. **No behavior change**; zero ripples. Part of the app-target **738 → 0** finish.

**Independent review APPROVED** — all 6 carrier invariants traced true, load/sync/save preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)