### PR TITLE
chore(tooling): dial in detector gates + both-target build + pool-responsiveness probe (pre-Sprint 79)

### DIFF
--- a/.forgeos/initiatives/2026-07-13-tooling-dial-in.md
+++ b/.forgeos/initiatives/2026-07-13-tooling-dial-in.md
@@ -1,0 +1,142 @@
+# Tooling Dial-In Initiative — pre-Sprint 79
+
+**Date:** 2026-07-13 · **Owner:** Maurice (solo) · **No PR — local branch only.**
+
+## Context
+
+Solo, agent-driven, local-first, cost-conscious. Sprint 78 retro found: the
+verification *infrastructure* is strong, but enforcement rests entirely on the
+agent PreToolUse hook (Channel A) — **the detectors ARE the wall.** That model is
+correct for an agent-driven shop, but it makes two audit findings load-bearing:
+
+1. Some **blocking** detectors were never tested → an invisible hole in the wall.
+2. Detectors are static → they caught **~0%** of real shipped runtime/build bugs
+   in the wall-failure backtest. Both Sprint-78 self-regressions (#1226 launch
+   crash, #1225/#1218 second-target build breaks) are outside detector reach.
+
+This initiative dials the tools in before Sprint 79. All work is LOCAL (scripts/,
+docs/, .forgeos/) — no Palace/ production Swift, no framework build, no CI push.
+
+## Work items
+
+- **WI-1 — Test the untested detectors.** Add a pytest in `scripts/tests/` for each
+  of the 6 untested detectors, priority on the two BLOCKING ones. Every test must
+  assert BOTH: (a) a real violation is caught (non-zero exit), AND (b) a clean diff
+  passes (exit 0) — the CLAUDE.md rule-#4 clean-path assertion. Model after an
+  existing sibling (`test_check_foreign_host_401_scoping.py`).
+  - `check-blast-radius.py` — **BLOCK**
+  - `check-contract-reconciliation.py` — **BLOCK**
+  - `check-test-name-vs-body.py` — DoD #1
+  - `check-superpartner-spectrum.py` — warn
+  - `check-adjacency-staleness.py` — warn
+  - `check-discipline-nudge.py` — nudge
+- **WI-2 — Both-target build gate.** Add an off-by-default pre-push hook script that
+  builds Palace + Palace-noDRM, documented as "run before pushing any AppContainer/
+  concurrency/startup change." Covers the #1225/#1218 second-target-break class that
+  no static detector can catch.
+- **WI-3 — Promote or retire the warn-only detectors.** Dry-run `superpartner-spectrum`
+  and `adjacency-staleness` against recent history; if zero false positives, wire a
+  promotion path (block on high-severity/critical-path, keep low-severity warn);
+  otherwise document why they stay warn. No silent half-on state.
+- **WI-4 — Prune lying docs.** `docs/Testing/Coverage_Roadmap.md` (stale: forbidden
+  workspace build, wrong sim, contradicts "honest 35%") → delete or rewrite to match
+  reality. Fix the stale hook-symlink description in CLAUDE.local.md.
+- **WI-5 — DECISION (Maurice): test pollution.** Not fixed tonight. Choose:
+  (a) invest — pool-responsiveness probe + local per-shard fresh process, then revive
+  the parked `greenboard-enforcement-deferred` gate; or (b) accept retry-mask —
+  delete the reverted scaffolding, document green = "passes within 3 retries." The
+  current parked-tag limbo is the one state to leave.
+
+## WI-3 decision — 2026-07-13 (soak evidence + call)
+
+**Verdict: BOTH stay fully warn-only. No promotion. No script edits.** Neither
+detector meets CLAUDE.md rule #4's "soaked with ZERO false positives" bar. A
+false-positive blocker is worse than a warn, and both would produce routine
+blocks on legitimate work that agents would learn to bypass (`--no-block` /
+`// no-superpartner:` / ignore) — reopening a hole in the wall via habituation.
+
+### `check-superpartner-spectrum.py` → KEEP WARN (do not block-on-high)
+
+Soak: working-tree diff + last 20 commits, `--dry-run` at high floor.
+- Working tree: **1 HIGH** — `AudiobookSessionPresenter.swift:559 func chapterProgress`.
+- Last 20 commits: **5 of 20 fired HIGH**, 13 HIGH findings total:
+  - `0437af6e4` ×3 `addBookmark` · `c4bee439c` ×3 `setPlaybackRate`
+  - `0ae5ebf9a` ×3 `setSleepTimer` · `ea9221571` ×3 `seek` · `5a99261e6` ×1 `fire`
+- Every HIGH is `Palace/Audiobooks/` (critical path → auto-HIGH per the path
+  globs), and every one is either a thin protocol accessor on
+  `AudiobookSessionManaging` + its `AudiobookSessionManager` impl
+  (`seek`/`setPlaybackRate`/`setSleepTimer`/`addBookmark` — pass-throughs to the
+  toolkit) or a local closure helper (`fire`).
+
+Why not promote: these are *true positives by the detector's definition* (no
+test in the SAME diff) but NOT defects worth blocking. Two structural reasons:
+(1) the check only sees the current diff, so the common test-later / test-at-the-
+manager-seam workflow (function in commit X, behavior test in commit Y) reads as
+a miss; (2) critical-path auto-HIGH means every audiobook accessor trips the
+block, not just risky logic. Block-on-high would have blocked ~25% of recent
+commits on this branch — a nuisance rate that trains bypass. The summary-nudge
+value ("did you add a test?") is real; keep it advisory. Mutation testing
+(`palace_mutate.py`, DoD #5) remains the actual proof-of-catch on critical paths.
+
+Re-evaluate to promote only if: (a) the accessor false-alarm is cut by
+exempting thin protocol-witness pass-throughs, and (b) it runs branch-clean
+(zero HIGH) across a 20-commit window. Not there yet.
+
+### `check-adjacency-staleness.py` → KEEP WARN (structurally warn-only)
+
+Soak: working-tree diff + last 30 commits, `--quiet`.
+- Working tree: **0** ("no removed declarations to check").
+- Last 30 commits: **4 fired**, with runaway false-positive clusters:
+  - `0c0ee344e` **N=211** on removed name `label`
+  - `c70e6b0f7` **N=50** on removed name `minimize`
+  - `6b865f222` N=3 · `d565ab9da` N=2 (`configureAudioSession`)
+
+Why not promote: the design greps *all surviving comments* for the bare removed
+identifier with `\b<name>\b`. Common words (`label`, `minimize`) match hundreds
+of unrelated comment lines (SwiftUI `.label`, accessibility labels, `Label`
+views, "minimize allocations" prose) that have nothing to do with the rename.
+The N=211/N=50 clusters are ~all false positives. The script's own docstring
+already states it is warn-only because "renames vs deletions are not mechanically
+distinguishable from the diff alone." This is a genuinely-useful *nudge* after a
+targeted rename of a distinctive symbol, but it is structurally unfit to block —
+promotion is not on the table without an identifier-distinctiveness/allowlist
+filter that the current design lacks. Keep exit-0 warn as written.
+
+## Definition of Done (WI-1..4)
+
+- pytest suite green; each new test asserts catch + clean-pass.
+- Build-gate script passes `bash -n`; wired off-by-default with a documented flag.
+- Warn-only detectors either promoted (with dry-run evidence) or documented as
+  intentionally-warn.
+- Stale docs corrected or removed.
+- Committed to a dedicated local branch; audiobook working-tree edits untouched; no push, no PR.
+
+## WI-2 — both-target build gate: how to enable
+
+Delivered: `scripts/pre-push-both-target-build.sh` (passes `bash -n`; repo-tracked,
+mirroring `scripts/pre-push-test-gate.sh` — note `scripts/hooks/` is a harness symlink
+and is NOT committable, so the gate lives directly under `scripts/`).
+It builds BOTH schemes with `xcodebuild -project Palace.xcodeproj` on the
+iPhone 16 Pro sim, build-only (no test): `Palace` (full DRM) then
+`Palace-noDRM` (open-source, mirroring `scripts/xcode-build-nodrm.sh`'s
+code-signing opt-out). This closes the #1225/#1218 second-target-break class —
+a change that compiles in `Palace` but breaks `Palace-noDRM` — which no static
+detector can catch.
+
+OFF BY DEFAULT (mirrors `pre-push-test-gate.sh`). Enable for a single push:
+
+```bash
+ENABLE_BOTH_TARGET_BUILD_GATE=1 git push ...
+```
+
+Bypass once while enabled: `SKIP_BOTH_TARGET_BUILD_GATE=1 git push ...`.
+
+Run it before pushing any AppContainer / concurrency (Swift 6 isolation,
+Sendable) / app-startup / target-conditional (`#if`) change — the diffs that
+can differ across the two targets. Chains `git lfs pre-push` first, so it is a
+safe drop-in as `.git/hooks/pre-push`. **It should be wired into the agent
+pre-push path** (export `ENABLE_BOTH_TARGET_BUILD_GATE=1` there, or chain the
+script from the agent's pre-push hook) so those risk-bearing pushes get the
+both-target compile automatically. Framework-absent worktrees (no
+`carthage bootstrap` / submodule init) are treated as a non-blocking WARN, same
+as the test gate — CI remains authoritative there.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -483,6 +483,7 @@
 		5977FE52E5B43328E7773533 /* TPPReaderFootnoteAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */; };
 		5A6C30A999D9E0264FD78074 /* ActiveSessionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A72A97BA91A0EB66D642A06 /* ActiveSessionsViewModelTests.swift */; };
 		5AD42A9111A49CFDF0AC22B1 /* AdobeRightsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E62D6F6D6313094B90E80E5 /* AdobeRightsParser.swift */; };
+		5ADD8B5E1F4D8868B3FEA17F /* PoolResponsivenessProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01209A378C5A59B2AA08C13D /* PoolResponsivenessProbeTests.swift */; };
 		5AE6D7440F7AEDED5F21C570 /* CredentialSnapshotInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1063BE37AED8A85F5812F422 /* CredentialSnapshotInvalidationTests.swift */; };
 		5AEA9E011B947419009F71DB /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503EA1993F91E009FB788 /* libc++.dylib */; };
 		5AEFB2EE17E8CB4115AEDA02 /* EPUBKeyCommandsPP4289Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28AA48F826072E449380BFBE /* EPUBKeyCommandsPP4289Tests.swift */; };
@@ -2053,6 +2054,7 @@
 		00A1B2C3D4E5F60700OPDS2E /* OPDS2CatalogFeed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = OPDS2CatalogFeed.json; sourceTree = "<group>"; };
 		00E9DF245319907059F86297 /* ReaderChromeToggleFadeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderChromeToggleFadeTests.swift; sourceTree = "<group>"; };
 		011100499302EE8A7CBC30C6 /* AudiobookEngineMock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookEngineMock.swift; sourceTree = "<group>"; };
+		01209A378C5A59B2AA08C13D /* PoolResponsivenessProbeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PoolResponsivenessProbeTests.swift; sourceTree = "<group>"; };
 		01407B71400FB30643B6A5CD /* AudioEngineWrapperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioEngineWrapperTests.swift; sourceTree = "<group>"; };
 		0149B8595768484A2C352B5B /* DownloadTaskPersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadTaskPersistenceTests.swift; sourceTree = "<group>"; };
 		01F470EA0E88BDCE56E27B86 /* LCPPDFDiskExtractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPDFDiskExtractTests.swift; sourceTree = "<group>"; };
@@ -3891,6 +3893,7 @@
 				4EF195BFDD71F9F64A017579 /* TearDownRequiredLintTests.swift */,
 				05CAE584B769CF73DD2B3740 /* RuntimeQuiescenceGateTests.swift */,
 				50E92EE539A615735164856F /* RuntimeQuiescenceLintTests.swift */,
+				01209A378C5A59B2AA08C13D /* PoolResponsivenessProbeTests.swift */,
 			);
 			name = MetaTests;
 			path = MetaTests;
@@ -7733,6 +7736,7 @@
 				C40757CBD12CF84CFC242548 /* AccountsManagerFirstRunDecodeTests.swift in Sources */,
 				61CB94A62C37F50A20D60E44 /* AudiobookMorphingPlayerViewTests.swift in Sources */,
 				4DE6468C2E4065037D7281F9 /* AlertPresentationRawGuardLintTests.swift in Sources */,
+				5ADD8B5E1F4D8868B3FEA17F /* PoolResponsivenessProbeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PalaceTests/MetaTests/PoolResponsivenessProbeTests.swift
+++ b/PalaceTests/MetaTests/PoolResponsivenessProbeTests.swift
@@ -1,0 +1,126 @@
+//
+//  PoolResponsivenessProbeTests.swift
+//  PalaceTests
+//
+//  Unit self-tests for the WS-0 class-4 pool-responsiveness GATE — the opt-in
+//  `PalaceTestCase.assertRuntimeResponsive` seam that converts a silent
+//  cross-test cooperative-pool hang into an ATTRIBUTED `tearDown` failure
+//  (docs/architecture/runtime-quiescence-gate-backlog.md, Deliverable A).
+//
+//  These exercise the probe's OWN decision logic — probe → pure detector →
+//  `XCTFail` — in isolation, via an injected responsiveness stub, so the wiring
+//  is proven RED (a saturated pool trips the gate) AND GREEN (a responsive pool
+//  does not) WITHOUT staging a real cross-test leak. That is the same
+//  synthetic-input, both-directions self-test discipline `RuntimeQuiescenceGateTests`
+//  applies to the defer-flag gate, and the green-board contract (#4) requires:
+//  an inert gate satisfies "it compiles" AND "the suite is green," so the ONLY
+//  trustworthy evidence is a run where a planted violation made it RED.
+//
+//  The live-pool probe itself (`measureCooperativePoolProbe` clean vs saturated)
+//  is covered by `RuntimeQuiescenceGateTests`; this file covers the GATE layer
+//  that decides + attributes on top of that probe.
+//
+//  Test-target-only. Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class PoolResponsivenessProbeTests: PalaceTestCase {
+
+    // MARK: - Wiring: probe → detector → attributed XCTFail (RED)
+
+    /// The decisive wiring proof: an injected "pool did NOT schedule the probe"
+    /// stub MUST make `assertRuntimeResponsive` record exactly one attributed
+    /// failure, whose message names the cooperative pool and the remediation. If
+    /// this ever passes WITHOUT a recorded failure, the gate is inert (the exact
+    /// fake-gate failure the WS-0 wall-failure documents).
+    func testAssertRuntimeResponsive_saturatedStub_recordsAttributedFailure() {
+        var captured: [RuntimeQuiescenceAuditor.Violation] = []
+
+        XCTExpectFailure("A saturated-pool stub MUST trip the pool-responsiveness gate") {
+            // Stub reports the pool never scheduled the probe within budget.
+            captured = assertRuntimeResponsive(budget: 5.0, probe: { _ in false })
+        }
+
+        XCTAssertEqual(
+            captured.count, 1,
+            "A pool that did not schedule the probe must produce exactly one violation"
+        )
+        XCTAssertEqual(
+            captured.first?.invariant,
+            "cooperative pool at rest (probe schedules within budget)",
+            "The violation must name the cooperative-pool invariant so the failure is self-explaining"
+        )
+        let detail = captured.first?.detail ?? ""
+        XCTAssertTrue(
+            detail.contains("cooperative"),
+            "Remediation must name the saturated resource (the cooperative thread pool)"
+        )
+        XCTAssertTrue(
+            detail.contains("tearDown") || detail.contains("cancel") || detail.contains("await"),
+            "Remediation must tell the engineer HOW to fix the leak (cancel/await the leaked Tasks in tearDown)"
+        )
+    }
+
+    // MARK: - Wiring: responsive pool does NOT false-positive (GREEN)
+
+    /// Symmetric clean-path proof: an injected "pool scheduled the probe" stub
+    /// MUST produce no violation and record no failure. A gate that fires on a
+    /// healthy pool would redden the board and train everyone to ignore it — the
+    /// anti-pattern the green-board contract exists to prevent.
+    func testAssertRuntimeResponsive_healthyStub_recordsNoFailure() {
+        let violations = assertRuntimeResponsive(budget: 5.0, probe: { _ in true })
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            "A responsive-pool stub must NOT trip the gate (no false positive)"
+        )
+    }
+
+    // MARK: - The DEFAULT probe is the real cooperative-pool probe (not constant-false)
+
+    /// Exercises the REAL default probe path (no stub) on a clean pool: the
+    /// high-priority detached Task schedules well within budget, so there is no
+    /// violation. This kills a mutation that hard-codes the default probe to
+    /// `false` (which would make the gate a permanent false-positive) — the stub
+    /// tests alone cannot catch that, because they replace the default.
+    func testAssertRuntimeResponsive_realProbeOnCleanPool_isResponsive() {
+        let violations = assertRuntimeResponsive(budget: 5.0)
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            "On a clean cooperative pool the real default probe must complete within budget → no violation"
+        )
+    }
+
+    /// Async sibling exercised on a clean pool: `assertRuntimeResponsiveAsync`
+    /// (the `@MainActor async` path for async test bodies) must also report the
+    /// runtime responsive when the pool is at rest. Proves the async decision
+    /// path is wired to the same pure detector and is not constant-failing.
+    @MainActor
+    func testAssertRuntimeResponsiveAsync_realProbeOnCleanPool_isResponsive() async {
+        let violations = await assertRuntimeResponsiveAsync(budget: 5.0)
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            "On a clean cooperative pool the async probe must schedule within budget → no violation"
+        )
+    }
+
+    // MARK: - Rollout safety: the hard gate is OFF by default
+
+    /// The pool-responsiveness HARD gate must stay OFF by default so it cannot
+    /// destabilize the ~7k-execution suite before a zero-false-positive audit
+    /// promotes it. Opt-in is per-class via overriding
+    /// `enforcesPoolResponsiveness`. This class does NOT override it, so it must
+    /// read `false`. Kills a mutation that flips the base default to `true`
+    /// (which would silently arm the wall-clock gate suite-wide).
+    func testEnforcesPoolResponsiveness_isOffByDefault() {
+        XCTAssertFalse(
+            enforcesPoolResponsiveness,
+            "The pool-responsiveness hard gate must be off-by-default; opt in per-class by "
+            + "overriding enforcesPoolResponsiveness to true only after proving the class leaves the pool at rest"
+        )
+    }
+}

--- a/PalaceTests/Support/PalaceTestCase.swift
+++ b/PalaceTests/Support/PalaceTestCase.swift
@@ -56,6 +56,15 @@ class PalaceTestCase: XCTestCase {
         try super.tearDownWithError()
         assertRuntimeQuiescent()
         warnOnObserverLeak()
+        // Class-4 (accumulation pool-starvation) HARD gate — OPT-IN. Runs only
+        // for classes that override `enforcesPoolResponsiveness` to `true`
+        // (default `false`), so it cannot destabilize the ~7k-execution suite
+        // before a zero-false-positive audit clears it. Every test still gets
+        // the process-wide WARN-only `[WS0-POOL-DIAG]` breadcrumb from the
+        // observer regardless of this flag.
+        if enforcesPoolResponsiveness {
+            assertRuntimeResponsive()
+        }
     }
 
     /// WARN-ONLY observer-leak check (leaked-observer class). Emits a
@@ -106,5 +115,163 @@ class PalaceTestCase: XCTestCase {
                 line: line
             )
         }
+    }
+
+    // MARK: - Pool-responsiveness gate-extension (WS-0 class 4, OPT-IN)
+
+    /// Opt-in switch for the pool-responsiveness HARD gate. Default `false`.
+    ///
+    /// Off-by-default on purpose. The probe (`assertRuntimeResponsive`) carries a
+    /// wall-clock deadline, and promoting a wall-clock probe to a suite-wide hard
+    /// gate before a zero-false-positive audit is exactly the premature-hard-gate
+    /// mistake the runtime-quiescence ADR warns against ("start warn-only, like
+    /// the NotificationCenter audit, then promote"). The process-wide WARN-only
+    /// `[WS0-POOL-DIAG]` diagnostic in `PalaceSingletonResetObserver` already
+    /// covers EVERY test cheaply. A class that has proven its own teardown leaves
+    /// the cooperative pool at rest overrides this to `true` — so that an
+    /// accumulation leak it (or a predecessor) introduces surfaces as an
+    /// ATTRIBUTED failure in its own tearDown, instead of a silent 120s/300s hang
+    /// in a random downstream async victim.
+    ///
+    /// Overriding is the ENTIRE opt-in — no per-test boilerplate:
+    /// ```swift
+    /// final class MyAsyncPoolTests: PalaceTestCase {
+    ///     override var enforcesPoolResponsiveness: Bool { true }
+    /// }
+    /// ```
+    var enforcesPoolResponsiveness: Bool { false }
+
+    /// Bounded check that the runtime is at rest — the class-4 (accumulation
+    /// pool-starvation) gate extension. Two cheap probes run in sequence:
+    ///
+    /// 1. **Main-queue drain** (`drainMainQueue`) — proves the main queue still
+    ///    flushes; a wedged main thread is its own hang class.
+    /// 2. **Cooperative-pool probe** — schedules a high-priority detached `Task`
+    ///    and waits, ON THE MAIN THREAD (via `XCTWaiter().wait` inside
+    ///    `measureCooperativePoolProbe`), up to `budget` for it to run. Blocking
+    ///    MAIN — not a pool worker — is load-bearing: a free pool thread can
+    ///    still run the probe, so a timeout means the pool is genuinely saturated
+    ///    by leaked blocking Tasks, not merely that main is busy.
+    ///
+    /// If the pool did not schedule the probe within `budget`, this fails the
+    /// CURRENT test's tearDown, naming the resource (cooperative thread pool) and
+    /// the remediation — converting a silent downstream hang into an attributed
+    /// upstream failure in the test whose boundary first saw the pool saturated.
+    ///
+    /// SYMPTOM, not root: it detects "runtime not at rest," not "test X leaked
+    /// Task Y." Under gradual accumulation it fires at whichever test's tearDown
+    /// FIRST sees the pool saturated — often the last big leaker, not the first.
+    /// It narrows the suspect window; pair with the seed-replay bisection
+    /// (Deliverable B) to name the exact leaker.
+    ///
+    /// **Do NOT call from an `@MainActor async` test body** — the synchronous
+    /// main-blocking wait deadlocks there (same caveat as `drainMainQueue` vs
+    /// `drainMainQueueAsync`). Use `assertRuntimeResponsiveAsync` instead.
+    ///
+    /// - Parameters:
+    ///   - budget: max seconds to wait for main-drain and for the pool to
+    ///     schedule the probe. Default 5s — a hung pool is *indefinite*, while
+    ///     legitimate background work finishes in <1s, so 5s cleanly separates
+    ///     them while tolerating CI-runner load.
+    ///   - probe: injection seam for the unit self-test — maps a budget to "did
+    ///     the pool schedule the probe within it." Defaults to the real
+    ///     cooperative-pool probe. The self-test passes a stub (`{ _ in false }`
+    ///     / `{ _ in true }`) to prove the probe→detector→`XCTFail` wiring fires
+    ///     AND does not false-positive, without staging a real leak.
+    /// - Returns: the violations produced (also surfaced via `XCTFail`), so the
+    ///   self-test can assert the message shape without capturing the failure.
+    @discardableResult
+    func assertRuntimeResponsive(
+        budget: TimeInterval = 5.0,
+        probe: ((TimeInterval) -> Bool)? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> [RuntimeQuiescenceAuditor.Violation] {
+        // 1. Main-queue drain — reuses the sleep-free FIFO drain helper.
+        drainMainQueue(timeout: budget)
+        // 2. Cooperative-pool probe (real, unless a stub is injected for the
+        //    self-test).
+        let poolScheduledProbe = (probe ?? {
+            PalaceSingletonResetObserver.measureCooperativePoolProbe(budget: $0).completed
+        })(budget)
+        let violations = RuntimeQuiescenceAuditor.poolResponsivenessViolations(
+            probeCompleted: poolScheduledProbe
+        )
+        for v in violations {
+            XCTFail(
+                "Runtime-quiescence gate [\(v.invariant)]: \(v.detail)",
+                file: file,
+                line: line
+            )
+        }
+        return violations
+    }
+
+    /// Async sibling of `assertRuntimeResponsive` for `@MainActor async` test
+    /// bodies / async teardown, where the synchronous main-blocking wait would
+    /// deadlock.
+    ///
+    /// `@MainActor` is load-bearing: the bounded poll's `Task.sleep` resumptions
+    /// hop back to the MAIN actor (free, because we `await` rather than block
+    /// it), so the poll itself can never be starved by the very cooperative-pool
+    /// saturation it is trying to detect — the async analogue of the sync
+    /// version's "block MAIN, not a pool worker" principle. The probe Task is
+    /// `detached` (runs on the pool); if the pool is saturated it never flips the
+    /// flag and we time out at `budget` → violation.
+    ///
+    /// - Returns: the violations produced (also surfaced via `XCTFail`).
+    @MainActor
+    @discardableResult
+    func assertRuntimeResponsiveAsync(
+        budget: TimeInterval = 5.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async -> [RuntimeQuiescenceAuditor.Violation] {
+        await drainMainQueueAsync(timeout: budget)
+        let completed = await Self.pollCooperativePoolProbe(budget: budget)
+        let violations = RuntimeQuiescenceAuditor.poolResponsivenessViolations(
+            probeCompleted: completed
+        )
+        for v in violations {
+            XCTFail(
+                "Runtime-quiescence gate [\(v.invariant)]: \(v.detail)",
+                file: file,
+                line: line
+            )
+        }
+        return violations
+    }
+
+    /// Detached-probe + bounded MAIN-actor poll behind `assertRuntimeResponsiveAsync`.
+    /// Returns whether the cooperative pool scheduled the probe within `budget`.
+    /// The `Task.sleep` resumes on the MAIN actor (this method is `@MainActor`),
+    /// so the poll loop is never starved by the pool it measures.
+    @MainActor
+    private static func pollCooperativePoolProbe(budget: TimeInterval) async -> Bool {
+        let flag = PoolProbeFlag()
+        Task.detached(priority: .high) { flag.markScheduled() }
+        let deadline = Date().addingTimeInterval(budget)
+        while Date() < deadline {
+            if flag.wasScheduled { return true }
+            // 5ms; resumes on MAIN because this method is @MainActor.
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return flag.wasScheduled
+    }
+}
+
+/// Thread-safe one-shot flag for the async cooperative-pool probe. `NSLock`-based
+/// (no executor dependency) so reading/writing it can never itself be starved by
+/// the cooperative pool the probe is measuring.
+private final class PoolProbeFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var scheduled = false
+    func markScheduled() {
+        lock.lock(); defer { lock.unlock() }
+        scheduled = true
+    }
+    var wasScheduled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return scheduled
     }
 }

--- a/docs/Testing/Coverage_Roadmap.md
+++ b/docs/Testing/Coverage_Roadmap.md
@@ -1,500 +1,68 @@
-# Test Coverage Roadmap
-
-**Target:** 80% Code Coverage
-**Timeline:** 6 Weeks
-**Current Estimate:** ~35-40% coverage
-
----
-
-## Executive Summary
-
-This roadmap provides a prioritized, incremental plan to achieve 80% test coverage in the Palace iOS codebase. Each stage includes specific targets, test types, expected coverage gains, and risk mitigation strategies.
-
----
-
-## Stage 1: Foundation & Quick Wins (Weeks 1-2)
-
-### Objectives
-- Establish testing infrastructure improvements
-- Add high-value, low-risk unit tests
-- Create reusable mock factories
-
-### 1.1 Infrastructure Setup (Week 1, Days 1-3)
-
-**Files to Create/Modify:**
-
-| File | Action | Purpose |
-|------|--------|---------|
-| `PalaceTests/TestSupport/TestDependencyContainer.swift` | Create | Centralized mock injection |
-| `PalaceTests/TestSupport/Clock.swift` | Create | Time abstraction for testing |
-| `PalaceTests/TestSupport/FileManagerMock.swift` | Create | File system abstraction |
-| `PalaceTests/Mocks/TPPSettingsMock.swift` | Create | Settings mock |
-| `PalaceTests/Mocks/AccountsManagerMock.swift` | Create | Accounts mock |
-| `PalaceTests/Fixtures/` | Organize | Consolidate test fixtures |
-
-**Production Files to Refactor:**
-
-| File | Change | Risk Level |
-|------|--------|------------|
-| `Palace/Settings/TPPSettings.swift` | Extract `TPPSettingsProviding` protocol | Low |
-| `Palace/Accounts/Library/AccountsManager.swift` | Add init with injected network executor | Medium |
-
-**Expected Coverage Delta:** +2%
-
----
-
-### 1.2 ViewModel Unit Tests (Week 1, Days 4-5)
-
-**Target ViewModels (already have DI support):**
-
-| ViewModel | File | Tests to Add |
-|-----------|------|--------------|
-| CatalogSearchViewModel | `Palace/CatalogUI/ViewModels/CatalogSearchViewModel.swift` | Debouncing, error states, pagination |
-| EPUBSearchViewModel | `Palace/Reader2/UI/EpubSearchView/EPUBSearchViewModel.swift` | Search execution, result handling |
-| HoldsViewModel | `Palace/Holds/HoldsViewModel.swift` | Hold actions, refresh |
-| BookDetailViewModel | `Palace/Book/UI/BookDetail/BookDetailViewModel.swift` | State transitions, actions |
-
-**Test Files to Create:**
-
-```
-PalaceTests/CatalogUI/CatalogSearchViewModelTests.swift
-PalaceTests/Reader2/EPUBSearchViewModelTests.swift
-PalaceTests/Holds/HoldsViewModelTests.swift
-PalaceTests/Book/BookDetailViewModelTests.swift
-```
-
-**Expected Coverage Delta:** +5%
-
----
-
-### 1.3 Pure Logic Unit Tests (Week 2)
-
-**Target: Classes with no singleton dependencies**
-
-| Class | File | Test Focus |
-|-------|------|------------|
-| CatalogFilter | `Palace/CatalogUI/Models/CatalogFilter.swift` | Property storage |
-| CatalogFilterGroup | `Palace/CatalogUI/Models/CatalogFilterGroup.swift` | Filter management |
-| CatalogLaneModel | `Palace/CatalogUI/Models/CatalogLaneModel.swift` | Lane construction |
-| TPPReaderSettings | `Palace/Reader2/Settings/TPPReaderSettings.swift` | Serialization |
-| TPPBookState | `Palace/Book/Models/TPPBookState.swift` | State transitions |
-| TPPCredentials | `Palace/SignInLogic/TPPCredentials.swift` | Credential handling |
-| CatalogCacheMetadata | `Palace/Accounts/Library/AccountsManager.swift:7-29` | Cache freshness |
-| TokenResponse | `Palace/Network/TokenRequest.swift` | Token parsing |
-
-**Test Files to Create:**
-
-```
-PalaceTests/CatalogUI/CatalogModelsTests.swift
-PalaceTests/SignInLogic/TPPCredentialsTests.swift
-PalaceTests/Network/TokenResponseTests.swift
-PalaceTests/Accounts/CatalogCacheMetadataTests.swift
-```
-
-**Expected Coverage Delta:** +5%
-
----
-
-### Stage 1 Summary
-
-| Metric | Target |
-|--------|--------|
-| New Test Files | 10-12 |
-| Tests Added | ~80-100 |
-| Coverage Delta | +12% |
-| Ending Coverage | ~47-52% |
-
-### Risks & Mitigation
-
-| Risk | Probability | Impact | Mitigation |
-|------|-------------|--------|------------|
-| Protocol extraction breaks ObjC interop | Medium | High | Keep `@objc` on protocol, test incrementally |
-| Test flakiness from async code | Medium | Medium | Use `XCTestExpectation` with timeouts |
-| Mock complexity grows | Low | Medium | Use factory pattern, limit mock scope |
-
----
-
-## Stage 2: High-Value Coverage Expansion (Weeks 3-4)
-
-### Objectives
-- Add tests for critical business logic
-- Implement network stubbing across tests
-- Cover authentication and download flows
-
-### 2.1 Authentication Tests (Week 3, Days 1-3)
-
-**Target Files:**
-
-| File | Test Focus | Priority |
-|------|------------|----------|
-| `TPPSignInBusinessLogic.swift` | OAuth flow, sign-out, DRM preservation | P0 |
-| `TPPReauthenticator.swift` | Re-auth triggers, completion | P0 |
-| `TPPNetworkExecutor.swift:312-430` | Token refresh, retry queue | P0 |
-| `TPPAgeCheck.swift` | Age verification states | P1 |
-
-**Tests to Add:**
-
-```swift
-// PalaceTests/SignInLogic/TPPSignInBusinessLogicTests.swift
-func testSignIn_WithValidCredentials_StoresInKeychain()
-func testSignIn_WithOAuth_RequestsToken()
-func testSignOut_PreservesAdobeDRMActivation()
-func testSignOut_ClearsCredentials()
-
-// PalaceTests/Network/TokenRefreshTests.swift
-func testTokenRefresh_On401_RetriesFailedRequest()
-func testTokenRefresh_AlreadyInProgress_QueuesRequest()
-func testTokenRefresh_FailsWith401_PresentsSignIn()
-```
-
-**Expected Coverage Delta:** +4%
-
----
-
-### 2.2 Book Registry & Download Tests (Week 3, Days 4-5)
-
-**Target Files:**
-
-| File | Test Focus | Priority |
-|------|------------|----------|
-| `TPPBookRegistry.swift` | State persistence, publishers | P0 |
-| `MyBooksDownloadCenter.swift` | Concurrent limits, recovery | P0 |
-| `DownloadCoordinator` (actor) | Lock-free coordination | P1 |
-
-**Tests to Add:**
-
-```swift
-// PalaceTests/BookStateManagement/TPPBookRegistryTests.swift
-func testRegistry_SavesAndLoadsFromDisk()
-func testRegistry_PublishesStateChanges()
-func testRegistry_HandlesCorruptedJSON()
-
-// PalaceTests/MyBooks/MyBooksDownloadCenterConcurrencyTests.swift
-func testDownload_EnforcesConcurrentLimit()
-func testDownload_QueuesExcessDownloads()
-func testDownload_RecoveriesAfterNetworkFailure()
-```
-
-**Expected Coverage Delta:** +4%
-
----
-
-### 2.3 OPDS Parsing Tests (Week 4, Days 1-2)
-
-**Target Files:**
-
-| File | Test Focus | Priority |
-|------|------------|----------|
-| `TPPOPDSFeed.swift` | OPDS 1.x parsing | P0 |
-| `OPDS2CatalogsFeed.swift` | OPDS 2.0 parsing | P0 |
-| `TPPOPDSEntry.swift` | Entry extraction | P1 |
-| `TPPOPDSLink.swift` | Link relations | P1 |
-
-**Fixtures to Add:**
-
-```
-PalaceTests/Fixtures/OPDSFeeds/
-├── opds1_catalog.xml
-├── opds1_search_results.xml
-├── opds1_with_facets.xml
-├── opds2_catalog.json
-├── opds2_auth_document.json
-└── opds2_publication.json
-```
-
-**Expected Coverage Delta:** +3%
-
----
-
-### 2.4 Catalog Repository Tests (Week 4, Days 3-5)
-
-**Target Files:**
-
-| File | Test Focus | Priority |
-|------|------------|----------|
-| `CatalogRepository.swift` | Stale-while-revalidate | P0 |
-| `DefaultCatalogAPI.swift` | Network integration | P0 |
-| `OPDSFeedService.swift` | Feed caching | P1 |
-
-**Tests to Add:**
-
-```swift
-// PalaceTests/CatalogDomain/CatalogRepositoryTests.swift
-func testLoadCatalog_WithFreshCache_ReturnsCachedData()
-func testLoadCatalog_WithStaleCache_ReturnsAndRefreshes()
-func testLoadCatalog_WithExpiredCache_FetchesFromNetwork()
-func testLoadCatalog_NetworkFailure_FallsBackToCache()
-```
-
-**Expected Coverage Delta:** +4%
-
----
-
-### Stage 2 Summary
-
-| Metric | Target |
-|--------|--------|
-| New Test Files | 8-10 |
-| Tests Added | ~60-80 |
-| Coverage Delta | +15% |
-| Ending Coverage | ~62-67% |
-
-### Risks & Mitigation
-
-| Risk | Probability | Impact | Mitigation |
-|------|-------------|--------|------------|
-| Keychain tests fail in CI | High | High | Mock keychain access, skip real keychain tests in CI |
-| Network stubbing incomplete | Medium | Medium | Use HTTPStubURLProtocol consistently |
-| Test data out of sync with production | Medium | Low | Generate fixtures from real API responses |
-
----
-
-## Stage 3: UI & Integration Hardening (Weeks 5-6)
-
-### Objectives
-- Add comprehensive snapshot tests
-- Implement end-to-end integration tests
-- Cover accessibility requirements
-- Establish UI tests for critical paths
-
-### 3.1 Snapshot Test Expansion (Week 5, Days 1-3)
-
-**Existing Snapshots to Expand:**
-
-| File | Additional Snapshots |
-|------|---------------------|
-| `CatalogSnapshotTests.swift` | Loading state, error state, empty state, dark mode |
-| `BookDetailSnapshotTests.swift` | All book states, download progress |
-| `MyBooksSnapshotTests.swift` | Empty library, downloading, mixed states |
-| `AudiobookPlayerSnapshotTests.swift` | Playing, paused, sleep timer |
-
-**New Snapshot Tests:**
-
-```
-PalaceTests/Snapshots/
-├── SignInSnapshotTests.swift         # Sign-in flows
-├── ReaderSettingsSnapshotTests.swift # Reader appearance
-├── CarPlaySnapshotTests.swift        # CarPlay UI
-└── ErrorStateSnapshotTests.swift     # Error presentations
-```
-
-**Expected Coverage Delta:** +3%
-
----
-
-### 3.2 Accessibility Test Expansion (Week 5, Days 4-5)
-
-**Existing Accessibility Tests to Expand:**
-
-| File | Additional Tests |
-|------|-----------------|
-| `CatalogAccessibilityTests.swift` | Lane navigation, filter controls |
-| `AudiobookAccessibilityTests.swift` | Player controls, chapter list |
-| `ReaderAccessibilityTests.swift` | Settings, TOC |
-
-**New Accessibility Tests:**
-
-```swift
-// PalaceTests/Accessibility/BookDetailAccessibilityTests.swift
-func testBookDetail_AllButtonsHaveLabels()
-func testBookDetail_VoiceOverOrder()
-
-// PalaceTests/Accessibility/SignInAccessibilityTests.swift
-func testSignIn_FormFieldsLabeled()
-func testSignIn_ErrorsAnnounced()
-```
-
-**Expected Coverage Delta:** +2%
-
----
-
-### 3.3 Integration Tests (Week 6, Days 1-3)
-
-**Target Flows:**
-
-| Flow | Components Involved | Priority |
-|------|---------------------|----------|
-| Sign-in → Catalog Load | Auth, Network, Catalog, UI | P0 |
-| Download → Read | MyBooks, DRM, Reader | P0 |
-| Account Switch | Accounts, Navigation, Cleanup | P1 |
-| Search → Results → Detail | Catalog, Search, Book | P1 |
-
-**Test Files to Create:**
-
-```
-PalaceTests/Integration/
-├── SignInToCatalogIntegrationTests.swift
-├── DownloadAndReadIntegrationTests.swift
-├── AccountSwitchIntegrationTests.swift
-└── SearchFlowIntegrationTests.swift
-```
-
-**Expected Coverage Delta:** +5%
-
----
-
-### 3.4 UI Tests (Week 6, Days 4-5)
-
-**Critical Paths:**
-
-| Path | Steps | Assertions |
-|------|-------|------------|
-| Library Selection | Launch → Select Library → Confirm | Catalog loads |
-| Sign In | Account → Sign In → Credentials | Session established |
-| Browse & Borrow | Catalog → Book → Borrow | Book in My Books |
-| Read EPUB | My Books → Book → Read | Reader opens |
-| Play Audiobook | My Books → Audiobook → Play | Audio plays |
-
-**Test Files to Create:**
-
-```
-PalaceUITests/
-├── LibrarySelectionUITests.swift
-├── SignInUITests.swift
-├── BrowseAndBorrowUITests.swift
-├── ReadingUITests.swift
-└── AudiobookUITests.swift
-```
-
-**Expected Coverage Delta:** +3%
-
----
-
-### Stage 3 Summary
-
-| Metric | Target |
-|--------|--------|
-| New Test Files | 12-15 |
-| Tests Added | ~80-100 |
-| Coverage Delta | +13% |
-| Ending Coverage | ~75-80% |
-
-### Risks & Mitigation
-
-| Risk | Probability | Impact | Mitigation |
-|------|-------------|--------|------------|
-| Snapshot tests brittle | High | Medium | Use tolerance, semantic snapshot naming |
-| UI tests slow | High | Medium | Parallelize, mock network |
-| Integration test isolation | Medium | High | Reset state between tests |
-
----
-
-## First 3 PRs - Concrete Implementation Plan
-
-### PR #1: Test Infrastructure Foundation
-
-**Branch:** `test/infrastructure-foundation`
-
-**Files Changed:**
-
-```
-A  PalaceTests/TestSupport/TestDependencyContainer.swift
-A  PalaceTests/TestSupport/Clock.swift
-A  PalaceTests/TestSupport/ClockProtocol.swift
-A  PalaceTests/Mocks/TPPSettingsMock.swift
-A  PalaceTests/Mocks/AccountsManagerProtocol.swift
-A  PalaceTests/Mocks/AccountsManagerMock.swift
-M  Palace/Settings/TPPSettings.swift (add TPPSettingsProviding protocol)
-M  Palace/Accounts/Library/AccountsManager.swift (add protocol conformance)
-```
-
-**Commit Messages:**
-
-1. `feat(test): add TestDependencyContainer for centralized mock injection`
-2. `feat(test): add Clock protocol and mock for time-dependent testing`
-3. `refactor: extract TPPSettingsProviding protocol for testability`
-4. `feat(test): add AccountsManagerProtocol and mock implementation`
-
-**Estimated LOC:** ~400 added, ~50 modified
-
----
-
-### PR #2: ViewModel Unit Tests
-
-**Branch:** `test/viewmodel-unit-tests`
-
-**Files Changed:**
-
-```
-A  PalaceTests/CatalogUI/CatalogSearchViewModelTests.swift
-A  PalaceTests/Holds/HoldsViewModelTests.swift
-A  PalaceTests/Book/BookDetailViewModelTests.swift
-A  PalaceTests/Reader2/EPUBSearchViewModelTests.swift
-M  PalaceTests/Mocks/CatalogRepositoryMock.swift (add search stubbing)
-```
-
-**Commit Messages:**
-
-1. `test(catalog): add CatalogSearchViewModel unit tests`
-2. `test(holds): add HoldsViewModel unit tests`
-3. `test(book): add BookDetailViewModel unit tests`
-4. `test(reader): add EPUBSearchViewModel unit tests`
-
-**Estimated LOC:** ~600 added
-
----
-
-### PR #3: Authentication Flow Tests
-
-**Branch:** `test/auth-flow-tests`
-
-**Files Changed:**
-
-```
-A  PalaceTests/SignInLogic/TPPSignInBusinessLogicTests.swift
-A  PalaceTests/Network/TokenRefreshTests.swift
-A  PalaceTests/Mocks/TPPUserAccountMock+Keychain.swift
-A  PalaceTests/Mocks/TPPDRMAuthorizingMock+Extended.swift
-A  PalaceTests/Fixtures/AuthDocs/oauth_token_response.json
-M  PalaceTests/Mocks/NYPLNetworkExecutorMock.swift (add token refresh stubbing)
-```
-
-**Commit Messages:**
-
-1. `test(auth): add TPPSignInBusinessLogic unit tests for OAuth flow`
-2. `test(auth): add tests for sign-out with DRM preservation`
-3. `test(network): add token refresh and retry queue tests`
-4. `feat(test): extend mocks for authentication testing`
-
-**Estimated LOC:** ~700 added
-
----
-
-## Coverage Tracking
-
-### Measurement Script
+# Test Quality Posture (not a coverage roadmap)
+
+**There is no line-coverage target and no coverage gate.** An earlier version of
+this file laid out a 6-week plan to hit 80% line coverage. That target has been
+retired: it contradicted the repo's actual quality posture and encouraged
+coverage-only tests, which are explicitly banned (see `CLAUDE.md` →
+"TDD & Test Quality"). Coverage is a byproduct of good tests, not a goal.
+
+> Honest 35% coverage with tests that catch bugs is better than 50% coverage
+> with tautologies that catch nothing.
+
+## The real quality bar
+
+Test value is measured by whether a test would fail when the production code it
+covers regresses — not by how many lines it executes. The canonical mechanisms,
+all defined in `CLAUDE.md`:
+
+- **TDD** — production changes get a failing test first.
+- **Mutation kill-rate** — `scripts/palace_mutate.py --file <f> --tests <class>
+  --diff-only`. Diff-scoped kill rate must be ≥ 50% (ideally 100% on touched
+  lines) for critical paths (`Palace/Audiobooks/`, `Palace/SignInLogic/`,
+  `Palace/MyBooks/Download*`, auth/borrow/return/DRM/credentials). Local-only —
+  run in `/regression` and pre-release, not CI (see `CLAUDE.md` →
+  "Mutation testing").
+- **Contract-snapshot tests** — for state machines that emit ordered dependency
+  calls (`Borrow`, `BookReturn`, `DownloadStart`, `BorrowReducer`). Framework in
+  `PalaceTests/Contract/`.
+- **Definition of Done (11 checks)** — SUT-instantiation, function-result usage,
+  multi-step body, scope-coverage, mutation, build + `verify-pr.sh`,
+  wiring-coverage, contract reconciliation, blast-radius, adjacency, and
+  test-pairing. Paste evidence before declaring work done.
+- **State-machine wiring tests** must drive full round-trips through the
+  production seam, not direct `_setState` shortcuts.
+
+Banned patterns (set-then-assert, enum-raw-value asserts, non-nil constructor
+asserts, bool toggles, tautologies) and the mutation-survival question are the
+gate — see `CLAUDE.md` for the full list.
+
+## Running the suite
+
+Local validation runs the **same full scheme CI runs** — never a
+`-only-testing:` subset (that is a spot-check only). Build with the **project**,
+not the workspace (the workspace hits Firebase SPM issues), against
+**iPhone 16 Pro** (the CI simulator):
 
 ```bash
-# Run after each PR merge
-xcodebuild test \
-  -workspace Palace.xcworkspace \
-  -scheme Palace \
-  -destination 'platform=iOS Simulator,name=iPhone 16' \
-  -enableCodeCoverage YES \
-  -resultBundlePath TestResults.xcresult
+# Full-scheme single pass:
+scripts/verify-pr.sh --quick
 
-# Extract coverage
-xcrun xccov view --report TestResults.xcresult --json > coverage.json
-python scripts/coverage-report.py coverage.json
+# CI parity (3 iterations, retry-on-failure):
+scripts/xcode-test-optimized.sh
+
+# Build only:
+xcodebuild -project Palace.xcodeproj -scheme Palace \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build
 ```
 
-### Weekly Targets
+A run is green only if it ends `** TEST SUCCEEDED **` with no
+`exceeded execution time allowance` / `Restarting after … test timeout` lines.
 
-| Week | Stage | Target Coverage |
-|------|-------|-----------------|
-| 1 | Foundation | 42% |
-| 2 | Quick Wins | 52% |
-| 3 | Auth + Downloads | 60% |
-| 4 | OPDS + Catalog | 67% |
-| 5 | Snapshots + A11y | 72% |
-| 6 | Integration + UI | 80% |
+## If you want to raise coverage of a specific area
 
----
-
-## Success Criteria
-
-1. **Coverage Target Met:** ≥80% line coverage
-2. **No Test Flakiness:** <1% flaky test rate over 100 runs
-3. **CI Integration:** All tests pass in GitHub Actions
-4. **Documentation:** All patterns documented in Test_Patterns.md
-5. **Traceability:** All P0 requirements have at least one test
+Pick an uncovered branch that could actually regress, write a behavior test that
+kills a mutant on it, and verify with `palace_mutate.py`. Do not write tests
+whose only purpose is to execute a line. If a line has no testable behavior
+(fire-and-forget analytics, empty delegate method), leave it uncovered.
+</content>
+</invoke>

--- a/docs/architecture/runtime-quiescence-gate-backlog.md
+++ b/docs/architecture/runtime-quiescence-gate-backlog.md
@@ -128,3 +128,130 @@ property made explicit.
 
 ## Sequencing
 Per Chairman: ship M0 (defer-flag gate + iters-3-green) first. Then this backlog, top-down: Deliverable A (pool-responsiveness probe — the durable structural win that turns silent hangs into attributed failures), then Deliverable B per victim as needed, alongside the keychain-hermetic (w-lane) and alert-hermetic (w-mutex) class fixes. All build ON the shipped `RuntimeQuiescenceAuditor` / `PalaceTestCase` substrate — one hierarchy, one auditor, N invariants.
+
+---
+
+## Deliverable A — IMPLEMENTATION STATUS (WI-5, 2026-07-13)
+
+**Status: AUTHORED, NOT VALIDATED.** The change was written in the
+`audiobook-dismiss` worktree, which cannot build the app (missing Carthage
+binaries + uninitialized submodule per the "fresh worktree lacks frameworks"
+memory), so the Palace suite was NOT run. Compile-correctness was established by
+inspection only. The validation commands the maintainer must run on a build
+machine are below.
+
+### What was already present (prior WS-0 waves), reused verbatim
+- `RuntimeQuiescenceAuditor.poolResponsivenessViolations(probeCompleted:)` — the
+  PURE detector (`false` → one violation naming the cooperative pool + the
+  remediation; `true` → empty).
+- `PalaceSingletonResetObserver.measureCooperativePoolProbe(budget:)` — the LIVE
+  probe (schedules a `.high` detached `Task`, waits for it on the MAIN thread via
+  `XCTWaiter().wait` so a free pool thread can still run it; returns
+  `(completed, latencyMs)`).
+- The process-wide WARN-only `[WS0-POOL-DIAG]` breadcrumb in the observer's
+  `testCaseDidFinish` (covers every test; never fails).
+- Probe self-tests in `RuntimeQuiescenceGateTests` (pure both-directions; clean
+  pool completes fast; saturated pool RED-first with full drain-on-teardown).
+
+### What this WI added — the missing GATE layer (turns the probe into attribution)
+- **`PalaceTestCase.assertRuntimeResponsive(budget:probe:file:line:)`** — the
+  opt-in per-test HARD gate. Runs the sleep-free `drainMainQueue`, then the
+  cooperative-pool probe, then routes the result through the pure detector and
+  `XCTFail`s each violation *inside the finishing test's own tearDown* — so a
+  silent downstream hang becomes an attributed upstream failure. `budget`
+  defaults to 5s (a hung pool is indefinite; legit background work finishes
+  <1s). Takes an injectable `probe` seam for the self-test. `@discardableResult`
+  returns the violations so tests can assert message shape.
+- **`PalaceTestCase.assertRuntimeResponsiveAsync(...)`** — `@MainActor async`
+  sibling for async test bodies / async teardown (the sync main-blocking wait
+  deadlocks under `@MainActor async`). Uses a detached probe + a bounded poll
+  whose `Task.sleep` resumes on MAIN (so the poll can't be starved by the pool it
+  measures) via a lock-guarded `PoolProbeFlag`.
+- **`PalaceTestCase.enforcesPoolResponsiveness: Bool { false }`** — the opt-in
+  switch. `tearDownWithError` runs the hard gate ONLY when a subclass overrides
+  this to `true`. **Off-by-default** on purpose: the wall-clock probe is not
+  promoted to a suite-wide hard gate before a zero-false-positive audit (the
+  "start warn-only, then promote" discipline the ADR mandates). No existing class
+  was flipped to `true` — the suite behaviour is unchanged; only the mechanism +
+  its unit coverage were added.
+- **`PalaceTests/MetaTests/PoolResponsivenessProbeTests.swift`** — dedicated
+  self-tests of the GATE layer, both directions via the injected stub
+  (saturated stub → attributed failure asserted under `XCTExpectFailure`; healthy
+  stub → no failure), plus a real-default-probe-on-clean-pool test (kills the
+  constant-`false` mutation the stub tests can't), an async clean-pool test, and
+  an off-by-default invariant test (kills a base-default flip to `true`).
+  Registered into the `PalaceTests` target via `scripts/pbxproj_add_swift.rb`.
+
+### Probe mechanism (precise)
+- **Resource probed:** the Swift cooperative thread pool (global concurrent
+  executor) + the main dispatch queue.
+- **Deadline:** `budget`, default **5.0 s** (drain and probe share it).
+- **Assertion:** (1) `DispatchQueue.main` flushes a FIFO no-op within budget;
+  (2) a `.high`-priority detached `Task` gets scheduled and runs within budget
+  while the *main* thread blocks on it (sync path) or suspends awaiting it (async
+  path). A timeout on (2) ⇒ the pool is saturated by leaked blocking/un-drained
+  Tasks ⇒ one `Violation` ⇒ `XCTFail` in the finishing test's tearDown.
+- **Attribution:** because the `XCTFail` is raised in `tearDownWithError` of the
+  *finishing* test (not from a global observer, which is empirically inert, and
+  not from a trailing "final" class, which randomized order defeats), the red
+  lands on the test whose boundary FIRST saw the pool saturated. Under gradual
+  accumulation that narrows the suspect window (often the last big leaker); pair
+  with Deliverable B to name the exact culprit.
+
+### Validation commands the MAINTAINER must run (on a build machine)
+```bash
+# 0. From a checkout that CAN build (frameworks present), land these 3 files:
+#    PalaceTests/Support/PalaceTestCase.swift
+#    PalaceTests/MetaTests/PoolResponsivenessProbeTests.swift
+#    Palace.xcodeproj/project.pbxproj   (PalaceTests target membership)
+
+# 1. Build both targets (DRM + noDRM) — compile-correctness of the new seam:
+xcodebuild -project Palace.xcodeproj -scheme Palace \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build
+xcodebuild -project Palace.xcodeproj -scheme Palace-noDRM \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build
+
+# 2. Spot-check the new gate's own unit tests (fast RED->GREEN proof):
+xcodebuild -project Palace.xcodeproj -scheme Palace \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+  -only-testing:PalaceTests/PoolResponsivenessProbeTests \
+  -only-testing:PalaceTests/RuntimeQuiescenceGateTests test
+#    Expect: PoolResponsivenessProbeTests green (the saturated-stub case records
+#    an EXPECTED failure via XCTExpectFailure — that is a PASS, not a red).
+
+# 3. FULL CI-parity suite (this is the real validation — never a -only-testing subset):
+scripts/xcode-test-optimized.sh
+#    Confirm it ends '** TEST SUCCEEDED **' with NO 'exceeded execution time
+#    allowance' / 'Restarting after ... test timeout' lines. Because the gate is
+#    OFF by default, this run must stay GREEN and identical to pre-change
+#    behaviour — the mechanism is inert until a class opts in.
+
+# 4. (Optional) Prove attribution end-to-end: temporarily add
+#    `override var enforcesPoolResponsiveness: Bool { true }` to a class that
+#    leaks a blocking Task in a predecessor, run the full suite at iters-1, and
+#    confirm the red lands in THAT class's tearDown with the
+#    'cooperative pool at rest' message — instead of a silent 120s hang in a
+#    random async victim. Revert the override before shipping.
+```
+
+### Honesty statement
+**AUTHORED — NOT VALIDATED (worktree can't build).** No `xcodebuild` was run; the
+Palace suite was not executed. Compile-correctness rests on inspection
+(imports, `@MainActor`/isolation, `XCTest` overrides, the injectable-probe seam,
+Sendable capture of the lock-guarded flag). The RED→GREEN wiring proof for the
+gate is encoded in `PoolResponsivenessProbeTests` but has NOT been observed
+green — step 2/3 above is where that becomes evidence.
+
+### What remains for the invest track
+- **Validate this deliverable** (steps 1–3 above) before relying on it.
+- **Deliverable B — seed-replay bisection** (this doc, above): the ordered-prefix
+  `--bisect` reproduction that NAMES an accumulation leaker. `assertRuntimeResponsive`
+  narrows the window; Deliverable B closes it. Not started.
+- **Promotion path:** once an FP audit confirms zero false positives, opt more
+  critical-path async classes into `enforcesPoolResponsiveness = true`, then
+  consider flipping the base default (guarded by the off-by-default unit test,
+  which will then need inverting).
+- **Revive the parked greenboard-enforcement-deferred gate** at tag
+  `greenboard-enforcement-deferred` / commit `041ef99b0` — the systemic
+  test-pollution enforcement that was deferred (see the `test-pollution-systemic`
+  handoff memo) is the umbrella this probe feeds into.

--- a/scripts/pre-push-both-target-build.sh
+++ b/scripts/pre-push-both-target-build.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# pre-push-both-target-build.sh — opt-in git pre-push hook that BUILDS BOTH
+# the Palace (full DRM) and Palace-noDRM (open-source) schemes before a push.
+#
+# WHY THIS EXISTS
+#   Sprint 78 shipped two regressions that no static detector can catch, because
+#   they are compile-time failures in the SECOND target only:
+#     - #1225 — a Swift 6 isolation change compiled clean in `Palace` but broke
+#               `Palace-noDRM`.
+#     - #1218 — a change that built `Palace` but broke the `Palace-noDRM` target.
+#   The single-target build everyone runs locally (and the fast pre-push test
+#   gate) exercises only `Palace`, so a `Palace-noDRM`-only break sails through
+#   to CI (or worse, to a red develop board). This hook closes that hole by
+#   compiling BOTH schemes locally before the push leaves the machine.
+#
+#   Build-ONLY (no test) — this is a compile/link gate, not a regression run.
+#   `verify-pr.sh` and CI remain the authoritative test gates.
+#
+# WHEN TO RUN IT
+#   Turn it on before pushing any change that can differ across the two targets:
+#     - AppContainer / composition-root wiring
+#     - concurrency / actor-isolation / Swift 6 Sendable changes
+#     - app startup / launch sequence
+#     - anything under a `#if FEATURE_DRM` / target-conditional compilation seam
+#   For a docs/scripts-only push it is pure drag; leave it off.
+#
+# OFF BY DEFAULT — mirrors the pre-push-test-gate.sh opt-in pattern.
+#   Enable for a single push:
+#     ENABLE_BOTH_TARGET_BUILD_GATE=1 git push ...
+#   Or export it in the agent pre-push path / your shell to make it standing.
+#   Bypass once (when enabled) without unsetting:
+#     SKIP_BOTH_TARGET_BUILD_GATE=1 git push ...
+#
+#   Wire-up note: this script is intended to be invoked from the agent pre-push
+#   path (or chained from .git/hooks/pre-push). When it runs AS the pre-push
+#   hook it chains `git lfs pre-push` first (below) so installing it never
+#   silently disables LFS object verification.
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# 0. Chain to git-lfs pre-push (the stock hook this one may replace).
+# ---------------------------------------------------------------------------
+# If this script is installed AS .git/hooks/pre-push it must run the stock LFS
+# handler first — otherwise LFS object verification is silently dropped. We
+# capture stdin (the ref list git feeds a pre-push hook) so we can replay it to
+# LFS. This runs regardless of the enable flag: LFS integrity is not optional.
+STDIN_CAPTURE="$(mktemp -t pre-push-btb-stdin.XXXXXX)"
+trap 'rm -f "$STDIN_CAPTURE"' EXIT
+cat > "$STDIN_CAPTURE"
+
+if command -v git-lfs >/dev/null 2>&1; then
+  if ! git lfs pre-push "$@" < "$STDIN_CAPTURE"; then
+    echo "[pre-push-both-target-build] git-lfs pre-push failed — push blocked by LFS layer." >&2
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Opt-in gate — OFF BY DEFAULT.
+# ---------------------------------------------------------------------------
+if [[ "${ENABLE_BOTH_TARGET_BUILD_GATE:-0}" != "1" ]]; then
+  # Silent no-op so it's harmless when installed but not enabled.
+  exit 0
+fi
+
+if [[ "${SKIP_BOTH_TARGET_BUILD_GATE:-0}" == "1" ]]; then
+  echo "[pre-push-both-target-build] SKIP_BOTH_TARGET_BUILD_GATE=1 — bypassing both-target build." >&2
+  echo "[pre-push-both-target-build] (Push proceeds. Re-enable by unsetting the env var.)" >&2
+  exit 0
+fi
+
+REPO_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_DIR" || exit 0
+
+# ---------------------------------------------------------------------------
+# 2. Destination — booted iPhone sim if available; stable name fallback.
+# ---------------------------------------------------------------------------
+# NEVER hardcode a UDID (harness convention — parallel agents collide). Pick a
+# booted iPhone sim by regex; fall back to the iPhone 16 Pro name.
+SIM_ID="$(xcrun simctl list devices iPhone 2>/dev/null \
+          | awk '/Booted/ { if (match($0, /[0-9A-F-]{36}/)) { print substr($0, RSTART, RLENGTH); exit } }')"
+
+declare -a DEST_ARGS
+if [[ -n "$SIM_ID" ]]; then
+  DEST_ARGS=(-destination "id=$SIM_ID")
+else
+  DEST_ARGS=(-destination 'platform=iOS Simulator,name=iPhone 16 Pro')
+fi
+
+# ---------------------------------------------------------------------------
+# 2a. Worktree DerivedData isolation.
+# ---------------------------------------------------------------------------
+# From a LINKED git worktree the shared default DerivedData resolves the SPM
+# graph against a different checkout root and package resolution dies with
+# "the package manifest at '/Package.swift' doesn't exist" — a false failure.
+# Scope a per-checkout DerivedData for worktree pushes only; the main checkout
+# keeps its warm default cache.
+declare -a DERIVED_ARGS=()
+if [[ "$(git rev-parse --git-common-dir 2>/dev/null)" != "$(git rev-parse --git-dir 2>/dev/null)" ]]; then
+  _repo_slug="$(printf '%s' "$REPO_DIR" | shasum 2>/dev/null | cut -c1-12)"
+  _dd_dir="${TMPDIR:-/tmp}/prepush-btb-dd-${_repo_slug:-wt}"
+  DERIVED_ARGS=(-derivedDataPath "$_dd_dir" -clonedSourcePackagesDirPath "$_dd_dir/SourcePackages")
+  echo "[pre-push-both-target-build] linked worktree detected — isolating DerivedData at $_dd_dir" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Build helper — one scheme, build-only, quiet, framework-aware.
+# ---------------------------------------------------------------------------
+# Per CLAUDE.md: use -project (NOT -workspace — the workspace hits Firebase SPM
+# issues). Clear the git hook environment before xcodebuild: git exports
+# GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE to hooks, and xcodebuild's internal SPM
+# git calls then resolve the local-package path to "/", failing with the
+# '/Package.swift' doesn't exist error. Unsetting them lets package resolution
+# hit the project root.
+build_scheme() {
+  local scheme="$1"
+  shift
+  local logf="$1"
+  shift
+  echo "[pre-push-both-target-build] Building scheme '$scheme' (build-only)…" >&2
+  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX -u GIT_EXEC_PATH \
+    xcodebuild \
+    -project Palace.xcodeproj \
+    -scheme "$scheme" \
+    ${DEST_ARGS[@]+"${DEST_ARGS[@]}"} \
+    ${DERIVED_ARGS[@]+"${DERIVED_ARGS[@]}"} \
+    "$@" \
+    build \
+    -quiet >"$logf" 2>&1
+}
+
+# A build that fails ONLY because Carthage / audiobook binary frameworks are
+# absent (a worktree never `carthage bootstrap`-ed / submodule-init'd) is an
+# ENVIRONMENT limitation, not a code failure — the same class the test gate
+# documents. Detect the framework-missing signature AND confirm there is no
+# real Swift/clang compile error before treating it as a non-blocking WARN.
+is_framework_only_failure() {
+  local logf="$1"
+  local fw_missing_re="no XCFramework found at|Copy Files build phase contains a reference to a missing file|R2LCPClient|xcframework"
+  local real_errors
+  real_errors="$(grep -E ' error:' "$logf" 2>/dev/null | grep -vE "$fw_missing_re" || true)"
+  if grep -qE "$fw_missing_re" "$logf" 2>/dev/null && [[ -z "$real_errors" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# 4. Build both schemes. Palace first (fast-fail on the common target), then
+#    Palace-noDRM (the target that Sprint-78 breaks slipped past). noDRM
+#    mirrors the CI invocation's code-signing opt-out (scripts/xcode-build-nodrm.sh).
+# ---------------------------------------------------------------------------
+declare -a SCHEMES=("Palace" "Palace-noDRM")
+OVERALL_RC=0
+
+for scheme in "${SCHEMES[@]}"; do
+  LOGF="/tmp/pre-push-btb-${scheme}.log"
+
+  declare -a EXTRA_ARGS=()
+  if [[ "$scheme" == "Palace-noDRM" ]]; then
+    # Mirror scripts/xcode-build-nodrm.sh — the noDRM target builds without a
+    # signing identity in CI and locally.
+    EXTRA_ARGS=(-configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO)
+  fi
+
+  if build_scheme "$scheme" "$LOGF" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}; then
+    echo "[pre-push-both-target-build] PASS — '$scheme' compiled clean." >&2
+    continue
+  fi
+
+  rc=$?
+  if is_framework_only_failure "$LOGF"; then
+    echo "" >&2
+    echo "[pre-push-both-target-build] '$scheme' could not LINK: Carthage/audiobook binary frameworks absent." >&2
+    echo "[pre-push-both-target-build]   (worktree not 'carthage bootstrap'-ed / submodule-initialised) — NOT a code failure." >&2
+    echo "[pre-push-both-target-build]   No compile ran to completion; CI has the frameworks and is authoritative — not blocking on this scheme." >&2
+    continue
+  fi
+
+  OVERALL_RC=1
+  echo "" >&2
+  echo "[pre-push-both-target-build] FAIL — '$scheme' did not build (exit $rc)." >&2
+  echo "[pre-push-both-target-build] Last 40 lines of $LOGF:" >&2
+  tail -n 40 "$LOGF" >&2 || true
+done
+
+# ---------------------------------------------------------------------------
+# 5. Verdict.
+# ---------------------------------------------------------------------------
+if [[ "$OVERALL_RC" -eq 0 ]]; then
+  echo "[pre-push-both-target-build] PASS — both targets build. Push proceeds." >&2
+  exit 0
+fi
+
+echo "" >&2
+echo "[pre-push-both-target-build] BLOCKED — a target failed to build (see logs above)." >&2
+echo "[pre-push-both-target-build] This is exactly the #1225/#1218 second-target-break class." >&2
+echo "[pre-push-both-target-build] To bypass (only with a real reason):" >&2
+echo "[pre-push-both-target-build]   SKIP_BOTH_TARGET_BUILD_GATE=1 git push ..." >&2
+exit 1

--- a/scripts/tests/fixtures/test_name_vs_body/clean_references_noun.swift
+++ b/scripts/tests/fixtures/test_name_vs_body/clean_references_noun.swift
@@ -1,0 +1,13 @@
+import XCTest
+
+// Clean wiring test: same multi-step name that embeds `TPPReauthenticator`,
+// but the body actually constructs and drives the production class. The
+// detector treats the instantiation as wiring evidence and PASSES.
+final class CleanWiring: XCTestCase {
+
+    func testTPPReauthenticatorPath_invokesRefreshToken() {
+        let sut = TPPReauthenticator()
+        sut.refreshToken()
+        XCTAssertNotNil(sut)
+    }
+}

--- a/scripts/tests/fixtures/test_name_vs_body/violation_fake_wiring.swift
+++ b/scripts/tests/fixtures/test_name_vs_body/violation_fake_wiring.swift
@@ -1,0 +1,14 @@
+import XCTest
+
+// Fake-wiring test: the method name promises a multi-step path THROUGH a
+// production class (`TPPReauthenticator`), but the body never constructs,
+// statically calls, or type-annotates that class. This is the exact shape the
+// detector must flag (wall-failures cs847892e8-arch1 / cs9a267b63-arch1).
+final class FakeWiring: XCTestCase {
+
+    func testTPPReauthenticatorPath_invokesRefreshToken() {
+        // Body only asserts on a bool — no reference to TPPReauthenticator.
+        let didSomething = true
+        XCTAssertTrue(didSomething)
+    }
+}

--- a/scripts/tests/test_check_adjacency_staleness.py
+++ b/scripts/tests/test_check_adjacency_staleness.py
@@ -1,0 +1,181 @@
+"""
+test_check_adjacency_staleness.py — pytest for the ADJ-STALE detector.
+
+scripts/check-adjacency-staleness.py is warn-only: it ALWAYS exits 0.
+Renames vs deletions are not mechanically distinguishable from a diff, so
+a strict gate would false-positive on legitimate deletes. The observable
+signal is therefore NOT the exit code but the presence of
+
+    ADJ-STALE: <file>:<line>: comment references removed/renamed `<name>`
+
+lines on stdout. Each test feeds a unified diff on stdin and points --root
+at a temp tree so the codebase scan is fully controlled.
+
+Coverage (both paths mandatory per CLAUDE.md gate rule #4):
+  - REAL violation: a type is removed in the diff and a surviving file
+    still references it in a comment  → ADJ-STALE emitted.
+  - CLEAN removal: a type is removed in the diff and NO surviving comment
+    references it                     → no ADJ-STALE (clean-pass wiring
+    assertion — the one that catches "scan-only called with --diff" bugs).
+  - Rename (removed AND re-added same name) is suppressed.
+  - Empty candidate set (no removed decls) is a clean pass.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-adjacency-staleness.py"
+
+
+def _run(diff_text: str, root: Path) -> subprocess.CompletedProcess:
+    """Invoke the detector with `diff_text` on stdin and --root=<root>.
+
+    Matches the real CLI: diff arrives via stdin (default), the codebase
+    scan is confined to --root, and --quiet suppresses the summary so we
+    assert on the ADJ-STALE findings alone.
+    """
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--root", str(root), "--quiet"],
+        input=diff_text,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _write_swift(root: Path, rel: str, body: str) -> None:
+    dst = root / rel
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(body, encoding="utf-8")
+
+
+# --- (a) REAL violation is caught -----------------------------------------
+
+def test_removed_type_with_surviving_comment_ref_is_flagged(tmp_path):
+    """A removed `class LegacyParser` while a surviving file's doc comment
+    still says `LegacyParser` must emit an ADJ-STALE finding."""
+    _write_swift(
+        tmp_path,
+        "Palace/Catalog/CatalogService.swift",
+        "import Foundation\n"
+        "/// Delegates parsing to LegacyParser for OPDS 1.x feeds.\n"
+        "final class CatalogService {\n"
+        "    func parse() {}\n"
+        "}\n",
+    )
+    diff = (
+        "diff --git a/Palace/Catalog/LegacyParser.swift b/Palace/Catalog/LegacyParser.swift\n"
+        "--- a/Palace/Catalog/LegacyParser.swift\n"
+        "+++ b/Palace/Catalog/LegacyParser.swift\n"
+        "@@ -1,3 +0,0 @@\n"
+        "-final class LegacyParser {\n"
+        "-    func parse() {}\n"
+        "-}\n"
+    )
+    result = _run(diff, tmp_path)
+    assert result.returncode == 0, (
+        f"detector is warn-only; expected exit 0, got {result.returncode}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert "ADJ-STALE" in result.stdout, (
+        f"expected an ADJ-STALE finding for the stale comment, "
+        f"got stdout: {result.stdout!r}"
+    )
+    assert "LegacyParser" in result.stdout
+    assert "CatalogService.swift" in result.stdout
+
+
+# --- (b) CLEAN removal passes (the wiring-bug assertion) -------------------
+
+def test_removed_type_with_no_surviving_ref_is_clean(tmp_path):
+    """A removed `class LegacyParser` with NO surviving comment mentioning
+    it is a legitimate delete — no ADJ-STALE should be emitted.
+
+    This is the clean-pass assertion: if the detector were wired wrong
+    (e.g. scanning added-line noise or ignoring --root), it would still
+    surface a phantom finding here."""
+    _write_swift(
+        tmp_path,
+        "Palace/Catalog/CatalogService.swift",
+        "import Foundation\n"
+        "/// Parses OPDS 2.0 feeds. No legacy dependency remains.\n"
+        "final class CatalogService {\n"
+        "    func parse() {}\n"
+        "}\n",
+    )
+    diff = (
+        "diff --git a/Palace/Catalog/LegacyParser.swift b/Palace/Catalog/LegacyParser.swift\n"
+        "--- a/Palace/Catalog/LegacyParser.swift\n"
+        "+++ b/Palace/Catalog/LegacyParser.swift\n"
+        "@@ -1,3 +0,0 @@\n"
+        "-final class LegacyParser {\n"
+        "-    func parse() {}\n"
+        "-}\n"
+    )
+    result = _run(diff, tmp_path)
+    assert result.returncode == 0
+    assert "ADJ-STALE" not in result.stdout, (
+        f"clean removal should emit no findings, got: {result.stdout!r}"
+    )
+
+
+# --- Rename (removed AND re-added) is suppressed --------------------------
+
+def test_rename_same_name_readded_is_suppressed(tmp_path):
+    """If the removed name is also re-added in the diff, it is an edit, not
+    a removal — even a comment ref must NOT be flagged (removed - added)."""
+    _write_swift(
+        tmp_path,
+        "Palace/Catalog/Notes.swift",
+        "// CatalogService owns the parse pipeline.\n"
+        "struct Notes {}\n",
+    )
+    diff = (
+        "diff --git a/Palace/Catalog/CatalogService.swift b/Palace/Catalog/CatalogService.swift\n"
+        "--- a/Palace/Catalog/CatalogService.swift\n"
+        "+++ b/Palace/Catalog/CatalogService.swift\n"
+        "@@ -1,3 +1,3 @@\n"
+        "-final class CatalogService {\n"
+        "+public final class CatalogService {\n"
+        "     func parse() {}\n"
+        " }\n"
+    )
+    result = _run(diff, tmp_path)
+    assert result.returncode == 0
+    assert "ADJ-STALE" not in result.stdout, (
+        f"re-added name is an edit, not a removal; got: {result.stdout!r}"
+    )
+
+
+# --- No removed declarations at all is a clean pass ----------------------
+
+def test_diff_with_no_removed_decls_is_clean(tmp_path):
+    """An add-only diff has no removal candidates — clean pass regardless
+    of what comments exist in the tree."""
+    _write_swift(
+        tmp_path,
+        "Palace/Catalog/CatalogService.swift",
+        "// Mentions AnythingAtAll in a comment.\n"
+        "final class CatalogService {}\n",
+    )
+    diff = (
+        "diff --git a/Palace/Catalog/New.swift b/Palace/Catalog/New.swift\n"
+        "--- a/dev/null\n"
+        "+++ b/Palace/Catalog/New.swift\n"
+        "@@ -0,0 +1,2 @@\n"
+        "+final class New {}\n"
+        "+// hello\n"
+    )
+    result = _run(diff, tmp_path)
+    assert result.returncode == 0
+    assert "ADJ-STALE" not in result.stdout
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_check_blast_radius.py
+++ b/scripts/tests/test_check_blast_radius.py
@@ -1,0 +1,185 @@
+"""
+test_check_blast_radius.py — pytest for the blast-radius detector (BLOCKING).
+
+scripts/check-blast-radius.py scans a UNIFIED DIFF (not a source tree) for
+newly-exposed API/visibility/test-seam surface. It reads the diff from
+`--diff <file>` or stdin, prints greppable `<file>:<line>: <BR-N>: <sev>: ...`
+findings, and exits:
+  0  — no finding at/above the severity floor (default: high)
+  1  — at least one finding at/above the floor
+  2  — argument / I/O error
+
+Because it is diff-driven, each test synthesizes a minimal unified diff and
+feeds it on stdin. Every BR category test asserts BOTH the violation path
+(exit 1 + the BR code present) and, per CLAUDE.md rule #4, a clean-diff path
+(exit 0 + no finding) — the clean-pass assertion is the one that catches the
+scan-only-detector-called-with-a-diff wiring bug.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-blast-radius.py"
+
+
+def _run(diff_text: str, *extra: str) -> subprocess.CompletedProcess:
+    """Invoke check-blast-radius.py with `diff_text` on stdin.
+
+    Passes `--quiet` to keep stderr clean; extra args are appended verbatim.
+    """
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--quiet", *extra],
+        input=diff_text,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _diff(path: str, added_lines: list[str], start: int = 1) -> str:
+    """Build a minimal unified diff that ADDS `added_lines` to `path`.
+
+    One leading context line is included so the hunk header is well-formed
+    for iter_hunk_lines (it only needs the `+++ b/` header + a `@@ +start @@`).
+    """
+    body = [f"+++ b/{path}", f"@@ -{start},1 +{start},{len(added_lines) + 1} @@",
+            " // context anchor"]
+    body.extend("+" + ln for ln in added_lines)
+    return "\n".join(body) + "\n"
+
+
+# --- BR-1: new public/open symbol on a prod Swift file ---------------------
+
+def test_new_public_decl_on_prod_file_is_flagged():
+    """A newly-added `public func` on a production Swift file is BR-1 (high)
+    and must block (exit 1)."""
+    diff = _diff("Palace/Book/BookDetail.swift",
+                 ["    public func newlyExposedAPI() -> Int { 42 }"])
+    r = _run(diff)
+    assert r.returncode == 1, (
+        f"expected exit 1, got {r.returncode}\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+    assert "BR-1" in r.stdout, f"expected BR-1 finding, got: {r.stdout!r}"
+    assert "Palace/Book/BookDetail.swift" in r.stdout
+
+
+def test_internal_decl_on_prod_file_is_clean():
+    """The clean-pass control: an `internal func` addition adds no public
+    surface, so the detector must PASS (exit 0, no finding)."""
+    diff = _diff("Palace/Book/BookDetail.swift",
+                 ["    internal func stillInternal() -> Int { 42 }"])
+    r = _run(diff)
+    assert r.returncode == 0, (
+        f"expected exit 0, got {r.returncode}\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+    assert r.stdout.strip() == "", f"expected no findings, got: {r.stdout!r}"
+
+
+def test_public_decl_with_PUBLIC_INTENT_annotation_is_suppressed():
+    """The documented escape hatch: a `// PUBLIC_INTENT:` comment on the
+    preceding line suppresses BR-1 for contracted SPM API. Must PASS."""
+    diff = _diff("Palace/CatalogDomain/ContentTypes.swift", [
+        "    // PUBLIC_INTENT: consumed by downstream Catalog SPM module",
+        "    public let contentTypeFoo = \"foo\"",
+    ])
+    r = _run(diff)
+    assert r.returncode == 0, (
+        f"expected exit 0 (suppressed), got {r.returncode}\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+    assert "BR-1" not in r.stdout, f"expected BR-1 suppressed, got: {r.stdout!r}"
+
+
+def test_public_decl_on_test_file_is_ignored():
+    """Non-prod paths (PalaceTests/, Mocks/, Utilities/Testing/) are exempt —
+    a `public` on a test file must NOT be flagged."""
+    diff = _diff("PalaceTests/Mocks/FakeThing.swift",
+                 ["    public func spyHook() {}"])
+    r = _run(diff)
+    assert r.returncode == 0, (
+        f"expected exit 0, got {r.returncode}\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+    assert "BR-1" not in r.stdout
+
+
+# --- BR-5: discarded function result without TODO justification ------------
+
+def test_discarded_result_without_todo_is_flagged_at_medium_floor():
+    """`let _ = fn(...)` without a `// TODO(TICKET):` is BR-5 (medium). It
+    blocks only when the floor is lowered to medium."""
+    diff = _diff("Palace/MyBooks/Downloader.swift",
+                 ["        let _ = startDownload(book)"])
+    r = _run(diff, "--severity-floor", "medium")
+    assert r.returncode == 1, (
+        f"expected exit 1 at medium floor, got {r.returncode}\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+    assert "BR-5" in r.stdout, f"expected BR-5 finding, got: {r.stdout!r}"
+
+
+def test_discarded_result_with_todo_is_clean():
+    """The clean-pass control: same discard WITH a `// TODO(PP-1234):`
+    justification on the line must PASS even at the medium floor."""
+    diff = _diff("Palace/MyBooks/Downloader.swift",
+                 ["        let _ = startDownload(book)  // TODO(PP-1234): fire-and-forget"])
+    r = _run(diff, "--severity-floor", "medium")
+    assert r.returncode == 0, (
+        f"expected exit 0, got {r.returncode}\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+    assert "BR-5" not in r.stdout, f"expected no BR-5, got: {r.stdout!r}"
+
+
+def test_medium_finding_does_not_block_at_default_high_floor():
+    """BR-5 is medium; at the DEFAULT high floor a lone discard prints but
+    does not block (exit 0). Guards the severity-floor wiring."""
+    diff = _diff("Palace/MyBooks/Downloader.swift",
+                 ["        let _ = startDownload(book)"])
+    r = _run(diff)  # default floor = high
+    assert r.returncode == 0, (
+        f"expected exit 0 at high floor, got {r.returncode}\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+    # The finding is still printed (visibility) even though it does not block.
+    assert "BR-5" in r.stdout
+
+
+# --- BR-4: composition-root init churn on a *Container.swift file ----------
+
+def test_new_init_on_container_file_is_flagged():
+    """A new `init(` on AppContainer.swift is BR-4 (high) — hidden
+    composition-root churn — and must block."""
+    diff = _diff("Palace/AppInfrastructure/AppContainer.swift",
+                 ["    init(testOverride: Foo) {"])
+    r = _run(diff)
+    assert r.returncode == 1, (
+        f"expected exit 1, got {r.returncode}\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+    assert "BR-4" in r.stdout, f"expected BR-4 finding, got: {r.stdout!r}"
+
+
+# --- Empty / no-op diff sanity --------------------------------------------
+
+def test_empty_diff_passes():
+    """A diff with no added prod-Swift lines yields no findings (exit 0).
+    The floor of the clean-pass contract."""
+    r = _run("")
+    assert r.returncode == 0, (
+        f"expected exit 0 on empty diff, got {r.returncode}\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+    assert r.stdout.strip() == ""
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_check_contract_reconciliation.py
+++ b/scripts/tests/test_check_contract_reconciliation.py
@@ -1,0 +1,181 @@
+"""
+test_check_contract_reconciliation.py — pytest for the M1 contract-
+reconciliation detector (scripts/check-contract-reconciliation.py).
+
+The detector parses claim phrases ("removes X", "renames X to Y",
+"adds field A to type B", "fixes N findings", ...) out of a
+commit-message / PR-body / intent / swarm-contract source, then greps
+the staged unified diff for evidence each claim is reflected. A claim
+with no supporting diff evidence exits 1; a fully-supported set of
+claims exits 0.
+
+Interface (matched exactly against the script's argparse):
+  --commit-msg <file>   claim source (also --pr-body/--intent/--swarm-contract)
+  --diff <file>         unified-diff input; `-` or omit reads stdin
+  exit 0 = all claims reconcile; exit 1 = ≥1 unsupported; exit 2 = I/O error
+
+Both the caught-violation path AND the clean-pass path are asserted for
+each grammar exercised — the clean-pass assertion is the one that would
+catch a wiring bug where the detector rejects an input it should accept.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-contract-reconciliation.py"
+
+
+def _run(commit_msg: Path, diff: Path) -> subprocess.CompletedProcess:
+    """Invoke the detector with a commit-msg source and a diff file."""
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--commit-msg",
+            str(commit_msg),
+            "--diff",
+            str(diff),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# --- REM grammar: "removes X" ---------------------------------------------
+
+def test_rem_claim_unsupported_by_diff_is_caught(tmp_path):
+    """Commit body claims `removes FooBar` but the diff only adds an
+    unrelated line — no `-class FooBar` and no FooBar file deletion.
+    The unsupported claim must exit 1 and name the claim."""
+    msg = _write(tmp_path, "msg.txt",
+                 "Refactor cleanup\n\nThis change removes FooBar from the app.\n")
+    diff = _write(tmp_path, "diff.txt",
+                  "diff --git a/Palace/Foo/Other.swift b/Palace/Foo/Other.swift\n"
+                  "index 111..222 100644\n"
+                  "--- a/Palace/Foo/Other.swift\n"
+                  "+++ b/Palace/Foo/Other.swift\n"
+                  "@@ -1,2 +1,3 @@\n"
+                  " import Foundation\n"
+                  "+let unrelated = 1\n")
+    result = _run(msg, diff)
+    assert result.returncode == 1, (
+        f"expected exit 1, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "UNSUPPORTED" in result.stdout
+    assert "FooBar" in result.stdout
+
+
+def test_rem_claim_supported_by_file_deletion_passes(tmp_path):
+    """Same `removes FooBar` claim, but now the diff deletes FooBar.swift
+    and removes `class FooBar`. The claim reconciles — must exit 0 with
+    no UNSUPPORTED marker. This is the wiring-bug guard: a clean input
+    the detector must accept."""
+    msg = _write(tmp_path, "msg.txt",
+                 "Refactor cleanup\n\nThis change removes FooBar from the app.\n")
+    diff = _write(tmp_path, "diff.txt",
+                  "diff --git a/Palace/Foo/FooBar.swift b/Palace/Foo/FooBar.swift\n"
+                  "deleted file mode 100644\n"
+                  "index 111..000\n"
+                  "--- a/Palace/Foo/FooBar.swift\n"
+                  "+++ /dev/null\n"
+                  "@@ -1,3 +0,0 @@\n"
+                  "-class FooBar {\n"
+                  "-    let x = 1\n"
+                  "-}\n")
+    result = _run(msg, diff)
+    assert result.returncode == 0, (
+        f"expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "UNSUPPORTED" not in result.stdout
+
+
+# --- ADDFLD grammar: "adds field A to type B" -----------------------------
+
+def test_addfld_claim_unsupported_by_diff_is_caught(tmp_path):
+    """Commit body claims `adds field enableRetry to type NetworkConfig`
+    but the diff never declares that member — must exit 1."""
+    msg = _write(tmp_path, "msg.txt",
+                 "Add config flag\n\n"
+                 "This adds field enableRetry to type NetworkConfig for retries.\n")
+    diff = _write(tmp_path, "diff.txt",
+                  "diff --git a/Palace/Net/Other.swift b/Palace/Net/Other.swift\n"
+                  "index 111..222 100644\n"
+                  "--- a/Palace/Net/Other.swift\n"
+                  "+++ b/Palace/Net/Other.swift\n"
+                  "@@ -1,2 +1,3 @@\n"
+                  " import Foundation\n"
+                  "+let unrelated = 1\n")
+    result = _run(msg, diff)
+    assert result.returncode == 1, (
+        f"expected exit 1, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "UNSUPPORTED" in result.stdout
+    assert "enableRetry" in result.stdout
+
+
+def test_addfld_claim_supported_by_added_member_passes(tmp_path):
+    """Same claim, but the diff adds `var enableRetry` inside a file
+    referencing NetworkConfig. The claim reconciles — must exit 0."""
+    msg = _write(tmp_path, "msg.txt",
+                 "Add config flag\n\n"
+                 "This adds field enableRetry to type NetworkConfig for retries.\n")
+    diff = _write(tmp_path, "diff.txt",
+                  "diff --git a/Palace/Net/NetworkConfig.swift b/Palace/Net/NetworkConfig.swift\n"
+                  "index 111..222 100644\n"
+                  "--- a/Palace/Net/NetworkConfig.swift\n"
+                  "+++ b/Palace/Net/NetworkConfig.swift\n"
+                  "@@ -1,3 +1,4 @@\n"
+                  " struct NetworkConfig {\n"
+                  "     var timeout = 30\n"
+                  "+    var enableRetry = false\n"
+                  " }\n")
+    result = _run(msg, diff)
+    assert result.returncode == 0, (
+        f"expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "UNSUPPORTED" not in result.stdout
+
+
+# --- No-claim path --------------------------------------------------------
+
+def test_no_parseable_claims_passes(tmp_path):
+    """A commit body with no claim-shaped phrases yields zero claims and
+    must exit 0 regardless of diff contents — the detector only gates
+    claims it can parse."""
+    msg = _write(tmp_path, "msg.txt",
+                 "Tidy imports\n\nGeneral housekeeping, nothing structural.\n")
+    diff = _write(tmp_path, "diff.txt",
+                  "diff --git a/Palace/Foo/Other.swift b/Palace/Foo/Other.swift\n"
+                  "index 111..222 100644\n"
+                  "--- a/Palace/Foo/Other.swift\n"
+                  "+++ b/Palace/Foo/Other.swift\n"
+                  "@@ -1,2 +1,3 @@\n"
+                  " import Foundation\n"
+                  "+let unrelated = 1\n")
+    result = _run(msg, diff)
+    assert result.returncode == 0, (
+        f"expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "UNSUPPORTED" not in result.stdout
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_check_discipline_nudge.py
+++ b/scripts/tests/test_check_discipline_nudge.py
@@ -1,0 +1,180 @@
+"""
+test_check_discipline_nudge.py — pytest for the discipline-nudge advisory.
+
+scripts/check-discipline-nudge.py is a NON-BLOCKING commit-discipline detector.
+It ALWAYS exits 0 (never fails a commit) and instead prints advisory nudges to
+stderr on two retro-tracked signals:
+
+  1. root-cause prose  — a `fix`-type commit whose body has no "why it broke" line
+  2. test:source ratio — a `fix`/`feat` commit that changes Palace/ source with
+                          zero accompanying test files
+
+Because exit is always 0, the observable behavior is the nudge text on stderr:
+  - a violation  → the "discipline nudge" banner appears on stderr
+  - a clean case → NO banner on stderr (the wiring-bug-catching assertion)
+
+Interface exercised (matches the detector exactly):
+  check-discipline-nudge.py --commit-msg <file> --diff <file|->
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-discipline-nudge.py"
+
+_BANNER = "discipline nudge"
+
+
+def _run(commit_msg: str, diff: str, tmp_path: Path) -> subprocess.CompletedProcess:
+    """Write commit-msg + diff to temp files and invoke the detector exactly
+    the way the commit-msg hook does: --commit-msg <file> --diff <file>."""
+    msg_file = tmp_path / "COMMIT_EDITMSG"
+    msg_file.write_text(commit_msg)
+    diff_file = tmp_path / "staged.diff"
+    diff_file.write_text(diff)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--commit-msg",
+            str(msg_file),
+            "--diff",
+            str(diff_file),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Violations — the nudge banner MUST appear on stderr.
+# ---------------------------------------------------------------------------
+
+def test_fix_commit_without_root_cause_line_nudges(tmp_path):
+    """A `fix`-type commit whose body never explains WHY it broke triggers the
+    root-cause nudge. Body deliberately avoids every root-cause phrase
+    (because / regression / the bug / due to / caused by / …)."""
+    msg = (
+        "fix: crash on audiobook open\n"
+        "\n"
+        "Resolves the startup problem seen in QA. Adds a guard on the\n"
+        "player state so open no longer terminates the session.\n"
+    )
+    result = _run(msg, diff="", tmp_path=tmp_path)
+
+    # Advisory — never blocks.
+    assert result.returncode == 0, (
+        f"detector must always exit 0, got {result.returncode}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert _BANNER in result.stderr, (
+        f"expected discipline nudge on stderr for a root-cause-less fix, "
+        f"got: {result.stderr!r}"
+    )
+    assert "root-cause" in result.stderr, (
+        f"expected the root-cause nudge specifically, got: {result.stderr!r}"
+    )
+
+
+def test_feat_touching_source_without_tests_nudges(tmp_path):
+    """A `feat` commit that changes a Palace/ production source file with no
+    accompanying test file triggers the test:source nudge."""
+    msg = "feat: add mini player scrubber\n"
+    diff = (
+        "diff --git a/Palace/Audiobooks/AudiobookMiniPlayerView.swift "
+        "b/Palace/Audiobooks/AudiobookMiniPlayerView.swift\n"
+        "--- a/Palace/Audiobooks/AudiobookMiniPlayerView.swift\n"
+        "+++ b/Palace/Audiobooks/AudiobookMiniPlayerView.swift\n"
+        "@@ -1,1 +1,2 @@\n"
+        " import SwiftUI\n"
+        "+// scrubber\n"
+    )
+    result = _run(msg, diff=diff, tmp_path=tmp_path)
+
+    assert result.returncode == 0, (
+        f"detector must always exit 0, got {result.returncode}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert _BANNER in result.stderr, (
+        f"expected discipline nudge for source-without-tests, "
+        f"got: {result.stderr!r}"
+    )
+    assert "production source" in result.stderr, (
+        f"expected the test:source nudge specifically, got: {result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Clean — the nudge banner MUST NOT appear (the wiring-bug-catching path).
+# ---------------------------------------------------------------------------
+
+def test_disciplined_fix_with_root_cause_and_test_is_clean(tmp_path):
+    """A well-formed fix — root-cause prose in the body AND a paired test file
+    in the diff — produces NO nudge. Both conditions must be satisfied so
+    neither branch fires."""
+    msg = (
+        "fix: audiobook session terminated on dismiss\n"
+        "\n"
+        "The regression was introduced by the morphing-player rework, which\n"
+        "released the toolkit player on collapse. Keep it retained.\n"
+    )
+    diff = (
+        "diff --git a/Palace/Audiobooks/AudiobookSessionManager.swift "
+        "b/Palace/Audiobooks/AudiobookSessionManager.swift\n"
+        "--- a/Palace/Audiobooks/AudiobookSessionManager.swift\n"
+        "+++ b/Palace/Audiobooks/AudiobookSessionManager.swift\n"
+        "@@ -1,1 +1,2 @@\n"
+        " import Foundation\n"
+        "+// retain player\n"
+        "diff --git a/PalaceTests/Audiobooks/AudiobookSessionManagerTests.swift "
+        "b/PalaceTests/Audiobooks/AudiobookSessionManagerTests.swift\n"
+        "--- a/PalaceTests/Audiobooks/AudiobookSessionManagerTests.swift\n"
+        "+++ b/PalaceTests/Audiobooks/AudiobookSessionManagerTests.swift\n"
+        "@@ -1,1 +1,2 @@\n"
+        " import XCTest\n"
+        "+// covers dismiss retention\n"
+    )
+    result = _run(msg, diff=diff, tmp_path=tmp_path)
+
+    assert result.returncode == 0, (
+        f"detector must always exit 0, got {result.returncode}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert _BANNER not in result.stderr, (
+        f"a root-caused fix with a paired test must NOT nudge, "
+        f"got: {result.stderr!r}"
+    )
+
+
+def test_non_fix_non_feat_commit_is_clean(tmp_path):
+    """A plain chore commit is neither fix nor feat, so no discipline branch
+    applies even with no root cause and no tests — NO nudge."""
+    msg = "chore: bump readme copyright year\n"
+    diff = (
+        "diff --git a/README.md b/README.md\n"
+        "--- a/README.md\n"
+        "+++ b/README.md\n"
+        "@@ -1,1 +1,1 @@\n"
+        "-2025\n"
+        "+2026\n"
+    )
+    result = _run(msg, diff=diff, tmp_path=tmp_path)
+
+    assert result.returncode == 0, (
+        f"detector must always exit 0, got {result.returncode}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert _BANNER not in result.stderr, (
+        f"a non-fix/non-feat chore must NOT nudge, got: {result.stderr!r}"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_check_superpartner_spectrum.py
+++ b/scripts/tests/test_check_superpartner_spectrum.py
@@ -1,0 +1,208 @@
+"""
+test_check_superpartner_spectrum.py — pytest for the SP (superpartner-spectrum)
+detector, `scripts/check-superpartner-spectrum.py` (severity: warn gate).
+
+The detector is DIFF-based, not scan-based: it reads a unified diff from
+`--diff <file>` (or stdin via `--diff -`) and flags new production Swift
+functions (SP-1), enum cases (SP-2), and state transitions (SP-3) that have no
+matching test in the SAME diff — unless marked `// no-superpartner: <reason>`.
+
+Interface pinned here (must match the script exactly, or the gate is wiring-bugged):
+  - input: unified diff on stdin (`--diff -`)
+  - `--severity-floor low|medium|high` (default high)
+  - exit 0 when nothing blocks at/above the floor; exit 1 when something does.
+
+Every test asserts BOTH the exit code AND the finding text (or its absence).
+The CLEAN-pass assertions are the ones that catch a wiring regression where the
+detector rejects an interface it should accept.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-superpartner-spectrum.py"
+
+
+def _run(diff_text: str, *extra_args: str) -> subprocess.CompletedProcess:
+    """Feed `diff_text` to the detector on stdin (`--diff -`)."""
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--diff", "-", *extra_args],
+        input=diff_text,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _prod_func_diff(*, comment_line: str = "") -> str:
+    """A diff adding a new func on a critical path (Palace/Audiobooks/).
+
+    `comment_line` (if given) is inserted as an added line immediately before
+    the func — used to exercise the `// no-superpartner:` escape hatch.
+    """
+    comment = f"+{comment_line}\n" if comment_line else ""
+    return (
+        "diff --git a/Palace/Audiobooks/AudiobookFoo.swift "
+        "b/Palace/Audiobooks/AudiobookFoo.swift\n"
+        "index 111..222 100644\n"
+        "--- a/Palace/Audiobooks/AudiobookFoo.swift\n"
+        "+++ b/Palace/Audiobooks/AudiobookFoo.swift\n"
+        "@@ -10,2 +10,6 @@ class AudiobookFoo {\n"
+        "     let x = 1\n"
+        f"{comment}"
+        "+    func computePlaybackOffset() -> Int {\n"
+        "+        return 42\n"
+        "+    }\n"
+    )
+
+
+# --- (a) VIOLATION IS CAUGHT ----------------------------------------------
+
+def test_new_func_without_test_is_flagged_high_and_blocks():
+    """A new non-private func on a critical path with no matching test is an
+    SP-1 high finding and blocks at the default (high) floor → exit 1."""
+    result = _run(_prod_func_diff())
+    assert result.returncode == 1, (
+        f"expected exit 1, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "SP-1" in result.stdout
+    assert "computePlaybackOffset" in result.stdout
+    assert ": high:" in result.stdout
+
+
+def test_new_enum_case_without_test_is_flagged():
+    """A new enum case with no test is an SP-2 finding (medium). It blocks at
+    --severity-floor medium → exit 1."""
+    diff = (
+        "diff --git a/Palace/Book/BookThing.swift b/Palace/Book/BookThing.swift\n"
+        "index 111..222 100644\n"
+        "--- a/Palace/Book/BookThing.swift\n"
+        "+++ b/Palace/Book/BookThing.swift\n"
+        "@@ -3,2 +3,3 @@ enum BookThing {\n"
+        "     case existing\n"
+        "+    case brandNewCase\n"
+    )
+    result = _run(diff, "--severity-floor", "medium")
+    assert result.returncode == 1, (
+        f"expected exit 1, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "SP-2" in result.stdout
+    assert "brandNewCase" in result.stdout
+
+
+def test_new_state_transition_without_test_is_flagged():
+    """A new `self.state = .buffering` with no round-trip / referencing test is
+    an SP-3 finding (capped at medium). Blocks at floor medium → exit 1."""
+    diff = (
+        "diff --git a/Palace/Audiobooks/Player.swift b/Palace/Audiobooks/Player.swift\n"
+        "index 111..222 100644\n"
+        "--- a/Palace/Audiobooks/Player.swift\n"
+        "+++ b/Palace/Audiobooks/Player.swift\n"
+        "@@ -8,2 +8,3 @@ func advance() {\n"
+        "     doThing()\n"
+        "+    self.state = .buffering\n"
+    )
+    result = _run(diff, "--severity-floor", "medium")
+    assert result.returncode == 1, (
+        f"expected exit 1, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "SP-3" in result.stdout
+    assert "buffering" in result.stdout
+
+
+# --- (b) CLEAN INPUT PASSES (the wiring-bug catchers) ----------------------
+
+def test_func_marked_no_superpartner_passes():
+    """The `// no-superpartner: <reason>` escape hatch on the preceding line
+    makes the same func an intentional, non-blocking decision → exit 0, no
+    finding printed."""
+    diff = _prod_func_diff(
+        comment_line="    // no-superpartner: trivial constant, no observable behavior"
+    )
+    result = _run(diff)
+    assert result.returncode == 0, (
+        f"expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "SP-1" not in result.stdout
+    # The summary should count it as intentional, not missing.
+    assert "1 marked intentional" in result.stderr
+
+
+def test_func_with_referencing_test_in_same_diff_passes():
+    """When the same diff adds a `func test…` that names/calls the new func,
+    the detector treats it as paired → exit 0, no finding."""
+    diff = (
+        "diff --git a/Palace/Audiobooks/AudiobookFoo.swift "
+        "b/Palace/Audiobooks/AudiobookFoo.swift\n"
+        "index 111..222 100644\n"
+        "--- a/Palace/Audiobooks/AudiobookFoo.swift\n"
+        "+++ b/Palace/Audiobooks/AudiobookFoo.swift\n"
+        "@@ -10,2 +10,5 @@ class AudiobookFoo {\n"
+        "     let x = 1\n"
+        "+    func computePlaybackOffset() -> Int {\n"
+        "+        return 42\n"
+        "+    }\n"
+        "diff --git a/PalaceTests/Audiobooks/AudiobookFooTests.swift "
+        "b/PalaceTests/Audiobooks/AudiobookFooTests.swift\n"
+        "index 333..444 100644\n"
+        "--- a/PalaceTests/Audiobooks/AudiobookFooTests.swift\n"
+        "+++ b/PalaceTests/Audiobooks/AudiobookFooTests.swift\n"
+        "@@ -5,2 +5,5 @@ class AudiobookFooTests: XCTestCase {\n"
+        "     let y = 2\n"
+        "+    func testComputePlaybackOffset_returnsExpected() {\n"
+        "+        XCTAssertEqual(AudiobookFoo().computePlaybackOffset(), 42)\n"
+        "+    }\n"
+    )
+    result = _run(diff)
+    assert result.returncode == 0, (
+        f"expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "SP-1" not in result.stdout
+    assert "1 have a test" in result.stderr
+
+
+def test_empty_diff_passes():
+    """No added lines → nothing to flag → exit 0."""
+    result = _run("")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+# --- Severity-floor wiring (finding printed, but does it BLOCK?) -----------
+
+def test_medium_finding_does_not_block_at_default_high_floor():
+    """A medium SP-2 finding is PRINTED but must NOT block at the default high
+    floor → exit 0 even though a finding line is emitted. This pins the
+    floor→exit-code wiring (the classic 'prints but wrong exit code' gap)."""
+    diff = (
+        "diff --git a/Palace/Book/BookThing.swift b/Palace/Book/BookThing.swift\n"
+        "index 111..222 100644\n"
+        "--- a/Palace/Book/BookThing.swift\n"
+        "+++ b/Palace/Book/BookThing.swift\n"
+        "@@ -3,2 +3,3 @@ enum BookThing {\n"
+        "     case existing\n"
+        "+    case brandNewCase\n"
+    )
+    result = _run(diff)  # default floor = high
+    assert result.returncode == 0, (
+        f"expected exit 0 (medium below high floor), got {result.returncode}\n"
+        f"stdout: {result.stdout!r}"
+    )
+    # Finding is still surfaced, just non-blocking.
+    assert "SP-2" in result.stdout
+    assert "brandNewCase" in result.stdout
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_check_test_name_vs_body.py
+++ b/scripts/tests/test_check_test_name_vs_body.py
@@ -1,0 +1,99 @@
+"""
+test_check_test_name_vs_body.py — pytest for the fake-wiring-test detector.
+
+Subject: scripts/check-test-name-vs-body.py
+
+The detector is a runnable-grep escalation for the "fake wiring test" pattern
+(wall-failures cs847892e8-arch1 / cs9a267b63-arch1): a Swift XCTest method
+whose name embeds a multi-step verb (`Path`, `invokes`, `via`, `Wiring`, ...)
+AND a PascalCase production-class noun, but whose body never references that
+noun. Such a test's name PROMISES a production seam it never exercises.
+
+CLI shape (learned by reading the detector):
+  python3 scripts/check-test-name-vs-body.py [--quiet] <file> [<file> ...]
+  exit 0 — clean (no multi-step name with an unreferenced embedded noun)
+  exit 1 — at least one fake-wiring test found
+  exit 2 — argument / file-read error
+The detector takes Swift file PATHS as positional args — there is no --diff or
+--scan mode, so we invoke it directly on the fixture files (no temp-dir/staging
+dance needed).
+
+Both paths are asserted, per CLAUDE.md CI rule #4 — the clean-pass assertion is
+the one that catches a wiring bug (a detector that fires on everything).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-test-name-vs-body.py"
+_FIXTURE_DIR = _REPO_ROOT / "scripts" / "tests" / "fixtures" / "test_name_vs_body"
+
+
+def _run(fixture_name: str) -> subprocess.CompletedProcess:
+    """Run the detector against a single fixture file under _FIXTURE_DIR."""
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(_FIXTURE_DIR / fixture_name)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_detector_flags_name_embedded_noun_absent_from_body():
+    """A test named testTPPReauthenticatorPath_invokesRefreshToken whose body
+    never references TPPReauthenticator must be flagged (exit 1)."""
+    result = _run("violation_fake_wiring.swift")
+    assert result.returncode == 1, (
+        f"expected exit 1 (violation), got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    # Greppable finding: names the offending test + the embedded noun.
+    assert "testTPPReauthenticatorPath_invokesRefreshToken" in result.stdout, (
+        f"expected the offending test name in output, got: {result.stdout!r}"
+    )
+    assert "TPPReauthenticator" in result.stdout, (
+        f"expected the embedded class noun in output, got: {result.stdout!r}"
+    )
+    assert "violation_fake_wiring.swift" in result.stdout
+
+
+def test_detector_passes_when_body_references_embedded_noun():
+    """Same multi-step name, but the body constructs TPPReauthenticator() —
+    the detector must treat that as wiring evidence and PASS (exit 0).
+
+    This is the wiring-bug guard: if the detector fired here too, it would be
+    flagging on the NAME alone and the gate would be worthless."""
+    result = _run("clean_references_noun.swift")
+    assert result.returncode == 0, (
+        f"expected exit 0 (clean), got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "no reference" not in result.stdout, (
+        f"did not expect a finding, got: {result.stdout!r}"
+    )
+
+
+def test_detector_arg_error_on_missing_file():
+    """A path that does not exist is an argument error (exit 2), not a
+    silently-clean pass — proves the detector actually opened the file."""
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT),
+         str(_FIXTURE_DIR / "does_not_exist.swift")],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2 (arg/file error), got {result.returncode}\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Pre-Sprint 79 tooling dial-in

Solo/agent-driven shop → the agent PreToolUse hook is the enforcement wall, so
the wall's correctness is load-bearing. This closes the gaps the Sprint-78 retro
surfaced. Full plan: `.forgeos/initiatives/2026-07-13-tooling-dial-in.md`.

**Draft — CI is the validator.** This worktree can't build (no Carthage
frameworks), so the probe + both-target gate were authored-not-run locally. The
detector suite IS verified locally (278 passed). Merging waits on a green CI run.

### What's in it

| WI | Change | Local status |
|----|--------|--------------|
| **1** | pytests for the 6 previously-untested detectors — priority on the two that **BLOCK** agent commits (`check-blast-radius`, `check-contract-reconciliation`) | ✅ 278 passed (+32); auto-gated by `tooling-checks.yml` |
| **2** | `scripts/pre-push-both-target-build.sh` — off-by-default Palace + Palace-noDRM build gate; covers the #1225/#1218 second-target-break class | ✅ `bash -n` clean; needs a build machine to exercise |
| **4** | `Coverage_Roadmap.md` rewritten (554→61) to the honest "35% / mutation-kill-rate is the bar" posture; drops the retired 80% target + forbidden-workspace build cmds | ✅ |
| **5** | Pool-responsiveness probe (invest track, Deliverable A) — per-test gate in `PalaceTestCase` (off-by-default) that turns a saturated cooperative pool into an **attributed** tearDown failure instead of a silent downstream hang | ⏳ CI validates the build |

### Deferred (tracked in the initiative doc)
- **WI-3** — `superpartner-spectrum` / `adjacency-staleness` stay warn-only; neither meets the zero-false-positive bar (`adjacency` fired **N=211** false hits on the bare word `label`). Promoting would train bypass.
- **WI-5 invest track continues** — validate the probe on CI, Deliverable B (seed-replay bisection), opt critical-path async classes into `enforcesPoolResponsiveness`, then revive the parked `greenboard-enforcement-deferred` gate.

### Not in this PR
The `CLAUDE.local.md` hook-doc-drift fix (WI-4) is gitignored/local-only, applied to the working copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
