### PR TITLE
feat(release-gates): fix-reconciliation + pre-GA crash-triage gates (3.2.0 retro)

### DIFF
--- a/scripts/check-pre-ga-crash-triage.py
+++ b/scripts/check-pre-ga-crash-triage.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+check-pre-ga-crash-triage.py — block promoting a release to GA while a crash
+signature that FIRST APPEARED in this release is still un-triaged on the
+RC / TestFlight builds.
+
+WHY THIS EXISTS (the 3.2.0 saveSync-deadlock retro)
+  The saveSync-deadlock crash produced events on the pre-GA RC builds
+  (3.2.0 479 / 481 / 482 = 8 events) DURING the release-candidate window, before
+  GA. The signal was already in Crashlytics — it just was not triaged until a
+  week AFTER GA. Nothing gated GA promotion on "read the RC crash board."
+
+  This gate does: given a Crashlytics export for the release's builds, it flags
+  every FATAL signature whose `firstSeenVersion` is THIS release (i.e. a
+  regression introduced by this release, not inherited) and blocks promotion
+  unless each is explicitly triaged — dispositioned with a ticket or a reason.
+  A crash you have looked at and decided to ship with is fine; a crash nobody
+  has looked at is not.
+
+INPUT (normalized JSON — the CI wrapper produces this from the Crashlytics API)
+  Either a bare list of issue objects, or `{"issues": [...]}`, each:
+    {
+      "id": "8afb1c66...",            # Crashlytics issue id
+      "title": "BookRegistrySync...", # human label
+      "errorType": "FATAL",           # FATAL | NON_FATAL | ANR
+      "firstSeenVersion": "3.2.0",    # marketing version it first appeared in
+      "eventsCount": 8,               # events in the window
+      "impactedUsersCount": 6
+    }
+  Extra keys are ignored, so the raw `crashlytics_get_report topIssues` groups
+  can be flattened into this shape by the wrapper without pruning.
+
+TRIAGE LEDGER
+  Default `.forgeos/crash-triage/<release>.txt`, override with --triage-file.
+  One `<issue-id> <ticket-or-reason>` per line; blank lines and `#`-comments
+  ignored (an id is a hex string, never bare `#...`, so `#` is always a comment
+  here — unlike the release-fix waiver which also accepts `#<pr>`). An issue is
+  triaged if its id (full or as a prefix) is the first token of a ledger line.
+
+USAGE
+  check-pre-ga-crash-triage.py --release-version 3.2.0 --issues-json export.json \
+      [--triage-file PATH] [--min-events N] [--include-anr] [--quiet]
+
+EXIT CODES
+  0  every new-in-release FATAL signature (>= --min-events) is triaged.
+  1  one or more un-triaged new-in-release crash signatures (printed).
+  2  usage / parse error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+
+def _load_issues(path: str) -> list[dict]:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    if isinstance(data, dict):
+        data = data.get("issues", [])
+    if not isinstance(data, list):
+        raise ValueError("issues JSON must be a list or {\"issues\": [...]}")
+    return data
+
+
+def _load_triaged(path: str | None, release_version: str) -> set[str]:
+    if path is None:
+        safe = release_version.replace("/", "-")
+        path = os.path.join(".forgeos", "crash-triage", f"{safe}.txt")
+    ids: set[str] = set()
+    if not os.path.exists(path):
+        return ids
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            ids.add(line.split()[0])
+    return ids
+
+
+def _is_triaged(issue_id: str, triaged: set[str]) -> bool:
+    for token in triaged:
+        if issue_id == token or issue_id.startswith(token):
+            return True
+    return False
+
+
+def evaluate(
+    issues: list[dict],
+    release_version: str,
+    triaged: set[str],
+    min_events: int,
+    include_anr: bool,
+) -> tuple[list[dict], list[dict]]:
+    """Return (untriaged, triaged_new) new-in-release crash signatures.
+
+    "New in release" = firstSeenVersion equals the release version. That is the
+    regression signal: a signature inherited from an older version is not this
+    release's fault to block on; one that debuts here is.
+    """
+    blocking_types = {"FATAL"}
+    if include_anr:
+        blocking_types.add("ANR")
+
+    untriaged: list[dict] = []
+    triaged_new: list[dict] = []
+
+    for issue in issues:
+        if issue.get("errorType") not in blocking_types:
+            continue
+        if str(issue.get("firstSeenVersion", "")) != str(release_version):
+            continue
+        if int(issue.get("eventsCount", 0) or 0) < min_events:
+            continue
+        record = {
+            "id": issue.get("id", "?"),
+            "title": issue.get("title", "?"),
+            "events": int(issue.get("eventsCount", 0) or 0),
+            "users": int(issue.get("impactedUsersCount", 0) or 0),
+            "type": issue.get("errorType"),
+        }
+        if _is_triaged(record["id"], triaged):
+            triaged_new.append(record)
+        else:
+            untriaged.append(record)
+
+    # Loudest first.
+    untriaged.sort(key=lambda r: r["events"], reverse=True)
+    return untriaged, triaged_new
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Block GA promotion on un-triaged new-in-release crash signatures."
+    )
+    parser.add_argument("--release-version", required=True,
+                        help="Marketing version being promoted (e.g. 3.2.0).")
+    parser.add_argument("--issues-json", required=True,
+                        help="Normalized Crashlytics issue export (list or {issues:[...]}).")
+    parser.add_argument("--triage-file", default=None,
+                        help="Triage ledger (default .forgeos/crash-triage/<version>.txt).")
+    parser.add_argument("--min-events", type=int, default=1,
+                        help="Ignore signatures below this event count (default 1).")
+    parser.add_argument("--include-anr", action="store_true",
+                        help="Also block on ANRs, not just FATAL crashes.")
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        issues = _load_issues(args.issues_json)
+        triaged = _load_triaged(args.triage_file, args.release_version)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"[pre-ga-crash-triage] ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    untriaged, triaged_new = evaluate(
+        issues, args.release_version, triaged, args.min_events, args.include_anr
+    )
+
+    if not args.quiet and triaged_new:
+        print(f"[pre-ga-crash-triage] {len(triaged_new)} new-in-{args.release_version} "
+              f"signature(s) triaged (dispositioned, shipping):", file=sys.stderr)
+        for r in triaged_new:
+            print(f"  ~ {r['id'][:12]} {r['title']}  ({r['events']} events)", file=sys.stderr)
+
+    if untriaged:
+        print(f"[pre-ga-crash-triage] BLOCK: {len(untriaged)} crash signature(s) that "
+              f"FIRST appeared in {args.release_version} are un-triaged:", file=sys.stderr)
+        for r in untriaged:
+            print(f"  ✗ {r['id'][:12]} [{r['type']}] {r['title']}", file=sys.stderr)
+            print(f"        {r['events']} events / {r['users']} users", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("  Triage each on the RC/TestFlight board BEFORE GA: file/​link a ticket", file=sys.stderr)
+        print("  and add `<issue-id> <ticket-or-reason>` to the triage ledger, or fix it.", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print(f"[pre-ga-crash-triage] ok — no un-triaged new-in-{args.release_version} "
+              f"crash signatures (>= {args.min_events} events).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-release-fix-reconciliation.py
+++ b/scripts/check-release-fix-reconciliation.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+check-release-fix-reconciliation.py — block shipping a release that is missing
+crash / critical-path fixes which have already landed on the integration branch.
+
+WHY THIS EXISTS (the 3.2.0 saveSync-deadlock retro)
+  The #1 crash on 3.2.0 (a BookRegistrySync.saveSync dispatch-reentrancy
+  deadlock, 6 patrons) was ALREADY fixed on develop — PR #1097 landed there on
+  2026-06-22, sixteen days before 3.2.0 shipped on 2026-07-08. It slipped only
+  because the release branch was cut on 2026-06-17 (before the fix) and NOTHING
+  reconciled "what crash/critical-path fixes landed on develop after the cut"
+  against the pending release. The fix existed, was tested, and sat in the
+  dashboard — the release process just never connected it to the release.
+
+  This gate closes that gap: before promoting a release, diff
+  `release..develop` for crash / critical-path fix commits that have NO
+  equivalent on the release branch, and force an explicit cherry-pick-or-waive
+  decision on each. Unreconciled critical fixes block the release.
+
+HOW
+  `git cherry <release-ref> <develop-ref>` is the load-bearing primitive: it
+  compares by PATCH-ID, so a commit that was cherry-picked into the release
+  (different SHA, same change) is correctly reported as already present ("-").
+  Only commits with no equivalent on the release ("+") are candidates. We then
+  keep the ones that (a) touch a critical-path file OR (b) read as a crash/bug
+  fix from the subject line, and fail on any that are not explicitly waived.
+
+WAIVERS
+  A waiver file (default `.forgeos/release-waivers/<release>.txt`, override with
+  --waiver-file) lists, one per line, `<sha-or-pr> <reason>`. A candidate is
+  reconciled if its abbreviated SHA, full SHA, or `#<pr>` appears as the first
+  token of a waiver line. Blank lines and `#`-comments are ignored. Waiving
+  leaves an audit trail — the point is a deliberate decision, not silence.
+
+USAGE
+  check-release-fix-reconciliation.py --release-ref release/3.2.0 \
+      [--develop-ref origin/develop] [--waiver-file PATH] [--quiet]
+
+EXIT CODES
+  0  every crash/critical-path fix on develop is either present on the release
+     or explicitly waived.
+  1  one or more unreconciled crash/critical-path fixes (printed).
+  2  usage / git error (bad ref, not a repo).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+# Critical-path file globs — a fix touching any of these is release-sensitive.
+# Mirrors the project's critical-path posture (auth / DRM / borrow / return /
+# download / audiobook / registry / migration / network executor). Override
+# with --critical-path-regex for a different tree.
+DEFAULT_CRITICAL_PATH_REGEX = (
+    r"(SignIn|Accounts|Keychain|DRM|LCP|Adobe|Borrow|Return|Download"
+    r"|Audiobook|BookRegistry|Registry|Migration|TPPNetworkExecutor"
+    r"|TPPNetworkResponder|TPPNetworkQueue|Fulfillment|Bookmark)"
+)
+
+# Subject-line signals that a commit is a crash / correctness fix even when it
+# does not touch a path we flagged (e.g. a fix in a util the app depends on).
+DEFAULT_FIX_SUBJECT_REGEX = (
+    r"\b(fix|crash|deadlock|race|data.?race|leak|hang|freeze|reentran"
+    r"|concurren|EXC_|SIG[A-Z]+|use.after.free|npe|nil.?unwrap)\b"
+)
+
+
+def _run_git(args: list[str]) -> str:
+    """Run a git command, returning stdout. Raises on non-zero exit."""
+    proc = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed ({proc.returncode}): {proc.stderr.strip()}"
+        )
+    return proc.stdout
+
+
+def _cherry_candidates(release_ref: str, develop_ref: str) -> list[str]:
+    """SHAs on develop_ref with NO patch-equivalent on release_ref.
+
+    `git cherry <upstream> <head>` prints `+ <sha>` for head commits missing
+    from upstream and `- <sha>` for those already present (by patch-id).
+    """
+    out = _run_git(["cherry", release_ref, develop_ref])
+    shas = []
+    for line in out.splitlines():
+        line = line.strip()
+        if line.startswith("+ "):
+            shas.append(line[2:].strip())
+    return shas
+
+
+def _commit_subject(sha: str) -> str:
+    return _run_git(["log", "-1", "--format=%s", sha]).strip()
+
+
+def _commit_files(sha: str) -> list[str]:
+    out = _run_git(["show", "--name-only", "--format=", sha])
+    return [ln.strip() for ln in out.splitlines() if ln.strip()]
+
+
+def _commit_pr_number(sha: str) -> str | None:
+    """Extract a squash-merge PR number `(#1234)` from the subject, if any."""
+    subject = _commit_subject(sha)
+    m = re.search(r"\(#(\d+)\)", subject)
+    return m.group(1) if m else None
+
+
+def _load_waivers(path: str | None, release_ref: str) -> set[str]:
+    """First token of each non-comment line: an SHA (any length) or `#<pr>`."""
+    if path is None:
+        safe = release_ref.replace("/", "-")
+        path = os.path.join(".forgeos", "release-waivers", f"{safe}.txt")
+    tokens: set[str] = set()
+    if not os.path.exists(path):
+        return tokens
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            # Skip blanks and comments — but `#1234` (hash + digit) is a PR-number
+            # waiver token, NOT a comment. Only `#` followed by whitespace or a
+            # non-digit is a comment.
+            if not line:
+                continue
+            if line.startswith("#") and not line[1:2].isdigit():
+                continue
+            tokens.add(line.split()[0])
+    return tokens
+
+
+def _is_waived(sha: str, pr: str | None, waivers: set[str]) -> bool:
+    if not waivers:
+        return False
+    # Match on full sha, any abbreviation that is a prefix, or #<pr>.
+    for token in waivers:
+        t = token.lstrip("#")
+        if sha == token or sha.startswith(t) or (pr is not None and t == pr):
+            return True
+    return False
+
+
+def evaluate(
+    release_ref: str,
+    develop_ref: str,
+    critical_path_regex: str,
+    fix_subject_regex: str,
+    waiver_file: str | None,
+) -> tuple[list[dict], list[dict]]:
+    """Return (unreconciled, waived) candidate lists.
+
+    A candidate is a commit on develop with no patch-equivalent on the release
+    that is EITHER critical-path (touches a flagged file) OR reads as a fix.
+    """
+    path_re = re.compile(critical_path_regex)
+    subj_re = re.compile(fix_subject_regex, re.IGNORECASE)
+    waivers = _load_waivers(waiver_file, release_ref)
+
+    unreconciled: list[dict] = []
+    waived: list[dict] = []
+
+    for sha in _cherry_candidates(release_ref, develop_ref):
+        subject = _commit_subject(sha)
+        files = _commit_files(sha)
+        touches_critical = any(path_re.search(f) for f in files)
+        looks_like_fix = bool(subj_re.search(subject))
+        # Flag only commits that BOTH touch a critical-path file AND read as a
+        # fix. A critical-path refactor with no fix wording, or a fix far from
+        # any critical path, is not release-blocking on its own — that keeps the
+        # gate high-signal (it fires on "a crash fix you forgot to port", not on
+        # every routine commit that grazes a flagged directory).
+        if not (touches_critical and looks_like_fix):
+            continue
+        pr = _commit_pr_number(sha)
+        record = {
+            "sha": sha[:9],
+            "pr": pr,
+            "subject": subject,
+            "critical_files": [f for f in files if path_re.search(f)],
+        }
+        if _is_waived(sha, pr, waivers):
+            waived.append(record)
+        else:
+            unreconciled.append(record)
+
+    return unreconciled, waived
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Block a release missing crash/critical-path fixes present on develop."
+    )
+    parser.add_argument("--release-ref", required=True,
+                        help="Release branch or tag being promoted (e.g. release/3.2.0).")
+    parser.add_argument("--develop-ref", default="origin/develop",
+                        help="Integration branch to reconcile against (default origin/develop).")
+    parser.add_argument("--critical-path-regex", default=DEFAULT_CRITICAL_PATH_REGEX)
+    parser.add_argument("--fix-subject-regex", default=DEFAULT_FIX_SUBJECT_REGEX)
+    parser.add_argument("--waiver-file", default=None,
+                        help="Waiver list (default .forgeos/release-waivers/<release>.txt).")
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        unreconciled, waived = evaluate(
+            args.release_ref,
+            args.develop_ref,
+            args.critical_path_regex,
+            args.fix_subject_regex,
+            args.waiver_file,
+        )
+    except RuntimeError as exc:
+        print(f"[release-fix-reconciliation] ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if not args.quiet and waived:
+        print(f"[release-fix-reconciliation] {len(waived)} waived fix(es) "
+              f"(explicitly excluded from {args.release_ref}):", file=sys.stderr)
+        for r in waived:
+            print(f"  ~ {r['sha']} {r['subject']}", file=sys.stderr)
+
+    if unreconciled:
+        print(f"[release-fix-reconciliation] BLOCK: {len(unreconciled)} crash/"
+              f"critical-path fix(es) on {args.develop_ref} are NOT on "
+              f"{args.release_ref} and are not waived:", file=sys.stderr)
+        for r in unreconciled:
+            pr = f" (#{r['pr']})" if r["pr"] else ""
+            print(f"  + {r['sha']}{pr} {r['subject']}", file=sys.stderr)
+            for f in r["critical_files"][:4]:
+                print(f"        {f}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("  Cherry-pick each into the release, OR waive with a reason in", file=sys.stderr)
+        print("  the waiver file (one `<sha-or-#pr> <reason>` per line).", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print(f"[release-fix-reconciliation] ok — {args.release_ref} is reconciled "
+              f"with {args.develop_ref} (no unwaived crash/critical-path fixes).",
+              file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/tests/test_check_pre_ga_crash_triage.py
+++ b/scripts/tests/test_check_pre_ga_crash_triage.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Tests for check-pre-ga-crash-triage.py.
+
+The anchor scenario is the real 3.2.0 miss: the saveSync-deadlock signature
+(8afb1c66), FATAL, firstSeenVersion 3.2.0, 8 RC-build events — un-triaged, so
+the gate must BLOCK GA; triaged, it must pass.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check-pre-ga-crash-triage.py"
+
+# The real regression that motivated the gate.
+SAVESYNC = {
+    "id": "8afb1c66ce5dde59b8774424240af778",
+    "title": "BookRegistrySync.saveSync reentrancy deadlock",
+    "errorType": "FATAL",
+    "firstSeenVersion": "3.2.0",
+    "eventsCount": 8,
+    "impactedUsersCount": 6,
+}
+# A crash inherited from an older version — NOT this release's fault to block on.
+INHERITED = {
+    "id": "deadbeef0001",
+    "title": "old TPPNetwork crash",
+    "errorType": "FATAL",
+    "firstSeenVersion": "3.1.0",
+    "eventsCount": 40,
+    "impactedUsersCount": 12,
+}
+# A brand-new NON_FATAL — the gate only blocks on FATAL (and ANR opt-in).
+NEW_NONFATAL = {
+    "id": "cafe0002",
+    "title": "handled exception",
+    "errorType": "NON_FATAL",
+    "firstSeenVersion": "3.2.0",
+    "eventsCount": 100,
+    "impactedUsersCount": 30,
+}
+
+
+def _write(tmp: Path, name: str, obj) -> Path:
+    p = tmp / name
+    p.write_text(json.dumps(obj))
+    return p
+
+
+def _run(tmp: Path, issues_path: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT),
+         "--release-version", "3.2.0", "--issues-json", str(issues_path), *extra],
+        cwd=tmp, capture_output=True, text=True,
+    )
+
+
+def test_new_fatal_untriaged_blocks(tmp_path: Path):
+    issues = _write(tmp_path, "i.json", [SAVESYNC, INHERITED])
+    res = _run(tmp_path, issues)
+    assert res.returncode == 1, res.stderr
+    assert "BLOCK" in res.stderr
+    assert "8afb1c66" in res.stderr
+
+
+def test_triaged_signature_passes(tmp_path: Path):
+    issues = _write(tmp_path, "i.json", [SAVESYNC])
+    ledger = tmp_path / "triage.txt"
+    ledger.write_text("8afb1c66ce5dde59b8774424240af778 PP-4819 fixed in 3.2.1 hotfix\n")
+    res = _run(tmp_path, issues, "--triage-file", str(ledger))
+    assert res.returncode == 0, res.stderr
+    assert "triaged" in res.stderr.lower()
+
+
+def test_triage_by_id_prefix(tmp_path: Path):
+    issues = _write(tmp_path, "i.json", [SAVESYNC])
+    ledger = tmp_path / "triage.txt"
+    ledger.write_text("8afb1c66 known — riding 3.3.0\n")  # prefix match
+    res = _run(tmp_path, issues, "--triage-file", str(ledger))
+    assert res.returncode == 0, res.stderr
+
+
+def test_inherited_crash_not_blocking(tmp_path: Path):
+    # Only the inherited (3.1.0) FATAL present — not new in 3.2.0.
+    issues = _write(tmp_path, "i.json", [INHERITED])
+    res = _run(tmp_path, issues)
+    assert res.returncode == 0, res.stderr
+
+
+def test_new_nonfatal_ignored(tmp_path: Path):
+    issues = _write(tmp_path, "i.json", [NEW_NONFATAL])
+    res = _run(tmp_path, issues)
+    assert res.returncode == 0, res.stderr
+
+
+def test_min_events_threshold(tmp_path: Path):
+    low = dict(SAVESYNC, eventsCount=2)
+    issues = _write(tmp_path, "i.json", [low])
+    res = _run(tmp_path, issues, "--min-events", "5")
+    assert res.returncode == 0, res.stderr  # below threshold -> ignored
+    res2 = _run(tmp_path, issues, "--min-events", "1")
+    assert res2.returncode == 1, res2.stderr  # at/above -> blocks
+
+
+def test_anr_opt_in(tmp_path: Path):
+    anr = {"id": "anr01", "title": "main-thread hang", "errorType": "ANR",
+           "firstSeenVersion": "3.2.0", "eventsCount": 10, "impactedUsersCount": 4}
+    issues = _write(tmp_path, "i.json", [anr])
+    assert _run(tmp_path, issues).returncode == 0                       # off by default
+    assert _run(tmp_path, issues, "--include-anr").returncode == 1      # opt-in blocks
+
+
+def test_issues_wrapper_shape(tmp_path: Path):
+    issues = _write(tmp_path, "i.json", {"issues": [SAVESYNC]})
+    res = _run(tmp_path, issues)
+    assert res.returncode == 1, res.stderr
+
+
+def test_clean_board_passes(tmp_path: Path):
+    issues = _write(tmp_path, "i.json", [INHERITED, NEW_NONFATAL])
+    res = _run(tmp_path, issues)
+    assert res.returncode == 0, res.stderr
+
+
+def test_bad_json_errors(tmp_path: Path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    res = _run(tmp_path, bad)
+    assert res.returncode == 2, res.stderr
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_check_release_fix_reconciliation.py
+++ b/scripts/tests/test_check_release_fix_reconciliation.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Tests for check-release-fix-reconciliation.py.
+
+Builds a throwaway git repo with a `release` branch and a `develop` branch, then
+drives the gate through the scenarios that matter for the 3.2.0 retro:
+
+  - a crash fix touching a critical-path file, landed on develop only  -> BLOCK
+  - the same fix cherry-picked into the release (different SHA)         -> pass
+    (proves the `git cherry` patch-id match, the crux of the tool)
+  - the fix explicitly waived                                          -> pass
+  - a non-critical-path fix                                            -> ignored
+  - a critical-path refactor with no fix wording                       -> ignored
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check-release-fix-reconciliation.py"
+
+
+def _git(repo: Path, *args: str, env: dict | None = None) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, env=env
+    )
+    assert proc.returncode == 0, f"git {args} failed: {proc.stderr}"
+    return proc.stdout.strip()
+
+
+def _commit(repo: Path, path: str, content: str, message: str) -> str:
+    f = repo / path
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(content)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _run_gate(repo: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT),
+         "--release-ref", "release", "--develop-ref", "develop", *extra],
+        cwd=repo, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "t@t.io")
+    _git(r, "config", "user.name", "t")
+    # Base commit, then cut `release` here — the divergence point.
+    _commit(r, "README.md", "base\n", "base")
+    _git(r, "branch", "release")
+    _git(r, "branch", "develop")
+    _git(r, "checkout", "-q", "develop")
+    return r
+
+
+def test_unreconciled_critical_fix_blocks(repo: Path):
+    # Crash fix on a critical-path file, develop only.
+    _commit(repo, "Palace/Book/Models/BookRegistrySync.swift",
+            "// fixed reentrancy\n",
+            "fix(registry): saveSync reentrancy deadlock (#999)")
+    res = _run_gate(repo)
+    assert res.returncode == 1, res.stderr
+    assert "BLOCK" in res.stderr
+    assert "#999" in res.stderr
+
+
+def test_cherry_picked_fix_is_reconciled(repo: Path):
+    sha = _commit(repo, "Palace/Book/Models/BookRegistrySync.swift",
+                  "// fixed reentrancy\n",
+                  "fix(registry): saveSync reentrancy deadlock (#999)")
+    # Cherry-pick the SAME change onto release — new SHA, identical patch.
+    _git(repo, "checkout", "-q", "release")
+    _git(repo, "cherry-pick", sha)
+    _git(repo, "checkout", "-q", "develop")
+    res = _run_gate(repo)
+    assert res.returncode == 0, res.stderr + res.stdout
+
+
+def test_waiver_reconciles(repo: Path):
+    sha = _commit(repo, "Palace/MyBooks/BorrowOperation.swift", "// x\n",
+                  "fix(borrow): guard nil acquisition (#1001)")
+    waiver = repo / "waivers.txt"
+    waiver.write_text(f"{sha[:9]} intentionally held for next release\n")
+    res = _run_gate(repo, "--waiver-file", str(waiver))
+    assert res.returncode == 0, res.stderr
+    assert "waived" in res.stderr.lower()
+
+
+def test_waiver_by_pr_number(repo: Path):
+    _commit(repo, "Palace/SignInLogic/OIDC.swift", "// x\n",
+            "fix(signin): OIDC token race (#1234)")
+    waiver = repo / "waivers.txt"
+    waiver.write_text("#1234 shipping separately\n")
+    res = _run_gate(repo, "--waiver-file", str(waiver))
+    assert res.returncode == 0, res.stderr
+
+
+def test_non_critical_fix_ignored(repo: Path):
+    _commit(repo, "docs/notes.md", "typo fix\n",
+            "fix(docs): correct a typo")
+    res = _run_gate(repo)
+    assert res.returncode == 0, res.stderr
+
+
+def test_critical_refactor_without_fix_wording_ignored(repo: Path):
+    _commit(repo, "Palace/Book/Models/BookRegistryStore.swift", "// refactor\n",
+            "refactor(registry): extract snapshot helper")
+    res = _run_gate(repo)
+    assert res.returncode == 0, res.stderr
+
+
+def test_clean_release_passes(repo: Path):
+    # develop == release (no new commits) -> nothing to reconcile.
+    res = _run_gate(repo)
+    assert res.returncode == 0, res.stderr
+
+
+def test_bad_ref_errors(repo: Path):
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT),
+         "--release-ref", "release", "--develop-ref", "nonexistent-ref"],
+        cwd=repo, capture_output=True, text=True,
+    )
+    assert res.returncode == 2, res.stderr
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Two release-process gates from the 3.2.0 crash retro

The 3.2.0 #1 crash (saveSync deadlock, 6 patrons) was fixed on develop **16 days before ship** but never pulled into the release, and produced **8 RC-build events pre-GA** that weren't triaged until a week after GA. These two gates each independently close that gap.

### 1. `check-release-fix-reconciliation.py`
Before promoting a release, diffs `release..develop` via `git cherry` (patch-id match — cherry-picks count as present) for crash/critical-path fixes missing from the release. Each must be cherry-picked or explicitly waived (audit trail). Run live against 3.2.0, it surfaces #1097 at the top of the unreconciled list.

### 2. `check-pre-ga-crash-triage.py`
Given a Crashlytics export, blocks GA on any FATAL signature whose `firstSeenVersion` is *this* release (a regression it introduced) that's still un-triaged. Would have stopped 3.2.0 promotion on the saveSync signature.

### Verification
- 18 pytests in `scripts/tests/` (auto-run by `tooling-checks.yml`), including the real saveSync scenario for each gate. All green locally.
- Follows the existing `check-*.py` convention (argparse, `main(argv)->int`, exit 0/1/2).

### Scope
Tooling only (`scripts/` + `scripts/tests/`) — no app code, no build settings. Wiring the gates into the release workflow (piping a live Crashlytics export into gate 2, running gate 1 at release-cut) is a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)