### PR TITLE
fix(build): repair develop build — hasActiveManager Swift 6 isolation errors (regression from #1222)

### DIFF
--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -118,7 +118,17 @@ public final class AudiobookSessionManager: ObservableObject {
 
     private(set) var audiobook: Audiobook?
     private(set) var manager: AudiobookManager? {
-        didSet { Self._hasActiveManagerMirror.withLock { $0 = (manager != nil) } }
+        didSet {
+            // Compute the Bool on the (main) actor BEFORE entering the
+            // `@Sendable` `withLock` closure. Referencing the `@MainActor`
+            // `manager` property from INSIDE that closure does not compile under
+            // Swift 6 ("main actor-isolated property 'manager' can not be
+            // referenced from a Sendable closure") — this broke the develop build
+            // after #1222 merged. The Bool snapshot is Sendable, so hoisting it
+            // out fixes it with identical behavior.
+            let isActive = (manager != nil)
+            Self._hasActiveManagerMirror.withLock { $0 = isActive }
+        }
     }
     private(set) var playbackModel: AudiobookPlaybackModel?
     private(set) var nowPlayingCoordinator: NowPlayingCoordinator?
@@ -143,7 +153,14 @@ public final class AudiobookSessionManager: ObservableObject {
     /// `AudiobookSessionManager` is the single per-session owner (see the
     /// "Singleton manager" contract below); if concurrent managers were ever
     /// possible this would move to an instance `nonisolated let`.
-    private static let _hasActiveManagerMirror =
+    // `nonisolated`: the class is `@MainActor`, so an un-annotated `static let`
+    // is main-actor-isolated and CANNOT be read from the `nonisolated`
+    // `hasActiveManagerSnapshot` below ("main actor-isolated static property
+    // '_hasActiveManagerMirror' can not be referenced from a nonisolated
+    // context") — the second half of the develop build break from #1222.
+    // `OSAllocatedUnfairLock` is `Sendable`, so a `nonisolated static let` is
+    // safe and is exactly the off-main read path this mirror exists to provide.
+    nonisolated private static let _hasActiveManagerMirror =
         OSAllocatedUnfairLock<Bool>(initialState: false)
 
     /// Off-main-safe read of "is a manager currently bound." Reflects the last


### PR DESCRIPTION
## develop is not building

After **#1222** ("Swift 6 off-main crashes — remote-command handlers + account-change sink") merged, `develop` stopped compiling. Two Swift 6 errors in `AudiobookSessionManager.swift` (the class is `@MainActor`):

```
error: main actor-isolated property 'manager' can not be referenced from a Sendable closure
error: main actor-isolated static property '_hasActiveManagerMirror' can not be referenced from a nonisolated context
```

## Fix
1. `manager.didSet` referenced `@MainActor` `manager` **inside** `_hasActiveManagerMirror.withLock { … }` — whose closure is `@Sendable`. Hoist the `manager != nil` Bool out of the closure (Sendable value, identical behavior).
2. `_hasActiveManagerMirror` was a plain `static let` (main-actor-isolated) but read from the `nonisolated hasActiveManagerSnapshot` getter — mark it `nonisolated` (`OSAllocatedUnfairLock` is `Sendable`; that's the entire point of this off-main mirror).

Pure isolation-annotation repair; no behavior change. **DRM `Palace` build SUCCEEDED** locally with the fix.

## ⚠️ Process note
#1222 merged with a red build — a green-board-contract violation. Recommend a wall-failure entry + confirming branch protection requires `build-and-test` green before merge to `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)