### PR TITLE
fix(audiobooks): Swift 6 regressions on develop — Now-Playing crash + Palace-noDRM build

### DIFF
--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -1739,26 +1739,6 @@ public final class AudiobookSessionManager: ObservableObject {
         return status == 410
     }
 
-    /// PP-4542: decides whether a `.playbackFailed` should trigger ONE silent
-    /// auto-reopen before surfacing the "Audiobook Unavailable" alert. Pure so
-    /// the per-session bound is unit-pinned without driving the auth-gated open
-    /// flow. Distributor-agnostic on purpose: the regression (Readium 3.9.0
-    /// rangeOutOfBounds on a not-yet-materialized LCP package) is a cold-load
-    /// race that any first-open can hit, and a reopen demonstrably recovers it.
-    /// - `hasEverStartedPlayback == false`: only a COLD-load failure (playback
-    ///   never started this session) is a candidate; a mid-playback failure is a
-    ///   different surface and must NOT silently reopen.
-    /// - `hasCurrentBook`: there must be a book to reopen.
-    /// - `alreadyAttempted == false`: bounded to one reopen per book per session
-    ///   so a genuinely persistent failure reaches the alert instead of looping.
-    static func shouldAutoReopenOnColdLoadFailure(
-        hasEverStartedPlayback: Bool,
-        hasCurrentBook: Bool,
-        alreadyAttempted: Bool
-    ) -> Bool {
-        !hasEverStartedPlayback && hasCurrentBook && !alreadyAttempted
-    }
-
     /// Extracts an HTTP status code from a playback error. The toolkit's network
     /// layer stamps `userInfo["httpStatusCode"]` on download/streaming failures
     /// (`OpenAccessDownloadTask`); we also walk one level of the
@@ -1773,6 +1753,32 @@ public final class AudiobookSessionManager: ObservableObject {
         return nil
     }
 #endif
+
+    /// PP-4542: decides whether a `.playbackFailed` should trigger ONE silent
+    /// auto-reopen before surfacing the "Audiobook Unavailable" alert. Pure so
+    /// the per-session bound is unit-pinned without driving the auth-gated open
+    /// flow. Distributor-agnostic on purpose: the regression (Readium 3.9.0
+    /// rangeOutOfBounds on a not-yet-materialized LCP package) is a cold-load
+    /// race that any first-open can hit, and a reopen demonstrably recovers it.
+    /// - `hasEverStartedPlayback == false`: only a COLD-load failure (playback
+    ///   never started this session) is a candidate; a mid-playback failure is a
+    ///   different surface and must NOT silently reopen.
+    /// - `hasCurrentBook`: there must be a book to reopen.
+    /// - `alreadyAttempted == false`: bounded to one reopen per book per session
+    ///   so a genuinely persistent failure reaches the alert instead of looping.
+    ///
+    /// Lives OUTSIDE `#if FEATURE_OVERDRIVE` (unlike the sibling OverDrive
+    /// helpers): the cold-load auto-recovery call site (`stopPlayback` error
+    /// path) is unconditional, so gating this behind FEATURE_OVERDRIVE broke the
+    /// `Palace-noDRM` target build (`type 'Self' has no member ...`). It is a
+    /// pure LCP/first-open helper with no OverDrive dependency.
+    static func shouldAutoReopenOnColdLoadFailure(
+        hasEverStartedPlayback: Bool,
+        hasCurrentBook: Bool,
+        alreadyAttempted: Bool
+    ) -> Bool {
+        !hasEverStartedPlayback && hasCurrentBook && !alreadyAttempted
+    }
 
     /// True once the LCP audiobook's full content package is on disk. The `.lcpa`
     /// is moved into place atomically on download completion

--- a/Palace/Audiobooks/NowPlayingCoordinator.swift
+++ b/Palace/Audiobooks/NowPlayingCoordinator.swift
@@ -215,7 +215,19 @@ public final class NowPlayingCoordinator {
             return
         }
 
-        let artwork = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
+        // MediaPlayer invokes this request handler OFF the main actor (it
+        // serializes the artwork on a background queue via
+        // `-[MPMediaItemArtwork jpegDataWithSize:]` when building the
+        // Now-Playing / lock-screen info). Under the Swift 6 language mode the
+        // closure would otherwise inherit this type's `@MainActor` isolation
+        // and trip `dispatch_assert_queue` → crash on every audiobook open
+        // (regression from the SWIFT_VERSION 5→6 flip, #1199). `@Sendable`
+        // strips the inherited isolation so the handler is callable on
+        // MediaPlayer's queue; `nonisolated(unsafe)` opts the captured image
+        // out of Sendable checking (reading a `UIImage` for rasterization is
+        // thread-safe here — it is created once and never mutated).
+        nonisolated(unsafe) let capturedImage = image
+        let artwork = MPMediaItemArtwork(boundsSize: image.size) { @Sendable _ in capturedImage }
         currentArtwork = artwork
 
         var info = currentInfo


### PR DESCRIPTION
## Two audiobook regressions on `develop` (both from the recent Swift 6 language-mode flip, #1199)

Found via a live simdrive audiobook-open pass on the current `develop` code.

### 1. 🔴 Crash: opening ANY audiobook crashes (runtime, shipping-blocker)

Every audiobook open crashes with a main-actor isolation assertion:

```
_dispatch_assert_queue_fail  ←  _swift_task_checkIsolatedSwift
NowPlayingCoordinator.updateArtwork(_:) closure #1
-[MPMediaItemArtwork jpegDataWithSize:]   (___MPToMRNowPlayingInfoDictionary_block_invoke)
```

`NowPlayingCoordinator` is `@MainActor`, so under Swift 6 the `MPMediaItemArtwork`
request-handler closure inherited main-actor isolation. MediaPlayer invokes that
handler on a **background queue** while building the Now-Playing / lock-screen
info, tripping `dispatch_assert_queue` → instant crash the moment playback starts.
Not caught by the build or unit tests — only fires when MediaPlayer actually
requests the artwork off-main during real playback (confirmed by 4 identical
`.ips` crash reports, one per audiobook-open attempt).

**Fix:** mark the request handler `@Sendable` (carries no actor isolation, callable
on MediaPlayer's queue) and capture the image via `nonisolated(unsafe)` (a `UIImage`
read for rasterization is thread-safe — created once, never mutated). Only one such
call site exists. **After the fix, no crash recurs on audiobook open.**

### 2. 🟠 Build: `Palace-noDRM` target does not compile

```
AudiobookSessionManager.swift:2078: type 'Self' has no member 'shouldAutoReopenOnColdLoadFailure'
```

`shouldAutoReopenOnColdLoadFailure(...)` was defined inside `#if FEATURE_OVERDRIVE`,
but its only call site (the PP-4542 cold-load auto-recovery in `stopPlayback`) is
**unconditional**. The DRM `Palace` target defines `FEATURE_OVERDRIVE` so it built;
`Palace-noDRM` did not. The function is a pure LCP/first-open helper (its own doc:
"Distributor-agnostic on purpose") with no OverDrive dependency.

**Fix:** move only that function out of the guard (the two genuinely OverDrive-only
helpers stay gated). Pure relocation, byte-identical body.

## Verification

- DRM `Palace` build: **BUILD SUCCEEDED**; audiobook now opens without crashing (simdrive).
- `Palace-noDRM` build: **BUILD SUCCEEDED** (was broken on develop).
- Both changes are on the audiobook critical path; each carries mutation-evidence notes in its commit body (both are concurrency-isolation / pure-relocation changes with no branch logic to mutate — correctness is "no crash" / "target compiles", verified by the builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
