### PR TITLE
feat(support): flag-gated Help buttons on book detail, sign-in & audiobook player (PP-4812)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -924,6 +924,7 @@
 		9AEC583C7317B6169A20C247 /* ExecutorNetworkHermeticityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD8A9D1E84E9CA99C5DA03D /* ExecutorNetworkHermeticityTests.swift */; };
 		9B1DAC606CFE2E2A8909DF15 /* BookOpenTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54010275AF91385B8410DF1 /* BookOpenTracker.swift */; };
 		9B59FADF2D253A34248757AC /* PalaceNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = 21749BFB0DADE2F60E284C27 /* PalaceNetwork */; };
+		9BA568440FF9AE4394243759 /* HelpButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01ADB3876C9A6D96D93385B /* HelpButton.swift */; };
 		9C195EB46F24EB789D68E05F /* AppHealthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9037960B1D57AADFD0485B6 /* AppHealthView.swift */; };
 		9C2F146198FD9E8862E88B57 /* AdobeDRMHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0CCABB8C99DA55C43F3DA3 /* AdobeDRMHandler.swift */; };
 		9C381F2CFABEBA792BE18DE8 /* BearerTokenAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DDC0D40C209F5D1ADE4D606 /* BearerTokenAdapterTests.swift */; };
@@ -1845,6 +1846,7 @@
 		F86966B4159DA3FBE6B36193 /* CatalogViewContinueRowsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B284DD9A4739D34937C4D0 /* CatalogViewContinueRowsIntegrationTests.swift */; };
 		F8724E8E85D04DC1941AFC2A /* AccountDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480ADB3F1AA842DE805EC230 /* AccountDetailView.swift */; };
 		F8724E8F85D04DC1941AFC2B /* AccountDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480ADB3F1AA842DE805EC230 /* AccountDetailView.swift */; };
+		F89449EAAC94D8724819F8A1 /* HelpButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01ADB3876C9A6D96D93385B /* HelpButton.swift */; };
 		F8A42595FF8E09407C980F50 /* CirculationAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2024455DC09E38D5FA3CE21 /* CirculationAnalyticsTests.swift */; };
 		F8B4510250E062DB59D60245 /* AdobeActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC72BB729EBF73C11F22B304 /* AdobeActivationTests.swift */; };
 		F8E16417A4F3BC323965B5A1 /* DeveloperSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE545556CC9FC4FC7DFF4B8 /* DeveloperSettingsView.swift */; };
@@ -3375,6 +3377,7 @@
 		F0130000ABC0DEF000000001 /* AppTabHostViewBadgeCountTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppTabHostViewBadgeCountTests.swift; sourceTree = "<group>"; };
 		F0130002ABC0DEF000000003 /* AnnouncementChainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnnouncementChainTests.swift; sourceTree = "<group>"; };
 		F0130004ABC0DEF000000005 /* AccountsManagerHelpersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerHelpersTests.swift; sourceTree = "<group>"; };
+		F01ADB3876C9A6D96D93385B /* HelpButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HelpButton.swift; path = ../Palace/Support/HelpButton.swift; sourceTree = "<group>"; };
 		F0AB00222E8E600100000003 /* TPPAccessibilityAnnouncementCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAccessibilityAnnouncementCenter.swift; sourceTree = "<group>"; };
 		F10001STOREFILEREF000001 /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		F15FCA49C708DFACA3FD66B6 /* PDFThumbnailStrip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFThumbnailStrip.swift; sourceTree = "<group>"; };
@@ -5117,6 +5120,15 @@
 			path = SignInLogic;
 			sourceTree = "<group>";
 		};
+		9D6A4B6D4B847BFED4CF0CC5 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				F01ADB3876C9A6D96D93385B /* HelpButton.swift */,
+			);
+			name = Support;
+			path = Support;
+			sourceTree = "<group>";
+		};
 		9DBC860BC4C3D6C0D59C6ECD /* Reader */ = {
 			isa = PBXGroup;
 			children = (
@@ -5215,6 +5227,7 @@
 				A823D80F192BABA400B55DE2 /* Frameworks */,
 				0452B249AF7C21DDAACD5C58 /* TPPBookmarkDeletionLog.swift */,
 				E754403E207AC4273348D160 /* Reader2 */,
+				9D6A4B6D4B847BFED4CF0CC5 /* Support */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -8356,6 +8369,7 @@
 				C8DC8F9202D050EEFBC61B4C /* SettingsSkeletonView.swift in Sources */,
 				E6E69301AC7D67018C6D027C /* TabBarModernization.swift in Sources */,
 				4CBAE27F5514252215941C7B /* AudiobookSkipIntervalSettings.swift in Sources */,
+				F89449EAAC94D8724819F8A1 /* HelpButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8925,6 +8939,7 @@
 				35008DD01991700FE81D6940 /* SettingsSkeletonView.swift in Sources */,
 				126F5079067F518749BEB335 /* TabBarModernization.swift in Sources */,
 				7EE86CCB66B20E8A8DBC9120 /* AudiobookSkipIntervalSettings.swift in Sources */,
+				9BA568440FF9AE4394243759 /* HelpButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
@@ -387,6 +387,14 @@ struct AudiobookMorphingPlayerView: View {
         ZStack {
             grabber
             HStack {
+                // Flag-gated Help entry point (PP-4812). Lives in the FULL
+                // player chrome only (topControls is not part of `miniContent`),
+                // and `HelpEntryPointPolicy` further gates it on the expanded
+                // state, so it never collides with the mini-player transport row.
+                HelpButton(
+                    entryPoint: .audiobookPlayer,
+                    audiobookPlayerExpanded: presenter.isPlayerExpanded
+                )
                 Spacer()
                 Button { showChaptersBookmarks = true } label: {
                     Image(systemName: "list.bullet")

--- a/Palace/Book/UI/BookDetail/BookDetailView.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailView.swift
@@ -225,6 +225,11 @@ struct BookDetailView: View {
                 })
                 .accessibilityLabel(Strings.Generic.goBack)
             }
+            // Flag-gated Help entry point (PP-4812). Vanishes with the triage-bot
+            // kill-switch via HelpEntryPointPolicy; monochrome per Palace chrome.
+            ToolbarItem(placement: .navigationBarTrailing) {
+                HelpButton(entryPoint: .bookDetail)
+            }
         }
         .toolbarBackground(.hidden, for: .navigationBar)
         .modifier(BookStateModifier(viewModel: viewModel, showHalfSheet: $viewModel.showHalfSheet))

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/HelpEntryPointPolicy.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/HelpEntryPointPolicy.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The surfaces that host the shared `HelpButton` — the flag-gated entry into
+/// the triage bot. Kept in TriageBotCore (not the host) so the visibility rule
+/// is pure, KMP-portable, and testable without a UIKit/SwiftUI host.
+///
+/// NB: the Settings "Get Help" row is intentionally NOT here — it resolves
+/// through `SupportSectionDecision` (which adds a legacy-email fallback when the
+/// bot is off), gated on the same `isTriageBotEnabled` kill-switch. This enum
+/// covers only the surfaces that construct a `HelpButton`.
+public enum HelpEntryPoint: String, Sendable, CaseIterable {
+    case bookDetail
+    case signIn
+    case audiobookPlayer
+}
+
+/// Pure decision for whether the shared Help affordance should be visible at a
+/// given entry point. Centralizes the two rules every entry point must obey:
+///
+///   1. **AC-14 kill-switch:** when `isTriageBotEnabled` is off, every entry
+///      point vanishes together — no Settings row, no toolbar button, no
+///      audiobook overlay.
+///   2. **Audiobook mini-player collision:** the audiobook Help control lives in
+///      the FULL player chrome only. On the mini-player it would sit on top of
+///      the transport row, so it stays hidden until the player is expanded.
+///
+/// Extracted here so both rules are mutation-testable in isolation from the
+/// SwiftUI hosts (which can't build under macOS `swift test`).
+public enum HelpEntryPointPolicy {
+
+    /// - Parameters:
+    ///   - entryPoint: which surface is asking.
+    ///   - triageBotEnabled: the master kill-switch
+    ///     (`RemoteFeatureFlags.shared.isTriageBotEnabled` on iOS).
+    ///   - audiobookPlayerExpanded: for `.audiobookPlayer`, whether the full
+    ///     player is currently expanded. Ignored for every other entry point.
+    /// - Returns: whether the Help affordance should render.
+    public static func shouldShowHelp(
+        at entryPoint: HelpEntryPoint,
+        triageBotEnabled: Bool,
+        audiobookPlayerExpanded: Bool = false
+    ) -> Bool {
+        guard triageBotEnabled else { return false }
+        switch entryPoint {
+        case .audiobookPlayer:
+            return audiobookPlayerExpanded
+        case .bookDetail, .signIn:
+            return true
+        }
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/HelpEntryPointPolicyTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/HelpEntryPointPolicyTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import TriageBotCore
+
+/// Behavior spec for `HelpEntryPointPolicy` — the pure visibility decision
+/// behind every flag-gated Help affordance (book detail, sign-in, audiobook
+/// player, settings). Pinning it here (macOS-buildable TriageBotCore) means the
+/// AC-14 kill-switch invariant and the audiobook mini-player-collision rule are
+/// verified without a sim.
+final class HelpEntryPointPolicyTests: XCTestCase {
+
+    // AC-14: when the master kill-switch is off, NO entry point shows Help —
+    // regardless of the audiobook-expanded flag. Kills a mutant that drops the
+    // `guard triageBotEnabled` short-circuit.
+    func testShouldShowHelp_whenFlagOff_isHiddenAtEveryEntryPoint() {
+        for entryPoint in HelpEntryPoint.allCases {
+            for expanded in [true, false] {
+                XCTAssertFalse(
+                    HelpEntryPointPolicy.shouldShowHelp(
+                        at: entryPoint,
+                        triageBotEnabled: false,
+                        audiobookPlayerExpanded: expanded
+                    ),
+                    "\(entryPoint) must be hidden when the flag is off (expanded=\(expanded))"
+                )
+            }
+        }
+    }
+
+    // With the flag on, the non-audiobook entry points are unconditionally
+    // visible. Kills a mutant that flips any of these branches to false.
+    func testShouldShowHelp_whenFlagOn_staticEntryPointsAreVisible() {
+        for entryPoint in [HelpEntryPoint.bookDetail, .signIn] {
+            XCTAssertTrue(
+                HelpEntryPointPolicy.shouldShowHelp(
+                    at: entryPoint,
+                    triageBotEnabled: true
+                ),
+                "\(entryPoint) must be visible when the flag is on"
+            )
+        }
+    }
+
+    // The audiobook Help control lives in the FULL player chrome only — showing
+    // it on the mini-player would collide with the transport row. So even with
+    // the flag on it is hidden until the player is expanded. Kills a mutant that
+    // returns `true` (always show) or `false` (never show) for this case.
+    func testShouldShowHelp_audiobookPlayer_isVisibleOnlyWhenExpanded() {
+        XCTAssertTrue(
+            HelpEntryPointPolicy.shouldShowHelp(
+                at: .audiobookPlayer,
+                triageBotEnabled: true,
+                audiobookPlayerExpanded: true
+            ),
+            "audiobook Help must show in the expanded full player"
+        )
+        XCTAssertFalse(
+            HelpEntryPointPolicy.shouldShowHelp(
+                at: .audiobookPlayer,
+                triageBotEnabled: true,
+                audiobookPlayerExpanded: false
+            ),
+            "audiobook Help must stay hidden on the mini-player to avoid collision"
+        )
+    }
+}

--- a/Palace/SignInLogic/SignInModalView.swift
+++ b/Palace/SignInLogic/SignInModalView.swift
@@ -32,6 +32,11 @@ struct SignInModalView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) { cancelButton }
+                    // Flag-gated Help entry point (PP-4812). Hidden entirely when
+                    // the triage-bot kill-switch is off via HelpEntryPointPolicy.
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        HelpButton(entryPoint: .signIn)
+                    }
                 }
                 .toolbarBackground(.visible, for: .navigationBar)
                 .toolbarBackground(Color(UIColor.systemGroupedBackground), for: .navigationBar)

--- a/Palace/Support/HelpButton.swift
+++ b/Palace/Support/HelpButton.swift
@@ -1,0 +1,67 @@
+//
+//  HelpButton.swift
+//  Palace
+//
+//  Shared, flag-gated "Get Help" affordance. One monochrome question-mark
+//  glyph that presents the triage-bot chat (`TriageBotSupportView`) as a sheet,
+//  reused across every entry point (book detail, sign-in, audiobook player).
+//  Settings has its own row (`TPPSettingsView.supportSection`) but resolves
+//  visibility through the SAME `HelpEntryPointPolicy`, so all entry points
+//  appear and vanish together with the master kill-switch (AC-14).
+//
+//  Monochrome by design — CLAUDE.md "Palace chrome is monochrome": the glyph is
+//  `.foregroundStyle(.primary)`, never a `.tint`/`.blue`.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+#if canImport(UIKit)
+import SwiftUI
+import TriageBotCore
+
+struct HelpButton: View {
+    /// Which surface is hosting this button. Drives the visibility policy and a
+    /// stable accessibility identifier.
+    let entryPoint: HelpEntryPoint
+
+    /// For `.audiobookPlayer`, whether the full player is expanded. The Help
+    /// control lives in the full-player chrome only, so on the mini-player it
+    /// stays hidden (would otherwise collide with the transport row). Ignored
+    /// for every other entry point.
+    var audiobookPlayerExpanded: Bool = false
+
+    @State private var showHelp = false
+
+    /// Resolve visibility through the shared pure policy so the kill-switch and
+    /// the audiobook-expanded rule are the single source of truth (and unit-
+    /// tested in `HelpEntryPointPolicyTests`). Reading the flag at body-eval
+    /// time mirrors how `TPPSettingsView.supportSection` resolves its row.
+    private var isVisible: Bool {
+        HelpEntryPointPolicy.shouldShowHelp(
+            at: entryPoint,
+            triageBotEnabled: RemoteFeatureFlags.shared.isTriageBotEnabled,
+            audiobookPlayerExpanded: audiobookPlayerExpanded
+        )
+    }
+
+    var body: some View {
+        if isVisible {
+            Button {
+                showHelp = true
+            } label: {
+                Image(systemName: "questionmark.circle")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("help.button.\(entryPoint.rawValue)")
+            .accessibilityLabel("Get Help — chat with our support bot")
+            .sheet(isPresented: $showHelp) {
+                TriageBotSupportView()
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## PP-4812 — flag-gated Help buttons on 3 screens + a shared component

Adds a shared monochrome **Get Help** affordance and wires it into three surfaces, all governed by a single pure visibility policy so every entry point vanishes together when the triage-bot kill-switch is off (AC-14).

### What changed
- **`HelpEntryPointPolicy`** (`TriageBotCore`) — pure decision:
  1. When `isTriageBotEnabled` is off, **no** entry point renders (AC-14).
  2. The audiobook Help control shows **only in the expanded full player**, so it never collides with the mini-player transport row.
  Unit-tested in `HelpEntryPointPolicyTests` (kill-switch invariant + expanded-only rule).
- **`HelpButton`** (`Palace/Support`) — shared SwiftUI component: SF Symbol `questionmark.circle`, `.foregroundStyle(.primary)` (monochrome per Palace chrome — no `.tint`/`.blue`), presents `TriageBotSupportView()` as a sheet. Resolves visibility through the policy against `RemoteFeatureFlags.shared.isTriageBotEnabled`.
- **`BookDetailView`** — trailing toolbar `ToolbarItem`.
- **`SignInModalView`** — trailing toolbar `ToolbarItem`.
- **`AudiobookMorphingPlayerView`** — leading item in the full-player `topControls`, driven by `AudiobookSessionPresenter.isPlayerExpanded` (host overlay; submodule untouched).
- **Settings > Get Help row** — confirmed already gated on `isTriageBotEnabled` via `SupportSectionDecision` (unchanged; keeps its legacy-email fallback the policy doesn't model).

### Testing
- `swift test --package-path Palace/Packages/PalaceTriageBot`: **123 passed, 0 failures** (incl. the 3 new policy specs).
- **Host code is CI-gated:** the SwiftUI hosts + overlay cannot build in this worktree (missing Carthage/submodule) — no `xcodebuild` run here. The overlays get a simdrive AC-verify pass under PP-4813.

### TDD
Policy test written first (red — types absent), then the minimum source to pass. Each test kills a real mutant (kill-switch guard, static-branch flip, audiobook expanded-only flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)