### PR TITLE
ci(tests): parallel testing to break serial-single-process test pollution

### DIFF
--- a/scripts/xcode-test-optimized.sh
+++ b/scripts/xcode-test-optimized.sh
@@ -66,6 +66,16 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
     export SIMCTL_CHILD_CI="${CI:-true}"
     export SIMCTL_CHILD_BUILD_CONTEXT="ci"
 
+    # Execution isolation — test-pollution fix (docs/Testing/test-pollution-investigation-handoff.md).
+    # CI previously ran serial single-process (all ~7k tests in ONE process/singleton-set), which
+    # AMPLIFIES cross-test pollution: an early polluter that aborts mid-teardown leaves a process-global
+    # (suspended queue, active mock scenario, stale registry) broken for thousands of later tests, so a
+    # different, shifting victim set fails every run (AccountsManagerLaunchSnapshot / Borrow* etc.).
+    # Parallel testing spawns simulator CLONES = SEPARATE PROCESSES: global state is per-clone, cross-shard
+    # bleed is impossible, and any leak's blast radius is bounded to one clone's subset. The local path
+    # already runs this way (workers=4) successfully; Xcode merges the clones into the single
+    # TestResults.xcresult so the downstream summary.failed gate is unchanged. Tune via CI_TEST_WORKERS if a
+    # runner has fewer cores (Xcode caps workers to available cores regardless).
     set +e
     xcodebuild test \
         -project Palace.xcodeproj \
@@ -79,7 +89,8 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
         -test-timeouts-enabled YES \
         -default-test-execution-time-allowance 120 \
         -maximum-test-execution-time-allowance 300 \
-        -parallel-testing-enabled NO \
+        -parallel-testing-enabled YES \
+        -maximum-parallel-testing-workers "${CI_TEST_WORKERS:-4}" \
         CODE_SIGNING_REQUIRED=NO \
         CODE_SIGNING_ALLOWED=NO \
         ONLY_ACTIVE_ARCH=YES \


### PR DESCRIPTION
## Break the serial-single-process test pollution via execution isolation

**Problem.** The full-suite CI run flakes 8–13 tests per run, with a **different victim set almost every run** (`AccountsManagerLaunchSnapshotTests`, `Borrow*`, `CatalogViewModelStateMachineTests`, …). Per `docs/Testing/test-pollution-investigation-handoff.md`, these are **victims, not bugs** — each passes in isolation; they only fail under the full ~7,000-test load. Four rounds of correct, SoD-approved targeted leak fixes (PR #1232) did **not** converge the aggregate.

**Root cause.** CI runs **serial single-process** (`-parallel-testing-enabled NO`) — all ~7k tests share one process / one set of global singletons. An early polluter that aborts mid-teardown leaves a process-global broken (suspended queue, active mock scenario, stale registry), and every later test that touches it hangs or corrupts — a different victim thousands of tests downstream each run.

**Fix (handoff's #1 recommendation — execution isolation).** Enable Xcode **parallel testing** on CI: `-parallel-testing-enabled YES -maximum-parallel-testing-workers 4` (tunable via `CI_TEST_WORKERS`). Parallel testing runs the suite across **simulator clones = separate processes**, so:
- global state is **per-clone** — cross-shard bleed is impossible;
- any leak's blast radius is bounded to one clone's subset instead of the whole 7k run;
- the **local** test path already runs exactly this way (workers=4) and is stable.

Xcode merges the clone results into the single `TestResults.xcresult`, so the downstream `summary.failed` gate and retry-as-flake-safety contract are unchanged. One-line-ish change; no test code touched.

### Validation is this PR's CI
This pollution **does not reproduce locally** (only under full CI load), so **CI on this PR is the experiment.** Success = the shifting-victim reds stop (0 genuine failures, or a stable/named small set instead of a moving target). If runner cores are the limiter, drop `CI_TEST_WORKERS` (Xcode caps to available cores regardless).

### Follow-up if this converges
Revive the deferred green-board enforcement gate (commit `041ef99b0` in history) so a genuinely-green suite stays green — the finish line noted in the handoff.

Off-ticket infra fix. No app-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
