### PR TITLE
docs(claude): slim contributor-facing CLAUDE.md + contributor-surface gate

### DIFF
--- a/.github/workflows/tooling-checks.yml
+++ b/.github/workflows/tooling-checks.yml
@@ -113,3 +113,18 @@ jobs:
           else
             echo "No chaos-replay test — skipping."
           fi
+
+      # 7. Contributor-surface gate (enforced against the tree, not just its
+      #    pytest). Fails the PR if CLAUDE.md reintroduces private maintainer-only
+      #    tooling references (harness/ForgeOS/simdrive/swarm) — those belong in
+      #    the git-ignored CLAUDE.local.md — or if a .claude/settings.json hook
+      #    that points at the git-ignored scripts/hooks/ dir is unguarded (which
+      #    would make a clean clone unusable). Keeps the repo safe + clean for
+      #    outside contributors who don't have the maintainer harness installed.
+      - name: contributor-surface gate
+        run: |
+          if [ -f scripts/check-contributor-surface.py ]; then
+            python3 scripts/check-contributor-surface.py
+          else
+            echo "No contributor-surface gate — skipping."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Library reading app supporting EPUB, PDF, and audiobooks with multiple DRM syste
 
 **Outside contributors:** standard GitHub flow — fork the repo, branch from `develop` (never `main`), open a PR back to `develop` when ready. Tests are mandatory for production changes (see [TDD & Test Quality](#tdd--test-quality--mandatory) below).
 
-**Maintainers** can additionally run through ForgeOS governance gates (changeset → evidence → review → promote). That tooling is in `scripts/forgeos-*.sh` and is exercised via the local-only `.claude/settings.json` PreToolUse hooks — but it is **opt-in**: the commit/push hooks `exit 0` early unless `FORGEOS_ENABLED=1` (and a shell `FORGEOS_API_KEY`) are set, so by default nothing is required and nothing is sent to the ForgeOS API. Outside contributors can ignore those scripts; they no-op gracefully without an API key. Note the `mcp__forgeos__*` MCP tools are a *separate* path that stays authenticated even when the hooks are off — calling them sends changeset/evidence/review metadata to `forgeos-api.synctek.io`, so only invoke them when you actually intend that.
+**Maintainers** run additional local review/governance tooling wired through git hooks and Claude Code settings. It is **opt-in and self-disabling** — the hooks no-op cleanly for anyone who doesn't have that tooling installed, so outside contributors can ignore it entirely: nothing extra is required to build, test, or open a PR.
 
 **Pre-PR self-check (anyone):** `scripts/verify-pr.sh --quick` runs the full battery — build, tests, lint, coverage, accessibility — against the iPhone 16 Pro simulator. JSON report optional: `--report /tmp/v.json`.
 
@@ -233,9 +233,6 @@ python3 scripts/palace_mutate.py \
   --tests PalaceTests/ChangedFileTests
 
 # Diff-scoped: only mutate lines this PR changes vs origin/develop.
-# Useful when a file has pre-existing low-coverage areas you don't want
-# to be punished for — kill rate reflects YOUR PR's coverage, not the
-# whole file's history. Cache-keyed independently from whole-file runs.
 python3 scripts/palace_mutate.py \
   --file Palace/Path/ChangedFile.swift \
   --tests PalaceTests/ChangedFileTests \
@@ -257,157 +254,6 @@ A test that doesn't kill any mutants should be rewritten to test the actual beha
 
 **Critical path tests must be air-tight.** For sign-in, borrow, download, DRM fulfillment, and payment flows: every branch must have a test, every error path must be exercised, and every test must kill at least one mutant. These paths handle user money and access — fluff is not acceptable here.
 
-## Definition of Done — paste evidence before declaring work complete
-
-<!-- audit-verified -->
-Per `.forgeos/wall-failures/` (lessons from PR #1018 reviewer-blocked findings + the swarm_c8fcab76 arch1 fake-wiring-test finding), every non-trivial work item — solo-agent or swarm — must pass these 11 self-checks BEFORE declaring READY or opening a PR. Paste the evidence in the commit body, the swarm transcript, or the user-facing summary. **Without evidence, the work is not done; it is "implemented but unverified."**
-
-1. **SUT instantiation check** — for every test file you added or modified named `<SUT>Tests.swift` (e.g. `BookReturnServiceTests.swift`, `TPPNetworkResponderAuthCoordinatorTests.swift`), run `grep -c "<SUT>(" <test-file>`. The count must be ≥ 1. If you wrote a `BookReturnServiceAuthCoordinatorTests` that never constructs a `BookReturnService`, the test is theater — rewrite or rename. Catches PR #1018 qa2/qa3 (fake-test-instantiation).
-
-   **Method-level extension (added wave 4 / cs_9a267b63 escalation):** For each test METHOD whose name embeds a PascalCase production-class noun (e.g. `testX_TPPReauthenticatorPath_invokesY` embeds `TPPReauthenticator` and `Y`), the same test method's body must call `TPPReauthenticator(...)` (instantiation) or `TPPReauthenticator.method(...)` (static call) or have an explicit type annotation `: TPPReauthenticator`. Verify mechanically with:
-
-   ```bash
-   python3 scripts/check-test-name-vs-body.py PalaceTests/<your-modified-file>.swift
-   ```
-
-   A non-zero exit means the test name embeds a noun the body doesn't reference. Fake-wiring tests of this shape have escaped into the codebase twice (cs_847892e8 arch1 + cs_9a267b63 arch1) and the runnable script is the structural fix that makes the pattern impossible to land. The same script is wired into `.claude/skills/swarm/SKILL.md` Phase 4.5 check 5b so the orchestrator gates all diffed test files automatically.
-
-2. **Function-result usage check** — for every new production-code call to a function added or contracted-in, paste evidence the result is used (bound via `let outcome = ...`, pattern-matched, returned, or has a `// TODO(ticket): result intentionally discarded because <reason>` comment). `grep -E "= <fnName>\(|let _ = <fnName>" <prod-file>`. Catches PR #1018 arch3 (dishonest migration — classifier called but outcome only logged).
-
-3. **Multi-step test body check** — for every test name containing `across`, `twice`, `reset`, `retry`, `again`, `roundtrip`, `inProduction`, `viaX`: confirm the body literally does each step the name claims. A test named `testCoordinator_perBookCircuitBreaker_isStillHonored_acrossTwoSeparateAttempts` MUST drive two attempts; if the second-attempt half is in comments, the test is fluff. Catches PR #1018 qa1 (half-done test) and arch2 (fake wiring test).
-
-4. **Scope coverage audit** — for every item in the original task (or contract, in swarm mode), confirm it's in your diff OR explicitly listed as a deferred scope item via the scope-deferral protocol below. Don't bury reductions in a gaps section while claiming done. Catches PR #1018 Module C scope-reduction.
-
-5. **Mutation pass (MANDATORY for critical paths)** — run `python3 scripts/palace_mutate.py --file <modified-file> --tests <test-class> --diff-only` for every modified production file in a critical path (`Palace/Audiobooks/`, `Palace/SignInLogic/`, `Palace/MyBooks/Download*`, `Palace/Packages/PalaceAuth/`, anything touching auth/borrow/return/DRM/credentials). Paste the kill rate. Must be ≥ 50% diff-scoped, ideally 100% on the touched lines. Catches PR #1018 qa1 (mutation deferred to integrator → half-done test shipped).
-
-6. **Build + verify-pr** — `xcodebuild ... build` clean and `scripts/verify-pr.sh --quick` PASS. Paste the tails.
-
-7. **Multi-step / wiring-claim check (v2):** for every test name claiming to exercise a multi-step path through production code, line-coverage report must show non-zero hits on the cited lines from that test. Catches `.forgeos/wall-failures/2026-05-28-cs847892e8-arch1.md` — the "fake wiring test" pattern where `openAudiobook(...)` mock-books fail in the loader before `bind() → startPlaybackAndSyncPosition()` ever runs, so the cited production lines (e.g. `AudiobookSessionManager.swift:684-710`) get zero coverage from the test claiming to exercise them. Without coverage evidence on the cited lines, the "multi-step production-seam test" claim is unverified — treat it as a check #3 failure.
-
-8. **Contract reconciliation** — for non-trivial work (≥10 prod LOC), every "removes X" / "deletes X" / "migrates Y to Z" / "renames X to Y" / "adds field A to type B" claim in your commit body, PR body, or `.forgeos/intent/<name>.md` must reconcile against the staged diff. Run `python3 scripts/check-contract-reconciliation.py --commit-msg <file>` — exit 0 means all claims supported. Catches cluster pattern from waves 1-4. Paste exit code.
-
-9. **Blast-radius check** — for ANY commit, run `python3 scripts/check-blast-radius.py --quiet`. Exit 0 means no new public API surface, no `#if DEBUG` on production paths, no test-only AppContainer init params, no discarded function results without `// TODO(ticket):` justification. High-severity findings block. Paste exit code.
-
-10. **Adjacency staleness check** — for ANY commit removing/renaming a production type, run `python3 scripts/check-adjacency-staleness.py --quiet`. Warn-only. Paste output.
-
-11. **Test-pairing check (superpartner spectrum)** — for ANY commit, run `python3 scripts/check-superpartner-spectrum.py --quiet`. Flags new functions, enum cases, and state changes that have no matching test in the diff. Add a test that references the item, or mark it intentional with `// no-superpartner: <reason>`. Warn-only for now (promotion path in `docs/architecture/superpartner-spectrum.md`); high-severity findings are on critical paths and should be cleared, not ignored. This is the fast "is there a test at all?" floor — mutation testing (`palace_mutate.py`, check #5) remains the proof that the test catches bugs. Paste exit code.
-
-12. **simdrive AC-verification (UI stories — MANDATORY when the ACs are visual)** — for any story whose acceptance criteria describe something a patron *sees or taps* (a new/changed screen, row, dialog, sheet, button, state, copy, or navigation), the ACs are NOT verified until they are verified **on a sim**. Unit tests prove the decision logic; they do not prove the pixels. Build the branch, install on a booted sim, and drive the changed surface with simdrive to **each** state the ACs describe — the new state **and** the unchanged (no-regression) states — reading the rendered screenshots (not just OCR) in BOTH light and dark; for accessibility ACs, confirm the trait/label (e.g. `.isLink` present/absent, VoiceOver static-text vs button) via the a11y tree. Paste the observation (screenshot refs + per-AC pass/fail) on the PR and ticket. If an AC state needs data a live catalog won't reliably produce (e.g. PP-4775's "series name but no series URL"), add a controlled fixture / debug toggle so the state is reachable — an un-reachable state is an un-verifiable AC, which is a DoD gap, not a pass. Pure-logic / infra / non-visual changes are exempt. Full protocol: the simdrive section's "simdrive AC-verification for UI stories" standing practice.
-
-If you cannot produce evidence for all 12 checks applicable to your change, do NOT report READY. Either complete the missing check OR explicitly STOP with a scope-deferral proposal (below) so the user can decide.
-
-## Scope-deferral protocol — STOP, do not partial-ship
-
-If you discover you cannot complete the original scope within your time/context budget, **STOP and propose scope reduction explicitly** — do not silently ship partial work. The right response is:
-
-```
-BLOCKED: scope reduction proposal.
-
-Original scope: <N> sites / files / tests.
-I can land cleanly: <M>.
-Remaining <N - M> have <specific reason — entangled state-machine cleanup,
-unrecoverable test-fixture dependency, time budget exhausted>.
-
-Options for the user/orchestrator:
-  (a) extend my pass with more budget
-  (b) accept the reduction; track remaining as next-sprint scope
-  (c) split into <K> smaller passes
-
-I will not ship partial as READY without explicit direction.
-```
-
-Burying scope reductions in a "gaps" / "deferred" / "follow-up" section while claiming READY is the failure mode this protocol prevents. The decision point is the user's, not yours. This applies to single-agent work AND swarm implementers.
-
-Canonical bad pattern (PR #1018 Module C): "Migrated 2 of 7 contracted sites. READY FOR INTEGRATION (partial). Remaining 5 have entangled cleanup — see gaps." → forced an unplanned continuation pass. Correct response would have been BLOCKED with the 3-option proposal up front.
-
-## Risk-driven rigor bar
-
-The "swarm vs single-agent" decision is based on module count (≥2 modules = swarm). The "how much rigor" decision is **risk-based, not size-based**. A 30-LOC change to `BookReturnService` (critical-path return flow) gets the same rigor as a 500-LOC multi-module refactor — because the consequences of a bug are the same regardless of LOC.
-
-**Critical paths requiring architect + SoD review regardless of LOC count:**
-- `Palace/SignInLogic/`, `Palace/Packages/PalaceAuth/` — auth, sign-in, credential storage
-- `Palace/MyBooks/Borrow*`, `Palace/MyBooks/BookReturn*`, `Palace/MyBooks/Download*` — borrow / return / download / DRM fulfillment
-- `Palace/Audiobooks/` — audiobook playback (toolkit fragile per memory)
-- `Palace/Migrations/` — anything touching persistence schema
-- `Palace/Network/TPPNetworkResponder.swift`, `Palace/Network/TPPNetworkExecutor.swift` — the auth-error decision point
-
-For single-module work in a critical path, use the `/rigorous-fix` skill (or `/swarm --solo`) — runs architect + SoD review without parallel implementers. For 1-LOC trivial fixes in a critical path, still run `/forge-review` after coding. The bar is: *if a regression here would hit users, the review must happen.*
-
-For non-critical paths under 50 LOC, single-agent + `/clean-code` (which now includes the skeptic-pass greps) is sufficient.
-
-**Auth-error host scoping (added 2026-06-05 per wall-failure `2026-06-05-pr1018-icarus-cross-host-logout.md`):** any 401 / credentials-stale decision must be scoped to the current account's auth-surface host. A 401 from a non-account host is never an account session expiry. Reviewers BLOCK any auth-error decision path that does not provably consult a current-account host set — base-domain matching (`URLResponse.isSameDomain`) is insufficient when multiple library backends share a base domain (true for every `*.palaceproject.io` library). The canonical mechanism is `Account.authSurfaceHosts` exposed via `AuthErrorClassifier.currentAccountHostsProvider` (the classifier returns `.ok` on a foreign-host 401), with parallel inline guards at the two legacy sibling sites `Palace/MyBooks/TokenRefreshInterceptor.swift` and `Palace/MyBooks/DownloadAuthRetryHandler.swift`. Property-fuzz Invariant 8 in `AuthErrorClassifierPropertyTests` enforces this structurally.
-
-## Architect reviewer canon
-
-For structural review — new abstractions, type-hierarchy changes, protocol surfaces, concurrency model shifts — consult [`.forgeos/reviewer-refs/architect-swift-canon.md`](./.forgeos/reviewer-refs/architect-swift-canon.md) as a **lens, not a checklist**. It covers Swift-native architecture defaults (POP, value semantics, structured concurrency), SOLID translated to Swift mechanisms, a GoF → Swift-idiom translation table (with anti-translations called out), and a smell vocabulary the architect can cite in findings.
-
-The canon and the [wall-failures catalog](./.forgeos/wall-failures/) are complements: the canon is *what good Swift architecture looks like*; the wall-failures are *what we've actually shipped that broke*. When they agree, the finding is strong. When they disagree, **trust the wall-failures** — they're real incidents from this codebase.
-
-Skip the canon for mechanical changes (renames, formatting, dependency bumps) where structure isn't the question. Do not pattern-match findings to canon entries to seem rigorous — approval still requires a real reason; rejection still requires a concrete failure mode.
-
-## Wall-failure catalog — every reviewer block becomes a permanent improvement
-
-When a reviewer BLOCKS a PR (whether via `/forge-review` or external code review), the finding is a **system bug**, not just an implementer bug. The system let it through; the wall has a hole. Per `.forgeos/wall-failures/README.md`:
-
-1. Within 24h of the block, create an entry at `.forgeos/wall-failures/YYYY-MM-DD-pr<NNNN>-<short-id>.md` using `TEMPLATE.md`.
-2. Classify which wall(s) should have caught it (contract / implementer / TDD / mutation / verify-pr / orchestrator / reviewer / hook).
-3. Propose a permanent fix — a contract clause, orchestrator check, implementer constraint, hook addition, CLAUDE.md edit — that makes the finding **structurally impossible to land**, not "more likely to be noticed."
-4. Within 1 week, apply the fix; link the commit back from the entry; update `INDEX.md` and `derived-improvements.md`.
-
-This is how the system gets less leaky over time. Without it, the same finding class can recur next swarm.
-
-**State-machine wiring tests must exercise round-trips, not just transitions.** Any code that drives a state machine (e.g. `_setState`, `setState`, reducer-action dispatches, accessor setters that write a terminal state) gets a test class that proves the **full lifecycle**, not just individual transitions. Required cycles:
-
-- **Write → reset → re-enter.** If a write can be undone (manually, via re-entry, or by a later setter call), a single test must drive the value through the cycle via the **production seam** (the public setter / driver function), not via direct `_setState` shortcuts. Direct shortcut writes prove the storage works; they don't prove the wiring works.
-- **Enum cases reused with two meanings get an explicit semantics test.** When a terminal case (e.g. `.detailsFailed(.accountNotFound)`) is written for both "real failure" and "eviction marker," there must be a test that pins each meaning and a third test that proves they're correctly disambiguated by downstream consumers. If you can't pin them separately, the enum needs to split.
-- **Consumer-side smoke test.** For every readiness gate (`awaitReady()`-style) that has ≥2 production consumers, write one test that drives the gate through a real consumer call site (audiobook open, token refresh, bookmark sync, CarPlay auth) after a non-trivial scenario (cold launch, library swap, sign-out/back-in). Unit-level transition tests are necessary but not sufficient — they prove the gate moves; the consumer test proves the gate is *useful*.
-- **User-action → registry-state cycle for new content types (added 2026-06-03 per PP-4161 wall-failure).** For every new `TPPBookContentType` case, add an integration-style test that drives `BookDetailViewModel.handleAction(for: .get)` (or the cell-side equivalent `BookCellModel.callDelegate(for: .get)`) AND asserts the book reaches the expected `BookButtonState` for that content type via the production seam — NOT via `bookRegistry.setState(...)` direct shortcuts. Direct shortcut writes prove the storage works; they don't prove the user-action → display wiring works. **PP-4161 took two layered escalations (v2.2 hotfix attempt + Wave 4 Path X) to catch this because Module C unit tests pinned `BookButtonState.downloadNeeded + .streamingHTML → [.readStreaming, .return]` without proving any production path could transition the registry to `.downloadNeeded` for streaming-HTML books.** The architect Phase 1a SKILL.md check #5 (call-graph completeness) is the upstream gate; this rule is the downstream test requirement.
-
-Reviewer checklist: when a PR adds a `case .Foo:` to a state-machine switch, ask "where's the test that proves we can recover from being IN `.Foo`?" When a PR adds a setter that writes a terminal state, ask "where's the test that proves the round-trip A→B→A works through this setter, not through `_setState` directly?" When a PR adds a new `TPPBookContentType` case, ask "where's the test that drives `handleAction(.get)` for that content type and asserts the book ends up in the right `BookButtonState` via the production path?"
-
-Canonical reference for the round-trip pattern: `PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift`, Test 7 (`testDriveCurrentAccountAuthDoc_staleAccountNotFoundMarker_redrives`).
-
-## pbxproj
-
-Two build phases (two targets) — new source files need entries in both Sources sections.
-
-**Don't hand-edit `Palace.xcodeproj/project.pbxproj`.** Use the helper:
-
-```bash
-ruby scripts/pbxproj_add_swift.rb [--targets Palace,Palace-noDRM] [--group <path>] FILE [FILE ...]
-```
-
-It's idempotent, auto-routes test files (`PalaceTests/...`) to the `PalaceTests` target, and adds all 6 entries (PBXBuildFile×N, PBXFileReference, PBXGroup membership, PBXSourcesBuildPhase×N) cleanly via the `xcodeproj` Ruby gem.
-
-## Multi-module orchestration — /swarm
-
-For changes that touch ≥2 top-level modules (e.g. SPM extractions, cross-module features, refactors with cross-target API changes), use the `/swarm` skill (`.claude/skills/swarm/SKILL.md`). It runs a triage→dispatch→integrate→promote loop: an architect agent identifies modules and writes contract deltas to `.forgeos/swarms/<id>/`; parallel module-implementer subagents land changes against those contracts; `verify-pr.sh` + `forge-review` gate integration. Single-module work and bugfixes <50 LOC stay single-agent — triage overhead exceeds parallelism gain. See [`docs/architecture/swarm-workflow.md`](./docs/architecture/swarm-workflow.md) for rationale and decision log.
-
-Module contracts under `.forgeos/contracts/<module>.json` are emitted by `scripts/export-module-contracts.py` and consumed by the architect; `verify-pr.sh` calls `--check` to flag PRs that change a module's public surface without contract update.
-
-## Mutation testing
-
-**Local-only as of 2026-05-15** — mutation runs are part of the **regression workflow** (`/regression` skill) and the pre-release self-check, not CI. macOS GitHub-hosted runners bill at $0.08/min; on a cold first-touch PR with 16+ changed production files, mutation walltime is 90–120 min ≈ $7–10 per push. We pay that once locally, before tag-cut, instead of every push to every PR. The mutation-on-pr.yml + mutation-gate.yml workflows were removed for this reason (commit history preserved if you need to revive them).
-
-```bash
-# Default — full battery sans mutation, fast (~5 min):
-scripts/verify-pr.sh --quick
-
-# Pre-release: add mutation gate (cache reuses across runs):
-scripts/verify-pr.sh --quick --enforce-mutations
-
-# Mutation-only for a single file (used by /regression skill):
-python3 scripts/palace_mutate.py \
-  --file Palace/Path/ChangedFile.swift \
-  --tests PalaceTests/ChangedFileTests
-```
-
-Mutation results cache to `.forgeos/mutation-cache/` keyed by file SHA + test selection. Repeat runs on unchanged files are near-instant (<1s vs minutes). `verify-pr.sh --enforce-mutations` makes the 50% kill-rate threshold strict for ALL changed files. Default mode keeps strict-only on critical paths: `Palace/Audiobooks/`, `Palace/SignInLogic/`, `Palace/MyBooks/Download*`.
-
-The mutation engine itself (`scripts/palace_mutate.py`) skips mutation points inside `Log.{trace,debug,info,warn,error}` / `print` / `NSLog` / `os_log` / `Logger` call lines — those flip a string interpolation but don't change observable behavior, so they were silently deflating every file's kill rate. AudiobookLoader.swift went from 9 discovered mutants (7 log-noise, 2 real, 0% kill rate) to 6 real mutants (6/6 = 100% kill rate) after the skip rule landed.
-
-Test-class resolution for changed production files goes through `scripts/resolve-tests-for.py` — it maps `Palace/Foo/Bar.swift` → `PalaceTests/<XCTestCaseClass>` selectors by scanning `PalaceTests/**/*Tests*.swift` filenames and extracting class declarations (an optional `TPP` prefix is stripped so `TPPLCPClient.swift` resolves to `LCPClientTests`). If a production file has no resolvable tests it is skipped with a logged warning — that warning is a signal the file is uncovered and should get tests.
-
 ## Contract-snapshot tests
 
 Some critical-path classes are easier to pin behaviorally than to mutation-test: state machines that emit ordered sequences of dependency calls (BorrowOperation → fetchBook then startDownload; BookReturnService → setProcessing → setState → removeBook → announce.returnSucceeded). For these we lock the *call order + argument shape* as a JSON snapshot — refactors that change the contract drift the snapshot and fail the test loudly.
@@ -426,6 +272,18 @@ Some critical-path classes are easier to pin behaviorally than to mutation-test:
 
 **Pattern:** instantiate the class under test with spy dependencies that record into a `CallLog`, drive the scenario, call `ContractSnapshot.assert(log, named: "scenarioName")`. Production-code seams that block deterministic exercise (static singletons inside the SUT) get documented as inline comments rather than worked around — the inability to write the test IS the test feedback.
 
+## pbxproj
+
+Two build phases (two targets) — new source files need entries in both Sources sections.
+
+**Don't hand-edit `Palace.xcodeproj/project.pbxproj`.** Use the helper:
+
+```bash
+ruby scripts/pbxproj_add_swift.rb [--targets Palace,Palace-noDRM] [--group <path>] FILE [FILE ...]
+```
+
+It's idempotent, auto-routes test files (`PalaceTests/...`) to the `PalaceTests` target, and adds all 6 entries (PBXBuildFile×N, PBXFileReference, PBXGroup membership, PBXSourcesBuildPhase×N) cleanly via the `xcodeproj` Ruby gem.
+
 ## Secrets
 
 Never commit: `APIKeys.swift`, `GoogleService-Info.plist`, `TPPSecrets.swift`, `.env` files.
@@ -438,120 +296,4 @@ per-machine/per-account — provide them via a gitignored `*.local.xcconfig` or 
 secret, never in git (`DEVELOPMENT_TEAM = ""` in the committed pbxproj is fine).
 Enforced by `scripts/check-no-committed-signing.sh` (diff-based; wired into the
 pre-commit hook + `verify-pr.sh` + `tooling-checks.yml`). To intentionally allow an
-entry, add a substring to `.forgeos/committed-signing-allowlist.txt` with a reason.
-
-## E2E / UI sim driving — simdrive
-
-**simdrive is the canonical iOS sim driver.** SpecterQA is **deprecated** as of 2026-04-29 (cutover) and **fully migrated** as of 2026-04-30 (everything moved under `.simdrive/`). The old SpecterQA corpus lives under `.simdrive/_archive/` (do **not** extend). Active flows live under `.simdrive/fixtures/flows/` (declarative, with `expects:` blocks) and `.simdrive/journeys/` (recording-aligned, paired with `~/.simdrive/recordings/`). Per-version visual baselines live under `.simdrive/fixtures/baselines/<version>/<flow>/<step>.{json,png}`.
-
-**Why:** simdrive uses real CoreSimulator HID input + a vision-first OCR loop; it sees pixels, not the XCTest accessibility tree. This unblocks Reader2 (Readium 3.x WKWebView is invisible to XCTest), iOS-26 UITextField focus, OAuth/SAML out-of-process Safari sheets, and OS-level alerts — all places SpecterQA failed silently or required workarounds.
-
-**MCP server:** `simdrive` (Python pkg). Surface: `session_start`, `session_end`, `session_status`, `observe`, `tap`, `swipe`, `type_text`, `press_key`, `record_start`, `record_stop`, `replay`, `logs`.
-
-### simdrive AC-verification for UI stories — MANDATORY, automatic
-
-Distinct from the *chaos* pass below (which hunts for NEW bugs), every
-**user-facing UI story** — one whose acceptance criteria describe something a
-patron sees or taps — gets a **simdrive AC-verification pass before the PR is
-marked done**. Not optional, not size-gated: if the ACs are visual, the proof
-must be visual, on a sim. This is DoD check #12. Unit tests prove the decision
-logic; simdrive proves the pixels the patron actually gets.
-
-The pass:
-1. Build the branch, install on a booted sim.
-2. Drive the changed surface with simdrive to **each** state the ACs describe —
-   the new state AND the unchanged (no-regression) states.
-3. **Read the rendered screenshots** (not just OCR marks) in BOTH light and dark
-   appearance; for accessibility ACs, confirm the trait/label (`.isLink`,
-   VoiceOver static-text vs button, etc.) via the a11y tree.
-4. Record the observation — screenshot refs + a per-AC pass/fail line — on the
-   PR and the ticket.
-
-**Fixture requirement.** If an AC state depends on data a live catalog won't
-reliably produce (e.g. PP-4775's "series name present but no series URL" →
-plain-text state), add a controlled fixture / debug toggle so the state is
-reachable deterministically, and record it under `.simdrive/fixtures/flows/`.
-An AC state you cannot reach on the sim is an AC you cannot verify — treat it as
-a DoD gap, not a pass.
-
-**Build note.** The shared checkout's `ios-audiobooktoolkit` submodule can drift
-to a non-`develop` commit (a persistent `M ios-audiobooktoolkit` dirty pointer).
-Run `git submodule update --init ios-audiobooktoolkit` to sync it to the
-branch-pinned commit BEFORE building, or the app fails to compile against
-`AudiobookPlaybackModel` / `AudiobookSessionPresenter` with spurious
-"inaccessible / no member" errors that have nothing to do with your change.
-
-### Local chaos pass for risk-bearing UI changes — standing practice
-
-**Any PR that adds or changes a user-facing SwiftUI/UIKit surface (dialog, sheet,
-overlay, new screen, routing between them) gets a local `chaos-qa` agent pass —
-driven live on the sim — BEFORE the PR opens.** Run it against the built candidate
-with the feature reachable (debug toggles are fine), and **read the rendered
-screenshots**, not just OCR marks. This is advisory, human-triaged, zero-infra —
-it caught both the dark-mode white-on-white button and the dismiss tap-bleed-through
-on the app-rating gate (Epic PP-4086) that unit tests and OCR assertions missed.
-
-Why *local* + *advisory*, not a blocking CI gate: live chaos is **non-deterministic
-by design** (it hunts for new bugs via vision + timing-sensitive input). As a
-blocking gate it would flake — and a usually-red-from-flakes board violates the
-green-board contract above (it trains everyone to ignore CI). So the split is
-deliberate:
-
-- **`chaos-replay-on-pr.yml`** — deterministic curated replays; the *blocking* gate
-  (dormant until a self-hosted `[macos, palace-ios]` runner + `ENABLE_CHAOS_QA_RUNNER=true`).
-- **`chaos-qa-on-demand.yml`** / **local `chaos-qa` agent** — live exploration;
-  *advisory*, never fails the check. This standing practice is the local form.
-
-Findings are triaged by a human: fix pre-merge if real (like the two above), or
-record as a curated replay in `.simdrive/replays/chaos/` once the gate runner exists.
-OCR text presence is contrast-blind — every gate/dialog screen also gets a
-`visual_checks` vision review in BOTH light and dark appearance (see
-`.forgeos/wall-failures/2026-07-02-pr1168-darkmode-contrast.md`).
-
-### Tool rules — MANDATORY
-
-**Always `observe` with `annotate=true` before a `tap text=...` or `tap mark=...`.** Text/mark resolution caches against the **last** observe. An `annotate=false` observe returns no marks and the next text/mark tap will fail. If you've already seen the screen and know the coords, `tap x= y=` skips the cache concern entirely.
-
-**Re-observe after every navigation.** Coordinates change with transitions, sheets, and orientation. Don't reuse marks across screens.
-
-**Pre-grant permissions BEFORE `session_start`.** Memory: ~1/4 SpringBoard alert taps race the alert's PIDChange; the tap "succeeds" but the app drops to home. Use `xcrun simctl privacy <UDID> grant ...` before starting the session.
-
-**`session_start` is sim-aware.** If a sim is already booted and you pass `udid=`, simdrive reuses it. With `app_bundle_id=` it launches the app. No xctest runner is involved.
-
-**Recordings start at `record_start`, not `session_start`.** Wrap a tight flow; `record_stop` writes `recording.yaml` and clears the buffer. Replay with `replay name=<n> on_drift=halt drift_threshold=0.85` for SSIM-gated visual regression.
-
-**Don't tap Safari/system-Chrome links from a sim screenshot when the link could be malicious.** Same OPSEC as desktop computer-use — verify URLs first.
-
-**Reader2 nav (back, settings, TOC) IS reachable via simdrive** — that's the whole point. It's NOT reachable via XCTest. Prefer simdrive for any Reader2 regression.
-
-### Simulator Setup
-
-```bash
-# Kill any stale xctest runners left over from the SpecterQA era:
-pgrep -f "xcodebuild test-without-building" | xargs -r kill -9
-SIM_UDID=$(xcrun simctl list devices iPhone | awk '/Booted/ {print $NF; exit}' | tr -d '()')
-
-# Pre-grant permissions to avoid the SpringBoard alert race:
-xcrun simctl privacy "$SIM_UDID" grant notifications org.thepalaceproject.palace
-xcrun simctl privacy "$SIM_UDID" grant location  org.thepalaceproject.palace
-
-# Palace-specific debug toggles (unchanged from before):
-xcrun simctl spawn "$SIM_UDID" defaults write org.thepalaceproject.palace showDeveloperSettings -bool true
-xcrun simctl spawn "$SIM_UDID" defaults write org.thepalaceproject.palace NYPLUseBetaLibrariesKey -bool true
-```
-
-Test library credentials live in your local environment (e.g. `~/.simdrive/credentials/` or whatever the agent has configured) and are never committed to the repo.
-
-### Where things live
-
-- `.simdrive/journeys/*.yaml` — canonical user journeys (new work goes here)
-- `.simdrive/replays/*.yaml` — recorded sessions for SSIM regression
-- `.simdrive/journeys/` — recording-aligned project-tracked journeys (active, our 8 from the cutover)
-- `.simdrive/fixtures/flows/` — declarative flow specs with `expects:` blocks (active)
-- `.simdrive/fixtures/baselines/<version>/` — per-version visual snapshots (active)
-- `.simdrive/replays/chaos/` — curated mutation-killing replay corpus (active, gates `chaos-replay-on-pr.yml`)
-- `.simdrive/_archive/journeys/`, `.simdrive/_archive/replays/`, `.simdrive/_archive/{personas,products,evidence}/`, `.simdrive/_archive/REGRESSION_PLAN.md` — old SpecterQA corpus (do not extend)
-- `~/.simdrive/sessions/<id>/observations/` — per-session screenshots + SoM annotations
-- `scripts/fix-replay-assertions.py`, `scripts/fix-replay-timing.py` — legacy replay-fixup tooling kept for archive-replay; do not author new SpecterQA scripts
-
-When in doubt, run `~/harness/bin/harness simdrive status` to confirm version + active sessions.
+entry, add a substring to the signing allowlist consulted by that script.

--- a/scripts/check-contributor-surface.py
+++ b/scripts/check-contributor-surface.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+r"""
+check-contributor-surface.py — keep the contributor-facing surface clean + safe.
+
+Two independent checks, both aimed at the experience of someone who clones this
+repo WITHOUT the maintainer's private local tooling (the harness, ForgeOS,
+simdrive, the swarm skills). That tooling lives outside the repo on purpose; the
+committed files must not (a) leak references to it into the contributor-facing
+docs, or (b) hard-depend on it at runtime so a clean clone breaks.
+
+    CHECK A — leak guard
+        The contributor-facing doc(s) (default: CLAUDE.md) must not reintroduce
+        references to private, maintainer-only tooling. Those belong in the
+        git-ignored CLAUDE.local.md, not the tracked file every contributor
+        reads. This is what stops CLAUDE.md from slowly re-accreting the
+        governance apparatus we just moved out.
+
+    CHECK B — clean-clone hook safety
+        Every hook command in .claude/settings.json that invokes a script under
+        the git-ignored scripts/hooks/ directory (a per-machine symlink into the
+        private harness, ABSENT on a clean clone) must be guarded so a missing
+        script is a silent no-op. Without the guard, every Claude Code hook fires
+        "No such file or directory" on a clean clone and the tool is unusable.
+        This locks in the fix from the clean-clone-safety PR.
+
+Exit 0 = clean. Exit 1 = violation(s) found (printed with file:line + guidance).
+
+Per-line opt-out for CHECK A: append an HTML comment containing `leak-ok` to the
+offending line (e.g. `... <!-- leak-ok: explains the opt-in boundary -->`). Use
+sparingly and only for a reference that is genuinely safe/necessary for
+contributors to see.
+
+Usage:
+    python3 scripts/check-contributor-surface.py                 # repo defaults
+    python3 scripts/check-contributor-surface.py --docs CLAUDE.md README.md
+    python3 scripts/check-contributor-surface.py --settings path/to/settings.json
+    python3 scripts/check-contributor-surface.py --root /path/to/repo
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# CHECK A denylist: (compiled regex, human label). Case-insensitive. These are
+# markers of private, maintainer-only tooling that a clean clone does not have.
+# Keep this list specific — false positives erode trust in the gate.
+_DENY = [
+    (r"~/harness\b", "harness home path (~/harness)"),
+    (r"\bbin/harness\b", "harness CLI (bin/harness)"),
+    (r"/harness/(?:core|bin|projects)\b", "harness internals path"),
+    (r"\bforgeos\b", "ForgeOS governance tooling"),
+    (r"\bFORGEOS_[A-Z_]+", "ForgeOS env var"),
+    (r"forgeos-api\.synctek", "ForgeOS API host"),
+    (r"\bmcp__forgeos__", "ForgeOS MCP tool"),
+    (r"\bmcp__simdrive__", "simdrive MCP tool"),
+    (r"\bsimdrive\b", "simdrive (private UI-driver tooling)"),
+    (r"\bSpecterQA\b", "SpecterQA (deprecated private tooling)"),
+    (r"(?<![\w-])/(?:swarm|forge-review|rigorous-fix|intent)\b",
+     "private maintainer skill invocation"),
+    (r"\.forgeos/", "private .forgeos/ path"),
+    (r"\.simdrive/", "private .simdrive/ path"),
+]
+_DENY = [(re.compile(pat, re.IGNORECASE), label) for pat, label in _DENY]
+
+_LEAK_OK = re.compile(r"leak-ok", re.IGNORECASE)
+
+# CHECK B: a hook command that references this path prefix depends on a script
+# that is git-ignored (scripts/hooks is a symlink into the harness) and thus
+# absent on a clean clone.
+_GITIGNORED_HOOK_PREFIX = "scripts/hooks/"
+
+# A command is considered guarded if it tolerates the script being absent.
+_GUARD_MARKERS = ("[ -e ", "[ -x ", "[ -f ", "|| exit 0", "|| true")
+
+
+def check_docs(doc_paths: list[Path]) -> list[str]:
+    """CHECK A — private-tooling leak guard over contributor-facing docs."""
+    violations: list[str] = []
+    for path in doc_paths:
+        if not path.exists():
+            continue  # a doc we don't ship is not a leak
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if _LEAK_OK.search(line):
+                continue
+            for pat, label in _DENY:
+                m = pat.search(line)
+                if m:
+                    violations.append(
+                        f"{path}:{lineno}: leaks {label} "
+                        f"(matched {m.group(0)!r})"
+                    )
+                    break  # one finding per line is enough
+    return violations
+
+
+def _iter_hook_commands(settings: dict):
+    """Yield every hook command string in a Claude Code settings.json."""
+    for _event, groups in (settings.get("hooks") or {}).items():
+        for group in groups or []:
+            for hook in group.get("hooks") or []:
+                cmd = hook.get("command")
+                if isinstance(cmd, str):
+                    yield cmd
+
+
+def check_settings(settings_path: Path) -> list[str]:
+    """CHECK B — clean-clone safety of hooks pointing at git-ignored scripts."""
+    if not settings_path.exists():
+        return []
+    try:
+        settings = json.loads(settings_path.read_text())
+    except json.JSONDecodeError as exc:
+        return [f"{settings_path}: not valid JSON ({exc})"]
+
+    violations: list[str] = []
+    for cmd in _iter_hook_commands(settings):
+        if _GITIGNORED_HOOK_PREFIX not in cmd:
+            continue
+        if not any(marker in cmd for marker in _GUARD_MARKERS):
+            violations.append(
+                f"{settings_path}: unguarded hook command depends on "
+                f"git-ignored {_GITIGNORED_HOOK_PREFIX} (breaks a clean clone): "
+                f"{cmd!r}"
+            )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repo root (default: cwd)")
+    parser.add_argument(
+        "--docs", nargs="*", default=None,
+        help="contributor-facing docs to leak-check (default: CLAUDE.md)",
+    )
+    parser.add_argument(
+        "--settings", default=None,
+        help="path to Claude settings.json (default: .claude/settings.json)",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    doc_paths = [root / d for d in (args.docs or ["CLAUDE.md"])]
+    settings_path = (
+        Path(args.settings) if args.settings
+        else root / ".claude" / "settings.json"
+    )
+
+    violations = check_docs(doc_paths) + check_settings(settings_path)
+
+    if violations:
+        print("Contributor-surface check FAILED:\n", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        print(
+            "\nMove maintainer/private-tooling guidance into the git-ignored "
+            "CLAUDE.local.md, guard clean-clone-absent hooks with "
+            "`[ -e <script> ] || exit 0`, or append `<!-- leak-ok -->` to a "
+            "doc line that is intentionally safe to expose.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Contributor-surface check passed: no private-tooling leaks, "
+          "all clean-clone-absent hooks guarded.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_contributor_surface.py
+++ b/scripts/tests/test_check_contributor_surface.py
@@ -1,0 +1,112 @@
+"""Tests for scripts/check-contributor-surface.py.
+
+Covers both checks in both directions — the clean path must pass (a gate that
+only ever sees a violation can hide a wiring bug that blocks everything) and the
+violation path must fail with a useful message.
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+_MOD_PATH = Path(__file__).resolve().parent.parent / "check-contributor-surface.py"
+_spec = importlib.util.spec_from_file_location("check_contributor_surface", _MOD_PATH)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+# ---- CHECK A: private-tooling leak guard over docs -------------------------
+
+def test_clean_doc_passes(tmp_path):
+    doc = tmp_path / "CLAUDE.md"
+    doc.write_text(
+        "# Palace iOS Core\n"
+        "Run `scripts/verify-pr.sh --quick` before opening a PR.\n"
+        "Architecture lives in docs/architecture/.\n"
+    )
+    assert mod.check_docs([doc]) == []
+
+
+def test_forgeos_reference_is_flagged(tmp_path):
+    doc = tmp_path / "CLAUDE.md"
+    doc.write_text("Run the ForgeOS governance gates before promote.\n")
+    v = mod.check_docs([doc])
+    assert len(v) == 1 and "ForgeOS" in v[0]
+
+
+def test_each_private_marker_is_flagged(tmp_path):
+    doc = tmp_path / "CLAUDE.md"
+    lines = [
+        "see ~/harness/bin for the CLI",
+        "drive it with mcp__simdrive__tap",
+        "use /swarm for multi-module work",
+        "canon lives in .forgeos/reviewer-refs/",
+        "export FORGEOS_API_KEY=xyz",
+        "flows under .simdrive/journeys/",
+        "SpecterQA is deprecated",
+    ]
+    doc.write_text("\n".join(lines) + "\n")
+    # every line trips exactly one finding
+    assert len(mod.check_docs([doc])) == len(lines)
+
+
+def test_leak_ok_marker_suppresses(tmp_path):
+    doc = tmp_path / "CLAUDE.md"
+    doc.write_text(
+        "Contributors without the harness can ignore it. <!-- leak-ok: opt-in boundary -->\n"
+    )
+    assert mod.check_docs([doc]) == []
+
+
+def test_missing_doc_is_not_a_violation(tmp_path):
+    assert mod.check_docs([tmp_path / "does-not-exist.md"]) == []
+
+
+# ---- CHECK B: clean-clone hook safety --------------------------------------
+
+def _write_settings(tmp_path, command):
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps({
+        "hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [
+            {"type": "command", "command": command}
+        ]}]}
+    }))
+    return p
+
+
+def test_guarded_hook_passes(tmp_path):
+    p = _write_settings(
+        tmp_path,
+        "[ -e scripts/hooks/pre-commit-check.sh ] || exit 0; bash scripts/hooks/pre-commit-check.sh",
+    )
+    assert mod.check_settings(p) == []
+
+
+def test_unguarded_hook_is_flagged(tmp_path):
+    p = _write_settings(tmp_path, "bash scripts/hooks/pre-commit-check.sh")
+    v = mod.check_settings(p)
+    assert len(v) == 1 and "scripts/hooks/" in v[0]
+
+
+def test_or_true_counts_as_guarded(tmp_path):
+    p = _write_settings(
+        tmp_path,
+        "jq -r '.x' | grep -q y && bash scripts/hooks/gate.sh || true",
+    )
+    assert mod.check_settings(p) == []
+
+
+def test_non_hooks_dir_command_is_ignored(tmp_path):
+    # a tracked, always-present script (not under scripts/hooks/) needs no guard
+    p = _write_settings(tmp_path, "bash scripts/pre-commit-phase35-detectors.sh")
+    assert mod.check_settings(p) == []
+
+
+def test_missing_settings_is_not_a_violation(tmp_path):
+    assert mod.check_settings(tmp_path / "nope.json") == []
+
+
+def test_invalid_json_is_flagged(tmp_path):
+    p = tmp_path / "settings.json"
+    p.write_text("{not json")
+    v = mod.check_settings(p)
+    assert len(v) == 1 and "not valid JSON" in v[0]


### PR DESCRIPTION
Follow-up to #1256. That PR was **squash-merged with only its first commit** (the `.claude/settings.json` clean-clone guard, now live on develop as `ada99c15`). Its second commit — the slim `CLAUDE.md` + the contributor-surface gate — was orphaned by the squash and never reached develop. This re-lands it.

## What it does
- **Slims `CLAUDE.md` 557 → 299 lines.** Removes maintainer-only governance that references private tooling an outside contributor can't run (ForgeOS, `/swarm`, simdrive, the `.forgeos/` apparatus). Reworded the "Maintainers" paragraph and the signing-allowlist line to drop private tokens. The removed governance is preserved out-of-tree (maintainer-side); nothing shared is lost.
- **Adds `scripts/check-contributor-surface.py`** — a CI gate that fails if `CLAUDE.md` reintroduces private-tooling markers (per-line `<!-- leak-ok -->` opt-out) **or** if a `.claude/settings.json` hook pointing at the git-ignored `scripts/hooks/` dir is unguarded (locks in #1256's clean-clone fix).
- **11-test pytest** (clean-pass and violation-fail for each check) + wired into `.github/workflows/tooling-checks.yml`.

## Verification
- `11/11` pytest pass.
- Gate passes on this branch (slim `CLAUDE.md` + develop's already-guarded `settings.json`); fails on the pre-trim `CLAUDE.md` (10+ leaks) proving it's not a no-op.
- Cherry-picked cleanly onto current develop; no conflicts.

## Scope
Contributor-facing docs + tooling only — **0 Palace prod LOC**, no Swift/pbxproj changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)