### PR TITLE
feat(book-detail): series name as plain text when no other series books in catalog (PP-4775)

### DIFF
--- a/.forgeos/intent/pp4775-series-plaintext.md
+++ b/.forgeos/intent/pp4775-series-plaintext.md
@@ -1,0 +1,52 @@
+---
+name: pp4775-series-plaintext
+created: 2026-07-13
+author: Maurice Carrier
+branch: feat/pp4775-series-plaintext
+priority: PP-4775 (Sprint 79) — Book Detail series display, non-critical-path UI
+---
+
+# Intent: show series name as plain text on Book Detail when no other series books are in the catalog
+
+## Context
+
+`BookDetailView.seriesRow(book:)` (PP-4463) renders the SERIES row ONLY when the
+book carries BOTH `seriesName` and `seriesURL` — the name is a `NavigationLink`
+to the series search lane. When the catalog has no other books in the series,
+the OPDS feed carries the series NAME but no series-search URL, so today the row
+is hidden entirely. PP-4775 brings iOS in line with the web catalog (CPW): show
+the series name as PLAIN, non-tappable text in that case.
+
+## Claims
+
+- Adds a pure, `nonisolated static` decision function
+  `BookDetailViewModel.seriesRowDisplay(name:url:) -> SeriesRowDisplay` returning
+  a new nested `enum SeriesRowDisplay: Equatable { case hidden; case
+  plainText(name:); case link(name:, url:) }`:
+  - name empty/nil → `.hidden`
+  - name present + url present → `.link` (unchanged PP-4463 linked behavior)
+  - name present + url nil → `.plainText` (NEW)
+- Refactors `BookDetailView.seriesRow(book:)` to `switch` on that decision:
+  the `.link` case is the existing NavigationLink rendering verbatim; the
+  `.plainText` case renders a non-underlined, non-tappable `Text` with NO
+  `.isLink` accessibility trait (VoiceOver reads it as static text, AC #4);
+  `.hidden` renders `EmptyView()`.
+- Adds `AccessibilityID.BookDetail.seriesPlainText` so QA/simdrive can
+  disambiguate the plain-text state from the linked state.
+- Adds unit tests for all four `seriesRowDisplay` cases (hidden via nil name,
+  hidden via empty name, link, plainText) in `BookDetailViewModelTests`.
+
+## Anti-claims
+
+- Does NOT change how series metadata is sourced/parsed (`TPPBook.seriesName` /
+  `seriesURL` untouched) — out of scope per the ticket.
+- Does NOT change the linked-state search-query behavior or destination
+  (`CatalogLaneMoreView`) — no regression to AC #2.
+- Does NOT show a row when there is no series name (AC #3 preserved).
+
+## Files in scope
+
+- `Palace/Book/UI/BookDetail/BookDetailViewModel.swift` (enum + pure func)
+- `Palace/Book/UI/BookDetail/BookDetailView.swift` (seriesRow switch)
+- `Palace/Utilities/Testing/AccessibilityIdentifiers.swift` (seriesPlainText id)
+- `PalaceTests/Book/BookDetailViewModelTests.swift` (4 decision tests)

--- a/Palace/Book/UI/BookDetail/BookDetailView.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailView.swift
@@ -631,16 +631,22 @@ struct BookDetailView: View {
             .lineLimit(1)
     }
 
-    /// PP-4463: SERIES information row. Renders only when the book carries
-    /// both a series name and series URL (AC #2). The series name is wrapped
-    /// in a NavigationLink whose destination matches the existing series-lane
-    /// "More" affordance at the bottom of the screen — `CatalogLaneMoreView`
-    /// keyed on `book.seriesURL` — so the row is an alternate path to the
-    /// same list, not a new navigation paradigm (AC #4).
+    /// PP-4463 / PP-4775: SERIES information row. Three states, decided purely by
+    /// `BookDetailViewModel.seriesRowDisplay`:
+    ///   - `.link` — series name + a series-search URL (other books in the
+    ///     catalog): the name is a `NavigationLink` to `CatalogLaneMoreView`
+    ///     keyed on `book.seriesURL`, an alternate path to the same series lane.
+    ///   - `.plainText` — series name known but NO series URL (no other books in
+    ///     the catalog, PP-4775): the name is shown as static, non-tappable text
+    ///     with no `.isLink` trait, so VoiceOver reads it as plain text (AC #4).
+    ///   - `.hidden` — no series name: no row.
     @ViewBuilder
     private func seriesRow(book: TPPBook) -> some View {
-        if let seriesName = book.seriesName, !seriesName.isEmpty,
-           let seriesURL = book.seriesURL {
+        switch BookDetailViewModel.seriesRowDisplay(name: book.seriesName, url: book.seriesURL) {
+        case .hidden:
+            EmptyView()
+
+        case let .link(seriesName, seriesURL):
             HStack(alignment: .top, spacing: 10) {
                 infoLabel(label: DisplayStrings.series.uppercased())
                     .frame(minWidth: 100, alignment: .leading)
@@ -659,6 +665,26 @@ struct BookDetailView: View {
             .accessibilityElement(children: .combine)
             .accessibilityLabel("\(DisplayStrings.series): \(seriesName)")
             .accessibilityAddTraits(.isLink)
+            .accessibilityIdentifier(AccessibilityID.BookDetail.seriesLabel)
+
+        case let .plainText(seriesName):
+            HStack(alignment: .top, spacing: 10) {
+                infoLabel(label: DisplayStrings.series.uppercased())
+                    .frame(minWidth: 100, alignment: .leading)
+                    .fixedSize(horizontal: true, vertical: false)
+                // No NavigationLink, no underline, and no `.isLink` trait below —
+                // when the catalog has no other books in the series the name is
+                // informational only (PP-4775 AC #1 / #4).
+                Text(seriesName)
+                    .font(.subheadline)
+                    .lineLimit(nil)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .foregroundStyle(.primary)
+                    .accessibilityIdentifier(AccessibilityID.BookDetail.seriesPlainText)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(DisplayStrings.series): \(seriesName)")
             .accessibilityIdentifier(AccessibilityID.BookDetail.seriesLabel)
         }
     }

--- a/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
@@ -17,6 +17,30 @@ struct BookLane {
 
 @MainActor
 final class BookDetailViewModel: ObservableObject {
+
+    // MARK: - Series row display (PP-4775)
+
+    /// Three-way decision for the Book Detail SERIES row, derived purely from a
+    /// book's series metadata.
+    /// - `.link`: series name + a series-search URL (other books in the catalog)
+    ///   → tappable NavigationLink (the PP-4463 behavior).
+    /// - `.plainText`: series name known but NO series-search URL (no other books
+    ///   in the catalog) → static, non-tappable text (PP-4775).
+    /// - `.hidden`: no series name → no row.
+    enum SeriesRowDisplay: Equatable {
+        case hidden
+        case plainText(name: String)
+        case link(name: String, url: URL)
+    }
+
+    /// Pure mapping from series metadata to the row's display state. `nonisolated`
+    /// + `static` so it is unit-testable without the `@MainActor` view-model graph.
+    nonisolated static func seriesRowDisplay(name: String?, url: URL?) -> SeriesRowDisplay {
+        guard let name, !name.isEmpty else { return .hidden }
+        if let url { return .link(name: name, url: url) }
+        return .plainText(name: name)
+    }
+
     // MARK: - Constants
     private let kTimerInterval: TimeInterval = 3.0
 

--- a/Palace/Utilities/Testing/AccessibilityIdentifiers.swift
+++ b/Palace/Utilities/Testing/AccessibilityIdentifiers.swift
@@ -147,6 +147,10 @@ public enum AccessibilityID {
         public static let distributorLabel = "bookDetail.distributorLabel"
         public static let seriesLabel = "bookDetail.seriesLabel"
         public static let seriesLink = "bookDetail.seriesLink"
+        /// PP-4775: series row rendered as static (non-tappable) text when the
+        /// catalog has no other books in the series. Distinct from `seriesLink`
+        /// so QA / simdrive can assert the non-link state.
+        public static let seriesPlainText = "bookDetail.seriesPlainText"
         public static let relatedBooksSection = "bookDetail.relatedBooksSection"
     }
 

--- a/PalaceTests/Book/BookDetailViewModelTests.swift
+++ b/PalaceTests/Book/BookDetailViewModelTests.swift
@@ -1642,4 +1642,35 @@ final class BookDetailViewModelTests: XCTestCase {
                        "downloadFailed state and locked the user out).")
     }
 
+    // MARK: - PP-4775: series row display decision
+
+    func testSeriesRowDisplay_nameAndURL_isLink() {
+        let url = URL(string: "https://example.com/series/dune")!
+        XCTAssertEqual(
+            BookDetailViewModel.seriesRowDisplay(name: "Dune", url: url),
+            .link(name: "Dune", url: url),
+            "A series name WITH a series-search URL (other books in the catalog) must render as a link")
+    }
+
+    func testSeriesRowDisplay_nameWithoutURL_isPlainText() {
+        XCTAssertEqual(
+            BookDetailViewModel.seriesRowDisplay(name: "Dune", url: nil),
+            .plainText(name: "Dune"),
+            "A series name with NO series URL (no other books in the catalog) must render as plain text, not a link")
+    }
+
+    func testSeriesRowDisplay_nilName_isHidden() {
+        XCTAssertEqual(
+            BookDetailViewModel.seriesRowDisplay(name: nil, url: URL(string: "https://example.com/s")!),
+            .hidden,
+            "No series name must render no row, even when a series URL is present")
+    }
+
+    func testSeriesRowDisplay_emptyName_isHidden() {
+        XCTAssertEqual(
+            BookDetailViewModel.seriesRowDisplay(name: "", url: nil),
+            .hidden,
+            "An empty series name must render no row")
+    }
+
 }


### PR DESCRIPTION
Closes **PP-4775** (Sprint 79).

## What
The Book Detail SERIES row previously rendered **only** when a book had *both* a series name and a series-search URL. When the catalog carries no other books in the series (name present, no URL), the row was hidden entirely. This brings iOS in line with the web catalog (CPW): show the series name as **static, non-tappable text** in that case.

## How
- Adds `BookDetailViewModel.SeriesRowDisplay` (`hidden` / `plainText` / `link`) + a pure `nonisolated static seriesRowDisplay(name:url:)` decision function — trivially unit-testable, no `@MainActor` graph needed.
- `seriesRow` now `switch`es on it: `.link` is the existing `NavigationLink` rendering **verbatim** (no regression); `.plainText` renders a non-underlined, non-tappable `Text` with **no `.isLink` trait** so VoiceOver reads it as static text; `.hidden` → `EmptyView`.
- Adds `AccessibilityID.BookDetail.seriesPlainText` so QA/simdrive can assert the non-link state.

## Acceptance criteria
- ✅ AC#1 plain text when name-without-URL
- ✅ AC#2 link preserved when name+URL (no regression)
- ✅ AC#3 no row when no series name
- ✅ AC#4 VoiceOver reads plain text as static (no `.isLink`)

## Tests & verification
- 4 unit tests in `BookDetailViewModelTests` cover every decision branch (kills the guard + branch mutants).
- Static gates green: test-name-vs-body, blast-radius, superpartner, adjacency, contract-reconciliation.
- Build + full suite → **this CI run** (worktree can't build the DRM app locally; CI is the gate). Non-critical-path UI → standard rigor, no SoD.
- The SwiftUI view rendering isn't unit-testable; the decision logic it renders from is fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)