### PR TITLE
fix(swift6): Reader2 DRM/LCP → complete-mode 0 (isolation-only)

### DIFF
--- a/Palace/Reader2/Bookmarks/AudiobookBookmarkBusinessLogic.swift
+++ b/Palace/Reader2/Bookmarks/AudiobookBookmarkBusinessLogic.swift
@@ -11,10 +11,21 @@ import PalaceLogging
 import PalaceReadingPosition
 @preconcurrency import PalaceAudiobookToolkit
 
-@objc public class AudiobookBookmarkBusinessLogic: NSObject {
-    public var book: TPPBook
-    private var registry: TPPBookRegistryProvider
-    private var annotationsManager: AnnotationsManager
+// Swift 6 `complete`: `@unchecked Sendable`. This class is captured by the
+// `@Sendable` `Task` / work-`queue` / `DispatchQueue.main.async` / `DispatchWorkItem`
+// closures throughout (save / fetch / delete / sync / debounce). INVARIANT:
+//   • The injected dependencies (`book`, `registry`, `annotationsManager`,
+//     `positionWriter`) are immutable `let`s assigned once in `init`.
+//   • All mutable sync state (`isSyncing`, `completionHandlersQueue`,
+//     `deletedBookmarkIds`) is only ever read/written through `onStateQueue`, and
+//     `debounceWorkItem` only on the serial work `queue` — the file's single
+//     serialization domain (see the "Serialized sync state" note below). No
+//     unsynchronized mutable state crosses the closure boundaries.
+// This waives no real race; it matches the existing per-closure boxing strategy.
+@objc public class AudiobookBookmarkBusinessLogic: NSObject, @unchecked Sendable {
+    public let book: TPPBook
+    private let registry: TPPBookRegistryProvider
+    private let annotationsManager: AnnotationsManager
     private let positionWriter: PositionWriter
     private let queue = DispatchQueue(label: "com.palace.audiobookBookmarkBusinessLogic")
     /// Identifies execution already on `queue` so `onStateQueue` runs inline
@@ -210,7 +221,11 @@ import PalaceReadingPosition
                     if let updatedLocation = updatedPosition.toAudioBookmark().toTPPBookLocation() {
                         self.registry.addOrReplaceGenericBookmark(updatedLocation, forIdentifier: self.book.identifier)
                     }
-                    DispatchQueue.main.async { completionBox.call?(updatedPosition) }
+                    // Swift 6 `complete`: snapshot the mutated `var updatedPosition`
+                    // to a `let` before the `@Sendable` `DispatchQueue.main.async`
+                    // closure so it captures an immutable value, not the captured var.
+                    let finalPosition = updatedPosition
+                    DispatchQueue.main.async { completionBox.call?(finalPosition) }
                 }
 
                 guard let data = location.toData(), let locationString = String(data: data, encoding: .utf8) else {
@@ -267,8 +282,14 @@ import PalaceReadingPosition
                     Log.warn(#file, "⚠️ BOOKMARK CONVERSION ISSUE: \(combinedBookmarks.count - trackPositions.count) bookmarks failed to convert to TrackPosition")
                 }
 
+                // Swift 6 `complete`: box the non-Sendable `[TrackPosition]` value
+                // (produced here on the serial work `queue`, consumed once on main)
+                // before the `@Sendable` `DispatchQueue.main.async` boundary — see
+                // `TrackPositionListBox`. `@preconcurrency import` covers the type's
+                // conformance but not this region-isolation `sending` of the array.
+                let trackPositionsBox = TrackPositionListBox(trackPositions)
                 DispatchQueue.main.async {
-                    completionBox.call(trackPositions)
+                    completionBox.call(trackPositionsBox.positions)
                 }
             }
         }
@@ -306,13 +327,19 @@ import PalaceReadingPosition
             }
         }
 
-        var localDeletionSucceeded = false
+        // Swift 6 `complete`: compute the local-deletion outcome as a `let` so the
+        // downstream `@Sendable` `DispatchQueue.main.async` / server-deletion
+        // completion closures capture an immutable value, not a captured `var`.
+        // `Bool` is already Sendable; the `let` clears the "reference to captured
+        // var 'localDeletionSucceeded' in concurrently-executing code" diagnostic.
+        let localDeletionSucceeded: Bool
         if let genericLocation = bookmark.toTPPBookLocation() {
             self.registry.deleteGenericBookmark(genericLocation, forIdentifier: self.book.identifier)
             Log.info(#file, "🗑️ ✅ Local bookmark deleted from registry")
             localDeletionSucceeded = true
         } else {
             Log.error(#file, "🗑️ ❌ Failed to convert bookmark to TPPBookLocation for local deletion")
+            localDeletionSucceeded = false
         }
 
         guard !bookmark.isUnsynced else {
@@ -644,7 +671,12 @@ import PalaceReadingPosition
         }
     }
 
-    private func debounce(action: @escaping () -> Void) {
+    // Swift 6 `complete`: `action` is `@Sendable` because it is captured by the
+    // `@Sendable` work-`queue` closure and wrapped in a `DispatchWorkItem` (whose
+    // `block:` init requires a `@Sendable` block). The sole caller (`saveBookmark`)
+    // passes a closure that captures only Sendable carriers (a `TrackPositionCompletionBox`
+    // and the `@preconcurrency`-imported `TrackPosition`), so this does not ripple.
+    private func debounce(action: @escaping @Sendable () -> Void) {
         queue.async { [weak self] in
             guard let self else { return }
             self.debounceWorkItem?.cancel()
@@ -732,6 +764,19 @@ private final class AudioBookmarkListCompletionBox: @unchecked Sendable {
 private final class AudioBookmarkListBox: @unchecked Sendable {
     let bookmarks: [AudioBookmark]
     init(_ bookmarks: [AudioBookmark]) { self.bookmarks = bookmarks }
+}
+
+/// Sendable carrier for a non-Sendable `[TrackPosition]` value crossing the
+/// `@Sendable` `DispatchQueue.main.async` boundary in `fetchBookmarks`.
+/// `TrackPosition` is a `@preconcurrency`-imported PalaceAudiobookToolkit value
+/// type: the pre-concurrency import covers its missing `Sendable` conformance,
+/// but region isolation still flags *sending* the array across the async hop.
+/// INVARIANT — the array is produced on the serial work `queue` and consumed
+/// exactly once on the main queue; no two contexts touch it concurrently, so
+/// `@unchecked Sendable` waives no real race. Mirrors `AudioBookmarkListBox`.
+private final class TrackPositionListBox: @unchecked Sendable {
+    let positions: [TrackPosition]
+    init(_ positions: [TrackPosition]) { self.positions = positions }
 }
 
 /// Sendable carrier for a single non-Sendable `AudioBookmark` handed off to the

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -170,10 +170,18 @@ protocol AnnotationsManager {
             var didResume = false
 
             postReadingPosition(forBook: bookID, selectorValue: selectorValue, motivation: .bookmark) { response in
-                DispatchQueue.main.async {
-                    guard !didResume else { return }
-                    didResume = true
+                // Swift 6 `complete`: the double-resume guard (`didResume`) is
+                // checked/set in this NON-`@Sendable` completion closure so the
+                // `@Sendable` `DispatchQueue.main.async` hop below no longer
+                // captures-and-mutates the local `var` (which the region-isolation
+                // checker rejects). `response` (a `Sendable` struct) and
+                // `continuation` (`Sendable`) are the only values that cross into
+                // the main hop. Behavior is unchanged: resume still happens on the
+                // main queue, exactly once.
+                guard !didResume else { return }
+                didResume = true
 
+                DispatchQueue.main.async {
                     if let response {
                         continuation.resume(returning: response)
                     } else {

--- a/Palace/Reader2/BusinessLogic/TPPReaderBookmarksBusinessLogic.swift
+++ b/Palace/Reader2/BusinessLogic/TPPReaderBookmarksBusinessLogic.swift
@@ -400,20 +400,29 @@ class TPPReaderBookmarksBusinessLogic: NSObject, @unchecked Sendable {
             let canUseExistingCredentials = userAccount.hasBarcodeAndPIN() ||
                 (userAccount.authDefinition?.isOauth == true)
 
+            // Swift 6 `complete`: box the non-Sendable `completion` closure before
+            // the `@Sendable` reauth-completion closure captures it (see
+            // `BookmarkSyncCompletionBox`). `authenticateIfNeeded`'s
+            // `authenticationCompletion` is `@Sendable`, so the trailing closure
+            // is `@Sendable` and cannot capture the raw `(Bool, [TPPReadiumBookmark])
+            // -> Void`. Boxing avoids `@Sendable`-ing `completion` on the
+            // `syncBookmarks`/`handleBookmarksSyncFail` signatures (which would
+            // ripple to every bookmark-sync caller).
+            let completionBox = BookmarkSyncCompletionBox(completion)
             reauthenticator.authenticateIfNeeded(userAccount, usingExistingCredentials: canUseExistingCredentials) { [weak self] in
                 guard let self = self else {
-                    completion(false, [])
+                    completionBox.call(false, [])
                     return
                 }
 
                 // Check if re-auth was successful
                 if userAccount.hasCredentials() && userAccount.authState == .loggedIn {
                     Log.info(#file, "📚 Re-authentication successful. Retrying bookmark sync...")
-                    self.performSyncBookmarks(completion: completion)
+                    self.performSyncBookmarks(completion: completionBox.call)
                 } else {
                     Log.info(#file, "📚 Re-authentication cancelled or failed. Returning local bookmarks.")
                     self.bookmarks = self.bookRegistry.readiumBookmarks(forIdentifier: self.book.identifier)
-                    completion(false, self.bookmarks)
+                    completionBox.call(false, self.bookmarks)
                 }
             }
             return
@@ -449,4 +458,23 @@ class TPPReaderBookmarksBusinessLogic: NSObject, @unchecked Sendable {
 private final class ReadiumBookmarkBox: @unchecked Sendable {
     let bookmark: TPPReadiumBookmark
     init(_ bookmark: TPPReadiumBookmark) { self.bookmark = bookmark }
+}
+
+/// Sendable carrier for the non-Sendable `(Bool, [TPPReadiumBookmark]) -> Void`
+/// bookmark-sync completion captured by the `@Sendable` reauth-completion closure
+/// in `handleBookmarksSyncFail`. `authenticateIfNeeded`'s `authenticationCompletion`
+/// is `@Sendable`, so the trailing closure is `@Sendable` and cannot capture the
+/// raw completion directly. Boxing keeps `syncBookmarks(completion:)` /
+/// `performSyncBookmarks(completion:)` / `handleBookmarksSyncFail(completion:)`
+/// signatures free of `@Sendable` (which would ripple to every bookmark-sync
+/// call site) and does NOT broaden `TPPReadiumBookmark` to `Sendable` (it has 10
+/// mutable `var`s — see `ReadiumBookmarkBox`).
+///
+/// INVARIANT — the boxed completion is invoked at most once per reauth outcome,
+/// on the reauth-completion path, which `TPPReauthenticator` drives on the main
+/// actor (`authenticateIfNeeded` hops `Task { @MainActor in }`). It is never
+/// invoked concurrently. Mirrors `ReadiumBookmarkBox`.
+private final class BookmarkSyncCompletionBox: @unchecked Sendable {
+    let call: (Bool, [TPPReadiumBookmark]) -> Void
+    init(_ call: @escaping (Bool, [TPPReadiumBookmark]) -> Void) { self.call = call }
 }

--- a/Palace/Reader2/BusinessLogic/TPPReaderPageListBusinessLogic.swift
+++ b/Palace/Reader2/BusinessLogic/TPPReaderPageListBusinessLogic.swift
@@ -10,7 +10,13 @@
 //
 
 import Foundation
-import ReadiumShared
+// Swift 6 `complete`: `Publication`, `Link`, and `Locator` are non-Sendable
+// Readium types. `currentPageLabel`/`locator(at:)` `await publication.locate(_:)`,
+// whose `async` receiver-send trips a region-isolation `sending 'self.publication'`
+// diagnostic. `@preconcurrency` is the honest ceiling until Readium annotates
+// these Sendable — matches the identical sibling `TPPReaderTOCBusinessLogic`
+// (`await publication.locate(tocElements[index].link)`).
+@preconcurrency import ReadiumShared
 
 typealias TPPReaderPageEntry = (label: String, link: Link)
 
@@ -19,6 +25,15 @@ typealias TPPReaderPageEntry = (label: String, link: Link)
 /// A "print page" is a hard-coded page boundary from the source print edition,
 /// exposed by Readium as `publication.pageList` — distinct from reflowed reading
 /// position, which changes with font size and screen dimensions.
+///
+/// Swift 6 `complete`: `@MainActor`-isolated. `currentPageLabel(for:)` takes a
+/// non-Sendable Readium `Locator`; isolating the class to the main actor keeps
+/// that argument inside the caller's main-actor region (the call site in
+/// `TPPEPUBViewController.announceCurrentPosition` runs in a `Task { @MainActor }`)
+/// so nothing is *sent* across an isolation boundary. Every consumer is already a
+/// `@MainActor` `UIViewController` (`TPPEPUBViewController`, `TPPReaderPositionsVC`).
+/// The only nonisolated caller is the XCTestCase test (see RIPPLES.md).
+@MainActor
 class TPPReaderPageListBusinessLogic {
     /// Page entries in document order, each a (display label, navigable link).
     /// Entries whose label is empty/whitespace are dropped — a page boundary
@@ -141,7 +156,10 @@ class TPPReaderPageListBusinessLogic {
     /// first (lowest-index) boundary — `>` keeps the first, matching the
     /// document-order start of a page. Returns nil when no entry qualifies
     /// (every progression is nil or strictly greater than `current`).
-    static func nearestPrecedingIndex(progressions: [Double?], current: Double) -> Int? {
+    // `nonisolated`: pure function over value-type args — no access to instance
+    // state — so it stays callable from the nonisolated XCTest without forcing the
+    // whole test onto `@MainActor` for these static-only assertions.
+    nonisolated static func nearestPrecedingIndex(progressions: [Double?], current: Double) -> Int? {
         var bestIndex: Int?
         var bestValue = -Double.greatestFiniteMagnitude
         var i = 0

--- a/Palace/Reader2/BusinessLogic/TPPReaderTOCBusinessLogic.swift
+++ b/Palace/Reader2/BusinessLogic/TPPReaderTOCBusinessLogic.swift
@@ -17,6 +17,14 @@ typealias TPPReaderTOCLink = (level: Int, link: Link)
 
 /// This class captures the business logic related to the Table Of Contents
 /// for a given Readium 2 Publication.
+///
+/// Swift 6 `complete`: `@MainActor`-isolated. The `Task` in `init` mutates
+/// `tocElements`, and every consumer is already a `@MainActor` `UIViewController`
+/// (`TPPReaderPositionsVC`, `TPPBaseReaderViewController`). Isolating the class to
+/// the main actor makes the `init` `Task` inherit main isolation, so the
+/// `tocElements` write is race-free without a lock. The only nonisolated caller is
+/// the XCTestCase test (see RIPPLES.md).
+@MainActor
 class TPPReaderTOCBusinessLogic {
     var tocElements: [TPPReaderTOCLink] = []
     private let publication: Publication

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeCertificate.swift
@@ -14,7 +14,12 @@ import PalaceLogging
 /// Adobe DRM Certificate structure.
 ///
 /// Includes only fields Palace checks to verify the certificate is not expired.
-@objc class AdobeCertificate: NSObject, Codable {
+///
+/// Swift 6 `complete`: `final` + `Sendable`. The only stored property is the
+/// immutable `let expireson: UInt?` (Sendable), so the value is deeply immutable
+/// and safe to share across concurrency domains — which is what lets the cached
+/// `static let defaultCertificate` be concurrency-safe. No subclasses exist.
+@objc final class AdobeCertificate: NSObject, Codable, Sendable {
 
     /// Certificate expiration date, seconds since UNIX epoch.
     ///
@@ -66,7 +71,11 @@ extension AdobeCertificate {
     }
 
     /// Default certificate for Palace app.
-    @objc static var defaultCertificate: AdobeCertificate? = {
+    ///
+    /// Swift 6 `complete`: `static let` (was `var`, never reassigned). Now that
+    /// `AdobeCertificate` is `Sendable`, this cached immutable value is
+    /// concurrency-safe to read from any thread.
+    @objc static let defaultCertificate: AdobeCertificate? = {
         let bundle: Bundle = (ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil) ? Bundle(for: TPPAppDelegate.self) : Bundle.main
         guard let adobeCertUrl = bundle.url(forResource: "ReaderClientCert", withExtension: "sig"),
               let adobeCertData = try? Data(contentsOf: adobeCertUrl),
@@ -89,21 +98,85 @@ extension AdobeCertificate {
     /// Period of notification for expired Adobe DRM certificate
     fileprivate static let notificationPeriod: TimeInterval = 60 * 60
 
-    /// Last expired DRM certificate notification date
-    fileprivate static var notificationDate: Date?
+    /// Last expired DRM certificate notification date.
+    ///
+    /// Swift 6 `complete`: backed by a lock-backed `@unchecked Sendable` holder
+    /// instead of a bare mutable `static var` (which is not concurrency-safe).
+    /// `shouldNotifyAboutExpiration` may be evaluated from any thread that hits an
+    /// expired-cert branch, so the read-decide-write must be serialized.
+    fileprivate static let notificationDateHolder = DateHolder()
 
     /// Returns true every `notificationPeriod` time interval.
     ///
     /// Used to avoid showing expiration message every time the user opens the app with expired certificate.
     @objc static var shouldNotifyAboutExpiration: Bool {
-        if let notificationDate = notificationDate, -notificationDate.timeIntervalSinceNow < notificationPeriod {
-            return false
-        } else {
-            notificationDate = Date()
-            return true
-        }
+        // Perform the read-decide-write atomically under the holder's lock so two
+        // concurrent expired-cert checks can't both return `true` for the same window.
+        notificationDateHolder.notifyIfElapsed(period: notificationPeriod)
     }
 
+}
+
+/// Lock-backed holder for the expired-certificate notification timestamp.
+///
+/// Swift 6 `complete`: replaces the bare mutable `static var notificationDate`.
+/// `@unchecked Sendable` is honest here because the single mutable field is only
+/// ever touched inside `notifyIfElapsed`, which holds `lock` for the whole
+/// read-decide-write — so no unsynchronized access is possible. Precedent:
+/// `AdobeDRMService`'s lock-backed statics in this same file.
+private final class DateHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var date: Date?
+
+    /// Atomically returns `true` at most once per `period`, recording "now" on the
+    /// firing call. Mirrors the original `shouldNotifyAboutExpiration` semantics.
+    func notifyIfElapsed(period: TimeInterval) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if let date, -date.timeIntervalSinceNow < period {
+            return false
+        }
+        date = Date()
+        return true
+    }
+}
+
+/// Lock-backed holder for the iPad-on-Mac static-destructor-bypass flags.
+///
+/// Swift 6 `complete`: replaces the two bare mutable `static var`s
+/// (`staticDestructorBypassRegistered`, `adobeDRMUsed`) and their `NSLock`.
+/// `@unchecked Sendable` is honest because both fields are only ever read or
+/// written inside a method that holds `lock` for the whole operation — there is no
+/// unsynchronized access. The `markRegisteredIfNeeded` closure runs while the lock
+/// is held, so the caller's decision sees a consistent `registered` snapshot and
+/// the flip is atomic with it.
+private final class BypassState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var registered = false
+    private var used = false
+
+    var adobeDRMUsed: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return used
+    }
+
+    func setAdobeDRMUsed(_ value: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        used = value
+    }
+
+    /// Atomically evaluates `decide(currentRegisteredFlag)` and, if it returns
+    /// `true`, flips `registered` to `true` and returns `true` (meaning "you should
+    /// install now"). Returns `false` otherwise. One-shot install guard.
+    func markRegisteredIfNeeded(_ decide: (Bool) -> Bool) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard decide(registered) else { return false }
+        registered = true
+        return true
+    }
 }
 
 // MARK: - Safe DRM Access
@@ -111,8 +184,15 @@ extension AdobeCertificate {
 /// Provides thread-safe access to Adobe DRM functionality.
 /// Wraps NYPLADEPT.sharedInstance() with defensive error handling to prevent crashes.
 /// Note: Named AdobeDRMService to avoid conflict with Obj-C AdobeDRMContainer (the decryption container)
+///
+/// Swift 6 `complete`: `@unchecked Sendable`. INVARIANT — all instance mutable
+/// state (`_adeptInstance`, `initializationAttempted`, `initializationFailed`) is
+/// accessed only under `lock`, and all mutable static state is owned by the
+/// `bypassState` lock-backed holder below. No unsynchronized shared mutation
+/// remains, which is what makes the `static let shared` singleton
+/// concurrency-safe.
 @objcMembers
-class AdobeDRMService: NSObject {
+class AdobeDRMService: NSObject, @unchecked Sendable {
 
     /// Singleton for safe DRM access
     static let shared = AdobeDRMService()
@@ -153,48 +233,31 @@ class AdobeDRMService: NSObject {
 
     // MARK: - iPad-on-Mac static-destructor bypass
 
-    /// Tracks whether the process-exit interceptor has been installed, so
-    /// repeated calls to `registerStaticDestructorBypassIfNeeded()` install it
-    /// at most once.
-    private static var staticDestructorBypassRegistered = false
-
-    /// Serializes the idempotency check + atexit registration + the
-    /// `adobeDRMUsed` flag.
-    private static let staticDestructorBypassLock = NSLock()
-
-    /// Set once Adobe DRM is being exercised at runtime this session. Marked at
-    /// `AdobeDRMContainer` construction in `AdobeDRMContentProtection.open` — the
-    /// sole `.adept` reader entry, which dominates every ungated RMSDK op
-    /// (decode / displayUntilDate license-read / init → `GPFile::lock`) that can
-    /// construct the faulting static `recursive_mutex`. Gates the watchdog-exit
-    /// interceptor install so we only bypass exit cleanup when there is actually
-    /// an Adobe dtor to outrun.
-    private static var adobeDRMUsed = false
+    /// Swift 6 `complete`: the two process-exit-bypass flags plus their lock are
+    /// consolidated into one lock-backed `@unchecked Sendable` holder instead of
+    /// bare mutable `static var`s (which are not concurrency-safe). The holder is
+    /// the single serialization domain for `registered` + `adobeDRMUsed`; every
+    /// read-decide-write below runs inside it, so the semantics are unchanged.
+    private static let bypassState = BypassState()
 
     /// Records that Adobe DRM is being exercised this session. Called when an
     /// `AdobeDRMContainer` is constructed (the broad reader-DRM umbrella).
     static func markAdobeDRMUsed() {
-        staticDestructorBypassLock.lock()
-        defer { staticDestructorBypassLock.unlock() }
-        adobeDRMUsed = true
+        bypassState.setAdobeDRMUsed(true)
     }
 
     /// Whether Adobe DRM has been exercised this session. The
     /// `applicationDidEnterBackground` install site consults this so the
     /// `_exit(0)` interceptor is only installed once an Adobe dtor exists.
     static var didUseAdobeDRMThisSession: Bool {
-        staticDestructorBypassLock.lock()
-        defer { staticDestructorBypassLock.unlock() }
-        return adobeDRMUsed
+        bypassState.adobeDRMUsed
     }
 
     /// Test-only: reset the session "DRM used" flag so the false→true contract
     /// can be asserted hermetically (the flag is otherwise set-once per process).
     /// Internal — not part of any production call path.
     static func resetAdobeDRMUsedForTesting() {
-        staticDestructorBypassLock.lock()
-        defer { staticDestructorBypassLock.unlock() }
-        adobeDRMUsed = false
+        bypassState.setAdobeDRMUsed(false)
     }
 
     /// Pure decision: should *this* call install the atexit interceptor now?
@@ -231,15 +294,18 @@ class AdobeDRMService: NSObject {
     /// Idempotent; no-op on iOS devices. End-to-end behavior (crash-at-exit) is
     /// not unit-testable — requires simdrive validation on a Mac host (CHECK 2).
     static func registerStaticDestructorBypassIfNeeded() {
-        staticDestructorBypassLock.lock()
-        defer { staticDestructorBypassLock.unlock() }
-
-        guard shouldRegisterStaticDestructorBypass(
-            isiOSAppOnMac: ProcessInfo.processInfo.isiOSAppOnMac,
-            alreadyRegistered: staticDestructorBypassRegistered
-        ) else { return }
-
-        staticDestructorBypassRegistered = true
+        // Atomic check-and-set inside the holder's lock: the pure decision
+        // (`shouldRegisterStaticDestructorBypass`) runs against the currently-stored
+        // `registered` flag, and the flag is only flipped to `true` when the guard
+        // passes — so the `atexit` interceptor installs at most once even under
+        // concurrent callers.
+        let shouldInstall = bypassState.markRegisteredIfNeeded { alreadyRegistered in
+            shouldRegisterStaticDestructorBypass(
+                isiOSAppOnMac: ProcessInfo.processInfo.isiOSAppOnMac,
+                alreadyRegistered: alreadyRegistered
+            )
+        }
+        guard shouldInstall else { return }
         _ = atexit { _exit(0) }
     }
 
@@ -316,10 +382,15 @@ class AdobeDRMService: NSObject {
     }
 
     /// Safely return a DRM loan.
+    // Swift 6 `complete`: `completion` is `@Sendable` because it is forwarded to
+    // `NYPLADEPT.returnLoan`, whose imported Obj-C block parameter is `@Sendable`
+    // (the DRM callback fires on a background RMSDK thread). The sole caller
+    // (`BookReturnService`) passes a closure that captures nothing non-Sendable, so
+    // this does not ripple.
     func returnLoan(_ fulfillmentId: String?,
                     userID: String?,
                     deviceID: String?,
-                    completion: @escaping (Bool, Error?) -> Void) {
+                    completion: @escaping @Sendable (Bool, Error?) -> Void) {
         guard let adept = adeptInstance else {
             Log.warn(#file, "Cannot return DRM loan - Adobe DRM not available")
             completion(false, NSError(domain: "AdobeDRM", code: -1, userInfo: [NSLocalizedDescriptionKey: "Adobe DRM not available"]))

--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
@@ -104,6 +104,20 @@ private extension AdobeDRMContentProtection {
     }
 }
 
+// Swift 6 `complete`: `@unchecked Sendable`. `AdobeDRMContainer` (Obj-C) is passed
+// into the `DRMDataResource` actor and captured by the `@Sendable` async bridge in
+// the `Container` subscript. Its one hot operation — `decodeData:at:` — is fully
+// serialized in the `.mm` behind `@synchronized(acsdrm_lock)`. The `epubDecodingError`
+// / `displayUntilDate` properties are NOT lock-covered, but they are accessed only
+// during single-threaded publication *open* (service-factory construction), which
+// completes before the lazy `decodeData:at:` decrypt path (invoked during *reading*)
+// ever runs — i.e. sequenced, not concurrent. So sharing the instance across
+// concurrency domains introduces no unsynchronized *concurrent* access. (Follow-up:
+// `acsdrm_lock` is reassigned per-init in the `.mm` — track making it a
+// `dispatch_once` immutable. Non-blocking, pre-existing.) Precedent:
+// `AdobeDRMService` in `AdobeCertificate.swift`.
+extension AdobeDRMContainer: @unchecked Sendable {}
+
 extension AdobeDRMContainer: Container {
 
     public var sourceURL: AbsoluteURL? {
@@ -123,14 +137,18 @@ extension AdobeDRMContainer: Container {
         let path = url.anyURL.string
 
         let data: Data? = {
-            var result: Data?
+            // Swift 6 `complete`: the completion runs on a background queue (a
+            // `@Sendable` closure), so the result is carried out through the
+            // lock-backed `SyncDataBridge` box rather than a captured mutable `var`.
+            // The semaphore still provides the synchronous wait; behavior unchanged.
+            let bridge = SyncDataBridge()
             let semaphore = DispatchSemaphore(value: 0)
             self.retrieveDataSynchronously(for: path) { retrievedData in
-                result = retrievedData
+                bridge.complete(with: retrievedData)
                 semaphore.signal()
             }
             semaphore.wait()
-            return result
+            return bridge.data
         }()
 
         guard let data else {
@@ -140,23 +158,23 @@ extension AdobeDRMContainer: Container {
         return DRMDataResource(encryptedData: data, path: path, drmContainer: self, sourceURL: sourceURL)
     }
 
-    private func retrieveDataSynchronously(for path: String, completion: @escaping (Data?) -> Void) {
+    private func retrieveDataSynchronously(for path: String, completion: @escaping @Sendable (Data?) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
             let runLoop = CFRunLoopGetCurrent()
-            var retrievedData: Data?
-            var isCompleted = false
+            // Swift 6 `complete`: the async-bridge result + done-flag are shared
+            // between the `@Sendable` `Task` (writer) and this run-loop-pumping
+            // closure (reader), so they cannot be captured as plain local `var`s.
+            // The lock-backed `SyncDataBridge` box is the single serialization
+            // point; behavior (spin the run loop until the Task finishes or the
+            // 10s cap elapses, then hand the data back) is unchanged.
+            let bridge = SyncDataBridge()
             Task {
-                do {
-                    retrievedData = try await self.retrieveData(for: path)
-                } catch {
-                    retrievedData = nil
-                }
-
-                isCompleted = true
+                let data = try? await self.retrieveData(for: path)
+                bridge.complete(with: data)
                 CFRunLoopStop(runLoop)
             }
 
-            while !isCompleted {
+            while !bridge.isCompleted {
                 CFRunLoopRunInMode(CFRunLoopMode.defaultMode, 0.1, false)
 
                 if Date() > Date(timeIntervalSinceNow: 10) {
@@ -164,7 +182,7 @@ extension AdobeDRMContainer: Container {
                 }
             }
 
-            completion(retrievedData)
+            completion(bridge.data)
         }
     }
 
@@ -287,6 +305,36 @@ extension ResourceProperties {
             return value.map(UInt64.init)
         }
         set { self["length"] = newValue.map { Int($0) } }
+    }
+}
+
+/// Lock-backed carrier for the async→sync bridge in `AdobeDRMContainer`'s
+/// `Container` subscript.
+///
+/// Swift 6 `complete`: replaces the mutable local `var retrievedData` / `var
+/// isCompleted` that were shared between the `@Sendable` `Task` (the writer) and
+/// the run-loop / semaphore reader. `@unchecked Sendable` is honest because every
+/// field access is serialized by `lock`. `complete(with:)` is idempotent-safe:
+/// the bridge is used for exactly one round trip per subscript call.
+private final class SyncDataBridge: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _data: Data?
+    private var _isCompleted = false
+
+    var data: Data? {
+        lock.lock(); defer { lock.unlock() }
+        return _data
+    }
+
+    var isCompleted: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _isCompleted
+    }
+
+    func complete(with data: Data?) {
+        lock.lock(); defer { lock.unlock() }
+        _data = data
+        _isCompleted = true
     }
 }
 

--- a/Palace/Reader2/ReaderStackConfiguration/LCP/LCPLibraryService.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LCP/LCPLibraryService.swift
@@ -16,27 +16,54 @@ import PalaceAudiobookToolkit
 import ReadiumShared
 import ReadiumLCP
 
-@objc class LCPLibraryService: NSObject, DRMLibraryService {
+// Swift 6 `complete`: `@unchecked Sendable`. This type is exposed as the shared
+// global `lcpService` (see `TPPLCPClient.swift`) which is read from multiple
+// concurrency domains (the Audiobooks LCP path in `LCPAudiobooks`, the reader
+// content-protection path). INVARIANT — every stored member is either immutable
+// (`licenseExtension`, `lcpClient`, `serviceQueue`, `serviceLock`) or guarded:
+// the lazily-built `_lcpService` and `_contentProtection` are both initialized
+// once behind `serviceQueue.sync` + `serviceLock`, so no unsynchronized mutable
+// state crosses threads. `TPPLCPClient` is itself lock-backed (its own
+// `contextQueue`). The parallel precedent is `AdobeDRMService` (lock-backed
+// `@unchecked Sendable`). The test subclass `SpyLCPLibraryService` overrides
+// `fulfill` only and adds no cross-thread mutable state.
+@objc class LCPLibraryService: NSObject, DRMLibraryService, @unchecked Sendable {
 
     /// Readium licensee file extension
     @objc public let licenseExtension = "lcpl"
 
-    private var lcpClient = TPPLCPClient()
+    private let lcpClient = TPPLCPClient()
     private var _lcpService: LCPService?
+    private var _contentProtection: ContentProtection?
     private let serviceQueue = DispatchQueue(label: "com.palace.LCPLibraryService.serviceQueue", qos: .userInitiated)
     private let serviceLock = NSLock()
 
-    /// ContentProtection unlocks protected publication, providing a custom `Fetcher`
-    lazy var contentProtection: ContentProtection? = lcpService?.contentProtection(with: LCPPassphraseAuthenticationService())
-
-    /// [LicenseDocument.id: passphrase callback]
-    private var authenticationCallbacks: [String: (String?) -> Void] = [:]
+    /// ContentProtection unlocks protected publication, providing a custom `Fetcher`.
+    ///
+    /// Init-once behind `serviceQueue.sync` so concurrent reads (reader open +
+    /// audiobook open) share a single instance without racing the lazy backing
+    /// store (a plain `lazy var` is not concurrency-safe under `complete`).
+    var contentProtection: ContentProtection? {
+        serviceQueue.sync {
+            if _contentProtection == nil {
+                _contentProtection = lcpService(locked: true)?.contentProtection(with: LCPPassphraseAuthenticationService())
+            }
+            return _contentProtection
+        }
+    }
 
     private var lcpService: LCPService? {
-        serviceQueue.sync {
-            if _lcpService == nil {
-                serviceLock.lock()
-                defer { serviceLock.unlock() }
+        lcpService(locked: false)
+    }
+
+    /// - Parameter locked: `true` when the caller already holds `serviceQueue`
+    ///   (the `contentProtection` accessor), to avoid re-entrant `serviceQueue.sync`
+    ///   deadlock; `false` for direct callers, which acquire the queue here.
+    private func lcpService(locked: Bool) -> LCPService? {
+        let build: () -> LCPService? = {
+            if self._lcpService == nil {
+                self.serviceLock.lock()
+                defer { self.serviceLock.unlock() }
 
                 // Readium 3.8.0+: license/passphrase storage moved from the
                 // deprecated SQLite repositories to the Keychain repositories
@@ -47,7 +74,7 @@ import ReadiumLCP
                 let licenseRepo = LCPKeychainLicenseRepository()
                 let passphraseRepo = LCPKeychainPassphraseRepository()
 
-                _lcpService = LCPService(
+                self._lcpService = LCPService(
                     client: TPPLCPClient(),
                     licenseRepository: licenseRepo,
                     passphraseRepository: passphraseRepo,
@@ -55,8 +82,9 @@ import ReadiumLCP
                     httpClient: LCPCredentialStrippingHTTPClient()
                 )
             }
-            return _lcpService
+            return self._lcpService
         }
+        return locked ? build() : serviceQueue.sync(execute: build)
     }
 
     override init() {

--- a/Palace/Reader2/ReaderStackConfiguration/LCP/LCPPassphraseAuthenticationService.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LCP/LCPPassphraseAuthenticationService.swift
@@ -1,13 +1,26 @@
 #if LCP
 
 import Foundation
-import ReadiumLCP
+// Swift 6 `complete`: `LCPAuthenticatedLicense` / `LCPAuthenticationReason` are
+// ReadiumLCP types that are not Sendable-audited upstream, so passing the inbound
+// `license` from the `nonisolated async` `retrievePassphrase` into the sibling
+// `retrievePassphraseFromLoan` trips a region-isolation `sending` diagnostic.
+// `@preconcurrency` is the honest ceiling until Readium annotates these — matches
+// `@preconcurrency import ReadiumShared` in the sibling AdobeDRM files.
+@preconcurrency import ReadiumLCP
 import PalaceCatalog
 
 /**
  For Passphrase in License Document, see https://readium.org/lcp-specs/releases/lcp/latest#41-introduction
  */
-class LCPPassphraseAuthenticationService: LCPAuthenticating {
+// `@unchecked Sendable` (Swift 6 complete-mode): all stored state is immutable
+// `let` (bookRegistry/accountsManager/networkExecutor/settings — each Sendable or
+// documented `@unchecked Sendable`); no mutable instance state (the transient
+// `passphraseField` is a local inside the alert closure, not stored). The
+// `nonisolated async` `retrievePassphrase` therefore sends a race-free `self`
+// into the sibling `retrievePassphraseFromLoan`. Matches the sibling LCP types
+// `LCPLibraryService` / `TPPLicensesService`. `final` to keep the invariant.
+final class LCPPassphraseAuthenticationService: LCPAuthenticating, @unchecked Sendable {
 
     private let bookRegistry: TPPBookRegistryProvider
     private let accountsManager: AccountsManager
@@ -26,7 +39,11 @@ class LCPPassphraseAuthenticationService: LCPAuthenticating {
         self.settings = settings
     }
 
-    private func retrievePassphraseFromLoan(for license: LCPAuthenticatedLicense, reason: LCPAuthenticationReason, allowUserInteraction: Bool, sender: Any?) async -> String? {
+    // Swift 6 `complete`: `sender` (`Any?`) was forwarded here but never used in
+    // this helper. Passing an opaque `Any?` across the `async` call boundary
+    // tripped a region-isolation `sending 'sender'` diagnostic. Dropping the
+    // unused parameter removes the send entirely — no box, no behavior change.
+    private func retrievePassphraseFromLoan(for license: LCPAuthenticatedLicense, reason: LCPAuthenticationReason, allowUserInteraction: Bool) async -> String? {
         let licenseId = license.document.id
         let registry = bookRegistry
 
@@ -164,7 +181,7 @@ class LCPPassphraseAuthenticationService: LCPAuthenticating {
                 }
             }
         } else {
-            return await retrievePassphraseFromLoan(for: license, reason: reason, allowUserInteraction: allowUserInteraction, sender: sender)
+            return await retrievePassphraseFromLoan(for: license, reason: reason, allowUserInteraction: allowUserInteraction)
         }
     }
 

--- a/Palace/Reader2/ReaderStackConfiguration/LCP/LicensesService.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LCP/LicensesService.swift
@@ -24,7 +24,20 @@ enum TPPLicensesServiceError: Error {
     }
 }
 
-class TPPLicensesService: NSObject {
+// Swift 6 `complete`: `@unchecked Sendable`. The instance is passed as
+// `delegate:` to `URLSession(configuration:delegate:delegateQueue:)`, which
+// requires a `Sendable` delegate under strict concurrency.
+// INVARIANT — no concurrent access to the mutable state:
+//   • `progressHandler`, `completionHandler`, `lcpl`, `link` are written exactly
+//     once, synchronously inside `acquirePublication(...)`, BEFORE `task.resume()`.
+//   • They are read only from the `URLSessionDownloadDelegate` callbacks, which
+//     this class always registers with `delegateQueue: .main`.
+//   • `task.resume()` establishes the happens-before edge, so the single writer
+//     precedes every reader and no read races a write.
+// This is the honest ceiling for a callback-style delegate; a `@MainActor`
+// isolation would instead ripple onto every (test) caller of the synchronous
+// `acquirePublication` entry point.
+class TPPLicensesService: NSObject, @unchecked Sendable {
 
     var progressHandler: ((_ progress: Double) -> Void)?
     var completionHandler: ((_ localUrl: URL?, _ error: Error?) -> Void)?

--- a/Palace/Reader2/UI/TPPBaseReaderViewController.swift
+++ b/Palace/Reader2/UI/TPPBaseReaderViewController.swift
@@ -518,6 +518,13 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
     // MARK: - Accessibility
 
     private lazy var accessibilityToolbar: UIToolbar = {
+        // Swift 6 `complete`: a nested local `func` does NOT inherit the enclosing
+        // type's `@MainActor` isolation, so its `UIBarButtonItem` / `accessibilityLabel`
+        // (both `@MainActor`) uses would cross into the main actor. This toolbar is
+        // built lazily on the main thread (UIKit view setup), so annotating the
+        // helper `@MainActor` is the honest isolation-only fix — no hop, no behavior
+        // change.
+        @MainActor
         func makeItem(_ item: UIBarButtonItem.SystemItem, label: String? = nil, action: UIKit.Selector? = nil) -> UIBarButtonItem {
             let button = UIBarButtonItem(barButtonSystemItem: item, target: (action != nil) ? self : nil, action: action)
             button.accessibilityLabel = label

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -640,7 +640,14 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.configureKeyboardInput()
+            // Swift 6 `complete`: the observer block is a nonisolated `@Sendable`
+            // closure, but `queue: .main` guarantees it is delivered on the main
+            // thread, so accessing the `@MainActor` members (`configureKeyboardInput`,
+            // `keyboardInput`) is provably safe. `MainActor.assumeIsolated` asserts
+            // that invariant without a hop — behavior unchanged. (Not a `deinit`.)
+            MainActor.assumeIsolated {
+                self?.configureKeyboardInput()
+            }
         }
 
         keyboardDisconnectObserver = NotificationCenter.default.addObserver(
@@ -648,8 +655,12 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.keyboardInput?.keyChangedHandler = nil
-            self?.keyboardInput = nil
+            // See the connect-observer note above: `queue: .main` makes the
+            // `@MainActor` teardown provably main-isolated.
+            MainActor.assumeIsolated {
+                self?.keyboardInput?.keyChangedHandler = nil
+                self?.keyboardInput = nil
+            }
         }
 
         configureKeyboardInput()

--- a/PalaceTests/DRM/AdobeDRMCharacterizationTests.swift
+++ b/PalaceTests/DRM/AdobeDRMCharacterizationTests.swift
@@ -35,6 +35,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AdobeDRMCharacterizationTests: XCTestCase {
 
     private var drm: TPPDRMAuthorizingMock!

--- a/PalaceTests/Reader2/TPPReaderPageListBusinessLogicTests.swift
+++ b/PalaceTests/Reader2/TPPReaderPageListBusinessLogicTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import ReadiumShared
 @testable import Palace
 
+@MainActor
 final class TPPReaderPageListBusinessLogicTests: XCTestCase {
 
     // MARK: - Publication builders

--- a/PalaceTests/Reader2/TPPReaderTOCBusinessLogicTests.swift
+++ b/PalaceTests/Reader2/TPPReaderTOCBusinessLogicTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import ReadiumShared
 @testable import Palace
 
+@MainActor
 final class TPPReaderTOCBusinessLogicTests: XCTestCase {
 
     // MARK: - Properties
@@ -325,6 +326,7 @@ final class TPPReaderTOCBusinessLogicTests: XCTestCase {
 
 // MARK: - TOC Flatten Logic Tests
 
+@MainActor
 final class TPPReaderTOCFlattenTests: XCTestCase {
 
     func testFlatten_nestedTOC_assignsCorrectLevels() async throws {

--- a/PalaceTests/Reader2/TPPReaderTOCBusinessLogicTests.swift
+++ b/PalaceTests/Reader2/TPPReaderTOCBusinessLogicTests.swift
@@ -75,7 +75,7 @@ final class TPPReaderTOCBusinessLogicTests: XCTestCase {
             predicate: NSPredicate { [weak self] _, _ in !(self?.tocBusinessLogic?.tocElements.isEmpty ?? true) },
             object: nil
         )
-        wait(for: [loaded], timeout: 10.0)
+        await fulfillment(of: [loaded], timeout: 10.0)
 
         guard !tocBusinessLogic.tocElements.isEmpty else {
             return
@@ -126,7 +126,7 @@ final class TPPReaderTOCBusinessLogicTests: XCTestCase {
             predicate: NSPredicate { [weak self] _, _ in !(self?.tocBusinessLogic?.tocElements.isEmpty ?? true) },
             object: nil
         )
-        wait(for: [loaded], timeout: 10.0)
+        await fulfillment(of: [loaded], timeout: 10.0)
 
         let title = tocBusinessLogic.title(for: "/nonexistent.xhtml")
 
@@ -142,7 +142,7 @@ final class TPPReaderTOCBusinessLogicTests: XCTestCase {
             predicate: NSPredicate { [weak self] _, _ in !(self?.tocBusinessLogic?.tocElements.isEmpty ?? true) },
             object: nil
         )
-        wait(for: [loaded], timeout: 10.0)
+        await fulfillment(of: [loaded], timeout: 10.0)
 
         guard !tocBusinessLogic.tocElements.isEmpty else {
             return
@@ -365,7 +365,7 @@ final class TPPReaderTOCFlattenTests: XCTestCase {
             predicate: NSPredicate { _, _ in businessLogic.tocElements.count > 0 },
             object: nil
         )
-        wait(for: [loaded], timeout: 10.0)
+        await fulfillment(of: [loaded], timeout: 10.0)
 
         guard businessLogic.tocElements.count > 0 else { return }
 


### PR DESCRIPTION
## Swift 6 Phase B — Reader2 DRM/LCP (DRM critical-path)

Isolation-only; no decryption/fulfillment/bookmark behavior change. AdobeDRM lock-backed holders + @unchecked Sendable, TPPReaderTOC/PageList → @MainActor (closes a pre-existing off-main race), LCP types @unchecked Sendable, @preconcurrency Readium imports. Part of **738 → 0**.

**Two independent SoD APPROVED** (soundness + behavior): every invariant true (one doc-accuracy comment corrected), DRM async→sync bridge byte-identical, LCP/bookmark preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)