### PR TITLE
feat(audiobooks): dismiss + collapse affordances for the persistent mini-player

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		3CB70F18B23A8A0BD17C91DA /* StreamingReaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7846827A6CC273AC21EFC4D0 /* StreamingReaderViewController.swift */; };
 		3CB7B4CE4126E40FDB6D54FC /* URLSessionStubbingResetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A963381EB27A2A8D0EFF8AB /* URLSessionStubbingResetTests.swift */; };
 		3CC7207CA0819A75DDE8D1F2 /* BadgesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55ABB7E13EF5B68C8635A58F /* BadgesViewModel.swift */; };
+		3CC8768E15C49F3155BE9C13 /* AudiobookCollapsedPillViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD915CEAF8971A45C83A512 /* AudiobookCollapsedPillViewTests.swift */; };
 		3CCEFB38AC674ECBAA6018BA /* CarPlayTemplateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B6CFD936164F32A7FD6A84 /* CarPlayTemplateManager.swift */; };
 		3CF91B08EF557AF27DD6323F /* TPPUserAccount+TPPUserAccountReadingWriting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA2444F7FCEF34F2D7BE23B /* TPPUserAccount+TPPUserAccountReadingWriting.swift */; };
 		3DDF3224DA8EDA75AA1FA64F /* TPPProblemReportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB1E4A5E6A1E450001D2751 /* TPPProblemReportViewController.swift */; };
@@ -1166,6 +1167,7 @@
 		CD15B16BF2F6CATPROBBD02 /* CatalogProblemDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD15B16AF2F6CATPROBFR02 /* CatalogProblemDocumentTests.swift */; };
 		CD15B16BF3F6CATLANEBD03 /* CatalogLaneAssemblyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD15B16AF3F6CATLANEFR03 /* CatalogLaneAssemblyTests.swift */; };
 		CD15B16BF4F6CATKEYIBD04 /* CatalogCacheKeyAndIsolationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD15B16AF4F6CATKEYIFR04 /* CatalogCacheKeyAndIsolationTests.swift */; };
+		CD40A1E825BE2ECE6CF13C2E /* AudiobookCollapsedPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0AED046757125924F6FF13D /* AudiobookCollapsedPillView.swift */; };
 		CD4E1D9ADBC4CF7A4614111C /* StreamingReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7955F7FD669DC987C9238D /* StreamingReaderViewModel.swift */; };
 		CD666F12EA5723110B343D96 /* TokenRefreshInterceptorAuthCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7EB324FFEC1D9BBC05AECF1 /* TokenRefreshInterceptorAuthCoordinatorTests.swift */; };
 		CDE41C3AEC1783FB1D454686 /* CrossFormatMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFD104EE843356CD66327E6 /* CrossFormatMappingTests.swift */; };
@@ -1614,6 +1616,7 @@
 		E5LOGTEST012F0A10000003 /* DeviceLogCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5LOGTEST012F0A10000002 /* DeviceLogCollectorTests.swift */; };
 		E5LOGTEST012F0A10000005 /* LogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5LOGTEST012F0A10000004 /* LogTests.swift */; };
 		E5LOGTEST012F0A10000007 /* ErrorLogExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5LOGTEST012F0A10000006 /* ErrorLogExporterTests.swift */; };
+		E607758A3DFCF7C270D2101B /* AudiobookCollapsedPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0AED046757125924F6FF13D /* AudiobookCollapsedPillView.swift */; };
 		E607991CDD7271F36FC99A67 /* FloatTPPAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807EEB2577D3B011EA278AB8 /* FloatTPPAdditionsTests.swift */; };
 		E6207B652118973800864143 /* TPPAppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6207B642118973800864143 /* TPPAppTheme.swift */; };
 		E627A2F1085C9FD98C8BC588 /* TriageBotSupportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C540202A7A2D7469AEF27B82 /* TriageBotSupportView.swift */; };
@@ -2499,6 +2502,7 @@
 		6A72A97BA91A0EB66D642A06 /* ActiveSessionsViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActiveSessionsViewModelTests.swift; sourceTree = "<group>"; };
 		6C493684B84FF9EDBEBCD104 /* MockCredentialsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCredentialsProvider.swift; sourceTree = "<group>"; };
 		6C7A26344806FE3471C298DF /* PositionSyncTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PositionSyncTests.swift; sourceTree = "<group>"; };
+		6CD915CEAF8971A45C83A512 /* AudiobookCollapsedPillViewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookCollapsedPillViewTests.swift; sourceTree = "<group>"; };
 		6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceCheckPropertyTests.swift; sourceTree = "<group>"; };
 		6CFCFF5C7BF41D65666565EC /* OPDSFeedServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDSFeedServiceTests.swift; sourceTree = "<group>"; };
 		6D3E99EDF9AFB815A1AEDE68 /* PalaceWiringTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalaceWiringTestCase.swift; sourceTree = "<group>"; };
@@ -3030,6 +3034,7 @@
 		E037F85949A0ED4B82C40B3F /* SearchAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchAccessibilityTests.swift; sourceTree = "<group>"; };
 		E0A2B3C4D5E6F7A8B9C0D1E2 /* DownloadStartDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadStartDispatcher.swift; sourceTree = "<group>"; };
 		E0A5B6C7D8E9F0A1B2C3D4E5 /* DownloadStartDispatcherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadStartDispatcherTests.swift; sourceTree = "<group>"; };
+		E0AED046757125924F6FF13D /* AudiobookCollapsedPillView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookCollapsedPillView.swift; sourceTree = "<group>"; };
 		E1A2B3C4D5E6F7A8B9C0D1E2 /* EPUBSearchViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EPUBSearchViewModelTests.swift; sourceTree = "<group>"; };
 		E1BBD43B97F3465E8AF2D60C /* NotificationTokenRegistrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationTokenRegistrationTests.swift; sourceTree = "<group>"; };
 		E1F2A3B4C5D6078900000001 /* MyBooksDownloadErrorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadErrorInfo.swift; sourceTree = "<group>"; };
@@ -4243,6 +4248,7 @@
 				5B500DE51F6502CF4983A267 /* AudiobookMiniPlayerView.swift */,
 				0F4A943502B7E2966FF50B0D /* AudiobookFullPlayerCoverContainer.swift */,
 				EA0E5A429454281B98614AA0 /* IsReaderActiveTrackingModifier.swift */,
+				E0AED046757125924F6FF13D /* AudiobookCollapsedPillView.swift */,
 			);
 			path = AppInfrastructure;
 			sourceTree = "<group>";
@@ -5561,6 +5567,7 @@
 				F4F19EF78203942EF0C864E9 /* AudiobookFullPlayerCoverContainerTests.swift */,
 				0D614C1396A316960F405535 /* IsReaderActiveTrackingModifierTests.swift */,
 				F3E2541AFE374BC6F841E19E /* AppTabHostMiniPlayerIntegrationTests.swift */,
+				6CD915CEAF8971A45C83A512 /* AudiobookCollapsedPillViewTests.swift */,
 			);
 			path = AppInfrastructure;
 			sourceTree = "<group>";
@@ -7705,6 +7712,7 @@
 				38D7F7CC34A4DFE23CA48CF5 /* LoanEvictionPolicyTests.swift in Sources */,
 				307510DEB0B0D7968310D0F1 /* LoanRenewalServiceTests.swift in Sources */,
 				86E78D8C26A06F97B310B1F1 /* OfflineQueueCoordinatorTests.swift in Sources */,
+				3CC8768E15C49F3155BE9C13 /* AudiobookCollapsedPillViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8266,6 +8274,7 @@
 				A5558892DBA894A001DE2F51 /* LoanEvictionPolicy.swift in Sources */,
 				C69957A9F5F137315389B9D1 /* LoanRenewalService.swift in Sources */,
 				FCC8A9905AF17077021995B7 /* OfflineQueueCoordinator.swift in Sources */,
+				E607758A3DFCF7C270D2101B /* AudiobookCollapsedPillView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8830,6 +8839,7 @@
 				E510BDCAF453CCCAE05C1B17 /* LoanEvictionPolicy.swift in Sources */,
 				17E56200137D997D9F5E32F4 /* LoanRenewalService.swift in Sources */,
 				585DADC5503DE0B1F64E227A /* OfflineQueueCoordinator.swift in Sources */,
+				CD40A1E825BE2ECE6CF13C2E /* AudiobookCollapsedPillView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -144,9 +144,57 @@ struct AppTabHostView: View {
         ZStack(alignment: .bottom) {
             tabViewContent
             persistentFullPlayerOverlay
+            collapsedPillOverlay
             SentimentGateView(presenter: ratingPromptPresenter)
         }
     }
+
+    /// The compact floating pill shown when the user has collapsed the
+    /// mini-bar (`presenter.isCollapsed == true`). Mounted as a bottom-
+    /// trailing overlay at the ZStack root — NOT a `.safeAreaInset` like the
+    /// mini-bar — so it floats over content without reserving full-width
+    /// height or pushing the tab content up. Pinned above the tab bar via
+    /// `pillBottomInset`. Gated behind the same feature flag as the mini-bar
+    /// so the flag flip removes all three player surfaces together.
+    @ViewBuilder
+    private var collapsedPillOverlay: some View {
+        if inAppPlaybackNavEnabled,
+           AudiobookCollapsedPillView.shouldShow(
+               hasActiveSession: audiobookSessionPresenter.hasActiveSession,
+               isReaderActive: audiobookSessionPresenter.isReaderActive,
+               isCollapsed: audiobookSessionPresenter.isCollapsed) {
+            // GeometryReader so the bottom inset is DERIVED from the device's
+            // real bottom safe-area inset (home indicator) rather than a magic
+            // constant — a hardcoded value floats too high on non-notched
+            // devices (iPhone SE: no home indicator) and can clip the tab bar
+            // on others. `ignoresSafeArea()` lets the reader report the true
+            // insets; our explicit padding then positions the pill.
+            GeometryReader { geo in
+                AudiobookCollapsedPillView(
+                    presenter: audiobookSessionPresenter,
+                    audiobookSession: appContainer.audiobookSession
+                )
+                .padding(.trailing, 16)
+                .padding(.bottom, geo.safeAreaInsets.bottom + Self.tabBarHeight + Self.pillMargin)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+            }
+            .ignoresSafeArea()
+            // Scale + fade in from the corner (paired with the mini-bar's
+            // slide-out) rather than popping.
+            .transition(.scale(scale: 0.6, anchor: .bottomTrailing).combined(with: .opacity))
+            .accessibleAnimation(PalaceMotion.standard, value: audiobookSessionPresenter.isCollapsed)
+        }
+    }
+
+    /// Standard `UITabBar` height (points) the floating pill must clear. The
+    /// device's variable home-indicator inset is added on top at runtime via
+    /// `GeometryReader.safeAreaInsets.bottom`, so only the fixed tab-bar height
+    /// lives here. NOTE: the exact resting position is a best-effort default —
+    /// it has NOT yet been visually confirmed on-device (the live simdrive pass
+    /// is deferred; see the PR's "Not done"). Refine after that pass if needed.
+    private static let tabBarHeight: CGFloat = 49
+    /// Breathing room between the pill and the tab bar.
+    private static let pillMargin: CGFloat = 12
 
     /// Persistent full-player overlay — keeps the toolkit's
     /// `AudiobookPlayerView` mounted across minimize/expand cycles so its

--- a/Palace/AppInfrastructure/AudiobookCollapsedPillView.swift
+++ b/Palace/AppInfrastructure/AudiobookCollapsedPillView.swift
@@ -1,0 +1,134 @@
+//
+//  AudiobookCollapsedPillView.swift
+//  Palace
+//
+//  The compact "collapsed" form of the root-level audiobook player. When the
+//  user swipes the mini-bar down (`AudiobookMiniPlayerView` →
+//  `presenter.collapse()`), the full-width bar is replaced by this small
+//  floating capsule pinned bottom-trailing above the tab bar. Playback keeps
+//  running — collapsing is strictly a chrome change.
+//
+//  Interaction:
+//    - Tap the cover thumbnail → `presenter.restoreFromCollapsed()` brings the
+//      full mini-bar back. (Same "tap the artwork to open the player" idiom
+//      the mini-bar uses for expand.)
+//    - Tap the play/pause glyph → `audiobookSession.togglePlayPause()`, so the
+//      user retains transport control without restoring the whole bar.
+//
+//  This is the third state on the now-playing surface's two axes:
+//    full player  ⇄  mini-bar  ⇄  collapsed pill        (+ hard dismiss `✕`)
+//                    isPlayerExpanded   isCollapsed
+//
+//  Visibility predicate is the exact complement of
+//  `AudiobookMiniPlayerView.shouldShowChrome` on the collapsed axis:
+//  `hasActiveSession && !isReaderActive && isCollapsed`. Extracted `static`
+//  for the same mutation-testability reason (SwiftUI bodies are opaque).
+//
+//  Copyright (c) 2026 The Palace Project. All rights reserved.
+//
+
+import PalaceAudiobookToolkit
+import SwiftUI
+import UIKit
+
+@MainActor
+struct AudiobookCollapsedPillView: View {
+
+    @ObservedObject var presenter: AudiobookSessionPresenter
+
+    /// Session manager used for the pill's play/pause control. Injected so
+    /// tests can substitute a `SpyShimSession` — same seam the mini-bar uses.
+    let audiobookSession: AudiobookSessionManaging
+
+    /// Pure visibility predicate — the complement of
+    /// `AudiobookMiniPlayerView.shouldShowChrome` on the `isCollapsed` axis.
+    /// The pill shows iff there's an active session, we're not in a reader,
+    /// AND the user has collapsed the bar. Extracted `static` so the
+    /// `&&` / `!` operators are mutation-testable directly.
+    static func shouldShow(hasActiveSession: Bool, isReaderActive: Bool, isCollapsed: Bool) -> Bool {
+        return hasActiveSession && !isReaderActive && isCollapsed
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            coverThumbnail
+                .contentShape(Rectangle())
+                .onTapGesture { restore() }
+            playPauseButton
+        }
+        .padding(6)
+        .background(.ultraThinMaterial, in: Capsule())
+        .overlay(
+            Capsule().strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.15), radius: 8, y: 2)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(Strings.Generic.restoreAudiobookPlayerHint)
+    }
+
+    // MARK: - Subviews
+
+    // Split the if/else into its own `@ViewBuilder` var WITHOUT a `Group`
+    // wrapper, then apply frame/clip in this wrapper — same shape the
+    // mini-player uses to dodge Xcode 26's `Group`-modifier CodingKey
+    // mis-inference (see `AudiobookMiniPlayerView.coverImageOrPlaceholder`).
+    @ViewBuilder
+    private var coverThumbnail: some View {
+        coverThumbnailImage
+            .frame(width: 36, height: 36)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private var coverThumbnailImage: some View {
+        if let cover = presenter.coverImage {
+            Image(uiImage: cover)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else {
+            Image(systemName: "book.closed")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .foregroundStyle(.secondary)
+                .padding(7)
+        }
+    }
+
+    private var playPauseButton: some View {
+        Button(action: { audiobookSession.togglePlayPause() }) {
+            Image(systemName: presenter.isPlaying ? "pause.fill" : "play.fill")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .padding(12)
+                .frame(width: 40, height: 40)
+                .contentTransition(.symbolEffect(.replace))
+                .accessibleAnimation(PalaceMotion.standard, value: presenter.isPlaying)
+        }
+        .buttonStyle(.plain)
+        .tint(.accentColor)
+        .accessibilityLabel(presenter.isPlaying ? Strings.Generic.pauseAudiobook : Strings.Generic.playAudiobook)
+    }
+
+    // MARK: - Actions
+
+    /// Restores the full mini-bar from the pill, honoring reduce-motion.
+    private func restore() {
+        if UIAccessibility.isReduceMotionEnabled {
+            presenter.restoreFromCollapsed()
+        } else {
+            withAnimation(PalaceMotion.standard) { presenter.restoreFromCollapsed() }
+        }
+        if UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .layoutChanged, argument: nil)
+        }
+    }
+
+    // MARK: - Derived
+
+    private var accessibilityLabel: String {
+        let title = presenter.currentBook?.title ?? ""
+        return String(format: Strings.Generic.nowPlayingCompactLabel, title)
+    }
+}

--- a/Palace/AppInfrastructure/AudiobookMiniPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMiniPlayerView.swift
@@ -56,13 +56,22 @@ struct AudiobookMiniPlayerView: View {
     /// cache. Production wires this to `appContainer.audiobookSession`.
     let audiobookSession: AudiobookSessionManaging
 
+    /// Guards against a rapid double-tap on `✕` enqueuing two teardowns: the
+    /// button stays mounted until `hasActiveSession` flips false (after the
+    /// async `stopPlayback` completes), so without this a second tap in that
+    /// window would fire a second `stopPlayback`. `stopPlayback` is idempotent,
+    /// but one teardown is the correct contract.
+    @State private var isDismissing = false
+
     @ViewBuilder
     var body: some View {
         // SwiftUI.Group + explicit else: Xcode 26's type-checker otherwise
         // mis-picks a Group initializer (CodingKey cascade) for an if-without-
         // else inside a modified Group.
         SwiftUI.Group {
-            if Self.shouldShowChrome(hasActiveSession: presenter.hasActiveSession, isReaderActive: presenter.isReaderActive) {
+            if Self.shouldShowChrome(hasActiveSession: presenter.hasActiveSession,
+                                     isReaderActive: presenter.isReaderActive,
+                                     isCollapsed: presenter.isCollapsed) {
                 miniPlayerChrome
                     // Slide in/out from the bottom (paired with a fade) instead
                     // of popping when a session starts/ends or a reader opens.
@@ -73,7 +82,8 @@ struct AudiobookMiniPlayerView: View {
         }
         .accessibleAnimation(PalaceMotion.standard,
                              value: Self.shouldShowChrome(hasActiveSession: presenter.hasActiveSession,
-                                                          isReaderActive: presenter.isReaderActive))
+                                                          isReaderActive: presenter.isReaderActive,
+                                                          isCollapsed: presenter.isCollapsed))
     }
 
     /// Pure decision predicate extracted for unit testability —
@@ -81,9 +91,12 @@ struct AudiobookMiniPlayerView: View {
     /// SwiftUI bodies are opaque and the test can only read the
     /// flags it set. The static fn makes the truth table directly
     /// testable. §7.3 Option α — mini-player visible iff session active
-    /// AND not in a reader.
-    static func shouldShowChrome(hasActiveSession: Bool, isReaderActive: Bool) -> Bool {
-        return hasActiveSession && !isReaderActive
+    /// AND not in a reader AND not collapsed to the pill (`isCollapsed`
+    /// hands off to `AudiobookCollapsedPillView` — see that view's
+    /// `shouldShow` predicate, which is the exact complement on the
+    /// collapsed axis).
+    static func shouldShowChrome(hasActiveSession: Bool, isReaderActive: Bool, isCollapsed: Bool) -> Bool {
+        return hasActiveSession && !isReaderActive && !isCollapsed
     }
 
     // MARK: - Chrome
@@ -103,6 +116,7 @@ struct AudiobookMiniPlayerView: View {
                 skipBackButton
                 playPauseButton
                 skipForwardButton
+                dismissButton
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
@@ -110,6 +124,12 @@ struct AudiobookMiniPlayerView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.ultraThinMaterial)
+        // Swipe the bar DOWN to collapse it to the compact floating pill
+        // (playback keeps running). Paired with the visible `✕` button that
+        // performs the hard dismiss — same discoverability lesson the full
+        // player learned (a gesture alone wasn't discoverable, so we ship
+        // both a gesture AND a visible control).
+        .gesture(swipeDownToCollapse)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint(Strings.Generic.expandPlayerHint)
@@ -221,6 +241,89 @@ struct AudiobookMiniPlayerView: View {
         .buttonStyle(.plain)
         .tint(.accentColor)
         .accessibilityLabel(Strings.Generic.skipForward30)
+    }
+
+    /// The `✕` hard-dismiss control. Unlike the swipe-down collapse (which
+    /// only tucks the bar into the pill and keeps audio playing), this ENDS
+    /// the session: `stopPlayback(dismissPhoneUI: true, persistFinalPosition:
+    /// true)` saves the final position, tears down the toolkit player, and —
+    /// via `dismissPlayerOnPhone` → `clearActiveSession()` — drops both the
+    /// mini-bar and the pill. Re-opening the book resumes from the saved
+    /// position. Rendered with a secondary tint + smaller glyph so it reads
+    /// as the low-frequency destructive action, not a transport control.
+    private var dismissButton: some View {
+        Button(action: dismiss) {
+            Image(systemName: "xmark")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .padding(14)
+                .frame(width: 44, height: 44)
+        }
+        .buttonStyle(.plain)
+        .tint(.secondary)
+        .accessibilityLabel(Strings.Generic.stopAudiobook)
+    }
+
+    /// Swipe DOWN on the bar → collapse to the pill. Mirrors the full
+    /// player's `swipeDownToMinimize` shape (drag with a directional +
+    /// horizontal-drift threshold) but drives `presenter.collapse()` instead
+    /// of `minimize()`. Threshold is smaller than the full player's 100pt
+    /// because the mini-bar is only ~60pt tall — a 100pt swipe would overshoot
+    /// the bar entirely before registering.
+    private var swipeDownToCollapse: some Gesture {
+        DragGesture(minimumDistance: 10, coordinateSpace: .local)
+            .onEnded { value in
+                handleCollapseDragEnd(translation: value.translation)
+            }
+    }
+
+    /// Test-visible drag-end handler — takes a raw `CGSize` so unit tests can
+    /// drive the boundary without spinning up a real `DragGesture`. Collapses
+    /// (honoring reduce-motion) iff the drag clears the pure `shouldCollapse`
+    /// threshold.
+    func handleCollapseDragEnd(translation: CGSize) {
+        guard Self.shouldCollapse(translation: translation) else { return }
+        if UIAccessibility.isReduceMotionEnabled {
+            presenter.collapse()
+        } else {
+            withAnimation(PalaceMotion.standard) { presenter.collapse() }
+        }
+    }
+
+    /// Downward-drag threshold (points) past which a swipe collapses the bar.
+    /// Smaller than the full player's 100pt (the bar is short).
+    static let collapseSwipeDownThreshold: CGFloat = 44
+
+    /// Max horizontal drift before a downward swipe stops counting as
+    /// "vertical" — filters diagonal scrolls, same contract as the full
+    /// player's `minimizeSwipeMaxHorizontalDrift`.
+    static let collapseSwipeMaxHorizontalDrift: CGFloat = 60
+
+    /// Pure collapse decision: a downward drag past the threshold with limited
+    /// horizontal drift. Extracted `static` so the `&&` / `>` / `<` operators
+    /// are mutation-testable without a SwiftUI host — the view body is opaque.
+    static func shouldCollapse(translation: CGSize) -> Bool {
+        return translation.height > collapseSwipeDownThreshold
+            && abs(translation.width) < collapseSwipeMaxHorizontalDrift
+    }
+
+    /// Fires the hard dismiss. `stopPlayback` is `async`, so we hop onto a
+    /// `Task` (the `@MainActor` context is preserved). The manager's
+    /// teardown clears the presenter, so no explicit UI mutation is needed
+    /// here — the bar/pill drop when `hasActiveSession` flips false.
+    private func dismiss() {
+        guard !isDismissing else { return }
+        isDismissing = true
+        Task { await performDismiss() }
+    }
+
+    /// The awaitable teardown the `✕` button drives. Split from `dismiss()`
+    /// (which only wraps it in a `Task` + double-tap guard) so tests can
+    /// `await` it directly and pin the exact arguments — `persistFinalPosition:
+    /// true` so re-opening resumes, `dismissPhoneUI: true` so the phone chrome
+    /// tears down.
+    func performDismiss() async {
+        await audiobookSession.stopPlayback(dismissPhoneUI: true, persistFinalPosition: true)
     }
 
     private var scrubber: some View {

--- a/Palace/Audiobooks/AudiobookSessionPresenter.swift
+++ b/Palace/Audiobooks/AudiobookSessionPresenter.swift
@@ -135,6 +135,21 @@ class AudiobookSessionPresenter: ObservableObject {
     /// can drive it directly.
     @Published var isReaderActive: Bool = false
 
+    /// True when the user has collapsed the mini-player down to the compact
+    /// floating pill (`AudiobookCollapsedPillView`). This is a SEPARATE axis
+    /// from `isPlayerExpanded`:
+    ///   - `isPlayerExpanded` is the full-player ⇄ mini-bar axis.
+    ///   - `isCollapsed` is the mini-bar ⇄ pill axis.
+    /// When `isCollapsed == true`, `AppTabHostView` renders the pill instead
+    /// of the full mini-bar; **playback keeps running** — collapsing is
+    /// strictly a chrome change, unlike the `✕` dismiss which tears the
+    /// session down via `stopPlayback`. Only reachable from the mini-bar
+    /// (swipe-down → `collapse()`); tapping the pill restores it
+    /// (`restoreFromCollapsed()`). Reset to false on every path that shows
+    /// the full chrome (`expand()`, `minimize()`, `presentOnFirstOpen()`,
+    /// `clearActiveSession()`) so the pill state is never stale.
+    @Published var isCollapsed: Bool = false
+
     // MARK: - Private state
 
     private let sessionManager: AudiobookSessionManaging
@@ -170,12 +185,17 @@ class AudiobookSessionPresenter: ObservableObject {
     /// `.forgeos/swarms/swarm_0b7616e7/contracts/C-AudiobookSessionPresenter-and-Migration.md`.
     func presentOnFirstOpen() {
         isPlayerExpanded = true
+        // A fresh open always shows the full chrome — never the leftover
+        // pill from a previously-collapsed session.
+        isCollapsed = false
     }
 
     /// Tap-on-mini-player entry point. Sets `isPlayerExpanded = true` so
     /// the root fullScreenCover shows the full player.
     func expand() {
         isPlayerExpanded = true
+        // Expanding to the full player supersedes the collapsed pill state.
+        isCollapsed = false
     }
 
     /// Swipe-down-on-full-player or CarPlay-disconnect entry point. Sets
@@ -184,6 +204,23 @@ class AudiobookSessionPresenter: ObservableObject {
     /// strictly a UI dismiss.
     func minimize() {
         isPlayerExpanded = false
+        // Returning from the full player always lands on the full mini-bar,
+        // not the pill — so a prior collapse doesn't survive an expand cycle.
+        isCollapsed = false
+    }
+
+    /// Swipe-down-on-mini-bar entry point. Collapses the full mini-bar to
+    /// the compact floating pill (`AudiobookCollapsedPillView`). Playback
+    /// keeps running — this is strictly a chrome change, distinct from the
+    /// `✕` dismiss which calls `stopPlayback`. Idempotent.
+    func collapse() {
+        isCollapsed = true
+    }
+
+    /// Tap-on-pill entry point. Restores the full mini-bar from the compact
+    /// pill. Playback is unaffected. Idempotent.
+    func restoreFromCollapsed() {
+        isCollapsed = false
     }
 
     /// Called by the session manager's `dismissPlayerOnPhone` path
@@ -204,6 +241,7 @@ class AudiobookSessionPresenter: ObservableObject {
         currentBook = nil
         hasActiveSession = false
         isPlayerExpanded = false
+        isCollapsed = false
         isPlaying = false
         coverImage = nil
         progress.currentLocation = nil

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -190,6 +190,19 @@ struct Strings {
             "Expands the full audiobook player",
             comment: "VoiceOver hint announced for the audiobook mini-player explaining that tapping expands the full player"
         )
+        // Accessibility - Audiobook mini-player dismiss + collapse
+        static let stopAudiobook = NSLocalizedString(
+            "Stop audiobook",
+            comment: "VoiceOver: X button on the audiobook mini-player. Stops playback, saves the position, and dismisses the player."
+        )
+        static let nowPlayingCompactLabel = NSLocalizedString(
+            "Now playing: %@",
+            comment: "VoiceOver: Accessibility label for the collapsed audiobook pill; %@ is the book title"
+        )
+        static let restoreAudiobookPlayerHint = NSLocalizedString(
+            "Shows the full audiobook player controls",
+            comment: "VoiceOver hint announced for the collapsed audiobook pill explaining that tapping restores the full mini-player"
+        )
 
         // Accessibility - EPUB Reader (Full Keyboard Access)
         static let bookReader = NSLocalizedString("Book reader", comment: "VoiceOver: Accessibility label for the book reading area")

--- a/PalaceTests/AppInfrastructure/AudiobookCollapsedPillViewTests.swift
+++ b/PalaceTests/AppInfrastructure/AudiobookCollapsedPillViewTests.swift
@@ -1,0 +1,124 @@
+//
+//  AudiobookCollapsedPillViewTests.swift
+//  PalaceTests
+//
+//  Visibility predicate, restore-wiring, and play/pause-wiring for the
+//  compact floating pill that replaces the mini-bar when the user collapses
+//  it. Same test posture as `AudiobookMiniPlayerViewTests` — no SwiftUI host
+//  harness in the repo, so we pin the static predicate + the injected-
+//  dependency call routing via the spy presenter / spy session.
+//
+//  Copyright (c) 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+import UIKit
+import PalaceAudiobookToolkit
+@testable import Palace
+
+@MainActor
+final class AudiobookCollapsedPillViewTests: XCTestCase {
+
+    private var spyPresenter: SpyAudiobookSessionPresenter!
+    private var spySession: SpyShimSession!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        spyPresenter = SpyAudiobookSessionPresenter()
+        spySession = SpyShimSession()
+    }
+
+    override func tearDown() async throws {
+        spyPresenter = nil
+        spySession = nil
+        try await super.tearDown()
+    }
+
+    private func makeSUT() -> AudiobookCollapsedPillView {
+        return AudiobookCollapsedPillView(presenter: spyPresenter, audiobookSession: spySession)
+    }
+
+    // MARK: - Visibility predicate (mutation-killing)
+
+    /// `shouldShow` is the exact complement of the mini-bar's
+    /// `shouldShowChrome` on the collapsed axis: the pill shows iff active +
+    /// not-in-reader + collapsed. The truth table pins every operator.
+    func testShouldShow_truthTable_killsBooleanMutations() {
+        // Happy path: active + no reader + collapsed → SHOW pill.
+        XCTAssertTrue(AudiobookCollapsedPillView.shouldShow(hasActiveSession: true, isReaderActive: false, isCollapsed: true),
+                      "active + no reader + collapsed → must SHOW the pill (happy path)")
+
+        // Not collapsed → HIDE (the mini-bar is showing instead). KEY ROW:
+        // dropping the `isCollapsed` term flips this true → bar + pill both show.
+        XCTAssertFalse(AudiobookCollapsedPillView.shouldShow(hasActiveSession: true, isReaderActive: false, isCollapsed: false),
+                       "active + not collapsed → must HIDE the pill (the full bar is showing). Kills a dropped `isCollapsed` term.")
+
+        // Reader active → HIDE even when collapsed (reader suppression wins).
+        XCTAssertFalse(AudiobookCollapsedPillView.shouldShow(hasActiveSession: true, isReaderActive: true, isCollapsed: true),
+                       "reader active → must HIDE the pill regardless of collapse. Kills a dropped `!isReaderActive`.")
+
+        // No session → HIDE even when collapsed. Distinguishes && from ||.
+        XCTAssertFalse(AudiobookCollapsedPillView.shouldShow(hasActiveSession: false, isReaderActive: false, isCollapsed: true),
+                       "no session → must HIDE the pill. KEY ROW: distinguishes `&&` from `||`.")
+    }
+
+    /// The pill and the mini-bar are mutually exclusive for the same active,
+    /// not-in-reader state — exactly one is visible, toggled by `isCollapsed`.
+    func testPillAndBar_areMutuallyExclusive_onCollapsedAxis() {
+        let collapsed = true
+        let barWhenCollapsed = AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: collapsed)
+        let pillWhenCollapsed = AudiobookCollapsedPillView.shouldShow(hasActiveSession: true, isReaderActive: false, isCollapsed: collapsed)
+        XCTAssertNotEqual(barWhenCollapsed, pillWhenCollapsed,
+                          "When collapsed: pill shows, bar hides — never both")
+
+        let barWhenExpanded = AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false)
+        let pillWhenExpanded = AudiobookCollapsedPillView.shouldShow(hasActiveSession: true, isReaderActive: false, isCollapsed: false)
+        XCTAssertNotEqual(barWhenExpanded, pillWhenExpanded,
+                          "When not collapsed: bar shows, pill hides — never both")
+    }
+
+    // MARK: - Restore wiring
+
+    /// Tapping the pill's cover restores the full mini-bar via
+    /// `presenter.restoreFromCollapsed()` — and does NOT stop playback.
+    func testPill_restore_callsRestoreFromCollapsed_withoutStoppingPlayback() {
+        spyPresenter.collapse()
+        XCTAssertTrue(spyPresenter.isCollapsed, "PRECONDITION: collapsed")
+        let restoresBefore = spyPresenter.restoreFromCollapsedCallCount
+
+        // Drive the production seam the cover's tap gesture invokes.
+        spyPresenter.restoreFromCollapsed()
+
+        XCTAssertEqual(spyPresenter.restoreFromCollapsedCallCount, restoresBefore + 1,
+                       "Tapping the pill must call restoreFromCollapsed() to bring the full bar back")
+        XCTAssertFalse(spyPresenter.isCollapsed, "Presenter must leave the collapsed state after restore")
+        XCTAssertEqual(spySession.stopPlaybackCallCount, 0,
+                       "Restoring must NOT stop playback — the pill keeps audio running")
+    }
+
+    // MARK: - Play/pause wiring
+
+    /// The pill's play/pause button routes through the injected session so the
+    /// user keeps transport control without restoring the whole bar.
+    func testPill_playPauseButton_routesThroughInjectedSession() {
+        let sut = makeSUT()
+        XCTAssertEqual(spySession.togglePlayPauseCallCount, 0, "PRECONDITION: no toggles yet")
+
+        sut.audiobookSession.togglePlayPause()
+
+        XCTAssertEqual(spySession.togglePlayPauseCallCount, 1,
+                       "Pill play/pause must call audiobookSession.togglePlayPause() exactly once")
+        XCTAssertTrue(sut.audiobookSession as AnyObject === spySession as AnyObject,
+                      "Pill must hold the INJECTED session — proves the wiring isn't a hardcoded singleton")
+    }
+
+    // MARK: - Accessibility
+
+    func testPill_accessibilityStringsAreNonEmpty() {
+        XCTAssertFalse(Strings.Generic.restoreAudiobookPlayerHint.isEmpty,
+                       "Pill a11y hint MUST be non-empty so VoiceOver users hear how to restore the player")
+        XCTAssertFalse(Strings.Generic.nowPlayingCompactLabel.isEmpty,
+                       "Pill a11y label format MUST come from the strings catalog")
+    }
+}

--- a/PalaceTests/AppInfrastructure/AudiobookMiniPlayerViewTests.swift
+++ b/PalaceTests/AppInfrastructure/AudiobookMiniPlayerViewTests.swift
@@ -74,24 +74,124 @@ final class AudiobookMiniPlayerViewTests: XCTestCase {
     ///   - Drop `!`: row (session=true, reader=true) flips
     ///     EXPECTED false → ACTUAL true.
     func testShouldShowChrome_truthTable_killsBooleanMutations() {
-        // Row 1: session active + no reader → SHOW (happy path).
-        XCTAssertTrue(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false),
-                      "Row 1: active session + no reader → must SHOW chrome (§11 row 7 Settings visibility, the happy path)")
+        // All rows below are NOT collapsed unless stated — the collapsed
+        // axis is exercised in its own row set at the bottom.
+
+        // Row 1: session active + no reader + not collapsed → SHOW (happy path).
+        XCTAssertTrue(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false),
+                      "Row 1: active session + no reader + not collapsed → must SHOW chrome (the happy path)")
 
         // Row 2: session active + reader active → HIDE (§7.3 Option α
         // — the load-bearing reader suppression).
-        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: true),
-                       "Row 2: active session + reader active → must HIDE chrome (§7.3 Option α reader suppression). A mutation dropping the `!` would flip this true.")
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: true, isCollapsed: false),
+                       "Row 2: active session + reader active → must HIDE chrome (§7.3 Option α reader suppression). A mutation dropping the `!` on isReaderActive would flip this true.")
 
         // Row 3: no session + no reader → HIDE. KEY ROW for &&→|| mutation:
         // with &&, `false && true == false`; with ||, `false || true == true`.
         // This row is the one that distinguishes && from ||.
-        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: false, isReaderActive: false),
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: false, isReaderActive: false, isCollapsed: false),
                        "Row 3: no session + no reader → must HIDE chrome. KEY ROW: distinguishes `&&` from `||` — with `||` this would flip true (no session SHOULD never show chrome).")
 
         // Row 4: no session + reader active → HIDE.
-        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: false, isReaderActive: true),
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: false, isReaderActive: true, isCollapsed: false),
                        "Row 4: no session + reader active → must HIDE chrome.")
+
+        // Row 5: session active + no reader BUT collapsed → HIDE the full
+        // bar (the pill is shown instead by AudiobookCollapsedPillView).
+        // KEY ROW for the new `!isCollapsed` term: dropping it flips this true
+        // and both the bar AND the pill would render at once.
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: true),
+                       "Row 5: active session + collapsed → must HIDE the full bar (pill takes over). Dropping `!isCollapsed` renders bar + pill simultaneously.")
+
+        // Row 6: collapsed complements the pill's predicate — the bar and the
+        // pill are never both visible for the same (active, not-in-reader) state.
+        XCTAssertNotEqual(
+            AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: true),
+            AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false),
+            "Bar visibility must flip with the collapsed axis — pins the bar/pill mutual exclusivity")
+    }
+
+    // MARK: - Collapse gesture (swipe-down → pill)
+
+    /// Truth table for `shouldCollapse(translation:)` — the pure swipe-down
+    /// decision. Extracted so the `&&` / `>` / `<` operators are mutation-
+    /// testable without a SwiftUI host.
+    func testShouldCollapse_truthTable_killsThresholdMutations() {
+        let threshold = AudiobookMiniPlayerView.collapseSwipeDownThreshold
+        let drift = AudiobookMiniPlayerView.collapseSwipeMaxHorizontalDrift
+
+        // Straight-down past threshold → collapse.
+        XCTAssertTrue(AudiobookMiniPlayerView.shouldCollapse(translation: CGSize(width: 0, height: threshold + 1)),
+                      "Downward drag past threshold with no drift → must collapse")
+        // EXACTLY at the threshold → no collapse. This is the ONLY input that
+        // distinguishes `>` from `>=`: at height == threshold, `> threshold`
+        // is false (no collapse) but `>= threshold` would be true (collapse).
+        // Testing threshold-1 does NOT kill the mutant (both false there).
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldCollapse(translation: CGSize(width: 0, height: threshold)),
+                       "Drag EXACTLY at threshold → must NOT collapse (kills `>` → `>=`)")
+        // Well under threshold → no collapse.
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldCollapse(translation: CGSize(width: 0, height: threshold - 1)),
+                       "Drag under threshold → must NOT collapse")
+        // Upward drag → no collapse (kills a sign flip).
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldCollapse(translation: CGSize(width: 0, height: -(threshold + 1))),
+                       "Upward drag → must NOT collapse (bar collapses on DOWN only)")
+        // EXACTLY at the horizontal-drift limit → no collapse. The ONLY input
+        // that distinguishes `<` from `<=`: at width == drift, `< drift` is
+        // false (no collapse) but `<= drift` would be true.
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldCollapse(translation: CGSize(width: drift, height: threshold + 1)),
+                       "Drift EXACTLY at limit → must NOT collapse (kills `<` → `<=`)")
+        // Past threshold vertically but too much horizontal drift → no collapse
+        // (kills dropping the horizontal-drift guard: a diagonal scroll must not collapse).
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldCollapse(translation: CGSize(width: drift + 1, height: threshold + 1)),
+                       "Diagonal drag beyond drift limit → must NOT collapse (kills `&&` → true / dropped drift guard)")
+    }
+
+    /// The swipe-down handler drives `presenter.collapse()` exactly once when
+    /// the drag clears the threshold — and does NOT tear the session down
+    /// (collapse keeps playing; only `✕` stops).
+    func testMiniPlayer_swipeDownPastThreshold_collapsesWithoutStoppingPlayback() {
+        let sut = makeSUT()
+        XCTAssertEqual(spyPresenter.collapseCallCount, 0, "PRECONDITION: not collapsed yet")
+
+        sut.handleCollapseDragEnd(translation: CGSize(width: 0, height: AudiobookMiniPlayerView.collapseSwipeDownThreshold + 20))
+
+        XCTAssertEqual(spyPresenter.collapseCallCount, 1,
+                       "A qualifying swipe-down must call presenter.collapse() exactly once")
+        XCTAssertTrue(spyPresenter.isCollapsed, "Presenter must be in the collapsed state after the swipe")
+        XCTAssertEqual(spySession.stopPlaybackCallCount, 0,
+                       "Collapse must NOT stop playback — kills a mutation that wires swipe-down to the hard dismiss")
+    }
+
+    /// A sub-threshold drag is a no-op (does not collapse).
+    func testMiniPlayer_swipeDownUnderThreshold_doesNotCollapse() {
+        let sut = makeSUT()
+        sut.handleCollapseDragEnd(translation: CGSize(width: 0, height: AudiobookMiniPlayerView.collapseSwipeDownThreshold - 5))
+        XCTAssertEqual(spyPresenter.collapseCallCount, 0,
+                       "A drag under the threshold must not collapse the bar")
+    }
+
+    // MARK: - Hard dismiss (✕ → stopPlayback)
+
+    /// The `✕` button routes through `audiobookSession.stopPlayback` with the
+    /// position-preserving arguments — NOT through `collapse()` (which would
+    /// leave audio playing). This is the load-bearing teardown wiring.
+    func testMiniPlayer_dismissButton_callsStopPlaybackPreservingPosition() async {
+        let sut = makeSUT()
+        XCTAssertEqual(spySession.stopPlaybackCallCount, 0, "PRECONDITION: no stopPlayback yet")
+
+        // Drive the PRODUCTION teardown seam the ✕ button's action wraps in a
+        // Task — so the arguments asserted below are the ones the production
+        // code bakes in (a mutation flipping persistFinalPosition is caught).
+        await sut.performDismiss()
+
+        XCTAssertEqual(spySession.stopPlaybackCallCount, 1,
+                       "Dismiss (✕) must call stopPlayback exactly once")
+        XCTAssertEqual(spySession.lastStopPlaybackDismissPhoneUI, true,
+                       "Dismiss must pass dismissPhoneUI: true so the phone chrome tears down")
+        XCTAssertEqual(spySession.lastStopPlaybackPersistFinalPosition, true,
+                       "Dismiss must pass persistFinalPosition: true so re-opening resumes where the user left off — kills a mutation flipping this to false")
+        XCTAssertTrue(sut.audiobookSession as AnyObject === spySession as AnyObject,
+                      "Mini-player must hold the INJECTED session — proves the dismiss routes to the spy, not a hardcoded singleton")
     }
 
     // MARK: - Visibility predicate (§7.3 Option α)
@@ -112,10 +212,14 @@ final class AudiobookMiniPlayerViewTests: XCTestCase {
         // type so the if/else short-circuit is mechanically pinned.
         let body = sut.body
 
-        // Assert
-        let predicate = spyPresenter.hasActiveSession && !spyPresenter.isReaderActive
-        XCTAssertFalse(predicate,
-                       "Visibility predicate must be false when hasActiveSession is false")
+        // Assert via the ACTUAL production predicate (not a recomputed copy)
+        // so a mutation in `shouldShowChrome` is caught here too.
+        XCTAssertFalse(
+            AudiobookMiniPlayerView.shouldShowChrome(
+                hasActiveSession: spyPresenter.hasActiveSession,
+                isReaderActive: spyPresenter.isReaderActive,
+                isCollapsed: spyPresenter.isCollapsed),
+            "Visibility predicate must be false when hasActiveSession is false")
         _ = body
     }
 
@@ -129,9 +233,12 @@ final class AudiobookMiniPlayerViewTests: XCTestCase {
         XCTAssertTrue(spyPresenter.hasActiveSession, "PRECONDITION: must be active")
         XCTAssertTrue(spyPresenter.isReaderActive, "PRECONDITION: reader active")
 
-        let predicate = spyPresenter.hasActiveSession && !spyPresenter.isReaderActive
-        XCTAssertFalse(predicate,
-                       "Reader-suppression predicate (§7.3 Option α): when isReaderActive == true, mini-player must hide regardless of hasActiveSession")
+        XCTAssertFalse(
+            AudiobookMiniPlayerView.shouldShowChrome(
+                hasActiveSession: spyPresenter.hasActiveSession,
+                isReaderActive: spyPresenter.isReaderActive,
+                isCollapsed: spyPresenter.isCollapsed),
+            "Reader-suppression predicate (§7.3 Option α): when isReaderActive == true, mini-player must hide regardless of hasActiveSession")
     }
 
     /// PRE: `hasActiveSession == true`, `isReaderActive == false`.
@@ -142,10 +249,14 @@ final class AudiobookMiniPlayerViewTests: XCTestCase {
         spyPresenter.isReaderActive = false
         XCTAssertTrue(spyPresenter.hasActiveSession, "PRECONDITION: must be active")
         XCTAssertFalse(spyPresenter.isReaderActive, "PRECONDITION: reader not active")
+        XCTAssertFalse(spyPresenter.isCollapsed, "PRECONDITION: not collapsed")
 
-        let predicate = spyPresenter.hasActiveSession && !spyPresenter.isReaderActive
-        XCTAssertTrue(predicate,
-                      "Happy path: active session + non-reader tab → mini-player must be visible")
+        XCTAssertTrue(
+            AudiobookMiniPlayerView.shouldShowChrome(
+                hasActiveSession: spyPresenter.hasActiveSession,
+                isReaderActive: spyPresenter.isReaderActive,
+                isCollapsed: spyPresenter.isCollapsed),
+            "Happy path: active session + non-reader tab + not collapsed → mini-player must be visible")
     }
 
     // MARK: - Tap → expand wiring
@@ -226,10 +337,12 @@ final class AudiobookMiniPlayerViewTests: XCTestCase {
         // injected. The button's action body calls
         // `audiobookSession.togglePlayPause()`; calling the same protocol
         // method directly on the SUT's injected reference exercises the
-        // same wiring. SpyShimSession's `togglePlayPause` is a no-op,
-        // but the identity assertion is the load-bearing pin.
+        // same wiring; the spy now records the call count so we pin BOTH the
+        // count and the injected identity.
         sut.audiobookSession.togglePlayPause()
 
+        XCTAssertEqual(spySession.togglePlayPauseCallCount, 1,
+                       "Play/pause button must call audiobookSession.togglePlayPause() exactly once")
         XCTAssertTrue(sut.audiobookSession as AnyObject === spySession as AnyObject,
                       "Mini-player must hold the INJECTED audiobookSession reference — proves the togglePlayPause action routes to the test spy, not a hardcoded production singleton")
         // Also pin the negative: skipBack/skipForward must NOT have been

--- a/PalaceTests/Audiobooks/AudiobookSessionPresenterTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookSessionPresenterTests.swift
@@ -313,6 +313,81 @@ final class AudiobookSessionPresenterTests: XCTestCase {
                       "Transition 3 (expand again): re-entry must work — collapsed → expanded after a minimize must drive published value back to true. This is the production seam round-trip per CLAUDE.md.")
     }
 
+    // MARK: - Collapse ⇄ restore (mini-bar ⇄ pill axis)
+
+    /// `collapse()` flips `isCollapsed` true AND emits to subscribers (the
+    /// pill overlay + mini-bar bind to it). `restoreFromCollapsed()` flips it
+    /// back. Drives the full round-trip via the production seams per the
+    /// CLAUDE.md state-machine wiring rule (write → reset → re-enter).
+    func testPresenter_collapse_restore_collapseAgain_drivesIsCollapsed_acrossThreeTransitions() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        XCTAssertFalse(presenter.isCollapsed, "PRECONDITION: must start un-collapsed (full bar)")
+
+        var observed: [Bool] = []
+        let cancellable = presenter.$isCollapsed.sink { observed.append($0) }
+        defer { cancellable.cancel() }
+
+        // Transition 1: bar → pill
+        presenter.collapse()
+        XCTAssertTrue(presenter.isCollapsed, "Transition 1 (collapse): full bar → pill must set isCollapsed true")
+
+        // Transition 2: pill → bar
+        presenter.restoreFromCollapsed()
+        XCTAssertFalse(presenter.isCollapsed, "Transition 2 (restore): pill → full bar must set isCollapsed false")
+
+        // Transition 3: bar → pill again (re-entry — proves the round-trip)
+        presenter.collapse()
+        XCTAssertTrue(presenter.isCollapsed, "Transition 3 (collapse again): re-entry after restore must set isCollapsed true again — a latch would fail here")
+
+        XCTAssertEqual(observed, [false, true, false, true],
+                       "@Published subscriber must observe initial → true → false → true; a plain (non-@Published) var would not emit and the pill/bar swap wouldn't react")
+    }
+
+    /// `expand()` must clear a prior collapse — expanding to the full player
+    /// always supersedes the pill so the user never lands back on a stale pill
+    /// after a minimize. Drives the cross-axis interaction via production seams.
+    func testPresenter_expand_clearsCollapsedState() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        presenter.collapse()
+        XCTAssertTrue(presenter.isCollapsed, "PRECONDITION: collapsed to pill")
+
+        presenter.expand()
+
+        XCTAssertFalse(presenter.isCollapsed,
+                       "expand() must reset isCollapsed — the full player supersedes the pill; a mutation dropping this line leaves the pill latched")
+        XCTAssertTrue(presenter.isPlayerExpanded, "expand() must still drive the full-player axis")
+    }
+
+    /// `minimize()` (full player → mini-bar) must land on the FULL bar, not a
+    /// leftover pill — so a collapse that predated an expand doesn't survive
+    /// the expand/minimize cycle. Pins the cross-axis reset.
+    func testPresenter_minimize_landsOnFullBar_notStalePill() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        // Simulate: user collapsed, then something expanded the player.
+        presenter.collapse()
+        presenter.expand()
+        XCTAssertFalse(presenter.isCollapsed, "PRECONDITION: expand cleared the collapse")
+
+        presenter.minimize()
+
+        XCTAssertFalse(presenter.isCollapsed,
+                       "minimize() must land on the full mini-bar, never the pill")
+        XCTAssertFalse(presenter.isPlayerExpanded, "minimize() must still collapse the full player")
+    }
+
+    /// A hard dismiss (`clearActiveSession()`) must also reset `isCollapsed`
+    /// so the next session starts from the full bar, not a stale pill.
+    func testPresenter_clearActiveSession_resetsCollapsedState() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        presenter.collapse()
+        XCTAssertTrue(presenter.isCollapsed, "PRECONDITION: collapsed to pill")
+
+        presenter.clearActiveSession()
+
+        XCTAssertFalse(presenter.isCollapsed,
+                       "clearActiveSession() must reset isCollapsed — a re-opened session must not inherit the previous session's pill state")
+    }
+
     // MARK: - Polish-phase: isPlaying derivation (Bug 2)
 
     /// PRE: presenter starts with `isPlaying == false`.

--- a/PalaceTests/Mocks/SpyAudiobookSessionPresenter.swift
+++ b/PalaceTests/Mocks/SpyAudiobookSessionPresenter.swift
@@ -108,6 +108,19 @@ final class SpyAudiobookSessionPresenter: AudiobookSessionPresenter {
         super.clearActiveSession()
     }
 
+    private(set) var collapseCallCount: Int = 0
+    private(set) var restoreFromCollapsedCallCount: Int = 0
+
+    override func collapse() {
+        collapseCallCount += 1
+        super.collapse()
+    }
+
+    override func restoreFromCollapsed() {
+        restoreFromCollapsedCallCount += 1
+        super.restoreFromCollapsed()
+    }
+
     override func adoptCoverImage(_ image: UIImage?) {
         adoptCoverImageCallCount += 1
         lastAdoptedCoverImage = image
@@ -169,6 +182,14 @@ final class SpyShimSession: AudiobookSessionManaging {
     /// / `audiobookSession.skipForward()` via AppContainer).
     private(set) var skipBackCallCount: Int = 0
     private(set) var skipForwardCallCount: Int = 0
+    private(set) var togglePlayPauseCallCount: Int = 0
+
+    /// Records the `✕`-dismiss teardown so mini-player tests can assert the
+    /// button routes through `stopPlayback` with the position-preserving
+    /// arguments (dismissPhoneUI: true, persistFinalPosition: true).
+    private(set) var stopPlaybackCallCount: Int = 0
+    private(set) var lastStopPlaybackDismissPhoneUI: Bool?
+    private(set) var lastStopPlaybackPersistFinalPosition: Bool?
 
     @discardableResult
     func openAudiobook(_ book: TPPBook, startPlaying: Bool) async -> Result<Void, AudiobookSessionError> {
@@ -176,12 +197,16 @@ final class SpyShimSession: AudiobookSessionManaging {
     }
     func play() {}
     func pause() {}
-    func togglePlayPause() {}
+    func togglePlayPause() { togglePlayPauseCallCount += 1 }
     func skipToChapter(at index: Int) {}
     func skipBack() { skipBackCallCount += 1 }
     func skipForward() { skipForwardCallCount += 1 }
     func cyclePlaybackRate() -> PlaybackRate { .normalTime }
-    func stopPlayback(dismissPhoneUI: Bool, persistFinalPosition: Bool) async {}
+    func stopPlayback(dismissPhoneUI: Bool, persistFinalPosition: Bool) async {
+        stopPlaybackCallCount += 1
+        lastStopPlaybackDismissPhoneUI = dismissPhoneUI
+        lastStopPlaybackPersistFinalPosition = persistFinalPosition
+    }
     func updateCoverImage(_ image: UIImage?) {}
     func recoverPlaybackForForegroundEntry() {}
 }


### PR DESCRIPTION
## What

Adds the two missing ways to get rid of the persistent audiobook mini-player, giving the now-playing surface a clean 4-state model:

```
full player  ⇄  mini-bar  ⇄  collapsed pill        (+ hard dismiss ✕)
                isPlayerExpanded   isCollapsed
```

- **✕ dismiss** (mini-bar): `stopPlayback(dismissPhoneUI: true, persistFinalPosition: true)` — stops audio, saves position, drops the bar. Re-opening the book resumes.
- **Swipe-down** (mini-bar) → **collapse** to a compact floating pill (`AudiobookCollapsedPillView`) pinned bottom-trailing. Playback keeps running; tap the pill's cover to restore the full bar; the pill's play/pause keeps transport control.

Both a visible control (✕) AND a gesture (swipe) ship together — the discoverability lesson the full player already learned (Bug 1, `in-app-nav-polish-2026-06-01`).

## Why

The mini-player let users navigate away from a playing audiobook but gave them **no way to end the session from the phone UI** — the full player only *minimized* (kept playing), and the bar had no close. Sessions only tore down via CarPlay disconnect, opening a reader, switching books, or an error.

## Files

- `AudiobookSessionPresenter` — new `isCollapsed` axis + `collapse()`/`restoreFromCollapsed()`; reset on every full-chrome path.
- `AudiobookMiniPlayerView` — ✕ button + swipe-to-collapse; pure `shouldCollapse` + awaitable `performDismiss` seams; double-tap guard.
- `AudiobookCollapsedPillView` (new) — the pill; mounted bottom-trailing in `AppTabHostView`, inset derived from safe area.
- Strings + pbxproj + spy extensions.

## Review & verification

- **Independent adversarial architect+QA review performed; BLOCK → all findings fixed** (boundary-exact mutation rows, removed a false "verified on simulator" comment + safe-area-derived inset, un-stale'd 3 predicate tests, tightened play/pause assertion, double-tap guard). State model / gesture wiring / ✕ arg-pinning verified clean.
- Structural DoD checks pass: `check-test-name-vs-body`, `check-blast-radius`, `check-superpartner-spectrum`, `check-adjacency-staleness` (all exit 0).
- Swift compile of all changed files: clean.

## ⚠️ Not verified locally (please confirm in CI / a runnable build)

- **Full XCTest suite + mutation run** — the isolated worktree can't complete a DRM build (symlinked subproject double-produces `AudioEngine.framework`); tests are mutation-*designed* but weren't executed. CI is the gate.
- **Live simdrive interaction pass** — visual placement of the pill above the tab bar (inset now safe-area-derived but unconfirmed on-device) and the real ✕/swipe/restore gestures on a playing audiobook. Deferred; a `chaos-qa` pass is the natural follow-up.

## Out of scope (flagged separately)

- `Palace-noDRM` does **not** compile on `origin/develop`: `AudiobookSessionManager.swift:2078` calls `shouldAutoReopenOnColdLoadFailure` (defined only inside `#if FEATURE_OVERDRIVE`) from unguarded code. Pre-existing; unrelated to this PR.
- One pre-existing mini-player test name (`testMiniPlayer_isPlayingPublished_drivesGlyphLabel`) overclaims; left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
