### PR TITLE
fix(ui): remove empty-state icons from Holds + My Books (keep copy)

### DIFF
--- a/Palace/Holds/HoldsView.swift
+++ b/Palace/Holds/HoldsView.swift
@@ -151,7 +151,10 @@ struct HoldsView: View {
     /// Empty state shown when the patron has no reserved or held books.
     private var emptyView: some View {
         ContentUnavailableView {
-            Label(DisplayStrings.emptyTitle, systemImage: "clock")
+            // Icon intentionally removed for now (was `systemImage: "clock"`,
+            // added in #1203/PP-4747). Copy unchanged — a plain title `Text`
+            // renders the same words without the SF Symbol above them.
+            Text(DisplayStrings.emptyTitle)
         } description: {
             Text(DisplayStrings.emptyMessage)
         }

--- a/Palace/MyBooks/MyBooks/MyBooksView.swift
+++ b/Palace/MyBooks/MyBooks/MyBooksView.swift
@@ -256,7 +256,10 @@ struct MyBooksView: View {
 
     private var emptyView: some View {
         ContentUnavailableView {
-            Label(DisplayStrings.emptyViewTitle, systemImage: "books.vertical")
+            // Icon intentionally removed for now (was `systemImage: "books.vertical"`,
+            // added in #1203/PP-4747). Copy unchanged — a plain title `Text`
+            // renders the same words without the SF Symbol above them.
+            Text(DisplayStrings.emptyViewTitle)
         } description: {
             Text(DisplayStrings.emptyViewMessage)
         } actions: {


### PR DESCRIPTION
Per product direction, remove the SF Symbol icons the P3 empty-states polish (#1203 / PP-4747) added above the title in the empty **Holds** and **My Books** views — `clock` and `books.vertical` respectively.

**Copy is unchanged.** Each was a `ContentUnavailableView` with `Label(title, systemImage: …)`; swapped for a plain `Text(title)` so the identical title + description strings render without the glyph. My Books' *Browse Catalog* action button is untouched.

Draft until CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)