### PR TITLE
chore(ci): repo-wide gate — never commit code-signing info; signing must be Manual

### DIFF
--- a/.forgeos/committed-signing-allowlist.txt
+++ b/.forgeos/committed-signing-allowlist.txt
@@ -1,0 +1,5 @@
+# Allowlist for scripts/check-no-committed-signing.sh — substrings matched against
+# the offending signing line to intentionally permit it. One per line; '#' = comment.
+# Normally EMPTY: the detector is path-aware (only scans .pbxproj/.xcconfig/.entitlements/
+# .plist), so its own test fixtures/docs don't need suppression. Add an entry only for a
+# genuine, reviewed exception — with a reason.

--- a/.github/workflows/tooling-checks.yml
+++ b/.github/workflows/tooling-checks.yml
@@ -89,3 +89,15 @@ jobs:
           else
             echo "No objc-witness detector test — skipping."
           fi
+
+      # 5. Committed-signing gate (repo rule: no team/profile in git, Manual only).
+      #    Diff-based (blocks NEW signing info); the one pre-existing Automatic
+      #    config (Palace Release) is cleaned separately once local dev-signing is
+      #    provided via a gitignored xcconfig — flipping it blind would break it.
+      - name: committed-signing detector test
+        run: |
+          if [ -f scripts/tests/test_check_no_committed_signing.sh ]; then
+            bash scripts/tests/test_check_no_committed_signing.sh
+          else
+            echo "No committed-signing detector test — skipping."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,10 @@ scripts/tests/__pycache__/
 
 # Regression-rebuild campaign run artifacts (generated, never committed)
 .regression-runs/
+
+# Code signing — provide team ID / provisioning locally, never commit (repo rule).
+# See scripts/check-no-committed-signing.sh.
+*.local.xcconfig
+Signing.local.xcconfig
+*.mobileprovision
+*.p12

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,6 +428,16 @@ Some critical-path classes are easier to pin behaviorally than to mutation-test:
 
 Never commit: `APIKeys.swift`, `GoogleService-Info.plist`, `TPPSecrets.swift`, `.env` files.
 
+**Code signing must be Manual, and signing info must NOT be committed.**
+`CODE_SIGN_STYLE = Manual` on every config (Automatic lets Xcode rewrite the team
+ID / provisioning profile into the pbxproj on each dev's machine, causing churn +
+leaking signing identity). `DEVELOPMENT_TEAM` and `PROVISIONING_PROFILE` are
+per-machine/per-account — provide them via a gitignored `*.local.xcconfig` or a CI
+secret, never in git (`DEVELOPMENT_TEAM = ""` in the committed pbxproj is fine).
+Enforced by `scripts/check-no-committed-signing.sh` (diff-based; wired into the
+pre-commit hook + `verify-pr.sh` + `tooling-checks.yml`). To intentionally allow an
+entry, add a substring to `.forgeos/committed-signing-allowlist.txt` with a reason.
+
 ## E2E / UI sim driving — simdrive
 
 **simdrive is the canonical iOS sim driver.** SpecterQA is **deprecated** as of 2026-04-29 (cutover) and **fully migrated** as of 2026-04-30 (everything moved under `.simdrive/`). The old SpecterQA corpus lives under `.simdrive/_archive/` (do **not** extend). Active flows live under `.simdrive/fixtures/flows/` (declarative, with `expects:` blocks) and `.simdrive/journeys/` (recording-aligned, paired with `~/.simdrive/recordings/`). Per-version visual baselines live under `.simdrive/fixtures/baselines/<version>/<flow>/<step>.{json,png}`.

--- a/scripts/check-no-committed-signing.sh
+++ b/scripts/check-no-committed-signing.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# check-no-committed-signing.sh
+#
+# Repo-wide rule: code-signing info must NOT be committed, and signing must be
+# Manual. This blocks a commit/diff that ADDS any of the following to a tracked
+# file (project.pbxproj, xcconfig, plist, …):
+#
+#   - CODE_SIGN_STYLE = Automatic            (repo rule: Manual only — Automatic
+#                                             lets Xcode rewrite team/profile into
+#                                             the pbxproj on every dev's machine)
+#   - DEVELOPMENT_TEAM = <real 10-char id>   (provide locally, not in git; blank
+#                                             `DEVELOPMENT_TEAM = ""` is allowed)
+#   - PROVISIONING_PROFILE = <uuid>          (per-machine profile UUID — never commit)
+#
+# Operates on ADDED diff lines (leading '+') so it prevents NEW leaks without
+# firing on values already committed (which are cleaned out separately). A
+# pre-existing team ID being present is not this gate's concern; a diff that
+# (re)introduces or changes one is.
+#
+# Usage: check-no-committed-signing.sh [<unified-diff-file>|--diff <f>]
+#        (default: `git diff --cached`)
+# Exit 0 = clean; 1 = signing info found; 2 = usage/error.
+#
+# Allowlist (optional): OBJC unrelated — NO_SIGNING_ALLOWLIST (default
+#   .forgeos/committed-signing-allowlist.txt); one substring per line, '#' comments.
+
+set -uo pipefail
+
+DIFF_FILE=""
+case "${1:-}" in
+  --diff) DIFF_FILE="${2:-}" ;;
+  "" ) : ;;
+  * ) DIFF_FILE="$1" ;;
+esac
+
+if [ -n "$DIFF_FILE" ]; then
+  [ -f "$DIFF_FILE" ] || { echo "[no-signing] no such diff file: $DIFF_FILE"; exit 2; }
+  DIFF="$(cat "$DIFF_FILE")"
+else
+  DIFF="$(git diff --cached 2>/dev/null)"
+fi
+
+ALLOW="${NO_SIGNING_ALLOWLIST:-.forgeos/committed-signing-allowlist.txt}"
+
+# PATH-AWARE: only evaluate ADDED lines that belong to a signing-bearing build
+# file (project.pbxproj / *.xcconfig / *.entitlements / *.plist). This is what
+# keeps the detector from flagging its OWN test fixtures and doc comments, which
+# live in scripts/tests/*.sh and this file — a diff of those is not a signing
+# leak. awk tracks the current `+++ b/<path>` header; the regex match is done
+# after (grep -E supports {N} intervals; POSIX awk may not).
+RELEVANT_ADDED="$(printf '%s\n' "$DIFF" | awk '
+  /^diff --git / { infile=0; next }
+  /^\+\+\+ b\// { f=$0; sub(/^\+\+\+ b\//,"",f);
+                  infile = (f ~ /\.(pbxproj|xcconfig|entitlements|plist)$/) ? 1 : 0; next }
+  /^\+\+\+/ { next }
+  infile==1 && /^\+/ { line=$0; sub(/^\+/,"",line); print line }
+')"
+
+# DEVELOPMENT_TEAM: trailing ';' (pbxproj) OR end-of-line (xcconfig has no ';').
+FINDINGS="$(printf '%s\n' "$RELEVANT_ADDED" | grep -nE \
+  'CODE_SIGN_STYLE[[:space:]]*=[[:space:]]*Automatic|DEVELOPMENT_TEAM[[:space:]]*=[[:space:]]*[A-Z0-9]{10}[[:space:]]*(;|$)|PROVISIONING_PROFILE[[:space:]]*=[[:space:]]*"?[0-9a-fA-F]{8}-[0-9a-fA-F-]{27}' \
+  2>/dev/null || true)"
+
+# Drop allowlisted lines.
+if [ -f "$ALLOW" ] && [ -n "$FINDINGS" ]; then
+  while IFS= read -r pat; do
+    [ -z "$pat" ] && continue
+    case "$pat" in \#*) continue ;; esac
+    FINDINGS="$(printf '%s\n' "$FINDINGS" | grep -vF -- "$pat" || true)"
+  done < "$ALLOW"
+fi
+
+if [ -n "$FINDINGS" ]; then
+  echo "[no-signing] BLOCK: this commit adds code-signing info to a tracked file."
+  echo "Repo rule: signing must be Manual, and the team ID / provisioning profile must"
+  echo "NOT be committed (provide them via a gitignored local xcconfig or CI secret)."
+  echo ""
+  printf '  %s\n' "$FINDINGS"
+  echo ""
+  echo "Fix: set CODE_SIGN_STYLE = Manual; set DEVELOPMENT_TEAM = \"\" (or remove it) and"
+  echo "     PROVISIONING_PROFILE via a local, gitignored config — not in git."
+  echo "If genuinely intentional, add a matching substring to $ALLOW with a reason."
+  exit 1
+fi
+
+echo "[no-signing] OK: no committed code-signing info / Automatic style added."
+exit 0

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -97,6 +97,16 @@ fi
 # Adjacency is warn-only at the hook layer too.
 run_m1_check "adjacency_staleness" "scripts/check-adjacency-staleness.py" || true
 
+# Repo rule: never commit code-signing info (team ID / provisioning profile) and
+# never add Automatic signing. Bash detector (not python), so invoked directly
+# rather than via run_m1_check. Diff-based — blocks NEW signing info only.
+if [[ -f "$REPO_ROOT_M1/scripts/check-no-committed-signing.sh" ]]; then
+  if ! _ns_out=$(bash "$REPO_ROOT_M1/scripts/check-no-committed-signing.sh" "$M1_DIFF" 2>&1); then
+    echo "$_ns_out" >&2
+    M1_FAIL=$((M1_FAIL + 1))
+  fi
+fi
+
 m1_enforce "$M1_FAIL"
 
 # Friendly nudge — non-blocking. Only print if anything is staged at all.

--- a/scripts/tests/test_check_no_committed_signing.sh
+++ b/scripts/tests/test_check_no_committed_signing.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# test_check_no_committed_signing.sh — verify the committed-signing gate.
+set -uo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+DET="$DIR/../check-no-committed-signing.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+ok(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+bad(){ echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# 1 — adds CODE_SIGN_STYLE = Automatic -> BLOCK
+cat > "$TMP/a.diff" <<'EOF'
+diff --git a/Palace.xcodeproj/project.pbxproj b/Palace.xcodeproj/project.pbxproj
+--- a/Palace.xcodeproj/project.pbxproj
++++ b/Palace.xcodeproj/project.pbxproj
+@@ -1 +1 @@
++				CODE_SIGN_STYLE = Automatic;
+EOF
+"$DET" "$TMP/a.diff" >/dev/null 2>&1; [ $? -eq 1 ] && ok "Automatic style blocked" || bad "Automatic not blocked"
+
+# 2 — adds a real DEVELOPMENT_TEAM -> BLOCK
+cat > "$TMP/t.diff" <<'EOF'
++++ b/Palace.xcodeproj/project.pbxproj
++				DEVELOPMENT_TEAM = 88CBA74T8K;
+EOF
+"$DET" "$TMP/t.diff" >/dev/null 2>&1; [ $? -eq 1 ] && ok "real DEVELOPMENT_TEAM blocked" || bad "team id not blocked"
+
+# 3 — adds a provisioning profile UUID -> BLOCK
+cat > "$TMP/p.diff" <<'EOF'
++++ b/Palace.xcodeproj/project.pbxproj
++				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
+EOF
+"$DET" "$TMP/p.diff" >/dev/null 2>&1; [ $? -eq 1 ] && ok "provisioning UUID blocked" || bad "profile uuid not blocked"
+
+# 4 — adds a BLANK team ("") + Manual -> PASS (the allowed target state)
+cat > "$TMP/blank.diff" <<'EOF'
++++ b/Palace.xcodeproj/project.pbxproj
++				CODE_SIGN_STYLE = Manual;
++				DEVELOPMENT_TEAM = "";
++				PROVISIONING_PROFILE_SPECIFIER = "";
+EOF
+"$DET" "$TMP/blank.diff" >/dev/null 2>&1; [ $? -eq 0 ] && ok "blank team + Manual allowed" || bad "blank/Manual wrongly blocked"
+
+# 5 — REMOVING signing (- lines) -> PASS (only added lines matter)
+cat > "$TMP/rm.diff" <<'EOF'
++++ b/Palace.xcodeproj/project.pbxproj
+-				DEVELOPMENT_TEAM = 88CBA74T8K;
+-				CODE_SIGN_STYLE = Automatic;
+EOF
+"$DET" "$TMP/rm.diff" >/dev/null 2>&1; [ $? -eq 0 ] && ok "removing signing allowed" || bad "removal wrongly blocked"
+
+# 6 — unrelated diff -> PASS
+cat > "$TMP/clean.diff" <<'EOF'
++++ b/Palace/Foo.swift
++    let x = 1
+EOF
+"$DET" "$TMP/clean.diff" >/dev/null 2>&1; [ $? -eq 0 ] && ok "unrelated diff passes" || bad "clean diff wrongly blocked"
+
+# 7 — allowlisted team -> PASS
+echo "88CBA74T8K" > "$TMP/allow.txt"
+NO_SIGNING_ALLOWLIST="$TMP/allow.txt" "$DET" "$TMP/t.diff" >/dev/null 2>&1; [ $? -eq 0 ] && ok "allowlisted team suppressed" || bad "allowlist not honored"
+
+# 8 — team ID in an .xcconfig (NO trailing semicolon) -> BLOCK (the xcconfig gap)
+cat > "$TMP/xcconfig.diff" <<'EOF'
++++ b/Signing.xcconfig
++DEVELOPMENT_TEAM = 88CBA74T8K
+EOF
+"$DET" "$TMP/xcconfig.diff" >/dev/null 2>&1; [ $? -eq 1 ] && ok "xcconfig team id (no semicolon) blocked" || bad "xcconfig team id slipped through"
+
+# 9 — signing-looking strings in a NON-build file (this detector's own test/docs)
+#     -> PASS. Proves path-awareness: fixtures/docs must not self-trigger the gate.
+cat > "$TMP/selftest.diff" <<'EOF'
++++ b/scripts/tests/test_check_no_committed_signing.sh
++CODE_SIGN_STYLE = Automatic;
++DEVELOPMENT_TEAM = 88CBA74T8K;
++PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
+EOF
+"$DET" "$TMP/selftest.diff" >/dev/null 2>&1; [ $? -eq 0 ] && ok "signing strings in non-build file ignored (no self-block)" || bad "path-blind: flagged a non-build file"
+
+echo "[test_check_no_committed_signing] $PASS passed / $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -450,6 +450,26 @@ else
   record "blast_radius" "pass" "check-blast-radius.py not found (skipped)"
 fi
 
+# Repo rule: never commit code-signing info (team ID / provisioning profile) and
+# never add Automatic signing. Diff-based. See `scripts/check-no-committed-signing.sh`.
+echo "--- Committed-signing ---"
+if [ "$MUTATION_ONLY" = "true" ]; then
+  record "committed_signing" "pass" "Skipped (--mutation-only)"
+elif [ -f scripts/check-no-committed-signing.sh ]; then
+  NS_DIFF=$(mktemp -t ns-diff.XXXX)
+  git diff "$BASE"...HEAD > "$NS_DIFF" 2>/dev/null || true
+  NS_OUT=$(bash scripts/check-no-committed-signing.sh "$NS_DIFF" 2>&1)
+  NS_EXIT=$?
+  rm -f "$NS_DIFF"
+  if [ "$NS_EXIT" -eq 0 ]; then
+    record "committed_signing" "pass" "No committed signing info / Automatic style added"
+  else
+    record "committed_signing" "fail" "$(echo "$NS_OUT" | grep -m1 BLOCK)"
+  fi
+else
+  record "committed_signing" "pass" "check-no-committed-signing.sh not found (skipped)"
+fi
+
 # 3c. Adjacency staleness (M1 universal-rigor-floor gate, warn-only)
 # Greps comments in the surviving codebase for references to removed/renamed
 # declarations in the diff. Always passes; counts warnings.


### PR DESCRIPTION
Repo-wide rule: **code signing must be Manual, and the team ID / provisioning profile must never be committed** (provide them via a gitignored `*.local.xcconfig` or CI secret).

### What's here (safe, diff-based, path-aware)
- **`scripts/check-no-committed-signing.sh`** — path-aware detector: on added lines in `.pbxproj`/`.xcconfig`/`.entitlements`/`.plist` only, blocks `CODE_SIGN_STYLE = Automatic`, a real 10-char `DEVELOPMENT_TEAM` (trailing `;` **or** end-of-line, so xcconfig is caught), or a provisioning-profile UUID. Blank `DEVELOPMENT_TEAM = ""` and removals pass.
- **Test (9/9)**: block paths, blank+Manual, removal, unrelated, allowlist, the xcconfig gap, and a path-skip fixture proving the detector doesn't self-flag its own fixtures/docs.
- **Wired**: pre-commit hook (local block), `verify-pr.sh`, `tooling-checks.yml`; `.gitignore` + CLAUDE.md rule; allowlist stub.

### Reviewed
Two independent local SoD reviewers (`rev_ada020a7` soundness, `rev_a014b4c0` QA) **BLOCKED** a first draft on a path-blind self-match (the detector flagged its own test fixtures → `verify-pr` + the pre-commit floor failed on this very PR — the PR #1045 self-defeating-gate class) and a `.xcconfig` no-semicolon gap. Both fixed (path-aware awk scan + `(;|$)` regex + allowlist stub); detector on this branch's own diff now exits 0. Record: `.forgeos/reviews/no-committed-signing-gate-2026-07-08.md`.

### Deliberately NOT in this PR (needs your input)
The currently-committed `DEVELOPMENT_TEAM = 88CBA74T8K`, two provisioning UUIDs, and the **1 Automatic config (Palace Release, dev signing)** are *not* removed here. There's **no CI signing** — release/archive is signed locally by you — and that Automatic config has no explicit profile, so flipping it to Manual + blanking the team/profile blind **would break your local archive signing**. That cleanup should: (1) add a gitignored `Signing.local.xcconfig` with your team + dev provisioning; (2) reference it from the pbxproj; (3) blank the inline values + flip Automatic→Manual. Happy to do it once you confirm the local-signing values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)