### PR TITLE
feat(triagebot): reducer/preview hardening spine — free-text redaction, no-dead-end failures, preview editor, diagnostics toggle, context race (PP-4805/PP-4808/PP-4807/PP-4809/PP-4811)

### DIFF
--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ContextSnapshot.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ContextSnapshot.swift
@@ -52,6 +52,12 @@ public struct ContextSnapshot: Codable, Equatable, Sendable {
     /// correlates with audiobook playback drops and reader rendering issues.
     public let availableMemoryMB: Int64?
 
+    /// The patron's library card barcode — captured for support to look up the
+    /// account, but HASHED by the redactor before it lands here and OMITTED
+    /// from the outgoing ticket by default (PP-4807). The user opts in from the
+    /// preview; even then only the hash is sent, never the raw card number.
+    public let libraryBarcode: String?
+
     public init(
         appVersion: String,
         appBuild: String,
@@ -71,7 +77,8 @@ public struct ContextSnapshot: Codable, Equatable, Sendable {
         lowPowerModeEnabled: Bool? = nil,
         appUptimeSeconds: Int64? = nil,
         buildChannel: String? = nil,
-        availableMemoryMB: Int64? = nil
+        availableMemoryMB: Int64? = nil,
+        libraryBarcode: String? = nil
     ) {
         self.appVersion = appVersion
         self.appBuild = appBuild
@@ -92,5 +99,6 @@ public struct ContextSnapshot: Codable, Equatable, Sendable {
         self.appUptimeSeconds = appUptimeSeconds
         self.buildChannel = buildChannel
         self.availableMemoryMB = availableMemoryMB
+        self.libraryBarcode = libraryBarcode
     }
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ContextSnapshot.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ContextSnapshot.swift
@@ -101,4 +101,13 @@ public struct ContextSnapshot: Codable, Equatable, Sendable {
         self.availableMemoryMB = availableMemoryMB
         self.libraryBarcode = libraryBarcode
     }
+
+    /// True for the all-"unknown" placeholder the reducer synthesizes when a
+    /// draft is assembled before the real context has loaded (PP-4811). Used to
+    /// decide whether a late-arriving `.contextLoaded` should be bound into an
+    /// already-drafted ticket.
+    public var isPlaceholder: Bool {
+        appVersion == "unknown" && appBuild == "unknown"
+            && osVersion == "unknown" && deviceModel == "unknown"
+    }
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
@@ -134,6 +134,14 @@ public enum ConversationAction: Equatable, Sendable {
     /// "just file a ticket" mid-walkthrough). Reducer records the trace
     /// with outcome=abandoned and escalates.
     case userTappedAbandonGuidedFlow
+    /// PP-4807 preview editor: toggle whether an optional field is included
+    /// in the outgoing ticket. Only valid while in `.drafting`.
+    case userToggledDraftField(TicketField)
+    /// PP-4807 preview editor: the user edited the description text before
+    /// sending. The reducer redacts it (PP-4805) and updates the preview.
+    case userEditedDescription(String)
+    /// PP-4807 preview editor: explicit include/omit for the log excerpt.
+    case userOmittedLogs(Bool)
     case userConfirmedTicketSubmit
     case userCancelledTicketSubmit
     case ticketSubmitted(TicketReceipt)

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
@@ -17,6 +17,11 @@ public struct ConversationMessage: Equatable, Identifiable, Sendable {
         case guidedStep(entryId: String, stepIndex: Int)
         case ticketPreview(TicketDraft)
         case ticketReceipt(TicketReceipt)
+        /// Terminal-but-recoverable submission failure. Renders Retry / Copy
+        /// details / Start over. Carries the failed draft (nil only if the
+        /// draft was somehow lost) so Retry re-submits the exact ticket and
+        /// Copy details can reconstruct it (PP-4808).
+        case errorActions(draft: TicketDraft?)
     }
 
     public let id: UUID
@@ -67,7 +72,10 @@ public struct ConversationState: Equatable, Sendable {
         case drafting(ticket: TicketDraft)
         case submitting(ticket: TicketDraft)
         case sent(receipt: TicketReceipt)
-        case error(message: String)
+        /// A real submission failure. Carries the friendly message AND the
+        /// failed draft so the user can Retry the exact ticket, Copy its
+        /// details, or Start over — never a dead end (PP-4808).
+        case error(message: String, failedDraft: TicketDraft?)
     }
 
     public var step: Step
@@ -129,7 +137,19 @@ public enum ConversationAction: Equatable, Sendable {
     case userConfirmedTicketSubmit
     case userCancelledTicketSubmit
     case ticketSubmitted(TicketReceipt)
-    case ticketSubmissionFailed(String)
+    /// Submission didn't complete. Carries a structured `SubmissionFailure`
+    /// so the reducer can distinguish a user cancel (restore the preview)
+    /// from a real transport failure (offer Retry / Copy / Start over and
+    /// persist the draft). Replaces the old raw-string form (PP-4808).
+    case ticketSubmissionFailed(SubmissionFailure)
+    /// User tapped Retry on the error card — re-submit the failed draft.
+    case userTappedRetrySubmission
+    /// User tapped Start over on the error card — reset to category chips
+    /// and clear any persisted pending draft.
+    case userTappedStartOver
+    /// Host loaded a draft persisted from a prior failed session and is
+    /// re-offering it (PP-4808). Reducer restores the preview.
+    case restorePendingDraft(TicketDraft)
     case inputChanged(String)
     /// AI fallback returned a classification. Reducer routes to .matched
     /// or .drafting based on the decision.

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/SubmissionFailure.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/SubmissionFailure.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Why a ticket submission didn't complete. PP-4808: the reducer must never
+/// dead-end the user on a failure, so it needs to distinguish a *user backing
+/// out* (not a failure — restore the preview and let them retry) from a *real
+/// transport problem* (offer Retry / Copy details / Start over and persist the
+/// draft so it survives to the next chat open).
+///
+/// Lives in TriageBotCore so the reducer can branch on it without importing
+/// MessageUI / the iOS gateway. Concrete gateway errors map into this via
+/// `SubmissionFailureConvertible`.
+public enum SubmissionFailure: Equatable, Sendable {
+    /// User cancelled the OS composer / share sheet. Nothing was sent and
+    /// nothing is wrong — the reducer restores the ticket preview.
+    case userCancelled
+    /// A real failure (no mail account, composer error, network, server).
+    /// `detail` is a raw, possibly-technical string surfaced ONLY behind a
+    /// "Copy details" affordance — never shown inline (see UserFacingErrorMessage).
+    case transport(detail: String)
+}
+
+/// Bridges a concrete gateway `Error` to a `SubmissionFailure`. The iOS
+/// `EmailGatewayError` conforms in TriageBotIOS; the ViewModel maps any thrown
+/// error through this and falls back to `.transport(detail:)` for unknown
+/// errors, so no error can strand the user.
+public protocol SubmissionFailureConvertible {
+    var asSubmissionFailure: SubmissionFailure { get }
+}
+
+/// Pure mapping from a failure to the patron-facing sentence. Replaces the old
+/// raw `error.localizedDescription` interpolation (PP-4808) — a technical
+/// server message never appears in the chat; the raw detail is reachable only
+/// via Copy details.
+public enum UserFacingErrorMessage {
+    public static func from(_ failure: SubmissionFailure) -> String {
+        switch failure {
+        case .userCancelled:
+            return "No problem — nothing was sent. Your ticket is still here whenever you're ready."
+        case .transport:
+            return "I couldn't send your ticket. You can try again, copy the details to email support yourself, or start over — nothing was lost."
+        }
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketDraft.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketDraft.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+/// A context field the patron can omit from the outgoing ticket via the preview
+/// editor (PP-4807). Only optional / potentially-identifying fields are listed;
+/// the description, category, app version, and device are always sent so the
+/// ticket is actionable. Omission is enforced at serialization time
+/// (`TicketDraft.sanitizedForSubmission`), not just hidden in the UI.
+public enum TicketField: String, Codable, Sendable, CaseIterable, Equatable {
+    case barcode
+    case library
+    case network
+    case logs
+    case distributor
+    case authType
+}
+
 /// What the bot will send to HelpSpot when the user confirms a ticket. The
 /// user sees this verbatim before send — no surprise fields, no background
 /// telemetry attached after preview. Anything sensitive must be redacted
@@ -21,6 +35,11 @@ public struct TicketDraft: Codable, Equatable, Sendable {
     /// answered or skipped. Support sees this in the email body so they
     /// don't have to ask for context that's already been collected.
     public let escalationFollowUp: EscalationFollowUpAnswer?
+    /// Fields the patron chose to leave out of the ticket via the preview
+    /// editor (PP-4807). Enforced by `sanitizedForSubmission()` — an omitted
+    /// field is dropped from the email body AND absent from the JSON
+    /// attachment, not merely hidden in the card.
+    public let omittedFields: Set<TicketField>
 
     public enum Priority: String, Codable, Sendable {
         case low      // user accepted bot's match, filing for impact tracking only
@@ -36,7 +55,8 @@ public struct TicketDraft: Codable, Equatable, Sendable {
         helpspotTags: [String] = [],
         priority: Priority = .normal,
         resolutionTrace: ResolutionTrace? = nil,
-        escalationFollowUp: EscalationFollowUpAnswer? = nil
+        escalationFollowUp: EscalationFollowUpAnswer? = nil,
+        omittedFields: Set<TicketField> = []
     ) {
         self.userDescription = userDescription
         self.category = category
@@ -46,6 +66,87 @@ public struct TicketDraft: Codable, Equatable, Sendable {
         self.priority = priority
         self.resolutionTrace = resolutionTrace
         self.escalationFollowUp = escalationFollowUp
+        self.omittedFields = omittedFields
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case userDescription, category, matchedEntryId, context, helpspotTags
+        case priority, resolutionTrace, escalationFollowUp, omittedFields
+    }
+
+    // Decode-tolerant: a draft persisted by an older build (or the sanitized
+    // attachment) may lack `omittedFields`; default it to empty rather than
+    // failing the whole decode.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        userDescription = try c.decode(String.self, forKey: .userDescription)
+        category = try c.decode(KBCategory.self, forKey: .category)
+        matchedEntryId = try c.decodeIfPresent(String.self, forKey: .matchedEntryId)
+        context = try c.decode(ContextSnapshot.self, forKey: .context)
+        helpspotTags = try c.decodeIfPresent([String].self, forKey: .helpspotTags) ?? []
+        priority = try c.decode(Priority.self, forKey: .priority)
+        resolutionTrace = try c.decodeIfPresent(ResolutionTrace.self, forKey: .resolutionTrace)
+        escalationFollowUp = try c.decodeIfPresent(EscalationFollowUpAnswer.self, forKey: .escalationFollowUp)
+        omittedFields = try c.decodeIfPresent(Set<TicketField>.self, forKey: .omittedFields) ?? []
+    }
+
+    // MARK: - Preview editor helpers (PP-4807)
+
+    /// A copy with the given omitted-field set. Used by the reducer as the
+    /// user toggles per-row include/omit switches in the preview.
+    public func withOmittedFields(_ fields: Set<TicketField>) -> TicketDraft {
+        TicketDraft(
+            userDescription: userDescription, category: category, matchedEntryId: matchedEntryId,
+            context: context, helpspotTags: helpspotTags, priority: priority,
+            resolutionTrace: resolutionTrace, escalationFollowUp: escalationFollowUp,
+            omittedFields: fields
+        )
+    }
+
+    /// A copy with an edited description. Callers redact the text first.
+    public func withUserDescription(_ text: String) -> TicketDraft {
+        TicketDraft(
+            userDescription: text, category: category, matchedEntryId: matchedEntryId,
+            context: context, helpspotTags: helpspotTags, priority: priority,
+            resolutionTrace: resolutionTrace, escalationFollowUp: escalationFollowUp,
+            omittedFields: omittedFields
+        )
+    }
+
+    /// The draft that actually goes on the wire: every omitted field is
+    /// stripped from the context so it is ABSENT from the email body and the
+    /// JSON attachment (PP-4807). The library barcode is already a hash (the
+    /// redactor hashed it) — this only decides whether that hash is sent.
+    public func sanitizedForSubmission() -> TicketDraft {
+        let c = context
+        let sanitizedContext = ContextSnapshot(
+            appVersion: c.appVersion,
+            appBuild: c.appBuild,
+            platform: c.platform,
+            osVersion: c.osVersion,
+            deviceModel: c.deviceModel,
+            libraryName: omittedFields.contains(.library) ? nil : c.libraryName,
+            libraryUUID: omittedFields.contains(.library) ? nil : c.libraryUUID,
+            distributor: omittedFields.contains(.distributor) ? nil : c.distributor,
+            authType: omittedFields.contains(.authType) ? nil : c.authType,
+            networkState: omittedFields.contains(.network) ? nil : c.networkState,
+            freeStorageBytes: c.freeStorageBytes,
+            recentLogLines: omittedFields.contains(.logs) ? [] : c.recentLogLines,
+            crashlyticsFingerprints: c.crashlyticsFingerprints,
+            capturedAt: c.capturedAt,
+            audioOutputRoute: c.audioOutputRoute,
+            lowPowerModeEnabled: c.lowPowerModeEnabled,
+            appUptimeSeconds: c.appUptimeSeconds,
+            buildChannel: c.buildChannel,
+            availableMemoryMB: c.availableMemoryMB,
+            libraryBarcode: omittedFields.contains(.barcode) ? nil : c.libraryBarcode
+        )
+        return TicketDraft(
+            userDescription: userDescription, category: category, matchedEntryId: matchedEntryId,
+            context: sanitizedContext, helpspotTags: helpspotTags, priority: priority,
+            resolutionTrace: resolutionTrace, escalationFollowUp: escalationFollowUp,
+            omittedFields: []
+        )
     }
 }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketDraft.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketDraft.swift
@@ -103,6 +103,17 @@ public struct TicketDraft: Codable, Equatable, Sendable {
         )
     }
 
+    /// A copy with a new context. Used to late-bind the real environment into a
+    /// draft that was assembled before context finished loading (PP-4811).
+    public func withContext(_ newContext: ContextSnapshot) -> TicketDraft {
+        TicketDraft(
+            userDescription: userDescription, category: category, matchedEntryId: matchedEntryId,
+            context: newContext, helpspotTags: helpspotTags, priority: priority,
+            resolutionTrace: resolutionTrace, escalationFollowUp: escalationFollowUp,
+            omittedFields: omittedFields
+        )
+    }
+
     /// A copy with an edited description. Callers redact the text first.
     public func withUserDescription(_ text: String) -> TicketDraft {
         TicketDraft(

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketEmailComposition.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketEmailComposition.swift
@@ -25,7 +25,10 @@ public enum TicketEmailComposition {
 
     /// Email body. Short by design — the full payload is in the JSON
     /// attachment. Keeps the support inbox readable.
-    public static func body(for draft: TicketDraft) -> String {
+    public static func body(for rawDraft: TicketDraft) -> String {
+        // PP-4807: honor the patron's omit choices at the source so an omitted
+        // field never reaches the wire, not just the UI.
+        let draft = rawDraft.sanitizedForSubmission()
         var lines: [String] = []
         lines.append("Hi Palace support,")
         lines.append("")
@@ -69,6 +72,7 @@ public enum TicketEmailComposition {
         lines.append("  Device: \(ctx.deviceModel)")
         lines.append("  iOS: \(ctx.osVersion)")
         if let library = ctx.libraryName { lines.append("  Library: \(library)") }
+        if let barcode = ctx.libraryBarcode { lines.append("  Library card (hashed): \(barcode)") }
         if let dist = ctx.distributor { lines.append("  Distributor: \(dist)") }
         if let auth = ctx.authType { lines.append("  Auth: \(auth)") }
         if let net = ctx.networkState { lines.append("  Network: \(net)") }
@@ -95,7 +99,10 @@ public enum TicketEmailComposition {
     /// Builds the attachments shipped with the email. JSON carries the full
     /// payload for automation; text file carries the log tail in a form
     /// support can scan without un-zipping.
-    public static func attachments(for draft: TicketDraft) -> [Attachment] {
+    public static func attachments(for rawDraft: TicketDraft) -> [Attachment] {
+        // PP-4807: encode the sanitized draft so omitted fields are ABSENT from
+        // the JSON attachment (nil optionals are dropped by encodeIfPresent).
+        let draft = rawDraft.sanitizedForSubmission()
         var result: [Attachment] = []
 
         let encoder = JSONEncoder()

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Persistence/PendingDraftStore.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Persistence/PendingDraftStore.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Serializes a pending TicketDraft so a submission that fails on one chat
+/// session can be re-offered on the next (PP-4808). Pure Foundation JSON —
+/// the draft graph (context + trace + follow-up) is fully Codable.
+public enum PendingDraftCodec {
+    // Internal persistence blob — not an external contract, so it uses the
+    // default `.deferredToDate` date strategy, which round-trips Date exactly
+    // (ISO8601 would truncate sub-second precision and break draft equality on
+    // re-offer).
+    public static func encode(_ draft: TicketDraft) -> Data? {
+        try? JSONEncoder().encode(draft)
+    }
+
+    public static func decode(_ data: Data) -> TicketDraft? {
+        try? JSONDecoder().decode(TicketDraft.self, from: data)
+    }
+}
+
+/// Persists at most one pending draft. The reducer emits
+/// `.persistPendingDraft(draft?)` (nil clears) and `.loadPendingDraft`; the
+/// ViewModel routes those to this store. Kept a protocol so tests inject an
+/// in-memory double and the iOS host backs it with UserDefaults.
+public protocol PendingDraftStore: Sendable {
+    /// Save the draft, or clear the slot when passed nil.
+    func save(_ draft: TicketDraft?)
+    /// The last-saved draft, or nil if none / decode failed.
+    func load() -> TicketDraft?
+}
+
+/// UserDefaults-backed store. Foundation-only (no UIKit) so it lives in Core
+/// and is testable under macOS `swift test`.
+public final class UserDefaultsPendingDraftStore: PendingDraftStore, @unchecked Sendable {
+    private let defaults: UserDefaults
+    private let key: String
+
+    public init(defaults: UserDefaults = .standard, key: String = "triagebot.pendingDraft") {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    public func save(_ draft: TicketDraft?) {
+        guard let draft, let data = PendingDraftCodec.encode(draft) else {
+            defaults.removeObject(forKey: key)
+            return
+        }
+        defaults.set(data, forKey: key)
+    }
+
+    public func load() -> TicketDraft? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        return PendingDraftCodec.decode(data)
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/ContextRedactor.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/ContextRedactor.swift
@@ -27,7 +27,10 @@ public struct ContextRedactor: Sendable {
             networkState: snapshot.networkState,
             freeStorageBytes: snapshot.freeStorageBytes,
             recentLogLines: snapshot.recentLogLines.map(redactLine),
-            crashlyticsFingerprints: snapshot.crashlyticsFingerprints,
+            // Crash fingerprints are hashes by contract, but a stack frame or
+            // a symbol name can accidentally carry a typed secret. Map them
+            // through the same line redactor defensively (PP-4805).
+            crashlyticsFingerprints: snapshot.crashlyticsFingerprints.map(redactLine),
             capturedAt: snapshot.capturedAt
         )
     }
@@ -129,6 +132,59 @@ public struct ContextRedactor: Sendable {
             label: "uuid",
             regex: #"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"#,
             replacement: "[uuid-redacted]"
+        ),
+
+        // === PP-4805: patron-typed free-text leaks =========================
+        // The HelpSpot forensic showed the real leaks are humans typing PINs /
+        // passwords / barcodes / tokens into the description, not the
+        // auto-context. These patterns run on every user-authored line the
+        // reducer assembles into a draft, as well as on captured log lines.
+
+        // Standalone JWT (header.payload[.signature]) — matches the eyJ base64url
+        // header prefix so a token pasted without a "Bearer " scheme is caught.
+        RedactionPattern(
+            label: "jwt",
+            regex: #"\beyJ[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]{4,}(?:\.[A-Za-z0-9_\-]+)?"#,
+            replacement: "[jwt-redacted]"
+        ),
+        // x-api-key request header.
+        RedactionPattern(
+            label: "x_api_key",
+            regex: #"(?i)x-api-key:\s*\S+"#,
+            replacement: "x-api-key: [REDACTED]"
+        ),
+        // Key/value credentials in JSON, query-string, or form encodings.
+        // The key list is the sensitive set; the value runs to the next
+        // quote / delimiter / whitespace. "password: <token>" is covered here
+        // too. `\b` before the key keeps "tokenizer" / "pinpoint" safe.
+        RedactionPattern(
+            label: "kv_creds",
+            regex: #"(?i)"?\b(access_token|refresh_token|client_secret|api_key|apikey|password|passwd|token|pin)\b"?\s*[:=]\s*"?[^"&\s,}\]]+"#,
+            replacement: "$1=[REDACTED]"
+        ),
+        // Generic Cookie / Set-Cookie value(s). Redacts each name=value pair's
+        // value while preserving the cookie NAME (so the existing SAML-cookie
+        // expectation still holds). Anchored on the ": " / "; " that separates
+        // a header keyword or a prior pair from the next name.
+        RedactionPattern(
+            label: "cookie_value",
+            regex: #"(?i)(?<=[:;]\s)([A-Za-z0-9_.\-]+)=[^;\s]+"#,
+            replacement: "$1=[REDACTED]"
+        ),
+        // PIN / passcode stated in prose without a delimiter ("my pin is 1234").
+        // `\b` on the keyword avoids "spinning"; the 3-4 digit run avoids
+        // longer identifiers.
+        RedactionPattern(
+            label: "pin_prose",
+            regex: #"(?i)\b(pin|passcode)\b[^\d\n]{0,10}\d{3,4}\b"#,
+            replacement: "$1 [REDACTED]"
+        ),
+        // Standalone 10-14 digit library barcode / card number typed inline.
+        // Word-boundaried so 4-digit years and 3-digit error codes survive.
+        RedactionPattern(
+            label: "barcode_standalone",
+            regex: #"\b\d{10,14}\b"#,
+            replacement: "[number-redacted]"
         )
     ]
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/ContextRedactor.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/ContextRedactor.swift
@@ -185,18 +185,27 @@ public struct ContextRedactor: Sendable {
             replacement: "$1=[REDACTED]"
         ),
         // PIN / passcode stated in prose without a delimiter ("my pin is 1234").
-        // `\b` on the keyword avoids "spinning"; the 3-4 digit run avoids
-        // longer identifiers.
+        // `\b` on the keyword avoids "spinning". Digit run is \d{3,8} to match
+        // the delimiter'd `pin` rule above — a prose "my pin is 12345" / "123456"
+        // must redact just like "pin: 12345" (PP-4805: the narrower \d{3,4} here
+        // leaked 5-6 digit prose PINs into the ticket).
         RedactionPattern(
             label: "pin_prose",
-            regex: #"(?i)\b(pin|passcode)\b[^\d\n]{0,10}\d{3,4}\b"#,
+            regex: #"(?i)\b(pin|passcode)\b[^\d\n]{0,10}\d{3,8}\b"#,
             replacement: "$1 [REDACTED]"
         ),
         // Standalone 10-14 digit library barcode / card number typed inline.
         // Word-boundaried so 4-digit years and 3-digit error codes survive.
+        // The negative lookahead carves out exactly a 13-digit 978/979 ISBN —
+        // patrons routinely type a book's ISBN into a reading-app report and it
+        // must not be mangled as a card number (PP-4805). Scoped tightly to
+        // `97[89]` + 10 more digits so real barcodes that merely start with 97
+        // are still redacted.
+        // follow-up: extend redaction to 15-16 digit card numbers — deferred,
+        // it risks new false positives against long non-card identifiers.
         RedactionPattern(
             label: "barcode_standalone",
-            regex: #"\b\d{10,14}\b"#,
+            regex: #"\b(?!97[89]\d{10}\b)\d{10,14}\b"#,
             replacement: "[number-redacted]"
         )
     ]

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/ContextRedactor.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/ContextRedactor.swift
@@ -31,7 +31,20 @@ public struct ContextRedactor: Sendable {
             // a symbol name can accidentally carry a typed secret. Map them
             // through the same line redactor defensively (PP-4805).
             crashlyticsFingerprints: snapshot.crashlyticsFingerprints.map(redactLine),
-            capturedAt: snapshot.capturedAt
+            capturedAt: snapshot.capturedAt,
+            // Additive diagnostics are non-sensitive and pass through unchanged.
+            // (Previously dropped here because the ContextSnapshot init defaults
+            // them to nil — that silently stripped them from every ticket; PP-4807
+            // restores them alongside the new barcode handling.)
+            audioOutputRoute: snapshot.audioOutputRoute,
+            lowPowerModeEnabled: snapshot.lowPowerModeEnabled,
+            appUptimeSeconds: snapshot.appUptimeSeconds,
+            buildChannel: snapshot.buildChannel,
+            availableMemoryMB: snapshot.availableMemoryMB,
+            // PP-4807: the raw library barcode never lands in state — hash it
+            // immediately (like libraryUUID). Support gets a stable cluster id,
+            // never the card number. Still omitted from the ticket by default.
+            libraryBarcode: snapshot.libraryBarcode.map(hashIdentifier)
         )
     }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/DiagnosticsPreference.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/DiagnosticsPreference.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// The patron's "Include diagnostics" choice (PP-4809). Default ON — the bot is
+/// most useful to support with the full context — but a privacy-conscious user
+/// can turn it OFF, in which case only the app version / OS / device basics are
+/// captured: no logs, no library, no network, no barcode.
+public protocol DiagnosticsPreference: Sendable {
+    var includeDiagnostics: Bool { get }
+}
+
+/// UserDefaults-backed preference. Foundation-only so it lives in Core and is
+/// testable under macOS `swift test`. Absent key reads as `true` (default ON).
+public final class UserDefaultsDiagnosticsPreference: DiagnosticsPreference, @unchecked Sendable {
+    private let defaults: UserDefaults
+    private let key: String
+
+    public init(defaults: UserDefaults = .standard, key: String = "triagebot.includeDiagnostics") {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    public var includeDiagnostics: Bool {
+        // `object(forKey:)` distinguishes "never set" (→ default ON) from an
+        // explicit false.
+        defaults.object(forKey: key) as? Bool ?? true
+    }
+
+    public func setIncludeDiagnostics(_ include: Bool) {
+        defaults.set(include, forKey: key)
+    }
+}
+
+/// Wraps a full ContextProvider and honors the diagnostics preference: when ON
+/// it delegates to the full capture; when OFF it returns a minimal snapshot
+/// WITHOUT invoking the full provider at all (so no logs are read, no network
+/// probe runs, no Palace account fields are touched). PP-4809.
+public final class DiagnosticsGatingContextProvider: ContextProvider {
+    private let full: ContextProvider
+    private let minimal: @Sendable () async -> ContextSnapshot
+    private let preference: DiagnosticsPreference
+
+    /// - Parameters:
+    ///   - full: the real provider, called only when diagnostics are ON.
+    ///   - minimal: cheap app/OS/device-only snapshot, returned when OFF.
+    ///   - preference: the persisted include/exclude choice.
+    public init(
+        full: ContextProvider,
+        minimal: @escaping @Sendable () async -> ContextSnapshot,
+        preference: DiagnosticsPreference
+    ) {
+        self.full = full
+        self.minimal = minimal
+        self.preference = preference
+    }
+
+    public func captureSnapshot() async -> ContextSnapshot {
+        preference.includeDiagnostics ? await full.captureSnapshot() : await minimal()
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -242,7 +242,8 @@ public struct ConversationReducer: Sendable {
                 matchedEntryId: entryId,
                 context: next.context ?? emptyContext(),
                 helpspotTags: [entry.helpspotTag ?? "triage-bot-known-issue", "user-requested-followup"],
-                priority: .low
+                priority: .low,
+                omittedFields: initialOmittedFields(next.context)
             )
             // Route through the follow-up gate too — even when the user
             // explicitly bails on the workaround, the entry's structured
@@ -489,6 +490,39 @@ public struct ConversationReducer: Sendable {
             next.messages.append(.init(sender: .bot, kind: .categoryChips))
             effects.append(.emitTelemetry(.init(name: "triage_ticket_cancel_returned_to_chips")))
 
+        case .userToggledDraftField(let field):
+            guard case .drafting(let draft) = next.step else { return (next, effects) }
+            var omitted = draft.omittedFields
+            let nowOmitted: Bool
+            if omitted.contains(field) { omitted.remove(field); nowOmitted = false }
+            else { omitted.insert(field); nowOmitted = true }
+            let updated = draft.withOmittedFields(omitted)
+            next.step = .drafting(ticket: updated)
+            replaceTicketPreview(&next, with: updated)
+            effects.append(.emitTelemetry(.init(
+                name: "triage_draft_field_toggled",
+                parameters: ["field": field.rawValue, "omitted": String(nowOmitted)]
+            )))
+
+        case .userOmittedLogs(let omit):
+            guard case .drafting(let draft) = next.step else { return (next, effects) }
+            var omitted = draft.omittedFields
+            if omit { omitted.insert(.logs) } else { omitted.remove(.logs) }
+            let updated = draft.withOmittedFields(omitted)
+            next.step = .drafting(ticket: updated)
+            replaceTicketPreview(&next, with: updated)
+            effects.append(.emitTelemetry(.init(
+                name: "triage_draft_field_toggled",
+                parameters: ["field": "logs", "omitted": String(omit)]
+            )))
+
+        case .userEditedDescription(let text):
+            guard case .drafting(let draft) = next.step else { return (next, effects) }
+            // PP-4805: an edited description is still patron free text — redact it.
+            let updated = draft.withUserDescription(redactor.redactLine(text))
+            next.step = .drafting(ticket: updated)
+            replaceTicketPreview(&next, with: updated)
+
         case .ticketSubmitted(let receipt):
             next.step = .sent(receipt: receipt)
             next.messages.append(.init(sender: .bot, kind: .ticketReceipt(receipt)))
@@ -595,7 +629,8 @@ public struct ConversationReducer: Sendable {
                 ],
                 priority: pendingDraft.priority,
                 resolutionTrace: pendingDraft.resolutionTrace,
-                escalationFollowUp: EscalationFollowUpAnswer(prompt: prompt, answer: redactedAnswer)
+                escalationFollowUp: EscalationFollowUpAnswer(prompt: prompt, answer: redactedAnswer),
+                omittedFields: pendingDraft.omittedFields
             )
             next.step = .drafting(ticket: enriched)
             next.inputText = ""
@@ -655,6 +690,25 @@ public struct ConversationReducer: Sendable {
         }
     }
 
+    /// Replaces the most recent `.ticketPreview` message in place so the card
+    /// re-renders with the edited draft without duplicating the row (PP-4807).
+    /// Appends one if none exists yet.
+    private func replaceTicketPreview(_ next: inout ConversationState, with draft: TicketDraft) {
+        if let idx = next.messages.lastIndex(where: { if case .ticketPreview = $0.kind { return true }; return false }) {
+            let old = next.messages[idx]
+            next.messages[idx] = ConversationMessage(id: old.id, sender: old.sender, kind: .ticketPreview(draft), timestamp: old.timestamp)
+        } else {
+            next.messages.append(.init(sender: .bot, kind: .ticketPreview(draft)))
+        }
+    }
+
+    /// Initial omit set for a freshly-assembled draft. The library barcode is
+    /// opt-IN — captured (as a hash) but left out of the outgoing ticket by
+    /// default (PP-4807). Everything else defaults to included.
+    private func initialOmittedFields(_ context: ContextSnapshot?) -> Set<TicketField> {
+        (context?.libraryBarcode != nil) ? [.barcode] : []
+    }
+
     private func lastUserText(_ messages: [ConversationMessage]) -> String? {
         for message in messages.reversed() {
             if message.sender == .user, case .text(let text) = message.kind {
@@ -688,7 +742,8 @@ public struct ConversationReducer: Sendable {
             matchedEntryId: matchedEntryId,
             context: next.context ?? emptyContext(),
             helpspotTags: ["triage-bot-\(tagSuffix)"],
-            priority: .normal
+            priority: .normal,
+            omittedFields: initialOmittedFields(next.context)
         )
         askEscalationFollowUpOrDraft(
             state: &next,
@@ -755,7 +810,8 @@ public struct ConversationReducer: Sendable {
             context: next.context ?? emptyContext(),
             helpspotTags: [helpspotTag, "guided-flow-\(trace.outcome.rawValue)"],
             priority: .normal,
-            resolutionTrace: trace
+            resolutionTrace: trace,
+            omittedFields: initialOmittedFields(next.context)
         )
         // Same follow-up gate as transitionToDrafting — if the entry has
         // an escalationFollowUp, ask it first; otherwise go straight to

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -67,7 +67,13 @@ public struct ConversationReducer: Sendable {
             effects.append(.emitTelemetry(.init(name: "triage_chat_opened")))
 
         case .contextLoaded(let snapshot):
-            next.context = redactor.redact(snapshot)
+            let redacted = redactor.redact(snapshot)
+            next.context = redacted
+            // PP-4811: the user can race ahead to a ticket draft before the
+            // async context capture returns. If that happened, the draft holds
+            // an all-"unknown" placeholder context — bind the real one in now so
+            // no ticket ships with an empty environment.
+            lateBindContext(&next, context: redacted)
 
         case .userTappedCategory(let category):
             next.step = .awaitingDescription(category: category)
@@ -699,6 +705,31 @@ public struct ConversationReducer: Sendable {
             next.messages[idx] = ConversationMessage(id: old.id, sender: old.sender, kind: .ticketPreview(draft), timestamp: old.timestamp)
         } else {
             next.messages.append(.init(sender: .bot, kind: .ticketPreview(draft)))
+        }
+    }
+
+    /// PP-4811: bind a late-arriving context into a draft that was built with
+    /// the placeholder (empty) context. Only rebinds placeholder drafts so a
+    /// restored draft's real context is never clobbered. Re-applies the
+    /// barcode default-omit now that the real context may carry a barcode.
+    private func lateBindContext(_ next: inout ConversationState, context: ContextSnapshot) {
+        func rebound(_ draft: TicketDraft) -> TicketDraft? {
+            guard draft.context.isPlaceholder else { return nil }
+            let omissions = draft.omittedFields.union(initialOmittedFields(context))
+            return draft.withContext(context).withOmittedFields(omissions)
+        }
+        switch next.step {
+        case .drafting(let d):
+            if let u = rebound(d) {
+                next.step = .drafting(ticket: u)
+                replaceTicketPreview(&next, with: u)
+            }
+        case .submitting(let d):
+            if let u = rebound(d) { next.step = .submitting(ticket: u) }
+        case .awaitingEscalationFollowUp(let prompt, let d):
+            if let u = rebound(d) { next.step = .awaitingEscalationFollowUp(prompt: prompt, pendingDraft: u) }
+        default:
+            break
         }
     }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -232,7 +232,9 @@ public struct ConversationReducer: Sendable {
             guard case .matched(let entryId) = next.step,
                   let entry = knowledgeBase.entry(id: entryId) else { return (next, effects) }
             let draft = TicketDraft(
-                userDescription: lastUserText(next.messages) ?? "(no description)",
+                // PP-4805: the last user message is raw free text — route it
+                // through the redactor before it can land in a ticket.
+                userDescription: redactor.redactLine(lastUserText(next.messages) ?? "(no description)"),
                 category: entry.category,
                 matchedEntryId: entryId,
                 context: next.context ?? emptyContext(),
@@ -512,6 +514,9 @@ public struct ConversationReducer: Sendable {
             }
             // Merge the answer (or skip marker) into the draft and proceed
             // to the standard drafting / preview flow.
+            // PP-4805: the follow-up answer is raw patron free text —
+            // redact it before it attaches to the draft / email body.
+            let redactedAnswer = answer.map(redactor.redactLine)
             let enriched = TicketDraft(
                 userDescription: pendingDraft.userDescription,
                 category: pendingDraft.category,
@@ -522,7 +527,7 @@ public struct ConversationReducer: Sendable {
                 ],
                 priority: pendingDraft.priority,
                 resolutionTrace: pendingDraft.resolutionTrace,
-                escalationFollowUp: EscalationFollowUpAnswer(prompt: prompt, answer: answer)
+                escalationFollowUp: EscalationFollowUpAnswer(prompt: prompt, answer: redactedAnswer)
             )
             next.step = .drafting(ticket: enriched)
             next.inputText = ""
@@ -609,7 +614,8 @@ public struct ConversationReducer: Sendable {
         tagSuffix: String
     ) {
         let draft = TicketDraft(
-            userDescription: userText,
+            // PP-4805: redact patron-typed free text at draft assembly.
+            userDescription: redactor.redactLine(userText),
             category: category ?? .other,
             matchedEntryId: matchedEntryId,
             context: next.context ?? emptyContext(),
@@ -674,7 +680,8 @@ public struct ConversationReducer: Sendable {
         tagSuffix: String
     ) {
         let draft = TicketDraft(
-            userDescription: userText,
+            // PP-4805: redact patron-typed free text at draft assembly.
+            userDescription: redactor.redactLine(userText),
             category: category,
             matchedEntryId: matchedEntryId,
             context: next.context ?? emptyContext(),

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -61,6 +61,9 @@ public struct ConversationReducer: Sendable {
             ))
             next.messages.append(.init(sender: .bot, kind: .categoryChips))
             effects.append(.captureContext)
+            // PP-4808: if a ticket failed to send last session, the host has
+            // it persisted — ask it to re-offer via .restorePendingDraft.
+            effects.append(.loadPendingDraft)
             effects.append(.emitTelemetry(.init(name: "triage_chat_opened")))
 
         case .contextLoaded(let snapshot):
@@ -489,18 +492,83 @@ public struct ConversationReducer: Sendable {
         case .ticketSubmitted(let receipt):
             next.step = .sent(receipt: receipt)
             next.messages.append(.init(sender: .bot, kind: .ticketReceipt(receipt)))
+            // PP-4808: submission succeeded — clear any persisted pending draft
+            // so it isn't re-offered on the next chat open.
+            effects.append(.persistPendingDraft(nil))
             effects.append(.emitTelemetry(.init(
                 name: "triage_ticket_submitted",
                 parameters: ["ticket_id": receipt.ticketId]
             )))
 
-        case .ticketSubmissionFailed(let message):
-            next.step = .error(message: message)
+        case .ticketSubmissionFailed(let failure):
+            // PP-4808: never dead-end. Pull the in-flight draft so every
+            // recovery path (retry / restore) has the exact ticket.
+            let inFlight: TicketDraft?
+            if case .submitting(let ticket) = next.step { inFlight = ticket } else { inFlight = nil }
+
+            switch failure {
+            case .userCancelled:
+                // The user backed out of the OS composer — NOT a failure.
+                // Restore the preview so they can send again or cancel for real.
+                if let draft = inFlight {
+                    next.step = .drafting(ticket: draft)
+                    next.messages.append(.init(
+                        sender: .bot,
+                        kind: .text(UserFacingErrorMessage.from(failure))
+                    ))
+                    next.messages.append(.init(sender: .bot, kind: .ticketPreview(draft)))
+                } else {
+                    // No draft to restore — fall back to fresh chips.
+                    next.step = .awaitingCategory
+                    next.messages.append(.init(
+                        sender: .bot,
+                        kind: .text("No problem — nothing was sent. Want to try a different category?")
+                    ))
+                    next.messages.append(.init(sender: .bot, kind: .categoryChips))
+                }
+                effects.append(.emitTelemetry(.init(name: "triage_ticket_submit_cancelled_by_user")))
+
+            case .transport:
+                next.step = .error(message: UserFacingErrorMessage.from(failure), failedDraft: inFlight)
+                next.messages.append(.init(
+                    sender: .bot,
+                    kind: .text(UserFacingErrorMessage.from(failure))
+                ))
+                next.messages.append(.init(sender: .bot, kind: .errorActions(draft: inFlight)))
+                // Persist so a real failure survives to the next chat open.
+                effects.append(.persistPendingDraft(inFlight))
+                effects.append(.emitTelemetry(.init(name: "triage_ticket_submit_failed")))
+            }
+
+        case .userTappedRetrySubmission:
+            guard case .error(_, let failedDraft) = next.step, let draft = failedDraft else {
+                return (next, effects)
+            }
+            next.messages.append(.init(sender: .bot, kind: .text("Trying again…")))
+            next.step = .submitting(ticket: draft)
+            effects.append(.submitTicket(draft))
+            effects.append(.emitTelemetry(.init(name: "triage_ticket_submit_retried")))
+
+        case .userTappedStartOver:
+            next.step = .awaitingCategory
             next.messages.append(.init(
                 sender: .bot,
-                kind: .text("I couldn't send the ticket — \(message). You can try again, or copy the details and email support.")
+                kind: .text("OK — let's start fresh. What's happening?")
             ))
-            effects.append(.emitTelemetry(.init(name: "triage_ticket_submit_failed")))
+            next.messages.append(.init(sender: .bot, kind: .categoryChips))
+            // Starting over abandons the failed draft — clear it.
+            effects.append(.persistPendingDraft(nil))
+            effects.append(.emitTelemetry(.init(name: "triage_ticket_start_over")))
+
+        case .restorePendingDraft(let draft):
+            // PP-4808: a ticket failed to send in a prior session; re-offer it.
+            next.step = .drafting(ticket: draft)
+            next.messages.append(.init(
+                sender: .bot,
+                kind: .text("Last time, a ticket didn't finish sending. Here it is again — tap Send to try, or start over.")
+            ))
+            next.messages.append(.init(sender: .bot, kind: .ticketPreview(draft)))
+            effects.append(.emitTelemetry(.init(name: "triage_pending_draft_restored")))
 
         case .userAnsweredFollowUp:
             // Phase 2 — disambiguation answer flow lands here. For demo we
@@ -739,6 +807,12 @@ public enum ConversationEffect: Equatable, Sendable {
     case captureContext
     case submitTicket(TicketDraft)
     case emitTelemetry(TelemetryEvent)
+    /// Persist (or, with nil, clear) the pending draft so a failed submission
+    /// survives to the next chat open. Host writes to a PendingDraftStore.
+    case persistPendingDraft(TicketDraft?)
+    /// Ask the host to load any persisted pending draft and, if present,
+    /// dispatch `.restorePendingDraft`. Emitted on `.start` (PP-4808).
+    case loadPendingDraft
     /// ViewModel hands this off to the wired FallbackClassifier
     /// (ClaudeFallbackClassifier in production). On success it dispatches
     /// `.aiFallbackResolved`, on any failure mode `.aiFallbackUnavailable`.

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/DefaultIosContextProvider.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/DefaultIosContextProvider.swift
@@ -98,6 +98,21 @@ public final class DefaultIosContextProvider: ContextProvider {
         )
     }
 
+    /// Cheap app/OS/device-only snapshot (PP-4809). Used when the patron turns
+    /// "Include diagnostics" OFF — no log tail, no network probe, no Palace
+    /// account fields, no barcode. Just the basics support always needs.
+    public func minimalSnapshot() -> ContextSnapshot {
+        ContextSnapshot(
+            appVersion: bundleString(forInfoKey: "CFBundleShortVersionString") ?? "unknown",
+            appBuild: bundleString(forInfoKey: kCFBundleVersionKey as String) ?? "unknown",
+            platform: "iOS",
+            osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            deviceModel: deviceModelIdentifier(),
+            capturedAt: Date(),
+            buildChannel: detectBuildChannel()
+        )
+    }
+
     // MARK: - Bundle / device
 
     private func bundleString(forInfoKey key: String) -> String? {

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/DefaultIosContextProvider.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/DefaultIosContextProvider.swift
@@ -20,17 +20,22 @@ public final class DefaultIosContextProvider: ContextProvider {
         public let libraryUUID: String?
         public let distributor: String?
         public let authType: String?
+        /// Raw library card barcode. Hashed by ContextRedactor before it lands
+        /// in state and omitted from the ticket by default (PP-4807).
+        public let barcode: String?
 
         public init(
             libraryName: String? = nil,
             libraryUUID: String? = nil,
             distributor: String? = nil,
-            authType: String? = nil
+            authType: String? = nil,
+            barcode: String? = nil
         ) {
             self.libraryName = libraryName
             self.libraryUUID = libraryUUID
             self.distributor = distributor
             self.authType = authType
+            self.barcode = barcode
         }
     }
 
@@ -88,7 +93,8 @@ public final class DefaultIosContextProvider: ContextProvider {
             lowPowerModeEnabled: ProcessInfo.processInfo.isLowPowerModeEnabled,
             appUptimeSeconds: Int64(now.timeIntervalSince(Self.processStartTime)),
             buildChannel: detectBuildChannel(),
-            availableMemoryMB: availableMemoryMB()
+            availableMemoryMB: availableMemoryMB(),
+            libraryBarcode: fields.barcode
         )
     }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/DefaultIosContextProvider.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/DefaultIosContextProvider.swift
@@ -198,6 +198,10 @@ public final class DefaultIosContextProvider: ContextProvider {
             let predicate = NSPredicate(format: "subsystem == %@", subsystem)
             let entries = try store.getEntries(at: since, matching: predicate)
             var lines: [String] = []
+            // Hoisted out of the per-entry loop (PP-4811): ISO8601DateFormatter
+            // is expensive to allocate and configure, and the log window can be
+            // hundreds of entries. One formatter for the whole tail.
+            let timestampFormatter = ISO8601DateFormatter()
             for entry in entries {
                 if let logEntry = entry as? OSLogEntryLog {
                     let levelTag: String
@@ -207,7 +211,7 @@ public final class DefaultIosContextProvider: ContextProvider {
                     case .debug: levelTag = "[D] "
                     default: levelTag = "[ ] "
                     }
-                    let ts = ISO8601DateFormatter().string(from: logEntry.date)
+                    let ts = timestampFormatter.string(from: logEntry.date)
                     lines.append("\(ts) \(levelTag)\(logEntry.composedMessage)")
                     if lines.count >= logMaxLines { break }
                 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/EmailTicketGateway.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/EmailTicketGateway.swift
@@ -168,4 +168,19 @@ public enum EmailGatewayError: Error, LocalizedError {
         }
     }
 }
+
+// PP-4808: map each gateway error to a structured SubmissionFailure so the
+// reducer can restore the preview on a cancel and offer recovery on a real
+// failure. `.userCancelled` is the only non-failure; everything else is a
+// transport failure whose description rides along for "Copy details".
+extension EmailGatewayError: SubmissionFailureConvertible {
+    public var asSubmissionFailure: SubmissionFailure {
+        switch self {
+        case .userCancelled:
+            return .userCancelled
+        case .mailUnavailable, .noPresenter, .composerFailed:
+            return .transport(detail: errorDescription ?? "\(self)")
+        }
+    }
+}
 #endif

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/SupportChatView.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/SupportChatView.swift
@@ -194,6 +194,12 @@ public struct SupportChatView: View {
             viewModel.send(.userConfirmedTicketSubmit)
         case .cancel:
             viewModel.send(.userCancelledTicketSubmit)
+        case .toggleField(let field):
+            viewModel.send(.userToggledDraftField(field))
+        case .omitLogs(let omit):
+            viewModel.send(.userOmittedLogs(omit))
+        case .editDescription(let text):
+            viewModel.send(.userEditedDescription(text))
         }
     }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/SupportChatView.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/SupportChatView.swift
@@ -82,6 +82,10 @@ public struct SupportChatView: View {
             }
         case .ticketReceipt(let receipt):
             TicketReceiptCard(receipt: receipt)
+        case .errorActions(let draft):
+            ErrorActionsCard(draft: draft) { action in
+                handleErrorAction(action)
+            }
         }
     }
 
@@ -190,6 +194,19 @@ public struct SupportChatView: View {
             viewModel.send(.userConfirmedTicketSubmit)
         case .cancel:
             viewModel.send(.userCancelledTicketSubmit)
+        }
+    }
+
+    private func handleErrorAction(_ action: ErrorActionsCard.Action) {
+        switch action {
+        case .retry:
+            viewModel.send(.userTappedRetrySubmission)
+        case .copyDetails(let draft):
+            // Let the patron email support themselves with the exact payload.
+            let details = TicketEmailComposition.body(for: draft)
+            UIPasteboard.general.string = details
+        case .startOver:
+            viewModel.send(.userTappedStartOver)
         }
     }
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TicketPreviewCard.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TicketPreviewCard.swift
@@ -6,46 +6,78 @@ struct TicketPreviewCard: View {
     enum Action {
         case send
         case cancel
+        /// PP-4807: toggle whether an optional field is included in the ticket.
+        case toggleField(TicketField)
+        /// PP-4807: include/omit the log excerpt.
+        case omitLogs(Bool)
+        /// PP-4807: the user edited the description before sending.
+        case editDescription(String)
     }
 
     let draft: TicketDraft
     let onAction: (Action) -> Void
+
+    // Local mirror of the description so typing doesn't fight the reducer's
+    // re-render; edits are pushed out via .editDescription (which redacts).
+    @State private var descriptionText: String = ""
+    @State private var didSeed = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: BotUI.Spacing.medium) {
             HStack(spacing: BotUI.Spacing.xsmall) {
                 Image(systemName: "envelope.fill")
                     .font(.headline)
-                    .foregroundStyle(Color(.systemBlue))
+                    .foregroundStyle(.primary)
                 Text("Ticket preview")
                     .font(.headline)
                 Spacer()
             }
 
+            // Editable description.
+            VStack(alignment: .leading, spacing: 4) {
+                Text("What you said")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField("Describe what's happening…", text: $descriptionText, axis: .vertical)
+                    .font(.caption)
+                    .textFieldStyle(.roundedBorder)
+                    .lineLimit(1...5)
+                    .onChange(of: descriptionText) { _, newValue in
+                        onAction(.editDescription(newValue))
+                    }
+                    .accessibilityLabel("Edit your ticket description")
+            }
+
             VStack(alignment: .leading, spacing: 6) {
-                row("What you said", value: draft.userDescription)
-                row("Category", value: draft.category.rawValue.capitalized)
-                row("App", value: "\(draft.context.appVersion) (\(draft.context.appBuild))")
-                row("Device", value: "\(draft.context.deviceModel) · iOS \(draft.context.osVersion)")
+                staticRow("Category", value: draft.category.rawValue.capitalized)
+                staticRow("App", value: "\(draft.context.appVersion) (\(draft.context.appBuild))")
+                staticRow("Device", value: "\(draft.context.deviceModel) · iOS \(draft.context.osVersion)")
+
                 if let library = draft.context.libraryName {
-                    row("Library", value: library)
+                    toggleRow("Library", value: library, field: .library)
                 }
                 if let network = draft.context.networkState {
-                    row("Network", value: network)
+                    toggleRow("Network", value: network, field: .network)
                 }
-                if !draft.context.recentLogLines.isEmpty {
-                    row("Recent logs", value: "\(draft.context.recentLogLines.count) lines · redacted")
+                if let barcode = draft.context.libraryBarcode {
+                    // Barcode is a privacy-sensitive opt-in — shown as a hash,
+                    // off by default (PP-4807).
+                    toggleRow("Library card", value: "\(barcode) · hashed", field: .barcode)
                 }
                 if let trace = draft.resolutionTrace {
-                    row("Steps tried", value: "\(trace.attempts.count) (\(trace.outcome.rawValue.replacingOccurrences(of: "_", with: " ")))")
+                    staticRow("Steps tried", value: "\(trace.attempts.count) (\(trace.outcome.rawValue.replacingOccurrences(of: "_", with: " ")))")
                 }
                 if let followUp = draft.escalationFollowUp {
                     let value: String = {
                         if let answer = followUp.answer, !answer.isEmpty { return answer }
                         return "(skipped)"
                     }()
-                    row("Your answer", value: value)
+                    staticRow("Your answer", value: value)
                 }
+            }
+
+            if !draft.context.recentLogLines.isEmpty {
+                logExcerptSection
             }
 
             HStack(spacing: BotUI.Spacing.small) {
@@ -59,10 +91,45 @@ struct TicketPreviewCard: View {
         .background(BotUI.cardBackground)
         .clipShape(RoundedRectangle(cornerRadius: BotUI.cardCornerRadius, style: .continuous))
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Ticket preview — review and send")
+        .accessibilityLabel("Ticket preview — review, edit, and send")
+        .onAppear {
+            if !didSeed {
+                descriptionText = draft.userDescription
+                didSeed = true
+            }
+        }
     }
 
-    @ViewBuilder private func row(_ label: String, value: String) -> some View {
+    // MARK: - Log excerpt (first few already-redacted lines)
+
+    @ViewBuilder private var logExcerptSection: some View {
+        let included = !draft.omittedFields.contains(.logs)
+        let excerpt = Array(draft.context.recentLogLines.prefix(3))
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle(isOn: Binding(
+                get: { included },
+                set: { onAction(.omitLogs(!$0)) }
+            )) {
+                Text("Recent logs (\(draft.context.recentLogLines.count) lines · redacted)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .tint(.primary)
+            if included {
+                ForEach(Array(excerpt.enumerated()), id: \.offset) { _, line in
+                    Text(line)
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+        }
+    }
+
+    // MARK: - Rows
+
+    @ViewBuilder private func staticRow(_ label: String, value: String) -> some View {
         HStack(alignment: .top, spacing: BotUI.Spacing.small) {
             Text(label)
                 .font(.caption)
@@ -73,6 +140,31 @@ struct TicketPreviewCard: View {
                 .foregroundStyle(.primary)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// A row with an include/omit toggle. Omitting drops the field from the
+    /// outgoing ticket (enforced in serialization, PP-4807).
+    @ViewBuilder private func toggleRow(_ label: String, value: String, field: TicketField) -> some View {
+        let included = !draft.omittedFields.contains(field)
+        HStack(alignment: .top, spacing: BotUI.Spacing.small) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 94, alignment: .leading)
+            Text(value)
+                .font(.caption)
+                .foregroundStyle(included ? .primary : .secondary)
+                .strikethrough(!included)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+            Toggle("", isOn: Binding(
+                get: { included },
+                set: { _ in onAction(.toggleField(field)) }
+            ))
+            .labelsHidden()
+            .tint(.primary)
+            .accessibilityLabel("Include \(label) in the ticket")
         }
     }
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TicketPreviewCard.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TicketPreviewCard.swift
@@ -77,6 +77,59 @@ struct TicketPreviewCard: View {
     }
 }
 
+/// PP-4808: shown when a submission fails for real. Offers Retry (re-submit
+/// the exact draft), Copy details (put the composed report on the clipboard so
+/// the patron can email support themselves), and Start over. Never a dead end.
+struct ErrorActionsCard: View {
+    enum Action {
+        case retry
+        case copyDetails(TicketDraft)
+        case startOver
+    }
+
+    let draft: TicketDraft?
+    let onAction: (Action) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: BotUI.Spacing.small) {
+            Label("Couldn't send", systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+                .foregroundStyle(.primary)
+            Text("Nothing was lost — pick one:")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: BotUI.Spacing.small) {
+                if let draft {
+                    BotUI.PrimaryButton(title: "Try again", systemImage: "arrow.clockwise") {
+                        onAction(.retry)
+                    }
+                    Button {
+                        onAction(.copyDetails(draft))
+                    } label: {
+                        Label("Copy details", systemImage: "doc.on.doc")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .accessibilityLabel("Copy the ticket details to email support yourself")
+                }
+                Button {
+                    onAction(.startOver)
+                } label: {
+                    Label("Start over", systemImage: "arrow.counterclockwise")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(BotUI.Spacing.cardPadding)
+        .background(BotUI.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: BotUI.cardCornerRadius, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Ticket couldn't send — retry, copy details, or start over")
+    }
+}
+
 struct TicketReceiptCard: View {
     let receipt: TicketReceipt
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TriageBotViewModel.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TriageBotViewModel.swift
@@ -24,6 +24,7 @@ public final class TriageBotViewModel: ObservableObject {
     private let ticketGateway: TicketGateway
     private let telemetry: TelemetrySink
     private let fallbackClassifier: FallbackClassifier?
+    private let pendingDraftStore: PendingDraftStore?
 
     public init(
         reducer: ConversationReducer,
@@ -31,6 +32,7 @@ public final class TriageBotViewModel: ObservableObject {
         ticketGateway: TicketGateway,
         telemetry: TelemetrySink,
         fallbackClassifier: FallbackClassifier? = nil,
+        pendingDraftStore: PendingDraftStore? = nil,
         initialState: ConversationState = ConversationState()
     ) {
         self.reducer = reducer
@@ -38,6 +40,7 @@ public final class TriageBotViewModel: ObservableObject {
         self.ticketGateway = ticketGateway
         self.telemetry = telemetry
         self.fallbackClassifier = fallbackClassifier
+        self.pendingDraftStore = pendingDraftStore
         self.state = initialState
     }
 
@@ -62,8 +65,20 @@ public final class TriageBotViewModel: ObservableObject {
                     let receipt = try await ticketGateway.submit(draft)
                     self.send(.ticketSubmitted(receipt))
                 } catch {
-                    self.send(.ticketSubmissionFailed(error.localizedDescription))
+                    // PP-4808: map the thrown error to a structured failure so
+                    // the reducer can tell a user cancel from a real failure.
+                    // Unknown errors fall back to .transport so nothing strands
+                    // the user; the raw description rides along for Copy details.
+                    let failure = (error as? SubmissionFailureConvertible)?.asSubmissionFailure
+                        ?? .transport(detail: error.localizedDescription)
+                    self.send(.ticketSubmissionFailed(failure))
                 }
+            }
+        case .persistPendingDraft(let draft):
+            pendingDraftStore?.save(draft)
+        case .loadPendingDraft:
+            if let draft = pendingDraftStore?.load() {
+                self.send(.restorePendingDraft(draft))
             }
         case .emitTelemetry(let event):
             telemetry.emit(event)

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ContextRedactorTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ContextRedactorTests.swift
@@ -98,6 +98,26 @@ final class ContextRedactorTests: XCTestCase {
         )
     }
 
+    // Fix 2 (PP-4807): the opt-in library barcode is hashed by redact(_:) via
+    // `.map(hashIdentifier)`. Mirror the libraryUUID hashing test so that if the
+    // `.map(hashIdentifier)` is ever dropped, an opted-in RAW card number would
+    // ship — and this test catches it.
+    func testRedactSnapshot_hashesLibraryBarcode() {
+        let rawBarcode = "21234000012345"
+        let raw = ContextSnapshot(
+            appVersion: "3.3.0",
+            appBuild: "500",
+            osVersion: "26.4.2",
+            deviceModel: "iPhone17,2",
+            libraryBarcode: rawBarcode
+        )
+
+        let redacted = redactor.redact(raw)
+
+        XCTAssertNotEqual(redacted.libraryBarcode, rawBarcode, "Barcode must be hashed, never raw")
+        XCTAssertEqual(redacted.libraryBarcode?.hasPrefix("anon-"), true, "Barcode must be hash-shaped")
+    }
+
     func testRedactSnapshot_isIdempotent() {
         let raw = ContextSnapshot(
             appVersion: "3.0.3",

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ConversationReducerTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ConversationReducerTests.swift
@@ -221,7 +221,7 @@ final class ConversationReducerTests: XCTestCase {
         }, "Fresh category chips must be offered so user can pick a different topic")
     }
 
-    func testTicketSubmissionFailed_transitionsToError() {
+    func testTicketSubmissionFailed_transportError_carriesDraftAndDoesNotLeakRawDetail() {
         let reducer = makeReducer()
         let draft = TicketDraft(
             userDescription: "test",
@@ -229,12 +229,109 @@ final class ConversationReducerTests: XCTestCase {
             context: ContextSnapshot(appVersion: "3", appBuild: "1", osVersion: "26", deviceModel: "x")
         )
         let state = ConversationState(step: .submitting(ticket: draft))
-        let (next, _) = reducer.reduce(state: state, action: .ticketSubmissionFailed("Network unavailable"))
+        let rawDetail = "URLSession 503 backend-stacktrace-goes-here"
+        let (next, effects) = reducer.reduce(
+            state: state,
+            action: .ticketSubmissionFailed(.transport(detail: rawDetail))
+        )
 
-        guard case .error(let message) = next.step else {
+        // PP-4808: error step must carry the failed draft so Retry re-submits it…
+        guard case .error(let message, let failedDraft) = next.step else {
             return XCTFail("Expected .error, got \(next.step)")
         }
-        XCTAssertTrue(message.contains("Network unavailable"))
+        XCTAssertEqual(failedDraft, draft, "Failed draft must be preserved for Retry / Copy details")
+        // …and the raw technical detail must NOT be shown inline.
+        XCTAssertFalse(message.contains(rawDetail), "Raw transport detail must not leak into the chat message")
+        XCTAssertTrue(next.messages.contains { if case .errorActions = $0.kind { return true }; return false },
+                      "Error card with recovery actions must be rendered")
+        XCTAssertTrue(effects.contains(.persistPendingDraft(draft)),
+                      "A real failure must persist the draft for the next session")
+    }
+
+    func testTicketSubmissionFailed_userCancelled_restoresPreviewInsteadOfDeadEnd() {
+        let reducer = makeReducer()
+        let draft = TicketDraft(
+            userDescription: "test",
+            category: .reader,
+            context: ContextSnapshot(appVersion: "3", appBuild: "1", osVersion: "26", deviceModel: "x")
+        )
+        let state = ConversationState(step: .submitting(ticket: draft))
+        let (next, effects) = reducer.reduce(state: state, action: .ticketSubmissionFailed(.userCancelled))
+
+        guard case .drafting(let restored) = next.step else {
+            return XCTFail("A user cancel must restore the preview, got \(next.step)")
+        }
+        XCTAssertEqual(restored, draft)
+        XCTAssertTrue(next.messages.contains { if case .ticketPreview = $0.kind { return true }; return false },
+                      "Preview card must be re-offered on cancel")
+        XCTAssertFalse(effects.contains(.persistPendingDraft(draft)),
+                       "A cancel is not a failure — nothing to persist")
+    }
+
+    func testRetrySubmission_reSubmitsExactFailedDraft() {
+        let reducer = makeReducer()
+        let draft = TicketDraft(
+            userDescription: "retry me",
+            category: .signin,
+            context: ContextSnapshot(appVersion: "3", appBuild: "1", osVersion: "26", deviceModel: "x")
+        )
+        let state = ConversationState(step: .error(message: "nope", failedDraft: draft))
+        let (next, effects) = reducer.reduce(state: state, action: .userTappedRetrySubmission)
+
+        guard case .submitting(let resubmitted) = next.step else {
+            return XCTFail("Retry must move to .submitting, got \(next.step)")
+        }
+        XCTAssertEqual(resubmitted, draft)
+        XCTAssertTrue(effects.contains(.submitTicket(draft)), "Retry must re-emit the submit effect for the exact draft")
+    }
+
+    func testStartOver_fromError_resetsToChipsAndClearsPersistedDraft() {
+        let reducer = makeReducer()
+        let draft = TicketDraft(
+            userDescription: "x", category: .other,
+            context: ContextSnapshot(appVersion: "3", appBuild: "1", osVersion: "26", deviceModel: "x")
+        )
+        let state = ConversationState(step: .error(message: "nope", failedDraft: draft))
+        let (next, effects) = reducer.reduce(state: state, action: .userTappedStartOver)
+
+        XCTAssertEqual(next.step, .awaitingCategory)
+        XCTAssertTrue(effects.contains(.persistPendingDraft(nil)), "Start over must clear the persisted draft")
+    }
+
+    func testStart_emitsLoadPendingDraft_soAFailedDraftCanBeReoffered() {
+        let reducer = makeReducer()
+        let (_, effects) = reducer.reduce(state: ConversationState(), action: .start)
+        XCTAssertTrue(effects.contains(.loadPendingDraft),
+                      "Chat open must ask the host to re-offer any persisted pending draft")
+    }
+
+    func testRestorePendingDraft_reoffersPreview() {
+        let reducer = makeReducer()
+        let draft = TicketDraft(
+            userDescription: "unsent from last time", category: .download,
+            context: ContextSnapshot(appVersion: "3", appBuild: "1", osVersion: "26", deviceModel: "x")
+        )
+        let (next, _) = reducer.reduce(state: ConversationState(step: .welcome), action: .restorePendingDraft(draft))
+
+        guard case .drafting(let restored) = next.step else {
+            return XCTFail("Expected .drafting, got \(next.step)")
+        }
+        XCTAssertEqual(restored, draft)
+        XCTAssertTrue(next.messages.contains { if case .ticketPreview = $0.kind { return true }; return false })
+    }
+
+    func testTicketSubmitted_clearsPersistedPendingDraft() {
+        let reducer = makeReducer()
+        let draft = TicketDraft(
+            userDescription: "x", category: .other,
+            context: ContextSnapshot(appVersion: "3", appBuild: "1", osVersion: "26", deviceModel: "x")
+        )
+        let state = ConversationState(step: .submitting(ticket: draft))
+        let (_, effects) = reducer.reduce(
+            state: state,
+            action: .ticketSubmitted(TicketReceipt(ticketId: "T-1", submittedAt: Date(timeIntervalSince1970: 0)))
+        )
+        XCTAssertTrue(effects.contains(.persistPendingDraft(nil)), "A successful send must clear the persisted draft")
     }
 
     // MARK: - Redactor integration

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/DiagnosticsPreferenceTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/DiagnosticsPreferenceTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import TriageBotCore
+
+/// PP-4809 — the "Include diagnostics" setting. When OFF, the gating provider
+/// must NOT run the full capture (no logs / network / account), and the setting
+/// must persist across provider/preference instances.
+final class DiagnosticsPreferenceTests: XCTestCase {
+
+    /// Records whether the full capture was invoked.
+    private actor SpyFullProvider: ContextProvider {
+        private(set) var captureCount = 0
+        let snapshot: ContextSnapshot
+        init(snapshot: ContextSnapshot) { self.snapshot = snapshot }
+        func captureSnapshot() async -> ContextSnapshot {
+            captureCount += 1
+            return snapshot
+        }
+    }
+
+    private struct FixedPreference: DiagnosticsPreference {
+        let includeDiagnostics: Bool
+    }
+
+    private func fullSnapshot() -> ContextSnapshot {
+        ContextSnapshot(
+            appVersion: "3.3.0", appBuild: "500", osVersion: "26.4.2", deviceModel: "iPhone17,2",
+            libraryName: "Morton", networkState: "wifi",
+            recentLogLines: ["[E] secret log"], libraryBarcode: "anon-hash"
+        )
+    }
+
+    private func minimalSnapshot() -> ContextSnapshot {
+        ContextSnapshot(appVersion: "3.3.0", appBuild: "500", osVersion: "26.4.2", deviceModel: "iPhone17,2")
+    }
+
+    func testDiagnosticsOff_skipsFullCapture_returnsMinimal() async {
+        let spy = SpyFullProvider(snapshot: fullSnapshot())
+        let minimal = minimalSnapshot()
+        let gating = DiagnosticsGatingContextProvider(
+            full: spy,
+            minimal: { minimal },
+            preference: FixedPreference(includeDiagnostics: false)
+        )
+
+        let result = await gating.captureSnapshot()
+
+        let count = await spy.captureCount
+        XCTAssertEqual(count, 0, "OFF must not invoke the full capture (no logs/network/account read)")
+        XCTAssertTrue(result.recentLogLines.isEmpty, "Minimal snapshot carries no logs")
+        XCTAssertNil(result.libraryName, "Minimal snapshot carries no library")
+        XCTAssertNil(result.libraryBarcode, "Minimal snapshot carries no barcode")
+        XCTAssertEqual(result.appVersion, "3.3.0")
+        XCTAssertEqual(result.osVersion, "26.4.2")
+    }
+
+    func testDiagnosticsOn_runsFullCapture() async {
+        let spy = SpyFullProvider(snapshot: fullSnapshot())
+        let gating = DiagnosticsGatingContextProvider(
+            full: spy,
+            minimal: { self.minimalSnapshot() },
+            preference: FixedPreference(includeDiagnostics: true)
+        )
+
+        let result = await gating.captureSnapshot()
+
+        let count = await spy.captureCount
+        XCTAssertEqual(count, 1, "ON must run the full capture exactly once")
+        XCTAssertEqual(result.recentLogLines, ["[E] secret log"], "ON returns the full snapshot")
+    }
+
+    // MARK: - Persistence
+
+    func testPreference_defaultsToOn() {
+        let suite = UserDefaults(suiteName: "diag.test.\(UUID().uuidString)")!
+        let pref = UserDefaultsDiagnosticsPreference(defaults: suite, key: "k")
+        XCTAssertTrue(pref.includeDiagnostics, "Default must be ON")
+    }
+
+    func testPreference_persistsAcrossInstances() {
+        let suiteName = "diag.test.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: suiteName)!
+
+        let first = UserDefaultsDiagnosticsPreference(defaults: suite, key: "k")
+        first.setIncludeDiagnostics(false)
+
+        // A fresh instance on the same store (simulating a new app launch / VM).
+        let second = UserDefaultsDiagnosticsPreference(defaults: suite, key: "k")
+        XCTAssertFalse(second.includeDiagnostics, "The OFF choice must survive across instances")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/FreeTextRedactionTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/FreeTextRedactionTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+@testable import TriageBotCore
+
+/// PP-4805 — the highest-value privacy leak is a patron TYPING a PIN /
+/// password / barcode into the free-text description or the follow-up answer.
+/// These tests pin each new redaction pattern (positive + decoy-negative so a
+/// pattern that's too greedy fails just as loudly as one that's too weak) and
+/// prove the reducer routes ALL user-authored text through the redactor before
+/// it can reach a draft, the email body, or the JSON attachment.
+final class FreeTextRedactionTests: XCTestCase {
+    private let redactor = ContextRedactor()
+
+    // MARK: - PIN adjacency (no colon — "my pin is 1234")
+
+    func testRedactsPinStatedInProse() {
+        let output = redactor.redactLine("hi, my pin is 1234 by the way")
+        XCTAssertFalse(output.contains("1234"), "A prose-stated PIN must be stripped")
+    }
+
+    func testRedactsPasscodeStatedInProse() {
+        let output = redactor.redactLine("passcode 8675 didn't work")
+        XCTAssertFalse(output.contains("8675"))
+    }
+
+    func testPinAdjacency_decoy_leavesSpinningWheelUntouched() {
+        // "spinning" contains the letters p-i-n but is not the word "pin".
+        // A pattern that redacts it would nuke the audiobook KB keyword.
+        let input = "the audiobook is spinning and never plays"
+        XCTAssertEqual(redactor.redactLine(input), input)
+    }
+
+    func testPinAdjacency_decoy_leavesPinWithNoNumberUntouched() {
+        let input = "please pin this message for me"
+        XCTAssertEqual(redactor.redactLine(input), input)
+    }
+
+    // MARK: - password: <token>
+
+    func testRedactsPasswordColonToken() {
+        let output = redactor.redactLine("password: hunter2swordfish")
+        XCTAssertFalse(output.contains("hunter2swordfish"))
+    }
+
+    func testPassword_decoy_leavesPasswordResetProseUntouched() {
+        // No token follows — "password reset requested" must survive so
+        // patrons can describe a password *problem* without it vanishing.
+        let input = "I clicked password reset requested twice"
+        XCTAssertEqual(redactor.redactLine(input), input)
+    }
+
+    // MARK: - standalone 10-14 digit barcode / card number
+
+    func testRedactsStandaloneBarcodeDigits() {
+        let output = redactor.redactLine("my card 21234000012345 stopped working")
+        XCTAssertFalse(output.contains("21234000012345"))
+    }
+
+    func testBarcode_decoy_leavesShortNumbersUntouched() {
+        // A 4-digit year and a 3-digit error code must survive.
+        let input = "error 500 happened in 2026"
+        XCTAssertEqual(redactor.redactLine(input), input)
+    }
+
+    // MARK: - generic Cookie / Set-Cookie value
+
+    func testRedactsGenericSetCookieValue() {
+        let output = redactor.redactLine("Set-Cookie: authsession=Zm9vYmFyMTIzNA")
+        XCTAssertFalse(output.contains("Zm9vYmFyMTIzNA"))
+    }
+
+    func testCookie_decoy_leavesCookieProseUntouched() {
+        // No key=value pair — patron mentioning "cookie policy" survives.
+        let input = "the cookie policy dialog blocks me"
+        XCTAssertEqual(redactor.redactLine(input), input)
+    }
+
+    // MARK: - key/value credential encodings (JSON / query / form)
+
+    func testRedactsAccessTokenInJSON() {
+        let output = redactor.redactLine(#"{"access_token":"aaa.bbb.ccc","x":1}"#)
+        XCTAssertFalse(output.contains("aaa.bbb.ccc"))
+    }
+
+    func testRedactsRefreshTokenInQueryString() {
+        let output = redactor.redactLine("GET /cb?refresh_token=SECRETVALUE123&state=ok")
+        XCTAssertFalse(output.contains("SECRETVALUE123"))
+    }
+
+    func testRedactsClientSecretAndApiKey() {
+        let output = redactor.redactLine("client_secret=abc123XYZ api_key=zzz999QQQ")
+        XCTAssertFalse(output.contains("abc123XYZ"))
+        XCTAssertFalse(output.contains("zzz999QQQ"))
+    }
+
+    func testKeyValueCreds_decoy_leavesTokenizerUntouched() {
+        // "tokenizer=swift" starts with "token" but is a different word —
+        // must not be redacted, or config/debug prose gets mangled.
+        let input = "tokenizer=swift stage=ready"
+        XCTAssertEqual(redactor.redactLine(input), input)
+    }
+
+    // MARK: - x-api-key header
+
+    func testRedactsXApiKeyHeader() {
+        let output = redactor.redactLine("x-api-key: sk-live-abcdef123456")
+        XCTAssertFalse(output.contains("sk-live-abcdef123456"))
+    }
+
+    func testXApiKey_decoy_leavesApiVersionHeaderUntouched() {
+        let input = "x-api-version: 2"
+        XCTAssertEqual(redactor.redactLine(input), input)
+    }
+
+    // MARK: - standalone JWT (eyJ...)
+
+    func testRedactsStandaloneJWT() {
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.SflKxwRJSMeKKF2QT4"
+        let output = redactor.redactLine("token was \(jwt) apparently")
+        XCTAssertFalse(output.contains(jwt))
+    }
+
+    func testJWT_decoy_leavesEyeballWordUntouched() {
+        let input = "keep an eyeball on the eyewear section"
+        XCTAssertEqual(redactor.redactLine(input), input)
+    }
+
+    // MARK: - crashlytics fingerprints routed through redactLine
+
+    func testRedactSnapshot_redactsCrashlyticsFingerprints() {
+        let raw = ContextSnapshot(
+            appVersion: "3.3.0", appBuild: "500", osVersion: "26.4.2", deviceModel: "iPhone17,2",
+            crashlyticsFingerprints: ["frame: my pin is 4321 in stack"]
+        )
+        let redacted = redactor.redact(raw)
+        XCTAssertFalse(
+            redacted.crashlyticsFingerprints[0].contains("4321"),
+            "A PIN accidentally captured in a crash fingerprint must be stripped"
+        )
+    }
+
+    // MARK: - Reducer end-to-end: typed secrets never reach the ticket
+
+    private func makeEscalatingReducer() -> ConversationReducer {
+        // Empty KB → any free-text description escalates to a draft, which is
+        // exactly the path where the raw user text would otherwise land in a
+        // ticket verbatim.
+        let catalog = KBCatalog(version: "test", updatedAt: "2026-07-16", entries: [])
+        return ConversationReducer(knowledgeBase: KnowledgeBase(catalog: catalog))
+    }
+
+    private func extractDraft(_ step: ConversationState.Step) -> TicketDraft? {
+        switch step {
+        case .drafting(let d), .submitting(let d): return d
+        case .awaitingEscalationFollowUp(_, let d): return d
+        default: return nil
+        }
+    }
+
+    func testEscalatedDescription_redactsTypedSecrets_inDraftEmailAndAttachment() {
+        let reducer = makeEscalatingReducer()
+        let secretPin = "1234"
+        let secretPassword = "hunter2swordfish"
+        let secretBarcode = "21234000012345"
+        let typed = "my pin is \(secretPin), password: \(secretPassword), card \(secretBarcode)"
+
+        var state = ConversationState(step: .awaitingDescription(category: .other))
+        (state, _) = reducer.reduce(state: state, action: .inputChanged(typed))
+        let (drafted, _) = reducer.reduce(state: state, action: .userSubmittedDescription)
+
+        guard let draft = extractDraft(drafted.step) else {
+            return XCTFail("Expected an escalation draft, got \(drafted.step)")
+        }
+
+        for secret in [secretPin, secretPassword, secretBarcode] {
+            XCTAssertFalse(draft.userDescription.contains(secret), "Secret \(secret) leaked into draft.userDescription")
+            XCTAssertFalse(TicketEmailComposition.subject(for: draft).contains(secret), "Secret \(secret) leaked into email subject")
+            XCTAssertFalse(TicketEmailComposition.body(for: draft).contains(secret), "Secret \(secret) leaked into email body")
+            for attachment in TicketEmailComposition.attachments(for: draft) {
+                let text = String(data: attachment.data, encoding: .utf8) ?? ""
+                XCTAssertFalse(text.contains(secret), "Secret \(secret) leaked into attachment \(attachment.fileName)")
+            }
+        }
+    }
+
+    func testEscalationFollowUpAnswer_redactsTypedSecrets_inDraftAndEmail() {
+        let reducer = makeEscalatingReducer()
+        let secret = "9876"
+        let pendingDraft = TicketDraft(
+            userDescription: "app broke",
+            category: .signin,
+            context: ContextSnapshot(appVersion: "3.3.0", appBuild: "500", osVersion: "26.4.2", deviceModel: "iPhone17,2")
+        )
+        let state = ConversationState(step: .awaitingEscalationFollowUp(prompt: "Which library?", pendingDraft: pendingDraft))
+
+        let (next, _) = reducer.reduce(state: state, action: .userAnsweredEscalationFollowUp(answer: "my pin is \(secret)"))
+
+        guard case .drafting(let draft) = next.step else {
+            return XCTFail("Expected .drafting, got \(next.step)")
+        }
+        XCTAssertFalse(draft.escalationFollowUp?.answer?.contains(secret) ?? false, "Secret leaked into follow-up answer on draft")
+        XCTAssertFalse(TicketEmailComposition.body(for: draft).contains(secret), "Secret leaked into email body via follow-up answer")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/FreeTextRedactionTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/FreeTextRedactionTests.swift
@@ -34,6 +34,27 @@ final class FreeTextRedactionTests: XCTestCase {
         XCTAssertEqual(redactor.redactLine(input), input)
     }
 
+    // Fix 1 (PP-4805): the delimiter'd `pin:` rule matches \d{3,8}, but the
+    // prose rule only matched \d{3,4} — so "my pin is 12345" / "123456" shipped
+    // RAW into the ticket. Widen the prose rule to \d{3,8} to match.
+
+    func testRedactsFiveDigitPinStatedInProse() {
+        let output = redactor.redactLine("my pin is 12345")
+        XCTAssertFalse(output.contains("12345"), "A 5-digit prose PIN must be stripped")
+    }
+
+    func testRedactsSixDigitPinStatedInProse() {
+        let output = redactor.redactLine("my pin is 123456")
+        XCTAssertFalse(output.contains("123456"), "A 6-digit prose PIN must be stripped")
+    }
+
+    func testPinProse_decoy_leavesPinnedBooksCountUntouched() {
+        // "pinned" is not the word "pin"; the "3" is a book count, not a PIN.
+        // A prose rule that over-matches would nuke this legitimate report.
+        let input = "I pinned 3 books to my shelf"
+        XCTAssertEqual(redactor.redactLine(input), input)
+    }
+
     // MARK: - password: <token>
 
     func testRedactsPasswordColonToken() {
@@ -59,6 +80,25 @@ final class FreeTextRedactionTests: XCTestCase {
         // A 4-digit year and a 3-digit error code must survive.
         let input = "error 500 happened in 2026"
         XCTAssertEqual(redactor.redactLine(input), input)
+    }
+
+    // Fix 3 (PP-4805): a reading app's patrons routinely type a book's 13-digit
+    // ISBN (978/979 prefix) into a report. The standalone-barcode rule redacted
+    // it as if it were a card number. Carve out exactly a 978/979 + 10-digit ISBN
+    // — without weakening real 10-14 digit barcode redaction.
+
+    func testBarcode_decoy_preservesThirteenDigitISBN() {
+        let input978 = "can't download 9780306406157 please help"
+        XCTAssertEqual(redactor.redactLine(input978), input978, "A 978-prefixed ISBN must be preserved")
+        let input979 = "book 9791234567896 won't open"
+        XCTAssertEqual(redactor.redactLine(input979), input979, "A 979-prefixed ISBN must be preserved")
+    }
+
+    func testBarcode_fourteenDigitCardStillRedacted_alongsideISBN() {
+        // The ISBN carve-out must not weaken real barcode redaction.
+        let output = redactor.redactLine("isbn 9780306406157 but card 21234000012345 leaked")
+        XCTAssertTrue(output.contains("9780306406157"), "ISBN preserved")
+        XCTAssertFalse(output.contains("21234000012345"), "14-digit card still redacted")
     }
 
     // MARK: - generic Cookie / Set-Cookie value

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/LateContextBindingTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/LateContextBindingTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import TriageBotCore
+
+/// PP-4811 — the context-capture race. The async `.captureContext` effect can
+/// return AFTER the patron has already raced ahead to a ticket draft (they tap
+/// a category, type, and escalate faster than OSLog/AVAudioSession answer). When
+/// that happens the draft was assembled with the all-"unknown" placeholder
+/// context, and without late-binding the ticket would ship to support with an
+/// empty environment — no app version, no OS, no logs. These tests pin that a
+/// late `.contextLoaded` binds the real context into an in-flight placeholder
+/// draft, and — critically — that it never clobbers a draft that already holds
+/// a real, patron-reviewed context.
+final class LateContextBindingTests: XCTestCase {
+
+    private func makeReducer() -> ConversationReducer {
+        let catalog = KBCatalog(version: "t", updatedAt: "2026-07-16", entries: [])
+        return ConversationReducer(knowledgeBase: KnowledgeBase(catalog: catalog))
+    }
+
+    /// Mirrors the reducer's `emptyContext()` — the placeholder synthesized when
+    /// a draft is assembled before context has loaded.
+    private func placeholderContext() -> ContextSnapshot {
+        ContextSnapshot(appVersion: "unknown", appBuild: "unknown",
+                        osVersion: "unknown", deviceModel: "unknown")
+    }
+
+    private func realContext(barcode: String? = nil) -> ContextSnapshot {
+        ContextSnapshot(
+            appVersion: "3.3.0", appBuild: "500", osVersion: "26.4.2",
+            deviceModel: "iPhone17,2", distributor: "palace_marketplace",
+            libraryBarcode: barcode
+        )
+    }
+
+    private func draftingState(context: ContextSnapshot,
+                               omitted: Set<TicketField> = []) -> ConversationState {
+        let draft = TicketDraft(
+            userDescription: "app crashes on open", category: .other,
+            context: context, omittedFields: omitted
+        )
+        return ConversationState(
+            step: .drafting(ticket: draft),
+            messages: [.init(sender: .bot, kind: .ticketPreview(draft))]
+        )
+    }
+
+    private func draft(from step: ConversationState.Step) -> TicketDraft? {
+        switch step {
+        case .drafting(let d), .submitting(let d): return d
+        case .awaitingEscalationFollowUp(_, let d): return d
+        default: return nil
+        }
+    }
+
+    // MARK: - Late bind into a placeholder draft
+
+    func testLateContext_whileDraftingWithPlaceholder_bindsRealContextIntoDraft() {
+        let reducer = makeReducer()
+        let state = draftingState(context: placeholderContext())
+        XCTAssertTrue(draft(from: state.step)?.context.isPlaceholder == true,
+                      "Precondition: draft starts with the placeholder context")
+
+        let (next, _) = reducer.reduce(state: state, action: .contextLoaded(realContext()))
+
+        let bound = draft(from: next.step)
+        XCTAssertEqual(bound?.context.appVersion, "3.3.0",
+                       "The real app version must be bound into the in-flight draft")
+        XCTAssertEqual(bound?.context.osVersion, "26.4.2")
+        XCTAssertFalse(bound?.context.isPlaceholder ?? true,
+                       "The draft must no longer carry the empty placeholder context")
+    }
+
+    func testLateContext_reboundDraft_updatesThePreviewMessageInPlace() {
+        let reducer = makeReducer()
+        let state = draftingState(context: placeholderContext())
+
+        let (next, _) = reducer.reduce(state: state, action: .contextLoaded(realContext()))
+
+        let previews = next.messages.filter {
+            if case .ticketPreview = $0.kind { return true }; return false
+        }
+        XCTAssertEqual(previews.count, 1, "Rebind must not duplicate the preview card")
+        if case .ticketPreview(let d) = previews.first?.kind {
+            XCTAssertEqual(d.context.appVersion, "3.3.0",
+                           "The rendered preview must show the newly-bound real context")
+        } else {
+            XCTFail("Expected a ticketPreview message")
+        }
+    }
+
+    // MARK: - Never clobber a real, patron-reviewed context
+
+    func testLateContext_whileDraftingWithRealContext_doesNotClobberTheDraft() {
+        let reducer = makeReducer()
+        // A restored/pre-loaded draft already holding a real context the patron
+        // may have reviewed. A late duplicate capture must NOT overwrite it.
+        let original = realContext()
+        let state = draftingState(context: original)
+
+        let laterDifferent = ContextSnapshot(
+            appVersion: "9.9.9", appBuild: "999", osVersion: "1.0",
+            deviceModel: "iPhoneXX", distributor: "palace_marketplace"
+        )
+        let (next, _) = reducer.reduce(state: state, action: .contextLoaded(laterDifferent))
+
+        XCTAssertEqual(draft(from: next.step)?.context.appVersion, "3.3.0",
+                       "A draft with a real context must be left untouched by a late capture")
+    }
+
+    // MARK: - Barcode default-omit is re-applied on rebind
+
+    func testLateContext_withBarcode_defaultOmitsBarcodeInReboundDraft() {
+        let reducer = makeReducer()
+        // Placeholder draft has no barcode yet, so barcode is not omitted.
+        let state = draftingState(context: placeholderContext(), omitted: [])
+
+        let (next, _) = reducer.reduce(
+            state: state, action: .contextLoaded(realContext(barcode: "anon-cardhash"))
+        )
+
+        XCTAssertTrue(draft(from: next.step)?.omittedFields.contains(.barcode) == true,
+                      "A barcode arriving via late context must default to omitted (opt-in), " +
+                      "not silently ship in the ticket")
+    }
+
+    func testLateContext_withBarcode_preservesPreExistingOmissions() {
+        let reducer = makeReducer()
+        // Patron had already omitted logs on the placeholder draft.
+        let state = draftingState(context: placeholderContext(), omitted: [.logs])
+
+        let (next, _) = reducer.reduce(
+            state: state, action: .contextLoaded(realContext(barcode: "anon-cardhash"))
+        )
+
+        let omitted = draft(from: next.step)?.omittedFields ?? []
+        XCTAssertTrue(omitted.contains(.logs), "The patron's prior omission must survive the rebind")
+        XCTAssertTrue(omitted.contains(.barcode), "The new barcode default-omit must be added on top")
+    }
+
+    // MARK: - Other in-flight steps
+
+    func testLateContext_whileSubmitting_bindsRealContext() {
+        let reducer = makeReducer()
+        let placeholderDraft = TicketDraft(
+            userDescription: "x", category: .other, context: placeholderContext()
+        )
+        let state = ConversationState(step: .submitting(ticket: placeholderDraft))
+
+        let (next, _) = reducer.reduce(state: state, action: .contextLoaded(realContext()))
+
+        if case .submitting(let d) = next.step {
+            XCTAssertFalse(d.context.isPlaceholder,
+                           "A ticket already submitting with a placeholder must still get the real context bound")
+        } else {
+            XCTFail("Expected to remain in .submitting")
+        }
+    }
+
+    // MARK: - The common case: context arrives before any draft exists
+
+    func testLateContext_whenNotYetDrafting_justStoresContextWithoutError() {
+        let reducer = makeReducer()
+        let state = ConversationState(step: .awaitingCategory)
+
+        let (next, _) = reducer.reduce(state: state, action: .contextLoaded(realContext()))
+
+        XCTAssertEqual(next.context?.appVersion, "3.3.0",
+                       "Normal ordering: context is stored for the draft that comes later")
+        XCTAssertEqual(next.step, .awaitingCategory, "No draft yet, so the step is unchanged")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/LateContextBindingTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/LateContextBindingTests.swift
@@ -156,6 +156,25 @@ final class LateContextBindingTests: XCTestCase {
         }
     }
 
+    // MARK: - emptyContext() placeholder invariant (guards late-bind)
+
+    func testEmptyContext_readsAsPlaceholder_andRealContextDoesNot() {
+        // Late-bind hinges on emptyContext().isPlaceholder == true. Drive the
+        // reducer to escalate a description with NO context loaded, so the draft
+        // is assembled from the REAL emptyContext() (not this file's mirror), and
+        // pin the invariant. A future edit to emptyContext() that breaks it — or
+        // an isPlaceholder that stops recognizing it — fails here.
+        let reducer = makeReducer()
+        var state = ConversationState(step: .awaitingDescription(category: .other))
+        (state, _) = reducer.reduce(state: state, action: .inputChanged("app crashes on open"))
+        let (next, _) = reducer.reduce(state: state, action: .userSubmittedDescription)
+
+        XCTAssertTrue(draft(from: next.step)?.context.isPlaceholder == true,
+                      "The reducer's real emptyContext() must read as a placeholder")
+        XCTAssertFalse(realContext().isPlaceholder,
+                       "A populated context must NOT read as a placeholder, or late-bind clobbers real data")
+    }
+
     // MARK: - The common case: context arrives before any draft exists
 
     func testLateContext_whenNotYetDrafting_justStoresContextWithoutError() {

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/PreviewEditorTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/PreviewEditorTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import TriageBotCore
+
+/// PP-4807 — the ticket preview editor. Proves per-field include/omit toggles
+/// and description edits flow through the reducer AND that an omitted field is
+/// truly absent from the serialized payload (email body + JSON attachment), not
+/// merely hidden in the card. Also pins the barcode's default-omitted + hashed
+/// behavior.
+final class PreviewEditorTests: XCTestCase {
+
+    private func emptyKBReducer() -> ConversationReducer {
+        let catalog = KBCatalog(version: "t", updatedAt: "2026-07-16", entries: [])
+        return ConversationReducer(knowledgeBase: KnowledgeBase(catalog: catalog))
+    }
+
+    private func contextWithEverything() -> ContextSnapshot {
+        ContextSnapshot(
+            appVersion: "3.3.0", appBuild: "500", osVersion: "26.4.2", deviceModel: "iPhone17,2",
+            libraryName: "Morton Public Library",
+            libraryUUID: "anon-abc12345",
+            distributor: "palace_marketplace",
+            authType: "oauth",
+            networkState: "wifi",
+            recentLogLines: ["[I] launched app", "[E] fetch failed", "[D] retrying"],
+            libraryBarcode: "anon-cardhash"
+        )
+    }
+
+    private func draftingState(omitted: Set<TicketField> = []) -> ConversationState {
+        let draft = TicketDraft(
+            userDescription: "original description",
+            category: .signin,
+            context: contextWithEverything(),
+            omittedFields: omitted
+        )
+        return ConversationState(
+            step: .drafting(ticket: draft),
+            messages: [.init(sender: .bot, kind: .ticketPreview(draft))]
+        )
+    }
+
+    private func draftFrom(_ step: ConversationState.Step) -> TicketDraft? {
+        if case .drafting(let d) = step { return d }
+        return nil
+    }
+
+    // MARK: - Per-field toggle
+
+    func testToggleField_addsThenRemovesFromOmittedSet() {
+        let reducer = emptyKBReducer()
+        let (afterOmit, _) = reducer.reduce(state: draftingState(), action: .userToggledDraftField(.library))
+        XCTAssertTrue(draftFrom(afterOmit.step)?.omittedFields.contains(.library) == true,
+                      "First toggle must omit the field")
+
+        let (afterInclude, _) = reducer.reduce(state: afterOmit, action: .userToggledDraftField(.library))
+        XCTAssertFalse(draftFrom(afterInclude.step)?.omittedFields.contains(.library) == true,
+                       "Second toggle must re-include the field")
+    }
+
+    func testToggleField_updatesThePreviewMessageInPlace() {
+        let reducer = emptyKBReducer()
+        let (next, _) = reducer.reduce(state: draftingState(), action: .userToggledDraftField(.network))
+        let previews = next.messages.filter { if case .ticketPreview = $0.kind { return true }; return false }
+        XCTAssertEqual(previews.count, 1, "Toggling must not duplicate the preview card")
+        if case .ticketPreview(let d) = previews.first?.kind {
+            XCTAssertTrue(d.omittedFields.contains(.network), "The rendered preview must reflect the toggle")
+        } else {
+            XCTFail("Expected a ticketPreview message")
+        }
+    }
+
+    func testToggleField_ignoredOutsideDrafting() {
+        let reducer = emptyKBReducer()
+        let state = ConversationState(step: .awaitingCategory)
+        let (next, effects) = reducer.reduce(state: state, action: .userToggledDraftField(.library))
+        XCTAssertEqual(next.step, .awaitingCategory)
+        XCTAssertTrue(effects.isEmpty)
+    }
+
+    // MARK: - Omitted field is ABSENT from the serialized payload
+
+    func testOmittedLibrary_absentFromBodyAndJSON() {
+        let reducer = emptyKBReducer()
+        let (next, _) = reducer.reduce(state: draftingState(), action: .userToggledDraftField(.library))
+        guard let draft = draftFrom(next.step) else { return XCTFail("no draft") }
+
+        let body = TicketEmailComposition.body(for: draft)
+        XCTAssertFalse(body.contains("Morton Public Library"), "Omitted library must not appear in the email body")
+
+        let json = jsonAttachmentString(for: draft)
+        XCTAssertFalse(json.contains("Morton Public Library"), "Omitted library must be ABSENT from the JSON attachment")
+        XCTAssertFalse(json.contains("anon-abc12345"), "Omitted library UUID must be absent too")
+    }
+
+    func testOmitLogs_dropsLogContentFromPayload() {
+        let reducer = emptyKBReducer()
+        let (next, _) = reducer.reduce(state: draftingState(), action: .userOmittedLogs(true))
+        guard let draft = draftFrom(next.step) else { return XCTFail("no draft") }
+
+        XCTAssertTrue(draft.omittedFields.contains(.logs))
+        let json = jsonAttachmentString(for: draft)
+        XCTAssertFalse(json.contains("[E] fetch failed"), "Omitted logs must not appear in the JSON payload")
+        // And the logs .txt attachment must not be produced.
+        XCTAssertFalse(
+            TicketEmailComposition.attachments(for: draft).contains { $0.fileName == "palace-logs.txt" },
+            "Omitting logs must drop the log attachment entirely"
+        )
+    }
+
+    // MARK: - Description editing (redacted, PP-4805 posture)
+
+    func testEditDescription_redactsAndReplacesDescription() {
+        let reducer = emptyKBReducer()
+        let (next, _) = reducer.reduce(state: draftingState(), action: .userEditedDescription("actually my pin is 4321"))
+        guard let draft = draftFrom(next.step) else { return XCTFail("no draft") }
+        XCTAssertFalse(draft.userDescription.contains("4321"), "Edited description must be redacted")
+        XCTAssertFalse(draft.userDescription.contains("original description"), "Edit must replace the old text")
+    }
+
+    // MARK: - Barcode: default omitted, hashed, opt-in
+
+    func testBarcode_defaultOmitted_absentFromPayload_untilIncluded() {
+        let reducer = emptyKBReducer()
+        // Assemble a real escalation draft so the reducer's default-omit policy runs.
+        var state = ConversationState(step: .awaitingDescription(category: .other), context: contextWithEverything())
+        (state, _) = reducer.reduce(state: state, action: .inputChanged("something novel"))
+        let (drafted, _) = reducer.reduce(state: state, action: .userSubmittedDescription)
+        guard let draft = draftFrom(drafted.step) else { return XCTFail("expected drafting, got \(drafted.step)") }
+
+        XCTAssertTrue(draft.omittedFields.contains(.barcode), "Barcode must default to omitted")
+        let jsonOmitted = jsonAttachmentString(for: draft)
+        XCTAssertFalse(jsonOmitted.contains("anon-cardhash"), "Omitted barcode must be absent from the payload")
+
+        // Opt in.
+        let (included, _) = reducer.reduce(state: drafted, action: .userToggledDraftField(.barcode))
+        guard let includedDraft = draftFrom(included.step) else { return XCTFail("no draft") }
+        let bodyIncluded = TicketEmailComposition.body(for: includedDraft)
+        XCTAssertTrue(bodyIncluded.contains("anon-cardhash"), "When opted in, the hashed barcode must be sent")
+        // Never the raw card number — only the hash form.
+        XCTAssertTrue(includedDraft.context.libraryBarcode?.hasPrefix("anon-") == true)
+    }
+
+    // MARK: - Contract snapshot of the payload for three configurations
+
+    func testPayloadContract_allOn_logsOmitted_everythingOmitted() {
+        // all-on
+        let allOn = TicketDraft(userDescription: "d", category: .signin, context: contextWithEverything(), omittedFields: [])
+        let allOnBody = TicketEmailComposition.body(for: allOn)
+        XCTAssertTrue(allOnBody.contains("Library: Morton Public Library"))
+        XCTAssertTrue(allOnBody.contains("Network: wifi"))
+        XCTAssertTrue(allOnBody.contains("Library card (hashed): anon-cardhash"))
+        XCTAssertTrue(TicketEmailComposition.attachments(for: allOn).contains { $0.fileName == "palace-logs.txt" })
+
+        // logs-omitted (everything else on)
+        let logsOff = allOn.withOmittedFields([.logs])
+        let logsOffBody = TicketEmailComposition.body(for: logsOff)
+        XCTAssertTrue(logsOffBody.contains("Library: Morton Public Library"))
+        XCTAssertFalse(TicketEmailComposition.attachments(for: logsOff).contains { $0.fileName == "palace-logs.txt" })
+
+        // everything-omittable off
+        let allOff = allOn.withOmittedFields(Set(TicketField.allCases))
+        let allOffBody = TicketEmailComposition.body(for: allOff)
+        XCTAssertFalse(allOffBody.contains("Morton Public Library"))
+        XCTAssertFalse(allOffBody.contains("Network: wifi"))
+        XCTAssertFalse(allOffBody.contains("anon-cardhash"))
+        XCTAssertFalse(allOffBody.contains("Distributor: palace_marketplace"))
+        // Core fields still present — the ticket stays actionable.
+        XCTAssertTrue(allOffBody.contains("App: 3.3.0 (500)"))
+        XCTAssertTrue(allOffBody.contains("Device: iPhone17,2"))
+    }
+
+    // MARK: - Helpers
+
+    private func jsonAttachmentString(for draft: TicketDraft) -> String {
+        let attachments = TicketEmailComposition.attachments(for: draft)
+        guard let data = attachments.first(where: { $0.fileName == "palace-diagnostics.json" })?.data else { return "" }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResponseDeterminismTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResponseDeterminismTests.swift
@@ -172,7 +172,7 @@ final class ResponseDeterminismTests: XCTestCase {
                     .inputChanged("novel reader issue we don't know about"),
                     .userSubmittedDescription,
                     .userConfirmedTicketSubmit,
-                    .ticketSubmissionFailed("network unavailable")
+                    .ticketSubmissionFailed(.transport(detail: "network unavailable"))
                   ]),
             .init(label: "cancel-mid-flow",
                   actions: [

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/SubmissionFailureTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/SubmissionFailureTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import TriageBotCore
+
+/// PP-4808 — never dead-end on a submit failure. Pins the pure error-message
+/// mapping and the pending-draft persistence contract (both TriageBotCore, so
+/// macOS-testable). The EmailGatewayError → SubmissionFailure mapping itself is
+/// exercised in the iOS-gated tests (EmailGatewayError needs MessageUI).
+final class SubmissionFailureTests: XCTestCase {
+
+    // MARK: - UserFacingErrorMessage
+
+    func testUserFacingMessage_transport_doesNotLeakRawDetail() {
+        let raw = "URLSession error 503: internal-backend-stacktrace"
+        let message = UserFacingErrorMessage.from(.transport(detail: raw))
+        XCTAssertFalse(message.contains(raw), "The raw technical detail must not appear in the patron-facing message")
+        XCTAssertFalse(message.isEmpty)
+    }
+
+    func testUserFacingMessage_distinguishesCancelFromTransport() {
+        let cancel = UserFacingErrorMessage.from(.userCancelled)
+        let transport = UserFacingErrorMessage.from(.transport(detail: "x"))
+        XCTAssertNotEqual(cancel, transport, "Cancel and real failure must read differently")
+    }
+
+    // MARK: - PendingDraftCodec round-trip
+
+    func testPendingDraftCodec_roundTripsFullyPopulatedDraft() {
+        let context = ContextSnapshot(
+            appVersion: "3.3.0", appBuild: "500", osVersion: "26.4.2", deviceModel: "iPhone17,2",
+            libraryName: "Morton", distributor: "palace_marketplace", authType: "oauth",
+            networkState: "wifi", recentLogLines: ["line a", "line b"],
+            crashlyticsFingerprints: ["fp1"]
+        )
+        let trace = ResolutionTrace(
+            entryId: "KI-1",
+            attempts: [StepAttempt(stepId: "s1", outcome: .didNotResolve, timestamp: Date(timeIntervalSince1970: 10))],
+            startedAt: Date(timeIntervalSince1970: 0),
+            endedAt: Date(timeIntervalSince1970: 60),
+            outcome: .escalatedAfterStepsExhausted
+        )
+        let draft = TicketDraft(
+            userDescription: "won't play",
+            category: .audiobook,
+            matchedEntryId: "KI-1",
+            context: context,
+            helpspotTags: ["a", "b"],
+            priority: .high,
+            resolutionTrace: trace,
+            escalationFollowUp: EscalationFollowUpAnswer(prompt: "Which title?", answer: "Dune")
+        )
+
+        guard let data = PendingDraftCodec.encode(draft) else {
+            return XCTFail("Encoding a valid draft must succeed")
+        }
+        let decoded = PendingDraftCodec.decode(data)
+        XCTAssertEqual(decoded, draft, "A persisted draft must decode back identically, including nested context / trace / follow-up")
+    }
+
+    func testPendingDraftCodec_decodeGarbage_returnsNil() {
+        XCTAssertNil(PendingDraftCodec.decode(Data("not json".utf8)))
+    }
+
+    // MARK: - UserDefaultsPendingDraftStore
+
+    private func makeIsolatedStore() -> UserDefaultsPendingDraftStore {
+        let suite = UserDefaults(suiteName: "triagebot.test.\(UUID().uuidString)")!
+        return UserDefaultsPendingDraftStore(defaults: suite, key: "pending")
+    }
+
+    func testStore_saveThenLoad_returnsDraft() {
+        let store = makeIsolatedStore()
+        let draft = TicketDraft(
+            userDescription: "x", category: .other,
+            context: ContextSnapshot(appVersion: "3", appBuild: "1", osVersion: "26", deviceModel: "d")
+        )
+        store.save(draft)
+        XCTAssertEqual(store.load(), draft)
+    }
+
+    func testStore_saveNil_clearsSlot() {
+        let store = makeIsolatedStore()
+        let draft = TicketDraft(
+            userDescription: "x", category: .other,
+            context: ContextSnapshot(appVersion: "3", appBuild: "1", osVersion: "26", deviceModel: "d")
+        )
+        store.save(draft)
+        store.save(nil)
+        XCTAssertNil(store.load(), "Saving nil must clear the persisted draft")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotUITests/EmailGatewayFailureMappingTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotUITests/EmailGatewayFailureMappingTests.swift
@@ -1,0 +1,35 @@
+#if canImport(MessageUI)
+import XCTest
+@testable import TriageBotCore
+@testable import TriageBotIOS
+
+/// PP-4808 — the EmailGatewayError → SubmissionFailure mapping. iOS/MessageUI
+/// gated (EmailGatewayError only exists where MessageUI imports), so this runs
+/// on the CI simulator, not under macOS `swift test`. Every case must map, and
+/// only `.userCancelled` may be a non-failure.
+final class EmailGatewayFailureMappingTests: XCTestCase {
+
+    func testUserCancelled_mapsToUserCancelled() {
+        XCTAssertEqual(EmailGatewayError.userCancelled.asSubmissionFailure, .userCancelled)
+    }
+
+    func testMailUnavailable_mapsToTransportFailure() {
+        guard case .transport = EmailGatewayError.mailUnavailable.asSubmissionFailure else {
+            return XCTFail("mailUnavailable must be a transport failure, not a silent cancel")
+        }
+    }
+
+    func testNoPresenter_mapsToTransportFailure() {
+        guard case .transport = EmailGatewayError.noPresenter.asSubmissionFailure else {
+            return XCTFail("noPresenter must be a transport failure")
+        }
+    }
+
+    func testComposerFailed_mapsToTransportFailure() {
+        guard case .transport(let detail) = EmailGatewayError.composerFailed.asSubmissionFailure else {
+            return XCTFail("composerFailed must be a transport failure")
+        }
+        XCTAssertFalse(detail.isEmpty, "Transport detail must carry something for Copy details")
+    }
+}
+#endif

--- a/Palace/Support/TriageBotFactory.swift
+++ b/Palace/Support/TriageBotFactory.swift
@@ -64,11 +64,18 @@ enum TriageBotFactory {
             aiFallbackEnabled: aiEnabled
         )
 
-        let contextProvider = DefaultIosContextProvider(
+        let fullContextProvider = DefaultIosContextProvider(
             palaceFields: { @Sendable in
                 await Self.currentPalaceFields()
             },
             logSubsystem: Bundle.main.bundleIdentifier
+        )
+        // PP-4809: honor the patron's "Include diagnostics" choice (default ON).
+        // OFF returns an app/OS/device-only snapshot without the full capture.
+        let contextProvider = DiagnosticsGatingContextProvider(
+            full: fullContextProvider,
+            minimal: { fullContextProvider.minimalSnapshot() },
+            preference: UserDefaultsDiagnosticsPreference()
         )
 
         // Gateway selection:

--- a/Palace/Support/TriageBotFactory.swift
+++ b/Palace/Support/TriageBotFactory.swift
@@ -125,7 +125,9 @@ enum TriageBotFactory {
                 libraryName: account?.name,
                 libraryUUID: account?.uuid,
                 distributor: nil,        // Phase 2: derive from catalog metadata
-                authType: nil            // Phase 2: derive from currentAuthentication
+                authType: nil,           // Phase 2: derive from currentAuthentication
+                // PP-4807: raw barcode — hashed by the redactor, omitted by default.
+                barcode: TPPUserAccount.sharedAccount().barcode
             )
         }
     }
@@ -153,7 +155,9 @@ private extension TriageBotFactory {
             contextProvider: contextProvider,
             ticketGateway: gateway,
             telemetry: sink,
-            fallbackClassifier: fallbackClassifier
+            fallbackClassifier: fallbackClassifier,
+            // PP-4808: persist a failed ticket so it can be re-offered next open.
+            pendingDraftStore: UserDefaultsPendingDraftStore()
         )
     }
 }


### PR DESCRIPTION
## Summary

The triage-bot reducer/preview hardening **spine** — five sequenced, critical-path (patron credentials + ticket submission) changes, one commit each, TDD throughout. All TriageBotCore work is proven green under `swift test --package-path Palace/Packages/PalaceTriageBot` (172 tests, 0 failures). UIKit/OSLog-importing targets (TriageBotUI, TriageBotIOS) and all host-app code do not build under macOS `swift test` or in this worktree (missing Carthage/submodule) — those slices are **CI-gated** and noted per commit.

### 1. PP-4805 — redact patron-typed free text
A HelpSpot forensic confirmed the real leaks are humans typing PINs/passwords/barcodes into **free text**, not the auto-context or template. All user-authored text now routes through `ContextRedactor.redactLine` at draft assembly (`transitionToDrafting`, `userTappedFileTicketAnyway`, `escalateWithTrace`, follow-up-answer merge). New redaction patterns: PIN/passcode-adjacent 3-4 digits, `password: <token>`, 10-14 digit barcode/card, Cookie/Set-Cookie, key-value creds across JSON/query/form, `x-api-key`, standalone JWT. Crashlytics fingerprints mapped through `redactLine`. Tests: positive + decoy-negative per pattern; a reducer test proving a typed "my pin is 1234" never reaches the draft, email body, or attachment.

### 2. PP-4808 — never dead-end on submit failure
`.error` now carries the failed `TicketDraft` so the UI can offer Retry / Copy details / Start over. New pure `UserFacingErrorMessage(from:)` replaces raw `localizedDescription`. `EmailGatewayError.userCancelled` routes back to `.drafting` with the preview restored (distinct from a real transport failure, which persists the pending draft and re-offers it on next open). Tests: each gateway-error path, cancel-restores-preview, persistence encode→decode round-trip.

### 3. PP-4807 — preview editor + barcode
Field-selection state + actions (`userToggledDraftField` / `userEditedDescription` / `userOmittedLogs`). `TicketPreviewCard` gets per-row omit toggles + a log-excerpt section. Omitted fields are **dropped from the serialized JSON attachment**, not just hidden. Library barcode is sourced from `TPPUserAccount` (host, CI-gated), carried additive-optional through `ContextSnapshot`, **default-omitted**, with a hashed-identifier option. Tests: per-toggle reducer tests, payload contract-snapshots (all-on / logs-omitted / everything-omitted), serialization test asserting omitted fields are absent from encoded JSON.

### 4. PP-4809 — "Include diagnostics" setting
Default ON, persisted in UserDefaults; OFF ⇒ minimal snapshot (app version / OS only). Threaded through `TriageBotFactory.makeViewModel`. Tests: spy `ContextProvider` proves OFF skips full capture; persistence across VM instances.

### 5. PP-4811 — context race + provider
The async `.captureContext` can return after the patron has already raced to a draft (assembled with the all-"unknown" placeholder context). A late `.contextLoaded` now late-binds the real redacted context into an in-flight placeholder draft and re-applies the barcode default-omit — and never clobbers a draft already holding a real, patron-reviewed context. `ISO8601DateFormatter` hoisted out of the per-entry log-tail loop in `DefaultIosContextProvider`. Tests: placeholder-rebind, do-not-clobber-real-context, barcode-default-omit-on-rebind, preview-updates-in-place, submitting-rebind. Guard + barcode-omit mutants verified killed.

## Validation
- `swift test --package-path Palace/Packages/PalaceTriageBot` → **172 tests, 0 failures** (TriageBotCore).
- TriageBotUI / TriageBotIOS tests written correctly but **CI/sim-gated** (import UIKit/OSLog — do not build under macOS `swift test`).
- Host-app changes (`Palace/Support/TriageBotFactory.swift`, barcode sourcing) are **CI-gated** — this worktree lacks Carthage/submodule; no `xcodebuild` run here.

## Notes
- Critical path (patron credentials + ticket submission): strict TDD, mutation-minded — each test fails if its production logic is negated.
- Chrome stays monochrome (no `.tint` / `.blue`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)