### PR TITLE
fix(audiobooks+signin): awaitRemotePosition + Sign-In off-main crashes (rebased on build-repair)

### DIFF
--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -118,7 +118,17 @@ public final class AudiobookSessionManager: ObservableObject {
 
     private(set) var audiobook: Audiobook?
     private(set) var manager: AudiobookManager? {
-        didSet { Self._hasActiveManagerMirror.withLock { $0 = (manager != nil) } }
+        didSet {
+            // Compute the Bool on the (main) actor BEFORE entering the
+            // `@Sendable` `withLock` closure. Referencing the `@MainActor`
+            // `manager` property from INSIDE that closure does not compile under
+            // Swift 6 ("main actor-isolated property 'manager' can not be
+            // referenced from a Sendable closure") — this broke the develop build
+            // after #1222 merged. The Bool snapshot is Sendable, so hoisting it
+            // out fixes it with identical behavior.
+            let isActive = (manager != nil)
+            Self._hasActiveManagerMirror.withLock { $0 = isActive }
+        }
     }
     private(set) var playbackModel: AudiobookPlaybackModel?
     private(set) var nowPlayingCoordinator: NowPlayingCoordinator?
@@ -143,7 +153,14 @@ public final class AudiobookSessionManager: ObservableObject {
     /// `AudiobookSessionManager` is the single per-session owner (see the
     /// "Singleton manager" contract below); if concurrent managers were ever
     /// possible this would move to an instance `nonisolated let`.
-    private static let _hasActiveManagerMirror =
+    // `nonisolated`: the class is `@MainActor`, so an un-annotated `static let`
+    // is main-actor-isolated and CANNOT be read from the `nonisolated`
+    // `hasActiveManagerSnapshot` below ("main actor-isolated static property
+    // '_hasActiveManagerMirror' can not be referenced from a nonisolated
+    // context") — the second half of the develop build break from #1222.
+    // `OSAllocatedUnfairLock` is `Sendable`, so a `nonisolated static let` is
+    // safe and is exactly the off-main read path this mirror exists to provide.
+    nonisolated private static let _hasActiveManagerMirror =
         OSAllocatedUnfairLock<Bool>(initialState: false)
 
     /// Off-main-safe read of "is a manager currently bound." Reflects the last

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -1327,8 +1327,21 @@ public final class AudiobookSessionManager: ObservableObject {
         let box: SendableTrackPositionBox = await withCheckedContinuation { (cont: CheckedContinuation<SendableTrackPositionBox, Never>) in
             let once = PositionResolveOnce()
             concreteRegistry.syncLocation(for: book) { (remoteBookmark: AudioBookmark?) in
-                let position = remoteBookmark.flatMap {
-                    TrackPosition(audioBookmark: $0, toc: toc.toc, tracks: toc.tracks)
+                // Build the position INLINE, not via `.flatMap { … }`. The
+                // syncLocation completion is `@Sendable` (non-isolated) and fires
+                // on a BACKGROUND queue (TPPBookRegistry's detached sync Task).
+                // A `.flatMap` transform closure, however, is NOT `@Sendable`, so
+                // it inherited this `@MainActor` method's isolation — and invoking
+                // that main-actor closure off-main tripped `dispatch_assert_queue_fail`
+                // (EXC_BREAKPOINT on every audiobook open with a remote bookmark;
+                // Crashlytics 6e05efb…, fresh in 3.3.0). Inline `if let` runs
+                // directly in the non-isolated completion closure — no nested
+                // closure, no inherited isolation.
+                let position: TrackPosition?
+                if let remoteBookmark {
+                    position = TrackPosition(audioBookmark: remoteBookmark, toc: toc.toc, tracks: toc.tracks)
+                } else {
+                    position = nil
                 }
                 let boxed = SendableTrackPositionBox(position)
                 once.fire { cont.resume(returning: boxed) }
@@ -2287,7 +2300,7 @@ public final class AudiobookSessionManager: ObservableObject {
 private final class PositionResolveOnce: @unchecked Sendable {
     private let lock = NSLock()
     private var fired = false
-    func fire(_ block: () -> Void) {
+    func fire(_ block: @Sendable () -> Void) {
         lock.lock()
         if fired {
             lock.unlock()

--- a/Palace/SignInLogic/TPPSignInBusinessLogic.swift
+++ b/Palace/SignInLogic/TPPSignInBusinessLogic.swift
@@ -525,17 +525,28 @@ class TPPSignInBusinessLogic: NSObject, @preconcurrency TPPSignedInStateProvider
                                            password: password,
                                            tokenURL: tokenURL,
                                            accountId: libraryAccountID) { [weak self] result in
-            defer {
-                completion?()
-            }
-
-            switch result {
-            case .success(let tokenResponse):
-                self?.dispatch(.bearerTokenReceived(token: tokenResponse.accessToken,
-                                                   expiration: tokenResponse.expirationDate))
-                self?.validateCredentials()
-            case .failure(let error):
-                self?.handleNetworkError(error as NSError, loggingContext: ["Context": self?.uiContext as Any])
+            // `executeTokenRefresh` invokes this completion on a BACKGROUND queue
+            // (its `Result<…> -> Void` param is neither `@Sendable` nor
+            // `@MainActor`). Everything below touches `@MainActor` state — the
+            // whole type is `@MainActor`, and `validateCredentials()` /
+            // `handleNetworkError()` read `uiContext` → the `@objc @MainActor`
+            // `AccountDetailViewModel.context` getter. Running that off-main traps
+            // under Swift 6 (`dispatch_assert_queue_fail`) and crashed **Sign In**
+            // (Crashlytics, 3.3.0, 2/2 repro). Hop to the main actor first.
+            // `nonisolated(unsafe)` keeps the non-Sendable `Result` (its `Error`
+            // is a non-Sendable existential) from tripping the region check as it
+            // crosses into the task — the value is only read, on main.
+            nonisolated(unsafe) let outcome = result
+            Task { @MainActor in
+                defer { completion?() }
+                switch outcome {
+                case .success(let tokenResponse):
+                    self?.dispatch(.bearerTokenReceived(token: tokenResponse.accessToken,
+                                                        expiration: tokenResponse.expirationDate))
+                    self?.validateCredentials()
+                case .failure(let error):
+                    self?.handleNetworkError(error as NSError, loggingContext: ["Context": self?.uiContext as Any])
+                }
             }
         }
     }


### PR DESCRIPTION
## Two Swift-6 off-main crashes not covered by #1218/#1222
Both confirmed via Firebase Crashlytics on 3.3.0 (device). Rebased onto the develop build-repair (#1225) so this builds cleanly; the account-sink + CarPlay fixes originally bundled here were **dropped** — #1222 already landed equivalents on develop.

1. **`AudiobookSessionManager.awaitRemotePosition`** — Crashlytics `6e05efb…`, fresh in 3.3.0. `TPPBookRegistry.syncLocation` fires its `@Sendable` completion on a background queue; the nested `remoteBookmark.flatMap { TrackPosition(…) }` transform is not `@Sendable`, inherited `@MainActor`, and trapped whenever a remote bookmark exists. Build the position **inline** (no nested closure); also make `PositionResolveOnce.fire`'s closure `@Sendable` (same latent trap on the nil path).
2. **`TPPSignInBusinessLogic.getBearerToken`** — `executeTokenRefresh`'s completion runs off-main and reached `validateCredentials()`/`uiContext` → the `@objc @MainActor` `AccountDetailViewModel.context` getter → trap on **Sign In** (2/2 repro, found by chaos-qa). Hop the completion body to the main actor.

**Base:** includes the #1225 build-repair commit as its base, so this PR builds green on its own. Once #1225 merges, this PR's net diff is just the two crash fixes above. DRM `Palace` build **SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)