### PR TITLE
docs(swift6): Phase C handoff — language-mode flip WIP + remaining layers

### DIFF
--- a/.forgeos/handoffs/phasec-progress-2026-07-07.patch
+++ b/.forgeos/handoffs/phasec-progress-2026-07-07.patch
@@ -1,0 +1,271 @@
+diff --git a/Palace.xcodeproj/project.pbxproj b/Palace.xcodeproj/project.pbxproj
+index 368aa90c5..eb0f4b716 100644
+--- a/Palace.xcodeproj/project.pbxproj
++++ b/Palace.xcodeproj/project.pbxproj
+@@ -8983,9 +8983,9 @@
+ 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG SIMPLYE";
+ 				SWIFT_OBJC_BRIDGING_HEADER = "Palace/AppInfrastructure/Palace-Bridging-Header.h";
+ 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+-				SWIFT_STRICT_CONCURRENCY = targeted;
++				SWIFT_STRICT_CONCURRENCY = complete;
+ 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+-				SWIFT_VERSION = 5.0;
++				SWIFT_VERSION = 6.0;
+ 				TARGETED_DEVICE_FAMILY = "1,2";
+ 				WARNING_CFLAGS = (
+ 					"-Wall",
+@@ -9042,9 +9042,9 @@
+ 				RUN_CLANG_STATIC_ANALYZER = YES;
+ 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SIMPLYE;
+ 				SWIFT_OBJC_BRIDGING_HEADER = "Palace/AppInfrastructure/Palace-Bridging-Header.h";
+-				SWIFT_STRICT_CONCURRENCY = targeted;
++				SWIFT_STRICT_CONCURRENCY = complete;
+ 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+-				SWIFT_VERSION = 5.0;
++				SWIFT_VERSION = 6.0;
+ 				TARGETED_DEVICE_FAMILY = "1,2";
+ 				WARNING_CFLAGS = (
+ 					"-Wall",
+@@ -9231,9 +9231,9 @@
+ 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING LCP FEATURE_OVERDRIVE";
+ 				SWIFT_OBJC_BRIDGING_HEADER = "Palace/AppInfrastructure/Palace-Bridging-Header.h";
+ 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+-				SWIFT_STRICT_CONCURRENCY = targeted;
++				SWIFT_STRICT_CONCURRENCY = complete;
+ 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+-				SWIFT_VERSION = 5.0;
++				SWIFT_VERSION = 6.0;
+ 				TARGETED_DEVICE_FAMILY = "1,2";
+ 				WARNING_CFLAGS = (
+ 					"-Wall",
+@@ -9293,9 +9293,9 @@
+ 				RUN_CLANG_STATIC_ANALYZER = YES;
+ 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING LCP FEATURE_OVERDRIVE";
+ 				SWIFT_OBJC_BRIDGING_HEADER = "Palace/AppInfrastructure/Palace-Bridging-Header.h";
+-				SWIFT_STRICT_CONCURRENCY = targeted;
++				SWIFT_STRICT_CONCURRENCY = complete;
+ 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+-				SWIFT_VERSION = 5.0;
++				SWIFT_VERSION = 6.0;
+ 				TARGETED_DEVICE_FAMILY = "1,2";
+ 				WARNING_CFLAGS = (
+ 					"-Wall",
+diff --git a/Palace/FeatureFlags/RemoteFeatureFlags.swift b/Palace/FeatureFlags/RemoteFeatureFlags.swift
+index 19b209be6..e8ac036da 100644
+--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
++++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
+@@ -158,9 +158,7 @@ final class RemoteFeatureFlags: @unchecked Sendable {
+     func fetchAndActivate() async -> Bool {
+         let success = await FirebaseManager.shared.fetchAndActivateRemoteConfig()
+ 
+-        lock.lock()
+-        lastFetchTime = Date()
+-        lock.unlock()
++        lock.withLock { lastFetchTime = Date() }
+ 
+         return success
+     }
+diff --git a/Palace/MyBooks/BookReturnService.swift b/Palace/MyBooks/BookReturnService.swift
+index 8723f94ad..d40ceaffd 100644
+--- a/Palace/MyBooks/BookReturnService.swift
++++ b/Palace/MyBooks/BookReturnService.swift
+@@ -234,9 +234,7 @@ final class BookReturnService: @unchecked Sendable {
+         let task = Task { [weak self] in
+             await body()
+             guard let self else { return }
+-            self.inFlightLock.lock()
+-            self.inFlightTasks.removeValue(forKey: id)
+-            self.inFlightLock.unlock()
++            self.inFlightLock.withLock { self.inFlightTasks.removeValue(forKey: id) }
+         }
+         inFlightLock.lock()
+         inFlightTasks[id] = task
+@@ -257,9 +255,7 @@ final class BookReturnService: @unchecked Sendable {
+         let task = Task { @MainActor [weak self] in
+             await body()
+             guard let self else { return }
+-            self.inFlightLock.lock()
+-            self.inFlightTasks.removeValue(forKey: id)
+-            self.inFlightLock.unlock()
++            self.inFlightLock.withLock { self.inFlightTasks.removeValue(forKey: id) }
+         }
+         inFlightLock.lock()
+         inFlightTasks[id] = task
+diff --git a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+index 867af8d8c..5133f467b 100644
+--- a/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
++++ b/Palace/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+@@ -208,15 +208,29 @@ extension AdobeDRMContainer: Container {
+         }
+ 
+         do {
+-            var data = Data()
+-            _ = try await archive.extract(entry, consumer: { data.append($0) })
+-            return data
++            // Swift 6: the `extract` consumer closure may execute in a
++            // concurrent context, so a captured `var data` is a data race.
++            // Accumulate into a lock-backed box (chunks arrive sequentially;
++            // the lock documents the invariant and satisfies the checker).
++            let accumulator = ArchiveDataAccumulator()
++            _ = try await archive.extract(entry, consumer: { accumulator.append($0) })
++            return accumulator.data
+         } catch {
+             return nil
+         }
+     }
+ }
+ 
++/// Lock-backed `Data` accumulator for `Archive.extract`'s `@Sendable` consumer
++/// closure (Swift 6 `complete`): chunks are appended under an `NSLock` so the
++/// captured accumulator is race-free even though extraction is sequential.
++private final class ArchiveDataAccumulator: @unchecked Sendable {
++    private let lock = NSLock()
++    private var storage = Data()
++    func append(_ chunk: Data) { lock.withLock { storage.append(chunk) } }
++    var data: Data { lock.withLock { storage } }
++}
++
+ /// A DRM-enabled Resource that decrypts (decodes) its data once and then serves
+ /// range requests (to support pagination) using the cached decrypted data.
+ public actor DRMDataResource: Resource {
+diff --git a/Palace/SignInLogic/TPPSignInBusinessLogic+DRM.swift b/Palace/SignInLogic/TPPSignInBusinessLogic+DRM.swift
+index dc7020dbf..153f047a9 100644
+--- a/Palace/SignInLogic/TPPSignInBusinessLogic+DRM.swift
++++ b/Palace/SignInLogic/TPPSignInBusinessLogic+DRM.swift
+@@ -134,43 +134,53 @@ extension TPPSignInBusinessLogic {
+       VendorID: \(vendor ?? "N/A")
+       """)
+ 
++        // Box the non-Sendable loggingContext in the (@MainActor) enclosing
++        // scope so the @Sendable authorize-completion captures the Sendable box,
++        // not the raw [String: Any].
++        let contextBox = DRMLoggingContextBox(loggingContext: loggingContext)
++
+         drmAuthorizer?
+             .authorize(withVendorID: vendor,
+                        username: username,
+                        password: password) { success, error, deviceID, userID in
+ 
+-                // make sure to cancel the previously scheduled selector
+-                // from the same thread it was scheduled on
+-                TPPMainThreadRun.asyncIfNeeded { [weak self] in
+-                    if let self = self {
+-                        NSObject.cancelPreviousPerformRequests(withTarget: self)
+-                    }
+-                }
+-
+-                Log.info(#file, """
+-                    Activation success: \(success)
+-                    Error: \(error?.localizedDescription ?? "N/A")
+-                    DeviceID: \(deviceID ?? "N/A")
+-                    UserID: \(userID ?? "N/A")
+-                    ***DRM Auth/Activation completion***
+-                    """)
+-
+-                var success = success
+-
+-                if success, let userID = userID, let deviceID = deviceID {
+-                    TPPMainThreadRun.asyncIfNeeded {
++                // Swift 6: the @objc DRM protocol completion is @Sendable
++                // (NYPLADEPT's ObjC block imports @Sendable) and fires from the
++                // Adobe activation thread. All work below touches @MainActor
++                // state (userAccount / libraryAccount / finalizeSignIn), so hop
++                // to the main actor once, carrying the non-Sendable error +
++                // loggingContext in a documented box. Behavior preserved: the
++                // cancel -> set-IDs -> finalize order is unchanged and now runs
++                // as one main-actor unit (set-IDs provably precede finalize).
++                let box = DRMAuthCompletionBox(error: error, loggingContext: contextBox.loggingContext)
++                Task { @MainActor in
++
++                    // cancel the previously scheduled unexpected-delay selector
++                    NSObject.cancelPreviousPerformRequests(withTarget: self)
++
++                    Log.info(#file, """
++                        Activation success: \(success)
++                        Error: \(box.error?.localizedDescription ?? "N/A")
++                        DeviceID: \(deviceID ?? "N/A")
++                        UserID: \(userID ?? "N/A")
++                        ***DRM Auth/Activation completion***
++                        """)
++
++                    var success = success
++
++                    if success, let userID = userID, let deviceID = deviceID {
+                         self.userAccount.setUserID(userID)
+                         self.userAccount.setDeviceID(deviceID)
++                    } else {
++                        success = false
++                        TPPErrorLogger.logLocalAuthFailed(error: box.error as NSError?,
++                                                          library: self.libraryAccount,
++                                                          metadata: box.loggingContext)
+                     }
+-                } else {
+-                    success = false
+-                    TPPErrorLogger.logLocalAuthFailed(error: error as NSError?,
+-                                                      library: self.libraryAccount,
+-                                                      metadata: loggingContext)
+-                }
+ 
+-                self.finalizeSignIn(forDRMAuthorization: success,
+-                                    error: error as NSError?)
++                    self.finalizeSignIn(forDRMAuthorization: success,
++                                        error: box.error as NSError?)
++                }
+             }
+ 
+         // Skip the 25-second timeout timer in test environments to prevent
+@@ -233,3 +243,19 @@ extension TPPSignInBusinessLogic {
+ }
+ 
+ #endif
++
++/// Carrier for the non-Sendable `error` / `loggingContext` handed to the
++/// `@Sendable` DRM-authorization completion and hopped once onto the main
++/// actor. `@unchecked Sendable`: both fields are read-only after construction
++/// and consumed on the main actor exactly once.
++private struct DRMAuthCompletionBox: @unchecked Sendable {
++    let error: Error?
++    let loggingContext: [String: Any]
++}
++
++/// Carrier for the non-Sendable `loggingContext` captured by the `@Sendable`
++/// DRM-authorization completion. Built in the enclosing `@MainActor` scope;
++/// read-only after construction.
++private struct DRMLoggingContextBox: @unchecked Sendable {
++    let loggingContext: [String: Any]
++}
+diff --git a/Palace/SignInLogic/TPPSignInBusinessLogic.swift b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+index e85384d75..60b7eb401 100644
+--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
++++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+@@ -29,8 +29,8 @@ import PalaceAuth
+ @objc protocol TPPDRMAuthorizing: NSObjectProtocol {
+     var workflowsInProgress: Bool {get}
+     func isUserAuthorized(_ userID: String!, withDevice device: String!) -> Bool
+-    func authorize(withVendorID vendorID: String!, username: String!, password: String!, completion: ((Bool, Error?, String?, String?) -> Void)!)
+-    func deauthorize(withUsername username: String!, password: String!, userID: String!, deviceID: String!, completion: ((Bool, Error?) -> Void)!)
++    func authorize(withVendorID vendorID: String!, username: String!, password: String!, completion: (@Sendable (Bool, Error?, String?, String?) -> Void)!)
++    func deauthorize(withUsername username: String!, password: String!, userID: String!, deviceID: String!, completion: (@Sendable (Bool, Error?) -> Void)!)
+ }
+ 
+ // NYPLADEPT's conformance to TPPDRMAuthorizing now lives at
+diff --git a/PalaceTests/Mocks/TPPDRMAuthorizingMock.swift b/PalaceTests/Mocks/TPPDRMAuthorizingMock.swift
+index 2f4ef0a43..bac3efe58 100644
+--- a/PalaceTests/Mocks/TPPDRMAuthorizingMock.swift
++++ b/PalaceTests/Mocks/TPPDRMAuthorizingMock.swift
+@@ -42,13 +42,13 @@ class TPPDRMAuthorizingMock: NSObject, TPPDRMAuthorizing {
+         return isUserAuthorizedReturnValue
+     }
+ 
+-    func authorize(withVendorID vendorID: String!, username: String!, password: String!, completion: ((Bool, Error?, String?, String?) -> Void)!) {
++    func authorize(withVendorID vendorID: String!, username: String!, password: String!, completion: (@Sendable (Bool, Error?, String?, String?) -> Void)!) {
+         authorizeWasCalled = true
+         authorizeCallCount += 1
+         completion(true, nil, deviceID, userID)
+     }
+ 
+-    func deauthorize(withUsername username: String!, password: String!, userID: String!, deviceID: String!, completion: ((Bool, Error?) -> Void)!) {
++    func deauthorize(withUsername username: String!, password: String!, userID: String!, deviceID: String!, completion: (@Sendable (Bool, Error?) -> Void)!) {
+         deauthorizeWasCalled = true
+         deauthorizeCallCount += 1
+         if shouldDeferDeauthorize {

--- a/docs/architecture/swift6-phaseC-handoff-2026-07-07.md
+++ b/docs/architecture/swift6-phaseC-handoff-2026-07-07.md
@@ -1,0 +1,125 @@
+<!-- audit-verified -->
+# Swift 6 Phase C — handoff (2026-07-07)
+
+**Purpose:** pick-up-cold handoff to finish **Phase C** (the `SWIFT_VERSION 5.0 → 6.0`
+language-mode flip). Phase A + Phase B are DONE and merged; Phase C is characterized and
+partially applied (a saved WIP patch), paused at a reviewable checkpoint. Read this before
+resuming. Companion: `swift6-modernization-handoff-2026-07-06.md` (the Phase-B arc + playbook).
+
+Tracked under epic **PP-4717** (PP-4723 = Phase C).
+
+---
+
+## 1. Status
+
+- **Packages → Swift 6:** DONE. **Phase A** (targeted → 0): DONE. **Phase B**
+  (`complete`-mode → 0): **DONE — 738 → 0, all 13 PRs merged** (develop `50faaa34e`,
+  wave-1 #1163-#1186 range + wave-2 #1190-#1196). See the 07-06 handoff for the wave map.
+- **Phase C** (`SWIFT_VERSION 6.0`): **IN PROGRESS, paused.** The flip surfaces a tail of
+  Swift-6-language-mode-only diagnostics (things `complete`-mode under Swift 5 does NOT
+  flag) across app + PalaceAuth-package code, several on auth/DRM critical paths.
+- **Phase D** (PalaceAudiobookToolkit submodule ~5): NOT STARTED, independent.
+
+**Key fact:** Phase B being 0 does NOT make Phase C a no-op. Full Swift 6 language mode adds
+diagnostics `complete`-mode-in-Swift-5 doesn't emit: ObjC-completion-block `@Sendable`
+import mismatches, `NSLock.lock()/unlock()` banned in async contexts, `sending`/captured-var
+in more places, static-mutable-global concurrency-safety, and `@MainActor`-from-nonisolated
+that only errors under full 6 mode. Expect to clear these **layer by layer** (each build
+stops at the first stratum; fixing it reveals the next).
+
+---
+
+## 2. The flip
+
+```bash
+# In the DRM integration worktree (adobe-rmsdk symlinked; recipe in 07-02 handoff §2b/§4):
+ruby scripts/set_strict_concurrency.rb complete          # sets the 4 app configs to complete
+# then flip SWIFT_VERSION 5.0 -> 6.0 in each config block that has complete:
+python3 - Palace.xcodeproj/project.pbxproj <<'PY'
+lines=open('Palace.xcodeproj/project.pbxproj').read().split('\n')
+for i,ln in enumerate(lines):
+    if 'SWIFT_STRICT_CONCURRENCY = complete' in ln:
+        for j in range(i, min(i+8, len(lines))):
+            if 'SWIFT_VERSION = 5.0' in lines[j]:
+                lines[j]=lines[j].replace('5.0','6.0'); break
+open('Palace.xcodeproj/project.pbxproj','w').write('\n'.join(lines))
+PY
+```
+Leaves the `4.2` (legacy) and `""` (inherited) SWIFT_VERSION entries alone. 4 configs flip
+(Palace + Palace-noDRM, Debug+Release). Build the `Palace` DRM scheme; iterate on errors.
+
+---
+
+## 3. WIP already applied (SAVE THIS — do not redo)
+
+A partial fix set is saved at **`scratchpad/phasec-progress.patch`** (7 files, ~271 lines)
+and lives uncommitted in the integ worktree `.claude/worktrees/s6-integ-0706`. If that
+worktree is gone, re-apply the patch onto a fresh integ worktree (flip applied). Layers
+fixed:
+
+1. **DRM protocol `@Sendable`** — `NYPLADEPT` (ObjC++) conforms to the `@objc`
+   `TPPDRMAuthorizing`; its ADEPT completion blocks import `@Sendable` in Swift 6, which
+   must match the protocol requirement. Fix: `@Sendable` on the two protocol completions in
+   `Palace/SignInLogic/TPPSignInBusinessLogic.swift` + the mirror in
+   `PalaceTests/Mocks/TPPDRMAuthorizingMock.swift`. (Tried `@preconcurrency` on the NYPLADEPT
+   conformance first — does NOT silence a function-type-sendability witness mismatch; the
+   protocol must actually gain `@Sendable`.)
+2. **`NSLock.lock()/unlock()` in async** — banned in Swift 6 (`Use async-safe scoped locking`).
+   Convert the async-context pairs to `lock.withLock { … }`:
+   `Palace/FeatureFlags/RemoteFeatureFlags.swift` (1), `Palace/MyBooks/BookReturnService.swift`
+   (2 pairs, inside the `Task` closures — the outer sync locks are fine, leave them).
+3. **AdobeDRM captured-`var` `data`** — `Palace/Reader2/.../AdobeDRMContentProtection.swift`
+   `readDataFromArchive`: the `archive.extract` consumer mutates a captured `var data`. Fix:
+   lock-backed `ArchiveDataAccumulator` (`@unchecked Sendable`).
+4. **[BEHAVIOR-SENSITIVE — SoD REQUIRED] `+DRM` sign-in completion** — making the DRM
+   completion `@Sendable` (layer 1) ripples into `TPPSignInBusinessLogic+DRM.swift`: the
+   completion now runs `@Sendable` from the Adobe activation thread but touches `@MainActor`
+   state (`userAccount`, `libraryAccount`, `finalizeSignIn`). Fix applied: wrap the body in
+   one `Task { @MainActor in … }` hop with strong `self` (preserving original retain), and
+   box the non-Sendable `error` + `loggingContext` (`DRMAuthCompletionBox`, and
+   `DRMLoggingContextBox` hoisted **before** the closure so the `@Sendable` completion
+   captures the box, not the raw `[String:Any]`). **Behavioral note for the reviewer:**
+   cancel → set-IDs → finalize ordering preserved and now runs as one main-actor unit
+   (set-IDs provably precede `finalizeSignIn`, which was NOT guaranteed before). This is the
+   one non-mechanical change and MUST get architect + SoD review.
+
+---
+
+## 4. Layers REMAINING (app-target not yet clean when paused)
+
+Next stratum (layer 8), plus almost certainly more behind it:
+- **`Palace/AppInfrastructure/TPPAppDelegate.swift:132`** — `PalaceAuthTokenProvider.tokenResolver`
+  static property "not concurrency-safe because it involves shared mutable state." The
+  resolver is set at launch. Fix likely lives in the **PalaceAuth package** (make
+  `tokenResolver` a lock-backed holder or `@MainActor`, NOT `nonisolated(unsafe)`). Package
+  change → package build + version consideration.
+- **`Palace/SignInLogic/TPPSignInBusinessLogic+SignOut.swift:475`** — `completeLogOutProcess()`
+  (`@MainActor`) called from a synchronous nonisolated context (`strongSelf.completeLogOutProcess()`
+  inside a nonisolated closure). Fix: main-actor hop.
+- **Then keep going** — each fix reveals the next stratum. Budget for several more layers,
+  and re-run a **fresh-DD** build each time (incremental under-reports).
+
+After app-target is clean: run **`build-for-testing`** (compiles the test target under Swift 6
+— the DRM mock + ~40 `TPPDRMAuthorizingMock` call sites, and any other test ripples), then a
+full `verify-pr.sh --quick` / CI (CI also builds **Palace-noDRM**, which this local DRM build
+does NOT cover — `#if FEATURE_DRM_CONNECTOR` paths differ).
+
+---
+
+## 5. Why this is its own reviewed pass (not a flag-flip)
+
+Phase C touches auth (`TPPSignInBusinessLogic`, `+DRM`, `+SignOut`, PalaceAuth
+`tokenResolver`) and DRM (`AdobeDRMContentProtection`, `NYPLADEPT`) — all critical-path. The
+`+DRM` completion restructure is a genuine behavior change. Per the CLAUDE.md rigor bar these
+get architect + SoD regardless of LOC. Recommended shape:
+1. Resume in a DRM integ worktree; re-apply `phasec-progress.patch`; iterate layers to
+   app-target-clean, then test-target-clean.
+2. Carve **one Phase C PR**: pbxproj flip + all residual fixes + any PalaceAuth package change.
+   Because it spans app + package + auth/DRM, give it 2 SoD (soundness + behavior) with
+   explicit attention to the `+DRM` ordering change and the `tokenResolver` concurrency model.
+3. Merge-on-green (CI verifies both Palace + Palace-noDRM). Then the migration is DONE →
+   optionally Phase D (submodule).
+
+**Do NOT** grind Phase C to merge at the tail of an unrelated long session — the auth/DRM
+changes deserve fresh-eyes review. Phase B (738→0) is already safely landed; there is no
+pressure to rush C.


### PR DESCRIPTION
## Swift 6 Phase C handoff

**Phase B is DONE** — 738 → 0 complete-mode warnings, 13 PRs merged (waves 1+2). **Phase C** (`SWIFT_VERSION 6.0` language-mode flip) is characterized and partially applied, **paused at a reviewable checkpoint** — NOT a trivial flag-flip: full Swift 6 mode surfaces a tail of mode-only diagnostics across app + PalaceAuth-package + auth/DRM code.

### Captures (pick-up-cold)
- The flip recipe (`SWIFT_VERSION 6.0` + complete on the 4 app configs).
- **4 residual layers already fixed** (WIP patch: `.forgeos/handoffs/phasec-progress-2026-07-07.patch`): DRM protocol `@Sendable`, `NSLock`→`withLock`, AdobeDRM `Data` accumulator, and the **behavior-sensitive `+DRM` sign-in completion** main-actor hop.
- **Remaining layers**: `PalaceAuthTokenProvider.tokenResolver` static concurrency-safety (PalaceAuth package), `completeLogOutProcess` hop, + more behind them.
- Why Phase C is its own architect+SoD reviewed pass.

Docs + saved patch only; no production change on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)