### PR TITLE
test(signin): regression-lock #1222 off-main account-change fix + mutation-test AccountDetailViewModel signed-in derivation

### DIFF
--- a/.forgeos/intent/accountvm-offmain-coverage.md
+++ b/.forgeos/intent/accountvm-offmain-coverage.md
@@ -1,0 +1,70 @@
+---
+name: accountvm-offmain-coverage
+created: 2026-07-13
+author: Maurice Carrier
+branch: fix/accountvm-offmain-coverage
+priority: critical-path (SignInLogic / auth-state) — coverage follow-up to #1222
+---
+
+# Intent: regression-lock the off-main account-change fix + make AccountDetailViewModel's signed-in derivation mutation-testable
+
+## Context
+
+Crashlytics issue `2aea34ee` (build 485 / 3.3.0, EXC_BREAKPOINT) was a Swift 6
+main-actor isolation trap: `.TPPUserAccountDidChange` is posted on a BACKGROUND
+queue (token-refresh path: `TPPNetworkResponder → setAuthState →
+notifyAccountDidChange`), and `AccountDetailViewModel.setupObservers()`'s
+`@MainActor`-isolated Combine sink was entered off-main. **PR #1222 (2026-07-08)
+already fixed the crash** by adding `.receive(on: RunLoop.main)` to all four
+subscribers — verified absent from all post-#1222 field builds.
+
+The gap this intent closes: that fix has **zero regression test**, and the file's
+signed-in derivation (`accountDidChange()`) is un-mutation-testable because the
+credential snapshot comes from `accountsManager.userAccount(for:).credentialSnapshot()`
+— a concrete `AccountsManager` returning a real keychain-backed `TPPUserAccount`,
+so existing tests (1171 LOC) construct via `.production()` and kill 0/4 mutants.
+
+## Claims
+
+- Adds ONE injectable seam to `AccountDetailViewModel`'s designated initializer:
+  `credentialSnapshotProvider: ((String) -> TPPUserAccount.CredentialSnapshot)? = nil`,
+  defaulting (`nil`) to the existing production path
+  `accountsManager.userAccount(for: id).credentialSnapshot()`. Mirrors the existing
+  `drmAuthorizerProvider` injection pattern already on this init.
+- Routes the three in-VM `credentialSnapshot()` call sites (init:150,
+  accountDidChange:571, :602) through the resolved provider so tests can feed a
+  controlled snapshot without keychain.
+- Adds a regression test that drives `.TPPUserAccountDidChange` **posted from a
+  background queue** through the real observer and asserts the state update lands
+  on the main actor without trapping — the structural lock on #1222's
+  `.receive(on: RunLoop.main)` (remove it → off-main `@MainActor` sink entry →
+  Swift 6 trap → test killed).
+- Adds behavioral tests for `accountDidChange()`'s signed-in derivation
+  (`hasCredentials && authState != .loggedOut`, barcode/pin population vs clear)
+  driven via the notification seam, killing the mutants on that derivation.
+
+## Anti-claims
+
+- Does NOT change the crash fix from #1222 (`.receive(on:)` stays); this is
+  test + seam only.
+- Does NOT change any production caller — the new init param is defaulted; the
+  convenience init and `AccountDetailView.swift` are untouched.
+- Does NOT alter `accountDidChange()`'s observable behavior — only the SOURCE of
+  the snapshot becomes injectable.
+- Does NOT attempt to kill the `canSignIn`/401-handler auth-TYPE mutants
+  (`isOauth/isOidc == true` @80-82/414-415, `httpStatusCode == 401` @785): those
+  need a separate `businessLogic.selectedAuthentication` seam and are DEFERRED to
+  a tracked follow-up (see Deferred).
+
+## Deferred
+
+- Auth-type/401 survivor mutants require injecting `businessLogic`'s auth
+  definition — a larger SignInLogic seam. Tracked as follow-up, not in this diff.
+- Mutation kill-rate evidence must be produced by a LOCAL `palace_mutate.py` run
+  (mutation is local-only per CLAUDE.md; CI does not run it). This branch's CI
+  proves build + full-suite green only.
+
+## Files in scope
+
+- `Palace/Settings/AccountDetailViewModel.swift` (seam: ~10 LOC)
+- `PalaceTests/ViewModels/AccountDetailViewModelTests.swift` (new tests)

--- a/Palace/Settings/AccountDetailViewModel.swift
+++ b/Palace/Settings/AccountDetailViewModel.swift
@@ -56,6 +56,12 @@ class AccountDetailViewModel: NSObject, ObservableObject {
     private let settings: TPPSettings
     private let userAccountPublisher: UserAccountPublisher
     private let drmAuthorizerProvider: () -> TPPDRMAuthorizing?
+    /// Source of the credential snapshot read by `accountDidChange()` and init.
+    /// Defaults to the live keychain-backed path
+    /// (`accountsManager.userAccount(for:).credentialSnapshot()`); injectable so
+    /// the signed-in derivation can be exercised without keychain. Mirrors
+    /// `drmAuthorizerProvider`.
+    private let credentialSnapshotProvider: (String) -> TPPUserAccount.CredentialSnapshot
     private var cancellables = Set<AnyCancellable>()
     var forceEditability = false
 
@@ -127,7 +133,8 @@ class AccountDetailViewModel: NSObject, ObservableObject {
         downloadCenter: MyBooksDownloadCenter,
         settings: TPPSettings,
         userAccountPublisher: UserAccountPublisher,
-        drmAuthorizerProvider: @escaping () -> TPPDRMAuthorizing?
+        drmAuthorizerProvider: @escaping () -> TPPDRMAuthorizing?,
+        credentialSnapshotProvider: ((String) -> TPPUserAccount.CredentialSnapshot)? = nil
     ) {
         self.libraryAccountID = libraryAccountID
         self.accountsManager = accountsManager
@@ -136,6 +143,9 @@ class AccountDetailViewModel: NSObject, ObservableObject {
         self.settings = settings
         self.userAccountPublisher = userAccountPublisher
         self.drmAuthorizerProvider = drmAuthorizerProvider
+        self.credentialSnapshotProvider = credentialSnapshotProvider ?? { [accountsManager] id in
+            accountsManager.userAccount(for: id).credentialSnapshot()
+        }
         self.businessLogic = TPPSignInBusinessLogic(
             libraryAccountID: libraryAccountID,
             libraryAccountsProvider: accountsManager,
@@ -147,7 +157,7 @@ class AccountDetailViewModel: NSObject, ObservableObject {
             drmAuthorizer: nil
         )
 
-        let snapshot = accountsManager.userAccount(for: libraryAccountID).credentialSnapshot()
+        let snapshot = self.credentialSnapshotProvider(libraryAccountID)
         self.isSignedIn = snapshot.hasCredentials && snapshot.authState != .loggedOut
 
         super.init()
@@ -568,7 +578,7 @@ class AccountDetailViewModel: NSObject, ObservableObject {
     }
 
     private func accountDidChange() {
-        let snapshot = accountsManager.userAccount(for: libraryAccountID).credentialSnapshot()
+        let snapshot = credentialSnapshotProvider(libraryAccountID)
 
         let newSignedIn = snapshot.hasCredentials && snapshot.authState != .loggedOut
 
@@ -599,7 +609,7 @@ class AccountDetailViewModel: NSObject, ObservableObject {
     func refreshSignInState() {
         let wasSignedIn = isSignedIn
 
-        let snapshot = accountsManager.userAccount(for: libraryAccountID).credentialSnapshot()
+        let snapshot = credentialSnapshotProvider(libraryAccountID)
         isSignedIn = snapshot.hasCredentials && snapshot.authState != .loggedOut
 
         if wasSignedIn != isSignedIn {

--- a/PalaceTests/ViewModels/AccountDetailViewModelTests.swift
+++ b/PalaceTests/ViewModels/AccountDetailViewModelTests.swift
@@ -1169,3 +1169,197 @@ final class AccountDetailSignOutConfirmationTests: XCTestCase {
                        "Cancel action title must be the localized Cancel string")
     }
 }
+
+// MARK: - Signed-in derivation + off-main observer safety
+
+/// Mutable holder so a test can change the credential snapshot the view model
+/// reads BETWEEN steps (the injected `credentialSnapshotProvider` closure reads
+/// `snapshot` each time `accountDidChange()` runs). Touched only on the main
+/// actor, matching the view model's isolation.
+private final class SnapshotBox {
+    var snapshot: TPPUserAccount.CredentialSnapshot
+    init(_ snapshot: TPPUserAccount.CredentialSnapshot) { self.snapshot = snapshot }
+}
+
+/// Covers the two gaps #1222 left open:
+///  1. Regression-locks the off-main fix: every test posts
+///     `.TPPUserAccountDidChange` from a BACKGROUND queue — the production path
+///     (token-refresh → `TPPUserAccount.notifyAccountDidChange` posts off-main).
+///     `setupObservers()`'s `@MainActor` sink must hop to main via
+///     `.receive(on: RunLoop.main)`; remove that hop and the sink is entered
+///     off-main → Swift 6 `dispatch_assert_queue` trap → these tests die.
+///  2. Makes `accountDidChange()`'s signed-in derivation
+///     (`hasCredentials && authState != .loggedOut`, barcode/pin population)
+///     mutation-testable by injecting the credential snapshot instead of reading
+///     the keychain.
+@MainActor
+final class AccountDetailViewModelSignedInDerivationTests: XCTestCase {
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Constructing the view model still spins up the real business-logic /
+        // network graph via `.production()`, which can round-trip TPPKeychain.
+        // Skip on CI hosts where SecItem returns -34018 (no entitlement) — same
+        // gate the sibling classes use. The injected snapshot means these tests
+        // are deterministic wherever they DO run (notably local mutation runs,
+        // which are where kill-rate is measured — mutation is local-only).
+        try KeychainAvailability.skipIfUnavailable()
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: Helpers
+
+    private func makeSnapshot(
+        hasCredentials: Bool,
+        authState: TPPAccountAuthState,
+        barcode: String? = nil,
+        pin: String? = nil
+    ) -> TPPUserAccount.CredentialSnapshot {
+        TPPUserAccount.CredentialSnapshot(
+            hasCredentials: hasCredentials,
+            hasAuthToken: false,
+            authState: authState,
+            barcode: barcode,
+            pin: pin,
+            authToken: nil,
+            authDefinition: nil,
+            cookies: nil
+        )
+    }
+
+    private func makeViewModel(box: SnapshotBox) throws -> AccountDetailViewModel {
+        let container = AppContainer.production()
+        guard let libraryID = container.accountsManager.currentAccountId else {
+            throw XCTSkip("No current account available for testing")
+        }
+        return AccountDetailViewModel(
+            libraryAccountID: libraryID,
+            accountsManager: container.accountsManager,
+            bookRegistry: container.bookRegistry,
+            downloadCenter: container.downloadCenter,
+            settings: container.settings,
+            userAccountPublisher: container.userAccountPublisher,
+            drmAuthorizerProvider: container.drmAuthorizerProvider,
+            credentialSnapshotProvider: { _ in box.snapshot }
+        )
+    }
+
+    /// Let the init-time `loadInitialData()` / `accountDidChange()` work settle so
+    /// the subsequent `dropFirst()` observation only sees OUR triggered change.
+    private func settle() async {
+        for _ in 0..<3 { await Task.yield() }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+    }
+
+    /// Posts `.TPPUserAccountDidChange` from a background queue (production shape)
+    /// and waits for `isSignedIn` to reach `expected`. If `setupObservers()` were
+    /// to lose its main-actor hop, entering the `@MainActor` sink off-main would
+    /// trap here rather than fulfill.
+    private func postAccountChangeOffMainAndAwaitSignedIn(
+        _ vm: AccountDetailViewModel,
+        expected: Bool
+    ) async {
+        let reached = expectation(description: "isSignedIn == \(expected)")
+        vm.$isSignedIn
+            .dropFirst()
+            .sink { if $0 == expected { reached.fulfill() } }
+            .store(in: &cancellables)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            NotificationCenter.default.post(name: .TPPUserAccountDidChange, object: nil)
+        }
+        await fulfillment(of: [reached], timeout: 3.0)
+    }
+
+    // MARK: Tests
+
+    func testOffMainAccountChange_withValidCredentials_signsInAndPopulatesBarcodeAndPin() async throws {
+        let box = SnapshotBox(makeSnapshot(hasCredentials: false, authState: .loggedOut))
+        let vm = try makeViewModel(box: box)
+        await settle()
+        XCTAssertFalse(vm.isSignedIn, "precondition: starts signed out")
+
+        box.snapshot = makeSnapshot(hasCredentials: true, authState: .loggedIn,
+                                    barcode: "BC-42", pin: "1111")
+        await postAccountChangeOffMainAndAwaitSignedIn(vm, expected: true)
+
+        XCTAssertTrue(vm.isSignedIn,
+                      "credentials present + authState != loggedOut must be signed-in")
+        XCTAssertEqual(vm.usernameText, "BC-42", "barcode from the snapshot must populate usernameText")
+        XCTAssertEqual(vm.pinText, "1111", "pin from the snapshot must populate pinText")
+    }
+
+    func testOffMainAccountChange_credentialsPresentButLoggedOut_isNotSignedInAndClearsFields() async throws {
+        let box = SnapshotBox(makeSnapshot(hasCredentials: true, authState: .loggedIn,
+                                           barcode: "OLD", pin: "OLD"))
+        let vm = try makeViewModel(box: box)
+        await settle()
+        XCTAssertTrue(vm.isSignedIn, "precondition: starts signed in")
+
+        // hasCredentials stays true, but authState becomes loggedOut. This pins
+        // the `authState != .loggedOut` half of the derivation: flip `!=` to `==`
+        // and this book would read as signed-in → assertion fails → mutant killed.
+        box.snapshot = makeSnapshot(hasCredentials: true, authState: .loggedOut)
+        await postAccountChangeOffMainAndAwaitSignedIn(vm, expected: false)
+
+        XCTAssertFalse(vm.isSignedIn,
+                       "loggedOut must not be signed-in even when credentials are still present")
+        XCTAssertEqual(vm.usernameText, "", "signed-out state must clear usernameText")
+        XCTAssertEqual(vm.pinText, "", "signed-out state must clear pinText")
+    }
+
+    func testOffMainAccountChange_noCredentials_isNotSignedIn() async throws {
+        let box = SnapshotBox(makeSnapshot(hasCredentials: true, authState: .loggedIn,
+                                           barcode: "X", pin: "Y"))
+        let vm = try makeViewModel(box: box)
+        await settle()
+        XCTAssertTrue(vm.isSignedIn, "precondition: starts signed in")
+
+        // Pins the `hasCredentials &&` half: no credentials → signed-out
+        // regardless of authState. Flip `&&` to `||` and loggedIn alone would
+        // read as signed-in → assertion fails → mutant killed.
+        box.snapshot = makeSnapshot(hasCredentials: false, authState: .loggedIn)
+        await postAccountChangeOffMainAndAwaitSignedIn(vm, expected: false)
+
+        XCTAssertFalse(vm.isSignedIn, "no credentials must never be signed-in")
+    }
+
+    func testOffMainAccountChange_credentialsStale_remainsSignedIn() async throws {
+        let box = SnapshotBox(makeSnapshot(hasCredentials: false, authState: .loggedOut))
+        let vm = try makeViewModel(box: box)
+        await settle()
+
+        // credentialsStale is "has credentials, session expired" — NOT loggedOut,
+        // so the account still reads as signed-in (token refreshes in background).
+        // Pins the boundary that only `.loggedOut` is signed-out.
+        box.snapshot = makeSnapshot(hasCredentials: true, authState: .credentialsStale,
+                                    barcode: "S", pin: "P")
+        await postAccountChangeOffMainAndAwaitSignedIn(vm, expected: true)
+
+        XCTAssertTrue(vm.isSignedIn,
+                      "credentialsStale (has creds, not loggedOut) must remain signed-in")
+    }
+
+    func testOffMainAccountChange_signedInWithNilBarcodeAndPin_fieldsFallThroughToEmpty() async throws {
+        let box = SnapshotBox(makeSnapshot(hasCredentials: false, authState: .loggedOut))
+        let vm = try makeViewModel(box: box)
+        await settle()
+
+        // Signed-in but the snapshot carries nil barcode/pin (token-only auth).
+        // Pins the `snapshot.barcode ?? ""` / `snapshot.pin ?? ""` fallthrough:
+        // mutate either default (e.g. `?? "x"`) and these fields would no longer
+        // be empty → assertion fails → mutant killed.
+        box.snapshot = makeSnapshot(hasCredentials: true, authState: .loggedIn, barcode: nil, pin: nil)
+        await postAccountChangeOffMainAndAwaitSignedIn(vm, expected: true)
+
+        XCTAssertTrue(vm.isSignedIn)
+        XCTAssertEqual(vm.usernameText, "", "nil barcode must fall through to empty string")
+        XCTAssertEqual(vm.pinText, "", "nil pin must fall through to empty string")
+    }
+}


### PR DESCRIPTION
## What & why

Verification of the operating-report finding on `AccountDetailViewModel`:

- **Gap 1 (the crash) is already fixed** on `develop`. PR #1222 (2026-07-08) added `.receive(on: RunLoop.main)` to `setupObservers()`, fixing the Swift-6 off-main main-actor trap (Crashlytics `2aea34ee`, build 485). Build 485 crashed because its snapshot was cut hours before that commit. **No production fix needed** — this PR does not change the crash fix.
- **Gap 2 (coverage) was real.** That fix had **zero regression test**, and the file's signed-in derivation was un-mutation-testable: the credential snapshot came from a concrete `AccountsManager` → keychain-backed `TPPUserAccount`, so the existing 1171-LOC suite killed **0/4 mutants**.

## Change

- **Seam (18 LOC, behavior-preserving):** adds `credentialSnapshotProvider: ((String) -> TPPUserAccount.CredentialSnapshot)? = nil` to the designated init (mirrors the existing `drmAuthorizerProvider`), defaulting to the live keychain path. Routes the 3 in-VM snapshot reads through it. Defaulted param → **no production caller changes**; byte-identical when nil.
- **Tests (5):** `AccountDetailViewModelSignedInDerivationTests` drives the real `.TPPUserAccountDidChange` observer **from a background queue** — regression-locking the off-main hop (remove `.receive(on:)` → off-main `@MainActor` sink entry → Swift-6 trap → tests die) and killing the `hasCredentials && authState != .loggedOut` derivation mutants plus the barcode/pin `?? ""` fallthrough.

## Review (critical path — auth/sign-in state)

Independent SoD review, both **APPROVE**:
- **Architect / concurrency** (`rev_a3f7c1e9`): behavior byte-identical with default, capture `[accountsManager]` correct & cycle-free, init ordering valid, zero caller breakage, right-sized seam.
- **QA / test-quality** (`rev_7c3f9a2e`): traced all core mutants to genuine kills; injection insulates against `NotificationCenter` bleed; no fluff.

## Verification status

- ✅ Static gates: SUT-instantiation, test-name-vs-body, blast-radius, adjacency, superpartner, contract-reconciliation — all pass.
- ⏳ **Build + full suite → this CI run** (worktree can't build the DRM app locally; per CLAUDE.md CI is the gate — local pre-push test gate skipped for missing Carthage frameworks, not a code failure).
- ⏳ **Mutation kill-rate → local `palace_mutate.py`** (mutation is local-only per CLAUDE.md; reasoning for each kill is in the reviews).

## Deferred (tracked follow-up, not this diff)

- `canSignIn` / 401 auth-type mutants (`isOauth`/`isOidc == true`, `httpStatusCode == 401`) need a separate `businessLogic` auth-definition seam.
- The off-main lock covers the `.TPPUserAccountDidChange` hop (#1222 crash path); sibling `.receive(on:)` hops aren't individually locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
