### PR TITLE
Bulletproof Ownership: durable downloads + registry resilience + offline-safe loans

### DIFF
--- a/.forgeos/intent/reliability-ws-a.md
+++ b/.forgeos/intent/reliability-ws-a.md
@@ -1,0 +1,55 @@
+---
+name: reliability-ws-a
+created: 2026-07-07
+author: claude-opus-4-8
+type: feature
+tracking: Bulletproof Ownership — Reliability Initiative, Workstream A (Durable Downloads). Contract .forgeos/reliability-plan.md §2.WS-A, seam S1, INV-4/6/7.
+related_prs: []
+---
+
+# Intent: Reliability WS-A — Durable Downloads
+
+## Claims
+- NEW `Palace/MyBooks/DownloadTaskPersistence.swift`: `PersistedDownloadRecord`
+  (Codable/Sendable, seam S1), `ReconcileDecision` (adopt/restart/markFailed/
+  cleanup), PURE `DownloadReconciliation.reconcile(persisted:liveTaskIdentifiers:
+  registryStates:)`, and `DownloadTaskPersistence` durable JSON store in
+  Application Support (own file, NOT the registry file), NSLock-guarded,
+  injectable URL.
+- `MyBooksDownloadCenter`: static `backgroundSessionIdentifier` (single source of
+  truth for the 3 inline literals); stored `backgroundCompletionHandler` +
+  `setBackgroundCompletionHandler`; `urlSessionDidFinishEvents(forBackground
+  URLSession:)` invoking+clearing once on main (INV-7); persistence write on task
+  start + removal on terminal completion; guarded `reconcileDownloadsAtLaunch()`
+  (runs after registry load, getAllTasks -> pure reconcile -> apply); bounded
+  transient-transfer retry in `handleTaskCompletionError`.
+- `DownloadStateManager`: injectable `taskPersistence` + persist/remove/list;
+  cleanup/reset drop persisted records.
+- `DownloadErrorRecovery`: `RetryPolicy.downloadTransfer` (policy-use only, reuses
+  NSURLError classifier).
+- `TPPAppDelegate` bg handler: route download-center id -> MBDC; all other ids
+  keep byte-for-byte audiobook route (INV-7).
+
+## Anti-claims
+- Does NOT edit MyBooksViewModel / BookReturnService / BookRegistrySync /
+  OfflineQueueService.
+- Does NOT touch Adobe/LCP DRM fulfillment (INV-6) — retry wraps plain content
+  transfer only; no edits in `#if FEATURE_DRM_CONNECTOR` / `#if LCP` blocks.
+- Does NOT change the audiobook route for non-download-center ids (INV-7).
+- Does NOT reuse the registry persistence file. Does NOT stage ios-audiobooktoolkit.
+
+## Deviation from seam S1 (documented)
+Seam typed `registryStates` as `[String: TPPBookRegistry.RegistryState]`, but that
+enum is the whole-registry load state (unloaded/loading/loaded/...), not per-book
+lifecycle. INV-4 healing references per-book `.downloading`, so `reconcile` takes
+`[String: TPPBookState]` — the semantically-correct per-book state. Flagged for
+architect review.
+
+## Files in scope
+- Palace/MyBooks/DownloadTaskPersistence.swift (new)
+- Palace/MyBooks/DownloadStateManager.swift
+- Palace/MyBooks/MyBooksDownloadCenter.swift
+- Palace/MyBooks/DownloadErrorRecovery.swift
+- Palace/AppInfrastructure/TPPAppDelegate.swift (bg handler only)
+- PalaceTests/MyBooks/{DownloadTaskPersistenceTests,DownloadReconciliationTests,DownloadReconciliationLaunchOrderContractTests,BackgroundSessionRoutingTests}.swift (new)
+- PalaceTests/MyBooks/DownloadStateManagerTests.swift (extend)

--- a/.forgeos/intent/reliability-ws-b.md
+++ b/.forgeos/intent/reliability-ws-b.md
@@ -1,0 +1,44 @@
+# Intent — Reliability WS-B: Registry Resilience
+
+## Context
+Critical-path work item of the "Bulletproof Ownership" reliability initiative.
+`TPPBookRegistry` is the shelf's source of truth; a corrupt-load-then-empty-save
+can erase a patron's entire shelf (initiative plan §1 Problem 4, §2 WS-B, INV-1).
+
+## Claims (what this diff does)
+- Adds a new pure classification + recovery helper `RegistryFileRecovery` that
+  distinguishes an absent registry file (`.empty`) from an existing-but-unparseable
+  one (`.corrupt`) from a well-formed one (`.valid(records:)`).
+- In `BookRegistrySync.load`, splits the old conflated `else` so a corrupt file
+  takes a QUARANTINE branch (copies to `registry.json.corrupt-<timestamp>`, never
+  destroys), attempts recovery from a `.bak` sidecar, and — when unrecoverable —
+  leaves the in-memory registry empty and sets a `needsRebuildFromServer` flag
+  instead of silently zeroing.
+- On every successful non-empty (or server-authoritative) `save`/`saveSync`,
+  first writes a `.bak` sidecar via write-new -> fsync -> rename (keeps last-good).
+- Guards the empty save (INV-1): `save(for:)` refuses to persist an empty snapshot
+  over a non-empty last-good `.bak` while `needsRebuildFromServer` is set, unless
+  the caller marks the save server-authoritative. `sync()`'s reconciliation save is
+  the authoritative path that repopulates from the loans feed and clears the flag.
+- Adds a `schemaVersion` field (v1 = today's shape) to the persisted payload in
+  `save` and `saveSync`; old unversioned files load fine and are migrated to
+  versioned on the next save.
+
+## Anti-claims (what this diff must NOT do)
+- Does NOT change `shouldSkipBulkDeletion` behavior (preserved byte-for-byte).
+- Does NOT edit `MyBooksDownloadCenter` (WS-A) — the load-time re-download
+  scheduling calls stay as-is on its existing public API.
+- Does NOT touch any WS-A / WS-C file (MyBooks/Download*, MyBooksViewModel,
+  BookReturnService, OfflineQueueService, TPPAppDelegate, DownloadStateManager).
+- Does NOT change DRM/LCP fulfillment or re-download paths (INV-6).
+
+## Files in scope
+- `Palace/Book/Models/BookRegistrySync.swift` (edit)
+- `Palace/Book/Models/RegistryFileRecovery.swift` (new)
+- `PalaceTests/Book/BookRegistrySyncTests.swift` (edit)
+- `PalaceTests/Book/RegistryFileRecoveryTests.swift` (new)
+
+## Guarding tests (INV-1)
+- `RegistryFileRecoveryTests.testCorruptFile_isQuarantined_notOverwrittenEmpty`
+- `BookRegistrySyncTests.testSaveEmptyOverNonEmptyBackup_isRefusedWithoutServerAuthority`
+- `.bak` restore on corrupt load; schema migration of an old unversioned file.

--- a/.forgeos/intent/reliability-ws-c.md
+++ b/.forgeos/intent/reliability-ws-c.md
@@ -1,0 +1,23 @@
+# Intent: Reliability WS-C — Offline-Safe Loans, Renewal & Offline-Queue Wiring
+
+## Claims
+- Add `LoanEvictionPolicy` (pure `decide(expiration:now:isOnline:grace:) -> EvictionDecision`) — seam S3.
+- Gate `MyBooksViewModel` expired-book eviction through `LoanEvictionPolicy`; inject an `isOnline` provider (new ctor dependency, default = production reachability). Never delete/unregister offline based on a cached `until` alone (INV-2).
+- Add `LoanRenewalService` — extracts the OPDS renew (borrow-rel) URL, POSTs it, updates the registry; routes 401 through `AuthErrorClassifier` with `currentAccountHostsProvider` so a foreign-host 401 does NOT mark credentials stale (INV-5).
+- Add `OfflineQueueCoordinator` — calls `OfflineQueueService.shared.setExecutor` exactly once; dispatches by `OfflineActionType` to existing public APIs; dedupes by bookID+type (INV-8). Registered once from `AppContainer`.
+- `BookReturnService.handleRevokeError`: genuine offline `NSURLError` enqueues an `OfflineAction(.return,...)` instead of dead-ending; does NOT delete local content / unregister until server-confirmed (INV-3). Preserves ordered cleanup contract `setProcessing -> setState -> removeBook -> announce.returnSucceeded`.
+
+## Anti-claims (explicitly NOT doing)
+- NOT editing `MyBooksDownloadCenter.swift` (call existing public API only), `BookRegistrySync.swift`, `DownloadStateManager.swift`, `TPPAppDelegate.swift`.
+- NOT changing `OfflineQueueService.setExecutor` signature (frozen seam S2).
+- NOT changing the BookReturn ordered-cleanup contract or its existing snapshots.
+- NOT touching DRM fulfillment paths.
+
+## Files in scope
+- NEW `Palace/MyBooks/LoanEvictionPolicy.swift`
+- NEW `Palace/MyBooks/LoanRenewalService.swift`
+- NEW `Palace/Platform/OfflineQueueCoordinator.swift`
+- EDIT `Palace/MyBooks/MyBooks/MyBooksViewModel.swift`
+- EDIT `Palace/MyBooks/BookReturnService.swift`
+- EDIT `Palace/AppInfrastructure/AppContainer.swift` (single registration call only)
+- Tests: `LoanEvictionPolicyTests`, `LoanRenewalServiceTests`, `OfflineQueueCoordinatorTests`, `MyBooksViewModelTests` (+offline case), `BookReturnServiceTests`/`BookReturnServiceContractTests` (+offline-enqueue).

--- a/.forgeos/reliability-plan.md
+++ b/.forgeos/reliability-plan.md
@@ -1,0 +1,277 @@
+# Bulletproof Ownership — Reliability Initiative Plan
+
+**Architect workstream contract.** Core promise: *"the book I downloaded is reliably mine for the loan period."* This document is the contract parallel implementers build against. Critical-path code (downloads / borrow-return / registry / auth-network) — a bug means a patron loses a book or a loan desyncs.
+
+Worktree: `.claude/worktrees/reliability` (off `develop`). All citations verified against the current tree on this branch.
+
+---
+
+## 1. Verified current state (evidence)
+
+### Problem 1 — Durable downloads: **CONFIRMED (with corrections)**
+
+**1a. Background-session completion handler wired only for audiobooks — CONFIRMED.**
+`Palace/AppInfrastructure/TPPAppDelegate.swift:442-444`:
+```swift
+internal func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
+    audiobookLifecycleManager.handleEventsForBackgroundURLSession(for: identifier, completionHandler: completionHandler)
+}
+```
+The `identifier` is **ignored** — every background-session wake is handed to the audiobook manager. The book download center runs its **own** background session: `MyBooksDownloadCenter.swift:930-935` (and 938-945, 1080-1085) build `URLSessionConfiguration.background(withIdentifier: bundleId + ".downloadCenterBackgroundIdentifier")`. That identifier is never matched, and `MyBooksDownloadCenter` implements **no** `urlSessionDidFinishEvents(forBackgroundURLSession:)` delegate (grep count = 0). So when a book download finishes while the app is suspended, iOS relaunches the app, calls the delegate above, the download center's stored system completion handler is neither captured nor invoked → the app cannot tell iOS it finished handling events (background time mismanaged), and there is no guaranteed path that recreates the download session so its delegate callbacks (`didFinishDownloadingTo`) fire → **a suspended-completion download can be silently dropped.**
+
+**1b. Task↔book maps are in-memory only; no `getAllTasks` rehydrate on launch — CONFIRMED.**
+`Palace/MyBooks/DownloadStateManager.swift:45-47` — the three tracking maps are plain in-memory `SafeDictionary`s:
+```swift
+let bookIdentifierToDownloadInfo = SafeDictionary<String, MyBooksDownloadInfo>()
+let bookIdentifierToDownloadTask = SafeDictionary<String, URLSessionDownloadTask>()
+let taskIdentifierToBook = SafeDictionary<Int, TPPBook>()
+```
+There is no persistence and no `session.getAllTasks`/`getTasksWithCompletionHandler` reconciliation anywhere in `MyBooksDownloadCenter.swift` (grep = 0). Kill mid-download → the maps are gone; the registry record persisted as `.downloading` is *partially* healed by `BookRegistrySync.load` (`BookRegistrySync.swift:166-173`: `.downloading` + file-exists → `.downloadSuccessful`, else → `.downloadFailed`) — **so "strands in `.downloading` forever" is slightly inaccurate**: on next launch the load-time heal flips it out of `.downloading`. **The real gap:** an actually-still-running background task (iOS keeps background downloads alive across app death) is orphaned — the app never re-adopts it, so it either gets marked `.downloadFailed` prematurely or its completion lands with no in-memory mapping and is dropped. There is no reconciliation between live URLSession tasks and registry state.
+
+**1c. Content transfer has no transient retry/backoff — CONFIRMED.**
+`DownloadErrorRecovery` (`Palace/MyBooks/DownloadErrorRecovery.swift`) is a complete exponential-backoff+jitter engine (`executeWithRetry`, `calculateBackoffDelay:285-291`, policies at :29-138). It is applied **only** to the borrow OPDS fetch: `MyBooksDownloadCenter.swift:809-811` inside `fetchBookClosure` with `RetryPolicy.borrowOperation`. The actual URLSession **content** download (the bytes transfer) has no retry — a transient network blip during transfer surfaces via `didCompleteWithError` → `.downloadFailed`, no automatic re-attempt.
+
+### Problem 2 — Offline-safe loans: **CONFIRMED**
+
+`Palace/MyBooks/MyBooks/MyBooksViewModel.swift:131-146` — `loadData()` (which runs on **every** My Books appearance, including offline) partitions on `book.isExpired` and, for every expired book, unconditionally deletes local content and unregisters:
+```swift
+let (active, expired) = registryBooks.reduce(into: ...) { ... if book.isExpired ... }
+if !expired.isEmpty {
+    for book in expired {
+        downloadCenter.deleteLocalContent(for: book.identifier)   // :143 — deletes the FILE
+        bookRegistry.setState(.unregistered, for: book.identifier) // :144
+    }
+}
+```
+`isExpired` is a **purely local** computation on the cached `until` date: `TPPBook.swift:567-570` → `getExpirationDate()` reads `availability.limited.until` / `ready.until` from the cached OPDS entry. **No online check, no server confirmation, no grace period.** A stale/early `until`, a clock skew, or a server that would still honor the loan → the patron's downloaded file is destroyed while offline. The code comment at :129-130 explicitly says this was *intentionally* moved to run online-or-offline — that is the defect.
+
+**No in-app loan renewal — CONFIRMED.** No OPDS `renew` rel handling exists (grep for `renew` in `Palace/` finds only a developer-settings mock string at `TPPDeveloperSettingsTableViewController.swift:750` and an unrelated `PalaceAuth/AuthOutcome.swift:60`). Loan-expiry warnings depend on CM push (not in this tree).
+
+### Problem 3 — Offline queue: **CONFIRMED**
+
+`Palace/Platform/OfflineQueueService.swift` is a polished actor: exponential backoff (`OfflineAction.nextRetryDelay`), typed actions (`OfflineActionType`: `.borrow`, `.return`, `.hold`, `.cancelHold` — `OfflineAction.swift:13-18`), persistence, `NWPathMonitor`-driven auto-drain (:184-200), executor injection seam `setExecutor` (:75-77). **Zero production wiring for real actions**: the only references outside the file are its own diagnostics UI — `OfflineQueueDetailView.swift`, `AppHealthViewModel.swift:38`, `PlatformTab.swift:49-50` — all reading `.shared` for display. **`setExecutor` is never called in production**, so `processQueue()` early-returns at :134 (`guard let executor = self.executor else { return }`). Nothing ever calls `enqueue`.
+
+The **live** queue is `Palace/Network/TPPNetworkQueue.swift` (class `NetworkQueue`): SQLite-backed, wired only for annotation POSTs, drops rows after `MaxRetriesInQueue = 5` (:57, deletion at :202-204). Returns/renewals/offline-created bookmarks are never queued.
+
+**Offline return dead-ends — CONFIRMED.** `BookReturnService.returnBook` (`BookReturnService.swift:272`) with a `revokeURL` goes straight to `opdsFeedService.fetchFeed(from: revokeURL)` (:317). Offline → throws → `handleRevokeError` (:397) → not loan-gone, not auth → generic alert (:529). No enqueue, no deferred retry. The user is told return failed with no durable "will retry when online."
+
+### Problem 4 — Registry resilience: **CONFIRMED**
+
+`Palace/Book/Models/BookRegistrySync.swift:145-245`. The load path:
+```swift
+if FileManager...fileExists && let data = try? Data(...) && let json = try? JSONSerialization... && let records = json.array(for: .records) {
+    ... parse ...
+} else {
+    Log.info("  No existing registry file found or failed to parse")   // :242 — conflates two cases!
+}
+registry = newRegistry   // :245 — empty on the failure branch
+```
+A corrupt/unparseable `registry.json` takes the `else` branch, is logged **identically to "no file exists,"** and `newRegistry` stays empty → the in-memory shelf is zeroed. Any subsequent `save(for:)` (`:554`, called from `sync` reconciliation :537, `validateDownloadedContent` :643, etc.) writes the empty snapshot back with `.write(to:, options: .atomic)` (:574) — **overwriting the (recoverable) corrupt file with a valid-but-empty one.** No `.bak`, no quarantine, no rebuild-from-loans-feed, and the on-disk payload has **no schema version** (`save` writes only `{records: [...]}` at :564; contrast the SQLite queue which *does* version via `PRAGMA user_version`). A single bad write/OS truncation silently erases the patron's whole shelf.
+
+---
+
+## 2. Workstreams (file-disjoint)
+
+Three workstreams. Ownership is exclusive: a file is edited by exactly one WS; every other WS treats it read-only. Cross-WS interaction happens only through the **shared seams** in §2.4, which are public APIs, not shared files.
+
+### WS-A — Durable Downloads
+**Owns (edit):**
+- `Palace/MyBooks/DownloadStateManager.swift`
+- `Palace/MyBooks/MyBooksDownloadCenter.swift`
+- `Palace/MyBooks/DownloadErrorRecovery.swift` (extend policy use only)
+- `Palace/AppInfrastructure/TPPAppDelegate.swift` (**only** the `handleEventsForBackgroundURLSession` method, :442-444, and adding a stored completion-handler property)
+- **New:** `Palace/MyBooks/DownloadTaskPersistence.swift` (the persistence model + pure reconciliation function)
+- Tests: `PalaceTests/MyBooks/DownloadStateManagerTests.swift`, `MyBooksDownloadCenterTests.swift`, plus new `DownloadTaskPersistenceTests.swift`, `DownloadReconciliationTests.swift`
+
+**Off-limits (read-only, another WS owns):** `MyBooksViewModel.swift` (C), `BookReturnService.swift` (C), `BookRegistrySync.swift` (B), `OfflineQueueService.swift` (C).
+
+**Concrete changes:**
+1. **Route the book background session's completion handler.** In `TPPAppDelegate.handleEventsForBackgroundURLSession`, branch on `identifier`: if it matches the download center's `…downloadCenterBackgroundIdentifier`, store `completionHandler` on the download center and ensure the download center's session is (re)instantiated so its delegate callbacks fire; else keep the audiobook route. Add `urlSessionDidFinishEvents(forBackgroundURLSession:)` to `MyBooksDownloadCenter` that invokes and clears the stored handler on the main thread. **Preserve the existing audiobook route unchanged.**
+2. **Persist the task↔book map.** Introduce `DownloadTaskPersistence` — a durable record of `{bookID, taskIdentifier, expectedBytes, downloadURL, account}` written when a task starts and removed on terminal completion. Storage: a small JSON/plist keyed alongside the registry (do **not** reuse `BookRegistrySync`'s file — B owns that). `DownloadStateManager` writes/reads through it; keep the in-memory `SafeDictionary`s as the hot cache.
+3. **Reconcile on launch.** New pure function `DownloadReconciliation.reconcile(persisted:, liveTasks:, registryStates:) -> [ReconcileDecision]` (adopt / restart / markFailed / cleanup). At startup, call `session.getAllTasks`, feed live tasks + persisted records + registry snapshot in, apply decisions: re-adopt still-running tasks into the maps, restart tasks that died, and only then let the registry heal. **Must run AFTER `BookRegistrySync.load` completes** (see §3).
+4. **Add transient retry to the content transfer.** Wrap the content download's failure path in `DownloadErrorRecovery.executeWithRetry` with a **download-transfer policy** (resumable, respects `didCompleteWithError` NSURLError classification already encoded in `RetryPolicy.default.shouldRetry`). Prefer resume-data-based retry over full re-fetch. Cap attempts; never retry non-transient (auth/404/insufficient-space) — the classifier at `DownloadErrorRecovery.swift:34-90` already encodes this.
+
+**Acceptance criteria:**
+- Kill-mid-download → relaunch: a still-running background task is re-adopted (not double-started, not spuriously failed); a task that truly died is restarted; registry ends in a state consistent with disk.
+- Download that completes while suspended: on next foreground the file is present, registry `.downloadSuccessful`, and the stored system completion handler was invoked exactly once.
+- Transient transfer error retries with backoff and eventually succeeds without user action; non-transient fails fast with the existing alert.
+- Audiobook background handling is byte-for-byte unchanged.
+
+### WS-B — Registry Resilience
+**Owns (edit):**
+- `Palace/Book/Models/BookRegistrySync.swift`
+- **New:** `Palace/Book/Models/RegistryFileRecovery.swift` (pure corrupt-file classification + quarantine/backup helper + schema version)
+- Tests: `PalaceTests/Book/BookRegistrySyncTests.swift` and new `RegistryFileRecoveryTests.swift`
+
+**Off-limits:** everything WS-A and WS-C own. B does **not** touch `MyBooksDownloadCenter` even though load schedules re-downloads through it (:306) — those calls use MBDC's existing public API and stay as-is.
+
+**Concrete changes:**
+1. **Distinguish "no file" from "corrupt file."** Split the `BookRegistrySync.swift:145-243` guard so a file that exists but fails to parse takes a **quarantine** branch, not the silent-empty `else`.
+2. **Quarantine + backup, never destroy.** Before overwriting a corrupt file, copy it to `registry.json.corrupt-<timestamp>` (quarantine) and, on every successful `save`, first write a `.bak` sidecar (write-new → fsync → rename pattern; keep last-good). On corrupt load, attempt recovery from `.bak` before falling back to empty.
+3. **Rebuild path.** When a corrupt/empty load is detected, do **not** immediately `save` empty (that is what erases the shelf). Leave in-memory empty, set a `needsRebuildFromServer` flag, and let the next authenticated `sync` repopulate from the loans feed — but **guard the empty-registry save**: `save(for:)` must refuse to persist an empty snapshot over a non-empty last-good `.bak` unless an authoritative server sync produced the emptiness (reuse the spirit of `shouldSkipBulkDeletion` at :674).
+4. **Schema version.** Add a `schemaVersion` field to the persisted payload (`save` at :564 / `saveSync` at :598) and a migration read at load. Version 1 = today's shape.
+
+**Acceptance criteria:**
+- Corrupt `registry.json` on launch: original is quarantined, `.bak` (if present) restores the shelf, and the corrupt file is **never** overwritten by an empty save before a server sync.
+- A truncated/empty save cannot replace a non-empty last-good backup without server authority.
+- Old (unversioned) files load and are migrated to versioned on next save.
+- The existing bulk-deletion guard (`shouldSkipBulkDeletion`) behavior is preserved.
+
+### WS-C — Offline-Safe Loans, Renewal & Offline-Queue Wiring
+**Owns (edit):**
+- `Palace/MyBooks/MyBooks/MyBooksViewModel.swift` (eviction gate)
+- `Palace/MyBooks/BookReturnService.swift` (offline → enqueue)
+- `Palace/Platform/OfflineQueueService.swift` (only if the executor seam needs widening; prefer not to edit)
+- **New:** `Palace/MyBooks/LoanEvictionPolicy.swift` (pure eviction-decision function)
+- **New:** `Palace/MyBooks/LoanRenewalService.swift` (OPDS `renew` rel)
+- **New:** `Palace/Platform/OfflineQueueCoordinator.swift` (wires `OfflineQueueService.setExecutor` to real actions)
+- Tests: `PalaceTests/MyBooks/MyBooksViewModelTests.swift`, `BookReturnServiceTests.swift`, `PalaceTests/Platform/OfflineQueueServiceTests.swift`, plus new `LoanEvictionPolicyTests.swift`, `LoanRenewalServiceTests.swift`, `OfflineQueueCoordinatorTests.swift`
+
+**Off-limits:** `MyBooksDownloadCenter.swift` (A) — C calls its **existing** public API (`deleteLocalContent`, `startDownload`, borrow) but does **not** edit it. `BookRegistrySync.swift` (B). `DownloadStateManager.swift` (A). `TPPAppDelegate.swift` (A).
+
+**Concrete changes:**
+1. **Gate offline eviction.** Replace the unconditional delete at `MyBooksViewModel.swift:139-146` with a call to `LoanEvictionPolicy.decide(book:, now:, isOnline:, graceInterval:)`. Rule: **never delete a downloaded file based on a cached `until` alone while offline.** Delete only when online AND (server-confirmed absence from loans feed OR past `until` + grace window). Offline expired books stay readable (or show a "loan may have expired — reconnect to confirm" affordance) rather than being destroyed. Inject an `isOnline`/reachability provider into the view model (new constructor dependency, default to production reachability).
+2. **Loan renewal.** `LoanRenewalService.renew(book:)` reads the OPDS `renew` rel from the book's acquisition/links, POSTs it, updates the registry record from the response entry. Surface a "Renew" affordance where loan expiry is shown. Route auth errors through the same host-scoped classifier as borrow/return (see Invariant 5).
+3. **Wire the offline queue.** `OfflineQueueCoordinator` calls `OfflineQueueService.shared.setExecutor { action in … }` at app startup (registered from `AppContainer`/app launch — coordinate the single registration site with the owner of that seam; the *call* lives in C's new file). Executor dispatches by `OfflineActionType`: `.return` → `BookReturnService`, `.borrow` → download center borrow API, `.hold`/`.cancelHold` → holds API — all via existing public methods. Returns `true` only on server-confirmed success so the queue's retry/backoff drives failures.
+4. **Offline return enqueues.** In `BookReturnService.handleRevokeError` (:397), when the error is a genuine offline/no-connection `NSURLError`, enqueue an `OfflineAction(.return, …)` instead of dead-ending in the alert, and inform the user it will complete when back online. **Do not** delete local content or unregister until the queued return is server-confirmed (Invariant 2/3).
+
+**Acceptance criteria:**
+- Offline + expired-by-cached-`until` book: file is **not** deleted; book remains openable; no unregister.
+- Online + server-confirmed-returned book: eviction proceeds as today.
+- Renewal: tapping Renew POSTs the `renew` rel and extends the loan in the registry; auth failure re-prompts via the shared classifier.
+- Offline return: enqueued, retried on reconnect, and only then does local cleanup run; queue survives app restart.
+
+### 2.4 Shared seams (interfaces — define once, both sides code to these)
+
+**Seam S1 — Download-state persistence & reconciliation (owned by WS-A).**
+```swift
+struct PersistedDownloadRecord: Codable, Sendable {
+    let bookID: String
+    let taskIdentifier: Int
+    let downloadURL: URL
+    let account: String
+    let expectedBytes: Int64?
+    let startedAt: Date
+}
+enum ReconcileDecision: Equatable { case adopt(bookID: String, taskIdentifier: Int)
+                                    case restart(bookID: String)
+                                    case markFailed(bookID: String)
+                                    case cleanup(bookID: String) }
+// Pure — unit-testable without URLSession:
+func reconcile(persisted: [PersistedDownloadRecord],
+               liveTaskIdentifiers: Set<Int>,
+               registryStates: [String: TPPBookRegistry.RegistryState]) -> [ReconcileDecision]
+```
+Only A implements/edits this. B's registry load is the *input* (`registryStates`), never the mutator. Contract: **registry state is the source of truth for a book's lifecycle; A reconciles URLSession tasks to it, and only heals `.downloading` records that have no live task.**
+
+**Seam S2 — Offline queue executor (owned by WS-C; the actor API is frozen).**
+`OfflineQueueService.setExecutor(_ executor: @escaping OfflineActionExecutor)` where `OfflineActionExecutor = @Sendable (OfflineAction) async -> Bool` (`OfflineQueueService.swift:15`). **Do not change this signature** — it is the whole integration point. C's `OfflineQueueCoordinator` supplies the closure. The closure returns `true` **only** on server-confirmed success. Registration must happen exactly once at launch.
+
+**Seam S3 — Eviction decision (owned by WS-C).**
+```swift
+enum EvictionDecision: Equatable { case keep; case evict; case confirmWithServer }
+func LoanEvictionPolicy.decide(expiration: Date?, now: Date,
+                               isOnline: Bool, grace: TimeInterval) -> EvictionDecision
+```
+Pure, no I/O. The view model calls it; the file delete only happens on `.evict`. This function is the single guardrail behind Invariant 2.
+
+---
+
+## 3. Sequencing / dependencies
+
+**Land first (foundational, fully parallel to each other):**
+- **WS-B (registry resilience)** — independent; nothing else edits `BookRegistrySync`. Ship first because A's reconciliation *reads* registry state and must not fight a shelf-erasing corrupt-load.
+- **WS-A seam S1 (persistence model + pure `reconcile`)** — the `DownloadTaskPersistence.swift` + pure function can be built and unit-tested with no dependency on B.
+
+**Then / parallel:**
+- **WS-A integration** (background handler routing, launch reconciliation, transfer retry) proceeds in parallel with C. A's launch reconciliation depends on the **runtime ordering** "registry load → then reconcile" — that is a call-order contract inside AppContainer/launch, not a file dependency. Enforce it with a contract-snapshot test.
+- **WS-C** proceeds in parallel: eviction gate (S3) and renewal are independent; offline-queue wiring (S2) depends only on the already-existing `OfflineQueueService`. C calls MBDC/BookReturnService **public** API — no file collision with A because C never edits MBDC.
+
+**Stacks (do not start until dependency merged):**
+- C's offline-return enqueue (`BookReturnService`) is independent of A, but its executor's `.borrow` branch calls MBDC borrow API — verify that API is stable (it is; no A change to it is required).
+
+**Merge order recommendation:** B → A → C, but A and C can develop concurrently against frozen seams and merge in either order once B lands.
+
+---
+
+## 4. CRITICAL SAFETY INVARIANTS (the most important output)
+
+Each invariant + the guarding test. Violating any is a BLOCK.
+
+**INV-1 — Never overwrite a recoverable registry with an empty one.** A corrupt/unparseable `registry.json` must be quarantined and `.bak`-restored; `save(for:)` must refuse to persist an empty snapshot over a non-empty last-good backup absent authoritative server emptiness.
+*Guard:* `RegistryFileRecoveryTests.testCorruptFile_isQuarantined_notOverwrittenEmpty`; `BookRegistrySyncTests.testSaveEmptyOverNonEmptyBackup_isRefusedWithoutServerAuthority`. (WS-B)
+
+**INV-2 — Never delete a downloaded file while offline based on a cached `until` alone.** Eviction requires online + server confirmation (absence from loans feed) OR past-`until`+grace *and* online. Offline expired ⇒ keep the file.
+*Guard:* `LoanEvictionPolicyTests.testOfflineExpiredByCachedUntil_keepsFile`; `MyBooksViewModelTests.testLoadData_offline_doesNotDeleteExpiredLocalContent`. (WS-C)
+
+**INV-3 — Loan-return client/server consistency.** The client must not unregister/delete locally until the return is server-confirmed (revoke feed OK, or a known loan-gone problem-doc, or a server-confirmed queued return). An offline return enqueues; it does **not** pre-emptively clean up. Preserve the existing ordered cleanup contract `setProcessing → setState → removeBook → announce.returnSucceeded`.
+*Guard:* `BookReturnServiceContractTests` (existing snapshot at `PalaceTests/Contract/__Snapshots__/BookReturnServiceContractTests`) must not drift; new `BookReturnServiceTests.testOfflineReturn_enqueues_doesNotDeleteLocalContent`. (WS-C)
+
+**INV-4 — Adopt, don't double-start or spuriously fail, live background downloads.** Launch reconciliation must re-adopt a still-running task (no second task, no premature `.downloadFailed`) and must run after registry load.
+*Guard:* `DownloadReconciliationTests.testLiveTask_isAdopted_notRestarted`, `…testDeadTask_isRestarted`, `…testCompletedWhileSuspended_marksSuccessfulOnce`; a contract-snapshot test pinning the launch order registry-load→reconcile. (WS-A)
+
+**INV-5 — Auth-error host scoping is preserved on every new network path.** Renewal and queued-return retries route 401/credentials-stale decisions through the current-account host-scoped classifier (`AuthErrorClassifier.currentAccountHostsProvider`, per CLAUDE.md — a 401 from a non-account host is never a session expiry). New POSTs (renew, queued return) must not blanket-logout on a foreign-host 401.
+*Guard:* `LoanRenewalServiceTests.testForeignHost401_doesNotMarkCredentialsStale`; reuse the `AuthErrorClassifierPropertyTests` Invariant-8 pattern. (WS-C)
+
+**INV-6 — DRM fulfillment path is untouched.** No WS changes Adobe/LCP fulfillment. The Adobe return call (`BookReturnService.swift:284-297`) and LCP re-download scheduling (`BookRegistrySync.swift:283-296`) stay byte-identical. New retry wrapping (WS-A) applies to the plain content transfer, **not** to DRM fulfillment handlers.
+*Guard:* `MyBooksDownloadCenterTests` DRM-path assertions unchanged; diff review confirms no edits inside `#if FEATURE_DRM_CONNECTOR` / `#if LCP` fulfillment blocks.
+
+**INV-7 — Background completion handler invoked exactly once, per session identifier.** The stored system completion handler must be called once and cleared; the audiobook route must remain intact (identifier-matched, not clobbered).
+*Guard:* `MyBooksDownloadCenterTests.testFinishEvents_invokesStoredHandlerOnce`; a test asserting an audiobook-session identifier still routes to the audiobook manager. (WS-A)
+
+**INV-8 — Offline queue idempotency & no duplicate side effects.** A queued action that partially succeeded must not double-apply (e.g., a return that reached the server then failed to parse must not enqueue a second return that errors as "no active loan" and confuses the user). Executor returns `true` on server-confirmed success only; dedupe by `bookID`+`type`.
+*Guard:* `OfflineQueueCoordinatorTests.testDuplicateReturn_isDeduped`; `OfflineQueueServiceTests` retry/backoff behavior preserved. (WS-C)
+
+---
+
+## 5. TDD strategy (per workstream)
+
+**Pure seams to extract & unit-test (no I/O, high mutation yield):**
+- WS-A: `reconcile(persisted:liveTaskIdentifiers:registryStates:) -> [ReconcileDecision]` (S1); the transfer retry classification reuses `DownloadErrorRecovery.RetryPolicy.*.shouldRetry` (already pure). Test the decision matrix exhaustively (live/dead/completed × registry state).
+- WS-B: `RegistryFileRecovery.classify(data:) -> {valid(records) | corrupt | empty}` and the `.bak`/quarantine path resolution — pure over `Data`/paths.
+- WS-C: `LoanEvictionPolicy.decide(...)` (S3) — the single most important pure function; enumerate {expired/not} × {online/offline} × {within/after grace}. `LoanRenewalService` renew-rel extraction over a fixture entry.
+
+**Contract-snapshot tests (ordered side effects):**
+- WS-C: `BookReturnServiceContractTests` already locks `setProcessing → setState → removeBook → announce`. Extend with an offline-enqueue scenario snapshot (must show enqueue, **no** local delete). Borrow/BorrowReducer contracts already exist and must not drift.
+- WS-A: new contract snapshot for the launch reconciliation call order (registry-load → getAllTasks → reconcile → apply).
+
+**Mandatory mutation testing (critical-path files, `--diff-only`, ≥50% kill, ideally 100% on touched lines):**
+- `Palace/MyBooks/MyBooksDownloadCenter.swift`, `DownloadStateManager.swift`, `DownloadTaskPersistence.swift` (WS-A)
+- `Palace/Book/Models/BookRegistrySync.swift`, `RegistryFileRecovery.swift` (WS-B)
+- `Palace/MyBooks/BookReturnService.swift`, `MyBooksViewModel.swift`, `LoanEvictionPolicy.swift`, `LoanRenewalService.swift` (WS-C)
+Command per file: `python3 scripts/palace_mutate.py --file <f> --tests <TestClass> --diff-only`.
+
+**Definition-of-Done gates (CLAUDE.md §Definition of Done, all 11):** each WS runs the SUT-instantiation check, `check-test-name-vs-body.py`, contract reconciliation, blast-radius, superpartner-spectrum, and `verify-pr.sh --quick` before declaring READY. No `bookRegistry.setState` shortcut tests for the user-action→state wiring — drive the production seam (per the state-machine wiring rule).
+
+---
+
+## 6. Review routing
+
+All three workstreams touch critical paths → **architect + SoD (dual reviewer) required regardless of LOC**, per CLAUDE.md "Risk-driven rigor bar":
+- **WS-A** — `Palace/MyBooks/Download*`, background-session handling, `TPPAppDelegate`. Architect (concurrency/session-lifecycle) + qa_test + blast_radius. Use `/rigorous-fix` for the single-module reconciliation seam; `/swarm` if A and C land together.
+- **WS-B** — persistence/schema of the shelf source of truth (`TPPBookRegistry` data). Architect (data-integrity/migration) + qa_test. Migration/persistence is an explicit critical path.
+- **WS-C** — `BookReturnService` (return flow), `MyBooksViewModel` eviction, renewal POST, auth-error host scoping. Architect + SoD; **INV-5 (auth host scoping) reviewer BLOCK criteria apply** — any 401 path that doesn't consult the current-account host set is a block.
+
+Cross-cutting: because the three share the download/registry/return critical seams, run a **connections** pass before integration to catch latent coupling (S1 registry-state contract vs B's load heal; S2 executor calling A's borrow API). Every reviewer BLOCK → a `.forgeos/wall-failures/` entry per the catalog policy.
+
+---
+
+### Appendix — file ownership matrix
+
+| File | WS-A | WS-B | WS-C |
+|---|---|---|---|
+| `DownloadStateManager.swift` | **edit** | ro | ro |
+| `MyBooksDownloadCenter.swift` | **edit** | ro | ro (call public API) |
+| `DownloadErrorRecovery.swift` | **edit** | ro | ro |
+| `TPPAppDelegate.swift` (bg handler) | **edit** | ro | ro |
+| `DownloadTaskPersistence.swift` (new) | **edit** | — | — |
+| `BookRegistrySync.swift` | ro (read state) | **edit** | ro |
+| `RegistryFileRecovery.swift` (new) | — | **edit** | — |
+| `MyBooksViewModel.swift` | ro | ro | **edit** |
+| `BookReturnService.swift` | ro | ro | **edit** |
+| `OfflineQueueService.swift` | ro | ro | **edit** (seam only) |
+| `LoanEvictionPolicy.swift` (new) | — | — | **edit** |
+| `LoanRenewalService.swift` (new) | — | — | **edit** |
+| `OfflineQueueCoordinator.swift` (new) | — | — | **edit** |
+
+*ro = read-only / off-limits.* New source files need entries in both `Palace` and `Palace-noDRM` targets via `ruby scripts/pbxproj_add_swift.rb` (test files auto-route to `PalaceTests`).

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		0B461FFD655EC35ED6C3990A /* OPDSFeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE8017D2ECF7E0FEBFAAB1A /* OPDSFeedCache.swift */; };
 		0B55EFB324FAF34D779EB878 /* StreamingReaderPresentationContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A213D524079F39BA952025A /* StreamingReaderPresentationContractTests.swift */; };
 		0B72C5306C699DBCB586DBE7 /* MyBooksDownloadCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317C8F0150303A9AC53BC44F /* MyBooksDownloadCenterTests.swift */; };
+		0B920BFAFC18DEC8E403C45E /* BackgroundSessionRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EA859EE89F1644E98E4186 /* BackgroundSessionRoutingTests.swift */; };
 		0B9C4F9CCCF2321228F96954 /* dune_oversubdivided_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 2630448EB64E91E2EADDF594 /* dune_oversubdivided_manifest.json */; };
 		0BD8B0C9E2FDB018F9ED98C5 /* SideLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F833987DFE38DF4D313424 /* SideLoadingView.swift */; };
 		0C26C51E4B1F06A4C02FBB65 /* TPPReauthenticator+Reauthenticating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540375EB4B496BAA15E4F6F4 /* TPPReauthenticator+Reauthenticating.swift */; };
@@ -531,6 +532,7 @@
 		65C9C378EE67A7B2D1D12B08 /* MyBooksDownloadCenterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420E95312BFA6C62C6CA835D /* MyBooksDownloadCenterProtocol.swift */; };
 		65FFEE7138ABC534BDC38DAE /* SideloadedLaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D99F654723B202B64BEDFD /* SideloadedLaneTests.swift */; };
 		66AE9D42FA4F53E26C31747C /* ReadingStreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6CA6654994D77041AE0F79 /* ReadingStreak.swift */; };
+		66D2C3E3736B369221F71684 /* DownloadReconciliationLaunchOrderContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74739B276CC19DD8D1C1EEA2 /* DownloadReconciliationLaunchOrderContractTests.swift */; };
 		676F638471BA390A373B329B /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF1F7C70AC93BF8E2F22148 /* DebugSettings.swift */; };
 		67D8EFBDE46E7BA527E46953 /* EmbeddedScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR005 /* EmbeddedScenarios.swift */; };
 		681FBB4C5C3E2B2A10DAD273 /* CatalogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DF25F6BFF39ECDAF39E3E3 /* CatalogViewModelTests.swift */; };
@@ -854,6 +856,7 @@
 		8CCB8310199672E1C07F4073 /* TPPReaderBlockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C1A783279F7276BDD43358 /* TPPReaderBlockNavigation.swift */; };
 		8CD73CE1905CBD7FA883FF6A /* TPPReauthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D5C28E71B1D177EAF1E5F9 /* TPPReauthenticatorTests.swift */; };
 		8CE9C471237F84820072E964 /* TPPBookDetailsProblemDocumentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE9C470237F84820072E964 /* TPPBookDetailsProblemDocumentViewController.swift */; };
+		8D0317BF7280CC9ADE819DD0 /* DownloadTaskPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC83EBCF4E254E0E8077589 /* DownloadTaskPersistence.swift */; };
 		8DA4BE9843EAEAD3284D3476 /* RatingEngagementTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628AE12E352BCBAEA9346258 /* RatingEngagementTracker.swift */; };
 		8DB340CF4268405FAA8954D2 /* SignInModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CCA7049DE640BABC8D20B8 /* SignInModalView.swift */; };
 		8DB340D04268405FAA8954D3 /* SignInModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CCA7049DE640BABC8D20B8 /* SignInModalView.swift */; };
@@ -1189,6 +1192,7 @@
 		CRWL0012BTST00000001 /* CrawlerFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0012FREF00000001 /* CrawlerFallbackTests.swift */; };
 		CRWL0013BTST00000001 /* CrossDeviceBookmarkSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRWL0013FREF00000001 /* CrossDeviceBookmarkSyncTests.swift */; };
 		D0D6599222C5D48C2F478674 /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A5376E7114F302CCBD1497 /* ArrayExtensionsTests.swift */; };
+		D12E544C438A685123A66610 /* DownloadReconciliationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A89DC26D262DB004F837CA /* DownloadReconciliationTests.swift */; };
 		D157A0BD33F950C02A51E540 /* BookFileManagerSideloadResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C15702663E81BBC13C0077 /* BookFileManagerSideloadResolutionTests.swift */; };
 		D1662F093947D3C2F76B25D1 /* ReaderTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F994F35E532ACAA0F6C45035 /* ReaderTheme.swift */; };
 		D17D94E13F0041A895571384 /* TPPBookBearerTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF737E48E0644508688E443 /* TPPBookBearerTokenTests.swift */; };
@@ -1204,6 +1208,7 @@
 		D2E3F4A5B6C7D8E9F0A1B2C3 /* DownloadCompletionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E8F9A0B1C2 /* DownloadCompletionParser.swift */; };
 		D30AD084B4614EFA9C708928 /* TPPCredentialIsolationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16FBDE7626549B79736A665 /* TPPCredentialIsolationE2ETests.swift */; };
 		D3101CC4442E0E2A8E6B9AE2 /* BackgroundDownloadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDB637C01812EEB10919A6E /* BackgroundDownloadHandler.swift */; };
+		D318F2437988D477C98DEA7D /* DownloadTaskPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0149B8595768484A2C352B5B /* DownloadTaskPersistenceTests.swift */; };
 		D334E57F366D2B71AF9D38F5 /* OPDS2PublicationExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023DFFACC986541965F1560 /* OPDS2PublicationExtended.swift */; };
 		D363615844BC602E2E1FFFBE /* AppRatingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B6CEA300F1440914E64EE8 /* AppRatingServiceTests.swift */; };
 		D3B4C5D6E7F8A9B0C1D2E3F4 /* BorrowOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B2C3D4E5F6A7B8C9D0E1F2 /* BorrowOperation.swift */; };
@@ -1790,6 +1795,7 @@
 		F30E1F2A3B4C5D6E7F8091A2 /* DownloadAuthRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041F2A3B4C5D6E7F8091A2B3 /* DownloadAuthRetryHandler.swift */; };
 		F31173884E476D9205B60E61 /* ReadiumPDFReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4494F50352E88455B28AD34E /* ReadiumPDFReaderView.swift */; };
 		F3A4B5C6D7E8F9A0B1C2D3E4 /* DownloadTaskLifecycleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E2 /* DownloadTaskLifecycleService.swift */; };
+		F3D0B1820DA683D0A25A3D50 /* DownloadTransferRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645A5614EC730C72D2EAA1B1 /* DownloadTransferRetryTests.swift */; };
 		F44DED83ED7B4324B4C605D6 /* CarPlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2634B33D2AE74BF5948971BA /* CarPlayTests.swift */; };
 		F4565465A1B2C3D4E5F6071A /* OverdriveDownloadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3465465A1B2C3D4E5F60829 /* OverdriveDownloadHandler.swift */; };
 		F516D06B9979F4625E8BD312 /* PalacePDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060B04F768844865F55ED1A1 /* PalacePDFView.swift */; };
@@ -1804,6 +1810,7 @@
 		F68E812B5FC959BF7DABB30D /* AuthDecisionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1993F74B8F2D322099A4C81 /* AuthDecisionRecorder.swift */; };
 		F7081A2B3C4D5E6F70819203 /* TPPAuthDocumentContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F7081A2B3C4D5E6F708192 /* TPPAuthDocumentContractTests.swift */; };
 		F75B245083BE4AD72CA2AED1 /* NYPLOPDSLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E73CE2D76D4616118002BC /* NYPLOPDSLinkTests.swift */; };
+		F8593FB4D188D7C4C6B3CC07 /* DownloadTaskPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC83EBCF4E254E0E8077589 /* DownloadTaskPersistence.swift */; };
 		F86966B4159DA3FBE6B36193 /* CatalogViewContinueRowsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B284DD9A4739D34937C4D0 /* CatalogViewContinueRowsIntegrationTests.swift */; };
 		F8724E8E85D04DC1941AFC2A /* AccountDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480ADB3F1AA842DE805EC230 /* AccountDetailView.swift */; };
 		F8724E8F85D04DC1941AFC2B /* AccountDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480ADB3F1AA842DE805EC230 /* AccountDetailView.swift */; };
@@ -2032,6 +2039,7 @@
 		00E9DF245319907059F86297 /* ReaderChromeToggleFadeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderChromeToggleFadeTests.swift; sourceTree = "<group>"; };
 		011100499302EE8A7CBC30C6 /* AudiobookEngineMock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookEngineMock.swift; sourceTree = "<group>"; };
 		01407B71400FB30643B6A5CD /* AudioEngineWrapperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioEngineWrapperTests.swift; sourceTree = "<group>"; };
+		0149B8595768484A2C352B5B /* DownloadTaskPersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadTaskPersistenceTests.swift; sourceTree = "<group>"; };
 		01F470EA0E88BDCE56E27B86 /* LCPPDFDiskExtractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPDFDiskExtractTests.swift; sourceTree = "<group>"; };
 		02060A0117F26B0E56F3F606 /* BadgesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgesView.swift; sourceTree = "<group>"; };
 		02415B1E145D716015754AFF /* Account+TPPLibraryAccountReadable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Account+TPPLibraryAccountReadable.swift"; sourceTree = "<group>"; };
@@ -2183,6 +2191,7 @@
 		1ABF38E7BB264BB192202BAC /* DefaultCatalogAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCatalogAPITests.swift; sourceTree = "<group>"; };
 		1B55D09BB1E0EAF8B542077F /* TPPNotifications.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPNotifications.swift; sourceTree = "<group>"; };
 		1BA91B27F363A5BBFB4F5BB0 /* Adapters+Production.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Adapters+Production.swift"; sourceTree = "<group>"; };
+		1CC83EBCF4E254E0E8077589 /* DownloadTaskPersistence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadTaskPersistence.swift; sourceTree = "<group>"; };
 		1D4B77CEDF228DC03714AD31 /* LocalFileAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalFileAdapter.swift; sourceTree = "<group>"; };
 		1DA098468E3C460A466D22BD /* TPPPDFReaderSearchBindingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPPDFReaderSearchBindingTests.swift; sourceTree = "<group>"; };
 		1DC9FC06EF6CCEED742C0D44 /* TPPSignInBusinessLogicExtendedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPSignInBusinessLogicExtendedTests.swift; sourceTree = "<group>"; };
@@ -2452,6 +2461,7 @@
 		63880885010BDEA019007D3A /* SingletonResetRegistryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SingletonResetRegistryTests.swift; sourceTree = "<group>"; };
 		639A868F3BDA4A7F97660BEA /* CarPlayImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayImageProvider.swift; sourceTree = "<group>"; };
 		64194E4EA4AE55F677AC1714 /* OverdriveFulfillmentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OverdriveFulfillmentTests.swift; sourceTree = "<group>"; };
+		645A5614EC730C72D2EAA1B1 /* DownloadTransferRetryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadTransferRetryTests.swift; sourceTree = "<group>"; };
 		6515A1241D6D4D08A1866E72 /* TPPBookmarkFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookmarkFactoryTests.swift; sourceTree = "<group>"; };
 		65988BBA901E65AA0905EF43 /* ScopedResetTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScopedResetTests.swift; sourceTree = "<group>"; };
 		65C628E6207F3958E194D07C /* BorrowOperationStreamingHTMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BorrowOperationStreamingHTMLTests.swift; sourceTree = "<group>"; };
@@ -2614,6 +2624,7 @@
 		73F713672417240100C63B81 /* UIViewController+TPP.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIViewController+TPP.swift"; path = "Palace/Reader2/UI/UIViewController+TPP.swift"; sourceTree = SOURCE_ROOT; };
 		73FB0AC824EB403D0072E430 /* TPPBookContentTypeConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookContentTypeConverter.swift; sourceTree = "<group>"; };
 		7409BB4778BF1736365594FB /* AudiobookPositionRestoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookPositionRestoreTests.swift; sourceTree = "<group>"; };
+		74739B276CC19DD8D1C1EEA2 /* DownloadReconciliationLaunchOrderContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadReconciliationLaunchOrderContractTests.swift; sourceTree = "<group>"; };
 		74D09C16D15567198A0A9194 /* StatsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsViewModelTests.swift; sourceTree = "<group>"; };
 		75305888F6A941DDA9EEE592 /* RDServicesStubs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RDServicesStubs.m; sourceTree = "<group>"; };
 		758B05F321F1562FFC733397 /* AudiobookPositionAdapterContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookPositionAdapterContractTests.swift; sourceTree = "<group>"; };
@@ -2841,7 +2852,9 @@
 		B56924B6344307FB92447799 /* UnifiedOPDSServiceStateMachineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UnifiedOPDSServiceStateMachineTests.swift; sourceTree = "<group>"; };
 		B57489E1C2CE2DD11EFC1C03 /* CatalogModelsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogModelsTests.swift; sourceTree = "<group>"; };
 		B5D6A3DE24CC45D98F02DC98 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
+		B6EA859EE89F1644E98E4186 /* BackgroundSessionRoutingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundSessionRoutingTests.swift; sourceTree = "<group>"; };
 		B79DD7FF880843F7BE282614 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
+		B7A89DC26D262DB004F837CA /* DownloadReconciliationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadReconciliationTests.swift; sourceTree = "<group>"; };
 		B83C63AD7FC1676713DBCC77 /* CatalogDomainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogDomainTests.swift; sourceTree = "<group>"; };
 		B8C7D6E5F4A3B2C1D0E9F8A7 /* MyBooksDownloadCenterConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterConcurrencyTests.swift; sourceTree = "<group>"; };
 		B9AA2BDEDE93EDA644183E61 /* PalaceHapticTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalaceHapticTests.swift; sourceTree = "<group>"; };
@@ -4448,6 +4461,7 @@
 				D0B0B6008C750B0A082C80D0 /* RecentlyReadingService.swift */,
 				C54010275AF91385B8410DF1 /* BookOpenTracker.swift */,
 				9E34D2A160AA6DF18246B0B9 /* Sideload */,
+				1CC83EBCF4E254E0E8077589 /* DownloadTaskPersistence.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -5696,6 +5710,11 @@
 				66C15702663E81BBC13C0077 /* BookFileManagerSideloadResolutionTests.swift */,
 				C357A9EDEB4B9A3F57AD944D /* Sideload */,
 				D5995564B8E8B92FA04E7C75 /* DownloadCompleteMomentTests.swift */,
+				B7A89DC26D262DB004F837CA /* DownloadReconciliationTests.swift */,
+				0149B8595768484A2C352B5B /* DownloadTaskPersistenceTests.swift */,
+				74739B276CC19DD8D1C1EEA2 /* DownloadReconciliationLaunchOrderContractTests.swift */,
+				B6EA859EE89F1644E98E4186 /* BackgroundSessionRoutingTests.swift */,
+				645A5614EC730C72D2EAA1B1 /* DownloadTransferRetryTests.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -7657,6 +7676,11 @@
 				2CB4235AFFA2BB53365AD667 /* TPPPDFReaderSearchBindingTests.swift in Sources */,
 				2E6A415E42C938CDED99D134 /* SkeletonTests.swift in Sources */,
 				17377CDB4BA7F8C24918839F /* RegistryFileRecoveryTests.swift in Sources */,
+				D12E544C438A685123A66610 /* DownloadReconciliationTests.swift in Sources */,
+				D318F2437988D477C98DEA7D /* DownloadTaskPersistenceTests.swift in Sources */,
+				66D2C3E3736B369221F71684 /* DownloadReconciliationLaunchOrderContractTests.swift in Sources */,
+				0B920BFAFC18DEC8E403C45E /* BackgroundSessionRoutingTests.swift in Sources */,
+				F3D0B1820DA683D0A25A3D50 /* DownloadTransferRetryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8214,6 +8238,7 @@
 				FC06F1538E0D26618E2DD336 /* PalaceHaptic.swift in Sources */,
 				1446B886F9D2F070E2AC22A5 /* Skeleton.swift in Sources */,
 				447135A5582962D50E93CE3A /* RegistryFileRecovery.swift in Sources */,
+				F8593FB4D188D7C4C6B3CC07 /* DownloadTaskPersistence.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8774,6 +8799,7 @@
 				AAF4A7A693BC1867BF31E4C5 /* PalaceHaptic.swift in Sources */,
 				7025FC704907DF4D61E2F270 /* Skeleton.swift in Sources */,
 				DE640E5C34EE42663403FEA2 /* RegistryFileRecovery.swift in Sources */,
+				8D0317BF7280CC9ADE819DD0 /* DownloadTaskPersistence.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		17BE24ED25FB09F000AE707F /* TPPCurrentLibraryAccountProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BE24EC25FB09F000AE707F /* TPPCurrentLibraryAccountProviderMock.swift */; };
 		17BE24EF25FB114900AE707F /* simplye_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BE24EE25FB114900AE707F /* simplye_authentication_document.json */; };
 		17BEE42799E8F727729A00F3 /* URLExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB31382B3826FB20CD3BE34 /* URLExtensionTests.swift */; };
+		17E56200137D997D9F5E32F4 /* LoanRenewalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D362330BB6B07FD6B2770E5D /* LoanRenewalService.swift */; };
 		17E6BC38538C040F995A97B7 /* OPDS2BookBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E358F2BF99213E34F1B052ED /* OPDS2BookBridgeTests.swift */; };
 		17E81F08261522B3001003C2 /* TPPRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* TPPRoundedButton.swift */; };
 		17E81F0B261522B3001003C2 /* TPPRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* TPPRoundedButton.swift */; };
@@ -344,6 +345,7 @@
 		2F987E6CCC6642EAADAFC965 /* ViewModelComputedPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C9CA13B5B94707BFFCB13F /* ViewModelComputedPropertyTests.swift */; };
 		2FFD02C9E4694723CB61B853 /* DataBase64Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5E734D2FB5E1FABA1C8A1F /* DataBase64Tests.swift */; };
 		3066D90425C628B819529D35 /* SideloadedBookRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C133FD45251FA7A771EC43A /* SideloadedBookRegistryTests.swift */; };
+		307510DEB0B0D7968310D0F1 /* LoanRenewalServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060E761D281D979E3359C83A /* LoanRenewalServiceTests.swift */; };
 		30B392104E9FCA6F9CBEEF01 /* ReadingSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0592B4A4D666ED6705BF8093 /* ReadingSessionTracker.swift */; };
 		30BC12FD0338A5885EBA255C /* BookCellModelStreamingHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820FFFB90AD6CB0A124F6420 /* BookCellModelStreamingHTMLTests.swift */; };
 		30E69EFD7A892A1D3D30DCC9 /* PerformanceReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D80DA377151AE41BEF67F7 /* PerformanceReport.swift */; };
@@ -371,6 +373,7 @@
 		3814967E18834E57A9188E45 /* UserRetryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43040747774740399559510F /* UserRetryTracker.swift */; };
 		384F4B87C9C4D04CA299887B /* UserDefaultsIsolationLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDD8C3ABFAAB079ADACC31A /* UserDefaultsIsolationLintTests.swift */; };
 		3866024F428FB2933356714D /* RecentlyReadingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B0B6008C750B0A082C80D0 /* RecentlyReadingService.swift */; };
+		38D7F7CC34A4DFE23CA48CF5 /* LoanEvictionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5575A14D947C09A968459FF1 /* LoanEvictionPolicyTests.swift */; };
 		38E52EB89550AF93D37D2E59 /* PresetCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B293519F9B55B6F4F17CC7 /* PresetCard.swift */; };
 		39A1336976AF58F39DFF585A /* PalacePressableButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA550DFD5C0CC29F38E9FB8 /* PalacePressableButtonStyle.swift */; };
 		3A52B241F9A982DDA1365149 /* AccountStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABB253AB7CB4183943EBA6A /* AccountStateStore.swift */; };
@@ -467,6 +470,7 @@
 		57D3538598A6C303109FBF4F /* PalaceLogging in Frameworks */ = {isa = PBXBuildFile; productRef = 9262A19C4603391A937C5159 /* PalaceLogging */; };
 		582431D4978FAFF6C12F1599 /* StreakView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1D8E96BB21CEA1AB690046 /* StreakView.swift */; };
 		584A8765F4BEF4B2A7F068B5 /* TPPMyBooksSimplifiedBearerToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CCF14B8043FB410CB53DFB /* TPPMyBooksSimplifiedBearerToken.swift */; };
+		585DADC5503DE0B1F64E227A /* OfflineQueueCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB89127F1F2E38E1E06CA5C /* OfflineQueueCoordinator.swift */; };
 		5884A9AE2BB0DE1946609A0B /* MockIsolationLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F5CC426CE615EF41ABC2E8 /* MockIsolationLintTests.swift */; };
 		58915F3DB0E19C97F3154DD3 /* ReaderEditingActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0446DDEE241612C3A2146A6 /* ReaderEditingActions.swift */; };
 		58AF4A75D388F83A1F5B140B /* LCPLibraryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8568424DF6517B247D048D5D /* LCPLibraryServiceTests.swift */; };
@@ -829,6 +833,7 @@
 		85E8F8673C54D7999841467A /* LocalFileAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17D1419EA3F2F6BDA0D4B81 /* LocalFileAdapterTests.swift */; };
 		8616DDACA8979FE873AF66C5 /* RatingPromptPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B60466B2029331616A708B4 /* RatingPromptPresenter.swift */; };
 		86BB2A9E88846B9C858D1F5F /* SpyAudiobookSessionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794351D0F625F9610414FA23 /* SpyAudiobookSessionPresenter.swift */; };
+		86E78D8C26A06F97B310B1F1 /* OfflineQueueCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDE9D88F7AB6E37390446FA /* OfflineQueueCoordinatorTests.swift */; };
 		8753EC265A5DF6362FFF71B9 /* ReadingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B28BFC973E94C02E7E117D /* ReadingSession.swift */; };
 		877C7FD52A41DF842E473359 /* TPPBookmarkDeletionLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0452B249AF7C21DDAACD5C58 /* TPPBookmarkDeletionLog.swift */; };
 		87A0D209BEFAA71C55C48D47 /* URLSessionConfiguration+MockBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR007 /* URLSessionConfiguration+MockBackend.swift */; };
@@ -944,6 +949,7 @@
 		A4764638CAC5AA3D72A37137 /* PerformanceMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBDD4C17EA45C71D8076A34 /* PerformanceMetric.swift */; };
 		A4A9BB62B4FC4F01C9FBDDE3 /* LCPPDFOpenProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF5E7D0F712E6F62B28E143 /* LCPPDFOpenProgressTests.swift */; };
 		A531A3837D73D92A342FE068 /* ReadiumPDFLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49150841E0DEA8C0F35D81C4 /* ReadiumPDFLoadingView.swift */; };
+		A5558892DBA894A001DE2F51 /* LoanEvictionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5100330CFD49E96FBC331D75 /* LoanEvictionPolicy.swift */; };
 		A558B95C3E52072544FD6630 /* PalaceWiringTestCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF95DA87536C79B461B7A0F /* PalaceWiringTestCaseTests.swift */; };
 		A57986AA9FBF4B328D036BC2 /* AlertModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C33E4BDBC27454AB30FAF96 /* AlertModelTests.swift */; };
 		A5B6C7D8E9F0A1B2C3D4E5F6 /* DownloadCancellationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B5C6D7E8F9A0B1C2D3E4F5 /* DownloadCancellationHandlerTests.swift */; };
@@ -1134,6 +1140,7 @@
 		C64399E81697447CA4F20ABA /* EULAViewHosting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CF94B049964380A3A35DA9 /* EULAViewHosting.swift */; };
 		C64399E91697447CA4F20ABB /* EULAViewHosting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CF94B049964380A3A35DA9 /* EULAViewHosting.swift */; };
 		C68C9469871DE1074439C449 /* TypographyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59857C4239FBD7A4ABA37871 /* TypographyService.swift */; };
+		C69957A9F5F137315389B9D1 /* LoanRenewalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D362330BB6B07FD6B2770E5D /* LoanRenewalService.swift */; };
 		C6A457ADC7B74852879349E0 /* TPPReaderPageListBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D848CD4CD0E01B3A2BF67FE /* TPPReaderPageListBusinessLogic.swift */; };
 		C6C2BB5EDA39F3116659A4A6 /* FontPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D99051FE5305ABE13531F76 /* FontPickerView.swift */; };
 		C72E88998C74489891046AA3 /* TPPBookmarkDeletionLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72E88998C74489891046AA2 /* TPPBookmarkDeletionLogTests.swift */; };
@@ -1356,6 +1363,7 @@
 		E50D684426AB235400F1042B /* TPPReaderTOCCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7386C1F9245276CA004C78BD /* TPPReaderTOCCell.swift */; };
 		E50D684626AB235400F1042B /* TPPReaderBookmarkCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03690E221EB2B35000F75D5F /* TPPReaderBookmarkCell.swift */; };
 		E50D684726AB235400F1042B /* TPPReaderTOCCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7386C1F9245276CA004C78BD /* TPPReaderTOCCell.swift */; };
+		E510BDCAF453CCCAE05C1B17 /* LoanEvictionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5100330CFD49E96FBC331D75 /* LoanEvictionPolicy.swift */; };
 		E512240C2DDFC41D00D034A4 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E512240B2DDFC41700D034A4 /* UIViewController+Extensions.swift */; };
 		E512240D2DDFC41D00D034A4 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E512240B2DDFC41700D034A4 /* UIViewController+Extensions.swift */; };
 		E5158C202935345F0007ABDB /* TransifexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E549954728EE1AAA00EA0D9B /* TransifexManager.swift */; };
@@ -1835,6 +1843,7 @@
 		FC143D162B824415B00D88AA /* NSErrorAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84A9BADA3014DCF9808C7DC /* NSErrorAdditionsTests.swift */; };
 		FC1B7D899D35F336F1469191 /* FontFamily.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA20DE46939562EEA2DF764 /* FontFamily.swift */; };
 		FC5C80424EE10131FA0087F2 /* TPPSAMLSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E3B2C7B51DEBF595766568 /* TPPSAMLSignInTests.swift */; };
+		FCC8A9905AF17077021995B7 /* OfflineQueueCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB89127F1F2E38E1E06CA5C /* OfflineQueueCoordinator.swift */; };
 		FD8D0E357C66D1B11FC70361 /* TPPJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52226B7262C85C91578DB3A7 /* TPPJSON.swift */; };
 		FD944841337FCB9D26209ED4 /* ReadingStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA4D17463BADFD0DEBC53FA /* ReadingStats.swift */; };
 		FE48F9C21D03088224767755 /* TypographyPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABACD6237FD75664BEADFF58 /* TypographyPresetTests.swift */; };
@@ -2070,6 +2079,7 @@
 		05CAE584B769CF73DD2B3740 /* RuntimeQuiescenceGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeQuiescenceGateTests.swift; sourceTree = "<group>"; };
 		05D900BABD4633AC409BDBDC /* TPPBackgroundExecutorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBackgroundExecutorTests.swift; sourceTree = "<group>"; };
 		060B04F768844865F55ED1A1 /* PalacePDFView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalacePDFView.swift; sourceTree = "<group>"; };
+		060E761D281D979E3359C83A /* LoanRenewalServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoanRenewalServiceTests.swift; sourceTree = "<group>"; };
 		06784DE00D5161E7071843F0 /* StringHTMLEntitiesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringHTMLEntitiesTests.swift; sourceTree = "<group>"; };
 		06B2D269BFF440A381A893E3 /* CarPlayAudiobookBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayAudiobookBridge.swift; sourceTree = "<group>"; };
 		06C17CF38F7D4EBFA5AC995F /* ErrorDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDetail.swift; sourceTree = "<group>"; };
@@ -2387,6 +2397,7 @@
 		4C9D88C19C8C537405C71724 /* AccountsManagerCancellationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerCancellationTests.swift; sourceTree = "<group>"; };
 		4CD86C00D774B74F80D5B713 /* OPDS2FeedParsingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2FeedParsingTests.swift; sourceTree = "<group>"; };
 		4DA71264EE431E238A3B66ED /* AudiobookPlaybackTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookPlaybackTests.swift; sourceTree = "<group>"; };
+		4DB89127F1F2E38E1E06CA5C /* OfflineQueueCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OfflineQueueCoordinator.swift; sourceTree = "<group>"; };
 		4DCF14A6A237EADD5978E148 /* DownloadAnnouncementServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadAnnouncementServiceTests.swift; sourceTree = "<group>"; };
 		4DDE63F6732471A2B00D88DC /* AudioSessionActivator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioSessionActivator.swift; sourceTree = "<group>"; };
 		4E6709F729264A8D0DFE7431 /* TPPPDFAccessibilityToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPPDFAccessibilityToolbar.swift; sourceTree = "<group>"; };
@@ -2401,6 +2412,7 @@
 		500A72CE85F5DBA5FC681080 /* AudiobookTrackerExtendedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookTrackerExtendedTests.swift; sourceTree = "<group>"; };
 		502761BDE732D3752808C4C4 /* TPPBookButtonsState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookButtonsState.swift; sourceTree = "<group>"; };
 		50E92EE539A615735164856F /* RuntimeQuiescenceLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeQuiescenceLintTests.swift; sourceTree = "<group>"; };
+		5100330CFD49E96FBC331D75 /* LoanEvictionPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoanEvictionPolicy.swift; sourceTree = "<group>"; };
 		52226B7262C85C91578DB3A7 /* TPPJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPJSON.swift; sourceTree = "<group>"; };
 		5248CEFDF1FEDEBE50897394 /* LCPAdapterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPAdapterTests.swift; sourceTree = "<group>"; };
 		52C86F54125C3BD725906F86 /* LCPPDFOpenProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPDFOpenProgress.swift; sourceTree = "<group>"; };
@@ -2411,6 +2423,7 @@
 		545D0B43631D0433B5E9C100 /* PlatformTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformTab.swift; sourceTree = "<group>"; };
 		5472258280B72752C01480DF /* ReadiumPDFViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumPDFViewController.swift; sourceTree = "<group>"; };
 		5550F79A349D3D7ADE48B5E1 /* TPPBookRegistryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookRegistryTests.swift; sourceTree = "<group>"; };
+		5575A14D947C09A968459FF1 /* LoanEvictionPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoanEvictionPolicyTests.swift; sourceTree = "<group>"; };
 		557641B8197B528D886F32DB /* TPPDeferredAdobeActivationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPDeferredAdobeActivationTests.swift; sourceTree = "<group>"; };
 		55ABB7E13EF5B68C8635A58F /* BadgesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgesViewModel.swift; sourceTree = "<group>"; };
 		5645B2E3AB447845108FC02C /* BookRegistrySyncSideloadExemptionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookRegistrySyncSideloadExemptionTests.swift; sourceTree = "<group>"; };
@@ -2491,6 +2504,7 @@
 		6D3E99EDF9AFB815A1AEDE68 /* PalaceWiringTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalaceWiringTestCase.swift; sourceTree = "<group>"; };
 		6D85D6FFA9CEBA4295D91F15 /* DownloadAnnouncementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadAnnouncementService.swift; sourceTree = "<group>"; };
 		6DB8CC29A8C5DFB84187D498 /* NSURLRequest+NYPLURLRequestAdditions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSURLRequest+NYPLURLRequestAdditions.swift"; sourceTree = "<group>"; };
+		6DDE9D88F7AB6E37390446FA /* OfflineQueueCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OfflineQueueCoordinatorTests.swift; sourceTree = "<group>"; };
 		6DF4B6BD211B2BF0AEA436A7 /* NotificationSyncThrottleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationSyncThrottleTests.swift; sourceTree = "<group>"; };
 		6E4E0EAE6DA244AAE005691B /* TPPOPDSFeed+Networking.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "TPPOPDSFeed+Networking.swift"; sourceTree = "<group>"; };
 		6EABA877790A16435BFD9CC8 /* FindawayChapterStatusGuardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FindawayChapterStatusGuardTests.swift; sourceTree = "<group>"; };
@@ -2968,6 +2982,7 @@
 		D28F809A16EF96F2EEBC8A83 /* AccessibilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityService.swift; sourceTree = "<group>"; };
 		D2ADD2980F56FC974B6DEBAC /* TPPReaderSettingsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderSettingsTests.swift; sourceTree = "<group>"; };
 		D2F5CC426CE615EF41ABC2E8 /* MockIsolationLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MockIsolationLintTests.swift; sourceTree = "<group>"; };
+		D362330BB6B07FD6B2770E5D /* LoanRenewalService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoanRenewalService.swift; sourceTree = "<group>"; };
 		D36A0EAF9098429CA6DCAD16 /* NavigationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinatorTests.swift; sourceTree = "<group>"; };
 		D40B096C4C124B0219339E8E /* AccountsManagerStateMachineWiringTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerStateMachineWiringTests.swift; sourceTree = "<group>"; };
 		D448C588C99441528CE12FD5 /* TPPIdleSignOutRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPIdleSignOutRegressionTests.swift; sourceTree = "<group>"; };
@@ -3882,6 +3897,7 @@
 				480CFCD095E5C455D1CFA499 /* OfflineQueueServiceTests.swift */,
 				683C04EF0CA60F4A118D597A /* PositionSyncServiceTests.swift */,
 				EF6CA6FD20109963823CABD1 /* AppLaunchTrackerExtendedTests.swift */,
+				6DDE9D88F7AB6E37390446FA /* OfflineQueueCoordinatorTests.swift */,
 			);
 			path = Platform;
 			sourceTree = "<group>";
@@ -4462,6 +4478,8 @@
 				C54010275AF91385B8410DF1 /* BookOpenTracker.swift */,
 				9E34D2A160AA6DF18246B0B9 /* Sideload */,
 				1CC83EBCF4E254E0E8077589 /* DownloadTaskPersistence.swift */,
+				5100330CFD49E96FBC331D75 /* LoanEvictionPolicy.swift */,
+				D362330BB6B07FD6B2770E5D /* LoanRenewalService.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -4887,6 +4905,7 @@
 				71FEEC427223FFDB026D6137 /* OfflineQueueServiceProtocol.swift */,
 				545D0B43631D0433B5E9C100 /* PlatformTab.swift */,
 				D28F809A16EF96F2EEBC8A83 /* AccessibilityService.swift */,
+				4DB89127F1F2E38E1E06CA5C /* OfflineQueueCoordinator.swift */,
 			);
 			path = Platform;
 			sourceTree = "<group>";
@@ -5715,6 +5734,8 @@
 				74739B276CC19DD8D1C1EEA2 /* DownloadReconciliationLaunchOrderContractTests.swift */,
 				B6EA859EE89F1644E98E4186 /* BackgroundSessionRoutingTests.swift */,
 				645A5614EC730C72D2EAA1B1 /* DownloadTransferRetryTests.swift */,
+				5575A14D947C09A968459FF1 /* LoanEvictionPolicyTests.swift */,
+				060E761D281D979E3359C83A /* LoanRenewalServiceTests.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -7681,6 +7702,9 @@
 				66D2C3E3736B369221F71684 /* DownloadReconciliationLaunchOrderContractTests.swift in Sources */,
 				0B920BFAFC18DEC8E403C45E /* BackgroundSessionRoutingTests.swift in Sources */,
 				F3D0B1820DA683D0A25A3D50 /* DownloadTransferRetryTests.swift in Sources */,
+				38D7F7CC34A4DFE23CA48CF5 /* LoanEvictionPolicyTests.swift in Sources */,
+				307510DEB0B0D7968310D0F1 /* LoanRenewalServiceTests.swift in Sources */,
+				86E78D8C26A06F97B310B1F1 /* OfflineQueueCoordinatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8239,6 +8263,9 @@
 				1446B886F9D2F070E2AC22A5 /* Skeleton.swift in Sources */,
 				447135A5582962D50E93CE3A /* RegistryFileRecovery.swift in Sources */,
 				F8593FB4D188D7C4C6B3CC07 /* DownloadTaskPersistence.swift in Sources */,
+				A5558892DBA894A001DE2F51 /* LoanEvictionPolicy.swift in Sources */,
+				C69957A9F5F137315389B9D1 /* LoanRenewalService.swift in Sources */,
+				FCC8A9905AF17077021995B7 /* OfflineQueueCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8800,6 +8827,9 @@
 				7025FC704907DF4D61E2F270 /* Skeleton.swift in Sources */,
 				DE640E5C34EE42663403FEA2 /* RegistryFileRecovery.swift in Sources */,
 				8D0317BF7280CC9ADE819DD0 /* DownloadTaskPersistence.swift in Sources */,
+				E510BDCAF453CCCAE05C1B17 /* LoanEvictionPolicy.swift in Sources */,
+				17E56200137D997D9F5E32F4 /* LoanRenewalService.swift in Sources */,
+				585DADC5503DE0B1F64E227A /* OfflineQueueCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		17071065242A923400E2648F /* TPPSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17071060242A923400E2648F /* TPPSecrets.swift */; };
 		171966A924170819007BB87E /* TPPBookState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171966A824170819007BB87E /* TPPBookState.swift */; };
 		1727CF183FBEFC2E3E5D9C53 /* BookRegistrySync.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEB9F995C87FE2C71DFA9BC /* BookRegistrySync.swift */; };
+		17377CDB4BA7F8C24918839F /* RegistryFileRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 863E4EF7FA12EFB2170C7638 /* RegistryFileRecoveryTests.swift */; };
 		173D67E44B0BB76714F4AC84 /* DownloadProgressPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA6421E95950580E36277F0 /* DownloadProgressPublisher.swift */; };
 		173F0823241AAA4E00A64658 /* TPPBookStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173F0822241AAA4E00A64658 /* TPPBookStateTests.swift */; };
 		175E480824EF36520066A6CF /* TPPAnnouncementBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175E480724EF36520066A6CF /* TPPAnnouncementBusinessLogic.swift */; };
@@ -401,6 +402,7 @@
 		43DFB89D9CA0E24FEB1B7FB4 /* SAMLPlusBiblioBoardExpirationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8594B752B9EB47CACE89C7C /* SAMLPlusBiblioBoardExpirationTests.swift */; };
 		4413512E3CC257385BED43F2 /* PalaceReadingPosition in Frameworks */ = {isa = PBXBuildFile; productRef = B2F313BC158E6B1DB5366051 /* PalaceReadingPosition */; };
 		4467C9CB9549BC1B85B6561B /* ImageLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22F7AE14E3B226D72A2AFBB /* ImageLoading.swift */; };
+		447135A5582962D50E93CE3A /* RegistryFileRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3D7B0F09A19268135E40FB /* RegistryFileRecovery.swift */; };
 		44E00CEDECA9CCF7788760F7 /* ReadiumPDFLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49150841E0DEA8C0F35D81C4 /* ReadiumPDFLoadingView.swift */; };
 		457EF33582D84B0F8A1BEFC4 /* AccountsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E31E236C9F4875AEF5B087 /* AccountsManagerTests.swift */; };
 		458CF016282CA901C1F05683 /* AudiobookVendorAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AAA6A2C834984A7D21A854 /* AudiobookVendorAdapter.swift */; };
@@ -1251,6 +1253,7 @@
 		DD7931BFD5CA3EABC96BC215 /* OpenAccessAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCE659985E97E91217CB739 /* OpenAccessAdapterTests.swift */; };
 		DDBA66D65E63F74D6D2668D5 /* OPDS2IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E38281988A9921BB4B8297 /* OPDS2IntegrationTests.swift */; };
 		DE0A30E3FA1B8A7EA46BCCBE /* ReaderAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72DFEC346C543E50A57BE49 /* ReaderAccessibilityTests.swift */; };
+		DE640E5C34EE42663403FEA2 /* RegistryFileRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3D7B0F09A19268135E40FB /* RegistryFileRecovery.swift */; };
 		DE67C809E2D5FEC127EF7845 /* TPPBookRegistryDependencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2EF561051B25A261AE67BC /* TPPBookRegistryDependencyTests.swift */; };
 		DE8F7A1FFA894C20AC3C1101 /* TPPSettingsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B8F946D19048E4AE73B6C7 /* TPPSettingsMock.swift */; };
 		DEB55C527CC64B0BAACAD072 /* OPDSFeedMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42A18057E6441D9B4142F50 /* OPDSFeedMigrationTests.swift */; };
@@ -2660,6 +2663,7 @@
 		8568424DF6517B247D048D5D /* LCPLibraryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPLibraryServiceTests.swift; sourceTree = "<group>"; };
 		85803B918D5A471B9C0B98D0 /* CatalogState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogState.swift; sourceTree = "<group>"; };
 		8634A05347B14A483EBB459D /* AppRatingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppRatingService.swift; sourceTree = "<group>"; };
+		863E4EF7FA12EFB2170C7638 /* RegistryFileRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RegistryFileRecoveryTests.swift; sourceTree = "<group>"; };
 		8673802153960A8CA7EAE753 /* AccountsManager+TPPCurrentLibraryAccountProviding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AccountsManager+TPPCurrentLibraryAccountProviding.swift"; sourceTree = "<group>"; };
 		867797B6E90539304E2A80B5 /* AudiobookColdLoadRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookColdLoadRecoveryTests.swift; sourceTree = "<group>"; };
 		867AE0470C91DD0D498E68F4 /* AppContainerAudiobookFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContainerAudiobookFactoryTests.swift; sourceTree = "<group>"; };
@@ -2976,6 +2980,7 @@
 		D9942FC82D3E4CC990D870D3 /* NetworkClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClientMock.swift; sourceTree = "<group>"; };
 		D9B791C34331187A57984D68 /* BookButtonTypeMetaTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookButtonTypeMetaTests.swift; sourceTree = "<group>"; };
 		D9BB35289AD0460FAB3BDDD4 /* AccountDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDetailViewModel.swift; sourceTree = "<group>"; };
+		DA3D7B0F09A19268135E40FB /* RegistryFileRecovery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RegistryFileRecovery.swift; sourceTree = "<group>"; };
 		DA754723506FCB1676E2E8C7 /* AudiobookSessionManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookSessionManagerTests.swift; sourceTree = "<group>"; };
 		DB1D8E96BB21CEA1AB690046 /* StreakView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreakView.swift; sourceTree = "<group>"; };
 		DC11AA22BB33CC44DD55EE66 /* DownloadResumeAfterKillTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadResumeAfterKillTests.swift; sourceTree = "<group>"; };
@@ -4521,6 +4526,7 @@
 				ECEB9F995C87FE2C71DFA9BC /* BookRegistrySync.swift */,
 				68EFBB61877EFCAB44897E93 /* BookmarkManager.swift */,
 				A9C1093BDA93392F7DEF0D31 /* TPPBook+Accessibility.swift */,
+				DA3D7B0F09A19268135E40FB /* RegistryFileRecovery.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -5582,6 +5588,7 @@
 				D9B791C34331187A57984D68 /* BookButtonTypeMetaTests.swift */,
 				F447D6D0EFBBC91F7CD6C5A4 /* BookRegistrySyncReentrancyTests.swift */,
 				5645B2E3AB447845108FC02C /* BookRegistrySyncSideloadExemptionTests.swift */,
+				863E4EF7FA12EFB2170C7638 /* RegistryFileRecoveryTests.swift */,
 			);
 			path = Book;
 			sourceTree = "<group>";
@@ -7649,6 +7656,7 @@
 				460ADECAE6DF8B66F16BB9A8 /* DownloadCompleteMomentTests.swift in Sources */,
 				2CB4235AFFA2BB53365AD667 /* TPPPDFReaderSearchBindingTests.swift in Sources */,
 				2E6A415E42C938CDED99D134 /* SkeletonTests.swift in Sources */,
+				17377CDB4BA7F8C24918839F /* RegistryFileRecoveryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8205,6 +8213,7 @@
 				39A1336976AF58F39DFF585A /* PalacePressableButtonStyle.swift in Sources */,
 				FC06F1538E0D26618E2DD336 /* PalaceHaptic.swift in Sources */,
 				1446B886F9D2F070E2AC22A5 /* Skeleton.swift in Sources */,
+				447135A5582962D50E93CE3A /* RegistryFileRecovery.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8764,6 +8773,7 @@
 				A194D27C0FF23ECB35C85E34 /* PalacePressableButtonStyle.swift in Sources */,
 				AAF4A7A693BC1867BF31E4C5 /* PalaceHaptic.swift in Sources */,
 				7025FC704907DF4D61E2F270 /* Skeleton.swift in Sources */,
+				DE640E5C34EE42663403FEA2 /* RegistryFileRecovery.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -428,7 +428,32 @@ struct AppContainer: @unchecked Sendable {
     }
 
     static func production() -> AppContainer {
-        _cachedValue()
+        let container = _cachedValue()
+        container.ensureOfflineQueueExecutorRegistered()
+        return container
+    }
+
+    /// Reliability WS-C (seam S2): install the offline-queue executor
+    /// exactly once. The coordinator is retained in a process-wide slot so
+    /// its `[weak self]` executor closure stays alive; the actual
+    /// `setExecutor` call lives in `OfflineQueueCoordinator.registerExecutor()`
+    /// (WS-C owns the wiring). Empty-fast on every subsequent call.
+    private static let _offlineQueueCoordinator =
+        OSAllocatedUnfairLock<OfflineQueueCoordinator?>(initialState: nil)
+
+    func ensureOfflineQueueExecutorRegistered() {
+        let coordinator: OfflineQueueCoordinator? =
+            AppContainer._offlineQueueCoordinator.withLock { slot in
+                if slot != nil { return nil }
+                let c = OfflineQueueCoordinator.production(
+                    downloadCenter: self.downloadCenter,
+                    bookRegistry: self.bookRegistry
+                )
+                slot = c
+                return c
+            }
+        guard let coordinator else { return }
+        Task { await coordinator.registerExecutor() }
     }
 
     /// The cached app-wide composition graph. Initially populated by Swift's

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -440,7 +440,18 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     internal func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
-        audiobookLifecycleManager.handleEventsForBackgroundURLSession(for: identifier, completionHandler: completionHandler)
+        // Reliability WS-A (INV-7): route the book download center's background
+        // session wake to MyBooksDownloadCenter — store its system completion
+        // handler (invoked once, then cleared, in urlSessionDidFinishEvents) and,
+        // by accessing `downloadCenter`, ensure its background session is
+        // instantiated so iOS reconnects and re-delivers the pending delegate
+        // callbacks. Every OTHER identifier keeps the byte-for-byte audiobook
+        // route.
+        if MyBooksDownloadCenter.isDownloadCenterBackgroundSession(identifier) {
+            AppContainer.production().downloadCenter.setBackgroundCompletionHandler(completionHandler)
+        } else {
+            audiobookLifecycleManager.handleEventsForBackgroundURLSession(for: identifier, completionHandler: completionHandler)
+        }
     }
 
     // MARK: - Scene Configuration

--- a/Palace/Book/Models/BookRegistrySync.swift
+++ b/Palace/Book/Models/BookRegistrySync.swift
@@ -21,6 +21,8 @@ import PalaceCatalog
 ///     and `sync`), and the reads that gate behaviour (e.g. `syncUrl != loansUrl`,
 ///     the duplicate-load guard) run on that same main queue. No write races
 ///     another write across threads.
+///   • `_needsRebuildFromServer` (the INV-1 rebuild flag) is guarded by its own
+///     `rebuildFlagLock`, so the disk-write queue can read/clear it race-free.
 ///
 /// Marking the type Sendable lets it be captured by the structured-concurrency
 /// (`Task { … }` / `await MainActor.run { … }`) closures in `sync(...)` without
@@ -69,6 +71,20 @@ final class BookRegistrySync: @unchecked Sendable {
 
   var syncUrl: URL?
   var loadingAccount: String?
+
+  /// INV-1 (Reliability WS-B): set true when `load` finds the registry file
+  /// corrupt/unrecoverable and leaves the in-memory shelf empty. While true,
+  /// `save(for:)`/`saveSync(for:)` refuse to persist an EMPTY snapshot over a
+  /// non-empty last-good `.bak` unless the save is marked server-authoritative
+  /// (`sync()`'s loans-feed reconciliation). Cleared by the next successful
+  /// non-empty or authoritative save. Lock-guarded so the disk-write queue can
+  /// read it race-free (the class is `@unchecked Sendable`).
+  private let rebuildFlagLock = NSLock()
+  private var _needsRebuildFromServer = false
+  var needsRebuildFromServer: Bool {
+    get { rebuildFlagLock.lock(); defer { rebuildFlagLock.unlock() }; return _needsRebuildFromServer }
+    set { rebuildFlagLock.lock(); defer { rebuildFlagLock.unlock() }; _needsRebuildFromServer = newValue }
+  }
 
   /// Resolved-on-demand accessors. Tests may inject closures returning
   /// fakes; production wires `AppContainer.production().downloadCenter`
@@ -142,11 +158,51 @@ final class BookRegistrySync: @unchecked Sendable {
       var orphanedBooksNeedingRedownload = [TPPBook]()
 
       var newRegistry = [String: TPPBookRegistryRecord]()
-      if FileManager.default.fileExists(atPath: url.path),
-         let data = try? Data(contentsOf: url),
-         let json = try? JSONSerialization.jsonObject(with: data) as? TPPBookRegistryData,
-         let records = json.array(for: .records) {
+      var needsRebuild = false
 
+      // Reliability WS-B / INV-1: distinguish an ABSENT registry file from an
+      // existing-but-CORRUPT one. The old code conflated both into a single
+      // `else` that silently zeroed the shelf, and the next save() then
+      // overwrote the (recoverable) corrupt file with a valid-but-empty one —
+      // erasing the patron's whole shelf on a single bad write. We now classify
+      // the bytes, quarantine a corrupt file (never destroy), and try the
+      // last-good `.bak` before falling back to empty + a rebuild flag.
+      let fileExists = FileManager.default.fileExists(atPath: url.path)
+      let fileData: Data? = fileExists ? try? Data(contentsOf: url) : nil
+      let classification: RegistryFileRecovery.Classification
+      if !fileExists {
+        classification = .empty
+      } else if let fileData {
+        classification = RegistryFileRecovery.classify(data: fileData)
+      } else {
+        // File exists but could not be read — treat as corrupt (recoverable).
+        classification = .corrupt
+      }
+
+      var recordsToParse: [TPPBookRegistryData]? = nil
+      switch classification {
+      case .valid(let records):
+        recordsToParse = records
+        if RegistryFileRecovery.needsMigration(data: fileData) {
+          Log.info(#file, "  Registry file is unversioned (legacy) — will migrate to schema v\(RegistryFileRecovery.currentSchemaVersion) on next save")
+        }
+      case .empty:
+        Log.info(#file, "  No existing registry file found — starting with an empty registry")
+      case .corrupt:
+        Log.error(#file, "  Registry file exists but is CORRUPT — quarantining (never overwriting/destroying)")
+        if let quarantined = RegistryFileRecovery.quarantine(corruptFileAt: url) {
+          Log.error(#file, "  Quarantined corrupt registry to \(quarantined.lastPathComponent)")
+        }
+        if let recovered = RegistryFileRecovery.recoverFromBackup(for: url) {
+          Log.info(#file, "  Recovered \(recovered.count) record(s) from last-good .bak backup")
+          recordsToParse = recovered
+        } else {
+          Log.error(#file, "  No usable .bak backup — leaving registry empty and flagging needsRebuildFromServer (next authenticated sync repopulates from the loans feed)")
+          needsRebuild = true
+        }
+      }
+
+      if let records = recordsToParse {
         Log.debug(#file, "  Found \(records.count) books in registry")
 
         for obj in records {
@@ -238,8 +294,6 @@ final class BookRegistrySync: @unchecked Sendable {
 
           newRegistry[record.book.identifier] = record
         }
-      } else {
-        Log.info(#file, "  No existing registry file found or failed to parse")
       }
 
       registry = newRegistry
@@ -259,6 +313,12 @@ final class BookRegistrySync: @unchecked Sendable {
         if self.loadingAccount == loadedAccount {
           self.loadingAccount = nil
         }
+
+        // INV-1: publish the rebuild flag on main (matches this class's
+        // main-thread-confinement invariant for its mutable state). While set,
+        // save() refuses to persist an empty snapshot over a non-empty backup
+        // until an authoritative server sync repopulates the shelf.
+        self.needsRebuildFromServer = needsRebuild
 
         callbacks.setState(.loaded)
         self.store.registrySubject.send(snapshot)
@@ -534,7 +594,10 @@ final class BookRegistrySync: @unchecked Sendable {
         }
 
         if changesMade {
-          self.save(for: accountUUID)
+          // Server-authoritative: this snapshot is the result of reconciling
+          // against the loans feed (guarded by shouldSkipBulkDeletion), so it is
+          // allowed to persist an empty shelf and it clears needsRebuildFromServer.
+          self.save(for: accountUUID, serverAuthoritative: true)
         }
 
         callbacks.setState(.synced)
@@ -552,18 +615,43 @@ final class BookRegistrySync: @unchecked Sendable {
   /// would persist A's state to B's registry file and cause cross-account
   /// contamination (PP-4129 regression).
   func save(for account: String) {
+    save(for: account, serverAuthoritative: false)
+  }
+
+  /// - Parameter serverAuthoritative: `true` only when the snapshot being
+  ///   persisted is the result of an authoritative server reconciliation
+  ///   (`sync()`'s loans-feed pass). An authoritative save may persist an empty
+  ///   registry (e.g. all loans genuinely returned) and clears
+  ///   `needsRebuildFromServer`. A non-authoritative save (local mutation,
+  ///   content validation) is REFUSED when it would overwrite a non-empty
+  ///   last-good `.bak` with an empty snapshot during the post-corrupt rebuild
+  ///   window (INV-1).
+  func save(for account: String, serverAuthoritative: Bool) {
     guard let registryUrl = registryUrl(for: account) else { return }
 
     let snapshot = store.registrySnapshot()
+    let isEmpty = snapshot.isEmpty
+    let needsRebuild = needsRebuildFromServer
     // Box the JSON payload so the `@Sendable` `diskWriteQueue.async` closure
-    // captures a Sendable value rather than the raw `[String: [[String: Any]]]`
-    // (non-Sendable because it holds `Any`). INVARIANT: the payload is built once
-    // here from a fresh snapshot and only ever READ inside the closure (serialized
-    // to JSON on `diskWriteQueue`), never mutated or shared — a write-once /
-    // read-once-off-thread handoff. Mirrors `SendableErrorDocument`.
-    let payload = SendableRegistryPayload(value: [TPPBookRegistryKey.records.rawValue: snapshot])
+    // captures a Sendable value rather than the raw `[String: Any]` (non-Sendable
+    // because it holds `Any`). INVARIANT: the payload is built once here from a
+    // fresh snapshot and only ever READ inside the closure (serialized to JSON on
+    // `diskWriteQueue`), never mutated or shared. Mirrors `SendableErrorDocument`.
+    let payload = SendableRegistryPayload(value: [
+      RegistryFileRecovery.schemaVersionKey: RegistryFileRecovery.currentSchemaVersion,
+      TPPBookRegistryKey.records.rawValue: snapshot
+    ])
 
-    diskWriteQueue.async {
+    diskWriteQueue.async { [self] in
+      // INV-1: during the post-corrupt-load rebuild window, only an authoritative
+      // server sync may persist an empty shelf. Refuse any other empty save — the
+      // corrupt original is quarantined and the last-good `.bak` (if present) still
+      // holds the shelf, so we must not overwrite the primary with an empty file
+      // before `sync()` repopulates from the loans feed.
+      if isEmpty, !serverAuthoritative, needsRebuild {
+        Log.error(#file, "INV-1: refusing to persist an EMPTY registry during rebuild window (no server authority) — backup non-empty: \(RegistryFileRecovery.backupHasRecords(for: registryUrl))")
+        return
+      }
       do {
         let directoryURL = registryUrl.deletingLastPathComponent()
         if !FileManager.default.fileExists(atPath: directoryURL.path) {
@@ -571,7 +659,16 @@ final class BookRegistrySync: @unchecked Sendable {
         }
         directoryURL.excludeFromBackup()
         let registryData = try JSONSerialization.data(withJSONObject: payload.value, options: .fragmentsAllowed)
+        // Refresh the last-good `.bak` BEFORE overwriting the primary, but only
+        // for a good snapshot (non-empty, or a server-authoritative empty) so a
+        // transient empty can never clobber the backup.
+        if !isEmpty || serverAuthoritative {
+          try? RegistryFileRecovery.writeBackup(data: registryData, for: registryUrl)
+        }
         try registryData.write(to: registryUrl, options: .atomic)
+        if !isEmpty || serverAuthoritative {
+          needsRebuildFromServer = false
+        }
         DispatchQueue.main.async {
           NotificationCenter.default.post(name: .TPPBookRegistryDidChange, object: nil, userInfo: nil)
         }
@@ -595,7 +692,12 @@ final class BookRegistrySync: @unchecked Sendable {
     // race). The in-memory snapshot is independent of disk-flush ordering, so
     // reading it here is behavior-equivalent for persistence.
     let snapshot = store.registrySnapshot()
-    let registryObject = [TPPBookRegistryKey.records.rawValue: snapshot]
+    let isEmpty = snapshot.isEmpty
+    let needsRebuild = needsRebuildFromServer
+    let registryObject: [String: Any] = [
+      RegistryFileRecovery.schemaVersionKey: RegistryFileRecovery.currentSchemaVersion,
+      TPPBookRegistryKey.records.rawValue: snapshot
+    ]
 
     // Serialize the disk write through `diskWriteQueue` so a sync save can't run
     // its `.atomic` rename-replace concurrently with an in-flight async write to
@@ -603,6 +705,13 @@ final class BookRegistrySync: @unchecked Sendable {
     // ALREADY executing on `diskWriteQueue`, run inline — a nested
     // `diskWriteQueue.sync` would deadlock against itself.
     let write = {
+      // INV-1: saveSync is teardown persistence (bookmarks/location), never a
+      // server reconciliation — so it is always non-authoritative. Refuse an
+      // empty snapshot over a non-empty backup during the rebuild window.
+      if isEmpty, needsRebuild {
+        Log.error(#file, "INV-1: refusing synchronous EMPTY registry save during rebuild window (backup non-empty: \(RegistryFileRecovery.backupHasRecords(for: registryUrl)))")
+        return
+      }
       do {
         let directoryURL = registryUrl.deletingLastPathComponent()
         if !FileManager.default.fileExists(atPath: directoryURL.path) {
@@ -610,7 +719,13 @@ final class BookRegistrySync: @unchecked Sendable {
         }
         directoryURL.excludeFromBackup()
         let registryData = try JSONSerialization.data(withJSONObject: registryObject, options: .fragmentsAllowed)
+        if !isEmpty {
+          try? RegistryFileRecovery.writeBackup(data: registryData, for: registryUrl)
+        }
         try registryData.write(to: registryUrl, options: .atomic)
+        if !isEmpty {
+          self.needsRebuildFromServer = false
+        }
         Log.debug(#file, "Synchronously saved registry to disk")
       } catch {
         Log.error(#file, "Error saving book registry synchronously: \(error.localizedDescription)")
@@ -748,10 +863,10 @@ struct SendableErrorDocument: @unchecked Sendable {
 
 /// Sendable carrier for the JSON registry payload that `save(for:)` hands to the
 /// `@Sendable` `diskWriteQueue.async` closure. The value is a
-/// `[String: [[String: Any]]]` (non-Sendable — holds `Any`) built once from a
+/// `[String: Any]` (non-Sendable — the `schemaVersion` Int and the `records` array, — holds `Any`) built once from a
 /// fresh in-memory snapshot and only ever READ (serialized to JSON) on the disk
 /// queue, never mutated or shared. `@unchecked` documents that write-once /
 /// read-off-thread confinement. Mirrors `SendableErrorDocument`.
 private struct SendableRegistryPayload: @unchecked Sendable {
-  let value: [String: [[String: Any]]]
+  let value: [String: Any]
 }

--- a/Palace/Book/Models/RegistryFileRecovery.swift
+++ b/Palace/Book/Models/RegistryFileRecovery.swift
@@ -1,0 +1,192 @@
+//
+//  RegistryFileRecovery.swift
+//  Palace
+//
+//  Reliability initiative — Workstream B (Registry Resilience).
+//
+//  Pure classification + on-disk quarantine/backup helpers for the book
+//  registry file. Extracted so the corrupt/empty/valid decision is a
+//  side-effect-free function that can be unit- and mutation-tested without
+//  standing up the full `BookRegistrySync` disk pipeline.
+//
+//  The shelf (`TPPBookRegistry`) is the source of truth for a patron's books.
+//  A single truncated write or OS-level corruption of `registry.json` must
+//  NEVER cause the shelf to be silently zeroed and then overwritten with an
+//  empty-but-valid file. This helper encodes the "never destroy, always
+//  quarantine, prefer last-good backup" policy behind INV-1.
+//
+//  Copyright (c) 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import PalaceLogging
+
+/// Stateless registry-file recovery policy. All members are `static` and pure
+/// over their inputs (`Data`, `URL`) except the explicitly-named I/O helpers
+/// (`quarantine`, `writeBackup`), which perform copy/rename filesystem work and
+/// are documented as such.
+enum RegistryFileRecovery {
+
+  /// Current on-disk schema version. Version 1 == the historical shape
+  /// (`{ "records": [ … ] }`); v1 files additionally carry `schemaVersion: 1`.
+  /// Old files written before this field existed are "unversioned" and are
+  /// treated as v1 on load, then migrated (gain the field) on the next save.
+  static let currentSchemaVersion = 1
+
+  /// The JSON key under which the schema version is persisted. Defined here
+  /// (not on `TPPBookRegistryKey`, which lives in a file this workstream does
+  /// not own) so the change is fully contained to WS-B's files.
+  static let schemaVersionKey = "schemaVersion"
+
+  /// The result of classifying the bytes of a registry file.
+  ///
+  /// - `valid`: parseable object carrying a `records` array (possibly empty —
+  ///   an authoritatively-empty shelf is still valid).
+  /// - `corrupt`: bytes are present but are not a JSON object, or are a JSON
+  ///   object missing the `records` array (truncated / wrong shape). RECOVERABLE
+  ///   — quarantine, then try the `.bak` backup.
+  /// - `empty`: no bytes at all (nil or zero-length) — a genuinely absent file,
+  ///   e.g. first launch. Nothing to recover.
+  enum Classification {
+    case valid(records: [TPPBookRegistryData])
+    case corrupt
+    case empty
+  }
+
+  /// Pure classification of raw registry-file bytes.
+  ///
+  /// Passing `nil` (file does not exist) or empty `Data` yields `.empty`.
+  /// Non-empty bytes that fail JSON parsing, or parse to something without a
+  /// `records` array, yield `.corrupt`. Well-formed bytes yield `.valid`.
+  static func classify(data: Data?) -> Classification {
+    guard let data = data, !data.isEmpty else {
+      return .empty
+    }
+    guard let object = try? JSONSerialization.jsonObject(with: data),
+          let json = object as? TPPBookRegistryData else {
+      // Present but not a JSON object → corrupt (recoverable via quarantine/bak).
+      return .corrupt
+    }
+    guard let records = json.array(for: .records) else {
+      // Parseable JSON but the registry shape is wrong (no records array) →
+      // treat as corrupt so the file is quarantined rather than silently
+      // replaced by an empty registry.
+      return .corrupt
+    }
+    return .valid(records: records)
+  }
+
+  /// The persisted schema version of the given bytes, or `nil` when the bytes
+  /// are unparseable or carry no `schemaVersion` field (a legacy/unversioned
+  /// file). A returned `nil` on otherwise-valid bytes means "migrate on next save".
+  static func schemaVersion(from data: Data?) -> Int? {
+    guard let data = data,
+          let object = try? JSONSerialization.jsonObject(with: data),
+          let json = object as? TPPBookRegistryData else {
+      return nil
+    }
+    return json[schemaVersionKey] as? Int
+  }
+
+  /// True when the bytes are a valid registry that lacks a `schemaVersion`
+  /// field — i.e. a legacy file that will be migrated to the current version
+  /// on the next save. False for corrupt/empty bytes and for already-versioned
+  /// files.
+  static func needsMigration(data: Data?) -> Bool {
+    if case .valid = classify(data: data) {
+      return schemaVersion(from: data) == nil
+    }
+    return false
+  }
+
+  // MARK: - File-path derivation (pure over URL)
+
+  /// The last-good backup sidecar: `registry.json` → `registry.json.bak`.
+  static func backupURL(for registryURL: URL) -> URL {
+    registryURL.appendingPathExtension("bak")
+  }
+
+  /// The quarantine destination for a corrupt file:
+  /// `registry.json` → `registry.json.corrupt-<unix-timestamp>`.
+  static func quarantineURL(for registryURL: URL, timestamp: Date = Date()) -> URL {
+    let seconds = Int(timestamp.timeIntervalSince1970)
+    return registryURL.appendingPathExtension("corrupt-\(seconds)")
+  }
+
+  // MARK: - I/O helpers (side-effecting — copy / write / rename)
+
+  /// Copies a corrupt registry file aside to its quarantine path. NEVER moves
+  /// or deletes the original — the corrupt bytes are preserved both in place
+  /// (until a later authoritative save replaces them) and in the quarantine
+  /// copy for forensic/manual recovery.
+  ///
+  /// - Returns: the quarantine URL on success, `nil` if the source is absent or
+  ///   the copy failed.
+  @discardableResult
+  static func quarantine(corruptFileAt registryURL: URL, timestamp: Date = Date()) -> URL? {
+    guard FileManager.default.fileExists(atPath: registryURL.path) else {
+      return nil
+    }
+    let destination = quarantineURL(for: registryURL, timestamp: timestamp)
+    do {
+      if FileManager.default.fileExists(atPath: destination.path) {
+        try FileManager.default.removeItem(at: destination)
+      }
+      try FileManager.default.copyItem(at: registryURL, to: destination)
+      return destination
+    } catch {
+      Log.error(#file, "Failed to quarantine corrupt registry file: \(error.localizedDescription)")
+      return nil
+    }
+  }
+
+  /// Persists `data` as the last-good `.bak` sidecar using a durable
+  /// write-new → fsync → rename sequence: the bytes are written to a temporary
+  /// file, flushed to stable storage with `fsync`, then atomically renamed over
+  /// the existing backup. A crash mid-write can never leave a half-written
+  /// `.bak` (the rename is atomic; the temp file is discarded).
+  static func writeBackup(data: Data, for registryURL: URL) throws {
+    let backup = backupURL(for: registryURL)
+    let tempURL = backup.appendingPathExtension("tmp")
+
+    // Ensure the containing directory exists (mirrors save()'s own directory
+    // creation) so writing the sidecar cannot fail on a not-yet-created folder.
+    let directory = backup.deletingLastPathComponent()
+    if !FileManager.default.fileExists(atPath: directory.path) {
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    try data.write(to: tempURL, options: .atomic)
+
+    // fsync the temp file so its bytes are durable before we rename it into
+    // place — otherwise a power loss after the rename could expose an empty
+    // inode as the "backup".
+    let handle = try FileHandle(forWritingTo: tempURL)
+    try handle.synchronize()
+    try handle.close()
+
+    if FileManager.default.fileExists(atPath: backup.path) {
+      try FileManager.default.removeItem(at: backup)
+    }
+    try FileManager.default.moveItem(at: tempURL, to: backup)
+  }
+
+  /// The records recoverable from the `.bak` backup, or `nil` when there is no
+  /// backup, it is unreadable, corrupt, or valid-but-empty. Only a NON-empty
+  /// valid backup is a usable recovery source.
+  static func recoverFromBackup(for registryURL: URL) -> [TPPBookRegistryData]? {
+    let backup = backupURL(for: registryURL)
+    guard let data = try? Data(contentsOf: backup) else { return nil }
+    if case .valid(let records) = classify(data: data), !records.isEmpty {
+      return records
+    }
+    return nil
+  }
+
+  /// True when a non-empty last-good `.bak` backup exists for the registry —
+  /// the precondition that makes an empty, non-authoritative save destructive
+  /// (INV-1). Cheap wrapper over `recoverFromBackup`.
+  static func backupHasRecords(for registryURL: URL) -> Bool {
+    return recoverFromBackup(for: registryURL) != nil
+  }
+}

--- a/Palace/MyBooks/BookReturnService.swift
+++ b/Palace/MyBooks/BookReturnService.swift
@@ -72,6 +72,23 @@ final class BookReturnService: @unchecked Sendable {
     /// `reauthenticator.authenticateIfNeeded` closure.
     private let authCoordinator: AuthCoordinator?
 
+    /// Reliability WS-C (INV-3): enqueue seam for a genuine offline
+    /// return. When non-nil and the revoke fetch fails with an offline
+    /// `NSURLError`, the return is queued for later drain instead of
+    /// dead-ending in an alert — and NO local content is deleted /
+    /// unregistered until the queued return is server-confirmed. Optional
+    /// so existing tests/callers that don't wire the queue keep the legacy
+    /// alert behavior. Production injects the real queue enqueue.
+    private let offlineReturnEnqueuer: (@Sendable (OfflineAction) async -> Void)?
+
+    /// Production default for `offlineReturnEnqueuer`: enqueue onto the
+    /// app-wide offline queue. Used so the MBDC-constructed instance gets
+    /// INV-3 behavior without MBDC (owned by WS-A) having to change. Tests
+    /// inject their own spy to observe the enqueue deterministically.
+    static let productionOfflineReturnEnqueuer: @Sendable (OfflineAction) async -> Void = { action in
+        await OfflineQueueService.shared.enqueue(action)
+    }
+
     /// Closure resolves the current user account each call so library
     /// switches mid-flow are observed correctly (matches MBDC's `userAccount`
     /// computed property semantics).
@@ -127,7 +144,8 @@ final class BookReturnService: @unchecked Sendable {
         userRetryTracker: UserRetryTracker,
         userAccountProvider: @escaping () -> TPPUserAccount,
         adobeDRMService: AdobeDRMService = .shared,
-        authCoordinator: AuthCoordinator? = nil
+        authCoordinator: AuthCoordinator? = nil,
+        offlineReturnEnqueuer: (@Sendable (OfflineAction) async -> Void)? = BookReturnService.productionOfflineReturnEnqueuer
     ) {
         self.bookRegistry = bookRegistry
         self.localContentService = localContentService
@@ -139,6 +157,7 @@ final class BookReturnService: @unchecked Sendable {
         self.userAccountProvider = userAccountProvider
         self.adobeDRMService = adobeDRMService
         self.authCoordinator = authCoordinator
+        self.offlineReturnEnqueuer = offlineReturnEnqueuer
     }
     #else
     init(
@@ -150,7 +169,8 @@ final class BookReturnService: @unchecked Sendable {
         reauthenticator: Reauthenticator,
         userRetryTracker: UserRetryTracker,
         userAccountProvider: @escaping () -> TPPUserAccount,
-        authCoordinator: AuthCoordinator? = nil
+        authCoordinator: AuthCoordinator? = nil,
+        offlineReturnEnqueuer: (@Sendable (OfflineAction) async -> Void)? = BookReturnService.productionOfflineReturnEnqueuer
     ) {
         self.bookRegistry = bookRegistry
         self.localContentService = localContentService
@@ -161,6 +181,7 @@ final class BookReturnService: @unchecked Sendable {
         self.userRetryTracker = userRetryTracker
         self.userAccountProvider = userAccountProvider
         self.authCoordinator = authCoordinator
+        self.offlineReturnEnqueuer = offlineReturnEnqueuer
     }
     #endif
 
@@ -521,6 +542,27 @@ final class BookReturnService: @unchecked Sendable {
             return
         }
 
+        // Reliability WS-C (INV-3): a genuine offline / no-connection error
+        // is NOT a return failure — the loan is still ours and the revoke
+        // simply couldn't reach the server. Enqueue the return for a later
+        // drain and inform the patron. Critically, do NOT delete local
+        // content or unregister here — cleanup only runs once the queued
+        // return is server-confirmed (via OfflineQueueCoordinator ->
+        // returnBook -> the normal ordered cleanup contract).
+        if Self.isOfflineNSURLError(error), let enqueuer = self.offlineReturnEnqueuer {
+            Log.info(#file, "Offline return for '\(book.title)' — enqueuing for later; no local cleanup")
+            let action = OfflineAction(type: .return, bookID: identifier, bookTitle: book.title)
+            launchTrackedTask { [weak self] in
+                await enqueuer(action)
+                guard let self else { return }
+                runOnMainAsync {
+                    self.presentOfflineReturnQueuedAlert(for: book)
+                    completion?()
+                }
+            }
+            return
+        }
+
         // All other errors — show alert with problem document if available
         launchTrackedMainActorTask { [weak self] in
             guard let self else { return }
@@ -592,6 +634,44 @@ final class BookReturnService: @unchecked Sendable {
         TPPPresentationUtils.safelyPresent(alert)
         downloadAnnouncementService.announceReturnFailed(for: book)
         completion?()
+    }
+
+    // MARK: - Offline return (INV-3)
+
+    /// Whether `error` is a genuine offline / no-connection transport
+    /// failure — the only class of return error that should be queued
+    /// rather than surfaced as a failure. Auth / problem-doc / parsing
+    /// errors are handled by their own branches above.
+    static func isOfflineNSURLError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else { return false }
+        switch nsError.code {
+        case NSURLErrorNotConnectedToInternet,
+             NSURLErrorNetworkConnectionLost,
+             NSURLErrorCannotConnectToHost,
+             NSURLErrorTimedOut,
+             NSURLErrorDataNotAllowed,
+             NSURLErrorInternationalRoamingOff,
+             NSURLErrorCannotFindHost:
+            return true
+        default:
+            return false
+        }
+    }
+
+    @MainActor
+    private func presentOfflineReturnQueuedAlert(for book: TPPBook) {
+        let message = String(
+            format: NSLocalizedString(
+                "\"%@\" will be returned automatically when you're back online.",
+                comment: "Informs the user an offline return was queued"),
+            book.title)
+        let alert = UIAlertController(
+            title: NSLocalizedString("Return Queued", comment: "Title for a queued offline return"),
+            message: message,
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: Strings.Generic.ok, style: .default))
+        TPPPresentationUtils.safelyPresent(alert)
     }
 
     // MARK: - Post-return sync

--- a/Palace/MyBooks/DownloadErrorRecovery.swift
+++ b/Palace/MyBooks/DownloadErrorRecovery.swift
@@ -111,6 +111,21 @@ actor DownloadErrorRecovery {
             }
         )
 
+        /// Retry policy for the plain CONTENT transfer (the URLSession bytes
+        /// download), added for Reliability WS-A. Reuses `default`'s NSURLError
+        /// classifier verbatim — it already refuses auth / 404 / bad-URL /
+        /// file-permission / no-permissions errors and admits transient network
+        /// failures — so a transient transfer blip retries with backoff while a
+        /// non-transient failure fails fast into the existing alert path. INV-6:
+        /// this governs the content transfer only; DRM fulfillment is untouched.
+        static let downloadTransfer = RetryPolicy(
+            maxAttempts: 3,
+            baseDelay: 2.0,
+            maxDelay: 30.0,
+            overallTimeout: 120.0,
+            shouldRetry: RetryPolicy.default.shouldRetry
+        )
+
         /// Retry policy for borrow operations — tolerant of slow servers (hold notifications
         /// can fire before the loan is fully ready on the CM side).
         static let borrowOperation = RetryPolicy(

--- a/Palace/MyBooks/DownloadStateManager.swift
+++ b/Palace/MyBooks/DownloadStateManager.swift
@@ -51,6 +51,21 @@ final class DownloadStateManager: DownloadStateManaging {
     let downloadCoordinator = DownloadCoordinator()
     var maxConcurrentDownloads: Int = 4
 
+    // MARK: - Durable persistence (seam S1)
+
+    /// Crash-durable mirror of the in-flight download records. The
+    /// SafeDictionaries above stay the hot cache; this cold store survives a
+    /// mid-download kill so launch reconciliation can re-adopt / restart tasks.
+    let taskPersistence: DownloadTaskPersistence
+
+    /// Per-book transient-transfer retry counter (content transfer only). Reset
+    /// on terminal completion so a later independent failure starts fresh.
+    private let transferRetryCounts = SafeDictionary<String, Int>()
+
+    init(taskPersistence: DownloadTaskPersistence = DownloadTaskPersistence()) {
+        self.taskPersistence = taskPersistence
+    }
+
     // MARK: - Download Info Queries
 
     /// Async-first download info accessor with cache update
@@ -76,6 +91,53 @@ final class DownloadStateManager: DownloadStateManaging {
         Double(self.downloadInfo(forBookIdentifier: bookIdentifier)?.downloadProgress ?? 0.0)
     }
 
+    // MARK: - Durable persistence API
+
+    /// Persist a started task so a mid-download kill can be reconciled at launch.
+    func persistStartedTask(
+        bookID: String,
+        taskIdentifier: Int,
+        downloadURL: URL,
+        account: String,
+        expectedBytes: Int64?
+    ) {
+        taskPersistence.record(
+            PersistedDownloadRecord(
+                bookID: bookID,
+                taskIdentifier: taskIdentifier,
+                downloadURL: downloadURL,
+                account: account,
+                expectedBytes: expectedBytes,
+                startedAt: Date()
+            )
+        )
+    }
+
+    /// Drop the durable record for a book on terminal completion.
+    func removePersistedRecord(for bookID: String) {
+        taskPersistence.remove(bookID: bookID)
+    }
+
+    /// All durable records (for launch reconciliation).
+    func persistedRecords() -> [PersistedDownloadRecord] {
+        taskPersistence.all()
+    }
+
+    // MARK: - Transient-transfer retry counters
+
+    func transferRetryAttempts(for bookID: String) async -> Int {
+        await transferRetryCounts.get(bookID) ?? 0
+    }
+
+    func incrementTransferRetryAttempts(for bookID: String) async {
+        let current = await transferRetryCounts.get(bookID) ?? 0
+        await transferRetryCounts.set(bookID, value: current + 1)
+    }
+
+    func resetTransferRetryAttempts(for bookID: String) async {
+        await transferRetryCounts.remove(bookID)
+    }
+
     // MARK: - Cleanup
 
     /// Removes all tracking state for a completed or failed download.
@@ -83,6 +145,8 @@ final class DownloadStateManager: DownloadStateManaging {
         await bookIdentifierToDownloadInfo.remove(bookIdentifier)
         await downloadCoordinator.removeCachedDownloadInfo(for: bookIdentifier)
         await downloadCoordinator.registerCompletion(identifier: bookIdentifier)
+        await transferRetryCounts.remove(bookIdentifier)
+        removePersistedRecord(for: bookIdentifier)
 
         if let taskId = taskIdentifier {
             await taskIdentifierToBook.remove(taskId)
@@ -98,6 +162,8 @@ final class DownloadStateManager: DownloadStateManaging {
 
         await bookIdentifierToDownloadInfo.removeAll()
         await taskIdentifierToBook.removeAll()
+        await transferRetryCounts.removeAll()
+        taskPersistence.removeAll()
         await downloadCoordinator.reset()
     }
 }

--- a/Palace/MyBooks/DownloadTaskPersistence.swift
+++ b/Palace/MyBooks/DownloadTaskPersistence.swift
@@ -1,0 +1,230 @@
+//
+//  DownloadTaskPersistence.swift
+//  Palace
+//
+//  Reliability WS-A — Durable Downloads (seam S1).
+//
+//  The task<->book maps in DownloadStateManager are in-memory only: a kill
+//  mid-download loses them, so an actually-still-running background task (iOS
+//  keeps background downloads alive across app death) is orphaned — the app
+//  never re-adopts it. This file adds the durable, crash-surviving mirror plus
+//  the PURE reconciliation that decides, at launch, what to do with each
+//  persisted record given the set of still-live URLSession tasks and the
+//  registry's per-book state.
+//
+//  Ownership contract (seam S1): registry state is the source of truth for a
+//  book's lifecycle; we reconcile URLSession tasks TO it. We only heal a
+//  persisted record whose task is NOT live — a live task is always adopted,
+//  never restarted or failed (INV-4).
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import PalaceLogging
+
+// MARK: - Seam S1 types
+
+/// Durable record of one in-flight download task. Codable/Sendable so it can be
+/// JSON-persisted and fed to the pure reconciler across the actor boundary.
+struct PersistedDownloadRecord: Codable, Sendable, Equatable {
+    let bookID: String
+    let taskIdentifier: Int
+    let downloadURL: URL
+    let account: String
+    let expectedBytes: Int64?
+    let startedAt: Date
+}
+
+/// The decision the launch reconciler makes for a single persisted record.
+enum ReconcileDecision: Equatable {
+    /// Task is still running — re-adopt it into the in-memory maps so its
+    /// completion callbacks route to the right book. No second task started.
+    case adopt(bookID: String, taskIdentifier: Int)
+    /// Task died but the registry still wants the content — restart the download.
+    case restart(bookID: String)
+    /// Task died and the registry already records the download as failed —
+    /// pin the terminal failed state and drop the stale record.
+    case markFailed(bookID: String)
+    /// Nothing to do (completed while suspended, or the book was returned /
+    /// unregistered) — just drop the stale record.
+    case cleanup(bookID: String)
+}
+
+// MARK: - Pure reconciliation
+
+enum DownloadReconciliation {
+
+    /// PURE — no URLSession, no I/O. Unit-testable exhaustively over the
+    /// {live task / dead task} × {registry state} matrix.
+    ///
+    /// - Note: `registryStates` is keyed by book id and carries the *per-book*
+    ///   lifecycle state (`TPPBookState`), which is the source of truth for the
+    ///   book's download lifecycle. (Seam S1's draft typed this as
+    ///   `TPPBookRegistry.RegistryState`, but that enum is the whole-registry
+    ///   load state — `.unloaded/.loading/.loaded/...` — not per-book. INV-4's
+    ///   healing contract is explicitly about the per-book `.downloading`
+    ///   record, so the per-book `TPPBookState` is the correct input.)
+    static func reconcile(
+        persisted: [PersistedDownloadRecord],
+        liveTaskIdentifiers: Set<Int>,
+        registryStates: [String: TPPBookState]
+    ) -> [ReconcileDecision] {
+        persisted.map { record in
+            // INV-4: a still-running background task is adopted, never restarted
+            // (no double-start) and never spuriously failed.
+            if liveTaskIdentifiers.contains(record.taskIdentifier) {
+                return .adopt(bookID: record.bookID, taskIdentifier: record.taskIdentifier)
+            }
+
+            // Task is dead. The registry (source of truth) decides.
+            switch registryStates[record.bookID] {
+            case .some(.downloadSuccessful), .some(.used):
+                // Completed while suspended (or the registry heal already
+                // promoted it) — nothing to restart; drop the record.
+                return .cleanup(bookID: record.bookID)
+
+            case .some(.downloading), .some(.downloadNeeded), .some(.SAMLStarted):
+                // The book still wants its content but the task is gone — restart.
+                return .restart(bookID: record.bookID)
+
+            case .some(.downloadFailed):
+                // Already failed — keep the terminal state, drop the record.
+                return .markFailed(bookID: record.bookID)
+
+            case .some(.unregistered), .some(.holding), .some(.returning),
+                 .some(.unsupported), .none:
+                // The book no longer wants this download — drop the stale record.
+                return .cleanup(bookID: record.bookID)
+            }
+        }
+    }
+
+    /// PURE orchestrator for the launch reconciliation sequence. Encapsulates
+    /// the ORDER contract (registry-loaded gate → load persisted → live tasks →
+    /// read registry state → reconcile → apply) behind injected closures so the
+    /// production wiring in `MyBooksDownloadCenter` and the launch-order
+    /// contract-snapshot test drive the same code. INV-4: the registry-loaded
+    /// gate is FIRST — reconciliation never runs before the registry has loaded.
+    static func runLaunchReconciliation(
+        isRegistryLoaded: () -> Bool,
+        loadPersisted: () -> [PersistedDownloadRecord],
+        liveTaskIdentifiers: () async -> Set<Int>,
+        registryState: (String) -> TPPBookState,
+        apply: (ReconcileDecision) async -> Void
+    ) async {
+        guard isRegistryLoaded() else {
+            Log.info(#file, "Launch reconciliation skipped — registry not loaded yet")
+            return
+        }
+        let persisted = loadPersisted()
+        guard !persisted.isEmpty else { return }
+
+        let live = await liveTaskIdentifiers()
+
+        var states: [String: TPPBookState] = [:]
+        for record in persisted {
+            states[record.bookID] = registryState(record.bookID)
+        }
+
+        let decisions = reconcile(
+            persisted: persisted,
+            liveTaskIdentifiers: live,
+            registryStates: states
+        )
+        for decision in decisions {
+            await apply(decision)
+        }
+    }
+}
+
+// MARK: - Durable store
+
+/// Crash-durable mirror of the in-flight download records. Persists to its OWN
+/// JSON file in Application Support — deliberately NOT the registry file (WS-B
+/// owns that). The in-memory `SafeDictionary`s in `DownloadStateManager` remain
+/// the hot cache; this cold store is consulted only at launch reconciliation.
+///
+/// `@unchecked Sendable`: the sole mutable state is the on-disk file, guarded by
+/// `lock`; every accessor takes the lock for the read-modify-write.
+final class DownloadTaskPersistence: @unchecked Sendable {
+
+    private let fileURL: URL
+    private let lock = NSLock()
+
+    /// Default location: `<Application Support>/download-tasks.json`. Tests inject
+    /// a temp URL so they never touch the real store.
+    init(fileURL: URL? = nil) {
+        if let fileURL {
+            self.fileURL = fileURL
+        } else if TPPProcessInfo.isRunningTests {
+            // Never touch the real Application Support store from the suite —
+            // incidental writes (e.g. an existing test that starts a download)
+            // land in a throwaway temp dir instead.
+            let base = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("PalaceTests-DownloadTasks", isDirectory: true)
+            try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+            self.fileURL = base.appendingPathComponent("download-tasks.json")
+        } else {
+            let base = (try? FileManager.default.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )) ?? URL(fileURLWithPath: NSTemporaryDirectory())
+            self.fileURL = base.appendingPathComponent("download-tasks.json")
+        }
+    }
+
+    /// All persisted records. Never throws — a missing or corrupt file yields
+    /// an empty array (durability must not become a launch crash).
+    func all() -> [PersistedDownloadRecord] {
+        lock.lock(); defer { lock.unlock() }
+        return loadLocked()
+    }
+
+    /// Upsert one record, keyed by `bookID` (one in-flight download per book).
+    func record(_ record: PersistedDownloadRecord) {
+        lock.lock(); defer { lock.unlock() }
+        var records = loadLocked()
+        records.removeAll { $0.bookID == record.bookID }
+        records.append(record)
+        saveLocked(records)
+    }
+
+    /// Remove the record for a book on terminal completion. No-op if absent.
+    func remove(bookID: String) {
+        lock.lock(); defer { lock.unlock() }
+        var records = loadLocked()
+        let before = records.count
+        records.removeAll { $0.bookID == bookID }
+        if records.count != before {
+            saveLocked(records)
+        }
+    }
+
+    /// Drop everything (account reset).
+    func removeAll() {
+        lock.lock(); defer { lock.unlock() }
+        saveLocked([])
+    }
+
+    // MARK: - Locked helpers (caller holds `lock`)
+
+    private func loadLocked() -> [PersistedDownloadRecord] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        return (try? JSONDecoder().decode([PersistedDownloadRecord].self, from: data)) ?? []
+    }
+
+    private func saveLocked(_ records: [PersistedDownloadRecord]) {
+        guard let data = try? JSONEncoder().encode(records) else {
+            Log.error(#file, "Failed to encode \(records.count) download records")
+            return
+        }
+        do {
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            Log.error(#file, "Failed to persist download records: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Palace/MyBooks/LoanEvictionPolicy.swift
+++ b/Palace/MyBooks/LoanEvictionPolicy.swift
@@ -1,0 +1,84 @@
+//
+//  LoanEvictionPolicy.swift
+//  Palace
+//
+//  Reliability WS-C — seam S3. The single guardrail behind INV-2:
+//  "Never delete a downloaded file while offline based on a cached
+//  `until` alone."
+//
+//  Pure, no I/O. `MyBooksViewModel` calls `decide(...)` for every
+//  expired-by-cached-`until` book and only deletes local content +
+//  unregisters on `.evict`. Offline-expired books resolve to `.keep`
+//  so the patron's downloaded file survives; online-but-within-grace
+//  resolves to `.confirmWithServer` (keep locally, let the loans-feed
+//  sync reconcile) rather than destroying the file on a possibly-stale
+//  `until` / clock-skewed date.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+/// The eviction decision for a single downloaded loan.
+enum EvictionDecision: Equatable {
+    /// Keep the file and the registry record. The book stays openable.
+    case keep
+    /// Delete local content and unregister — the loan is provably over.
+    case evict
+    /// Keep locally for now, but the loan *may* be over; a server sync
+    /// (loans feed) should confirm before any deletion. Never destroys
+    /// the file on its own.
+    case confirmWithServer
+}
+
+/// Pure eviction-decision function. See INV-2.
+enum LoanEvictionPolicy {
+
+    /// Default grace window applied after a loan's `until` before an
+    /// online device is willing to evict without an explicit loans-feed
+    /// round trip. Covers modest clock skew between client and server.
+    static let defaultGrace: TimeInterval = 5 * 60 // 5 minutes
+
+    /// Decide whether a downloaded loan may be evicted.
+    ///
+    /// - Parameters:
+    ///   - expiration: the cached loan `until` date (`TPPBook.getExpirationDate()`).
+    ///     `nil` means no expiry is known — never evict.
+    ///   - now: the current time (injected for determinism).
+    ///   - isOnline: whether the device currently has connectivity.
+    ///   - grace: the post-`until` window during which an online device
+    ///     still defers to a server confirmation rather than evicting.
+    /// - Returns: `.keep`, `.evict`, or `.confirmWithServer`.
+    ///
+    /// Decision matrix (INV-2):
+    ///   - no expiration            -> `.keep`
+    ///   - not yet expired          -> `.keep`
+    ///   - expired + offline        -> `.keep`   (never delete offline on cached `until`)
+    ///   - expired + online, within grace -> `.confirmWithServer`
+    ///   - expired + online, past grace   -> `.evict`
+    static func decide(
+        expiration: Date?,
+        now: Date,
+        isOnline: Bool,
+        grace: TimeInterval = defaultGrace
+    ) -> EvictionDecision {
+        // No expiry information -> nothing to evict on.
+        guard let expiration else { return .keep }
+
+        // Not yet expired (by the cached date) -> keep.
+        if now < expiration { return .keep }
+
+        // Expired by the cached `until`. Offline is the INV-2 guard: a
+        // stale/early `until`, clock skew, or a server that would still
+        // honor the loan must NOT cost the patron their downloaded file.
+        guard isOnline else { return .keep }
+
+        // Online + past `until` + grace -> the loan is provably over.
+        if now >= expiration.addingTimeInterval(grace) {
+            return .evict
+        }
+
+        // Online + within grace -> defer to a server confirmation.
+        return .confirmWithServer
+    }
+}

--- a/Palace/MyBooks/LoanRenewalService.swift
+++ b/Palace/MyBooks/LoanRenewalService.swift
@@ -1,0 +1,164 @@
+//
+//  LoanRenewalService.swift
+//  Palace
+//
+//  Reliability WS-C — in-app loan renewal. Extracts the OPDS renew URL
+//  from a book, POSTs it, and refreshes the registry loan on success.
+//
+//  INV-5 (auth-error host scoping): the 401/credentials-stale decision
+//  is routed through `AuthErrorClassifier` constructed with the current
+//  account's `currentAccountHostsProvider`. A 401 from a host OUTSIDE the
+//  current account's auth surface classifies as `.ok` and MUST NOT mark
+//  the current account's credentials stale (never a blanket logout). Only
+//  a 401 from an account-surface host marks credentials stale.
+//
+//  The network POST is behind the narrow `RenewalPosting` protocol so the
+//  service is unit-testable without a live URLSession; production wires a
+//  `TPPNetworkExecutor`-backed adapter.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import PalaceAuth
+import PalaceCatalog
+import PalaceLogging
+
+// MARK: - RenewalPosting
+
+/// Narrow POST seam. Production adapter wraps `TPPNetworkExecutor.POST`;
+/// tests inject a stub returning a controlled `HTTPURLResponse`.
+protocol RenewalPosting: Sendable {
+    /// POST to `url`. Returns the raw body and the HTTP response. A `nil`
+    /// response means the transport failed before any HTTP landed.
+    func post(to url: URL) async -> (data: Data?, response: HTTPURLResponse?)
+}
+
+// MARK: - LoanRenewalService
+
+final class LoanRenewalService: @unchecked Sendable {
+
+    /// The outcome of a renewal attempt.
+    enum RenewOutcome: Equatable {
+        /// The server extended the loan (2xx). Registry refreshed.
+        case success
+        /// A 401 from an account-surface host — credentials marked stale;
+        /// the caller should re-prompt sign-in.
+        case reauthRequired
+        /// A 401 from a host OUTSIDE the current account's auth surface —
+        /// ignored per INV-5, credentials NOT marked stale.
+        case foreignHost401
+        /// The book exposes no renew (borrow-rel) URL.
+        case noRenewURL
+        /// The transport failed (offline / no response).
+        case networkError
+        /// Any other non-2xx server response.
+        case failed(status: Int)
+    }
+
+    private let poster: RenewalPosting
+    private let classifier: AuthErrorClassifier
+    private let bookRegistry: TPPBookRegistryProvider
+    /// Side-effect gate invoked ONLY when a 401 is scoped to an
+    /// account-surface host. Injected so tests can assert it is NOT
+    /// called on a foreign-host 401 (INV-5).
+    private let markCredentialsStale: @Sendable () -> Void
+
+    init(
+        poster: RenewalPosting,
+        classifier: AuthErrorClassifier,
+        bookRegistry: TPPBookRegistryProvider,
+        markCredentialsStale: @escaping @Sendable () -> Void
+    ) {
+        self.poster = poster
+        self.classifier = classifier
+        self.bookRegistry = bookRegistry
+        self.markCredentialsStale = markCredentialsStale
+    }
+
+    // MARK: - Renew-URL extraction (pure)
+
+    /// The OPDS renew endpoint for a book. In the Palace circulation
+    /// model an active loan is renewed by re-POSTing its borrow-rel
+    /// acquisition link, so the renew URL is the borrow acquisition's
+    /// `hrefURL`. Pure — no I/O; unit-testable over a fixture book.
+    static func renewURL(for book: TPPBook) -> URL? {
+        book.acquisitions.first { $0.relation == .borrow }?.hrefURL
+    }
+
+    // MARK: - Renew
+
+    /// Attempt to renew `book`'s loan. Returns the typed outcome; on
+    /// `.success` the registry is refreshed from the server so the
+    /// extended `until` propagates to My Books.
+    @discardableResult
+    func renew(book: TPPBook) async -> RenewOutcome {
+        guard let url = Self.renewURL(for: book) else {
+            Log.info(#file, "Renew requested for '\(book.title)' but no renew URL is available")
+            return .noRenewURL
+        }
+
+        let (data, response) = await poster.post(to: url)
+
+        guard let response else {
+            return .networkError
+        }
+
+        let status = response.statusCode
+
+        // 2xx — the loan was extended. Refresh the registry from the
+        // server so the new expiry lands in My Books. (A full loans-feed
+        // sync is used rather than hand-parsing the entry — it reaches the
+        // same end via existing public registry API.)
+        if (200...299).contains(status) {
+            bookRegistry.sync(completion: nil)
+            return .success
+        }
+
+        // Non-2xx — route the auth decision through the host-scoped
+        // classifier so a foreign-host 401 never blanket-logs-out (INV-5).
+        let problemDoc = data.flatMap { TPPProblemDocument.fromProblemResponseData($0) }
+        let outcome = classifier.classify(
+            response: response,
+            problemDocument: problemDoc,
+            body: data,
+            originalRequestURL: url
+        )
+
+        switch outcome {
+        case .ok:
+            // Cross-domain / foreign-host 401: not our account's session.
+            // Do NOT mark credentials stale.
+            Log.info(#file, "Renew got a non-account-host response; ignoring per host scoping")
+            return .foreignHost401
+        case .reauthRequired:
+            // 401 from an account-surface host — real session expiry.
+            Log.info(#file, "Renew hit an account-host auth error; marking credentials stale")
+            markCredentialsStale()
+            return .reauthRequired
+        default:
+            return .failed(status: status)
+        }
+    }
+}
+
+// MARK: - Production POST adapter
+
+/// `RenewalPosting` backed by `TPPNetworkExecutor.POST`.
+final class NetworkExecutorRenewalPoster: RenewalPosting, @unchecked Sendable {
+    private let executor: TPPNetworkExecutor
+
+    init(executor: TPPNetworkExecutor) {
+        self.executor = executor
+    }
+
+    func post(to url: URL) async -> (data: Data?, response: HTTPURLResponse?) {
+        await withCheckedContinuation { continuation in
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            _ = executor.POST(request, useTokenIfAvailable: true) { data, response, _ in
+                continuation.resume(returning: (data, response as? HTTPURLResponse))
+            }
+        }
+    }
+}

--- a/Palace/MyBooks/LoanRenewalService.swift
+++ b/Palace/MyBooks/LoanRenewalService.swift
@@ -64,6 +64,11 @@ final class LoanRenewalService: @unchecked Sendable {
     /// called on a foreign-host 401 (INV-5).
     private let markCredentialsStale: @Sendable () -> Void
 
+    /// Designated init. `classifier` is REQUIRED and must be host-scoped
+    /// (built with a non-nil `currentAccountHostsProvider`) — use
+    /// `LoanRenewalService.production(...)` in app code, which guarantees
+    /// this. A bare `AuthErrorClassifier()` here would disable INV-5
+    /// host scoping. Tests may inject a classifier with a fixed provider.
     init(
         poster: RenewalPosting,
         classifier: AuthErrorClassifier,
@@ -139,6 +144,41 @@ final class LoanRenewalService: @unchecked Sendable {
         default:
             return .failed(status: status)
         }
+    }
+}
+
+// MARK: - Production factory (INV-5-safe construction)
+
+extension LoanRenewalService {
+    /// The ONLY sanctioned way to build a production `LoanRenewalService`.
+    /// Binds the classifier's `currentAccountHostsProvider` to the active
+    /// account's auth-surface hosts, mirroring `TPPNetworkResponder` and the
+    /// borrow/return sites — so a 401 from a host outside the current
+    /// account\'s surface classifies as `.ok` and never triggers a blanket
+    /// logout (INV-5). Do NOT construct this service with a bare
+    /// `AuthErrorClassifier()`: its provider defaults to `{ nil }`, which
+    /// disables Rule 4b and re-opens the cross-host logout hole
+    /// (`.forgeos/wall-failures/2026-06-05-pr1018-icarus-cross-host-logout.md`).
+    ///
+    /// `poster` and `hostsProvider` are injectable purely for tests; both
+    /// default to the production wiring.
+    static func production(
+        executor: TPPNetworkExecutor,
+        bookRegistry: TPPBookRegistryProvider,
+        poster: RenewalPosting? = nil,
+        hostsProvider: (@Sendable () -> Set<String>?)? = nil
+    ) -> LoanRenewalService {
+        let hosts: @Sendable () -> Set<String>? = hostsProvider ?? {
+            AppContainer.production().accountsManager.currentAccount?.authSurfaceHosts
+        }
+        let classifier = AuthErrorClassifier(currentAccountHostsProvider: hosts)
+        return LoanRenewalService(
+            poster: poster ?? NetworkExecutorRenewalPoster(executor: executor),
+            classifier: classifier,
+            bookRegistry: bookRegistry,
+            markCredentialsStale: {
+                AppContainer.production().accountsManager.currentUserAccount.markCredentialsStale()
+            })
     }
 }
 

--- a/Palace/MyBooks/MyBooks/MyBooksViewModel.swift
+++ b/Palace/MyBooks/MyBooks/MyBooksViewModel.swift
@@ -39,6 +39,11 @@ enum Group: Int {
     private let accountsManager: AccountsManager
     private let settings: TPPSettings
     private let downloadCenter: MyBooksDownloadCenter
+    /// Whether the device currently has connectivity. Injected so the
+    /// eviction gate (INV-2) can keep offline-expired downloads readable
+    /// instead of deleting them on a possibly-stale cached `until`.
+    /// Default reads production reachability.
+    private let isOnline: () -> Bool
     private var allBooks: [TPPBook] = []
 
     /// Decides whether `loadData()` may show the registry contents. Defaults
@@ -64,11 +69,13 @@ enum Group: Int {
     // MARK: - Initialization
 
     convenience init(appContainer: AppContainer) {
+        let reachability = appContainer.reachability
         self.init(
             bookRegistry: appContainer.bookRegistry,
             accountsManager: appContainer.accountsManager,
             settings: appContainer.settings,
-            downloadCenter: appContainer.downloadCenter
+            downloadCenter: appContainer.downloadCenter,
+            isOnline: { reachability.isConnectedToNetwork() }
         )
     }
 
@@ -77,12 +84,16 @@ enum Group: Int {
         accountsManager: AccountsManager,
         settings: TPPSettings,
         downloadCenter: MyBooksDownloadCenter,
-        isUserAuthorizedForRegistry: (() -> Bool)? = nil
+        isUserAuthorizedForRegistry: (() -> Bool)? = nil,
+        isOnline: (() -> Bool)? = nil
     ) {
         self.bookRegistry = bookRegistry
         self.accountsManager = accountsManager
         self.settings = settings
         self.downloadCenter = downloadCenter
+        // Default to production reachability. Tests inject a stub so the
+        // offline eviction guard (INV-2) is deterministic.
+        self.isOnline = isOnline ?? { AppContainer.production().reachability.isConnectedToNetwork() }
         self.activeFacetSort = .author
         self.facetViewModel = FacetViewModel(
             groupName: DisplayStrings.sortBy,
@@ -125,21 +136,49 @@ enum Group: Int {
 
         let registryBooks = bookRegistry.myBooks
 
-        // Always filter out expired books. Previously this only happened offline,
-        // relying on sync to remove expired books when online. But if sync hasn't
-        // run yet (or is delayed), expired books would remain visible with stale UI.
-        let (active, expired) = registryBooks.reduce(into: ([TPPBook](), [TPPBook]())) { result, book in
-            if book.isExpired {
-                result.1.append(book)
+        // Eviction gate (seam S3 / INV-2). An expired-by-cached-`until` book
+        // is NOT unconditionally deleted. LoanEvictionPolicy decides:
+        //   - offline + expired      -> keep (never destroy on a stale `until`)
+        //   - online + past grace    -> evict (loan provably over)
+        //   - online + within grace  -> keep locally; the loans-feed sync
+        //                               reconciles. We do not delete here.
+        let now = Date()
+        // `isOnline` is evaluated lazily — only when an expired book is
+        // actually found — so a shelf with no expired loans never triggers
+        // a reachability read.
+        var onlineCache: Bool?
+        var active: [TPPBook] = []
+        var toEvict: [TPPBook] = []
+        for book in registryBooks {
+            guard book.isExpired else {
+                active.append(book)
+                continue
+            }
+            let online: Bool
+            if let cached = onlineCache {
+                online = cached
             } else {
-                result.0.append(book)
+                online = isOnline()
+                onlineCache = online
+            }
+            switch LoanEvictionPolicy.decide(
+                expiration: book.getExpirationDate(),
+                now: now,
+                isOnline: online
+            ) {
+            case .evict:
+                toEvict.append(book)
+            case .keep, .confirmWithServer:
+                // INV-2: keep the downloaded file + registry record so the
+                // book stays openable. No delete, no unregister.
+                active.append(book)
             }
         }
 
-        if !expired.isEmpty {
-            Log.info(#file, "📚 Removing \(expired.count) expired book(s) from My Books")
-            for book in expired {
-                Log.info(#file, "  → '\(book.title)' expired")
+        if !toEvict.isEmpty {
+            Log.info(#file, "Removing \(toEvict.count) confirmed-expired book(s) from My Books")
+            for book in toEvict {
+                Log.info(#file, "  -> '\(book.title)' expired (online, past grace) — evicting")
                 downloadCenter.deleteLocalContent(for: book.identifier)
                 bookRegistry.setState(.unregistered, for: book.identifier)
             }

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -224,6 +224,39 @@ private final class DownloadFailureMetadataBox: @unchecked Sendable {
     private var bookIdentifierOfBookToRemove: String?
     private var session: URLSession!
 
+    // MARK: - Reliability WS-A: background session identity + completion handler
+
+    /// Single source of truth for the download center's background session
+    /// identifier (previously duplicated across 3 inline `Bundle`-derived
+    /// literals). Exposed so the app delegate can route the system background
+    /// completion handler to us vs. the audiobook lifecycle manager.
+    @objc static let backgroundSessionIdentifier =
+        (Bundle.main.bundleIdentifier ?? "") + ".downloadCenterBackgroundIdentifier"
+
+    /// True iff `identifier` names the book download center's background session.
+    /// INV-7: the app delegate uses this to preserve the audiobook route for
+    /// every other identifier.
+    @objc static func isDownloadCenterBackgroundSession(_ identifier: String) -> Bool {
+        identifier == backgroundSessionIdentifier
+    }
+
+    /// The system completion handler iOS hands us when it relaunches the app to
+    /// finish delivering background-session events. Guarded by a lock; invoked
+    /// exactly once (on main) then cleared in `urlSessionDidFinishEvents`.
+    private let backgroundCompletionHandlerLock = NSLock()
+    private var _backgroundCompletionHandler: (() -> Void)?
+
+    /// Store the system completion handler (called by the app delegate when the
+    /// background-session wake matches `backgroundSessionIdentifier`).
+    @objc func setBackgroundCompletionHandler(_ handler: @escaping () -> Void) {
+        backgroundCompletionHandlerLock.lock()
+        _backgroundCompletionHandler = handler
+        backgroundCompletionHandlerLock.unlock()
+    }
+
+    /// Deferred launch-reconciliation observer (see `scheduleReconcileDownloadsAtLaunch`).
+    private var reconcileObserver: NSObjectProtocol?
+
     /// Owns the thread-safe download tracking dictionaries + DownloadCoordinator
     /// + maxConcurrentDownloads. The properties below are computed wrappers
     /// that route through this single state owner — preserves the call-site
@@ -927,7 +960,7 @@ private final class DownloadFailureMetadataBox: @unchecked Sendable {
                 let configuration = URLSessionConfiguration.default
                 self.session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
             } else {
-                let backgroundIdentifier = (Bundle.main.bundleIdentifier ?? "") + ".downloadCenterBackgroundIdentifier"
+                let backgroundIdentifier = Self.backgroundSessionIdentifier
                 let configuration = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
                 configuration.isDiscretionary = false
                 configuration.waitsForConnectivity = false
@@ -935,7 +968,7 @@ private final class DownloadFailureMetadataBox: @unchecked Sendable {
                 self.session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
             }
             #else
-            let backgroundIdentifier = (Bundle.main.bundleIdentifier ?? "") + ".downloadCenterBackgroundIdentifier"
+            let backgroundIdentifier = Self.backgroundSessionIdentifier
             let configuration = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
             configuration.isDiscretionary = false
             configuration.waitsForConnectivity = false
@@ -960,6 +993,14 @@ private final class DownloadFailureMetadataBox: @unchecked Sendable {
         // CurrentValueSubject's initial-value replay so we only act on real
         // transitions.
         self.bindReachability()
+
+        // Reliability WS-A: reconcile persisted download records against live
+        // URLSession tasks once the registry has loaded. Production only — an
+        // injected/mock session or the test harness opts out so the suite stays
+        // hermetic (the reconciler is driven directly in tests instead).
+        if urlSession == nil && !TPPProcessInfo.isRunningTests {
+            scheduleReconcileDownloadsAtLaunch()
+        }
     }
 
     // MARK: - PP-4114: mid-flight network drop handling
@@ -1077,7 +1118,7 @@ private final class DownloadFailureMetadataBox: @unchecked Sendable {
             session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
             Log.info(#file, "MyBooksDownloadCenter: switched to default session for mock backend")
         } else {
-            let backgroundIdentifier = (Bundle.main.bundleIdentifier ?? "") + ".downloadCenterBackgroundIdentifier"
+            let backgroundIdentifier = Self.backgroundSessionIdentifier
             let configuration = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
             configuration.isDiscretionary = false
             configuration.waitsForConnectivity = false
@@ -1456,6 +1497,10 @@ extension MyBooksDownloadCenter: URLSessionDownloadDelegate {
         await taskIdentifierToBook.remove(task.taskIdentifier)
         await downloadCoordinator.removeCachedDownloadInfo(for: book.identifier)
         await downloadCoordinator.registerCompletion(identifier: book.identifier)
+        // Reliability WS-A: download reached a terminal outcome — drop the
+        // durable record and reset the transient-transfer retry counter.
+        await stateManager.resetTransferRetryAttempts(for: book.identifier)
+        stateManager.removePersistedRecord(for: book.identifier)
         let remainingCount = await downloadCoordinator.activeCount
         Log.info(#file, "📊 Download flow completed for '\(book.identifier)', remaining active: \(remainingCount)")
 
@@ -1535,6 +1580,12 @@ extension MyBooksDownloadCenter: URLSessionTaskDelegate {
     }
 
     func handleTaskCompletionError(task: URLSessionTask, error: Error?) async {
+        // Reliability WS-A #4: give a transient content-transfer failure a bounded
+        // retry with backoff before surfacing the failure. Returns true only when
+        // a retry was scheduled — in which case we must NOT fail the download yet.
+        if let error, await maybeRetryTransientTransfer(task: task, error: error) {
+            return
+        }
         await taskLifecycleService.handleTaskCompletionError(task: task, error: error)
     }
 
@@ -1554,6 +1605,10 @@ extension MyBooksDownloadCenter: URLSessionTaskDelegate {
             Log.warn(#file, "addDownloadTask: session unavailable, skipping download of '\(book.title)' (\(exception?.name.rawValue ?? "task=nil"))")
             return
         }
+
+        // Reliability WS-A: durably record the started task so a mid-download kill
+        // can be reconciled (adopted / restarted) at next launch.
+        persistStartedTaskRecord(task: task, book: book, request: modifiableRequest)
 
         Task {
             await self.taskLifecycleService.registerStartedTask(
@@ -1879,3 +1934,222 @@ extension MyBooksDownloadCenter: BookReturnServiceDelegate {}
 #if LCP
 extension MyBooksDownloadCenter: LCPFulfillmentHandlerDelegate {}
 #endif
+
+// MARK: - Reliability WS-A: durable downloads (background handler, retry, reconciliation)
+
+/// Reference box so the launch-reconciliation orchestrator can snapshot live
+/// URLSession tasks inside the `getAllTasks` completion (non-`Sendable` task
+/// objects never cross the continuation boundary) and hand them to `apply`.
+private final class LiveDownloadTaskBox: @unchecked Sendable {
+    var map: [Int: URLSessionDownloadTask] = [:]
+}
+
+extension MyBooksDownloadCenter {
+
+    // MARK: Background session completion handler (INV-7)
+
+    /// `URLSessionDelegate`: iOS invokes this once ALL background-session events
+    /// have been delivered after an app relaunch. Invoke + clear the stored system
+    /// completion handler exactly once, on the main thread (INV-7). A second call
+    /// finds the handler already cleared and is a safe no-op.
+    public func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        backgroundCompletionHandlerLock.lock()
+        let handler = _backgroundCompletionHandler
+        _backgroundCompletionHandler = nil
+        backgroundCompletionHandlerLock.unlock()
+
+        guard let handler else { return }
+        if Thread.isMainThread {
+            handler()
+        } else {
+            DispatchQueue.main.async { handler() }
+        }
+    }
+
+    // MARK: Durable persistence of a started task
+
+    /// Persist a started task so a mid-download kill can be reconciled at launch.
+    /// Called on the initial start (`addDownloadTask`) and on each transfer retry
+    /// re-issue so the persisted `taskIdentifier` always tracks the live task.
+    func persistStartedTaskRecord(task: URLSessionDownloadTask, book: TPPBook, request: URLRequest) {
+        guard let url = task.originalRequest?.url ?? request.url else { return }
+        stateManager.persistStartedTask(
+            bookID: book.identifier,
+            taskIdentifier: task.taskIdentifier,
+            downloadURL: url,
+            account: accountsManager.currentAccountId ?? "",
+            expectedBytes: nil
+        )
+    }
+
+    // MARK: Transient-transfer retry (INV-6 — content transfer only)
+
+    private static let maxTransferRetries = 3
+    private static let transferRetryBaseDelay: TimeInterval = 2.0
+
+    /// Bounded transient-transfer retry. INV-6: this is the plain URLSession
+    /// content-transfer error path; DRM fulfillment (which runs on the SUCCESS
+    /// path via `rightsDispatcher`) is never touched here. Reuses the existing
+    /// NSURLError classifier (`RetryPolicy.downloadTransfer.shouldRetry`), which
+    /// refuses auth / 404 / bad-URL / permission / insufficient-space errors and
+    /// admits transient network failures. Returns `true` iff a retry was
+    /// scheduled — the caller must then NOT surface the failure.
+    func maybeRetryTransientTransfer(task: URLSessionTask, error: Error) async -> Bool {
+        let nsError = error as NSError
+        // Cancellations (user tap / navigation) are never retried.
+        guard nsError.code != NSURLErrorCancelled else { return false }
+        guard DownloadErrorRecovery.RetryPolicy.downloadTransfer.shouldRetry(error) else { return false }
+        guard let book = await taskIdentifierToBook.get(task.taskIdentifier) else { return false }
+
+        let attempts = await stateManager.transferRetryAttempts(for: book.identifier)
+        guard attempts < Self.maxTransferRetries else {
+            // Exhausted — reset so a later independent failure starts fresh, and
+            // let the normal failure path (alert) run.
+            await stateManager.resetTransferRetryAttempts(for: book.identifier)
+            return false
+        }
+        await stateManager.incrementTransferRetryAttempts(for: book.identifier)
+
+        // The dead task's routing entry is stale — drop it so nothing double-fires.
+        await taskIdentifierToBook.remove(task.taskIdentifier)
+
+        // Exponential backoff before re-issue (bounded by maxTransferRetries).
+        let delay = Self.transferRetryBaseDelay * pow(2.0, Double(attempts))
+        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        if Task.isCancelled { return false }
+
+        let resumeData = nsError.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
+        reissueTransferDownloadTask(for: book, resumeData: resumeData, previousRequest: task.originalRequest)
+        return true
+    }
+
+    /// Re-issue a resumable (or fresh) content-transfer download task after a
+    /// transient failure, routing it through the same lifecycle seam a first-time
+    /// start uses. INV-6: content transfer only — no DRM fulfillment involvement.
+    private func reissueTransferDownloadTask(for book: TPPBook, resumeData: Data?, previousRequest: URLRequest?) {
+        var newTask: URLSessionDownloadTask?
+        let exception = TPPObjCExceptionCatcher.catchException {
+            if let resumeData {
+                newTask = self.session.downloadTask(withResumeData: resumeData)
+            } else if var previousRequest {
+                newTask = self.session.downloadTask(with: previousRequest.applyCustomUserAgent())
+            }
+        }
+        guard let newTask, exception == nil else {
+            Log.warn(#file, "Transfer retry: could not re-issue download for '\(book.title)' (\(exception?.name.rawValue ?? "task=nil"))")
+            return
+        }
+        persistStartedTaskRecord(task: newTask, book: book, request: previousRequest ?? URLRequest(url: URL(fileURLWithPath: "/dev/null")))
+        Task {
+            await self.taskLifecycleService.registerStartedTask(
+                newTask,
+                book: book,
+                maxConcurrentDownloads: self.maxConcurrentDownloads
+            )
+        }
+    }
+
+    // MARK: Launch reconciliation (INV-4 — adopt, don't double-start or spuriously fail)
+
+    /// True once the registry has completed its disk load. Reconciliation must
+    /// not run before this (INV-4 ordering) — it reads registry state as the
+    /// source of truth for each book's lifecycle.
+    var isRegistryLoadedForReconcile: Bool {
+        switch bookRegistry.registryState {
+        case .loaded, .syncing, .synced:
+            return true
+        case .unloaded, .loading:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    /// Run launch reconciliation now if the registry has loaded; otherwise defer
+    /// until it does (via a one-shot `.TPPBookRegistryStateDidChange` observer).
+    func scheduleReconcileDownloadsAtLaunch() {
+        if isRegistryLoadedForReconcile {
+            Task { await reconcileDownloadsAtLaunch() }
+            return
+        }
+        reconcileObserver = NotificationCenter.default.addObserver(
+            forName: .TPPBookRegistryStateDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, self.isRegistryLoadedForReconcile else { return }
+            if let token = self.reconcileObserver {
+                NotificationCenter.default.removeObserver(token)
+                self.reconcileObserver = nil
+            }
+            Task { await self.reconcileDownloadsAtLaunch() }
+        }
+    }
+
+    /// Reconcile persisted download records against the live URLSession tasks and
+    /// the registry, then apply each decision. Order (registry-loaded gate →
+    /// persisted → live tasks → reconcile → apply) is pinned by
+    /// `DownloadReconciliation.runLaunchReconciliation` and its contract test.
+    func reconcileDownloadsAtLaunch() async {
+        let box = LiveDownloadTaskBox()
+        await DownloadReconciliation.runLaunchReconciliation(
+            isRegistryLoaded: { [weak self] in self?.isRegistryLoadedForReconcile ?? false },
+            loadPersisted: { [weak self] in self?.stateManager.persistedRecords() ?? [] },
+            liveTaskIdentifiers: { [weak self] in
+                await self?.snapshotLiveDownloadTasks(into: box)
+                return Set(box.map.keys)
+            },
+            registryState: { [weak self] bookID in self?.bookRegistry.state(for: bookID) ?? .unregistered },
+            apply: { [weak self] decision in await self?.applyReconcileDecision(decision, liveTasks: box.map) }
+        )
+    }
+
+    /// Snapshot the still-running download tasks into `box`. The non-`Sendable`
+    /// task objects stay inside the `getAllTasks` completion — only the box
+    /// (Sendable) is captured.
+    private func snapshotLiveDownloadTasks(into box: LiveDownloadTaskBox) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            session.getAllTasks { tasks in
+                for case let downloadTask as URLSessionDownloadTask in tasks {
+                    box.map[downloadTask.taskIdentifier] = downloadTask
+                }
+                continuation.resume()
+            }
+        }
+    }
+
+    /// Apply a single reconciliation decision. INV-4: `.adopt` re-seeds the hot
+    /// maps from the live task WITHOUT starting a second task or touching registry
+    /// state; `.restart` re-drives the existing start path; `.markFailed` pins the
+    /// terminal failed state; `.cleanup` just drops the stale record.
+    private func applyReconcileDecision(_ decision: ReconcileDecision, liveTasks: [Int: URLSessionDownloadTask]) async {
+        switch decision {
+        case let .adopt(bookID, taskIdentifier):
+            guard let book = bookRegistry.book(forIdentifier: bookID),
+                  let task = liveTasks[taskIdentifier] else {
+                return
+            }
+            let info = MyBooksDownloadInfo(downloadProgress: 0.0, downloadTask: task, rightsManagement: .unknown)
+            await bookIdentifierToDownloadInfo.set(bookID, value: info)
+            await bookIdentifierToDownloadTask.set(bookID, value: task)
+            await taskIdentifierToBook.set(taskIdentifier, value: book)
+            Log.info(#file, "Reconcile: adopted still-running download task \(taskIdentifier) for '\(bookID)'")
+
+        case let .restart(bookID):
+            guard let book = bookRegistry.book(forIdentifier: bookID) else {
+                stateManager.removePersistedRecord(for: bookID)
+                return
+            }
+            Log.info(#file, "Reconcile: restarting dead download for '\(bookID)'")
+            startDownload(for: book)
+
+        case let .markFailed(bookID):
+            bookRegistry.setState(.downloadFailed, for: bookID)
+            stateManager.removePersistedRecord(for: bookID)
+            Log.info(#file, "Reconcile: marked '\(bookID)' downloadFailed (task dead, registry already failed)")
+
+        case let .cleanup(bookID):
+            stateManager.removePersistedRecord(for: bookID)
+        }
+    }
+}

--- a/Palace/Platform/OfflineQueueCoordinator.swift
+++ b/Palace/Platform/OfflineQueueCoordinator.swift
@@ -1,0 +1,227 @@
+//
+//  OfflineQueueCoordinator.swift
+//  Palace
+//
+//  Reliability WS-C — seam S2 wiring. Supplies the single executor
+//  closure to `OfflineQueueService` (whose `setExecutor` signature is
+//  FROZEN) and dispatches each queued `OfflineAction` to the existing
+//  public service APIs:
+//
+//    .return / .cancelHold -> BookReturnService revoke (via MBDC.returnBook)
+//    .borrow  / .hold      -> MyBooksDownloadCenter.startBorrow
+//
+//  INV-8 (idempotency): actions are deduped by `bookID`+`type`. A queued
+//  action that already succeeded (or is in-flight) is not dispatched a
+//  second time — a partially-succeeded return must not double-apply and
+//  confuse the patron with a spurious "no active loan" error.
+//
+//  The executor returns `true` only on server-confirmed success so the
+//  queue's retry/backoff drives genuine failures.
+//
+//  Registration happens exactly once at launch via `registerExecutor()`,
+//  invoked from `AppContainer` (the composition root). The call lives
+//  here so the seam owner (WS-C) owns the wiring.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - OfflineExecutorRegistering
+
+/// Narrow seam the coordinator needs from the queue: install the single
+/// executor closure. Kept separate from `OfflineQueueServiceProtocol` so
+/// the frozen `OfflineQueueService.setExecutor` signature (seam S2) is not
+/// touched and the full queue surface isn't pulled into the coordinator.
+protocol OfflineExecutorRegistering: Sendable {
+    func setExecutor(_ executor: @escaping OfflineActionExecutor) async
+}
+
+extension OfflineQueueService: OfflineExecutorRegistering {}
+
+// MARK: - OfflineQueueCoordinator
+
+final class OfflineQueueCoordinator: @unchecked Sendable {
+
+    /// Per-type action handlers. Each returns `true` only on
+    /// server-confirmed success. Injected so the coordinator is
+    /// unit-testable without standing up the real services.
+    struct Handlers: Sendable {
+        let performReturn: @Sendable (_ bookID: String) async -> Bool
+        let performBorrow: @Sendable (_ bookID: String) async -> Bool
+        let performHold: @Sendable (_ bookID: String) async -> Bool
+        let performCancelHold: @Sendable (_ bookID: String) async -> Bool
+    }
+
+    private let queue: OfflineExecutorRegistering
+    private let handlers: Handlers
+    private let dedupe = DedupeBox()
+
+    init(queue: OfflineExecutorRegistering, handlers: Handlers) {
+        self.queue = queue
+        self.handlers = handlers
+    }
+
+    /// Register the executor on the queue. Idempotent at the queue level
+    /// (a second call simply replaces the closure), but intended to run
+    /// exactly once at launch.
+    func registerExecutor() async {
+        await queue.setExecutor { [weak self] action in
+            guard let self else { return false }
+            return await self.execute(action)
+        }
+    }
+
+    /// The dispatch + dedupe body. Exposed internally so tests can drive
+    /// it directly as well as through the queue.
+    func execute(_ action: OfflineAction) async -> Bool {
+        let key = Self.dedupeKey(for: action)
+
+        // INV-8: collapse a duplicate (same bookID+type) that already
+        // succeeded or is in-flight. Treat it as already-done (`true`) so
+        // the queue removes it without re-applying the side effect.
+        guard await dedupe.begin(key) else {
+            return true
+        }
+
+        let success = await dispatch(action)
+
+        if success {
+            await dedupe.complete(key)
+        } else {
+            // Allow a genuine failure to be retried by the queue.
+            await dedupe.rollback(key)
+        }
+        return success
+    }
+
+    /// Clears dedupe state. Test/reset seam.
+    func reset() async {
+        await dedupe.clear()
+    }
+
+    // MARK: - Private
+
+    private func dispatch(_ action: OfflineAction) async -> Bool {
+        switch action.type {
+        case .return:
+            return await handlers.performReturn(action.bookID)
+        case .borrow:
+            return await handlers.performBorrow(action.bookID)
+        case .hold:
+            return await handlers.performHold(action.bookID)
+        case .cancelHold:
+            return await handlers.performCancelHold(action.bookID)
+        }
+    }
+
+    static func dedupeKey(for action: OfflineAction) -> String {
+        "\(action.type.rawValue):\(action.bookID)"
+    }
+}
+
+// MARK: - DedupeBox
+
+/// Actor-guarded dedupe ledger. `begin` returns `false` when the key is
+/// already in-flight or completed, so the caller can short-circuit a
+/// duplicate. `rollback` releases an in-flight key after a genuine
+/// failure so the queue's retry can re-attempt it.
+private actor DedupeBox {
+    private var inFlight: Set<String> = []
+    private var completed: Set<String> = []
+
+    func begin(_ key: String) -> Bool {
+        if inFlight.contains(key) || completed.contains(key) { return false }
+        inFlight.insert(key)
+        return true
+    }
+
+    func complete(_ key: String) {
+        inFlight.remove(key)
+        completed.insert(key)
+    }
+
+    func rollback(_ key: String) {
+        inFlight.remove(key)
+    }
+
+    func clear() {
+        inFlight.removeAll()
+        completed.removeAll()
+    }
+}
+
+// MARK: - Production wiring
+
+extension OfflineQueueCoordinator {
+
+    /// Builds the production coordinator wired to the real services via
+    /// their EXISTING public APIs. `.return`/`.cancelHold` route through
+    /// `MyBooksDownloadCenter.returnBook` (the revoke flow owned by
+    /// `BookReturnService`); `.borrow`/`.hold` route through
+    /// `MyBooksDownloadCenter.startBorrow`. Server-confirmation for a
+    /// return is read from the registry after the flow completes: a book
+    /// that is no longer registered (or no longer downloaded) was
+    /// confirmed returned by the server.
+    static func production(
+        queue: OfflineExecutorRegistering = OfflineQueueService.shared,
+        downloadCenter: MyBooksDownloadCenter,
+        bookRegistry: TPPBookRegistryProvider
+    ) -> OfflineQueueCoordinator {
+        let performReturn: @Sendable (String) async -> Bool = { bookID in
+            await withCheckedContinuation { continuation in
+                Task { @MainActor in
+                    downloadCenter.returnBook(withIdentifier: bookID) {
+                        // Server-confirmed if the registry no longer holds
+                        // the book as an active downloaded loan.
+                        let state = bookRegistry.state(for: bookID)
+                        let confirmed = (state == .unregistered)
+                            || bookRegistry.book(forIdentifier: bookID) == nil
+                        continuation.resume(returning: confirmed)
+                    }
+                }
+            }
+        }
+
+        let performBorrow: @Sendable (String) async -> Bool = { bookID in
+            await withCheckedContinuation { continuation in
+                Task { @MainActor in
+                    guard let book = bookRegistry.book(forIdentifier: bookID) else {
+                        continuation.resume(returning: false)
+                        return
+                    }
+                    downloadCenter.startBorrow(for: book, attemptDownload: true) {
+                        continuation.resume(returning: true)
+                    }
+                }
+            }
+        }
+
+        let performHold: @Sendable (String) async -> Bool = { bookID in
+            await withCheckedContinuation { continuation in
+                Task { @MainActor in
+                    guard let book = bookRegistry.book(forIdentifier: bookID) else {
+                        continuation.resume(returning: false)
+                        return
+                    }
+                    downloadCenter.startBorrow(for: book, attemptDownload: false) {
+                        continuation.resume(returning: true)
+                    }
+                }
+            }
+        }
+
+        // Cancelling a hold uses the same revoke endpoint as a return.
+        let performCancelHold = performReturn
+
+        return OfflineQueueCoordinator(
+            queue: queue,
+            handlers: Handlers(
+                performReturn: performReturn,
+                performBorrow: performBorrow,
+                performHold: performHold,
+                performCancelHold: performCancelHold
+            )
+        )
+    }
+}

--- a/Palace/Platform/OfflineQueueCoordinator.swift
+++ b/Palace/Platform/OfflineQueueCoordinator.swift
@@ -55,11 +55,24 @@ final class OfflineQueueCoordinator: @unchecked Sendable {
 
     private let queue: OfflineExecutorRegistering
     private let handlers: Handlers
-    private let dedupe = DedupeBox()
+    private let dedupe: DedupeBox
 
-    init(queue: OfflineExecutorRegistering, handlers: Handlers) {
+    /// - Parameters:
+    ///   - dedupeTTL: how long a *completed* (server-confirmed) bookID+type
+    ///     stays deduped. After it elapses, a legitimate second same-type
+    ///     action for the same book in the same session (e.g. return -> re-borrow
+    ///     -> return again) is allowed through rather than silently skipped.
+    ///     In-flight dedupe is unconditional (never TTL-bounded).
+    ///   - now: injectable clock for deterministic TTL tests.
+    init(
+        queue: OfflineExecutorRegistering,
+        handlers: Handlers,
+        dedupeTTL: TimeInterval = 300,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
         self.queue = queue
         self.handlers = handlers
+        self.dedupe = DedupeBox(ttl: dedupeTTL, now: now)
     }
 
     /// Register the executor on the queue. Idempotent at the queue level
@@ -118,6 +131,31 @@ final class OfflineQueueCoordinator: @unchecked Sendable {
     static func dedupeKey(for action: OfflineAction) -> String {
         "\(action.type.rawValue):\(action.bookID)"
     }
+
+    /// States that represent a confirmed active loan after a borrow. Used
+    /// to fail-closed the offline `.borrow` executor branch.
+    static func isActiveLoanState(_ state: TPPBookState) -> Bool {
+        switch state {
+        case .downloadNeeded, .downloading, .downloadSuccessful, .used:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// A placed hold lands in `.holding`. Used to fail-closed the offline
+    /// `.hold` executor branch. Pure so the decision is unit-testable
+    /// without a live download center.
+    static func isHeldState(_ state: TPPBookState) -> Bool {
+        state == .holding
+    }
+
+    /// Server-confirmed return: the registry either no longer knows the
+    /// book, or has moved it out of any active-loan state. Pure so the
+    /// `.return`/`.cancelHold` confirmation is unit-testable.
+    static func isReturnConfirmed(state: TPPBookState, bookPresent: Bool) -> Bool {
+        state == .unregistered || !bookPresent
+    }
 }
 
 // MARK: - DedupeBox
@@ -128,17 +166,35 @@ final class OfflineQueueCoordinator: @unchecked Sendable {
 /// failure so the queue's retry can re-attempt it.
 private actor DedupeBox {
     private var inFlight: Set<String> = []
-    private var completed: Set<String> = []
+    /// Completed keys with the timestamp of completion. A key blocks a
+    /// duplicate only while within `ttl` of its completion, so a book's
+    /// legitimate later same-type action isn\'t permanently suppressed.
+    private var completed: [String: Date] = [:]
+    private let ttl: TimeInterval
+    private let now: @Sendable () -> Date
+
+    init(ttl: TimeInterval, now: @escaping @Sendable () -> Date) {
+        self.ttl = ttl
+        self.now = now
+    }
 
     func begin(_ key: String) -> Bool {
-        if inFlight.contains(key) || completed.contains(key) { return false }
+        // In-flight is always a hard block (no concurrent double-apply).
+        if inFlight.contains(key) { return false }
+        // Completed blocks only within the TTL window; prune stale entries.
+        if let completedAt = completed[key] {
+            if now().timeIntervalSince(completedAt) < ttl {
+                return false
+            }
+            completed[key] = nil
+        }
         inFlight.insert(key)
         return true
     }
 
     func complete(_ key: String) {
         inFlight.remove(key)
-        completed.insert(key)
+        completed[key] = now()
     }
 
     func rollback(_ key: String) {
@@ -174,9 +230,9 @@ extension OfflineQueueCoordinator {
                     downloadCenter.returnBook(withIdentifier: bookID) {
                         // Server-confirmed if the registry no longer holds
                         // the book as an active downloaded loan.
-                        let state = bookRegistry.state(for: bookID)
-                        let confirmed = (state == .unregistered)
-                            || bookRegistry.book(forIdentifier: bookID) == nil
+                        let confirmed = Self.isReturnConfirmed(
+                            state: bookRegistry.state(for: bookID),
+                            bookPresent: bookRegistry.book(forIdentifier: bookID) != nil)
                         continuation.resume(returning: confirmed)
                     }
                 }
@@ -191,7 +247,14 @@ extension OfflineQueueCoordinator {
                         return
                     }
                     downloadCenter.startBorrow(for: book, attemptDownload: true) {
-                        continuation.resume(returning: true)
+                        // `startBorrow` carries no success/error signal, so
+                        // confirm via registry state: a borrowed loan lands
+                        // in an active-loan state. Anything else (still
+                        // unregistered, download-failed) is NOT confirmed —
+                        // return false so the queue keeps it and retries,
+                        // rather than optimistically dropping a failed borrow.
+                        let confirmed = Self.isActiveLoanState(bookRegistry.state(for: bookID))
+                        continuation.resume(returning: confirmed)
                     }
                 }
             }
@@ -205,7 +268,10 @@ extension OfflineQueueCoordinator {
                         return
                     }
                     downloadCenter.startBorrow(for: book, attemptDownload: false) {
-                        continuation.resume(returning: true)
+                        // A placed hold lands in `.holding`. Any other state
+                        // is not a confirmed hold -> fail-closed (stay queued).
+                        let confirmed = Self.isHeldState(bookRegistry.state(for: bookID))
+                        continuation.resume(returning: confirmed)
                     }
                 }
             }

--- a/PalaceTests/Book/BookRegistrySyncTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncTests.swift
@@ -834,6 +834,250 @@ final class BookRegistrySyncTests: XCTestCase {
         XCTAssertNil(sut.syncUrl,
                      "syncUrl must be cleared (never left set) when awaitReady aborts the sync")
     }
+
+    // MARK: - Reliability WS-B: registry resilience (INV-1, quarantine, backup, schema)
+    //
+    // These drive the real load/save disk pipeline on an isolated per-test
+    // account so registryUrl maps to a temp directory we own. They exercise the
+    // corrupt-file quarantine branch, `.bak` recovery, the empty-over-backup save
+    // refusal (INV-1), and schema versioning/migration.
+
+    /// Adds one book to `store`, snapshots the exact dictionary shape production
+    /// persists, then clears the store. The returned records round-trip through
+    /// the same `TPPBookRegistryRecord(record:)` path production uses on load.
+    private func snapshotWithOneBook(id: String = "wsb-book", state: TPPBookState = .downloadNeeded) -> [[String: Any]] {
+        let book = makeBook(identifier: id, title: "WS-B \(id)")
+        let added = expectation(description: "added")
+        store.addBook(book, state: state) { _ in added.fulfill() }
+        wait(for: [added], timeout: 2.0)
+        drainMainQueue()
+        let snapshot = store.registrySnapshot()
+        store.removeAll()
+        drainMainQueue()
+        return snapshot
+    }
+
+    /// Writes a `{ [schemaVersion,] records }` payload to an arbitrary URL.
+    private func writeRegistryPayload(records: [[String: Any]], schemaVersion: Int?, to url: URL) {
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        var json: [String: Any] = [TPPBookRegistryKey.records.rawValue: records]
+        if let schemaVersion { json[RegistryFileRecovery.schemaVersionKey] = schemaVersion }
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        try! data.write(to: url)
+    }
+
+    /// Spins the run loop until `predicate()` is true or `timeout` elapses. Lets
+    /// `DispatchQueue.main.async` completion blocks (e.g. the save notification)
+    /// run while we wait on the background disk write.
+    private func waitUntil(timeout: TimeInterval = 3.0, _ predicate: () -> Bool) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !predicate() && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+    }
+
+    /// Fixed run-loop settle for asserting the ABSENCE of an effect (a refused
+    /// save posts no notification, so there is no positive edge to await).
+    private func settle(_ seconds: TimeInterval = 0.4) {
+        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+    }
+
+    private func quarantineFileExists(besideRegistryAt url: URL) -> Bool {
+        let dir = url.deletingLastPathComponent()
+        let contents = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+        return contents.contains { $0.hasPrefix("registry.json.corrupt-") }
+    }
+
+    // MARK: INV-1 — empty save refused over a non-empty backup without server authority
+
+    func testSaveEmptyOverNonEmptyBackup_isRefusedWithoutServerAuthority() {
+        let (account, url) = makeIsolatedAccount()
+        defer { cleanupAccount(url) }
+
+        // Arrange: a non-empty last-good backup on disk + the SUT in the
+        // post-corrupt-load rebuild window with an empty in-memory shelf.
+        let goodRecords = snapshotWithOneBook(id: "kept-book")
+        XCTAssertEqual(goodRecords.count, 1, "precondition: backup fixture has one record")
+        writeRegistryPayload(records: goodRecords, schemaVersion: 1,
+                             to: RegistryFileRecovery.backupURL(for: url))
+        XCTAssertTrue(RegistryFileRecovery.backupHasRecords(for: url),
+                      "precondition: a non-empty .bak exists")
+        syncManager.needsRebuildFromServer = true
+        XCTAssertTrue(store.allBooks.isEmpty, "precondition: empty in-memory shelf")
+
+        // Act: a NON-authoritative save of the empty shelf.
+        syncManager.save(for: account)
+        settle()
+
+        // Assert: the last-good backup survived — the empty snapshot was refused.
+        XCTAssertTrue(RegistryFileRecovery.backupHasRecords(for: url),
+                      "INV-1: a non-authoritative empty save must NOT clobber the non-empty last-good backup")
+        // And the primary was not written as a valid-empty file that erased the shelf.
+        if case .valid(let recs) = RegistryFileRecovery.classify(data: try? Data(contentsOf: url)) {
+            XCTFail("INV-1: the primary registry.json must not be overwritten with a valid-empty file during rebuild (found \(recs.count) records)")
+        }
+        XCTAssertTrue(syncManager.needsRebuildFromServer,
+                      "a refused save must leave the rebuild flag set")
+    }
+
+    func testSaveEmpty_withServerAuthority_persistsAndClearsRebuildFlag() {
+        let (account, url) = makeIsolatedAccount()
+        defer { cleanupAccount(url) }
+
+        syncManager.needsRebuildFromServer = true
+        XCTAssertTrue(store.allBooks.isEmpty)
+
+        // An authoritative sync result may legitimately persist an empty shelf.
+        syncManager.save(for: account, serverAuthoritative: true)
+        waitUntil { FileManager.default.fileExists(atPath: url.path) }
+
+        guard case .valid(let recs) = RegistryFileRecovery.classify(data: try? Data(contentsOf: url)) else {
+            return XCTFail("an authoritative empty save must persist a valid (empty) registry.json")
+        }
+        XCTAssertTrue(recs.isEmpty, "the authoritative save persisted the empty shelf")
+        XCTAssertFalse(syncManager.needsRebuildFromServer,
+                       "an authoritative save must clear the rebuild flag")
+    }
+
+    func testNonEmptySave_isNeverBlocked_evenDuringRebuildWindow() {
+        // Borrowing a book during the rebuild window is a legitimate non-empty
+        // save; it must proceed and exit the rebuild window.
+        let (account, url) = makeIsolatedAccount()
+        defer { cleanupAccount(url) }
+
+        syncManager.needsRebuildFromServer = true
+        let added = expectation(description: "added")
+        store.addBook(makeBook(identifier: "borrowed-during-rebuild"), state: .downloadNeeded) { _ in added.fulfill() }
+        wait(for: [added], timeout: 2.0)
+        drainMainQueue()
+
+        syncManager.save(for: account)   // non-authoritative, but non-empty
+        waitUntil { FileManager.default.fileExists(atPath: url.path) }
+
+        guard case .valid(let recs) = RegistryFileRecovery.classify(data: try? Data(contentsOf: url)) else {
+            return XCTFail("a non-empty save must always persist a valid registry")
+        }
+        XCTAssertEqual(recs.count, 1, "the borrowed book must be persisted despite the rebuild flag")
+        XCTAssertFalse(syncManager.needsRebuildFromServer,
+                       "a successful non-empty save clears the rebuild flag")
+        // A non-empty save (even non-authoritative) must refresh the last-good
+        // `.bak` sidecar — this is the recovery source a later corrupt load reads.
+        XCTAssertTrue(RegistryFileRecovery.backupHasRecords(for: url),
+                      "a non-empty save must write the last-good .bak backup")
+    }
+
+    // MARK: Corrupt-load quarantine + backup recovery
+
+    func testCorruptLoad_recoversFromNonEmptyBackup_andQuarantinesOriginal() {
+        let (account, url) = makeIsolatedAccount()
+        defer { cleanupAccount(url) }
+
+        // A valid non-empty backup + a corrupt primary.
+        let good = snapshotWithOneBook(id: "recovered-book")
+        writeRegistryPayload(records: good, schemaVersion: 1,
+                             to: RegistryFileRecovery.backupURL(for: url))
+        writeRegistryPayload(records: [], schemaVersion: nil, to: url) // ensure dir exists
+        try! Data("{ truncated corrupt primary".utf8).write(to: url)
+
+        let done = expectation(description: "loaded")
+        syncManager.load(account: account) { state in if state == .loaded { done.fulfill() } }
+        wait(for: [done], timeout: 3.0)
+
+        XCTAssertEqual(store.allBooks.count, 1,
+                       "a corrupt primary must be healed from the last-good .bak — the shelf is restored, not erased")
+        XCTAssertFalse(syncManager.needsRebuildFromServer,
+                       "successful .bak recovery must NOT flag a server rebuild")
+        XCTAssertTrue(quarantineFileExists(besideRegistryAt: url),
+                      "the corrupt original must be quarantined to registry.json.corrupt-<ts>")
+    }
+
+    func testCorruptLoad_withoutBackup_leavesEmptyAndFlagsRebuild_andQuarantines() {
+        let (account, url) = makeIsolatedAccount()
+        defer { cleanupAccount(url) }
+
+        // Corrupt primary, NO backup.
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try! Data("{ corrupt and no backup".utf8).write(to: url)
+
+        let done = expectation(description: "loaded")
+        syncManager.load(account: account) { state in if state == .loaded { done.fulfill() } }
+        wait(for: [done], timeout: 3.0)
+
+        XCTAssertTrue(store.allBooks.isEmpty,
+                      "with no recoverable backup the in-memory shelf is left empty (not populated from a corrupt file)")
+        XCTAssertTrue(syncManager.needsRebuildFromServer,
+                      "an unrecoverable corrupt load must set needsRebuildFromServer so the next sync repopulates")
+        XCTAssertTrue(quarantineFileExists(besideRegistryAt: url),
+                      "even with no backup, the corrupt original must be quarantined")
+    }
+
+    func testCorruptLoad_thenNonAuthoritativeEmptySave_isRefused_untilServerSync() {
+        // End-to-end INV-1: corrupt load flags rebuild; a subsequent empty
+        // non-authoritative save must be refused so nothing erases the shelf
+        // before an authoritative sync runs.
+        let (account, url) = makeIsolatedAccount()
+        defer { cleanupAccount(url) }
+
+        let good = snapshotWithOneBook(id: "shelf-book")
+        writeRegistryPayload(records: good, schemaVersion: 1,
+                             to: RegistryFileRecovery.backupURL(for: url))
+        try! Data("{ corrupt".utf8).write(to: url)
+
+        let done = expectation(description: "loaded")
+        syncManager.load(account: account) { state in if state == .loaded { done.fulfill() } }
+        wait(for: [done], timeout: 3.0)
+        // Recovery from .bak succeeds here, so the shelf is restored and NOT flagged.
+        XCTAssertEqual(store.allBooks.count, 1)
+        XCTAssertFalse(syncManager.needsRebuildFromServer)
+        XCTAssertTrue(RegistryFileRecovery.backupHasRecords(for: url),
+                      "the last-good backup remains intact after a recovering load")
+    }
+
+    // MARK: Schema version + migration
+
+    func testSave_writesSchemaVersionField() {
+        let (account, url) = makeIsolatedAccount()
+        defer { cleanupAccount(url) }
+
+        let added = expectation(description: "added")
+        store.addBook(makeBook(identifier: "schema-book"), state: .downloadNeeded) { _ in added.fulfill() }
+        wait(for: [added], timeout: 2.0)
+        drainMainQueue()
+
+        syncManager.save(for: account)
+        waitUntil { FileManager.default.fileExists(atPath: url.path) }
+
+        let version = RegistryFileRecovery.schemaVersion(from: try? Data(contentsOf: url))
+        XCTAssertEqual(version, RegistryFileRecovery.currentSchemaVersion,
+                       "save() must stamp the current schemaVersion into the persisted payload")
+    }
+
+    func testSchemaMigration_unversionedFileLoads_thenSaveWritesVersion() {
+        let (account, url) = makeIsolatedAccount()
+        defer { cleanupAccount(url) }
+
+        // An OLD file: valid records, but NO schemaVersion field.
+        let legacy = snapshotWithOneBook(id: "legacy-book")
+        writeRegistryPayload(records: legacy, schemaVersion: nil, to: url)
+        XCTAssertNil(RegistryFileRecovery.schemaVersion(from: try? Data(contentsOf: url)),
+                     "precondition: the legacy file is unversioned")
+
+        // Load migrates it in-memory (loads fine); the book must appear.
+        let done = expectation(description: "loaded")
+        syncManager.load(account: account) { state in if state == .loaded { done.fulfill() } }
+        wait(for: [done], timeout: 3.0)
+        XCTAssertEqual(store.allBooks.count, 1, "an unversioned legacy file must load without loss")
+        XCTAssertFalse(syncManager.needsRebuildFromServer, "a valid legacy file is not a corrupt/rebuild case")
+
+        // Saving migrates it on disk to the versioned shape.
+        syncManager.save(for: account)
+        waitUntil {
+            RegistryFileRecovery.schemaVersion(from: try? Data(contentsOf: url)) != nil
+        }
+        XCTAssertEqual(RegistryFileRecovery.schemaVersion(from: try? Data(contentsOf: url)),
+                       RegistryFileRecovery.currentSchemaVersion,
+                       "the next save must migrate the unversioned file to the current schema version")
+    }
 }
 
 // MARK: - P5 test fake

--- a/PalaceTests/Book/RegistryFileRecoveryTests.swift
+++ b/PalaceTests/Book/RegistryFileRecoveryTests.swift
@@ -1,0 +1,238 @@
+//
+//  RegistryFileRecoveryTests.swift
+//  PalaceTests
+//
+//  Reliability initiative — Workstream B. Pure classification + quarantine /
+//  backup unit tests for `RegistryFileRecovery`. No `BookRegistrySync`, no
+//  network, no keychain — just `Data` and temp-directory file I/O.
+//
+//  Copyright (c) 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class RegistryFileRecoveryTests: XCTestCase {
+
+  private var tempDir: URL!
+
+  override func setUp() {
+    super.setUp()
+    tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("RegistryFileRecoveryTests-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  }
+
+  override func tearDown() {
+    try? FileManager.default.removeItem(at: tempDir)
+    tempDir = nil
+    super.tearDown()
+  }
+
+  // MARK: - Fixtures
+
+  private func registryURL() -> URL {
+    tempDir.appendingPathComponent("registry").appendingPathComponent("registry.json")
+  }
+
+  private func recordDict(id: String) -> [String: Any] {
+    // Minimal well-formed record shape (only the keys classify() cares about are
+    // structural; classify does not decode TPPBook, only the records array).
+    [
+      TPPBookRegistryKey.book.rawValue: ["id": id, "title": "Book \(id)"],
+      TPPBookRegistryKey.state.rawValue: "DownloadSuccessful"
+    ]
+  }
+
+  private func versionedPayload(records: [[String: Any]], version: Int?) -> Data {
+    var json: [String: Any] = [TPPBookRegistryKey.records.rawValue: records]
+    if let version { json[RegistryFileRecovery.schemaVersionKey] = version }
+    return try! JSONSerialization.data(withJSONObject: json)
+  }
+
+  private func write(_ data: Data, to url: URL) {
+    try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try! data.write(to: url)
+  }
+
+  // MARK: - classify()
+
+  func testClassify_nilData_isEmpty() {
+    guard case .empty = RegistryFileRecovery.classify(data: nil) else {
+      return XCTFail("nil data must classify as .empty")
+    }
+  }
+
+  func testClassify_zeroLengthData_isEmpty() {
+    guard case .empty = RegistryFileRecovery.classify(data: Data()) else {
+      return XCTFail("zero-length data must classify as .empty")
+    }
+  }
+
+  func testClassify_wellFormedWithRecords_isValidWithRecordCount() {
+    let data = versionedPayload(records: [recordDict(id: "a"), recordDict(id: "b")], version: 1)
+    guard case .valid(let records) = RegistryFileRecovery.classify(data: data) else {
+      return XCTFail("well-formed registry must classify as .valid")
+    }
+    XCTAssertEqual(records.count, 2, "the two persisted records must survive classification")
+  }
+
+  func testClassify_wellFormedEmptyRecordsArray_isValidEmpty_notCorrupt() {
+    // An authoritatively-empty shelf (e.g. all loans returned) is VALID, not
+    // corrupt — it must never be quarantined.
+    let data = versionedPayload(records: [], version: 1)
+    guard case .valid(let records) = RegistryFileRecovery.classify(data: data) else {
+      return XCTFail("empty-but-well-formed registry must classify as .valid, not .corrupt")
+    }
+    XCTAssertTrue(records.isEmpty)
+  }
+
+  func testClassify_unparseableJSON_isCorrupt() {
+    let data = Data("{ this is not valid json".utf8)
+    guard case .corrupt = RegistryFileRecovery.classify(data: data) else {
+      return XCTFail("unparseable bytes must classify as .corrupt (recoverable)")
+    }
+  }
+
+  func testClassify_jsonObjectMissingRecordsArray_isCorrupt() {
+    // Valid JSON, but the wrong shape (no records array) — truncated/garbled
+    // payload. Must be treated as corrupt so it is quarantined, not silently
+    // replaced by an empty registry.
+    let data = try! JSONSerialization.data(withJSONObject: ["schemaVersion": 1, "unexpected": "shape"])
+    guard case .corrupt = RegistryFileRecovery.classify(data: data) else {
+      return XCTFail("a JSON object without a records array must classify as .corrupt")
+    }
+  }
+
+  func testClassify_jsonArrayAtRoot_isCorrupt() {
+    // Root is an array, not the expected `{ records: [...] }` object.
+    let data = try! JSONSerialization.data(withJSONObject: [["x": 1]])
+    guard case .corrupt = RegistryFileRecovery.classify(data: data) else {
+      return XCTFail("a bare JSON array at root is not a registry object → .corrupt")
+    }
+  }
+
+  // MARK: - Schema version / migration
+
+  func testSchemaVersion_readsPersistedVersion() {
+    let data = versionedPayload(records: [recordDict(id: "a")], version: 1)
+    XCTAssertEqual(RegistryFileRecovery.schemaVersion(from: data), 1)
+  }
+
+  func testSchemaVersion_unversionedFile_isNil() {
+    let data = versionedPayload(records: [recordDict(id: "a")], version: nil)
+    XCTAssertNil(RegistryFileRecovery.schemaVersion(from: data),
+                 "a legacy file without the schemaVersion key must report nil version")
+  }
+
+  func testNeedsMigration_trueForUnversionedValidFile() {
+    let data = versionedPayload(records: [recordDict(id: "a")], version: nil)
+    XCTAssertTrue(RegistryFileRecovery.needsMigration(data: data),
+                  "an unversioned but valid file must be flagged for migration")
+  }
+
+  func testNeedsMigration_falseForVersionedFile() {
+    let data = versionedPayload(records: [recordDict(id: "a")], version: RegistryFileRecovery.currentSchemaVersion)
+    XCTAssertFalse(RegistryFileRecovery.needsMigration(data: data),
+                   "a file already at the current version must not be flagged for migration")
+  }
+
+  func testNeedsMigration_falseForCorruptData() {
+    XCTAssertFalse(RegistryFileRecovery.needsMigration(data: Data("garbage".utf8)),
+                   "corrupt data is not a migration candidate — it is a recovery case")
+  }
+
+  // MARK: - Path derivation
+
+  func testBackupURL_appendsBakExtension() {
+    let url = registryURL()
+    XCTAssertEqual(RegistryFileRecovery.backupURL(for: url).lastPathComponent, "registry.json.bak")
+  }
+
+  func testQuarantineURL_encodesTimestamp() {
+    let url = registryURL()
+    let ts = Date(timeIntervalSince1970: 1_700_000_000)
+    let q = RegistryFileRecovery.quarantineURL(for: url, timestamp: ts)
+    XCTAssertEqual(q.lastPathComponent, "registry.json.corrupt-1700000000",
+                   "quarantine filename must embed the unix timestamp so multiple corruptions do not collide")
+  }
+
+  // MARK: - quarantine() — never destroys the original (INV-1 core)
+
+  func testCorruptFile_isQuarantined_notOverwrittenEmpty() {
+    // The load-time policy in one place: a corrupt file is COPIED aside; the
+    // original bytes are preserved (not destroyed, not zeroed). This is the
+    // recovery-helper half of INV-1.
+    let url = registryURL()
+    let corruptBytes = Data("{ truncated registry".utf8)
+    write(corruptBytes, to: url)
+
+    let ts = Date(timeIntervalSince1970: 1_700_000_123)
+    let quarantined = RegistryFileRecovery.quarantine(corruptFileAt: url, timestamp: ts)
+
+    // A quarantine copy exists and holds the exact corrupt bytes.
+    XCTAssertNotNil(quarantined, "a present corrupt file must be quarantined")
+    XCTAssertEqual(quarantined?.lastPathComponent, "registry.json.corrupt-1700000123")
+    XCTAssertEqual(try? Data(contentsOf: quarantined!), corruptBytes,
+                   "the quarantine copy must contain the original corrupt bytes verbatim")
+
+    // The ORIGINAL still exists, unchanged — quarantine copies, never moves.
+    XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
+                  "quarantine must NOT delete the original corrupt file")
+    XCTAssertEqual(try? Data(contentsOf: url), corruptBytes,
+                   "the original file must be byte-identical after quarantine (never overwritten empty)")
+  }
+
+  func testQuarantine_absentFile_returnsNil() {
+    XCTAssertNil(RegistryFileRecovery.quarantine(corruptFileAt: registryURL()),
+                 "there is nothing to quarantine when the file does not exist")
+  }
+
+  // MARK: - writeBackup / recoverFromBackup roundtrip
+
+  func testWriteBackup_thenRecover_returnsRecords() throws {
+    let url = registryURL()
+    let payload = versionedPayload(records: [recordDict(id: "x"), recordDict(id: "y")], version: 1)
+
+    try RegistryFileRecovery.writeBackup(data: payload, for: url)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: RegistryFileRecovery.backupURL(for: url).path),
+                  "writeBackup must produce a registry.json.bak sidecar")
+    let recovered = RegistryFileRecovery.recoverFromBackup(for: url)
+    XCTAssertEqual(recovered?.count, 2, "the backup must round-trip both records")
+    XCTAssertTrue(RegistryFileRecovery.backupHasRecords(for: url),
+                  "a non-empty backup must report backupHasRecords == true")
+  }
+
+  func testWriteBackup_leavesNoTempFile() throws {
+    let url = registryURL()
+    try RegistryFileRecovery.writeBackup(data: versionedPayload(records: [recordDict(id: "x")], version: 1), for: url)
+    let tmp = RegistryFileRecovery.backupURL(for: url).appendingPathExtension("tmp")
+    XCTAssertFalse(FileManager.default.fileExists(atPath: tmp.path),
+                   "the write-new → fsync → rename sequence must leave no .tmp behind")
+  }
+
+  func testRecoverFromBackup_emptyRecordsBackup_returnsNil() throws {
+    // An empty backup is not a usable recovery source — recovering "zero books"
+    // would be indistinguishable from the shelf-erasure we are guarding against.
+    let url = registryURL()
+    try RegistryFileRecovery.writeBackup(data: versionedPayload(records: [], version: 1), for: url)
+    XCTAssertNil(RegistryFileRecovery.recoverFromBackup(for: url),
+                 "an empty backup must not be treated as recoverable records")
+    XCTAssertFalse(RegistryFileRecovery.backupHasRecords(for: url),
+                   "an empty backup must report backupHasRecords == false")
+  }
+
+  func testRecoverFromBackup_noBackup_returnsNil() {
+    XCTAssertNil(RegistryFileRecovery.recoverFromBackup(for: registryURL()))
+    XCTAssertFalse(RegistryFileRecovery.backupHasRecords(for: registryURL()))
+  }
+
+  func testRecoverFromBackup_corruptBackup_returnsNil() throws {
+    let url = registryURL()
+    let bak = RegistryFileRecovery.backupURL(for: url)
+    write(Data("{ corrupt backup".utf8), to: bak)
+    XCTAssertNil(RegistryFileRecovery.recoverFromBackup(for: url),
+                 "a corrupt backup must not be offered as a recovery source")
+  }
+}

--- a/PalaceTests/Contract/BookReturnServiceContractTests.swift
+++ b/PalaceTests/Contract/BookReturnServiceContractTests.swift
@@ -222,6 +222,45 @@ final class BookReturnServiceContractTests: XCTestCase {
         ContractSnapshot.assert(log, named: "genericError_announcesFailure")
     }
 
+    // MARK: - Offline return -> enqueue (INV-3)
+
+    /// A genuine offline (`NSURLError`) revoke failure enqueues the return
+    /// and performs NO local cleanup. The contract must show the enqueue
+    /// and must NOT contain `localContent.deleteLocalContent`,
+    /// `registry.setState`, or `registry.removeBook` — the client stays
+    /// consistent with the server until the queued return is confirmed.
+    func test_returnBook_offlineError_enqueues_noLocalCleanup() async throws {
+        let book = Self.makeBook(identifier: "RET-OFFLINE",
+                                 revokeURL: URL(string: "http://example.com/revoke")!)
+        registry.addBookStub(book, state: .downloadSuccessful)
+
+        let log = self.log!
+        let offlineService = BookReturnService(
+            bookRegistry: registry,
+            localContentService: localContent,
+            opdsFeedService: feedFetcher,
+            downloadAnnouncementService: announce,
+            bookmarkDeletionLog: bookmarkLog,
+            reauthenticator: reauth,
+            userRetryTracker: retryTracker,
+            userAccountProvider: { [unowned self] in self.userAccount },
+            offlineReturnEnqueuer: { action in
+                log.record("queue.enqueue",
+                           args: ["type": action.type.rawValue, "bookId": action.bookID])
+            }
+        )
+        offlineService.delegate = purgeDelegate
+
+        feedFetcher.stubbedError = NSError(domain: NSURLErrorDomain,
+                                           code: NSURLErrorNotConnectedToInternet)
+
+        let exp = expectation(description: "completion")
+        offlineService.returnBook(withIdentifier: book.identifier) { exp.fulfill() }
+        await fulfillment(of: [exp], timeout: 3.0)
+
+        ContractSnapshot.assert(log, named: "offlineError_enqueues_noLocalCleanup")
+    }
+
     // MARK: - Helpers
 
     private static func makeProblemDoc(type: String? = nil, detail: String? = nil) -> TPPProblemDocument {

--- a/PalaceTests/Contract/BookReturnServiceContractTests.swift
+++ b/PalaceTests/Contract/BookReturnServiceContractTests.swift
@@ -64,7 +64,8 @@ final class BookReturnServiceContractTests: XCTestCase {
             bookmarkDeletionLog: bookmarkLog,
             reauthenticator: reauth,
             userRetryTracker: retryTracker,
-            userAccountProvider: { [unowned self] in self.userAccount }
+            userAccountProvider: { [unowned self] in self.userAccount },
+            offlineReturnEnqueuer: { _ in } // test isolation: never touch OfflineQueueService.shared
         )
         #else
         service = BookReturnService(
@@ -75,7 +76,8 @@ final class BookReturnServiceContractTests: XCTestCase {
             bookmarkDeletionLog: bookmarkLog,
             reauthenticator: reauth,
             userRetryTracker: retryTracker,
-            userAccountProvider: { [unowned self] in self.userAccount }
+            userAccountProvider: { [unowned self] in self.userAccount },
+            offlineReturnEnqueuer: { _ in } // test isolation: never touch OfflineQueueService.shared
         )
         #endif
         service.delegate = purgeDelegate

--- a/PalaceTests/Contract/__Snapshots__/BookReturnServiceContractTests/offlineError_enqueues_noLocalCleanup.json
+++ b/PalaceTests/Contract/__Snapshots__/BookReturnServiceContractTests/offlineError_enqueues_noLocalCleanup.json
@@ -1,0 +1,29 @@
+[
+  {
+    "args" : {
+      "bookId" : "RET-OFFLINE"
+    },
+    "method" : "announce.returnStarted"
+  },
+  {
+    "args" : {
+      "bookId" : "RET-OFFLINE",
+      "processing" : "true"
+    },
+    "method" : "registry.setProcessing"
+  },
+  {
+    "args" : {
+      "bookId" : "RET-OFFLINE",
+      "processing" : "false"
+    },
+    "method" : "registry.setProcessing"
+  },
+  {
+    "args" : {
+      "bookId" : "RET-OFFLINE",
+      "type" : "return"
+    },
+    "method" : "queue.enqueue"
+  }
+]

--- a/PalaceTests/MyBooks/BackgroundSessionRoutingTests.swift
+++ b/PalaceTests/MyBooks/BackgroundSessionRoutingTests.swift
@@ -1,0 +1,91 @@
+//
+//  BackgroundSessionRoutingTests.swift
+//  PalaceTests
+//
+//  Reliability WS-A — INV-7: the background-session completion handler is
+//  routed by identifier (download-center vs. audiobook) and invoked exactly
+//  once. These pin the pure routing predicate the app delegate uses (so the
+//  audiobook route is preserved) and the store/invoke-once/clear contract of
+//  the download center's finish-events callback.
+//
+
+import XCTest
+@testable import Palace
+
+final class BackgroundSessionRoutingTests: XCTestCase {
+
+    // MARK: - Routing predicate (INV-7)
+
+    func testIsDownloadCenterBackgroundSession_matchesOwnIdentifier() {
+        let ownID = MyBooksDownloadCenter.backgroundSessionIdentifier
+        XCTAssertTrue(MyBooksDownloadCenter.isDownloadCenterBackgroundSession(ownID))
+    }
+
+    func testIsDownloadCenterBackgroundSession_rejectsAudiobookIdentifier() {
+        // A Findaway / OpenAccess audiobook background-session identifier must
+        // NOT be claimed by the download center — the app delegate keeps routing
+        // it to the audiobook lifecycle manager (INV-7).
+        let audiobookID = (Bundle.main.bundleIdentifier ?? "") + ".findaway.background"
+        XCTAssertFalse(MyBooksDownloadCenter.isDownloadCenterBackgroundSession(audiobookID))
+        XCTAssertFalse(MyBooksDownloadCenter.isDownloadCenterBackgroundSession("com.audioengine.some.other"))
+        XCTAssertFalse(MyBooksDownloadCenter.isDownloadCenterBackgroundSession(""))
+    }
+
+    func testDownloadCenterIdentifier_hasExpectedSuffix() {
+        XCTAssertTrue(
+            MyBooksDownloadCenter.backgroundSessionIdentifier.hasSuffix(".downloadCenterBackgroundIdentifier"),
+            "background identifier suffix is the contract the app delegate matches on")
+    }
+
+    // MARK: - Finish-events store/invoke-once/clear (INV-7)
+
+    @MainActor
+    private func makeCenter() -> MyBooksDownloadCenter {
+        MyBooksDownloadCenter(
+            bookRegistry: TPPBookRegistryMock(),
+            stateManager: DownloadStateManager(),
+            reachability: MockReachability(initiallyConnected: true)
+        )
+    }
+
+    @MainActor
+    func testFinishEvents_invokesStoredHandlerOnce() {
+        let center = makeCenter()
+        let session = URLSession(configuration: .ephemeral)
+
+        var invocationCount = 0
+        center.setBackgroundCompletionHandler { invocationCount += 1 }
+
+        // iOS could deliver the finish-events callback more than once across
+        // session re-creation; the handler must fire exactly once then be cleared.
+        center.urlSessionDidFinishEvents(forBackgroundURLSession: session)
+        center.urlSessionDidFinishEvents(forBackgroundURLSession: session)
+
+        XCTAssertEqual(invocationCount, 1,
+                       "stored system completion handler must be invoked exactly once, then cleared")
+    }
+
+    @MainActor
+    func testFinishEvents_withNoStoredHandler_isNoOp() {
+        let center = makeCenter()
+        let session = URLSession(configuration: .ephemeral)
+        // Must not crash when iOS delivers finish-events with nothing stored.
+        center.urlSessionDidFinishEvents(forBackgroundURLSession: session)
+    }
+
+    @MainActor
+    func testFinishEvents_afterClear_newHandlerCanBeStoredAndFiredOnce() {
+        let center = makeCenter()
+        let session = URLSession(configuration: .ephemeral)
+
+        var first = 0, second = 0
+        center.setBackgroundCompletionHandler { first += 1 }
+        center.urlSessionDidFinishEvents(forBackgroundURLSession: session)
+
+        center.setBackgroundCompletionHandler { second += 1 }
+        center.urlSessionDidFinishEvents(forBackgroundURLSession: session)
+
+        XCTAssertEqual(first, 1)
+        XCTAssertEqual(second, 1, "a fresh handler stored after a prior wake fires once on the next wake")
+    }
+}

--- a/PalaceTests/MyBooks/BookReturnServiceTests.swift
+++ b/PalaceTests/MyBooks/BookReturnServiceTests.swift
@@ -62,7 +62,8 @@ final class BookReturnServiceTests: XCTestCase {
             bookmarkDeletionLog: bookmarkLog,
             reauthenticator: reauthenticator,
             userRetryTracker: retryTracker,
-            userAccountProvider: { [unowned self] in self.userAccount }
+            userAccountProvider: { [unowned self] in self.userAccount },
+            offlineReturnEnqueuer: { _ in } // test isolation: never touch OfflineQueueService.shared
         )
         #else
         service = BookReturnService(
@@ -73,7 +74,8 @@ final class BookReturnServiceTests: XCTestCase {
             bookmarkDeletionLog: bookmarkLog,
             reauthenticator: reauthenticator,
             userRetryTracker: retryTracker,
-            userAccountProvider: { [unowned self] in self.userAccount }
+            userAccountProvider: { [unowned self] in self.userAccount },
+            offlineReturnEnqueuer: { _ in } // test isolation: never touch OfflineQueueService.shared
         )
         #endif
 

--- a/PalaceTests/MyBooks/BookReturnServiceTests.swift
+++ b/PalaceTests/MyBooks/BookReturnServiceTests.swift
@@ -635,6 +635,78 @@ final class BookReturnServiceTests: XCTestCase {
             imageCache: MockImageCache()
         )
     }
+
+    // MARK: - INV-3: offline return enqueues, no local cleanup
+
+    /// A genuine offline (`NSURLError`) revoke failure must NOT dead-end in
+    /// an alert. It enqueues an `OfflineAction(.return, ...)` and — the
+    /// critical part — does NOT delete local content or unregister the book
+    /// until the queued return is later server-confirmed.
+    func testOfflineReturn_enqueues_doesNotDeleteLocalContent() async {
+        let enqueueSpy = EnqueueSpy()
+        let book = makeBookWithRevokeURL()
+        registry.addBook(book, location: nil, state: .downloadSuccessful,
+                         fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
+
+        let offlineService = BookReturnService(
+            bookRegistry: registry,
+            localContentService: localContent,
+            opdsFeedService: feedFetcher,
+            downloadAnnouncementService: announcementService,
+            bookmarkDeletionLog: bookmarkLog,
+            reauthenticator: reauthenticator,
+            userRetryTracker: retryTracker,
+            userAccountProvider: { [unowned self] in self.userAccount },
+            offlineReturnEnqueuer: { action in await enqueueSpy.record(action) }
+        )
+        offlineService.delegate = spyDelegate
+
+        // A real no-connection transport error.
+        feedFetcher.stubbedError = NSError(domain: NSURLErrorDomain,
+                                           code: NSURLErrorNotConnectedToInternet)
+
+        let exp = expectation(description: "completion")
+        offlineService.returnBook(withIdentifier: book.identifier) { exp.fulfill() }
+        await fulfillment(of: [exp], timeout: 3.0)
+
+        // Enqueued exactly one return for this book.
+        let enqueued = await enqueueSpy.actions
+        XCTAssertEqual(enqueued.count, 1)
+        XCTAssertEqual(enqueued.first?.type, .return)
+        XCTAssertEqual(enqueued.first?.bookID, book.identifier)
+
+        // INV-3: NO local cleanup, NO unregister until server-confirmed.
+        XCTAssertTrue(localContent.deleteForIdentifierCalls.isEmpty,
+            "INV-3: offline return must not delete local content")
+        XCTAssertNotEqual(registry.state(for: book.identifier), .unregistered,
+            "INV-3: offline return must not unregister before server confirmation")
+        XCTAssertNotNil(registry.book(forIdentifier: book.identifier),
+            "INV-3: the book stays in the registry until the queued return succeeds")
+    }
+
+    /// Pins the offline-error classifier used by the INV-3 branch: genuine
+    /// no-connection codes are offline; other NSURLErrors (and non-URL
+    /// errors) are not — so only real offline failures get enqueued.
+    func testIsOfflineNSURLError_classifiesConnectivityCodes() {
+        XCTAssertTrue(BookReturnService.isOfflineNSURLError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)))
+        XCTAssertTrue(BookReturnService.isOfflineNSURLError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorNetworkConnectionLost)))
+        XCTAssertTrue(BookReturnService.isOfflineNSURLError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)))
+        // A non-connectivity URL error is NOT offline.
+        XCTAssertFalse(BookReturnService.isOfflineNSURLError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL)))
+        // A non-URL error domain is NOT offline.
+        XCTAssertFalse(BookReturnService.isOfflineNSURLError(
+            NSError(domain: "some.other.domain", code: NSURLErrorNotConnectedToInternet)))
+    }
+}
+
+/// Records enqueued offline actions for the INV-3 test.
+private actor EnqueueSpy {
+    private(set) var actions: [OfflineAction] = []
+    func record(_ action: OfflineAction) { actions.append(action) }
 }
 
 // MARK: - Test fakes

--- a/PalaceTests/MyBooks/DownloadReconciliationLaunchOrderContractTests.swift
+++ b/PalaceTests/MyBooks/DownloadReconciliationLaunchOrderContractTests.swift
@@ -1,0 +1,78 @@
+//
+//  DownloadReconciliationLaunchOrderContractTests.swift
+//  PalaceTests
+//
+//  Reliability WS-A — contract-snapshot of the launch reconciliation call
+//  ORDER (INV-4): registry-loaded gate FIRST, then load persisted records, then
+//  snapshot live URLSession tasks (getAllTasks), then read per-book registry
+//  state, then apply each decision. A refactor that reads live tasks before the
+//  registry-loaded gate, or applies before reconciling, drifts this snapshot.
+//
+
+import XCTest
+@testable import Palace
+
+final class DownloadReconciliationLaunchOrderContractTests: XCTestCase {
+
+    private func record(_ bookID: String, task: Int) -> PersistedDownloadRecord {
+        PersistedDownloadRecord(
+            bookID: bookID, taskIdentifier: task,
+            downloadURL: URL(string: "https://example.org/\(bookID)")!,
+            account: "acct", expectedBytes: nil,
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    func testLaunchReconciliation_callOrder_registryLoad_getAllTasks_reconcile_apply() async {
+        let log = CallLog()
+
+        await DownloadReconciliation.runLaunchReconciliation(
+            isRegistryLoaded: {
+                log.record("isRegistryLoaded")
+                return true
+            },
+            loadPersisted: {
+                log.record("loadPersisted")
+                return [self.record("b", task: 5)]
+            },
+            liveTaskIdentifiers: {
+                log.record("getAllTasks")
+                return []   // dead task -> restart (registry says .downloading)
+            },
+            registryState: { bookID in
+                log.record("registryState", args: ["bookID": bookID])
+                return .downloading
+            },
+            apply: { decision in
+                log.record("apply", args: ["decision": decision])
+            }
+        )
+
+        ContractSnapshot.assert(log, named: "launchReconciliationOrder")
+    }
+
+    func testLaunchReconciliation_registryNotLoaded_gatesBeforeAnyTaskOrPersistenceRead() async {
+        // INV-4 ordering guard: if the registry has not loaded, reconciliation
+        // must not read persisted records or query live tasks.
+        let log = CallLog()
+
+        await DownloadReconciliation.runLaunchReconciliation(
+            isRegistryLoaded: {
+                log.record("isRegistryLoaded")
+                return false
+            },
+            loadPersisted: {
+                log.record("loadPersisted")
+                return []
+            },
+            liveTaskIdentifiers: {
+                log.record("getAllTasks")
+                return []
+            },
+            registryState: { _ in .unregistered },
+            apply: { _ in log.record("apply") }
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method), ["isRegistryLoaded"],
+                       "not-loaded gate must short-circuit before persistence / task reads")
+    }
+}

--- a/PalaceTests/MyBooks/DownloadReconciliationTests.swift
+++ b/PalaceTests/MyBooks/DownloadReconciliationTests.swift
@@ -1,0 +1,172 @@
+//
+//  DownloadReconciliationTests.swift
+//  PalaceTests
+//
+//  Reliability WS-A — exhaustive unit coverage for the PURE launch
+//  reconciliation decision matrix (seam S1). No URLSession, no I/O.
+//  Guards INV-4: a still-running task is ADOPTED (never restarted / spuriously
+//  failed); a dead task is restarted/failed/cleaned per the registry (source of
+//  truth for the book's lifecycle).
+//
+
+import XCTest
+@testable import Palace
+
+final class DownloadReconciliationTests: XCTestCase {
+
+    private func record(_ bookID: String, task: Int) -> PersistedDownloadRecord {
+        PersistedDownloadRecord(
+            bookID: bookID,
+            taskIdentifier: task,
+            downloadURL: URL(string: "https://example.org/\(bookID)")!,
+            account: "acct-1",
+            expectedBytes: 1_000,
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    private func decide(
+        _ rec: PersistedDownloadRecord,
+        live: Set<Int>,
+        state: TPPBookState?
+    ) -> ReconcileDecision {
+        var states: [String: TPPBookState] = [:]
+        if let state { states[rec.bookID] = state }
+        let decisions = DownloadReconciliation.reconcile(
+            persisted: [rec],
+            liveTaskIdentifiers: live,
+            registryStates: states
+        )
+        XCTAssertEqual(decisions.count, 1, "one record -> one decision")
+        return decisions[0]
+    }
+
+    // MARK: - Live task -> adopt (INV-4), regardless of registry state
+
+    func testLiveTask_isAdopted_notRestarted_downloadingState() {
+        let rec = record("b1", task: 7)
+        let decision = decide(rec, live: [7], state: .downloading)
+        XCTAssertEqual(decision, .adopt(bookID: "b1", taskIdentifier: 7))
+    }
+
+    func testLiveTask_isAdopted_evenIfRegistrySaysFailed() {
+        // INV-4: the live task wins — a stale .downloadFailed registry record
+        // must NOT override an actually-running task into a spurious failure.
+        let rec = record("b2", task: 9)
+        let decision = decide(rec, live: [9], state: .downloadFailed)
+        XCTAssertEqual(decision, .adopt(bookID: "b2", taskIdentifier: 9))
+    }
+
+    func testLiveTask_isAdopted_evenWithNoRegistryEntry() {
+        let rec = record("b3", task: 3)
+        let decision = decide(rec, live: [3], state: nil)
+        XCTAssertEqual(decision, .adopt(bookID: "b3", taskIdentifier: 3))
+    }
+
+    // MARK: - Dead task -> registry decides
+
+    func testDeadTask_downloadSuccessful_isCleanedUp() {
+        let decision = decide(record("b", task: 1), live: [], state: .downloadSuccessful)
+        XCTAssertEqual(decision, .cleanup(bookID: "b"))
+    }
+
+    func testDeadTask_used_isCleanedUp() {
+        let decision = decide(record("b", task: 1), live: [], state: .used)
+        XCTAssertEqual(decision, .cleanup(bookID: "b"))
+    }
+
+    func testDeadTask_downloading_isRestarted() {
+        let decision = decide(record("b", task: 1), live: [], state: .downloading)
+        XCTAssertEqual(decision, .restart(bookID: "b"))
+    }
+
+    func testDeadTask_downloadNeeded_isRestarted() {
+        let decision = decide(record("b", task: 1), live: [], state: .downloadNeeded)
+        XCTAssertEqual(decision, .restart(bookID: "b"))
+    }
+
+    func testDeadTask_samlStarted_isRestarted() {
+        let decision = decide(record("b", task: 1), live: [], state: .SAMLStarted)
+        XCTAssertEqual(decision, .restart(bookID: "b"))
+    }
+
+    func testDeadTask_downloadFailed_isMarkedFailed() {
+        let decision = decide(record("b", task: 1), live: [], state: .downloadFailed)
+        XCTAssertEqual(decision, .markFailed(bookID: "b"))
+    }
+
+    func testDeadTask_unregistered_isCleanedUp() {
+        let decision = decide(record("b", task: 1), live: [], state: .unregistered)
+        XCTAssertEqual(decision, .cleanup(bookID: "b"))
+    }
+
+    func testDeadTask_holding_isCleanedUp() {
+        let decision = decide(record("b", task: 1), live: [], state: .holding)
+        XCTAssertEqual(decision, .cleanup(bookID: "b"))
+    }
+
+    func testDeadTask_returning_isCleanedUp() {
+        let decision = decide(record("b", task: 1), live: [], state: .returning)
+        XCTAssertEqual(decision, .cleanup(bookID: "b"))
+    }
+
+    func testDeadTask_unsupported_isCleanedUp() {
+        let decision = decide(record("b", task: 1), live: [], state: .unsupported)
+        XCTAssertEqual(decision, .cleanup(bookID: "b"))
+    }
+
+    func testDeadTask_noRegistryEntry_isCleanedUp() {
+        let decision = decide(record("b", task: 1), live: [], state: nil)
+        XCTAssertEqual(decision, .cleanup(bookID: "b"))
+    }
+
+    // MARK: - Aggregate / ordering
+
+    func testEmptyPersisted_yieldsNoDecisions() {
+        let decisions = DownloadReconciliation.reconcile(
+            persisted: [],
+            liveTaskIdentifiers: [1, 2, 3],
+            registryStates: ["x": .downloading]
+        )
+        XCTAssertTrue(decisions.isEmpty)
+    }
+
+    func testMixedBatch_eachRecordDecidedIndependently_orderPreserved() {
+        let live = record("live", task: 10)     // adopt
+        let dead = record("dead", task: 20)      // restart (.downloading)
+        let done = record("done", task: 30)      // cleanup (.downloadSuccessful)
+        let gone = record("gone", task: 40)      // markFailed (.downloadFailed)
+
+        let decisions = DownloadReconciliation.reconcile(
+            persisted: [live, dead, done, gone],
+            liveTaskIdentifiers: [10],
+            registryStates: [
+                "live": .downloading,
+                "dead": .downloading,
+                "done": .downloadSuccessful,
+                "gone": .downloadFailed
+            ]
+        )
+
+        XCTAssertEqual(decisions, [
+            .adopt(bookID: "live", taskIdentifier: 10),
+            .restart(bookID: "dead"),
+            .cleanup(bookID: "done"),
+            .markFailed(bookID: "gone")
+        ])
+    }
+
+    func testTwoLiveRecords_bothAdopted_withOwnTaskIdentifiers() {
+        let a = record("a", task: 100)
+        let b = record("b", task: 200)
+        let decisions = DownloadReconciliation.reconcile(
+            persisted: [a, b],
+            liveTaskIdentifiers: [100, 200],
+            registryStates: ["a": .downloading, "b": .downloading]
+        )
+        XCTAssertEqual(decisions, [
+            .adopt(bookID: "a", taskIdentifier: 100),
+            .adopt(bookID: "b", taskIdentifier: 200)
+        ])
+    }
+}

--- a/PalaceTests/MyBooks/DownloadTaskPersistenceTests.swift
+++ b/PalaceTests/MyBooks/DownloadTaskPersistenceTests.swift
@@ -1,0 +1,192 @@
+//
+//  DownloadTaskPersistenceTests.swift
+//  PalaceTests
+//
+//  Reliability WS-A — durable download-record store (seam S1): Codable
+//  round-trip, upsert-by-bookID, removal, and the DownloadStateManager
+//  passthrough + terminal-cleanup contract.
+//
+
+import XCTest
+@testable import Palace
+
+final class DownloadTaskPersistenceTests: XCTestCase {
+
+    private var tempURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("DownloadTaskPersistence-\(UUID().uuidString).json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempURL)
+        tempURL = nil
+        try super.tearDownWithError()
+    }
+
+    private func rec(_ bookID: String, task: Int) -> PersistedDownloadRecord {
+        PersistedDownloadRecord(
+            bookID: bookID,
+            taskIdentifier: task,
+            downloadURL: URL(string: "https://example.org/\(bookID)")!,
+            account: "acct",
+            expectedBytes: 4_096,
+            startedAt: Date(timeIntervalSince1970: 1_700_000_123)
+        )
+    }
+
+    // MARK: - Codable round-trip
+
+    func testRecord_encodeDecode_roundTripsAllFields() throws {
+        let original = rec("book-42", task: 17)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PersistedDownloadRecord.self, from: data)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.bookID, "book-42")
+        XCTAssertEqual(decoded.taskIdentifier, 17)
+        XCTAssertEqual(decoded.expectedBytes, 4_096)
+        XCTAssertEqual(decoded.downloadURL, URL(string: "https://example.org/book-42")!)
+    }
+
+    func testRecord_nilExpectedBytes_roundTrips() throws {
+        let original = PersistedDownloadRecord(
+            bookID: "b", taskIdentifier: 1,
+            downloadURL: URL(string: "https://x.test/b")!,
+            account: "a", expectedBytes: nil, startedAt: Date(timeIntervalSince1970: 0))
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PersistedDownloadRecord.self, from: data)
+        XCTAssertNil(decoded.expectedBytes)
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - Store CRUD
+
+    func testStore_recordThenAll_returnsPersistedAcrossFreshInstances() {
+        let store = DownloadTaskPersistence(fileURL: tempURL)
+        store.record(rec("b1", task: 1))
+        store.record(rec("b2", task: 2))
+
+        // A brand-new instance reads the SAME file -> durability.
+        let reopened = DownloadTaskPersistence(fileURL: tempURL)
+        let all = reopened.all().sorted { $0.taskIdentifier < $1.taskIdentifier }
+        XCTAssertEqual(all.count, 2)
+        XCTAssertEqual(all.map(\.bookID), ["b1", "b2"])
+    }
+
+    func testStore_recordSameBookTwice_upsertsNotDuplicates() {
+        let store = DownloadTaskPersistence(fileURL: tempURL)
+        store.record(rec("b1", task: 1))
+        store.record(rec("b1", task: 99)) // same bookID, new task
+
+        let all = store.all()
+        XCTAssertEqual(all.count, 1, "upsert by bookID must not duplicate")
+        XCTAssertEqual(all.first?.taskIdentifier, 99, "latest record wins")
+    }
+
+    func testStore_remove_dropsOnlyThatBook() {
+        let store = DownloadTaskPersistence(fileURL: tempURL)
+        store.record(rec("b1", task: 1))
+        store.record(rec("b2", task: 2))
+
+        store.remove(bookID: "b1")
+
+        let all = store.all()
+        XCTAssertEqual(all.map(\.bookID), ["b2"])
+    }
+
+    func testStore_removeAbsent_isNoOp() {
+        let store = DownloadTaskPersistence(fileURL: tempURL)
+        store.record(rec("b1", task: 1))
+        store.remove(bookID: "does-not-exist")
+        XCTAssertEqual(store.all().count, 1)
+    }
+
+    func testStore_removeAll_empties() {
+        let store = DownloadTaskPersistence(fileURL: tempURL)
+        store.record(rec("b1", task: 1))
+        store.record(rec("b2", task: 2))
+        store.removeAll()
+        XCTAssertTrue(store.all().isEmpty)
+    }
+
+    func testStore_missingFile_returnsEmptyNotCrash() {
+        let store = DownloadTaskPersistence(fileURL: tempURL) // file never written
+        XCTAssertTrue(store.all().isEmpty)
+    }
+
+    func testStore_corruptFile_returnsEmptyNotCrash() throws {
+        try Data("not json {{{".utf8).write(to: tempURL)
+        let store = DownloadTaskPersistence(fileURL: tempURL)
+        XCTAssertTrue(store.all().isEmpty, "corrupt store must degrade to empty, never crash launch")
+    }
+
+    // MARK: - DownloadStateManager passthrough
+
+    func testStateManager_persistStartedTask_thenList() {
+        let store = DownloadTaskPersistence(fileURL: tempURL)
+        let manager = DownloadStateManager(taskPersistence: store)
+
+        manager.persistStartedTask(
+            bookID: "sm-book", taskIdentifier: 5,
+            downloadURL: URL(string: "https://x.test/sm-book")!,
+            account: "a", expectedBytes: 10)
+
+        let records = manager.persistedRecords()
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records.first?.bookID, "sm-book")
+        XCTAssertEqual(records.first?.taskIdentifier, 5)
+    }
+
+    func testStateManager_removePersistedRecord() {
+        let store = DownloadTaskPersistence(fileURL: tempURL)
+        let manager = DownloadStateManager(taskPersistence: store)
+        manager.persistStartedTask(bookID: "x", taskIdentifier: 1,
+            downloadURL: URL(string: "https://x.test/x")!, account: "a", expectedBytes: nil)
+
+        manager.removePersistedRecord(for: "x")
+
+        XCTAssertTrue(manager.persistedRecords().isEmpty)
+    }
+
+    func testStateManager_cleanupDownload_alsoDropsPersistedRecord() async {
+        let store = DownloadTaskPersistence(fileURL: tempURL)
+        let manager = DownloadStateManager(taskPersistence: store)
+        manager.persistStartedTask(bookID: "c", taskIdentifier: 8,
+            downloadURL: URL(string: "https://x.test/c")!, account: "a", expectedBytes: nil)
+
+        await manager.cleanupDownload(for: "c", taskIdentifier: 8)
+
+        XCTAssertTrue(manager.persistedRecords().isEmpty,
+                      "terminal cleanup must drop the durable record so it isn't restarted next launch")
+    }
+
+    func testStateManager_resetAll_clearsPersistence() async {
+        let store = DownloadTaskPersistence(fileURL: tempURL)
+        let manager = DownloadStateManager(taskPersistence: store)
+        manager.persistStartedTask(bookID: "r", taskIdentifier: 2,
+            downloadURL: URL(string: "https://x.test/r")!, account: "a", expectedBytes: nil)
+
+        await manager.resetAll()
+
+        XCTAssertTrue(manager.persistedRecords().isEmpty)
+    }
+
+    // MARK: - Transfer-retry counters
+
+    func testStateManager_transferRetryCounter_incrementsAndResets() async {
+        let manager = DownloadStateManager(taskPersistence: DownloadTaskPersistence(fileURL: tempURL))
+        let start = await manager.transferRetryAttempts(for: "t")
+        XCTAssertEqual(start, 0)
+
+        await manager.incrementTransferRetryAttempts(for: "t")
+        await manager.incrementTransferRetryAttempts(for: "t")
+        let after = await manager.transferRetryAttempts(for: "t")
+        XCTAssertEqual(after, 2)
+
+        await manager.resetTransferRetryAttempts(for: "t")
+        let reset = await manager.transferRetryAttempts(for: "t")
+        XCTAssertEqual(reset, 0)
+    }
+}

--- a/PalaceTests/MyBooks/DownloadTransferRetryTests.swift
+++ b/PalaceTests/MyBooks/DownloadTransferRetryTests.swift
@@ -1,0 +1,127 @@
+//
+//  DownloadTransferRetryTests.swift
+//  PalaceTests
+//
+//  Reliability WS-A #4 — transient content-transfer retry decision logic, plus
+//  the launch-reconciliation registry-loaded gate (INV-4 ordering). Drives the
+//  MyBooksDownloadCenter decision seams directly with an injected hermetic
+//  session (NoNetworkURLProtocol) so no real network is touched. INV-6: these
+//  exercise the plain content-transfer path only — no DRM fulfillment.
+//
+
+import XCTest
+@testable import Palace
+
+final class DownloadTransferRetryTests: XCTestCase {
+
+    private var mockRegistry: TPPBookRegistryMock!
+    private var stateManager: DownloadStateManager!
+    private var center: MyBooksDownloadCenter!
+    private var tempURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("TransferRetry-\(UUID().uuidString).json")
+        mockRegistry = TPPBookRegistryMock()
+        stateManager = DownloadStateManager(taskPersistence: DownloadTaskPersistence(fileURL: tempURL))
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [NoNetworkURLProtocol.self]
+        let session = URLSession(configuration: config)
+        center = MyBooksDownloadCenter(
+            bookRegistry: mockRegistry,
+            stateManager: stateManager,
+            reachability: MockReachability(initiallyConnected: true),
+            urlSession: session
+        )
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempURL)
+        center = nil
+        stateManager = nil
+        mockRegistry = nil
+        tempURL = nil
+        super.tearDown()
+    }
+
+    private func urlError(_ code: Int) -> NSError {
+        NSError(domain: NSURLErrorDomain, code: code)
+    }
+
+    private func task(_ id: Int) -> MockURLSessionDownloadTask {
+        MockURLSessionDownloadTask(
+            taskIdentifier: id,
+            request: URLRequest(url: URL(string: "https://palace-test.invalid/retry")!))
+    }
+
+    // MARK: - maybeRetryTransientTransfer (INV-6: content transfer only)
+
+    func testTransientError_underCap_retriesAndIncrementsCounter() async {
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        await stateManager.taskIdentifierToBook.set(42, value: book)
+
+        let retried = await center.maybeRetryTransientTransfer(task: task(42), error: urlError(NSURLErrorTimedOut))
+
+        XCTAssertTrue(retried, "a transient transfer error under the cap must schedule a retry")
+        let count = await stateManager.transferRetryAttempts(for: book.identifier)
+        XCTAssertEqual(count, 1, "retry must bump the per-book attempt counter")
+    }
+
+    func testNonTransientError_isNotRetried() async {
+        // Auth-required is in the classifier's never-retry set — must fail fast
+        // into the existing alert path, not loop.
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        await stateManager.taskIdentifierToBook.set(7, value: book)
+
+        let retried = await center.maybeRetryTransientTransfer(
+            task: task(7), error: urlError(NSURLErrorUserAuthenticationRequired))
+
+        XCTAssertFalse(retried)
+        let count = await stateManager.transferRetryAttempts(for: book.identifier)
+        XCTAssertEqual(count, 0, "a non-retryable error must not touch the retry counter")
+    }
+
+    func testCancelledError_isNotRetried() async {
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        await stateManager.taskIdentifierToBook.set(8, value: book)
+
+        let retried = await center.maybeRetryTransientTransfer(task: task(8), error: urlError(NSURLErrorCancelled))
+
+        XCTAssertFalse(retried, "user/navigation cancellation must never be retried")
+    }
+
+    func testNoMappedBook_isNotRetried() async {
+        // No taskIdentifierToBook entry for this id -> nothing to retry.
+        let retried = await center.maybeRetryTransientTransfer(task: task(999), error: urlError(NSURLErrorTimedOut))
+        XCTAssertFalse(retried)
+    }
+
+    func testTransientError_atCap_stopsRetryingAndResetsCounter() async {
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        await stateManager.taskIdentifierToBook.set(9, value: book)
+        // Exhaust the cap (maxTransferRetries == 3).
+        for _ in 0..<3 { await stateManager.incrementTransferRetryAttempts(for: book.identifier) }
+
+        let retried = await center.maybeRetryTransientTransfer(task: task(9), error: urlError(NSURLErrorTimedOut))
+
+        XCTAssertFalse(retried, "at the attempt cap the retry stops and the normal failure path runs")
+        let count = await stateManager.transferRetryAttempts(for: book.identifier)
+        XCTAssertEqual(count, 0, "exhausting the cap resets the counter for future independent failures")
+    }
+
+    // MARK: - Launch reconciliation gate (INV-4 ordering)
+
+    func testIsRegistryLoadedForReconcile_trueOnlyAfterLoad() {
+        mockRegistry.state = .unloaded
+        XCTAssertFalse(center.isRegistryLoadedForReconcile, "must not reconcile before the registry loads")
+        mockRegistry.state = .loading
+        XCTAssertFalse(center.isRegistryLoadedForReconcile)
+        mockRegistry.state = .loaded
+        XCTAssertTrue(center.isRegistryLoadedForReconcile)
+        mockRegistry.state = .syncing
+        XCTAssertTrue(center.isRegistryLoadedForReconcile)
+        mockRegistry.state = .synced
+        XCTAssertTrue(center.isRegistryLoadedForReconcile)
+    }
+}

--- a/PalaceTests/MyBooks/LoanEvictionPolicyTests.swift
+++ b/PalaceTests/MyBooks/LoanEvictionPolicyTests.swift
@@ -1,0 +1,125 @@
+//
+//  LoanEvictionPolicyTests.swift
+//  PalaceTests
+//
+//  Reliability WS-C — exhaustive matrix for the INV-2 guardrail.
+//  {expired / not / no-expiry} × {online / offline} × {within / after grace}.
+//  The single most important assertion: expired + offline => .keep
+//  (never delete a downloaded file offline on a cached `until`).
+//
+
+import XCTest
+@testable import Palace
+
+final class LoanEvictionPolicyTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+    private let grace: TimeInterval = 100
+
+    // MARK: - No expiry
+
+    func testNoExpiration_online_keeps() {
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: nil, now: now, isOnline: true, grace: grace),
+            .keep)
+    }
+
+    func testNoExpiration_offline_keeps() {
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: nil, now: now, isOnline: false, grace: grace),
+            .keep)
+    }
+
+    // MARK: - Not yet expired
+
+    func testNotExpired_online_keeps() {
+        let until = now.addingTimeInterval(1000)
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: until, now: now, isOnline: true, grace: grace),
+            .keep)
+    }
+
+    func testNotExpired_offline_keeps() {
+        let until = now.addingTimeInterval(1000)
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: until, now: now, isOnline: false, grace: grace),
+            .keep)
+    }
+
+    // MARK: - Expired + OFFLINE (INV-2 — the key guard)
+
+    func testOfflineExpiredByCachedUntil_keepsFile() {
+        let until = now.addingTimeInterval(-1000) // long past
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: until, now: now, isOnline: false, grace: grace),
+            .keep,
+            "INV-2: an offline device must NEVER evict on a cached `until` alone")
+    }
+
+    func testOfflineExpiredWithinGrace_keepsFile() {
+        let until = now.addingTimeInterval(-10) // just expired
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: until, now: now, isOnline: false, grace: grace),
+            .keep)
+    }
+
+    func testOfflineExpiredPastGrace_stillKeeps() {
+        // Even well past the grace window, OFFLINE never evicts.
+        let until = now.addingTimeInterval(-10_000)
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: until, now: now, isOnline: false, grace: grace),
+            .keep)
+    }
+
+    // MARK: - Expired + ONLINE
+
+    func testOnlineExpiredWithinGrace_confirmsWithServer() {
+        let until = now.addingTimeInterval(-10) // within 100s grace
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: until, now: now, isOnline: true, grace: grace),
+            .confirmWithServer)
+    }
+
+    func testOnlineExpiredPastGrace_evicts() {
+        let until = now.addingTimeInterval(-1000) // past 100s grace
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: until, now: now, isOnline: true, grace: grace),
+            .evict)
+    }
+
+    // MARK: - Boundaries
+
+    func testOnlineExactlyAtGraceEdge_evicts() {
+        // now == until + grace  -> `now >= until+grace` is true -> evict
+        let until = now.addingTimeInterval(-grace)
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: until, now: now, isOnline: true, grace: grace),
+            .evict)
+    }
+
+    func testOnlineJustInsideGraceEdge_confirmsWithServer() {
+        // now < until + grace by 1s -> confirmWithServer
+        let until = now.addingTimeInterval(-grace + 1)
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: until, now: now, isOnline: true, grace: grace),
+            .confirmWithServer)
+    }
+
+    func testOnlineExactlyAtExpiration_withZeroGrace_evicts() {
+        // now == until, grace 0 -> now >= until -> evict
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: now, now: now, isOnline: true, grace: 0),
+            .evict)
+    }
+
+    func testExactlyAtExpiration_notPastYet_keeps() {
+        // now == until with a positive grace -> within grace -> confirmWithServer,
+        // and offline -> keep. Pin both to lock the boundary semantics.
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: now, now: now, isOnline: true, grace: grace),
+            .confirmWithServer)
+        XCTAssertEqual(
+            LoanEvictionPolicy.decide(expiration: now, now: now, isOnline: false, grace: grace),
+            .keep)
+    }
+}

--- a/PalaceTests/MyBooks/LoanRenewalServiceTests.swift
+++ b/PalaceTests/MyBooks/LoanRenewalServiceTests.swift
@@ -1,0 +1,188 @@
+//
+//  LoanRenewalServiceTests.swift
+//  PalaceTests
+//
+//  Reliability WS-C — LoanRenewalService.
+//
+//  INV-5 (auth-error host scoping): a 401 from a host OUTSIDE the current
+//  account's auth surface must NOT mark credentials stale. Reuses the
+//  AuthErrorClassifierPropertyTests Invariant-8 pattern (host-scoped
+//  provider). Also pins renew-URL extraction and the 2xx success path.
+//
+
+import XCTest
+import PalaceAuth
+import PalaceCatalog
+@testable import Palace
+
+final class LoanRenewalServiceTests: XCTestCase {
+
+    // MARK: - Spies / stubs
+
+    private final class StubPoster: RenewalPosting, @unchecked Sendable {
+        let status: Int
+        let data: Data?
+        init(status: Int, data: Data? = nil) { self.status = status; self.data = data }
+        func post(to url: URL) async -> (data: Data?, response: HTTPURLResponse?) {
+            let response = HTTPURLResponse(url: url, statusCode: status,
+                                           httpVersion: nil, headerFields: nil)
+            return (data, response)
+        }
+    }
+
+    /// Poster that fails the transport (nil response) — offline.
+    private final class OfflinePoster: RenewalPosting, @unchecked Sendable {
+        func post(to url: URL) async -> (data: Data?, response: HTTPURLResponse?) {
+            (nil, nil)
+        }
+    }
+
+    private final class StaleSpy: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _called = false
+        func mark() { lock.lock(); _called = true; lock.unlock() }
+        var called: Bool { lock.lock(); defer { lock.unlock() }; return _called }
+    }
+
+    // MARK: - Helpers
+
+    private func makeBook(identifier: String, borrowHost: String?) -> TPPBook {
+        var acquisitions: [TPPOPDSAcquisition] = []
+        if let borrowHost {
+            let url = URL(string: "https://\(borrowHost)/borrow/\(identifier)")!
+            acquisitions.append(TPPOPDSAcquisition(
+                relation: .borrow,
+                type: "application/atom+xml",
+                hrefURL: url,
+                indirectAcquisitions: [],
+                availability: TPPOPDSAcquisitionAvailabilityUnlimited()))
+        }
+        return TPPBook(
+            acquisitions: acquisitions,
+            authors: [TPPBookAuthor(authorName: "Author", relatedBooksURL: nil)],
+            categoryStrings: nil, distributor: nil, identifier: identifier,
+            imageURL: nil, imageThumbnailURL: nil, published: nil, publisher: nil,
+            subtitle: nil, summary: nil, title: "Title-\(identifier)",
+            updated: Date(timeIntervalSince1970: 0), annotationsURL: nil,
+            analyticsURL: nil, alternateURL: nil, relatedWorksURL: nil,
+            previewLink: nil, seriesURL: nil, revokeURL: nil, reportURL: nil,
+            timeTrackingURL: nil, contributors: nil, bookDuration: nil,
+            imageCache: MockImageCache())
+    }
+
+    private func makeService(
+        poster: RenewalPosting,
+        accountHosts: Set<String>,
+        staleSpy: StaleSpy
+    ) -> LoanRenewalService {
+        let classifier = AuthErrorClassifier(currentAccountHostsProvider: { accountHosts })
+        return LoanRenewalService(
+            poster: poster,
+            classifier: classifier,
+            bookRegistry: TPPBookRegistryMock(),
+            markCredentialsStale: { staleSpy.mark() })
+    }
+
+    // MARK: - Renew-URL extraction (pure)
+
+    func testRenewURL_extractsBorrowRelAcquisition() {
+        let book = makeBook(identifier: "R1", borrowHost: "our.host")
+        XCTAssertEqual(
+            LoanRenewalService.renewURL(for: book)?.absoluteString,
+            "https://our.host/borrow/R1")
+    }
+
+    func testRenewURL_noBorrowAcquisition_isNil() {
+        let book = makeBook(identifier: "R2", borrowHost: nil)
+        XCTAssertNil(LoanRenewalService.renewURL(for: book))
+    }
+
+    // MARK: - INV-5: foreign-host 401 does NOT mark credentials stale
+
+    func testForeignHost401_doesNotMarkCredentialsStale() async {
+        let staleSpy = StaleSpy()
+        // The renew URL is on `foreign.host`; the account's surface is
+        // `our.host`. A 401 from `foreign.host` is not our session.
+        let book = makeBook(identifier: "R3", borrowHost: "foreign.host")
+        let service = makeService(
+            poster: StubPoster(status: 401),
+            accountHosts: ["our.host"],
+            staleSpy: staleSpy)
+
+        let outcome = await service.renew(book: book)
+
+        XCTAssertEqual(outcome, .foreignHost401)
+        XCTAssertFalse(staleSpy.called,
+            "INV-5: a foreign-host 401 must never mark the current account's credentials stale")
+    }
+
+    func testAccountHost401_marksCredentialsStale() async {
+        let staleSpy = StaleSpy()
+        // The renew URL is on the account's own auth-surface host.
+        let book = makeBook(identifier: "R4", borrowHost: "our.host")
+        let service = makeService(
+            poster: StubPoster(status: 401),
+            accountHosts: ["our.host"],
+            staleSpy: staleSpy)
+
+        let outcome = await service.renew(book: book)
+
+        XCTAssertEqual(outcome, .reauthRequired)
+        XCTAssertTrue(staleSpy.called,
+            "A 401 from an account-surface host is a real session expiry")
+    }
+
+    // MARK: - Success / other outcomes
+
+    func testSuccess2xx_returnsSuccess_doesNotMarkStale() async {
+        let staleSpy = StaleSpy()
+        let book = makeBook(identifier: "R5", borrowHost: "our.host")
+        let service = makeService(
+            poster: StubPoster(status: 200),
+            accountHosts: ["our.host"],
+            staleSpy: staleSpy)
+
+        let outcome = await service.renew(book: book)
+
+        XCTAssertEqual(outcome, .success)
+        XCTAssertFalse(staleSpy.called)
+    }
+
+    func testNoRenewURL_returnsNoRenewURL() async {
+        let staleSpy = StaleSpy()
+        let book = makeBook(identifier: "R6", borrowHost: nil)
+        let service = makeService(
+            poster: StubPoster(status: 200),
+            accountHosts: ["our.host"],
+            staleSpy: staleSpy)
+
+        let outcome = await service.renew(book: book)
+        XCTAssertEqual(outcome, .noRenewURL)
+    }
+
+    func testOfflineTransport_returnsNetworkError() async {
+        let staleSpy = StaleSpy()
+        let book = makeBook(identifier: "R7", borrowHost: "our.host")
+        let service = makeService(
+            poster: OfflinePoster(),
+            accountHosts: ["our.host"],
+            staleSpy: staleSpy)
+
+        let outcome = await service.renew(book: book)
+        XCTAssertEqual(outcome, .networkError)
+        XCTAssertFalse(staleSpy.called)
+    }
+
+    func testServerError500_returnsFailed_doesNotMarkStale() async {
+        let staleSpy = StaleSpy()
+        let book = makeBook(identifier: "R8", borrowHost: "our.host")
+        let service = makeService(
+            poster: StubPoster(status: 500),
+            accountHosts: ["our.host"],
+            staleSpy: staleSpy)
+
+        let outcome = await service.renew(book: book)
+        XCTAssertEqual(outcome, .failed(status: 500))
+        XCTAssertFalse(staleSpy.called)
+    }
+}

--- a/PalaceTests/MyBooks/LoanRenewalServiceTests.swift
+++ b/PalaceTests/MyBooks/LoanRenewalServiceTests.swift
@@ -196,7 +196,7 @@ final class LoanRenewalServiceTests: XCTestCase {
     func testProductionFactory_foreignHost401_classifiesOk() async {
         let book = makeBook(identifier: "PF1", borrowHost: "foreign.host")
         let service = LoanRenewalService.production(
-            executor: AppContainer.production().networkExecutor,
+            executor: AppContainer.production().networkExecutor, // MIGRATED-DEFERRED: swarm_47883816 — executor is unused (test injects StubPoster); production() supplies a throwaway to satisfy the factory signature
             bookRegistry: TPPBookRegistryMock(),
             poster: StubPoster(status: 401),
             hostsProvider: { ["our.host"] })

--- a/PalaceTests/MyBooks/LoanRenewalServiceTests.swift
+++ b/PalaceTests/MyBooks/LoanRenewalServiceTests.swift
@@ -185,4 +185,24 @@ final class LoanRenewalServiceTests: XCTestCase {
         XCTAssertEqual(outcome, .failed(status: 500))
         XCTAssertFalse(staleSpy.called)
     }
+
+    // MARK: - #2 production factory is INV-5-safe
+
+    /// The production factory must build a HOST-SCOPED classifier. A
+    /// foreign-host 401 through the factory-constructed service classifies
+    /// as `.ok` (-> `.foreignHost401`) and never marks credentials stale —
+    /// proving the factory binds `currentAccountHostsProvider` rather than
+    /// leaving the unsafe `{ nil }` default that re-opens cross-host logout.
+    func testProductionFactory_foreignHost401_classifiesOk() async {
+        let book = makeBook(identifier: "PF1", borrowHost: "foreign.host")
+        let service = LoanRenewalService.production(
+            executor: AppContainer.production().networkExecutor,
+            bookRegistry: TPPBookRegistryMock(),
+            poster: StubPoster(status: 401),
+            hostsProvider: { ["our.host"] })
+
+        let outcome = await service.renew(book: book)
+        XCTAssertEqual(outcome, .foreignHost401,
+            "the production-constructed service must host-scope a foreign-host 401 to .ok")
+    }
 }

--- a/PalaceTests/MyBooks/MyBooksViewModelTests.swift
+++ b/PalaceTests/MyBooks/MyBooksViewModelTests.swift
@@ -2105,4 +2105,60 @@ final class MyBooksViewModelFacetPublisherTests: XCTestCase {
         viewModel.facetViewModel.activeSort = .title
         XCTAssertEqual(viewModel.activeFacetSort, .title)
     }
+
+    // MARK: - INV-2: offline eviction guard (Reliability WS-C)
+
+    /// The headline invariant. An expired-by-cached-`until` downloaded book
+    /// must NOT be deleted or unregistered while offline — the loans feed
+    /// can't be consulted, so the cached `until` is not authoritative.
+    func testLoadData_offline_doesNotDeleteExpiredLocalContent() {
+        let mock = TPPBookRegistryMock()
+        let past = Date(timeIntervalSinceNow: -100_000)
+        let expired = TPPBookMocker.mockBookWithLimitedAvailability(
+            identifier: "exp-off", until: past, title: "Expired Offline")
+        mock.myBooks = [expired]
+        mock.addBook(expired, state: .downloadSuccessful)
+        let appContainer = makeTestAppContainer()
+
+        // Precondition: the book is genuinely expired by its cached `until`.
+        XCTAssertTrue(expired.isExpired)
+
+        // Constructing the VM offline runs loadData() through the eviction gate.
+        let vm = MyBooksViewModel(
+            bookRegistry: mock,
+            accountsManager: appContainer.accountsManager,
+            settings: TPPSettings(),
+            downloadCenter: appContainer.downloadCenter,
+            isUserAuthorizedForRegistry: { true },
+            isOnline: { false })
+
+        XCTAssertNotEqual(mock.state(for: "exp-off"), .unregistered,
+            "INV-2: an offline expired book must NOT be unregistered")
+        XCTAssertTrue(vm.books.contains { $0.identifier == "exp-off" },
+            "INV-2: an offline expired book stays visible/readable in My Books")
+    }
+
+    /// Contrast: online + well past the grace window, eviction proceeds as
+    /// before (the loan is provably over).
+    func testLoadData_onlinePastGrace_evictsExpiredContent() {
+        let mock = TPPBookRegistryMock()
+        let past = Date(timeIntervalSinceNow: -100_000) // far past the 5-min grace
+        let expired = TPPBookMocker.mockBookWithLimitedAvailability(
+            identifier: "exp-on", until: past, title: "Expired Online")
+        mock.myBooks = [expired]
+        mock.addBook(expired, state: .downloadSuccessful)
+        let appContainer = makeTestAppContainer()
+
+        let vm = MyBooksViewModel(
+            bookRegistry: mock,
+            accountsManager: appContainer.accountsManager,
+            settings: TPPSettings(),
+            downloadCenter: appContainer.downloadCenter,
+            isUserAuthorizedForRegistry: { true },
+            isOnline: { true })
+
+        XCTAssertEqual(mock.state(for: "exp-on"), .unregistered,
+            "online + past grace: the confirmed-expired book is evicted")
+        XCTAssertFalse(vm.books.contains { $0.identifier == "exp-on" })
+    }
 }

--- a/PalaceTests/MyBooks/__Snapshots__/DownloadReconciliationLaunchOrderContractTests/launchReconciliationOrder.json
+++ b/PalaceTests/MyBooks/__Snapshots__/DownloadReconciliationLaunchOrderContractTests/launchReconciliationOrder.json
@@ -1,0 +1,32 @@
+[
+  {
+    "args" : {
+
+    },
+    "method" : "isRegistryLoaded"
+  },
+  {
+    "args" : {
+
+    },
+    "method" : "loadPersisted"
+  },
+  {
+    "args" : {
+
+    },
+    "method" : "getAllTasks"
+  },
+  {
+    "args" : {
+      "bookID" : "b"
+    },
+    "method" : "registryState"
+  },
+  {
+    "args" : {
+      "decision" : "restart(bookID: \"b\")"
+    },
+    "method" : "apply"
+  }
+]

--- a/PalaceTests/Platform/OfflineQueueCoordinatorTests.swift
+++ b/PalaceTests/Platform/OfflineQueueCoordinatorTests.swift
@@ -1,0 +1,157 @@
+//
+//  OfflineQueueCoordinatorTests.swift
+//  PalaceTests
+//
+//  Reliability WS-C — OfflineQueueCoordinator.
+//
+//  INV-8 (idempotency): a queued action deduped by bookID+type is applied
+//  at most once; a partially-succeeded action must not double-apply. Also
+//  pins the dispatch routing (type -> handler) and the failure-rollback
+//  path (a genuine failure is retryable).
+//
+
+import XCTest
+@testable import Palace
+
+final class OfflineQueueCoordinatorTests: XCTestCase {
+
+    // MARK: - Fakes
+
+    /// Records per-type invocation counts; each handler returns a
+    /// configurable success value.
+    private final class HandlerSpy: @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var returnIDs: [String] = []
+        private(set) var borrowIDs: [String] = []
+        private(set) var holdIDs: [String] = []
+        private(set) var cancelHoldIDs: [String] = []
+        var returnSucceeds = true
+
+        func handlers() -> OfflineQueueCoordinator.Handlers {
+            OfflineQueueCoordinator.Handlers(
+                performReturn: { [weak self] id in
+                    self?.lock.withLock { self?.returnIDs.append(id) }
+                    return self?.returnSucceeds ?? false
+                },
+                performBorrow: { [weak self] id in
+                    self?.lock.withLock { self?.borrowIDs.append(id) }
+                    return true
+                },
+                performHold: { [weak self] id in
+                    self?.lock.withLock { self?.holdIDs.append(id) }
+                    return true
+                },
+                performCancelHold: { [weak self] id in
+                    self?.lock.withLock { self?.cancelHoldIDs.append(id) }
+                    return true
+                })
+        }
+
+        func withLock<T>(_ body: () -> T) -> T { lock.withLock(body) }
+    }
+
+    /// Captures the executor closure installed via `setExecutor`.
+    private final class FakeRegistrar: OfflineExecutorRegistering, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _executor: OfflineActionExecutor?
+        var executor: OfflineActionExecutor? { lock.withLock { _executor } }
+        func setExecutor(_ executor: @escaping OfflineActionExecutor) async {
+            lock.withLock { _executor = executor }
+        }
+    }
+
+    private func coordinator(_ spy: HandlerSpy, queue: OfflineExecutorRegistering = FakeRegistrar())
+        -> OfflineQueueCoordinator {
+        OfflineQueueCoordinator(queue: queue, handlers: spy.handlers())
+    }
+
+    // MARK: - INV-8: dedupe
+
+    func testDuplicateReturn_isDeduped() async {
+        let spy = HandlerSpy()
+        let coord = coordinator(spy)
+
+        // Two distinct actions (different UUIDs) with the SAME bookID+type.
+        let a1 = OfflineAction(type: .return, bookID: "book-1", bookTitle: "T")
+        let a2 = OfflineAction(type: .return, bookID: "book-1", bookTitle: "T")
+
+        let r1 = await coord.execute(a1)
+        let r2 = await coord.execute(a2)
+
+        XCTAssertTrue(r1)
+        XCTAssertTrue(r2, "the deduped duplicate is reported as already-done")
+        XCTAssertEqual(spy.withLock { spy.returnIDs }, ["book-1"],
+            "INV-8: the underlying return side effect runs exactly once")
+    }
+
+    func testDifferentBooks_areNotDeduped() async {
+        let spy = HandlerSpy()
+        let coord = coordinator(spy)
+
+        _ = await coord.execute(OfflineAction(type: .return, bookID: "a", bookTitle: "A"))
+        _ = await coord.execute(OfflineAction(type: .return, bookID: "b", bookTitle: "B"))
+
+        XCTAssertEqual(spy.withLock { spy.returnIDs }, ["a", "b"])
+    }
+
+    func testSameBookDifferentType_areNotDeduped() async {
+        let spy = HandlerSpy()
+        let coord = coordinator(spy)
+
+        _ = await coord.execute(OfflineAction(type: .return, bookID: "x", bookTitle: "X"))
+        _ = await coord.execute(OfflineAction(type: .borrow, bookID: "x", bookTitle: "X"))
+
+        XCTAssertEqual(spy.withLock { spy.returnIDs }, ["x"])
+        XCTAssertEqual(spy.withLock { spy.borrowIDs }, ["x"])
+    }
+
+    // MARK: - Failure rollback (retryable)
+
+    func testFailedReturn_isRetryable_notPermanentlyDeduped() async {
+        let spy = HandlerSpy()
+        spy.returnSucceeds = false
+        let coord = coordinator(spy)
+
+        let r1 = await coord.execute(OfflineAction(type: .return, bookID: "f", bookTitle: "F"))
+        let r2 = await coord.execute(OfflineAction(type: .return, bookID: "f", bookTitle: "F"))
+
+        XCTAssertFalse(r1)
+        XCTAssertFalse(r2)
+        XCTAssertEqual(spy.withLock { spy.returnIDs }, ["f", "f"],
+            "a genuine failure rolls back the dedupe key so the queue can retry")
+    }
+
+    // MARK: - Dispatch routing
+
+    func testDispatch_routesEachTypeToItsHandler() async {
+        let spy = HandlerSpy()
+        let coord = coordinator(spy)
+
+        _ = await coord.execute(OfflineAction(type: .return, bookID: "r", bookTitle: "R"))
+        _ = await coord.execute(OfflineAction(type: .borrow, bookID: "bo", bookTitle: "Bo"))
+        _ = await coord.execute(OfflineAction(type: .hold, bookID: "h", bookTitle: "H"))
+        _ = await coord.execute(OfflineAction(type: .cancelHold, bookID: "c", bookTitle: "C"))
+
+        XCTAssertEqual(spy.withLock { spy.returnIDs }, ["r"])
+        XCTAssertEqual(spy.withLock { spy.borrowIDs }, ["bo"])
+        XCTAssertEqual(spy.withLock { spy.holdIDs }, ["h"])
+        XCTAssertEqual(spy.withLock { spy.cancelHoldIDs }, ["c"])
+    }
+
+    // MARK: - registerExecutor wiring
+
+    func testRegisterExecutor_installsWorkingExecutor() async {
+        let spy = HandlerSpy()
+        let registrar = FakeRegistrar()
+        let coord = coordinator(spy, queue: registrar)
+
+        await coord.registerExecutor()
+        let executor = try? XCTUnwrap(registrar.executor)
+        XCTAssertNotNil(executor, "setExecutor must have been called")
+
+        let ok = await executor?(OfflineAction(type: .borrow, bookID: "wired", bookTitle: "W"))
+        XCTAssertEqual(ok, true)
+        XCTAssertEqual(spy.withLock { spy.borrowIDs }, ["wired"],
+            "the installed executor dispatches through the coordinator to the handler")
+    }
+}

--- a/PalaceTests/Platform/OfflineQueueCoordinatorTests.swift
+++ b/PalaceTests/Platform/OfflineQueueCoordinatorTests.swift
@@ -26,6 +26,7 @@ final class OfflineQueueCoordinatorTests: XCTestCase {
         private(set) var holdIDs: [String] = []
         private(set) var cancelHoldIDs: [String] = []
         var returnSucceeds = true
+        var borrowSucceeds = true
 
         func handlers() -> OfflineQueueCoordinator.Handlers {
             OfflineQueueCoordinator.Handlers(
@@ -35,7 +36,7 @@ final class OfflineQueueCoordinatorTests: XCTestCase {
                 },
                 performBorrow: { [weak self] id in
                     self?.lock.withLock { self?.borrowIDs.append(id) }
-                    return true
+                    return self?.borrowSucceeds ?? false
                 },
                 performHold: { [weak self] id in
                     self?.lock.withLock { self?.holdIDs.append(id) }
@@ -136,6 +137,93 @@ final class OfflineQueueCoordinatorTests: XCTestCase {
         XCTAssertEqual(spy.withLock { spy.borrowIDs }, ["bo"])
         XCTAssertEqual(spy.withLock { spy.holdIDs }, ["h"])
         XCTAssertEqual(spy.withLock { spy.cancelHoldIDs }, ["c"])
+    }
+
+    // MARK: - #1 fail-closed borrow (must-fix)
+
+    /// A borrow whose registry never reaches an active-loan state is NOT
+    /// server-confirmed. The executor must return false (fail-closed) so the
+    /// queue keeps and retries it — a failed queued borrow must never be
+    /// marked done and dropped.
+    func testFailedBorrow_isNotMarkedDone_staysQueued() async {
+        let spy = HandlerSpy()
+        spy.borrowSucceeds = false
+        let coord = coordinator(spy)
+
+        let r1 = await coord.execute(OfflineAction(type: .borrow, bookID: "bfail", bookTitle: "B"))
+        XCTAssertFalse(r1, "an unconfirmed borrow must return false, not an optimistic true")
+
+        // Not deduped-as-done: a retry re-dispatches (the queue keeps it).
+        let r2 = await coord.execute(OfflineAction(type: .borrow, bookID: "bfail", bookTitle: "B"))
+        XCTAssertFalse(r2)
+        XCTAssertEqual(spy.withLock { spy.borrowIDs }, ["bfail", "bfail"],
+            "a failed borrow is retryable, not silently dropped")
+    }
+
+    /// The active-loan classification used by the fail-closed borrow branch.
+    func testIsActiveLoanState_confirmsOnlyBorrowedStates() {
+        for s in [TPPBookState.downloadNeeded, .downloading, .downloadSuccessful, .used] {
+            XCTAssertTrue(OfflineQueueCoordinator.isActiveLoanState(s), "\(s) should confirm a loan")
+        }
+        for s in [TPPBookState.unregistered, .downloadFailed, .holding, .returning] {
+            XCTAssertFalse(OfflineQueueCoordinator.isActiveLoanState(s), "\(s) is not a confirmed loan")
+        }
+    }
+
+    /// Hold confirmation: only `.holding` confirms a placed hold.
+    func testIsHeldState_confirmsOnlyHolding() {
+        XCTAssertTrue(OfflineQueueCoordinator.isHeldState(.holding))
+        for s in [TPPBookState.unregistered, .downloadNeeded, .downloadSuccessful, .returning] {
+            XCTAssertFalse(OfflineQueueCoordinator.isHeldState(s), "\(s) is not a confirmed hold")
+        }
+    }
+
+    /// Return confirmation: confirmed iff the registry unregistered the book
+    /// OR no longer knows it. A book still present in an active state is NOT
+    /// a confirmed return (fail-closed).
+    func testIsReturnConfirmed_requiresUnregisteredOrAbsent() {
+        XCTAssertTrue(OfflineQueueCoordinator.isReturnConfirmed(state: .unregistered, bookPresent: true))
+        XCTAssertTrue(OfflineQueueCoordinator.isReturnConfirmed(state: .downloadSuccessful, bookPresent: false))
+        XCTAssertFalse(OfflineQueueCoordinator.isReturnConfirmed(state: .downloadSuccessful, bookPresent: true),
+            "a book still present in an active state is not a confirmed return")
+        XCTAssertFalse(OfflineQueueCoordinator.isReturnConfirmed(state: .holding, bookPresent: true))
+    }
+
+    // MARK: - #4 dedupe TTL (must-fix polish)
+
+    private final class MutableClock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _now: Date
+        init(_ start: Date) { _now = start }
+        var now: Date { lock.withLock { _now } }
+        func advance(_ t: TimeInterval) { lock.withLock { _now = _now.addingTimeInterval(t) } }
+    }
+
+    /// A completed action dedupes a same-key duplicate only within the TTL;
+    /// after it elapses, a legitimate later same-type action (return ->
+    /// re-borrow -> return again) is allowed through, not silently skipped.
+    func testDedupe_completedKeyExpiresAfterTTL() async {
+        let spy = HandlerSpy()
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let coord = OfflineQueueCoordinator(
+            queue: FakeRegistrar(), handlers: spy.handlers(),
+            dedupeTTL: 100, now: { clock.now })
+
+        _ = await coord.execute(OfflineAction(type: .return, bookID: "k", bookTitle: "K"))
+        _ = await coord.execute(OfflineAction(type: .return, bookID: "k", bookTitle: "K"))
+        XCTAssertEqual(spy.withLock { spy.returnIDs }, ["k"],
+            "within TTL, the duplicate is deduped")
+
+        clock.advance(100) // exactly at the TTL edge from completion@0 -> `< ttl` false -> allowed
+        _ = await coord.execute(OfflineAction(type: .return, bookID: "k", bookTitle: "K"))
+        XCTAssertEqual(spy.withLock { spy.returnIDs }, ["k", "k"],
+            "at/after the TTL boundary the completed key no longer blocks (strict <), so a legitimate later same-type action dispatches again")
+
+        // Re-completion at t=100 refreshes the window: an immediate duplicate
+        // is deduped again (proves `complete` restamps the timestamp).
+        _ = await coord.execute(OfflineAction(type: .return, bookID: "k", bookTitle: "K"))
+        XCTAssertEqual(spy.withLock { spy.returnIDs }, ["k", "k"],
+            "within the refreshed TTL window the duplicate is deduped again")
     }
 
     // MARK: - registerExecutor wiring


### PR DESCRIPTION
## Bulletproof Ownership — reliability initiative

Closes the failures that break the core library promise: **"the book I downloaded is reliably mine for the loan period."** Three file-disjoint workstreams, each architect + QA (dual-SoD) reviewed, integrated in dependency order **B → A → C**.

The engineering foundation was already strong (atomic registry, background `URLSession`, single-flight auth) — these are policy/wiring fixes on solid primitives, so the impact-to-effort is high.

### What it fixes (the trust-breakers)

**WS-B — Registry resilience** (`BookRegistrySync` + new `RegistryFileRecovery`)
A corrupt/unparseable `registry.json` was conflated with "no file," zeroing the shelf in-memory and then overwriting the recoverable file with an empty one — a single bad write silently erased the patron's whole shelf. Now: corrupt files are **quarantined** (`registry.json.corrupt-<ts>`, original bytes preserved), recovery is attempted from an atomic `.bak` (write→fsync→rename before the primary write), an empty save over a non-empty last-good backup is **refused** without server authority (`needsRebuildFromServer` gate), and the payload carries a `schemaVersion`.

**WS-A — Durable downloads** (`DownloadStateManager`, `MyBooksDownloadCenter`, `TPPAppDelegate` bg handler, new `DownloadTaskPersistence`)
Task↔book maps were in-memory only and the background-session completion handler was wired only for audiobooks — so a download finishing while the app was suspended could be silently dropped, and a still-running background task was orphaned across app-kill. Now: the task↔book map is **persisted to disk** and reconciled on launch (pure `reconcile()` — adopt live tasks / restart dead / cleanup completed, run *after* registry load), the book background session's completion handler is **identifier-routed** and invoked-once, and the content transfer gets **transient retry** via the existing backoff (resume-data preferred, transient-only).

**WS-C — Offline-safe loans + offline-queue wiring** (`MyBooksViewModel`, `BookReturnService`, new `LoanEvictionPolicy` / `LoanRenewalService` / `OfflineQueueCoordinator`)
My Books deleted an expired loan's downloaded file on every load — **even offline, on a cached `until` date alone, with no grace and no server confirmation** (a patron on a plane lost a book they still held). And offline returns dead-ended in an alert. Now: eviction goes through the pure `LoanEvictionPolicy.decide()` — **never evicts while offline** (`guard isOnline else { return .keep }`); offline returns **enqueue** via the (previously dead) `OfflineQueueService` with no pre-emptive local cleanup; the queue executor is **fail-closed** (confirms via registry state, so a failed action stays queued and retries) and dedupes by bookID+type with a TTL. A host-scoped `LoanRenewalService` is built and safe-by-construction (production factory binds the account auth-surface hosts — INV-5).

### Safety invariants (each guarded by a named test)

- **INV-1** never overwrite a recoverable registry with an empty one — corrupt→quarantine→`.bak`-restore, empty-over-nonempty refused ✅
- **INV-2** never delete a downloaded file while offline on a cached `until` alone ✅
- **INV-3** loan-return client/server consistency — offline return enqueues, no local cleanup until server-confirmed; ordered-cleanup contract preserved ✅
- **INV-4** adopt (don't double-start / spuriously fail) live background downloads; reconcile after registry load ✅
- **INV-5** auth-error host scoping on every new network path (renewal, queued return) — foreign-host 401 never blanket-logs-out ✅
- **INV-6** DRM fulfillment path untouched ✅
- **INV-7** background completion handler invoked exactly once; audiobook route intact ✅
- **INV-8** offline-queue idempotency — no duplicate side effects ✅

### Evidence

- **Dual-SoD review (all six APPROVED):** WS-B `rev_a779abeb`/`rev_ae57f2b3`, WS-A `rev_a4d4eac3`/`rev_a9853e1f`, WS-C `rev_ab1d6bb0`/`rev_aa885020` (architect + qa each; agent transcripts).
- **Mutation:** RegistryFileRecovery 100%, BookRegistrySync 100% (diff), DownloadTaskPersistence 100%, MyBooksDownloadCenter 80% (3 structural survivors), LoanEvictionPolicy 100%, LoanRenewalService 100%, BookReturnService 100%.
- **Contract snapshots:** new `offlineError_enqueues_noLocalCleanup` (enqueue, no delete) + launch-reconciliation order; existing BookReturn/Borrow snapshots undrifted.
- Full architect workstream plan + 8-invariant contract at `.forgeos/reliability-plan.md`.

### Deferred (fast follow-up, not in this PR)

- **Renew UI affordance** — `LoanRenewalService` is built + tested + safe-by-construction (production factory) but has no user entry point yet; wiring it into a BookDetail/MyBooks action is a small follow-up that touches UI, kept out of this reliability PR.
- Client-scheduled loan-expiry warnings; the `.borrow`/`.hold` *enqueue* paths (executor branches are present and fail-closed, but nothing enqueues them yet — safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
