### PR TITLE
fix(audiobooks): reject zero-track audiobooks in finalizeBuild (PP-4768)

### DIFF
--- a/Palace/Audiobooks/AudiobookLoader.swift
+++ b/Palace/Audiobooks/AudiobookLoader.swift
@@ -322,9 +322,12 @@ final class AudiobookLoader {
     }
 
     // F-004 EXC_BREAKPOINT (Crashlytics, 3.0.0, distributor=Overdrive,
-    // decryptor=nil, bearerToken present) enters here. Mockability seam
-    // captured in `PalaceTests/Audiobooks/AudiobookLoaderFinalizeBuildTests`.
-    private func finalizeBuild(
+    // decryptor=nil, bearerToken present) enters here. `internal` (not
+    // `private`) so `AudiobookLoaderFinalizeBuildTests` can drive the decode →
+    // factory → guard chain directly: the zero-track guard below (PP-4768)
+    // returns BEFORE the AppContainer.production() reads further down, so the
+    // failure path is exercisable without touching singletons.
+    func finalizeBuild(
         book: TPPBook,
         jsonData: Data,
         decryptor: DRMDecryptor?,
@@ -356,6 +359,24 @@ final class AudiobookLoader {
             fulfillURL: book.bearerTokenFulfillURL
         ) else {
             Log.error(#file, "  ❌ AudiobookFactory failed to create audiobook")
+            completion(.failure(.factoryFailed(manifestType: manifest.metadata?.type)))
+            return
+        }
+
+        // PP-4768 (F-004 residual): the OverDrive / open-access decode exemption
+        // (Manifest.swift, PP-4631) lets a manifest with no metadata and no
+        // readingOrder/spine pass decode when it carries a non-empty
+        // `contentlinks` — the tracks are expected to come from those links. But
+        // `Audiobook.init?` never fails on empty tracks, so if none of the
+        // content links resolve to a playable track (e.g. an unusable href in a
+        // malformed distributor response), the factory returns a NON-nil but
+        // TRACKLESS audiobook. Building a manager from it lets the toolkit player
+        // later trap on unguarded `[0]` track subscripts (EXC_BREAKPOINT,
+        // Crashlytics-attributed to finalizeBuild). Reject it here via the
+        // existing `.factoryFailed` path → "Failed to create audio player.
+        // Please try again." (the PP-3707 retry dialog); no new error case.
+        guard !audiobook.tableOfContents.allTracks.isEmpty else {
+            Log.error(#file, "  ❌ Factory produced a zero-track audiobook — rejecting to avoid a trackless player")
             completion(.failure(.factoryFailed(manifestType: manifest.metadata?.type)))
             return
         }

--- a/PalaceTests/Audiobooks/AudiobookLoaderFinalizeBuildTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookLoaderFinalizeBuildTests.swift
@@ -363,4 +363,90 @@ final class AudiobookLoaderFinalizeBuildTests: XCTestCase {
             XCTFail(".manifestDecodingFailed pattern must match — refactor regression if it doesn't")
         }
     }
+
+    // MARK: - PP-4768: zero-track OverDrive audiobook must fail, not build a trackless player
+
+    /// F-004 residual fixture. An OverDrive manifest that hits the PP-4631 decode
+    /// exemption (formatType=overdrive + a non-empty `contentlinks`) but whose
+    /// single content link has an empty `href`: it decodes fine (Link requires
+    /// `href` present, "" satisfies that) and the exemption is satisfied, but
+    /// `URL(string: "")` is nil so `OverdriveTrack` throws and NO track is built —
+    /// yielding a NON-nil but trackless audiobook. This is the exact shape that
+    /// slips past the factory guard-let and lets the toolkit player later trap on
+    /// an unguarded `[0]` track subscript.
+    private func zeroTrackOverdriveManifestJSON(id: String) -> [String: Any] {
+        return [
+            "id": id,
+            "formatType": "audiobook-overdrive",
+            "links": [
+                "contentlinks": [
+                    ["href": ""]
+                ]
+            ]
+        ]
+    }
+
+    /// PREMISE (the reason the guard is needed): this manifest decodes, and
+    /// `AudiobookFactory.audiobook(...)` returns a NON-nil audiobook — because
+    /// `Audiobook.init?` never fails on empty tracks — yet the audiobook has
+    /// ZERO tracks. If this premise ever stops holding (e.g. the toolkit starts
+    /// rejecting trackless OverDrive manifests at decode or in the factory), this
+    /// test fails loudly and the guard below can be reconsidered.
+    func test_finalizeBuild_zeroTrackOverdrive_premise_factoryReturnsNonNilButTrackless() throws {
+        let bookId = "overdrive-zerotrack-\(UUID().uuidString)"
+        let json = zeroTrackOverdriveManifestJSON(id: bookId)
+        let jsonData = try JSONSerialization.data(withJSONObject: json, options: [])
+
+        let manifest = try Manifest.customDecoder().decode(Manifest.self, from: jsonData)
+        XCTAssertEqual(manifest.audiobookType, .overdrive,
+                       "formatType=audiobook-overdrive must classify as .overdrive")
+
+        let audiobook = AudiobookFactory.audiobook(
+            for: manifest,
+            bookIdentifier: bookId,
+            decryptor: nil,
+            token: "bearer-token-abc",   // F-004 shape: OverDrive w/ bearer token, nil decryptor
+            fulfillURL: nil
+        )
+        XCTAssertNotNil(audiobook,
+                        "PREMISE: the factory must return a NON-nil audiobook for this shape — Audiobook.init? does not fail on empty tracks, which is exactly why finalizeBuild needs its own zero-track guard")
+        XCTAssertTrue(audiobook?.tableOfContents.allTracks.isEmpty == true,
+                      "PREMISE: the OverDrive content link with an empty href must resolve to ZERO tracks (OverdriveTrack throws on URL(string: \"\") == nil)")
+    }
+
+    /// WIRING: driving `finalizeBuild` with the zero-track OverDrive manifest must
+    /// surface `.failure(.factoryFailed)` — NOT `.success` (a playable-looking but
+    /// trackless audiobook) and NOT a crash. The guard returns before the
+    /// AppContainer.production() reads further down finalizeBuild, so this failure
+    /// path is exercisable without touching singletons. Mutation kill point:
+    /// flipping the guard (`!allTracks.isEmpty` → `allTracks.isEmpty`) makes the
+    /// original zero-track input fall THROUGH the guard into the manager-build
+    /// path instead of failing here, so this assertion breaks the mutant.
+    func test_finalizeBuild_zeroTrackAudiobook_failsWithFactoryFailed_notSuccess() throws {
+        let loader = AudiobookLoader(adapters: [])
+        let bookId = "overdrive-zerotrack-\(UUID().uuidString)"
+        let book = TPPBookMocker.mockBook(identifier: bookId, title: "Trackless OverDrive")
+        let jsonData = try JSONSerialization.data(
+            withJSONObject: zeroTrackOverdriveManifestJSON(id: bookId), options: []
+        )
+
+        let done = expectation(description: "finalizeBuild completes")
+        var received: Result<LoadedAudiobook, AudiobookLoadError>?
+        loader.finalizeBuild(book: book, jsonData: jsonData, decryptor: nil) { result in
+            received = result
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 2.0)
+
+        switch received {
+        case .failure(.factoryFailed):
+            break  // expected: rejected cleanly, no trackless player built
+        case .success:
+            XCTFail("A zero-track audiobook must NOT succeed — that builds a trackless player that later traps on [0] subscripts (F-004)")
+        case .failure(let other):
+            XCTFail("Expected .factoryFailed, got \(String(describing: other))")
+        case nil:
+            XCTFail("finalizeBuild never called its completion")
+        }
+    }
 }


### PR DESCRIPTION
## PP-4768 — residual F-004 audiobook open crash

An OverDrive/open-access manifest that hits the PP-4631 decode exemption (`formatType=overdrive` + a non-empty `contentlinks`) but whose links resolve to **no playable tracks** passes BOTH decode and `AudiobookFactory` — `Audiobook.init?` never fails on empty tracks — yielding a NON-nil but **trackless** audiobook. `finalizeBuild` then builds a manager from it and the toolkit player later traps on an unguarded `[0]` track subscript: the residual F-004 `EXC_BREAKPOINT` (Crashlytics `7bf923ee`, 31 crashes / 9 patrons on 3.1.0).

## Fix
A guard on `tableOfContents.allTracks.isEmpty` immediately after the factory guard-let, failing via the **existing** `.factoryFailed` path → the "Failed to create audio player. Please try again." retry dialog. No new error case, no change to the success path. The guard returns before `finalizeBuild`'s `AppContainer.production()` reads, so `finalizeBuild` is now `internal` (was `private`) — making the failure path testable without touching singletons.

## Tests (`AudiobookLoaderFinalizeBuildTests` — now constructs `AudiobookLoader`)
- **premise:** the zero-track OverDrive fixture decodes and the factory returns a non-nil audiobook with `allTracks.isEmpty` — proves *why* the guard is needed (empirically verified against the toolkit).
- **wiring:** `finalizeBuild` on that fixture returns `.failure(.factoryFailed)` — not `.success`, not a crash — driving the real production seam.

## Verification
- Build clean; `AudiobookLoaderFinalizeBuildTests` 11/11 pass; pre-push gate ran all 5 AudiobookLoader classes green.
- Diff-scoped mutation: 0 mutation points on the `!isEmpty` guard (not a recognized operator); the wiring test kills the semantic mutant (flipping the guard → `.success` instead of `.factoryFailed` → assertion fails).
- Independent SoD review: architect `rev_7f3c9a1e` + qa `rev_a3f79c21`, both approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)