### PR TITLE
fix(settings): correct dev toggle label to Ticket Submission (Email) [PP-4815]

### DIFF
--- a/Palace/Settings/DeveloperSettings/DeveloperSettingsView.swift
+++ b/Palace/Settings/DeveloperSettings/DeveloperSettingsView.swift
@@ -80,7 +80,7 @@ struct DeveloperSettingsView: View {
     @ViewBuilder private var triageBotSection: some View {
         Section(header: Text("Triage Bot")) {
             DevToggleRow(title: "Enabled (master)", isOn: $viewModel.triageBotEnabled)
-            DevToggleRow(title: "Ticket Submission (HelpSpot)", isOn: $viewModel.triageBotTicketSubmissionEnabled)
+            DevToggleRow(title: "Ticket Submission (Email)", isOn: $viewModel.triageBotTicketSubmissionEnabled)
             DevToggleRow(title: "AI Fallback (Claude)", isOn: $viewModel.triageBotAIFallbackEnabled)
             DevDisclosureValueRow(
                 title: "Anthropic API Key",


### PR DESCRIPTION
## PP-4815 — fix mislabeled developer toggle

The developer settings row that controls triage-bot ticket submission was titled **"Ticket Submission (HelpSpot)"**, but the v1 transport is email, not HelpSpot. This one-line change corrects the label to **"Ticket Submission (Email)"** so the toggle accurately describes what it does.

### Change
- `Palace/Settings/DeveloperSettings/DeveloperSettingsView.swift` line 83: label string only. No behavior change.

### Testing
- Host-app change (`Palace/**`) — cannot build in this worktree (missing Carthage/submodule). **CI-gated**; not built locally.
- No logic change, so no test added (label string only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)