### PR TITLE
fix(audiobook): OverDrive audiobooks recover from expired signed URLs (PP-4800)

### DIFF
--- a/.forgeos/changesets/fix-overdrive-expired-url-refulfill-minus1008/fix-contract.md
+++ b/.forgeos/changesets/fix-overdrive-expired-url-refulfill-minus1008/fix-contract.md
@@ -1,0 +1,63 @@
+# Fix-contract — OverDrive expired signed-URL playback recovery fires on AVPlayer -1008
+
+## Problem (empirically confirmed)
+OverDrive audiobooks stream their tracks from time-limited signed URLs baked into the
+on-disk OverDrive manifest (`links.contentlinks`, ~24h `URLExpirationUTC`). When the
+local track download did NOT complete (large books over background URLSession) OR the
+URLs have since expired, playback falls back to streaming those stale URLs → server
+returns HTTP 410 Gone → AVFoundation surfaces it to the app as `NSURLErrorDomain -1008`
+(NSURLErrorResourceUnavailable) with NO `httpStatusCode` in the error. Symptoms: open
+hangs / "A Problem Has Occurred", and skipping across tracks breaks (each track's URL
+is dead). Real repro captured on device (Moes Max, Mi historia / A1QA), 2026-07-15.
+
+The 3.2.0 recovery `AudiobookSessionManager.shouldTriggerOverdriveRefulfillForPlaybackFailure`
+re-fulfills fresh URLs — but gates on `httpStatusCode(from:error) == 410`, which is
+`nil` for the -1008 shape, so the bounded one-shot re-fulfill NEVER fires in the field.
+
+## Scope (in)
+- File: `Palace/Audiobooks/AudiobookSessionManager.swift`, `#if FEATURE_OVERDRIVE`
+  region (~1981-2021).
+  - Add `isResourceUnavailable(from:) -> Bool` helper: true iff the error is
+    `NSURLErrorDomain` code `NSURLErrorResourceUnavailable` (-1008) at top level, via
+    the flattened `underlyingDomain`/`underlyingCode` userInfo scalars (the
+    `buildPlaybackFailureRecord` shape), or one level down `NSUnderlyingErrorKey`.
+  - `shouldTriggerOverdriveRefulfillForPlaybackFailure`: keep OverDrive-only +
+    !alreadyAttempted guards; return true when `httpStatusCode == 410` **OR**
+    `isResourceUnavailable(error)`.
+- File: `PalaceTests/DRM/OverdriveFulfillmentTests.swift` — add tests for the new shapes.
+
+## Scope (out) — DO NOT touch
+- `httpStatusCode(from:)` — unchanged (410 path preserved).
+- `shouldTriggerSAMLReauthForPlaybackFailure` — sibling; NOT broadened to -1008 (a
+  -1008 on a SAML book must not loop into a revoked session).
+- The proactive "re-fulfill on open before streaming stale URLs" layer — deferred
+  (reactive -1008 recovery already resolves the open-hangup AND skip-break, since both
+  surface as -1008 → trigger the bounded re-fulfill → fresh contentlinks). Documented
+  as a follow-up, not silently dropped.
+- `ios-audiobooktoolkit` submodule — no change (app-side fix only).
+
+## Conservative exclusions (preserved)
+No re-fulfill on: 401/auth, 403 (ambiguous), -1009 (no network), -1001 (timeout), or
+any error with neither a 410 nor a -1008 resource-unavailable signal. One attempt per
+book per session (`alreadyAttempted`).
+
+## Tests required (TDD, red first)
+- `-1008` at top level (domain NSURLErrorDomain) on OverDrive book → true.
+- `-1008` via flattened `underlyingCode`/`underlyingDomain` scalars → true.
+- `-1008` nested in `NSUnderlyingErrorKey` → true.
+- `-1009` (not-connected) on OverDrive book → false (no network is not expiry).
+- `-1001` (timeout) → false.
+- `-1008` but `alreadyAttempted` → false (bounded).
+- `-1008` but non-OverDrive distributor → false.
+- Existing 410 / 403 / 401 / no-status tests stay green (additive change).
+
+## Verification criteria
+- `grep -c "AudiobookSessionManager(" ...` not required (static-method SUT; tests call
+  `AudiobookSessionManager.shouldTriggerOverdriveRefulfillForPlaybackFailure(...)`).
+- New tests fail against current code (return false for -1008), pass after the change.
+- Mutation on the two edited functions ≥ 50% diff-scoped (critical path → aim 100%).
+- Build clean; OverdriveFulfillmentTests green; no existing test regresses.
+
+## Release targeting
+develop (3.3.0) + cherry-pick to `release/3.2.0` (blocker-class OverDrive regression
+present in 3.2.0).

--- a/.forgeos/intent/ws3-overdrive-expired-url-refulfill.md
+++ b/.forgeos/intent/ws3-overdrive-expired-url-refulfill.md
@@ -77,3 +77,45 @@ Cached-manifest-replay fork:
   manifest-persistence path.
 - Tests: `PalaceTests/DRM/OverdriveFulfillmentTests.swift` +
   `AudiobookSessionManager` playback-failed tests.
+
+---
+
+# Follow-up (2026-07-15): recovery fires on AVPlayer -1008 (the real field shape)
+
+branch: `fix/overdrive-expired-url-refulfill-minus1008`
+
+## Context
+
+The 410-only predicate above NEVER fired in the field. OverDrive streams tracks
+through AVFoundation, which collapses the CDN's HTTP 410 (expired signed URL) into
+`NSURLErrorDomain -1008` (NSURLErrorResourceUnavailable) with NO `httpStatusCode`, so
+`httpStatusCode(from:error) == 410` is nil → the bounded re-fulfill never triggered.
+Device repro captured on Moes Max (Mi historia / A1QA staging, 2026-07-15): expired
+`links.contentlinks` → 410 → surfaced as -1008 → dead-ended to "A Problem Has Occurred",
+and skip-across-tracks broke identically (each track's URL dead).
+
+## Claims
+
+- broadens `shouldTriggerOverdriveRefulfillForPlaybackFailure` to also return true on an
+  `NSURLErrorResourceUnavailable` (-1008) signal, IN ADDITION TO the existing 410 path
+- adds `static func isResourceUnavailable(from:)` matching -1008 in three shapes:
+  top-level `NSURLErrorDomain`, the flattened `underlyingCode`/`underlyingDomain` userInfo
+  scalars, and one level down the `NSUnderlyingError` chain
+- adds unit tests in `OverdriveFulfillmentTests.swift` for the three recover shapes plus
+  the negative/guard cases (offline -1009, timeout -1001, already-attempted bound,
+  non-OverDrive distributor, non-URL-domain -1008, nil)
+
+## Anti-claims
+
+- does NOT touch `httpStatusCode(from:)`; the 410 path is byte-preserved
+- does NOT broaden the SAML sibling to -1008 (a -1008 on a SAML book must not loop a
+  revoked session)
+- does NOT re-fulfill on -1009 (offline), -1001 (timeout), 401, or 403; the
+  one-attempt-per-book-per-session bound is preserved
+- does NOT add the proactive re-fulfill-on-open layer (deferred) and does NOT modify the
+  `ios-audiobooktoolkit` submodule (app-side only)
+
+## Files in scope
+
+- `Palace/Audiobooks/AudiobookSessionManager.swift`
+- `PalaceTests/DRM/OverdriveFulfillmentTests.swift`

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -583,7 +583,7 @@ public final class AudiobookSessionManager: ObservableObject {
     ///   instead of replaying the expired on-disk manifest. Internal (not part of
     ///   the public `AudiobookSessionManaging` surface); the public 2-param
     ///   witness above delegates here, and the in-class recovery branch calls it.
-    func openAudiobook(_ book: TPPBook, startPlaying: Bool, forceRefulfill: Bool, isColdLoadRecovery: Bool = false) async -> Result<Void, AudiobookSessionError> {
+    func openAudiobook(_ book: TPPBook, startPlaying: Bool, forceRefulfill: Bool, isColdLoadRecovery: Bool = false, isRecoveryReopen: Bool = false) async -> Result<Void, AudiobookSessionError> {
         Log.info(#file, "Opening audiobook: '\(book.title)' (id: \(book.identifier))\(forceRefulfill ? " [re-fulfill]" : "")\(isColdLoadRecovery ? " [cold-load recovery]" : "")")
         // Polish-phase (in-app-nav-polish-2026-06-01): record wall-clock
         // open time so the Continue Reading row's sort surfaces the real
@@ -605,7 +605,16 @@ public final class AudiobookSessionManager: ObservableObject {
             }
         }
 
-        if case .loading(let loadingId) = state, loadingId == book.identifier {
+        // A recovery re-open (OverDrive re-fulfill / PP-4800) deliberately re-opens
+        // a book whose `state` is still `.loading` — the `.playbackFailed` handler
+        // parks it at `.loading` (not `.error`) so the presenter shows a loading
+        // shell during recovery instead of flashing an error. Without the
+        // `!isRecoveryReopen` bypass this guard would trip on that `.loading` and
+        // silently swallow the re-open (the exact dead-end the recovery fixes),
+        // making success timing-dependent on a follow-on toolkit stop event. The
+        // bypass makes the recovery re-open deterministic; the teardown below still
+        // runs, and `loadGeneration` supersedes any concurrent load.
+        if case .loading(let loadingId) = state, loadingId == book.identifier, !isRecoveryReopen {
             Log.warn(#file, "Audiobook already loading: \(book.identifier)")
             return .failure(.alreadyLoading)
         }
@@ -2157,7 +2166,10 @@ public final class AudiobookSessionManager: ObservableObject {
         guard currentBook?.identifier == id else { return }
         if landed {
             Log.info(#file, "OverDrive re-fulfillment landed a fresh manifest — re-opening '\(book.title)'")
-            _ = await openAudiobook(book, startPlaying: true)
+            // isRecoveryReopen bypasses openAudiobook's `.alreadyLoading` guard —
+            // `state` is still `.loading` from the anti-flash handler. forceRefulfill
+            // stays false so the re-open reads the freshly-refreshed LOCAL manifest.
+            _ = await openAudiobook(book, startPlaying: true, forceRefulfill: false, isRecoveryReopen: true)
         } else {
             Log.info(#file, "OverDrive re-fulfillment did not complete — surfacing unavailable for '\(book.title)'")
             await dismissAndPresentColdLoadUnavailable()
@@ -2178,16 +2190,29 @@ public final class AudiobookSessionManager: ObservableObject {
             try? await Task.sleep(nanoseconds: pollNanos)
             waited += 0.25
             guard currentBook?.identifier == id else { return false }
-            switch bookRegistry.state(for: id) {
-            case .downloadSuccessful, .used:
-                return true
-            case .downloadFailed, .unregistered, .unsupported:
-                return false
-            default:
-                continue
+            if let outcome = Self.overdriveRefulfillOutcome(for: bookRegistry.state(for: id)) {
+                return outcome
             }
         }
         return false
+    }
+
+    /// Pure classification of a registry state during the OverDrive re-fulfill poll:
+    /// `.some(true)` = a fresh manifest landed (stop polling, re-open); `.some(false)`
+    /// = a terminal failure (stop, surface unavailable); `nil` = not yet terminal
+    /// (keep polling). Extracted so the state→outcome mapping is unit-pinned — a
+    /// future edit that adds a terminal state or flips `.downloadFailed` to "landed"
+    /// would otherwise regress the recovery silently (both SoD reviewers flagged
+    /// this seam).
+    static func overdriveRefulfillOutcome(for state: TPPBookState) -> Bool? {
+        switch state {
+        case .downloadSuccessful, .used:
+            return true
+        case .downloadFailed, .unregistered, .unsupported:
+            return false
+        default:
+            return nil
+        }
     }
 #endif
 

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -2001,8 +2001,48 @@ public final class AudiobookSessionManager: ObservableObject {
     ) -> Bool {
         guard !alreadyAttempted, let book else { return false }
         guard book.distributor?.lowercased() == OverdriveDistributorKey.lowercased() else { return false }
-        guard let status = httpStatusCode(from: error) else { return false }
-        return status == 410
+        // A clean HTTP 410 (Gone) is the textbook signed-URL expiry. But the toolkit
+        // streams OverDrive tracks through AVFoundation, which collapses a 410 on a
+        // track fetch into `NSURLErrorDomain -1008` (NSURLErrorResourceUnavailable)
+        // with NO extractable httpStatusCode — so the 410-only gate never actually
+        // fired in the field (device repro: Mi historia / A1QA, 2026-07-15: expired
+        // `links.contentlinks` signed URLs → 410 → surfaced as -1008 → dead-ended to
+        // "A Problem Has Occurred"). Treat that resource-unavailable signal as the
+        // same recoverable expiry a fresh re-fulfill fixes. Still conservative: 401/
+        // 403 arrive as an httpStatusCode (!= 410) and no-network (-1009) / timeout
+        // (-1001) are NOT resource-unavailable, so all fall through to false.
+        if httpStatusCode(from: error) == 410 { return true }
+        return isResourceUnavailable(from: error)
+    }
+
+    /// True iff `error` carries an `NSURLErrorResourceUnavailable` (-1008) signal —
+    /// the AVFoundation manifestation of an expired OverDrive signed-URL 410. Checks
+    /// the top-level error (the raw shape handed to `.playbackFailed`), the flattened
+    /// `underlyingDomain`/`underlyingCode` userInfo scalars stamped by
+    /// `buildPlaybackFailureRecord`, and one level down the `NSUnderlyingError` chain.
+    /// Scoped to -1008 ONLY: -1009 (offline) and -1001 (timeout) are deliberately not
+    /// matched — re-fulfilling into those would just fail again.
+    static func isResourceUnavailable(from error: Error?) -> Bool {
+        guard let nsError = error as NSError? else { return false }
+        func matches(domain: String, code: Int) -> Bool {
+            domain == NSURLErrorDomain && code == NSURLErrorResourceUnavailable
+        }
+        if matches(domain: nsError.domain, code: nsError.code) { return true }
+        // Defensive: the flattened `underlyingDomain`/`underlyingCode` scalars are the
+        // shape `buildPlaybackFailureRecord` produces for the Crashlytics record. That
+        // record is NOT the error handed to this gate at runtime (the raw error is —
+        // caught by the top-level and nested-chain branches), so this branch is
+        // belt-and-suspenders against a future call site that passes the built record.
+        if let underlyingDomain = nsError.userInfo["underlyingDomain"] as? String,
+           let underlyingCode = nsError.userInfo["underlyingCode"] as? Int,
+           matches(domain: underlyingDomain, code: underlyingCode) {
+            return true
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError,
+           matches(domain: underlying.domain, code: underlying.code) {
+            return true
+        }
+        return false
     }
 
     /// Extracts an HTTP status code from a playback error. The toolkit's network

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -2132,6 +2132,65 @@ public final class AudiobookSessionManager: ObservableObject {
         }
     }
 
+#if FEATURE_OVERDRIVE
+    /// PP-4800: recovers an OverDrive audiobook whose on-disk manifest holds
+    /// expired signed URLs (surfaced as AVPlayer -1008). The audiobook loader
+    /// CANNOT re-fulfill OverDrive — its `forceRefulfill` routes to
+    /// `OpenAccessAdapter`, whose generic bearer-token second leg hits OverDrive's
+    /// `downloadlink` WITHOUT the `x-overdrive-scope`/`x-overdrive-patron-
+    /// authorization` headers → 401 (device-confirmed). Only the download path
+    /// (`OverdriveDownloadHandler.processOverdriveDownload`) runs the 302 header
+    /// dance that authorizes fresh URLs. The download center refuses a start for a
+    /// `.downloadSuccessful` book (`DownloadStartCoordinator`: "Ignoring
+    /// nonsensical download request"), so reset to `.downloadNeeded` first, trigger
+    /// the fresh fulfillment, await the registry returning to `.downloadSuccessful`
+    /// (fresh manifest on disk, bounded), then re-open from the fresh LOCAL file.
+    /// Bounded to one attempt/book/session by the caller.
+    private func recoverExpiredOverdriveByRefulfilling(_ book: TPPBook) async {
+        let id = book.identifier
+        // The download center rejects a start for an already-downloaded book, so
+        // mark it needs-download before triggering the fresh OverDrive fulfillment.
+        bookRegistry.setState(.downloadNeeded, for: id)
+        AppContainer.production().downloadCenter.startDownload(for: book, withRequest: nil)
+        let landed = await awaitDownloadSuccessful(id, timeout: 90)
+        // A newer open (user tapped a different book) supersedes this recovery.
+        guard currentBook?.identifier == id else { return }
+        if landed {
+            Log.info(#file, "OverDrive re-fulfillment landed a fresh manifest — re-opening '\(book.title)'")
+            _ = await openAudiobook(book, startPlaying: true)
+        } else {
+            Log.info(#file, "OverDrive re-fulfillment did not complete — surfacing unavailable for '\(book.title)'")
+            await dismissAndPresentColdLoadUnavailable()
+        }
+    }
+
+    /// Polls the registry (on the main actor) for `id` reaching a terminal
+    /// download state after a re-fulfillment: `.downloadSuccessful`/`.used` → true
+    /// (fresh manifest on disk); `.downloadFailed`/`.unregistered`/`.unsupported`
+    /// → false; otherwise keep waiting up to `timeout` seconds. Polling (vs a
+    /// Combine subscription racing a timeout) keeps the whole recovery on the main
+    /// actor with no continuation/`Sendable` hazard, and can't miss an event since
+    /// each tick reads the current state. Bails early if a newer open supersedes.
+    private func awaitDownloadSuccessful(_ id: String, timeout: TimeInterval) async -> Bool {
+        let pollNanos: UInt64 = 250_000_000
+        var waited: TimeInterval = 0
+        while waited < timeout {
+            try? await Task.sleep(nanoseconds: pollNanos)
+            waited += 0.25
+            guard currentBook?.identifier == id else { return false }
+            switch bookRegistry.state(for: id) {
+            case .downloadSuccessful, .used:
+                return true
+            case .downloadFailed, .unregistered, .unsupported:
+                return false
+            default:
+                continue
+            }
+        }
+        return false
+    }
+#endif
+
     private func validateRequirements(for book: TPPBook) async -> AudiobookSessionError? {
         if !(await isUserAuthenticated()) {
             return .notAuthenticated
@@ -2352,23 +2411,29 @@ public final class AudiobookSessionManager: ObservableObject {
             }
 
 #if FEATURE_OVERDRIVE
-            // WS-3 (3.2.0 crash-triage): OverDrive streams from time-limited
-            // signed URLs and has no SAML session to re-auth — an expired URL
-            // (HTTP 410) would otherwise dead-end here as `.unknown`. Re-fulfill
-            // FRESH signed URLs (bypassing the stale on-disk manifest) and
-            // re-open. Bounded to one attempt per session so a persistent
-            // failure cannot loop on this shared handler.
+            // WS-3 (3.2.0 crash-triage / PP-4800): OverDrive streams from
+            // time-limited signed URLs and has no SAML session to re-auth — an
+            // expired URL surfaces here (as AVPlayer -1008 / HTTP 410) and would
+            // otherwise dead-end as `.unknown`. Recover by re-fulfilling FRESH
+            // signed URLs. NOTE: this must route through the DOWNLOAD path, not
+            // the audiobook loader — the loader's `forceRefulfill` sends OverDrive
+            // to `OpenAccessAdapter`, whose generic bearer-token second leg hits
+            // OverDrive's `downloadlink` WITHOUT the `x-overdrive-scope` /
+            // `x-overdrive-patron-authorization` headers → 401 (device-confirmed).
+            // Only `OverdriveDownloadHandler.processOverdriveDownload` runs the 302
+            // header dance that authorizes fresh URLs. Bounded to one attempt per
+            // session so a persistent failure cannot loop on this shared handler.
             if Self.shouldTriggerOverdriveRefulfillForPlaybackFailure(
                 error: error,
                 book: currentBook,
                 alreadyAttempted: overdriveRefulfillAttemptedBookIds.contains(bookId)
             ), let book = currentBook {
-                Log.info(#file, "OverDrive audiobook playback failed on an expired signed URL — re-fulfilling fresh URLs and re-opening")
+                Log.info(#file, "OverDrive audiobook playback failed on an expired signed URL — re-fulfilling via the download center and re-opening")
                 overdriveRefulfillAttemptedBookIds.insert(bookId)
                 Task { [weak self] in
                     guard let self else { return }
                     guard self.currentBook?.identifier == book.identifier else { return }
-                    _ = await self.openAudiobook(book, startPlaying: true, forceRefulfill: true)
+                    await self.recoverExpiredOverdriveByRefulfilling(book)
                 }
                 return
             }

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -2362,7 +2362,31 @@ public final class AudiobookSessionManager: ObservableObject {
 
             Log.error(#file, "Playback failed at position: \(String(describing: position))")
             isPlaying = false
-            state = .error(bookId: bookId, message: "Playback failed")
+
+            // Decide up front whether ANY recovery will be attempted. If one will,
+            // keep the player in a `.loading` (recovering) state so the presenter
+            // shows the loading shell instead of flashing an error dialog that the
+            // recovery then immediately undoes — the error-then-recover flicker
+            // patrons saw on the OverDrive expired-URL path (PP-4800). Only a truly
+            // terminal failure (no recovery applies) publishes `.error`. The
+            // predicates are pure and side-effect-free, so evaluating them here
+            // changes none of the recovery control flow below.
+            let userAccount = accountsManager.currentUserAccount
+            var willRecover = Self.shouldTriggerSAMLReauthForPlaybackFailure(
+                error: error, userAccount: userAccount, currentBook: currentBook)
+#if FEATURE_OVERDRIVE
+            willRecover = willRecover || Self.shouldTriggerOverdriveRefulfillForPlaybackFailure(
+                error: error, book: currentBook,
+                alreadyAttempted: overdriveRefulfillAttemptedBookIds.contains(bookId))
+#endif
+            willRecover = willRecover || Self.shouldAutoReopenOnColdLoadFailure(
+                hasEverStartedPlayback: hasEverStartedPlayback,
+                hasCurrentBook: currentBook != nil,
+                alreadyAttempted: coldLoadReopenAttemptedBookIds.contains(bookId))
+
+            state = willRecover
+                ? .loading(bookId: bookId)
+                : .error(bookId: bookId, message: "Playback failed")
             playbackStatePublisher.send(state)
 
             // Record a Crashlytics non-fatal so audiobook playback failures
@@ -2384,7 +2408,7 @@ public final class AudiobookSessionManager: ObservableObject {
             // the entire path) — but the IdP-specific reauth (`new
             // TPPReauthenticator()` + `markCredentialsStale()`) is
             // collapsed into a single `refreshCredentialsIfNeeded` call.
-            let userAccount = accountsManager.currentUserAccount
+            // (`userAccount` is computed once above for the willRecover check.)
             if Self.shouldTriggerSAMLReauthForPlaybackFailure(error: error, userAccount: userAccount, currentBook: currentBook),
                let book = currentBook {
                 Log.info(#file, "Playback failed with auth-required signal — dispatching through AuthCoordinator")

--- a/PalaceTests/DRM/OverdriveFulfillmentTests.swift
+++ b/PalaceTests/DRM/OverdriveFulfillmentTests.swift
@@ -362,6 +362,107 @@ final class OverdriveFulfillmentTests: XCTestCase {
         XCTAssertNil(AudiobookSessionManager.httpStatusCode(from: playbackError(httpStatus: nil)))
     }
 
+    // MARK: - WS-3b: -1008 resource-unavailable is the REAL field shape of the expiry
+    //
+    // OverDrive streams tracks through AVFoundation, which collapses an expired signed-
+    // URL's HTTP 410 into `NSURLErrorDomain -1008` (NSURLErrorResourceUnavailable) with
+    // NO httpStatusCode. The 410-only gate therefore never fired in the field (device
+    // repro: Mi historia / A1QA, 2026-07-15 — expired `links.contentlinks` → 410 → -1008
+    // → "A Problem Has Occurred", and skip-across-tracks broke identically). These pin
+    // that the three real -1008 shapes now trigger the bounded re-fulfill, while the
+    // non-expiry NSURLErrors (offline, timeout) and the bound/distributor guards hold.
+
+    private func resourceUnavailableTopLevel() -> NSError {
+        NSError(domain: NSURLErrorDomain, code: NSURLErrorResourceUnavailable, userInfo: [:])
+    }
+
+    func testOverdriveRefulfill_resourceUnavailable1008_topLevel_returnsTrue() {
+        XCTAssertTrue(AudiobookSessionManager.shouldTriggerOverdriveRefulfillForPlaybackFailure(
+            error: resourceUnavailableTopLevel(), book: makeOverdriveBook(), alreadyAttempted: false),
+            "AVPlayer surfaces an expired signed-URL 410 as NSURLErrorDomain -1008 — the real field shape must re-fulfill")
+    }
+
+    func testOverdriveRefulfill_resourceUnavailable1008_flattenedScalars_returnsTrue() {
+        // The shape buildPlaybackFailureRecord produces: wrapper domain + flattened scalars.
+        let err = NSError(domain: "org.thepalaceproject.palace.audiobookPlayback", code: -1008,
+                          userInfo: ["underlyingCode": NSURLErrorResourceUnavailable, "underlyingDomain": NSURLErrorDomain])
+        XCTAssertTrue(AudiobookSessionManager.shouldTriggerOverdriveRefulfillForPlaybackFailure(
+            error: err, book: makeOverdriveBook(), alreadyAttempted: false),
+            "The flattened underlyingCode/underlyingDomain -1008 shape must also re-fulfill")
+    }
+
+    func testOverdriveRefulfill_resourceUnavailable1008_nestedUnderlying_returnsTrue() {
+        let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorResourceUnavailable, userInfo: [:])
+        let wrapped = NSError(domain: "av", code: -11800, userInfo: [NSUnderlyingErrorKey: underlying])
+        XCTAssertTrue(AudiobookSessionManager.shouldTriggerOverdriveRefulfillForPlaybackFailure(
+            error: wrapped, book: makeOverdriveBook(), alreadyAttempted: false),
+            "A -1008 one level down the NSUnderlyingError chain must re-fulfill")
+    }
+
+    func testOverdriveRefulfill_notConnected1009_returnsFalse_offlineIsNotExpiry() {
+        let err = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: [:])
+        XCTAssertFalse(AudiobookSessionManager.shouldTriggerOverdriveRefulfillForPlaybackFailure(
+            error: err, book: makeOverdriveBook(), alreadyAttempted: false),
+            "No network (-1009) is not a signed-URL expiry — re-fulfilling would just fail again offline")
+    }
+
+    func testOverdriveRefulfill_timedOut1001_returnsFalse_transientNotExpiry() {
+        let err = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: [:])
+        XCTAssertFalse(AudiobookSessionManager.shouldTriggerOverdriveRefulfillForPlaybackFailure(
+            error: err, book: makeOverdriveBook(), alreadyAttempted: false),
+            "A timeout (-1001) is transient, not an expiry — must NOT re-fulfill")
+    }
+
+    func testOverdriveRefulfill_resourceUnavailable1008_alreadyAttempted_returnsFalse_bounded() {
+        XCTAssertFalse(AudiobookSessionManager.shouldTriggerOverdriveRefulfillForPlaybackFailure(
+            error: resourceUnavailableTopLevel(), book: makeOverdriveBook(), alreadyAttempted: true),
+            "Bounded: a second -1008 in the same session must NOT re-fulfill again (no loop)")
+    }
+
+    func testOverdriveRefulfill_resourceUnavailable1008_notOverdrive_returnsFalse() {
+        let nonOverdrive = TPPBookMocker.mockBook(title: "Not OverDrive")
+        XCTAssertFalse(AudiobookSessionManager.shouldTriggerOverdriveRefulfillForPlaybackFailure(
+            error: resourceUnavailableTopLevel(), book: nonOverdrive, alreadyAttempted: false),
+            "Re-fulfill is OverDrive-only — a -1008 on another distributor must not enter this path")
+    }
+
+    func testIsResourceUnavailable_flattenedScalars_wrongDomain_returnsFalse() {
+        // The flattened branch must honor the same domain scoping as the others: a -1008
+        // code stamped with a NON-NSURLErrorDomain underlyingDomain is not our expiry.
+        // Guards the shared `matches` conjunction on the flattened branch specifically.
+        let wrongDomain = NSError(domain: "org.thepalaceproject.palace.audiobookPlayback", code: -1008,
+                                  userInfo: ["underlyingCode": NSURLErrorResourceUnavailable, "underlyingDomain": "not-a-url-domain"])
+        XCTAssertFalse(AudiobookSessionManager.isResourceUnavailable(from: wrongDomain),
+            "Flattened -1008 with a non-NSURLErrorDomain underlyingDomain must NOT match")
+        let wrongCode = NSError(domain: "org.thepalaceproject.palace.audiobookPlayback", code: -1001,
+                                userInfo: ["underlyingCode": NSURLErrorTimedOut, "underlyingDomain": NSURLErrorDomain])
+        XCTAssertFalse(AudiobookSessionManager.isResourceUnavailable(from: wrongCode),
+            "Flattened underlyingCode -1001 (timeout) must NOT match even on NSURLErrorDomain")
+    }
+
+    func testIsResourceUnavailable_throughBuildPlaybackFailureRecord_stillTriggers() {
+        // Couples the helper to buildPlaybackFailureRecord's actual key names: feed a raw
+        // -1008 through the record builder and assert the produced NSError still trips the
+        // gate. If buildPlaybackFailureRecord renamed underlyingCode/underlyingDomain, the
+        // recovery would silently stop matching the record shape — this catches that drift.
+        let raw = NSError(domain: NSURLErrorDomain, code: NSURLErrorResourceUnavailable, userInfo: [:])
+        let record = AudiobookSessionManager.buildPlaybackFailureRecord(error: raw, position: nil, bookId: "b")
+        XCTAssertTrue(AudiobookSessionManager.isResourceUnavailable(from: record),
+            "The NSError buildPlaybackFailureRecord produces for a -1008 must still be recognized as resource-unavailable")
+    }
+
+    func testIsResourceUnavailable_matchesMinus1008_rejectsOffline_timeout_andNil() {
+        XCTAssertTrue(AudiobookSessionManager.isResourceUnavailable(from: resourceUnavailableTopLevel()))
+        XCTAssertFalse(AudiobookSessionManager.isResourceUnavailable(
+            from: NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: [:])))
+        XCTAssertFalse(AudiobookSessionManager.isResourceUnavailable(
+            from: NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: [:])))
+        XCTAssertFalse(AudiobookSessionManager.isResourceUnavailable(
+            from: NSError(domain: "test.playback", code: -1008, userInfo: [:])),
+            "-1008 must be scoped to NSURLErrorDomain, not any domain that happens to use code -1008")
+        XCTAssertFalse(AudiobookSessionManager.isResourceUnavailable(from: nil))
+    }
+
     // MARK: - WS-3: fresh re-fulfilled URL is CONSUMED into the built audiobook (loader-level)
     //
     // Assertions 2+3 of the recovery proof, at the loader boundary (no session

--- a/PalaceTests/DRM/OverdriveFulfillmentTests.swift
+++ b/PalaceTests/DRM/OverdriveFulfillmentTests.swift
@@ -463,6 +463,31 @@ final class OverdriveFulfillmentTests: XCTestCase {
         XCTAssertFalse(AudiobookSessionManager.isResourceUnavailable(from: nil))
     }
 
+    // MARK: - PP-4800: re-fulfill poll state classification (drives re-open vs unavailable)
+    //
+    // awaitDownloadSuccessful polls the registry after triggering the download-center
+    // re-fulfillment; overdriveRefulfillOutcome is the pure state→outcome mapping it
+    // uses. Pin every TPPBookState so a future edit adding a terminal state or flipping
+    // a case (e.g. .downloadFailed → "landed") can't silently break the recovery.
+
+    func testOverdriveRefulfillOutcome_landed_terminalFailure_and_keepPolling() {
+        // Fresh manifest landed → stop polling, re-open.
+        XCTAssertEqual(AudiobookSessionManager.overdriveRefulfillOutcome(for: .downloadSuccessful), true)
+        XCTAssertEqual(AudiobookSessionManager.overdriveRefulfillOutcome(for: .used), true)
+        // Terminal failure → stop polling, surface unavailable.
+        XCTAssertEqual(AudiobookSessionManager.overdriveRefulfillOutcome(for: .downloadFailed), false,
+                       ".downloadFailed must be a terminal FAILURE, not treated as landed")
+        XCTAssertEqual(AudiobookSessionManager.overdriveRefulfillOutcome(for: .unregistered), false)
+        XCTAssertEqual(AudiobookSessionManager.overdriveRefulfillOutcome(for: .unsupported), false)
+        // Not yet terminal → keep polling (nil).
+        XCTAssertNil(AudiobookSessionManager.overdriveRefulfillOutcome(for: .downloadNeeded),
+                     ".downloadNeeded is the transient reset state — must keep polling, not fail")
+        XCTAssertNil(AudiobookSessionManager.overdriveRefulfillOutcome(for: .downloading))
+        XCTAssertNil(AudiobookSessionManager.overdriveRefulfillOutcome(for: .holding))
+        XCTAssertNil(AudiobookSessionManager.overdriveRefulfillOutcome(for: .returning))
+        XCTAssertNil(AudiobookSessionManager.overdriveRefulfillOutcome(for: .SAMLStarted))
+    }
+
     // MARK: - WS-3: fresh re-fulfilled URL is CONSUMED into the built audiobook (loader-level)
     //
     // Assertions 2+3 of the recovery proof, at the loader boundary (no session


### PR DESCRIPTION
## Problem (PP-4800 / relates to PP-4770)
OverDrive audiobooks stream tracks from ~24h **signed URLs** baked into a cached on-disk manifest. When those URLs expire (loan still valid — production loans run 7–21 days), playback fails as AVPlayer **`-1008`** ("resource unavailable") and the patron gets a "try again" dead-end. **Long-standing gap** — as far back as OverDrive audiobook support (~2020); the app has never re-fulfilled expired URLs. The 3.1.0 telemetry "burst" is instrumentation onset (Crashlytics logging added in the 3.1.0 release commit), not a new failure. Not a 3.2.0 regression → **not a 3.2.0 blocker; fix targets 3.3.0.**

Device-confirmed on Moes Max (Mi historia / A1QA, 2026-07-15). The `-1008` is genuine URL-expiry with a valid loan (the manifest's `URLExpirationUTC` dies ~23h before `contentExpirationUTC`; the recovery re-fulfills successfully, which is only possible on an active loan).

## Fix
1. **Trigger on the real failure shape.** The 3.2.0 recovery gated on HTTP `410`, but the failure reaches the app as AVPlayer `-1008` — so it never fired. Broadened `shouldTriggerOverdriveRefulfillForPlaybackFailure` to also fire on `-1008` (`isResourceUnavailable`: top-level, flattened `underlyingCode/Domain`, nested `NSUnderlyingError`).
2. **Route recovery through the DOWNLOAD path.** The loader's `forceRefulfill` sends OverDrive to `OpenAccessAdapter`, whose generic second-leg hits OverDrive's `downloadlink` without the `x-overdrive-scope`/`patron-authorization` headers → **401**. Only `OverdriveDownloadHandler.processOverdriveDownload` runs the 302 handshake. `recoverExpiredOverdriveByRefulfilling` resets state → `.downloadNeeded` (the download center refuses an already-downloaded book), triggers `startDownload`, polls the registry for `.downloadSuccessful`, then re-opens from the fresh local manifest.
3. **No error flash.** Publish `.loading` (not `.error`) before recovery so the presenter shows a loading shell, not a dialog the recovery undoes.
4. **Deterministic re-open.** `openAudiobook` gains `isRecoveryReopen` to bypass the `.alreadyLoading` guard (which the `.loading` state would otherwise trip, silently swallowing the re-open).

## Testing / review
- OverdriveFulfillmentTests **25/25** green; diff-scoped mutation **100%** on the gate; Palace + Palace-noDRM build clean (recovery is `#if FEATURE_OVERDRIVE`).
- SoD review (advisory, all APPROVE): architect (routing correct, re-open deterministic, no double-load), qa_test (tests mutation-killing, poll state-map pins all 10 `TPPBookState`), blast_radius (no new public API, `.loading` change safe for LCP/Findaway/SAML).
- **Pending pre-release device retest:** a St. Mary's County Library title (12-day loan) for an unambiguous URL-expiry test (A1QA's 24h loans overlap the ~24h URL TTL).

**Follow-ups (non-blocking):** a `RecoveryMode` enum for `openAudiobook`'s params; the mid-recovery `.downloadNeeded` is patron-visible; deeper thread — reduce how often OverDrive downloads stall into streaming (separate ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)