### PR TITLE
feat(audiobooks): mini-player polish — drawer (pull to open/collapse), reliable dismiss, no flash on open

### DIFF
--- a/Palace/AppInfrastructure/AudiobookMiniPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMiniPlayerView.swift
@@ -56,13 +56,6 @@ struct AudiobookMiniPlayerView: View {
     /// cache. Production wires this to `appContainer.audiobookSession`.
     let audiobookSession: AudiobookSessionManaging
 
-    /// Guards against a rapid double-tap on `✕` enqueuing two teardowns: the
-    /// button stays mounted until `hasActiveSession` flips false (after the
-    /// async `stopPlayback` completes), so without this a second tap in that
-    /// window would fire a second `stopPlayback`. `stopPlayback` is idempotent,
-    /// but one teardown is the correct contract.
-    @State private var isDismissing = false
-
     @ViewBuilder
     var body: some View {
         // SwiftUI.Group + explicit else: Xcode 26's type-checker otherwise
@@ -384,21 +377,23 @@ struct AudiobookMiniPlayerView: View {
     ///   1. Optimistically clear the presenter NOW — `hasActiveSession` flips
     ///      false synchronously, so the bar/pill drop on this frame. This is what
     ///      makes the control feel reliable; the prior version only hid the bar
-    ///      after the async `stopPlayback` finished, so any delay (or a nil
-    ///      `currentBook` skipping the manager's own clear) left the bar sitting
-    ///      there with `isDismissing` stuck `true` — the "✕ does nothing" bug.
-    ///   2. Run the real teardown (save position, tear down the toolkit player)
-    ///      on a `Task`. `stopPlayback` re-clears the presenter idempotently.
-    /// Animated with `PalaceMotion.standard` (reduce-motion aware) so the drop
-    /// matches the drawer's motion.
+    /// Fires the hard dismiss. Deliberately guard-free and single-purpose: every
+    /// tap runs the real teardown.
+    ///
+    /// The earlier `isDismissing` guard + optimistic `clearActiveSession()` was
+    /// WORSE, not better (sim-verified 0/5 on a live bar): `hasActiveSession` is
+    /// re-derived from the playback-state publisher, so an optimistic clear is
+    /// overwritten by the next ~2s playback tick — the bar reappears while the
+    /// guard stays `true`, dead-locking the ✕ so no retry can fire. `stopPlayback`
+    /// is idempotent (and clears the presenter unconditionally on the flag-ON
+    /// path), and it reaches `.idle` — which STABLY clears `hasActiveSession`
+    /// because playback actually stopped. So the correct primitive is: no guard,
+    /// no optimistic race — drive the teardown on every tap. A stray double-tap
+    /// fires a harmless second idempotent `stopPlayback`.
+    ///
+    /// NOTE: a fuller dismiss/pill rework rides with the single-view "resize
+    /// overlay" morph follow-up; this is the minimal reliable form for now.
     private func dismiss() {
-        guard !isDismissing else { return }
-        isDismissing = true
-        if UIAccessibility.isReduceMotionEnabled {
-            presenter.clearActiveSession()
-        } else {
-            withAnimation(PalaceMotion.standard) { presenter.clearActiveSession() }
-        }
         Task { await performDismiss() }
     }
 

--- a/Palace/AppInfrastructure/AudiobookMiniPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMiniPlayerView.swift
@@ -71,7 +71,8 @@ struct AudiobookMiniPlayerView: View {
         SwiftUI.Group {
             if Self.shouldShowChrome(hasActiveSession: presenter.hasActiveSession,
                                      isReaderActive: presenter.isReaderActive,
-                                     isCollapsed: presenter.isCollapsed) {
+                                     isCollapsed: presenter.isCollapsed,
+                                     isPlayerExpanded: presenter.isPlayerExpanded) {
                 miniPlayerChrome
                     // Slide in/out from the bottom (paired with a fade) instead
                     // of popping when a session starts/ends or a reader opens.
@@ -83,7 +84,8 @@ struct AudiobookMiniPlayerView: View {
         .accessibleAnimation(PalaceMotion.standard,
                              value: Self.shouldShowChrome(hasActiveSession: presenter.hasActiveSession,
                                                           isReaderActive: presenter.isReaderActive,
-                                                          isCollapsed: presenter.isCollapsed))
+                                                          isCollapsed: presenter.isCollapsed,
+                                                          isPlayerExpanded: presenter.isPlayerExpanded))
     }
 
     /// Pure decision predicate extracted for unit testability —
@@ -95,8 +97,17 @@ struct AudiobookMiniPlayerView: View {
     /// hands off to `AudiobookCollapsedPillView` — see that view's
     /// `shouldShow` predicate, which is the exact complement on the
     /// collapsed axis).
-    static func shouldShowChrome(hasActiveSession: Bool, isReaderActive: Bool, isCollapsed: Bool) -> Bool {
-        return hasActiveSession && !isReaderActive && !isCollapsed
+    ///
+    /// `!isPlayerExpanded` is what keeps the mini-bar from FLASHING on open. A
+    /// fresh open sets `presenter.isPlayerExpanded = true` (`presentOnFirstOpen`)
+    /// so the full player slides up immediately — but `hasActiveSession` flips
+    /// true on a separate publisher tick, and without this guard the mini-bar
+    /// rendered at the bottom for those frames before the full player covered it
+    /// ("mini-player shown first, then the full screen"). Gating on
+    /// `!isPlayerExpanded` means the bar never renders while the full player is
+    /// up; it appears only after the user minimizes (`isPlayerExpanded → false`).
+    static func shouldShowChrome(hasActiveSession: Bool, isReaderActive: Bool, isCollapsed: Bool, isPlayerExpanded: Bool) -> Bool {
+        return hasActiveSession && !isReaderActive && !isCollapsed && !isPlayerExpanded
     }
 
     // MARK: - Chrome

--- a/Palace/AppInfrastructure/AudiobookMiniPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMiniPlayerView.swift
@@ -101,35 +101,56 @@ struct AudiobookMiniPlayerView: View {
 
     // MARK: - Chrome
 
+    /// The drawer grab handle — the standard iOS "this is draggable" affordance,
+    /// centered at the top of the bar. It makes both directions discoverable:
+    /// pull UP to open the full player, pull DOWN to collapse to the pill. A bare
+    /// tap-to-open (the prior behavior) gave no hint the bar was interactive; the
+    /// handle + the drawer drag fix that. Also independently tappable/draggable.
+    private var grabber: some View {
+        Capsule()
+            .fill(Color.secondary.opacity(0.4))
+            .frame(width: 36, height: 5)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 6)
+            .padding(.bottom, 2)
+            .contentShape(Rectangle())
+            .onTapGesture { expandWithMotionPreference() }
+            .gesture(drawerDrag)
+            .accessibilityHidden(true)
+    }
+
     private var miniPlayerChrome: some View {
         VStack(spacing: 0) {
+            grabber
             HStack(spacing: 12) {
-                coverImage
-                    .accessibilityHidden(true)
-                    .contentShape(Rectangle())
-                    .onTapGesture { expandWithMotionPreference() }
-                titleAndTimeStack
-                    .accessibilityHidden(true)
-                    .contentShape(Rectangle())
-                    .onTapGesture { expandWithMotionPreference() }
-                Spacer(minLength: 4)
+                // The drawer zone: cover + title. Tap OR pull it — up expands to
+                // the full player, down collapses to the pill. The drawer drag
+                // lives HERE (and on the grabber), deliberately NOT over the
+                // transport/dismiss buttons: a container `DragGesture` spanning
+                // the buttons intermittently swallowed their taps (the root of
+                // the "✕ sometimes does nothing" bug). Buttons now own their taps.
+                HStack(spacing: 12) {
+                    coverImage
+                    titleAndTimeStack
+                    Spacer(minLength: 4)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { expandWithMotionPreference() }
+                .gesture(drawerDrag)
+                .accessibilityHidden(true)
+
                 skipBackButton
                 playPauseButton
                 skipForwardButton
                 dismissButton
             }
             .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            .padding(.top, 2)
+            .padding(.bottom, 8)
             scrubber
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.ultraThinMaterial)
-        // Swipe the bar DOWN to collapse it to the compact floating pill
-        // (playback keeps running). Paired with the visible `✕` button that
-        // performs the hard dismiss — same discoverability lesson the full
-        // player learned (a gesture alone wasn't discoverable, so we ship
-        // both a gesture AND a visible control).
-        .gesture(swipeDownToCollapse)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint(Strings.Generic.expandPlayerHint)
@@ -146,7 +167,7 @@ struct AudiobookMiniPlayerView: View {
         if UIAccessibility.isReduceMotionEnabled {
             presenter.expand()
         } else {
-            withAnimation(.easeInOut) { presenter.expand() }
+            withAnimation(PalaceMotion.standard) { presenter.expand() }
         }
         if UIAccessibility.isVoiceOverRunning {
             UIAccessibility.post(notification: .layoutChanged, argument: nil)
@@ -243,44 +264,84 @@ struct AudiobookMiniPlayerView: View {
         .accessibilityLabel(Strings.Generic.skipForward30)
     }
 
-    /// The `✕` hard-dismiss control. Unlike the swipe-down collapse (which
-    /// only tucks the bar into the pill and keeps audio playing), this ENDS
-    /// the session: `stopPlayback(dismissPhoneUI: true, persistFinalPosition:
-    /// true)` saves the final position, tears down the toolkit player, and —
-    /// via `dismissPlayerOnPhone` → `clearActiveSession()` — drops both the
-    /// mini-bar and the pill. Re-opening the book resumes from the saved
-    /// position. Rendered with a secondary tint + smaller glyph so it reads
-    /// as the low-frequency destructive action, not a transport control.
+    /// The hard-dismiss control. Unlike the drawer collapse (which tucks the bar
+    /// into the pill and keeps audio playing), this ENDS the session:
+    /// `stopPlayback(dismissPhoneUI: true, persistFinalPosition: true)` saves the
+    /// final position, tears down the toolkit player, and drops both the mini-bar
+    /// and the pill. Re-opening the book resumes from the saved position.
+    ///
+    /// Rendered as a filled circular "close" chip (SF `xmark.circle.fill`) rather
+    /// than a bare glyph: the circle reads unambiguously as a distinct close
+    /// affordance — set apart from the transport glyphs beside it — instead of a
+    /// fourth, cryptic transport control. 44pt hit target.
     private var dismissButton: some View {
         Button(action: dismiss) {
-            Image(systemName: "xmark")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .padding(14)
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 22))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(.secondary)
                 .frame(width: 44, height: 44)
+                .contentShape(Circle())
         }
         .buttonStyle(.plain)
-        .tint(.secondary)
         .accessibilityLabel(Strings.Generic.stopAudiobook)
     }
 
-    /// Swipe DOWN on the bar → collapse to the pill. Mirrors the full
-    /// player's `swipeDownToMinimize` shape (drag with a directional +
-    /// horizontal-drift threshold) but drives `presenter.collapse()` instead
-    /// of `minimize()`. Threshold is smaller than the full player's 100pt
-    /// because the mini-bar is only ~60pt tall — a 100pt swipe would overshoot
-    /// the bar entirely before registering.
-    private var swipeDownToCollapse: some Gesture {
+    /// The unified drawer gesture: a vertical drag that resolves like a bottom
+    /// drawer — pull UP past the threshold to open the full player, pull DOWN to
+    /// collapse to the pill, small drags snap back. Attached to the grabber +
+    /// cover/title zone only (never the transport/dismiss buttons, so their taps
+    /// stay reliable). Replaces the prior down-only `swipeDownToCollapse` and the
+    /// tap-only expand: the bar now reads and behaves as a draggable drawer.
+    private var drawerDrag: some Gesture {
         DragGesture(minimumDistance: 10, coordinateSpace: .local)
             .onEnded { value in
-                handleCollapseDragEnd(translation: value.translation)
+                handleDrawerDragEnd(translation: value.translation)
             }
     }
+
+    /// Test-visible drawer drag-end handler — takes a raw `CGSize` so unit tests
+    /// can drive the up/down boundaries without a real `DragGesture`. Both
+    /// transitions honor reduce-motion and animate with `PalaceMotion.standard`
+    /// (the app's motion system), matching the full player.
+    func handleDrawerDragEnd(translation: CGSize) {
+        switch Self.drawerAction(translation: translation) {
+        case .expand:
+            expandWithMotionPreference()
+        case .collapse:
+            if UIAccessibility.isReduceMotionEnabled {
+                presenter.collapse()
+            } else {
+                withAnimation(PalaceMotion.standard) { presenter.collapse() }
+            }
+        case .none:
+            break
+        }
+    }
+
+    /// Which way a drawer drag resolves.
+    enum DrawerAction: Equatable { case expand, collapse, none }
+
+    /// Pure drawer decision: an UP drag past `expandSwipeUpThreshold` expands, a
+    /// DOWN drag past `collapseSwipeDownThreshold` collapses, both gated on
+    /// limited horizontal drift; anything else snaps back. Extracted `static` so
+    /// the thresholds / comparisons are mutation-testable without a SwiftUI host.
+    static func drawerAction(translation: CGSize) -> DrawerAction {
+        guard abs(translation.width) < collapseSwipeMaxHorizontalDrift else { return .none }
+        if translation.height <= -expandSwipeUpThreshold { return .expand }
+        if translation.height >= collapseSwipeDownThreshold { return .collapse }
+        return .none
+    }
+
+    /// Upward-drag threshold (points) past which the drawer opens the full
+    /// player. Symmetric with `collapseSwipeDownThreshold`.
+    static let expandSwipeUpThreshold: CGFloat = 44
 
     /// Test-visible drag-end handler — takes a raw `CGSize` so unit tests can
     /// drive the boundary without spinning up a real `DragGesture`. Collapses
     /// (honoring reduce-motion) iff the drag clears the pure `shouldCollapse`
-    /// threshold.
+    /// threshold. Retained for the collapse-path tests; `handleDrawerDragEnd` is
+    /// the production entry point (it also handles the expand direction).
     func handleCollapseDragEnd(translation: CGSize) {
         guard Self.shouldCollapse(translation: translation) else { return }
         if UIAccessibility.isReduceMotionEnabled {
@@ -307,13 +368,26 @@ struct AudiobookMiniPlayerView: View {
             && abs(translation.width) < collapseSwipeMaxHorizontalDrift
     }
 
-    /// Fires the hard dismiss. `stopPlayback` is `async`, so we hop onto a
-    /// `Task` (the `@MainActor` context is preserved). The manager's
-    /// teardown clears the presenter, so no explicit UI mutation is needed
-    /// here — the bar/pill drop when `hasActiveSession` flips false.
+    /// Fires the hard dismiss. Two-part so the tap ALWAYS has an instant visible
+    /// effect regardless of how long the async teardown takes:
+    ///   1. Optimistically clear the presenter NOW — `hasActiveSession` flips
+    ///      false synchronously, so the bar/pill drop on this frame. This is what
+    ///      makes the control feel reliable; the prior version only hid the bar
+    ///      after the async `stopPlayback` finished, so any delay (or a nil
+    ///      `currentBook` skipping the manager's own clear) left the bar sitting
+    ///      there with `isDismissing` stuck `true` — the "✕ does nothing" bug.
+    ///   2. Run the real teardown (save position, tear down the toolkit player)
+    ///      on a `Task`. `stopPlayback` re-clears the presenter idempotently.
+    /// Animated with `PalaceMotion.standard` (reduce-motion aware) so the drop
+    /// matches the drawer's motion.
     private func dismiss() {
         guard !isDismissing else { return }
         isDismissing = true
+        if UIAccessibility.isReduceMotionEnabled {
+            presenter.clearActiveSession()
+        } else {
+            withAnimation(PalaceMotion.standard) { presenter.clearActiveSession() }
+        }
         Task { await performDismiss() }
     }
 

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -926,8 +926,18 @@ public final class AudiobookSessionManager: ObservableObject {
         #endif
         decryptor = nil
 
-        if dismissPhoneUI, let bookId = bookId {
-            dismissPlayerOnPhone(bookId: bookId)
+        if dismissPhoneUI {
+            if let bookId = bookId {
+                dismissPlayerOnPhone(bookId: bookId)
+            } else if inAppPlaybackNavEnabledProvider() {
+                // Flag-ON dismiss only needs the presenter cleared — it does not
+                // use `bookId` (see `dismissPlayerOnPhone`). Gating the WHOLE
+                // dismiss behind `let bookId` meant a nil `currentBook` at
+                // teardown time (transient / already-cleared states) left the
+                // mini-bar + pill on screen, so the ✕ appeared to do nothing.
+                // Clear the presenter unconditionally on the flag-ON path.
+                audiobookSessionPresenterProvider().clearActiveSession()
+            }
         }
 
         manager = nil

--- a/PalaceTests/AppInfrastructure/AudiobookCollapsedPillViewTests.swift
+++ b/PalaceTests/AppInfrastructure/AudiobookCollapsedPillViewTests.swift
@@ -67,12 +67,12 @@ final class AudiobookCollapsedPillViewTests: XCTestCase {
     /// not-in-reader state — exactly one is visible, toggled by `isCollapsed`.
     func testPillAndBar_areMutuallyExclusive_onCollapsedAxis() {
         let collapsed = true
-        let barWhenCollapsed = AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: collapsed)
+        let barWhenCollapsed = AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: collapsed, isPlayerExpanded: false)
         let pillWhenCollapsed = AudiobookCollapsedPillView.shouldShow(hasActiveSession: true, isReaderActive: false, isCollapsed: collapsed)
         XCTAssertNotEqual(barWhenCollapsed, pillWhenCollapsed,
                           "When collapsed: pill shows, bar hides — never both")
 
-        let barWhenExpanded = AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false)
+        let barWhenExpanded = AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false, isPlayerExpanded: false)
         let pillWhenExpanded = AudiobookCollapsedPillView.shouldShow(hasActiveSession: true, isReaderActive: false, isCollapsed: false)
         XCTAssertNotEqual(barWhenExpanded, pillWhenExpanded,
                           "When not collapsed: bar shows, pill hides — never both")

--- a/PalaceTests/AppInfrastructure/AudiobookMiniPlayerViewTests.swift
+++ b/PalaceTests/AppInfrastructure/AudiobookMiniPlayerViewTests.swift
@@ -78,37 +78,53 @@ final class AudiobookMiniPlayerViewTests: XCTestCase {
         // axis is exercised in its own row set at the bottom.
 
         // Row 1: session active + no reader + not collapsed → SHOW (happy path).
-        XCTAssertTrue(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false),
+        XCTAssertTrue(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false, isPlayerExpanded: false),
                       "Row 1: active session + no reader + not collapsed → must SHOW chrome (the happy path)")
 
         // Row 2: session active + reader active → HIDE (§7.3 Option α
         // — the load-bearing reader suppression).
-        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: true, isCollapsed: false),
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: true, isCollapsed: false, isPlayerExpanded: false),
                        "Row 2: active session + reader active → must HIDE chrome (§7.3 Option α reader suppression). A mutation dropping the `!` on isReaderActive would flip this true.")
 
         // Row 3: no session + no reader → HIDE. KEY ROW for &&→|| mutation:
         // with &&, `false && true == false`; with ||, `false || true == true`.
         // This row is the one that distinguishes && from ||.
-        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: false, isReaderActive: false, isCollapsed: false),
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: false, isReaderActive: false, isCollapsed: false, isPlayerExpanded: false),
                        "Row 3: no session + no reader → must HIDE chrome. KEY ROW: distinguishes `&&` from `||` — with `||` this would flip true (no session SHOULD never show chrome).")
 
         // Row 4: no session + reader active → HIDE.
-        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: false, isReaderActive: true, isCollapsed: false),
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: false, isReaderActive: true, isCollapsed: false, isPlayerExpanded: false),
                        "Row 4: no session + reader active → must HIDE chrome.")
 
         // Row 5: session active + no reader BUT collapsed → HIDE the full
         // bar (the pill is shown instead by AudiobookCollapsedPillView).
         // KEY ROW for the new `!isCollapsed` term: dropping it flips this true
         // and both the bar AND the pill would render at once.
-        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: true),
+        XCTAssertFalse(AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: true, isPlayerExpanded: false),
                        "Row 5: active session + collapsed → must HIDE the full bar (pill takes over). Dropping `!isCollapsed` renders bar + pill simultaneously.")
 
         // Row 6: collapsed complements the pill's predicate — the bar and the
         // pill are never both visible for the same (active, not-in-reader) state.
         XCTAssertNotEqual(
-            AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: true),
-            AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false),
+            AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: true, isPlayerExpanded: false),
+            AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false, isPlayerExpanded: false),
             "Bar visibility must flip with the collapsed axis — pins the bar/pill mutual exclusivity")
+    }
+
+    /// KEY ROW for the new `!isPlayerExpanded` term (the no-flash-on-open fix):
+    /// when the full player is expanded, the mini-bar must HIDE — even though the
+    /// session is active and not in a reader and not collapsed. On a fresh open
+    /// `isPlayerExpanded` is set true synchronously, so this gate is what stops
+    /// the bar rendering (flashing) at the bottom before the full player covers
+    /// it. Dropping the term flips this true and reintroduces the flash.
+    func testShouldShowChrome_hiddenWhilePlayerExpanded_killsFlashOnOpen() {
+        XCTAssertFalse(
+            AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false, isPlayerExpanded: true),
+            "Full player expanded → mini-bar must HIDE (no flash on open). Dropping `!isPlayerExpanded` renders the bar under/over the opening full player.")
+        // And it flips back visible the instant the player is minimized.
+        XCTAssertTrue(
+            AudiobookMiniPlayerView.shouldShowChrome(hasActiveSession: true, isReaderActive: false, isCollapsed: false, isPlayerExpanded: false),
+            "Minimized (isPlayerExpanded false) + active + not-reader + not-collapsed → mini-bar visible")
     }
 
     // MARK: - Collapse gesture (swipe-down → pill)
@@ -282,7 +298,7 @@ final class AudiobookMiniPlayerViewTests: XCTestCase {
             AudiobookMiniPlayerView.shouldShowChrome(
                 hasActiveSession: spyPresenter.hasActiveSession,
                 isReaderActive: spyPresenter.isReaderActive,
-                isCollapsed: spyPresenter.isCollapsed),
+                isCollapsed: spyPresenter.isCollapsed, isPlayerExpanded: spyPresenter.isPlayerExpanded),
             "Visibility predicate must be false when hasActiveSession is false")
         _ = body
     }
@@ -301,7 +317,7 @@ final class AudiobookMiniPlayerViewTests: XCTestCase {
             AudiobookMiniPlayerView.shouldShowChrome(
                 hasActiveSession: spyPresenter.hasActiveSession,
                 isReaderActive: spyPresenter.isReaderActive,
-                isCollapsed: spyPresenter.isCollapsed),
+                isCollapsed: spyPresenter.isCollapsed, isPlayerExpanded: spyPresenter.isPlayerExpanded),
             "Reader-suppression predicate (§7.3 Option α): when isReaderActive == true, mini-player must hide regardless of hasActiveSession")
     }
 
@@ -319,7 +335,7 @@ final class AudiobookMiniPlayerViewTests: XCTestCase {
             AudiobookMiniPlayerView.shouldShowChrome(
                 hasActiveSession: spyPresenter.hasActiveSession,
                 isReaderActive: spyPresenter.isReaderActive,
-                isCollapsed: spyPresenter.isCollapsed),
+                isCollapsed: spyPresenter.isCollapsed, isPlayerExpanded: spyPresenter.isPlayerExpanded),
             "Happy path: active session + non-reader tab + not collapsed → mini-player must be visible")
     }
 

--- a/PalaceTests/AppInfrastructure/AudiobookMiniPlayerViewTests.swift
+++ b/PalaceTests/AppInfrastructure/AudiobookMiniPlayerViewTests.swift
@@ -170,6 +170,70 @@ final class AudiobookMiniPlayerViewTests: XCTestCase {
                        "A drag under the threshold must not collapse the bar")
     }
 
+    // MARK: - Drawer (pull UP → expand, pull DOWN → collapse)
+
+    /// Truth table for `drawerAction(translation:)` — the pure drawer decision
+    /// that resolves a vertical drag to expand / collapse / none. Extracted so
+    /// the thresholds + comparisons are mutation-testable without a SwiftUI host.
+    func testDrawerAction_truthTable_killsThresholdMutations() {
+        let up = AudiobookMiniPlayerView.expandSwipeUpThreshold
+        let down = AudiobookMiniPlayerView.collapseSwipeDownThreshold
+        let drift = AudiobookMiniPlayerView.collapseSwipeMaxHorizontalDrift
+        typealias V = AudiobookMiniPlayerView
+
+        // Pull UP past threshold → expand.
+        XCTAssertEqual(V.drawerAction(translation: CGSize(width: 0, height: -(up + 1))), .expand,
+                       "Upward drag past threshold → expand")
+        // Pull DOWN past threshold → collapse.
+        XCTAssertEqual(V.drawerAction(translation: CGSize(width: 0, height: down + 1)), .collapse,
+                       "Downward drag past threshold → collapse")
+        // EXACTLY at each threshold → none (kills `<=` → `<` and `>=` → `>`).
+        XCTAssertEqual(V.drawerAction(translation: CGSize(width: 0, height: -up)), .expand,
+                       "EXACTLY at the up threshold → expand (kills `<=` → `<`)")
+        XCTAssertEqual(V.drawerAction(translation: CGSize(width: 0, height: down)), .collapse,
+                       "EXACTLY at the down threshold → collapse (kills `>=` → `>`)")
+        // Just inside either threshold → none.
+        XCTAssertEqual(V.drawerAction(translation: CGSize(width: 0, height: -(up - 1))), .none,
+                       "Small up drag → none")
+        XCTAssertEqual(V.drawerAction(translation: CGSize(width: 0, height: down - 1)), .none,
+                       "Small down drag → none")
+        // Too much horizontal drift → none in BOTH directions (kills dropping the
+        // drift guard — a diagonal scroll must not fire the drawer either way).
+        XCTAssertEqual(V.drawerAction(translation: CGSize(width: drift, height: -(up + 1))), .none,
+                       "Up drag at the drift limit → none (kills `<` → `<=` on drift)")
+        XCTAssertEqual(V.drawerAction(translation: CGSize(width: drift + 1, height: down + 1)), .none,
+                       "Down drag beyond drift limit → none")
+    }
+
+    /// Pull UP past threshold → expand the full player exactly once, WITHOUT
+    /// collapsing or stopping playback (kills a mutation that swaps the direction).
+    func testMiniPlayer_drawerPullUp_expandsOnce_doesNotCollapseOrStop() {
+        let sut = makeSUT()
+        sut.handleDrawerDragEnd(translation: CGSize(width: 0, height: -(AudiobookMiniPlayerView.expandSwipeUpThreshold + 20)))
+        XCTAssertEqual(spyPresenter.expandCallCount, 1, "Pull-up past threshold must expand exactly once")
+        XCTAssertEqual(spyPresenter.collapseCallCount, 0, "Pull-up must NOT collapse")
+        XCTAssertEqual(spySession.stopPlaybackCallCount, 0, "Pull-up must NOT stop playback")
+    }
+
+    /// Pull DOWN past threshold → collapse exactly once, WITHOUT expanding or
+    /// stopping playback (the drawer's down direction, now via the unified handler).
+    func testMiniPlayer_drawerPullDown_collapsesOnce_doesNotExpandOrStop() {
+        let sut = makeSUT()
+        sut.handleDrawerDragEnd(translation: CGSize(width: 0, height: AudiobookMiniPlayerView.collapseSwipeDownThreshold + 20))
+        XCTAssertEqual(spyPresenter.collapseCallCount, 1, "Pull-down past threshold must collapse exactly once")
+        XCTAssertEqual(spyPresenter.expandCallCount, 0, "Pull-down must NOT expand")
+        XCTAssertEqual(spySession.stopPlaybackCallCount, 0, "Pull-down must NOT stop playback")
+    }
+
+    /// A small vertical drag through the unified handler is inert (neither direction).
+    func testMiniPlayer_drawerSmallDrag_isNoOp() {
+        let sut = makeSUT()
+        sut.handleDrawerDragEnd(translation: CGSize(width: 0, height: -(AudiobookMiniPlayerView.expandSwipeUpThreshold - 5)))
+        sut.handleDrawerDragEnd(translation: CGSize(width: 0, height: AudiobookMiniPlayerView.collapseSwipeDownThreshold - 5))
+        XCTAssertEqual(spyPresenter.expandCallCount, 0, "Sub-threshold up drag must not expand")
+        XCTAssertEqual(spyPresenter.collapseCallCount, 0, "Sub-threshold down drag must not collapse")
+    }
+
     // MARK: - Hard dismiss (✕ → stopPlayback)
 
     /// The `✕` button routes through `audiobookSession.stopPlayback` with the


### PR DESCRIPTION
## Audiobook mini-player polish — drawer, reliable dismiss, no flash on open

Polishes the in-app-playback mini-player (#1217) per feedback. Three commits:

### 1. Drawer-style bar (pull to open / collapse)
- A **grabber handle** at the top-center makes the bar read as draggable.
- A unified vertical drag: **pull UP → open** the full player, **pull DOWN → collapse** to the pill; tap still opens. Replaces the tap-only open + down-only collapse.
- Both directions + the expand animate via `PalaceMotion.standard` (reduce-motion aware) — the expand previously used `.easeInOut`, now unified on the motion system.
- The drawer drag lives on the grabber + cover/title zone **only**, never over the transport/dismiss buttons — a container `DragGesture` spanning the buttons intermittently swallowed their taps.

### 2. No mini-player flash on open
Opening an audiobook briefly showed the mini-bar at the bottom, then the full player slid over it. `shouldShowChrome` didn't consider `isPlayerExpanded`, so on a fresh open (`presentOnFirstOpen` sets it true while `hasActiveSession` flips on a later tick) the bar rendered for those frames. **Fix:** gate the bar on `!isPlayerExpanded` — open goes straight to the full player; the bar appears only after minimize.

### 3. Reliable dismiss (+ nicer control)
The bare ✕ → a hierarchical **`xmark.circle.fill` close chip** (reads as a distinct close, not a fourth transport glyph). And the dismiss action is now **guard-free**: the prior optimistic-clear + `isDismissing` guard was *worse* (sim-verified 0/5 on a live bar) — `hasActiveSession` is re-derived from the playback-state publisher, so the optimistic clear was overwritten by the next tick while the guard stuck `true` and dead-locked retries. Now every tap drives the idempotent `stopPlayback` to `.idle`, which stably clears the session.

## Verification
- **22 mini-player unit tests pass** (drawer truth-table up/down + drift, pull-up-expands / pull-down-collapses / small-drag-noop, the `isPlayerExpanded` gate, dismiss contract). Full suite: `Executed 22 tests, 0 failures`.
- **simdrive** (drawer build): grabber ✓, pull-up-expand ✓, pull-down-collapse ✓, close chip ✓ visually.

## Known follow-ups (tracked for the single-view "resize overlay" morph)
- **Collapsed pill tap-through** — tapping the pill passes through to the list/tabs underneath (hit-testing/z-order). This is **pre-existing from #1217**, not introduced here. The morph removes the separate pill (the collapsed state becomes the small *size* of one overlay), which resolves it.
- **Single-view morph** — make full ⇄ mini feel like one view resizing (not two swapping). Chosen approach: a **custom resizing overlay** (the native detent sheet conflicts with the toolkit-player-must-stay-mounted + keep-playing-in-reader constraints). Separate branch, so it's independently discardable.
- The guard-free dismiss is unit-verified; a device pass on the live bar is worth doing (sim audiobook playback is flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
