### PR TITLE
fix(swift6): Audiobooks residual → complete-mode 0 (structural sending fixes)

### DIFF
--- a/Palace/Audiobooks/AudioBookVendors+Extensions.swift
+++ b/Palace/Audiobooks/AudioBookVendors+Extensions.swift
@@ -43,6 +43,13 @@ extension AudioBookVendors {
             return
         }
 
+        // `DPLAAudiobooks.drmKey`'s completion is `@Sendable`, but the caller's
+        // `completion` is a plain `((Error?) -> Void)?` (the public API can't
+        // require `@Sendable` without rippling to every caller). Capturing that
+        // bare optional closure inside the `@Sendable` callback trips
+        // `sending 'completion' risks data races`. Box it once before entering
+        // `drmKey` so the `@Sendable` closure captures the Sendable carrier.
+        let completionBox = SendableCertCompletion(completion)
         // Fetch a new drmKey
         DPLAAudiobooks.drmKey { (data, date, error) in
             if let error = error {
@@ -51,13 +58,13 @@ extension AudioBookVendors {
                 } else {
                     Log.error(#file, "Could not receive DRM public key, URL: \(DPLAAudiobooks.certificateUrl): \(error)")
                 }
-                completion?(error)
+                completionBox.fire(error)
                 return
             }
             // drmKey completion handler returns either non-empty data value or an error
             guard let keyData = data else {
                 Log.error(#file, "Public key data is empty, URL: \(DPLAAudiobooks.certificateUrl)")
-                completion?(DPLAAudiobooks.DPLAError.drmKeyError("Public key data is empty, URL: \(DPLAAudiobooks.certificateUrl)"))
+                completionBox.fire(DPLAAudiobooks.DPLAError.drmKeyError("Public key data is empty, URL: \(DPLAAudiobooks.certificateUrl)"))
                 return
             }
             // Check if we have a valid date
@@ -83,8 +90,34 @@ extension AudioBookVendors {
                 TPPKeychainManager.logKeychainError(forVendor: self.rawValue, status: status, message: "FeedbookDrmPrivateKeyManagement Error:")
             }
 
-            completion?(nil)
+            completionBox.fire(nil)
         }
     }
 
+}
+
+/// `Sendable` wrapper for the optional `(Error?) -> Void` completion of
+/// `updateDrmCertificate`.
+///
+/// `DPLAAudiobooks.drmKey`'s completion is `@Sendable`, so the caller's plain
+/// (non-`@Sendable`) optional completion cannot be captured inside it without a
+/// `sending` diagnostic. This box lets the completion cross that boundary while
+/// keeping the public `updateDrmCertificate` API free of a `@Sendable`
+/// requirement that would ripple to callers. Mirrors `SendableDecryptCompletion`
+/// (LCPAudiobooks).
+///
+/// - Sendable invariant: `fire(_:)` forwards to the wrapped closure. The
+///   underlying `drmKey` contract invokes its completion exactly once, so
+///   `fire(_:)` runs at most once per certificate update. The wrapped closure is
+///   otherwise opaque, hence `@unchecked`.
+private struct SendableCertCompletion: @unchecked Sendable {
+    private let completion: ((Error?) -> Void)?
+
+    init(_ completion: ((Error?) -> Void)?) {
+        self.completion = completion
+    }
+
+    func fire(_ error: Error?) {
+        completion?(error)
+    }
 }

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -1271,19 +1271,29 @@ public final class AudiobookSessionManager: ObservableObject {
     ) async -> TrackPosition? {
         guard let concreteRegistry = bookRegistry as? TPPBookRegistry else { return nil }
         let toc = audiobook.tableOfContents
-        return await withCheckedContinuation { (cont: CheckedContinuation<TrackPosition?, Never>) in
+        // `TrackPosition` (PalaceAudiobookToolkit) is not Sendable-audited, so
+        // resuming the continuation with a bare `TrackPosition?` trips the
+        // `sending 'position' risks data races` diagnostic — the `syncLocation`
+        // completion fires off the caller's actor (inside TPPBookRegistry's
+        // detached sync Task, see `SyncLocationBox`), and `@preconcurrency
+        // import` downgrades the Sendable-conformance warning but NOT the
+        // `sending` one. Carry the value through the continuation in a Sendable
+        // box and unwrap after the `await` (back on this `@MainActor` method).
+        let box: SendableTrackPositionBox = await withCheckedContinuation { (cont: CheckedContinuation<SendableTrackPositionBox, Never>) in
             let once = PositionResolveOnce()
             concreteRegistry.syncLocation(for: book) { (remoteBookmark: AudioBookmark?) in
                 let position = remoteBookmark.flatMap {
                     TrackPosition(audioBookmark: $0, toc: toc.toc, tracks: toc.tracks)
                 }
-                once.fire { cont.resume(returning: position) }
+                let boxed = SendableTrackPositionBox(position)
+                once.fire { cont.resume(returning: boxed) }
             }
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: UInt64(max(0, timeout) * 1_000_000_000))
-                once.fire { cont.resume(returning: nil) }
+                once.fire { cont.resume(returning: SendableTrackPositionBox(nil)) }
             }
         }
+        return box.value
     }
 
     /// True iff `remote` should be preferred over `local` — i.e. the remote save
@@ -2235,5 +2245,26 @@ private final class PositionResolveOnce: @unchecked Sendable {
         fired = true
         lock.unlock()
         block()
+    }
+}
+
+/// `Sendable` carrier for a resolved `TrackPosition?` crossing the
+/// `awaitRemotePosition` continuation boundary.
+///
+/// `TrackPosition` lives in the un-Sendable-audited PalaceAudiobookToolkit, so
+/// resuming `CheckedContinuation<TrackPosition?, …>` with it trips the
+/// `sending` diagnostic (which `@preconcurrency import` does not silence). The
+/// value is produced fresh inside the off-actor `syncLocation` completion and
+/// consumed once on `@MainActor` after the `await`, so boxing it makes the
+/// hand-off explicit rather than crossing a bare non-Sendable value.
+///
+/// - Sendable invariant: `value` is set once at init and only read thereafter
+///   — the wrapped `TrackPosition?` is never mutated after boxing, so there is
+///   no shared mutation. The `@unchecked` waiver covers only the toolkit type
+///   the compiler cannot prove `Sendable`.
+private struct SendableTrackPositionBox: @unchecked Sendable {
+    let value: TrackPosition?
+    init(_ value: TrackPosition?) {
+        self.value = value
     }
 }

--- a/Palace/Audiobooks/LCP/LCPAudiobooks.swift
+++ b/Palace/Audiobooks/LCP/LCPAudiobooks.swift
@@ -100,8 +100,14 @@ import PalaceCatalog
         }
         DispatchQueue.global(qos: .userInitiated).async {
             self.loadContentDictionary { json, error in
+                // `NSDictionary` / `NSError` are not Sendable-audited, so
+                // capturing `json` / `error` into the `main.async` `@Sendable`
+                // closure trips `sending … risks data races`. Snapshot the pair
+                // into a Sendable carrier for the single main-thread hop; the
+                // values are freshly produced by the load and consumed once.
+                let resultBox = LCPContentResultBox(json: json, error: error)
                 DispatchQueue.main.async {
-                    completion(json, error)
+                    completion(resultBox.json, resultBox.error)
                 }
             }
         }
@@ -446,6 +452,24 @@ private struct SendableDecryptCompletion: @unchecked Sendable {
     func fire(_ error: Error?) {
         completion(error)
     }
+}
+
+/// `Sendable` carrier for the `(NSDictionary?, NSError?)` result of
+/// `loadContentDictionary`, used to cross the single `DispatchQueue.main.async`
+/// hop in `contentDictionary` without a `sending` diagnostic.
+///
+/// `NSDictionary` (the parsed LCP manifest) and `NSError` are `@objc` reference
+/// types the compiler does not treat as `Sendable`. Both are produced fresh by
+/// the load and only read once on the main thread, so boxing them makes the
+/// hand-off explicit rather than sending bare non-Sendable references.
+///
+/// - Sendable invariant: `json` / `error` are set once at init and only read
+///   thereafter — neither the manifest dictionary nor the error is mutated
+///   after boxing, so there is no shared mutation. The `@unchecked` waiver
+///   covers only the un-audited `@objc` payload types.
+private struct LCPContentResultBox: @unchecked Sendable {
+    let json: NSDictionary?
+    let error: NSError?
 }
 
 #endif

--- a/Palace/Audiobooks/Tracker/AudiobookDataManager.swift
+++ b/Palace/Audiobooks/Tracker/AudiobookDataManager.swift
@@ -217,10 +217,14 @@ class AudiobookDataManager: @unchecked Sendable {
         // than capturing a mutable local `var` by reference across the
         // concurrency boundaries. Behavior is unchanged: begin once, end once.
         let backgroundTask = BackgroundTaskToken()
-        backgroundTask.set(UIApplication.shared.beginBackgroundTask(withName: "AudiobookTimeSync") {
-            // Cleanup handler if time expires
-            backgroundTask.end()
-        })
+        // `UIApplication.shared` is `@MainActor`-isolated, so both the
+        // `beginBackgroundTask` and `endBackgroundTask` touches must run on the
+        // main actor. The token owns those hops internally (see `begin`/`end`),
+        // which keeps `syncValues` free of a `@MainActor` annotation that would
+        // ripple to its Combine-sink call sites and tests. The main-queue hops
+        // are FIFO-ordered — `begin` is enqueued here before `syncQueue.async`
+        // can enqueue any `end`, so "begin once, end once" ordering holds.
+        backgroundTask.begin(named: "AudiobookTimeSync")
 
         syncQueue.async { [weak self] in
             guard let self = self else {
@@ -437,27 +441,49 @@ class AudiobookDataManager: @unchecked Sendable {
 /// expiration handler and every POST-completion `@Sendable` closure; the lock
 /// serializes access and makes the holder `Sendable`.
 ///
+/// The token also owns the two `UIApplication.shared` touches. Because
+/// `UIApplication.shared` is `@MainActor`-isolated, both `beginBackgroundTask`
+/// and `endBackgroundTask` are performed inside a `DispatchQueue.main.async`
+/// hop (mirroring `TPPBackgroundExecutor`), so callers on any queue — the
+/// `syncQueue.async` body and the per-request POST completions — can drive the
+/// lifecycle without a main-actor-isolation error and without forcing
+/// `@MainActor` onto `AudiobookDataManager`.
+///
 /// - Sendable invariant: `id` is only ever read/written under `lock`. `end()`
 ///   is idempotent — it ends the task at most once and resets to `.invalid`,
 ///   preserving the original code's "begin once, end once" semantics even if
-///   two completion paths race to finish.
+///   two completion paths race to finish. The main-queue is FIFO, so a `begin`
+///   enqueued before any `end` always runs first.
 private final class BackgroundTaskToken: @unchecked Sendable {
     private let lock = NSLock()
     private var id: UIBackgroundTaskIdentifier = .invalid
 
-    func set(_ newId: UIBackgroundTaskIdentifier) {
+    private func set(_ newId: UIBackgroundTaskIdentifier) {
         lock.lock()
         id = newId
         lock.unlock()
     }
 
+    /// Begins the background task on the main actor and stores its identifier.
+    /// The expiration handler ends the task via `end()` (also main-hopped).
+    func begin(named name: String) {
+        DispatchQueue.main.async { [self] in
+            let newId = UIApplication.shared.beginBackgroundTask(withName: name) { [self] in
+                end()
+            }
+            set(newId)
+        }
+    }
+
     func end() {
-        lock.lock()
-        let current = id
-        id = .invalid
-        lock.unlock()
-        if current != .invalid {
-            UIApplication.shared.endBackgroundTask(current)
+        DispatchQueue.main.async { [self] in
+            lock.lock()
+            let current = id
+            id = .invalid
+            lock.unlock()
+            if current != .invalid {
+                UIApplication.shared.endBackgroundTask(current)
+            }
         }
     }
 }

--- a/Palace/Audiobooks/Vendors/AudiobookVendorAdapter.swift
+++ b/Palace/Audiobooks/Vendors/AudiobookVendorAdapter.swift
@@ -113,3 +113,23 @@ struct ManifestJSONBox: @unchecked Sendable {
         self.value = value
     }
 }
+
+/// `Sendable` carrier for a `BearerTokenManifestFetching` existential.
+///
+/// `BearerTokenManifestFetching` is a Palace-local protocol that intentionally
+/// does NOT refine `Sendable` — refining it would ripple to the production
+/// `BookService` conformance and every adapter test stub. `BearerTokenAdapter`
+/// and `OpenAccessAdapter` capture the fetcher into a `Task { @MainActor in }`
+/// hop to run the bearer-token second leg on the main actor; the bare
+/// existential cannot cross that boundary. This box carries it across.
+///
+/// - Sendable invariant: `fetcher` is set once at init and only read thereafter.
+///   Both adapters invoke `fetcher.fetchManifest(...)` exclusively from inside
+///   the main-actor hop, so there is no concurrent access. The `@unchecked`
+///   waiver covers only the non-`Sendable` protocol existential.
+struct BearerManifestFetcherBox: @unchecked Sendable {
+    let fetcher: BearerTokenManifestFetching
+    init(_ fetcher: BearerTokenManifestFetching) {
+        self.fetcher = fetcher
+    }
+}

--- a/Palace/Audiobooks/Vendors/BearerTokenAdapter.swift
+++ b/Palace/Audiobooks/Vendors/BearerTokenAdapter.swift
@@ -90,7 +90,14 @@ final class BearerTokenAdapter: AudiobookVendorAdapter {
         // onto the `AudiobookVendorAdapter` protocol. See
         // `AudiobookAdapterCompletionBox`.
         let completionBox = AudiobookAdapterCompletionBox(completion)
-        network.fetchData(from: url) { [manifestFetcher] data, response, error in
+        // `BearerTokenManifestFetching` is a Palace-local protocol that does NOT
+        // refine `Sendable` (refining it would ripple to `BookService` and every
+        // adapter test stub). Capturing the bare existential into the
+        // `Task { @MainActor in }` hop below trips `sending … risks data races`.
+        // Carry it in an `@unchecked Sendable` box whose invariant is that the
+        // fetcher is only invoked from the main-actor hop.
+        let fetcherBox = BearerManifestFetcherBox(manifestFetcher)
+        network.fetchData(from: url) { [fetcherBox] data, response, error in
             Task { @MainActor in
                 if let error = error {
                     Log.error(#file, "  ❌ Network error fetching bearer-token wrapper: \(error.localizedDescription)")
@@ -126,15 +133,22 @@ final class BearerTokenAdapter: AudiobookVendorAdapter {
                 book.bearerToken = bearerToken.accessToken
                 book.bearerTokenFulfillURL = url
 
-                manifestFetcher.fetchManifest(with: bearerToken, for: book) { manifestJSON in
+                fetcherBox.fetcher.fetchManifest(with: bearerToken, for: book) { manifestJSON in
+                    // `[String: Any]?` is not Sendable (it holds `Any`
+                    // existentials), so capturing `manifestJSON` into the
+                    // `Task { @MainActor in }` hop trips `sending … risks data
+                    // races`. Unwrap on the callback's thread and box the
+                    // dictionary before the hop; the manifest is produced once
+                    // and only read on the main actor thereafter.
+                    guard let manifestJSON = manifestJSON else {
+                        Log.error(#file, "  ❌ Bearer-token second-leg manifest fetch returned nil")
+                        Task { @MainActor in completionBox.fire(.failure(.manifestFetchFailed)) }
+                        return
+                    }
+                    let jsonBox = ManifestJSONBox(manifestJSON)
                     Task { @MainActor in
-                        guard let manifestJSON = manifestJSON else {
-                            Log.error(#file, "  ❌ Bearer-token second-leg manifest fetch returned nil")
-                            completionBox.fire(.failure(.manifestFetchFailed))
-                            return
-                        }
                         Log.debug(#file, "  ✅ Successfully fetched manifest via bearer token")
-                        completionBox.fire(.success((json: manifestJSON, decryptor: nil)))
+                        completionBox.fire(.success((json: jsonBox.value, decryptor: nil)))
                     }
                 }
             }

--- a/Palace/Audiobooks/Vendors/LCPAdapter.swift
+++ b/Palace/Audiobooks/Vendors/LCPAdapter.swift
@@ -203,7 +203,34 @@ final class LCPAdapter: AudiobookVendorAdapter {
         _ result: AudiobookAdapterCompletionBox.Outcome
     ) {
         if Thread.isMainThread { completionBox.fire(result) }
-        else { DispatchQueue.main.async { completionBox.fire(result) } }
+        else {
+            // The `Outcome` payload carries `[String: Any]` (manifest) and a
+            // `DRMDecryptor?` (toolkit protocol), neither Sendable-audited, so
+            // capturing `result` directly into the `main.async` `@Sendable`
+            // closure trips `sending 'result' risks data races`. Box it for the
+            // single main hop — the outcome is produced once and consumed once.
+            let outcomeBox = LCPOutcomeBox(result)
+            DispatchQueue.main.async { completionBox.fire(outcomeBox.value) }
+        }
+    }
+}
+
+/// `Sendable` carrier for an `AudiobookAdapterCompletionBox.Outcome` crossing
+/// the `finishOnMain` `DispatchQueue.main.async` hop.
+///
+/// The outcome's success payload holds a non-Sendable `[String: Any]` manifest
+/// and an un-audited `DRMDecryptor?`; boxing lets it cross the main hop without
+/// a `sending` diagnostic while keeping the `AudiobookVendorAdapter` completion
+/// (and its loader/test call sites) free of a `@Sendable` requirement.
+///
+/// - Sendable invariant: `value` is set once at init and only read on the main
+///   thread thereafter — the outcome is not mutated after boxing, so there is
+///   no shared mutation. The `@unchecked` waiver covers only the un-audited
+///   payload types. Mirrors `ManifestJSONBox` (AudiobookVendorAdapter).
+private struct LCPOutcomeBox: @unchecked Sendable {
+    let value: AudiobookAdapterCompletionBox.Outcome
+    init(_ value: AudiobookAdapterCompletionBox.Outcome) {
+        self.value = value
     }
 }
 

--- a/Palace/Audiobooks/Vendors/OpenAccessAdapter.swift
+++ b/Palace/Audiobooks/Vendors/OpenAccessAdapter.swift
@@ -96,7 +96,14 @@ final class OpenAccessAdapter: AudiobookVendorAdapter {
         // onto the `AudiobookVendorAdapter` protocol (which would ripple to the
         // loader + every adapter test mock). See `AudiobookAdapterCompletionBox`.
         let completionBox = AudiobookAdapterCompletionBox(completion)
-        network.fetchData(from: url) { [bearerTokenManifestFetcher] data, response, error in
+        // `BearerTokenManifestFetching` is a Palace-local protocol that does NOT
+        // refine `Sendable` (refining it would ripple to `BookService` and every
+        // adapter test stub). Capturing the bare optional existential into the
+        // `Task { @MainActor in }` hop trips `sending … risks data races`. Carry
+        // it in an `@unchecked Sendable` box; the fetcher is only invoked from
+        // the main-actor hop. `nil` (open-access-only tests) stays `nil`.
+        let fetcherBox = bearerTokenManifestFetcher.map(BearerManifestFetcherBox.init)
+        network.fetchData(from: url) { [fetcherBox] data, response, error in
             Task { @MainActor in
                 if let error = error {
                     Log.error(#file, "  ❌ Network error fetching manifest: \(error.localizedDescription)")
@@ -131,21 +138,28 @@ final class OpenAccessAdapter: AudiobookVendorAdapter {
                 // runtime (body-based) bearer-token detection so the wrapper
                 // is followed to the real manifest instead of being mis-parsed
                 // as one (which fails decode → "error opening this book").
-                if let bearerTokenManifestFetcher,
+                if let bearerTokenManifestFetcher = fetcherBox?.fetcher,
                    let bearerToken = MyBooksSimplifiedBearerToken.simplifiedBearerToken(with: json) {
                     Log.info(#file, "  🔑 Open-access fetch returned a bearer-token wrapper - following second leg to the real manifest")
                     bearerToken.fulfillURL = url
                     book.bearerToken = bearerToken.accessToken
                     book.bearerTokenFulfillURL = url
                     bearerTokenManifestFetcher.fetchManifest(with: bearerToken, for: book) { manifestJSON in
+                        // `[String: Any]?` is not Sendable (it holds `Any`
+                        // existentials), so capturing `manifestJSON` into the
+                        // `Task { @MainActor in }` hop trips `sending … risks
+                        // data races`. Unwrap on the callback's thread and box
+                        // the dictionary before the hop; the manifest is
+                        // produced once and only read on the main actor after.
+                        guard let manifestJSON = manifestJSON else {
+                            Log.error(#file, "  ❌ Bearer-token second-leg manifest fetch returned nil")
+                            Task { @MainActor in completionBox.fire(.failure(.manifestFetchFailed)) }
+                            return
+                        }
+                        let jsonBox = ManifestJSONBox(manifestJSON)
                         Task { @MainActor in
-                            guard let manifestJSON = manifestJSON else {
-                                Log.error(#file, "  ❌ Bearer-token second-leg manifest fetch returned nil")
-                                completionBox.fire(.failure(.manifestFetchFailed))
-                                return
-                            }
                             Log.debug(#file, "  ✅ Successfully fetched manifest via bearer token (open-access fallback)")
-                            completionBox.fire(.success((json: manifestJSON, decryptor: nil)))
+                            completionBox.fire(.success((json: jsonBox.value, decryptor: nil)))
                         }
                     }
                     return


### PR DESCRIPTION
## Swift 6 Phase B — Audiobooks residual (structural)

Closes the structural `sending` diagnostics `@preconcurrency` couldn't, via carrier boxes + main-hops. No protocol made Sendable → zero test ripple. Part of the app-target **738 → 0** finish.

**Two independent SoD APPROVED** (soundness + behavior): all box invariants true, `BackgroundTaskToken` begin-once/end-once ordering verified, LCP/DRM decrypt timing byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)