### PR TITLE
fix(signin): restore WKNavigationDelegate policy callback on Xcode 26.2 (@MainActor witness)

### DIFF
--- a/.forgeos/intent/wknavigationdelegate-mainactor-witness.md
+++ b/.forgeos/intent/wknavigationdelegate-mainactor-witness.md
@@ -1,0 +1,46 @@
+---
+name: wknavigationdelegate-mainactor-witness
+created: 2026-07-07
+author: claude-opus-4-8
+---
+
+## Context
+
+The Xcode 26.2 WebKit SDK annotates `WKNavigationDelegate` (and its `decisionHandler`
+blocks) `@MainActor` (`WK_SWIFT_UI_ACTOR`). Three delegate implementations declare
+`webView(_:decidePolicyFor:decisionHandler:)` with a plain, non-`@MainActor`
+`decisionHandler`, so the method only "nearly matches" the `@objc` optional requirement
+and is NOT registered as the witness. WebKit's `-respondsToSelector:` then skips the
+policy delegate entirely and default-allows every navigation — silently breaking
+universal-links interception (web-sheet OAuth/SAML sign-in never completes) and external
+`.linkActivated` handling in the bundled/remote HTML viewers. This reliably hangs
+`SignInWebSheetIntegrationTests.test_navigatingToUniversalLinksURL_...` at its 30s timeout
+on the current toolchain (it passed pre-toolchain-bump). Surfaced dogfooding the Swift 6
+Phase C landing (PR #1199); this fix is independent of Phase C and fixes develop.
+
+## Claims
+
+- migrates `webView(_:decidePolicyFor:decisionHandler:)` (both navigationAction and
+  navigationResponse overloads) in `SignInWebViewCoordinator` from `nonisolated` +
+  `Task { @MainActor }` + `DecisionHandlerBox` to a plain `@MainActor` method with an
+  `@escaping @MainActor` `decisionHandler` called synchronously (async cookie fetch stays
+  in a `Task`), so it matches the SDK's `@MainActor` witness and WebKit invokes it
+- removes the now-obsolete `DecisionHandlerBox` type from `SignInWebViewCoordinator`
+- adds `@MainActor` to the `decisionHandler` parameter of the `decidePolicyFor`
+  implementations in `BundledHTMLViewController` and `RemoteHTMLViewController`
+
+## Anti-claims
+
+- does NOT change the navigation-policy decision logic (`decideAction` / `decideResponse`
+  matching is unchanged) or any observable sign-in behavior beyond restoring the
+  policy-delegate invocation the SDK bump silently disabled
+- does NOT touch `SignInWebSheetViewModel` or the pure decision-logic unit tests
+- does NOT modify the `SWIFT_VERSION` / build settings (this is not the Phase C flip)
+- does NOT alter the lifecycle delegate methods (`didStartProvisionalNavigation`, etc.)
+
+## Files in scope
+
+- Palace/SignInLogic/SignInWebViewCoordinator.swift
+- Palace/Network/BundledHTMLViewController.swift
+- Palace/Network/RemoteHTMLViewController.swift
+- .forgeos/intent/wknavigationdelegate-mainactor-witness.md

--- a/.forgeos/reviews/wknavigationdelegate-mainactor-witness-2026-07-07.md
+++ b/.forgeos/reviews/wknavigationdelegate-mainactor-witness-2026-07-07.md
@@ -1,0 +1,36 @@
+<!-- audit-verified -->
+# WKNavigationDelegate @MainActor witness fix — SoD review record (2026-07-07)
+
+Local in-session Separation-of-Duties review (ForgeOS OFF). Critical-path (sign-in / web
+navigation). Two independent reviewers, both APPROVE.
+
+## rev_a70be5c0 — SoD-A (soundness / concurrency) — APPROVE
+All 6 points CONFIRMED-SOUND: (1) `@MainActor` class → methods legitimately `@MainActor`,
+exactly matching the `WK_SWIFT_UI_ACTOR` SDK witness; (2) synchronous `decisionHandler`
+on the main actor is correct + single-invocation per path; (3) cancel-before-await
+ordering + `self`/`viewModel` capture into the `@MainActor` cookie Task is sound; (4)
+`DecisionHandlerBox` fully removed, zero dangling refs, no unsafe `@Sendable` capture; (5)
+compiles under both develop (5.0/targeted) and Phase C (6.0/complete) — `@escaping
+@MainActor` is Swift-5.5+ valid and the SDK protocol is `@MainActor` regardless of app
+Swift version; (6) Bundled/Remote nested-delegate witnesses aligned. Scope-complete: all
+3 `decidePolicyFor` sites migrated, no 4th. The pre-existing integration test genuinely
+guards the fix path.
+
+## rev_a42075fe — SoD-B (behavior-preservation) — APPROVE
+All 5 points PRESERVED/IMPROVED: (1) `decideAction` decision + `recordLoginCompletion`
+cookie logic unchanged; (2) `navigationResponse` `.bookFound`/`.problemFound` paths
+preserved (problemFound kept synchronous); (3) IMPROVED — synchronous dispatch removes the
+old decision-timeout race; (4) Bundled/Remote external-link `.linkActivated` logic
+byte-identical; (5) no regression from restoring the delegate — the broken allow-all state
+was wrongly navigating external links in-app; the fix restores correct OS-open behavior and
+does not over-cancel (non-linkActivated navs still `.allow`).
+
+VERDICT (both): APPROVE. No blocking items.
+
+## Mutation note
+No diff-scoped mutation evidence: this is a delegate signature/isolation fix with NO
+branch-logic change — the `decideAction`/`decideResponse` switch cases are unchanged
+(only relocated from a `Task` to a synchronous call), so the diff-scoped mutation surface
+is ~0. Behavior is covered by `SignInWebSheetIntegrationTests` (34 tests, 0 failures; the
+universal-links test flips from a reliable 30s hang to a 0.76s pass — it exercises the
+restored delegate path end-to-end via a real WKWebView).

--- a/Palace/Network/BundledHTMLViewController.swift
+++ b/Palace/Network/BundledHTMLViewController.swift
@@ -57,7 +57,7 @@ import WebKit
     fileprivate class WebViewDelegate: NSObject, WKNavigationDelegate {
         func webView(_ webView: WKWebView,
                      decidePolicyFor navigationAction: WKNavigationAction,
-                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+                     decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
             if navigationAction.navigationType == .linkActivated,
                let url = navigationAction.request.url {
                 if !UIApplication.shared.canOpenURL(url) {

--- a/Palace/Network/RemoteHTMLViewController.swift
+++ b/Palace/Network/RemoteHTMLViewController.swift
@@ -71,7 +71,7 @@ import WebKit
         self.present(alert, animated: true, completion: nil)
     }
 
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
 
         guard navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url else {
             decisionHandler(.allow)

--- a/Palace/SignInLogic/SignInWebViewCoordinator.swift
+++ b/Palace/SignInLogic/SignInWebViewCoordinator.swift
@@ -10,29 +10,11 @@
 //
 
 import Foundation
-// `@preconcurrency` for the iOS-17+ WebKit SDK's non-Sendable delegate types
-// carried into the `@MainActor` hops below (`WKNavigationAction`,
-// `WKNavigationResponse`, `WKWebView`). The `sending decisionHandler` closures
-// are additionally boxed in `DecisionHandlerBox` (see below) — WebKit guarantees
-// delegate callbacks on main and each hop re-enters main before invoking the
-// handler, so the box waives no real race, it satisfies the `@Sendable` capture.
+// `@preconcurrency` for the WebKit SDK's non-Sendable delegate value types
+// (`WKNavigationAction`, `WKNavigationResponse`) captured into the async cookie
+// `Task` hops below.
 @preconcurrency import WebKit
 import PalaceLogging
-
-/// Sendable carrier for WebKit's non-Sendable `decisionHandler` closures
-/// (`@escaping (WKNavigationActionPolicy) -> Void` /
-/// `@escaping (WKNavigationResponsePolicy) -> Void`) captured by the
-/// `@Sendable` `Task { @MainActor in }` hops in the `decidePolicyFor` delegate
-/// methods below. Boxing lets the Task capture a Sendable carrier instead of the
-/// raw handler, clearing the "sending 'decisionHandler' risks data races"
-/// diagnostic. INVARIANT — WebKit delivers `WKNavigationDelegate` callbacks on
-/// the main thread and each hop re-enters the main actor before calling the
-/// handler, so the boxed closure is invoked exactly once, on main, from inside
-/// that single Task. Mirrors the carrier-box precedent (`ReadiumBookmarkBox`).
-private final class DecisionHandlerBox<Policy>: @unchecked Sendable {
-    let call: (Policy) -> Void
-    init(_ call: @escaping (Policy) -> Void) { self.call = call }
-}
 
 @MainActor
 final class SignInWebViewCoordinator: NSObject, WKNavigationDelegate {
@@ -47,74 +29,68 @@ final class SignInWebViewCoordinator: NSObject, WKNavigationDelegate {
 
     // MARK: - WKNavigationDelegate
 
-    nonisolated func webView(
+    // The current WebKit SDK annotates `WKNavigationDelegate` (and its
+    // `decisionHandler` blocks) `@MainActor` (`WK_SWIFT_UI_ACTOR`). A
+    // `nonisolated` witness with a non-`@MainActor` `decisionHandler` no longer
+    // matches that `@objc` requirement, so WebKit's `-respondsToSelector:` skips
+    // the policy delegate entirely and defaults to allowing every navigation —
+    // silently breaking universal-links interception (web-sheet sign-in never
+    // completes). Implement it as the `@MainActor` method the SDK expects and
+    // call `decisionHandler` synchronously; only the genuinely-async cookie
+    // fetch hops through a `Task`.
+    func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction,
-        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
     ) {
-        // `WKNavigationAction.request` is main actor-isolated; read it inside the
-        // @MainActor hop (capturing `navigationAction`, like `webView` already
-        // is) rather than in this nonisolated delegate body, which would trip the
-        // `targeted` "main actor-isolated property referenced from nonisolated
-        // context" diagnostic. `URLRequest` is a value type, so the deferred read
-        // observes the same request.
-        // Swift 6 `complete`: box the non-Sendable `decisionHandler` before the
-        // `@Sendable` `Task { @MainActor in }` hop (see `DecisionHandlerBox`);
-        // WebKit delivers on main and the hop re-enters main before calling it.
-        let decisionBox = DecisionHandlerBox(decisionHandler)
-        Task { @MainActor in
-            let request = navigationAction.request
-            let decision = self.viewModel.decideAction(for: request)
-            switch decision {
-            case .allow:
-                decisionBox.call(.allow)
+        let request = navigationAction.request
+        let decision = viewModel.decideAction(for: request)
+        switch decision {
+        case .allow:
+            decisionHandler(.allow)
 
-            case .completeLogin(let destination):
-                decisionBox.call(.cancel)
+        case .completeLogin(let destination):
+            decisionHandler(.cancel)
+            Task { @MainActor in
                 let cookies = await webView.configuration.websiteDataStore.httpCookieStore.allCookies()
                 self.viewModel.recordLoginCompletion(destinationURL: destination, cookies: cookies)
-
-            case .cancel, .bookFound, .problemFound:
-                // decideAction never returns these; defensive only.
-                decisionBox.call(.allow)
             }
+
+        case .cancel, .bookFound, .problemFound:
+            // decideAction never returns these; defensive only.
+            decisionHandler(.allow)
         }
     }
 
-    nonisolated func webView(
+    func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationResponse: WKNavigationResponse,
-        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+        decisionHandler: @escaping @MainActor (WKNavigationResponsePolicy) -> Void
     ) {
-        // `WKNavigationResponse.response` is main actor-isolated; read its
-        // `mimeType` inside the @MainActor hop (capturing `navigationResponse`)
-        // rather than in this nonisolated delegate body, which would trip the
-        // `targeted` "main actor-isolated property referenced from nonisolated
-        // context" diagnostic.
-        // Swift 6 `complete`: box the non-Sendable `decisionHandler` before the
-        // `@Sendable` `Task { @MainActor in }` hop (see `DecisionHandlerBox`);
-        // WebKit delivers on main and the hop re-enters main before calling it.
-        let decisionBox = DecisionHandlerBox(decisionHandler)
-        Task { @MainActor in
-            let mime = navigationResponse.response.mimeType
-            let decision = self.viewModel.decideResponse(mimeType: mime)
-            switch decision {
-            case .allow:
-                decisionBox.call(.allow)
+        // See the `navigationAction` method above: the current WebKit SDK's
+        // `@MainActor` `WKNavigationDelegate` requires an `@MainActor` witness, so
+        // this is a plain `@MainActor` method that calls `decisionHandler`
+        // synchronously; only the async cookie fetch hops through a `Task`.
+        let mime = navigationResponse.response.mimeType
+        let decision = viewModel.decideResponse(mimeType: mime)
+        switch decision {
+        case .allow:
+            decisionHandler(.allow)
 
-            case .bookFound:
-                decisionBox.call(.cancel)
+        case .bookFound:
+            decisionHandler(.cancel)
+            Task { @MainActor in
                 let cookies = await webView.configuration.websiteDataStore.httpCookieStore.allCookies()
                 self.viewModel.recordBookFound(cookies: cookies)
-
-            case .problemFound:
-                decisionBox.call(.cancel)
-                self.viewModel.recordProblem(document: nil)
-
-            case .cancel, .completeLogin:
-                // decideResponse never returns these; defensive only.
-                decisionBox.call(.allow)
             }
+
+        case .problemFound:
+            decisionHandler(.cancel)
+            viewModel.recordProblem(document: nil)
+
+        case .cancel, .completeLogin:
+            // decideResponse never returns these; defensive only.
+            decisionHandler(.allow)
         }
     }
 


### PR DESCRIPTION
## Restore WKNavigationDelegate policy callback on Xcode 26.2

**This is a production sign-in bug fix**, surfaced while landing Swift 6 Phase C (#1199) but independent of it — it affects `develop` on the current toolchain.

### The bug
The Xcode 26.2 WebKit SDK annotates `WKNavigationDelegate` **and its `decisionHandler` blocks** `@MainActor` (`WK_SWIFT_UI_ACTOR`). Three delegate implementations declare `webView(_:decidePolicyFor:decisionHandler:)` with a **non-`@MainActor`** `decisionHandler`, so they only *"nearly match"* the `@objc` optional requirement (the compiler literally warns this) and are **not registered as the witness**. WebKit's `-respondsToSelector:` then skips the policy delegate and **default-allows every navigation**:

- **Web-sheet OAuth/SAML sign-in** — the universal-links callback is never intercepted → login never completes (a reliable hang).
- **Bundled/Remote HTML viewers** — external `.linkActivated` links wrongly navigate *in-app* instead of opening in the OS.

### The fix
Make the `decidePolicyFor` methods `@MainActor` (matching the `@MainActor` class + SDK requirement) with an `@escaping @MainActor decisionHandler`, called **synchronously**; the genuinely-async cookie fetch stays in a `Task`. This removes the now-obsolete `nonisolated` / `DecisionHandlerBox` / Task-hop scaffolding that Phase B added back when the SDK protocol was still `nonisolated`. `BundledHTMLViewController` + `RemoteHTMLViewController` get the same `@MainActor` `decisionHandler` annotation.

Net **−24 lines** in the coordinator — it's a simplification.

### Verification
- `SignInWebSheetIntegrationTests.test_navigatingToUniversalLinksURL_...`: reliable **30s hang → 0.76s pass** (3/3). Full `SignInWebSheetIntegrationTests` + `SignInWebSheetViewModelTests`: **34 tests, 0 failures**.
- Build clean; **0** remaining `decidePolicyFor` "nearly matches" warnings across all three sites.
- Isolated the cause: identical hang on a Swift-5 build of the same tree → **not** the Phase C language flip; it's the SDK bump. Instrumentation confirmed WebKit never called `decidePolicyFor` (only the lifecycle callbacks fired).
- Local SoD review (soundness + behavior) both **APPROVE** — `.forgeos/reviews/wknavigationdelegate-mainactor-witness-2026-07-07.md`.
- Full suite + **Palace-noDRM** are CI-gated here.

### Why it matters for the board
This is the reason Phase C #1199's CI (and any full-suite run on the current toolchain) was red. Merging this greens the board; #1199 then rebases and re-runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
