### PR TITLE
PP-4712: in-app player reflects + honors the configured skip interval

### DIFF
--- a/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
@@ -47,6 +47,13 @@ struct AudiobookMorphingPlayerView: View {
     /// is exactly the historical hardcoded behavior. See `TabBarModernization`.
     @Environment(\.miniPlayerTabBarInset) private var injectedTabBarInset
 
+    /// PP-4712: the patron's configured skip intervals, read reactively from the
+    /// same UserDefaults keys the settings screen writes — so the transport
+    /// glyphs (`gobackward.N` / `goforward.N`) and their VoiceOver labels reflect
+    /// the current value and update live when it changes in Settings.
+    @AppStorage(AudiobookSkipIntervalSettings.forwardKey) private var skipForwardInterval: Int = AudiobookSkipIntervalSettings.defaultInterval
+    @AppStorage(AudiobookSkipIntervalSettings.backKey) private var skipBackInterval: Int = AudiobookSkipIntervalSettings.defaultInterval
+
     /// Namespace for the cover's `matchedGeometryEffect` — the single element
     /// that morphs between the full and mini layouts.
     @Namespace private var morphNamespace
@@ -492,7 +499,7 @@ struct AudiobookMorphingPlayerView: View {
     /// the system appearance).
     private func transportRow(metrics: ControlMetrics) -> some View {
         HStack(spacing: metrics.transportSpacing) {
-            transportButton("gobackward.30", label: Strings.Generic.skipBack30, size: metrics.skipGlyph) {
+            transportButton("gobackward.\(skipBackInterval)", label: Strings.Generic.skipBackSeconds(skipBackInterval), size: metrics.skipGlyph) {
                 audiobookSession.skipBack()
             }
             Button(action: { audiobookSession.togglePlayPause() }) {
@@ -507,7 +514,7 @@ struct AudiobookMorphingPlayerView: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel(presenter.isPlaying ? Strings.Generic.pauseAudiobook : Strings.Generic.playAudiobook)
-            transportButton("goforward.30", label: Strings.Generic.skipForward30, size: metrics.skipGlyph) {
+            transportButton("goforward.\(skipForwardInterval)", label: Strings.Generic.skipForwardSeconds(skipForwardInterval), size: metrics.skipGlyph) {
                 audiobookSession.skipForward()
             }
         }
@@ -813,12 +820,12 @@ struct AudiobookMorphingPlayerView: View {
                 Spacer(minLength: 2)
 
                 Button(action: { audiobookSession.skipBack() }) {
-                    Image(systemName: "gobackward.30")
+                    Image(systemName: "gobackward.\(skipBackInterval)")
                         .font(.system(size: 18, weight: .regular))
                         .frame(width: 40, height: 44)
                 }
                 .buttonStyle(.plain).tint(.primary)
-                .accessibilityLabel(Strings.Generic.skipBack30)
+                .accessibilityLabel(Strings.Generic.skipBackSeconds(skipBackInterval))
 
                 Button(action: { audiobookSession.togglePlayPause() }) {
                     Image(systemName: presenter.isPlaying ? "pause.fill" : "play.fill")
@@ -830,12 +837,12 @@ struct AudiobookMorphingPlayerView: View {
                 .accessibilityLabel(presenter.isPlaying ? Strings.Generic.pauseAudiobook : Strings.Generic.playAudiobook)
 
                 Button(action: { audiobookSession.skipForward() }) {
-                    Image(systemName: "goforward.30")
+                    Image(systemName: "goforward.\(skipForwardInterval)")
                         .font(.system(size: 18, weight: .regular))
                         .frame(width: 40, height: 44)
                 }
                 .buttonStyle(.plain).tint(.primary)
-                .accessibilityLabel(Strings.Generic.skipForward30)
+                .accessibilityLabel(Strings.Generic.skipForwardSeconds(skipForwardInterval))
 
                 Button(action: stop) {
                     Image(systemName: "xmark.circle.fill")

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -944,10 +944,12 @@ public final class AudiobookSessionManager: ObservableObject {
             Log.warn(#file, "Cannot skipBack — no active manager")
             return
         }
+        // PP-4712: honor the patron's configured back interval (not a fixed 30).
+        let interval = AudiobookSkipIntervalSettings().backTimeInterval
         Task { @MainActor in
-            _ = await manager.audiobook.player.skipPlayhead(-Self.defaultSkipInterval)
+            _ = await manager.audiobook.player.skipPlayhead(-interval)
         }
-        Log.debug(#file, "Skipping back \(Self.defaultSkipInterval)s")
+        Log.debug(#file, "Skipping back \(interval)s")
     }
 
     /// Skips the playhead forward by `defaultSkipInterval` seconds. See
@@ -957,10 +959,12 @@ public final class AudiobookSessionManager: ObservableObject {
             Log.warn(#file, "Cannot skipForward — no active manager")
             return
         }
+        // PP-4712: honor the patron's configured forward interval (not a fixed 30).
+        let interval = AudiobookSkipIntervalSettings().forwardTimeInterval
         Task { @MainActor in
-            _ = await manager.audiobook.player.skipPlayhead(Self.defaultSkipInterval)
+            _ = await manager.audiobook.player.skipPlayhead(interval)
         }
-        Log.debug(#file, "Skipping forward \(Self.defaultSkipInterval)s")
+        Log.debug(#file, "Skipping forward \(interval)s")
     }
 
     /// Seeks to a fractional position (0…1) within the CURRENT CHAPTER via the

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -176,6 +176,13 @@ struct Strings {
         static let pauseAudiobook = NSLocalizedString("Pause", comment: "VoiceOver: Pause audiobook")
         static let skipBack30 = NSLocalizedString("Skip back 30 seconds", comment: "VoiceOver: Rewind audiobook 30 seconds")
         static let skipForward30 = NSLocalizedString("Skip forward 30 seconds", comment: "VoiceOver: Skip audiobook forward 30 seconds")
+        // PP-4712: dynamic skip labels reflecting the patron's configured interval.
+        static func skipBackSeconds(_ seconds: Int) -> String {
+            String.localizedStringWithFormat(NSLocalizedString("Skip back %d seconds", comment: "VoiceOver: Rewind audiobook by the configured interval"), seconds)
+        }
+        static func skipForwardSeconds(_ seconds: Int) -> String {
+            String.localizedStringWithFormat(NSLocalizedString("Skip forward %d seconds", comment: "VoiceOver: Skip audiobook forward by the configured interval"), seconds)
+        }
         static let dismissPlayer = NSLocalizedString("Dismiss player", comment: "VoiceOver: Done button on the full audiobook player, dismisses to the mini-player")
         // Accessibility - Audiobook mini-player (swarm_0b7616e7 Module D)
         static let nowPlayingLabelTitleAndAuthor = NSLocalizedString(


### PR DESCRIPTION
## PP-4712 follow-up: the in-app player shows + honors the configured skip interval

#1264 shipped configurable skip intervals through the **toolkit's** full player, but the **ios-core in-app morphing/mini player is a separate surface** that still hardcoded 30 — the skip *amount* (`AudiobookSessionManager.defaultSkipInterval`) and the button *glyph* (`gobackward.30` / `goforward.30`).

### What changed
- `AudiobookSessionManager.skipForward/skipBack` read the patron's configured interval (`AudiobookSkipIntervalSettings`) instead of the fixed 30.
- `AudiobookMorphingPlayerView` renders `gobackward.\(N)` / `goforward.\(N)` glyphs + dynamic VoiceOver labels, bound reactively via `@AppStorage` to the same UserDefaults keys the Settings screen writes — so the in-app player **shows the correct value and updates live** when the setting changes.

### Review
Independent architect + qa_test review under heka governance — **both APPROVED** at the tip. The SF-Symbol set (15/30/45/60) maps 1:1 to `gobackward.N` symbols and the store clamps to that set, so no blank-glyph risk. Build green (sim).

### Fast-follow (both reviewers flagged, non-blocking)
- Add a unit test for the new `Strings.Generic.skipBackSeconds/skipForwardSeconds` pure format helpers (guards a `%d` / fwd-back-swap regression).
- Remove the now-orphaned `skipForward30` string.
- On-sim AC-verify of the live glyph update.

Story: PP-4712. Depends on nothing further (#1264 + toolkit #192 already carry the store + toolkit half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
