### PR TITLE
fix(startup): break AppContainer lock re-entrancy that crashes launch for signed-in users (regression from #1224)

### DIFF
--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -604,7 +604,25 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             // (audiobook open, token refresh, bookmark sync, CarPlay auth)
             // resolve without waiting on the full off-main materialization.
             // `currentAccount` resolves via `account(_:)`'s slim fallback.
-            driveCurrentAccountAuthDocIfNeeded()
+            //
+            // DEFERRED off this synchronous stack (was a direct call). This path
+            // is reached from `AccountsManager.init` → `preloadAccountsFromDiskCacheSync`,
+            // and on cold launch `AccountsManager()` is constructed INSIDE
+            // `AppContainer._buildCachedAppContainer()`, which runs under
+            // `AppContainer._cachedLock.withLock`. The drive transitively calls
+            // `AppContainer.production()` again (`Account.fetchAuthenticationDocument`
+            // → `.networkExecutor`), and re-entering the non-recursive
+            // `OSAllocatedUnfairLock` on the same thread traps (`EXC_BREAKPOINT`)
+            // — it crashed launch for every signed-in user (a logged-out sim has
+            // no current account to drive, which is why it didn't reproduce there).
+            // Hopping to the next main-runloop turn lets the container finish
+            // building and release the lock first, so the re-entrant
+            // `production()` returns the now-cached graph. The drive is an async
+            // fire-and-forget network fetch, so a one-turn defer is behaviorally
+            // inert for `awaitReady()` consumers (all of which run well after launch).
+            DispatchQueue.main.async { [weak self] in
+                self?.driveCurrentAccountAuthDocIfNeeded()
+            }
             Log.info(#file, "CP-D1: slim launch snapshot hydrated \(accounts.count) accounts (hash=\(hash))")
             return true
         } catch {

--- a/PalaceTests/Accounts/AccountsManagerLaunchSnapshotTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerLaunchSnapshotTests.swift
@@ -412,6 +412,73 @@ final class AccountsManagerLaunchSnapshotTests: PalaceWiringTestCase {
         }
     }
 
+    // MARK: - Regression (PR #1226): launch-time drive must be deferred off the sync stack
+
+    /// Regression for the cold-launch re-entrancy crash (PR #1226). At cold launch
+    /// `AccountsManager()` is built INSIDE `AppContainer._buildCachedAppContainer()`,
+    /// which runs under `AppContainer._cachedLock` (a non-recursive
+    /// `OSAllocatedUnfairLock`). `hydrateSlimLaunchSnapshot` used to drive the
+    /// current account's auth-doc SYNCHRONOUSLY on that stack — and the drive calls
+    /// `AppContainer.production()` again (`Account.fetchAuthenticationDocument`),
+    /// re-entering the held lock → `_os_unfair_lock_recursive_abort` /
+    /// `EXC_BREAKPOINT`. It crashed launch for every SIGNED-IN user (a logged-out
+    /// sim has no current account to drive, so it never reproduced there — which is
+    /// how it shipped).
+    ///
+    /// The fix defers the drive one main-runloop turn. This test pins that at the
+    /// seam we can unit-test: immediately after the SYNCHRONOUS preload returns, the
+    /// current account must NOT yet be driving (the deferred block hasn't run on this
+    /// runloop turn); it must begin driving only AFTER the runloop turns. A revert to
+    /// an inline drive flips the first assertion — the same change that reintroduces
+    /// the re-entrant launch crash — and fails here.
+    func testColdLaunch_authDocDrive_isDeferredOffSyncPreloadStack_notInline() throws {
+        let catalogs = try loadFeedCatalogs()
+        let aUUID = catalogs[0].metadata.id
+
+        let defaults = testUserDefaults()
+        defaults.set(aUUID, forKey: currentAccountIdentifierKey)
+        let manager = makeFreshAccountsManager(defaults: defaults)
+
+        let hash = activeHash()
+        try seedFullCache(hash: hash, data: feedData)
+        try seedSlimSnapshot(hash: hash, keepUUIDs: [aUUID])
+        defer { tearDownCaches(hash: hash) }
+
+        #if DEBUG
+        AccountStateStore.shared._resetAllForTesting()
+        #endif
+
+        // Synchronous preload — same runloop turn as the (deferred) drive schedule.
+        manager.preloadAccountsFromDiskCacheSync()
+
+        // The deferred drive has NOT run yet (we haven't yielded the runloop). If it
+        // were inline — the re-entrancy regression — the account would already be
+        // `.detailsLoading`.
+        switch AccountStateStore.shared.state(for: aUUID) {
+        case .detailsLoading, .detailsLoaded, .detailsFailed:
+            XCTFail("Auth-doc drive ran SYNCHRONOUSLY inside preloadAccountsFromDiskCacheSync — at cold launch this re-enters AppContainer.production() under the held _cachedLock and aborts (PR #1226). It must be deferred off this stack. Observed \(label(AccountStateStore.shared.state(for: aUUID)))")
+        default:
+            break // .notLoaded / .basicInfoLoaded — deferred, correct.
+        }
+
+        // After the runloop turns, the deferred drive fires — the launch-readiness
+        // contract (awaitReady() consumers resolve) is preserved.
+        awaitCondition(timeout: 6.0) {
+            switch AccountStateStore.shared.state(for: aUUID) {
+            case .detailsLoading, .detailsLoaded, .detailsFailed:
+                return true
+            default:
+                return false
+            }
+        }
+        switch AccountStateStore.shared.state(for: aUUID) {
+        case .detailsLoading, .detailsLoaded, .detailsFailed:
+            break
+        default:
+            XCTFail("Deferred drive must still fire on the next runloop turn; observed \(label(AccountStateStore.shared.state(for: aUUID)))")
+        }
+    }
+
     // MARK: - Finding 4: slim→full instance reuse (no auth-doc split-brain)
 
     /// Contract (architect Finding 4): `details`/`authenticationDocument` are


### PR DESCRIPTION
## develop crashes on launch for every signed-in user
`EXC_BREAKPOINT` at cold launch. Regression from **#1224** (cold-launch hydration), surfaced now that develop compiles + runs again (post-#1225). Not reproducible on a fresh logged-out sim — **signed-in only**, which is why it slipped CI/sim smoke.

## Root cause — non-recursive lock re-entrancy (backtrace: `_cachedValue` appears twice, main thread)
```
applicationDidFinishLaunching
 → AppContainer.production() → _cachedValue()          [acquires _cachedLock]
  → _buildCachedAppContainer() (AppContainer.swift:611 → AccountsManager())
   → AccountsManager.init → preloadAccountsFromDiskCacheSync (546)
    → hydrateSlimLaunchSnapshot (607) → driveCurrentAccountAuthDocIfNeeded (1699)
     → Account.fetchAuthenticationDocument (827)
      → AppContainer.production() → _cachedValue()     [RE-LOCKS non-recursive lock → TRAP]
```
`hydrateSlimLaunchSnapshot` drove the current account's auth-doc **synchronously** inside `AccountsManager.init`, which runs inside `_buildCachedAppContainer()` under `AppContainer._cachedLock` (a non-recursive `OSAllocatedUnfairLock`). The auth-doc fetch calls `AppContainer.production()` again → same-thread re-entry → abort. A logged-out sim has no current account to drive, so the re-entrant branch is never taken.

## Fix
Defer the launch-time drive one main-runloop turn (`DispatchQueue.main.async`) so `_buildCachedAppContainer` returns and releases the lock before the re-entrant `production()` runs (it then resolves the now-cached graph). The drive is an async fire-and-forget network fetch, so the defer is behaviorally inert for `awaitReady()` consumers (all post-launch). Only the line-607 launch/build-path call is deferred; the two post-launch callers (869, 1121) aren't under the lock and stay synchronous.

DRM `Palace` build **SUCCEEDED**. Empirical sim repro (signed-in cold relaunch) in progress.

## Process
Third bug from this cluster that reached develop uncompiled/uncrashing — recommend a wall-failure entry + a **signed-in cold-launch smoke** in CI/sim (the logged-out smoke is blind to this whole class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)