### PR TITLE
fix(regression): cold-load recipe stages a real in-flight download (Dungeon Crawler Carl)

### DIFF
--- a/.simdrive/RECORDING_COVERAGE_GAP.md
+++ b/.simdrive/RECORDING_COVERAGE_GAP.md
@@ -50,8 +50,8 @@ Ordered by area-group priority. Each needs a fresh simdrive recording at
 - [ ] `PP-4161-streaming-html-reader` — streaming-HTML reader (open DRM, substitutable). Journey spec present; recording not yet captured.
 
 ### `audiobook` (2)
-- [ ] `audiobook-cold-load-first-open`  (PP-4542/PP-4613): first-cold-open of a fresh-borrow LCP audiobook must not dead-end on "Audiobook Unavailable". Spec authored; staging is DETERMINISTIC (forge_streaming_state recipe = "ready", no longer PHASE2) — capture is unblocked and is the only remaining step.
-- [ ] `audiobook-download-indicator-stateful`  (stays PHASE2 — needs a live active-download %, not solved by the content-delete forge).
+- [ ] `audiobook-cold-load-first-open`  (PP-4542/PP-4613): first-cold-open of a fresh-borrow LCP audiobook must not dead-end on "Audiobook Unavailable". Spec authored; staging recipe is CORRECT (`reborrow_audiobook_streaming` — return + re-borrow a large LCP audiobook, "Dungeon Crawler Carl", and open it mid-download; supersedes the retired `forge_streaming_state`, whose delete-a-completed-`.lcpa` premise no longer reproduces the regression post-#1094). **Capture is BLOCKED on a per-sim network throttle**, NOT unblocked: on an un-throttled sim the ~715 MB `.lcpa` downloads in ~6–13s, too fast to reliably catch the open mid-download via UI-timed taps (+ a SpringBoard tap-race). Needs a download-window widener (host-level NLC or a per-sim shaper) before the recording can be captured.
+- [ ] `audiobook-download-indicator-stateful`  (stays PHASE2 — asserts the live "Downloading… %" indicator; the `reborrow_audiobook_streaming` mid-download stage now produces a real active transfer, so it's a promotion candidate, but it hits the SAME throttle blocker as cold-load: the % window is too brief to catch reliably un-throttled).
 
 ## Journeys on disk but not yet in the area manifest
 These `.simdrive/journeys/*.yaml` specs exist but are NOT in

--- a/.simdrive/journeys/audiobook-cold-load-first-open.yaml
+++ b/.simdrive/journeys/audiobook-cold-load-first-open.yaml
@@ -32,14 +32,22 @@ scenario:
   staging:
     recipe: audiobook-cold-load-first-open   # scripts/regression_staging.py (status: ready)
     note: |
-      DETERMINISTIC staging via the `forge_streaming_state` primitive — no longer
-      needs to race the live ~1.5s download window (the reason this was PHASE2).
-      The recipe signs into A1QA, lands on My Books, then deletes the downloaded
-      LCP audiobook's .lcpa CONTENT file while keeping its .lcpl license + the
-      registry's .downloadSuccessful marker. Opening then routes through the LCP
-      streaming path — the exact PP-4613 surface — reproducibly. (registry-state
-      and content-file presence are decoupled: a book is marked downloadSuccessful
-      when the tiny .lcpl lands, independent of the .lcpa content.)
+      Stages a REAL in-flight download via `reborrow_audiobook_streaming`: sign
+      into A1QA, then return-and-re-borrow a LARGE LCP audiobook (the Audible-lane
+      "Dungeon Crawler Carl", a long ~15 hr LitRPG audiobook) and leave WITHOUT
+      waiting for the download to finish. The journey then opens it while the `.lcpa` content is
+      still downloading — the exact PP-4613 surface. A large title keeps the
+      download window wide, so the open reliably lands mid-transfer without racing
+      a ~1.5s window (the old PHASE2 flake).
+
+      Supersedes the earlier `forge_streaming_state` delete-shortcut: the PP-4542
+      fix (#1094) replaced the LCP streaming path with `awaitAudiobookContentLocal`
+      — a bounded 180s POLL of an ALREADY-in-flight download. Deleting a COMPLETED
+      `.lcpa` leaves no active transfer, so that poll can only time out after 3
+      minutes → an artifact, not the regression. The state IS decoupled (a book is
+      `.downloadSuccessful` the instant its tiny `.lcpl` lands, independent of the
+      `.lcpa` content) — which is exactly why opening mid-download exercises the
+      gate.
 
   recording:
     path: "~/.simdrive/recordings/audiobook-cold-load-first-open/recording.yaml"
@@ -112,7 +120,7 @@ scenario:
     isRefreshInProgressError); this journey is the end-to-end backstop.
 
   known_issues:
-    - "No longer time-sensitive: the forge_streaming_state staging primitive deletes the .lcpa deterministically, so the not-yet-local window no longer depends on catching a live ~1.5s download. (Previously PHASE2 for exactly that reason.)"
-    - "Does not assert WHICH LCP title is open (A1QA ODL feed contents change) — book-agnostic by design; the forge content-strips every downloaded LCP audiobook, so whichever one My Books shows is exercised."
-    - "forge_streaming_state strips the LOCAL .lcpa cache (not the loan) — a re-download or A1QA fixture re-provision restores it; it does NOT return/mutate the read-only standing fixture."
-    - "Sibling journey audiobook-download-indicator-stateful stays PHASE2 — it needs a genuinely ACTIVE download to show 'Downloading… %', which the content-delete forge cannot produce (a different mechanism: a per-sim download throttle / progress-injection seam)."
+    - "Window-sensitive by design (but wide): the open must land while the .lcpa is still downloading. Mitigated by using a LARGE title (a long ~15 hr audiobook) whose download window is minutes, not the ~1.5s of a small audiobook — the reason this was PHASE2. If the open still races ahead of the download, borrow a larger title / throttle the sim network."
+    - "Title-coupled: pins the Audible-lane 'Dungeon Crawler Carl' (a returnable LCP audiobook; the earlier pin 'Carl's Doomsday Scenario' was dropped from the A1QA feed 2026-07-08). If the A1QA feed drops it, update _COLD_LOAD_LCP_AUDIOBOOK in scripts/regression_staging.py to another large returnable LCP audiobook (must fulfill as 'Listen' + download a .lcpa)."
+    - "reborrow_audiobook_streaming returns-then-re-borrows a RETURNABLE loan (not the read-only standing fixture), so each run re-downloads a fresh copy — idempotent. It never mutates a standing fixture."
+    - "Sibling journey audiobook-download-indicator-stateful stays PHASE2 — it asserts the 'Downloading… %' progress UI mid-transfer; this recipe's mid-download stage now produces a real active transfer, so that journey is a candidate for promotion using the same reborrow primitive (revisit separately)."

--- a/scripts/regression_staging.py
+++ b/scripts/regression_staging.py
@@ -875,17 +875,28 @@ def _app_data_container(udid: str) -> Path:
 
 
 def forge_streaming_state(d: Driver) -> None:
-    """Deterministically forge the "license landed but .lcpa content NOT local"
-    state for every downloaded LCP audiobook: delete each .lcpa CONTENT file while
-    leaving its .lcpl license sibling (and the registry's `.downloadSuccessful`
-    marker) intact. Opening such a book then routes through the LCP STREAMING path
-    — the exact PP-4613 cold-load regression surface — with ZERO dependence on
-    catching the live ~1.5s download window (the reason this journey was PHASE2).
+    """SUPERSEDED (2026-07-08) — no longer used by the cold-load recipe. Kept only
+    as a documented lesson; do NOT wire into a recipe.
 
-    The .lcpl sibling is preserved so LCPAdapter's tier-2 fallback opens via
-    streaming (not a license re-download). Raises StagingError if no .lcpa is
-    present — nothing downloaded to forge, so the recipe gates honestly rather than
-    recording against a fully-local book that wouldn't exercise the regression."""
+    Original premise: delete each downloaded `.lcpa` CONTENT file (keeping its
+    `.lcpl` license + registry `.downloadSuccessful`) so the next open routes
+    through the LCP *streaming* path — the Readium-3.9.0 "Audiobook Unavailable"
+    surface — without racing the live download.
+
+    Why it's retired: the PP-4542 fix (#1094) REPLACED that streaming path. A
+    fresh-borrow LCP audiobook whose `.lcpa` isn't local now goes through the
+    download-gate (`AudiobookSessionManager.awaitAudiobookContentLocal`), which is
+    a bounded (180s) *poll of the file* — "the download is already in flight … this
+    is a wait, not a trigger." Deleting a COMPLETED `.lcpa` leaves NO active
+    transfer, so the poll can only ever TIME OUT → "Audiobook Unavailable" after
+    3 minutes — an artifact of an impossible state, not the real cold-load path.
+    The correct stage is a GENUINE in-flight download (see
+    `reborrow_audiobook_streaming`). The fixture assumption also drifted: the A1QA
+    standing "Animal Farm" is now a BiblioBoard bearer-token audiobook (zero
+    `.lcpa`), so this raised `StagingError` and could not even reach its
+    precondition.
+
+    Raises StagingError if no .lcpa is present."""
     container = _app_data_container(d.udid)
     lcpas = audiobook_content_files_under(container)
     if not lcpas:
@@ -896,6 +907,60 @@ def forge_streaming_state(d: Driver) -> None:
         f.unlink()
     print(f"[staging] forge_streaming_state: deleted {len(lcpas)} .lcpa content "
           f"file(s) (kept .lcpl) → next open streams (PP-4613 path)")
+
+
+# A LARGE, RETURNABLE LCP audiobook from the A1QA "Audible Titles" lane. Size is a
+# FEATURE: the download window must comfortably outlast the journey's open so
+# "tap Listen while still downloading" is reliable (small audiobooks race the
+# ~1.5s window — the original PHASE2 flake). Swap this if the A1QA feed changes;
+# it MUST be a true LCP audiobook (fulfills as "Listen", downloads a `.lcpa`) and
+# returnable (so the recipe can reset + re-borrow to force a fresh in-flight
+# download each run).
+#
+# Retitled 2026-07-08 (live validation): the prior pin "Carl's Doomsday Scenario"
+# was DROPPED from the A1QA Audible lane — a "Carl" search returned Carl Seelig /
+# Carl The Trailer / Dungeon Crawler Carl / "Carl: The Apocalypse..." but NO
+# "Carl's Doomsday Scenario", so reborrow_audiobook_streaming could not find a
+# Borrow/Get and raised StagingError. "Dungeon Crawler Carl" (Matt Dinniman, narr.
+# Jeff Hays) is the replacement: same Audible lane, confirmed live to fulfill as
+# "Listen" + offer "Return" (a returnable LCP audiobook), and it is a long
+# (~15 hr, multi-hundred-MB) LitRPG audiobook, so its download window is wide.
+_COLD_LOAD_LCP_AUDIOBOOK = "Dungeon Crawler Carl"
+
+
+def reborrow_audiobook_streaming(d: Driver, title: str = _COLD_LOAD_LCP_AUDIOBOOK) -> None:
+    """Leave `title` MID-DOWNLOAD in My Books so the journey's next 'Listen' tap
+    exercises the REAL cold-open-during-download path (PP-4613 / the PP-4542
+    await-gate) — the correct replacement for the retired forge_streaming_state.
+
+    Flow: reach detail via search → if already borrowed, Return first (so the
+    re-borrow triggers a FRESH download, not an instant open from a complete local
+    cache) → Borrow → return IMMEDIATELY without waiting for completion. The book
+    is large by design, so the `.lcpa` is still downloading when the journey opens
+    it: the await-gate polls the genuine in-flight transfer, content lands, playback
+    starts (fixed) or the 'Audiobook Unavailable' alert fires (regressed). A live
+    download also renders real 'Downloading… %' UI, which the journey's
+    required_text_any asserts as forward progress.
+
+    Idempotent: the Return→re-Borrow reset makes each run start a fresh download.
+    Raises StagingError if the book offers no Borrow/Get affordance."""
+    _open_book_detail(d, title)
+    # Reset a prior run's completed/partial download so the re-borrow re-downloads.
+    if d.find("Return"):
+        d.tap_text("Return")
+        tap_dialog_button(d, "Return", "Cancel")
+        time.sleep(2.5)
+        _open_book_detail(d, title)
+    if d.find("Borrow"):
+        d.tap_text("Borrow")
+    elif d.find("Get"):
+        d.tap_text("Get")
+    else:
+        raise StagingError(
+            f"reborrow_audiobook_streaming: no Borrow/Get on '{title}' detail — "
+            f"is it still in the A1QA Audible lane? (update _COLD_LOAD_LCP_AUDIOBOOK)")
+    # Do NOT poll for 'Listen'/completion — leaving it in flight IS the point.
+    time.sleep(2.5)   # let the loan register + the download kick off
 
 
 PRIMITIVES = {
@@ -912,7 +977,8 @@ PRIMITIVES = {
     "search_present_title": lambda d, *a: search_present_title(d),
     "return_book": lambda d, *a: return_book(d, *(a or (None,))),
     "goto": lambda d, screen: navigate_to(d, screen),
-    "forge_streaming_state": lambda d, *a: forge_streaming_state(d),
+    "forge_streaming_state": lambda d, *a: forge_streaming_state(d),  # SUPERSEDED — kept for the lesson; no recipe wires it
+    "reborrow_audiobook_streaming": lambda d, *a: reborrow_audiobook_streaming(d, *(a or (_COLD_LOAD_LCP_AUDIOBOOK,))),
 }
 
 
@@ -1040,18 +1106,22 @@ STAGING_RECIPES: dict[str, list[tuple]] = {
         ("sign_in", "a1qa"), ("goto", "my_books"), ("dismiss_save_password",),
     ],
 
-    # --- audiobook COLD-LOAD (PP-4613, deterministic forge) ---
-    # Open a "downloaded" LCP audiobook whose .lcpa content is NOT local → forces
-    # the LCP streaming path (the Readium-3.9.0 "Audiobook Unavailable" regression).
-    # forge_streaming_state deletes the standing fixture's .lcpa (keeping the .lcpl
-    # license + registry .downloadSuccessful), so opening streams — deterministically,
-    # without racing the ~1.5s live download. The .lcpa is a local cache artifact, not
-    # the loan, so this does NOT mutate/return the read-only A1QA standing fixture; a
-    # re-download (or fixture re-provision) restores it.
+    # --- audiobook COLD-LOAD (PP-4613, real in-flight download) ---
+    # Leave a LARGE LCP audiobook MID-DOWNLOAD, then the journey opens it before the
+    # `.lcpa` content lands — the real cold-open-during-download path the PP-4542
+    # download-gate handles (hold `.loading`, poll the in-flight transfer, open from
+    # the local package when it lands; regressed = "Audiobook Unavailable").
+    # Supersedes the old forge_streaming_state delete-premise: PP-4542 replaced the
+    # LCP streaming path with a 180s file-poll of an ALREADY-in-flight download, so
+    # deleting a COMPLETED `.lcpa` (no active transfer) can only time out — it no
+    # longer reproduces the regression. A large title keeps the download window wide
+    # enough that the open reliably lands mid-transfer. `reborrow_audiobook_streaming`
+    # returns-then-re-borrows, so it re-downloads a FRESH copy each run (idempotent);
+    # the Audible-lane title is a returnable loan, not the read-only standing fixture.
     "audiobook-cold-load-first-open": [
         ("dismiss_first_launch",), ("add_library", "A1QA Test Library"),
-        ("sign_in", "a1qa"), ("goto", "my_books"), ("dismiss_save_password",),
-        ("forge_streaming_state",),
+        ("sign_in", "a1qa"), ("dismiss_save_password",),
+        ("reborrow_audiobook_streaming",), ("goto", "my_books"),
     ],
 }
 

--- a/scripts/tests/test_regression_staging.py
+++ b/scripts/tests/test_regression_staging.py
@@ -479,15 +479,26 @@ def test_audiobook_content_files_empty_when_no_support_dir(tmp_path):
     assert st.audiobook_content_files_under(tmp_path) == []
 
 
-def test_cold_load_journey_is_ready_and_forges():
-    # Promoted out of PHASE2: it now has a staging recipe whose last step is the forge.
+def test_cold_load_journey_stages_a_real_in_flight_download():
+    # Post-PP-4542 the cold-load recipe stages a GENUINE in-flight download (open
+    # DURING download), not the retired forge_streaming_state delete-premise — the
+    # 180s file-poll can only time out on a deleted-with-no-transfer file.
     assert st.staging_status("audiobook-cold-load-first-open") == "ready"
     assert "audiobook-cold-load-first-open" not in st.PHASE2_JOURNEYS
     recipe = st.STAGING_RECIPES["audiobook-cold-load-first-open"]
-    assert ("forge_streaming_state",) in recipe, "cold-load recipe must forge the streaming state"
-    # The forge runs AFTER sign-in (the audiobook must be present/downloaded first).
     prims = [step[0] for step in recipe]
-    assert prims.index("sign_in") < prims.index("forge_streaming_state")
+    assert "reborrow_audiobook_streaming" in prims, \
+        "cold-load recipe must leave a real LCP audiobook mid-download"
+    # The retired forge must NOT be wired into the recipe (its state can't reproduce
+    # the regression anymore — see forge_streaming_state docstring).
+    assert "forge_streaming_state" not in prims, \
+        "forge_streaming_state is superseded — remove it from the recipe"
+    # Re-borrow runs AFTER sign-in (must be authenticated to borrow) and BEFORE the
+    # My Books navigation the journey opens from.
+    assert prims.index("sign_in") < prims.index("reborrow_audiobook_streaming")
+    assert prims.index("reborrow_audiobook_streaming") < prims.index("goto")
+    # The primitive is registered/callable.
+    assert "reborrow_audiobook_streaming" in st.PRIMITIVES
 
 
 def test_download_indicator_stays_phase2():


### PR DESCRIPTION
## Why

The `audiobook-cold-load-first-open` staging recipe (the regression backstop for PP-4613) was broken two ways — found by a live capture on 3.3.0 build 485:

1. **Stale mechanism.** It used `forge_streaming_state` to delete a *completed* `.lcpa`, expecting the next open to stream. But the PP-4542 fix (#1094) **replaced** the LCP streaming path with `awaitAudiobookContentLocal` — a bounded 180s *poll of an already-in-flight download*. Deleting a finished download leaves no active transfer, so the poll can only time out → "Audiobook Unavailable" after 3 min: an artifact, not the regression. (This is why an earlier capture saw the alert — a forge false-positive, not a product bug.)
2. **Stale fixture.** The A1QA standing "Animal Farm" is now a BiblioBoard bearer-token audiobook (zero `.lcpa`), so the forge raised `StagingError` and never reached its precondition.

## Fix

New `reborrow_audiobook_streaming` primitive: return-then-re-borrow a **large returnable LCP audiobook** and leave it **mid-download**, so opening it exercises the genuine PP-4542 await-gate. Title pinned to **"Dungeon Crawler Carl"** (Audible lane) — verified live as the *searchable* catalog title (the cover/My-Books display "Carl's Doomsday Scenario" isn't search-resolvable), returnable, fulfills as "Listen", ~715 MB `.lcpa`. `forge_streaming_state` retired from the recipe (kept + documented as superseded). Unit test pins the new shape.

## Status

- **Scope:** regression staging tooling + the cold-load journey doc. No Palace production code (the product fix already shipped in #1094).
- **Not done — live capture BLOCKED:** on an un-throttled sim the ~715 MB `.lcpa` downloads in ~6–13s, too fast to reliably catch mid-download via UI-timed taps (plus a SpringBoard tap-race). Capturing the recording needs a per-sim network throttle to widen the download window (in the journey's `known_issues`).
- pytest: **43 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)