### PR TITLE
fix(swift6): SignInLogic TPPSignInBusinessLogic @MainActor → complete-mode 0

### DIFF
--- a/Palace/Packages/PalaceAuth/Sources/PalaceAuth/TPPSAMLHelper.swift
+++ b/Palace/Packages/PalaceAuth/Sources/PalaceAuth/TPPSAMLHelper.swift
@@ -15,7 +15,7 @@ public protocol UniversalLinksProviding: AnyObject {
 /// What `TPPSAMLHelper` needs from the sign-in orchestrator. Decouples the
 /// helper from the concrete `TPPSignInBusinessLogic` class so the package
 /// has no app-target dependency.
-public protocol SAMLAuthContext: AnyObject {
+@MainActor public protocol SAMLAuthContext: AnyObject {
     /// Resolved URL of the user-selected IdP for this SAML attempt.
     var selectedIDPURL: URL? { get }
     /// Cached cookies for re-using the IdP session, expired ones filtered
@@ -30,7 +30,7 @@ public protocol SAMLAuthContext: AnyObject {
 /// What `TPPSAMLHelper` needs to present the SAML WebView. The main target
 /// implements this against `SignInWebSheetPresenter` (or any other
 /// presentation surface) and injects it.
-public protocol SAMLWebViewPresenting: AnyObject {
+@MainActor public protocol SAMLWebViewPresenting: AnyObject {
     func presentSAMLWebView(url: URL, cookies: [HTTPCookie],
                             loginCompletion: @escaping (URL, [HTTPCookie]) -> Void,
                             loginCancel: @escaping () -> Void)
@@ -39,7 +39,7 @@ public protocol SAMLWebViewPresenting: AnyObject {
 
 // MARK: - SAML Helper
 
-public class TPPSAMLHelper {
+@MainActor public class TPPSAMLHelper {
 
     /// Cookies obtained during the SAML login flow. Cleared on `clearState()`.
     public var cookies: [HTTPCookie]?

--- a/Palace/SignInLogic/LegacySAMLAuthAdapter.swift
+++ b/Palace/SignInLogic/LegacySAMLAuthAdapter.swift
@@ -40,12 +40,16 @@ final class UniversalLinksAdapter: NSObject, UniversalLinksProviding {
 /// payload through the existing OAuth/SAML handler, and surface errors
 /// through the UI delegate.
 ///
-/// Both adapters here are deliberately NOT `@MainActor` so they can be
-/// constructed from `TPPSignInBusinessLogic`'s nonisolated designated
-/// initializer. Every callback either re-enters main via `Task { @MainActor }`
-/// or `DispatchQueue.main.async`; the underlying calls to UIKit, SwiftUI, and
-/// `TPPSignInBusinessLogic` all bounce through the main thread before
-/// touching anything actor-isolated.
+/// `@MainActor`: this adapter reads/writes `@MainActor` `TPPSignInBusinessLogic`
+/// state synchronously (`selectedIDPURL`, `savedCookies`, `handleSAMLRedirect`)
+/// and is only ever constructed from `TPPSignInBusinessLogic.init` (now itself
+/// `@MainActor`) and driven by `TPPSAMLHelper` on the main-thread SAML login
+/// flow. Its `SAMLAuthContext` conformance is main-actor because the PalaceAuth
+/// protocol is `@MainActor` (see RIPPLES.md). The residual `asyncIfNeeded` hops
+/// below stay for their sync-if-already-on-main ordering guarantee, but no
+/// longer need `assumeIsolated` gymnastics to reach main-actor state — the whole
+/// adapter is now main-isolated.
+@MainActor
 final class LegacySAMLAuthContext: NSObject, SAMLAuthContext {
     weak var businessLogic: TPPSignInBusinessLogic?
 
@@ -109,14 +113,17 @@ final class LegacySAMLAuthContext: NSObject, SAMLAuthContext {
 /// `SAMLWebViewPresenting`. Mirrors the legacy `LegacySAMLWebViewPresenter`
 /// that lived inside `TPPSAMLHelper.swift` before the package extraction.
 ///
-/// Not `@MainActor` for the same reason as `LegacySAMLAuthContext`: it must be
-/// constructible from a nonisolated init. Each method hops to main via
-/// `Task { @MainActor }` before touching the SwiftUI presenter.
+/// `@MainActor` for the same reason as `LegacySAMLAuthContext`: it is
+/// constructed from `TPPSignInBusinessLogic.init` (now `@MainActor`), drives the
+/// `@MainActor` `SignInWebSheetPresenter`, and its `SAMLWebViewPresenting`
+/// conformance is main-actor because the PalaceAuth protocol is `@MainActor`
+/// (see RIPPLES.md).
 ///
 /// Holds a reference to the same `urlSettingsProvider` the businessLogic was
 /// constructed with so the universal-links URL is read from the injected
 /// settings object rather than reaching back through `AppContainer.production()`
 /// (which is a singleton seam the rest of the sign-in path no longer touches).
+@MainActor
 final class LegacySAMLWebViewPresenter: NSObject, SAMLWebViewPresenting {
     private let universalLinksProvider: NYPLUniversalLinksSettings
 
@@ -240,7 +247,13 @@ final class LegacySAMLWebViewPresenter: NSObject, SAMLWebViewPresenting {
 /// `PalaceAuth.TPPUserAccountFrontEndValidation` reads. PalaceAuth doesn't
 /// see `LoginKeyboard` (it lives on `AccountDetails`); this extension
 /// flattens each predicate to a Bool the validator can act on.
-extension TPPSignInBusinessLogic: TPPSignInValidationContext {
+// `@preconcurrency`: `TPPSignInValidationContext` (PalaceAuth) is a nonisolated
+// protocol, but these witnesses read `@MainActor` instance state
+// (`selectedAuthentication`, `userAccount`). The sole consumer,
+// `TPPUserAccountFrontEndValidation` (a `UITextFieldDelegate`), only calls them
+// on the main thread, so `@preconcurrency` accepts the isolated witnesses and
+// inserts a runtime main-actor check at the dynamic-dispatch boundary.
+extension TPPSignInBusinessLogic: @preconcurrency TPPSignInValidationContext {
     public var usernameIsEmailKeyboard: Bool {
         selectedAuthentication?.patronIDKeyboard == .email
     }

--- a/Palace/SignInLogic/SignInWebViewCoordinator.swift
+++ b/Palace/SignInLogic/SignInWebViewCoordinator.swift
@@ -10,15 +10,29 @@
 //
 
 import Foundation
-// `@preconcurrency` so the iOS-17+ WebKit SDK's `sending decisionHandler`
-// parameters on `WKNavigationDelegate.decidePolicyFor` don't trip the
-// `complete`-mode "sending value risks data races" diagnostic when the handler
-// is carried into the `@MainActor` hop below. The handler is always invoked on
-// the main actor (WebKit guarantees delegate callbacks on main; the hop
-// re-enters main before calling it), so the pre-concurrency import is a
-// suppression of a false positive, not a correctness change.
+// `@preconcurrency` for the iOS-17+ WebKit SDK's non-Sendable delegate types
+// carried into the `@MainActor` hops below (`WKNavigationAction`,
+// `WKNavigationResponse`, `WKWebView`). The `sending decisionHandler` closures
+// are additionally boxed in `DecisionHandlerBox` (see below) — WebKit guarantees
+// delegate callbacks on main and each hop re-enters main before invoking the
+// handler, so the box waives no real race, it satisfies the `@Sendable` capture.
 @preconcurrency import WebKit
 import PalaceLogging
+
+/// Sendable carrier for WebKit's non-Sendable `decisionHandler` closures
+/// (`@escaping (WKNavigationActionPolicy) -> Void` /
+/// `@escaping (WKNavigationResponsePolicy) -> Void`) captured by the
+/// `@Sendable` `Task { @MainActor in }` hops in the `decidePolicyFor` delegate
+/// methods below. Boxing lets the Task capture a Sendable carrier instead of the
+/// raw handler, clearing the "sending 'decisionHandler' risks data races"
+/// diagnostic. INVARIANT — WebKit delivers `WKNavigationDelegate` callbacks on
+/// the main thread and each hop re-enters the main actor before calling the
+/// handler, so the boxed closure is invoked exactly once, on main, from inside
+/// that single Task. Mirrors the carrier-box precedent (`ReadiumBookmarkBox`).
+private final class DecisionHandlerBox<Policy>: @unchecked Sendable {
+    let call: (Policy) -> Void
+    init(_ call: @escaping (Policy) -> Void) { self.call = call }
+}
 
 @MainActor
 final class SignInWebViewCoordinator: NSObject, WKNavigationDelegate {
@@ -44,21 +58,25 @@ final class SignInWebViewCoordinator: NSObject, WKNavigationDelegate {
         // `targeted` "main actor-isolated property referenced from nonisolated
         // context" diagnostic. `URLRequest` is a value type, so the deferred read
         // observes the same request.
+        // Swift 6 `complete`: box the non-Sendable `decisionHandler` before the
+        // `@Sendable` `Task { @MainActor in }` hop (see `DecisionHandlerBox`);
+        // WebKit delivers on main and the hop re-enters main before calling it.
+        let decisionBox = DecisionHandlerBox(decisionHandler)
         Task { @MainActor in
             let request = navigationAction.request
             let decision = self.viewModel.decideAction(for: request)
             switch decision {
             case .allow:
-                decisionHandler(.allow)
+                decisionBox.call(.allow)
 
             case .completeLogin(let destination):
-                decisionHandler(.cancel)
+                decisionBox.call(.cancel)
                 let cookies = await webView.configuration.websiteDataStore.httpCookieStore.allCookies()
                 self.viewModel.recordLoginCompletion(destinationURL: destination, cookies: cookies)
 
             case .cancel, .bookFound, .problemFound:
                 // decideAction never returns these; defensive only.
-                decisionHandler(.allow)
+                decisionBox.call(.allow)
             }
         }
     }
@@ -73,25 +91,29 @@ final class SignInWebViewCoordinator: NSObject, WKNavigationDelegate {
         // rather than in this nonisolated delegate body, which would trip the
         // `targeted` "main actor-isolated property referenced from nonisolated
         // context" diagnostic.
+        // Swift 6 `complete`: box the non-Sendable `decisionHandler` before the
+        // `@Sendable` `Task { @MainActor in }` hop (see `DecisionHandlerBox`);
+        // WebKit delivers on main and the hop re-enters main before calling it.
+        let decisionBox = DecisionHandlerBox(decisionHandler)
         Task { @MainActor in
             let mime = navigationResponse.response.mimeType
             let decision = self.viewModel.decideResponse(mimeType: mime)
             switch decision {
             case .allow:
-                decisionHandler(.allow)
+                decisionBox.call(.allow)
 
             case .bookFound:
-                decisionHandler(.cancel)
+                decisionBox.call(.cancel)
                 let cookies = await webView.configuration.websiteDataStore.httpCookieStore.allCookies()
                 self.viewModel.recordBookFound(cookies: cookies)
 
             case .problemFound:
-                decisionHandler(.cancel)
+                decisionBox.call(.cancel)
                 self.viewModel.recordProblem(document: nil)
 
             case .cancel, .completeLogin:
                 // decideResponse never returns these; defensive only.
-                decisionHandler(.allow)
+                decisionBox.call(.allow)
             }
         }
     }

--- a/Palace/SignInLogic/TPPReauthenticator.swift
+++ b/Palace/SignInLogic/TPPReauthenticator.swift
@@ -13,7 +13,7 @@ import PalaceLogging
 protocol Reauthenticator: NSObject {
     func authenticateIfNeeded(_ user: TPPUserAccount,
                               usingExistingCredentials: Bool,
-                              authenticationCompletion: (() -> Void)?)
+                              authenticationCompletion: (@Sendable () -> Void)?)
 }
 
 /// This class is a front-end for taking care of situations where an
@@ -94,7 +94,7 @@ protocol Reauthenticator: NSObject {
     ///   flow completes.
     @objc func authenticateIfNeeded(_ user: TPPUserAccount,
                                     usingExistingCredentials: Bool,
-                                    authenticationCompletion: (() -> Void)?) {
+                                    authenticationCompletion: (@Sendable () -> Void)?) {
         authenticateCallCountLock.withLock { $0 += 1 }
         Task { @MainActor in
             Log.info(#file, "TPPReauthenticator: Re-authentication requested, using existing credentials: \(usingExistingCredentials)")

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+CardCreation.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+CardCreation.swift
@@ -10,7 +10,13 @@ import Foundation
 import CoreLocation
 import SafariServices
 
-extension TPPSignInBusinessLogic: CLLocationManagerDelegate {
+// `@preconcurrency`: `CLLocationManagerDelegate` is a nonisolated system
+// protocol; `TPPSignInBusinessLogic` is `@MainActor`. CoreLocation delivers
+// `locationManagerDidChangeAuthorization` on the thread the manager was created
+// on (main here — the manager is configured in `continueRegularCardCreation` on
+// main), so the isolated witness is runtime-correct. `@preconcurrency` accepts
+// the `@MainActor` witness against the nonisolated requirement.
+extension TPPSignInBusinessLogic: @preconcurrency CLLocationManagerDelegate {
     @objc
     func startRegularCardCreation(completion: @escaping (UINavigationController?, Error?) -> Void) {
         // Bucket A migration: card creation is user-initiated (Sign Up button

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+ForceReset.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+ForceReset.swift
@@ -64,12 +64,31 @@ private final class ForceResetDefaultsBox: @unchecked Sendable {
 }
 private let forceResetDefaultsBox = ForceResetDefaultsBox()
 
+/// Sendable carrier for the non-Sendable `() -> Void` `completion` closure
+/// captured by WebKit's `@Sendable` `removeData` completion closure (and the
+/// `DispatchQueue.main.async` inside it) in `performForceReset`. Boxing avoids
+/// marking `performForceReset(completion:)` `@Sendable` — which would ripple to
+/// the `Settings/` call site whose closure captures non-Sendable UI state (per
+/// the lane's RIPPLES §3). INVARIANT — the boxed closure is invoked exactly
+/// once, on the main queue (the `DispatchQueue.main.async` inside `removeData`'s
+/// completion). `performForceReset` is driven from the main-thread
+/// developer-settings VC. Mirrors `VoidWorkBox` in `AccountsManager`.
+private final class ForceResetCompletionBox: @unchecked Sendable {
+    let call: () -> Void
+    init(_ call: @escaping () -> Void) { self.call = call }
+}
+
 extension TPPSignInBusinessLogic {
 
     /// UserDefaults key for the one-shot "use ephemeral browser session for
     /// the next OIDC sign-in" flag. Set by `performForceReset(...)`. Read
     /// (and cleared) by the OIDC sign-in entry points.
-    public static let nextOIDCSessionEphemeralKey =
+    // `nonisolated`: an immutable key string read from nonisolated call sites
+    // outside SignInLogic — `TPPDeveloperSettingsTableViewController` and the
+    // reset test suites read it at nonisolated stored-property-initializer
+    // scope. Keeping it off the type's `@MainActor` isolation avoids rippling
+    // those sites.
+    nonisolated public static let nextOIDCSessionEphemeralKey =
         "PalaceForceReset.nextOIDCSessionEphemeral"
 
     /// `UserDefaults` backing store for the one-shot ephemeral-session
@@ -89,7 +108,12 @@ extension TPPSignInBusinessLogic {
     // Swift 6 `complete`: backed by the file-private `OSAllocatedUnfairLock`
     // above (not `nonisolated(unsafe)`); the public get/set contract is
     // unchanged so every existing caller and test seam works verbatim.
-    public static var forceResetUserDefaults: UserDefaults {
+    // `nonisolated`: backed by the file-private lock-box `ForceResetDefaultsBox`
+    // (already `@unchecked Sendable`, `OSAllocatedUnfairLock`-guarded), so it is
+    // thread-safe independent of actor isolation. The reset test suites read and
+    // restore it from nonisolated `setUp`/`tearDown`; keeping it off `@MainActor`
+    // preserves that seam without an actor hop.
+    nonisolated public static var forceResetUserDefaults: UserDefaults {
         get { forceResetDefaultsBox.defaults }
         set { forceResetDefaultsBox.defaults = newValue }
     }
@@ -99,7 +123,12 @@ extension TPPSignInBusinessLogic {
     /// return false until the next reset. The OIDC sign-in code calls this
     /// to decide whether to force `prefersEphemeralWebBrowserSession = true`
     /// for this single session, defeating Safari-shared-cookie reuse.
-    @objc public static func consumeNextOIDCSessionEphemeralFlag() -> Bool {
+    // `nonisolated`: reached from a nonisolated context — the OIDC redirect
+    // build in `BorrowOperation`/`TokenRefreshInterceptor` reads-and-clears the
+    // one-shot flag while assembling the `ASWebAuthenticationSession`. Backed by
+    // the thread-safe `forceResetUserDefaults` lock-box, so it is safe off
+    // `@MainActor`; the `@objc` surface is preserved for ObjC callers.
+    @objc nonisolated public static func consumeNextOIDCSessionEphemeralFlag() -> Bool {
         let value = forceResetUserDefaults.bool(forKey: nextOIDCSessionEphemeralKey)
         if value {
             forceResetUserDefaults.removeObject(forKey: nextOIDCSessionEphemeralKey)
@@ -116,6 +145,12 @@ extension TPPSignInBusinessLogic {
     ///   cleanup step has finished (or skipped). Always called exactly once.
     @objc public func performForceReset(completion: @escaping () -> Void) {
         Log.info(#file, "[RESET_ACCOUNT] start — libraryAccountID=\(libraryAccountID)")
+
+        // Swift 6 `complete`: box the non-Sendable `completion` for the step-6
+        // WebKit `removeData` `@Sendable` completion capture (see
+        // `ForceResetCompletionBox`). Keeps `completion` non-`@Sendable` so the
+        // `Settings/` caller doesn't ripple.
+        let completionBox = ForceResetCompletionBox(completion)
 
         // 1. Best-effort DELETE FCM token from CM. Don't gate any cleanup on
         //    the result — that's the bug Sign Out has when the patron's app
@@ -178,10 +213,11 @@ extension TPPSignInBusinessLogic {
         //    `WKWebsiteDataStore.default()`/`.allWebsiteDataTypes()`/`.removeData`
         //    are `@MainActor`-isolated. `performForceReset` is driven from the
         //    main-thread developer-settings VC, so assert the isolation for the
-        //    `complete`-mode checker. (The `removeData` completion-capture of the
-        //    non-Sendable `completion` param is a separate, flagged item —
-        //    closing it requires a `@Sendable` completion signature that ripples
-        //    into the non-owned `Settings/` call site.)
+        //    `complete`-mode checker. The `removeData` completion-capture of the
+        //    non-Sendable `completion` param is boxed (`completionBox`) so the
+        //    `@Sendable` closure captures a Sendable carrier rather than the raw
+        //    closure — avoiding a `@Sendable` completion signature that would
+        //    ripple into the non-owned `Settings/` call site.
         MainActor.assumeIsolated {
         let dataStore = WKWebsiteDataStore.default()
         let dataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
@@ -190,7 +226,7 @@ extension TPPSignInBusinessLogic {
             Log.info(#file, "[RESET_ACCOUNT] step 6 ok — WKWebsiteDataStore wiped (all types, since epoch)")
             Log.info(#file, "[RESET_ACCOUNT] complete — patron should be returned to sign-in flow")
             DispatchQueue.main.async {
-                completion()
+                completionBox.call()
             }
         }
         }
@@ -320,7 +356,9 @@ extension TPPSignInBusinessLogic {
     /// Pure, testable computation of which hosts the scoped reset clears web
     /// cookies for: the active library's auth-surface hosts. Empty when the
     /// account is nil or has no web surface (cold launch / basic-auth library).
-    static func webHostsToClear(for account: Account?) -> Set<String> {
+    // `nonisolated`: pure host-set computation exercised directly by
+    // `ScopedResetTests` from a nonisolated context; touches no actor state.
+    nonisolated static func webHostsToClear(for account: Account?) -> Set<String> {
         account?.authSurfaceHosts ?? []
     }
 
@@ -357,7 +395,7 @@ extension TPPSignInBusinessLogic {
     /// exact host, a leading-dot cookie domain (`.minotaur.example.org`), and a
     /// parent-domain cookie that covers the host. Does NOT match a sibling host
     /// under a shared parent (`gorgon.example.org` vs target `minotaur.example.org`).
-    static func hostMatches(_ cookieDomain: String, _ hosts: Set<String>) -> Bool {
+    nonisolated static func hostMatches(_ cookieDomain: String, _ hosts: Set<String>) -> Bool {
         let normalized = cookieDomain.hasPrefix(".")
             ? String(cookieDomain.dropFirst()).lowercased()
             : cookieDomain.lowercased()

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+OIDC.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+OIDC.swift
@@ -16,8 +16,13 @@ extension TPPSignInBusinessLogic {
     /// Mirrors Android's `palace-oidc-callback` scheme. The CM redirects to
     /// this scheme with `access_token` and `patron_info` parameters after the
     /// identity provider completes authentication.
-    static let oidcCallbackScheme = "palace-oidc-callback"
-    static let oidcCallbackHost  = "org.thepalaceproject.oidc"
+    // `nonisolated`: immutable scheme/host literals read from nonisolated
+    // cross-module call sites — `BorrowOperation.attemptOIDCSilentReauth`
+    // (a nonisolated `static async` helper) and `TokenRefreshInterceptor`
+    // (main-actor, but reads these to build the OIDC redirect URI). Keeping
+    // them off the type's `@MainActor` isolation avoids rippling those sites.
+    nonisolated static let oidcCallbackScheme = "palace-oidc-callback"
+    nonisolated static let oidcCallbackHost  = "org.thepalaceproject.oidc"
 
     /// Builds the callback URL the CM should redirect to after OIDC login.
     /// Format: `palace-oidc-callback://org.thepalaceproject.oidc/callback`
@@ -38,7 +43,9 @@ extension TPPSignInBusinessLogic {
     /// `palace-oidc-callback://…/logout?logout_status=success`. URLSession cannot
     /// follow custom-scheme redirects and surfaces this as NSURLErrorUnsupportedURL.
     /// Detecting this pattern lets us log success rather than a spurious warning.
-    private static func isOIDCLogoutCallbackRedirect(_ error: Error) -> Bool {
+    // `nonisolated`: pure NSError inspection, no actor state (mirrors the SAML
+    // sibling `isSAMLLogoutCallbackRedirect`).
+    private nonisolated static func isOIDCLogoutCallbackRedirect(_ error: Error) -> Bool {
         func hasCallbackSchemeURL(_ nsError: NSError) -> Bool {
             let key = NSURLErrorFailingURLStringErrorKey
             if let url = nsError.userInfo[key] as? String,
@@ -316,7 +323,10 @@ extension TPPSignInBusinessLogic {
 
 // MARK: - ASWebAuthenticationPresentationContextProviding
 
-extension TPPSignInBusinessLogic: ASWebAuthenticationPresentationContextProviding {
+// `@preconcurrency`: `ASWebAuthenticationPresentationContextProviding` is a
+// nonisolated system protocol; the witness returns a `@MainActor` UIWindow and
+// is only ever invoked by `ASWebAuthenticationSession` on the main thread.
+extension TPPSignInBusinessLogic: @preconcurrency ASWebAuthenticationPresentationContextProviding {
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         UIApplication.shared.mainKeyWindow ?? ASPresentationAnchor()
     }

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+SAML.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+SAML.swift
@@ -19,11 +19,15 @@ extension TPPSignInBusinessLogic {
     /// when initiating SAML SLO. URLSession cannot follow custom-scheme
     /// redirects — the CM's 302 back to this URL surfaces as
     /// `NSURLErrorUnsupportedURL`, which we detect as SLO success.
-    static let samlCallbackScheme = "palace-saml-callback"
-    static let samlCallbackHost = "org.thepalaceproject.saml"
+    // `nonisolated`: immutable scheme/host literals + pure derived URI, no
+    // actor state. Matches the OIDC-callback statics and the network/error
+    // classifier statics — pure SAML-logout helpers stay off the type's
+    // `@MainActor` isolation so they can be called from any context.
+    nonisolated static let samlCallbackScheme = "palace-saml-callback"
+    nonisolated static let samlCallbackHost = "org.thepalaceproject.saml"
 
     /// The full `post_logout_redirect_uri` value sent to the CM.
-    static var samlPostLogoutRedirectURI: String {
+    nonisolated static var samlPostLogoutRedirectURI: String {
         "\(samlCallbackScheme)://\(samlCallbackHost)/logout"
     }
 
@@ -37,7 +41,7 @@ extension TPPSignInBusinessLogic {
     ///
     /// - Returns: nil when the template is malformed or the href cannot be
     ///            parsed as a URL. Callers fall back to local-only cleanup.
-    static func expandSAMLLogoutHref(_ href: String,
+    nonisolated static func expandSAMLLogoutHref(_ href: String,
                                      isTemplated: Bool,
                                      postLogoutRedirectURI: String) -> URL? {
         let expanded: String
@@ -59,7 +63,7 @@ extension TPPSignInBusinessLogic {
     /// Returns `true` when the error is an `NSURLErrorUnsupportedURL` (-1002)
     /// whose failing URL starts with the SAML callback scheme — signalling a
     /// successful CM redirect that URLSession could not follow.
-    static func isSAMLLogoutCallbackRedirect(_ error: Error) -> Bool {
+    nonisolated static func isSAMLLogoutCallbackRedirect(_ error: Error) -> Bool {
         func hasCallbackSchemeURL(_ nsError: NSError) -> Bool {
             let key = NSURLErrorFailingURLStringErrorKey
             if let url = nsError.userInfo[key] as? String,

--- a/Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift
@@ -10,6 +10,24 @@ import Foundation
 import WebKit
 import PalaceLogging
 
+/// Sendable carrier for the non-Sendable `() -> Void` sign-out `completion`
+/// closure captured by WebKit's `@Sendable` `removeData` completion closures in
+/// `performFinalSignOutCleanup` (the two `self == nil` fallback branches) and
+/// `clearWebViewData`. Boxing avoids marking those `completion` params
+/// `@Sendable` — whose ultimate source is `completeLogOutProcess`'s
+/// `{ [weak self] in … }` closure capturing the non-Sendable
+/// `TPPSignInBusinessLogic self` (see handoff §F); making `completion`
+/// `@Sendable` cannot be done while the class is neither `Sendable` nor
+/// `@MainActor`. INVARIANT — the boxed closure is invoked exactly once, on the
+/// main queue: every `removeData` call site here runs inside a
+/// `DispatchQueue.main.async` (or WebKit's main-thread completion), and each
+/// sign-out path calls `completion` on exactly one terminal branch. Mirrors
+/// `ForceResetCompletionBox` / `VoidWorkBox`.
+private final class SignOutCompletionBox: @unchecked Sendable {
+    let call: () -> Void
+    init(_ call: @escaping () -> Void) { self.call = call }
+}
+
 extension TPPSignInBusinessLogic {
 
     // MARK: - Sign-Out Race Condition Guard
@@ -306,18 +324,16 @@ extension TPPSignInBusinessLogic {
     /// SAML + logout link present (PP-3452): authenticated API call to CM
     ///   saml_logout_redirect, then WKWebView cleanup.
     /// Everything else: WKWebView cleanup only.
-    // FLAGGED (shared-type dependency): the residual `complete`-mode warnings on
-    // the `completion`-capturing `DispatchQueue.main.async` / WebKit `removeData`
-    // closures in the `self == nil` fallback branches below (and in
-    // `clearWebViewData`) are rooted in `completion` being a non-Sendable
-    // `() -> Void`. Its ultimate source is `completeLogOutProcess`'s
-    // `{ [weak self] in … }` closure, which captures the non-Sendable
-    // `TPPSignInBusinessLogic self`. Making `completion` `@Sendable` here would
-    // require that upstream closure to be `@Sendable`, which it cannot be while
-    // `TPPSignInBusinessLogic` is neither `Sendable` nor `@MainActor`. Closing
-    // this cluster is gated on the class-isolation decision (handoff §F). Left
-    // runtime-correct (all hops land on main) pending that decision — NOT worked
-    // around with an unsafe cast on the sign-out critical path.
+    // Swift 6 `complete`: the `completion`-capturing WebKit `removeData`
+    // `@Sendable` closures in the `self == nil` fallback branches below (and in
+    // `clearWebViewData`) capture a non-Sendable `() -> Void`. Its ultimate
+    // source is `completeLogOutProcess`'s `{ [weak self] in … }` closure, which
+    // captures the non-Sendable `TPPSignInBusinessLogic self`, so `completion`
+    // cannot be made `@Sendable` while the class is neither `Sendable` nor
+    // `@MainActor` (handoff §F). We box it (`SignOutCompletionBox`) so the
+    // `@Sendable` `removeData` closures capture a Sendable carrier — runtime
+    // behavior unchanged (all hops land on main), no unsafe cast on the sign-out
+    // critical path.
     private func performFinalSignOutCleanup(cmLogoutAccessToken: String? = nil,
                                             completion: @escaping () -> Void) {
         if selectedAuthentication?.isOidc == true {
@@ -325,6 +341,7 @@ extension TPPSignInBusinessLogic {
                 guard let self = self else {
                     // self deallocated — still clear WebView data and call completion
                     // to ensure the UI state is reset.
+                    let completionBox = SignOutCompletionBox(completion)
                     DispatchQueue.main.async {
                         let dataStore = WKWebsiteDataStore.default()
                         let dataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
@@ -332,7 +349,7 @@ extension TPPSignInBusinessLogic {
                             if let cookies = HTTPCookieStorage.shared.cookies {
                                 for cookie in cookies { HTTPCookieStorage.shared.deleteCookie(cookie) }
                             }
-                            completion()
+                            completionBox.call()
                         }
                     }
                     return
@@ -342,6 +359,7 @@ extension TPPSignInBusinessLogic {
         } else if selectedAuthentication?.samlLogoutHref != nil {
             samlLogOut(accessToken: cmLogoutAccessToken) { [weak self] in
                 guard let self = self else {
+                    let completionBox = SignOutCompletionBox(completion)
                     DispatchQueue.main.async {
                         let dataStore = WKWebsiteDataStore.default()
                         let dataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
@@ -349,7 +367,7 @@ extension TPPSignInBusinessLogic {
                             if let cookies = HTTPCookieStorage.shared.cookies {
                                 for cookie in cookies { HTTPCookieStorage.shared.deleteCookie(cookie) }
                             }
-                            completion()
+                            completionBox.call()
                         }
                     }
                     return
@@ -374,6 +392,10 @@ extension TPPSignInBusinessLogic {
         }
         #endif
 
+        // Swift 6 `complete`: box the non-Sendable `completion` before the WebKit
+        // `removeData` `@Sendable` completion closure captures it (see
+        // `SignOutCompletionBox`); invoked once on the main queue.
+        let completionBox = SignOutCompletionBox(completion)
         // WebKit operations MUST run on the main thread
         DispatchQueue.main.async {
             let dataStore = WKWebsiteDataStore.default()
@@ -390,7 +412,7 @@ extension TPPSignInBusinessLogic {
                     }
                 }
 
-                completion()
+                completionBox.call()
             }
         }
     }

--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
@@ -37,7 +37,22 @@ import PalaceAuth
 // `Palace/Accounts/User/NYPLADEPT+TPPDRMAuthorizing.swift` (added to xcodeproj
 // during the swarm_ea663ab6 recovery wiring stage).
 
-class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibraryAccountProvider {
+// Swift 6 `complete` mode: `TPPSignInBusinessLogic` is a UI-driving auth
+// orchestrator — it reads/writes `@MainActor`-isolated UIKit state (alerts,
+// `UIApplication.shared`, `WKWebsiteDataStore`), its `uiDelegate` is a UIKit
+// view controller / `@MainActor` view model, and every entry point
+// (`logIn`, `logOut`, `performForceReset`, card creation, DRM authorize) is
+// reached from the main thread. Isolating the whole type to `@MainActor` is
+// the correct isolation-only fix: it replaces the ~28 scattered
+// `MainActor.assumeIsolated` / non-`@Sendable`-hop workarounds that only
+// existed because the type was nonisolated. The two `@objc` provider
+// protocols (`TPPSignedInStateProvider`, `TPPCurrentLibraryAccountProvider`)
+// are nonisolated `@objc` protocols whose witnesses read main-actor instance
+// state, so the conformances carry `@preconcurrency` — the runtime is already
+// main-thread-correct (every call site is on main); `@preconcurrency` tells the
+// checker to accept the isolated witnesses against the nonisolated requirement.
+@MainActor
+class TPPSignInBusinessLogic: NSObject, @preconcurrency TPPSignedInStateProvider, @preconcurrency TPPCurrentLibraryAccountProvider {
     var onLocationAuthorizationCompletion: (UINavigationController?, Error?) -> Void = {_, _ in }
 
     /// Makes a business logic object with a network request executor that
@@ -564,7 +579,10 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
     /// Precedence: server-supplied problem document > network-connectivity
     /// error > default "invalid credentials". Without the connectivity check,
     /// a dropped Wi-Fi or LTE during sign-in was misreported as bad creds.
-    static func userFacingSignInError(
+    // `nonisolated`: pure error classifier over an `NSError` + optional
+    // problem document, no actor state. Kept off `@MainActor` so nonisolated
+    // callers (and the PalaceAuth `AuthReducer` mirror) can invoke it directly.
+    nonisolated static func userFacingSignInError(
         for error: NSError,
         problemDocument: TPPProblemDocument?
     ) -> (title: String?, message: String?) {
@@ -591,14 +609,14 @@ class TPPSignInBusinessLogic: NSObject, TPPSignedInStateProvider, TPPCurrentLibr
     /// `TokenRequest` after its bounded retry was exhausted (5xx / 429 / 408).
     /// A genuine 401/403 has a different code and is NOT matched here, so it
     /// still falls through to the "Invalid Credentials" message.
-    static func isTransientServerError(_ error: NSError) -> Bool {
+    nonisolated static func isTransientServerError(_ error: NSError) -> Bool {
         guard error.domain == TokenRequest.httpErrorDomain else { return false }
         return error.code == 408 || error.code == 429 || (500...599).contains(error.code)
     }
 
     /// True when the error is from URLSession indicating the request never
     /// reached the server (lost connection, DNS failure, TLS handshake, etc).
-    static func isNetworkConnectivityError(_ error: NSError) -> Bool {
+    nonisolated static func isNetworkConnectivityError(_ error: NSError) -> Bool {
         guard error.domain == NSURLErrorDomain else { return false }
         switch error.code {
         case NSURLErrorNotConnectedToInternet,

--- a/PalaceTests/Accounts/AccountDetailsAuthenticationIsBrowserBasedTests.swift
+++ b/PalaceTests/Accounts/AccountDetailsAuthenticationIsBrowserBasedTests.swift
@@ -18,6 +18,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountDetailsAuthenticationIsBrowserBasedTests: XCTestCase {
 
     // MARK: - Truth table — one row per auth type

--- a/PalaceTests/Contract/BookReturnServiceContractTests.swift
+++ b/PalaceTests/Contract/BookReturnServiceContractTests.swift
@@ -363,7 +363,7 @@ private final class SpyReauthRecorder: NSObject, Reauthenticator {
 
     func authenticateIfNeeded(_ user: TPPUserAccount,
                                usingExistingCredentials: Bool,
-                               authenticationCompletion: (() -> Void)?) {
+                               authenticationCompletion: (@Sendable () -> Void)?) {
         log.record("reauth.authenticateIfNeeded",
                    args: ["usingExistingCredentials": "\(usingExistingCredentials)"])
         // Fire completion synchronously so the service's retry-bail-out

--- a/PalaceTests/MetaTests/UserDefaultsIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/UserDefaultsIsolationLintTests.swift
@@ -17,6 +17,7 @@ import XCTest
 /// (`testLintCatchesSyntheticViolatorIfStrictModeEnabled`) so the
 /// detector logic itself is covered without affecting the warn-only
 /// posture for the real codebase.
+@MainActor
 final class UserDefaultsIsolationLintTests: XCTestCase {
 
     /// Files that are allowed to reference `UserDefaults.standard`

--- a/PalaceTests/Mocks/MockSAMLAuthContext.swift
+++ b/PalaceTests/Mocks/MockSAMLAuthContext.swift
@@ -10,6 +10,10 @@ import Foundation
 import PalaceAuth
 @testable import Palace
 
+// `@MainActor`: `SAMLAuthContext` (PalaceAuth) becomes a `@MainActor` protocol
+// as part of the `TPPSignInBusinessLogic: @MainActor` conversion (see RIPPLES.md),
+// so its conformers — including this test mock — inherit the isolation.
+@MainActor
 class MockSAMLAuthContext: SAMLAuthContext {
     /// Test convenience: tests set the full IDP object via `selectedIDP`;
     /// the protocol-required `selectedIDPURL` is computed from it.

--- a/PalaceTests/Mocks/MockSAMLWebViewPresenter.swift
+++ b/PalaceTests/Mocks/MockSAMLWebViewPresenter.swift
@@ -10,6 +10,11 @@ import Foundation
 import PalaceAuth
 @testable import Palace
 
+// `@MainActor`: `SAMLWebViewPresenting` (PalaceAuth) becomes a `@MainActor`
+// protocol as part of the `TPPSignInBusinessLogic: @MainActor` conversion
+// (see RIPPLES.md — SAML-protocol cascade), so its conformers — including this
+// test mock — inherit the isolation.
+@MainActor
 class MockSAMLWebViewPresenter: SAMLWebViewPresenting {
 
     // MARK: - Present Tracking

--- a/PalaceTests/Mocks/TPPReauthenticatorMock.swift
+++ b/PalaceTests/Mocks/TPPReauthenticatorMock.swift
@@ -38,7 +38,7 @@ class TPPReauthenticatorMock: NSObject, Reauthenticator {
     func authenticateIfNeeded(
         _ user: TPPUserAccount,
         usingExistingCredentials: Bool,
-        authenticationCompletion: (() -> Void)?
+        authenticationCompletion: (@Sendable () -> Void)?
     ) {
         authenticateIfNeededCalled = true
         authenticateCallCount += 1

--- a/PalaceTests/Security/CredentialPrivacyTests.swift
+++ b/PalaceTests/Security/CredentialPrivacyTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class CredentialPrivacyTests: XCTestCase {
 
     // Realistic-looking credential fixtures we will scan log payloads for.

--- a/PalaceTests/SignInLogic/AuthErrorProblemDocSeamTests.swift
+++ b/PalaceTests/SignInLogic/AuthErrorProblemDocSeamTests.swift
@@ -18,6 +18,7 @@ import PalaceAuth
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class AuthErrorProblemDocSeamTests: XCTestCase {
 
     private let tokenURL = URL(string: "https://auth.example.com/token")!

--- a/PalaceTests/SignInLogic/ForceResetTests.swift
+++ b/PalaceTests/SignInLogic/ForceResetTests.swift
@@ -25,6 +25,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ForceResetTests: XCTestCase {
 
     private let key = TPPSignInBusinessLogic.nextOIDCSessionEphemeralKey

--- a/PalaceTests/SignInLogic/LegacySAMLProblemDocumentPropagationTests.swift
+++ b/PalaceTests/SignInLogic/LegacySAMLProblemDocumentPropagationTests.swift
@@ -49,6 +49,7 @@ private final class ValidationErrorCapturingUIDelegate:
     }
 }
 
+@MainActor
 final class LegacySAMLProblemDocumentPropagationTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/ScopedResetTests.swift
+++ b/PalaceTests/SignInLogic/ScopedResetTests.swift
@@ -17,6 +17,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ScopedResetTests: XCTestCase {
 
     private let ephemeralKey = TPPSignInBusinessLogic.nextOIDCSessionEphemeralKey

--- a/PalaceTests/SignInLogic/SignInOAuthErrorPropagationTests.swift
+++ b/PalaceTests/SignInLogic/SignInOAuthErrorPropagationTests.swift
@@ -22,6 +22,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class SignInOAuthErrorPropagationTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/TPPAccountAuthStateTests.swift
+++ b/PalaceTests/SignInLogic/TPPAccountAuthStateTests.swift
@@ -181,6 +181,7 @@ final class TPPUserAccountAuthStateTests: XCTestCase {
 
 // MARK: - Adobe Activation Skip Tests
 
+@MainActor
 final class TPPAdobeActivationSkipTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -420,6 +421,7 @@ final class UserAccountPublisherAuthStateTests: XCTestCase {
 
 // MARK: - Integration Test: Full SAML Re-auth Flow
 
+@MainActor
 final class TPPSAMLReauthFlowTests: XCTestCase {
 
     override func setUp() {

--- a/PalaceTests/SignInLogic/TPPCredentialVisibilityTests.swift
+++ b/PalaceTests/SignInLogic/TPPCredentialVisibilityTests.swift
@@ -18,6 +18,7 @@ import XCTest
 
 /// Tests that barcode and PIN remain accessible after a successful sign-in flow.
 /// This is the core regression test for PP-3784 where the barcode would disappear.
+@MainActor
 final class TPPCredentialPersistenceTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -207,6 +208,7 @@ final class TPPCredentialPersistenceTests: XCTestCase {
 
 /// Tests that DRM-related failures do NOT wipe basic auth credentials.
 /// PP-3784 root cause: DRM failure was calling userAccount.removeAll().
+@MainActor
 final class TPPDRMFailureCredentialPreservationTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -463,6 +465,7 @@ final class TPPCredentialSnapshotTests: XCTestCase {
 // MARK: - Auth State Transition Tests
 
 /// Tests that auth state transitions during sign-in produce the correct end state.
+@MainActor
 final class TPPSignInAuthStateTransitionTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -567,6 +570,7 @@ final class TPPSignInAuthStateTransitionTests: XCTestCase {
 // MARK: - Profile Document Edge Cases
 
 /// Tests for sign-in behavior with various user profile document formats.
+@MainActor
 final class TPPSignInProfileDocEdgeCaseTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -776,6 +780,7 @@ final class TPPCredentialConcurrencyTests: XCTestCase {
 /// Tests that barcode/PIN are captured at login time and used by finalizeSignIn,
 /// preventing credential loss when the ViewModel's text fields are cleared by
 /// intermediate accountDidChange notifications.
+@MainActor
 final class TPPCapturedCredentialsTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/TPPCrossLibrarySignOutTests.swift
+++ b/PalaceTests/SignInLogic/TPPCrossLibrarySignOutTests.swift
@@ -45,6 +45,7 @@ private class TPPMultiLibraryAccountMock: TPPUserAccountMock, @unchecked Sendabl
 
 // MARK: - Cross-Library Sign-Out Tests
 
+@MainActor
 final class TPPCrossLibrarySignOutTests: XCTestCase {
 
     private static let activeLibraryUUID = "urn:uuid:active-library-aaa"

--- a/PalaceTests/SignInLogic/TPPDeferredAdobeActivationTests.swift
+++ b/PalaceTests/SignInLogic/TPPDeferredAdobeActivationTests.swift
@@ -17,6 +17,7 @@ import PalaceCatalog
 
 // MARK: - saveDRMCredentials Tests
 
+@MainActor
 final class TPPSaveDRMCredentialsTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -148,6 +149,7 @@ final class TPPSaveDRMCredentialsTests: XCTestCase {
 
 // MARK: - Login Flow No-Activation Tests
 
+@MainActor
 final class TPPLoginNoActivationTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/TPPIdleSignOutRegressionTests.swift
+++ b/PalaceTests/SignInLogic/TPPIdleSignOutRegressionTests.swift
@@ -24,6 +24,7 @@ import XCTest
 
 // MARK: - PP-3819 Regression Tests
 
+@MainActor
 final class TPPIdleSignOutRegressionTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/TPPPreferredAuthSelectionTests.swift
+++ b/PalaceTests/SignInLogic/TPPPreferredAuthSelectionTests.swift
@@ -20,6 +20,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPPreferredAuthSelectionTests: XCTestCase {
 
     private var libraryAccountMock: TPPLibraryAccountMock!

--- a/PalaceTests/SignInLogic/TPPSAMLFlowTests.swift
+++ b/PalaceTests/SignInLogic/TPPSAMLFlowTests.swift
@@ -14,6 +14,9 @@ import PalaceAuth
 
 // MARK: - Phase 1+2: UI Decoupling + Force-Unwrap Elimination
 
+// `@MainActor`: constructs `TPPSAMLHelper` and drives `samlHelper.logIn(...)`,
+// both `@MainActor` after the SAML-protocol cascade (see RIPPLES.md §1).
+@MainActor
 final class TPPSAMLFlowTests: XCTestCase {
 
     private var mockContext: MockSAMLAuthContext!
@@ -244,6 +247,9 @@ final class TPPSAMLFlowTests: XCTestCase {
 
 // MARK: - Phase 3: Cookie Expiration Validation
 
+// `@MainActor`: constructs `TPPSAMLHelper` and drives `samlHelper.logIn(...)`,
+// both `@MainActor` after the SAML-protocol cascade (see RIPPLES.md §1).
+@MainActor
 final class TPPSAMLCookieExpirationTests: XCTestCase {
 
     private var mockContext: MockSAMLAuthContext!
@@ -470,6 +476,7 @@ final class TPPSAMLCookieExpirationTests: XCTestCase {
 
 // MARK: - Phase 4: State Machine (ignoreSignedInState replacement)
 
+@MainActor
 final class TPPSAMLStateMachineTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -594,6 +601,7 @@ final class TPPSAMLStateMachineTests: XCTestCase {
 
 // MARK: - Phase 5: SAML State Isolation
 
+@MainActor
 final class TPPSAMLStateIsolationTests: XCTestCase {
 
     // MARK: - Test 22: Non-SAML library doesn't create helper
@@ -723,6 +731,7 @@ final class TPPSAMLStateIsolationTests: XCTestCase {
 
 // MARK: - Regression + Contract Tests
 
+@MainActor
 final class TPPSAMLRegressionTests: XCTestCase {
 
     // MARK: - Test 27: Redirect URL matches CM pattern

--- a/PalaceTests/SignInLogic/TPPSAMLLogoutTests.swift
+++ b/PalaceTests/SignInLogic/TPPSAMLLogoutTests.swift
@@ -162,6 +162,7 @@ final class SAMLLogoutLinkParsingTests: XCTestCase {
 
 // MARK: - URL construction
 
+@MainActor
 final class SAMLLogoutURLTests: XCTestCase {
 
     func testSAMLLogoutURL_ExpandsTemplateWithRedirectURI() throws {
@@ -208,6 +209,7 @@ final class SAMLLogoutURLTests: XCTestCase {
 
 // MARK: - isSAMLLogoutCallbackRedirect detection
 
+@MainActor
 final class SAMLLogoutCallbackDetectionTests: XCTestCase {
 
     func testCallbackSchemeError_DetectedAsSuccess() {

--- a/PalaceTests/SignInLogic/TPPSAMLSignInTests.swift
+++ b/PalaceTests/SignInLogic/TPPSAMLSignInTests.swift
@@ -12,6 +12,7 @@ import Combine
 
 // MARK: - SAML Sign-In Regression Tests
 
+@MainActor
 final class TPPSAMLSignInTests: XCTestCase {
   
   // MARK: - Properties

--- a/PalaceTests/SignInLogic/TPPSignInAdobeSkipTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInAdobeSkipTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import Palace
 
 /// SRS: DRM-001 - Adobe DRM activation skip logic prevents burning device activations
+@MainActor
 final class TPPSignInAdobeSkipTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/TPPSignInBusinessLogicExtendedTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInBusinessLogicExtendedTests.swift
@@ -11,6 +11,7 @@ import Combine
 
 // MARK: - Extended Sign-In Business Logic Tests
 
+@MainActor
 final class TPPSignInBusinessLogicExtendedTests: XCTestCase {
 
     // MARK: - Properties
@@ -993,6 +994,7 @@ final class TPPSignInBusinessLogicExtendedTests: XCTestCase {
 
 // MARK: - OAuth Flow Tests
 
+@MainActor
 final class TPPSignInOAuthFlowTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -1030,6 +1032,7 @@ final class TPPSignInOAuthFlowTests: XCTestCase {
 
 // MARK: - Error Handling Tests
 
+@MainActor
 final class TPPSignInErrorHandlingTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/TPPSignInBusinessLogicOAuthTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInBusinessLogicOAuthTests.swift
@@ -73,6 +73,7 @@ private final class TokenRefresherMock: TokenRefreshing {
 
 // MARK: - OAuth Redirect URL Parser Tests
 
+@MainActor
 final class TPPSignInBusinessLogicOAuthTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -363,6 +364,7 @@ final class TPPSignInBusinessLogicOAuthTests: XCTestCase {
 
 // MARK: - Token-Flow (Basic → Bearer) Tests
 
+@MainActor
 final class TPPSignInBusinessLogicTokenFlowTests: XCTestCase {
 
     private let tokenURL = URL(string: "https://stub.example.com/token")!
@@ -493,6 +495,7 @@ final class TPPSignInBusinessLogicTokenFlowTests: XCTestCase {
 
 // MARK: - Basic-auth Validation Delegate-Callback Order
 
+@MainActor
 final class TPPSignInBusinessLogicValidationCallbackOrderTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/TPPSignInBusinessLogicSignOutTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInBusinessLogicSignOutTests.swift
@@ -27,6 +27,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPSignInBusinessLogicSignOutTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/TPPSignInBusinessLogicStateMachineTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInBusinessLogicStateMachineTests.swift
@@ -31,6 +31,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPSignInBusinessLogicStateMachineTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/TPPSignInOIDCTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInOIDCTests.swift
@@ -206,6 +206,7 @@ final class OIDCNSCodingTests: XCTestCase {
 
 // MARK: - Unit Tests: Business Logic — Make Request
 
+@MainActor
 final class OIDCMakeRequestTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -274,6 +275,7 @@ final class OIDCMakeRequestTests: XCTestCase {
 
 // MARK: - Unit Tests: Business Logic — Login Routing
 
+@MainActor
 final class OIDCLoginRoutingTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -338,6 +340,7 @@ final class OIDCLoginRoutingTests: XCTestCase {
 
 // MARK: - Unit Tests: Business Logic — Update User Account
 
+@MainActor
 final class OIDCUpdateUserAccountTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -454,6 +457,7 @@ final class OIDCUpdateUserAccountTests: XCTestCase {
 
 // MARK: - Unit Tests: OIDC Callback Scheme Constants
 
+@MainActor
 final class OIDCCallbackSchemeTests: XCTestCase {
 
     func testOidcCallbackScheme_matchesAndroidConvention() {
@@ -484,6 +488,7 @@ final class OIDCCallbackSchemeTests: XCTestCase {
 
 // MARK: - Integration Tests: OIDC Callback Handling
 
+@MainActor
 final class OIDCCallbackHandlingTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -602,6 +607,7 @@ final class OIDCCallbackHandlingTests: XCTestCase {
 
 // MARK: - Integration Tests: Selected Authentication Routing
 
+@MainActor
 final class OIDCSelectedAuthenticationTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -666,6 +672,7 @@ final class OIDCSelectedAuthenticationTests: XCTestCase {
 
 // MARK: - Regression Tests: Existing Auth Flows Unbroken
 
+@MainActor
 final class OIDCRegressionTests: XCTestCase {
 
     private var libraryMock: TPPLibraryAccountMock!
@@ -867,6 +874,7 @@ final class OIDCViewModelRegressionTests: XCTestCase {
 
 // MARK: - Unit Tests: handleOIDCCallback Edge Cases
 
+@MainActor
 final class OIDCCallbackEdgeCaseTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -1012,6 +1020,7 @@ final class OIDCCallbackEdgeCaseTests: XCTestCase {
 
 // MARK: - Unit Tests: Redirect URI Construction
 
+@MainActor
 final class OIDCRedirectURIConstructionTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -1093,6 +1102,7 @@ final class OIDCRedirectURIConstructionTests: XCTestCase {
 
 // MARK: - Regression Tests: OAuth/SAML handleRedirectURL Unaffected
 
+@MainActor
 final class OAuthSAMLRedirectRegressionTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -1200,6 +1210,7 @@ final class OAuthSAMLRedirectRegressionTests: XCTestCase {
 
 // MARK: - Regression Tests: Sign-Out Flow With OIDC
 
+@MainActor
 final class OIDCSignOutRegressionTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -1404,6 +1415,7 @@ final class OIDCSignOutRegressionTests: XCTestCase {
 
 // MARK: - Regression Tests: Token Refresh Logic
 
+@MainActor
 final class OIDCTokenRefreshRegressionTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!
@@ -1541,6 +1553,7 @@ final class OIDCTokenRefreshRegressionTests: XCTestCase {
 
 // MARK: - Regression Tests: OIDC Does Not Interfere With Other Flows
 
+@MainActor
 final class OIDCIsolationRegressionTests: XCTestCase {
 
     private var libraryMock: TPPLibraryAccountMock!
@@ -1656,6 +1669,7 @@ final class OIDCIsolationRegressionTests: XCTestCase {
 
 // MARK: - Tests: OIDC Re-Auth on 401 / Stale Credentials
 
+@MainActor
 final class OIDCReauthOnExpiredTokenTests: XCTestCase {
 
     private var businessLogic: TPPSignInBusinessLogic!

--- a/PalaceTests/SignInLogic/UserAccountValidationTests.swift
+++ b/PalaceTests/SignInLogic/UserAccountValidationTests.swift
@@ -31,6 +31,7 @@ private class MockAuthentication: NSObject {
 
 // MARK: - Tests
 
+@MainActor
 final class UserAccountValidationTests: XCTestCase {
 
     private var usernameField: UITextField!

--- a/PalaceTests/TPPSignInBusinessLogicTests.swift
+++ b/PalaceTests/TPPSignInBusinessLogicTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPSignInBusinessLogicTests: XCTestCase {
     var businessLogic: TPPSignInBusinessLogic!
     var libraryAccountMock: TPPLibraryAccountMock!

--- a/PalaceTests/VisualRegression/AnonymousBorrowFixtureTests.swift
+++ b/PalaceTests/VisualRegression/AnonymousBorrowFixtureTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+@MainActor
 final class AnonymousBorrowBaselineFixtureTests: XCTestCase {
 
   override func tearDown() {


### PR DESCRIPTION
## Swift 6 Phase B — SignInLogic (auth critical-path)

The atomic `TPPSignInBusinessLogic: @MainActor` conversion + 2 coordinated cascades (PalaceAuth SAML → @MainActor; `Reauthenticator.authenticateIfNeeded` completion → @Sendable). Isolation-only; auth-flow behavior unchanged. 29 test classes → @MainActor (concurrency tests deliberately excluded). Part of the app-target **738 → 0** finish.

**Two independent SoD APPROVED** (isolation soundness + qa/behavior): nonisolated statics safe, every @preconcurrency witness proven main-thread, SAML cascade has no background caller, sign-out completion boxes fire once, no concurrency test @MainActor'd, host scoping untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)