### PR TITLE
Make ios-core safe + clean for outside contributors (clean-clone hooks + slim CLAUDE.md + surface gate)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/hooks/session-start.sh",
+            "command": "[ -e scripts/hooks/session-start.sh ] || exit 0; bash scripts/hooks/session-start.sh",
             "timeout": 45,
             "statusMessage": "Loading governance requirements..."
           }
@@ -19,19 +19,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/hooks/pre-destructive-check.sh",
+            "command": "[ -e scripts/hooks/pre-destructive-check.sh ] || exit 0; bash scripts/hooks/pre-destructive-check.sh",
             "timeout": 5,
             "statusMessage": "Checking active swarms..."
           },
           {
             "type": "command",
-            "command": "bash scripts/hooks/pre-commit-check.sh",
+            "command": "[ -e scripts/hooks/pre-commit-check.sh ] || exit 0; bash scripts/hooks/pre-commit-check.sh",
             "timeout": 10,
             "statusMessage": "Checking ForgeOS changeset..."
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command // empty' | grep -q 'gh pr create' && bash scripts/forgeos-gate-hook.sh || true",
+            "command": "jq -r '.tool_input.command // empty' | grep -q 'gh pr create' && [ -n \"${FORGEOS_API_URL:-}\" ] && [ -e scripts/forgeos-gate-hook.sh ] && bash scripts/forgeos-gate-hook.sh || true",
             "timeout": 30,
             "statusMessage": "Checking ForgeOS gates for PR..."
           }
@@ -42,31 +42,31 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/hooks/clean-code-check.sh",
+            "command": "[ -e scripts/hooks/clean-code-check.sh ] || exit 0; bash scripts/hooks/clean-code-check.sh",
             "timeout": 15,
             "statusMessage": "Clean-code (git commit only)..."
           },
           {
             "type": "command",
-            "command": "bash scripts/hooks/pre-public-surface-drift.sh",
+            "command": "[ -e scripts/hooks/pre-public-surface-drift.sh ] || exit 0; bash scripts/hooks/pre-public-surface-drift.sh",
             "timeout": 5,
             "statusMessage": "Checking public-surface drift (PalaceAuth + SPM packages)..."
           },
           {
             "type": "command",
-            "command": "bash scripts/hooks/pre-critical-path-mutation.sh",
+            "command": "[ -e scripts/hooks/pre-critical-path-mutation.sh ] || exit 0; bash scripts/hooks/pre-critical-path-mutation.sh",
             "timeout": 5,
             "statusMessage": "Checking mutation evidence for critical-path changes..."
           },
           {
             "type": "command",
-            "command": "bash scripts/pre-commit-phase35-detectors.sh",
+            "command": "[ -e scripts/pre-commit-phase35-detectors.sh ] || exit 0; bash scripts/pre-commit-phase35-detectors.sh",
             "timeout": 15,
             "statusMessage": "Phase 3.5 class-detectable detectors (6 wall-failure detectors)..."
           },
           {
             "type": "command",
-            "command": "bash scripts/hooks/pre-commit-doc-lifecycle.sh",
+            "command": "[ -e scripts/hooks/pre-commit-doc-lifecycle.sh ] || exit 0; bash scripts/hooks/pre-commit-doc-lifecycle.sh",
             "timeout": 10,
             "statusMessage": "Validating governance doc frontmatter..."
           }
@@ -77,13 +77,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/hooks/pre-push-check.sh",
+            "command": "[ -e scripts/hooks/pre-push-check.sh ] || exit 0; bash scripts/hooks/pre-push-check.sh",
             "timeout": 30,
             "statusMessage": "Pre-push gate (git push only)..."
           },
           {
             "type": "command",
-            "command": "bash scripts/hooks/pre-push-critical-path-review.sh",
+            "command": "[ -e scripts/hooks/pre-push-critical-path-review.sh ] || exit 0; bash scripts/hooks/pre-push-critical-path-review.sh",
             "timeout": 10,
             "statusMessage": "Checking critical-path review evidence (git push only)..."
           }
@@ -94,7 +94,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 scripts/hooks/audit-before-assert.py",
+            "command": "[ -e scripts/hooks/audit-before-assert.py ] || exit 0; python3 scripts/hooks/audit-before-assert.py",
             "timeout": 5,
             "statusMessage": "Auditing factual claims..."
           }
@@ -107,7 +107,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/hooks/session-stop.sh",
+            "command": "[ -e scripts/hooks/session-stop.sh ] || exit 0; bash scripts/hooks/session-stop.sh",
             "statusMessage": "Harness cleanup...",
             "timeout": 5
           }
@@ -120,7 +120,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/hooks/post-pr-retro.sh",
+            "command": "[ -e scripts/hooks/post-pr-retro.sh ] || exit 0; bash scripts/hooks/post-pr-retro.sh",
             "timeout": 5,
             "statusMessage": "Checking for post-PR retro..."
           }


### PR DESCRIPTION
Makes the repo usable and presentable for anyone who clones it **without the maintainer's private local tooling** (the harness / ForgeOS / simdrive / swarm skills). Reported by a contributor whose Claude Code session was non-functional on a clean clone.

Three parts, one theme:

## 1. Clean-clone hook safety (commit 1)
The tracked `.claude/settings.json` wired every Claude Code hook to `scripts/hooks/*`, but `scripts/hooks` is git-ignored (`.gitignore:130`) — on a maintainer machine it's a symlink into a private harness; on a clean clone it doesn't exist, so **every hook fired `No such file or directory`** on session start and on every tool call. Each harness-private hook is now guarded with `[ -e <script> ] || exit 0`:
- clean clone → hooks no-op silently, Claude Code fully functional;
- maintainer machine → hooks run exactly as before, **including blocking exit codes** (verified: present+exit-2 → wrapper exits 2; absent → exit 0).

## 2. Slim contributor-facing CLAUDE.md (commit 2)
`CLAUDE.md` was **557 lines**, ~half of it maintainer-only governance referencing private tooling a contributor can't run (ForgeOS gates, `/swarm`, `/forge-review`, simdrive, the `.forgeos/` apparatus). Trimmed to **299 lines** of universal, tool-independent guidance (architecture, structure, build & test, TDD/test-quality rules, release policy, pbxproj, secrets, CI green-board contract). The maintainer governance moves to the git-ignored `CLAUDE.local.md` (which Claude Code merges over `CLAUDE.md`), so maintainer sessions keep the full ruleset while contributors get a focused iOS-engineering doc. **Nothing is lost.**

## 3. Systemic guard so it can't silently regress (commit 2)
`scripts/check-contributor-surface.py`:
- **Check A** fails CI if `CLAUDE.md` reintroduces private-tooling markers (harness/ForgeOS/simdrive/swarm/`.forgeos/`…); per-line `<!-- leak-ok -->` opt-out.
- **Check B** fails CI if a `.claude/settings.json` hook pointing at the git-ignored `scripts/hooks/` dir is unguarded — locks in part 1.
- 11-test pytest (clean-pass **and** violation-fail for each check); wired into `.github/workflows/tooling-checks.yml`.

## Verification
- Guard semantics proven both directions (block preserved when present; no-op when absent).
- Simulated clean machine: all 14 hook commands exit 0, zero output.
- `11/11` pytest; gate passes on the trimmed tree; gate **fails** on the pre-trim `CLAUDE.md` (10+ leaks) proving it's not a no-op; full `scripts/tests` suite still collects (289 tests).

## Scope
Contributor-facing docs + tooling only — **0 Palace prod LOC**, no Swift/pbxproj changes. Maintainer governance is preserved out-of-tree in `CLAUDE.local.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)