### PR TITLE
feat(ui): Settings libraries skeleton + PalaceForceSkeletons verification tool (PP-4797)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 		33E4592AA16E9AC09BB58FB5 /* FakeStreamingReaderProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A12F5637D02B11F6E2EC36 /* FakeStreamingReaderProgressStore.swift */; };
 		3499C23886EB7E4BCD55F2E9 /* AccessibilityLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724E4CF383350791D09DE972 /* AccessibilityLabelTests.swift */; };
 		34D9B1937E8049DE9B0729A3 /* AudiobookIssueFixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CF38F572AE4A88961FCA46 /* AudiobookIssueFixTests.swift */; };
+		35008DD01991700FE81D6940 /* SettingsSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551562029D888E2A48F22A52 /* SettingsSkeletonView.swift */; };
 		35E2134603214DAEB86865D9 /* CarPlayImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639A868F3BDA4A7F97660BEA /* CarPlayImageProvider.swift */; };
 		364459D0B4CBC9DACC5C6C2F /* AccessibilityServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21803F06C0E1741DD2F7973E /* AccessibilityServiceProtocol.swift */; };
 		36650A19392D0CF505DA037D /* TPPMigrationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3391CCE50BC961BC7A5726 /* TPPMigrationManagerTests.swift */; };
@@ -1162,6 +1163,7 @@
 		C7BA5AA8F4F0099226CE67F5 /* StreamingReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7955F7FD669DC987C9238D /* StreamingReaderViewModel.swift */; };
 		C7E59C3E09A16D6F9B65233F /* IntExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5A0D270E8AC2DDFBC62044 /* IntExtensionsTests.swift */; };
 		C89594A0D21089924B82E71D /* TypographyServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1B8AF7EB40C9DE22ED5ED0 /* TypographyServiceProtocol.swift */; };
+		C8DC8F9202D050EEFBC61B4C /* SettingsSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551562029D888E2A48F22A52 /* SettingsSkeletonView.swift */; };
 		C911BB897D0420A06D49D6CA /* AnonymousBorrowFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB73BECBC7822AE7F95B941B /* AnonymousBorrowFixtureTests.swift */; };
 		C91D9FA152701F5BD7E13C86 /* ImageLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22F7AE14E3B226D72A2AFBB /* ImageLoading.swift */; };
 		C998049BB2CFF2AE01EA1C36 /* TypographySettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D440766BDBF7EFBBA87B19A /* TypographySettingsViewModelTests.swift */; };
@@ -2443,6 +2445,7 @@
 		5431B832D502714505B6EAF5 /* StatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsView.swift; sourceTree = "<group>"; };
 		545D0B43631D0433B5E9C100 /* PlatformTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformTab.swift; sourceTree = "<group>"; };
 		5472258280B72752C01480DF /* ReadiumPDFViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumPDFViewController.swift; sourceTree = "<group>"; };
+		551562029D888E2A48F22A52 /* SettingsSkeletonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsSkeletonView.swift; sourceTree = "<group>"; };
 		5550F79A349D3D7ADE48B5E1 /* TPPBookRegistryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookRegistryTests.swift; sourceTree = "<group>"; };
 		5575A14D947C09A968459FF1 /* LoanEvictionPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoanEvictionPolicyTests.swift; sourceTree = "<group>"; };
 		557641B8197B528D886F32DB /* TPPDeferredAdobeActivationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPDeferredAdobeActivationTests.swift; sourceTree = "<group>"; };
@@ -4178,6 +4181,15 @@
 			path = Accounts;
 			sourceTree = "<group>";
 		};
+		729974636226A0B8880EC44A /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				551562029D888E2A48F22A52 /* SettingsSkeletonView.swift */,
+			);
+			name = Components;
+			path = Components;
+			sourceTree = "<group>";
+		};
 		7300D467258829E1002256A3 /* .github */ = {
 			isa = PBXGroup;
 			children = (
@@ -4219,6 +4231,7 @@
 				E5AD65D52684FA9E00C62951 /* AccountList */,
 				839CDA0D0B5BC07729C1E528 /* Debug */,
 				87F6DEC8A63194712483BB6B /* TPPSettings+UniversalLinksProviding.swift */,
+				729974636226A0B8880EC44A /* Components */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -8312,6 +8325,7 @@
 				D15E5B4BBFF3F2A2ECADDF9E /* DeveloperSettingsView.swift in Sources */,
 				281BAB2E2AEA3A1F867B7345 /* DeveloperSettingsRows.swift in Sources */,
 				FCBE8B68654DA29199B7490D /* AppAdvancedSettingsView.swift in Sources */,
+				C8DC8F9202D050EEFBC61B4C /* SettingsSkeletonView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8878,6 +8892,7 @@
 				F8E16417A4F3BC323965B5A1 /* DeveloperSettingsView.swift in Sources */,
 				82193678E858613CE236C800 /* DeveloperSettingsRows.swift in Sources */,
 				DE4396B97927CA9E6978B33B /* AppAdvancedSettingsView.swift in Sources */,
+				35008DD01991700FE81D6940 /* SettingsSkeletonView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -889,6 +889,7 @@
 		935781EA3FD5B824D9A52F21 /* OfflineQueueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634E8A7700449B3157A0E943 /* OfflineQueueDetailView.swift */; };
 		935B58EA66D6CDC630490B7E /* FindawaySavedVsPlayedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F774A40BD0FCA32D809EFDA7 /* FindawaySavedVsPlayedTests.swift */; };
 		937A08D0914606B4C64933F3 /* UIAlertCACommitGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EB45618938C811D051DEB7 /* UIAlertCACommitGuardTests.swift */; };
+		93B119D71089105A82A3F6B9 /* DebugSettingsForceSkeletonsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D9E48257A5316F73B06B65 /* DebugSettingsForceSkeletonsTests.swift */; };
 		93C86ECD853FB5864CE8B5FF /* AccountTestSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51335D9B0719C849AA9B591 /* AccountTestSeeder.swift */; };
 		953B933A06DA6AF6ABAFB7EC /* BadgeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6837ACC21376FE419332599B /* BadgeDetailView.swift */; };
 		9551D5385E148DD1FA10C632 /* TPPBookmarkDeletionLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0452B249AF7C21DDAACD5C58 /* TPPBookmarkDeletionLog.swift */; };
@@ -3006,6 +3007,7 @@
 		D1A2B3C4D5E6F7A8B9C0D1E2 /* OverdriveDownloadHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OverdriveDownloadHandlerTests.swift; sourceTree = "<group>"; };
 		D1A2B3C4E5F6071800000001 /* MyBooksDownloadQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadQueue.swift; sourceTree = "<group>"; };
 		D1B2C3D4E5F6A7B8C9D0E1F2 /* BorrowOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorrowOperation.swift; sourceTree = "<group>"; };
+		D1D9E48257A5316F73B06B65 /* DebugSettingsForceSkeletonsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DebugSettingsForceSkeletonsTests.swift; sourceTree = "<group>"; };
 		D1E2F30415263748495C6D7E /* DownloadAlertPresenterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadAlertPresenterTests.swift; sourceTree = "<group>"; };
 		D1E2F3A4B5C6D7E8F9A0B1C2 /* DownloadCompletionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadCompletionParser.swift; sourceTree = "<group>"; };
 		D28F809A16EF96F2EEBC8A83 /* AccessibilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityService.swift; sourceTree = "<group>"; };
@@ -6613,6 +6615,7 @@
 				0B9A4E1085F59AB6E4E0AD4C /* SupportSectionDecisionTests.swift */,
 				C30A128848513D0DC4CA0410 /* SignInFormPresentationTests.swift */,
 				210E954A43CCA5ECCCB12227 /* DeveloperSettingsViewModelTests.swift */,
+				D1D9E48257A5316F73B06B65 /* DebugSettingsForceSkeletonsTests.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -7762,6 +7765,7 @@
 				4DE6468C2E4065037D7281F9 /* AlertPresentationRawGuardLintTests.swift in Sources */,
 				5ADD8B5E1F4D8868B3FEA17F /* PoolResponsivenessProbeTests.swift in Sources */,
 				690980939C808C26D5565353 /* DeveloperSettingsViewModelTests.swift in Sources */,
+				93B119D71089105A82A3F6B9 /* DebugSettingsForceSkeletonsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/CatalogUI/Views/CatalogView.swift
+++ b/Palace/CatalogUI/Views/CatalogView.swift
@@ -156,6 +156,15 @@ private extension CatalogView {
 
     @ViewBuilder
     private var catalogStateView: some View {
+        // Debug skeleton verification (PP-4797): force the initial-load skeleton
+        // regardless of the feed state machine so it can be inspected on the sim
+        // in both appearances. No-op in release (DebugSettings.forceSkeletons is
+        // a compile-time `false`).
+        if DebugSettings.forceSkeletons {
+            skeletonList
+                .accessibilityIdentifier(AccessibilityID.Catalog.loadingIndicator)
+                .transition(.opacity)
+        } else {
         switch viewModel.state {
         case .loading:
             skeletonList
@@ -201,6 +210,7 @@ private extension CatalogView {
                 },
                 onRefresh: { await viewModel.refresh() }
             )
+        }
         }
     }
 

--- a/Palace/Holds/HoldsView.swift
+++ b/Palace/Holds/HoldsView.swift
@@ -119,7 +119,7 @@ struct HoldsView: View {
     @ViewBuilder
     private var content: some View {
         GeometryReader { geometry in
-            if model.isLoading {
+            if model.isLoading || DebugSettings.forceSkeletons {
                 BookListSkeletonView(rows: 10)
                     .accessibilityIdentifier(AccessibilityID.Holds.loadingIndicator)
             } else if model.visibleBooks.isEmpty {

--- a/Palace/MyBooks/MyBooks/MyBooksView.swift
+++ b/Palace/MyBooks/MyBooks/MyBooksView.swift
@@ -28,7 +28,7 @@ struct MyBooksView: View {
 
     var body: some View {
         ZStack {
-            if model.isLoading {
+            if model.isLoading || DebugSettings.forceSkeletons {
                 BookListSkeletonView(rows: 10)
                     .transition(.opacity)
             } else {

--- a/Palace/Settings/AccountDetailView.swift
+++ b/Palace/Settings/AccountDetailView.swift
@@ -62,7 +62,7 @@ struct AccountDetailView: View {
 
     @ViewBuilder
     private var contentView: some View {
-        if viewModel.isLoadingAuth {
+        if viewModel.isLoadingAuth || DebugSettings.forceSkeletons {
             AccountDetailSkeletonView()
         } else {
             mainContent

--- a/Palace/Settings/Components/SettingsSkeletonView.swift
+++ b/Palace/Settings/Components/SettingsSkeletonView.swift
@@ -1,0 +1,72 @@
+//
+//  SettingsSkeletonView.swift
+//  Palace
+//
+//  Skeleton for the Settings screen's MY LIBRARIES section (PP-4797), built on
+//  the unified `Skeleton` primitives (PP-4752). Shown during the brief
+//  launch-hydration window before the full account catalog materializes, so
+//  the section renders placeholder library rows instead of a blank list that
+//  pops in when hydration completes.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import SwiftUI
+
+/// A single placeholder row that traces `LibraryRowView` (the real MY LIBRARIES
+/// row) so a loaded row and its skeleton have identical height and column
+/// positions (zero layout shift). Values are pulled 1:1 from `LibraryRowView`:
+///   * Outer `HStack(spacing: 12)` — matches the real row.
+///   * Leading selection glyph gutter: the real row reserves a 28pt-wide column
+///     for the `circle` / `checkmark.circle.fill` symbol (`.frame(width: 28)`).
+///   * Logo: `Image(uiImage:).scaledToFit().frame(width: 44, height: 44)` ⇒
+///     44×44, SQUARE (r=0) to match the un-rounded real logo — a rounded
+///     skeleton snaps to square when the logo loads.
+///   * Text column: a `.body` name line (17pt) + a `.footnote` subtitle line
+///     (13pt), `VStack(alignment: .leading, spacing: 2)` — mirrors the real
+///     row's name + optional subtitle.
+///   * `.padding(.vertical, 4)` — matches the real row.
+struct SettingsLibraryRowSkeletonView: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            // Reserve the 28pt selection-glyph gutter so the logo starts at the
+            // same x as the real row.
+            Color.clear.frame(width: 28)
+
+            // Square (r=0) to match the real library logo, which renders as a
+            // plain `Image(uiImage:).scaledToFit()` with no corner rounding.
+            SkeletonBox(width: 44, height: 44, cornerRadius: 0)
+
+            VStack(alignment: .leading, spacing: 2) {
+                SkeletonBox(width: 180, height: 17, cornerRadius: 4)
+                SkeletonBox(width: 110, height: 13, cornerRadius: 4)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+/// The MY LIBRARIES section skeleton: the section header ("Libraries") plus a
+/// few placeholder library rows. Rendered inside the settings `List` in place
+/// of the real `librariesSection` while `LibrariesSectionViewModel.isLoading`.
+///
+/// `.accessibilityHidden(true)` follows the established skeleton convention
+/// (Catalog / MyBooks / Account skeletons): the placeholder shapes are not
+/// exposed to VoiceOver as real content; the surrounding "Settings" navigation
+/// title conveys screen context.
+struct SettingsLibrariesSkeletonView: View {
+    typealias DisplayStrings = Strings.Settings
+
+    var rows: Int = 3
+
+    var body: some View {
+        Section(header: Text(DisplayStrings.libraries)) {
+            ForEach(0..<max(rows, 0), id: \.self) { _ in
+                SettingsLibraryRowSkeletonView()
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}

--- a/Palace/Settings/Debug/DebugSettings.swift
+++ b/Palace/Settings/Debug/DebugSettings.swift
@@ -24,6 +24,34 @@ final class DebugSettings: @unchecked Sendable {
 
     private let defaults = UserDefaults.standard
 
+    // MARK: - Skeleton Verification (QA / dev only)
+
+    /// Forces every first-load skeleton gate ON so the transient loading
+    /// placeholders — normally visible for only a few hundred ms during
+    /// hydration — can be inspected on the simulator in both light and dark
+    /// appearance. Set via a launch argument (`-PalaceForceSkeletons YES`) or
+    ///
+    ///     xcrun simctl spawn <udid> defaults write \
+    ///       org.thepalaceproject.palace PalaceForceSkeletons -bool true
+    ///
+    /// then relaunch. DEBUG-only: the release build returns the constant `false`
+    /// so production render paths are byte-identical (no UserDefaults read, and
+    /// the `#if DEBUG` lives here — call sites stay clean).
+    static var forceSkeletons: Bool {
+        forceSkeletons(in: .standard)
+    }
+
+    /// Testable seam — reads the override from an injectable defaults store so
+    /// the flag can be exercised without touching `UserDefaults.standard`. In
+    /// release the override is ignored and this is a compile-time `false`.
+    static func forceSkeletons(in defaults: UserDefaults) -> Bool {
+        #if DEBUG
+        return defaults.bool(forKey: "PalaceForceSkeletons")
+        #else
+        return false
+        #endif
+    }
+
     // MARK: - Keys
 
     private enum Keys {

--- a/Palace/Settings/NewSettings/LibrariesSectionViewModel.swift
+++ b/Palace/Settings/NewSettings/LibrariesSectionViewModel.swift
@@ -22,6 +22,14 @@ protocol LibrariesSectionEnvironment {
     func lookupAccount(_ uuid: String) -> Account?
     func persistAccountIds(_ ids: [String])
     func deleteToken(for account: Account)
+    /// Whether the full library catalog has materialized. During the brief
+    /// launch-hydration window (`false`) the persisted-account lookup can
+    /// resolve to an empty list even though the user HAS configured libraries
+    /// — the full `AccountsManager` account set simply hasn't loaded yet. The
+    /// view model uses this to distinguish "genuinely no libraries" from
+    /// "libraries not loaded yet" so the Settings screen shows a skeleton
+    /// during hydration instead of a blank list that then pops in.
+    func accountsHaveLoaded() -> Bool
     /// Switches the active library to `account`. Mirrors
     /// `MyBooksViewModel.updateFeed` — adds to the persisted accounts list,
     /// updates the main-feed URL, assigns `accountsManager.currentAccount`,
@@ -39,6 +47,13 @@ final class LibrariesSectionViewModel: ObservableObject {
     @Published private(set) var accounts: [Account] = []
     @Published private(set) var currentAccountUUID: String?
     @Published private(set) var isSwitching: Bool = false
+    /// True while the library list is in the launch-hydration window: no
+    /// accounts have resolved yet AND the full catalog hasn't finished
+    /// loading. Drives the Settings skeleton so the MY LIBRARIES section shows
+    /// placeholder rows instead of a blank list that pops in when hydration
+    /// completes. Once a library resolves (or the catalog reports loaded) this
+    /// flips false and stays false.
+    @Published private(set) var isLoading: Bool = false
     @Published var showAddLibrarySheet: Bool = false
 
     /// Upper bound on how long the loading overlay parks the user — picked
@@ -98,11 +113,28 @@ final class LibrariesSectionViewModel: ObservableObject {
 
         accounts = (current.map { [$0] } ?? []) + others
         currentAccountUUID = currentUUID
+        isLoading = LibrariesSectionViewModel.shouldShowSkeleton(
+            resolvedAccountCount: resolved.count,
+            accountsHaveLoaded: environment.accountsHaveLoaded()
+        )
 
         let resolvedIds = resolved.map { $0.uuid }
         if resolvedIds.count != persisted.count {
             environment.persistAccountIds(resolvedIds)
         }
+    }
+
+    /// Pure decision: show the MY LIBRARIES skeleton only during the
+    /// launch-hydration window — when NO library has resolved yet AND the full
+    /// catalog is still loading. Once any account resolves, or the catalog
+    /// reports loaded (even with zero libraries — a genuinely empty
+    /// configuration), the real (possibly empty) section shows instead of a
+    /// perpetual skeleton.
+    ///
+    /// Kept static + primitive-typed so it is unit-testable without the view,
+    /// the environment, or a SwiftUI host.
+    static func shouldShowSkeleton(resolvedAccountCount: Int, accountsHaveLoaded: Bool) -> Bool {
+        resolvedAccountCount == 0 && !accountsHaveLoaded
     }
 
     /// Sets `account` as the active library. No-ops when it already is.
@@ -200,6 +232,10 @@ struct ProductionLibrariesSectionEnvironment: LibrariesSectionEnvironment {
 
     func deleteToken(for account: Account) {
         tokenDeleter(account)
+    }
+
+    func accountsHaveLoaded() -> Bool {
+        accountsManager.accountsHaveLoaded
     }
 
     func switchToAccount(_ account: Account, completion: @escaping () -> Void) {

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -113,7 +113,7 @@ struct TPPSettingsView: View {
             // skeleton for the MY LIBRARIES section instead of a blank list
             // that pops in. Cross-fades to the real section via the shared
             // gentle motion (Reduce Motion drops the animation).
-            if librariesVM.isLoading {
+            if librariesVM.isLoading || DebugSettings.forceSkeletons {
                 SettingsLibrariesSkeletonView()
                     .transition(.opacity)
             } else {

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -108,7 +108,18 @@ struct TPPSettingsView: View {
 
     @ViewBuilder private var listView: some View {
         List {
-            librariesSection
+            // During the launch-hydration window the persisted-account lookup
+            // can resolve empty before the full catalog materializes; show a
+            // skeleton for the MY LIBRARIES section instead of a blank list
+            // that pops in. Cross-fades to the real section via the shared
+            // gentle motion (Reduce Motion drops the animation).
+            if librariesVM.isLoading {
+                SettingsLibrariesSkeletonView()
+                    .transition(.opacity)
+            } else {
+                librariesSection
+                    .transition(.opacity)
+            }
             downloadsSection
             supportSection
             advancedSection
@@ -118,6 +129,7 @@ struct TPPSettingsView: View {
         }
         .navigationBarTitle(DisplayStrings.settings)
         .listStyle(GroupedListStyle())
+        .accessibleAnimation(PalaceMotion.gentle, value: librariesVM.isLoading)
         .onAppear {
             librariesVM.refresh()
         }

--- a/PalaceTests/Settings/DebugSettingsForceSkeletonsTests.swift
+++ b/PalaceTests/Settings/DebugSettingsForceSkeletonsTests.swift
@@ -1,0 +1,66 @@
+//
+//  DebugSettingsForceSkeletonsTests.swift
+//  PalaceTests
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+//  Covers the `DebugSettings.forceSkeletons` QA/dev override (PP-4797). The
+//  flag forces every first-load skeleton gate ON so the transient loading
+//  placeholders can be inspected on the sim. Tests exercise the injectable
+//  seam so they never touch `UserDefaults.standard`.
+//
+
+import XCTest
+@testable import Palace
+
+final class DebugSettingsForceSkeletonsTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "DebugSettingsForceSkeletonsTests.\(name)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testForceSkeletons_whenOverrideKeyUnset_isFalse() {
+        XCTAssertFalse(DebugSettings.forceSkeletons(in: defaults))
+    }
+
+    func testForceSkeletons_whenOverrideKeySet_isTrueInDebug() {
+        defaults.set(true, forKey: "PalaceForceSkeletons")
+        #if DEBUG
+        XCTAssertTrue(DebugSettings.forceSkeletons(in: defaults))
+        #else
+        // Release builds gate the override off entirely — production render
+        // paths must be byte-identical regardless of the key.
+        XCTAssertFalse(DebugSettings.forceSkeletons(in: defaults))
+        #endif
+    }
+
+    /// Mutation guard: pins the exact override key. If the production read
+    /// drifts to a similarly-named key, the decoy value makes this fail.
+    func testForceSkeletons_readsExactKey_notADecoy() {
+        defaults.set(false, forKey: "ForceSkeletons")       // decoy #1
+        defaults.set(false, forKey: "PalaceForceSkeleton")  // decoy #2 (singular)
+        defaults.set(true, forKey: "PalaceForceSkeletons")  // the real key
+        #if DEBUG
+        XCTAssertTrue(DebugSettings.forceSkeletons(in: defaults))
+        #else
+        XCTAssertFalse(DebugSettings.forceSkeletons(in: defaults))
+        #endif
+    }
+
+    func testForceSkeletons_whenOverrideExplicitlyFalse_isFalse() {
+        defaults.set(false, forKey: "PalaceForceSkeletons")
+        XCTAssertFalse(DebugSettings.forceSkeletons(in: defaults))
+    }
+}

--- a/PalaceTests/Settings/LibrariesSectionViewModelTests.swift
+++ b/PalaceTests/Settings/LibrariesSectionViewModelTests.swift
@@ -91,6 +91,87 @@ final class LibrariesSectionViewModelTests: XCTestCase {
         XCTAssertNil(sut.currentAccountUUID)
     }
 
+    // MARK: - isLoading (Settings skeleton gate)
+
+    /// Fresh launch: nothing resolves yet AND the catalog hasn't loaded ⇒ the
+    /// MY LIBRARIES skeleton must show instead of a blank list that pops in.
+    func test_isLoading_true_whenNoAccountsResolveAndCatalogNotLoaded() {
+        let env = FakeLibrariesEnvironment(currentUUID: nil, persisted: [], accountsLoaded: false)
+
+        let sut = LibrariesSectionViewModel(environment: env, observeNotifications: false)
+
+        XCTAssertTrue(sut.isLoading,
+                      "During hydration (no resolved accounts, catalog not loaded) the section is loading.")
+        XCTAssertTrue(sut.accounts.isEmpty)
+    }
+
+    /// Once a library resolves, the real row can render — the skeleton must
+    /// come down even if the full catalog is still materializing.
+    func test_isLoading_false_whenAnAccountResolves_evenIfCatalogNotLoaded() {
+        let bookshelf = makeAccount(uuid: "bookshelf", name: "Palace Bookshelf")
+        let env = FakeLibrariesEnvironment(currentUUID: bookshelf.uuid,
+                                           persisted: [bookshelf],
+                                           accountsLoaded: false)
+        env.lookupResponses = [bookshelf.uuid: bookshelf]
+
+        let sut = LibrariesSectionViewModel(environment: env, observeNotifications: false)
+
+        XCTAssertFalse(sut.isLoading,
+                       "A resolved library means real content is available — no skeleton.")
+        XCTAssertEqual(sut.accounts.map { $0.uuid }, ["bookshelf"])
+    }
+
+    /// Genuinely-empty configuration AFTER the catalog has loaded is NOT a
+    /// loading state — the skeleton must not park forever on a user who has no
+    /// libraries. Guards the `!accountsHaveLoaded` half of the decision.
+    func test_isLoading_false_whenEmptyButCatalogHasLoaded() {
+        let env = FakeLibrariesEnvironment(currentUUID: nil, persisted: [], accountsLoaded: true)
+
+        let sut = LibrariesSectionViewModel(environment: env, observeNotifications: false)
+
+        XCTAssertFalse(sut.isLoading,
+                       "An empty list after the catalog loaded is a real empty state, not a skeleton.")
+    }
+
+    /// Hydration completes mid-session: a re-`refresh()` (fired by the Settings
+    /// view on appear / current-account change) must flip the skeleton off once
+    /// an account resolves. Drives the flag through the production seam
+    /// (`refresh`), not by writing it directly.
+    func test_isLoading_flipsFalse_onRefresh_afterAccountBecomesResolvable() {
+        let bookshelf = makeAccount(uuid: "bookshelf", name: "Palace Bookshelf")
+        let env = FakeLibrariesEnvironment(currentUUID: bookshelf.uuid,
+                                           persisted: [bookshelf],
+                                           accountsLoaded: false)
+        // Account is persisted but does NOT resolve yet (pre-hydration).
+        let sut = LibrariesSectionViewModel(environment: env, observeNotifications: false)
+        XCTAssertTrue(sut.isLoading, "Sanity: persisted account not yet resolvable ⇒ loading.")
+
+        // Hydration completes: the lookup now resolves.
+        env.lookupResponses = [bookshelf.uuid: bookshelf]
+        env.accountsLoaded = true
+        sut.refresh()
+
+        XCTAssertFalse(sut.isLoading, "Once the account resolves, the skeleton must come down.")
+        XCTAssertEqual(sut.accounts.map { $0.uuid }, ["bookshelf"])
+    }
+
+    // MARK: - shouldShowSkeleton (pure decision)
+
+    func test_shouldShowSkeleton_onlyWhenEmptyAndNotLoaded() {
+        // The one true case: nothing resolved AND catalog still loading.
+        XCTAssertTrue(LibrariesSectionViewModel.shouldShowSkeleton(
+            resolvedAccountCount: 0, accountsHaveLoaded: false))
+
+        // Any resolved account ⇒ no skeleton (real content exists).
+        XCTAssertFalse(LibrariesSectionViewModel.shouldShowSkeleton(
+            resolvedAccountCount: 1, accountsHaveLoaded: false))
+        // Catalog loaded ⇒ empty is a real empty state, not a skeleton.
+        XCTAssertFalse(LibrariesSectionViewModel.shouldShowSkeleton(
+            resolvedAccountCount: 0, accountsHaveLoaded: true))
+        XCTAssertFalse(LibrariesSectionViewModel.shouldShowSkeleton(
+            resolvedAccountCount: 3, accountsHaveLoaded: true))
+    }
+
     // MARK: - deleteSecondary
 
     func test_deleteSecondary_callsTokenDeleter_andRemovesAccount_andPersists() {
@@ -226,11 +307,13 @@ private final class FakeLibrariesEnvironment: LibrariesSectionEnvironment {
     var persistedIds: [String]?
     var tokensDeleted: [String] = []
     var switchedTo: [String] = []
+    var accountsLoaded: Bool = true
     private var pendingSwitchCompletions: [String: () -> Void] = [:]
 
-    init(currentUUID: String?, persisted: [Account]) {
+    init(currentUUID: String?, persisted: [Account], accountsLoaded: Bool = true) {
         self.currentUUID = currentUUID
         self.persisted = persisted
+        self.accountsLoaded = accountsLoaded
     }
 
     nonisolated func currentAccountUUID() -> String? {
@@ -247,6 +330,9 @@ private final class FakeLibrariesEnvironment: LibrariesSectionEnvironment {
     }
     nonisolated func deleteToken(for account: Account) {
         MainActor.assumeIsolated { self.tokensDeleted.append(account.uuid) }
+    }
+    nonisolated func accountsHaveLoaded() -> Bool {
+        MainActor.assumeIsolated { self.accountsLoaded }
     }
     nonisolated func switchToAccount(_ account: Account, completion: @escaping () -> Void) {
         MainActor.assumeIsolated {


### PR DESCRIPTION
Closes **PP-4797** (Sprint 79) — skeleton loading placeholders for Settings + a debug tool to verify every skeleton surface.

## What
The shimmering skeleton system (`Skeleton.swift`) and four of its surfaces (My Books, Holds, Account detail, Catalog) already shipped with PP-4752. This PR adds the **fifth** — the Settings **MY LIBRARIES** section — and a **DEBUG-only verification tool** that makes all five transient loaders reliably inspectable, then verifies each one on the sim.

## Changes
- **Settings MY LIBRARIES skeleton** — `SettingsLibrariesSkeletonView` shown during the launch-hydration window (when the persisted-account lookup resolves empty before the catalog materializes), cross-fading to the real section via the shared gentle motion. Driven by `LibrariesSectionViewModel.isLoading` / `shouldShowSkeleton(resolvedAccountCount:accountsHaveLoaded:)`.
- **`DebugSettings.forceSkeletons`** — a DEBUG-only override (launch arg `-PalaceForceSkeletons YES`, or the `PalaceForceSkeletons` user default) that forces every first-load skeleton gate ON, so the placeholders — normally visible for only a few hundred ms — can be inspected on the sim in both appearances. The `#if DEBUG` lives inside the getter (release returns a compile-time `false`), so the five call sites stay clean and production render paths are byte-identical. Testable seam `forceSkeletons(in:)` injects the defaults store.
- **Wired the flag into all five gates**: My Books / Holds (`model.isLoading`), Account (`isLoadingAuth`), Catalog (`state == .loading`), Settings (`librariesVM.isLoading`).

## Verification (DoD #12)
All five skeletons driven on-sim and **screenshots read** in **light + dark**:

| Surface | Light | Dark |
|---|---|---|
| Catalog (entry-points + 3 lanes) | ✅ | ✅ |
| My Books (book rows) | ✅ | ✅ (identical `BookListSkeletonView`) |
| Holds (book rows) | ✅ | ✅ |
| Settings — MY LIBRARIES | ✅ | ✅ |
| Account detail | ✅ | ✅ |

Every skeleton adapts contrast via the semantic `Skeleton.baseColor`/`highlightColor` tokens (dark-gray-on-black in dark, light-gray-on-white in light — no white-on-white), and faithfully traces its real layout. **No adjustments needed.** (The Account skeleton is normally unreachable with the flag on — forcing the libraries skeleton hides the tappable rows — so it was verified by flipping the flag on while on the account screen and re-rendering; documented for future runs.)

## Tests
`DebugSettingsForceSkeletonsTests` — 4 cases (unset → false, set → true in DEBUG, exact-key vs two decoys, explicit-false) exercising the injectable seam without touching `UserDefaults.standard`. Existing `LibrariesSectionViewModelTests` cover the `shouldShowSkeleton` gate. Static gates green (test-name-vs-body, blast-radius, superpartner, adjacency). Build + build-for-testing SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
