### PR TITLE
fix(alerts): route 3 residual raw alert presents through the coordinator-wait guard (fe741015)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -438,6 +438,7 @@
 		4D9CC44A6FB732FADC183874 /* TPPKeychainManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FEA90508D9A3EEE2D86046 /* TPPKeychainManagerTests.swift */; };
 		4DA9016C156344339B0236ED /* ErrorDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF8D2CE6E794892B5C8C6FD /* ErrorDetailViewController.swift */; };
 		4DE364F5D585D79C2FCFF132 /* TPPBook+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C1093BDA93392F7DEF0D31 /* TPPBook+Accessibility.swift */; };
+		4DE6468C2E4065037D7281F9 /* AlertPresentationRawGuardLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2919A501EF80BC9A88CF2B58 /* AlertPresentationRawGuardLintTests.swift */; };
 		4E0F1B6A8D7C5F23E9B0A1C4 /* DiskBudgetManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1A2C7B9E8D6A34F0C1B2D5 /* DiskBudgetManagerTests.swift */; };
 		4E664E6EC32C604AFBC8A623 /* CatalogSearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFF70FF762C60CE8CD8D811 /* CatalogSearchViewModelTests.swift */; };
 		4EE6AD0F199527926C3BB1F8 /* CatalogFilterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5948988DD314B94674443C4F /* CatalogFilterServiceTests.swift */; };
@@ -2311,6 +2312,7 @@
 		28AA48F826072E449380BFBE /* EPUBKeyCommandsPP4289Tests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EPUBKeyCommandsPP4289Tests.swift; sourceTree = "<group>"; };
 		28B6ED44D40E09EC72287887 /* AdobeDRMHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AdobeDRMHandlerTests.swift; sourceTree = "<group>"; };
 		28FD1DBB8243D1E1B6EC6083 /* AuthDecisionEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthDecisionEvent.swift; sourceTree = "<group>"; };
+		2919A501EF80BC9A88CF2B58 /* AlertPresentationRawGuardLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertPresentationRawGuardLintTests.swift; sourceTree = "<group>"; };
 		29B6905F170E4D98A985ABF4 /* HTMLTextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLTextViewTests.swift; sourceTree = "<group>"; };
 		2A7140DF0127F1C8BA633644 /* BadgeServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeServiceProtocol.swift; sourceTree = "<group>"; };
 		2AC116D83FA0E5E94E26508B /* ReadiumPDFTOCCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReadiumPDFTOCCache.swift; sourceTree = "<group>"; };
@@ -3759,6 +3761,7 @@
 				22C9565C8C9D4F8F6DA585CE /* LCPBotanCRLGuardTests.swift */,
 				C20222DD2B8B50BD8CDF984D /* iPadOnMacRMSDKGuardTests.swift */,
 				6EABA877790A16435BFD9CC8 /* FindawayChapterStatusGuardTests.swift */,
+				2919A501EF80BC9A88CF2B58 /* AlertPresentationRawGuardLintTests.swift */,
 			);
 			path = RegressionGuards;
 			sourceTree = "<group>";
@@ -7753,6 +7756,7 @@
 				28E3A953BE971D4599DF4015 /* AccountsManagerLaunchSnapshotTests.swift in Sources */,
 				C40757CBD12CF84CFC242548 /* AccountsManagerFirstRunDecodeTests.swift in Sources */,
 				3CC8768E15C49F3155BE9C13 /* AudiobookCollapsedPillViewTests.swift in Sources */,
+				4DE6468C2E4065037D7281F9 /* AlertPresentationRawGuardLintTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/ReaderService.swift
+++ b/Palace/AppInfrastructure/ReaderService.swift
@@ -403,7 +403,14 @@ final class ReaderService {
             preferredStyle: .alert
         )
         alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default))
-        top.present(alert, animated: true)
+        // Route through the coordinator-waiting guarded presenter instead of a raw
+        // present() on `top`: this fires from an async open-completion during a
+        // reader push, exactly when presenting raw hits the fe741015 CA-commit
+        // race (a deferred throw the synchronous ObjC catcher cannot trap).
+        TPPAlertUtils.presentFromViewControllerOrNil(alertController: alert,
+                                                     viewController: top,
+                                                     animated: true,
+                                                     completion: nil)
         TPPErrorLogger.logError(
             withCode: .lcpDRMFulfillmentFail,
             summary: "LCP PDF open aborted due to runaway decrypt",

--- a/Palace/Reader2/BusinessLogic/TPPLastReadPositionSynchronizer.swift
+++ b/Palace/Reader2/BusinessLogic/TPPLastReadPositionSynchronizer.swift
@@ -183,26 +183,18 @@ final class TPPLastReadPositionSynchronizer: @unchecked Sendable {
                 alert.addAction(stayAction)
                 alert.addAction(moveAction)
 
-                // Present *after* any in-flight transition settles. This prompt
-                // fires during launch/book-open, exactly when a push/modal
-                // transition can still be animating; presenting into it is the
-                // fe741015 CA-commit race. Wait on the transition coordinator
-                // (re-walking to the settled topmost) instead of presenting raw.
-                // The continuation is resumed only by the alert's actions, so the
-                // alert must always be presented — never dropped.
-                if let coordinator = topVC.transitionCoordinator {
-                    coordinator.animate(alongsideTransition: nil) { _ in
-                        DispatchQueue.main.async {
-                            var settledTop = rootVC
-                            while let presented = settledTop.presentedViewController {
-                                settledTop = presented
-                            }
-                            settledTop.present(alert, animated: true)
-                        }
-                    }
-                } else {
-                    topVC.present(alert, animated: true)
-                }
+                // Present through the coordinator-waiting primitive so the prompt
+                // is never presented into an in-flight push/modal transition — the
+                // fe741015 CA-commit race. `safelyPresent` re-walks to the settled
+                // topmost and waits on the transition coordinator, recursing until
+                // the presenter is settled rather than dropping on contention, so
+                // the continuation — resumed only by the alert's actions — resumes
+                // on every path where a presenter still exists. (The one non-
+                // resuming path is the app root being torn down mid-transition,
+                // which the earlier raw present would have crashed on outright.)
+                // Replaces a hand-rolled coordinator-wait whose `else`
+                // (nil-coordinator) branch still presented raw.
+                TPPPresentationUtils.safelyPresent(alert, animated: true)
             }
         }
     }

--- a/Palace/Reader2/ReaderStackConfiguration/TPPR3Owner.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/TPPR3Owner.swift
@@ -52,7 +52,13 @@ extension TPPR3Owner: ModuleDelegate {
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
             let dismissButton = UIAlertAction(title: Strings.Generic.ok, style: .cancel)
             alert.addAction(dismissButton)
-            viewController.present(alert, animated: true)
+            // Route through the coordinator-waiting guarded presenter rather than a
+            // raw present() on the passed VC, which can be mid-transition during
+            // reader init — the fe741015 CA-commit race.
+            TPPAlertUtils.presentFromViewControllerOrNil(alertController: alert,
+                                                         viewController: viewController,
+                                                         animated: true,
+                                                         completion: nil)
         }
     }
 

--- a/PalaceTests/RegressionGuards/AlertPresentationRawGuardLintTests.swift
+++ b/PalaceTests/RegressionGuards/AlertPresentationRawGuardLintTests.swift
@@ -1,0 +1,163 @@
+//
+//  AlertPresentationRawGuardLintTests.swift
+//  PalaceTests
+//
+//  Structural regression guard for the fe741015 CACommit crash family
+//  (NSInternalInconsistencyException — "A view controller not containing an
+//  alert controller was asked for its contained alert controller", the #1 crash
+//  on 3.1.0). See PalaceTests/RegressionGuards/UIAlertCACommitGuardTests.swift
+//  for the mechanism guard and
+//  .forgeos/wall-failures/2026-06-29-fe741015-guard-tested-wrong-surface.md for
+//  the narrative.
+//
+//  Why a STRUCTURAL guard here (not a behavioral one)
+//  ==================================================
+//  The crash is a *deferred* CA-commit throw — UIKit defers the alert's own
+//  transition into the next `_UIAfterCACommitBlock`, so it cannot be
+//  deterministically reproduced in a unit test (that in-action reproduction is
+//  simdrive's job — see the wall-failure). What a unit test CAN lock down is the
+//  invariant the fix establishes: the launch/book-open alert sites that raced the
+//  transition must NEVER present a `UIAlertController` raw — they must route
+//  through a coordinator-waiting guarded presenter
+//  (`TPPPresentationUtils.safelyPresent` or
+//  `TPPAlertUtils.presentFromViewControllerOrNil`), both of which wait on the
+//  presenter's `transitionCoordinator` before presenting.
+//
+//  The prior fix (#1125) hardened the main launch alert paths but left three raw
+//  `present(alert)` sites bypassing the guard — the LCP-PDF runaway abort, the
+//  Readium module-error alert, and the sync-reading-position prompt's
+//  nil-coordinator branch. This lint makes reintroducing a raw alert present at
+//  any of those sites structurally impossible: if the suite runs, the rule runs
+//  (a `--no-verify` hook flag cannot bypass it). Mirrors RuntimeQuiescenceLintTests.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+final class AlertPresentationRawGuardLintTests: XCTestCase {
+
+    // MARK: - Resolution
+
+    /// Repo root resolved relative to this file
+    /// (`<root>/PalaceTests/RegressionGuards/AlertPresentationRawGuardLintTests.swift`).
+    private static let repoRoot: URL = {
+        URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()  // RegressionGuards/
+            .deletingLastPathComponent()  // PalaceTests/
+            .deletingLastPathComponent()  // repo root
+    }()
+
+    /// The alert sites that raced the launch/book-open transition and were
+    /// hardened for fe741015. A raw `UIAlertController` present in any of these
+    /// is a regression.
+    private static let guardedSites: [String] = [
+        "Palace/Reader2/BusinessLogic/TPPLastReadPositionSynchronizer.swift",
+        "Palace/AppInfrastructure/ReaderService.swift",
+        "Palace/Reader2/ReaderStackConfiguration/TPPR3Owner.swift",
+    ]
+
+    // MARK: - Detectors (pure, self-testable)
+
+    /// True iff `line` presents an alert *raw* — a `.present(alert…` call that
+    /// bypasses the coordinator-waiting guarded presenters. Comments do not
+    /// count. The guarded calls do NOT match: `safelyPresent(` has no `.present(`
+    /// substring and `presentFromViewControllerOrNil(` is `.presentFrom…`, not
+    /// `.present(`.
+    static func presentsAlertRaw(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("//") || trimmed.hasPrefix("*") || trimmed.hasPrefix("///") {
+            return false
+        }
+        return line.range(of: #"\.present\(\s*alert"#, options: .regularExpression) != nil
+    }
+
+    /// True iff `source` routes alerts through a coordinator-waiting guarded
+    /// presenter at least once — proves the fix is present, not merely that the
+    /// raw pattern is absent (a file could drop alert presentation entirely and
+    /// still pass rule 1).
+    static func routesThroughGuardedPresenter(_ source: String) -> Bool {
+        source.contains("safelyPresent(")
+            || source.contains("presentFromViewControllerOrNil(")
+    }
+
+    // MARK: - Rule 1 — no raw alert present at the guarded sites
+
+    func testGuardedSites_neverPresentAnAlertRaw() throws {
+        var failures: [String] = []
+        for relPath in Self.guardedSites {
+            let url = Self.repoRoot.appendingPathComponent(relPath)
+            guard let source = try? String(contentsOf: url, encoding: .utf8) else {
+                XCTFail("Could not read guarded site: \(relPath) (at \(url.path))")
+                continue
+            }
+            for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+                if Self.presentsAlertRaw(String(line)) {
+                    failures.append("\(relPath):\(idx + 1): raw alert present() — must route through "
+                        + "TPPPresentationUtils.safelyPresent or "
+                        + "TPPAlertUtils.presentFromViewControllerOrNil (fe741015 CA-commit race)")
+                }
+            }
+        }
+        if !failures.isEmpty {
+            XCTFail("fe741015 raw-alert-present guard tripped:\n\n" + failures.joined(separator: "\n"))
+        }
+    }
+
+    // MARK: - Rule 2 — the fix is actually present at the guarded sites
+
+    func testGuardedSites_routeThroughAGuardedPresenter() throws {
+        for relPath in Self.guardedSites {
+            let url = Self.repoRoot.appendingPathComponent(relPath)
+            guard let source = try? String(contentsOf: url, encoding: .utf8) else {
+                XCTFail("Could not read guarded site: \(relPath)")
+                continue
+            }
+            XCTAssertTrue(Self.routesThroughGuardedPresenter(source),
+                "\(relPath) must present its alert through a coordinator-waiting guarded "
+                + "presenter — the fe741015 fix. If this file no longer presents any alert, "
+                + "remove it from `guardedSites`.")
+        }
+    }
+
+    // MARK: - Rule 3 — detector self-tests (BAD / GOOD / CLEAN per green-board contract #4)
+
+    func testDetector_flagsRawAlertPresent() {
+        XCTAssertTrue(Self.presentsAlertRaw("        top.present(alert, animated: true)"),
+            "A raw `top.present(alert, …)` MUST be flagged")
+        XCTAssertTrue(Self.presentsAlertRaw("            settledTop.present(alert, animated: true)"),
+            "A raw `settledTop.present(alert, …)` MUST be flagged")
+        XCTAssertTrue(Self.presentsAlertRaw("viewController.present( alert , animated: true)"),
+            "Whitespace between `(` and `alert` MUST still be flagged")
+    }
+
+    func testDetector_passesGuardedPresenters() {
+        XCTAssertFalse(Self.presentsAlertRaw("        TPPPresentationUtils.safelyPresent(alert, animated: true)"),
+            "safelyPresent is a guarded presenter — must NOT be flagged")
+        XCTAssertFalse(Self.presentsAlertRaw("        TPPAlertUtils.presentFromViewControllerOrNil(alertController: alert,"),
+            "presentFromViewControllerOrNil is a guarded presenter — must NOT be flagged")
+    }
+
+    func testDetector_passesCommentsAndNonAlertPresents() {
+        XCTAssertFalse(Self.presentsAlertRaw("// top.present(alert, animated: true) — old raced path"),
+            "A `//` comment must NOT be flagged")
+        XCTAssertFalse(Self.presentsAlertRaw("     * top.present(alert, animated: true) — old raced path"),
+            "A `*` block-comment continuation line must NOT be flagged")
+        XCTAssertFalse(Self.presentsAlertRaw("        /// top.present(alert) in a doc comment"),
+            "A `///` doc-comment line must NOT be flagged")
+        XCTAssertFalse(Self.presentsAlertRaw("        top.present(nav, animated: true)"),
+            "Presenting a non-alert (nav) controller must NOT be flagged")
+        XCTAssertFalse(Self.presentsAlertRaw("        base.present(payload.viewController, animated: animated)"),
+            "Presenting a non-alert view controller must NOT be flagged")
+    }
+
+    func testDetector_routeDetector_bothPathsAndClean() {
+        XCTAssertTrue(Self.routesThroughGuardedPresenter("x = TPPPresentationUtils.safelyPresent(alert)"),
+            "safelyPresent presence MUST satisfy the route detector")
+        XCTAssertTrue(Self.routesThroughGuardedPresenter("presentFromViewControllerOrNil(alertController: alert)"),
+            "presentFromViewControllerOrNil presence MUST satisfy the route detector")
+        XCTAssertFalse(Self.routesThroughGuardedPresenter("let alert = UIAlertController(title: t)"),
+            "A file that never routes through a guarded presenter must NOT satisfy the route detector")
+    }
+}


### PR DESCRIPTION
## Why

**fe741015** — `NSInternalInconsistencyException: "A view controller not containing an alert controller was asked for its contained alert controller"` — is the **#1 crash on production 3.1.0 (334 events / 84 users)**. It's a *deferred* CA-commit throw: a `UIAlertController` presented raw while a `UIPresentationController` transition is in flight; the exception fires later in `_UIAfterCACommitBlock`, so a synchronous ObjC try/catch can't trap it.

The dedicated fix **#1125** (`coordinator-wait`) is already on `develop` → 3.3.0 and hardened the main launch alert paths. This PR closes the **three raw `present(alert)` sites that survived #1125** and can still throw during book-open / reader init.

Tracked in **PP-4771**.

## What

| Site | Alert | Now routes through |
|---|---|---|
| `ReaderService.abortRunawayOpen` | LCP-PDF "too large to open" | `presentFromViewControllerOrNil` (explicit VC) |
| `TPPR3Owner.presentAlert` | Readium module error | `presentFromViewControllerOrNil` (passed VC) |
| `TPPLastReadPositionSynchronizer` | sync-reading-position prompt (nil-coordinator branch) | `safelyPresent` — **guaranteed delivery**, required because its `withCheckedContinuation` resumes only from an alert action |

Both target presenters wait on the presenter's `transitionCoordinator` before presenting. The reading-position **conflict-resolution logic is byte-for-byte unchanged** — only the presentation call moved.

**Regression guard:** `AlertPresentationRawGuardLintTests` structurally forbids a raw `.present(alert` at these three sites (and asserts each routes through a guarded presenter), with BAD/GOOD/CLEAN detector self-tests. A deferred CA-commit throw is not unit-reproducible, so this locks the *invariant* the fix establishes.

## Review

Single-module critical-path change (reading-position sync). Two independent SoD reviews — both **APPROVED_WITH_CONCERNS**, no blockers:
- **Architect** (`rev_af2faf95`): presenter choices justified per site; conflict-resolution untouched; isolation sound; guard is a legitimate invariant lock. One nit applied — softened the site-3 "guaranteed to run" comment to reflect the narrow root-teardown-mid-transition non-resuming edge.
- **QA** (`rev_aed7526c`): verified the guard fails on reversion of any site and its self-tests kill regex-weakening mutants. Added `*`/`///` comment-prefix self-test cases.

## Follow-up obligations (tracked on PP-4771, NOT discharged here)
- simdrive in-action repro for the deferred throw (the wall-failure's mandated structural-guard + in-action pair).
- a unit test pinning `safelyPresent`'s never-drop recursion in isolation.

## Verification
Targeted build + tests green on iPhone 17 Pro — `AlertPresentationRawGuardLintTests` + `UIAlertCACommitGuardTests`, **TEST SUCCEEDED**. Full-suite is the CI gate on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)