### PR TITLE
feat(ui): tab-bar modernization — iOS-18 Tab builder, monochrome bar, iOS-26 minimize, mini-player fixes

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		1246CC54E04F756C2913D438 /* LCPPDFDiskExtractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F470EA0E88BDCE56E27B86 /* LCPPDFDiskExtractTests.swift */; };
 		1266D86E87E4AA575EB966BD /* BookmarkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EFBB61877EFCAB44897E93 /* BookmarkManager.swift */; };
 		12695B15A63B66C4B42E9B13 /* TPPReaderFootnoteAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD60FEA388441F72F8C8D85C /* TPPReaderFootnoteAccessibilityTests.swift */; };
+		126F5079067F518749BEB335 /* TabBarModernization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919D0E3F3618D29FCDBCB3C3 /* TabBarModernization.swift */; };
 		134F3EF0E81145878D455EFF /* UserRetryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43040747774740399559510F /* UserRetryTracker.swift */; };
 		137A5C5FCEB1C3E9F22B6A99 /* TPPPDFModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3D078322CEC4B660EC470F /* TPPPDFModelTests.swift */; };
 		1387B2F9424A9B052E3B353F /* TPPLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C7D04F855F2DA251329CDD /* TPPLocalization.swift */; };
@@ -833,6 +834,7 @@
 		84B7A3471B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */; };
 		84B7A3481B84E8FE00584FB2 /* OpenDyslexic3-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3451B84E8FE00584FB2 /* OpenDyslexic3-Regular.ttf */; };
 		84F958504600B9812A5C9A00 /* TPPNetworkExecutorConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3248EFDDABC9F2BE1324CA2A /* TPPNetworkExecutorConcurrencyTests.swift */; };
+		84C69EA8FE64C58B402E6CD0 /* TabBarModernizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036520F6ED04D581E2F1C8BC /* TabBarModernizationTests.swift */; };
 		84FCD2611B7BA79200BFEDD9 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84FCD2601B7BA79200BFEDD9 /* CoreLocation.framework */; };
 		85031AE3613087E467CEBA07 /* TPPErrorLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED738AB4311CF5D59516022 /* TPPErrorLoggerTests.swift */; };
 		8587EB0A7355DFD5E73FC4C8 /* AppLaunchTrackerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6CA6FD20109963823CABD1 /* AppLaunchTrackerExtendedTests.swift */; };
@@ -1643,6 +1645,7 @@
 		E6BC315D1E009F3E0021B65E /* TPPAgeCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BC315C1E009F3E0021B65E /* TPPAgeCheck.swift */; };
 		E6D848E32171334800CEC142 /* TPPContentTypeBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D848E22171334800CEC142 /* TPPContentTypeBadge.swift */; };
 		E6DA7EA01F2A718600CFBEC8 /* TPPBookAuthor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DA7E9F1F2A718600CFBEC8 /* TPPBookAuthor.swift */; };
+		E6E69301AC7D67018C6D027C /* TabBarModernization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919D0E3F3618D29FCDBCB3C3 /* TabBarModernization.swift */; };
 		E6F431E9F6704A43AE542A9E /* ErrorDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C17CF38F7D4EBFA5AC995F /* ErrorDetail.swift */; };
 		E704804E2859253900019B31 /* TPPPDFReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E704804D2859253900019B31 /* TPPPDFReaderView.swift */; };
 		E704804F2859253900019B31 /* TPPPDFReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E704804D2859253900019B31 /* TPPPDFReaderView.swift */; };
@@ -2073,6 +2076,7 @@
 		02415B1E145D716015754AFF /* Account+TPPLibraryAccountReadable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Account+TPPLibraryAccountReadable.swift"; sourceTree = "<group>"; };
 		02B8F946D19048E4AE73B6C7 /* TPPSettingsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPSettingsMock.swift; sourceTree = "<group>"; };
 		0345BFD61DBF002E00398B6F /* APIKeys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIKeys.swift; sourceTree = "<group>"; };
+		036520F6ED04D581E2F1C8BC /* TabBarModernizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabBarModernizationTests.swift; sourceTree = "<group>"; };
 		03690E221EB2B35000F75D5F /* TPPReaderBookmarkCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPReaderBookmarkCell.swift; sourceTree = "<group>"; };
 		03690E281EB2B44300F75D5F /* TPPReadiumBookmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPReadiumBookmark.swift; sourceTree = "<group>"; };
 		03B092231E78839D00AD338D /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
@@ -2748,6 +2752,7 @@
 		90F16E79F7C14C0F72FC36B3 /* ReadingStatsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsStoreTests.swift; sourceTree = "<group>"; };
 		91156C0148DA43679D576FBB /* BookCellModelStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCellModelStateTests.swift; sourceTree = "<group>"; };
 		913F56D4F2AA03D69839AB40 /* CoverageGapTests3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverageGapTests3.swift; sourceTree = "<group>"; };
+		919D0E3F3618D29FCDBCB3C3 /* TabBarModernization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabBarModernization.swift; sourceTree = "<group>"; };
 		9234DD4339B85855A91CE3DE /* BookRegistryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookRegistryStore.swift; sourceTree = "<group>"; };
 		9363B8BAFC71462390D7DD31 /* AudiobookLoadFailureSAMLReauthTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookLoadFailureSAMLReauthTests.swift; sourceTree = "<group>"; };
 		93925AD8656015E0036615C8 /* NotificationServiceTokenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationServiceTokenTests.swift; sourceTree = "<group>"; };
@@ -4295,6 +4300,7 @@
 				A4E7A9EF8B06FD43D1E1BAD9 /* Telemetry */,
 				EA0E5A429454281B98614AA0 /* IsReaderActiveTrackingModifier.swift */,
 				8FDDCAF42BE33E8FFEE03FE5 /* AudiobookMorphingPlayerView.swift */,
+				919D0E3F3618D29FCDBCB3C3 /* TabBarModernization.swift */,
 			);
 			path = AppInfrastructure;
 			sourceTree = "<group>";
@@ -5613,6 +5619,7 @@
 				0D614C1396A316960F405535 /* IsReaderActiveTrackingModifierTests.swift */,
 				F3E2541AFE374BC6F841E19E /* AppTabHostMiniPlayerIntegrationTests.swift */,
 				7510F2474FBF692B90EF902A /* AudiobookMorphingPlayerViewTests.swift */,
+				036520F6ED04D581E2F1C8BC /* TabBarModernizationTests.swift */,
 			);
 			path = AppInfrastructure;
 			sourceTree = "<group>";
@@ -7774,6 +7781,7 @@
 				93B119D71089105A82A3F6B9 /* DebugSettingsForceSkeletonsTests.swift in Sources */,
 				84F958504600B9812A5C9A00 /* TPPNetworkExecutorConcurrencyTests.swift in Sources */,
 				F0484E1308E55E4B0EB6F5E7 /* TPPNetworkResponderSizeLimitTests.swift in Sources */,
+				84C69EA8FE64C58B402E6CD0 /* TabBarModernizationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8338,6 +8346,7 @@
 				281BAB2E2AEA3A1F867B7345 /* DeveloperSettingsRows.swift in Sources */,
 				FCBE8B68654DA29199B7490D /* AppAdvancedSettingsView.swift in Sources */,
 				C8DC8F9202D050EEFBC61B4C /* SettingsSkeletonView.swift in Sources */,
+				E6E69301AC7D67018C6D027C /* TabBarModernization.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8905,6 +8914,7 @@
 				82193678E858613CE236C800 /* DeveloperSettingsRows.swift in Sources */,
 				DE4396B97927CA9E6978B33B /* AppAdvancedSettingsView.swift in Sources */,
 				35008DD01991700FE81D6940 /* SettingsSkeletonView.swift in Sources */,
+				126F5079067F518749BEB335 /* TabBarModernization.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -333,18 +333,22 @@ struct AppTabHostView: View {
             appContainer: appContainer
         ))
         .environmentObject(router)
+        .tabContentTint()
     }
 
     private var myBooksRoot: some View {
         NavigationHostView(rootView: MyBooksView(model: myBooksViewModel, appContainer: appContainer))
+            .tabContentTint()
     }
 
     private var holdsRoot: some View {
         NavigationHostView(rootView: HoldsView(appContainer: appContainer))
+            .tabContentTint()
     }
 
     private var settingsRoot: some View {
         NavigationHostView(rootView: TPPSettingsView())
+            .tabContentTint()
     }
 
     /// The one label idiom shared by both builders. Settings uses the SF Symbol
@@ -422,6 +426,12 @@ private struct TabViewChrome: ViewModifier {
             // default `Color.accentColor` here resolved to the SYSTEM blue,
             // since the app ships no AccentColor asset; a neutral tint is the
             // intended look per product.)
+            //
+            // `.tint` is hierarchical, so this would ALSO neutralize nav-bar
+            // chrome / links / controls inside each tab. That is scoped back OUT:
+            // every tab root re-establishes the content accent via
+            // `.tabContentTint()`, so ONLY the tab-bar items are monochrome while
+            // the search icon and in-content controls stay blue.
             .tint(.primary)
             // Selection haptic (iOS 17+ `.sensoryFeedback` under the hood).
             // `palaceHaptic` is preference- AND Reduce-Motion-gated, so it
@@ -583,6 +593,17 @@ fileprivate extension AppTabHostView {
             }
         }
     }
+}
+
+private extension View {
+    /// Re-establishes the app's content accent (system blue) INSIDE a tab so the
+    /// monochrome `.tint(.primary)` applied to the `TabView` (which colors the
+    /// tab-bar items) does not propagate into nav-bar chrome / links / controls.
+    /// The tab-bar items read the `TabView`-level tint; content reads this inner
+    /// one. Applied to all four tab roots so the monochrome look is bar-only —
+    /// the search icon and in-content controls stay blue, matching the app's
+    /// filled `Color.blue` CTAs.
+    func tabContentTint() -> some View { self.tint(Color.blue) }
 }
 
 extension Notification.Name {

--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -416,12 +416,13 @@ private struct TabViewChrome: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            // FIX (latent bug): brand-blue selected tab. `Color.accentColor`
-            // fell back to system blue because the app ships no AccentColor
-            // asset; `TabBarModern.brandTint` reads `TPPConfiguration
-            // .accentColor()` (#0090C4) so the selected tab is actually
-            // brand-colored, in both light and dark.
-            .tint(TabBarModern.brandTint)
+            // Monochrome selected tab: `.primary` (the label color) rather than
+            // a color accent, so the selected tab reads black in light / white
+            // in dark and the bar stays neutral — no blue. (For reference: the
+            // default `Color.accentColor` here resolved to the SYSTEM blue,
+            // since the app ships no AccentColor asset; a neutral tint is the
+            // intended look per product.)
+            .tint(.primary)
             // Selection haptic (iOS 17+ `.sensoryFeedback` under the hood).
             // `palaceHaptic` is preference- AND Reduce-Motion-gated, so it
             // no-ops when the patron has haptics off or Reduce Motion on.

--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -5,9 +5,18 @@ import PalaceNetwork
 import PalaceCatalog
 
 struct AppTabHostView: View {
-    @StateObject private var router = AppTabRouter()
+    // `fileprivate` (not `private`) so the same-file `TabViewChrome` view
+    // modifier — which both the iOS 18+ and legacy builders apply — can read
+    // the router, container, and tab-bar observer. Still file-scoped.
+    @StateObject fileprivate var router = AppTabRouter()
     @State private var holdsBadgeCount: Int = 0
-    private let appContainer: AppContainer
+    /// Publishes the live `UITabBar` height so the floating audiobook
+    /// mini-player tracks the ACTUAL bar position instead of a hardcoded 49pt
+    /// constant — required so the card stays glued to the bar when the iOS 26
+    /// minimize-on-scroll behavior makes the bar height dynamic. See
+    /// `TabBarModernization.swift`.
+    @StateObject fileprivate var tabBarHeightObserver = TabBarHeightObserver()
+    fileprivate let appContainer: AppContainer
     let bookRegistry: TPPBookRegistryProvider
     @StateObject private var catalogViewModel: CatalogViewModel
     /// Owned once here (NOT created inline in `body`). `MyBooksViewModel.init`
@@ -199,98 +208,275 @@ struct AppTabHostView: View {
                 progress: audiobookSessionPresenter.progress,
                 audiobookSession: appContainer.audiobookSession
             )
+            // Feed the mini-player the inset derived from the LIVE tab-bar
+            // height (measured in `TabBarHeightObserver`) instead of the
+            // hardcoded 49pt, so the floating card stays glued to the bar even
+            // as the iOS 26 minimize-on-scroll behavior changes the bar height.
+            // A `nil` (unmeasured) value leaves the mini-player on its own
+            // window-based fallback — identical to the historical behavior.
+            .environment(
+                \.miniPlayerTabBarInset,
+                TabBarModern.miniPlayerBottomInset(
+                    safeAreaBottom: bottomSafeInset,
+                    tabBarHeight: tabBarHeightObserver.tabBarHeight
+                )
+            )
         }
     }
 
+    /// Whether the audiobook mini-player overlay is currently mounted (an
+    /// active session floats above the tab bar). Mirrors the predicate in
+    /// `resizingPlayerOverlay`. Gates the iOS 26 minimize-on-scroll behavior:
+    /// we pin the bar while a mini-player is up so it can't minimize out from
+    /// under the floating card.
+    fileprivate var miniPlayerActive: Bool {
+        inAppPlaybackNavEnabled && audiobookSessionPresenter.playbackModel != nil
+    }
+
+    /// Whether the iOS 26 minimize-on-scroll behavior should be active. Pinned
+    /// (`false`) while a mini-player is up so the bar can't minimize out from
+    /// under the floating card. See `TabBarModern.shouldEnableTabBarMinimize`.
+    fileprivate var shouldMinimizeTabBar: Bool {
+        TabBarModern.shouldEnableTabBarMinimize(miniPlayerActive: miniPlayerActive)
+    }
+
+    /// The whole tab host. Picks the typed `Tab(value:role:)` builder on iOS 18+
+    /// and the classic `.tabItem` + `.tag` builder below it. Both apply the same
+    /// shared chrome (`tabViewChrome`) so there is no drift between the paths.
     private var tabViewContent: some View {
+        Group {
+            if #available(iOS 18, *) {
+                modernTabView
+            } else {
+                legacyTabView
+            }
+        }
+    }
+
+    // MARK: - iOS 18+ typed builder
+
+    @available(iOS 18, *)
+    private var modernTabView: some View {
         TabView(selection: $router.selected) {
-            NavigationHostView(rootView: CatalogView(
-                viewModel: catalogViewModel,
-                activeSessionsViewModel: activeSessionsViewModel,
-                appContainer: appContainer
-            ))
-                .environmentObject(router)
-                .tabItem {
-                    VStack {
-                        Image("Catalog").renderingMode(.template)
-                        Text(Strings.Settings.catalog)
-                    }
-                }
+            Tab(value: AppTab.catalog) {
+                catalogRoot
+            } label: {
+                Self.tabLabel(for: .catalog)
+            }
+            .accessibilityIdentifier(AccessibilityID.TabBar.catalogTab)
+
+            Tab(value: AppTab.myBooks) {
+                myBooksRoot
+            } label: {
+                Self.tabLabel(for: .myBooks)
+            }
+            .accessibilityIdentifier(AccessibilityID.TabBar.myBooksTab)
+
+            Tab(value: AppTab.holds) {
+                holdsRoot
+            } label: {
+                Self.tabLabel(for: .holds)
+            }
+            .badge(holdsBadgeCount)
+            .accessibilityIdentifier(AccessibilityID.TabBar.holdsTab)
+
+            Tab(value: AppTab.settings) {
+                settingsRoot
+            } label: {
+                Self.tabLabel(for: .settings)
+            }
+            .accessibilityIdentifier(AccessibilityID.TabBar.settingsTab)
+        }
+        .modifier(TabViewChrome(host: self))
+    }
+
+    // MARK: - Pre-iOS-18 builder (deployment floor is iOS 17)
+
+    private var legacyTabView: some View {
+        TabView(selection: $router.selected) {
+            catalogRoot
+                .tabItem { Self.tabLabel(for: .catalog) }
                 .tag(AppTab.catalog)
                 .accessibilityIdentifier(AccessibilityID.TabBar.catalogTab)
 
-            NavigationHostView(rootView: MyBooksView(model: myBooksViewModel, appContainer: appContainer))
-                .tabItem {
-                    VStack {
-                        Image("MyBooks").renderingMode(.template)
-                        Text(Strings.MyBooksView.navTitle)
-                    }
-                }
+            myBooksRoot
+                .tabItem { Self.tabLabel(for: .myBooks) }
                 .tag(AppTab.myBooks)
                 .accessibilityIdentifier(AccessibilityID.TabBar.myBooksTab)
 
-            NavigationHostView(rootView: HoldsView(appContainer: appContainer))
-                .tabItem {
-                    VStack {
-                        Image("Holds").renderingMode(.template)
-                        Text(Strings.HoldsView.reservations)
-                    }
-                }
+            holdsRoot
+                .tabItem { Self.tabLabel(for: .holds) }
                 .badge(holdsBadgeCount)
                 .tag(AppTab.holds)
                 .accessibilityIdentifier(AccessibilityID.TabBar.holdsTab)
 
-            NavigationHostView(rootView: TPPSettingsView())
-                .tabItem { Label(Strings.Settings.settings, systemImage: "gearshape") }
+            settingsRoot
+                .tabItem { Self.tabLabel(for: .settings) }
                 .tag(AppTab.settings)
                 .accessibilityIdentifier(AccessibilityID.TabBar.settingsTab)
         }
-        .tint(Color.accentColor)
-        // Polish-phase (in-app-nav-polish-2026-06-01): the full-player
-        // is no longer hosted in a fullScreenCover (the cover's dismiss
-        // unmounted the toolkit's AudiobookPlayerView, which fires
-        // playbackModel.stop() in its onDisappear → unloads the player).
-        // It's now rendered in `persistentFullPlayerOverlay` at the
-        // ZStack root, animated off-screen on minimize, so its
-        // onDisappear never fires and playback survives minimize/expand
-        // cycles intact.
-        .onAppear {
-            appContainer.tabRouterHub.router = router
-            appContainer.tabRouterHub.applyPending()
+        .modifier(TabViewChrome(host: self))
+    }
+
+    // MARK: - Shared tab roots (one source of truth for both builders)
+
+    private var catalogRoot: some View {
+        NavigationHostView(rootView: CatalogView(
+            viewModel: catalogViewModel,
+            activeSessionsViewModel: activeSessionsViewModel,
+            appContainer: appContainer
+        ))
+        .environmentObject(router)
+    }
+
+    private var myBooksRoot: some View {
+        NavigationHostView(rootView: MyBooksView(model: myBooksViewModel, appContainer: appContainer))
+    }
+
+    private var holdsRoot: some View {
+        NavigationHostView(rootView: HoldsView(appContainer: appContainer))
+    }
+
+    private var settingsRoot: some View {
+        NavigationHostView(rootView: TPPSettingsView())
+    }
+
+    /// The one label idiom shared by both builders. Settings uses the SF Symbol
+    /// `gearshape`; the other three use their raster PNG assets rendered as
+    /// template images so the tint tints them. Icons/order/direction unchanged.
+    @ViewBuilder
+    static func tabLabel(for tab: AppTab) -> some View {
+        switch tab {
+        case .catalog:
+            Label { Text(Strings.Settings.catalog) } icon: {
+                Image("Catalog").renderingMode(.template)
+            }
+        case .myBooks:
+            Label { Text(Strings.MyBooksView.navTitle) } icon: {
+                Image("MyBooks").renderingMode(.template)
+            }
+        case .holds:
+            Label { Text(Strings.HoldsView.reservations) } icon: {
+                Image("Holds").renderingMode(.template)
+            }
+        case .settings:
+            Label(Strings.Settings.settings, systemImage: "gearshape")
+        default:
+            EmptyView()
         }
-        .onChange(of: router.selected) { _, newTab in
-            // Respect reduce motion accessibility setting
-            if UIAccessibility.isReduceMotionEnabled {
+    }
+
+    // MARK: - Shared side effects
+
+    /// Runs on tab selection change: pop-to-root, dismiss top VC, sync, announce.
+    /// Extracted so the iOS 18+ and legacy builders share one implementation.
+    func handleTabSelectionChange(to newTab: AppTab) {
+        // Respect reduce motion accessibility setting
+        if UIAccessibility.isReduceMotionEnabled {
+            appContainer.navigationCoordinatorHub.coordinator?.popToRoot()
+        } else {
+            withAnimation(.easeInOut) {
                 appContainer.navigationCoordinatorHub.coordinator?.popToRoot()
-            } else {
-                withAnimation(.easeInOut) {
-                    appContainer.navigationCoordinatorHub.coordinator?.popToRoot()
-                }
-            }
-            if let appDelegate = UIApplication.shared.delegate as? TPPAppDelegate,
-               let top = appDelegate.topViewController() {
-                top.dismiss(animated: true)
-            }
-            NotificationCenter.default.post(name: .AppTabSelectionDidChange, object: nil)
-            // F-035: Auto-refresh My Books and Holds when their tabs
-            // become visible so the user doesn't have to pull-to-refresh
-            // to see newly borrowed/returned/held books.
-            if newTab == .myBooks || newTab == .holds {
-                appContainer.bookRegistry.sync()
-            }
-            // Announce the new tab for VoiceOver when tab changes
-            if UIAccessibility.isVoiceOverRunning {
-                let message = Self.accessibilityLabel(for: newTab)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                    UIAccessibility.post(notification: .announcement, argument: message)
-                }
             }
         }
-        .onAppear {
-            updateHoldsBadge()
+        if let appDelegate = UIApplication.shared.delegate as? TPPAppDelegate,
+           let top = appDelegate.topViewController() {
+            top.dismiss(animated: true)
         }
-        .onReceive(NotificationCenter.default.publisher(for: .TPPBookRegistryStateDidChange)) { _ in
-            updateHoldsBadge()
+        NotificationCenter.default.post(name: .AppTabSelectionDidChange, object: nil)
+        // F-035: Auto-refresh My Books and Holds when their tabs
+        // become visible so the user doesn't have to pull-to-refresh
+        // to see newly borrowed/returned/held books.
+        if newTab == .myBooks || newTab == .holds {
+            appContainer.bookRegistry.sync()
+        }
+        // Announce the new tab for VoiceOver when tab changes
+        if UIAccessibility.isVoiceOverRunning {
+            let message = Self.accessibilityLabel(for: newTab)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                UIAccessibility.post(notification: .announcement, argument: message)
+            }
+        }
+    }
+}
+
+/// The shared chrome applied to BOTH the iOS 18+ typed `Tab` builder and the
+/// pre-18 `.tabItem` builder — brand tint, selection haptic, tab-bar material,
+/// the iOS 26 Liquid-Glass minimize behavior, plus the lifecycle/selection/
+/// badge side effects. Factored into one `ViewModifier` so the two builders
+/// can never drift.
+private struct TabViewChrome: ViewModifier {
+    let host: AppTabHostView
+
+    func body(content: Content) -> some View {
+        content
+            // FIX (latent bug): brand-blue selected tab. `Color.accentColor`
+            // fell back to system blue because the app ships no AccentColor
+            // asset; `TabBarModern.brandTint` reads `TPPConfiguration
+            // .accentColor()` (#0090C4) so the selected tab is actually
+            // brand-colored, in both light and dark.
+            .tint(TabBarModern.brandTint)
+            // Selection haptic (iOS 17+ `.sensoryFeedback` under the hood).
+            // `palaceHaptic` is preference- AND Reduce-Motion-gated, so it
+            // no-ops when the patron has haptics off or Reduce Motion on.
+            .palaceHaptic(.selection, trigger: host.router.selected)
+            // Idiomatic tab-bar background. On iOS 26 the Liquid-Glass system
+            // material owns the bar chrome, so we DON'T force a material there
+            // (forcing one fights the glass + the minimize animation). Below
+            // 26, make the standard system-material bar background explicit.
+            .modifier(TabBarBackgroundModifier())
+            .modifier(TabBarMinimizeModifier(enabled: host.shouldMinimizeTabBar))
+            // Polish-phase (in-app-nav-polish-2026-06-01): the full-player
+            // is no longer hosted in a fullScreenCover; it's rendered in the
+            // resizing overlay at the ZStack root so playback survives
+            // minimize/expand cycles intact.
+            .onAppear {
+                host.appContainer.tabRouterHub.router = host.router
+                host.appContainer.tabRouterHub.applyPending()
+                host.tabBarHeightObserver.measure()
+            }
+            .onChange(of: host.router.selected) { _, newTab in
+                host.handleTabSelectionChange(to: newTab)
+                // Re-measure: selecting a tab can change bar chrome/height
+                // (esp. under iOS 26 minimize), keeping the mini-player glued.
+                host.tabBarHeightObserver.measure()
+            }
+            .onAppear {
+                host.updateHoldsBadge()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .TPPBookRegistryStateDidChange)) { _ in
+                host.updateHoldsBadge()
+            }
+    }
+}
+
+/// Availability-gated tab-bar background. iOS 26's Liquid Glass owns the bar
+/// background, so we only make the system material explicit on 18–25.
+private struct TabBarBackgroundModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            // Liquid Glass provides the bar material; don't override it.
+            content
+        } else {
+            content
+                .toolbarBackground(.visible, for: .tabBar)
+                .toolbarBackground(Material.bar, for: .tabBar)
+        }
+    }
+}
+
+/// Availability-gated iOS 26 Liquid-Glass minimize-on-scroll behavior. The
+/// `enabled` flag is the conditional gate: it is `false` while an audiobook
+/// mini-player is active so the bar can't minimize out from under the floating
+/// card (see `TabBarModern.shouldEnableTabBarMinimize`).
+private struct TabBarMinimizeModifier: ViewModifier {
+    let enabled: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content.tabBarMinimizeBehavior(enabled ? .onScrollDown : .never)
+        } else {
+            content
         }
     }
 }
@@ -334,7 +520,7 @@ extension AppTabHostView {
     }
 }
 
-private extension AppTabHostView {
+fileprivate extension AppTabHostView {
     /// VoiceOver announcement label for each tab (matches tab item text).
     static func accessibilityLabel(for tab: AppTab) -> String {
         switch tab {

--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -243,13 +243,19 @@ struct AppTabHostView: View {
     /// The whole tab host. Picks the typed `Tab(value:role:)` builder on iOS 18+
     /// and the classic `.tabItem` + `.tag` builder below it. Both apply the same
     /// shared chrome (`tabViewChrome`) so there is no drift between the paths.
+    @ViewBuilder
     private var tabViewContent: some View {
-        Group {
-            if #available(iOS 18, *) {
-                modernTabView
-            } else {
-                legacyTabView
-            }
+        // AnyView-erase each branch: the iOS-18 `Tab(value:)` builder and the
+        // legacy `.tabItem` builder produce different opaque `some View` types,
+        // and materializing a `_ConditionalContent` of an availability-gated
+        // opaque type trips the type-checker (surfaces as a misleading
+        // `CodingKeyRepresentable` error). Erasing resolves each branch
+        // independently. The extra AnyView is inconsequential at the tab-host
+        // root (evaluated once per launch).
+        if #available(iOS 18, *) {
+            AnyView(modernTabView)
+        } else {
+            AnyView(legacyTabView)
         }
     }
 

--- a/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
@@ -39,6 +39,14 @@ struct AudiobookMorphingPlayerView: View {
     @ObservedObject var progress: AudiobookPlaybackProgress
     let audiobookSession: AudiobookSessionManaging
 
+    /// The bottom inset (safe area + LIVE tab-bar height + margin) the host
+    /// measures and injects so the minimized card stays glued to the ACTUAL
+    /// tab bar — including under the iOS 26 minimize-on-scroll behavior where
+    /// the bar height is dynamic. `nil` means the host hasn't measured yet;
+    /// we then fall back to the window-safe-area + default-height math, which
+    /// is exactly the historical hardcoded behavior. See `TabBarModernization`.
+    @Environment(\.miniPlayerTabBarInset) private var injectedTabBarInset
+
     /// Namespace for the cover's `matchedGeometryEffect` — the single element
     /// that morphs between the full and mini layouts.
     @Namespace private var morphNamespace
@@ -129,8 +137,12 @@ struct AudiobookMorphingPlayerView: View {
     // MARK: - Layout constants
 
     private static let miniBarHeight: CGFloat = 74
+    /// Horizontal inset of the minimized card from the screen edges.
     private static let miniMargin: CGFloat = 8
-    private static let tabBarHeight: CGFloat = 49
+    // The tab-bar-height component of the mini card's BOTTOM inset now comes
+    // from the host's live measurement via `\.miniPlayerTabBarInset` (see
+    // `minimizedBottomInset`) rather than a hardcoded 49pt — required so the
+    // card tracks the tab bar under the iOS 26 dynamic-height minimize behavior.
     private static let coverMatchID = "audiobookCover"
 
     // MARK: - Body
@@ -197,10 +209,14 @@ struct AudiobookMorphingPlayerView: View {
         .shadow(color: .black.opacity(expanded ? 0 : 0.18),
                 radius: expanded ? 0 : 10, y: -2)
         .padding(.horizontal, expanded ? 0 : Self.miniMargin)
-        // Float the mini card clear of the tab bar + home indicator. Read the
-        // real bottom inset from the window (the GeometryReader ignores safe area
-        // for the full-bleed expanded state, so its inset is 0).
-        .padding(.bottom, expanded ? 0 : bottomSafeInset + Self.tabBarHeight + Self.miniMargin)
+        // Float the mini card clear of the tab bar + home indicator. Prefer the
+        // host-measured inset (LIVE tab-bar height, injected via
+        // `\.miniPlayerTabBarInset`) so the card tracks the ACTUAL bar — even
+        // under the iOS 26 minimize-on-scroll behavior. When unmeasured, fall
+        // back to the window safe-area + default height math (the historical
+        // hardcoded behavior). The GeometryReader ignores safe area for the
+        // full-bleed expanded state, so its inset is 0 — hence the window read.
+        .padding(.bottom, expanded ? 0 : minimizedBottomInset)
         // No `.contentShape` on the padded frame: when minimized, the bottom
         // padding sits OVER the tab bar, and a rectangular content-shape there
         // swallowed the tab bar's taps. The mini bar's own `Color` fill (the
@@ -1088,6 +1104,21 @@ struct AudiobookMorphingPlayerView: View {
 
     private var topSafeInset: CGFloat { Self.keyWindowInsets.top }
     private var bottomSafeInset: CGFloat { Self.keyWindowInsets.bottom }
+
+    /// Bottom padding for the minimized card so it floats above the tab bar.
+    /// Prefers the host-measured inset (LIVE tab-bar height); when the host
+    /// hasn't measured yet, falls back to the window safe-area + default
+    /// tab-bar-height math — the historical hardcoded value, so the card is
+    /// never worse-positioned than before.
+    private var minimizedBottomInset: CGFloat {
+        if let injectedTabBarInset {
+            return injectedTabBarInset
+        }
+        return TabBarModern.miniPlayerBottomInset(
+            safeAreaBottom: bottomSafeInset,
+            tabBarHeight: TabBarModern.defaultTabBarHeight
+        )
+    }
 
     private static var keyWindowInsets: UIEdgeInsets {
         UIApplication.shared.connectedScenes

--- a/Palace/AppInfrastructure/TabBarModernization.swift
+++ b/Palace/AppInfrastructure/TabBarModernization.swift
@@ -55,12 +55,22 @@ enum TabBarModern {
         tabBarHeight: CGFloat,
         margin: CGFloat = miniMargin
     ) -> CGFloat {
-        // Guard against a spurious non-finite / negative measurement (e.g. a
-        // window torn down mid-transition reporting garbage) so the card never
-        // flies off-screen — fall back to the known-good default height.
+        // Clamp a spurious non-finite / negative safe area (e.g. a window torn
+        // down mid-transition reporting garbage) so the card never flies off.
         let safe = safeAreaBottom.isFinite && safeAreaBottom >= 0 ? safeAreaBottom : 0
-        let bar = tabBarHeight.isFinite && tabBarHeight > 0 ? tabBarHeight : defaultTabBarHeight
-        return safe + bar + margin
+        // A LIVE `UITabBar.frame.height` already spans from the screen bottom to
+        // the bar's TOP edge — it INCLUDES the home-indicator safe area (the bar
+        // draws down into it). So the card's offset from the bottom is that full
+        // height plus a small margin; adding `safe` on top double-counts the home
+        // indicator and floats the card ~34pt too high above the bar. We treat
+        // any real measurement (strictly taller than the 49pt bar-only default)
+        // as the full offset and pass it straight through. When we have no such
+        // measurement (the unmeasured 49 seed, or a bogus 0 / non-finite value)
+        // reconstruct a plausible full height from the historical bar-only
+        // default + the live safe area.
+        let isFullFrameMeasurement = tabBarHeight.isFinite && tabBarHeight > defaultTabBarHeight
+        let fullBarHeight = isFullFrameMeasurement ? tabBarHeight : defaultTabBarHeight + safe
+        return fullBarHeight + margin
     }
 
     /// Whether the iOS 26 `.tabBarMinimizeBehavior(.onScrollDown)` enhancement

--- a/Palace/AppInfrastructure/TabBarModernization.swift
+++ b/Palace/AppInfrastructure/TabBarModernization.swift
@@ -28,27 +28,6 @@ import UIKit
 /// the values `AppTabHostView` reads, so each is independently testable.
 enum TabBarModern {
 
-    /// The selected-tab tint. Resolves to the Palace brand blue (`#0090C4`) via
-    /// `TPPConfiguration.accentColor()` rather than SwiftUI's `Color.accentColor`.
-    ///
-    /// LATENT BUG this fixes: the app ships **no** `AccentColor` asset-catalog
-    /// entry and sets no `ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME`, so
-    /// `Color.accentColor` fell back to the SwiftUI default system blue
-    /// (`#007AFF`) — the selected tab was NOT brand-colored. Sourcing the tint
-    /// from `TPPConfiguration.accentColor()` (the single brand-blue source the
-    /// rest of the app already uses, e.g. `NormalBookCell`) makes the selected
-    /// tab render brand blue in both light and dark appearance.
-    static var brandTint: Color { Color(TPPConfiguration.accentColor()) }
-
-    /// The brand tint as sRGB components, exposed for tests to assert the
-    /// resolved value is brand blue and not the system default. Reads the same
-    /// `UIColor` that `brandTint` wraps.
-    static var brandTintRGBA: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
-        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
-        TPPConfiguration.accentColor().getRed(&r, green: &g, blue: &b, alpha: &a)
-        return (r, g, b, a)
-    }
-
     /// Default `UITabBar` height (points) used before a live measurement is
     /// available, and the value the hardcoded constant historically assumed.
     static let defaultTabBarHeight: CGFloat = 49

--- a/Palace/AppInfrastructure/TabBarModernization.swift
+++ b/Palace/AppInfrastructure/TabBarModernization.swift
@@ -1,0 +1,179 @@
+//
+//  TabBarModernization.swift
+//  Palace
+//
+//  Extracted, unit-testable seams for the modern tab-bar refresh (the main app
+//  `TabView` in `AppTabHostView`). Keeping the *decisions* here — the resolved
+//  brand tint, the mini-player bottom-inset math, and the minimize-behavior
+//  gate — means the SwiftUI view stays declarative while the behavior that could
+//  regress (wrong tint, mini-player desync under a minimizing bar, minimize
+//  enabled while a session floats above the bar) is covered by tests that don't
+//  need a SwiftUI host.
+//
+//  Deployment floor is iOS 17 (see `PalaceMotion` / project settings), so
+//  `.tint(_:)` and `.sensoryFeedback`/`palaceHaptic` are available
+//  unconditionally. Only the iOS 18 `Tab(value:role:)` builder and the iOS 26
+//  Liquid-Glass `.tabBarMinimizeBehavior` are `@available`-gated progressive
+//  enhancements in `AppTabHostView`.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - Pure decisions
+
+/// Namespace for the modern tab-bar's pure decisions. Not a view — a home for
+/// the values `AppTabHostView` reads, so each is independently testable.
+enum TabBarModern {
+
+    /// The selected-tab tint. Resolves to the Palace brand blue (`#0090C4`) via
+    /// `TPPConfiguration.accentColor()` rather than SwiftUI's `Color.accentColor`.
+    ///
+    /// LATENT BUG this fixes: the app ships **no** `AccentColor` asset-catalog
+    /// entry and sets no `ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME`, so
+    /// `Color.accentColor` fell back to the SwiftUI default system blue
+    /// (`#007AFF`) — the selected tab was NOT brand-colored. Sourcing the tint
+    /// from `TPPConfiguration.accentColor()` (the single brand-blue source the
+    /// rest of the app already uses, e.g. `NormalBookCell`) makes the selected
+    /// tab render brand blue in both light and dark appearance.
+    static var brandTint: Color { Color(TPPConfiguration.accentColor()) }
+
+    /// The brand tint as sRGB components, exposed for tests to assert the
+    /// resolved value is brand blue and not the system default. Reads the same
+    /// `UIColor` that `brandTint` wraps.
+    static var brandTintRGBA: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        TPPConfiguration.accentColor().getRed(&r, green: &g, blue: &b, alpha: &a)
+        return (r, g, b, a)
+    }
+
+    /// Default `UITabBar` height (points) used before a live measurement is
+    /// available, and the value the hardcoded constant historically assumed.
+    static let defaultTabBarHeight: CGFloat = 49
+
+    /// Breathing room between the minimized mini-player card and the tab bar.
+    static let miniMargin: CGFloat = 8
+
+    /// The bottom inset the floating audiobook mini-player must apply to sit
+    /// exactly above the tab bar (and clear of the home-indicator safe area).
+    ///
+    /// Pure function of three measured inputs so the mini-player's vertical
+    /// position tracks the ACTUAL tab bar — not a hardcoded 49pt guess. Under
+    /// the iOS 26 minimize-on-scroll behavior the bar height is dynamic; feeding
+    /// the *measured* `tabBarHeight` here keeps the card glued to the bar in
+    /// every state. (We additionally gate minimize OFF while a session is active
+    /// — see `shouldEnableTabBarMinimize` — so the height is also stable, giving
+    /// belt-and-suspenders correctness.)
+    ///
+    /// - Parameters:
+    ///   - safeAreaBottom: live bottom safe-area inset (home indicator).
+    ///   - tabBarHeight: the measured tab bar height, or `defaultTabBarHeight`.
+    ///   - margin: gap between the card and the bar.
+    static func miniPlayerBottomInset(
+        safeAreaBottom: CGFloat,
+        tabBarHeight: CGFloat,
+        margin: CGFloat = miniMargin
+    ) -> CGFloat {
+        // Guard against a spurious non-finite / negative measurement (e.g. a
+        // window torn down mid-transition reporting garbage) so the card never
+        // flies off-screen — fall back to the known-good default height.
+        let safe = safeAreaBottom.isFinite && safeAreaBottom >= 0 ? safeAreaBottom : 0
+        let bar = tabBarHeight.isFinite && tabBarHeight > 0 ? tabBarHeight : defaultTabBarHeight
+        return safe + bar + margin
+    }
+
+    /// Whether the iOS 26 `.tabBarMinimizeBehavior(.onScrollDown)` enhancement
+    /// should be ACTIVE.
+    ///
+    /// Minimize-on-scroll continuously changes the tab bar's height as the user
+    /// scrolls. The audiobook mini-player floats above the bar and is glued to
+    /// it; letting the bar minimize out from under an active mini-player would
+    /// leave the card hovering over empty space (or over content) mid-scroll.
+    /// So the enhancement is a *conditional* one: enabled only when there is no
+    /// active audiobook session. With no session there is no mini-player to
+    /// desync, so scroll-to-minimize is free to run.
+    ///
+    /// - Parameter miniPlayerActive: whether the mini-player overlay is mounted
+    ///   (an audiobook session is active — the same predicate `AppTabHostView`
+    ///   uses to mount `resizingPlayerOverlay`).
+    /// - Returns: `true` to enable minimize-on-scroll, `false` to pin the bar.
+    static func shouldEnableTabBarMinimize(miniPlayerActive: Bool) -> Bool {
+        return !miniPlayerActive
+    }
+}
+
+// MARK: - Environment: measured tab-bar inset for the mini-player
+
+/// The measured bottom inset (safe area + live tab-bar height + margin) the
+/// floating audiobook mini-player should apply. Injected by `AppTabHostView`
+/// from a live measurement so the mini-player tracks the ACTUAL bar position
+/// instead of a hardcoded 49pt constant. `nil` means "not measured yet" — the
+/// mini-player then falls back to its own window-based default, which is exactly
+/// the historical behavior, so there is never a worse position than before.
+private struct MiniPlayerTabBarInsetKey: EnvironmentKey {
+    static let defaultValue: CGFloat? = nil
+}
+
+extension EnvironmentValues {
+    /// See `MiniPlayerTabBarInsetKey`.
+    var miniPlayerTabBarInset: CGFloat? {
+        get { self[MiniPlayerTabBarInsetKey.self] }
+        set { self[MiniPlayerTabBarInsetKey.self] = newValue }
+    }
+}
+
+// MARK: - Live tab-bar height measurement
+
+/// Publishes the live height of the app's `UITabBar` so the floating mini-player
+/// can track the bar's ACTUAL position instead of a hardcoded 49pt constant.
+///
+/// The main `TabView` is backed by a `UITabBarController`; we read the real
+/// `UITabBar.frame.height` from the key window. This is correct across device
+/// classes and — critically — under the iOS 26 minimize-on-scroll behavior,
+/// where the height is no longer a fixed 49.
+///
+/// Reading is best-effort: if no tab bar is found (early launch, torn-down
+/// window) the published value stays at `TabBarModern.defaultTabBarHeight`,
+/// which is exactly the value the old hardcoded path used — so there is never a
+/// worse position than before.
+@MainActor
+final class TabBarHeightObserver: ObservableObject {
+
+    /// Live tab-bar height; seeded with the historical default.
+    @Published private(set) var tabBarHeight: CGFloat = TabBarModern.defaultTabBarHeight
+
+    /// Re-measure the tab bar from the key window and publish if it changed.
+    /// Cheap enough to call from `onAppear` and on layout/selection changes.
+    func measure() {
+        guard let measured = Self.currentTabBarHeight() else { return }
+        // Ignore obviously-bogus measurements (0 or non-finite): keep the last
+        // good value rather than collapsing the mini-player onto the tab bar.
+        guard measured.isFinite, measured > 1 else { return }
+        if abs(measured - tabBarHeight) > 0.5 {
+            tabBarHeight = measured
+        }
+    }
+
+    /// Finds the frontmost `UITabBar` in the key window's view hierarchy and
+    /// returns its height, or `nil` if none is mounted yet.
+    static func currentTabBarHeight() -> CGFloat? {
+        let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+        guard let root = keyWindow?.rootViewController else { return nil }
+        guard let tabBar = firstTabBar(in: root.view) else { return nil }
+        return tabBar.frame.height
+    }
+
+    /// Depth-first search for the first `UITabBar` in a view subtree.
+    private static func firstTabBar(in view: UIView) -> UITabBar? {
+        if let tabBar = view as? UITabBar { return tabBar }
+        for subview in view.subviews {
+            if let found = firstTabBar(in: subview) { return found }
+        }
+        return nil
+    }
+}

--- a/Palace/CatalogUI/Views/ContinueRowSection.swift
+++ b/Palace/CatalogUI/Views/ContinueRowSection.swift
@@ -128,7 +128,11 @@ private struct ContinueSingleItemRow: View {
                         Text(typeLabel)
                             .font(.caption)
                     }
-                    .foregroundStyle(Color.accentColor)
+                    // Content-type indicator (play/pause glyph + "Audiobook"/
+                    // "Ebook") is metadata, not an accent affordance — style it as
+                    // muted secondary text (grouped with the author line above) so
+                    // it doesn't pick up the ambient tint and render blue.
+                    .foregroundStyle(.secondary)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Palace/MyBooks/MyBooks/MyBooksView.swift
+++ b/Palace/MyBooks/MyBooks/MyBooksView.swift
@@ -255,18 +255,35 @@ struct MyBooksView: View {
     }
 
     private var emptyView: some View {
-        ContentUnavailableView {
-            // Icon intentionally removed for now (was `systemImage: "books.vertical"`,
-            // added in #1203/PP-4747). Copy unchanged — a plain title `Text`
-            // renders the same words without the SF Symbol above them.
-            Text(DisplayStrings.emptyViewTitle)
-        } description: {
-            Text(DisplayStrings.emptyViewMessage)
-        } actions: {
-            Button(DisplayStrings.browseCatalog) {
-                appContainer.tabRouterHub.navigate(to: .catalog)
+        // The CTA is rendered OUTSIDE `ContentUnavailableView` (below its title +
+        // description) rather than in its `actions:` slot: that slot styles
+        // buttons as plain tinted text links, so the button read as a bare link.
+        // It uses the app's standard filled-CTA style — an explicit `Color.blue`
+        // capsule with white text (matching the catalog "Reload" button,
+        // `CatalogView.swift`) rather than `.borderedProminent`, which the app
+        // doesn't use elsewhere and which would inherit the tab bar's neutral
+        // tint. Explicit `Color.blue` keeps it brand-consistent regardless of tint.
+        VStack(spacing: 20) {
+            ContentUnavailableView {
+                // Icon intentionally removed for now (was `systemImage:
+                // "books.vertical"`, added in #1203/PP-4747). Copy unchanged — a
+                // plain title `Text` renders the same words without the SF Symbol.
+                Text(DisplayStrings.emptyViewTitle)
+            } description: {
+                Text(DisplayStrings.emptyViewMessage)
             }
-            .buttonStyle(.borderedProminent)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Button {
+                appContainer.tabRouterHub.navigate(to: .catalog)
+            } label: {
+                Text(DisplayStrings.browseCatalog)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 12)
+                    .background(Color.blue)
+                    .foregroundStyle(.white)
+                    .cornerRadius(8)
+            }
         }
         .transition(.opacity)
         .accessibilityIdentifier(AccessibilityID.MyBooks.emptyStateView)

--- a/PalaceTests/AppInfrastructure/TabBarModernizationTests.swift
+++ b/PalaceTests/AppInfrastructure/TabBarModernizationTests.swift
@@ -126,14 +126,20 @@ final class TabBarModernizationTests: XCTestCase {
                        "unmeasured observer must report the 49pt default, not 0")
     }
 
-    /// `measure()` in a headless test has no key window → no `UITabBar` → the
-    /// published height must stay at the seeded default (best-effort read never
-    /// corrupts the value). Kills a mutant that writes 0 when no bar is found.
+    /// `measure()` is a best-effort read: it updates to a real mounted tab-bar
+    /// height when one exists and otherwise keeps the last good value — it must
+    /// NEVER corrupt the published height to a bogus 0 / non-finite value, which
+    /// would collapse the mini-player onto the bar. Kills the mutant that writes
+    /// 0 when no valid bar is found (the `guard measured > 1 else { return }`
+    /// bogus-guard). The XCTest host mounts a real tab bar, so this also confirms
+    /// measure() picks up a plausible height rather than leaving a stale seed.
     @MainActor
-    func test_tabBarHeightObserver_measureWithNoWindow_keepsDefault() {
+    func test_tabBarHeightObserver_measure_neverCorruptsToBogusHeight() {
         let observer = TabBarHeightObserver()
         observer.measure()
-        XCTAssertEqual(observer.tabBarHeight, TabBarModern.defaultTabBarHeight, accuracy: 0.001,
-                       "measure() with no mounted tab bar must keep the last good value")
+        XCTAssertTrue(observer.tabBarHeight.isFinite,
+                      "measured height must stay finite")
+        XCTAssertGreaterThan(observer.tabBarHeight, 1,
+                             "measure() must keep a valid positive height (the default or a real bar), never collapse to ~0")
     }
 }

--- a/PalaceTests/AppInfrastructure/TabBarModernizationTests.swift
+++ b/PalaceTests/AppInfrastructure/TabBarModernizationTests.swift
@@ -6,10 +6,9 @@
 //  refresh (`TabBarModern` + `TabBarHeightObserver` in
 //  `Palace/AppInfrastructure/TabBarModernization.swift`):
 //
-//    - the brand-tint fix (selected tab must be Palace blue #0090C4, NOT the
-//      SwiftUI default system blue that the missing AccentColor asset caused),
-//    - the mini-player bottom-inset math (must track the LIVE tab-bar height and
-//      clamp bogus measurements so the floating card never desyncs / flies off),
+//    - the mini-player bottom-inset math (must track the LIVE tab-bar height,
+//      not double-count the home-indicator safe area, and clamp bogus
+//      measurements so the floating card never desyncs / flies off),
 //    - the iOS 26 minimize-behavior gate (pin the bar while a mini-player is up).
 //
 //  Copyright © 2026 The Palace Project. All rights reserved.
@@ -23,9 +22,10 @@ final class TabBarModernizationTests: XCTestCase {
 
     // MARK: - Mini-player bottom inset
 
-    /// The nominal case: inset = safeArea + measured bar height + margin. Kills
-    /// the `+` → `-` mutant (would place the card below the bar) and any mutant
-    /// that drops one of the three terms.
+    /// The unmeasured fallback: with only the 49pt bar-only seed, the full
+    /// height is reconstructed as safeArea + default bar + margin. Kills the
+    /// `+` → `-` mutant (would place the card below the bar) and any mutant that
+    /// drops one of the three terms.
     func test_miniPlayerBottomInset_sumsSafeAreaBarAndMargin() {
         let inset = TabBarModern.miniPlayerBottomInset(
             safeAreaBottom: 34,
@@ -35,14 +35,24 @@ final class TabBarModernizationTests: XCTestCase {
         XCTAssertEqual(inset, 34 + 49 + 8, accuracy: 0.001)
     }
 
-    /// A DYNAMIC (minimized) bar height must flow straight through so the card
-    /// tracks the shrinking bar — proves the value is not hardcoded to 49.
-    func test_miniPlayerBottomInset_tracksDynamicBarHeight() {
-        let tall = TabBarModern.miniPlayerBottomInset(safeAreaBottom: 34, tabBarHeight: 49, margin: 8)
-        let minimized = TabBarModern.miniPlayerBottomInset(safeAreaBottom: 34, tabBarHeight: 24, margin: 8)
-        XCTAssertEqual(minimized, 34 + 24 + 8, accuracy: 0.001)
-        XCTAssertLessThan(minimized, tall,
-                          "a shorter (minimized) bar must yield a smaller inset — the card follows the bar down")
+    /// A live `UITabBar.frame.height` measurement ALREADY includes the bottom
+    /// safe-area inset (the bar draws into the home-indicator region), so it must
+    /// flow straight through as `height + margin` — NOT have the safe area added
+    /// a second time. Adding it again floated the card ~34pt too high above the
+    /// bar (the double-count bug). A taller measured bar must also yield a taller
+    /// inset so the card keeps tracking the real bar. Kills a mutant that
+    /// re-introduces the `safe +` term.
+    func test_miniPlayerBottomInset_fullFrameMeasurement_doesNotDoubleCountSafeArea() {
+        // 83 = 49pt bar + 34pt home indicator — the real measured frame height.
+        let inset = TabBarModern.miniPlayerBottomInset(safeAreaBottom: 34, tabBarHeight: 83, margin: 8)
+        XCTAssertEqual(inset, 83 + 8, accuracy: 0.001,
+                       "a full-frame measurement must pass through as height+margin, not add the 34pt safe area again")
+        XCTAssertNotEqual(inset, 34 + 83 + 8, accuracy: 0.001,
+                          "must NOT double-count the safe area — that is the too-high bug this fixes")
+
+        let taller = TabBarModern.miniPlayerBottomInset(safeAreaBottom: 34, tabBarHeight: 100, margin: 8)
+        XCTAssertGreaterThan(taller, inset,
+                             "a taller measured bar yields a taller inset — the card tracks the real bar")
     }
 
     /// A bogus (zero / non-finite) measurement must fall back to the default

--- a/PalaceTests/AppInfrastructure/TabBarModernizationTests.swift
+++ b/PalaceTests/AppInfrastructure/TabBarModernizationTests.swift
@@ -21,36 +21,6 @@ import SwiftUI
 
 final class TabBarModernizationTests: XCTestCase {
 
-    // MARK: - Brand tint (latent-bug fix)
-
-    /// The resolved tab tint MUST be the Palace brand blue #0090C4
-    /// (rgb 0, 144, 196), i.e. `TPPConfiguration.accentColor()` — NOT the
-    /// SwiftUI default system blue that `Color.accentColor` fell back to because
-    /// the app ships no AccentColor asset. Kills a regression that reverts the
-    /// tint source back to `Color.accentColor`.
-    func test_brandTint_resolvesToPalaceBrandBlue_notSystemBlue() {
-        let (r, g, b, a) = TabBarModern.brandTintRGBA
-
-        XCTAssertEqual(r, 0.0 / 255.0, accuracy: 0.001, "red channel must be 0")
-        XCTAssertEqual(g, 144.0 / 255.0, accuracy: 0.001, "green channel must be 144")
-        XCTAssertEqual(b, 196.0 / 255.0, accuracy: 0.001, "blue channel must be 196 (#0090C4)")
-        XCTAssertEqual(a, 1.0, accuracy: 0.001, "alpha must be opaque")
-    }
-
-    /// Guard against silent drift toward the iOS default system blue (#007AFF ≈
-    /// rgb 0, 122, 255). The brand blue's green (144) and blue (196) differ from
-    /// the system blue's (122 / 255), so this pins the two apart — if someone
-    /// re-points the tint at `Color.accentColor`, the green/blue channels move.
-    func test_brandTint_isDistinctFromSystemDefaultBlue() {
-        let (_, g, b, _) = TabBarModern.brandTintRGBA
-        let systemBlueGreen = 122.0 / 255.0
-        let systemBlueBlue = 255.0 / 255.0
-        XCTAssertNotEqual(g, systemBlueGreen, accuracy: 0.01,
-                          "brand green (144) must not equal system-blue green (122)")
-        XCTAssertNotEqual(b, systemBlueBlue, accuracy: 0.01,
-                          "brand blue (196) must not equal system-blue blue (255)")
-    }
-
     // MARK: - Mini-player bottom inset
 
     /// The nominal case: inset = safeArea + measured bar height + margin. Kills

--- a/PalaceTests/AppInfrastructure/TabBarModernizationTests.swift
+++ b/PalaceTests/AppInfrastructure/TabBarModernizationTests.swift
@@ -1,0 +1,139 @@
+//
+//  TabBarModernizationTests.swift
+//  PalaceTests
+//
+//  Unit tests for the extracted, testable decisions behind the modern tab-bar
+//  refresh (`TabBarModern` + `TabBarHeightObserver` in
+//  `Palace/AppInfrastructure/TabBarModernization.swift`):
+//
+//    - the brand-tint fix (selected tab must be Palace blue #0090C4, NOT the
+//      SwiftUI default system blue that the missing AccentColor asset caused),
+//    - the mini-player bottom-inset math (must track the LIVE tab-bar height and
+//      clamp bogus measurements so the floating card never desyncs / flies off),
+//    - the iOS 26 minimize-behavior gate (pin the bar while a mini-player is up).
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+@testable import Palace
+
+final class TabBarModernizationTests: XCTestCase {
+
+    // MARK: - Brand tint (latent-bug fix)
+
+    /// The resolved tab tint MUST be the Palace brand blue #0090C4
+    /// (rgb 0, 144, 196), i.e. `TPPConfiguration.accentColor()` — NOT the
+    /// SwiftUI default system blue that `Color.accentColor` fell back to because
+    /// the app ships no AccentColor asset. Kills a regression that reverts the
+    /// tint source back to `Color.accentColor`.
+    func test_brandTint_resolvesToPalaceBrandBlue_notSystemBlue() {
+        let (r, g, b, a) = TabBarModern.brandTintRGBA
+
+        XCTAssertEqual(r, 0.0 / 255.0, accuracy: 0.001, "red channel must be 0")
+        XCTAssertEqual(g, 144.0 / 255.0, accuracy: 0.001, "green channel must be 144")
+        XCTAssertEqual(b, 196.0 / 255.0, accuracy: 0.001, "blue channel must be 196 (#0090C4)")
+        XCTAssertEqual(a, 1.0, accuracy: 0.001, "alpha must be opaque")
+    }
+
+    /// Guard against silent drift toward the iOS default system blue (#007AFF ≈
+    /// rgb 0, 122, 255). The brand blue's green (144) and blue (196) differ from
+    /// the system blue's (122 / 255), so this pins the two apart — if someone
+    /// re-points the tint at `Color.accentColor`, the green/blue channels move.
+    func test_brandTint_isDistinctFromSystemDefaultBlue() {
+        let (_, g, b, _) = TabBarModern.brandTintRGBA
+        let systemBlueGreen = 122.0 / 255.0
+        let systemBlueBlue = 255.0 / 255.0
+        XCTAssertNotEqual(g, systemBlueGreen, accuracy: 0.01,
+                          "brand green (144) must not equal system-blue green (122)")
+        XCTAssertNotEqual(b, systemBlueBlue, accuracy: 0.01,
+                          "brand blue (196) must not equal system-blue blue (255)")
+    }
+
+    // MARK: - Mini-player bottom inset
+
+    /// The nominal case: inset = safeArea + measured bar height + margin. Kills
+    /// the `+` → `-` mutant (would place the card below the bar) and any mutant
+    /// that drops one of the three terms.
+    func test_miniPlayerBottomInset_sumsSafeAreaBarAndMargin() {
+        let inset = TabBarModern.miniPlayerBottomInset(
+            safeAreaBottom: 34,
+            tabBarHeight: 49,
+            margin: 8
+        )
+        XCTAssertEqual(inset, 34 + 49 + 8, accuracy: 0.001)
+    }
+
+    /// A DYNAMIC (minimized) bar height must flow straight through so the card
+    /// tracks the shrinking bar — proves the value is not hardcoded to 49.
+    func test_miniPlayerBottomInset_tracksDynamicBarHeight() {
+        let tall = TabBarModern.miniPlayerBottomInset(safeAreaBottom: 34, tabBarHeight: 49, margin: 8)
+        let minimized = TabBarModern.miniPlayerBottomInset(safeAreaBottom: 34, tabBarHeight: 24, margin: 8)
+        XCTAssertEqual(minimized, 34 + 24 + 8, accuracy: 0.001)
+        XCTAssertLessThan(minimized, tall,
+                          "a shorter (minimized) bar must yield a smaller inset — the card follows the bar down")
+    }
+
+    /// A bogus (zero / non-finite) measurement must fall back to the default
+    /// height, never to 0 — otherwise the card would collapse onto the tab bar.
+    /// Kills a mutant that drops the `tabBarHeight > 0` guard.
+    func test_miniPlayerBottomInset_bogusBarHeight_fallsBackToDefault() {
+        let zero = TabBarModern.miniPlayerBottomInset(safeAreaBottom: 34, tabBarHeight: 0, margin: 8)
+        XCTAssertEqual(zero, 34 + TabBarModern.defaultTabBarHeight + 8, accuracy: 0.001,
+                       "a 0 measurement must use the default bar height, not collapse to the bar")
+
+        let nan = TabBarModern.miniPlayerBottomInset(safeAreaBottom: 34, tabBarHeight: .nan, margin: 8)
+        XCTAssertEqual(nan, 34 + TabBarModern.defaultTabBarHeight + 8, accuracy: 0.001,
+                       "a non-finite measurement must use the default bar height")
+    }
+
+    /// A negative safe-area inset (garbage from a torn-down window) must clamp
+    /// to 0, never subtract — otherwise the card would ride up over content.
+    func test_miniPlayerBottomInset_negativeSafeArea_clampsToZero() {
+        let inset = TabBarModern.miniPlayerBottomInset(safeAreaBottom: -20, tabBarHeight: 49, margin: 8)
+        XCTAssertEqual(inset, 0 + 49 + 8, accuracy: 0.001,
+                       "a negative safe-area must clamp to 0, not reduce the inset")
+    }
+
+    // MARK: - iOS 26 minimize-behavior gate
+
+    /// With an active mini-player the bar MUST be pinned (minimize disabled) so
+    /// it can't minimize out from under the floating card. Kills the `!` → ``
+    /// mutant (which would enable minimize during playback — the exact desync
+    /// the gate exists to prevent).
+    func test_shouldEnableTabBarMinimize_miniPlayerActive_returnsFalse() {
+        XCTAssertFalse(TabBarModern.shouldEnableTabBarMinimize(miniPlayerActive: true),
+                       "an active mini-player must PIN the bar (minimize disabled)")
+    }
+
+    /// With no mini-player, minimize-on-scroll is free to run — there is no
+    /// floating card to desync.
+    func test_shouldEnableTabBarMinimize_noMiniPlayer_returnsTrue() {
+        XCTAssertTrue(TabBarModern.shouldEnableTabBarMinimize(miniPlayerActive: false),
+                      "with no mini-player the bar may minimize on scroll")
+    }
+
+    // MARK: - TabBarHeightObserver
+
+    /// The observer seeds with the historical default so the first frame (before
+    /// any measurement) positions the card exactly where the old hardcoded path
+    /// did. Kills a mutant that seeds it to 0.
+    @MainActor
+    func test_tabBarHeightObserver_seedsWithHistoricalDefault() {
+        let observer = TabBarHeightObserver()
+        XCTAssertEqual(observer.tabBarHeight, TabBarModern.defaultTabBarHeight, accuracy: 0.001,
+                       "unmeasured observer must report the 49pt default, not 0")
+    }
+
+    /// `measure()` in a headless test has no key window → no `UITabBar` → the
+    /// published height must stay at the seeded default (best-effort read never
+    /// corrupts the value). Kills a mutant that writes 0 when no bar is found.
+    @MainActor
+    func test_tabBarHeightObserver_measureWithNoWindow_keepsDefault() {
+        let observer = TabBarHeightObserver()
+        observer.measure()
+        XCTAssertEqual(observer.tabBarHeight, TabBarModern.defaultTabBarHeight, accuracy: 0.001,
+                       "measure() with no mounted tab bar must keep the last good value")
+    }
+}


### PR DESCRIPTION
## What changed

Modernizes the main app tab bar and closes out two product-review follow-ups, with the audiobook mini-player kept correctly glued to the (now-modern) bar.

**Tab bar**
- Adopts the typed **iOS-18 `Tab(value:)`** builder, with the classic `.tabItem`+`.tag` builder retained below iOS 18 — both route through one shared `TabViewChrome` modifier so the two paths can't drift.
- **iOS-26 Liquid-Glass minimize-on-scroll** (`.tabBarMinimizeBehavior`), gated OFF while an audiobook mini-player is up so the bar can't minimize out from under the floating card.
- Explicit tab-bar **material** below iOS 26; glass owns the chrome on 26.
- Selection **haptic** (Reduce-Motion/preference-gated).

**Monochrome selected tab (bar-only)**
- The selected tab reads `.primary` (black in light / white in dark) instead of the default system-blue accent. Because `.tint` is hierarchical, monochrome is scoped back to the bar via `.tabContentTint()` on each tab root — so the **search icon, links, and in-content controls stay blue** (matching the app's filled `Color.blue` CTAs).

**Mini-player position fix**
- The collapsed mini-player floated ~34pt too high: `UITabBar.frame.height` already includes the home-indicator safe area, but `miniPlayerBottomInset` was adding `safeAreaBottom` again. Fixed to treat a real full-frame measurement as the complete offset (no double-count); the card now sits just above the bar. `TabBarModernizationTests` pins the no-double-count invariant.

**Empty My Books CTA**
- "Browse the Catalog" moved out of `ContentUnavailableView`'s actions slot (which renders a bare text link) into an explicit `Color.blue` filled capsule, matching the catalog "Reload" button.

## Verification
- `TabBarModernizationTests` — 8/8 green; the inset double-count fix is mutation-verified (kills the `safe +` mutant).
- Pre-push gate: `AppTabHostViewBadgeCountTests`, `AudiobookMorphingPlayerViewTests`, `FacetEnumTests`, `TabBarModernizationTests` green.
- **On-sim (DoD #12), light + dark:** selected tab monochrome; search icon + "More…" links blue; collapsed mini-player sits just above the bar; expanded player follows system appearance (no forced-dark flip); empty-My-Books CTA renders as a blue filled capsule.
- Independent **architect + qa** review — both APPROVE (critical-path Audiobooks touch is the mini-player inset plumbing only; no change to playback/session lifecycle).

## Critical path
Touches `Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift` (Audiobooks) — limited to the minimized card's bottom-inset source. Reviewed under critical-path rigor (architect `rev_c2b7f4a1` + qa_test `rev_9e5d3b08`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)