### PR TITLE
test(concurrency): heavy concurrency/teardown coverage for the 3.2.0 crash classes

### DIFF
--- a/PalaceTests/Audiobooks/AudiobookSessionManagerShutdownTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookSessionManagerShutdownTests.swift
@@ -157,6 +157,74 @@ final class AudiobookSessionManagerShutdownTests: XCTestCase {
                           "stopPlayback from unbound state must complete in <500ms — guard against F-001 watchdog budget consumption")
     }
 
+    // MARK: - F-001: teardown serializes against off-main remote-command reads
+
+    /// Off-main remote/CarPlay/lock-screen command handlers reach the session
+    /// through the ONE `nonisolated` accessor built for that purpose —
+    /// `hasActiveManagerSnapshot` (an `OSAllocatedUnfairLock`-backed mirror of
+    /// `manager != nil`, written only on the main actor at the bind/unbind
+    /// seams). This is the exact class of read that trips
+    /// `dispatch_assert_queue_fail` if it ever synchronously touches a
+    /// `@MainActor` member off-main — the #1218 Now-Playing artwork crash.
+    ///
+    /// Here we hammer that snapshot from ~5 concurrent background tasks WHILE
+    /// the main actor runs `stopPlayback` (teardown). The off-main reads must
+    /// never trap, the main-actor teardown must complete, and the post-teardown
+    /// state must be coherent: no bound manager, `.idle`, and the off-main
+    /// snapshot converged to `false` (its writer is the `manager` `didSet` that
+    /// teardown fires). If teardown didn't serialize safely — or a refactor
+    /// made the snapshot read a `@MainActor` member off-main — this either
+    /// crashes or leaves the snapshot stuck `true`.
+    func test_concurrentRemoteCommandsAndStopPlayback_teardownSerializes() async {
+        // ~5 background readers simulating remote/CarPlay handlers firing
+        // off-main. They only touch the `nonisolated` snapshot — the single
+        // legal off-main accessor — never a `@MainActor` member. Each spins a
+        // tight read loop so reads overlap the main-actor teardown window.
+        let readerCount = 5
+        let readsPerReader = 200
+        let readers: [Task<Bool, Never>] = (0..<readerCount).map { _ in
+            Task.detached {
+                var sawAnyValueSafely = true
+                for _ in 0..<readsPerReader {
+                    // A synchronous off-main read of an isolated member would
+                    // trap here; reaching the OR proves the read returned.
+                    let snapshot = AudiobookSessionManager.hasActiveManagerSnapshot
+                    sawAnyValueSafely = sawAnyValueSafely && (snapshot || !snapshot)
+                    await Task.yield()
+                }
+                return sawAnyValueSafely
+            }
+        }
+
+        // Drive main-actor teardown concurrently with the off-main readers.
+        // Repeat so the teardown/read windows interleave many times.
+        for _ in 0..<20 {
+            await manager.stopPlayback(dismissPhoneUI: false)
+            await Task.yield()
+        }
+
+        // All readers must have completed without trapping.
+        for reader in readers {
+            let completedSafely = await reader.value
+            XCTAssertTrue(completedSafely,
+                          "Off-main remote-command reads of hasActiveManagerSnapshot must complete without an actor-isolation trap while teardown runs")
+        }
+
+        // Teardown completed and left coherent state.
+        XCTAssertEqual(manager.state, .idle,
+                       "Teardown under concurrent off-main reads must settle in .idle")
+        XCTAssertNil(manager.manager,
+                     "No manager may be bound after teardown")
+        XCTAssertFalse(manager.hasActiveManager,
+                       "hasActiveManager must be false after teardown")
+
+        // The off-main snapshot is the mirror teardown's manager-didSet writes;
+        // after the last stop it must have converged to false. This is the leg
+        // that proves the off-main read path reflects the serialized teardown.
+        XCTAssertFalse(AudiobookSessionManager.hasActiveManagerSnapshot,
+                       "Post-teardown, the off-main snapshot must reflect the unbound manager (false)")
+    }
+
     // MARK: - F-001: validate non-fatal record builder is pure & non-MainActor
 
     /// `buildPlaybackFailureRecord` is the Crashlytics NSError builder

--- a/PalaceTests/Book/BookRegistrySyncReentrancyTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncReentrancyTests.swift
@@ -184,4 +184,110 @@ final class BookRegistrySyncReentrancyTests: XCTestCase {
             "saveSync must serialize through diskWriteQueue so its 2-record snapshot lands after the in-flight 1-record async writes; an inline (unserialized) write is clobbered by a trailing async save"
         )
     }
+
+    // MARK: - Real bookmark → saveSync chain under concurrency
+
+    /// Drives the ACTUAL production reentrancy path end-to-end:
+    /// `BookmarkManager.setLocationSync` → `store.mutateRegistrySync` →
+    /// `onComplete` (runs inside the `syncQueue` barrier) → `saveSync(for:)`.
+    /// This is the exact call chain of Crashlytics 8afb1c66 — the previous
+    /// reentrancy test invoked `saveSync` through a hand-rolled `mutateRegistrySync`
+    /// onComplete; this one goes through the real `BookmarkManager` seam wired with
+    /// the same `saveSync` closure production uses (`TPPBookRegistry.init` wires
+    /// `saveSync: { sync?.saveSync(for: account) }`). ~20-way concurrent to smoke
+    /// out the barrier-reentrancy hang under contention. Fails by timeout if the
+    /// deadlock returns; asserts the location persisted to disk.
+    func testSetLocationSync_fromMultipleThreads_savesyncSucceeds() throws {
+        let (account, url) = isolatedAccount()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let book = makeBook(identifier: "setlocsync-1")
+        store.mutateRegistrySync { $0[book.identifier] = TPPBookRegistryRecord(book: book, state: .downloadSuccessful) }
+
+        // Wire the BookmarkManager exactly as TPPBookRegistry.init does: its
+        // `saveSync` closure forwards to the sync manager under test, so
+        // setLocationSync reaches the real saveSync via the onComplete barrier.
+        let bookmarkManager = BookmarkManager(
+            store: store,
+            save: { [syncManager] account in syncManager?.save(for: account) },
+            saveSync: { [syncManager] account in syncManager?.saveSync(for: account) }
+        )
+
+        let iterations = 20
+        let done = expectation(description: "all setLocationSync return")
+        done.expectedFulfillmentCount = iterations
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            let location = TPPBookLocation(locationString: "loc-\(i)", renderer: "test-renderer")
+            bookmarkManager.setLocationSync(location, forIdentifier: book.identifier, account: account)
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 10.0)
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: url.path),
+            "the real setLocationSync → saveSync chain must persist the registry to disk"
+        )
+        let data = try Data(contentsOf: url)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let records = try XCTUnwrap(json[TPPBookRegistryKey.records.rawValue] as? [[String: Any]])
+        XCTAssertEqual(records.count, 1, "the one seeded book must be persisted after the concurrent location writes")
+    }
+
+    // MARK: - Concurrent load() + sync() must not deadlock and must not empty the shelf
+
+    /// Runs `load()` (which takes a `store.mutateRegistry` barrier while it reads
+    /// the on-disk registry) concurrently with `sync()` (which runs its guard /
+    /// credential checks and, on a fresh unsigned-in account, takes the safe
+    /// `currentAccount == nil` early return). The two barrier-adjacent paths race:
+    /// a sync can fire while load's barrier is active. Pre-seeds the on-disk file
+    /// so load has real records to restore — asserting the registry is REBUILT
+    /// from disk (merged, non-empty), never overwritten to empty by the race.
+    /// Fails by timeout if either path deadlocks against the store barrier.
+    func testConcurrentLoadAndSync_bothComplete() {
+        let (account, _) = isolatedAccount()
+        let url = syncManager.registryUrl(for: account)!
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        // Seed the on-disk registry so load() has records to restore. Without a
+        // file on disk load() legitimately settles to an empty registry — the
+        // pre-seed is what lets us distinguish "merged/rebuilt" from
+        // "overwritten to empty by the concurrent sync".
+        let book = makeBook(identifier: "loadsync-1")
+        store.mutateRegistrySync { $0[book.identifier] = TPPBookRegistryRecord(book: book, state: .downloadSuccessful) }
+        syncManager.saveSync(for: account)
+        store.removeAll()
+
+        let loadDone = expectation(description: "load completes")
+        let syncDone = expectation(description: "sync completes")
+
+        DispatchQueue.concurrentPerform(iterations: 2) { i in
+            if i == 0 {
+                self.syncManager.load(account: account, setState: { _ in }) {
+                    loadDone.fulfill()
+                }
+            } else {
+                // sync() at currentState == .loaded runs its state guard + the
+                // `currentAccount` lookup concurrently with load's barrier — the
+                // reentrancy-adjacent surface under test. On a fresh unsigned-in
+                // account it takes the safe early return (`currentAccount == nil`)
+                // and returns SYNCHRONOUSLY without invoking `completion`, so we
+                // signal on the call returning — its returning at all (not
+                // hanging) is the deadlock check.
+                self.syncManager.sync(
+                    currentState: .loaded,
+                    setState: { _ in },
+                    completion: { _, _ in }
+                )
+                syncDone.fulfill()
+            }
+        }
+        wait(for: [loadDone, syncDone], timeout: 10.0)
+
+        // Merged/rebuilt from disk, not overwritten to empty by the concurrent sync.
+        let restored = store.readRegistry { $0[book.identifier] }
+        XCTAssertNotNil(
+            restored,
+            "load() must rebuild the seeded record from disk; the concurrent sync must not have overwritten the shelf to empty"
+        )
+    }
 }

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterAccountIdThreadingTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterAccountIdThreadingTests.swift
@@ -369,4 +369,168 @@ final class MyBooksDownloadCenterAccountIdThreadingTests: XCTestCase {
         XCTAssertFalse(manager.userAccountForCalls.contains("ghost-current"),
                        "instance overload with explicit accountId must NOT read currentAccountId or currentUserAccount — those are the legacy swap-window paths")
     }
+
+    // MARK: - 7. Concurrent downloads across rapid account switches → no cross-account leak
+
+    /// Test 7 — the concurrency generalization of Test 3. Test 3 pins the
+    /// capture-once invariant for a SINGLE swap window; this drives ~50
+    /// `startDownloadAsync` calls in parallel while a background task
+    /// rapidly flips the shared `ControllableAccountsManagerMock`'s
+    /// `currentAccountId` among three configured accounts (A, B, C).
+    ///
+    /// Each in-flight download captures `currentAccountId` at its own start
+    /// via `currentAccountIdProvider` (a `let` snapshot inside
+    /// `startDownloadAsync`), then threads that captured id into the REAL
+    /// `TPPNetworkExecutor.bearerAuthorized(request:accountId:)` inside the
+    /// `processWithCredentials` closure — exactly the production path. The
+    /// resulting `Authorization` header is recorded into a thread-safe audit
+    /// trail alongside the id the download captured.
+    ///
+    /// Invariant pinned (NO cross-account leak):
+    ///  1. Every request's Authorization value is a well-formed
+    ///     `Bearer <token>` for SOME configured account — never empty,
+    ///     never a torn/partial string, never a token that belongs to no
+    ///     account. A rapid flip must not produce a request that ends up
+    ///     with a mismatched or missing token.
+    ///  2. Per download, the applied token is the token for the id THAT
+    ///     download captured (capture-once holds under contention) — a
+    ///     download that captured B must carry B's token even if the current
+    ///     account was flipped to A or C before/after its bearer-auth step.
+    ///
+    /// A real cross-account leak — e.g. `bearerAuthorized` re-resolving
+    /// `currentAccountId` at request-build time instead of honoring the
+    /// captured arg, or the capture reading a torn value mid-flip — makes
+    /// some request carry a token that mismatches the id it recorded,
+    /// failing invariant #2 (and, if it resolved an un-installed id, #1).
+    func testConcurrentDownloadsAcrossRapidAccountSwitches_allUseCorrectToken() async {
+        let accountIdC = "test-library-C-uuid"
+        let tokenForA = "tokenForA"
+        let tokenForB = "tokenForB"
+        let tokenForC = "tokenForC"
+
+        // One shared manager + executor across every concurrent download —
+        // this is what makes a cross-account leak observable: all downloads
+        // resolve credentials through the SAME injected accountsManager whose
+        // current account is being flipped underneath them.
+        let manager = ControllableAccountsManagerMock()
+        installAccount(uuid: accountIdA, token: tokenForA, on: manager)
+        installAccount(uuid: accountIdB, token: tokenForB, on: manager)
+        installAccount(uuid: accountIdC, token: tokenForC, on: manager)
+        manager.mockedCurrentAccountId = accountIdA
+
+        let executor = makeExecutor(with: manager)
+
+        // Valid (capturedId → expected Authorization header) pairs. Any
+        // recorded header MUST be one of these three, and MUST match the id
+        // the download captured.
+        let expectedHeaderForId: [String: String] = [
+            accountIdA: "Bearer \(tokenForA)",
+            accountIdB: "Bearer \(tokenForB)",
+            accountIdC: "Bearer \(tokenForC)"
+        ]
+        let switchableIds = [accountIdA, accountIdB, accountIdC]
+
+        // Thread-safe audit trail: (capturedId, appliedAuthorizationHeader)
+        // per download. NSLock-guarded because the recording happens from the
+        // many concurrent `processWithCredentials` closures.
+        final class AuditTrail: @unchecked Sendable {
+            private let lock = NSLock()
+            private var entries: [(capturedId: String, header: String)] = []
+            func record(capturedId: String, header: String) {
+                lock.lock(); defer { lock.unlock() }
+                entries.append((capturedId, header))
+            }
+            var snapshot: [(capturedId: String, header: String)] {
+                lock.lock(); defer { lock.unlock() }
+                return entries
+            }
+        }
+        let audit = AuditTrail()
+
+        final class CoordinatorDelegateSpy: DownloadStartCoordinatorDelegate {
+            func borrowAsync(_ book: TPPBook, attemptDownload: Bool) async throws -> TPPBook { book }
+            func schedulePendingStartsIfPossible() {}
+        }
+
+        let downloadCount = 50
+
+        // Rapidly flip the shared manager's current account among A/B/C in the
+        // background while the downloads run, maximizing the swap-window
+        // overlap with each download's capture + bearer-auth steps.
+        let switcher = Task { @Sendable in
+            var i = 0
+            while !Task.isCancelled {
+                manager.mockedCurrentAccountId = switchableIds[i % switchableIds.count]
+                i += 1
+                await Task.yield()
+            }
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<downloadCount {
+                group.addTask {
+                    // Each download gets its own coordinator + book + registry so
+                    // the per-download state machine is independent; they all
+                    // share `manager`, `executor`, and `audit`.
+                    let delegate = CoordinatorDelegateSpy()
+                    let stateManager = DownloadStateManager()
+                    stateManager.maxConcurrentDownloads = downloadCount
+                    let registry = TPPBookRegistryMock()
+                    let userAccount = TPPUserAccountMock()
+                    let queue = DownloadQueueOrchestrator(bookRegistry: registry, stateManager: stateManager)
+
+                    let coordinator = DownloadStartCoordinator(
+                        stateManager: stateManager,
+                        bookRegistry: registry,
+                        userAccountProvider: { userAccount },
+                        // Capture reads the shared, actively-flipping current id.
+                        currentAccountIdProvider: { manager.currentAccountId },
+                        errorActivityTracker: .shared,
+                        queueOrchestrator: queue,
+                        processUnregistered: { _, _, _ in .downloadNeeded },
+                        // Production path: feed the CAPTURED id into the real
+                        // executor and record the token it actually applied.
+                        processWithCredentials: { _, _, _, capturedId in
+                            let request = URLRequest(url: URL(string: "https://example.com/loans/book")!)
+                            let authed = executor.bearerAuthorized(request: request, accountId: capturedId)
+                            let header = authed.value(forHTTPHeaderField: "Authorization") ?? ""
+                            audit.record(capturedId: capturedId, header: header)
+                        },
+                        requestCredentials: { _ in }
+                    )
+                    coordinator.delegate = delegate
+
+                    let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+                    registry.addBook(book, state: .downloadNeeded)
+
+                    await coordinator.startDownloadAsync(for: book)
+                }
+            }
+        }
+
+        switcher.cancel()
+
+        let recorded = audit.snapshot
+
+        XCTAssertEqual(recorded.count, downloadCount,
+                       "every one of \(downloadCount) concurrent downloads must reach the bearer-auth boundary exactly once")
+
+        for (index, entry) in recorded.enumerated() {
+            // Invariant #1: the captured id is a real configured account —
+            // never the sentinel, never a torn/empty value. (The flip only
+            // ever assigns A/B/C, so a captured id outside that set would mean
+            // the snapshot read a value that never existed.)
+            guard let expected = expectedHeaderForId[entry.capturedId] else {
+                XCTFail("download #\(index) captured an unconfigured accountId '\(entry.capturedId)' — a torn/leaked read; must be one of A/B/C")
+                continue
+            }
+            // Invariant #1 (header well-formed) + #2 (matches captured id):
+            // the applied Authorization is EXACTLY the token for the id this
+            // download captured — no cross-account leak, no empty/partial header.
+            XCTAssertEqual(entry.header, expected,
+                           "download #\(index) captured '\(entry.capturedId)' but applied '\(entry.header)' — a cross-account token leak (expected '\(expected)')")
+            XCTAssertFalse(entry.header.isEmpty,
+                           "download #\(index) applied an EMPTY Authorization — a configured account must resolve a non-empty bearer token")
+        }
+    }
 }

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterConcurrencyTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterConcurrencyTests.swift
@@ -592,6 +592,74 @@ final class MyBooksDownloadCenterConcurrencyTests: XCTestCase {
                        "Actor must serialize concurrent enqueues — final count must equal unique inputs (\(books.count)). Kills mutants that race on pendingQueue.append.")
     }
 
+    /// Many concurrent download lifecycles each flip the registry's
+    /// per-book processing flag on (start) then off (barrier/cleanup
+    /// completion) — exactly what BorrowOperation / BookReturnService drive
+    /// around `setProcessing(true, …)` … `setProcessing(false, …)`. The
+    /// registry's processing state is guarded by a reader/writer barrier
+    /// (`BookRegistryStore.performBarrier`) / lock (mock). This pins two
+    /// contracts under real thread contention:
+    ///   1. Liveness — no deadlock: the barrier/lock must not stall when
+    ///      writers from many threads and readers interleave (a generous
+    ///      timeout catches a hang instead of hanging the suite forever).
+    ///   2. Consistency — the final processing set is exactly right: every
+    ///      book that finished its lifecycle (true→false) must NOT be left
+    ///      stuck processing. A lost/racy write to `processingIdentifiers`
+    ///      would strand a book as "processing forever," which is the
+    ///      user-visible spinner-that-never-stops bug.
+    /// Uses `DispatchQueue.concurrentPerform` to get genuine OS-thread
+    /// parallelism into the synchronized write path (stronger than a
+    /// cooperative-pool `withTaskGroup`, which may not truly parallelize).
+    func testConcurrentSetProcessing_fromMultipleDownloads_serializes() async {
+        let books = (0..<10).map { _ in makeBook() }
+        let ids = books.map { $0.identifier }
+
+        // A distinct book that stays processing the whole time — its flag is
+        // set once and never cleared. Verifies the concurrent churn on the
+        // other 10 identifiers does NOT clobber an unrelated in-flight entry.
+        let inflight = makeBook()
+        bookRegistry.setProcessing(true, for: inflight.identifier)
+
+        // Drive ~10 concurrent "download lifecycles" from real parallel
+        // threads. Each thread flips its book on, then off — the terminal
+        // state for all 10 must be "not processing." Repeat the on/off toggle
+        // several times per thread to widen the race window on the shared set.
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global(qos: .userInitiated).async { [bookRegistry] in
+                DispatchQueue.concurrentPerform(iterations: ids.count) { index in
+                    let id = ids[index]
+                    for _ in 0..<20 {
+                        bookRegistry?.setProcessing(true, for: id)
+                        bookRegistry?.setProcessing(false, for: id)
+                    }
+                    // Terminal write for this lifecycle: cleared (download
+                    // finished / cancelled). This is the state that must win.
+                    bookRegistry?.setProcessing(false, for: id)
+                }
+                continuation.resume()
+            }
+        }
+
+        // 1. Liveness: reaching here (the continuation resumed) already proves
+        //    no deadlock. Guard the end-state read behind the shared timeout
+        //    helper so a stalled barrier surfaces as a loud timeout, not a hang.
+        await waitForAsync(timeout: 15.0) { [bookRegistry] in
+            ids.allSatisfy { bookRegistry!.processing(forIdentifier: $0) == false }
+        }
+
+        // 2. Consistency: no lifecycle-completed book is stuck processing.
+        for id in ids {
+            XCTAssertFalse(bookRegistry.processing(forIdentifier: id),
+                           "After a true→false lifecycle from many threads, book \(id) must NOT be left processing — a lost write to processingIdentifiers strands the spinner forever")
+        }
+
+        // 3. Isolation: the concurrent churn must not have touched the
+        //    unrelated in-flight book (kills mutants that swap the per-id
+        //    remove for a removeAll / clobber the whole set on any write).
+        XCTAssertTrue(bookRegistry.processing(forIdentifier: inflight.identifier),
+                      "A book still in-flight must remain processing — concurrent set/clear on OTHER identifiers must not clear it")
+    }
+
     // MARK: - 13. Orchestrator: empty queue is no-op, never calls delegate
 
     /// Kills mutants that make `schedulePendingStartsAsync` call the

--- a/PalaceTests/Network/TPPNetworkExecutorConcurrencyTests.swift
+++ b/PalaceTests/Network/TPPNetworkExecutorConcurrencyTests.swift
@@ -224,4 +224,80 @@ final class TPPNetworkExecutorConcurrencyTests: XCTestCase {
         XCTAssertTrue(doubles.isEmpty, "completions double-fired: \(doubles)")
         XCTAssertEqual(total, n, "total completion fire count \(total) != \(n)")
     }
+
+    // MARK: - Concurrent cancellation — cancelled OR completed, always exactly once
+
+    /// Fans out ~30 concurrent requests through the raw completion-handler
+    /// `GET(_:useTokenIfAvailable:completion:)` overload — the overload that
+    /// RETURNS the `URLSessionDataTask`, which is the real per-request
+    /// cancellation entry point (the executor exposes no `cancel(request:)`;
+    /// production callers cancel by holding the returned task handle, and the
+    /// account-switch path funnels through the same `URLSessionTask.cancel()`
+    /// via `transport.cancelNonEssentialTasks()`). Roughly half the tasks are
+    /// cancelled while requests are being registered (`addCompletion`) and
+    /// delivered (`didCompleteWithError`) concurrently — the exact interleave
+    /// that produced the use-after-free.
+    ///
+    /// What this pins: EVERY task's completion arm fires EXACTLY once, whoever
+    /// wins the cancel-vs-deliver race. A `.cancel()` surfaces in the responder
+    /// as `didCompleteWithError` with `NSURLErrorCancelled`, which
+    /// `removeValue(forKey:)`s the taskInfo (single ownership) and fires one
+    /// `.failure`. If the natural response already landed first, the later
+    /// cancel event finds no taskInfo and fires nothing. So a cancelled task
+    /// resolves once (cancelled `.failure` OR success, depending on the race)
+    /// and a non-cancelled task completes once — never dropped, never doubled.
+    ///
+    /// This uses the raw completion-handler seam (NOT the async
+    /// `ContinuationGuard`-guarded bridge), so a genuine responder double-fire
+    /// would reach the ledger and FAIL here — it is not absorbed upstream. A
+    /// dropped completion leaves a task un-fulfilled → the expectation times
+    /// out → FAIL. The test therefore fails on a real drop OR a real
+    /// double-fire; it is not a tautology.
+    func testConcurrentNetworkCancellation_allTasksCancelOrComplete() {
+        let body = "payload".data(using: .utf8)!
+        HTTPStubURLProtocol.register { _ in
+            .init(statusCode: 200, headers: nil, body: body)
+        }
+
+        let ledger = FireLedger()
+        let n = 30
+        let allDone = expectation(description: "all requests resolved (cancelled or completed)")
+        allDone.expectedFulfillmentCount = n
+
+        // Fan out from a concurrent queue so registration, delivery, and
+        // cancellation all race against each other.
+        let queue = DispatchQueue(label: "pp4769.cancel.fanout", attributes: .concurrent)
+        for i in 0..<n {
+            // Cancel roughly half (the even indices) mid-flight.
+            let shouldCancel = (i % 2 == 0)
+            queue.async { [executor] in
+                let url = URL(string: "https://api.example.com/cancel/\(i)")!
+                let task = executor!.GET(url, useTokenIfAvailable: false) { _, _, _ in
+                    // Both arms — cancelled (`.failure` → error non-nil) and
+                    // completed (`.success` → data) — funnel here. We assert
+                    // fire-count, not which arm won, because the cancel-vs-
+                    // deliver race is inherently nondeterministic; the invariant
+                    // under test is EXACTLY ONCE, not WHICH outcome.
+                    ledger.record(i)
+                    allDone.fulfill()
+                }
+                if shouldCancel {
+                    // The real cancellation mechanism: cancel the returned
+                    // URLSession task. Racing this against the synchronous stub
+                    // delivery is the point — either the cancel wins (one
+                    // `.failure(NSURLErrorCancelled)`) or delivery already won
+                    // (one `.success`); the responder's `removeValue` guarantees
+                    // the loser fires nothing.
+                    task?.cancel()
+                }
+            }
+        }
+
+        wait(for: [allDone], timeout: 30.0)
+
+        let (unique, doubles, total) = ledger.snapshot()
+        XCTAssertEqual(unique, n, "expected all \(n) requests to resolve exactly once (cancelled or completed)")
+        XCTAssertTrue(doubles.isEmpty, "requests double-fired (cancel + delivery both reached completion): \(doubles)")
+        XCTAssertEqual(total, n, "total resolution count \(total) != \(n) (a cancelled or completed request was dropped)")
+    }
 }


### PR DESCRIPTION
## Concurrency test hardening — 3.2.0 crash retro (Track B)

6 concurrency regression tests across the crash-adjacent surfaces the 3.2.0 retro exposed. Each **extends an existing proven-pattern test file** (no new files, no pbxproj churn, no production changes), mirrors that file's helpers/idioms, and asserts a **falsifiable end-state** (not "didn't crash").

| Test | Guards | Crash class |
|---|---|---|
| `testSetLocationSync_fromMultipleThreads_savesyncSucceeds` | real bookmark→`mutateRegistrySync`-onComplete→`saveSync` reentrancy chain, 20-way, no deadlock + disk persist | **8afb1c66** (the hotfixed deadlock) |
| `testConcurrentLoadAndSync_bothComplete` | `load` barrier vs `sync`, both complete, registry rebuilt not clobbered | registry reentrancy |
| `test_concurrentRemoteCommandsAndStopPlayback_teardownSerializes` | 5 off-main readers of `hasActiveManagerSnapshot` vs main-actor `stopPlayback` | **#1218** off-main @MainActor |
| `testConcurrentSetProcessing_fromMultipleDownloads_serializes` | 10 downloads toggling `setProcessing`; no stuck-processing + per-id isolation | download barrier |
| `testConcurrentDownloadsAcrossRapidAccountSwitches_allUseCorrectToken` | 50-way `startDownloadAsync` under rotating account; no cross-account token leak | account-id threading |
| `testConcurrentNetworkCancellation_allTasksCancelOrComplete` | 30-way, cancel half mid-flight; exactly-once via raw seam | network completion |

### Verification
- All 5 files pass `swiftc -parse` (syntax gate). **CI is the compiler** for these — fresh worktree can't build the DRM app locally; expect the full-suite CI run to be the real gate.
- Test-only, add-only, PalaceTests target (Swift 4.2 mode).

### Deliberately separate (not in this PR)
**Track B1** — ratcheting the PalaceTests target to Swift 6 / strict-concurrency. It would enforce isolation across every test closure at once; it needs its own PR where CI reveals the true blast radius, rather than reddening this one.

Companion to #1281 (release-process gates from the same retro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)