### PR TITLE
chore(ci): mirror dependabot.yml onto develop (parity with main)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot configuration.
+#
+# NOTE: This file is read from the repository's DEFAULT branch (main), but we
+# route the update PRs to `develop` — the integration branch — because `main`
+# is release-only (see the release-merge policy in CLAUDE.md). This keeps
+# dependency + security bumps flowing through the normal develop → release path
+# instead of landing directly on the protected release branch.
+version: 2
+updates:
+  - package-ecosystem: "bundler" # the Gemfile (fastlane + its transitive deps: faraday, excon, addressable, …)
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions" # the CI workflows under .github/workflows/
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
Mirrors `.github/dependabot.yml` (added to `main` in #1236) onto `develop` for branch parity — **byte-identical** to main's version.

**Context:** #1236 put the Dependabot config on `main` (the default branch Dependabot reads config from), routing bump PRs to `develop`. It's already working (see #1239, the actions/checkout bump that landed on develop). This copies the same file onto develop so the config travels with the integration branch and doesn't read as main-only. No behavior change — Dependabot still reads the copy on `main`.

0 code LOC; config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)