### PR TITLE
fix(debug): make simulated borrow errors unmistakable in the UI (PP-4454)

### DIFF
--- a/Palace/Settings/Debug/DebugSettings.swift
+++ b/Palace/Settings/Debug/DebugSettings.swift
@@ -157,16 +157,50 @@ final class DebugSettings: @unchecked Sendable {
         return simulatedBorrowError != .none
     }
 
+    // MARK: - Debug-simulation marker
+
+    /// Unmistakable banner stamped onto every simulated debug error. PP-4454
+    /// follow-up: a QA tester left the "Simulate Borrow Error" toggle on and
+    /// reported the resulting fake 500 as a real server bug, because the alert
+    /// was indistinguishable from a genuine failure. The marker leads the alert
+    /// body and the "Palace Error Report" so a simulation can never masquerade
+    /// as a real error again.
+    static let debugSimulationMarker = "⚠️ DEBUG SIMULATION"
+
+    /// Actionable banner line that names the toggle and how to disable it.
+    private static func debugSimulationBanner(_ displayName: String) -> String {
+        "\(debugSimulationMarker) — this is a FAKE error triggered by "
+        + "Developer Settings ▸ Simulate Borrow Error (\(displayName)). "
+        + "It is NOT a real failure. Set it to “None” to stop seeing it."
+    }
+
     // MARK: - Error Generation
 
-    /// Creates a simulated NSError with problem document for testing
-    /// Returns nil if simulation is disabled
+    /// Creates a simulated NSError with problem document for testing.
+    /// Returns nil if simulation is disabled.
+    ///
+    /// The returned problem document is a *marked* copy of the catalog document:
+    /// its title and detail carry `debugSimulationMarker` so the simulation is
+    /// obvious in every surface QA sees (borrow-error alert body + error report),
+    /// while the genuine copy is preserved beneath the banner for realistic preview.
     func createSimulatedBorrowError() -> (error: NSError, problemDocument: TPPProblemDocument)? {
-        guard let problemDoc = simulatedBorrowError.problemDocument else {
+        let simulated = simulatedBorrowError
+        guard let baseDoc = simulated.problemDocument else {
             return nil
         }
 
-        Log.warn(#file, "⚠️ DEBUG: Simulating borrow error: \(simulatedBorrowError.displayName)")
+        Log.warn(#file, "⚠️ DEBUG: Simulating borrow error: \(simulated.displayName)")
+
+        let markedTitle = "\(Self.debugSimulationMarker): \(baseDoc.title ?? "Simulated error")"
+        let markedDetail = Self.debugSimulationBanner(simulated.displayName)
+            + "\n\n" + (baseDoc.detail ?? "")
+
+        let problemDoc = TPPProblemDocument.fromDictionary([
+            "type": baseDoc.type ?? "",
+            "title": markedTitle,
+            "status": baseDoc.status ?? 403,
+            "detail": markedDetail
+        ])
 
         let error = NSError.makeFromProblemDocument(
             problemDoc,

--- a/PalaceTests/Settings/DebugSettingsTests.swift
+++ b/PalaceTests/Settings/DebugSettingsTests.swift
@@ -124,6 +124,61 @@ final class DebugSettingsTests: XCTestCase {
         XCTAssertNotNil(result?.problemDocument)
     }
 
+    // MARK: - Debug-simulation marker (PP-4454 follow-up)
+    // A stale "Simulate Borrow Error" toggle was reported as a real server bug
+    // because the simulated alert was indistinguishable from a genuine failure.
+    // Every simulated error must now carry an unmistakable banner.
+
+    // SRS: the simulated problem-document detail leads with the debug banner so
+    // it is the first thing shown in the borrow-error alert body AND the report.
+    func testCreateSimulatedBorrowError_detailIsBannerPrefixed() {
+        settings.simulatedBorrowError = .genericServerError
+        let detail = settings.createSimulatedBorrowError()?.problemDocument.detail
+
+        XCTAssertNotNil(detail)
+        XCTAssertTrue(detail?.hasPrefix(DebugSettings.debugSimulationMarker) == true,
+                      "Simulated detail must LEAD with the marker so it heads the alert body; got: \(detail ?? "nil")")
+        // Actionable: it must tell the reader where the toggle lives and how to stop it.
+        XCTAssertTrue(detail?.contains("Developer Settings") == true,
+                      "Banner must name Developer Settings so QA can find the toggle")
+        XCTAssertTrue(detail?.localizedCaseInsensitiveContains("not a real") == true,
+                      "Banner must state this is not a real failure")
+    }
+
+    // SRS: the banner is additive — the original realistic detail is preserved
+    // below it, so QA can still preview what the genuine error copy looks like.
+    func testCreateSimulatedBorrowError_preservesOriginalDetailBelowBanner() {
+        settings.simulatedBorrowError = .genericServerError
+        let originalDetail = DebugSettings.SimulatedBorrowError.genericServerError.problemDocument?.detail
+        let markedDetail = settings.createSimulatedBorrowError()?.problemDocument.detail
+
+        XCTAssertNotNil(originalDetail)
+        XCTAssertTrue(markedDetail?.contains(originalDetail!) == true,
+                      "The genuine detail copy must survive beneath the banner for QA preview")
+    }
+
+    // SRS: the problem-document title is marked too, so the "Palace Error Report"
+    // Title line and any title-driven UI reads as a simulation at a glance.
+    func testCreateSimulatedBorrowError_titleIsMarked() {
+        settings.simulatedBorrowError = .credentialsSuspended
+        let title = settings.createSimulatedBorrowError()?.problemDocument.title
+
+        XCTAssertNotNil(title)
+        XCTAssertTrue(title?.contains(DebugSettings.debugSimulationMarker) == true,
+                      "Simulated problem-document title must carry the debug marker")
+    }
+
+    // SRS: the marked error keeps its debug domain + simulated HTTP status so the
+    // report's Domain line and downstream status handling are unchanged.
+    func testCreateSimulatedBorrowError_keepsDebugDomainAndStatus() {
+        settings.simulatedBorrowError = .genericServerError
+        let result = settings.createSimulatedBorrowError()
+
+        XCTAssertEqual(result?.error.domain, "DebugSimulatedBorrowError")
+        XCTAssertEqual(result?.error.code, 500, "Generic server error must retain its 500 status")
+        XCTAssertEqual(result?.problemDocument.status, 500)
+    }
+
     // MARK: - Badge Logging
 
     // SRS: isBadgeLoggingEnabled defaults to false


### PR DESCRIPTION
## Why

QA reported PP-4454 (LCP-wrapped *Family Matters*) as **still broken in build 483**. It isn't — the LCP-PDF fix is on `release/3.2.0` and in 483. The pasted "Palace Error Report" was actually a **debug simulation**: `Developer Settings ▸ Simulate Borrow Error` was left set to *Generic Server Error*, so the app returned a fake 500 (`Domain: DebugSimulatedBorrowError`) at the borrow step. The book never downloaded, so the reader/PDF path — the thing PP-4454 fixed — was never even reached.

The simulated alert was **indistinguishable** from a real server error, which is what caused the confusion. This makes simulated errors self-identify so it can't happen again.

## What

Single chokepoint: `DebugSettings.createSimulatedBorrowError()` now returns a **marked copy** of the catalog problem document.

- Title + detail carry a `⚠️ DEBUG SIMULATION` banner that **names the toggle and how to disable it**.
- The banner **leads the detail**, so it heads both the borrow-error alert body *and* the "Palace Error Report" pasted into Jira.
- The genuine copy is preserved **beneath** the banner, so QA can still preview real error wording.

Rendered alert body now reads:

> Borrowing Family Matters could not be completed.
>
> ⚠️ DEBUG SIMULATION — this is a FAKE error triggered by Developer Settings ▸ Simulate Borrow Error (Generic Server Error). It is NOT a real failure. Set it to “None” to stop seeing it.
>
> An unexpected error occurred on the server. Please try again later.

Debug-only — still gated behind `applicationEnvironment != .production` + the hidden Developer Settings toggle. **No production borrow/alert code touched.**

## Tests

4 new `DebugSettingsTests` cases: marker-prefix on detail, actionable banner text (`Developer Settings` / `not a real`), original-detail preservation below the banner, and domain/status round-trip.

## Scope / verification

- **Scope:** borrow-error simulation only (the wired path). The sync-failure simulator isn't wired into a user-facing flow, so it's intentionally left unchanged.
- **Local build note:** app-target XCTest can't build under local Xcode 26.3 (pre-existing `develop` strict-concurrency error at `TPPAppDelegate.swift:132`, identical to `origin/develop`, unrelated to this diff). **CI (Xcode 26.0) is the suite gate.** Marker logic proven standalone; `check-test-name-vs-body` / `check-blast-radius` / `check-superpartner-spectrum` all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)