### PR TITLE
chore(ci): route Dependabot updates to develop (not release-only main)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot configuration.
+#
+# NOTE: This file is read from the repository's DEFAULT branch (main), but we
+# route the update PRs to `develop` — the integration branch — because `main`
+# is release-only (see the release-merge policy in CLAUDE.md). This keeps
+# dependency + security bumps flowing through the normal develop → release path
+# instead of landing directly on the protected release branch.
+version: 2
+updates:
+  - package-ecosystem: "bundler" # the Gemfile (fastlane + its transitive deps: faraday, excon, addressable, …)
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions" # the CI workflows under .github/workflows/
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## Why

There is no `.github/dependabot.yml`, so Dependabot runs with defaults and targets the **default branch (main)**. But `main` is release-only (see the release-merge policy in CLAUDE.md), and Dependabot-triggered runs can't access CI secrets — so its `build-and-test` check is a false red (`Input required and not supplied: token`), and the PRs sit on the wrong branch.

## What

Adds `dependabot.yml` routing **bundler** (Gemfile — fastlane + transitive faraday/excon/addressable) and **github-actions** updates to `develop` via `target-branch: develop`, so bumps flow through the normal develop → release path.

## Notes

- Dependabot reads this config from the **default branch (main)** — that's why this PR targets main. Once merged, future bundler/security PRs (and the two open ones, #1135 faraday-HIGH / #1235 excon) can be recreated onto develop (`@dependabot recreate`).
- The **HIGH `addressable` ReDoS** alert has no PR yet; with this config Dependabot can raise one against develop.
- excon #1235 is a **major** bump (0.78→1.5) — worth a real `fastlane` run before a release (local smoke was blocked by an RVM env issue, not the bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)