### PR TITLE
fix(audiobooks): Swift 6 off-main crashes — remote-command handlers + account-change sink

### DIFF
--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -12,6 +12,7 @@
 import Combine
 import Foundation
 import MediaPlayer
+import os
 import PalaceAudiobookToolkit
 import PalaceLogging
 import PalaceNetwork
@@ -116,7 +117,9 @@ public final class AudiobookSessionManager: ObservableObject {
     // MARK: - Internal State
 
     private(set) var audiobook: Audiobook?
-    private(set) var manager: AudiobookManager?
+    private(set) var manager: AudiobookManager? {
+        didSet { Self._hasActiveManagerMirror.withLock { $0 = (manager != nil) } }
+    }
     private(set) var playbackModel: AudiobookPlaybackModel?
     private(set) var nowPlayingCoordinator: NowPlayingCoordinator?
 
@@ -124,6 +127,31 @@ public final class AudiobookSessionManager: ObservableObject {
     /// an `AudiobookManager` is bound without leaking the toolkit type
     /// through the protocol.
     public var hasActiveManager: Bool { manager != nil }
+
+    /// Off-main-safe mirror of `hasActiveManager` (`manager != nil`).
+    ///
+    /// The remote-command handlers in `PlaybackBootstrapper` are invoked by
+    /// MediaRemote / CarPlay / the lock screen on a BACKGROUND daemon queue.
+    /// Under the Swift 6 language mode (#1199) those closures inherit
+    /// `@MainActor` isolation from their enclosing type, so a synchronous read
+    /// of the `@MainActor` `hasActiveManager` off-main trips
+    /// `dispatch_assert_queue_fail` — the same crash class as the #1218
+    /// Now-Playing artwork crash. This lock-guarded snapshot is the off-main
+    /// read path: written only on the main actor (via `manager`'s `didSet` at
+    /// the two bind/unbind seams — the ONLY writers of `manager`), read
+    /// atomically from any thread. A `static` mirror is correct because
+    /// `AudiobookSessionManager` is the single per-session owner (see the
+    /// "Singleton manager" contract below); if concurrent managers were ever
+    /// possible this would move to an instance `nonisolated let`.
+    private static let _hasActiveManagerMirror =
+        OSAllocatedUnfairLock<Bool>(initialState: false)
+
+    /// Off-main-safe read of "is a manager currently bound." Reflects the last
+    /// main-actor `bind`/`stopPlayback` transition; the write window is a single
+    /// main-actor hop, so any staleness is sub-frame and self-correcting.
+    nonisolated static var hasActiveManagerSnapshot: Bool {
+        _hasActiveManagerMirror.withLock { $0 }
+    }
 
     /// DRM decryptor tied to the currently loaded audiobook. Owned atomically
     /// alongside manager/audiobook/playbackModel so stopPlayback can release

--- a/Palace/Audiobooks/PlaybackBootstrapper.swift
+++ b/Palace/Audiobooks/PlaybackBootstrapper.swift
@@ -64,6 +64,16 @@ public final class PlaybackBootstrapper {
     /// tests inject a mock and lets the production closure resolve through
     /// `AppContainer.production().audiobookSession` lazily.
     private let audiobookSessionProvider: () -> AudiobookSessionManaging
+    /// Off-main-safe read of "is an audiobook manager currently bound," used by
+    /// the `@Sendable` remote-command handlers (which run on MediaRemote's
+    /// BACKGROUND queue and therefore MUST NOT touch `@MainActor` state — that is
+    /// the #1218 / #1199 crash class). Kept SEPARATE from
+    /// `audiobookSessionProvider` (whose production closure reads the `@MainActor`
+    /// `AppContainer.audiobookSession` and is thus main-only): this source reads
+    /// the `nonisolated` `AudiobookSessionManager.hasActiveManagerSnapshot`
+    /// mirror instead. `@Sendable` so it can be captured by the off-main handlers;
+    /// tests inject a controllable `Bool` for deterministic gating.
+    private let hasActiveManagerSnapshot: @Sendable () -> Bool
     /// Dispatches the deferred audio-session configuration off the synchronous
     /// launch path (see `ensureInitialized()`). Production hops to a background
     /// queue; tests inject an inline/capturing dispatcher to observe the
@@ -81,12 +91,14 @@ public final class PlaybackBootstrapper {
     private init(
         bookRegistry: TPPBookRegistryProvider,
         audiobookSessionProvider: @escaping () -> AudiobookSessionManaging,
+        hasActiveManagerSnapshot: @escaping @Sendable () -> Bool = { AudiobookSessionManager.hasActiveManagerSnapshot },
         launchAudioSessionDispatcher: @escaping (@escaping @Sendable () -> Void) -> Void = { work in
             DispatchQueue.global(qos: .utility).async(execute: work)
         }
     ) {
         self.bookRegistry = bookRegistry
         self.audiobookSessionProvider = audiobookSessionProvider
+        self.hasActiveManagerSnapshot = hasActiveManagerSnapshot
         self.launchAudioSessionDispatcher = launchAudioSessionDispatcher
         Log.info(#file, "🚀 PlaybackBootstrapper created - app launch context")
 
@@ -102,6 +114,7 @@ public final class PlaybackBootstrapper {
     convenience init(
         appContainer: AppContainer,
         audiobookSessionProvider: @escaping () -> AudiobookSessionManaging,
+        hasActiveManagerSnapshot: @escaping @Sendable () -> Bool = { AudiobookSessionManager.hasActiveManagerSnapshot },
         launchAudioSessionDispatcher: @escaping (@escaping @Sendable () -> Void) -> Void = { work in
             DispatchQueue.global(qos: .utility).async(execute: work)
         }
@@ -109,6 +122,7 @@ public final class PlaybackBootstrapper {
         self.init(
             bookRegistry: appContainer.bookRegistry,
             audiobookSessionProvider: audiobookSessionProvider,
+            hasActiveManagerSnapshot: hasActiveManagerSnapshot,
             launchAudioSessionDispatcher: launchAudioSessionDispatcher
         )
     }
@@ -355,28 +369,28 @@ public final class PlaybackBootstrapper {
 
     private func addCommandTargets() {
         // Play command
-        let playTarget = commandCenter.playCommand.addTarget { [weak self] _ in
+        let playTarget = commandCenter.playCommand.addTarget { @Sendable [weak self] _ in
             Log.debug(#file, "🎮 ▶️ PLAY command received")
             return self?.handlePlay() ?? .noActionableNowPlayingItem
         }
         commandTargets.append(playTarget)
 
         // Pause command
-        let pauseTarget = commandCenter.pauseCommand.addTarget { [weak self] _ in
+        let pauseTarget = commandCenter.pauseCommand.addTarget { @Sendable [weak self] _ in
             Log.debug(#file, "🎮 ⏸️ PAUSE command received")
             return self?.handlePause() ?? .noActionableNowPlayingItem
         }
         commandTargets.append(pauseTarget)
 
         // Toggle play/pause (headphone button, steering wheel)
-        let toggleTarget = commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
+        let toggleTarget = commandCenter.togglePlayPauseCommand.addTarget { @Sendable [weak self] _ in
             Log.debug(#file, "🎮 ⏯️ TOGGLE command received")
             return self?.handleTogglePlayPause() ?? .noActionableNowPlayingItem
         }
         commandTargets.append(toggleTarget)
 
         // Skip forward (30 seconds)
-        let skipForwardTarget = commandCenter.skipForwardCommand.addTarget { [weak self] event in
+        let skipForwardTarget = commandCenter.skipForwardCommand.addTarget { @Sendable [weak self] event in
             guard let skipEvent = event as? MPSkipIntervalCommandEvent else {
                 Log.error(#file, "🎮 skipForward event cast failed")
                 return .commandFailed
@@ -387,7 +401,7 @@ public final class PlaybackBootstrapper {
         commandTargets.append(skipForwardTarget)
 
         // Skip backward (30 seconds)
-        let skipBackwardTarget = commandCenter.skipBackwardCommand.addTarget { [weak self] event in
+        let skipBackwardTarget = commandCenter.skipBackwardCommand.addTarget { @Sendable [weak self] event in
             guard let skipEvent = event as? MPSkipIntervalCommandEvent else {
                 Log.error(#file, "🎮 skipBackward event cast failed")
                 return .commandFailed
@@ -398,7 +412,7 @@ public final class PlaybackBootstrapper {
         commandTargets.append(skipBackwardTarget)
 
         // Change playback rate
-        let rateTarget = commandCenter.changePlaybackRateCommand.addTarget { [weak self] event in
+        let rateTarget = commandCenter.changePlaybackRateCommand.addTarget { @Sendable [weak self] event in
             guard let rateEvent = event as? MPChangePlaybackRateCommandEvent else {
                 Log.error(#file, "🎮 changePlaybackRate event cast failed")
                 return .commandFailed
@@ -433,90 +447,71 @@ public final class PlaybackBootstrapper {
     /// The session manager's `hasActiveManager` flag is false until a book is
     /// opened; opening the book binds the manager directly on the session.
 
-    private func handlePlay() -> MPRemoteCommandHandlerStatus {
-        let hasManager = audiobookSessionProvider().hasActiveManager
+    /// The gate shared by all six remote-command handlers. When a manager is
+    /// bound the toolkit's `MediaControlPublisher` performs the actual transport
+    /// action, so we return `.success` to acknowledge the command; with no
+    /// manager there is nothing to act on, so `.noActionableNowPlayingItem`
+    /// (which keeps the lock screen from presenting a dead control before a book
+    /// is opened). Extracted as a `nonisolated static` PURE function so the gate
+    /// is unit-testable directly — MPRemoteCommand exposes no public
+    /// invoke-handler-and-read-status API, so this is the seam that lets a test
+    /// kill the gate-inversion mutant without an MPRemoteCommand invocation or a
+    /// bound-manager fixture. `internal` for `@testable` access.
+    nonisolated static func remoteCommandStatus(hasActiveManager: Bool) -> MPRemoteCommandHandlerStatus {
+        hasActiveManager ? .success : .noActionableNowPlayingItem
+    }
+
+    nonisolated private func handlePlay() -> MPRemoteCommandHandlerStatus {
+        // Off-main-safe: reads the nonisolated snapshot, NOT the @MainActor
+        // `audiobookSessionProvider().hasActiveManager` (which would trip
+        // dispatch_assert_queue when this handler runs on MediaRemote's queue).
+        let hasManager = hasActiveManagerSnapshot()
         Log.debug(#file, "🎮 handlePlay - manager: \(hasManager)")
-
-        // When AudiobookManager is active, the toolkit's MediaControlPublisher handles
-        // play/pause commands. We return .success to indicate we handled it (preventing error)
-        // but don't actually play - the toolkit does the actual play.
-        if hasManager {
-            return .success
-        }
-
-        Log.debug(#file, "🎮 Play command received but no active manager")
-        return .noActionableNowPlayingItem
+        return Self.remoteCommandStatus(hasActiveManager: hasManager)
     }
 
-    private func handlePause() -> MPRemoteCommandHandlerStatus {
-        let hasManager = audiobookSessionProvider().hasActiveManager
+    nonisolated private func handlePause() -> MPRemoteCommandHandlerStatus {
+        // Off-main-safe: reads the nonisolated snapshot, NOT the @MainActor
+        // `audiobookSessionProvider().hasActiveManager` (which would trip
+        // dispatch_assert_queue when this handler runs on MediaRemote's queue).
+        let hasManager = hasActiveManagerSnapshot()
         Log.debug(#file, "🎮 handlePause - manager: \(hasManager)")
-
-        // When AudiobookManager is active, the toolkit's MediaControlPublisher handles
-        // play/pause commands. We return .success but defer actual action to toolkit.
-        if hasManager {
-            return .success
-        }
-
-        Log.debug(#file, "🎮 Pause command received but no active manager")
-        return .noActionableNowPlayingItem
+        return Self.remoteCommandStatus(hasActiveManager: hasManager)
     }
 
-    private func handleTogglePlayPause() -> MPRemoteCommandHandlerStatus {
-        let hasManager = audiobookSessionProvider().hasActiveManager
+    nonisolated private func handleTogglePlayPause() -> MPRemoteCommandHandlerStatus {
+        // Off-main-safe: reads the nonisolated snapshot, NOT the @MainActor
+        // `audiobookSessionProvider().hasActiveManager` (which would trip
+        // dispatch_assert_queue when this handler runs on MediaRemote's queue).
+        let hasManager = hasActiveManagerSnapshot()
         Log.debug(#file, "🎮 handleTogglePlayPause - manager: \(hasManager)")
-
-        // When AudiobookManager is active, the toolkit's MediaControlPublisher handles
-        // play/pause commands. We return .success but defer actual action to toolkit.
-        if hasManager {
-            return .success
-        }
-
-        Log.debug(#file, "🎮 TogglePlayPause command received but no active manager")
-        return .noActionableNowPlayingItem
+        return Self.remoteCommandStatus(hasActiveManager: hasManager)
     }
 
-    private func handleSkipForward(interval: TimeInterval) -> MPRemoteCommandHandlerStatus {
-        let hasManager = audiobookSessionProvider().hasActiveManager
+    nonisolated private func handleSkipForward(interval: TimeInterval) -> MPRemoteCommandHandlerStatus {
+        // Off-main-safe: reads the nonisolated snapshot, NOT the @MainActor
+        // `audiobookSessionProvider().hasActiveManager` (which would trip
+        // dispatch_assert_queue when this handler runs on MediaRemote's queue).
+        let hasManager = hasActiveManagerSnapshot()
         Log.debug(#file, "🎮 handleSkipForward(\(interval)s) - manager: \(hasManager)")
-
-        // When AudiobookManager is active, the toolkit's MediaControlPublisher handles
-        // skip commands. We return .success to indicate we handled it (preventing error)
-        // but don't actually skip - the toolkit does the actual skip.
-        if hasManager {
-            return .success
-        }
-
-        Log.debug(#file, "🎮 SkipForward command received but no active manager")
-        return .noActionableNowPlayingItem
+        return Self.remoteCommandStatus(hasActiveManager: hasManager)
     }
 
-    private func handleSkipBackward(interval: TimeInterval) -> MPRemoteCommandHandlerStatus {
-        let hasManager = audiobookSessionProvider().hasActiveManager
+    nonisolated private func handleSkipBackward(interval: TimeInterval) -> MPRemoteCommandHandlerStatus {
+        // Off-main-safe: reads the nonisolated snapshot, NOT the @MainActor
+        // `audiobookSessionProvider().hasActiveManager` (which would trip
+        // dispatch_assert_queue when this handler runs on MediaRemote's queue).
+        let hasManager = hasActiveManagerSnapshot()
         Log.debug(#file, "🎮 handleSkipBackward(\(interval)s) - manager: \(hasManager)")
-
-        // When AudiobookManager is active, the toolkit's MediaControlPublisher handles
-        // skip commands. We return .success to indicate we handled it (preventing error)
-        // but don't actually skip - the toolkit does the actual skip.
-        if hasManager {
-            return .success
-        }
-
-        Log.debug(#file, "🎮 SkipBackward command received but no active manager")
-        return .noActionableNowPlayingItem
+        return Self.remoteCommandStatus(hasActiveManager: hasManager)
     }
 
-    private func handleChangePlaybackRate(rate: Float) -> MPRemoteCommandHandlerStatus {
-        let hasManager = audiobookSessionProvider().hasActiveManager
+    nonisolated private func handleChangePlaybackRate(rate: Float) -> MPRemoteCommandHandlerStatus {
+        // Off-main-safe: reads the nonisolated snapshot, NOT the @MainActor
+        // `audiobookSessionProvider().hasActiveManager` (which would trip
+        // dispatch_assert_queue when this handler runs on MediaRemote's queue).
+        let hasManager = hasActiveManagerSnapshot()
         Log.debug(#file, "🎮 handleChangePlaybackRate(\(rate)x) - manager: \(hasManager)")
-
-        // When AudiobookManager is active, the toolkit's MediaControlPublisher handles
-        // playback rate commands. We return .success but defer actual action to toolkit.
-        if hasManager {
-            return .success
-        }
-
-        Log.debug(#file, "🎮 ChangePlaybackRate command received but no active manager")
-        return .noActionableNowPlayingItem
+        return Self.remoteCommandStatus(hasActiveManager: hasManager)
     }
 }

--- a/Palace/CarPlay/CarPlaySceneDelegate.swift
+++ b/Palace/CarPlay/CarPlaySceneDelegate.swift
@@ -202,8 +202,17 @@ final class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplica
             }
             .store(in: &cancellables)
 
-        // Subscribe to account changes to update library name
+        // Subscribe to account changes to update library name.
+        // `.receive(on: DispatchQueue.main)` guards the same Swift 6 bug class as
+        // the AccountDetailViewModel fix: this closure is `@MainActor`-isolated
+        // (calls `templateManager` on the main actor), and NotificationCenter
+        // delivers synchronously on the posting thread. Every current
+        // `.TPPCurrentAccountDidChange` poster is on main, so this is defensive —
+        // but it was the lone bare sink here (the two registry sinks above hop
+        // via `.debounce(scheduler: DispatchQueue.main)`), so a future off-main
+        // poster would trap. Match the siblings.
         NotificationCenter.default.publisher(for: .TPPCurrentAccountDidChange)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 Log.info(#file, "🚗 Account changed - updating CarPlay library name and refreshing")
                 self?.templateManager?.updateLibraryName()

--- a/Palace/Settings/AccountDetailViewModel.swift
+++ b/Palace/Settings/AccountDetailViewModel.swift
@@ -187,21 +187,25 @@ class AccountDetailViewModel: NSObject, ObservableObject {
     // MARK: - Setup
 
     private func setupObservers() {
+        // `.receive(on: RunLoop.main)` is REQUIRED, not cosmetic: this sink
+        // closure is `@MainActor`-isolated (the view model is `@MainActor`), and
+        // `.TPPUserAccountDidChange` is posted on WHATEVER thread `setAuthToken`
+        // runs on — notably a BACKGROUND queue during the token-refresh-before-
+        // playback path (`TPPNetworkExecutor.executeTokenRefresh` →
+        // `TPPUserAccount.notifyAccountDidChange`). Without the hop, Combine runs
+        // the `@MainActor` closure on that background queue and Swift 6 traps
+        // (`dispatch_assert_queue_fail`) — it crashed audiobook startup. The
+        // hop also makes the inner `Task { @MainActor }` unnecessary. Mirrors the
+        // two subscribers below that already receive on main.
         NotificationCenter.default.publisher(for: .TPPUserAccountDidChange)
-            .sink { [weak self] _ in
-                Task { @MainActor in
-                    self?.accountDidChange()
-                }
-            }
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.accountDidChange() }
             .store(in: &cancellables)
 
         // Listen for account switches to refresh sign-in state
         NotificationCenter.default.publisher(for: .TPPCurrentAccountDidChange)
-            .sink { [weak self] _ in
-                Task { @MainActor in
-                    self?.accountDidChange()
-                }
-            }
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.accountDidChange() }
             .store(in: &cancellables)
 
         // Belt-and-suspenders refresh signals. The `.TPPUserAccountDidChange`

--- a/PalaceTests/Audiobooks/PlaybackBootstrapperTests.swift
+++ b/PalaceTests/Audiobooks/PlaybackBootstrapperTests.swift
@@ -177,4 +177,25 @@ final class AudiobookSessionErrorTests: XCTestCase {
         // Unknown with different message
         XCTAssertNotEqual(AudiobookSessionError.unknown("a"), AudiobookSessionError.unknown("b"))
     }
+
+    // MARK: - Remote-command gate (Swift 6 off-main crash fix)
+
+    /// `PlaybackBootstrapper.remoteCommandStatus(hasActiveManager:)` is the pure,
+    /// `nonisolated` gate that all six `MPRemoteCommand` handlers now return
+    /// through after the Swift 6 off-main crash fix. Pinning BOTH branches kills
+    /// the gate-inversion mutant on the changed lines — a swapped pair of
+    /// statuses, or a `!hasActiveManager`, fails here. This is the mutation-
+    /// killing coverage that MPRemoteCommand's lack of a public
+    /// invoke-handler-and-read-status API otherwise blocks, achieved without a
+    /// bound-manager fixture by testing the extracted pure gate directly.
+    func testRemoteCommandStatus_gatesOnActiveManager() {
+        XCTAssertEqual(
+            PlaybackBootstrapper.remoteCommandStatus(hasActiveManager: true).rawValue,
+            MPRemoteCommandHandlerStatus.success.rawValue,
+            "With an active manager the command is acknowledged (.success) so the toolkit performs the transport action")
+        XCTAssertEqual(
+            PlaybackBootstrapper.remoteCommandStatus(hasActiveManager: false).rawValue,
+            MPRemoteCommandHandlerStatus.noActionableNowPlayingItem.rawValue,
+            "With no manager there is nothing to act on — .noActionableNowPlayingItem keeps the lock screen from presenting a dead control")
+    }
 }


### PR DESCRIPTION
## Why

Bundles the remaining unmerged **Swift 6 (#1199) off-main main-actor crashes** in the audiobook lane. All are the same class: an `@MainActor`-isolated closure invoked off-main by a framework → `dispatch_assert_queue_fail` at runtime, invisible to the build and unit tests. Surfaced by a 4-zone crash audit of the language-mode flip.

## Crashes fixed

1. **`PlaybackBootstrapper` remote-command handlers (NEW — this audit).** The 6 `MPRemoteCommandCenter.addTarget` closures inherited `@MainActor` and read `@MainActor` `hasActiveManager` off-main (MediaRemote/CarPlay/lock-screen deliver on a background daemon queue). Presented as "pause/skip from lock-screen, CarPlay, or headphones crashes the app." Fix: a `nonisolated static` `OSAllocatedUnfairLock` mirror on `AudiobookSessionManager` (written on main via `manager.didSet`), read by `@Sendable`/`nonisolated` handlers through a separate injected snapshot source — **not** the `@MainActor` provider (which would just relocate the crash). Gate extracted to a pure `nonisolated static` function for direct testing.
2. **Account-change sink** (`c202eb1d9`, `bde3222f8` — already on the branch): a bare `.sink` on `.TPPUserAccountDidChange`, posted off-main by the token refresh → `.receive(on: RunLoop.main)`.

## Rigor (critical-path: audiobook / CarPlay)

- **Architect review: APPROVED** — all 6 Swift 6 isolation rules traced; the fix removes the off-main `@MainActor` read at root and does not relocate the crash; both `manager` write-sites route through the `didSet`.
- **QA review: BLOCK → APPROVE** — round 1 (`rev_9df75309`) blocked on zero mutation coverage of the changed gate lines; addressed by extracting the pure gate + `testRemoteCommandStatus_gatesOnActiveManager` (pins both branches, kills the gate-inversion mutant); round 2 (`rev_a3c81f47`) confirmed resolved.

## ⚠️ Verification note

**Not built locally** — a fresh worktree lacks the Carthage frameworks, and `@Sendable`/`nonisolated` isolation is exactly the class that only the DRM CI build surfaces. **CI on this PR is the compile authority.** The `manager.didSet` mirror-sync (true→false round-trip) needs a heavy bound-manager fixture and is deferred; the pure-gate test covers the changed handler logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)