### PR TITLE
fix(debug): DebugSettingsForceSkeletons tests gate on the Palace module's DEBUG, not the test target's

### DIFF
--- a/Palace/Settings/Debug/DebugSettings.swift
+++ b/Palace/Settings/Debug/DebugSettings.swift
@@ -52,6 +52,24 @@ final class DebugSettings: @unchecked Sendable {
         #endif
     }
 
+    /// Whether THIS build honors the `PalaceForceSkeletons` override at all —
+    /// `true` in DEBUG (and any build that defines DEBUG, e.g. the Debug-
+    /// configured app the unit tests link against), `false` in release.
+    ///
+    /// Exposed so tests assert `forceSkeletons`' behavior against the *Palace
+    /// module's* compile-time DEBUG (the module the code-under-test lives in),
+    /// NOT the test target's — the `PalaceTests` target intentionally does not
+    /// define `DEBUG` (its `SWIFT_ACTIVE_COMPILATION_CONDITIONS` is
+    /// `LCP FEATURE_OVERDRIVE`), so a `#if DEBUG` written in a test file
+    /// mis-evaluates this gate and diverges from the built app's real behavior.
+    static var honorsForceSkeletonsOverride: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+
     // MARK: - Keys
 
     private enum Keys {

--- a/PalaceTests/Settings/DebugSettingsForceSkeletonsTests.swift
+++ b/PalaceTests/Settings/DebugSettingsForceSkeletonsTests.swift
@@ -35,15 +35,25 @@ final class DebugSettingsForceSkeletonsTests: XCTestCase {
         XCTAssertFalse(DebugSettings.forceSkeletons(in: defaults))
     }
 
-    func testForceSkeletons_whenOverrideKeySet_isTrueInDebug() {
+    // NOTE on the DEBUG gate: `forceSkeletons` compiles in the *Palace* module,
+    // whose Debug config defines DEBUG — so the Debug-built app these tests link
+    // against DOES honor the override. The `PalaceTests` target itself does NOT
+    // define DEBUG (its compilation conditions are `LCP FEATURE_OVERDRIVE`), so a
+    // `#if DEBUG` written here would mis-evaluate and diverge from the app under
+    // test. Gate on `DebugSettings.honorsForceSkeletonsOverride` — the Palace
+    // module's own compile-time truth — so the expectation always matches reality.
+
+    func testForceSkeletons_whenOverrideKeySet_isHonoredPerBuild() {
         defaults.set(true, forKey: "PalaceForceSkeletons")
-        #if DEBUG
-        XCTAssertTrue(DebugSettings.forceSkeletons(in: defaults))
-        #else
-        // Release builds gate the override off entirely — production render
-        // paths must be byte-identical regardless of the key.
-        XCTAssertFalse(DebugSettings.forceSkeletons(in: defaults))
-        #endif
+        if DebugSettings.honorsForceSkeletonsOverride {
+            XCTAssertTrue(DebugSettings.forceSkeletons(in: defaults),
+                          "A build that honors the override must read PalaceForceSkeletons=true as true")
+        } else {
+            // Release builds gate the override off entirely — production render
+            // paths must be byte-identical regardless of the key.
+            XCTAssertFalse(DebugSettings.forceSkeletons(in: defaults),
+                           "A release build must ignore the override and return false")
+        }
     }
 
     /// Mutation guard: pins the exact override key. If the production read
@@ -52,11 +62,12 @@ final class DebugSettingsForceSkeletonsTests: XCTestCase {
         defaults.set(false, forKey: "ForceSkeletons")       // decoy #1
         defaults.set(false, forKey: "PalaceForceSkeleton")  // decoy #2 (singular)
         defaults.set(true, forKey: "PalaceForceSkeletons")  // the real key
-        #if DEBUG
-        XCTAssertTrue(DebugSettings.forceSkeletons(in: defaults))
-        #else
-        XCTAssertFalse(DebugSettings.forceSkeletons(in: defaults))
-        #endif
+        if DebugSettings.honorsForceSkeletonsOverride {
+            XCTAssertTrue(DebugSettings.forceSkeletons(in: defaults),
+                          "Must read the exact key PalaceForceSkeletons, not a decoy")
+        } else {
+            XCTAssertFalse(DebugSettings.forceSkeletons(in: defaults))
+        }
     }
 
     func testForceSkeletons_whenOverrideExplicitlyFalse_isFalse() {


### PR DESCRIPTION
## Problem
Two tests have been **red on develop since PP-4797 (#1249)**:
- `testForceSkeletons_whenOverrideKeySet_isTrueInDebug` (renamed → `_isHonoredPerBuild`)
- `testForceSkeletons_readsExactKey_notADecoy`

## Root cause
They gated on the **PalaceTests target's** `DEBUG` — but that target intentionally does **not** define `DEBUG` (its `SWIFT_ACTIVE_COMPILATION_CONDITIONS` is `LCP FEATURE_OVERDRIVE`, a documented convention the RuntimeQuiescence infra + ~33 other test files rely on). So each test compiled its `#else` branch and asserted `false`, while the **Debug-built Palace app module** (which *does* define `DEBUG`) correctly returned `true` for `PalaceForceSkeletons=true` → assertion mismatch → fail. Production `forceSkeletons` was correct all along; the tests referenced the wrong module's compile flag.

## Fix
- Add `DebugSettings.honorsForceSkeletonsOverride` — the **Palace module's own** compile-time `DEBUG` truth.
- Gate the two tests on that accessor instead of the test target's dead `#if DEBUG`, so the expectation always matches the built-app behavior under any configuration.
- **No** change to the shared build setting (adding `DEBUG` to the test target would flip all ~33 `#if DEBUG` test sites and break the RuntimeQuiescence infra). Scoped to 2 tests + 1 small accessor.

## Verification
`DebugSettingsForceSkeletonsTests` + `DebugSettingsTests` **35/35 green** in isolation; pre-push gate green. Independent of the OverDrive expired-URL work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)