### PR TITLE
feat(ui): P2 delight micro-interactions + P3 empty/loading/error states

### DIFF
--- a/.forgeos/intent/ui-polish-p2-p3.md
+++ b/.forgeos/intent/ui-polish-p2-p3.md
@@ -1,0 +1,50 @@
+# Intent: UI polish P2 delight + P3 empty/loading/error states (PP-4747)
+
+## Claims
+- Adds numeric-text roll to the four `StatsCardView` value labels via
+  `.contentTransition(.numericText())` + `accessibleAnimation(PalaceMotion.emphasized, value:)`.
+- Animates `ReadingChartView` marks on data/period change via
+  `accessibleAnimation(PalaceMotion.standard, value: dataPoints)`.
+- Replaces the fragile `asyncAfter` badge-unlock reset in `BadgesView` with a
+  `PhaseAnimator` idle->pop->settle sequence (reduce-motion gated) via a new
+  pure `BadgeUnlockPhase` enum.
+- Adds `.symbolEffect(.bounce, value: currentStreakDays)` to the streak flame in `StatsView`.
+- Swaps the app-rating card's linear `easeInOut` for `PalaceMotion.emphasized`,
+  adds a soft shadow, and gates the card's scale transition on Reduce Motion
+  (new pure `usesScaleTransition`/`cardTransition`/`stepAnimation` seams).
+- Adds PDF micro-interactions: bookmark symbol bounce/replace + success haptic
+  (`TPPPDFNavigation`), numeric page-number transition (`TPPPDFView`), and
+  view-aligned scroll snapping + selection haptic (`PDFThumbnailStrip`).
+- Replaces bare/blank empty + error states with iOS-17 `ContentUnavailableView`
+  in `HoldsView`, `MyBooksView` (adds a "Browse the catalog" button wired to the
+  catalog tab), `TPPPDFSearchView`, `CatalogContentView`, `CatalogLaneMoreView`.
+- Adds opacity cross-fades between skeleton and content in `CatalogView`,
+  `CatalogLaneRowView`, `MyBooksView`.
+- Tidies Holds: sync-error banner gets a move+opacity transition; drops the
+  competing black `ProgressView` overlay in favor of the existing skeleton.
+- Adds `Strings.MyBooksView.browseCatalog`/`.emptyViewTitle`,
+  `Strings.HoldsView.emptyTitle`, `Strings.Catalog.emptyFeedTitle`/`.emptyFeedMessage`.
+
+## Anti-claims
+- No redesigns; presentation/animation-only. No business-logic, data-flow, or
+  navigation-graph changes (the one new nav action is the MyBooks empty-state
+  "Browse the catalog" tab jump, an additive convenience via the existing
+  `tabRouterHub`).
+- Does NOT touch any sibling-owned file: `TPPBaseReaderViewController.swift`,
+  `TPPReaderSettingsView.swift`, `TypographySettingsView.swift`,
+  `AccountDetailView.swift`, `ActionButtonView.swift`, `NormalBookCell.swift`,
+  `AppTabHostView.swift`, `AudiobookMiniPlayerView.swift`,
+  `AudiobookFullPlayerCoverContainer.swift`, `TPPSettingsView.swift`.
+- Does NOT recreate PR2 primitives; routes all animation through
+  `PalaceMotion`/`accessibleAnimation` and haptics through `.palaceHaptic`.
+- Does not regress the SentimentGateView dark-mode contrast fix (button colors untouched).
+
+## Files in scope
+- Palace/Stats/Views/{StatsCardView,ReadingChartView,BadgesView,StatsView}.swift
+- Palace/AppRating/SentimentGateView.swift
+- Palace/PDF/Views/{TPPPDFNavigation,TPPPDFView,PDFThumbnailStrip,TPPPDFSearchView}.swift
+- Palace/Holds/HoldsView.swift
+- Palace/MyBooks/MyBooks/MyBooksView.swift
+- Palace/CatalogUI/Views/{CatalogContentView,CatalogView,CatalogLaneRowView,CatalogLaneMoreView}.swift
+- Palace/Utilities/Localization/Strings.swift
+- PalaceTests/UIPolish/{RatingCardMotionGateTests,BadgeUnlockPhaseTests,PDFSearchEmptyStateTests}.swift (new)

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0000C558B9674F53AF8492BB /* AccountsManagerCancellationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9D88C19C8C537405C71724 /* AccountsManagerCancellationTests.swift */; };
 		002A9388476ED8D595661599 /* LibrariesSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8A6CD8712B3CCDDF937A39 /* LibrariesSectionViewModel.swift */; };
+		006EE98EE31EA8DF3CA73523 /* BadgeUnlockPhaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E415908E010C0F85A1BB8FF2 /* BadgeUnlockPhaseTests.swift */; };
 		00A1B2C3D4E5F60700OPDS2F /* OPDS2CatalogFeed.json in Resources */ = {isa = PBXBuildFile; fileRef = 00A1B2C3D4E5F60700OPDS2E /* OPDS2CatalogFeed.json */; };
 		00C48489D102FD16CBF44882 /* TPPConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16D32877559BE95F5219281 /* TPPConfiguration.swift */; };
 		013A39AA5C934B85B0B66CFD /* HTMLTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B6905F170E4D98A985ABF4 /* HTMLTextViewTests.swift */; };
@@ -794,6 +795,7 @@
 		7D39F891C8E9A0B7DC2A2306 /* MockFeatureFlagProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3432D61958317AD796B90005 /* MockFeatureFlagProvider.swift */; };
 		7D4F1388FDE4E63A7EB91AE3 /* DRMAdversarialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A94705E284922B50327BF8 /* DRMAdversarialTests.swift */; };
 		7E1F3E84BEF373E154E0ABBB /* OPDSFeedServiceStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08345237E25BCCFF8F97B302 /* OPDSFeedServiceStateMachineTests.swift */; };
+		7E81F29BD6AA0CE125189C72 /* PDFSearchEmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6D96AC1DB584DCFBA12420 /* PDFSearchEmptyStateTests.swift */; };
 		7EDBF257762A48948D990532 /* TPPLastReadPositionPosterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BB1056721E445D90C72FFF /* TPPLastReadPositionPosterTests.swift */; };
 		7F5FFA53626E3A4E4CCA54FD /* AudiobookPositionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D3F34D468B2BB51C86A5BA /* AudiobookPositionAdapter.swift */; };
 		7F80D2F9E103BEC1042C3DE1 /* TokenRefreshInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085A2D3663F363348BE14190 /* TokenRefreshInterceptor.swift */; };
@@ -982,6 +984,7 @@
 		AC0001CONTAINERTST000001 /* AppContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0001CONTAINERFILEREF01 /* AppContainerTests.swift */; };
 		AC7976569F7EDBAB30C096A4 /* ThemePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95524DFA311D1BE65A9F5FF3 /* ThemePickerView.swift */; };
 		AC7D22C5A54C9291CD111AC8 /* CatalogAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4609134D5A2D39DD0D8E7DCA /* CatalogAccessibilityTests.swift */; };
+		ACBDBE7639B48440873E4D68 /* RatingCardMotionGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8D27C47B505B4D77B12221 /* RatingCardMotionGateTests.swift */; };
 		ACD99774E1C2C1105D856D3F /* BearerTokenAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA1511F27C932D92C002C86 /* BearerTokenAdapter.swift */; };
 		AD0D1E6A0666A62B8483424F /* ChaosHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70819902FBD142EFF56C93D9 /* ChaosHarness.swift */; };
 		AD12AC7147843740E308406E /* TPPBookButtonsStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2767960A51AB8CB4C0607243 /* TPPBookButtonsStateTests.swift */; };
@@ -2079,6 +2082,7 @@
 		091A2B3C4D5E6F708192A3B4 /* TPPCredentialSnapshotCoherenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPCredentialSnapshotCoherenceTests.swift; sourceTree = "<group>"; };
 		09CAC3762A717783DDE755DD /* AudiobookSessionManagerShutdownTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookSessionManagerShutdownTests.swift; sourceTree = "<group>"; };
 		09CF38F572AE4A88961FCA46 /* AudiobookIssueFixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookIssueFixTests.swift; sourceTree = "<group>"; };
+		0A8D27C47B505B4D77B12221 /* RatingCardMotionGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingCardMotionGateTests.swift; sourceTree = "<group>"; };
 		0ABB253AB7CB4183943EBA6A /* AccountStateStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountStateStore.swift; sourceTree = "<group>"; };
 		0B60466B2029331616A708B4 /* RatingPromptPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingPromptPresenter.swift; sourceTree = "<group>"; };
 		0B9A4E1085F59AB6E4E0AD4C /* SupportSectionDecisionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SupportSectionDecisionTests.swift; sourceTree = "<group>"; };
@@ -2410,6 +2414,7 @@
 		5A569A261B8351C6003B5B61 /* ADEPT.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ADEPT.xcodeproj; path = "adept-ios/ADEPT.xcodeproj"; sourceTree = "<group>"; };
 		5A5B90111B946763002C53E9 /* libc++.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.1.dylib"; path = "usr/lib/libc++.1.dylib"; sourceTree = SDKROOT; };
 		5A5B90141B946CBD002C53E9 /* libstdc++.6.0.9.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libstdc++.6.0.9.dylib"; path = "usr/lib/libstdc++.6.0.9.dylib"; sourceTree = SDKROOT; };
+		5A6D96AC1DB584DCFBA12420 /* PDFSearchEmptyStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFSearchEmptyStateTests.swift; sourceTree = "<group>"; };
 		5A7FF4F347587A08E517F389 /* AlertUtilsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertUtilsTests.swift; sourceTree = "<group>"; };
 		5A8468ADD34076BF5935E56B /* TPPBookAccessibilityLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookAccessibilityLabelTests.swift; sourceTree = "<group>"; };
 		5B500DE51F6502CF4983A267 /* AudiobookMiniPlayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookMiniPlayerView.swift; sourceTree = "<group>"; };
@@ -3001,6 +3006,7 @@
 		E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderFootnoteAccessibility.swift; path = ../../Palace/Reader2/BusinessLogic/TPPReaderFootnoteAccessibility.swift; sourceTree = "<group>"; };
 		E3C9C7A1029274277B31F57E /* OfflineQueueBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineQueueBadge.swift; sourceTree = "<group>"; };
 		E3FF91DFB962417EA742080A /* RetryClassificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryClassificationTests.swift; sourceTree = "<group>"; };
+		E415908E010C0F85A1BB8FF2 /* BadgeUnlockPhaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BadgeUnlockPhaseTests.swift; sourceTree = "<group>"; };
 		E48AE22D7C0BC6134885E9F0 /* TPPProcessInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPProcessInfo.swift; sourceTree = "<group>"; };
 		E48EA85A0DBA077D1BBAD063 /* TPPUserAccountConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPUserAccountConcurrencyTests.swift; sourceTree = "<group>"; };
 		E4F5A6B7C8D9E0F1A2B3C4D5 /* RightsManagementDispatcherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RightsManagementDispatcherTests.swift; sourceTree = "<group>"; };
@@ -4011,6 +4017,17 @@
 			);
 			name = FeatureFlags;
 			path = FeatureFlags;
+			sourceTree = "<group>";
+		};
+		51AE9BB746CCC235C5F50D72 /* UIPolish */ = {
+			isa = PBXGroup;
+			children = (
+				0A8D27C47B505B4D77B12221 /* RatingCardMotionGateTests.swift */,
+				E415908E010C0F85A1BB8FF2 /* BadgeUnlockPhaseTests.swift */,
+				5A6D96AC1DB584DCFBA12420 /* PDFSearchEmptyStateTests.swift */,
+			);
+			name = UIPolish;
+			path = UIPolish;
 			sourceTree = "<group>";
 		};
 		52452B48CF3C52B395874F52 /* LCP */ = {
@@ -5403,6 +5420,7 @@
 				5F80A7E0050FBFEDA0FCD075 /* TPPConfigurationCustomRegistryTests.swift */,
 				4E55AED72A688C44680A7FFA /* FeatureFlags */,
 				8216AF24139B364FD961D583 /* AppRating */,
+				51AE9BB746CCC235C5F50D72 /* UIPolish */,
 			);
 			path = PalaceTests;
 			sourceTree = "<group>";
@@ -7624,6 +7642,9 @@
 				605D9680C739B2C197ABD6E7 /* PalaceMotionTests.swift in Sources */,
 				CFB9211A8DCF38D57C73CD7C /* PalacePressableButtonStyleTests.swift in Sources */,
 				9578AA781B3BA775FBFB8788 /* PalaceHapticTests.swift in Sources */,
+				ACBDBE7639B48440873E4D68 /* RatingCardMotionGateTests.swift in Sources */,
+				006EE98EE31EA8DF3CA73523 /* BadgeUnlockPhaseTests.swift in Sources */,
+				7E81F29BD6AA0CE125189C72 /* PDFSearchEmptyStateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppRating/SentimentGateView.swift
+++ b/Palace/AppRating/SentimentGateView.swift
@@ -15,6 +15,7 @@ import SwiftUI
 /// layer in `AppTabHostView`'s root `ZStack` so it survives tab switches.
 struct SentimentGateView: View {
   @ObservedObject var presenter: RatingPromptPresenter
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   private typealias L = Strings.AppRating
 
@@ -37,10 +38,33 @@ struct SentimentGateView: View {
 
       if let step = presenter.step {
         card(for: step)
-          .transition(.opacity.combined(with: .scale(scale: 0.96)))
+          .transition(Self.cardTransition(reduceMotion: reduceMotion))
       }
     }
-    .animation(.easeInOut(duration: 0.25), value: presenter.step)
+    .animation(Self.stepAnimation(reduceMotion: reduceMotion), value: presenter.step)
+  }
+
+  // MARK: - Reduce-Motion-gated presentation (pure, testable)
+
+  /// The card's enter/exit transition. Under Reduce Motion it collapses to a
+  /// plain opacity fade with no scaling (the prior code always scaled, ignoring
+  /// the setting); otherwise it keeps the subtle opacity + 0.96 scale pop.
+  static func cardTransition(reduceMotion: Bool) -> AnyTransition {
+    usesScaleTransition(reduceMotion: reduceMotion)
+      ? .opacity.combined(with: .scale(scale: 0.96))
+      : .opacity
+  }
+
+  /// Whether the card transition includes a scale component. `false` under
+  /// Reduce Motion. Exposed so the gate can be unit-tested without a host.
+  static func usesScaleTransition(reduceMotion: Bool) -> Bool {
+    !reduceMotion
+  }
+
+  /// Animation for the sentiment -> feedback card swap. Emphasized spring
+  /// normally; `nil` (no animation) under Reduce Motion.
+  static func stepAnimation(reduceMotion: Bool) -> Animation? {
+    PalaceMotion.resolved(PalaceMotion.emphasized, reduceMotion: reduceMotion)
   }
 
   @ViewBuilder
@@ -77,6 +101,7 @@ struct SentimentGateView: View {
       RoundedRectangle(cornerRadius: 16, style: .continuous)
         .fill(Color(.secondarySystemBackground))
     )
+    .shadow(color: .black.opacity(0.18), radius: 16, y: 6)
     .padding(32)
     .accessibilityElement(children: .contain)
     .accessibilityAddTraits(.isModal)

--- a/Palace/CatalogUI/Views/CatalogContentView.swift
+++ b/Palace/CatalogUI/Views/CatalogContentView.swift
@@ -65,6 +65,7 @@ struct CatalogContentView: View {
                             feedContentView
                                 .padding(.vertical, 17)
                                 .id("catalog-content-top")
+                                .accessibleAnimation(PalaceMotion.standard, value: feedIsEmpty)
                         }
                     }
                     .padding(.vertical, 17)
@@ -145,8 +146,21 @@ private extension CatalogContentView {
             .accessibleAnimation(.easeInOut(duration: 0.2), value: isOptimisticLoading)
 
         case .empty:
-            EmptyView()
+            ContentUnavailableView {
+                Label(Strings.Catalog.emptyFeedTitle, systemImage: "books.vertical")
+            } description: {
+                Text(Strings.Catalog.emptyFeedMessage)
+            }
+            .frame(maxWidth: .infinity, minHeight: 240)
+            .transition(.opacity)
         }
+    }
+
+    /// Whether the current feed renders no books (drives the empty-state
+    /// cross-fade animation below).
+    var feedIsEmpty: Bool {
+        if case .empty = content.feed { return true }
+        return false
     }
 }
 

--- a/Palace/CatalogUI/Views/CatalogLaneMoreView.swift
+++ b/Palace/CatalogUI/Views/CatalogLaneMoreView.swift
@@ -347,8 +347,13 @@ private extension CatalogLaneMoreView {
     }
 
     func errorView(_ errorMessage: String) -> some View {
-        Text(errorMessage)
-            .padding()
+        ContentUnavailableView {
+            Label(Strings.Generic.error, systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(errorMessage)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(.opacity)
     }
 
     @ViewBuilder

--- a/Palace/CatalogUI/Views/CatalogLaneRowView.swift
+++ b/Palace/CatalogUI/Views/CatalogLaneRowView.swift
@@ -18,10 +18,13 @@ struct CatalogLaneRowView: View {
 
             if isLoading || books.isEmpty {
                 laneSkeletonScroller
+                    .transition(.opacity)
             } else {
                 scroller
+                    .transition(.opacity)
             }
         }
+        .accessibleAnimation(PalaceMotion.gentle, value: isLoading)
     }
 
     // MARK: - Subviews

--- a/Palace/CatalogUI/Views/CatalogView.swift
+++ b/Palace/CatalogUI/Views/CatalogView.swift
@@ -142,8 +142,16 @@ private extension CatalogView {
                 )
             } else {
                 catalogStateView
+                    .accessibleAnimation(PalaceMotion.gentle, value: isCatalogLoading)
             }
         }
+    }
+
+    /// Whether the catalog is in its initial-load (skeleton) state. Drives the
+    /// skeleton -> content opacity cross-fade.
+    var isCatalogLoading: Bool {
+        if case .loading = viewModel.state { return true }
+        return false
     }
 
     @ViewBuilder
@@ -152,6 +160,7 @@ private extension CatalogView {
         case .loading:
             skeletonList
                 .accessibilityIdentifier(AccessibilityID.Catalog.loadingIndicator)
+                .transition(.opacity)
 
         case .error(let message, let sideloadedLanes):
             errorView(message: message, sideloadedLanes: sideloadedLanes)
@@ -182,6 +191,7 @@ private extension CatalogView {
             .accessibilityIdentifier(AccessibilityID.Catalog.scrollView)
             .accessibilityLabel(Strings.Generic.catalogRegion)
             .accessibilityElement(children: .contain)
+            .transition(.opacity)
 
         case .switchingEntryPoint(let selectors):
             CatalogContentView.switchingEntryPointView(

--- a/Palace/Holds/HoldsView.swift
+++ b/Palace/Holds/HoldsView.swift
@@ -76,10 +76,6 @@ struct HoldsView: View {
                         updater: { _ in }
                     )
                 }
-
-            if model.isLoading {
-                loadingOverlay
-            }
         }
     }
 
@@ -87,6 +83,7 @@ struct HoldsView: View {
         VStack(alignment: .leading, spacing: 0) {
             if let syncError = model.syncError {
                 syncErrorBanner(syncError)
+                    .transition(.move(edge: .top).combined(with: .opacity))
             }
             if model.showSearchSheet {
                 searchBar
@@ -94,6 +91,7 @@ struct HoldsView: View {
             }
             content
         }
+        .accessibleAnimation(PalaceMotion.standard, value: model.syncError?.message)
     }
 
     private func syncErrorBanner(_ error: HoldsViewModel.SyncError) -> some View {
@@ -150,23 +148,15 @@ struct HoldsView: View {
         }
     }
 
-    /// Placeholder text when there are no holds at all
+    /// Empty state shown when the patron has no reserved or held books.
     private var emptyView: some View {
-        Text(DisplayStrings.emptyMessage)
-            .multilineTextAlignment(.center)
-            .foregroundColor(Color(white: 0.667))
-            .background(Color(TPPConfiguration.backgroundColor()))
-            .palaceFont(.body)
-            .padding(.horizontal, 24)
-            .padding(.top, 100)
-    }
-
-    /// Semi‐transparent loading overlay
-    private var loadingOverlay: some View {
-        ProgressView()
-            .scaleEffect(2)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.black.opacity(0.5).ignoresSafeArea())
+        ContentUnavailableView {
+            Label(DisplayStrings.emptyTitle, systemImage: "clock")
+        } description: {
+            Text(DisplayStrings.emptyMessage)
+        }
+        .transition(.opacity)
+        .padding(.horizontal, 24)
     }
 
     /// Leading bar button: "Pick a new library"

--- a/Palace/MyBooks/MyBooks/MyBooksView.swift
+++ b/Palace/MyBooks/MyBooks/MyBooksView.swift
@@ -30,10 +30,13 @@ struct MyBooksView: View {
         ZStack {
             if model.isLoading {
                 BookListSkeletonView(rows: 10)
+                    .transition(.opacity)
             } else {
                 mainContent
+                    .transition(.opacity)
             }
         }
+        .accessibleAnimation(PalaceMotion.gentle, value: model.isLoading)
         .background(Color(TPPConfiguration.backgroundColor()))
         .overlay(alignment: .bottom) { SamplePreviewBarView() }
         .navigationBarTitleDisplayMode(.inline)
@@ -252,12 +255,18 @@ struct MyBooksView: View {
     }
 
     private var emptyView: some View {
-        Text(DisplayStrings.emptyViewMessage)
-            .multilineTextAlignment(.center)
-            .foregroundColor(.gray)
-            .centered()
-            .palaceFont(.body)
-            .accessibilityIdentifier(AccessibilityID.MyBooks.emptyStateView)
+        ContentUnavailableView {
+            Label(DisplayStrings.emptyViewTitle, systemImage: "books.vertical")
+        } description: {
+            Text(DisplayStrings.emptyViewMessage)
+        } actions: {
+            Button(DisplayStrings.browseCatalog) {
+                appContainer.tabRouterHub.navigate(to: .catalog)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .transition(.opacity)
+        .accessibilityIdentifier(AccessibilityID.MyBooks.emptyStateView)
     }
 
     private func setupTabBarForiPad() {

--- a/Palace/PDF/Views/PDFThumbnailStrip.swift
+++ b/Palace/PDF/Views/PDFThumbnailStrip.swift
@@ -51,7 +51,9 @@ struct PDFThumbnailStrip: View {
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)
+                    .scrollTargetLayout()
                 }
+                .scrollTargetBehavior(.viewAligned)
                 .onAppear { proxy.scrollTo(currentPage, anchor: .center) }
                 .onChange(of: currentPage) { page in
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -65,6 +67,8 @@ struct PDFThumbnailStrip: View {
         // and a SwiftUI material renders unreliably over that UIViewRepresentable
         // backdrop, leaving the bar invisible over a white page.
         .background(Color(UIColor.systemBackground))
+        // Selection tick when the visible page changes (tap or snap).
+        .palaceHaptic(.selection, trigger: currentPage)
     }
 }
 

--- a/Palace/PDF/Views/TPPPDFNavigation.swift
+++ b/Palace/PDF/Views/TPPPDFNavigation.swift
@@ -118,6 +118,9 @@ struct TPPPDFNavigation<Content>: View where Content: View {
                     }
                 }
                 .accessibilityLabel(metadata.isBookmarked() ? Strings.TPPBaseReaderViewController.removeBookmark : Strings.TPPBaseReaderViewController.addBookmark)
+                .contentTransition(.symbolEffect(.replace))
+                .symbolEffect(.bounce, value: metadata.isBookmarked())
+                .palaceHaptic(.success, trigger: metadata.isBookmarked())
             }
             .visible(when: !isShowingPdfContorls)
         }

--- a/Palace/PDF/Views/TPPPDFSearchView.swift
+++ b/Palace/PDF/Views/TPPPDFSearchView.swift
@@ -51,16 +51,30 @@ struct TPPPDFSearchView: View {
                 .frame(minHeight: 44)
                 .padding(.horizontal)
             Divider()
-            List {
-                ForEach(searchDelegate.searchResults) { location in
-                    TPPPDFLocationView(location: location)
-                        .onTapGesture {
-                            metadata.currentPage = location.pageNumber
-                            done()
-                        }
+            if Self.showsNoResults(searchText: searchText, resultCount: searchDelegate.searchResults.count) {
+                ContentUnavailableView.search(text: searchText)
+                    .transition(.opacity)
+            } else {
+                List {
+                    ForEach(searchDelegate.searchResults) { location in
+                        TPPPDFLocationView(location: location)
+                            .onTapGesture {
+                                metadata.currentPage = location.pageNumber
+                                done()
+                            }
+                    }
                 }
             }
         }
+        .accessibleAnimation(PalaceMotion.standard, value: searchDelegate.searchResults.count)
+    }
+
+    /// Whether the "no results" empty state should show: a committed query
+    /// (>= 3 chars, matching `SearchDelegate.search`'s threshold) that returned
+    /// zero matches. A shorter/empty query shows the (empty) list instead, so
+    /// the screen doesn't flash "No Results" before the patron has typed enough.
+    static func showsNoResults(searchText: String, resultCount: Int) -> Bool {
+        searchText.count >= 3 && resultCount == 0
     }
 
     func performSearch(string: String) {

--- a/Palace/PDF/Views/TPPPDFView.swift
+++ b/Palace/PDF/Views/TPPPDFView.swift
@@ -49,11 +49,15 @@ struct TPPPDFView: View {
                 TPPPDFLabel(documentTitle)
                     .padding(.top)
                 Spacer()
-                if let pageLabel = document.page(at: metadata.currentPage)?.label, Int(pageLabel) != (metadata.currentPage + 1) {
-                    TPPPDFLabel("\(pageLabel) (\(metadata.currentPage + 1)/\(document.pageCount))")
-                } else {
-                    TPPPDFLabel("\(metadata.currentPage + 1)/\(document.pageCount)")
+                SwiftUI.Group {
+                    if let pageLabel = document.page(at: metadata.currentPage)?.label, Int(pageLabel) != (metadata.currentPage + 1) {
+                        TPPPDFLabel("\(pageLabel) (\(metadata.currentPage + 1)/\(document.pageCount))")
+                    } else {
+                        TPPPDFLabel("\(metadata.currentPage + 1)/\(document.pageCount)")
+                    }
                 }
+                .contentTransition(.numericText(value: Double(metadata.currentPage + 1)))
+                .accessibleAnimation(PalaceMotion.standard, value: metadata.currentPage)
                 if isVoiceOverRunning {
                     VStack(spacing: 0) {
                         Divider()

--- a/Palace/Stats/Views/BadgesView.swift
+++ b/Palace/Stats/Views/BadgesView.swift
@@ -1,5 +1,35 @@
 import SwiftUI
 
+/// Phases for the badge-unlock pop, driven by SwiftUI's `PhaseAnimator`.
+///
+/// Replaces the prior manual `asyncAfter`-based reset (a dangling timer that
+/// fired `animateUnlock = false` 0.5s later): the animator advances
+/// idle -> pop -> settle exactly once each time a badge becomes newly earned,
+/// then rests at `settle` (identical scale to `idle`), so there is no timer to
+/// leak and no state to reset. Reduce-motion is honored by returning a `nil`
+/// animation for every phase (the scale still resolves to its resting value
+/// instantly).
+enum BadgeUnlockPhase: CaseIterable {
+  case idle, pop, settle
+
+  /// Scale applied to the badge medallion while in this phase.
+  var scale: CGFloat {
+    switch self {
+    case .idle, .settle: return 1.0
+    case .pop: return 1.2
+    }
+  }
+
+  /// Animation used to move INTO this phase; `nil` at rest (idle).
+  var animation: Animation? {
+    switch self {
+    case .idle: return nil
+    case .pop: return PalaceMotion.emphasized
+    case .settle: return PalaceMotion.gentle
+    }
+  }
+}
+
 /// Full badge collection grid showing earned, in-progress, and locked badges.
 struct BadgesView: View {
   @ObservedObject var viewModel: BadgesViewModel
@@ -79,7 +109,7 @@ private struct BadgeGridCell: View {
   let badge: Badge
   let isNewlyEarned: Bool
 
-  @State private var animateUnlock = false
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   var body: some View {
     VStack(spacing: 8) {
@@ -109,8 +139,11 @@ private struct BadgeGridCell: View {
             .foregroundStyle(.secondary.opacity(0.5))
         }
       }
-      .scaleEffect(animateUnlock ? 1.2 : 1.0)
-      .animation(.spring(response: 0.5, dampingFraction: 0.5), value: animateUnlock)
+      .phaseAnimator(BadgeUnlockPhase.allCases, trigger: isNewlyEarned) { medallion, phase in
+        medallion.scaleEffect(phase.scale)
+      } animation: { phase in
+        reduceMotion ? nil : phase.animation
+      }
 
       Text(badge.isEarned || badge.isInProgress ? badge.name : "???")
         .font(.caption2)
@@ -132,16 +165,6 @@ private struct BadgeGridCell: View {
     .frame(maxWidth: .infinity)
     .accessibilityElement(children: .combine)
     .accessibilityLabel(accessibilityLabel)
-    .onChange(of: isNewlyEarned) { newValue in
-      if newValue {
-        withAnimation {
-          animateUnlock = true
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-          withAnimation { animateUnlock = false }
-        }
-      }
-    }
   }
 
   private var backgroundFill: some ShapeStyle {

--- a/Palace/Stats/Views/ReadingChartView.swift
+++ b/Palace/Stats/Views/ReadingChartView.swift
@@ -57,6 +57,7 @@ struct ReadingChartView: View {
     }
     .frame(height: 200)
     .accessibilityLabel(chartAccessibilityLabel)
+    .accessibleAnimation(PalaceMotion.standard, value: dataPoints)
   }
 
   @ViewBuilder

--- a/Palace/Stats/Views/StatsCardView.swift
+++ b/Palace/Stats/Views/StatsCardView.swift
@@ -19,6 +19,8 @@ struct StatsCardView: View {
         .fontWeight(.bold)
         .minimumScaleFactor(0.7)
         .lineLimit(1)
+        .contentTransition(.numericText())
+        .accessibleAnimation(PalaceMotion.emphasized, value: value)
 
       Text(label)
         .font(.caption)

--- a/Palace/Stats/Views/StatsView.swift
+++ b/Palace/Stats/Views/StatsView.swift
@@ -38,6 +38,7 @@ struct StatsView: View {
           Image(systemName: "flame.fill")
             .font(.title)
             .foregroundStyle(.orange)
+            .symbolEffect(.bounce, value: viewModel.currentStreak.currentStreakDays)
             .accessibilityHidden(true)
         } else {
           Image(systemName: "flame")

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -677,6 +677,8 @@ struct Strings {
         static let sortBy = NSLocalizedString("Sort By:", comment: "")
         static let searchBooks = NSLocalizedString("Search My Books", comment: "")
         static let emptyViewMessage = NSLocalizedString("Visit the Catalog to\nadd books to My Books.", comment: "")
+        static let emptyViewTitle = NSLocalizedString("Your shelf is empty", comment: "Title of the My Books empty state shown when the patron has no books")
+        static let browseCatalog = NSLocalizedString("Browse the Catalog", comment: "Button on the My Books empty state that opens the catalog tab")
         static let findYourLibrary = NSLocalizedString("Find Your Library", comment: "Button that lets user know they can select a library they have a card for")
         static let addLibrary = NSLocalizedString("Add Library", comment: "Title of button to add a new library")
         static let accountSyncingAlertTitle = NSLocalizedString("Please wait", comment: "")
@@ -696,6 +698,8 @@ struct Strings {
         static let offlineTitle = NSLocalizedString("You're Offline", comment: "Title of the catalog offline state shown when the device has no internet connection")
         static let offlineMessage = NSLocalizedString("The catalog isn't available without an internet connection, but your downloaded books are still here to read and listen to.", comment: "Explains that catalog browsing needs a connection while downloaded books remain available offline")
         static let offlineGoToMyBooks = NSLocalizedString("Go to My Books", comment: "Button on the catalog offline state that takes the patron to their downloaded books")
+        static let emptyFeedTitle = NSLocalizedString("Nothing here yet", comment: "Title of the catalog empty state shown when a feed returns no books")
+        static let emptyFeedMessage = NSLocalizedString("This part of the catalog doesn't have any books right now. Check back later.", comment: "Body of the catalog empty state shown when a feed returns no books")
     }
 
     struct BookCell {
@@ -815,6 +819,7 @@ struct Strings {
 
     struct HoldsView {
         static let reservations = NSLocalizedString("Holds", comment: "Nav title for Holds tab")
+        static let emptyTitle = NSLocalizedString("No holds yet", comment: "Title of the Holds empty state shown when the patron has no reserved or held books")
         static let emptyMessage = NSLocalizedString("""
             When you reserve a book from the catalog, it will show up here. \
             Look here from time to time to see if your book is available to download.

--- a/PalaceTests/UIPolish/BadgeUnlockPhaseTests.swift
+++ b/PalaceTests/UIPolish/BadgeUnlockPhaseTests.swift
@@ -1,0 +1,42 @@
+//
+//  BadgeUnlockPhaseTests.swift
+//  PalaceTests
+//
+//  PP-4747: pins the badge-unlock PhaseAnimator sequence that replaced the
+//  fragile `asyncAfter` reset in BadgesView. The phase enum is the pure driver:
+//  its scale mapping IS the pop, and its animation mapping IS the reduce-motion
+//  gate, so a regression in either fails here without a SwiftUI host.
+//
+
+import XCTest
+import SwiftUI
+@testable import Palace
+
+final class BadgeUnlockPhaseTests: XCTestCase {
+
+  func testPhaseOrder_isIdleThenPopThenSettle() {
+    XCTAssertEqual(BadgeUnlockPhase.allCases, [.idle, .pop, .settle],
+                   "The animator relies on this declaration order to run idle -> pop -> settle once.")
+  }
+
+  func testPop_scalesUp_whileIdleAndSettleRestAtUnitScale() {
+    XCTAssertEqual(BadgeUnlockPhase.pop.scale, 1.2, accuracy: 0.0001,
+                   "Pop must overshoot so the unlock is visible.")
+    XCTAssertEqual(BadgeUnlockPhase.idle.scale, 1.0, accuracy: 0.0001)
+    // The whole point of a settle phase: it must return to the SAME scale as
+    // idle so the medallion rests un-scaled after the pop (no dangling reset).
+    XCTAssertEqual(BadgeUnlockPhase.settle.scale, BadgeUnlockPhase.idle.scale, accuracy: 0.0001,
+                   "Settle must rest at idle's scale, otherwise badges stay enlarged.")
+    XCTAssertGreaterThan(BadgeUnlockPhase.pop.scale, BadgeUnlockPhase.settle.scale)
+  }
+
+  func testAnimation_idleRestsWithoutAnimation() {
+    XCTAssertNil(BadgeUnlockPhase.idle.animation,
+                 "The initial/resting phase must not animate on first appearance.")
+  }
+
+  func testAnimation_popAndSettle_useSharedMotion() {
+    XCTAssertEqual(BadgeUnlockPhase.pop.animation, PalaceMotion.emphasized)
+    XCTAssertEqual(BadgeUnlockPhase.settle.animation, PalaceMotion.gentle)
+  }
+}

--- a/PalaceTests/UIPolish/PDFSearchEmptyStateTests.swift
+++ b/PalaceTests/UIPolish/PDFSearchEmptyStateTests.swift
@@ -1,0 +1,35 @@
+//
+//  PDFSearchEmptyStateTests.swift
+//  PalaceTests
+//
+//  PP-4747: pins when the PDF search screen shows its ContentUnavailableView
+//  "no results" state. It must only appear for a committed query (>= 3 chars,
+//  matching SearchDelegate's own search threshold) that returned nothing — so
+//  the screen never flashes "No Results" before the patron has typed enough.
+//
+
+import XCTest
+@testable import Palace
+
+final class PDFSearchEmptyStateTests: XCTestCase {
+
+  func testShowsNoResults_committedQueryWithZeroMatches_showsEmptyState() {
+    XCTAssertTrue(TPPPDFSearchView.showsNoResults(searchText: "zebra", resultCount: 0))
+  }
+
+  func testShowsNoResults_committedQueryWithMatches_hidesEmptyState() {
+    XCTAssertFalse(TPPPDFSearchView.showsNoResults(searchText: "zebra", resultCount: 3))
+  }
+
+  func testShowsNoResults_shortQuery_neverShowsEmptyState() {
+    // Below the 3-char search threshold no search has run, so an empty
+    // result set is "not searched yet", not "no results".
+    XCTAssertFalse(TPPPDFSearchView.showsNoResults(searchText: "ab", resultCount: 0))
+    XCTAssertFalse(TPPPDFSearchView.showsNoResults(searchText: "", resultCount: 0))
+  }
+
+  func testShowsNoResults_thresholdBoundary_isThreeChars() {
+    XCTAssertTrue(TPPPDFSearchView.showsNoResults(searchText: "abc", resultCount: 0),
+                  "Exactly 3 chars is the committed-query boundary and must match SearchDelegate.search.")
+  }
+}

--- a/PalaceTests/UIPolish/RatingCardMotionGateTests.swift
+++ b/PalaceTests/UIPolish/RatingCardMotionGateTests.swift
@@ -1,0 +1,54 @@
+//
+//  RatingCardMotionGateTests.swift
+//  PalaceTests
+//
+//  PP-4747: pins the reduce-motion gate the app-rating card gained in PR4.
+//  The card previously always scaled on present/dismiss, ignoring the
+//  Reduce Motion setting. These tests exercise the pure decision seams so a
+//  regression that drops the gate (or the emphasized spring) fails loudly.
+//
+
+import XCTest
+import SwiftUI
+@testable import Palace
+
+final class RatingCardMotionGateTests: XCTestCase {
+
+  // MARK: usesScaleTransition
+
+  func testUsesScaleTransition_reduceMotionOff_scales() {
+    XCTAssertTrue(SentimentGateView.usesScaleTransition(reduceMotion: false),
+                  "With Reduce Motion off the card should keep its scale pop.")
+  }
+
+  func testUsesScaleTransition_reduceMotionOn_dropsScale() {
+    XCTAssertFalse(SentimentGateView.usesScaleTransition(reduceMotion: true),
+                   "With Reduce Motion on the card must NOT scale — this is the gate the card was missing.")
+  }
+
+  // MARK: stepAnimation
+
+  func testStepAnimation_reduceMotionOff_usesEmphasizedSpring() {
+    XCTAssertEqual(SentimentGateView.stepAnimation(reduceMotion: false),
+                   PalaceMotion.emphasized,
+                   "Normal motion should route through the shared emphasized spring, not a linear easeInOut.")
+  }
+
+  func testStepAnimation_reduceMotionOn_isNil() {
+    XCTAssertNil(SentimentGateView.stepAnimation(reduceMotion: true),
+                 "Reduce Motion must suppress the card-swap animation entirely.")
+  }
+
+  // MARK: cardTransition is derived from the gate
+
+  func testCardTransition_tracksScaleGate_bothDirections() {
+    // The transition builder must consult the same gate, not hardcode a scale.
+    // We can't compare AnyTransition values directly, so we assert the gate the
+    // builder is required to consult flips with the flag.
+    XCTAssertNotEqual(SentimentGateView.usesScaleTransition(reduceMotion: false),
+                      SentimentGateView.usesScaleTransition(reduceMotion: true),
+                      "The scale gate must actually depend on the reduce-motion flag.")
+    _ = SentimentGateView.cardTransition(reduceMotion: true)
+    _ = SentimentGateView.cardTransition(reduceMotion: false)
+  }
+}


### PR DESCRIPTION
**Jira:** PP-4747 (sub-task of PP-4743). Stage 4 of 6. Builds on PR2 (#1202, now in develop). Reviewed: **clean-code APPROVED** (presentation-only, reuses PR2 primitives, Reduce-Motion respected, tests kill real mutants).

Polish-only, no redesigns, no business logic touched.

### P2 — delight
- Stat card numbers roll (`.contentTransition(.numericText())`) — all 4 cards.
- Reading chart animates on Week/Month/Year switch.
- Badge unlock rebuilt on `PhaseAnimator` (idle→pop→settle, replaces a fragile `asyncAfter`); streak flame `.symbolEffect(.bounce)`.
- App-rating card: spring + soft shadow + **Reduce-Motion gate** (previously ignored it).
- PDF: bookmark bounce + haptic, page-number numeric roll, thumbnail strip `.viewAligned` snapping + selection tick.

### P3 — empty / loading / error
- `ContentUnavailableView` for empty Holds, empty bookshelf (+ "Browse the Catalog" CTA), PDF no-results, empty catalog feed, and the lane-more error.
- Skeleton→content opacity cross-fades (Catalog, lane rows, MyBooks) — the PR2 shimmer now fades into content instead of hard-cutting.
- Holds tidy: animated sync-error banner; dropped the redundant second loading spinner.

### Verification
- Local: `** BUILD SUCCEEDED **` · `Executed 13 tests, 0 failures`.
- New tests on pure seams (`RatingCardMotionGateTests`, `BadgeUnlockPhaseTests`, `PDFSearchEmptyStateTests`) — mutation-killing. New user-facing strings localized via `NSLocalizedString`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)