### PR TITLE
fix(swift6): mop-up modules → complete-mode 0 (isolation-only, wave 2)

### DIFF
--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -4,7 +4,18 @@ import os
 import PalaceAuth
 import PalaceNetwork
 
-struct AppContainer {
+// Swift 6 `complete` — `@unchecked Sendable` invariant: every stored member is
+// an immutable `let` established once at the composition root and only read
+// thereafter; the struct is a value-typed bag of long-lived DI references
+// (`_cachedValue()` builds it once and hands out copies). It cannot synthesize
+// `: Sendable` because `drmAuthorizerProvider` is a non-`@Sendable` closure and
+// several collaborator classes (`TPPNetworkExecutor`, `AccountsManager`, …) are
+// not yet Sendable-audited upstream — forcing `: Sendable` here would cascade
+// the requirement across the entire DI graph. The value carries no unguarded
+// mutable state of its own, so sharing a copy across the `OSAllocatedUnfairLock`
+// slot and the test-only rebuild `@Sendable` closure is data-race-free. This
+// comment is the documented invariant, not a bare waiver.
+struct AppContainer: @unchecked Sendable {
 
     let bookRegistry: TPPBookRegistryProvider
     let networkExecutor: TPPNetworkExecutor

--- a/Palace/AppInfrastructure/DLNavigator.swift
+++ b/Palace/AppInfrastructure/DLNavigator.swift
@@ -79,13 +79,13 @@ final class DLNavigator: Sendable {
         guard let topViewController = (UIApplication.shared.delegate as? TPPAppDelegate)?.topViewController(),
               let newAccount = accountsManager.account(libraryId)
         else {
-            callOnce(on: .TPPAccountSetDidLoad) { [weak self] _ in
+            callOnce(on: .TPPAccountSetDidLoad) { [weak self] in
                 self?.login(libraryId: libraryId, barcode: barcode)
             }
             return
         }
         if newAccount.uuid != accountsManager.currentAccount?.uuid {
-            callOnce(on: .TPPCurrentAccountDidChange) { [weak self] _ in
+            callOnce(on: .TPPCurrentAccountDidChange) { [weak self] in
                 self?.login(libraryId: libraryId, barcode: barcode)
             }
             DispatchQueue.main.async {
@@ -121,7 +121,13 @@ final class DLNavigator: Sendable {
     // callers drive `@MainActor login(...)`. The observer registers with
     // `queue: .main`, so the block provably runs on the main actor — invoked via
     // `MainActor.assumeIsolated`, not a hop, so timing is unchanged.
-    private func callOnce(on name: Notification.Name, block: @escaping @MainActor @Sendable (_ notification: Notification) -> Void) {
+    //
+    // `complete`: the block takes NO `Notification` argument. Both call sites
+    // ignore the payload (`{ _ in … }`), and passing the non-Sendable
+    // `Notification` into the `@MainActor` block was the "sending 'notification'
+    // risks data races" diagnostic. Dropping the unused argument removes the only
+    // non-Sendable value that crossed the boundary — behavior is unchanged.
+    private func callOnce(on name: Notification.Name, block: @escaping @MainActor @Sendable () -> Void) {
         // Mirror `ObserverTokenBox` (TPPBookRegistry.swift): a self-removing
         // `@Sendable` observer block can't reference a `var token` assigned after
         // the block is formed — the `targeted` checker rejects it as "'token'
@@ -130,12 +136,12 @@ final class DLNavigator: Sendable {
         // thereafter, so `@unchecked Sendable` documents write-once-then-read
         // confinement, not a race waiver.
         let box = ObserverTokenBox()
-        box.token = NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { notification in
+        box.token = NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { _ in
             box.removeObserver(name: name)
             // Provably on main: registered with `queue: .main`. `assumeIsolated`
             // to call the `@MainActor` block without a re-async hop.
             MainActor.assumeIsolated {
-                block(notification)
+                block()
             }
         }
     }

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -152,9 +152,15 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
         // `@MainActor` `isSigningIn` flag. Post can arrive off-main, so hop to the
         // main actor before touching main-actor state (previously `queue: nil`
         // fired on the posting thread — a `complete`-mode data race on `isSigningIn`).
+        //
+        // `complete`: snapshot the Sendable `Bool` payload out of the non-Sendable
+        // `Notification` BEFORE the `@MainActor` Task so we don't `send` the whole
+        // notification across the boundary. `signingIn` only ever reads
+        // `notification.object as? Bool`, so this is behavior-preserving.
         NotificationCenter.default.addObserver(forName: .TPPIsSigningIn, object: nil, queue: .main) { [weak self] notification in
+            let isSigningIn = notification.object as? Bool
             Task { @MainActor in
-                self?.signingIn(notification)
+                self?.setSigningIn(isSigningIn)
             }
         }
     }
@@ -476,9 +482,13 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: - User Sign-in Tracking
 
-    func signingIn(_ notification: Notification) {
-        if let boolValue = notification.object as? Bool {
-            isSigningIn = boolValue
+    /// Updates the `@MainActor` `isSigningIn` flag from the Sendable `Bool`
+    /// snapshotted out of the `.TPPIsSigningIn` notification's `object` at the
+    /// observer boundary (see `addObserver` above). Taking the `Bool` rather than
+    /// the `Notification` keeps a non-Sendable value off the `@MainActor` hop.
+    func setSigningIn(_ isSigningIn: Bool?) {
+        if let isSigningIn {
+            self.isSigningIn = isSigningIn
         }
     }
 

--- a/Palace/CarPlay/CarPlaySceneDelegate.swift
+++ b/Palace/CarPlay/CarPlaySceneDelegate.swift
@@ -18,9 +18,16 @@ import PalaceLogging
 // callback drives main-actor CarPlay UI. Annotating the type is the `complete`-mode
 // fix for the "conformance crosses into the main actor" warning on
 // `CPTemplateApplicationSceneDelegate`; all members are already main-only.
+//
+// `@preconcurrency` on the `CPTemplateApplicationSceneDelegate` conformance: the
+// protocol's requirements are declared `nonisolated` by CarPlay (not yet
+// Sendable/isolation-audited upstream), so a `@MainActor` type satisfying them
+// still trips "conformance crosses into main actor-isolated code." Every callback
+// is delivered on the main thread by CarPlay, so the `@preconcurrency` conformance
+// is the honest ceiling until Apple annotates the protocol.
 @MainActor
 @objc(CarPlaySceneDelegate)
-final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+final class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSceneDelegate {
 
     // MARK: - Properties
 

--- a/Palace/ErrorHandling/TPPPresentationUtils.swift
+++ b/Palace/ErrorHandling/TPPPresentationUtils.swift
@@ -38,9 +38,17 @@ class TPPPresentationUtils: NSObject {
     @objc class func safelyPresent(_ vc: UIViewController,
                                    animated: Bool = true,
                                    completion: (() -> Void)? = nil) {
+        // Box the non-`Sendable` UIKit payload ONCE, here in the nonisolated
+        // function region, before any `@Sendable` boundary. Every downstream use
+        // (the off-main hop, the coordinator completion, the nested main.async)
+        // reads `payload.viewController` / `payload.completion` from the
+        // `@unchecked Sendable` carrier rather than re-capturing `vc`/`completion`
+        // directly — which is what produced the "sending 'completion' risks data
+        // races" diagnostic when the box was rebuilt inside `assumeIsolated`.
+        let payload = MainActorPresentation(vc, completion)
+
         // Ensure this block is always executed on the main thread
         if !Thread.isMainThread {
-            let payload = MainActorPresentation(vc, completion)
             DispatchQueue.main.async {
                 safelyPresent(payload.viewController, animated: animated, completion: payload.completion)
             }
@@ -71,7 +79,7 @@ class TPPPresentationUtils: NSObject {
             }
 
             if let baseNavController = base as? UINavigationController,
-               let inputNavController = vc as? UINavigationController,
+               let inputNavController = payload.viewController as? UINavigationController,
                baseNavController.viewControllers.count == inputNavController.viewControllers.count,
                let baseVC = baseNavController.viewControllers.first,
                let inputVC = inputNavController.viewControllers.first {
@@ -88,13 +96,12 @@ class TPPPresentationUtils: NSObject {
             // the in-flight transition to complete, then re-walk to the (possibly
             // new) topmost VC and present there. HelpSpot 17716 follow-up.
             if let coordinator = base.transitionCoordinator {
-                // Box the non-Sendable UIKit payload BEFORE the escaping coordinator
-                // completion so only the @unchecked-Sendable carrier crosses the
-                // closure boundary — `vc`/`completion` themselves never cross. The
-                // box is built, and later read, only on the main actor (both the
-                // coordinator completion and the nested main.async run on main), so
-                // the transfer is data-race-free. Dispatch structure unchanged.
-                let payload = MainActorPresentation(vc, completion)
+                // Only the `@unchecked Sendable` `payload` carrier (built once at
+                // function entry) crosses the escaping coordinator completion —
+                // `vc`/`completion` themselves never cross. The box is built, and
+                // later read, only on the main actor (both the coordinator
+                // completion and the nested main.async run on main), so the
+                // transfer is data-race-free. Dispatch structure unchanged.
                 coordinator.animate(alongsideTransition: nil) { _ in
                     DispatchQueue.main.async {
                         safelyPresent(payload.viewController, animated: animated, completion: payload.completion)
@@ -103,7 +110,7 @@ class TPPPresentationUtils: NSObject {
                 return
             }
 
-            base.present(vc, animated: animated, completion: completion)
+            base.present(payload.viewController, animated: animated, completion: payload.completion)
         }
     }
 }

--- a/Palace/PDF/Extensions/Binding+onChange.swift
+++ b/Palace/PDF/Extensions/Binding+onChange.swift
@@ -14,11 +14,16 @@ extension Binding {
     /// - Returns: Binding with the provided handler
     ///
     /// This is a workaround for iOS versions prior to 14, where SwiftUI doesn't have `.onChange` modifier
-    // `@MainActor @Sendable`: SwiftUI's `Binding.init(get:set:)` closures are
-    // `@MainActor @Sendable` under `complete`, so the captured `handler` must match.
-    // Its callers (`TPPPDFSearchView`, `TPPPDFNavigation`) pass `@MainActor` View
-    // methods, so this is a no-op for them. Resolves the closure-capture warnings on
-    // the `get`/`set` bodies.
+    // `@MainActor`: SwiftUI's `Binding.init(get:set:)` closures are `@MainActor
+    // @Sendable` under `complete`. Those closures capture `self` (a
+    // `Binding<Value>`, which is not `Sendable`) — a capture the checker rejects
+    // in a bare `@Sendable` context. Isolating `onChange` itself to the main actor
+    // makes `self` a main-actor-isolated value, and a `@MainActor @Sendable`
+    // closure may capture main-actor-isolated non-`Sendable` values without a data
+    // race, which clears the `self`-capture and `sending 'newValue'` diagnostics on
+    // the `get`/`set` bodies. Callers (`TPPPDFSearchView`, `TPPPDFNavigation`) are
+    // SwiftUI `View`s already on the main actor, so this is a no-op for them.
+    @MainActor
     func onChange(_ handler: @escaping @MainActor @Sendable (Value) -> Void) -> Binding<Value> {
         return Binding(
             get: { self.wrappedValue },

--- a/Palace/PDF/Views/TPPPDFDocumentView.swift
+++ b/Palace/PDF/Views/TPPPDFDocumentView.swift
@@ -72,7 +72,17 @@ struct TPPPDFDocumentView: UIViewRepresentable {
         return Coordinator(currentPage: $metadata.currentPage)
     }
 
-    class Coordinator: NSObject, PDFViewDelegate {
+    // `@MainActor` + `@preconcurrency PDFViewDelegate`: the coordinator holds a
+    // `@Binding` and drives main-actor SwiftUI state. Previously the nonisolated
+    // `pdfViewPerformGo` requirement forced a `MainActor.assumeIsolated` block that
+    // captured `self` (the non-`Sendable` `Coordinator`) into a `@Sendable`
+    // closure — the "sending 'self' risks data races" diagnostic. Isolating the
+    // whole coordinator to the main actor and satisfying the nonisolated PDFKit
+    // requirement via `@preconcurrency` removes the send: PDFKit delivers
+    // `PDFViewDelegate` callbacks on the main thread, so the main-actor method is a
+    // faithful, race-free implementation.
+    @MainActor
+    class Coordinator: NSObject, @preconcurrency PDFViewDelegate {
         @Binding var currentPage: Int
 
         init(currentPage: Binding<Int>) {
@@ -80,14 +90,8 @@ struct TPPPDFDocumentView: UIViewRepresentable {
         }
 
         func pdfViewPerformGo(toPage sender: PDFView) {
-            // PDFKit invokes `PDFViewDelegate` callbacks on the main thread, but
-            // the protocol requirement is nonisolated, so `sender`'s main-actor
-            // `currentPage`/`document` (and the `@Binding currentPage` write) must
-            // be reached through an explicit main-actor assumption.
-            MainActor.assumeIsolated {
-                if let page = sender.currentPage, let pageIndex = sender.document?.index(for: page) {
-                    currentPage = pageIndex
-                }
+            if let page = sender.currentPage, let pageIndex = sender.document?.index(for: page) {
+                currentPage = pageIndex
             }
         }
     }

--- a/Palace/PDF/Views/TPPPDFNavigation.swift
+++ b/Palace/PDF/Views/TPPPDFNavigation.swift
@@ -77,7 +77,13 @@ struct TPPPDFNavigation<Content>: View where Content: View {
                 .accessibilityLabel(Strings.Generic.tableOfContents)
                 .visible(when: !isShowingPdfContorls)
 
-                Picker("", selection: $pickerSelection.onChange(changeReaderMode)) {
+                // `complete`: pass a closure literal rather than the bare
+                // `changeReaderMode` method value. A method reference is a
+                // non-`Sendable` function value, so converting it to the
+                // `@MainActor @Sendable` `onChange` parameter warns; a closure
+                // literal formed in this main-actor `View` is inferred `@MainActor
+                // @Sendable` and captures only main-actor-isolated `self`.
+                Picker("", selection: $pickerSelection.onChange { changeReaderMode($0) }) {
                     ForEach(TPPPDFReaderModeValues.allValues) { readerModeValue in
                         readerModeValue.image
                             .tag(readerModeValue.rawValue)

--- a/Palace/PDF/Views/TPPPDFSearchView.swift
+++ b/Palace/PDF/Views/TPPPDFSearchView.swift
@@ -40,7 +40,12 @@ struct TPPPDFSearchView: View {
             // PP-4421: explicit prompt with `.secondary` foreground overrides
             // the default `.placeholderText` (~30% gray) that reads as
             // disabled. Entered text retains its own .foregroundColor.
-            TextField(Strings.Generic.search, text: $searchText.onChange(performSearch),
+            // `complete`: closure literal rather than the bare `performSearch`
+            // method value — the method reference is a non-`Sendable` function
+            // value that warns when converted to `onChange`'s `@MainActor
+            // @Sendable` parameter; the literal is inferred `@MainActor @Sendable`
+            // in this main-actor `View`.
+            TextField(Strings.Generic.search, text: $searchText.onChange { performSearch(string: $0) },
                       prompt: Text(Strings.Generic.search).foregroundColor(.secondary))
                 .palaceFont(.body)
                 .frame(minHeight: 44)

--- a/Palace/PDF/Views/TPPPDFView.swift
+++ b/Palace/PDF/Views/TPPPDFView.swift
@@ -78,11 +78,7 @@ struct TPPPDFView: View {
             // injected, and the view is mounted before any long-press
             // gesture can fire.
             pdfView.allowsCopy = !metadata.book.isDRMProtected
-            Task {
-                if let title = await fetchDocumentTitle() {
-                    documentTitle = title
-                }
-            }
+            documentTitle = resolveDocumentTitle()
         }
         .onReceive(pageChangePublisher) { value in
             if let pdfView = (value.object as? PDFView), let page = pdfView.currentPage, let pageIndex = pdfView.document?.index(for: page) {
@@ -110,7 +106,20 @@ struct TPPPDFView: View {
         UIAccessibility.post(notification: .pageScrolled, argument: status)
     }
 
-    private func fetchDocumentTitle() async -> String? {
-        try? await document.title() ?? metadata.book.title
+    /// Resolves the document title synchronously on the main actor.
+    ///
+    /// `complete` (structural fix): the prior `try? await document.title()` sent
+    /// the non-`Sendable` PDFKit `PDFDocument` across the `await` boundary
+    /// ("sending 'self.document' risks data races"), which `@preconcurrency import
+    /// PDFKit` does not clear because the send is of the concrete document value,
+    /// not a cross-module type-annotation issue. PDFKit exposes the title
+    /// synchronously via `documentAttributes[.titleAttribute]` — the same read
+    /// `TPPPDFDocument.title` performs — so we read it here on the current (main)
+    /// actor without ever crossing an isolation boundary. `TPPPDFView` is a
+    /// main-actor `View` and `document` is main-actor-held, so this is
+    /// behavior-preserving and strictly cheaper (no Task/await hop).
+    private func resolveDocumentTitle() -> String {
+        let attributeTitle = document.documentAttributes?[PDFDocumentAttribute.titleAttribute] as? String
+        return attributeTitle ?? metadata.book.title
     }
 }

--- a/Palace/Samples/EpubSamplePlayer/EpubSampleFactory.swift
+++ b/Palace/Samples/EpubSamplePlayer/EpubSampleFactory.swift
@@ -22,7 +22,10 @@ import PalaceLogging
     }
 }
 
-@objc class EpubSampleWebURL: EpubLocationSampleURL {}
+// `@unchecked Sendable` restated: Swift requires a subclass to re-declare an
+// inherited `@unchecked Sendable` conformance. Same write-once-then-read `url`
+// invariant as the `EpubLocationSampleURL` superclass — no added mutable state.
+@objc class EpubSampleWebURL: EpubLocationSampleURL, @unchecked Sendable {}
 
 /// Carries the non-`Sendable` `createSample` completion across the `@Sendable`
 /// `fetchSample` / `main.async` boundaries. Invoked exactly once. Mirrors

--- a/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
+++ b/Palace/Settings/Debug/MockBackend/MockBackendURLProtocol.swift
@@ -50,6 +50,16 @@ private final class MockBackendConfigStore: @unchecked Sendable {
     }
 }
 
+/// Carries the `@unchecked Sendable` `MockBackendURLProtocol` instance across the
+/// `@Sendable` `DispatchQueue.main.async` boundary in `deliverResponse` as a single
+/// owned handoff — the region-analysis-friendly form of "send `self` to main."
+/// The URL Loading System owns the protocol instance for the request lifetime and
+/// the finish callback fires once, so the strong reference is safe.
+private final class MockProtocolBox: @unchecked Sendable {
+    let value: MockBackendURLProtocol
+    init(_ value: MockBackendURLProtocol) { self.value = value }
+}
+
 // Swift 6 `complete` — `@unchecked Sendable` invariant: this `URLProtocol` subclass
 // has NO instance stored properties of its own — all configuration lives in the
 // lock-backed `static let config` (`MockBackendConfigStore`, itself
@@ -263,9 +273,16 @@ final class MockBackendURLProtocol: URLProtocol, @unchecked Sendable {
         // progressData may be empty when it tries to parse the problem document.
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: data)
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.client?.urlProtocolDidFinishLoading(self)
+        // `complete`: box `self` (an `@unchecked Sendable` `URLProtocol` subclass)
+        // into a carrier before the `@Sendable` `main.async` closure so the
+        // region checker sees a single owned handoff rather than "sending 'self'
+        // risks data races." The URL Loading System owns this protocol instance
+        // for the request's lifetime, and the finish callback runs exactly once,
+        // so the strong reference in the box is safe. Dispatch timing unchanged.
+        let selfBox = MockProtocolBox(self)
+        DispatchQueue.main.async {
+            let this = selfBox.value
+            this.client?.urlProtocolDidFinishLoading(this)
         }
     }
 

--- a/Palace/Utilities/Concurrency/TPPBackgroundExecutor.swift
+++ b/Palace/Utilities/Concurrency/TPPBackgroundExecutor.swift
@@ -98,9 +98,10 @@ import PalaceLogging
     /// `@Sendable` `beginBackgroundTask` expiration handler, the `endQueue`/main
     /// hops in `endTaskIfNeeded`, and the `startBackground` closure. A by-ref
     /// captured `var bgTask` is a data race under strict concurrency, so we hold it
-    /// in a lock-backed carrier box shared by all those closures. The lock also makes
-    /// the "begin → end → invalidate" transition atomic (previously the identifier
-    /// was a plain local, relying on queue ordering). Not `nonisolated(unsafe)`:
+    /// in a lock-backed carrier box shared by all those closures. The lock guards
+    /// each individual get/set of the identifier (the begin→end→invalidate sequence
+    /// itself is kept single-entry by the existing `isEndingTask`/`endLock` guard +
+    /// main-thread serialization, not by this lock). Not `nonisolated(unsafe)`:
     /// the box is a documented, lock-guarded holder, not a race waiver.
     private final class BackgroundTaskIDBox: @unchecked Sendable {
         private let lock = NSLock()
@@ -116,7 +117,12 @@ import PalaceLogging
 
         let endQueue = DispatchQueue(label: "com.thepalaceproject.backgroundEndQueue", qos: .userInitiated)
 
-        func endTaskIfNeeded(context: String) {
+        // `@Sendable`: `endTaskIfNeeded` is invoked from the `@Sendable`
+        // `beginBackgroundTask` expiration handler and the owner work item, so the
+        // `complete` checker requires it to be `@Sendable`. Its captures are all
+        // Sendable — `self` is `@unchecked Sendable`, `endQueue` is a `let`
+        // `DispatchQueue`, and `bgTaskBox` is `@unchecked Sendable`.
+        @Sendable func endTaskIfNeeded(context: String) {
             endQueue.async { [weak self] in
                 guard let self = self else { return }
 
@@ -136,28 +142,39 @@ import PalaceLogging
                 // must be called on main thread, so async is the correct pattern here.
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
+                    // Provably on main (dispatched to `DispatchQueue.main`);
+                    // `assumeIsolated` lets the `@MainActor` `UIApplication.shared`
+                    // calls run without another hop under `complete`.
+                    MainActor.assumeIsolated {
+                        let timeRemaining = UIApplication.shared.backgroundTimeRemaining
 
-                    let timeRemaining = UIApplication.shared.backgroundTimeRemaining
-
-                    Log.info(#file, """
+                        Log.info(#file, """
             \(context) \(self.taskName) background task \(bgTaskBox.rawValue). \
             Time remaining: \(timeRemaining)
             """)
 
-                    let currentTask = bgTaskBox.get()
-                    if currentTask != .invalid {
-                        UIApplication.shared.endBackgroundTask(currentTask)
-                        bgTaskBox.set(.invalid)
-                    }
+                        let currentTask = bgTaskBox.get()
+                        if currentTask != .invalid {
+                            UIApplication.shared.endBackgroundTask(currentTask)
+                            bgTaskBox.set(.invalid)
+                        }
 
-                    self.endLock.lock()
-                    self.isEndingTask = false
-                    self.endLock.unlock()
+                        self.endLock.lock()
+                        self.isEndingTask = false
+                        self.endLock.unlock()
+                    }
                 }
             }
         }
 
-        let startBackground: () -> Void = {
+        // `@MainActor @Sendable`: `startBackground` calls `@MainActor`
+        // `UIApplication.shared.beginBackgroundTask` (line below) and is scheduled
+        // onto `DispatchQueue.main` in the non-main branch — so it must be both
+        // main-actor-isolated (to touch `UIApplication.shared`) and `@Sendable`
+        // (to cross `main.async`). The `beginBackgroundTask` expiration handler is
+        // itself a `@Sendable @convention(block)`; it only calls the now-`@Sendable`
+        // `endTaskIfNeeded`.
+        let startBackground: @MainActor @Sendable () -> Void = {
             bgTaskBox.set(UIApplication.shared.beginBackgroundTask(withName: self.taskName) {
                 endTaskIfNeeded(context: "Expiring")
             })
@@ -179,13 +196,38 @@ import PalaceLogging
                 return
             }
 
-            self.queue.async(execute: workItem)
+            // `workItem` is the owner-supplied `(() -> Void)?` — a non-`Sendable`
+            // function value. Box it so the `queue.async(execute:)` `@Sendable
+            // @convention(block)` conversion is an explicit, documented single-use
+            // handoff rather than an implicit non-Sendable conversion. The work
+            // item is invoked exactly once on `self.queue`.
+            let workItemBox = WorkItemBox(workItem)
+            self.queue.async {
+                workItemBox.run()
+            }
         }
 
         if Thread.isMainThread {
-            startBackground()
+            // Provably on main; call the `@MainActor` closure without a re-hop.
+            MainActor.assumeIsolated {
+                startBackground()
+            }
         } else {
-            DispatchQueue.main.async(execute: startBackground)
+            DispatchQueue.main.async {
+                startBackground()
+            }
         }
     }
+}
+
+/// Carries the owner-supplied, non-`Sendable` background work item across the
+/// `@Sendable` `DispatchQueue.async` boundary in `dispatchBackgroundWork()`. The
+/// item is created by the owner (via `setUpWorkItem(wrapping:)`) and executed
+/// exactly once on the executor's serial background queue, so wrapping it in an
+/// `@unchecked Sendable` carrier is a documented single-use handoff, not a race
+/// waiver.
+private final class WorkItemBox: @unchecked Sendable {
+    private let work: () -> Void
+    init(_ work: @escaping () -> Void) { self.work = work }
+    func run() { work() }
 }


### PR DESCRIPTION
## Swift 6 Phase B — mop-up (non-critical, wave 2)

AppInfrastructure/CarPlay/ErrorHandling/PDF/Samples/Settings/Utilities. Isolation-only. Includes the structural `TPPPDFView:114` fix (synchronous documentAttributes read — document no longer crosses isolation). Part of **738 → 0**.

**Independent review APPROVED**: invariants true (one comment corrected), TPPPDFView title read behavior-equivalent, assumeIsolated provably-main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)