### PR TITLE
fix(ci): iOS 17 deployment target in fastlane — unblock release archive/export

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,8 +9,8 @@ platform :ios do
       project: "Palace.xcodeproj",
       devices: ["iPhone 14"],
       scheme: "Palace",
-      destination: "platform=iOS Simulator,name=iPhone 14,OS=16.1",
-      xcargs: "ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO IPHONEOS_DEPLOYMENT_TARGET=16.0"
+      destination: "platform=iOS Simulator,name=iPhone 14,OS=17.0",
+      xcargs: "ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO IPHONEOS_DEPLOYMENT_TARGET=17.0"
     )
   end
 
@@ -25,8 +25,8 @@ platform :ios do
       skip_archive: true,
       skip_codesigning: true,
       sdk: "iphonesimulator",
-      destination: "platform=iOS Simulator,OS=16.1",
-      xcargs: "ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO IPHONEOS_DEPLOYMENT_TARGET=16.0",
+      destination: "platform=iOS Simulator,OS=17.0",
+      xcargs: "ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO IPHONEOS_DEPLOYMENT_TARGET=17.0",
       skip_profile_detection: true,
       silent: true
     )
@@ -58,7 +58,7 @@ platform :ios do
       include_bitcode: false,
       silent: true,
       sdk: "iphoneos",
-      xcargs: "ONLY_ACTIVE_ARCH=NO ARCHS=arm64 IPHONEOS_DEPLOYMENT_TARGET=16.0",
+      xcargs: "ONLY_ACTIVE_ARCH=NO ARCHS=arm64 IPHONEOS_DEPLOYMENT_TARGET=17.0",
       output_name: options[:output_name],
       output_directory: options[:export_path],
       export_method: "ad-hoc",
@@ -86,7 +86,7 @@ platform :ios do
       include_symbols: true,
       include_bitcode: false,
       sdk: "iphoneos",
-      xcargs: "ONLY_ACTIVE_ARCH=NO ARCHS=arm64 IPHONEOS_DEPLOYMENT_TARGET=16.0",
+      xcargs: "ONLY_ACTIVE_ARCH=NO ARCHS=arm64 IPHONEOS_DEPLOYMENT_TARGET=17.0",
       export_method: "app-store",
       export_options: {
         method: "app-store",


### PR DESCRIPTION
## Unblock release archives — align the Fastfile deployment target with the iOS 17 project

**Why the export keeps failing:** the project and the PalaceTriageBot SPM package both target **iOS 17.0**, and the code uses iOS-17-only APIs (e.g. `onChange(of:) { _, _ in }` in `SupportChatView.swift:44`). But all four `fastlane/Fastfile` lanes forced `IPHONEOS_DEPLOYMENT_TARGET=16.0` — a leftover from before the iOS 17 bump. Forcing the Release archive to iOS 16 makes the compiler reject the iOS 17 API:

```
SupportChatView.swift:44: 'onChange(of:initial:_:)' is only available in iOS 17.0 or newer
** ARCHIVE FAILED **
```

→ no binary is produced. That's the failure on the last "Palace Build" run.

**Fix:** bump the forced target `16.0 → 17.0` in all four lanes (test/nodrm/beta/appstore), and the stale iOS 16.1 test/nodrm simulators → 17.0. Ruby syntax verified. The next release archive validates it.

CI config only; no app-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
