### PR TITLE
fix(audiobooks): dismiss download half-sheet on shell-present, show progress during LCP wait (first-open hang)

### DIFF
--- a/.forgeos/changesets/fix-audiobook-first-open-hang/architect-review.md
+++ b/.forgeos/changesets/fix-audiobook-first-open-hang/architect-review.md
@@ -1,0 +1,44 @@
+# Architect review — fix-contract "Audiobook first-open hang" (BUG A)
+
+**Reviewer role:** architect (independent)
+**Branch:** `fix/audiobook-first-open-hang` (contract-only; no code staged)
+**Round 2 verdict:** **APPROVED** — the round-1 block (F1) is resolved by the additive-backstop design. Three non-blocking warnings to fold into implementation.
+
+---
+
+## Round-1 findings — disposition
+
+### F1 (was fail) — RESOLVED
+Dismissal is now additive, not a move (scope-in bullet 5, `:23`). The final-`onFinish` dismissal at `BookDetailViewModel.swift:689` STAYS; the early `onLoadingShellPresented` callback ADDS an earlier dismissal on the shell-present path. This fully closes the stuck-sheet gap on ALL early-return paths, because `BookService.dispatchOpen`'s audiobook `defer { … onFinish?() }` (`:84-88`) wraps `await openAudiobook(...)` and fires `onFinish` **regardless of the Result** — including the `.alreadyLoading` (`:617-620`) and validation-failure (`:640-645`) early returns, which never present a shell and never fire the early callback. Both writes are `showHalfSheet = false` → idempotent, order-independent. Verified against the actual `defer` semantics.
+
+### F2 (was concern) — RESOLVED
+Self-contradictory "single fire" grep removed. The at-most-once (0-or-1) `didFireLoadingShellPresented` Bool design (`:37`) is sound, and **test 2b** (`:49`) is exactly the right guard: mock manager returns `.failure` WITHOUT firing the early callback → assert `showHalfSheet` still becomes false via the backstop. That test catches the never-fire regression; a grep never could.
+
+### F3 / F4 (were warnings) — RESOLVED
+Sibling callers named in Scope(out) (`:30`): `BookCellModel.openAudiobookFromCell` (`:641`, no half-sheet → default `nil`, unchanged) and the OverDrive cold-load recovery reopen (`:2544`, a re-open, not a first open). Both correctly unaffected via the defaulted param. `downloadProgress(for:)` confirmed as the progress source.
+
+---
+
+## New (round-2) findings — all warnings, none blocking
+
+### W1 — verification / **warning**: iPad present-then-dismiss timing is asserted, not verified
+Scope-out (`:31`) reasserts "No iPad modal-transition race reintroduced," and Acceptance (`:55`) verifies in-sim on **iPhone only** (repro env is iPhone 17 Pro, `:5`). The additive change moves the sheet dismissal from ~19s-after-present (current shipping behavior) to **~same tick as `presentLoadingShell`**. `presentLoadingShell` only *kicks off* the morphing-player fullScreenCover (sets `isPlayerExpanded = true`); the UIKit transition completes asynchronously. PP-4633's own in-code note (`BookDetailViewModel:676-686`) says dismissing the form-sheet *while the player is being presented* races on iPad and freezes the player — the fix relied on temporal separation, which the early callback compresses. The additive backstop guarantees the sheet dismisses eventually, but it does NOT protect against a player-fails-to-present freeze. Exposure is limited to `inAppPlaybackNavEnabled == true` (morphing player on).
+**Recommendation:** add one iPad-sim acceptance pass (drive `.listen` on an LCP audiobook with in-app nav ON → assert the morphing player presents AND the sheet dismisses, no freeze). Optionally defer the early dismiss by one runloop tick after `presentLoadingShell` so the presentation transaction completes first (literal present-then-dismiss). Cheap to close; I assessed this axis as passing in round 1, so this is a verify-don't-assume ask, not a design objection.
+
+### W2 — scope / **warning**: two-site vs one-site fire description is internally inconsistent
+Scope-in bullet 2 (`:19`, unchanged) still says fire "after `presentLoadingShell`" AND "when the shell is NOT presented … invoke it right before returning" (two fire sites). The new F2 text (`:37`) says it "fires only in the shell-present branch." Under the additive backstop both readings are SAFE (no double-fire via the Bool; no stuck sheet via the backstop), so this is editorial, not a correctness gap — but reconcile them. The non-shell fallback fire is now redundant with the backstop; simplest is to delete it from `:19` and let the shell-present branch be the sole early-fire site.
+
+### W3 — scope / **warning**: wrong file citation for the progress source
+`:30` cites `downloadProgress(for:)` as `AudiobookSessionManager.swift:1786`. The method is `MyBooksDownloadCenter.downloadProgress(for:) -> Double` at **`MyBooksDownloadCenter.swift:1786`** (reached via `AppContainer.production().downloadCenter`). Intent is correct; fix the file label so the implementer reads off the right source.
+
+---
+
+## Confirmations carried forward (pass)
+- **F-011 / PP-4436 preserved:** `awaitAudiobookContentLocal` + the PP-4542 gate (`:681-699`) untouched; early callback fires at `:660`, before the gate (`:681`) and the `loadGeneration` bump (`:710`); `presentOnFirstOpen()` sync-before-Task ordering (`AudiobookSessionPresenter.swift:220`) intact.
+- **Presenter later-wins:** `adoptPlaybackModel` (`:317`) unconditionally re-snapshots `overallDownloadProgress`/`isDownloading` (`:333-334`) after the wait/bind; `clearActiveSession` resets both. The `showDownloadProgress` setter is safe.
+- **BUG B split:** clean disjoint-module split (now its own PR per product-owner direction, `:59-64`) — BUG A does not touch the throttle/label surface.
+
+---
+
+## Bottom line
+APPROVED. The substantive block (stuck sheet on pre-shell failure) is correctly closed by keeping the always-fired final `onFinish` as an idempotent backstop, and test 2b locks it. Fold W1 (iPad verification — the only one with any runtime risk), W2 (reconcile the fire-site wording), and W3 (fix the file citation) into implementation. None block; W1 must be verified before merge, not before contract approval.

--- a/.forgeos/changesets/fix-audiobook-first-open-hang/fix-contract.md
+++ b/.forgeos/changesets/fix-audiobook-first-open-hang/fix-contract.md
@@ -1,0 +1,89 @@
+# Fix-contract — Audiobook first-checkout open looks hung (BUG A)
+
+**Branch:** `fix/audiobook-first-open-hang`
+**Area:** `audiobook` (see `docs/architecture/areas/audiobook/verification-checklist.md`)
+**Reproduced:** live on sim (iPhone 17 Pro, build 486) with *The Confusion* (LCP/Cantook) in A1QA — ~19s from Listen tap to player; download-progress half-sheet + spinning Listen button stacked over a static loading skeleton the entire time; dismisses only when the full `.lcpa` lands. Cold open (already-local) is fast. simdrive recording: `audiobook-first-open-hang-repro`.
+
+## Root cause (confirmed against current source)
+
+1. **Half-sheet dismissal is chained to FULL open completion.** `BookDetailViewModel.handleAction(.read/.listen)` dismisses the half-sheet only in the open *completion* (`BookDetailViewModel.swift:687-690`), which fires from `BookService.dispatchOpen`'s `defer` (`BookService.swift:84-88`) — i.e. only after `await openAudiobook(...)` returns.
+2. **`openAudiobook` blocks until the whole audio package is local.** The PP-4542 LCP content-local gate (`AudiobookSessionManager.swift:681-699`) `await`s `awaitAudiobookContentLocal` (polls disk up to 180s, `:2113`) before constructing the player. This wait is the **intentional fix for F-011/PP-4436** (the dominant 3.2.0 LCP first-open hang — streaming-from-license is broken under Readium 3.9.0). **It must NOT be removed or shortened.**
+3. **The shell shows no progress during the wait.** `presentLoadingShell` fires up front (`AudiobookSessionManager.swift:660-665`) but the presenter's `overallDownloadProgress`/`isDownloading` are fed ONLY from the toolkit playback model (`AudiobookSessionPresenter.swift:512-519`), which is adopted at `bind()` — *after* the wait. So during the wait the shell is a static skeleton → reads as "hung."
+
+Net: the sheet can't dismiss and the shell can't show progress until the entire download finishes.
+
+## Scope (in)
+
+- **`Palace/Audiobooks/AudiobookSessionManaging.swift`** — add an optional early-present hook to the protocol entry point(s): `onLoadingShellPresented: (@MainActor () -> Void)?` (default `nil`). Non-breaking (defaulted).
+- **`Palace/Audiobooks/AudiobookSessionManager.swift`**
+  - `openAudiobook(...)` (public `:544` + internal `:586`): accept `onLoadingShellPresented`. Invoke it **at most once** (W2: single fire site), on `@MainActor`, immediately after `presentLoadingShell(...)` at `:660-665` — i.e. only when the shell is actually presented (`startPlaying && inAppPlaybackNavEnabledProvider()`). Do NOT add a non-shell fallback fire — the always-fired final `onFinish` backstop (below) covers the non-shell / early-failure paths, so a second fire site is redundant. Guard with a local `didFireLoadingShellPresented` Bool for defense-in-depth.
+  - During the PP-4542 wait (`:681-699`): feed **download-center** progress into the presenter so the shell shows a determinate progress bar + "Downloading…" instead of a static skeleton. Read progress from `AppContainer.production().downloadCenter` for `book.identifier`; push into the presenter via the new presenter method below. Poll cadence reuses the existing `awaitAudiobookContentLocal` loop (no new timer).
+- **`Palace/Audiobooks/AudiobookSessionPresenter.swift`** — add a pre-bind progress setter, e.g. `func showDownloadProgress(_ fraction: Float)` that sets `isDownloading = true` + `overallDownloadProgress = fraction` (cleared normally at `bind()` / `clearActiveSession()`). Guarded so a later real `adoptPlaybackModel` mirror wins.
+- **`Palace/Book/UI/BookDetail/BookService.swift`** — thread the early callback through `open(...)` + `dispatchOpen(...)` **audiobook case only**. EPUB/PDF/streaming cases unchanged (they present synchronously; their existing `onFinish` is already prompt).
+- **`Palace/Book/UI/BookDetail/BookDetailViewModel.swift`** — in the `.read/.listen` audiobook path, dismiss the half-sheet EARLY (`showHalfSheet = false`) in the new `onLoadingShellPresented` callback. **ADDITIVE, not a move (architect F1):** the existing final-`onFinish` dismissal (`:687-690`) STAYS as an idempotent backstop, so an open that fails BEFORE the shell is presented (`.alreadyLoading` `:617-620`, validation failure `:640-645` — both reachable on the real Listen path, and neither presents a shell) still dismisses the sheet via the final completion. Both writes set `showHalfSheet = false` → idempotent, order-independent, no stuck sheet on any path. Non-audiobook read/listen (EPUB) keeps current behavior. Also keep the final `onFinish` for `removeProcessingButton`.
+
+## Scope (out) — DO NOT touch
+
+- **Do NOT remove/shorten `awaitAudiobookContentLocal` or the PP-4542 gate** — F-011/PP-4436 preservation. The wait stays; only the UI coupling changes.
+- **Do NOT change `presentOnFirstOpen()` / `presentLoadingShell` sync-before-Task ordering** — F-011 preservation contract (`swarm_0b7616e7` C-AudiobookSessionPresenter). The early callback fires AFTER `presentLoadingShell`, preserving order.
+- **Do NOT touch** `AudiobookLoader`, vendor adapters, `NowPlayingCoordinator`, `PlaybackBootstrapper`, CarPlay. This is a UI-coupling + progress-surfacing change, not a load-path change.
+- **Sibling `openAudiobook` callers (architect F3/F4) — named, unaffected via defaulted param, NOT modified:** `BookCellModel.openAudiobookFromCell` (`BookCellModel.swift:641`) opens from the My Books cell (no half-sheet there → no early callback needed; relies on default `nil`). The OverDrive cold-load recovery reopen inside `AudiobookSessionManager` (`:2544`, via `awaitAudiobookContentLocal` `:2118`) is a re-open, not a first open — it does not thread the early callback. **(W3 cite fix)** `downloadProgress(for:)` is on `MyBooksDownloadCenter.swift:1786`, reached via `AppContainer.production().downloadCenter` — the confirmed source for the determinate progress bar.
+- **Do NOT reorder the PP-4633 iPad dismissal** — present the shell first, THEN dismiss the sheet underneath (the early callback fires after `presentLoadingShell`, which is exactly present-then-dismiss). No iPad modal-transition race reintroduced.
+- **BUG B (button-label flicker on first open) is DEFERRED** to a fast-follow — it lives in a different module cluster (`BookCellModel` throttle, `BorrowReducer`, `LCPFulfillmentHandler` early `.downloadSuccessful`) and would push this past single-module scope. Filed as follow-up; see "Not done."
+
+## Verification criteria (grep-able before declaring done)
+
+- `grep -c "onLoadingShellPresented" Palace/Audiobooks/AudiobookSessionManager.swift` ≥ 3 (param on 2 overloads + ≥1 invocation site).
+- **Wiring guard (extracted-seam):** the shell-present + fire is extracted to `presentLoadingShellIfEligible(for:startPlaying:onLoadingShellPresented:)` (deterministically unit-testable without the auth/registry/network gauntlet the full `openAudiobook` requires). `grep -c "presentLoadingShellIfEligible" Palace/Audiobooks/AudiobookSessionManager.swift` ≥ 2 (definition + the call inside `openAudiobook` — the call is the wiring; deleting it re-hangs the sheet). Unit tests drive the extracted method directly and assert presenter-adopts-book + hook-fires.
+- **At-most-once fire** (F2 — corrected): the early callback fires 0 or 1 times per open, never twice. It fires only in the shell-present branch (after `presentLoadingShell`). It does NOT fire on the early-failure returns (`.alreadyLoading`, validation) — that is BY DESIGN; the sheet is dismissed there by the final-`onFinish` backstop. A local `Bool` (`didFireLoadingShellPresented`) guards against a second fire if the shell-present branch is ever re-entered. Assert via test, not a contradictory grep.
+- **Backstop present:** `grep -n "showHalfSheet = false" Palace/Book/UI/BookDetail/BookDetailViewModel.swift` still shows the dismissal inside the final read/listen completion (`~:689`) — NOT removed.
+- `grep -c "showDownloadProgress" Palace/Audiobooks/AudiobookSessionPresenter.swift` ≥ 1 and the manager's wait loop calls it: `grep -c "showDownloadProgress" Palace/Audiobooks/AudiobookSessionManager.swift` ≥ 1.
+- `grep -n "awaitAudiobookContentLocal" Palace/Audiobooks/AudiobookSessionManager.swift` still present at the open path (wait NOT removed).
+- Every new `await` boundary added in production is driven by a test via the public entry — see Tests. If not drivable (loader needs real audio), STOP + scope-defer that assertion (per skill Phase 1 rule).
+- Mutation kill ≥ 80% (diff-only) on `BookService.swift` seam + the presenter progress setter.
+- `scripts/verify-pr.sh --quick` PASS (pass `HARNESS_SESSION_SIM_UDID`).
+
+## Tests required (TDD — write first)
+
+1. **`BookService` early-callback ordering** (new `BookServiceAudiobookOpenTests` or extend existing): with a mock `AudiobookSessionManaging` whose `openAudiobook` invokes `onLoadingShellPresented` before its async return, assert the early callback fires BEFORE the final `onFinish`. This is the core regression guard for "sheet dismisses on shell-present, not on full completion."
+2. **`BookDetailViewModel` half-sheet dismissal timing**: driving `.listen` on an audiobook, assert `showHalfSheet` flips to `false` on the early presented signal (mock manager fires it) while the open Result is still pending. Contract-snapshot candidate (ordered dependency calls).
+2b. **`BookDetailViewModel` stuck-sheet regression (architect F1/F2 — the block):** driving `.listen` on an audiobook where the mock manager returns `.failure` (`.alreadyLoading` / validation) and NEVER fires `onLoadingShellPresented`, assert `showHalfSheet` STILL becomes `false` via the final `onFinish` backstop. This is the must-have guard that the never-fire path doesn't strand the sheet.
+3. **`AudiobookSessionPresenter.showDownloadProgress`**: asserts `isDownloading == true` + `overallDownloadProgress == fraction`, and that a subsequent `adoptPlaybackModel` mirror overrides it (later-wins).
+4. **Regression floor (must stay green):** `CrossVendorSmokeTests`, `AudiobookOpenStateRaceTests` (loadGeneration supersession — the early callback must not break the generation guard), `AudiobookLoadFailureSAMLReauthTests`.
+
+## Acceptance
+
+- Early presented callback fires once, on MainActor, after `presentLoadingShell`; half-sheet dismisses at shell-present (verified in-sim: sheet gone within ~1s of Listen tap, morphing player skeleton + **download progress bar** visible during the wait, not a frozen sheet).
+- **(W1) iPad verify-before-merge:** run one iPad-sim `.listen` pass (in-app nav ON) confirming the player still presents cleanly when the sheet dismisses near-same-tick as `presentLoadingShell` — PP-4633's freeze was "dismiss WHILE player presents." If any iPad freeze appears, defer the early dismiss by one runloop tick (`DispatchQueue.main.async`) so present fully commits first. iPhone repro already clean.
+- PP-4542 wait intact; F-011 does not regress (LCP first-open still opens from the local package).
+- All Verification criteria pass; regression floor green; mutation ≥ 80% diff-only; `verify-pr.sh --quick` PASS.
+
+## Companion workstream — BUG B (separate PR, same effort)
+
+Per product-owner direction (2026-07-16): **fold BUG B into this effort but ship as its OWN PR** (split A/B in PR). BUG B gets its own branch + fix-contract + architect review + SoD review, tracked at `.forgeos/changesets/fix-audiobook-first-open-flicker/fix-contract.md`.
+
+- **BUG B — first-open button-label flicker** (Cancel↔Download↔Listen bounce). Root: `throttle(50ms,latest:true)` leading+trailing replay (`BookCellModel.swift:365-375`, `BookDetailViewModel.swift:416-428`) + optimistic `bookState=.downloading` racing the registry (`BookDetailViewModel.swift:820`) + LCP early `.downloadSuccessful` promotion (`LCPFulfillmentHandler.swift:204`). Module cluster: `Book` + `MyBooks`.
+- **Sequencing:** BUG A (this PR) lands first — it's the reproduced primary complaint and is `Audiobooks`-centered. BUG B follows on its own branch off develop (or stacked on A if it touches shared BookDetailViewModel lines). Two PRs so each gets clean, focused SoD review.
+
+## SoD review round 1 (2026-07-16) — all 3 request-changes, addressed
+
+architect + qa_test + blast_radius all approved the DESIGN (F-011 preserved, dispatch correct, no scope drift) but blocked on two consistent findings, both now fixed:
+
+1. **Contract tests 1/2/2b absent** (all 3 reviewers). Fixed: injected `audiobookSession` into `BookService.open`/`dispatchOpen` (mirrors the existing `bookRegistry` injection) and added `PalaceTests/Book/BookServiceAudiobookOpenTests.swift` — Test 1 (early hook fires before `onFinish`) + Test 2b (session returns `.failure` without firing the hook → `onFinish` backstop still fires → half-sheet still dismisses). A `HookRecordingSession` mock overrides the 3-arg `openAudiobook` so the wiring is driven, not the global singleton.
+2. **iPad present-while-dismiss race** (architect). Fixed: the VM's `onLoadingShellPresented` closure now defers the dismiss one runloop tick (`DispatchQueue.main.async`) so the player present commits before the sheet dismisses underneath — preserves present-first-then-dismiss on iPad (PP-4633).
+
+Warnings folded in: mutation "0/0" reworded (no operator surface on changed lines; behavioral coverage by construction — not cited as proof); progress-feed reads the global download center (see Not done).
+
+## SoD review round 2 (2026-07-16) — all 3 approved; VM Test 2 then added
+
+architect + qa_test + blast_radius all APPROVED at tip 7ca030ffc (`review:architect` green). All three left ONE shared non-blocking warning: contract Test 2 (VM-level `showHalfSheet` dismissal) was delivered at the BookService seam, not the VM, and wasn't reconciled in "Not done". Per product-owner direction, Test 2 is now DELIVERED:
+- Added an `audiobookSession` injection seam to `BookDetailViewModel` (init param, default nil → BookService resolves the DI-root session) so the audiobook open path is drivable with a mock.
+- `BookDetailViewModelAudiobookDismissTests.testHandleActionListen_earlyShellHook_dismissesHalfSheetBeforeOpenCompletes`: drives the REAL `handleAction(.listen)` path (auth gate completes fast in-test, no network) with a mock session that fires the shell hook then HOLDS the open 3s; asserts the half-sheet dismisses within 1.5s. This ISOLATES the early hook — a mutant removing the early dismissal leaves the sheet up until onFinish (3s) and fails the 1.5s window. 9 new tests total; full set 48/48 green.
+
+## Not done (this PR)
+
+- **Progress-feed-during-wait mutation/unit coverage** (qa/blast warning): the `onProgress` sampling inside the static `awaitAudiobookContentLocal` reads `AppContainer.production().downloadCenter` and lives behind the `#if LCP` auth/registry/network gauntlet — not unit-driven. `showDownloadProgress` (the sink) IS fully tested; that it's *fed during the wait* is verified by the live sim repro, not a unit test. Cosmetic (progress bar). Explicit scope-defer.
+- **iPad-sim verify** still recommended as belt-and-suspenders even with the one-tick deferral (architect W1).
+- **Palace-noDRM build** (not in CI) — hook is outside `#if LCP`; blast_radius reasoned it compiles; verify by launching noDRM on a sim.
+- **Full-suite CI-parity run** — spot-check only so far.
+- BUG B — its own PR (above), not deferred.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1870,6 +1870,7 @@
 		FC5C80424EE10131FA0087F2 /* TPPSAMLSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E3B2C7B51DEBF595766568 /* TPPSAMLSignInTests.swift */; };
 		FCBE8B68654DA29199B7490D /* AppAdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B75E0B61DBA872395691E65 /* AppAdvancedSettingsView.swift */; };
 		FCC8A9905AF17077021995B7 /* OfflineQueueCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB89127F1F2E38E1E06CA5C /* OfflineQueueCoordinator.swift */; };
+		FCD12E3016C092CF32FB00F3 /* BookServiceAudiobookOpenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C7C68049D8AF012626234B /* BookServiceAudiobookOpenTests.swift */; };
 		FD8D0E357C66D1B11FC70361 /* TPPJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52226B7262C85C91578DB3A7 /* TPPJSON.swift */; };
 		FD944841337FCB9D26209ED4 /* ReadingStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA4D17463BADFD0DEBC53FA /* ReadingStats.swift */; };
 		FE48F9C21D03088224767755 /* TypographyPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABACD6237FD75664BEADFF58 /* TypographyPresetTests.swift */; };
@@ -2776,6 +2777,7 @@
 		989EAF4764014D23B7BE358F /* TPPProblemDocumentCacheManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPProblemDocumentCacheManagerTests.swift; sourceTree = "<group>"; };
 		9905AB408890B78E7B723F22 /* RatingConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingConfig.swift; sourceTree = "<group>"; };
 		99895C63131766252D87F554 /* BackupExclusionMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupExclusionMigration.swift; sourceTree = "<group>"; };
+		99C7C68049D8AF012626234B /* BookServiceAudiobookOpenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookServiceAudiobookOpenTests.swift; sourceTree = "<group>"; };
 		9A35DE944F78A26A081622BA /* TPPReaderPageListBusinessLogicTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderPageListBusinessLogicTests.swift; sourceTree = "<group>"; };
 		9A399B178C9ECF3F62C62172 /* AccountsManagerIsolationLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerIsolationLintTests.swift; sourceTree = "<group>"; };
 		9A586098465213BD58E11860 /* PDFReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderTests.swift; sourceTree = "<group>"; };
@@ -5689,6 +5691,7 @@
 				5645B2E3AB447845108FC02C /* BookRegistrySyncSideloadExemptionTests.swift */,
 				535929C8F559713321004F38 /* HostFailureTrackerTests.swift */,
 				863E4EF7FA12EFB2170C7638 /* RegistryFileRecoveryTests.swift */,
+				99C7C68049D8AF012626234B /* BookServiceAudiobookOpenTests.swift */,
 			);
 			path = Book;
 			sourceTree = "<group>";
@@ -7790,6 +7793,7 @@
 				F0484E1308E55E4B0EB6F5E7 /* TPPNetworkResponderSizeLimitTests.swift in Sources */,
 				84C69EA8FE64C58B402E6CD0 /* TabBarModernizationTests.swift in Sources */,
 				41D4DBBE207AF14A529ADE72 /* AudiobookSkipIntervalSettingsTests.swift in Sources */,
+				FCD12E3016C092CF32FB00F3 /* BookServiceAudiobookOpenTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -545,6 +545,42 @@ public final class AudiobookSessionManager: ObservableObject {
         await openAudiobook(book, startPlaying: startPlaying, forceRefulfill: false)
     }
 
+    /// Protocol witness for the early-present variant — threads the
+    /// `onLoadingShellPresented` hook into the internal overload so a presenting
+    /// caller can dismiss its transient UI (BookDetail half-sheet) the moment the
+    /// loading shell appears, not after the whole download lands. See
+    /// fix/audiobook-first-open-hang.
+    public func openAudiobook(_ book: TPPBook, startPlaying: Bool, onLoadingShellPresented: (@MainActor () -> Void)?) async -> Result<Void, AudiobookSessionError> {
+        await openAudiobook(book, startPlaying: startPlaying, forceRefulfill: false, onLoadingShellPresented: onLoadingShellPresented)
+    }
+
+    /// Presents the morphing player's loading shell and fires the early
+    /// `onLoadingShellPresented` hook — but ONLY for a user-initiated open
+    /// (`startPlaying`) with in-app nav on (the two conditions under which a
+    /// shell is actually shown). Returns whether the shell was presented.
+    ///
+    /// Called once from `openAudiobook` immediately after the auth/registry/
+    /// network validation passes and BEFORE the PP-4542 content-download wait, so
+    /// the hook lets a presenting caller (BookDetail half-sheet) dismiss its
+    /// transient UI the instant the player is on screen rather than after the
+    /// whole `.lcpa` lands. Extracted (rather than inlined) so the fire-on-present
+    /// contract is deterministically unit-testable without driving the full open
+    /// path. fix/audiobook-first-open-hang.
+    @discardableResult
+    func presentLoadingShellIfEligible(
+        for book: TPPBook,
+        startPlaying: Bool,
+        onLoadingShellPresented: (@MainActor () -> Void)?
+    ) -> Bool {
+        guard startPlaying, inAppPlaybackNavEnabledProvider() else { return false }
+        audiobookSessionPresenterProvider().presentLoadingShell(
+            for: book,
+            coverImage: book.coverImage ?? book.thumbnailImage
+        )
+        onLoadingShellPresented?()
+        return true
+    }
+
     /// WS-3: per-session bound on the OverDrive expired-URL re-fulfill recovery.
     /// A book id is inserted when its recovery re-open fires and removed when the
     /// user initiates a fresh open — so a persistent failure re-fulfills at most
@@ -583,7 +619,7 @@ public final class AudiobookSessionManager: ObservableObject {
     ///   instead of replaying the expired on-disk manifest. Internal (not part of
     ///   the public `AudiobookSessionManaging` surface); the public 2-param
     ///   witness above delegates here, and the in-class recovery branch calls it.
-    func openAudiobook(_ book: TPPBook, startPlaying: Bool, forceRefulfill: Bool, isColdLoadRecovery: Bool = false, isRecoveryReopen: Bool = false) async -> Result<Void, AudiobookSessionError> {
+    func openAudiobook(_ book: TPPBook, startPlaying: Bool, forceRefulfill: Bool, isColdLoadRecovery: Bool = false, isRecoveryReopen: Bool = false, onLoadingShellPresented: (@MainActor () -> Void)? = nil) async -> Result<Void, AudiobookSessionError> {
         Log.info(#file, "Opening audiobook: '\(book.title)' (id: \(book.identifier))\(forceRefulfill ? " [re-fulfill]" : "")\(isColdLoadRecovery ? " [cold-load recovery]" : "")")
         // Polish-phase (in-app-nav-polish-2026-06-01): record wall-clock
         // open time so the Continue Reading row's sort surfaces the real
@@ -657,12 +693,18 @@ public final class AudiobookSessionManager: ObservableObject {
         // idempotent with the bind-time `presentOnFirstOpen()`. The loading
         // skeleton clears once the toolkit reports `isLoaded`; a failed load
         // publishes `.error`, which the presenter tears down.
-        if startPlaying, inAppPlaybackNavEnabledProvider() {
-            audiobookSessionPresenterProvider().presentLoadingShell(
-                for: book,
-                coverImage: book.coverImage ?? book.thumbnailImage
-            )
-        }
+        // Present the shell, then fire the early hook so the caller can dismiss
+        // its transient UI (BookDetail half-sheet) NOW — underneath the shell,
+        // present-first per the PP-4633 iPad ordering — instead of leaving it
+        // stacked over the loading skeleton for the entire PP-4542 wait below.
+        // Extracted to `presentLoadingShellIfEligible` so the fire-on-present
+        // contract is unit-testable without the auth/registry/network gauntlet
+        // above. fix/audiobook-first-open-hang.
+        presentLoadingShellIfEligible(
+            for: book,
+            startPlaying: startPlaying,
+            onLoadingShellPresented: onLoadingShellPresented
+        )
 
 #if LCP
         // PP-4542 (gate): a freshly-borrowed LCP audiobook is marked
@@ -682,7 +724,21 @@ public final class AudiobookSessionManager: ObservableObject {
            LCPAudiobooks.canOpenBook(book),
            !Self.audiobookContentIsLocal(book.identifier) {
             Log.info(#file, "LCP audiobook content still downloading — awaiting local package before opening (PP-4542 gate)")
-            let landed = await Self.awaitAudiobookContentLocal(book.identifier)
+            // Feed download-center progress into the loading shell during the
+            // wait so it shows a determinate "Downloading…" bar instead of a
+            // static skeleton that reads as hung. Only when the shell is actually
+            // on screen (in-app nav); the toolkit playback model that normally
+            // drives this bar doesn't exist until bind, which is after the wait.
+            let feedProgressToShell = startPlaying && inAppPlaybackNavEnabledProvider()
+            let bookId = book.identifier
+            var progressSink: (@MainActor @Sendable (Float) -> Void)?
+            if feedProgressToShell {
+                progressSink = { [weak self] fraction in
+                    guard let self else { return }
+                    self.audiobookSessionPresenterProvider().showDownloadProgress(fraction)
+                }
+            }
+            let landed = await Self.awaitAudiobookContentLocal(bookId, onProgress: progressSink)
             // A newer open (user tapped a different book) would have replaced
             // currentBook + the .loading state; bail if so.
             guard currentBook?.identifier == book.identifier,
@@ -2110,14 +2166,24 @@ public final class AudiobookSessionManager: ObservableObject {
     /// a stalled/failed download can't hold the loading state forever; on timeout
     /// the caller surfaces the unavailable alert (i.e. no worse than today, just
     /// after giving the in-flight download a chance to finish).
+    /// - parameter onProgress: optional per-poll sink for the in-flight
+    ///   download fraction (0…1), read from the download center. Lets the caller
+    ///   drive a determinate "Downloading…" bar in the loading shell during the
+    ///   wait instead of showing a static skeleton (fix/audiobook-first-open-hang).
+    ///   MainActor-isolated to match the presenter it typically feeds.
     static func awaitAudiobookContentLocal(
         _ bookId: String,
         timeout: TimeInterval = 180,
-        pollInterval: TimeInterval = 0.5
+        pollInterval: TimeInterval = 0.5,
+        onProgress: (@MainActor @Sendable (Float) -> Void)? = nil
     ) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if audiobookContentIsLocal(bookId) { return true }
+            if let onProgress {
+                let fraction = Float(AppContainer.production().downloadCenter.downloadProgress(for: bookId))
+                await onProgress(fraction)
+            }
             try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
         }
         return audiobookContentIsLocal(bookId)

--- a/Palace/Audiobooks/AudiobookSessionManaging.swift
+++ b/Palace/Audiobooks/AudiobookSessionManaging.swift
@@ -65,6 +65,18 @@ protocol AudiobookSessionManaging: AnyObject {
     @discardableResult
     func openAudiobook(_ book: TPPBook, startPlaying: Bool) async -> Result<Void, AudiobookSessionError>
 
+    /// Opens an audiobook, invoking `onLoadingShellPresented` on the main actor
+    /// the moment the loading-player shell is presented — i.e. BEFORE the
+    /// PP-4542 content-download wait, not after full playback readiness. Lets a
+    /// presenting caller (BookDetail half-sheet) dismiss its transient UI as soon
+    /// as the morphing player is on screen, instead of leaving it stacked over
+    /// the loading shell for the whole `.lcpa` download (fix/audiobook-first-open-hang).
+    /// Fired at most once. A protocol-extension default forwards to the 2-arg
+    /// witness above, so existing test doubles keep conforming unchanged; the
+    /// production manager overrides it with the real hook.
+    @discardableResult
+    func openAudiobook(_ book: TPPBook, startPlaying: Bool, onLoadingShellPresented: (@MainActor () -> Void)?) async -> Result<Void, AudiobookSessionError>
+
     /// Plays the current audiobook.
     func play()
 
@@ -201,6 +213,16 @@ extension AudiobookSessionManaging {
     var chapterTimeLeft: TimeInterval { 0 }
     var toastMessage: String? { nil }
     func addBookmark(completion: @escaping (Error?) -> Void) { completion(nil) }
+
+    /// Default: forwards to the 2-arg witness, ignoring the shell-presented hook.
+    /// Lightweight test doubles that implement only `openAudiobook(_:startPlaying:)`
+    /// keep conforming; the production `AudiobookSessionManager` overrides this
+    /// with the real early-present hook. A mock that wants to exercise the hook
+    /// overrides this method directly.
+    @discardableResult
+    func openAudiobook(_ book: TPPBook, startPlaying: Bool, onLoadingShellPresented: (@MainActor () -> Void)?) async -> Result<Void, AudiobookSessionError> {
+        await openAudiobook(book, startPlaying: startPlaying)
+    }
 }
 
 // MARK: - AudiobookSessionManager Conformance

--- a/Palace/Audiobooks/AudiobookSessionPresenter.swift
+++ b/Palace/Audiobooks/AudiobookSessionPresenter.swift
@@ -220,6 +220,20 @@ class AudiobookSessionPresenter: ObservableObject {
         presentOnFirstOpen()
     }
 
+    /// Feeds *pre-bind* download progress into the loading shell during the
+    /// PP-4542 content-local wait — the window after `presentLoadingShell` but
+    /// before `adoptPlaybackModel`, when there is no toolkit playback model yet
+    /// to mirror `$overallDownloadProgress` from. Without this the shell shows a
+    /// static skeleton for the whole `.lcpa` download and reads as "hung" (see
+    /// fix/audiobook-first-open-hang). `fraction` is the download-center's
+    /// `downloadProgress(for:)` (0…1). Sets `isDownloading = true` so the bar is
+    /// visible. Superseded the moment `adoptPlaybackModel` re-snapshots both
+    /// mirrors at bind (`:333-334`), so this is strictly a pre-bind placeholder.
+    func showDownloadProgress(_ fraction: Float) {
+        overallDownloadProgress = max(0, min(1, fraction))
+        isDownloading = true
+    }
+
     /// Tap-on-mini-player entry point. Sets `isPlayerExpanded = true` so
     /// the root fullScreenCover shows the full player.
     func expand() {

--- a/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+++ b/Palace/Book/UI/BookDetail/BookDetailViewModel.swift
@@ -131,6 +131,16 @@ final class BookDetailViewModel: ObservableObject {
     private let samplePreviewManager: SamplePreviewManager
     private let readerService: ReaderService
     private let metadataHydrator: BookMetadataHydrator
+    /// Optional injected audiobook session — nil in production (BookService
+    /// resolves the DI-root session). A test injects a mock so the audiobook
+    /// open → half-sheet-dismiss wiring is drivable. fix/audiobook-first-open-hang.
+    private let injectedAudiobookSession: AudiobookSessionManaging?
+    /// Optional auth-gate override — nil in production (the read/listen path runs
+    /// the real `ensureAuthAndExecute`, which loads the auth document and may
+    /// present a sign-in modal against real singletons / UserDefaults / network).
+    /// A test injects an immediate pass-through so the dismissal wiring is driven
+    /// deterministically without touching auth. fix/audiobook-first-open-hang.
+    private let authGateOverride: ((@escaping () -> Void) -> Void)?
     private var cancellables = Set<AnyCancellable>()
 
     typealias BookMetadataHydrator = (URL) async throws -> TPPBook?
@@ -183,7 +193,9 @@ final class BookDetailViewModel: ObservableObject {
         opdsFeedService: OPDSFeedService,
         samplePreviewManager: SamplePreviewManager,
         readerService: ReaderService,
-        metadataHydrator: BookMetadataHydrator? = nil
+        metadataHydrator: BookMetadataHydrator? = nil,
+        audiobookSession: AudiobookSessionManaging? = nil,
+        authGateOverride: ((@escaping () -> Void) -> Void)? = nil
     ) {
         self.book = book
         self.registry = registry
@@ -193,6 +205,12 @@ final class BookDetailViewModel: ObservableObject {
         self.opdsFeedService = opdsFeedService
         self.samplePreviewManager = samplePreviewManager
         self.readerService = readerService
+        // Test seam (fix/audiobook-first-open-hang): lets a test drive the
+        // audiobook open path with a mock session so the half-sheet dismissal
+        // wiring is exercised. nil in production → BookService falls back to the
+        // AppContainer DI-root session.
+        self.injectedAudiobookSession = audiobookSession
+        self.authGateOverride = authGateOverride
         // Default hydrator captures the injected services instead of reading
         // .shared singletons. Tests pass a custom hydrator to short-circuit.
         self.metadataHydrator = metadataHydrator ?? { url in
@@ -678,16 +696,35 @@ final class BookDetailViewModel: ObservableObject {
             // full-screen presentation; on iPad it renders as a floating
             // form-sheet that otherwise stays on screen.
             //
-            // The dismiss MUST happen in the open completion (after the
-            // reader/player is presented), NOT on tap: on iPad, dismissing the
-            // form-sheet while the player is being presented races the two
-            // modal transitions, so the player fails to present and the screen
-            // freezes. Presenting first, then dismissing the sheet underneath,
-            // avoids the race. Mirrors the .reserve / .return cases.
-            didSelectRead(for: book) {
+            // The dismiss MUST happen AFTER the reader/player is presented, NOT on
+            // tap: on iPad, dismissing the form-sheet while the player is being
+            // presented races the two modal transitions, so the player fails to
+            // present and the screen freezes. Presenting first, then dismissing
+            // the sheet underneath, avoids the race. Mirrors .reserve / .return.
+            //
+            // fix/audiobook-first-open-hang: for AUDIOBOOKS the open completion
+            // fires only after the PP-4542 content-download wait (up to minutes on
+            // a fresh checkout), which left the half-sheet stacked over the loading
+            // shell looking hung. So dismiss EARLY via `onLoadingShellPresented` —
+            // fired the instant the morphing player's loading shell is on screen,
+            // still present-first-then-dismiss (no iPad race). The completion
+            // dismissal below STAYS as an idempotent backstop: EPUB has no shell
+            // hook, and audiobook opens that fail BEFORE presenting a shell
+            // (already-loading / validation) never fire the early hook, so the
+            // always-fired completion still clears the sheet. Both write the same
+            // value → order-independent, no stuck sheet on any path.
+            didSelectRead(for: book, completion: {
                 self.removeProcessingButton(button)
                 self.showHalfSheet = false
-            }
+            }, onLoadingShellPresented: { [weak self] in
+                // Defer the dismiss one runloop tick so the player's present
+                // (the shell hook fires in the SAME tick that sets
+                // isPlayerExpanded = true) fully commits before we dismiss the
+                // sheet underneath. Dismissing in the same tick is exactly the
+                // PP-4633 iPad present-while-dismiss modal race; the one-tick
+                // hop keeps present-first-then-dismiss ordering on iPad too.
+                DispatchQueue.main.async { self?.showHalfSheet = false }
+            })
 
         case .readStreaming:
             // PP-4161: streaming-HTML titles don't go through ensureAuthAndExecute
@@ -732,6 +769,19 @@ final class BookDetailViewModel: ObservableObject {
     // MARK: - Authentication Helper
 
     /// Ensures authentication document is loaded and handles sign-in if needed.
+    /// Routes an action through the auth gate. In production this is the real
+    /// `ensureAuthAndExecute` (auth-doc load + possible sign-in modal); a test can
+    /// inject `authGateOverride` (an immediate pass-through) so the read/listen
+    /// path is driven deterministically without touching the real accountsManager
+    /// / UserDefaults / network. fix/audiobook-first-open-hang.
+    private func runAuthGate(_ action: @escaping () -> Void) {
+        if let authGateOverride {
+            authGateOverride(action)
+        } else {
+            ensureAuthAndExecute(action)
+        }
+    }
+
     private func ensureAuthAndExecute(_ action: @escaping () -> Void) {
         let businessLogic = TPPSignInBusinessLogic(
             libraryAccountID: accountsManager.currentAccount?.uuid ?? "",
@@ -865,8 +915,8 @@ final class BookDetailViewModel: ObservableObject {
     // MARK: - Reading
 
     @MainActor
-    func didSelectRead(for book: TPPBook, completion: (() -> Void)?) {
-        ensureAuthAndExecute { [weak self] in
+    func didSelectRead(for book: TPPBook, completion: (() -> Void)?, onLoadingShellPresented: (@MainActor () -> Void)? = nil) {
+        runAuthGate { [weak self] in
             Task { @MainActor in
                 guard let self = self else { return }
                 #if FEATURE_DRM_CONNECTOR
@@ -874,7 +924,7 @@ final class BookDetailViewModel: ObservableObject {
 
                 if user.hasCredentials() {
                     if user.hasAuthToken() {
-                        self.openBook(book, completion: completion)
+                        self.openBook(book, completion: completion, onLoadingShellPresented: onLoadingShellPresented)
                         return
                     } else if AdobeCertificate.isDRMAvailable &&
                                 !AdobeDRMService.shared.isUserAuthorized(user.userID, deviceID: user.deviceID) {
@@ -882,7 +932,7 @@ final class BookDetailViewModel: ObservableObject {
                         Task {
                             do {
                                 try await AdobeDRMService.shared.ensureDeviceActivated()
-                                await MainActor.run { self.openBook(book, completion: completion) }
+                                await MainActor.run { self.openBook(book, completion: completion, onLoadingShellPresented: onLoadingShellPresented) }
                             } catch {
                                 Log.error(#file, "Adobe DRM activation failed for open: \(error.localizedDescription)")
                                 await MainActor.run { completion?() }
@@ -892,13 +942,13 @@ final class BookDetailViewModel: ObservableObject {
                     }
                 }
                 #endif
-                self.openBook(book, completion: completion)
+                self.openBook(book, completion: completion, onLoadingShellPresented: onLoadingShellPresented)
             }
         }
     }
 
     @MainActor
-    func openBook(_ book: TPPBook, completion: (() -> Void)?) {
+    func openBook(_ book: TPPBook, completion: (() -> Void)?, onLoadingShellPresented: (@MainActor () -> Void)? = nil) {
         Log.debug(#file, "🎬 [OPEN BOOK] User requested to open book: \(book.title) (ID: \(book.identifier))")
         TPPCirculationAnalytics.postEvent("open_book", withBook: book)
 
@@ -927,12 +977,12 @@ final class BookDetailViewModel: ObservableObject {
             }
         case .audiobook:
             Log.debug(#file, "  → Opening as AUDIOBOOK")
-            openAudiobook(resolvedBook) { [weak self] in
+            openAudiobook(resolvedBook, completion: { [weak self] in
                 DispatchQueue.main.async {
                     self?.processingButtons.removeAll()
                     completion?()
                 }
-            }
+            }, onLoadingShellPresented: onLoadingShellPresented)
         case .streamingHTML:
             // PP-4161: streaming-media titles use the in-app WKWebView reader
             // presented via NavigationCoordinator. Note: handleAction(.readStreaming)
@@ -960,8 +1010,8 @@ final class BookDetailViewModel: ObservableObject {
 
     // MARK: - Audiobook Opening
 
-    func openAudiobook(_ book: TPPBook, completion: (() -> Void)? = nil) {
-        BookService.open(book, onFinish: completion)
+    func openAudiobook(_ book: TPPBook, completion: (() -> Void)? = nil, onLoadingShellPresented: (@MainActor () -> Void)? = nil) {
+        BookService.open(book, audiobookSession: injectedAudiobookSession, onFinish: completion, onLoadingShellPresented: onLoadingShellPresented)
     }
 
     // MARK: - Streaming HTML Reader (PP-4161)

--- a/Palace/Book/UI/BookDetail/BookService.swift
+++ b/Palace/Book/UI/BookDetail/BookService.swift
@@ -28,8 +28,14 @@ enum BookService {
     /// lock from latching permanently and silently swallowing every retry.
     private static let openLockSafetyRelease: TimeInterval = 30
 
+    /// - parameter onLoadingShellPresented: audiobook-only early hook — fired the
+    ///   moment the morphing player's loading shell is presented (before the
+    ///   PP-4542 content-download wait) so a presenting caller can dismiss its
+    ///   transient UI (BookDetail half-sheet) immediately rather than after full
+    ///   playback readiness. Nil for EPUB/PDF/streaming (they present promptly and
+    ///   rely on `onFinish`). fix/audiobook-first-open-hang.
     @MainActor
-    static func open(_ book: TPPBook, bookRegistry: TPPBookRegistryProvider = AppContainer.production().bookRegistry, onFinish: (() -> Void)? = nil) {
+    static func open(_ book: TPPBook, bookRegistry: TPPBookRegistryProvider = AppContainer.production().bookRegistry, audiobookSession: AudiobookSessionManaging? = nil, onFinish: (() -> Void)? = nil, onLoadingShellPresented: (@MainActor () -> Void)? = nil) {
         guard !openingBooks.contains(book.identifier) else {
             Log.warn(#file, "Book \(book.title) is already being opened, ignoring duplicate request")
             onFinish?()
@@ -40,7 +46,7 @@ enum BookService {
         scheduleOpenLockSafetyRelease(for: book.identifier)
         let resolvedBook = bookRegistry.book(forIdentifier: book.identifier) ?? book
 
-        dispatchOpen(resolvedBook, onFinish: onFinish)
+        dispatchOpen(resolvedBook, audiobookSession: audiobookSession, onFinish: onFinish, onLoadingShellPresented: onLoadingShellPresented)
     }
 
     @MainActor
@@ -58,7 +64,7 @@ enum BookService {
     }
 
     @MainActor
-    private static func dispatchOpen(_ book: TPPBook, onFinish: (() -> Void)?) {
+    private static func dispatchOpen(_ book: TPPBook, audiobookSession: AudiobookSessionManaging? = nil, onFinish: (() -> Void)?, onLoadingShellPresented: (@MainActor () -> Void)? = nil) {
         switch book.defaultBookContentType {
         case .epub:
             Task { @MainActor in
@@ -80,12 +86,17 @@ enum BookService {
             // stops the previous session (releasing its DRM decryptor) before
             // loading the new audiobook — the ordering invariant that prevents
             // a stale LCP Publication from hanging publicationOpener.open().
+            let session = audiobookSession ?? AppContainer.production().audiobookSession
             Task { @MainActor in
                 defer {
                     openingBooks.remove(book.identifier)
                     onFinish?()
                 }
-                _ = await AppContainer.production().audiobookSession.openAudiobook(book, startPlaying: true)
+                _ = await session.openAudiobook(
+                    book,
+                    startPlaying: true,
+                    onLoadingShellPresented: onLoadingShellPresented
+                )
             }
         case .streamingHTML:
             // PP-4161: streaming-HTML titles route through NavigationCoordinator

--- a/PalaceTests/Audiobooks/AudiobookFirstOpenHangTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookFirstOpenHangTests.swift
@@ -541,6 +541,98 @@ final class AudiobookFirstOpenHangTests: XCTestCase {
         XCTAssertEqual(spy.stopCallCount, 1, "probe.stop must run via defer even on exhaustion")
     }
 
+    // MARK: - fix/audiobook-first-open-hang: early loading-shell-presented hook
+    //
+    // BUG A: on first checkout+open of an LCP audiobook, the BookDetail
+    // download-progress half-sheet stayed presented over the loading shell for
+    // the ENTIRE PP-4542 content-download wait (~19s in the live repro), because
+    // its dismissal was chained to the FULL open completion. The fix fires
+    // `onLoadingShellPresented` the moment the morphing player's loading shell is
+    // on screen (before the wait) so the caller can dismiss its transient UI
+    // immediately, present-first-then-dismiss (no iPad race). These tests pin the
+    // production fire site (`AudiobookSessionManager` open path, after
+    // `presentLoadingShell`) and its gating.
+
+    /// Builds a session manager bound to a SPECIFIC presenter instance (captured
+    /// + reset so cross-test pollution on the shared presenter can't leak
+    /// `isPlayerExpanded`/`currentBook` into these assertions) with a fixed
+    /// in-app-nav flag. Returns both so the test can assert on the same presenter
+    /// the manager drives.
+    private func makeManagerForShellTests(inAppNavEnabled: Bool) -> (AudiobookSessionManager, AudiobookSessionPresenter) {
+        let presenter = appContainer.audiobookSessionPresenter
+        presenter.clearActiveSession()
+        let manager = AudiobookSessionManager(
+            appContainer: appContainer,
+            audiobookSessionPresenterProvider: { presenter },
+            inAppPlaybackNavEnabledProvider: { inAppNavEnabled }
+        )
+        return (manager, presenter)
+    }
+
+    /// PRE: in-app nav ON, `startPlaying: true` → the shell IS eligible.
+    /// EXPECTED: `presentLoadingShellIfEligible` presents the shell (presenter
+    /// adopts the book + expands) and fires `onLoadingShellPresented` exactly
+    /// once, returning true. This is the seam `openAudiobook` calls after
+    /// validation and BEFORE the PP-4542 wait — firing here is what lets
+    /// BookDetail dismiss the half-sheet before the download instead of after.
+    /// Deleting the `onLoadingShellPresented?()` call makes fireCount fail;
+    /// deleting the `presentLoadingShell` call makes the presenter assertions fail.
+    func testPresentLoadingShellIfEligible_presentsShellAndFiresHook_whenEligible() {
+        let (manager, presenter) = makeManagerForShellTests(inAppNavEnabled: true)
+        let book = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+        var fireCount = 0
+
+        let presented = manager.presentLoadingShellIfEligible(
+            for: book, startPlaying: true, onLoadingShellPresented: { fireCount += 1 }
+        )
+
+        XCTAssertTrue(presented, "An eligible user-initiated open with in-app nav on must present the shell")
+        XCTAssertEqual(fireCount, 1,
+                       "onLoadingShellPresented must fire exactly once when the shell is presented — this is the early half-sheet-dismiss signal")
+        XCTAssertEqual(presenter.currentBook?.identifier, book.identifier,
+                       "Presenting the shell must adopt the book so the morphing player shows its cover/title")
+        XCTAssertTrue(presenter.isPlayerExpanded,
+                      "Presenting the shell must expand the player (present-first, so the sheet dismisses underneath it — no iPad race)")
+    }
+
+    /// PRE: in-app nav OFF → not eligible (legacy pushed route, no shell).
+    /// EXPECTED: returns false, does NOT fire the hook, does NOT present a shell.
+    /// The caller relies on its always-fired final `onFinish` backstop to dismiss
+    /// its transient UI on this path — the architect-F1 stuck-sheet guard. A
+    /// mutant that drops the `inAppPlaybackNavEnabledProvider()` gate fails this.
+    func testPresentLoadingShellIfEligible_doesNotFireOrPresent_whenInAppNavOff() {
+        let (manager, presenter) = makeManagerForShellTests(inAppNavEnabled: false)
+        let book = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+        var fireCount = 0
+
+        let presented = manager.presentLoadingShellIfEligible(
+            for: book, startPlaying: true, onLoadingShellPresented: { fireCount += 1 }
+        )
+
+        XCTAssertFalse(presented, "With in-app nav off no shell is shown — the hook must not fire")
+        XCTAssertEqual(fireCount, 0, "The early hook must not fire when no shell is presented")
+        XCTAssertFalse(presenter.isPlayerExpanded,
+                       "No shell must be presented when in-app nav is off")
+    }
+
+    /// PRE: `startPlaying: false` (background/resume open) → not eligible.
+    /// EXPECTED: returns false, hook does not fire. Pins the `startPlaying` half
+    /// of the eligibility gate (a mutant dropping the `startPlaying` guard fails).
+    func testPresentLoadingShellIfEligible_doesNotFire_whenNotStartPlaying() {
+        let (manager, presenter) = makeManagerForShellTests(inAppNavEnabled: true)
+        let book = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+        var fireCount = 0
+
+        let presented = manager.presentLoadingShellIfEligible(
+            for: book, startPlaying: false, onLoadingShellPresented: { fireCount += 1 }
+        )
+
+        XCTAssertFalse(presented, "A non-user-initiated open (startPlaying: false) presents no shell")
+        XCTAssertEqual(fireCount, 0, "The early hook must not fire on a non-start-playing open")
+        XCTAssertFalse(presenter.isPlayerExpanded,
+                       "A non-start-playing open must not expand the player")
+    }
+
     // MARK: - Helpers
 
     /// Builds a TrackPosition without touching the toolkit's heavy

--- a/PalaceTests/Audiobooks/AudiobookSessionPresenterTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookSessionPresenterTests.swift
@@ -761,4 +761,55 @@ final class AudiobookSessionPresenterTests: XCTestCase {
         XCTAssertEqual(AudiobookSessionPresenter.chapterProgress(offset: -30, timeLeft: 90), 0, accuracy: 0.0001,
                        "A negative chapter offset must clamp to 0, not produce a negative scrubber position")
     }
+
+    // MARK: - fix/audiobook-first-open-hang: pre-bind download progress
+    //
+    // During the PP-4542 content-download wait the toolkit playback model that
+    // normally mirrors `$overallDownloadProgress` doesn't exist yet, so the
+    // loading shell showed a static skeleton that read as "hung." `showDownloadProgress`
+    // feeds download-center progress into the shell during that window so it shows
+    // a determinate "Downloading…" bar. Superseded by `adoptPlaybackModel` at bind.
+
+    /// EXPECTED: sets the download fraction and flips `isDownloading` true so the
+    /// shell's download bar becomes visible during the pre-bind wait.
+    /// Mutates: dropping the `isDownloading = true` assignment hides the bar and
+    /// fails this; changing the assigned fraction fails the value assertion.
+    func testShowDownloadProgress_setsProgressAndDownloadingFlag() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        presenter.showDownloadProgress(0.42)
+        XCTAssertEqual(presenter.overallDownloadProgress, 0.42, accuracy: 0.0001,
+                       "showDownloadProgress must publish the download fraction so the shell bar is determinate")
+        XCTAssertTrue(presenter.isDownloading,
+                      "showDownloadProgress must flip isDownloading true so the shell's download bar is visible during the wait")
+    }
+
+    /// EXPECTED: fractions outside 0…1 clamp. Pins BOTH bounds of the
+    /// `max(0, min(1, fraction))` guard — a garbage download-center reading must
+    /// never drive the bar past full or negative.
+    /// Mutates: dropping the upper `min(1,_)` lets 1.7 through; dropping the lower
+    /// `max(0,_)` lets -0.3 through — each fails the respective assertion.
+    func testShowDownloadProgress_clampsOutOfRangeFractions() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        presenter.showDownloadProgress(1.7)
+        XCTAssertEqual(presenter.overallDownloadProgress, 1.0, accuracy: 0.0001,
+                       "A fraction > 1 must clamp to 1.0 — the download bar can't exceed full")
+        presenter.showDownloadProgress(-0.3)
+        XCTAssertEqual(presenter.overallDownloadProgress, 0.0, accuracy: 0.0001,
+                       "A negative fraction must clamp to 0 — the download bar can't go negative")
+    }
+
+    /// EXPECTED: the pre-bind placeholder is torn down by `clearActiveSession`
+    /// (the stopPlayback/dismiss path), so a superseded/failed open doesn't leave
+    /// a stale "Downloading…" bar behind.
+    /// Mutates: if clearActiveSession stops resetting these mirrors, the bar
+    /// persists and this fails.
+    func testShowDownloadProgress_clearedByClearActiveSession() {
+        let presenter = AudiobookSessionPresenter(sessionManager: spySession)
+        presenter.showDownloadProgress(0.6)
+        presenter.clearActiveSession()
+        XCTAssertEqual(presenter.overallDownloadProgress, 0, accuracy: 0.0001,
+                       "clearActiveSession must reset the pre-bind download fraction so no stale bar survives teardown")
+        XCTAssertFalse(presenter.isDownloading,
+                       "clearActiveSession must clear the pre-bind isDownloading flag")
+    }
 }

--- a/PalaceTests/Book/BookServiceAudiobookOpenTests.swift
+++ b/PalaceTests/Book/BookServiceAudiobookOpenTests.swift
@@ -1,0 +1,223 @@
+//
+//  BookServiceAudiobookOpenTests.swift
+//  PalaceTests
+//
+//  fix/audiobook-first-open-hang (BUG A) — pins the BookService audiobook-open
+//  wiring that the SoD reviewers (architect/qa/blast_radius) flagged as
+//  untested: the early `onLoadingShellPresented` hook forwarding + the
+//  always-fired `onFinish` backstop.
+//
+//  These are the contract's Test 1 (early hook fires BEFORE onFinish) and
+//  Test 2b (the "must-have guard" — when the session presents NO shell and
+//  never fires the hook, onFinish STILL fires, so BookDetail's completion
+//  closure still dismisses the half-sheet: no stuck sheet on the pre-shell
+//  failure paths — the exact round-1 architect F1 block).
+//
+//  Uses the injectable `audiobookSession` seam on `BookService.open` (mirrors
+//  the pre-existing `bookRegistry` injection) so the wiring is drivable with a
+//  mock instead of the global singleton.
+//
+//  Copyright (c) 2026 The Palace Project. All rights reserved.
+//
+
+import Combine
+import UIKit
+import XCTest
+import PalaceAudiobookToolkit
+import PalaceCatalog
+@testable import Palace
+
+@MainActor
+final class BookServiceAudiobookOpenTests: XCTestCase {
+
+    /// Test 1 — the early hook fires the instant the session reports the shell
+    /// presented, BEFORE the open completes and `onFinish` runs. This ordering is
+    /// what lets BookDetail dismiss the half-sheet at shell-present time instead
+    /// of after the (up-to-minutes) PP-4542 content-download wait.
+    ///
+    /// Mutates: forwarding `nil` for the hook at the `dispatchOpen` call site
+    /// (dropping the early-dismiss wiring) makes `order` == ["finish"] and fails.
+    func testOpen_audiobook_firesLoadingShellPresentedBeforeOnFinish() async {
+        let book = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+        let session = HookRecordingSession(fireHook: true, result: .success(()))
+        var order: [String] = []
+        let finished = expectation(description: "onFinish called")
+
+        BookService.open(
+            book,
+            audiobookSession: session,
+            onFinish: { order.append("finish"); finished.fulfill() },
+            onLoadingShellPresented: { order.append("shell") }
+        )
+
+        await fulfillment(of: [finished], timeout: 3)
+        XCTAssertEqual(order, ["shell", "finish"],
+                       "The early loading-shell hook must fire BEFORE the open completion — that ordering is the whole point of dismissing the half-sheet at shell-present rather than at full-open")
+        XCTAssertTrue(session.threeArgHookVariantCalled,
+                      "BookService must route audiobook opens through the hook-carrying openAudiobook variant, not the 2-arg one — else the hook is silently dropped")
+    }
+
+    /// Test 2b (the block) — the session returns `.failure` WITHOUT ever firing
+    /// the shell hook (the `.alreadyLoading` / validation early-return paths that
+    /// never present a shell). `onFinish` MUST still fire via BookService's
+    /// `defer`, so BookDetail's completion closure still runs `showHalfSheet =
+    /// false`. This is the idempotent backstop that guarantees no path strands
+    /// the half-sheet.
+    ///
+    /// Mutates: removing `onFinish?()` from the audiobook `defer` in
+    /// `BookService.dispatchOpen` makes the expectation time out — the sheet
+    /// would hang forever on the pre-shell failure paths.
+    func testOpen_audiobook_failureWithoutShellHook_stillCallsOnFinishBackstop() async {
+        let book = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+        let session = HookRecordingSession(fireHook: false, result: .failure(.alreadyLoading))
+        var hookFired = false
+        let finished = expectation(description: "onFinish backstop called")
+
+        BookService.open(
+            book,
+            audiobookSession: session,
+            onFinish: { finished.fulfill() },
+            onLoadingShellPresented: { hookFired = true }
+        )
+
+        await fulfillment(of: [finished], timeout: 3)
+        XCTAssertFalse(hookFired,
+                       "When the session presents no shell (early-failure path), the early hook must NOT fire")
+        // onFinish firing (fulfillment succeeded) proves the always-fired backstop:
+        // BookDetail's completion closure — which sets showHalfSheet = false — still
+        // runs, so the half-sheet dismisses even though the early hook never did.
+    }
+}
+
+// MARK: - VM-level dismissal (contract Test 2)
+
+/// Pins the BookDetailViewModel `.listen` wiring: the early shell hook fired by
+/// the (injected) session dismisses the half-sheet. Uses the `audiobookSession`
+/// injection seam on BookDetailViewModel so the audiobook open path is driven
+/// with a mock instead of the DI-root session. fix/audiobook-first-open-hang.
+@MainActor
+final class BookDetailViewModelAudiobookDismissTests: XCTestCase {
+
+    /// PRE: half-sheet is showing; the mock session fires `onLoadingShellPresented`
+    /// then HOLDS the open for 3s (simulating the PP-4542 download wait) before
+    /// completing. EXPECTED: `handleAction(.listen)` dismisses the half-sheet
+    /// PROMPTLY (well within the 3s hold) — proving the dismissal came from the
+    /// EARLY shell hook, not the delayed `onFinish` backstop. This is the whole
+    /// fix: the sheet no longer waits on the full open.
+    /// Mutates: deleting `showHalfSheet = false` from the `.read/.listen`
+    /// onLoadingShellPresented closure means the sheet can only clear at
+    /// onFinish (3s later), so the 1.5s assertion fails.
+    func testHandleActionListen_earlyShellHook_dismissesHalfSheetBeforeOpenCompletes() async {
+        let book = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+        let registry = TPPBookRegistryMock()
+        registry.addBook(book, location: nil, state: .downloadSuccessful, fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
+        // Fire the early hook, then hold the open 3s before onFinish — so only the
+        // early-hook dismissal can win the 1.5s assertion window.
+        let session = HookRecordingSession(fireHook: true, result: .success(()), holdOpenSeconds: 3)
+        // Isolated test container (no production singletons) + an immediate
+        // auth-gate pass-through, so the path touches NO real accountsManager /
+        // UserDefaults / network (qa round-3): the seam bypasses the real
+        // ensureAuthAndExecute and runs the action straight through.
+        let container = makeTestAppContainer()
+
+        let vm = BookDetailViewModel(
+            book: book,
+            registry: registry,
+            downloadCenter: container.downloadCenter,
+            accountsManager: container.accountsManager,
+            settings: TPPSettings(),
+            opdsFeedService: container.opdsFeedService,
+            samplePreviewManager: container.samplePreviewManager,
+            readerService: container.readerService,
+            audiobookSession: session,
+            authGateOverride: { action in action() }
+        )
+        vm.showHalfSheet = true
+
+        vm.handleAction(for: .listen)
+        // Assert dismissal within 1.5s — half the hold — so the delayed onFinish
+        // backstop (3s) cannot be what dismisses it.
+        let dismissedEarly = await pollUntil(timeout: 1.5) { vm.showHalfSheet == false }
+
+        XCTAssertTrue(dismissedEarly,
+                      "The half-sheet must dismiss at shell-present time (early hook), NOT after the full open — that decoupling is the fix; a dismissal that waits for onFinish would miss this window")
+    }
+
+    /// Spins the main runloop until `condition` is true or the timeout elapses.
+    private func pollUntil(timeout: TimeInterval, _ condition: () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return condition()
+    }
+}
+
+// MARK: - Mock
+
+/// Minimal `AudiobookSessionManaging` that OVERRIDES the hook-carrying 3-arg
+/// `openAudiobook` (rather than inheriting the extension default) so a test can
+/// (a) choose whether the "shell presented" hook fires, and (b) control the
+/// returned result — modelling both the shell-presented success path and the
+/// pre-shell early-failure path. All other protocol members are boilerplate or
+/// inherited defaults.
+@MainActor
+private final class HookRecordingSession: AudiobookSessionManaging {
+    private let fireHook: Bool
+    private let result: Result<Void, AudiobookSessionError>
+    /// Seconds to hold the open (simulating the PP-4542 content-download wait)
+    /// AFTER firing the shell hook, before returning — so a test can prove the
+    /// dismissal came from the EARLY hook, not the (delayed) `onFinish` backstop.
+    private let holdOpenSeconds: Double
+    private(set) var threeArgHookVariantCalled = false
+
+    init(fireHook: Bool, result: Result<Void, AudiobookSessionError>, holdOpenSeconds: Double = 0) {
+        self.fireHook = fireHook
+        self.result = result
+        self.holdOpenSeconds = holdOpenSeconds
+    }
+
+    // The variant BookService must call — records that it was reached and,
+    // when configured, fires the shell hook before returning the result.
+    @discardableResult
+    func openAudiobook(_ book: TPPBook, startPlaying: Bool, onLoadingShellPresented: (@MainActor () -> Void)?) async -> Result<Void, AudiobookSessionError> {
+        threeArgHookVariantCalled = true
+        if fireHook { onLoadingShellPresented?() }
+        if holdOpenSeconds > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(holdOpenSeconds * 1_000_000_000))
+        }
+        return result
+    }
+
+    // 2-arg witness — required; should NOT be the path BookService takes.
+    @discardableResult
+    func openAudiobook(_ book: TPPBook, startPlaying: Bool) async -> Result<Void, AudiobookSessionError> {
+        result
+    }
+
+    // MARK: Protocol boilerplate (unused by these tests)
+    var state: AudiobookSessionState = .idle
+    var currentBook: TPPBook?
+    var currentChapters: [Chapter] = []
+    var currentChapter: Chapter?
+    var currentPosition: TrackPosition?
+    var isPlaying: Bool { false }
+    var coverImage: UIImage?
+    var hasActiveManager: Bool = false
+
+    let playbackStatePublisher = PassthroughSubject<AudiobookSessionState, Never>()
+    let chapterUpdatePublisher = PassthroughSubject<(chapters: [Chapter], current: Chapter?), Never>()
+    let errorPublisher = PassthroughSubject<AudiobookSessionError, Never>()
+
+    func play() {}
+    func pause() {}
+    func togglePlayPause() {}
+    func skipToChapter(at index: Int) {}
+    func skipBack() {}
+    func skipForward() {}
+    func cyclePlaybackRate() -> PlaybackRate { .normalTime }
+    func stopPlayback(dismissPhoneUI: Bool, persistFinalPosition: Bool) async {}
+    func updateCoverImage(_ image: UIImage?) {}
+    func recoverPlaybackForForegroundEntry() {}
+}


### PR DESCRIPTION
## What & why

First checkout+download of an LCP audiobook (repro: "The Confusion" on the A1QA test library) made the BookDetail **download-progress half-sheet look hung** — it stayed presented over the loading player for the **entire** `.lcpa` content download (~19s in a live sim repro), because the sheet's dismissal was chained to the *full* open completion. The PP-4542 gate deliberately waits for the local package (LCP streaming-from-license is broken under Readium 3.9.0), so the wait is correct — but the **UI was coupled to it**.

## The fix (decouple the UI from the wait — the wait itself is untouched)

1. **Dismiss the half-sheet at shell-present, not at full-open.** A new `onLoadingShellPresented` hook (threaded protocol → `AudiobookSessionManager` → `BookService` → `BookDetailViewModel`, fired from the extracted `presentLoadingShellIfEligible`, *before* the PP-4542 wait) lets BookDetail dismiss the sheet the instant the morphing player's loading shell is on screen. Deferred one runloop tick (`DispatchQueue.main.async`) so the present commits first — preserving the PP-4633 iPad present-then-dismiss ordering. The existing final-`onFinish` dismissal stays as an **idempotent backstop**, so opens that fail *before* presenting a shell (already-loading / validation) still dismiss the sheet — no stuck sheet on any path.
2. **Show real download progress during the wait.** `AudiobookSessionPresenter.showDownloadProgress(_:)` feeds download-center progress into the shell while it waits (the toolkit model that normally drives the bar doesn't exist until bind), so the wait reads "Downloading…" instead of "hung".

**F-011/PP-4542 preserved** — `awaitAudiobookContentLocal` and the LCP content-local gate are unchanged; the audiobook still opens from the reliable local package.

## Tests (9 new)
- `BookServiceAudiobookOpenTests`: early hook fires **before** `onFinish` (ordering) + failure-without-hook still fires the `onFinish` backstop; plus a VM-level test that drives `handleAction(.listen)` and asserts the half-sheet dismisses within 1.5s while the open is held 3s — **isolating the early hook** (uses an `authGateOverride` test seam so it touches no real singletons/network).
- `AudiobookFirstOpenHangTests`: `presentLoadingShellIfEligible` fires/gates correctly + adopts the book.
- `AudiobookSessionPresenterTests`: `showDownloadProgress` set / clamps both bounds / cleared on teardown.

Verified `** BUILD SUCCEEDED **` + `** TEST SUCCEEDED **` (48/48 in the touched suites) on iPhone 17 Pro sim.

## Review
Reproduced live on simulator. Architect-reviewed (2 pre-impl rounds) + full SoD review (architect + qa_test + blast_radius) — all **APPROVED**, verdicts recorded to the local heka ledger (chain-intact, Ed25519-signed).

## Not done (tracked in the commit body)
- iPad-sim verify-before-merge (belt-and-suspenders even with the one-tick defer).
- Palace-noDRM launch (not in CI; the shell hook is outside `#if LCP`).
- Full-suite CI-parity run (CI on this PR covers it).
- The progress-feed-during-wait sampling is scope-deferred for unit coverage (cosmetic; sink is tested, feed verified in-sim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
