### PR TITLE
fix(ui): match skeleton placeholder shapes to real covers/logos (square)

### DIFF
--- a/Palace/CatalogUI/Views/CatalogLaneSkeletonView.swift
+++ b/Palace/CatalogUI/Views/CatalogLaneSkeletonView.swift
@@ -25,7 +25,9 @@ struct CatalogLaneSkeletonView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             // Header — traces `Text(title).font(.title2)` (~28pt line height).
-            SkeletonBox(width: 200, height: 28, cornerRadius: PalaceRadius.control)
+            // Text-bar radius (4) — matches the other text placeholders; a text
+            // line has no shape to snap against, so this is convention-consistency.
+            SkeletonBox(width: 200, height: 28, cornerRadius: 4)
                 .padding(.horizontal, 12)
 
             // Scroller — mirrors `CatalogLaneRowView.scroller` exactly.

--- a/Palace/Settings/Components/AccountDetailSkeletonView.swift
+++ b/Palace/Settings/Components/AccountDetailSkeletonView.swift
@@ -41,7 +41,11 @@ struct AccountDetailSkeletonView: View {
     //     real header's x/y, and `.listRowBackground(.clear)`.
     private var headerSkeleton: some View {
         HStack(spacing: 12) {
-            SkeletonBox(width: 50, height: 50, cornerRadius: PalaceRadius.card)
+            // Square (r=0) to match the real library logo, which renders as a
+            // plain `Image(uiImage:).scaledToFit()` with no corner rounding
+            // (AccountDetailView headerView / headerRow). A rounded skeleton
+            // here snaps to square when the logo loads.
+            SkeletonBox(width: 50, height: 50, cornerRadius: 0)
 
             SkeletonBox(width: 150, height: 20, cornerRadius: 4)
 

--- a/Palace/Utilities/SwiftUI/Skeleton.swift
+++ b/Palace/Utilities/SwiftUI/Skeleton.swift
@@ -340,11 +340,19 @@ struct SkeletonText: View {
   }
 }
 
-/// A book-cover placeholder — cover aspect at the caller's size, card radius.
+/// A book-cover placeholder — cover aspect at the caller's size, SQUARE corners
+/// to match the settled cover. `BookImageView` renders the real cover as a plain
+/// `Image(...).aspectRatio(.fit)` with NO corner rounding, so a rounded skeleton
+/// (previously `PalaceRadius.card` = 12pt) visibly snapped to square corners when
+/// the cover faded in. Square here keeps the placeholder → cover transition
+/// shape-stable. If book covers ever gain a corner radius, change BOTH sites.
 struct SkeletonCover: View {
   var width: CGFloat = 100
   var height: CGFloat = 150
   var active: Bool = true
+
+  /// Matches `BookImageView`'s cover, which is not corner-rounded. `0` = square.
+  static let coverCornerRadius: CGFloat = 0
 
   init(width: CGFloat = 100, height: CGFloat = 150, active: Bool = true) {
     self.width = width
@@ -355,7 +363,7 @@ struct SkeletonCover: View {
   var body: some View {
     SkeletonBox(
       width: width, height: height,
-      cornerRadius: PalaceRadius.card, active: active
+      cornerRadius: Self.coverCornerRadius, active: active
     )
   }
 }


### PR DESCRIPTION
## Match skeleton placeholder shapes to the real UI they trace

The unified skeleton system (#1207) rounded several placeholders whose real
counterparts render **square**, so loading content visibly "snapped" shape when
it faded in. Fixed after auditing **every** skeleton placeholder against the real
element it traces.

### Fixed (real shape-snaps)
- **Book covers** — `SkeletonCover` used `PalaceRadius.card` (12pt), but real
  covers render as a plain `Image(...).aspectRatio(.fit)` in `BookImageView` with
  **no** corner rounding. Squared it. One primitive fix corrects all 5 cover
  placeholder sites (catalog lanes, lane row, My Books list, Book Detail,
  BookImageView).
- **Library logo** (`AccountDetailSkeletonView`) — used 12pt, but the real logo is
  a square `scaledToFit` image (no rounding). Squared it.

### Nit
- Lane-title text bar radius 8 → 4 to match the text-bar convention used by every
  other text placeholder (no shape-snap; consistency only).

### Verified MATCH (left as-is)
Audited and confirmed correct against the real elements: My Books action button
(skeleton r=8 == `BookButtonsView` r=8), entry-point selector (r=8 == segmented
control), all text bars (r=4). No other `Skeleton*` sites exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
