### PR TITLE
fix(tests): reconcile 6 stale tests failing on develop (#1215 threshold + #1212 .bak + teardown-lint)

### DIFF
--- a/PalaceTests/BookRegistry/TPPBookRegistryAtomicWriteTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryAtomicWriteTests.swift
@@ -149,9 +149,17 @@ class TPPBookRegistryAtomicWriteTests: PalaceWiringTestCase {
         let contents = try FileManager.default.contentsOfDirectory(atPath: dir.path)
             // Filter macOS metadata
             .filter { !$0.hasPrefix(".") }
+            .sorted()
 
-        XCTAssertEqual(contents, ["registry.json"],
-                       "Registry dir must contain only registry.json — kills mutant that leaves staging .tmp files")
+        // #1212 ("Bulletproof Ownership") writes a durable last-good
+        // `registry.json.bak` sidecar on every non-empty save
+        // (RegistryFileRecovery.writeBackup, BookRegistrySync.saveSync) — an
+        // INTENTIONAL backup, not a staging artifact. The mutant this test kills
+        // is a leaked `.tmp` staging file from the atomic rename, so assert the dir
+        // holds exactly registry.json + its backup and NOTHING else: a stray
+        // `.tmp` (or any other file) makes this set comparison fail.
+        XCTAssertEqual(contents, ["registry.json", "registry.json.bak"],
+                       "Registry dir must contain only registry.json + its durable .bak backup — no leaked staging .tmp files")
     }
 
     /// Two back-to-back saves (write a registry, then a smaller one) must

--- a/PalaceTests/MyBooks/LoanRenewalServiceTests.swift
+++ b/PalaceTests/MyBooks/LoanRenewalServiceTests.swift
@@ -196,7 +196,13 @@ final class LoanRenewalServiceTests: XCTestCase {
     func testProductionFactory_foreignHost401_classifiesOk() async {
         let book = makeBook(identifier: "PF1", borrowHost: "foreign.host")
         let service = LoanRenewalService.production(
-            executor: AppContainer.production().networkExecutor, // MIGRATED-DEFERRED: swarm_47883816 — executor is unused (test injects StubPoster); production() supplies a throwaway to satisfy the factory signature
+            // The factory takes a concrete TPPNetworkExecutor, but this test
+            // injects `poster:` so the executor is never used (see production():
+            // it only wraps `executor` when `poster == nil`). Use a throwaway
+            // ephemeral executor rather than the shared production container, so
+            // the test touches no process-wide singleton (TearDownRequiredLint)
+            // and needs no teardown.
+            executor: TPPNetworkExecutor(credentialsProvider: nil, cachingStrategy: .ephemeral, delegateQueue: nil),
             bookRegistry: TPPBookRegistryMock(),
             poster: StubPoster(status: 401),
             hostsProvider: { ["our.host"] })

--- a/PalaceTests/TPPBookCoverRegistryTests.swift
+++ b/PalaceTests/TPPBookCoverRegistryTests.swift
@@ -150,8 +150,12 @@ final class TPPBookCoverRegistryTests: XCTestCase {
     /// returning DNS errors), it should be marked as failing so subsequent requests skip immediately
     /// instead of waiting for DNS timeouts.
     func testHostFailureTracker_RecordsFailureAndSkips() async {
-        // Arrange
-        let tracker = HostFailureTracker(cooldownInterval: 300)
+        // Arrange — pin failureThreshold: 1 so a single recorded failure trips the
+        // breaker. The production DEFAULT is now 3 (#1215: don't blacklist a whole
+        // cover CDN after one Wi-Fi↔cellular blip); the below/at-threshold semantics
+        // are covered by HostFailureTrackerTests.swift. This test isolates the
+        // "a tripped host is skipped" behavior, so threshold 1 keeps it single-failure.
+        let tracker = HostFailureTracker(cooldownInterval: 300, failureThreshold: 1)
         let failingHost = "palace-bookshelf-downloads.dp.la"
 
         // Initially not failing
@@ -170,8 +174,9 @@ final class TPPBookCoverRegistryTests: XCTestCase {
 
     /// Verify that a successful request clears the failure record
     func testHostFailureTracker_SuccessClearsFailure() async {
-        // Arrange
-        let tracker = HostFailureTracker(cooldownInterval: 300)
+        // Arrange — threshold 1 so one failure trips; this test targets the
+        // success-clears-the-record behavior, not the threshold (see comment above).
+        let tracker = HostFailureTracker(cooldownInterval: 300, failureThreshold: 1)
         let host = "example.com"
 
         await tracker.recordFailure(for: host)
@@ -189,8 +194,9 @@ final class TPPBookCoverRegistryTests: XCTestCase {
 
     /// Verify that the circuit breaker resets after the cooldown period
     func testHostFailureTracker_ResetsAfterCooldown() async {
-        // Arrange - Use a very short cooldown for testing
-        let tracker = HostFailureTracker(cooldownInterval: 0.1) // 100ms
+        // Arrange - Use a very short cooldown for testing; threshold 1 so one
+        // failure trips (this test targets cooldown expiry, not the threshold).
+        let tracker = HostFailureTracker(cooldownInterval: 0.1, failureThreshold: 1) // 100ms
         let host = "expired-failure.example.com"
 
         await tracker.recordFailure(for: host)
@@ -219,7 +225,9 @@ final class TPPBookCoverRegistryTests: XCTestCase {
 
     /// Verify that different hosts are tracked independently
     func testHostFailureTracker_TracksHostsIndependently() async {
-        let tracker = HostFailureTracker()
+        // threshold 1 so one failure trips the failing host; this test targets
+        // per-host independence, not the threshold (see RecordsFailureAndSkips).
+        let tracker = HostFailureTracker(failureThreshold: 1)
         let failingHost = "dead-host.example.com"
         let healthyHost = "healthy-host.example.com"
 


### PR DESCRIPTION
## Why

A full-suite run surfaced **6 deterministically-failing tests on develop**. They show up on every open PR's merge-preview (this is what PR #1217 was seeing — "13 failing tests"), and are hidden from the develop board only because no full develop run has executed since #1215/#1216 merged.

**None are flakes.** Each is a test that wasn't updated when production behavior intentionally changed. #1217 (and any branch) is just the messenger — its diff touches none of these areas. Root fix belongs on develop.

## The 6 failures + fixes

**1. `TPPBookCoverRegistryTests` — 4× `testHostFailureTracker_*`**
Asserted a host is marked failing after **one** recorded failure. **#1215** changed the production default to `failureThreshold: 3` (comment: don't blacklist a whole cover CDN after one Wi-Fi↔cellular blip). The correct threshold coverage now lives in the new `HostFailureTrackerTests.swift`. These 4 tests target *other* behaviors (success-clears, cooldown-expiry, host-independence, skip-on-trip), so they pin `failureThreshold: 1` to isolate their real intent.

**2. `TPPBookRegistryAtomicWriteTests.testSaveSync_LeavesNoStagingArtifactsInRegistryDir`**
Asserted the registry dir is exactly `["registry.json"]`. **#1212** ("Bulletproof Ownership") now writes a durable `registry.json.bak` sidecar on every non-empty save (`RegistryFileRecovery.writeBackup`, unconditional) — an intentional backup, not a staging leak. Now asserts `["registry.json", "registry.json.bak"]`; a leaked `.tmp` (the mutant this kills) still breaks the set comparison.

**3. `LoanRenewalServiceTests.testProductionFactory_foreignHost401_classifiesOk`**
Tripped `TearDownRequiredLint` — extends `XCTestCase` and touched `AppContainer.production().networkExecutor`. That executor is **unused** here (the test injects `poster:`, so `production()` never wraps it). Swapped for a throwaway ephemeral `TPPNetworkExecutor` → touches no process-wide singleton, needs no teardown.

## Verification

- Logic traced against production source: threshold semantics (`isTripped: consecutiveFailures >= failureThreshold`), `writeBackup` is unconditional on non-empty save + cleans its `.tmp`, and the factory's executor-unused path.
- `TearDownRequiredLint` real exclusions read (skips `MetaTests/`, strips full-line `//` comments): `LoanRenewalServiceTests` was the **sole** violator, now cleared; #1215's new `HostFailureTrackerTests.swift` has no polluter substring (clean).
- Local full-suite build not run (fresh worktree lacks Carthage frameworks, per project convention) — **CI's CI-parity suite is the gate**.

**Scope:** 3 test files, no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)