### PR TITLE
feat(triagebot): prove AI fallback inert + production telemetry sink (PP-4810, PP-4814)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -526,6 +526,7 @@
 		612FD8DA16387F71EB3CA398 /* HoldsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADE8A45C4B4AAE67143A272 /* HoldsViewModelTests.swift */; };
 		61757D3F95012F8F4340FABB /* TPPAccountAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56509A03466E0531DBC27 /* TPPAccountAuthState.swift */; };
 		61CB94A62C37F50A20D60E44 /* AudiobookMorphingPlayerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7510F2474FBF692B90EF902A /* AudiobookMorphingPlayerViewTests.swift */; };
+		623B25D26DCF91EAA4183E29 /* FirebaseTriageTelemetrySink.swift in Sources */ = {isa = PBXBuildFile; fileRef = C814ACEF8225153039002C2F /* FirebaseTriageTelemetrySink.swift */; };
 		624388D87B1CA40CD178FA52 /* LCPAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D27685071B8A1E07185FD0 /* LCPAdapter.swift */; };
 		626AD1F36BC818F5E9FAC725 /* LibrariesSectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4C9FAC4974D7D0F087712 /* LibrariesSectionViewModelTests.swift */; };
 		62842E5CA00D435AAD8F227E /* NavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A0EAF9098429CA6DCAD16 /* NavigationCoordinatorTests.swift */; };
@@ -783,6 +784,7 @@
 		75B5588EA36A739A060A657E /* Account+TPPLibraryAccountReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02415B1E145D716015754AFF /* Account+TPPLibraryAccountReadable.swift */; };
 		76099E9C88874D19A8E1E4F1 /* BookCellModelCacheInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ED6D3F5630D42CFBE6A59A3 /* BookCellModelCacheInvalidationTests.swift */; };
 		766C1BDB436AA9586293ABF7 /* ReadingStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB660AAD998ACFC41771539E /* ReadingStatsStore.swift */; };
+		767A5147E32D8898618AAA81 /* FirebaseTriageTelemetrySink.swift in Sources */ = {isa = PBXBuildFile; fileRef = C814ACEF8225153039002C2F /* FirebaseTriageTelemetrySink.swift */; };
 		76A3FDFF52B8F948C2C13A65 /* ReadingStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F8EBC8684EF42942C688A7 /* ReadingStatsService.swift */; };
 		76C676B1C1BF8F2434C03DB9 /* AccountDetailViewModelLeakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACF84E5F5C8C9579E5C61B9 /* AccountDetailViewModelLeakTests.swift */; };
 		76FD3B6DF6B2C07153FBBADE /* TPPBookDetailDownloadFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDA3478B2DF503D6CBD4575 /* TPPBookDetailDownloadFailedView.swift */; };
@@ -2973,6 +2975,7 @@
 		C7A10001AAAA000000000001 /* PreviewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewControllerFactory.swift; sourceTree = "<group>"; };
 		C7A10002AAAA000000000001 /* BookAvailabilityFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookAvailabilityFormatter.swift; sourceTree = "<group>"; };
 		C7A10003AAAA000000000001 /* TPPBook+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TPPBook+Presentation.swift"; sourceTree = "<group>"; };
+		C814ACEF8225153039002C2F /* FirebaseTriageTelemetrySink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirebaseTriageTelemetrySink.swift; sourceTree = "<group>"; };
 		C8F8EBC8684EF42942C688A7 /* ReadingStatsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsService.swift; sourceTree = "<group>"; };
 		C927D5FB4DCC629EEF09DE4C /* BadgeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeServiceTests.swift; sourceTree = "<group>"; };
 		C9E38281988A9921BB4B8297 /* OPDS2IntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2IntegrationTests.swift; sourceTree = "<group>"; };
@@ -6519,6 +6522,7 @@
 				F9C1BD2745D8CAF0EC81AEE8 /* TriageBotFactory.swift */,
 				C540202A7A2D7469AEF27B82 /* TriageBotSupportView.swift */,
 				17CF4EB59391A34A6315985E /* TriageBotKeyAdmin.swift */,
+				C814ACEF8225153039002C2F /* FirebaseTriageTelemetrySink.swift */,
 			);
 			name = Support;
 			path = Support;
@@ -8370,6 +8374,7 @@
 				E6E69301AC7D67018C6D027C /* TabBarModernization.swift in Sources */,
 				4CBAE27F5514252215941C7B /* AudiobookSkipIntervalSettings.swift in Sources */,
 				F89449EAAC94D8724819F8A1 /* HelpButton.swift in Sources */,
+				767A5147E32D8898618AAA81 /* FirebaseTriageTelemetrySink.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8940,6 +8945,7 @@
 				126F5079067F518749BEB335 /* TabBarModernization.swift in Sources */,
 				7EE86CCB66B20E8A8DBC9120 /* AudiobookSkipIntervalSettings.swift in Sources */,
 				9BA568440FF9AE4394243759 /* HelpButton.swift in Sources */,
+				623B25D26DCF91EAA4183E29 /* FirebaseTriageTelemetrySink.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Packages/PalaceTriageBot/Package.swift
+++ b/Palace/Packages/PalaceTriageBot/Package.swift
@@ -53,6 +53,15 @@ let package = Package(
             dependencies: ["TriageBotCore"],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
+        // iOS-adapter tests. Depends on TriageBotIOS (ClaudeFallbackClassifier)
+        // and TriageBotUI (TriageBotViewModel). Both targets are gated on
+        // `canImport(UIKit)`, so on macOS `swift test` this target compiles to an
+        // empty bundle — the real assertions run only on an iOS sim (CI).
+        .testTarget(
+            name: "TriageBotIOSTests",
+            dependencies: ["TriageBotIOS", "TriageBotUI"],
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
         .testTarget(
             name: "TriageBotUITests",
             dependencies: ["TriageBotUI"],

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Telemetry/TelemetryContract.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Telemetry/TelemetryContract.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The complete, enumerable set of parameter keys the triage bot is allowed to
+/// attach to a ``TelemetryEvent``. Every value behind these keys is an id, a
+/// count, or an enum `rawValue` — **never** free text (a user-typed symptom
+/// description, an email address, a library barcode). Because the key space is a
+/// finite enum, a reviewer can audit exactly what leaves the device, and
+/// ``TelemetryContract`` drops any key not listed here before an event reaches an
+/// analytics backend.
+///
+/// Keep this list in sync with the reducer: every key emitted by
+/// `ConversationReducer` must have a case here. `TelemetryContractTests` drives
+/// the reducer and asserts the union of emitted keys is a subset of this enum, so
+/// a new free-text parameter — or a stale enum — fails a unit test.
+public enum TelemetryParameterKey: String, CaseIterable, Sendable {
+    case category
+    case entryId = "entry_id"
+    case confidence
+    case candidateCount = "candidate_count"
+    case stepId = "step_id"
+    case stepCount = "step_count"
+    case stepsAttempted = "steps_attempted"
+    case nextIndex = "next_index"
+    case priority
+    case ticketId = "ticket_id"
+    case attemptsCount = "attempts_count"
+    case outcome
+}
+
+/// Enforcement point for the "no free text in telemetry" contract. The production
+/// (Firebase) sink forwards **only** the parameters this returns, so a free-text
+/// parameter can never reach an analytics backend even if a future caller adds one.
+public enum TelemetryContract {
+
+    /// Keeps only the parameters whose key is part of the enumerable contract
+    /// (``TelemetryParameterKey``). Any other key is dropped.
+    public static func enumerableParameters(of event: TelemetryEvent) -> [String: String] {
+        event.parameters.filter { TelemetryParameterKey(rawValue: $0.key) != nil }
+    }
+
+    /// The parameter keys on `event` that are **not** part of the enumerable
+    /// contract. Empty for every event the bot emits today; a non-empty result
+    /// means a caller introduced a key that must either be added to
+    /// ``TelemetryParameterKey`` (if it is genuinely an id/count/enum) or removed
+    /// (if it is free text).
+    public static func nonEnumerableKeys(of event: TelemetryEvent) -> [String] {
+        event.parameters.keys
+            .filter { TelemetryParameterKey(rawValue: $0) == nil }
+            .sorted()
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Wiring/AIFallbackWiring.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Wiring/AIFallbackWiring.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Pure predicate for the single security invariant that keeps the network-backed
+/// Claude AI fallback **inert by default**: the fallback classifier is only ever
+/// wired behind the local keyword matcher when BOTH a remote kill-switch flag is
+/// on AND an API key is actually present on the device. Either condition alone is
+/// not enough — a flag with no key, or a key with the flag off, both stay local-only.
+///
+/// The host composition root (`TriageBotFactory`) is the only caller, but the
+/// factory imports UIKit/Firebase and cannot be unit-tested inside the package.
+/// Extracting the decision here (no UIKit) means the invariant is exercised by
+/// `swift test` on macOS, so a refactor that accidentally loosens it — e.g. wiring
+/// the fallback on the flag alone — fails a table test rather than shipping silently.
+public enum TriageBotAIWiring {
+
+    /// Whether the AI fallback classifier should be wired.
+    ///
+    /// - Parameters:
+    ///   - flagEnabled: the `triage_bot_ai_fallback_enabled` Remote Config value.
+    ///   - keyPresent: whether an Anthropic API key is present (Keychain, after
+    ///     the DEBUG env bootstrap).
+    /// - Returns: `true` only when the flag is enabled **and** a key is present.
+    public static func aiWiring(flagEnabled: Bool, keyPresent: Bool) -> Bool {
+        flagEnabled && keyPresent
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/TelemetryContractTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/TelemetryContractTests.swift
@@ -13,6 +13,8 @@ final class TelemetryContractTests: XCTestCase {
         func emit(_ event: TelemetryEvent) { events.append(event) }
     }
 
+    /// Single-entry audiobook KB — the confident-match path (entry_id +
+    /// confidence) plus the category and ticket-submitted keys.
     private func makeReducer() -> ConversationReducer {
         let entries = [
             KBEntry(
@@ -31,53 +33,168 @@ final class TelemetryContractTests: XCTestCase {
         return ConversationReducer(knowledgeBase: KnowledgeBase(catalog: catalog))
     }
 
-    /// Drives the reducer through a param-rich flow, forwards every emitted
-    /// telemetry event to a spy sink, and asserts NONE of them carry a
-    /// non-enumerable (free-text) parameter key. If a caller adds
-    /// `parameters: ["user_text": ...]` to any event on this path, or drops a
-    /// case from `TelemetryParameterKey`, this fails.
-    func testReducerEmittedParameterKeys_areAllEnumerable() {
-        let reducer = makeReducer()
-        let spy = SpyTelemetrySink()
+    /// Two same-category entries that tie on keyword score so the local
+    /// classifier can neither confidently suggest nor escalate — it must
+    /// disambiguate, which is the only emitter of `candidate_count`.
+    private func makeDisambiguateReducer() -> ConversationReducer {
+        let entries = [
+            KBEntry(id: "KI-AMBIG-A", category: .audiobook, status: .open,
+                    symptomKeywords: ["audio", "glitch"],
+                    userFacingWorkaround: "A.", confidenceThreshold: 0.1),
+            KBEntry(id: "KI-AMBIG-B", category: .audiobook, status: .open,
+                    symptomKeywords: ["audio", "glitch"],
+                    userFacingWorkaround: "B.", confidenceThreshold: 0.1)
+        ]
+        return ConversationReducer(knowledgeBase: KnowledgeBase(
+            catalog: KBCatalog(version: "test", updatedAt: "x", entries: entries)))
+    }
 
-        func run(_ state: ConversationState, _ action: ConversationAction) -> ConversationState {
-            let (next, effects) = reducer.reduce(state: state, action: action)
-            for case .emitTelemetry(let event) in effects { spy.emit(event) }
-            return next
-        }
+    /// An entry with a 3-step guided flow — drives step_count / step_id /
+    /// steps_attempted / next_index and the exhaustion escalate
+    /// (attempts_count / outcome).
+    private func makeGuidedReducer() -> ConversationReducer {
+        let entry = KBEntry(
+            id: "KI-GUIDED",
+            category: .audiobook,
+            status: .open,
+            symptomKeywords: ["test"],
+            userFacingWorkaround: "Summary.",
+            userFacingSteps: [
+                KBStep(id: "step1", instruction: "Try X.", check: "Did X work?"),
+                KBStep(id: "step2", instruction: "Try Y.", check: "Did Y work?"),
+                KBStep(id: "step3", instruction: "Try Z.", check: "Did Z work?")
+            ],
+            confidenceThreshold: 0.1
+        )
+        return ConversationReducer(knowledgeBase: KnowledgeBase(
+            catalog: KBCatalog(version: "test", updatedAt: "x", entries: [entry])))
+    }
 
-        let context = ContextSnapshot(
-            appVersion: "3.0.3",
-            appBuild: "478",
-            osVersion: "26.4.2",
-            deviceModel: "iPhone17,2",
+    private func makeContext() -> ContextSnapshot {
+        ContextSnapshot(
+            appVersion: "3.0.3", appBuild: "478",
+            osVersion: "26.4.2", deviceModel: "iPhone17,2",
             distributor: "palace_marketplace"
         )
+    }
 
-        var state = run(ConversationState(), .start)                       // triage_chat_opened
-        state = run(state, .contextLoaded(context))
-        state = run(state, .userTappedCategory(.audiobook))                // category
-        state = run(state, .inputChanged("my audiobook keeps spinning and won't play the first time I open it"))
-        state = run(state, .userSubmittedDescription)                      // entry_id + confidence
-        guard case .matched(let entryId) = state.step else {
-            return XCTFail("Expected .matched, got \(state.step)")
+    /// Threads `actions` through `reducer` starting at `state`, forwarding
+    /// every `.emitTelemetry` effect into `sink` exactly as the host would.
+    @discardableResult
+    private func drive(
+        _ reducer: ConversationReducer,
+        from state: ConversationState,
+        _ actions: [ConversationAction],
+        into sink: SpyTelemetrySink
+    ) -> ConversationState {
+        var current = state
+        for action in actions {
+            let (next, effects) = reducer.reduce(state: current, action: action)
+            for case .emitTelemetry(let event) in effects { sink.emit(event) }
+            current = next
         }
-        state = run(state, .userTappedNotifyMeOnFix(entryId: entryId))     // entry_id
-        // Unconditional ticket-submitted emission → ticket_id.
-        _ = run(state, .ticketSubmitted(TicketReceipt(ticketId: "HS-42", submittedAt: Date())))
+        return current
+    }
 
-        // We must have actually captured parameterized events, else the
-        // invariant assertion below is vacuous.
-        let keyUnion = Set(spy.events.flatMap { $0.parameters.keys })
-        XCTAssertTrue(keyUnion.isSuperset(of: ["category", "entry_id", "confidence", "ticket_id"]),
-                      "Expected the flow to exercise these keys; saw \(keyUnion.sorted())")
+    /// Drives the reducer through EVERY parameterized emission path (confident
+    /// match, disambiguate, all four guided-troubleshooting emitters, the
+    /// exhaustion escalate, the AI-fallback match, ticket-submit-requested and
+    /// ticket-submitted) and enforces two things the docstring on
+    /// ``TelemetryParameterKey`` promises:
+    ///
+    ///  1. Per event: NO emitted parameter key is non-enumerable (free text) —
+    ///     if a caller adds `parameters: ["user_text": ...]` anywhere, it fails.
+    ///  2. Across all flows: the UNION of observed keys equals the full
+    ///     `TelemetryParameterKey.allCases` set. A new case added to the enum
+    ///     without a driven emission fails (superset direction); a key emitted
+    ///     by the reducer that isn't in the enum fails via #1 (subset direction).
+    ///     Together the two directions pin the enum to what the reducer emits.
+    func testReducerEmittedParameterKeys_coverAndAreConfinedTo_theEnumerableContract() {
+        let spy = SpyTelemetrySink()
+        let context = makeContext()
+        let startedAt = Date(timeIntervalSince1970: 0)
 
+        // Confident local match → category, entry_id, confidence, ticket_id.
+        drive(makeReducer(), from: ConversationState(), [
+            .start,
+            .contextLoaded(context),
+            .userTappedCategory(.audiobook),
+            .inputChanged("my audiobook keeps spinning and won't play the first time I open it"),
+            .userSubmittedDescription,
+            .ticketSubmitted(TicketReceipt(ticketId: "HS-42", submittedAt: Date()))
+        ], into: spy)
+
+        // Ambiguous local match → candidate_count.
+        drive(makeDisambiguateReducer(), from: ConversationState(), [
+            .userTappedCategory(.audiobook),
+            .inputChanged("audio glitch"),
+            .userSubmittedDescription
+        ], into: spy)
+
+        let guided = makeGuidedReducer()
+
+        // Guided flow started → entry_id, step_count.
+        drive(guided, from: ConversationState(step: .matched(entryId: "KI-GUIDED")),
+              [.userTappedStartGuidedFlow(entryId: "KI-GUIDED")], into: spy)
+
+        // Step resolved → entry_id, step_id, steps_attempted.
+        drive(guided, from: ConversationState(step: .guidedStep(
+            entryId: "KI-GUIDED", stepIndex: 0, startedAt: startedAt, attempts: [])),
+              [.userConfirmedStepResolved(stepId: "step1")], into: spy)
+
+        // Step did-not-resolve, more steps remain → entry_id, step_id, next_index.
+        drive(guided, from: ConversationState(step: .guidedStep(
+            entryId: "KI-GUIDED", stepIndex: 0, startedAt: startedAt, attempts: [])),
+              [.userConfirmedStepDidNotResolve(stepId: "step1")], into: spy)
+
+        // Final step did-not-resolve → escalate-with-trace → entry_id,
+        // attempts_count, outcome.
+        let priorAttempts = [
+            StepAttempt(stepId: "step1", outcome: .didNotResolve, timestamp: startedAt),
+            StepAttempt(stepId: "step2", outcome: .didNotResolve, timestamp: startedAt)
+        ]
+        drive(guided, from: ConversationState(
+            step: .guidedStep(entryId: "KI-GUIDED", stepIndex: 2, startedAt: startedAt, attempts: priorAttempts),
+            context: context),
+              [.userConfirmedStepDidNotResolve(stepId: "step3")], into: spy)
+
+        // AI fallback match → entry_id, confidence (the AI path, distinct from
+        // the local kb_match emitter).
+        let aiReducer = ConversationReducer(
+            knowledgeBase: guided.knowledgeBase, aiFallbackEnabled: true)
+        drive(aiReducer, from: ConversationState(
+            step: .awaitingAIClassification(userText: "x", category: .audiobook)),
+              [.aiFallbackResolved(ClassificationResult(
+                decision: .suggest(entryId: "KI-GUIDED"), confidence: 0.91))], into: spy)
+
+        // Ticket submit requested → priority.
+        let draft = TicketDraft(
+            userDescription: "d", category: .audiobook, context: context, priority: .high)
+        drive(makeReducer(), from: ConversationState(step: .drafting(ticket: draft)),
+              [.userConfirmedTicketSubmit], into: spy)
+
+        // --- Direction 1: every emitted key is enumerable (no free text). ---
         for event in spy.events {
             XCTAssertEqual(
                 TelemetryContract.nonEnumerableKeys(of: event), [],
                 "Event \(event.name) emitted non-enumerable (free-text) keys"
             )
         }
+
+        // --- Direction 2: the driven flows cover EVERY enumerable key. ---
+        let observedKeys = Set(spy.events.flatMap { $0.parameters.keys })
+        let allContractKeys = Set(TelemetryParameterKey.allCases.map { $0.rawValue })
+        XCTAssertEqual(
+            observedKeys, allContractKeys,
+            """
+            The union of parameter keys emitted across all driven reducer flows \
+            must exactly equal TelemetryParameterKey.allCases. \
+            Missing from the flows (enum case with no driven emission): \
+            \(allContractKeys.subtracting(observedKeys).sorted()). \
+            Emitted but not in the enum (should be impossible — caught above): \
+            \(observedKeys.subtracting(allContractKeys).sorted()).
+            """
+        )
     }
 
     /// The enforcement filter keeps enumerable keys and drops everything else —

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/TelemetryContractTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/TelemetryContractTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import TriageBotCore
+
+/// Pins the "telemetry carries no free text" contract: every parameter key the
+/// reducer emits is one of the enumerable ``TelemetryParameterKey`` cases (an
+/// id / count / enum), and the enforcement filter drops anything that is not.
+final class TelemetryContractTests: XCTestCase {
+
+    /// Records every event handed to the sink, exactly as the production sink
+    /// would receive it.
+    private final class SpyTelemetrySink: TelemetrySink, @unchecked Sendable {
+        private(set) var events: [TelemetryEvent] = []
+        func emit(_ event: TelemetryEvent) { events.append(event) }
+    }
+
+    private func makeReducer() -> ConversationReducer {
+        let entries = [
+            KBEntry(
+                id: "KI-2026-001-audiobook-first-open-hang",
+                category: .audiobook,
+                status: .open,
+                fixedInVersion: "3.2.0",
+                symptomKeywords: ["audiobook", "won't play", "spinning", "first time", "hangs"],
+                distributorFilter: ["palace_marketplace"],
+                userFacingWorkaround: "Tap back, tap again.",
+                confidenceThreshold: 0.4,
+                helpspotTag: "known-issue-PP-4436"
+            )
+        ]
+        let catalog = KBCatalog(version: "test", updatedAt: "2026-05-28", entries: entries)
+        return ConversationReducer(knowledgeBase: KnowledgeBase(catalog: catalog))
+    }
+
+    /// Drives the reducer through a param-rich flow, forwards every emitted
+    /// telemetry event to a spy sink, and asserts NONE of them carry a
+    /// non-enumerable (free-text) parameter key. If a caller adds
+    /// `parameters: ["user_text": ...]` to any event on this path, or drops a
+    /// case from `TelemetryParameterKey`, this fails.
+    func testReducerEmittedParameterKeys_areAllEnumerable() {
+        let reducer = makeReducer()
+        let spy = SpyTelemetrySink()
+
+        func run(_ state: ConversationState, _ action: ConversationAction) -> ConversationState {
+            let (next, effects) = reducer.reduce(state: state, action: action)
+            for case .emitTelemetry(let event) in effects { spy.emit(event) }
+            return next
+        }
+
+        let context = ContextSnapshot(
+            appVersion: "3.0.3",
+            appBuild: "478",
+            osVersion: "26.4.2",
+            deviceModel: "iPhone17,2",
+            distributor: "palace_marketplace"
+        )
+
+        var state = run(ConversationState(), .start)                       // triage_chat_opened
+        state = run(state, .contextLoaded(context))
+        state = run(state, .userTappedCategory(.audiobook))                // category
+        state = run(state, .inputChanged("my audiobook keeps spinning and won't play the first time I open it"))
+        state = run(state, .userSubmittedDescription)                      // entry_id + confidence
+        guard case .matched(let entryId) = state.step else {
+            return XCTFail("Expected .matched, got \(state.step)")
+        }
+        state = run(state, .userTappedNotifyMeOnFix(entryId: entryId))     // entry_id
+        // Unconditional ticket-submitted emission → ticket_id.
+        _ = run(state, .ticketSubmitted(TicketReceipt(ticketId: "HS-42", submittedAt: Date())))
+
+        // We must have actually captured parameterized events, else the
+        // invariant assertion below is vacuous.
+        let keyUnion = Set(spy.events.flatMap { $0.parameters.keys })
+        XCTAssertTrue(keyUnion.isSuperset(of: ["category", "entry_id", "confidence", "ticket_id"]),
+                      "Expected the flow to exercise these keys; saw \(keyUnion.sorted())")
+
+        for event in spy.events {
+            XCTAssertEqual(
+                TelemetryContract.nonEnumerableKeys(of: event), [],
+                "Event \(event.name) emitted non-enumerable (free-text) keys"
+            )
+        }
+    }
+
+    /// The enforcement filter keeps enumerable keys and drops everything else —
+    /// this is the byte-level guarantee the Firebase sink relies on.
+    func testEnumerableParameters_dropsFreeTextKeys_keepsEnumerableOnes() {
+        let event = TelemetryEvent(
+            name: "triage_kb_match",
+            parameters: [
+                "entry_id": "KI-2026-001",
+                "confidence": "0.91",
+                "user_text": "my barcode is 21221012345678 and my pin is 1234"
+            ]
+        )
+
+        let filtered = TelemetryContract.enumerableParameters(of: event)
+
+        XCTAssertEqual(filtered, ["entry_id": "KI-2026-001", "confidence": "0.91"])
+        XCTAssertNil(filtered["user_text"], "free-text key must not survive the filter")
+    }
+
+    func testNonEnumerableKeys_flagsAFreeTextKey() {
+        let event = TelemetryEvent(name: "x", parameters: ["entry_id": "KI-1", "note": "free text"])
+        XCTAssertEqual(TelemetryContract.nonEnumerableKeys(of: event), ["note"])
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/TriageBotAIWiringTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/TriageBotAIWiringTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import TriageBotCore
+
+/// Table test for the AI-fallback wiring invariant. The whole point of the AI
+/// fallback being "inert by default" is that it wires ONLY when the flag is on
+/// AND a key is present — so all four flag×key combinations are pinned here.
+final class TriageBotAIWiringTests: XCTestCase {
+
+    func testAIWiring_requiresBothFlagAndKey() {
+        // Neither → off.
+        XCTAssertFalse(TriageBotAIWiring.aiWiring(flagEnabled: false, keyPresent: false))
+        // Flag on but no key → off (the demo-machine / TestFlight-without-key case).
+        XCTAssertFalse(TriageBotAIWiring.aiWiring(flagEnabled: true, keyPresent: false))
+        // Key present but flag off → off (support dialed the kill-switch back).
+        XCTAssertFalse(TriageBotAIWiring.aiWiring(flagEnabled: false, keyPresent: true))
+        // Both → the only true case.
+        XCTAssertTrue(TriageBotAIWiring.aiWiring(flagEnabled: true, keyPresent: true))
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotIOSTests/AIFallbackInertTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotIOSTests/AIFallbackInertTests.swift
@@ -12,21 +12,30 @@ import XCTest
 /// URLProtocol that records every request a session (or `URLSession.shared`,
 /// when registered globally) attempts to send. Used to prove the AI fallback is
 /// inert: zero recorded requests means nothing hit the network.
-final class RecordingURLProtocol: URLProtocol {
+///
+/// Recording is keyed by the **concrete subclass metatype**, not a single
+/// shared array. Two test classes each register their own subclass
+/// (``InertPathRecordingURLProtocol`` / ``GuardOrderRecordingURLProtocol``), so
+/// their request logs are fully isolated even when Xcode runs the classes in
+/// parallel. `reset()` / `recordedCount` are `class`-scoped so `self` resolves
+/// to the concrete subclass at the call site — a shared `static` array (the
+/// prior shape) let a `reset()` or a recorded request in one class bleed into
+/// the other's count under concurrent execution.
+class RecordingURLProtocol: URLProtocol {
     private static let lock = NSLock()
-    private static var _recorded: [URLRequest] = []
+    private static var recordedByClass: [ObjectIdentifier: [URLRequest]] = [:]
 
-    static func reset() {
-        lock.lock(); _recorded = []; lock.unlock()
+    class func reset() {
+        lock.lock(); recordedByClass[ObjectIdentifier(self)] = []; lock.unlock()
     }
 
-    static var recordedCount: Int {
+    class var recordedCount: Int {
         lock.lock(); defer { lock.unlock() }
-        return _recorded.count
+        return recordedByClass[ObjectIdentifier(self)]?.count ?? 0
     }
 
     override class func canInit(with request: URLRequest) -> Bool {
-        lock.lock(); _recorded.append(request); lock.unlock()
+        lock.lock(); recordedByClass[ObjectIdentifier(self), default: []].append(request); lock.unlock()
         // Handle the request so a would-be network call completes (and can't
         // leak to the real network) rather than hanging the test.
         return true
@@ -47,9 +56,17 @@ final class RecordingURLProtocol: URLProtocol {
     override func stopLoading() {}
 }
 
+/// Per-test-class recorder for ``AIFallbackInertViewModelTests`` — registered
+/// globally so it catches any stray `URLSession.shared` traffic.
+final class InertPathRecordingURLProtocol: RecordingURLProtocol {}
+
+/// Per-test-class recorder for ``ClaudeFallbackClassifierGuardOrderTests`` —
+/// wired only into that class's ephemeral session.
+final class GuardOrderRecordingURLProtocol: RecordingURLProtocol {}
+
 private func recordingSession() -> URLSession {
     let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [RecordingURLProtocol.self]
+    config.protocolClasses = [GuardOrderRecordingURLProtocol.self]
     return URLSession(configuration: config)
 }
 
@@ -81,9 +98,9 @@ final class AIFallbackInertViewModelTests: XCTestCase {
     /// conversation (including the escalate path) must never touch the network.
     @MainActor
     func testFlagOffConversation_makesZeroNetworkRequests() async {
-        URLProtocol.registerClass(RecordingURLProtocol.self)
-        defer { URLProtocol.unregisterClass(RecordingURLProtocol.self) }
-        RecordingURLProtocol.reset()
+        URLProtocol.registerClass(InertPathRecordingURLProtocol.self)
+        defer { URLProtocol.unregisterClass(InertPathRecordingURLProtocol.self) }
+        InertPathRecordingURLProtocol.reset()
 
         // aiFallbackEnabled: false mirrors the flag-off reducer the factory builds.
         let reducer = ConversationReducer(knowledgeBase: emptyKnowledgeBase(), aiFallbackEnabled: false)
@@ -103,7 +120,7 @@ final class AIFallbackInertViewModelTests: XCTestCase {
         await Task.yield()
         await Task.yield()
 
-        XCTAssertEqual(RecordingURLProtocol.recordedCount, 0,
+        XCTAssertEqual(InertPathRecordingURLProtocol.recordedCount, 0,
                        "Flag-off conversation must make zero network requests")
     }
 }
@@ -117,7 +134,7 @@ final class ClaudeFallbackClassifierGuardOrderTests: XCTestCase {
     /// order (rate-limit → key check → network): if a refactor moved the network
     /// call above the key guard, a request would be recorded and this fails.
     func testClassify_withNoKey_throwsApiKeyMissing_beforeAnyRequest() async {
-        RecordingURLProtocol.reset()
+        GuardOrderRecordingURLProtocol.reset()
         let classifier = ClaudeFallbackClassifier(
             keyProvider: { nil },
             session: recordingSession()
@@ -137,13 +154,13 @@ final class ClaudeFallbackClassifierGuardOrderTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
 
-        XCTAssertEqual(RecordingURLProtocol.recordedCount, 0,
+        XCTAssertEqual(GuardOrderRecordingURLProtocol.recordedCount, 0,
                        "Key guard must fire before any network call")
     }
 
     /// An empty-string key is treated the same as missing — still no network.
     func testClassify_withEmptyKey_throwsApiKeyMissing_beforeAnyRequest() async {
-        RecordingURLProtocol.reset()
+        GuardOrderRecordingURLProtocol.reset()
         let classifier = ClaudeFallbackClassifier(
             keyProvider: { "" },
             session: recordingSession()
@@ -163,7 +180,7 @@ final class ClaudeFallbackClassifierGuardOrderTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
 
-        XCTAssertEqual(RecordingURLProtocol.recordedCount, 0,
+        XCTAssertEqual(GuardOrderRecordingURLProtocol.recordedCount, 0,
                        "Key guard must fire before any network call")
     }
 }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotIOSTests/AIFallbackInertTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotIOSTests/AIFallbackInertTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+@testable import TriageBotCore
+
+// These tests exercise UIKit-gated code (ClaudeFallbackClassifier in TriageBotIOS,
+// TriageBotViewModel in TriageBotUI). On macOS `swift test` both targets compile to
+// empty modules (`#if canImport(UIKit)`), so this whole file compiles away there and
+// the real assertions run only on an iOS simulator under CI.
+#if canImport(UIKit)
+@testable import TriageBotIOS
+@testable import TriageBotUI
+
+/// URLProtocol that records every request a session (or `URLSession.shared`,
+/// when registered globally) attempts to send. Used to prove the AI fallback is
+/// inert: zero recorded requests means nothing hit the network.
+final class RecordingURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var _recorded: [URLRequest] = []
+
+    static func reset() {
+        lock.lock(); _recorded = []; lock.unlock()
+    }
+
+    static var recordedCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _recorded.count
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        lock.lock(); _recorded.append(request); lock.unlock()
+        // Handle the request so a would-be network call completes (and can't
+        // leak to the real network) rather than hanging the test.
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "https://example.invalid")!,
+            statusCode: 200, httpVersion: nil, headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("{}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private func recordingSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [RecordingURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func emptyKnowledgeBase() -> KnowledgeBase {
+    KnowledgeBase(catalog: KBCatalog(version: "test", updatedAt: "2026-05-28", entries: []))
+}
+
+// MARK: - Inert view-model path (flag off, no classifier wired)
+
+private struct NoopContextProvider: ContextProvider {
+    func captureSnapshot() async -> ContextSnapshot {
+        ContextSnapshot(appVersion: "1", appBuild: "1", osVersion: "1", deviceModel: "sim")
+    }
+}
+
+private struct NoopTicketGateway: TicketGateway {
+    func submit(_ draft: TicketDraft) async throws -> TicketReceipt {
+        TicketReceipt(ticketId: "noop", submittedAt: Date())
+    }
+}
+
+private struct NoopTelemetrySink: TelemetrySink {
+    func emit(_ event: TelemetryEvent) {}
+}
+
+final class AIFallbackInertViewModelTests: XCTestCase {
+
+    /// Flag off → the factory wires `fallbackClassifier: nil`. Driving a whole
+    /// conversation (including the escalate path) must never touch the network.
+    @MainActor
+    func testFlagOffConversation_makesZeroNetworkRequests() async {
+        URLProtocol.registerClass(RecordingURLProtocol.self)
+        defer { URLProtocol.unregisterClass(RecordingURLProtocol.self) }
+        RecordingURLProtocol.reset()
+
+        // aiFallbackEnabled: false mirrors the flag-off reducer the factory builds.
+        let reducer = ConversationReducer(knowledgeBase: emptyKnowledgeBase(), aiFallbackEnabled: false)
+        let viewModel = TriageBotViewModel(
+            reducer: reducer,
+            contextProvider: NoopContextProvider(),
+            ticketGateway: NoopTicketGateway(),
+            telemetry: NoopTelemetrySink(),
+            fallbackClassifier: nil
+        )
+
+        viewModel.send(.start)
+        viewModel.send(.userTappedCategory(.audiobook))
+        viewModel.send(.inputChanged("some symptom text that will not match any known issue zzz"))
+        viewModel.send(.userSubmittedDescription)
+        // Drain any effect Tasks the view model may have spawned.
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(RecordingURLProtocol.recordedCount, 0,
+                       "Flag-off conversation must make zero network requests")
+    }
+}
+
+// MARK: - Classifier guard order (flag on, but no key)
+
+final class ClaudeFallbackClassifierGuardOrderTests: XCTestCase {
+
+    /// With the flag on but NO key present, `classify` must throw
+    /// `.apiKeyMissing` BEFORE issuing any network request. This pins the guard
+    /// order (rate-limit → key check → network): if a refactor moved the network
+    /// call above the key guard, a request would be recorded and this fails.
+    func testClassify_withNoKey_throwsApiKeyMissing_beforeAnyRequest() async {
+        RecordingURLProtocol.reset()
+        let classifier = ClaudeFallbackClassifier(
+            keyProvider: { nil },
+            session: recordingSession()
+        )
+
+        do {
+            _ = try await classifier.classify(
+                userText: "audiobook won't play",
+                category: nil,
+                context: nil,
+                knowledgeBase: emptyKnowledgeBase()
+            )
+            XCTFail("Expected FallbackError.apiKeyMissing")
+        } catch let error as FallbackError {
+            XCTAssertEqual(error, .apiKeyMissing)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(RecordingURLProtocol.recordedCount, 0,
+                       "Key guard must fire before any network call")
+    }
+
+    /// An empty-string key is treated the same as missing — still no network.
+    func testClassify_withEmptyKey_throwsApiKeyMissing_beforeAnyRequest() async {
+        RecordingURLProtocol.reset()
+        let classifier = ClaudeFallbackClassifier(
+            keyProvider: { "" },
+            session: recordingSession()
+        )
+
+        do {
+            _ = try await classifier.classify(
+                userText: "audiobook won't play",
+                category: nil,
+                context: nil,
+                knowledgeBase: emptyKnowledgeBase()
+            )
+            XCTFail("Expected FallbackError.apiKeyMissing")
+        } catch let error as FallbackError {
+            XCTAssertEqual(error, .apiKeyMissing)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(RecordingURLProtocol.recordedCount, 0,
+                       "Key guard must fire before any network call")
+    }
+}
+#endif

--- a/Palace/Support/FirebaseTriageTelemetrySink.swift
+++ b/Palace/Support/FirebaseTriageTelemetrySink.swift
@@ -1,0 +1,30 @@
+//
+//  FirebaseTriageTelemetrySink.swift
+//  Palace
+//
+//  Production TelemetrySink for the PalaceTriageBot package. Forwards triage-bot
+//  events to Firebase Analytics in release builds, replacing OSLogTelemetrySink
+//  (see TriageBotFactory, PP-4814).
+//
+//  Host-side, NOT in the package: Firebase is a Palace-target dependency and the
+//  package deliberately stays SDK-free + KMP-portable. This file therefore cannot
+//  build in a package-only worktree — it is CI-gated.
+//
+//  Privacy contract: TelemetryEvents already carry only ids / counts / enum
+//  categories (never free text). As a defense-in-depth boundary, this sink runs
+//  every event through TelemetryContract.enumerableParameters so that even if a
+//  future caller attaches a non-enumerable (free-text) key, it is dropped before
+//  anything reaches Analytics.
+//
+
+import Foundation
+import FirebaseAnalytics
+import TriageBotCore
+
+struct FirebaseTriageTelemetrySink: TelemetrySink {
+
+    func emit(_ event: TelemetryEvent) {
+        let parameters = TelemetryContract.enumerableParameters(of: event)
+        Analytics.logEvent(event.name, parameters: parameters.isEmpty ? nil : parameters)
+    }
+}

--- a/Palace/Support/TriageBotFactory.swift
+++ b/Palace/Support/TriageBotFactory.swift
@@ -48,8 +48,12 @@ enum TriageBotFactory {
         // (today's behavior — no regression).
         let keyStore = AnthropicKeyStore()
         let bootstrappedKey = keyStore.bootstrapFromEnvironmentIfNeeded()
-        let aiEnabled = RemoteFeatureFlags.shared.isTriageBotAIFallbackEnabled
-            && bootstrappedKey != nil
+        // Inert-by-default invariant (flag AND key) lives in TriageBotAIWiring so
+        // it is unit-tested under `swift test`; see TriageBotAIWiringTests (PP-4810).
+        let aiEnabled = TriageBotAIWiring.aiWiring(
+            flagEnabled: RemoteFeatureFlags.shared.isTriageBotAIFallbackEnabled,
+            keyPresent: bootstrappedKey != nil
+        )
 
         let fallbackClassifier: FallbackClassifier? = aiEnabled
             ? ClaudeFallbackClassifier(keyProvider: { keyStore.read() })
@@ -87,7 +91,16 @@ enum TriageBotFactory {
             gateway = ClipboardTicketGateway()
         }
 
-        let sink = OSLogTelemetrySink(subsystem: Bundle.main.bundleIdentifier ?? "palace", category: "triagebot")
+        // Telemetry sink: OSLog for local/dev visibility, Firebase Analytics in
+        // release builds (PP-4814). Both forward only enumerable id/count/enum
+        // parameters — FirebaseTriageTelemetrySink runs TelemetryContract so no
+        // free text can reach Analytics.
+        let sink: TelemetrySink
+        #if DEBUG
+        sink = OSLogTelemetrySink(subsystem: Bundle.main.bundleIdentifier ?? "palace", category: "triagebot")
+        #else
+        sink = FirebaseTriageTelemetrySink()
+        #endif
 
         return makeViewModel(
             reducer: reducer,


### PR DESCRIPTION
## Summary

Two factory-lane subtasks on one branch for the PalaceTriageBot package.

### PP-4810 — prove the AI fallback is inert by default
- Extracted the wiring decision (`aiEnabled = flag && key != nil`) out of `TriageBotFactory` into a pure `TriageBotAIWiring.aiWiring(flagEnabled:keyPresent:)` in **TriageBotCore**, so the "inert unless BOTH flag and key" invariant is unit-tested under `swift test` on macOS (the factory itself imports UIKit/Firebase and can't be package-tested). Table test pins all four flag×key combinations.
- New **TriageBotIOSTests** target with a `URLProtocol` recording harness:
  - (a) a flag-off conversation driven through `TriageBotViewModel` with `fallbackClassifier: nil` records **zero** network requests;
  - (b) `ClaudeFallbackClassifier` with a nil/empty key throws `.apiKeyMissing` **before** any request is recorded — pinning the guard order (rate-limit → key check → network) at `ClaudeFallbackClassifier.swift` ~64-69 so a refactor can't move the network call ahead of the key guard.
  - These import UIKit, so the target compiles to an empty bundle under macOS `swift test` and the real assertions run only on an iOS sim under **CI**.

### PP-4814 — production telemetry sink
- Added `TelemetryParameterKey` (the enumerable id/count/enum key space) + `TelemetryContract` to **TriageBotCore**. A spy-sink unit test drives the reducer and asserts every emitted parameter key is enumerable (no free-text parameter); a second test asserts the filter drops a free-text key.
- Host-side `FirebaseTriageTelemetrySink` forwards **only** enumerable parameters to `Analytics.logEvent`. `TriageBotFactory` selects it in release builds (`#else`), OSLog in DEBUG.

## Testing
- `swift test --package-path Palace/Packages/PalaceTriageBot` → **124 tests, 0 failures** (all TriageBotCore, incl. the new `TriageBotAIWiringTests` and `TelemetryContractTests`).
- Host code (`FirebaseTriageTelemetrySink`, the `TriageBotFactory` edits) and `TriageBotIOSTests` cannot build in this package-only worktree — **CI-gated**. Firebase sink added to both `Palace` and `Palace-noDRM` Sources phases via `scripts/pbxproj_add_swift.rb`.

## Notes
- `TriageBotFactory` edits kept localized (another PR also touches this file).
- Telemetry parameter values were already ids/counts/enum rawValues across the reducer; this change makes that a tested, enforced contract rather than a convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)