### PR TITLE
fix(swift6): MyBooks download-machinery → complete-mode 0 (isolation-only)

### DIFF
--- a/Palace/MyBooks/BookContentResetService.swift
+++ b/Palace/MyBooks/BookContentResetService.swift
@@ -21,7 +21,18 @@ import PalaceLogging
 /// downloads, clears state-manager bookkeeping, removes the on-disk
 /// content directory, and (for current-account paths) broadcasts a UI
 /// update.
-final class BookContentResetService {
+///
+/// - Sendable invariant (Swift 6 `complete`-mode): every stored dependency is a
+///   `let` bound at init (`bookRegistry`, `accountsManager`, `stateManager`,
+///   `bookFileManager`, `progressReporter`, `localContentService`, `fileManager`)
+///   and there is no mutable instance state. `reset()` hops the download-state
+///   teardown into a `Task` that only touches the actor-serialized
+///   `stateManager.downloadCoordinator` / `SafeDictionary` members — the same
+///   already-shared services this flow drove under Swift-5 mode. `@unchecked`
+///   (rather than a synthesized conformance) only because the stored service
+///   types are not themselves `Sendable`; the conformance asserts the
+///   immutable-dependency contract above and does not change behavior.
+final class BookContentResetService: @unchecked Sendable {
 
     private let bookRegistry: TPPBookRegistryProvider
     private let accountsManager: AccountsManager

--- a/Palace/MyBooks/BookReturnService.swift
+++ b/Palace/MyBooks/BookReturnService.swift
@@ -251,7 +251,7 @@ final class BookReturnService: @unchecked Sendable {
     /// callers don't have to thread the lock through their UI work.
     @discardableResult
     private func launchTrackedMainActorTask(
-        _ body: @escaping @MainActor () async -> Void
+        _ body: @escaping @MainActor @Sendable () async -> Void
     ) -> Task<Void, Never> {
         let id = UUID()
         let task = Task { @MainActor [weak self] in
@@ -634,29 +634,35 @@ final class BookReturnService: @unchecked Sendable {
 /// Internal-only — accessible from PalaceTests via `@testable import
 /// Palace` but not exported publicly.
 internal enum BookReturnServiceTestHook {
-    private static let lock = NSLock()
-    private static var _deinitCount = 0
+    /// Lock-backed counter holder. Replaces the previous `static var _deinitCount`
+    /// + free-standing `NSLock`: under Swift 6 `complete`-mode a mutable static is
+    /// nonisolated global shared mutable state (a warning even when guarded by a
+    /// sibling lock, because the compiler can't see the pairing). Wrapping the
+    /// count + its lock in one `@unchecked Sendable` holder makes the
+    /// serialization contract explicit and the storage a single immutable `let`.
+    /// Precedent: `LockedFlag` in `TPPAccessibilityAnnouncementCenter`.
+    private final class Counter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = 0
+
+        func increment() { lock.withLock { value += 1 } }
+        func get() -> Int { lock.withLock { value } }
+    }
+
+    private static let counter = Counter()
 
     static func recordDeinit() {
-        lock.lock()
-        _deinitCount += 1
-        lock.unlock()
+        counter.increment()
     }
 
     /// Async accessor — used in test arrange / assert hops.
     static var deinitCount: Int {
-        get async {
-            lock.lock()
-            defer { lock.unlock() }
-            return _deinitCount
-        }
+        get async { counter.get() }
     }
 
     /// Sync accessor — used inside `awaitConditionAsync` predicates
     /// which are non-async closures.
     static var deinitCountSync: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return _deinitCount
+        counter.get()
     }
 }

--- a/Palace/MyBooks/BorrowOperation.swift
+++ b/Palace/MyBooks/BorrowOperation.swift
@@ -86,8 +86,8 @@ private enum BorrowAuthErrorDecision {
 ///   member is `weak var delegate`, assigned exactly once during owner
 ///   (`MyBooksDownloadCenter`) construction and never reassigned; weak-reference
 ///   reads and ARC zeroing are atomic in the Swift runtime, so no explicit lock
-///   is required. Circuit-breaker state (`borrowReauthAttempted`) is `static`
-///   and serialized by `borrowReauthLock` (NSLock). `@unchecked` (rather than a
+///   is required. Circuit-breaker state lives in the `static let reauthTracker`
+///   (`ReauthTracker`), a lock-backed `@unchecked Sendable` holder. `@unchecked` (rather than a
 ///   synthesized conformance) because `delegate`'s protocol existential and the
 ///   shared service types are not themselves `Sendable`; this conformance
 ///   asserts the serialization contract above and does not change runtime
@@ -102,34 +102,43 @@ final class BorrowOperation: @unchecked Sendable {
     /// borrow operation. Prevents infinite re-auth loops for persistent
     /// auth failures. Shared across BorrowOperation instances so
     /// account-switch state can be cleared centrally.
-    private static var borrowReauthAttempted: Set<String> = []
-    private static let borrowReauthLock = NSLock()
+    ///
+    /// Lock-backed holder rather than a `static var` + sibling `NSLock`:
+    /// under Swift 6 `complete`-mode a mutable static is nonisolated global
+    /// shared mutable state (a warning even when a paired lock guards every
+    /// access, because the compiler can't see the pairing). Wrapping the set
+    /// and its lock in one `@unchecked Sendable` holder makes the serialization
+    /// contract explicit and the storage a single immutable `let`. Behavior is
+    /// identical to the previous lock/defer accessors.
+    private final class ReauthTracker: @unchecked Sendable {
+        private let lock = NSLock()
+        private var attempted: Set<String> = []
+
+        func hasAttempted(_ bookId: String) -> Bool { lock.withLock { attempted.contains(bookId) } }
+        func mark(_ bookId: String) { lock.withLock { _ = attempted.insert(bookId) } }
+        func clear(_ bookId: String) { lock.withLock { attempted.remove(bookId) } }
+        func clearAll() { lock.withLock { attempted.removeAll() } }
+    }
+
+    private static let reauthTracker = ReauthTracker()
 
     private static func hasBorrowReauthBeenAttempted(for bookId: String) -> Bool {
-        borrowReauthLock.lock()
-        defer { borrowReauthLock.unlock() }
-        return borrowReauthAttempted.contains(bookId)
+        reauthTracker.hasAttempted(bookId)
     }
 
     private static func markBorrowReauthAttempted(for bookId: String) {
-        borrowReauthLock.lock()
-        defer { borrowReauthLock.unlock() }
-        borrowReauthAttempted.insert(bookId)
+        reauthTracker.mark(bookId)
     }
 
     private static func clearBorrowReauthAttempted(for bookId: String) {
-        borrowReauthLock.lock()
-        defer { borrowReauthLock.unlock() }
-        borrowReauthAttempted.remove(bookId)
+        reauthTracker.clear(bookId)
     }
 
     /// Clears all re-auth tracking. Called on account switch via the
     /// MBDC forwarder so stale circuit-breaker state from the previous
     /// account can't suppress legitimate re-auth attempts.
     static func clearAllBorrowReauthState() {
-        borrowReauthLock.lock()
-        defer { borrowReauthLock.unlock() }
-        borrowReauthAttempted.removeAll()
+        reauthTracker.clearAll()
     }
 
     // MARK: - Pure Helpers

--- a/Palace/MyBooks/DiskBudgetManager.swift
+++ b/Palace/MyBooks/DiskBudgetManager.swift
@@ -17,6 +17,50 @@ import Foundation
 import UIKit
 import PalaceLogging
 
+/// Resolves the "is this an iPhone SE/8-class (small) device" flag without
+/// touching the main-actor-isolated `UIScreen.main` from a background thread.
+///
+/// The production default for `DiskBudgetManager.isSmallDevice` used to read
+/// `UIScreen.main.nativeBounds.height` inline; under Swift 6 `complete`-mode
+/// that is a main-actor-isolated access, and it was in fact already being
+/// evaluated off-main (the eviction entrypoint runs on `TPPAppDelegate`'s
+/// background `monitorQueue`). This holder resolves the pixel height exactly
+/// once, hopping to the main actor when necessary, and caches it under a lock.
+/// Screen native bounds don't change at runtime, so a one-shot cache preserves
+/// the original `<= 1334` threshold behavior exactly.
+///
+/// - Sendable invariant: the only mutable state (`cachedHeight`) is read and
+///   written solely under `lock`; `@unchecked` because `CGFloat`'s optional
+///   box isn't expressible as a stored `Sendable` without the lock contract.
+private final class SmallDeviceResolver: @unchecked Sendable {
+    static let shared = SmallDeviceResolver()
+
+    private let lock = NSLock()
+    private var cachedHeight: CGFloat?
+
+    /// iPhone 6/7/8/SE-class devices report a native height of 1334 px or less.
+    func isSmallDevice() -> Bool {
+        lock.lock()
+        if let height = cachedHeight {
+            lock.unlock()
+            return height <= 1334
+        }
+        lock.unlock()
+
+        let resolved: CGFloat
+        if Thread.isMainThread {
+            resolved = MainActor.assumeIsolated { UIScreen.main.nativeBounds.height }
+        } else {
+            resolved = DispatchQueue.main.sync { UIScreen.main.nativeBounds.height }
+        }
+
+        lock.lock()
+        cachedHeight = resolved
+        lock.unlock()
+        return resolved <= 1334
+    }
+}
+
 /// Reclaims disk space under the per-account content directory by evicting
 /// least-recently-used files until total usage + the anticipated next-write
 /// fits under the budget. Atomically flips evicted books' registry records
@@ -39,7 +83,7 @@ final class DiskBudgetManager {
         accountsManager: AccountsManager = AppContainer.production().accountsManager,
         bookFileManager: BookFileManager? = nil,
         fileManager: FileManager = .default,
-        isSmallDevice: @escaping () -> Bool = { UIScreen.main.nativeBounds.height <= 1334 }
+        isSmallDevice: @escaping () -> Bool = { SmallDeviceResolver.shared.isSmallDevice() }
     ) {
         self.bookRegistry = bookRegistry
         self.accountsManager = accountsManager

--- a/Palace/MyBooks/DownloadCancellationHandler.swift
+++ b/Palace/MyBooks/DownloadCancellationHandler.swift
@@ -36,7 +36,16 @@ protocol DownloadCancellationHandlerDelegate: AnyObject {
 
 // MARK: - DownloadCancellationHandler
 
-final class DownloadCancellationHandler {
+/// - Sendable invariant (Swift 6 `complete`-mode): the stored dependencies
+///   (`stateManager`, `bookRegistry`, `adobeDRMService`) are all `let` bound at
+///   init; the only mutable member is `weak var delegate`, assigned exactly once
+///   during owner (`MyBooksDownloadCenter`) construction and never reassigned
+///   (weak-ref reads + ARC zeroing are atomic). The cancel paths hop teardown
+///   into `Task { }` / the URLSession `cancel` completion, touching only the
+///   actor-serialized `stateManager.downloadCoordinator` / `SafeDictionary`
+///   members and the main-thread `delegate` callbacks. `@unchecked` only
+///   because the stored service types are not themselves `Sendable`.
+final class DownloadCancellationHandler: @unchecked Sendable {
 
     /// Bookkeeping states that signify a download or borrow is in flight
     /// without a URL session task — cancellation must clean these up.

--- a/Palace/MyBooks/DownloadErrorRecovery.swift
+++ b/Palace/MyBooks/DownloadErrorRecovery.swift
@@ -13,13 +13,18 @@ actor DownloadErrorRecovery {
 
     // MARK: - Retry Policy
 
-    struct RetryPolicy {
+    struct RetryPolicy: Sendable {
         let maxAttempts: Int
         let baseDelay: TimeInterval
         let maxDelay: TimeInterval
         /// Overall timeout for all retry attempts combined (prevents indefinite freezing)
         let overallTimeout: TimeInterval
-        let shouldRetry: (Error) -> Bool
+        /// `@Sendable`: every assigned classifier below is a pure, capture-free
+        /// closure over the passed-in `Error`, so it is safe to share across the
+        /// actor boundary. Required for the enclosing `RetryPolicy` to be
+        /// `Sendable` and thus a valid `static let` on the `DownloadErrorRecovery`
+        /// actor.
+        let shouldRetry: @Sendable (Error) -> Bool
 
         static let `default` = RetryPolicy(
             maxAttempts: 3,

--- a/Palace/MyBooks/DownloadProgressPublisher.swift
+++ b/Palace/MyBooks/DownloadProgressPublisher.swift
@@ -33,7 +33,18 @@ protocol DownloadProgressPublishing: AnyObject {
 
 /// Handles Combine-based progress reporting, error publishing, and
 /// throttled broadcast notifications for download state changes.
-final class DownloadProgressReporter: DownloadProgressPublishing {
+///
+/// - Sendable invariant (Swift 6 `complete`-mode): the stored dependencies
+///   (`accessibilityAnnouncements`, `downloadAnnouncementService`) plus the two
+///   `PassthroughSubject` publishers are `let` bound at init. All broadcast-
+///   throttling mutable state (`lastBroadcastTime`, `pendingBroadcast`) is
+///   `@MainActor`-isolated and only touched inside the `@MainActor` broadcast
+///   methods. The one non-isolated mutable member is `weak var notificationSender`,
+///   assigned once by the owner during composition-root wiring (weak-ref reads +
+///   ARC zeroing are atomic). `sendProgress` / `broadcastUpdate` hop to
+///   `@MainActor` before touching any of that state. `@unchecked` only because
+///   the stored service types are not themselves `Sendable`.
+final class DownloadProgressReporter: DownloadProgressPublishing, @unchecked Sendable {
 
     // MARK: - Publishers
 

--- a/Palace/MyBooks/DownloadQueueOrchestrator.swift
+++ b/Palace/MyBooks/DownloadQueueOrchestrator.swift
@@ -43,7 +43,17 @@ protocol DownloadQueueOrchestratorDelegate: AnyObject {
 /// Coordinates the pending-download queue: parks books past the
 /// concurrency cap with the right state-broadcast UX, and pumps the
 /// queue whenever capacity opens up.
-final class DownloadQueueOrchestrator {
+///
+/// - Sendable invariant (Swift 6 `complete`-mode): the stored dependencies
+///   (`bookRegistry`, `stateManager`, `notificationCenter`) are all `let` bound
+///   at init; the only mutable member is `weak var delegate`, assigned exactly
+///   once during owner (`MyBooksDownloadCenter`) construction and never
+///   reassigned (weak-ref reads + ARC zeroing are atomic). The enqueue / pump
+///   paths hop into `Task { }`, touching only the actor-serialized
+///   `stateManager.downloadCoordinator` and posting on `notificationCenter`
+///   (thread-safe). `@unchecked` only because the stored service types are not
+///   themselves `Sendable`.
+final class DownloadQueueOrchestrator: @unchecked Sendable {
 
     weak var delegate: DownloadQueueOrchestratorDelegate?
 

--- a/Palace/MyBooks/DownloadStartCoordinator.swift
+++ b/Palace/MyBooks/DownloadStartCoordinator.swift
@@ -49,7 +49,36 @@ protocol DownloadStartCoordinatorDelegate: AnyObject {
 
 // MARK: - DownloadStartCoordinator
 
-final class DownloadStartCoordinator {
+/// - Sendable invariant (Swift 6 `complete`-mode): every stored dependency is a
+///   `let` bound at init (`stateManager`, `bookRegistry`, `userAccountProvider`,
+///   `currentAccountIdProvider`, `errorActivityTracker`, `queueOrchestrator`,
+///   and the three closure-injected per-state handlers). The only mutable member
+///   is `weak var delegate`, assigned exactly once during owner
+///   (`MyBooksDownloadCenter`) construction and never reassigned (weak-ref reads
+///   + ARC zeroing are atomic). `startBorrow` / `startDownloadAsync` hop into
+///   `Task { }`, touching only the actor-serialized
+///   `stateManager.downloadCoordinator` and the injected closures. The captured
+///   account-id (a `String`) is snapshotted into a `let` at start so the
+///   library-swap window stays closed — no auth-host scoping is broadened here.
+///   `@unchecked` only because the stored service types are not themselves
+///   `Sendable`.
+/// Sendable carrier for the non-Sendable `(() -> Void)?` `borrowCompletion`
+/// closure captured by the `sending` `Task` closure in `startBorrow`. Boxing
+/// lets the `Task` capture a Sendable carrier instead of the raw closure,
+/// clearing the "passing closure as a 'sending' parameter" diagnostic WITHOUT
+/// marking `borrowCompletion` `@Sendable` — which would ripple onto every
+/// caller closure (`TokenRefreshInterceptor`, `DownloadStartDispatcher`,
+/// `DownloadAuthRetryHandler`) that captures `[weak delegate]`/`[weak self]`
+/// and mutates non-Sendable state.
+/// INVARIANT — the boxed closure is invoked at most once, inside the single
+/// `startBorrow` `Task` (both the success and `catch` terminal paths), never
+/// concurrently; its own thread-affinity is the caller's contract (unchanged).
+private final class BorrowCompletionBox: @unchecked Sendable {
+    let call: (() -> Void)?
+    init(_ call: (() -> Void)?) { self.call = call }
+}
+
+final class DownloadStartCoordinator: @unchecked Sendable {
 
     weak var delegate: DownloadStartCoordinatorDelegate?
 
@@ -159,6 +188,10 @@ final class DownloadStartCoordinator {
         attemptDownload shouldAttemptDownload: Bool,
         borrowCompletion: (() -> Void)? = nil
     ) {
+        // Swift 6 `complete`: box the non-Sendable `borrowCompletion` before the
+        // `sending` `Task` boundary (see `BorrowCompletionBox`). Boxing avoids
+        // `@Sendable`-ing the param, which would ripple to the caller closures.
+        let borrowCompletionBox = BorrowCompletionBox(borrowCompletion)
         Task { [weak self] in
             guard let self else { return }
             do {
@@ -172,14 +205,14 @@ final class DownloadStartCoordinator {
                     self.delegate?.schedulePendingStartsIfPossible()
                 }
 
-                borrowCompletion?()
+                borrowCompletionBox.call?()
             } catch {
                 Log.error(#file, "Borrow failed: \(error.localizedDescription)")
                 await self.stateManager.downloadCoordinator.registerCompletion(identifier: book.identifier)
                 let remainingCount = await self.stateManager.downloadCoordinator.activeCount
                 Log.info(#file, "📊 Borrow failed for '\(book.title)', released slot, remaining active: \(remainingCount)")
                 self.delegate?.schedulePendingStartsIfPossible()
-                borrowCompletion?()
+                borrowCompletionBox.call?()
             }
         }
     }

--- a/Palace/MyBooks/DownloadThrottlingService.swift
+++ b/Palace/MyBooks/DownloadThrottlingService.swift
@@ -38,7 +38,19 @@ protocol DownloadThrottlingServiceDelegate: AnyObject {
 /// Concurrency policy for the download center. Suspends non-audiobook tasks
 /// when over the cap, resumes suspended tasks when under it, and re-applies
 /// the cap whenever the app becomes active again.
-final class DownloadThrottlingService {
+///
+/// - Sendable invariant (Swift 6 `complete`-mode): the stored dependencies
+///   (`stateManager`, `notificationCenter`) are `let` bound at init. `weak var
+///   delegate` is assigned exactly once during owner (`MyBooksDownloadCenter`)
+///   construction (weak-ref reads + ARC zeroing are atomic). The only other
+///   mutable member, `didBecomeActiveObserver`, is written only in
+///   `setupNetworkMonitoring` (invoked once, on the main thread, during owner
+///   wiring) and read in `deinit` — a single-threaded lifecycle, never touched
+///   from the `Task { }` hops. Those hops touch only the actor-serialized
+///   `stateManager.downloadCoordinator` / `SafeDictionary` members and the
+///   `URLSessionTask` suspend/resume API (thread-safe). `@unchecked` only
+///   because the stored service types are not themselves `Sendable`.
+final class DownloadThrottlingService: @unchecked Sendable {
 
     weak var delegate: DownloadThrottlingServiceDelegate?
 

--- a/Palace/MyBooks/MyBooks/BookListView.swift
+++ b/Palace/MyBooks/MyBooks/BookListView.swift
@@ -11,6 +11,18 @@ private final class PrefetchBooksBox: @unchecked Sendable {
     init(_ books: [TPPBook]) { self.books = books }
 }
 
+/// Carrier box that lets the `ImageLoading` reference cross into the
+/// `@Sendable` detached prefetch task. `ImageLoading` is a class-bound
+/// (`AnyObject`) protocol not yet annotated `Sendable`; the boxed reference is
+/// read-only (only `thumbnailImage(for:)` is called, whose own implementation
+/// is internally synchronized), consumed by exactly one detached task, so
+/// `@unchecked Sendable` is sound. Removable once `ImageLoading` is made
+/// `Sendable` upstream (tracked in RIPPLES.md). Mirrors `PrefetchBooksBox`.
+private final class PrefetchImageLoaderBox: @unchecked Sendable {
+    let loader: ImageLoading
+    init(_ loader: ImageLoading) { self.loader = loader }
+}
+
 struct BookListView: View {
     let books: [TPPBook]
     @Binding var isLoading: Bool
@@ -115,18 +127,20 @@ struct BookListView: View {
         // the AppContainer-owned cache + circuit breaker rather than reaching
         // for TPPBookCoverRegistry.shared. Capture the value to avoid touching
         // the SwiftUI Environment from the detached task.
-        let imageLoader = appContainer.imageLoader
-        // `TPPBook` is a non-Sendable `NSObject`, so `[TPPBook]` cannot cross
-        // into the `@Sendable` detached task under `complete`-mode strict
-        // concurrency. Wrap the snapshot in a carrier box: the array is a
-        // read-only snapshot handed to a single detached task that only reads
-        // each book to fetch its thumbnail — never mutated, never shared with
-        // another consumer — so `@unchecked Sendable` is sound. (Precedent:
-        // `CarPlayImageCompletionBox`, `ReadiumBookmarkBox`.)
+        // `TPPBook` is a non-Sendable `NSObject` and `ImageLoading` is a
+        // class-bound protocol not yet annotated `Sendable`, so neither
+        // `[TPPBook]` nor the loader can cross into the `@Sendable` detached
+        // task under `complete`-mode strict concurrency. Wrap both in carrier
+        // boxes: the array is a read-only snapshot and the loader reference is
+        // read-only (thumbnail fetch only), each handed to a single detached
+        // task — never mutated, never shared with another consumer — so
+        // `@unchecked Sendable` is sound. (Precedent: `CarPlayImageCompletionBox`,
+        // `ReadiumBookmarkBox`.)
         let upcomingBooksBox = PrefetchBooksBox(upcomingBooks)
+        let imageLoaderBox = PrefetchImageLoaderBox(appContainer.imageLoader)
         Task.detached(priority: .utility) {
             for book in upcomingBooksBox.books {
-                _ = await imageLoader.thumbnailImage(for: book)
+                _ = await imageLoaderBox.loader.thumbnailImage(for: book)
             }
         }
 

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -21,7 +21,54 @@ import OverdriveProcessor
 
 // DownloadCoordinator is defined in MyBooksDownloadQueue.swift
 
-@objc class MyBooksDownloadCenter: NSObject, URLSessionDelegate {
+/// Sendable carrier for the non-Sendable `@escaping (URLRequest?) -> Void`
+/// redirection completion handler captured by the `sending` `Task` closure in
+/// `urlSession(_:task:willPerformHTTPRedirection:...)`. Boxing lets the `Task`
+/// capture a Sendable carrier instead of the raw handler, clearing the "passing
+/// closure as a 'sending' parameter" diagnostic. INVARIANT — the session's
+/// `delegateQueue` is `.main` (see the class Sendable invariant), so WebKit/
+/// URLSession delivers this delegate callback on main and the handler is invoked
+/// exactly once, on main, from inside that single `Task`.
+private final class RedirectCompletionBox: @unchecked Sendable {
+    let call: (URLRequest?) -> Void
+    init(_ call: @escaping (URLRequest?) -> Void) { self.call = call }
+}
+
+/// Sendable carrier for a non-Sendable `[String: Any]` failure-metadata
+/// dictionary crossing the `sending` `Task` boundary in `logBookDownloadFailure`.
+/// INVARIANT — the dictionary is fully assembled synchronously before the `Task`
+/// is enqueued and thereafter read-only; only the single logging `Task` consumes
+/// it, so `@unchecked Sendable` waives no real race. Mirrors `BorrowErrorDictBox`.
+private final class DownloadFailureMetadataBox: @unchecked Sendable {
+    let metadata: [String: Any]
+    init(_ metadata: [String: Any]) { self.metadata = metadata }
+}
+
+/// - Sendable invariant (Swift 6 `complete`-mode): `MyBooksDownloadCenter` is a
+///   single long-lived instance owned by `AppContainer` (stored as
+///   `let downloadCenter`, cached behind `OSAllocatedUnfairLock<AppContainer?>`),
+///   which forces the container's stored services to be `Sendable`. The vast
+///   majority of MBDC's stored members are `let`-bound service references; the
+///   handful of mutable `var`s are all single-threaded:
+///     • `session` (`URLSession!`) — created during `setupSession()` at init and
+///       only re-created via main-thread flows (`recreateSessionForMockBackend`,
+///       DEBUG-only, and the reset path); the session's own `delegateQueue` is
+///       `.main`, so every delegate callback lands on the main thread.
+///     • `bookIdentifierOfBookToRemove` — scratch state for the remove-from-device
+///       confirmation alert, written and read only on the main-thread UI flow.
+///     • `reachabilityCancellable` — installed once by `bindReachability()` during
+///       main-thread wiring.
+///   The concurrent teardown/scheduling hops the class performs run through
+///   `Task { }` / `runOnMainAsync` and touch only the actor-serialized
+///   `stateManager` (`SafeDictionary` + `DownloadCoordinator` actor) or hop back
+///   to `@MainActor` before touching UI state — the same execution shape this
+///   flow had under Swift-5 mode. `@unchecked` (rather than a synthesized
+///   conformance) because the `@objc NSObject` base, the `URLSession` delegate
+///   surface, and the shared service types are not themselves `Sendable`; this
+///   conformance formalizes the single-instance, main-delegate-queue serialization
+///   contract and does not change behavior. No auth-error host scoping is
+///   broadened by this conformance.
+@objc class MyBooksDownloadCenter: NSObject, URLSessionDelegate, @unchecked Sendable {
     typealias DisplayStrings = Strings.MyDownloadCenter
 
     /// Optional override used by tests / fault-injection harnesses to pin a
@@ -69,8 +116,8 @@ import OverdriveProcessor
         return accountsManager.userAccount(for: capturedAccountId)
     }
 
-    private var reauthenticator: Reauthenticator
-    var bookRegistry: TPPBookRegistryProvider
+    private let reauthenticator: Reauthenticator
+    let bookRegistry: TPPBookRegistryProvider
     private let accountsManager: AccountsManager
     private let networkExecutor: TPPNetworkExecutor
     private let accessibilityAnnouncements: TPPAccessibilityAnnouncementCenter
@@ -1463,13 +1510,17 @@ extension MyBooksDownloadCenter: URLSessionTaskDelegate {
         newRequest request: URLRequest,
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
+        // Swift 6 `complete`: box the non-Sendable `completionHandler` before the
+        // `sending` `Task` boundary (see `RedirectCompletionBox`). Delivered and
+        // invoked on the session's `.main` delegate queue.
+        let completionBox = RedirectCompletionBox(completionHandler)
         Task {
             let decision = await redirectPolicy.decide(
                 taskIdentifier: task.taskIdentifier,
                 originalScheme: task.originalRequest?.url?.scheme,
                 newRequest: request
             )
-            completionHandler(decision)
+            completionBox.call(decision)
         }
     }
 
@@ -1592,13 +1643,17 @@ extension MyBooksDownloadCenter {
         dict["response"] = downloadTask.response ?? "N/A"
         dict["downloadError"] = downloadTask.error ?? "N/A"
 
-        // Use enhanced logging if enabled
+        // Use enhanced logging if enabled.
+        // Swift 6 `complete`: box the non-Sendable `[String: Any]` metadata before
+        // the `sending` `Task` boundary (see `DownloadFailureMetadataBox`); `dict`
+        // is fully built above and read-only thereafter.
+        let metadataBox = DownloadFailureMetadataBox(dict)
         Task { [weak self] in
             await self?.deviceSpecificErrorMonitor.logDownloadFailure(
                 book: book,
                 reason: reason,
                 error: downloadTask.error,
-                metadata: dict
+                metadata: metadataBox.metadata
             )
         }
     }

--- a/Palace/MyBooks/OverdriveDownloadHandler.swift
+++ b/Palace/MyBooks/OverdriveDownloadHandler.swift
@@ -38,7 +38,18 @@ protocol OverdriveDownloadHandlerDelegate: AnyObject {
 
 /// Coordinates the Overdrive fulfillment redirect → manifest-fetch
 /// flow, plus the loans-feed-out-of-sync defer path.
-final class OverdriveDownloadHandler {
+///
+/// - Sendable invariant (Swift 6 `complete`-mode): every stored dependency is a
+///   `let` bound at init (`bookRegistry`, `stateManager`, `progressReporter`,
+///   `alertPresenter`, `userAccountProvider`, `fulfillBookRequest`,
+///   `manifestRequestFactory`). The only mutable member is `weak var delegate`,
+///   assigned exactly once during owner (`MyBooksDownloadCenter`) construction
+///   and never reassigned (weak-ref reads + ARC zeroing are atomic). The defer
+///   path hops slot-release into a `Task` (touching only the actor-serialized
+///   `stateManager.downloadCoordinator`) and the error announce into
+///   `runOnMainAsync`. `@unchecked` only because the stored service types are
+///   not themselves `Sendable`.
+final class OverdriveDownloadHandler: @unchecked Sendable {
 
     typealias DisplayStrings = Strings.MyDownloadCenter
 
@@ -114,14 +125,18 @@ final class OverdriveDownloadHandler {
     /// the registry and surface a "loan already exists" notice.
     func deferOverdriveFulfillment(for book: TPPBook) {
         Log.warn(#file, "Overdrive audiobook '\(book.title)' routed to fulfillment but default acquisition is still borrow — deferring and syncing loans feed")
+        // Snapshot the Sendable identifier so the concurrency hops below don't
+        // capture the non-Sendable `TPPBook` across the actor / MainActor
+        // boundary under Swift 6 `complete`-mode.
+        let bookIdentifier = book.identifier
         Task { [weak self] in
-            await self?.stateManager.downloadCoordinator.registerCompletion(identifier: book.identifier)
+            await self?.stateManager.downloadCoordinator.registerCompletion(identifier: bookIdentifier)
         }
         bookRegistry.sync()
         runOnMainAsync { [weak self] in
             self?.progressReporter.publishAndAnnounceError(
                 DownloadErrorInfo(
-                    bookId: book.identifier,
+                    bookId: bookIdentifier,
                     title: DisplayStrings.borrowFailed,
                     message: DisplayStrings.loanAlreadyExistsAlertMessage,
                     kind: .borrow


### PR DESCRIPTION
## Swift 6 Phase B — MyBooks download-machinery (borrow/return/download critical-path)

Isolation-only; download state machine + auth-error host scoping unchanged. 8 services + MBDC → documented @unchecked Sendable, lock-backed holders, sending-closure boxes. **Bonus: fixes a latent off-main `UIScreen.main` bug** in DiskBudgetManager (main-hopped cache, ≤1334 threshold preserved). Part of **738 → 0**.

**Two independent SoD APPROVED** (soundness + behavior): every invariant sound, SmallDeviceResolver deadlock-free, 401 host-scoping intact, boxes fire-once, no test ripple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)