### PR TITLE
fix(covers): guard non-finite display dimensions — PP-4772 / 077218fc EXC_BREAKPOINT

### DIFF
--- a/Palace/Book/Models/TPPBook+Presentation.swift
+++ b/Palace/Book/Models/TPPBook+Presentation.swift
@@ -40,6 +40,11 @@ extension TPPBook {
     /// than the conservative device memory-tier cap, so the image is always sharp at its
     /// actual display size without wasting memory decoding more than needed.
     func fetchCoverImage(forDisplayHeight displayHeight: CGFloat?) {
+        // A view can hand back a NaN / infinite / non-positive height while it is
+        // still laying out; `Int($0)` in the size key below would trap
+        // (EXC_BREAKPOINT). Treat an unusable height as "no size" and take the
+        // unsized path. PP-4772 / Crashlytics 077218fc.
+        let displayHeight = displayHeight?.finitePositiveDimension
         let sizeKey: String? = displayHeight.map { "\(identifier)_\(Int($0))pt" }
         let lookupKeys: [String] = if let sizeKey { [sizeKey, identifier] } else { [identifier] }
 

--- a/Palace/Book/Models/TPPBookCoverRegistry.swift
+++ b/Palace/Book/Models/TPPBookCoverRegistry.swift
@@ -4,6 +4,24 @@ import ImageIO
 import PalaceLogging
 import PalaceNetwork
 
+// MARK: - Display-dimension sanitizing
+
+extension CGFloat {
+    /// The value when it is a finite, strictly-positive display dimension; otherwise `nil`.
+    ///
+    /// A view can report a `NaN`, infinite, or non-positive size while it is still
+    /// laying out. Feeding such a value into `Int(_:)` traps with `EXC_BREAKPOINT`
+    /// ("… not representable in Int"), and into a `CGSize` / CoreGraphics renderer
+    /// produces an invalid-context crash. The cover pipeline converted a raw display
+    /// height straight into an `Int` cache key and a decode dimension without this
+    /// guard — the source of PP-4772 / Crashlytics `077218fc` (`fetchCoverImage`
+    /// `EXC_BREAKPOINT`). Callers use this to fall back to the unsized cover path
+    /// instead of trapping.
+    var finitePositiveDimension: CGFloat? {
+        (isFinite && self > 0) ? self : nil
+    }
+}
+
 // MARK: - Host Failure Tracker (Circuit Breaker)
 
 /// Tracks hosts that are consistently failing (e.g., DNS resolution errors) and allows
@@ -241,6 +259,12 @@ actor TPPBookCoverRegistry {
     /// and clamps to a sensible max. Use this instead of `coverImage(for:)` when you know
     /// the display size ahead of time so you don't over- or under-fetch.
     func coverImage(for book: TPPBook, displayPoints: CGFloat) async -> UIImage? {
+        // A non-finite / non-positive display size (a view mid-layout) would trap at
+        // `Int(neededPixels)` below and in the downstream TenPrint size math. Drop to
+        // the unsized cover path instead. PP-4772 / 077218fc.
+        guard let displayPoints = displayPoints.finitePositiveDimension else {
+            return await coverImage(for: book)
+        }
         let scale = await MainActor.run { UIScreen.main.scale }
         let neededPixels = min(displayPoints * scale * 1.5, 1200) // 1.5× for sharp rendering
         let key = "\(book.identifier)_\(Int(neededPixels))px"
@@ -463,7 +487,11 @@ actor TPPBookCoverRegistry {
     ///   - maxDimension: Maximum width or height for the decoded image
     /// - Returns: A decoded UIImage at the target size, or nil if decoding fails
     nonisolated static func downsampleImage(data: Data, maxDimension: CGFloat) -> UIImage? {
-        autoreleasepool {
+        // A non-finite / non-positive max dimension yields a bogus
+        // `kCGImageSourceThumbnailMaxPixelSize` and can propagate into `Int`
+        // conversions upstream; treat it as an unusable request. PP-4772.
+        guard let maxDimension = maxDimension.finitePositiveDimension else { return nil }
+        return autoreleasepool {
             let options: [CFString: Any] = [
                 kCGImageSourceShouldCache: false  // Don't cache the full-size image
             ]

--- a/Palace/Utilities/ImageCache/ImageLoaderImpl.swift
+++ b/Palace/Utilities/ImageCache/ImageLoaderImpl.swift
@@ -64,6 +64,11 @@ public class ImageLoader: ImageLoading {
     /// (`<identifier>_<px>px`) so a cache pre-warmed by an earlier read at the
     /// same display height is honored without re-fetch.
     public func coverImage(for book: TPPBook, displayPoints: CGFloat) async -> UIImage? {
+        // A non-finite / non-positive display size (a view mid-layout) would trap at
+        // `Int(neededPixels)` below. Fall back to the unsized cover. PP-4772 / 077218fc.
+        guard let displayPoints = displayPoints.finitePositiveDimension else {
+            return await coverImage(for: book)
+        }
         let scale = await MainActor.run { UIScreen.main.scale }
         let neededPixels = min(displayPoints * scale * 1.5, 1200)
         let key = "\(book.identifier)_\(Int(neededPixels))px"

--- a/PalaceTests/ImageLoading/ImageLoaderTests.swift
+++ b/PalaceTests/ImageLoading/ImageLoaderTests.swift
@@ -250,4 +250,54 @@ final class ImageLoaderTests: XCTestCase {
         let maxSide = max(result!.size.width, result!.size.height)
         XCTAssertLessThanOrEqual(maxSide, 64, "downsampled side must not exceed maxDimension")
     }
+
+    // MARK: - PP-4772 / 077218fc — non-finite display dimensions must not trap
+
+    /// The sanitizer that guards every `Int(displayDimension)` conversion in the
+    /// cover pipeline. Keeps finite positive values; rejects the NaN / infinite /
+    /// non-positive sizes a view can report mid-layout (the EXC_BREAKPOINT source).
+    func testFinitePositiveDimension_keepsFinitePositive_rejectsEverythingElse() {
+        XCTAssertEqual(CGFloat(120).finitePositiveDimension, 120)
+        XCTAssertEqual(CGFloat(0.5).finitePositiveDimension, 0.5)
+        XCTAssertNil(CGFloat.nan.finitePositiveDimension)
+        XCTAssertNil(CGFloat.infinity.finitePositiveDimension)
+        XCTAssertNil((-CGFloat.infinity).finitePositiveDimension)
+        XCTAssertNil(CGFloat(0).finitePositiveDimension)
+        XCTAssertNil(CGFloat(-5).finitePositiveDimension)
+    }
+
+    /// Regression for Crashlytics 077218fc: `ImageLoader.coverImage(for:displayPoints:)`
+    /// computed `Int(min(displayPoints * scale * 1.5, 1200))` for its cache key. When a
+    /// view reported a NaN / infinite / non-positive height, that `Int(_:)` conversion
+    /// trapped with EXC_BREAKPOINT. The loader must instead fall back to the unsized
+    /// cover. Pre-loading the unsized cover key makes the fallback deterministic (no
+    /// network, no TenPrint).
+    func testCoverImage_displayPoints_nonFinite_fallsBackToUnsizedCover_withoutTrapping() async {
+        let book = makeBook()
+        let sentinel = makeImage(width: 10, height: 10)
+        cache.set(sentinel, for: "\(book.identifier)_cover", expiresIn: nil)
+
+        for bad: CGFloat in [.nan, .infinity, -.infinity, 0, -5] {
+            // Pre-fix, the next line traps before returning.
+            let result = await loader.coverImage(for: book, displayPoints: bad)
+            XCTAssertEqual(result?.pngData(), sentinel.pngData(),
+                           "displayPoints=\(bad) must fall back to the unsized cover, not trap")
+        }
+    }
+
+    /// Same regression one layer down, at the registry seam the loader composes.
+    /// `TPPBookCoverRegistry.coverImage(for:displayPoints:)` had the identical
+    /// unguarded `Int(neededPixels)` conversion.
+    func testRegistryCoverImage_displayPoints_nonFinite_fallsBackToUnsizedCover_withoutTrapping() async {
+        let registry = TPPBookCoverRegistry(imageCache: cache)
+        let book = makeBook(imageURL: URL(string: "https://example.com/cover.jpg")!)
+        let sentinel = makeImage(width: 10, height: 10)
+        cache.set(sentinel, for: "\(book.identifier)_cover", expiresIn: nil)
+
+        for bad: CGFloat in [.nan, .infinity, 0, -5] {
+            let result = await registry.coverImage(for: book, displayPoints: bad)
+            XCTAssertEqual(result?.pngData(), sentinel.pngData(),
+                           "registry displayPoints=\(bad) must fall back to the unsized cover, not trap")
+        }
+    }
 }

--- a/PalaceTests/TPPBookCoverRegistryTests.swift
+++ b/PalaceTests/TPPBookCoverRegistryTests.swift
@@ -271,6 +271,25 @@ final class TPPBookCoverRegistryTests: XCTestCase {
                        "Image fetches should fail immediately without connectivity, not wait")
     }
 
+    // MARK: - PP-4772 / 077218fc — non-finite decode dimension
+
+    /// The shared decode chokepoint must reject a NaN / infinite / non-positive
+    /// `maxDimension` (which would otherwise feed a bogus
+    /// `kCGImageSourceThumbnailMaxPixelSize` and propagate into upstream `Int(_:)`
+    /// conversions) while still decoding a valid dimension.
+    func testDownsampleImage_nonFiniteMaxDimension_returnsNil() {
+        let jpeg = createTestJPEGData(size: CGSize(width: 400, height: 600))
+
+        XCTAssertNil(TPPBookCoverRegistry.downsampleImage(data: jpeg, maxDimension: .nan))
+        XCTAssertNil(TPPBookCoverRegistry.downsampleImage(data: jpeg, maxDimension: .infinity))
+        XCTAssertNil(TPPBookCoverRegistry.downsampleImage(data: jpeg, maxDimension: 0))
+        XCTAssertNil(TPPBookCoverRegistry.downsampleImage(data: jpeg, maxDimension: -10))
+
+        // Positive control: a valid dimension still decodes, so the guard is not
+        // over-rejecting.
+        XCTAssertNotNil(TPPBookCoverRegistry.downsampleImage(data: jpeg, maxDimension: 256))
+    }
+
     // MARK: - Helpers
 
     /// Creates JPEG data for a solid-color test image at the specified size


### PR DESCRIPTION
## PP-4772 — cover-load `EXC_BREAKPOINT` (`fetchCoverImage`, Crashlytics `077218fc`, 26 patrons)

The larger of PP-4772's two crash variants had **no targeted fix on develop**. Root cause: the cover pipeline converted a raw, view-supplied display dimension straight into `Int(_:)` for a cache key / decode size. When a view reports a `NaN` / infinite / non-positive height mid-layout, `Int(_:)` traps with `EXC_BREAKPOINT` ("not representable in Int"). Catalog cells pass a literal `150` (safe); the book-detail path (`BookImageView`) passes a live geometry height — the exposed surface.

### Fix
Add `CGFloat.finitePositiveDimension` and apply it at all four unguarded conversion sites, each falling back to the unsized cover path:

| Site | File |
|---|---|
| `fetchCoverImage(forDisplayHeight:)` size key (the crash symbol) | `TPPBook+Presentation.swift` |
| `coverImage(for:displayPoints:)` — first hop on the async path | `ImageLoaderImpl.swift` |
| `coverImage(for:displayPoints:)` | `TPPBookCoverRegistry.swift` |
| `downsampleImage(data:maxDimension:)` — decode chokepoint | `TPPBookCoverRegistry.swift` |

### Tests (network-free, deterministic via `MockImageCache`)
- `finitePositiveDimension` semantics — keeps finite-positive, rejects `NaN`/`∞`/`≤0`
- `ImageLoader` + registry `coverImage(displayPoints:)` fall back to the unsized cover for `.nan`/`.infinity`/`0`/negative instead of trapping (reproduces the crash pre-fix)
- `downsampleImage` returns `nil` for a non-finite `maxDimension`, still decodes a valid one

### Scope
The sibling variant `0f06402c` (`updateDominantColor` SIGABRT) was already hardened on develop (#1126); this closes the remaining, larger variant. **Done-when** per the ticket ("both issues stop accruing on the next build") is verifiable only after a release carries this.

**Not done:** post-release Crashlytics confirmation (requires the next build in production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)