### PR TITLE
feat(audiobooks): instant-present audiobook player + follows system appearance (PP-4798)

### DIFF
--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -186,7 +186,14 @@ struct AppTabHostView: View {
     /// morph inside `AudiobookMorphingPlayerView`.
     @ViewBuilder
     private var resizingPlayerOverlay: some View {
-        if inAppPlaybackNavEnabled, audiobookSessionPresenter.playbackModel != nil {
+        // Mount on `currentBook` (set by `presentLoadingShell` the instant a
+        // fresh open begins) OR `playbackModel` (set when the loader binds), so
+        // the player slides up immediately with its loading skeleton instead of
+        // waiting for the whole load chain. Both are cleared by
+        // `clearActiveSession()` on close / error, so the overlay unmounts then.
+        if inAppPlaybackNavEnabled,
+           audiobookSessionPresenter.playbackModel != nil
+            || audiobookSessionPresenter.currentBook != nil {
             AudiobookMorphingPlayerView(
                 presenter: audiobookSessionPresenter,
                 progress: audiobookSessionPresenter.progress,

--- a/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
@@ -260,11 +260,12 @@ struct AudiobookMorphingPlayerView: View {
         .onChange(of: presenter.toastMessage) { _, newValue in
             if let msg = newValue, !msg.isEmpty { presentToast(msg) }
         }
-        // Match the toolkit player (AudiobookPlayerView ~L118): the full player
-        // commits to a dark visual design so the `Color.white.opacity(0.10)` chips
-        // and white-opacity foreground read correctly. Applied ONLY to the full
-        // content — the mini bar (rendered when minimized) keeps the app scheme.
-        .preferredColorScheme(.dark)
+        // The full player follows the SYSTEM appearance (no forced scheme). Its
+        // chrome uses semantic `.primary` colors (title, transport glyphs, chips)
+        // over a `Color(.systemBackground)` canvas, so it reads correctly in both
+        // light and dark. Previously this forced `.preferredColorScheme(.dark)`,
+        // which flipped a light-mode patron into a dark player the instant they
+        // tapped Continue/Listen — the jarring open flip removed in PP-4798.
     }
 
     private func fullContentPortrait(metrics: ControlMetrics) -> some View {
@@ -471,8 +472,8 @@ struct AudiobookMorphingPlayerView: View {
     /// (`AudiobookPlayerView.swift` ~L471-491): skip-back · play/pause · skip-
     /// forward on an `HStack(spacing: 40)` (landscape 25), fixed `.frame(height: 72)`
     /// (landscape 56). The play button matches the toolkit `playButton` — a
-    /// `Color.white.opacity(0.12)` circle with a white glyph (correct on the
-    /// forced-dark canvas).
+    /// `Color.primary.opacity(0.12)` circle with a `.primary` glyph (adapts to
+    /// the system appearance).
     private func transportRow(metrics: ControlMetrics) -> some View {
         HStack(spacing: metrics.transportSpacing) {
             transportButton("gobackward.30", label: Strings.Generic.skipBack30, size: metrics.skipGlyph) {
@@ -480,10 +481,10 @@ struct AudiobookMorphingPlayerView: View {
             }
             Button(action: { audiobookSession.togglePlayPause() }) {
                 ZStack {
-                    Circle().fill(Color.white.opacity(0.12))
+                    Circle().fill(Color.primary.opacity(0.12))
                     Image(systemName: presenter.isPlaying ? "pause.fill" : "play.fill")
                         .font(.system(size: metrics.playGlyph))
-                        .foregroundStyle(.white)
+                        .foregroundStyle(.primary)
                         .contentTransition(.symbolEffect(.replace))
                 }
                 .frame(width: metrics.playButton, height: metrics.playButton)
@@ -502,10 +503,10 @@ struct AudiobookMorphingPlayerView: View {
     /// AirPlay · SLEEP · BOOKMARK — on an `HStack(spacing: chipSpacing)` with a
     /// `Spacer(minLength: 0)` BETWEEN EACH (even distribution). Adaptive sizing
     /// (`chipHeight`/`fontSize`/`iconSize`/`chipPadH`/`outerPadH`/`chipSpacing`)
-    /// comes straight from the toolkit. Chips use `Color.white.opacity(0.10)` on
-    /// the forced-dark canvas with `.foregroundColor(.white.opacity(0.9))`.
+    /// comes straight from the toolkit. Chips use `Color.primary.opacity(0.10)`
+    /// with a `.primary.opacity(0.9)` foreground — adapts to the system appearance.
     private func bottomControls(metrics: ControlMetrics) -> some View {
-        let chipBg = Color.white.opacity(0.10)
+        let chipBg = Color.primary.opacity(0.10)
 
         return HStack(spacing: metrics.chipSpacing) {
             // Speed → opens the stepped speed sheet.
@@ -576,7 +577,7 @@ struct AudiobookMorphingPlayerView: View {
             .buttonStyle(.plain)
             .accessibilityLabel(Strings.Generic.addBookmark)
         }
-        .foregroundColor(.white.opacity(0.9))
+        .foregroundColor(.primary.opacity(0.9))
         .padding(.horizontal, metrics.outerPadH)
     }
 
@@ -669,9 +670,10 @@ struct AudiobookMorphingPlayerView: View {
     /// `AudiobookSessionManager`'s pre-loader `presentLoadingShell`) reads as the
     /// player "materializing" rather than a blank scrim. Mirrors the portrait
     /// full-player layout (grabber · title · scrubber · cover · transport ·
-    /// bottom chips). Opaque background matches the player's forced `.dark`
-    /// scheme; `SkeletonBox`/`SkeletonCircle` handle the shimmer + Reduce-Motion
-    /// gating internally. Cross-fades out when `audiobookSession.isLoaded` flips.
+    /// bottom chips). Opaque `Color(.systemBackground)` matches the player, which
+    /// follows the system appearance; `SkeletonBox`/`SkeletonCircle` handle the
+    /// shimmer + Reduce-Motion gating internally. Cross-fades out when
+    /// `audiobookSession.isLoaded` flips.
     private var playerLoadingSkeleton: some View {
         ZStack {
             Color(.systemBackground).ignoresSafeArea()
@@ -762,9 +764,9 @@ struct AudiobookMorphingPlayerView: View {
                 .frame(width: 44, height: 44)
         }
         .buttonStyle(.plain)
-        // White glyph to match the toolkit skip controls (`.foregroundColor(.primary)`
-        // on the forced-dark canvas).
-        .tint(.white)
+        // `.primary` glyph to match the toolkit skip controls; adapts to the
+        // system appearance now that the player no longer forces `.dark`.
+        .tint(.primary)
         .accessibilityLabel(label)
     }
 

--- a/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
@@ -620,7 +620,12 @@ struct AudiobookMorphingPlayerView: View {
 
     @ViewBuilder
     private var loadingOverlay: some View {
-        if !audiobookSession.isLoaded {
+        // `|| DebugSettings.forceSkeletons` (the PP-4797 QA override, a
+        // compile-time `false` in release) holds the loading skeleton up over a
+        // loaded player so it can be inspected on the sim — the real
+        // `!isLoaded` window is shorter than simdrive's observe latency on a
+        // warm manifest, so this is the DoD-#12 fixture seam for this state.
+        if !audiobookSession.isLoaded || DebugSettings.forceSkeletons {
             if loadingTimedOut {
                 ZStack {
                     Color.black.opacity(0.5).ignoresSafeArea()
@@ -645,27 +650,79 @@ struct AudiobookMorphingPlayerView: View {
                 }
                 .accessibilityElement(children: .contain)
             } else {
-                ZStack {
-                    Color.black.opacity(0.5).ignoresSafeArea()
-                    VStack {
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                            .scaleEffect(2)
-                        Text(Strings.Generic.audiobookLoading)
-                            .foregroundStyle(.white).padding(.top, 8)
-                    }
-                }
-                .onAppear {
-                    // Arm the 30s timeout; reset on (re)appear (mirrors toolkit).
-                    loadingTimedOut = false
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
-                        if !audiobookSession.isLoaded {
-                            loadingTimedOut = true
+                playerLoadingSkeleton
+                    .onAppear {
+                        // Arm the 30s timeout; reset on (re)appear (mirrors toolkit).
+                        loadingTimedOut = false
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
+                            if !audiobookSession.isLoaded {
+                                loadingTimedOut = true
+                            }
                         }
                     }
-                }
             }
         }
+    }
+
+    /// Skeleton lockup shown while the audiobook loads — replaces the old
+    /// spinner so a fresh open (which now presents the player IMMEDIATELY, via
+    /// `AudiobookSessionManager`'s pre-loader `presentLoadingShell`) reads as the
+    /// player "materializing" rather than a blank scrim. Mirrors the portrait
+    /// full-player layout (grabber · title · scrubber · cover · transport ·
+    /// bottom chips). Opaque background matches the player's forced `.dark`
+    /// scheme; `SkeletonBox`/`SkeletonCircle` handle the shimmer + Reduce-Motion
+    /// gating internally. Cross-fades out when `audiobookSession.isLoaded` flips.
+    private var playerLoadingSkeleton: some View {
+        ZStack {
+            Color(.systemBackground).ignoresSafeArea()
+            VStack(spacing: 0) {
+                SkeletonBox(width: 40, height: 5, cornerRadius: 2.5)
+                    .padding(.top, 12)
+
+                Spacer(minLength: 20)
+
+                VStack(spacing: 10) {
+                    SkeletonBox(width: 220, height: 20, cornerRadius: 4)
+                    SkeletonBox(width: 150, height: 14, cornerRadius: 4)
+                }
+
+                VStack(spacing: 10) {
+                    SkeletonBox(height: 4, cornerRadius: 2)
+                    HStack {
+                        SkeletonBox(width: 40, height: 12, cornerRadius: 3)
+                        Spacer()
+                        SkeletonBox(width: 40, height: 12, cornerRadius: 3)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 22)
+
+                Spacer(minLength: 24)
+
+                SkeletonBox(width: 240, height: 240, cornerRadius: 12)
+
+                Spacer(minLength: 24)
+
+                HStack(spacing: 26) {
+                    SkeletonCircle(size: 40)
+                    SkeletonCircle(size: 52)
+                    SkeletonCircle(size: 72)
+                    SkeletonCircle(size: 52)
+                    SkeletonCircle(size: 40)
+                }
+
+                HStack(spacing: 40) {
+                    SkeletonBox(width: 60, height: 30, cornerRadius: 15)
+                    SkeletonBox(width: 44, height: 30, cornerRadius: 15)
+                    SkeletonBox(width: 60, height: 30, cornerRadius: 15)
+                }
+                .padding(.top, 26)
+                .padding(.bottom, bottomSafeInset + 24)
+            }
+            .padding(.horizontal, 24)
+        }
+        .accessibilityElement()
+        .accessibilityLabel(Strings.Generic.audiobookLoading)
     }
 
     // MARK: - Toast overlay (toolkit `bookmarkAddedToastView` parity)

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -640,6 +640,21 @@ public final class AudiobookSessionManager: ObservableObject {
         hasEverStartedPlayback = false
         playbackStatePublisher.send(state)
 
+        // Present the player shell IMMEDIATELY — before the loader chain
+        // (manifest fetch / DRM / factory) runs — so the morphing player slides
+        // up the instant the patron taps Continue / Listen, showing the cover +
+        // a loading skeleton, instead of dead time until load completes. Only
+        // for a fresh user-initiated open (`startPlaying`) with in-app nav on;
+        // idempotent with the bind-time `presentOnFirstOpen()`. The loading
+        // skeleton clears once the toolkit reports `isLoaded`; a failed load
+        // publishes `.error`, which the presenter tears down.
+        if startPlaying, inAppPlaybackNavEnabledProvider() {
+            audiobookSessionPresenterProvider().presentLoadingShell(
+                for: book,
+                coverImage: book.coverImage ?? book.thumbnailImage
+            )
+        }
+
 #if LCP
         // PP-4542 (gate): a freshly-borrowed LCP audiobook is marked
         // download-successful the instant its tiny .lcpl license lands, but the

--- a/Palace/Audiobooks/AudiobookSessionPresenter.swift
+++ b/Palace/Audiobooks/AudiobookSessionPresenter.swift
@@ -198,6 +198,28 @@ class AudiobookSessionPresenter: ObservableObject {
         isCollapsed = false
     }
 
+    /// Presents the player shell IMMEDIATELY on a fresh open — BEFORE the loader
+    /// chain (manifest fetch / DRM / factory) runs — so the morphing player
+    /// slides up the instant the patron taps Continue / Listen, showing the
+    /// book's cover + a loading skeleton, instead of dead time until load
+    /// completes. Adopts the book identity (so the root mount gate and title/
+    /// author chrome have a source) + a low-res cover, then expands.
+    ///
+    /// Idempotent with the bind-time `presentOnFirstOpen()` (both set
+    /// `isPlayerExpanded = true`); the loader's later `adoptPlaybackModel(_:)`
+    /// fills in playback state and the skeleton clears once `isLoaded`. A failed
+    /// load publishes `.error`, which `clearActiveSession()` tears down (see
+    /// `subscribeToSessionState`), so the shell never lingers without a book.
+    ///
+    /// `coverImage` is always written (even `nil`) so a coverless book shows the
+    /// placeholder rather than a stale cover from a prior session — though the
+    /// manager's pre-open `stopPlayback` has already cleared it.
+    func presentLoadingShell(for book: TPPBook, coverImage: UIImage?) {
+        adoptBook(book)
+        adoptCoverImage(coverImage)
+        presentOnFirstOpen()
+    }
+
     /// Tap-on-mini-player entry point. Sets `isPlayerExpanded = true` so
     /// the root fullScreenCover shows the full player.
     func expand() {

--- a/PalaceTests/Audiobooks/AudiobookSessionPresenterTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookSessionPresenterTests.swift
@@ -188,6 +188,70 @@ final class AudiobookSessionPresenterTests: XCTestCase {
                      "Errored session must drop the current book so no chrome lingers after a failed open")
     }
 
+    // MARK: - Instant-present loading shell (present before the loader runs)
+
+    /// The manager calls `presentLoadingShell(for:coverImage:)` the instant a
+    /// fresh open begins — BEFORE the loader chain runs — so the player slides
+    /// up immediately with a cover + skeleton. This pins that the shell adopts
+    /// the book identity + cover and expands, WITHOUT any playback model yet
+    /// (the loader binds that later). Mutates: dropping any of the three writes
+    /// in `presentLoadingShell` fails a corresponding assertion.
+    func testPresentLoadingShell_adoptsBookAndCoverAndExpands_withNoPlaybackModelYet() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        let book = TPPBookMocker.mockBook(title: "Instant Open", authors: "Author")
+        let cover = UIImage()
+        XCTAssertFalse(presenter.isPlayerExpanded, "PRECONDITION: collapsed")
+        XCTAssertNil(presenter.currentBook, "PRECONDITION: no book")
+        XCTAssertNil(presenter.playbackModel, "PRECONDITION: no model")
+
+        presenter.presentLoadingShell(for: book, coverImage: cover)
+
+        XCTAssertEqual(presenter.currentBook?.identifier, book.identifier,
+                       "shell must adopt the book so the root mount gate + title/author chrome have a source")
+        XCTAssertTrue(presenter.coverImage === cover,
+                      "shell must adopt the low-res cover so it shows the instant the skeleton clears")
+        XCTAssertTrue(presenter.isPlayerExpanded,
+                      "shell must expand so the morphing player slides up on tap, not after load")
+        XCTAssertNil(presenter.playbackModel,
+                     "shell must present BEFORE the loader binds a playback model — this is the whole point of instant-present")
+    }
+
+    /// A coverless book must clear the mirror (placeholder), not inherit a stale
+    /// cover. Mutates: `adoptCoverImage(coverImage)` → skipping the write leaves
+    /// a prior cover in place; this test would then see the stale image.
+    func testPresentLoadingShell_withNilCover_clearsCoverForPlaceholder() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        presenter.adoptCoverImage(UIImage())  // stale cover from a prior session
+        let book = TPPBookMocker.mockBook(title: "No Cover", authors: "Author")
+
+        presenter.presentLoadingShell(for: book, coverImage: nil)
+
+        XCTAssertNil(presenter.coverImage,
+                     "a coverless open must show the placeholder, not a stale cover from a previous session")
+    }
+
+    /// Round-trip through the production seam: present the shell via
+    /// `presentLoadingShell`, then a failed load publishes `.error` — the shell
+    /// must tear down completely so it never lingers with no book actually
+    /// loaded. Mutates: removing the `.error` teardown leaves the shell up.
+    func testPresentLoadingShell_thenErrorState_tearsDownShell() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        let book = TPPBookMocker.mockBook(title: "Fails To Load", authors: "Author")
+
+        presenter.presentLoadingShell(for: book, coverImage: UIImage())
+        XCTAssertTrue(presenter.isPlayerExpanded, "PRECONDITION: shell up")
+        XCTAssertNotNil(presenter.currentBook, "PRECONDITION: book adopted")
+
+        spySession.state = .error(bookId: book.identifier, message: "boom")
+        spySession.playbackStatePublisher.send(.error(bookId: book.identifier, message: "boom"))
+        spinRunLoopForPublisherDelivery()  // the .error teardown sink hops via receive(on: .main)
+
+        XCTAssertFalse(presenter.isPlayerExpanded,
+                       "a failed open must collapse the shell — no phantom loading player")
+        XCTAssertNil(presenter.currentBook,
+                     "a failed open must drop the book so the root overlay unmounts")
+    }
+
     // MARK: - First-open expand (§7.4 / F-011)
 
     /// PRE: presenter has `isPlayerExpanded == false`.


### PR DESCRIPTION
## PP-4798 — audiobook player opens instantly + no forced dark flip

Two related changes to the in-app audiobook player (gated behind the `inAppPlaybackNavEnabled` RemoteConfig flag — the legacy toolkit player path is untouched).

### 1. Instant present
When a patron taps Continue/Listen, the morphing player now slides up **immediately** with the cover + a full loading skeleton (grabber · title · scrubber · cover · transport · chips), before the loader chain (manifest/DRM/factory) runs — instead of dead time. The skeleton cross-fades to the real player once `isLoaded` flips; a failed open tears the shell down cleanly (no phantom player).
- `AudiobookSessionManager`: on a fresh `startPlaying` open with in-app nav on, calls `presenter.presentLoadingShell(book, cover)` before the loader.
- `AudiobookSessionPresenter`: new `presentLoadingShell(for:coverImage:)` — adopts book + cover, expands; idempotent with the bind-time `presentOnFirstOpen()`.
- `AppTabHostView`: the overlay mounts on `currentBook != nil || playbackModel != nil` so it appears immediately; both cleared by `clearActiveSession()` on close/error.
- `AudiobookMorphingPlayerView`: spinner → player-shaped skeleton, held up by `DebugSettings.forceSkeletons` for QA inspection; 30s load-timeout preserved.

### 2. Player follows system appearance (no forced dark flip)
The player forced `.preferredColorScheme(.dark)`, so tapping Continue flipped a light-mode patron into a dark player. Removed the forced scheme and converted the hardcoded white-on-dark chrome (play button/glyph, skip glyphs, chip bg/fg) to semantic `.primary`/`Color.primary.opacity(…)`. In dark mode `.primary` == white → pixel-identical to before; in light mode → black-on-light. Title/scrubber/secondary text were already semantic; the skeleton already uses `Color(.systemBackground)`.

## Verification
- 3 new presenter tests (adopt-book/cover/expand, nil-cover clears, `.error`-teardown round-trip through the production seam) — all pass; each kills an identified mutant. Pre-push gate ran 7 audiobook classes green.
- **DoD #12 (on-sim, In-App Playback Navigation enabled — the real morphing-player path):** instant-present confirmed presenting the player immediately; **light system → light player, dark system → dark player, no flip on open** (both appearances read).
- Independent SoD review: architect `rev_a3f7c1e9` + qa `rev_a4f19c2e`, both approved.

Jira: PP-4798

🤖 Generated with [Claude Code](https://claude.com/claude-code)