### PR TITLE
feat(ui): unified skeleton loading system (shared-clock, light/dark, low-power aware)

### DIFF
--- a/.forgeos/intent/ui-polish-skeleton-system.md
+++ b/.forgeos/intent/ui-polish-skeleton-system.md
@@ -1,0 +1,43 @@
+# Intent — Unified Skeleton Loading System (PP-4752)
+
+## Summary
+Build a single, premium, scheme-adaptive skeleton loading system
+(`Palace/Utilities/SwiftUI/Skeleton.swift`) and adopt it across the app,
+replacing the flat gray horizontal shimmer and the bare `ProgressView()`
+spinners that appear where the loading surface has a known content shape.
+Polish-only; no redesign of the underlying screens.
+
+## Claims
+- Adds a `Skeleton` design-token namespace: scheme-adaptive base fill + highlight,
+  one shimmer duration, a diagonal sweep angle; radii from `PalaceRadius`.
+- Adds a premium `.shimmering(active:)` ViewModifier: adaptive base (light AND
+  dark), a soft wide highlight that sweeps diagonally in a continuous loop;
+  Reduce Motion shows a calm static base (no sweep).
+- Extracts the sweep math into pure static seams on `Skeleton`
+  (`sweepTranslationX`, `SkeletonText.lineWidth`) so they are unit-testable.
+- Adds shape primitives `SkeletonBox`, `SkeletonText`, `SkeletonCover`,
+  `SkeletonCircle`, all adaptive + radius-tokenized.
+- Adds a `.skeleton(_:placeholder:)` container modifier that cross-fades
+  (`accessibleAnimation(PalaceMotion.gentle)`) between skeleton and content.
+- Rebuilds the 4 existing skeletons on the new primitives.
+- Replaces bare-spinner loading states that have a known content shape with
+  content-shaped skeletons (catalog, my-books, holds, book detail, search, PDF).
+- Re-implements the old `shimmerEffect()` / `ShimmerView` / `loadingOverlay`
+  as thin wrappers over the new system so remaining call sites keep working.
+- Adds unit tests for the pure seams.
+
+## Anti-claims
+- Does NOT redesign any screen layout or change navigation/behavior.
+- Does NOT convert genuinely-indeterminate/short spinners (inline button
+  spinners, web/EULA page loads, determinate progress bars).
+- Does NOT touch critical-path auth/borrow/return/DRM logic.
+
+## Files in scope
+- Palace/Utilities/SwiftUI/Skeleton.swift (new)
+- Palace/Utilities/SwiftUI/LoadingOverlayModifier.swift (wrappers)
+- Palace/MyBooks/MyBooks/BookListSkeletonView.swift
+- Palace/CatalogUI/Views/CatalogLaneSkeletonView.swift
+- Palace/CatalogUI/Views/CatalogLaneRowView.swift
+- Palace/Settings/Components/AccountDetailSkeletonView.swift
+- High-traffic loading call sites (catalog, my-books, holds, book detail, PDF, search)
+- PalaceTests/.../SkeletonTests.swift (new)

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		141494C5B2EF5102AE3CDC4E /* SupportSectionDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9A4E1085F59AB6E4E0AD4C /* SupportSectionDecisionTests.swift */; };
 		14342D20DADCD5B6AA7ECC97 /* DownloadAnnouncementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D85D6FFA9CEBA4295D91F15 /* DownloadAnnouncementService.swift */; };
 		1441E97FEA8E24E5676576B5 /* UIButton+NYPLAppearanceAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68831365CC1FF46BE9A9C2C9 /* UIButton+NYPLAppearanceAdditions.swift */; };
+		1446B886F9D2F070E2AC22A5 /* Skeleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E510DC675E5215E00B444EE /* Skeleton.swift */; };
 		145798F6215BE9E300F68AFD /* ProblemReportEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145798F5215BE9E300F68AFD /* ProblemReportEmail.swift */; };
 		151C578EEB3CBF8B804952F6 /* DeveloperSettingsTierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5EC7969F38A050E5947FA5 /* DeveloperSettingsTierTests.swift */; };
 		152A3B4C5D6E7F8091A2B3C4 /* DownloadAuthRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041F2A3B4C5D6E7F8091A2B3 /* DownloadAuthRetryHandler.swift */; };
@@ -332,6 +333,7 @@
 		2DE514351DC3F0BE005A58BD /* TPPCirculationAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66AE32F1DC0FCFC00124AE2 /* TPPCirculationAnalytics.swift */; };
 		2DF321831DC3B83500E1858F /* TPPAnnotations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF321821DC3B83500E1858F /* TPPAnnotations.swift */; };
 		2E41D465410B8D25959BB5DD /* FirebaseCrashlyticsBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74362E9DDB10D6F6B404D57 /* FirebaseCrashlyticsBridge.swift */; };
+		2E6A415E42C938CDED99D134 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC145A45F58593EC659F754B /* SkeletonTests.swift */; };
 		2E97EABBC5988E7CE735BA13 /* Account+TPPLibraryAccountReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02415B1E145D716015754AFF /* Account+TPPLibraryAccountReadable.swift */; };
 		2ED038CE38DD3A761C3D4441 /* Reader2PositionAdapterContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7336DCAC8206364153A59C /* Reader2PositionAdapterContractTests.swift */; };
 		2F1D7D501EBB74D0A990E167 /* TPPObjCExceptionCatcher.mm in Sources */ = {isa = PBXBuildFile; fileRef = 48B834DC53BA4A1C8B4EBDC6 /* TPPObjCExceptionCatcher.mm */; };
@@ -561,6 +563,7 @@
 		6F1E28BFDD2B51A198F52989 /* TypographySettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA121652A5D3675E6CEE9849 /* TypographySettingsViewModel.swift */; };
 		6F43F5BD087C388167B78C2B /* Adapters+Production.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA91B27F363A5BBFB4F5BB0 /* Adapters+Production.swift */; };
 		6F52C77B328F4EC581D1F51A /* CarPlayAudiobookBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B2D269BFF440A381A893E3 /* CarPlayAudiobookBridge.swift */; };
+		7025FC704907DF4D61E2F270 /* Skeleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E510DC675E5215E00B444EE /* Skeleton.swift */; };
 		707AD1A69207A4DA0FCE502C /* ManifestFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F826CF3A1D6633781419179 /* ManifestFetchTests.swift */; };
 		7096661E3AAF4B878E1F49DB /* RDServicesStubs.m in Sources */ = {isa = PBXBuildFile; fileRef = 75305888F6A941DDA9EEE592 /* RDServicesStubs.m */; };
 		70A92DCAEFF993926A3B7AE1 /* TPPSettings+UniversalLinksProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F6DEC8A63194712483BB6B /* TPPSettings+UniversalLinksProviding.swift */; };
@@ -2295,6 +2298,7 @@
 		2DA4F2321C68363B008853D7 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
 		2DF321821DC3B83500E1858F /* TPPAnnotations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPAnnotations.swift; sourceTree = "<group>"; };
 		2DF737E48E0644508688E443 /* TPPBookBearerTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookBearerTokenTests.swift; sourceTree = "<group>"; };
+		2E510DC675E5215E00B444EE /* Skeleton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Skeleton.swift; sourceTree = "<group>"; };
 		2E5BAC81314C28A366BF6BB7 /* AudiobookSessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookSessionManager.swift; sourceTree = "<group>"; };
 		2FDA12704CE45280D151E7AC /* OPDSParsingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDSParsingTests.swift; sourceTree = "<group>"; };
 		2FF4CC60E96981C8BF94891C /* BadgeDefinitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeDefinitionTests.swift; sourceTree = "<group>"; };
@@ -2781,6 +2785,7 @@
 		ABSSTATE0001FREF000001 /* AudiobookSessionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookSessionStateTests.swift; sourceTree = "<group>"; };
 		ABTEDGE0001FREF000001 /* AudiobookTimeTrackerEdgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookTimeTrackerEdgeTests.swift; sourceTree = "<group>"; };
 		AC0001CONTAINERFILEREF01 /* AppContainerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContainerTests.swift; sourceTree = "<group>"; };
+		AC145A45F58593EC659F754B /* SkeletonTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SkeletonTests.swift; sourceTree = "<group>"; };
 		AC1B8AF7EB40C9DE22ED5ED0 /* TypographyServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographyServiceProtocol.swift; sourceTree = "<group>"; };
 		ACE8017D2ECF7E0FEBFAAB1A /* OPDSFeedCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OPDSFeedCache.swift; path = OPDS2/Cache/OPDSFeedCache.swift; sourceTree = "<group>"; };
 		AD2A4750286AC64A2D15FD94 /* StreamingReaderViewControllerScrollRestoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingReaderViewControllerScrollRestoreTests.swift; sourceTree = "<group>"; };
@@ -5763,6 +5768,7 @@
 				CF4E37ED1C3EFEF6CB717835 /* PalaceMotionTests.swift */,
 				450A1E779E10FABB4CF59037 /* PalacePressableButtonStyleTests.swift */,
 				B9AA2BDEDE93EDA644183E61 /* PalaceHapticTests.swift */,
+				AC145A45F58593EC659F754B /* SkeletonTests.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -5923,6 +5929,7 @@
 				B4CB1433E14A95CBB1AAA208 /* PalaceMotion.swift */,
 				CAA550DFD5C0CC29F38E9FB8 /* PalacePressableButtonStyle.swift */,
 				A86B71A57CABD0B81CD36844 /* PalaceHaptic.swift */,
+				2E510DC675E5215E00B444EE /* Skeleton.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -7641,6 +7648,7 @@
 				A701AF3AE365FEB190800CAA /* SignInFormPresentationTests.swift in Sources */,
 				460ADECAE6DF8B66F16BB9A8 /* DownloadCompleteMomentTests.swift in Sources */,
 				2CB4235AFFA2BB53365AD667 /* TPPPDFReaderSearchBindingTests.swift in Sources */,
+				2E6A415E42C938CDED99D134 /* SkeletonTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8196,6 +8204,7 @@
 				C0EDC3F1E222BA838B50817A /* PalaceMotion.swift in Sources */,
 				39A1336976AF58F39DFF585A /* PalacePressableButtonStyle.swift in Sources */,
 				FC06F1538E0D26618E2DD336 /* PalaceHaptic.swift in Sources */,
+				1446B886F9D2F070E2AC22A5 /* Skeleton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8754,6 +8763,7 @@
 				AB1B01218C19BD85FE46DC3A /* PalaceMotion.swift in Sources */,
 				A194D27C0FF23ECB35C85E34 /* PalacePressableButtonStyle.swift in Sources */,
 				AAF4A7A693BC1867BF31E4C5 /* PalaceHaptic.swift in Sources */,
+				7025FC704907DF4D61E2F270 /* Skeleton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Book/UI/BookDetail/BookDetailView.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailView.swift
@@ -27,7 +27,6 @@ struct BookDetailView: View {
     @State private var titleOpacity: CGFloat = 1.0
     @State private var dragOffset: CGFloat = 0
     @State private var imageBottomPosition: CGFloat = 400
-    @State private var pulseSkeleton: Bool = false
     @State private var lastBookIdentifier: String?
     @AccessibilityFocusState private var isTitleFocused: Bool
     @State private var initialLayoutComplete: Bool = false
@@ -111,9 +110,6 @@ struct BookDetailView: View {
                 viewModel.fetchRelatedBooks()
                 Task { await viewModel.hydrateMetadataIfNeeded() }
                 self.descriptionText = viewModel.book.summary ?? ""
-                accessibleWithAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
-                    pulseSkeleton = true
-                }
 
                 NotificationCenter.default.post(name: .TPPAccessibilityScreenTransition, object: nil)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
@@ -506,10 +502,7 @@ struct BookDetailView: View {
                                             })
                                             .accessibilityLabel(bookAccessibilityLabel(for: book))
                                         } else {
-                                            RoundedRectangle(cornerRadius: 8)
-                                                .fill(Color.gray.opacity(0.25))
-                                                .frame(width: 100, height: 160)
-                                                .opacity(pulseSkeleton ? 0.6 : 1.0)
+                                            SkeletonCover(width: 100, height: 160)
                                         }
                                     }
                                 }

--- a/Palace/Book/UI/BookDetail/BookImageView.swift
+++ b/Palace/Book/UI/BookDetail/BookImageView.swift
@@ -7,6 +7,11 @@ struct BookImageView: View {
     var usePulseSkeleton: Bool = true
     /// When true, the cover is not announced by VoiceOver (e.g. in list cells where the cell already announces title/author).
     var treatImageAsDecorativeInLists: Bool = false
+    /// Drop shadow radius applied ONLY to the settled cover image — never to the
+    /// loading placeholder. Keeping the shadow off the animated placeholder
+    /// avoids re-rasterizing 4 shadow layers every frame while it pulses (the
+    /// real GPU cost on a full catalog). `nil` = no shadow.
+    var coverShadowRadius: CGFloat? = nil
 
     @State private var showSkeleton: Bool = true
 
@@ -18,13 +23,16 @@ struct BookImageView: View {
         ZStack(alignment: .bottomTrailing) {
             // Show pulsing skeleton until image is ready
             if showSkeleton && !hasPreloadedCover {
-                PulsingSkeletonView(width: width ?? (height * 2.0 / 3.0), height: height)
+                // Shared-clock skeleton (one TimelineView driver, reduce-motion +
+                // low-power aware) — replaces the old per-cover repeatForever pulse.
+                SkeletonCover(width: width ?? (height * 2.0 / 3.0), height: height)
             }
 
             if let coverImage = book.coverImage ?? book.thumbnailImage {
                 Image(uiImage: coverImage)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
+                    .modifier(SettledCoverShadow(radius: coverShadowRadius))
                     .transition(.opacity)
                     .accessibilityLabel(treatImageAsDecorativeInLists ? "" : String(format: NSLocalizedString("Cover image for %@", comment: "Book cover accessibility"), book.title))
                     .accessibilityHidden(treatImageAsDecorativeInLists)
@@ -95,24 +103,21 @@ struct BookImageView: View {
     }
 }
 
-// MARK: - Pulsing Skeleton
+// MARK: - Settled-cover shadow
 
-/// Self-contained pulsing skeleton that starts animating immediately on init
-private struct PulsingSkeletonView: View {
-    let width: CGFloat
-    let height: CGFloat
+/// Applies `adaptiveShadow` to the settled cover image only when a radius is
+/// provided. Deliberately NOT applied to the loading skeleton: an animated
+/// shadow re-rasterizes its (4-layer) blur every frame, which on a full catalog
+/// is the dominant GPU cost. The shadow therefore appears once, on the static
+/// settled cover, and never animates.
+private struct SettledCoverShadow: ViewModifier {
+    let radius: CGFloat?
 
-    @State private var pulse: Bool = false
-
-    var body: some View {
-        Rectangle()
-            .fill(Color.gray.opacity(0.25))
-            .frame(width: width, height: height)
-            .opacity(pulse ? 0.6 : 1.0)
-            .onAppear {
-                withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
-                    pulse = true
-                }
-            }
+    func body(content: Content) -> some View {
+        if let radius {
+            content.adaptiveShadow(radius: radius)
+        } else {
+            content
+        }
     }
 }

--- a/Palace/CatalogUI/Views/CatalogLaneRowView.swift
+++ b/Palace/CatalogUI/Views/CatalogLaneRowView.swift
@@ -40,9 +40,12 @@ struct CatalogLaneRowView: View {
                             width: nil,
                             height: 150,
                             usePulseSkeleton: true,
-                            treatImageAsDecorativeInLists: true
+                            treatImageAsDecorativeInLists: true,
+                            // Shadow rides the settled cover only — never the
+                            // pulsing skeleton — so the 4-layer shadow blur is
+                            // not re-rasterized every animation frame.
+                            coverShadowRadius: 4
                         )
-                        .adaptiveShadow(radius: 4)
                         .padding(.vertical)
                     })
                     .buttonStyle(.palacePressable)
@@ -101,14 +104,12 @@ private struct LaneSkeletonView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: 12) {
                 ForEach(0..<6, id: \.self) { _ in
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.25))
-                        .frame(width: 100, height: 150)
-                        .shimmerEffect()
+                    SkeletonCover(width: 100, height: 150)
                         .padding(.vertical)
                 }
             }
             .padding(.horizontal, 12)
         }
+        .accessibilityHidden(true)
     }
 }

--- a/Palace/CatalogUI/Views/CatalogLaneSkeletonView.swift
+++ b/Palace/CatalogUI/Views/CatalogLaneSkeletonView.swift
@@ -1,35 +1,29 @@
 import SwiftUI
 
-/// Skeleton placeholder matching the exact layout of CatalogLaneRowView.
+/// Skeleton placeholder matching the layout of `CatalogLaneRowView`: a lane
+/// title followed by a horizontal row of cover placeholders.
 ///
-/// Measured from live element positions (SpecterQA):
-/// - Title: 26pt height, left-aligned at x=12
-/// - Books: 100×150pt, 12pt spacing, starts 12pt from left edge
-/// - VStack spacing between title and books: 5pt
-/// - Vertical padding around book scroller: inherits from .padding(.vertical)
+/// Built on the unified `Skeleton` primitives so the base color, card radius,
+/// and diagonal shimmer match every other skeleton. Measurements mirror the
+/// live lane (title left-aligned at x=12, 100×150 covers, 12pt spacing).
 struct CatalogLaneSkeletonView: View {
     var itemCount: Int = 6
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
-            Rectangle()
-                .fill(Color.gray.opacity(0.25))
-                .frame(width: 200, height: 26)
-                .shimmerEffect()
+            SkeletonBox(width: 200, height: 26, cornerRadius: PalaceRadius.control)
                 .padding(.horizontal, 12)
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 12) {
                     ForEach(0..<itemCount, id: \.self) { _ in
-                        Rectangle()
-                            .fill(Color.gray.opacity(0.25))
-                            .frame(width: 100, height: 150)
-                            .shimmerEffect()
+                        SkeletonCover(width: 100, height: 150)
                     }
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical)
             }
         }
+        .accessibilityHidden(true)
     }
 }

--- a/Palace/CatalogUI/Views/CatalogLaneSkeletonView.swift
+++ b/Palace/CatalogUI/Views/CatalogLaneSkeletonView.swift
@@ -1,27 +1,42 @@
 import SwiftUI
 
-/// Skeleton placeholder matching the layout of `CatalogLaneRowView`: a lane
-/// title followed by a horizontal row of cover placeholders.
+/// Skeleton placeholder that is a graytone tracing of `CatalogLaneRowView`: a
+/// lane header followed by a horizontal row of cover placeholders.
 ///
-/// Built on the unified `Skeleton` primitives so the base color, card radius,
-/// and diagonal shimmer match every other skeleton. Measurements mirror the
-/// live lane (title left-aligned at x=12, 100×150 covers, 12pt spacing).
+/// Every value is pulled 1:1 from the live lane so content lands exactly where
+/// the skeleton boxes were (zero layout shift):
+///   * `VStack(alignment: .leading, spacing: 5)` — same as the real lane.
+///   * Header: a `.title2` line is ~28pt tall (22pt point size). A ~200pt bar
+///     (~50% width) at `.padding(.horizontal, 12)` traces `Text(title)
+///     .font(.title2)` (the real header's leading inset is also 12).
+///   * Scroller: identical `ScrollView(.horizontal)` → `LazyHStack(spacing: 12)`
+///     with `.padding(.horizontal, 12)`, each cover `.padding(.vertical)` — a
+///     byte-for-byte structural mirror of `CatalogLaneRowView.scroller`.
+///   * Cover: `BookImageView(width: nil, height: 150)` reserves its skeleton at
+///     `height * 2/3 = 100` wide (the 2:3 portrait modal), so 100×150 matches
+///     the width the real layout reserves.
+///
+/// Note: the real header height is dynamic — a "More…" button forces the row to
+/// `minHeight: 44` and a long title wraps up to 3 lines. We trace the common
+/// single-line-title case (~28pt); see the header comment.
 struct CatalogLaneSkeletonView: View {
     var itemCount: Int = 6
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
-            SkeletonBox(width: 200, height: 26, cornerRadius: PalaceRadius.control)
+            // Header — traces `Text(title).font(.title2)` (~28pt line height).
+            SkeletonBox(width: 200, height: 28, cornerRadius: PalaceRadius.control)
                 .padding(.horizontal, 12)
 
+            // Scroller — mirrors `CatalogLaneRowView.scroller` exactly.
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 12) {
+                LazyHStack(spacing: 12) {
                     ForEach(0..<itemCount, id: \.self) { _ in
                         SkeletonCover(width: 100, height: 150)
+                            .padding(.vertical)
                     }
                 }
                 .padding(.horizontal, 12)
-                .padding(.vertical)
             }
         }
         .accessibilityHidden(true)

--- a/Palace/CatalogUI/Views/CatalogLaneSkeletonView.swift
+++ b/Palace/CatalogUI/Views/CatalogLaneSkeletonView.swift
@@ -42,3 +42,41 @@ struct CatalogLaneSkeletonView: View {
         .accessibilityHidden(true)
     }
 }
+
+/// Skeleton placeholder that traces `EntryPointsSelectorView` — the segmented
+/// "All · Ebooks · Audiobooks" control that renders above the first lane once
+/// the grouped catalog feed loads. The initial-load skeleton (`skeletonList`)
+/// has no selector of its own, so without this placeholder the first lane sits
+/// ~44pt higher in the skeleton than in the loaded state and every lane visibly
+/// pops DOWN when the selector appears (PP-4752).
+///
+/// Geometry is pulled 1:1 from `EntryPointsSelectorView` so the real control
+/// lands in exactly the space the placeholder reserved (zero layout shift):
+///   * height `placeholderHeight` (44) — the selector's
+///     `Picker(.segmented).frame(minHeight: 44)`. The real control has NO
+///     vertical padding, so its reserved footprint IS this height.
+///   * `.frame(maxWidth: 700)` then centered — same width clamp as the control.
+///   * `.padding(.horizontal, 12)` — same leading/trailing inset.
+///   * radius `PalaceRadius.control` (8) — the segmented control's pill radius.
+///
+/// Only trace this where the real selector actually appears: the initial-load
+/// skeleton. The switching-entry-point skeleton (`CatalogLoadingView`, driven by
+/// `switchingEntryPointView`) already renders the *real* `EntryPointsSelectorView`
+/// above it, so it must NOT get a second placeholder.
+struct CatalogEntryPointsSkeletonView: View {
+    /// The vertical footprint (points) the entry-point selector reserves, and
+    /// therefore the height the placeholder must reserve. Mirrors
+    /// `EntryPointsSelectorView`'s `Picker(.segmented).frame(minHeight: 44)`
+    /// (the control carries no vertical padding). A regression that zeroes or
+    /// shrinks this reintroduces the ~44pt lane pop (PP-4752), so it is pinned
+    /// by `SkeletonTests`.
+    static let placeholderHeight: CGFloat = 44
+
+    var body: some View {
+        SkeletonBox(height: Self.placeholderHeight, cornerRadius: PalaceRadius.control)
+            .frame(maxWidth: 700)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, 12)
+            .accessibilityHidden(true)
+    }
+}

--- a/Palace/CatalogUI/Views/CatalogSearchView.swift
+++ b/Palace/CatalogUI/Views/CatalogSearchView.swift
@@ -145,7 +145,18 @@ private extension CatalogSearchView {
 
     var resultsContent: some View {
         ScrollView {
-            if viewModel.shouldShowNoResultsState {
+            if viewModel.isLoading && viewModel.filteredBooks.isEmpty {
+                // Initial search load: show a content-shaped skeleton list
+                // (mirrors the result rows) instead of a blank screen + a lone
+                // field spinner. Built on the unified Skeleton primitives.
+                VStack(spacing: 0) {
+                    ForEach(0..<8, id: \.self) { _ in
+                        BookRowSkeletonView()
+                    }
+                }
+                .padding()
+                .id("search-results-top")
+            } else if viewModel.shouldShowNoResultsState {
                 // BUG-003: When a completed search returns zero results, render
                 // a visible empty state rather than a blank screen so the user
                 // can distinguish "no matches" from a hung request.

--- a/Palace/CatalogUI/Views/CatalogSearchView.swift
+++ b/Palace/CatalogUI/Views/CatalogSearchView.swift
@@ -154,7 +154,10 @@ private extension CatalogSearchView {
                         BookRowSkeletonView()
                     }
                 }
-                .padding()
+                // Match `BookListView`'s insets (the loaded results container)
+                // so rows don't shift horizontally when the search completes.
+                .padding(.horizontal, 12)
+                .padding(.vertical, 12)
                 .id("search-results-top")
             } else if viewModel.shouldShowNoResultsState {
                 // BUG-003: When a completed search returns zero results, render

--- a/Palace/CatalogUI/Views/CatalogView.swift
+++ b/Palace/CatalogUI/Views/CatalogView.swift
@@ -400,15 +400,30 @@ private extension CatalogView {
     // MARK: - Subviews
 
     /// Top-level skeleton used during initial load.
+    ///
+    /// Mirrors `CatalogContentView`'s loaded layout so the first lane lands at
+    /// the same y in both states and does not pop when content arrives (PP-4752):
+    ///   * `CatalogEntryPointsSkeletonView` traces the "All · Ebooks ·
+    ///     Audiobooks" segmented selector that renders above the lanes once the
+    ///     grouped feed loads (reserving its ~44pt footprint).
+    ///   * the lane scroller carries a 34pt vertical inset — matching
+    ///     `CatalogContentView`'s doubled `.padding(.vertical, 17)` (the outer
+    ///     `LazyVStack` plus the inner feed content) — so the first lane's top
+    ///     inset equals the loaded feed's.
     @ViewBuilder
     var skeletonList: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
-                ForEach(0..<3, id: \.self) { _ in
-                    CatalogLaneSkeletonView()
+        VStack(alignment: .leading, spacing: 0) {
+            CatalogEntryPointsSkeletonView()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    ForEach(0..<3, id: \.self) { _ in
+                        CatalogLaneSkeletonView()
+                    }
                 }
+                // 17 (outer LazyVStack) + 17 (feed content) in CatalogContentView.
+                .padding(.vertical, 34)
             }
-            .padding(.vertical, 17)
         }
     }
 }

--- a/Palace/MyBooks/MyBooks/BookListSkeletonView.swift
+++ b/Palace/MyBooks/MyBooks/BookListSkeletonView.swift
@@ -1,30 +1,52 @@
 import SwiftUI
 
-/// Skeleton row mirroring the real MyBooks book cell: a cover on the left, a
-/// title + author + a short button-shaped block on the right. Built on the
-/// unified `Skeleton` primitives so the base color, radii, and diagonal shimmer
-/// match every other skeleton in the app.
+/// Skeleton row that is a graytone tracing of `NormalBookCell` (the real
+/// MyBooks / Holds / search-result row). Every value is pulled 1:1 from
+/// `NormalBookCell` so a loaded row and its skeleton have identical height and
+/// column positions (zero layout shift):
+///   * Outer `HStack(alignment: .center, spacing: 15)` — matches the real cell.
+///   * Leading unread-badge gutter: `HStack(spacing: 5)` with a 10pt reserve
+///     (the real `unreadImageView` is a 10pt-wide column that reserves its
+///     layout width even when the indicator is hidden), then the cover.
+///   * Cover: `BookImageView(height: 180).frame(width: cellHeight * 2/3 = 120)`
+///     ⇒ 120×180.
+///   * Text column mirrors the real right stack: `VStack(spacing: 10)` of
+///     [infoView (title 17pt + author 12pt), then a `VStack(spacing: 4)` with a
+///     44pt button row (BookButtonsView `minHeight: 44`) + a footnote due/hold
+///     line, `.padding(.bottom, 5)`], `.frame(maxWidth: .infinity, .leading)`.
+///   * `.padding(5)` + `.frame(minHeight: 180)` — the real cell's `cellHeight`.
+///   * iPhone bottom hairline matches `BorderStyleModifier` (1pt gray @0.5).
 struct BookRowSkeletonView: View {
-    var imageSize: CGSize = CGSize(width: 100, height: 150)
+    var imageSize: CGSize = CGSize(width: 120, height: 180)
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            SkeletonCover(width: imageSize.width, height: imageSize.height)
+        HStack(alignment: .center, spacing: 15) {
+            HStack(spacing: 5) {
+                // Reserve the unread-badge gutter (10pt) so the cover starts at
+                // the same x as the real cell.
+                Color.clear.frame(width: 10, height: 10)
+                SkeletonCover(width: imageSize.width, height: imageSize.height)
+            }
 
             VStack(alignment: .leading, spacing: 10) {
-                // Title — wider, heavier line.
-                SkeletonBox(width: 180, height: 14, cornerRadius: 4)
-                // Author — shorter, lighter line.
-                SkeletonBox(width: 120, height: 12, cornerRadius: 4)
+                // infoView: title (17pt) + author (12pt).
+                VStack(alignment: .leading, spacing: 6) {
+                    SkeletonBox(width: 200, height: 18, cornerRadius: 4)
+                    SkeletonBox(width: 130, height: 13, cornerRadius: 4)
+                }
 
-                Spacer(minLength: 8)
-
-                // A button-shaped placeholder where the Read/Download control sits.
-                SkeletonBox(width: 96, height: 32, cornerRadius: PalaceRadius.control)
+                // Button block: a 44pt control (BookButtonsView `minHeight: 44`)
+                // + the footnote due-date / hold line, `.padding(.bottom, 5)`.
+                VStack(alignment: .leading, spacing: 4) {
+                    SkeletonBox(width: 120, height: 44, cornerRadius: PalaceRadius.control)
+                    SkeletonBox(width: 150, height: 12, cornerRadius: 4)
+                }
+                .padding(.bottom, 5)
             }
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(5)
+        .frame(minHeight: 180)
         .overlay(
             Rectangle()
                 .frame(height: 1)
@@ -37,16 +59,19 @@ struct BookRowSkeletonView: View {
 
 struct BookListSkeletonView: View {
     var rows: Int = 8
-    var imageSize: CGSize = CGSize(width: 100, height: 150)
+    var imageSize: CGSize = CGSize(width: 120, height: 180)
 
     var body: some View {
         ScrollView {
+            // Matches `BookListView`'s `.padding(.horizontal, 12)
+            // .padding(.vertical, 12)` so rows align with loaded content.
             VStack(spacing: 0) {
                 ForEach(0..<rows, id: \.self) { _ in
                     BookRowSkeletonView(imageSize: imageSize)
                 }
             }
-            .padding()
+            .padding(.horizontal, 12)
+            .padding(.vertical, 12)
         }
         .accessibilityHidden(true)
     }

--- a/Palace/MyBooks/MyBooks/BookListSkeletonView.swift
+++ b/Palace/MyBooks/MyBooks/BookListSkeletonView.swift
@@ -1,24 +1,26 @@
 import SwiftUI
 
+/// Skeleton row mirroring the real MyBooks book cell: a cover on the left, a
+/// title + author + a short button-shaped block on the right. Built on the
+/// unified `Skeleton` primitives so the base color, radii, and diagonal shimmer
+/// match every other skeleton in the app.
 struct BookRowSkeletonView: View {
     var imageSize: CGSize = CGSize(width: 100, height: 150)
+
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            RoundedRectangle(cornerRadius: PalaceRadius.control)
-                .fill(Color.gray.opacity(0.25))
-                .frame(width: imageSize.width, height: imageSize.height)
-                .shimmerEffect()
+            SkeletonCover(width: imageSize.width, height: imageSize.height)
 
             VStack(alignment: .leading, spacing: 10) {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(Color.gray.opacity(0.25))
-                    .frame(width: 180, height: 14)
-                    .shimmerEffect()
+                // Title — wider, heavier line.
+                SkeletonBox(width: 180, height: 14, cornerRadius: 4)
+                // Author — shorter, lighter line.
+                SkeletonBox(width: 120, height: 12, cornerRadius: 4)
 
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(Color.gray.opacity(0.25))
-                    .frame(width: 120, height: 12)
-                    .shimmerEffect()
+                Spacer(minLength: 8)
+
+                // A button-shaped placeholder where the Read/Download control sits.
+                SkeletonBox(width: 96, height: 32, cornerRadius: PalaceRadius.control)
             }
             Spacer()
         }
@@ -46,5 +48,6 @@ struct BookListSkeletonView: View {
             }
             .padding()
         }
+        .accessibilityHidden(true)
     }
 }

--- a/Palace/Settings/Components/AccountDetailSkeletonView.swift
+++ b/Palace/Settings/Components/AccountDetailSkeletonView.swift
@@ -30,20 +30,25 @@ struct AccountDetailSkeletonView: View {
         .accessibilityHidden(true)
     }
 
+    // Traces `AccountDetailView.accountHeaderSection` 1:1:
+    //   * `HStack(spacing: 12)` (Layout.logoSpacingList)
+    //   * 50×50 logo (Layout.logoSizeList) — a rounded square, since the real
+    //     logo is `Image.scaledToFit().frame(50×50)`, not a circular avatar.
+    //   * ONE headline line (`Text(libraryName).palaceFont(.headline)`) — the
+    //     real header has no subtitle, so there is no second line.
+    //   * `.listRowInsets(top: 8, leading: 25, bottom: 8, trailing: 25)` =
+    //     (verticalPaddingSmall, horizontalPadding) so the logo/text land at the
+    //     real header's x/y, and `.listRowBackground(.clear)`.
     private var headerSkeleton: some View {
         HStack(spacing: 12) {
-            SkeletonCircle(size: 50)
+            SkeletonBox(width: 50, height: 50, cornerRadius: PalaceRadius.card)
 
-            VStack(alignment: .leading, spacing: 8) {
-                SkeletonBox(width: 150, height: 20, cornerRadius: 4)
-                SkeletonBox(width: 90, height: 12, cornerRadius: 4)
-            }
+            SkeletonBox(width: 150, height: 20, cornerRadius: 4)
 
             Spacer()
         }
-        .padding(.vertical, 8)
         .listRowBackground(Color.clear)
-        .listRowInsets(EdgeInsets())
+        .listRowInsets(EdgeInsets(top: 8, leading: 25, bottom: 8, trailing: 25))
     }
 
     private var fieldSkeleton: some View {

--- a/Palace/Settings/Components/AccountDetailSkeletonView.swift
+++ b/Palace/Settings/Components/AccountDetailSkeletonView.swift
@@ -2,6 +2,10 @@
 //  AccountDetailSkeletonView.swift
 //  Palace
 //
+//  Skeleton for the account-detail screen, built on the unified `Skeleton`
+//  primitives (PP-4752): a header avatar + library name, then grouped field
+//  rows — mirroring the real AccountDetailView layout.
+//
 //  Copyright © 2025 The Palace Project. All rights reserved.
 //
 
@@ -23,19 +27,17 @@ struct AccountDetailSkeletonView: View {
             }
         }
         .listStyle(GroupedListStyle())
+        .accessibilityHidden(true)
     }
 
     private var headerSkeleton: some View {
         HStack(spacing: 12) {
-            Circle()
-                .fill(Color.gray.opacity(0.25))
-                .frame(width: 50, height: 50)
-                .shimmerEffect()
+            SkeletonCircle(size: 50)
 
-            Rectangle()
-                .fill(Color.gray.opacity(0.25))
-                .frame(width: 150, height: 20)
-                .shimmerEffect()
+            VStack(alignment: .leading, spacing: 8) {
+                SkeletonBox(width: 150, height: 20, cornerRadius: 4)
+                SkeletonBox(width: 90, height: 12, cornerRadius: 4)
+            }
 
             Spacer()
         }
@@ -45,9 +47,7 @@ struct AccountDetailSkeletonView: View {
     }
 
     private var fieldSkeleton: some View {
-        Rectangle()
-            .fill(Color.gray.opacity(0.25))
-            .frame(height: 44)
-            .shimmerEffect()
+        SkeletonBox(height: 44, cornerRadius: PalaceRadius.control)
+            .frame(maxWidth: .infinity)
     }
 }

--- a/Palace/Utilities/SwiftUI/LoadingOverlayModifier.swift
+++ b/Palace/Utilities/SwiftUI/LoadingOverlayModifier.swift
@@ -1,88 +1,65 @@
+//
+//  LoadingOverlayModifier.swift
+//  Palace
+//
+//  Backwards-compatible wrappers over the unified skeleton system
+//  (`Skeleton.swift`, PP-4752). These types predate the system; they now
+//  delegate to it so every skeleton in the app shares one base color, one
+//  shimmer cadence + diagonal direction, and one set of radii by construction.
+//
+//  Prefer the new API in new code:
+//    * `SkeletonBox` / `SkeletonText` / `SkeletonCover` / `SkeletonCircle`
+//    * `.shimmering(active:)`
+//    * `.skeleton(_:placeholder:)`
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
 import SwiftUI
 
+/// Cross-fades content with a single full-bleed skeleton block while loading.
+/// Thin wrapper over `.skeleton(_:placeholder:)`.
 struct LoadingOverlayModifier: ViewModifier {
-    var isLoading: Bool
+  var isLoading: Bool
 
-    func body(content: Content) -> some View {
-        ZStack {
-            content
-                .opacity(isLoading ? 0 : 1.0)
-
-            if isLoading {
-                RoundedRectangle(cornerRadius: PalaceRadius.control)
-                    .fill(Color.gray.opacity(0.25))
-                    .shimmerEffect()
-                    .transition(.opacity)
-            }
-        }
-        .accessibleAnimation(PalaceMotion.gentle, value: isLoading)
+  func body(content: Content) -> some View {
+    content.skeleton(isLoading) {
+      SkeletonBox(cornerRadius: PalaceRadius.control)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
+  }
 }
 
 extension View {
-    func loadingOverlay(isLoading: Bool) -> some View {
-        self.modifier(LoadingOverlayModifier(isLoading: isLoading))
-    }
+  func loadingOverlay(isLoading: Bool) -> some View {
+    self.modifier(LoadingOverlayModifier(isLoading: isLoading))
+  }
 }
 
-/// A moving-highlight shimmer for loading skeletons. A light band sweeps across
-/// the masked content, driven by an animated `phase` — the offset is a function
-/// of `phase` (`PalaceMotion.shimmerOffset`), so the band actually travels.
-///
-/// (The previous implementation animated a `@State` bool that no visual property
-/// read, so it rendered as a static grey wash.) Reduce-motion aware: when Reduce
-/// Motion is on the band is parked off-screen and the content shows as a plain
-/// static placeholder.
+/// Legacy shimmer entry point. Now delegates to the unified `.shimmering`
+/// sweep so callers that apply `.shimmerEffect()` to their own filled shape
+/// get the premium diagonal, reduce-motion-aware sweep.
 struct ShimmerEffect: ViewModifier {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var phase: CGFloat = -1
-
-    func body(content: Content) -> some View {
-        content
-            .overlay(
-                GeometryReader { geo in
-                    LinearGradient(
-                        gradient: Gradient(colors: [
-                            Color.white.opacity(0.0),
-                            Color.white.opacity(0.5),
-                            Color.white.opacity(0.0)
-                        ]),
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    )
-                    .frame(width: geo.size.width)
-                    .offset(x: PalaceMotion.shimmerOffset(phase: phase, width: geo.size.width))
-                }
-                .mask(content)
-                .allowsHitTesting(false)
-            )
-            .onAppear {
-                guard !reduceMotion else { return }
-                withAnimation(PalaceMotion.shimmer) {
-                    phase = 1
-                }
-            }
-    }
+  func body(content: Content) -> some View {
+    content.shimmering(active: true)
+  }
 }
 
 extension View {
-    func shimmerEffect() -> some View {
-        self.modifier(ShimmerEffect())
-    }
+  func shimmerEffect() -> some View {
+    self.shimmering(active: true)
+  }
 }
 
-/// A grey placeholder rectangle that shimmers. Convenience wrapper used by
-/// hand-rolled skeletons that want a single shimmering block.
+/// Legacy single-block placeholder. Now a thin wrapper over `SkeletonBox` so it
+/// picks up the adaptive base fill + shared shimmer.
 struct ShimmerView: View {
-    var width: CGFloat
-    var height: CGFloat
-    var cornerRadius: CGFloat = 0
+  var width: CGFloat
+  var height: CGFloat
+  var cornerRadius: CGFloat = 0
 
-    var body: some View {
-        RoundedRectangle(cornerRadius: cornerRadius)
-            .fill(Color.gray.opacity(0.25))
-            .frame(width: width, height: height)
-            .shimmerEffect()
-            .transition(.opacity)
-    }
+  var body: some View {
+    SkeletonBox(width: width, height: height, cornerRadius: cornerRadius)
+      .transition(.opacity)
+  }
 }

--- a/Palace/Utilities/SwiftUI/PalaceMotion.swift
+++ b/Palace/Utilities/SwiftUI/PalaceMotion.swift
@@ -39,6 +39,19 @@ enum PalaceMotion {
         reduceMotion ? nil : animation
     }
 
+    /// The single global gate for CONTINUOUS, always-on animations (skeleton
+    /// shimmer sweeps, cover-load pulses — anything that loops until content
+    /// arrives). Such loops are suppressed when Reduce Motion is on (a11y) OR
+    /// when Low Power Mode is on (battery / GPU). One seam so every continuous
+    /// loop in the app makes the same decision.
+    ///
+    /// Pure so it is unit-testable without a SwiftUI host; the reactive views
+    /// pass the live `@Environment(\.accessibilityReduceMotion)` and
+    /// `ProcessInfo.processInfo.isLowPowerModeEnabled`.
+    static func shouldAnimateContinuously(reduceMotion: Bool, lowPower: Bool) -> Bool {
+        !reduceMotion && !lowPower
+    }
+
     /// Horizontal offset (in points) of the shimmer highlight band for a given
     /// normalized `phase` in `[-1, 1]` over a content of `width` points.
     ///

--- a/Palace/Utilities/SwiftUI/Skeleton.swift
+++ b/Palace/Utilities/SwiftUI/Skeleton.swift
@@ -1,0 +1,418 @@
+//
+//  Skeleton.swift
+//  Palace
+//
+//  Unified skeleton loading system (PP-4752).
+//
+//  A single source of truth for content-shaped loading placeholders. Every
+//  skeleton in the app is built from the primitives here, so the base color,
+//  the shimmer cadence + direction, and the corner radii are identical
+//  everywhere by construction — they all flow from the `Skeleton` tokens.
+//
+//  Design goals ("great", not "compiles"):
+//    * Scheme-adaptive — reads correct in BOTH light and dark.
+//    * A soft, wide highlight that sweeps DIAGONALLY in a continuous, smooth
+//      loop (not a hard horizontal band).
+//    * Reduce Motion → NO sweep; a calm static base.
+//    * The sweep math is a pure static seam so it is unit-testable without a
+//      SwiftUI host.
+//
+//  Deployment target is iOS 17.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import SwiftUI
+
+// MARK: - Design tokens
+
+/// Namespace for the skeleton design tokens + pure geometry seams. The visual
+/// system (base fill, highlight, cadence, angle) lives here so every primitive
+/// and every call site resolves to the same look.
+enum Skeleton {
+
+  // MARK: Colors (scheme-adaptive)
+
+  /// The resting placeholder fill. Light mode uses a soft near-white gray;
+  /// dark mode a low-luminance gray that sits just above the background.
+  static func baseColor(_ scheme: ColorScheme) -> Color {
+    scheme == .dark ? Color(white: 0.22) : Color(white: 0.90)
+  }
+
+  /// The traveling highlight color. In light mode a near-white sheen; in dark
+  /// mode a lifted gray (pure white would blow out on a dark base).
+  static func highlightColor(_ scheme: ColorScheme) -> Color {
+    scheme == .dark ? Color(white: 0.40) : Color(white: 1.0)
+  }
+
+  /// Peak opacity of the highlight at the band's center. Kept below 1 so the
+  /// sweep reads as a soft sheen rather than a hard flash.
+  static func highlightPeakOpacity(_ scheme: ColorScheme) -> Double {
+    scheme == .dark ? 0.55 : 0.75
+  }
+
+  // MARK: Cadence + geometry
+
+  /// One shimmer cycle duration. A single value everywhere → one cadence.
+  static let duration: Double = 1.3
+
+  /// The diagonal tilt of the sweep, measured from vertical. A gentle lean so
+  /// the highlight crosses as a diagonal band, not a horizontal wipe.
+  static let angle: Angle = .degrees(18)
+
+  /// The highlight band width as a fraction of the content width. Wide + soft.
+  static let highlightWidthFraction: CGFloat = 0.7
+
+  /// Minimum band width (points) so tiny elements still get a visible sheen.
+  static let minBandWidth: CGFloat = 80
+
+
+  // MARK: Pure seams (unit-testable)
+
+  /// The width (points) of the highlight band for a content of `contentWidth`.
+  /// Wide and soft, but never narrower than `minBandWidth`.
+  static func bandWidth(contentWidth: CGFloat) -> CGFloat {
+    max(contentWidth * highlightWidthFraction, minBandWidth)
+  }
+
+  /// Horizontal translation (points) of the diagonal highlight band for a
+  /// normalized `phase` in `[-1, 1]`.
+  ///
+  /// The band must travel from fully off the leading edge to fully off the
+  /// trailing edge. Because the band is tilted by `angle`, the effective
+  /// horizontal span it must cross is the content width plus the horizontal
+  /// shadow of the content height across the tilt (`height * tan(angle)`),
+  /// plus the band's own width. Centered geometry ⇒ the travel is symmetric:
+  ///
+  ///   phase = -1 → band fully off the leading edge   (negative offset)
+  ///   phase =  0 → band centered on the content      (zero)
+  ///   phase = +1 → band fully off the trailing edge  (positive offset)
+  ///
+  /// This is the visual property whose absence made the old shimmer render as
+  /// a static wash: a moving `phase` here produces a visible traveling sweep.
+  static func sweepTranslationX(phase: CGFloat,
+                                width: CGFloat,
+                                height: CGFloat,
+                                angle: Angle,
+                                bandWidth: CGFloat) -> CGFloat {
+    let tilt = abs(CGFloat(tan(angle.radians)))
+    let extendedWidth = width + height * tilt
+    let travel = extendedWidth + bandWidth
+    return phase * (travel / 2)
+  }
+
+  /// The normalized sweep phase in `[-1, 1)` for a given wall-clock `time`.
+  ///
+  /// A pure function of time so ALL skeletons share one OS-driven clock (a
+  /// `TimelineView(.animation)`) instead of each owning a `repeatForever`
+  /// timer — the single most important perf decision when a full catalog shows
+  /// ~30 skeletons at once. `time` ramps the phase linearly from `-1` to `+1`
+  /// over `duration`, then wraps back to `-1`. The wrap is invisible because
+  /// the band is fully off-screen at both ends (see `sweepTranslationX`).
+  static func phase(at time: TimeInterval, duration: Double) -> CGFloat {
+    guard duration > 0 else { return -1 }
+    let fraction = (time.truncatingRemainder(dividingBy: duration) + duration)
+      .truncatingRemainder(dividingBy: duration) / duration   // 0 ..< 1
+    return CGFloat(fraction * 2 - 1)                           // -1 ..< 1
+  }
+
+  /// Whether the sweep should animate. The sweep is suppressed — a calm static
+  /// base shows instead — when the skeleton is inactive, or whenever continuous
+  /// animation is globally disallowed (Reduce Motion OR Low Power Mode). Routes
+  /// through `PalaceMotion.shouldAnimateContinuously` so the shimmer and the
+  /// cover-load pulse share ONE gate.
+  static func shouldAnimateSweep(active: Bool, reduceMotion: Bool, lowPower: Bool) -> Bool {
+    active && PalaceMotion.shouldAnimateContinuously(reduceMotion: reduceMotion, lowPower: lowPower)
+  }
+}
+
+// MARK: - Shimmer engine (shared clock, gated once)
+
+/// The moving highlight band. Driven by a single OS-driven `TimelineView(.animation)`
+/// clock; the phase is a pure function of wall-clock time
+/// (`Skeleton.phase(at:duration:)`). There is NO per-view `repeatForever` timer,
+/// so a full catalog (~30 skeletons) shares one clock instead of 30 always-on
+/// loops. `TimelineView` pauses off-screen and stops when the view is removed
+/// once content loads. Per-frame work is one 3-stop `LinearGradient` offset —
+/// no blur, no `.plusLighter`, no offscreen render pass.
+private struct SkeletonSweepBand: View {
+  let scheme: ColorScheme
+
+  var body: some View {
+    GeometryReader { geo in
+      let w = geo.size.width
+      let h = geo.size.height
+      let band = Skeleton.bandWidth(contentWidth: w)
+      let peak = Skeleton.highlightPeakOpacity(scheme)
+      let highlight = Skeleton.highlightColor(scheme)
+
+      TimelineView(.animation) { timeline in
+        let phase = Skeleton.phase(
+          at: timeline.date.timeIntervalSinceReferenceDate,
+          duration: Skeleton.duration
+        )
+        Rectangle()
+          .fill(
+            LinearGradient(
+              gradient: Gradient(colors: [
+                highlight.opacity(0),
+                highlight.opacity(peak),
+                highlight.opacity(0)
+              ]),
+              startPoint: .leading,
+              endPoint: .trailing
+            )
+          )
+          // Tall enough that the tilted band fully covers the content corners.
+          .frame(width: band, height: hypot(w, h) * 1.6)
+          .rotationEffect(Skeleton.angle)
+          .offset(
+            x: Skeleton.sweepTranslationX(
+              phase: phase, width: w, height: h,
+              angle: Skeleton.angle, bandWidth: band
+            )
+          )
+          .frame(width: w, height: h, alignment: .center)
+      }
+    }
+    .allowsHitTesting(false)
+  }
+}
+
+/// Owns the ONE gate + power-state observation for the sweep. Renders the moving
+/// band only when a continuous animation is allowed (active, and not Reduce
+/// Motion / Low Power Mode); otherwise renders nothing so the calm static base
+/// shows and no clock is created.
+private struct SkeletonSweepOverlay: View {
+  var active: Bool
+
+  @Environment(\.colorScheme) private var scheme
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var lowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+
+  private var animate: Bool {
+    Skeleton.shouldAnimateSweep(active: active, reduceMotion: reduceMotion, lowPower: lowPower)
+  }
+
+  var body: some View {
+    band
+      .onReceive(
+        NotificationCenter.default.publisher(for: Notification.Name.NSProcessInfoPowerStateDidChange)
+      ) { _ in
+        lowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+      }
+  }
+
+  @ViewBuilder private var band: some View {
+    if animate {
+      SkeletonSweepBand(scheme: scheme)
+    } else {
+      // Calm static base: no band, no clock created.
+      Color.clear
+    }
+  }
+}
+
+/// Generic shimmer for arbitrary content (legacy `shimmerEffect()` callers).
+/// Uses `.mask(content)` because the content shape is not statically known.
+/// The shape primitives below use the cheaper `.clipShape` path instead.
+struct ShimmerModifier: ViewModifier {
+  var active: Bool = true
+
+  func body(content: Content) -> some View {
+    content.overlay {
+      SkeletonSweepOverlay(active: active)
+        .mask(content)
+    }
+  }
+}
+
+extension View {
+  /// Overlays the premium diagonal shimmer sweep on a base-filled shape.
+  /// Reduce Motion / Low Power Mode show a calm static base (no sweep).
+  func shimmering(active: Bool = true) -> some View {
+    modifier(ShimmerModifier(active: active))
+  }
+
+  /// Shape-aware shimmer for the primitives: fills `shape` with the adaptive
+  /// base, overlays the sweep, and CLIPS to `shape` (cheap) rather than masking
+  /// (which forces a per-frame offscreen content re-render).
+  fileprivate func skeletonSurface<S: Shape>(_ shape: S, base: Color, active: Bool) -> some View {
+    shape
+      .fill(base)
+      .overlay { SkeletonSweepOverlay(active: active) }
+      .clipShape(shape)
+  }
+}
+
+// MARK: - Shape primitives
+
+/// A single rounded placeholder block. The atom of the system: adaptive base
+/// fill + the shared shimmer + a radius token.
+struct SkeletonBox: View {
+  var width: CGFloat?
+  var height: CGFloat?
+  var cornerRadius: CGFloat = PalaceRadius.control
+  var active: Bool = true
+
+  @Environment(\.colorScheme) private var scheme
+
+  init(width: CGFloat? = nil,
+       height: CGFloat? = nil,
+       cornerRadius: CGFloat = PalaceRadius.control,
+       active: Bool = true) {
+    self.width = width
+    self.height = height
+    self.cornerRadius = cornerRadius
+    self.active = active
+  }
+
+  var body: some View {
+    skeletonSurface(
+      RoundedRectangle(cornerRadius: cornerRadius, style: .continuous),
+      base: Skeleton.baseColor(scheme),
+      active: active
+    )
+    .frame(width: width, height: height)
+    .accessibilityHidden(true)
+  }
+}
+
+/// A run of text lines, the last one shorter to mimic real prose. Widths flow
+/// from the available width via a `GeometryReader`; the fraction math is the
+/// pure `SkeletonText.lineWidth` seam.
+struct SkeletonText: View {
+  var lines: Int
+  var lineHeight: CGFloat = 12
+  var spacing: CGFloat = 8
+  var lastLineFraction: CGFloat = 0.6
+  var cornerRadius: CGFloat = 4
+  var active: Bool = true
+
+  init(lines: Int,
+       lineHeight: CGFloat = 12,
+       spacing: CGFloat = 8,
+       lastLineFraction: CGFloat = 0.6,
+       cornerRadius: CGFloat = 4,
+       active: Bool = true) {
+    self.lines = lines
+    self.lineHeight = lineHeight
+    self.spacing = spacing
+    self.lastLineFraction = lastLineFraction
+    self.cornerRadius = cornerRadius
+    self.active = active
+  }
+
+  /// The width of the line at `index` given the total available `totalWidth`.
+  /// Pure seam: the last line of a multi-line block is `lastLineFraction` wide.
+  static func lineWidth(index: Int,
+                        count: Int,
+                        totalWidth: CGFloat,
+                        lastLineFraction: CGFloat) -> CGFloat {
+    guard count > 1, index == count - 1 else { return totalWidth }
+    return totalWidth * lastLineFraction
+  }
+
+  private var totalHeight: CGFloat {
+    guard lines > 0 else { return 0 }
+    return CGFloat(lines) * lineHeight + CGFloat(lines - 1) * spacing
+  }
+
+  var body: some View {
+    GeometryReader { geo in
+      VStack(alignment: .leading, spacing: spacing) {
+        ForEach(0..<max(lines, 0), id: \.self) { index in
+          SkeletonBox(
+            width: SkeletonText.lineWidth(
+              index: index, count: lines,
+              totalWidth: geo.size.width,
+              lastLineFraction: lastLineFraction
+            ),
+            height: lineHeight,
+            cornerRadius: cornerRadius,
+            active: active
+          )
+        }
+      }
+    }
+    .frame(height: totalHeight)
+    .accessibilityHidden(true)
+  }
+}
+
+/// A book-cover placeholder — cover aspect at the caller's size, card radius.
+struct SkeletonCover: View {
+  var width: CGFloat = 100
+  var height: CGFloat = 150
+  var active: Bool = true
+
+  init(width: CGFloat = 100, height: CGFloat = 150, active: Bool = true) {
+    self.width = width
+    self.height = height
+    self.active = active
+  }
+
+  var body: some View {
+    SkeletonBox(
+      width: width, height: height,
+      cornerRadius: PalaceRadius.card, active: active
+    )
+  }
+}
+
+/// A circular placeholder (avatars, logos, badges).
+struct SkeletonCircle: View {
+  var size: CGFloat
+  var active: Bool = true
+
+  @Environment(\.colorScheme) private var scheme
+
+  init(size: CGFloat, active: Bool = true) {
+    self.size = size
+    self.active = active
+  }
+
+  var body: some View {
+    skeletonSurface(Circle(), base: Skeleton.baseColor(scheme), active: active)
+      .frame(width: size, height: size)
+      .accessibilityHidden(true)
+  }
+}
+
+// MARK: - Container cross-fade
+
+/// Cross-fades between a skeleton placeholder and the real content using the
+/// shared gentle motion. When `isActive` the placeholder shows; otherwise the
+/// content. The hand-off is animated (Reduce Motion drops the animation).
+struct SkeletonContainerModifier<Placeholder: View>: ViewModifier {
+  let isActive: Bool
+  let placeholder: Placeholder
+
+  func body(content: Content) -> some View {
+    ZStack {
+      if isActive {
+        placeholder
+          .transition(.opacity)
+      } else {
+        content
+          .transition(.opacity)
+      }
+    }
+    .accessibleAnimation(PalaceMotion.gentle, value: isActive)
+  }
+}
+
+extension View {
+  /// Cross-fades this content with a skeleton placeholder while `isActive`.
+  ///
+  /// ```swift
+  /// realContent
+  ///   .skeleton(model.isLoading) { MyContentSkeletonView() }
+  /// ```
+  func skeleton<Placeholder: View>(
+    _ isActive: Bool,
+    @ViewBuilder placeholder: () -> Placeholder
+  ) -> some View {
+    modifier(SkeletonContainerModifier(isActive: isActive, placeholder: placeholder()))
+  }
+}

--- a/PalaceTests/Utilities/PalaceMotionTests.swift
+++ b/PalaceTests/Utilities/PalaceMotionTests.swift
@@ -63,6 +63,29 @@ final class PalaceMotionTests: XCTestCase {
         XCTAssertEqual(PalaceMotion.shimmerOffset(phase: 0, width: 200), 0, accuracy: 0.001)
     }
 
+    // MARK: - shouldAnimateContinuously — the global continuous-loop gate
+
+    /// The single gate every always-on loop (shimmer sweep, cover pulse) routes
+    /// through. Continuous animation is allowed only at full power with motion on.
+    func testShouldAnimateContinuously_fullPowerMotionOn_returnsTrue() {
+        XCTAssertTrue(PalaceMotion.shouldAnimateContinuously(reduceMotion: false, lowPower: false))
+    }
+
+    /// Reduce Motion suppresses all continuous loops (accessibility).
+    func testShouldAnimateContinuously_reduceMotion_returnsFalse() {
+        XCTAssertFalse(PalaceMotion.shouldAnimateContinuously(reduceMotion: true, lowPower: false))
+    }
+
+    /// Low Power Mode suppresses all continuous loops (battery / GPU).
+    func testShouldAnimateContinuously_lowPower_returnsFalse() {
+        XCTAssertFalse(PalaceMotion.shouldAnimateContinuously(reduceMotion: false, lowPower: true))
+    }
+
+    /// Either condition alone is sufficient to stop the loops (logical OR).
+    func testShouldAnimateContinuously_eitherConditionStops() {
+        XCTAssertFalse(PalaceMotion.shouldAnimateContinuously(reduceMotion: true, lowPower: true))
+    }
+
     // MARK: - Radius tokens
 
     /// The two shared radii are the design tokens PR2 commits to. Layout that

--- a/PalaceTests/Utilities/SkeletonTests.swift
+++ b/PalaceTests/Utilities/SkeletonTests.swift
@@ -185,4 +185,25 @@ final class SkeletonTests: XCTestCase {
     XCTAssertNotEqual(Skeleton.highlightColor(.light), Skeleton.highlightColor(.dark),
                       "Highlight must adapt to color scheme")
   }
+
+  // MARK: - Catalog entry-point selector placeholder (PP-4752 lane-pop fix)
+
+  /// The initial-load catalog skeleton reserves the entry-point segmented
+  /// selector's vertical footprint so the first lane lands at the same y in the
+  /// skeleton and the loaded feed — no downward pop when content arrives. The
+  /// real control is `EntryPointsSelectorView`'s
+  /// `Picker(.segmented).frame(minHeight: 44)` with no vertical padding, so the
+  /// placeholder MUST reserve exactly that 44pt. A mutant that zeroes or shrinks
+  /// the placeholder reintroduces the lane pop this fix removed.
+  func testEntryPointsSkeleton_reservesRealSelectorFootprint() {
+    XCTAssertEqual(CatalogEntryPointsSkeletonView.placeholderHeight, 44, accuracy: 0.001,
+                   "Placeholder must reserve the selector's 44pt minHeight footprint")
+  }
+
+  /// Guards the specific regression: a non-positive placeholder height means no
+  /// space is reserved and the lanes pop down when the real selector appears.
+  func testEntryPointsSkeleton_footprintIsNonDegenerate() {
+    XCTAssertGreaterThan(CatalogEntryPointsSkeletonView.placeholderHeight, 0,
+                         "A zero-height placeholder reserves no space — lanes would pop")
+  }
 }

--- a/PalaceTests/Utilities/SkeletonTests.swift
+++ b/PalaceTests/Utilities/SkeletonTests.swift
@@ -1,0 +1,188 @@
+//
+//  SkeletonTests.swift
+//  PalaceTests
+//
+//  PP-4752 — pins the pure geometry seams of the unified skeleton system:
+//  the diagonal sweep translation across phase, the text last-line fraction,
+//  and the reduce-motion sweep gate. These are the parts that render the
+//  "great" bar mechanical + regression-proof without a SwiftUI host.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+@testable import Palace
+
+final class SkeletonTests: XCTestCase {
+
+  // MARK: - sweepTranslationX — the diagonal band actually travels
+
+  private let angle = Skeleton.angle
+
+  /// A moving phase MUST change the offset — a constant offset is the
+  /// static-wash regression the whole system exists to avoid.
+  func testSweepTranslation_movesWithPhase() {
+    let w: CGFloat = 200, h: CGFloat = 150
+    let band = Skeleton.bandWidth(contentWidth: w)
+    let start = Skeleton.sweepTranslationX(phase: -1, width: w, height: h, angle: angle, bandWidth: band)
+    let end = Skeleton.sweepTranslationX(phase: 1, width: w, height: h, angle: angle, bandWidth: band)
+    XCTAssertNotEqual(start, end, accuracy: 0.001,
+                      "Offset must change across phase — constant offset = static wash")
+    XCTAssertLessThan(start, end, "Phase -1 parks left of phase +1")
+  }
+
+  /// Mid-phase the band is centered on the content (offset 0). Catches an
+  /// off-center `phase * travel` vs `phase * travel + k` mutant.
+  func testSweepTranslation_centeredAtMidPhase() {
+    let band = Skeleton.bandWidth(contentWidth: 200)
+    XCTAssertEqual(
+      Skeleton.sweepTranslationX(phase: 0, width: 200, height: 150, angle: angle, bandWidth: band),
+      0, accuracy: 0.001)
+  }
+
+  /// The travel is symmetric about center: +phase and -phase are mirror offsets.
+  func testSweepTranslation_symmetricAboutCenter() {
+    let band = Skeleton.bandWidth(contentWidth: 120)
+    let neg = Skeleton.sweepTranslationX(phase: -0.5, width: 120, height: 90, angle: angle, bandWidth: band)
+    let pos = Skeleton.sweepTranslationX(phase: 0.5, width: 120, height: 90, angle: angle, bandWidth: band)
+    XCTAssertEqual(neg, -pos, accuracy: 0.001)
+  }
+
+  /// The band must fully clear the content at the extremes: at phase ±1 the
+  /// absolute offset must exceed half the content width plus half the band, so
+  /// no sheen is left parked on-screen at the loop seam.
+  func testSweepTranslation_fullyClearsContentAtExtremes() {
+    let w: CGFloat = 200, h: CGFloat = 150
+    let band = Skeleton.bandWidth(contentWidth: w)
+    let end = Skeleton.sweepTranslationX(phase: 1, width: w, height: h, angle: angle, bandWidth: band)
+    XCTAssertGreaterThan(end, w / 2 + band / 2,
+                         "At phase 1 the band must be fully off the trailing edge")
+  }
+
+  /// The diagonal tilt widens the required travel vs a purely horizontal band:
+  /// taller content ⇒ more travel (the height casts a horizontal shadow across
+  /// the tilt). A zero-angle mutant would make height irrelevant.
+  func testSweepTranslation_tiltMakesTallerContentTravelFarther() {
+    let w: CGFloat = 200
+    let band = Skeleton.bandWidth(contentWidth: w)
+    let shortEnd = Skeleton.sweepTranslationX(phase: 1, width: w, height: 20, angle: angle, bandWidth: band)
+    let tallEnd = Skeleton.sweepTranslationX(phase: 1, width: w, height: 400, angle: angle, bandWidth: band)
+    XCTAssertGreaterThan(tallEnd, shortEnd,
+                         "A diagonal sweep must travel farther over taller content")
+  }
+
+  // MARK: - bandWidth — soft + wide, with a floor
+
+  func testBandWidth_isFractionOfWideContent() {
+    XCTAssertEqual(Skeleton.bandWidth(contentWidth: 400),
+                   400 * Skeleton.highlightWidthFraction, accuracy: 0.001)
+  }
+
+  func testBandWidth_floorsForTinyContent() {
+    XCTAssertEqual(Skeleton.bandWidth(contentWidth: 10), Skeleton.minBandWidth, accuracy: 0.001,
+                   "Tiny elements still get a visible band via the floor")
+  }
+
+  // MARK: - SkeletonText.lineWidth — last line is shorter
+
+  /// A multi-line block's last line is `lastLineFraction` of the width; all
+  /// earlier lines are full width. This is what makes the block read as prose.
+  func testLineWidth_lastLineIsShorter() {
+    let full = SkeletonText.lineWidth(index: 0, count: 3, totalWidth: 300, lastLineFraction: 0.6)
+    let last = SkeletonText.lineWidth(index: 2, count: 3, totalWidth: 300, lastLineFraction: 0.6)
+    XCTAssertEqual(full, 300, accuracy: 0.001)
+    XCTAssertEqual(last, 180, accuracy: 0.001, "Last line = 0.6 * width")
+    XCTAssertLessThan(last, full)
+  }
+
+  /// A middle line is full width (only the terminal line shortens).
+  func testLineWidth_middleLineIsFullWidth() {
+    XCTAssertEqual(SkeletonText.lineWidth(index: 1, count: 3, totalWidth: 300, lastLineFraction: 0.6),
+                   300, accuracy: 0.001)
+  }
+
+  /// A single-line block does NOT shorten — a lone short bar looks broken, not
+  /// like prose. Guards the `count > 1` condition.
+  func testLineWidth_singleLineIsFullWidth() {
+    XCTAssertEqual(SkeletonText.lineWidth(index: 0, count: 1, totalWidth: 300, lastLineFraction: 0.6),
+                   300, accuracy: 0.001,
+                   "A single line must stay full width, not shrink")
+  }
+
+  // MARK: - phase(at:duration:) — the shared time-driven clock
+
+  /// The phase is a pure function of wall-clock time so every skeleton shares
+  /// ONE OS clock (a TimelineView) instead of N repeatForever timers. It must
+  /// move with time — a constant would be the static-wash regression again.
+  func testPhase_movesWithTime() {
+    let d = Skeleton.duration
+    let a = Skeleton.phase(at: 0, duration: d)
+    let b = Skeleton.phase(at: d * 0.5, duration: d)
+    XCTAssertNotEqual(a, b, accuracy: 0.0001, "Phase must advance with time")
+    XCTAssertLessThan(a, b, "Phase ramps upward within a cycle")
+  }
+
+  /// The phase starts fully off the leading edge and ramps toward the trailing
+  /// edge over one duration: t=0 → -1, t≈duration → ≈+1.
+  func testPhase_rampsFromMinusOneTowardPlusOne() {
+    let d = Skeleton.duration
+    XCTAssertEqual(Skeleton.phase(at: 0, duration: d), -1, accuracy: 0.0001)
+    XCTAssertEqual(Skeleton.phase(at: d * 0.999, duration: d), 1, accuracy: 0.01)
+  }
+
+  /// The clock loops seamlessly: the phase at time T equals the phase at T + one
+  /// full duration (so 30 skeletons stay in sync forever without drift).
+  func testPhase_loopsWithPeriodEqualToDuration() {
+    let d = Skeleton.duration
+    let t: TimeInterval = 0.37
+    XCTAssertEqual(Skeleton.phase(at: t, duration: d),
+                   Skeleton.phase(at: t + d, duration: d), accuracy: 0.0001)
+    XCTAssertEqual(Skeleton.phase(at: t, duration: d),
+                   Skeleton.phase(at: t + d * 5, duration: d), accuracy: 0.0001)
+  }
+
+  /// A zero/negative duration must not divide-by-zero — it parks the band.
+  func testPhase_zeroDurationIsSafe() {
+    XCTAssertEqual(Skeleton.phase(at: 3, duration: 0), -1, accuracy: 0.0001)
+  }
+
+  // MARK: - shouldAnimateSweep — reduce-motion / low-power / active gate
+
+  /// Reduce Motion ⇒ no sweep, even when active: a calm static base.
+  func testShouldAnimateSweep_reduceMotionOn_returnsFalse() {
+    XCTAssertFalse(Skeleton.shouldAnimateSweep(active: true, reduceMotion: true, lowPower: false),
+                   "Reduce Motion must suppress the sweep")
+  }
+
+  /// Low Power Mode ⇒ no sweep (spare battery/GPU), even when active + motion on.
+  func testShouldAnimateSweep_lowPowerOn_returnsFalse() {
+    XCTAssertFalse(Skeleton.shouldAnimateSweep(active: true, reduceMotion: false, lowPower: true),
+                   "Low Power Mode must suppress the sweep")
+  }
+
+  /// Active + motion allowed + full power ⇒ sweep animates.
+  func testShouldAnimateSweep_activeAndMotionAllowed_returnsTrue() {
+    XCTAssertTrue(Skeleton.shouldAnimateSweep(active: true, reduceMotion: false, lowPower: false))
+  }
+
+  /// Inactive ⇒ no sweep regardless of other settings.
+  func testShouldAnimateSweep_inactive_returnsFalse() {
+    XCTAssertFalse(Skeleton.shouldAnimateSweep(active: false, reduceMotion: false, lowPower: false))
+    XCTAssertFalse(Skeleton.shouldAnimateSweep(active: false, reduceMotion: true, lowPower: true))
+  }
+
+  // MARK: - Color tokens read differently per scheme (adaptive by construction)
+
+  /// The base fill MUST differ between light and dark — the core "great in both
+  /// appearances" requirement. Equal colors would mean a non-adaptive wash.
+  func testBaseColor_differsBetweenSchemes() {
+    XCTAssertNotEqual(Skeleton.baseColor(.light), Skeleton.baseColor(.dark),
+                      "Base fill must adapt to color scheme")
+  }
+
+  func testHighlightColor_differsBetweenSchemes() {
+    XCTAssertNotEqual(Skeleton.highlightColor(.light), Skeleton.highlightColor(.dark),
+                      "Highlight must adapt to color scheme")
+  }
+}


### PR DESCRIPTION
**Jira:** PP-4752 (sub-task of PP-4743). Rebuilds the loading experience into one polished, consistent, **performance-hardened** skeleton system — and fixes a shipped battery/a11y bug along the way.

### The system (`Palace/Utilities/SwiftUI/Skeleton.swift`)
- Tokens (scheme-adaptive base/highlight, 1.3s duration, 18° diagonal), `.shimmering(active:)`, primitives (`SkeletonBox`/`SkeletonText`/`SkeletonCover`/`SkeletonCircle`), `.skeleton(_:placeholder:)` cross-fade container. Pure testable seams.
- Adopted in every content-shaped loading state (catalog lanes/lane-more, MyBooks, Holds, account detail, book-detail cover, **new** catalog-search skeleton). Old `shimmerEffect`/`ShimmerView`/`loadingOverlay` are now thin wrappers over the new system. Spinners kept only where there's no content shape (inline buttons, web/EULA loads, determinate bars).

### Performance (the important part — from two perf audits)
- **Single `TimelineView(.animation)` clock** drives all skeletons: a full catalog (~30 placeholders) shares **one** OS-driven clock, in sync, auto-pausing off-screen and stopping when content loads. **No per-view `repeatForever`** (was O(N) always-on loops).
- **Fixed the shipped battery/a11y bug**: `PulsingSkeletonView` (per-cover `repeatForever`, *no* reduce-motion guard) → replaced by `SkeletonCover` on the shared clock; and its **4-layer `.adaptiveShadow` is decoupled** onto the settled cover so it no longer re-rasterizes every frame (~96 offscreen passes/frame on a cold SE catalog, gone).
- **One global gate** `PalaceMotion.shouldAnimateContinuously` — Reduce Motion **or** Low Power Mode → calm static base, no clock created (observes power-state live). `clipShape` not `mask`; 3 stops; no blur/blend.

### Light/dark
Base/highlight differ per `colorScheme` (unit-tested light ≠ dark; dark uses a muted sheen that never blows out).

### Verification
Local `** BUILD SUCCEEDED **`; 20 `SkeletonTests` + 11 `PalaceMotionTests` (4 new) pass. **Draft** because the light/dark look is reasoned + unit-tested but not yet screenshot-verified — a simdrive light/dark pass on a live loading state (PP-4751) is the final gate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)