### PR TITLE
[EXPERIMENT] chore(test): ratchet PalaceTests to Swift 6 — measuring blast radius

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -9100,7 +9100,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "PalaceTests/PalaceTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Palace.app/Palace";
 				WARNING_CFLAGS = (
 					"-Wall",
@@ -9160,7 +9160,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "LCP FEATURE_OVERDRIVE";
 				SWIFT_OBJC_BRIDGING_HEADER = "PalaceTests/PalaceTests-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Palace.app/Palace";
 				WARNING_CFLAGS = (
 					"-Wall",

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1172,6 +1172,7 @@
 		C7A10003AAAA000100000001 /* TPPBook+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A10003AAAA000000000001 /* TPPBook+Presentation.swift */; };
 		C7A10003AAAA000100000002 /* TPPBook+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A10003AAAA000000000001 /* TPPBook+Presentation.swift */; };
 		C7BA5AA8F4F0099226CE67F5 /* StreamingReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7955F7FD669DC987C9238D /* StreamingReaderViewModel.swift */; };
+		C7DFB8533719B493E14C6A56 /* LockIsolated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5192F4C62AA2DDC7E9752A5E /* LockIsolated.swift */; };
 		C7E59C3E09A16D6F9B65233F /* IntExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5A0D270E8AC2DDFBC62044 /* IntExtensionsTests.swift */; };
 		C89594A0D21089924B82E71D /* TypographyServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1B8AF7EB40C9DE22ED5ED0 /* TypographyServiceProtocol.swift */; };
 		C8DC8F9202D050EEFBC61B4C /* SettingsSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551562029D888E2A48F22A52 /* SettingsSkeletonView.swift */; };
@@ -2452,6 +2453,7 @@
 		502761BDE732D3752808C4C4 /* TPPBookButtonsState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookButtonsState.swift; sourceTree = "<group>"; };
 		50E92EE539A615735164856F /* RuntimeQuiescenceLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeQuiescenceLintTests.swift; sourceTree = "<group>"; };
 		5100330CFD49E96FBC331D75 /* LoanEvictionPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoanEvictionPolicy.swift; sourceTree = "<group>"; };
+		5192F4C62AA2DDC7E9752A5E /* LockIsolated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LockIsolated.swift; sourceTree = "<group>"; };
 		52226B7262C85C91578DB3A7 /* TPPJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPJSON.swift; sourceTree = "<group>"; };
 		5248CEFDF1FEDEBE50897394 /* LCPAdapterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPAdapterTests.swift; sourceTree = "<group>"; };
 		52C86F54125C3BD725906F86 /* LCPPDFOpenProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPDFOpenProgress.swift; sourceTree = "<group>"; };
@@ -3675,6 +3677,7 @@
 				3E793B64D2FB472246D9A244 /* RuntimeQuiescenceAuditor.swift */,
 				DF90048A6DDD9A6025494F1A /* PalaceTestCase.swift */,
 				E775BA9B323D098F690BE354 /* TriageBotKeyAdminTests.swift */,
+				5192F4C62AA2DDC7E9752A5E /* LockIsolated.swift */,
 			);
 			name = Support;
 			path = Support;
@@ -7815,6 +7818,7 @@
 				41D4DBBE207AF14A529ADE72 /* AudiobookSkipIntervalSettingsTests.swift in Sources */,
 				FCD12E3016C092CF32FB00F3 /* BookServiceAudiobookOpenTests.swift in Sources */,
 				1C4CC3753B75E8677FEB66B0 /* ButtonStateMonotonicClampTests.swift in Sources */,
+				C7DFB8533719B493E14C6A56 /* LockIsolated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PalaceTests/Accessibility/AccessLintComplianceTests.swift
+++ b/PalaceTests/Accessibility/AccessLintComplianceTests.swift
@@ -14,6 +14,7 @@ import XCTest
 
 // MARK: - AccessLint Compliance Tests
 
+@MainActor
 final class AccessLintComplianceTests: XCTestCase {
 
     // MARK: - A11Y.SWIFTUI.TOUCH_TARGET — Minimum 44pt

--- a/PalaceTests/Accessibility/AccessibilityAnnouncementCenterTests.swift
+++ b/PalaceTests/Accessibility/AccessibilityAnnouncementCenterTests.swift
@@ -18,7 +18,7 @@ final class AccessibilityAnnouncementCenterTests: XCTestCase {
     private func makeAnnouncer(
         voiceOverRunning: Bool = true,
         deduplicationInterval: TimeInterval = 2.0,
-        time: @escaping () -> Date = { Date() }
+        time: @escaping @Sendable () -> Date = { Date() }
     ) -> (TPPAccessibilityAnnouncementCenter, Announcements) {
         let store = Announcements()
         let announcer = TPPAccessibilityAnnouncementCenter(
@@ -35,7 +35,7 @@ final class AccessibilityAnnouncementCenterTests: XCTestCase {
     private func makeExpectingAnnouncer(
         voiceOverRunning: Bool = true,
         deduplicationInterval: TimeInterval = 2.0,
-        time: @escaping () -> Date = { Date() },
+        time: @escaping @Sendable () -> Date = { Date() },
         expectedCount: Int,
         description: String
     ) -> (TPPAccessibilityAnnouncementCenter, Announcements, XCTestExpectation) {
@@ -59,7 +59,7 @@ final class AccessibilityAnnouncementCenterTests: XCTestCase {
     private func makeNonFiringAnnouncer(
         voiceOverRunning: Bool = true,
         deduplicationInterval: TimeInterval = 2.0,
-        time: @escaping () -> Date = { Date() },
+        time: @escaping @Sendable () -> Date = { Date() },
         description: String
     ) -> (TPPAccessibilityAnnouncementCenter, Announcements, XCTestExpectation) {
         let store = Announcements()
@@ -193,7 +193,7 @@ final class AccessibilityAnnouncementCenterTests: XCTestCase {
 
     /// PP-3673: Updated search (re-run) produces a new announcement with new count.
     func testPP3673_searchRerun_announcesUpdatedResults() {
-        var currentTime = Date(timeIntervalSince1970: 1000)
+        let currentTime = LockIsolated<Date>(Date(timeIntervalSince1970: 1000))
         let expectation = expectation(description: "Two search announcements")
         expectation.expectedFulfillmentCount = 2
         var announcements: [String] = []
@@ -204,13 +204,13 @@ final class AccessibilityAnnouncementCenterTests: XCTestCase {
                 expectation.fulfill()
             },
             isVoiceOverRunning: { true },
-            timeProvider: { currentTime },
+            timeProvider: { currentTime.value },
             deduplicationInterval: 2.0
         )
 
         announcer.announceSearchResults(query: "robots", count: 5)
         // Advance time past dedup window to ensure second announcement fires
-        currentTime = currentTime.addingTimeInterval(3.0)
+        currentTime.value = currentTime.value.addingTimeInterval(3.0)
         announcer.announceSearchResults(query: "robots", count: 10)
 
         wait(for: [expectation], timeout: 1.0)
@@ -316,17 +316,17 @@ final class AccessibilityAnnouncementCenterTests: XCTestCase {
 
     /// PP-3673: Identical messages within the deduplication window are suppressed.
     func testPP3673_deduplication_suppressesDuplicateWithinWindow() {
-        var currentTime = Date(timeIntervalSince1970: 1000)
+        let currentTime = LockIsolated<Date>(Date(timeIntervalSince1970: 1000))
         let (announcer, store, delivered) = makeExpectingAnnouncer(
             deduplicationInterval: 2.0,
-            time: { currentTime },
+            time: { currentTime.value },
             expectedCount: 1,
             description: "First announcement delivered"
         )
 
         announcer.announceError("Something went wrong.")
         // Same message, 0.5s later -- should be suppressed
-        currentTime = currentTime.addingTimeInterval(0.5)
+        currentTime.value = currentTime.value.addingTimeInterval(0.5)
         announcer.announceError("Something went wrong.")
 
         wait(for: [delivered], timeout: 1.0)
@@ -335,17 +335,17 @@ final class AccessibilityAnnouncementCenterTests: XCTestCase {
 
     /// PP-3673: Same message after deduplication window passes is allowed.
     func testPP3673_deduplication_allowsRepeatAfterWindowExpires() {
-        var currentTime = Date(timeIntervalSince1970: 1000)
+        let currentTime = LockIsolated<Date>(Date(timeIntervalSince1970: 1000))
         let (announcer, store, delivered) = makeExpectingAnnouncer(
             deduplicationInterval: 2.0,
-            time: { currentTime },
+            time: { currentTime.value },
             expectedCount: 2,
             description: "Both announcements delivered"
         )
 
         announcer.announceError("Something went wrong.")
         // Advance past dedup window
-        currentTime = currentTime.addingTimeInterval(3.0)
+        currentTime.value = currentTime.value.addingTimeInterval(3.0)
         announcer.announceError("Something went wrong.")
 
         wait(for: [delivered], timeout: 1.0)
@@ -354,16 +354,16 @@ final class AccessibilityAnnouncementCenterTests: XCTestCase {
 
     /// PP-3673: Different messages within the window are NOT suppressed.
     func testPP3673_deduplication_allowsDifferentMessages() {
-        var currentTime = Date(timeIntervalSince1970: 1000)
+        let currentTime = LockIsolated<Date>(Date(timeIntervalSince1970: 1000))
         let (announcer, store, delivered) = makeExpectingAnnouncer(
             deduplicationInterval: 2.0,
-            time: { currentTime },
+            time: { currentTime.value },
             expectedCount: 2,
             description: "Both different messages delivered"
         )
 
         announcer.announceError("Error A")
-        currentTime = currentTime.addingTimeInterval(0.1)
+        currentTime.value = currentTime.value.addingTimeInterval(0.1)
         announcer.announceError("Error B")
 
         wait(for: [delivered], timeout: 1.0)
@@ -372,10 +372,10 @@ final class AccessibilityAnnouncementCenterTests: XCTestCase {
 
     /// PP-3673: Rapid-fire identical messages result in only one announcement.
     func testPP3673_deduplication_rapidFireSameMessage_onlyOneAnnouncement() {
-        let currentTime = Date(timeIntervalSince1970: 1000)
+        let currentTime = LockIsolated<Date>(Date(timeIntervalSince1970: 1000))
         let (announcer, store, delivered) = makeExpectingAnnouncer(
             deduplicationInterval: 2.0,
-            time: { currentTime },
+            time: { currentTime.value },
             expectedCount: 1,
             description: "Only one announcement from rapid fire"
         )
@@ -390,10 +390,10 @@ final class AccessibilityAnnouncementCenterTests: XCTestCase {
 
     /// PP-3673: Deduplication applies across announcement types using same message text.
     func testPP3673_deduplication_crossMethod_sameText() {
-        let currentTime = Date(timeIntervalSince1970: 1000)
+        let currentTime = LockIsolated<Date>(Date(timeIntervalSince1970: 1000))
         let (announcer, store, delivered) = makeExpectingAnnouncer(
             deduplicationInterval: 2.0,
-            time: { currentTime },
+            time: { currentTime.value },
             expectedCount: 1,
             description: "Only one announcement for cross-method same text"
         )

--- a/PalaceTests/Accessibility/AccessibilityAnnouncementCenterTests.swift
+++ b/PalaceTests/Accessibility/AccessibilityAnnouncementCenterTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AccessibilityAnnouncementCenterTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/Accessibility/AccessibilityLabelTests.swift
+++ b/PalaceTests/Accessibility/AccessibilityLabelTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AccessibilityLabelTests: XCTestCase {
 
     // MARK: - Localized Strings Tests

--- a/PalaceTests/Accessibility/AudiobookAccessibilityTests.swift
+++ b/PalaceTests/Accessibility/AudiobookAccessibilityTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AudiobookAccessibilityTests: XCTestCase {
 
     // MARK: - Play/Pause Button Tests

--- a/PalaceTests/Accessibility/BookImageViewAccessibilityTests.swift
+++ b/PalaceTests/Accessibility/BookImageViewAccessibilityTests.swift
@@ -15,6 +15,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class BookImageViewAccessibilityTests: XCTestCase {
 
   // MARK: - Combined accessibility label

--- a/PalaceTests/Accessibility/BookListViewAccessibilityTests.swift
+++ b/PalaceTests/Accessibility/BookListViewAccessibilityTests.swift
@@ -39,6 +39,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BookListViewAccessibilityTests: XCTestCase {
 
     // MARK: - Source-level sentinels (BookListView)

--- a/PalaceTests/Accessibility/CatalogAccessibilityTests.swift
+++ b/PalaceTests/Accessibility/CatalogAccessibilityTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class CatalogAccessibilityTests: XCTestCase {
 
     // MARK: - Lane "More" Button Tests

--- a/PalaceTests/Accessibility/FacetToolbarAccessibilityTests.swift
+++ b/PalaceTests/Accessibility/FacetToolbarAccessibilityTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class FacetToolbarAccessibilityTests: XCTestCase {
 
     // MARK: - Sort Button Accessibility

--- a/PalaceTests/Accessibility/FocusIndicationTests.swift
+++ b/PalaceTests/Accessibility/FocusIndicationTests.swift
@@ -13,6 +13,7 @@ import XCTest
 
 /// Tests for visual focus indication across the app
 /// AC1: Visible focus indication on iOS
+@MainActor
 final class FocusIndicationTests: XCTestCase {
 
     // MARK: - Test: Focus Ring Visibility

--- a/PalaceTests/Accessibility/PDFAccessibilityToolbarTests.swift
+++ b/PalaceTests/Accessibility/PDFAccessibilityToolbarTests.swift
@@ -14,6 +14,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class PDFAccessibilityToolbarTests: XCTestCase {
 
   // MARK: - Forward navigation

--- a/PalaceTests/Accessibility/ReaderAccessibilityTests.swift
+++ b/PalaceTests/Accessibility/ReaderAccessibilityTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ReaderAccessibilityTests: XCTestCase {
 
     // MARK: - Table of Contents Tests

--- a/PalaceTests/Accessibility/SearchAccessibilityTests.swift
+++ b/PalaceTests/Accessibility/SearchAccessibilityTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class SearchAccessibilityTests: XCTestCase {
 
     // MARK: - Clear Search Button Tests

--- a/PalaceTests/Accessibility/StatusAnnouncementTests.swift
+++ b/PalaceTests/Accessibility/StatusAnnouncementTests.swift
@@ -29,7 +29,7 @@ final class StatusAnnouncementTests: XCTestCase {
         capture: Capture,
         voiceOverRunning: Bool = true,
         deduplicationInterval: TimeInterval = 0.0,
-        timeProvider: @escaping () -> Date = { Date() }
+        timeProvider: @escaping @Sendable () -> Date = { Date() }
     ) -> TPPAccessibilityAnnouncementCenter {
         TPPAccessibilityAnnouncementCenter(
             postHandler: { notification, message in

--- a/PalaceTests/Accessibility/StatusAnnouncementTests.swift
+++ b/PalaceTests/Accessibility/StatusAnnouncementTests.swift
@@ -14,6 +14,7 @@ import Combine
 
 // MARK: - Status Announcement Integration Tests (PP-3673)
 
+@MainActor
 final class StatusAnnouncementTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/Accessibility/TPPBookAccessibilityLabelTests.swift
+++ b/PalaceTests/Accessibility/TPPBookAccessibilityLabelTests.swift
@@ -15,6 +15,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPBookAccessibilityLabelTests: XCTestCase {
 
   // MARK: - Ebook

--- a/PalaceTests/Accounts/AccountAuthSurfaceHostsTests.swift
+++ b/PalaceTests/Accounts/AccountAuthSurfaceHostsTests.swift
@@ -18,6 +18,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountAuthSurfaceHostsTests: XCTestCase {
 
     private var mockImageCache: MockImageCache!

--- a/PalaceTests/Accounts/AccountDetailsTests.swift
+++ b/PalaceTests/Accounts/AccountDetailsTests.swift
@@ -14,6 +14,7 @@ import PalaceCatalog
 
 // MARK: - LoginKeyboard Tests
 
+@MainActor
 final class LoginKeyboardTests: XCTestCase {
 
     func testInit_WithDefaultString_ReturnsStandard() {
@@ -73,6 +74,7 @@ final class LoginKeyboardTests: XCTestCase {
 
 // MARK: - AuthType Tests
 
+@MainActor
 final class AuthTypeTests: XCTestCase {
 
     func testAuthType_BasicRawValue_IsCorrect() {
@@ -114,6 +116,7 @@ final class AuthTypeTests: XCTestCase {
 
 // MARK: - Authentication Tests
 
+@MainActor
 final class AuthenticationTests: XCTestCase {
 
     func testNeedsAuth_ForBasicType_ReturnsTrue() {
@@ -220,6 +223,7 @@ final class AuthenticationTests: XCTestCase {
 /// BUG-004 holds-fetch suppression — when an anonymous library
 /// (Palace Bookshelf) is selected, holds must not be fetched and the error
 /// banner must not appear.
+@MainActor
 final class AccountDetailsNeedsAuthAggregateTests: XCTestCase {
 
     func testAccountDetails_NeedsAuth_BasicOnly_ReturnsTrue() {
@@ -381,6 +385,7 @@ final class AccountDetailsNeedsAuthAggregateTests: XCTestCase {
 
 // MARK: - URLType Tests
 
+@MainActor
 final class URLTypeTests: XCTestCase {
 
     func testURLType_HasAllExpectedCases() {

--- a/PalaceTests/Accounts/AccountDetailsURLTests.swift
+++ b/PalaceTests/Accounts/AccountDetailsURLTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountDetailsURLTests: XCTestCase {
 
     private var sut: AccountDetails!

--- a/PalaceTests/Accounts/AccountModelTests.swift
+++ b/PalaceTests/Accounts/AccountModelTests.swift
@@ -16,6 +16,7 @@ import PalaceCatalog
 
 // MARK: - Account Initialization Tests
 
+@MainActor
 final class AccountModelTests: XCTestCase {
 
     private var mockImageCache: MockImageCache!
@@ -317,6 +318,7 @@ final class AccountModelTests: XCTestCase {
 
 // MARK: - OPDS2SamlIDP Tests
 
+@MainActor
 final class OPDS2SamlIDPTests: XCTestCase {
 
     func testInit_WithValidLink_MapsURLCorrectly() {
@@ -398,6 +400,7 @@ final class OPDS2SamlIDPTests: XCTestCase {
 // that the real TPPSignedInStateProvider conformance on TPPUserAccount reflects
 // actual credential state rather than a private stub.
 
+@MainActor
 final class TPPSignedInStateProviderTests: XCTestCase {
 
     private var mockAccount: TPPUserAccountMock!

--- a/PalaceTests/Accounts/AccountProfileDocumentTests.swift
+++ b/PalaceTests/Accounts/AccountProfileDocumentTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountProfileDocumentTests: XCTestCase {
 
     private var mockImageCache: MockImageCache!

--- a/PalaceTests/Accounts/AccountStateMachineTests.swift
+++ b/PalaceTests/Accounts/AccountStateMachineTests.swift
@@ -17,6 +17,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountStateMachineTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/Accounts/AccountSwitchCleanupTests.swift
+++ b/PalaceTests/Accounts/AccountSwitchCleanupTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AccountSwitchCleanupTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Accounts/AccountsManagerAccountIndexTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerAccountIndexTests.swift
@@ -22,6 +22,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountsManagerAccountIndexTests: PalaceWiringTestCase {
 
     private func stubAccount(_ uuid: String) -> Account {

--- a/PalaceTests/Accounts/AccountsManagerCacheReadTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerCacheReadTests.swift
@@ -41,6 +41,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountsManagerCacheReadTests: PalaceWiringTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/Accounts/AccountsManagerCacheTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerCacheTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountsManagerCacheTests: XCTestCase {
 
     // MARK: - Properties

--- a/PalaceTests/Accounts/AccountsManagerCancellationTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerCancellationTests.swift
@@ -36,6 +36,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class AccountsManagerCancellationTests: PalaceWiringTestCase {
 
     // MARK: - Tests

--- a/PalaceTests/Accounts/AccountsManagerCancellationTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerCancellationTests.swift
@@ -525,7 +525,11 @@ private enum TestAccountFactory {
 /// Thread-safe counter used by the race-guard test to track whether the
 /// post-resume commit branch and post-resume side effects fired. NSLock
 /// is sufficient — we only increment from inside a single Task body.
-private final class TestAtomicCounter {
+///
+/// `@unchecked Sendable`: the only mutable state (`_value`) is read and written
+/// exclusively under `lock`, so instances cross into the `@Sendable` Task
+/// closure safely. Swift 6 requires this to be explicit.
+private final class TestAtomicCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var _value: Int = 0
 

--- a/PalaceTests/Accounts/AccountsManagerFirstRunDecodeTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerFirstRunDecodeTests.swift
@@ -43,6 +43,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountsManagerFirstRunDecodeTests: PalaceWiringTestCase {
 
     // MARK: - Stub resolver

--- a/PalaceTests/Accounts/AccountsManagerLaunchSnapshotTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerLaunchSnapshotTests.swift
@@ -37,6 +37,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountsManagerLaunchSnapshotTests: PalaceWiringTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
@@ -21,6 +21,7 @@ import Combine
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
@@ -878,31 +878,40 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         // `_setState(.detailsLoading)` once at the entry of each non-deduped
         // call. A duplicate fetch would observe two `.detailsLoading`
         // transitions.
-        let lock = NSLock()
-        var detailsLoadingCount = 0
-        var sawTerminal = false
+        // Swift 6: NSLock.lock()/unlock() are unavailable in async contexts, and
+        // the captured `var` counters would be data races inside the Task. Fold
+        // both into one lock-guarded @unchecked Sendable box shared by the stream
+        // task and the assertion below.
+        final class Counters: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _detailsLoadingCount = 0
+            private var _sawTerminal = false
+            var detailsLoadingCount: Int { lock.withLock { _detailsLoadingCount } }
+            func incrementDetailsLoading() { lock.withLock { _detailsLoadingCount += 1 } }
+            /// True exactly once — on the first terminal transition.
+            func markTerminalOnce() -> Bool {
+                lock.withLock {
+                    if _sawTerminal { return false }
+                    _sawTerminal = true
+                    return true
+                }
+            }
+        }
+        let counters = Counters()
         let observed = expectation(description: "stream reaches terminal")
         observed.assertForOverFulfill = false
 
         let streamTask = Task {
             for await state in account.stateStream {
-                lock.lock()
                 if case .detailsLoading = state {
-                    detailsLoadingCount += 1
+                    counters.incrementDetailsLoading()
                 }
                 if case .detailsFailed = state {
-                    if !sawTerminal {
-                        sawTerminal = true
-                        observed.fulfill()
-                    }
+                    if counters.markTerminalOnce() { observed.fulfill() }
                 }
                 if case .detailsLoaded = state {
-                    if !sawTerminal {
-                        sawTerminal = true
-                        observed.fulfill()
-                    }
+                    if counters.markTerminalOnce() { observed.fulfill() }
                 }
-                lock.unlock()
             }
         }
 
@@ -935,9 +944,7 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         drainMainQueue()
         streamTask.cancel()
 
-        lock.lock()
-        let count = detailsLoadingCount
-        lock.unlock()
+        let count = counters.detailsLoadingCount
 
         // The kill case: a non-single-flight wiring would fire
         // `_setState(.detailsLoading)` twice. The single-flight guard

--- a/PalaceTests/Accounts/AccountsManagerTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerTests.swift
@@ -16,6 +16,7 @@ import Combine
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class AccountsManagerTests: XCTestCase {
 
     // MARK: - Properties
@@ -886,6 +887,7 @@ extension AccountsManagerTests {
 /// Regression: loadAccountSetsAndAuthDoc created new Account objects that lost
 /// the authenticationDocument/details from the old ones, causing
 /// syncIsPossibleAndPermitted() to return false (PP-3810).
+@MainActor
 final class AccountAuthDocCarryoverTests: XCTestCase {
 
     private var feedURL: URL!

--- a/PalaceTests/Accounts/AgeCheck/TPPAgeCheckStateMachineTests.swift
+++ b/PalaceTests/Accounts/AgeCheck/TPPAgeCheckStateMachineTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPAgeCheckStateMachineTests: XCTestCase {
 
     private var ageCheckChoiceStorageMock: TPPAgeCheckChoiceStorageMock!

--- a/PalaceTests/Accounts/CatalogCacheMetadataTests.swift
+++ b/PalaceTests/Accounts/CatalogCacheMetadataTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class CatalogCacheMetadataTests: XCTestCase {
 
     // MARK: - isStale (default TTL = 6 hours)

--- a/PalaceTests/Accounts/CredentialSnapshotInvalidationTests.swift
+++ b/PalaceTests/Accounts/CredentialSnapshotInvalidationTests.swift
@@ -38,6 +38,7 @@ import Combine
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class CredentialSnapshotInvalidationTests: PalaceWiringTestCase {
 
     override func setUpWithError() throws {

--- a/PalaceTests/Accounts/TPPCredentialIsolationE2ETests.swift
+++ b/PalaceTests/Accounts/TPPCredentialIsolationE2ETests.swift
@@ -4,6 +4,7 @@ import XCTest
 /// End-to-end credential isolation tests simulating the full user journey:
 /// sign in to Library A → switch to Library B → sign in to B → verify A intact.
 /// Extends the unit-level isolation tests in TPPPerAccountIsolationTests.
+@MainActor
 final class TPPCredentialIsolationE2ETests: XCTestCase {
 
     private let uuidA = "urn:uuid:e2e-isolation-library-a"

--- a/PalaceTests/Accounts/TPPPerAccountIsolationTests.swift
+++ b/PalaceTests/Accounts/TPPPerAccountIsolationTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 /// Tests that per-account TPPUserAccount instances are fully isolated.
 /// These validate the systemic fix for F-034 (credential cross-contamination).
+@MainActor
 final class TPPPerAccountIsolationTests: XCTestCase {
 
     private let uuidA = "urn:uuid:isolation-test-library-a"

--- a/PalaceTests/Accounts/TPPUserAccountConcurrencyTests.swift
+++ b/PalaceTests/Accounts/TPPUserAccountConcurrencyTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPUserAccountConcurrencyTests: XCTestCase {
 
   /// Concurrent increments must each count exactly once.

--- a/PalaceTests/AccountsManagerHelpersTests.swift
+++ b/PalaceTests/AccountsManagerHelpersTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AccountsManagerHelpersTests: XCTestCase {
 
     // MARK: - shouldFinishSwitchingImmediately

--- a/PalaceTests/AnnouncementChainTests.swift
+++ b/PalaceTests/AnnouncementChainTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AnnouncementChainTests: XCTestCase {
 
     // MARK: - chainAttachmentIndices

--- a/PalaceTests/AppInfrastructure/AppContainerAudiobookFactoryTests.swift
+++ b/PalaceTests/AppInfrastructure/AppContainerAudiobookFactoryTests.swift
@@ -14,6 +14,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AppContainerAudiobookFactoryTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/AppInfrastructure/AppContainerImageLoaderInjectionTests.swift
+++ b/PalaceTests/AppInfrastructure/AppContainerImageLoaderInjectionTests.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// `AppContainer`. The point is to prove a `MockImageLoader` can be threaded
 /// through the SwiftUI Environment and that prod code reads it rather than
 /// reaching for the legacy singletons.
+@MainActor
 final class AppContainerImageLoaderInjectionTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/AppInfrastructure/AppContainerResetTests.swift
+++ b/PalaceTests/AppInfrastructure/AppContainerResetTests.swift
@@ -23,6 +23,7 @@ import XCTest
 // quiescence base. Its `tearDown()` restores the flag to `true`; the inherited
 // `PalaceTestCase` assert runs AFTER that restore (assert-after-super), so it
 // confirms — rather than false-fails — the cleanup.
+@MainActor
 final class AppContainerResetTests: PalaceTestCase {
 
     // MARK: - Setup / Teardown

--- a/PalaceTests/AppInfrastructure/AppContainerTests.swift
+++ b/PalaceTests/AppInfrastructure/AppContainerTests.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// (no `.shared` reads hidden in default parameters), substitution MUST work
 /// for every exposed service, and `@Environment(\.appContainer)` MUST route
 /// through the same production factory used by the app entry points.
+@MainActor
 final class AppContainerTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/AppInfrastructure/AppInfrastructureCoverageTests.swift
+++ b/PalaceTests/AppInfrastructure/AppInfrastructureCoverageTests.swift
@@ -14,6 +14,7 @@ import Combine
 
 // MARK: - AlertModel Tests
 
+@MainActor
 final class AlertModelCoverageTests: XCTestCase {
 
     // SRS: AlertModel stores title and message
@@ -84,6 +85,7 @@ final class AlertModelCoverageTests: XCTestCase {
 
 // MARK: - ImageCacheType Protocol Tests
 
+@MainActor
 final class ImageCacheTypeTests: XCTestCase {
 
     // SRS: ImageCacheType default set uses 7-day TTL
@@ -160,6 +162,7 @@ final class AppTabRouterCoverageTests: XCTestCase {
 
 // MARK: - TPPBookContentType Tests
 
+@MainActor
 final class TPPBookContentTypeExtendedTests: XCTestCase {
 
     // SRS: TPPBookContentType from nil mime type returns unsupported
@@ -205,6 +208,7 @@ final class TPPBookContentTypeExtendedTests: XCTestCase {
 
 // MARK: - URLRequest+Extensions Tests
 
+@MainActor
 final class URLRequestExtensionsCoverageTests: XCTestCase {
 
     // SRS: URLRequest init with custom user agent sets header

--- a/PalaceTests/AppInfrastructure/AuthCoordinatorTelemetryTests.swift
+++ b/PalaceTests/AppInfrastructure/AuthCoordinatorTelemetryTests.swift
@@ -16,6 +16,7 @@ import XCTest
 import PalaceAuth
 @testable import Palace
 
+@MainActor
 final class AuthCoordinatorTelemetryTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/AppInfrastructure/AuthDecisionEventEmissionTests.swift
+++ b/PalaceTests/AppInfrastructure/AuthDecisionEventEmissionTests.swift
@@ -16,6 +16,7 @@ import XCTest
 import PalaceAuth
 @testable import Palace
 
+@MainActor
 final class AuthDecisionEventEmissionTests: XCTestCase {
 
     // MARK: - errorDomain

--- a/PalaceTests/AppInfrastructure/NavigationCoordinatorTests.swift
+++ b/PalaceTests/AppInfrastructure/NavigationCoordinatorTests.swift
@@ -235,6 +235,7 @@ final class NavigationCoordinatorTests: XCTestCase {
 
 // MARK: - AppRoute Tests
 
+@MainActor
 final class AppRouteTests: XCTestCase {
 
     func testAppRoute_BookDetail_IsHashable() {

--- a/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
+++ b/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class RemoteFeatureFlagsTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/AppInfrastructure/StoreTests.swift
+++ b/PalaceTests/AppInfrastructure/StoreTests.swift
@@ -12,6 +12,7 @@ import Combine
 ///      the same reducer. State updates remain on the main actor.
 ///   3. `@Published state` emits in order, giving SwiftUI a single source
 ///      of truth with no race between reads and writes.
+@MainActor
 final class StoreTests: XCTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/AppInfrastructure/TabBarModernizationTests.swift
+++ b/PalaceTests/AppInfrastructure/TabBarModernizationTests.swift
@@ -18,6 +18,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class TabBarModernizationTests: XCTestCase {
 
     // MARK: - Mini-player bottom inset

--- a/PalaceTests/AppRating/RatingEligibilityPolicyTests.swift
+++ b/PalaceTests/AppRating/RatingEligibilityPolicyTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class RatingEligibilityPolicyTests: XCTestCase {
 
   /// Fixed "now" so cooldown math is deterministic.

--- a/PalaceTests/AppRating/RatingEngagementTrackerTests.swift
+++ b/PalaceTests/AppRating/RatingEngagementTrackerTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class RatingEngagementTrackerTests: XCTestCase {
 
   private var suiteName: String!

--- a/PalaceTests/AppTabHostViewBadgeCountTests.swift
+++ b/PalaceTests/AppTabHostViewBadgeCountTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AppTabHostViewBadgeCountTests: XCTestCase {
 
     // MARK: - computeReadyCount

--- a/PalaceTests/Audiobook/AudiobookBookmarkBusinessLogicPositionWriteTests.swift
+++ b/PalaceTests/Audiobook/AudiobookBookmarkBusinessLogicPositionWriteTests.swift
@@ -96,6 +96,7 @@ private final class SpyPositionWriter: PositionWriter, @unchecked Sendable {
 
 // MARK: - Tests
 
+@MainActor
 final class AudiobookBookmarkBusinessLogicPositionWriteTests: XCTestCase {
 
     private let bookIdentifier = "spy-book-1"

--- a/PalaceTests/Audiobook/AudiobookBookmarkBusinessLogicPositionWriteTests.swift
+++ b/PalaceTests/Audiobook/AudiobookBookmarkBusinessLogicPositionWriteTests.swift
@@ -64,11 +64,10 @@ private final class SpyPositionWriter: PositionWriter, @unchecked Sendable {
     }
 
     func save(_ snapshot: PositionSnapshot) async throws -> ServerPositionID? {
-        lock.lock()
-        _savedSnapshots.append(snapshot)
-        let result = _saveResult
-        let hook = _onSave
-        lock.unlock()
+        let (result, hook) = lock.withLock { () -> (SaveOutcome, (() -> Void)?) in
+            _savedSnapshots.append(snapshot)
+            return (_saveResult, _onSave)
+        }
 
         hook?()  // race-window injection: tests can mutate registry between SUT's local-save and post-save guard
 
@@ -83,14 +82,11 @@ private final class SpyPositionWriter: PositionWriter, @unchecked Sendable {
     }
 
     func load(for bookID: String) async throws -> PositionSnapshot? {
-        lock.lock(); defer { lock.unlock() }
-        return _loadResult
+        return lock.withLock { _loadResult }
     }
 
     func cancel(for bookID: String) async {
-        lock.lock()
-        _cancelledBookIDs.append(bookID)
-        lock.unlock()
+        lock.withLock { _cancelledBookIDs.append(bookID) }
     }
 }
 

--- a/PalaceTests/Audiobook/AudiobookDataManagerModelsTests.swift
+++ b/PalaceTests/Audiobook/AudiobookDataManagerModelsTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AudiobookDataManagerModelsTests: XCTestCase {
 
     // MARK: - Test Data

--- a/PalaceTests/Audiobook/AudiobookDataManagerSyncTests.swift
+++ b/PalaceTests/Audiobook/AudiobookDataManagerSyncTests.swift
@@ -113,6 +113,7 @@ class MockNetworkExecutorForSync: TPPNetworkExecutor, @unchecked Sendable {
 
 // MARK: - Network Sync Tests
 
+@MainActor
 final class AudiobookDataManagerNetworkSyncTests: XCTestCase {
 
     private var mockNetworkExecutor: MockNetworkExecutorForSync!
@@ -314,6 +315,7 @@ final class AudiobookDataManagerNetworkSyncTests: XCTestCase {
 
 // MARK: - Error Response Handling Tests
 
+@MainActor
 final class AudiobookDataManagerErrorHandlingTests: XCTestCase {
 
     private var mockNetworkExecutor: MockNetworkExecutorForSync!
@@ -475,6 +477,7 @@ final class AudiobookDataManagerErrorHandlingTests: XCTestCase {
 
 // MARK: - Store Corruption Recovery Tests
 
+@MainActor
 final class AudiobookDataManagerStoreRecoveryTests: XCTestCase {
 
     private var testStoreDirectory: URL!
@@ -587,6 +590,7 @@ final class AudiobookDataManagerStoreRecoveryTests: XCTestCase {
 
 // MARK: - Empty Queue Tests
 
+@MainActor
 final class AudiobookDataManagerEmptyQueueTests: XCTestCase {
 
     private var mockNetworkExecutor: MockNetworkExecutorForSync!

--- a/PalaceTests/Audiobook/AudiobookIssueFixTests.swift
+++ b/PalaceTests/Audiobook/AudiobookIssueFixTests.swift
@@ -22,6 +22,7 @@ import XCTest
 /// Tests the save suppression bypass logic.
 /// AudiobookPlaybackModel can't be easily mocked (requires full AudiobookManager),
 /// so we test the decision logic directly.
+@MainActor
 final class PositionPersistenceLogicTests: XCTestCase {
 
     /// Simulates the old saveLocation() behavior WITH suppression check
@@ -117,6 +118,7 @@ final class PositionPersistenceLogicTests: XCTestCase {
 
 /// Tests the interruption resume logic extracted from OpenAccessPlayer.
 /// The real handler is @objc private, so we test the decision logic independently.
+@MainActor
 final class AudioInterruptionLogicTests: XCTestCase {
 
     /// Simulates the decision logic in handleAudioSessionInterruption
@@ -213,6 +215,7 @@ final class AudioInterruptionLogicTests: XCTestCase {
 
 // MARK: - Sync Deletion Guard Tests (Bug 5: CONTENT_DISAPPEARING)
 
+@MainActor
 final class SyncDeletionGuardTests: XCTestCase {
 
     func testVersionComparison_emptyIsLessThan() {
@@ -247,6 +250,7 @@ final class SyncDeletionGuardTests: XCTestCase {
 
 // MARK: - Post-Update Migration Tests (Bug 6: APP_UPDATE_BREAK)
 
+@MainActor
 final class PostUpdateMigrationTests: XCTestCase {
 
     private let buildKey = "TPPMigrationManager.lastLaunchBuild"
@@ -331,6 +335,7 @@ final class PostUpdateMigrationTests: XCTestCase {
 
 // MARK: - Bearer Token Auth Header Tests (Bug 1/2: DOWNLOAD_STUCK / PLAYBACK_STOPS)
 
+@MainActor
 final class BearerTokenRefreshTests: XCTestCase {
 
     func testRefreshRequest_includesAuthHeader() {
@@ -391,6 +396,7 @@ final class BearerTokenRefreshTests: XCTestCase {
 
 // MARK: - Sync Deletion Ratio Tests
 
+@MainActor
 final class SyncDeletionRatioTests: XCTestCase {
 
     func testEmptyFeedWithLocalBooks_shouldSkipDeletion() {
@@ -468,6 +474,7 @@ final class SyncDeletionRatioTests: XCTestCase {
 
 // MARK: - Return Flow Tests (Bug 7: RETURN_FAILED)
 
+@MainActor
 final class ReturnFlowTests: XCTestCase {
 
     func testRetryTracker_limitsRetries() {
@@ -497,6 +504,7 @@ final class ReturnFlowTests: XCTestCase {
 
 /// Tests that isNavigating is properly cleared on error/unload to prevent
 /// the seek slider from becoming permanently frozen (HelpSpot #17335).
+@MainActor
 final class NavigationFreezePreventionTests: XCTestCase {
 
     /// Simulates the isNavigating state machine.
@@ -579,6 +587,7 @@ final class NavigationFreezePreventionTests: XCTestCase {
 
 /// Tests that stop() uses persistLocation() (bypasses suppression)
 /// instead of saveLocation() (subject to suppression). HelpSpot #16317.
+@MainActor
 final class StopPositionSaveTests: XCTestCase {
 
     func testStop_bypassesSaveSuppression() {

--- a/PalaceTests/Audiobook/AudiobookLoaderPredicateTests.swift
+++ b/PalaceTests/Audiobook/AudiobookLoaderPredicateTests.swift
@@ -22,6 +22,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AudiobookLoaderPredicateTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Audiobook/AudiobookPositionPolicyTests.swift
+++ b/PalaceTests/Audiobook/AudiobookPositionPolicyTests.swift
@@ -14,6 +14,7 @@ import XCTest
 
 // MARK: - BeginningPositionPolicy
 
+@MainActor
 final class BeginningPositionPolicyTests: XCTestCase {
 
     func testIsAtBeginning_track0_time0_isBeginning() {
@@ -63,6 +64,7 @@ final class BeginningPositionPolicyTests: XCTestCase {
 
 // MARK: - AudiobookPositionPolicy (validator)
 
+@MainActor
 final class AudiobookPositionPolicyValidatorTests: XCTestCase {
 
     private let okTrackKey = "track-key-1"
@@ -183,6 +185,7 @@ final class AudiobookPositionPolicyValidatorTests: XCTestCase {
 
 // MARK: - ChapterChangeDetector
 
+@MainActor
 final class ChapterChangeDetectorTests: XCTestCase {
 
     func testDidChange_noPriorChapter_fires() {
@@ -237,6 +240,7 @@ final class ChapterChangeDetectorTests: XCTestCase {
 
 // MARK: - ChapterTOCNormalizer
 
+@MainActor
 final class ChapterTOCNormalizerTests: XCTestCase {
 
     func testIsOversubdivided_belowThreshold_returnsFalse() {
@@ -317,6 +321,7 @@ final class ChapterTOCNormalizerTests: XCTestCase {
 //     the `!`) reintroduces FINDING-D and fails Test 1 / Test 2.
 //   * Swapping the struct field assignments fails all four tests.
 
+@MainActor
 final class PlaybackOpenPolicyTests: XCTestCase {
 
     // Test 1 — FINDING-D regression guard: re-borrow of same book must

--- a/PalaceTests/Audiobook/AudiobookReliabilityTests.swift
+++ b/PalaceTests/Audiobook/AudiobookReliabilityTests.swift
@@ -18,6 +18,7 @@ import XCTest
 
 // MARK: - Download Watchdog Tests
 
+@MainActor
 final class DownloadWatchdogTests: XCTestCase {
 
     func testWatchdogConfiguration() {
@@ -69,6 +70,7 @@ final class DownloadWatchdogTests: XCTestCase {
 
 // MARK: - Download Persistence Store Tests
 
+@MainActor
 final class DownloadPersistenceStoreTests: XCTestCase {
 
     private var store: DownloadPersistenceStore!
@@ -227,6 +229,7 @@ final class DownloadPersistenceStoreTests: XCTestCase {
 
 // MARK: - Storage Location Tests
 
+@MainActor
 final class AudiobookStorageLocationTests: XCTestCase {
 
     func testApplicationSupportDirectoryExists() {
@@ -288,6 +291,7 @@ final class AudiobookStorageLocationTests: XCTestCase {
 
 // MARK: - Background Listener Tests
 
+@MainActor
 final class BackgroundListenerTests: XCTestCase {
 
     func testOpenAccessListenerIdentifiesCorrectSessions() {

--- a/PalaceTests/Audiobook/AudiobookSessionManagerTests.swift
+++ b/PalaceTests/Audiobook/AudiobookSessionManagerTests.swift
@@ -14,6 +14,7 @@ import PalaceCatalog
 
 // MARK: - AudiobookSessionState Tests
 
+@MainActor
 final class AudiobookSessionStateTests: XCTestCase {
 
     func testIdleState() {
@@ -65,6 +66,7 @@ final class AudiobookSessionStateTests: XCTestCase {
 
 // MARK: - AudiobookSessionError Tests
 
+@MainActor
 final class AudiobookSessionErrorExtTests: XCTestCase {
 
     func testErrorEquality() {
@@ -397,6 +399,7 @@ final class AudiobookPhoneAlertContentTests: XCTestCase {
 /// produced **zero** Crashlytics records, so the issue was invisible to ops.
 /// These tests pin the userInfo shape so future regressions don't drop the
 /// HTTP status / track URL / book id keys.
+@MainActor
 final class PlaybackFailureRecordTests: XCTestCase {
 
     private let kPalaceAudiobookDomain = "org.thepalaceproject.palace.audiobookPlayback"

--- a/PalaceTests/Audiobook/AudiobookTOCTests.swift
+++ b/PalaceTests/Audiobook/AudiobookTOCTests.swift
@@ -12,6 +12,7 @@ import XCTest
 @testable import PalaceAudiobookToolkit
 
 /// Tests for audiobook Table of Contents and chapter navigation functionality.
+@MainActor
 class AudiobookTOCTests: XCTestCase {
 
     var tracks: Tracks!

--- a/PalaceTests/Audiobook/AudiobookTimeEntryTests.swift
+++ b/PalaceTests/Audiobook/AudiobookTimeEntryTests.swift
@@ -15,6 +15,7 @@ import Combine
 
 // MARK: - AudiobookTimeEntry Tests
 
+@MainActor
 final class AudiobookTimeEntryTests: XCTestCase {
 
     // SRS: AudiobookTimeEntry stores all properties
@@ -93,6 +94,7 @@ final class AudiobookTimeEntryTests: XCTestCase {
 
 // MARK: - NotificationService.TokenData Tests
 
+@MainActor
 final class NotificationTokenDataTests: XCTestCase {
 
     // SRS: TokenData initializes with token and sets type
@@ -134,6 +136,7 @@ final class NotificationTokenDataTests: XCTestCase {
 
 // MARK: - NSNotification+TPP Tests
 
+@MainActor
 final class NSNotificationTPPTests: XCTestCase {
 
     // SRS: Notification.Name constants exist
@@ -171,6 +174,7 @@ final class NSNotificationTPPTests: XCTestCase {
 
 // MARK: - DPLAAudiobooks.DPLAError Tests
 
+@MainActor
 final class DPLAErrorTests: XCTestCase {
 
     // SRS: DPLAError requestError has readable description
@@ -198,6 +202,7 @@ final class DPLAErrorTests: XCTestCase {
 
 // MARK: - OPDSParser Tests
 
+@MainActor
 final class OPDSParserTests: XCTestCase {
 
     // SRS: OPDSParser.ParserError invalidXML has description

--- a/PalaceTests/Audiobook/AudiobookTrackerExtendedTests.swift
+++ b/PalaceTests/Audiobook/AudiobookTrackerExtendedTests.swift
@@ -11,6 +11,7 @@ import Combine
 
 // MARK: - Playback State Transition Tests
 
+@MainActor
 final class AudiobookPlaybackStateTests: XCTestCase {
 
     private var tracker: AudiobookTimeTracker!
@@ -83,6 +84,7 @@ final class AudiobookPlaybackStateTests: XCTestCase {
 
 // MARK: - Time Entry Tests
 
+@MainActor
 final class TimeEntryTests: XCTestCase {
 
     func testTimeEntry_creation() {
@@ -131,6 +133,7 @@ final class TimeEntryTests: XCTestCase {
 
 // MARK: - Track Completion Tests
 
+@MainActor
 final class AudiobookTrackCompletionTests: XCTestCase {
 
     private var mockDataManager: MockDataManager!
@@ -188,6 +191,7 @@ final class AudiobookTrackCompletionTests: XCTestCase {
 
 /// The bug was that playbackStarted() was called unconditionally in setupNowPlayingInfoTimer()
 /// even when the player wasn't actually playing, causing time to be tracked incorrectly.
+@MainActor
 final class PP3596RegressionTests: XCTestCase {
 
     private var mockDataManager: MockDataManager!
@@ -296,6 +300,7 @@ final class PP3596RegressionTests: XCTestCase {
 
 // MARK: - Background Audio Tests
 
+@MainActor
 final class AudiobookBackgroundAudioTests: XCTestCase {
 
     private var mockDataManager: MockDataManager!

--- a/PalaceTests/Audiobook/FindawaySavedVsPlayedTests.swift
+++ b/PalaceTests/Audiobook/FindawaySavedVsPlayedTests.swift
@@ -23,6 +23,7 @@ import XCTest
 @testable import Palace
 @testable import PalaceAudiobookToolkit
 
+@MainActor
 final class FindawaySavedVsPlayedTests: XCTestCase {
   private let testID = "DuneSavedVsPlayed"
   private let playedKey = "urn:org.thepalaceproject:findaway:1:3"

--- a/PalaceTests/Audiobook/LCPAcquisitionPredicateTests.swift
+++ b/PalaceTests/Audiobook/LCPAcquisitionPredicateTests.swift
@@ -23,6 +23,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class LCPAcquisitionPredicateTests: XCTestCase {
 
     // MARK: - MIME constants (mirrored from production for fixture readability)

--- a/PalaceTests/Audiobook/Vendors/AudiobookVendorAdapterTests.swift
+++ b/PalaceTests/Audiobook/Vendors/AudiobookVendorAdapterTests.swift
@@ -15,6 +15,7 @@ import XCTest
 @preconcurrency import PalaceAudiobookToolkit
 @testable import Palace
 
+@MainActor
 final class AudiobookVendorAdapterTests: XCTestCase {
 
     // MARK: - Spy conformance

--- a/PalaceTests/Audiobook/Vendors/LCPAdapterTests.swift
+++ b/PalaceTests/Audiobook/Vendors/LCPAdapterTests.swift
@@ -19,6 +19,7 @@ import PalaceCatalog
 @preconcurrency import PalaceAudiobookToolkit
 @testable import Palace
 
+@MainActor
 final class LCPAdapterTests: XCTestCase {
 
     // MARK: - MIME constants

--- a/PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift
+++ b/PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift
@@ -153,9 +153,23 @@ final class AudiobookBookmarkBusinessLogicConcurrencyTests: XCTestCase {
 
         let n = 25
         let expectations = (0..<n).map { expectation(description: "sync completion \($0)") }
-        let countLock = NSLock()
-        var fireCount = [Int: Int]()
-        var fulfilledOnce = Set<Int>()
+        // Swift 6: captured mutable vars can't be mutated inside the @Sendable
+        // concurrentPerform closure even under a lock — the var storage is shared.
+        // Fold the count + first-fire set + lock into one Sendable tracker.
+        final class FireTracker: @unchecked Sendable {
+            private let lock = NSLock()
+            private var counts = [Int: Int]()
+            private var fulfilled = Set<Int>()
+            /// Records a fire for `i`; returns true iff this is its FIRST fire.
+            func recordFire(_ i: Int) -> Bool {
+                lock.withLock {
+                    counts[i, default: 0] += 1
+                    return fulfilled.insert(i).inserted
+                }
+            }
+            var snapshot: [Int: Int] { lock.withLock { counts } }
+        }
+        let tracker = FireTracker()
 
         // When a sync is already in flight, additional callers enqueue their
         // completion in `completionHandlersQueue`, which `finalizeSync` drains.
@@ -173,18 +187,12 @@ final class AudiobookBookmarkBusinessLogicConcurrencyTests: XCTestCase {
         // drain must not be misread as a lost completion.
         DispatchQueue.concurrentPerform(iterations: n) { i in
             sut.syncBookmarks(localBookmarks: []) { _ in
-                countLock.lock()
-                fireCount[i, default: 0] += 1
-                let firstFire = fulfilledOnce.insert(i).inserted
-                countLock.unlock()
-                if firstFire { expectations[i].fulfill() }
+                if tracker.recordFire(i) { expectations[i].fulfill() }
             }
         }
 
         wait(for: expectations, timeout: 60.0) // FLAKE-003-OK: 25-way concurrent sync fan-out via DispatchQueue.main.async; generous ceiling tolerates main-queue saturation under full-suite load (fires in <1s uncontended). Crash-safe via idempotent fulfill.
-        countLock.lock()
-        let counts = fireCount
-        countLock.unlock()
+        let counts = tracker.snapshot
         for i in 0..<n {
             XCTAssertEqual(counts[i], 1, "sync completion \(i) must fire exactly once")
         }

--- a/PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift
+++ b/PalaceTests/AudiobookBookmarkBusinessLogicConcurrencyTests.swift
@@ -20,6 +20,7 @@ import PalaceCatalog
 @testable import Palace
 @testable import PalaceAudiobookToolkit
 
+@MainActor
 final class AudiobookBookmarkBusinessLogicConcurrencyTests: XCTestCase {
 
     // MARK: - Thread-safe mock so concurrency failures are attributable to the SUT

--- a/PalaceTests/AudiobookBookmarkBusinessLogicTests.swift
+++ b/PalaceTests/AudiobookBookmarkBusinessLogicTests.swift
@@ -11,6 +11,7 @@ import PalaceCatalog
 @testable import Palace
 @testable import PalaceAudiobookToolkit
 
+@MainActor
 class AudiobookBookmarkBusinessLogicTests: XCTestCase {
 
     var sut: AudiobookBookmarkBusinessLogic!

--- a/PalaceTests/AudiobookPlaybackTests.swift
+++ b/PalaceTests/AudiobookPlaybackTests.swift
@@ -13,6 +13,7 @@ import PalaceCatalog
 
 /// Tests for audiobook playback functionality including skip navigation,
 /// chapter transitions, and playback speed calculations.
+@MainActor
 class AudiobookPlaybackTests: XCTestCase {
 
     var mockRegistry: TPPBookRegistryMock!

--- a/PalaceTests/AudiobookTrackerTests.swift
+++ b/PalaceTests/AudiobookTrackerTests.swift
@@ -43,6 +43,7 @@ class MockDataManager: DataManager {
     }
 }
 
+@MainActor
 class AudiobookTimeTrackerTests: XCTestCase {
 
     var sut: AudiobookTimeTracker!
@@ -261,6 +262,7 @@ class AudiobookTimeTrackerTests: XCTestCase {
 /// These tests verify fixes for:
 /// 1. playbackStopped() not saving accumulated time
 /// 2. Multiple timers running simultaneously causing overcounting
+@MainActor
 final class PlaybackTrackingRegressionTests: XCTestCase {
 
     private var tracker: AudiobookTimeTracker!
@@ -430,6 +432,7 @@ final class PlaybackTrackingRegressionTests: XCTestCase {
 
 /// Tests for app lifecycle events affecting time tracking
 /// Covers: background/foreground/termination data persistence
+@MainActor
 final class AudiobookTimeTrackerLifecycleTests: XCTestCase {
 
     private var tracker: AudiobookTimeTracker!
@@ -588,6 +591,7 @@ final class AudiobookTimeTrackerLifecycleTests: XCTestCase {
 
 /// Tests for time tracking during track/chapter transitions
 /// During continuous playback, handlePlaybackCompleted() must call playbackStopped()
+@MainActor
 final class ContinuousPlaybackTrackingTests: XCTestCase {
 
     private var tracker: AudiobookTimeTracker!
@@ -707,6 +711,7 @@ final class ContinuousPlaybackTrackingTests: XCTestCase {
 
 /// Tests to verify time tracking works correctly via CarPlay code paths
 /// CarPlay uses the same BookService.open() -> AudiobookManager flow
+@MainActor
 final class CarPlayTimeTrackingTests: XCTestCase {
 
     private var tracker: AudiobookTimeTracker!
@@ -816,6 +821,7 @@ final class CarPlayTimeTrackingTests: XCTestCase {
 
 /// Tests for sleep timer integration with time tracking
 /// Covers: sleep timer triggering proper time save
+@MainActor
 final class AudiobookSleepTimerIntegrationTests: XCTestCase {
 
     private var tracker: AudiobookTimeTracker!

--- a/PalaceTests/AudiobookmarkTests.swift
+++ b/PalaceTests/AudiobookmarkTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AudiobookmarkTests: XCTestCase {
 
     // Verifies that the legacy v1 format (time/chapter/part) is parsed into the

--- a/PalaceTests/Audiobooks/AudiobookEventsTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookEventsTests.swift
@@ -16,6 +16,7 @@ import XCTest
 // MARK: - AudiobookDataManager Save Tests
 
 /// SRS: AUDIO-004 -- Time entries are queued and persisted correctly
+@MainActor
 final class AudiobookDataManagerSaveTests: XCTestCase {
 
     override func setUp() {

--- a/PalaceTests/Audiobooks/AudiobookPlaytimesLifecycleTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookPlaytimesLifecycleTests.swift
@@ -29,6 +29,7 @@ private func clearAudiobookTimeTrackerStore() {
     }
 }
 
+@MainActor
 final class AudiobookPlaytimesLifecycleTests: XCTestCase {
 
     private var spyExecutor: SpyAudiobookNetworkExecutor!

--- a/PalaceTests/Audiobooks/AudiobookSkipIntervalSettingsTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookSkipIntervalSettingsTests.swift
@@ -4,6 +4,7 @@ import XCTest
 /// PP-4712 — patron-configurable audiobook skip intervals.
 /// Behavior spec for the global skip-interval store: defaults, independence,
 /// persistence, and validation against the allowed option set.
+@MainActor
 final class AudiobookSkipIntervalSettingsTests: XCTestCase {
   private var defaults: UserDefaults!
   private var suiteName: String!

--- a/PalaceTests/Audiobooks/AudiobookTimeTrackerEdgeTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookTimeTrackerEdgeTests.swift
@@ -12,6 +12,7 @@ import XCTest
 @testable import Palace
 
 /// SRS: AUDIO-003 -- Time tracking accumulates and persists correctly
+@MainActor
 final class AudiobookTimeTrackerEdgeTests: XCTestCase {
 
     private var tracker: AudiobookTimeTracker!

--- a/PalaceTests/Book/BookAvailabilityFormatterTests.swift
+++ b/PalaceTests/Book/BookAvailabilityFormatterTests.swift
@@ -16,6 +16,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BookAvailabilityFormatterTests: XCTestCase {
 
     // MARK: - String.isDate(_:moreRecentThan:with:) — Core Sync Decision Logic

--- a/PalaceTests/Book/BookButtonMapperTests.swift
+++ b/PalaceTests/Book/BookButtonMapperTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class BookButtonMapperExtendedTests: XCTestCase {
 
     // MARK: - Registry State Priority Tests

--- a/PalaceTests/Book/BookButtonTypeTests.swift
+++ b/PalaceTests/Book/BookButtonTypeTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class BookButtonTypeTests: XCTestCase {
 
     // SRS: BookButtonType all cases have raw values
@@ -143,6 +144,7 @@ final class BookButtonTypeTests: XCTestCase {
 
 // MARK: - ButtonStyleType Tests
 
+@MainActor
 final class ButtonStyleTypeTests: XCTestCase {
 
     // SRS: ButtonStyleType all cases exist
@@ -167,6 +169,7 @@ final class ButtonStyleTypeTests: XCTestCase {
 
 // MARK: - BookButtonState Tests
 
+@MainActor
 final class BookButtonStateTests: XCTestCase {
 
     // SRS: BookButtonState all cases exist

--- a/PalaceTests/Book/BookRegistryStoreTests.swift
+++ b/PalaceTests/Book/BookRegistryStoreTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import Combine
 @testable import Palace
 
+@MainActor
 final class BookRegistryStoreTests: XCTestCase {
 
     private var store: BookRegistryStore!

--- a/PalaceTests/Book/BookRegistrySyncReadinessTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncReadinessTests.swift
@@ -34,6 +34,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BookRegistrySyncReadinessTests: XCTestCase {
 
     private var libraryMock: TPPLibraryAccountMock!

--- a/PalaceTests/Book/BookRegistrySyncReentrancyTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncReentrancyTests.swift
@@ -19,6 +19,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class BookRegistrySyncReentrancyTests: XCTestCase {
 
     private var store: BookRegistryStore!

--- a/PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncSideloadExemptionTests.swift
@@ -28,6 +28,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class BookRegistrySyncSideloadExemptionTests: XCTestCase {
 
   private let loansURLString = "https://sideload-exemption-test.example.com/loans"

--- a/PalaceTests/Book/BookRegistrySyncTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class BookRegistrySyncTests: XCTestCase {
 
     private var store: BookRegistryStore!

--- a/PalaceTests/Book/BookmarkManagerTests.swift
+++ b/PalaceTests/Book/BookmarkManagerTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BookmarkManagerTests: XCTestCase {
 
     private var store: BookRegistryStore!

--- a/PalaceTests/Book/HostFailureTrackerTests.swift
+++ b/PalaceTests/Book/HostFailureTrackerTests.swift
@@ -13,6 +13,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class HostFailureTrackerTests: XCTestCase {
 
     func testHostFailureTracker_singleFailure_belowThreshold_notTripped() async {

--- a/PalaceTests/Book/RegistryFileRecoveryTests.swift
+++ b/PalaceTests/Book/RegistryFileRecoveryTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class RegistryFileRecoveryTests: XCTestCase {
 
   private var tempDir: URL!

--- a/PalaceTests/Book/TPPBookAuthorTests.swift
+++ b/PalaceTests/Book/TPPBookAuthorTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPBookAuthorTests: XCTestCase {
 
     // MARK: - Initialization Tests

--- a/PalaceTests/Book/TPPBookButtonsStateTests.swift
+++ b/PalaceTests/Book/TPPBookButtonsStateTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPBookButtonsStateTests: XCTestCase {
 
   func testStateForNilAvailability_returnsUnsupported() {

--- a/PalaceTests/Book/TPPBookContentTypeConverterTests.swift
+++ b/PalaceTests/Book/TPPBookContentTypeConverterTests.swift
@@ -18,6 +18,7 @@ import PalaceCatalog
 // pre-existing class lived inline in TPPBookLocationTests. The new class
 // scopes to streamingHTML token coverage; legacy `TPPBookContentTypeConverterTests`
 // in TPPBookLocationTests still owns the .epub/.audiobook/.pdf/.unsupported cases.
+@MainActor
 final class TPPBookContentTypeConverterStreamingHTMLTests: XCTestCase {
 
     // MARK: - PP-4161: Streaming-HTML token

--- a/PalaceTests/Book/TPPBookContentTypeTests.swift
+++ b/PalaceTests/Book/TPPBookContentTypeTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPBookContentTypeTests: XCTestCase {
 
   // MARK: - TPPBookContentType.from(mimeType:)

--- a/PalaceTests/Book/TPPBookDRMProtectedTests.swift
+++ b/PalaceTests/Book/TPPBookDRMProtectedTests.swift
@@ -14,6 +14,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPBookIsDRMProtectedTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Book/TPPBookExtensionsTests.swift
+++ b/PalaceTests/Book/TPPBookExtensionsTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPBookExtensionsTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/Book/TPPBookLocationTests.swift
+++ b/PalaceTests/Book/TPPBookLocationTests.swift
@@ -15,6 +15,7 @@ import PalaceCatalog
 
 // MARK: - TPPBookLocation Tests
 
+@MainActor
 final class TPPBookLocationCoverageTests: XCTestCase {
 
     // SRS: TPPBookLocation init with valid strings succeeds
@@ -102,6 +103,7 @@ final class TPPBookLocationCoverageTests: XCTestCase {
 
 // MARK: - TPPBookLocationKey Tests
 
+@MainActor
 final class TPPBookLocationKeyTests: XCTestCase {
 
     // SRS: TPPBookLocationKey cases match the dictionary keys produced by TPPBookLocation.
@@ -142,6 +144,7 @@ final class TPPBookLocationKeyTests: XCTestCase {
 
 // MARK: - TPPBookContentTypeConverter Tests
 
+@MainActor
 final class TPPBookContentTypeConverterTests: XCTestCase {
 
     // SRS: TPPBookContentTypeConverter epub string — and it is distinct from other types
@@ -185,6 +188,7 @@ final class TPPBookContentTypeConverterTests: XCTestCase {
 
 // MARK: - TPPBookAuthor Tests
 
+@MainActor
 final class TPPBookAuthorCoverageTests: XCTestCase {
 
     // SRS: TPPBookAuthor initializes with name and URL
@@ -222,6 +226,7 @@ final class TPPBookAuthorCoverageTests: XCTestCase {
 
 // MARK: - TPPProblemDocument Tests
 
+@MainActor
 final class TPPProblemDocumentTests: XCTestCase {
 
     // SRS: TPPProblemDocument fromData decodes valid JSON
@@ -458,6 +463,7 @@ final class TPPProblemDocumentTests: XCTestCase {
 
 // MARK: - TPPBookLocation Edge Case Tests
 
+@MainActor
 final class TPPBookLocationEdgeCaseTests: XCTestCase {
 
     // MARK: - Init from string/renderer

--- a/PalaceTests/Book/TPPBookRegistryAsyncReadinessTests.swift
+++ b/PalaceTests/Book/TPPBookRegistryAsyncReadinessTests.swift
@@ -18,6 +18,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPBookRegistryAsyncReadinessTests: XCTestCase {
 
     private var libraryMock: TPPLibraryAccountMock!

--- a/PalaceTests/Book/TPPBookSerializationTests.swift
+++ b/PalaceTests/Book/TPPBookSerializationTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class TPPBookSerializationTests: XCTestCase {
 
   // MARK: - Dictionary round-trip

--- a/PalaceTests/Book/TPPBookTests.swift
+++ b/PalaceTests/Book/TPPBookTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPBookTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/BookPreviewTests.swift
+++ b/PalaceTests/BookPreviewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class BookPreviewTests: XCTestCase {
     func testEpubBookPreviewExtraction() throws {
         let acquisitions = [TPPFake.genericAcquisition.dictionaryRepresentation()]

--- a/PalaceTests/BookRegistry/TPPBookRegistryAtomicWriteTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryAtomicWriteTests.swift
@@ -31,6 +31,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class TPPBookRegistryAtomicWriteTests: PalaceWiringTestCase {
 
     private var account: String!

--- a/PalaceTests/BookRegistry/TPPBookRegistryDependencyTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryDependencyTests.swift
@@ -31,6 +31,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class TPPBookRegistryDependencyTests: PalaceWiringTestCase {
 
     override func setUpWithError() throws {

--- a/PalaceTests/BookRegistry/TPPBookRegistryIntegrationTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryIntegrationTests.swift
@@ -35,6 +35,7 @@ import Combine
 
 // MARK: - TPPBookRegistry State Management Integration Tests
 
+@MainActor
 final class TPPBookRegistryStateManagementTests: XCTestCase {
 
     override func tearDown() {
@@ -182,6 +183,7 @@ final class TPPBookRegistryStateManagementTests: XCTestCase {
 
 // MARK: - TPPBookRegistry Combine Publisher Integration Tests
 
+@MainActor
 final class TPPBookRegistryPublisherTests: XCTestCase {
 
     private var cancellables: Set<AnyCancellable>!
@@ -372,6 +374,7 @@ final class TPPBookRegistryPublisherTests: XCTestCase {
 
 // MARK: - TPPBookRegistry Location Management Tests
 
+@MainActor
 final class TPPBookRegistryLocationTests: XCTestCase {
 
     func testSetLocation_UpdatesLocation() {
@@ -438,6 +441,7 @@ final class TPPBookRegistryLocationTests: XCTestCase {
 
 // MARK: - TPPBookRegistry Bookmark Tests
 
+@MainActor
 final class TPPBookRegistryBookmarkTests: XCTestCase {
 
     // MARK: - Generic Bookmark Tests
@@ -606,6 +610,7 @@ final class TPPBookRegistryBookmarkTests: XCTestCase {
 
 // MARK: - TPPBookRegistry Processing Flag Tests
 
+@MainActor
 final class TPPBookRegistryProcessingTests: XCTestCase {
 
     func testSetProcessing_TracksProcessingState() {
@@ -637,6 +642,7 @@ final class TPPBookRegistryProcessingTests: XCTestCase {
 
 // MARK: - TPPBookRegistry FulfillmentId Tests
 
+@MainActor
 final class TPPBookRegistryFulfillmentIdTests: XCTestCase {
 
     func testSetFulfillmentId_UpdatesFulfillmentId() {
@@ -669,6 +675,7 @@ final class TPPBookRegistryFulfillmentIdTests: XCTestCase {
 
 // MARK: - TPPBookRegistry Book Retrieval Tests
 
+@MainActor
 final class TPPBookRegistryBookRetrievalTests: XCTestCase {
 
     func testBook_ForValidIdentifier_ReturnsBook() {
@@ -767,6 +774,7 @@ final class TPPBookRegistryBookRetrievalTests: XCTestCase {
 
 // MARK: - TPPBookRegistry updateAndRemoveBook Tests
 
+@MainActor
 final class TPPBookRegistryUpdateAndRemoveTests: XCTestCase {
 
     func testUpdateAndRemoveBook_SetsStateToUnregistered() {
@@ -789,6 +797,7 @@ final class TPPBookRegistryUpdateAndRemoveTests: XCTestCase {
 
 /// Regression tests for Crashlytics issue 30c41d7e: concurrent read/write on
 /// the registry dictionary causing EXC_BAD_ACCESS.
+@MainActor
 final class TPPBookRegistryThreadSafetyTests: XCTestCase {
 
     private var cancellables: Set<AnyCancellable>!

--- a/PalaceTests/BookRegistry/TPPBookRegistryLargeCorpusTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryLargeCorpusTests.swift
@@ -25,6 +25,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class TPPBookRegistryLargeCorpusTests: PalaceWiringTestCase {
 
     private var account: String!

--- a/PalaceTests/BookRegistry/TPPBookRegistryMigrationTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryMigrationTests.swift
@@ -25,6 +25,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class TPPBookRegistryMigrationTests: PalaceWiringTestCase {
 
     private var account: String!

--- a/PalaceTests/BookRegistry/TPPBookRegistryPersistenceTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryPersistenceTests.swift
@@ -34,6 +34,7 @@ import XCTest
 import Combine
 @testable import Palace
 
+@MainActor
 class TPPBookRegistryPersistenceTests: PalaceWiringTestCase {
 
     private var account: String!

--- a/PalaceTests/BookRegistry/TPPBookRegistryStateConcurrencyTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryStateConcurrencyTests.swift
@@ -25,6 +25,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPBookRegistryStateConcurrencyTests: PalaceWiringTestCase {
 
     private func makeRegistry() -> TPPBookRegistry {

--- a/PalaceTests/BookRegistry/TPPBookRegistryTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryTests.swift
@@ -22,6 +22,7 @@ import Combine
 
 // MARK: - TPPBookRegistryRecord Persistence Tests
 
+@MainActor
 final class TPPBookRegistryRecordPersistenceTests: XCTestCase {
 
     // MARK: - Dictionary Round-trip Tests
@@ -88,6 +89,7 @@ final class TPPBookRegistryRecordPersistenceTests: XCTestCase {
 
 // MARK: - TPPBookRegistryData Extension Tests
 
+@MainActor
 final class TPPBookRegistryDataTests: XCTestCase {
 
     func testValueForKey_ReturnsValue() {
@@ -135,6 +137,7 @@ final class TPPBookRegistryDataTests: XCTestCase {
 
 // MARK: - Corrupted/Missing Data Tests
 
+@MainActor
 final class TPPBookRegistryCorruptedDataTests: XCTestCase {
 
     func testRecordInit_WithMissingBook_ReturnsNil() {
@@ -214,6 +217,7 @@ final class TPPBookRegistryCorruptedDataTests: XCTestCase {
 
 // MARK: - TPPBookState Tests
 
+@MainActor
 final class TPPBookStateInitializationTests: XCTestCase {
 
     func testStateInit_FromValidStrings() {
@@ -275,6 +279,7 @@ final class TPPBookStateInitializationTests: XCTestCase {
 
 // MARK: - TPPBookLocation Tests
 
+@MainActor
 final class TPPBookLocationTests: XCTestCase {
 
     func testInit_WithValidParams_Succeeds() {
@@ -410,6 +415,7 @@ final class TPPBookLocationTests: XCTestCase {
 
 // MARK: - deriveInitialState Tests
 
+@MainActor
 final class DeriveInitialStateTests: XCTestCase {
 
     func testDeriveInitialState_ForStandardBook_ReturnsDownloadNeeded() {
@@ -455,6 +461,7 @@ final class DeriveInitialStateTests: XCTestCase {
 
 /// Tests for the re-entrancy guard added to prevent EXC_BAD_ACCESS crashes
 /// when load() is called multiple times rapidly during account changes.
+@MainActor
 final class TPPBookRegistryLoadReentrancyTests: XCTestCase {
 
     var registry: TPPBookRegistry!

--- a/PalaceTests/BookStateManagement/BookButtonMapperHoldReadyTests.swift
+++ b/PalaceTests/BookStateManagement/BookButtonMapperHoldReadyTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class BookButtonMapperHoldReadyTests: XCTestCase {
 
     // MARK: - Ready Availability + Holding Registry State

--- a/PalaceTests/BookStateManagement/BookButtonMapperTests.swift
+++ b/PalaceTests/BookStateManagement/BookButtonMapperTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class BookButtonMapperTests: XCTestCase {
 
     // MARK: - Direct State Mappings

--- a/PalaceTests/BookStateManagement/TPPBookRegistryRecordTests.swift
+++ b/PalaceTests/BookStateManagement/TPPBookRegistryRecordTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPBookRegistryRecordTests: XCTestCase {
 
     // MARK: - Helper

--- a/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
+++ b/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
@@ -196,6 +196,7 @@ enum AnnotationsTestFixtures {
 
 // MARK: - TPPAnnotations Tests
 
+@MainActor
 final class TPPAnnotationsTests: XCTestCase {
 
     private var libraryAccountMock: TPPLibraryAccountMock!
@@ -1198,6 +1199,7 @@ private final class RecordingExecutorMock: TPPNetworkExecutor, @unchecked Sendab
 // intentionally NOT gated by `syncIsPossibleAndPermitted`, so we can exercise
 // the full request-building and response-parsing paths hermetically without
 // depending on shared account state.
+@MainActor
 final class TPPAnnotationsHermeticTests: XCTestCase {
 
     private var mock: RecordingExecutorMock!
@@ -1435,6 +1437,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
 // seams introduced by the architectural-triad Phase 4 refactor.
 // They lock in the contract that, when an override is set, TPPAnnotations and
 // AnnotationDevice route through it instead of `*.shared`.
+@MainActor
 final class TPPAnnotationsOverrideTests: XCTestCase {
 
     override func tearDown() {
@@ -1547,6 +1550,7 @@ final class TPPAnnotationsOverrideTests: XCTestCase {
 /// 23 annotations on the server with empty device IDs, all from non-DRM
 /// devices. Cross-referenced TPPAnnotations.swift and found the fallback
 /// to TPPUserAccount.deviceID (Adobe-only) with ?? "" default.
+@MainActor
 class AnnotationDeviceIDTests: XCTestCase {
 
     override func setUp() {

--- a/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
+++ b/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
@@ -17,10 +17,18 @@ import PalaceCatalog
 final class MockAnnotationsURLProtocol: URLProtocol {
 
     /// Handler that determines the response for a given request
-    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+    private static let _requestHandler = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data?))?>(nil)
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))? {
+        get { _requestHandler.value }
+        set { _requestHandler.value = newValue }
+    }
 
     /// Tracks all requests made during a test for verification
-    static var capturedRequests: [URLRequest] = []
+    private static let _capturedRequests = LockIsolated<[URLRequest]>([])
+    static var capturedRequests: [URLRequest] {
+        get { _capturedRequests.value }
+        set { _capturedRequests.value = newValue }
+    }
 
     /// Reset state between tests
     static func reset() {

--- a/PalaceTests/Bookmarks/TPPBookmarkDeletionLogTests.swift
+++ b/PalaceTests/Bookmarks/TPPBookmarkDeletionLogTests.swift
@@ -12,6 +12,7 @@ import PalaceLogging
 
 /// Tests for the bookmark deletion log which tracks explicitly deleted bookmarks
 /// to ensure they get deleted from the server during sync, regardless of device ID.
+@MainActor
 final class TPPBookmarkDeletionLogTests: XCTestCase {
 
     private var deletionLog: TPPBookmarkDeletionLog!

--- a/PalaceTests/Bookmarks/TPPBookmarkSpecTests.swift
+++ b/PalaceTests/Bookmarks/TPPBookmarkSpecTests.swift
@@ -10,6 +10,7 @@ import XCTest
 @testable import Palace
 
 // TODO: SIMPLY-3645
+@MainActor
 class TPPBookmarkSpecTests: XCTestCase {
 
     override func setUpWithError() throws {

--- a/PalaceTests/ButtonStateTests.swift
+++ b/PalaceTests/ButtonStateTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ButtonStateTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/CarPlay/CarPlayAuthHelperReadinessTests.swift
+++ b/PalaceTests/CarPlay/CarPlayAuthHelperReadinessTests.swift
@@ -20,6 +20,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class CarPlayAuthHelperReadinessTests: XCTestCase {
 
     private var libraryMock: TPPLibraryAccountMock!

--- a/PalaceTests/CatalogDomain/CatalogCacheKeyAndIsolationTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogCacheKeyAndIsolationTests.swift
@@ -62,6 +62,7 @@ import UIKit
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class CatalogCacheKeyAndIsolationTests: XCTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/CatalogDomain/CatalogDomainTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogDomainTests.swift
@@ -14,6 +14,7 @@ import XCTest
 
 // MARK: - CatalogRepository Tests
 
+@MainActor
 final class CatalogRepositoryCoreTests: XCTestCase {
 
     private var api: CatalogAPIMock!
@@ -175,6 +176,7 @@ final class CatalogRepositoryCoreTests: XCTestCase {
 
 // MARK: - OPDSParser Tests
 
+@MainActor
 final class OPDSParserCoreTests: XCTestCase {
 
     private let parser = OPDSParser()
@@ -220,6 +222,7 @@ final class OPDSParserCoreTests: XCTestCase {
 
 // MARK: - CatalogFeed Model Tests
 
+@MainActor
 final class CatalogFeedModelTests: XCTestCase {
 
     func testCatalogFeedFromNilFeedReturnsNil() {
@@ -255,6 +258,7 @@ final class CatalogFeedModelTests: XCTestCase {
 
 // MARK: - DefaultCatalogAPI.extractSearchEntryPoints Tests
 
+@MainActor
 final class CatalogAPIEntryPointTests: XCTestCase {
 
     func testExtractSearchEntryPointsFromEmptyFeed() {

--- a/PalaceTests/CatalogDomain/CatalogLaneAssemblyTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogLaneAssemblyTests.swift
@@ -15,6 +15,7 @@ import XCTest
 @testable import Palace
 @testable import PalaceCatalog
 
+@MainActor
 final class CatalogLaneAssemblyTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/CatalogDomain/CatalogLaneSortingTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogLaneSortingTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class CatalogLaneSortingTests: XCTestCase {
 
   override func tearDown() {

--- a/PalaceTests/CatalogDomain/CatalogOPDS2NegotiationTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogOPDS2NegotiationTests.swift
@@ -44,6 +44,7 @@ import XCTest
 import PalaceNetwork
 @testable import Palace
 
+@MainActor
 final class CatalogOPDS2NegotiationTests: XCTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/CatalogDomain/CatalogProblemDocumentTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogProblemDocumentTests.swift
@@ -16,6 +16,7 @@ import XCTest
 @testable import PalaceCatalog
 import PalaceNetwork
 
+@MainActor
 final class CatalogProblemDocumentTests: XCTestCase {
 
     // MARK: - Properties

--- a/PalaceTests/CatalogDomain/CatalogRepositoryStaleWhileRevalidateTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogRepositoryStaleWhileRevalidateTests.swift
@@ -27,6 +27,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
 
     // MARK: - Fixtures
@@ -419,6 +420,7 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
 // using two ticks one nanosecond apart so the assertion is unambiguous about
 // the operator's exclusivity.
 
+@MainActor
 final class CatalogCacheMetadataExactBoundaryTests: XCTestCase {
 
     /// Mutant killed: flipping `> defaultStaleTTL` (21600) to `>=

--- a/PalaceTests/CatalogDomain/CatalogRepositoryTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogRepositoryTests.swift
@@ -13,6 +13,7 @@ import PalaceNetwork
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class CatalogRepositoryTests: XCTestCase {
 
     // MARK: - Properties
@@ -415,6 +416,7 @@ extension CatalogRepositoryTests {
 // resolve the OPDS2 search URL. These tests pin the invariant that concurrent
 // callers share one network fetch.
 
+@MainActor
 final class CatalogAPIDedupeTests: XCTestCase {
 
     private var networkClient: NetworkClientMock!

--- a/PalaceTests/CatalogSortServiceTests.swift
+++ b/PalaceTests/CatalogSortServiceTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class CatalogSortServiceTests: XCTestCase {
 
     // MARK: - Test Data

--- a/PalaceTests/CatalogUI/CatalogFilterServiceTests.swift
+++ b/PalaceTests/CatalogUI/CatalogFilterServiceTests.swift
@@ -12,6 +12,7 @@ import XCTest
 @testable import Palace
 
 /// SRS: CAT-005 — Filter service manages catalog facet state consistently
+@MainActor
 final class CatalogFilterServiceTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/CatalogUI/CatalogLaneRowViewAccessibilityTests.swift
+++ b/PalaceTests/CatalogUI/CatalogLaneRowViewAccessibilityTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class CatalogLaneRowViewAccessibilityTests: XCTestCase {
 
     // MARK: - Regression Tests

--- a/PalaceTests/CatalogUI/CatalogModelsTests.swift
+++ b/PalaceTests/CatalogUI/CatalogModelsTests.swift
@@ -17,6 +17,7 @@ import PalaceCatalog
 
 // MARK: - CatalogFilter Tests
 
+@MainActor
 final class CatalogFilterModelTests: XCTestCase {
 
     // MARK: - Initialization Tests
@@ -231,6 +232,7 @@ final class CatalogFilterModelTests: XCTestCase {
 
 // MARK: - CatalogFilterGroup Tests
 
+@MainActor
 final class CatalogFilterGroupModelTests: XCTestCase {
 
     // MARK: - Initialization Tests
@@ -463,6 +465,7 @@ final class CatalogFilterGroupModelTests: XCTestCase {
 
 // MARK: - CatalogLaneModel Struct Tests
 
+@MainActor
 final class CatalogLaneModelStructTests: XCTestCase {
 
     // MARK: - Initialization Tests

--- a/PalaceTests/CatalogUI/CatalogViewModelTests.swift
+++ b/PalaceTests/CatalogUI/CatalogViewModelTests.swift
@@ -9,6 +9,7 @@ import PalaceNetwork
 
 // MARK: - CatalogState Tests
 
+@MainActor
 final class CatalogStateTests: XCTestCase {
 
     func testState_Loading_HasNoContent() {
@@ -70,6 +71,7 @@ final class CatalogStateTests: XCTestCase {
 
 // MARK: - CatalogSelectors Tests
 
+@MainActor
 final class CatalogSelectorsTests: XCTestCase {
 
     func testWithSelectedFacet_UpdatesActiveState() {
@@ -104,6 +106,7 @@ final class CatalogSelectorsTests: XCTestCase {
 
 // MARK: - MappedCatalog Bridge Tests
 
+@MainActor
 final class MappedCatalogBridgeTests: XCTestCase {
 
     func testToCatalogContent_GroupedFeed() {
@@ -533,6 +536,7 @@ private actor PrefetchCancelFlag {
 
 // MARK: - Model Tests
 
+@MainActor
 final class CatalogFilterTests: XCTestCase {
     func testCatalogFilter_StoresValues() {
         let f = CatalogFilter(id: "t", title: "Audiobooks", href: URL(string: "https://a.com"), active: false)
@@ -541,6 +545,7 @@ final class CatalogFilterTests: XCTestCase {
     }
 }
 
+@MainActor
 final class CatalogLaneModelTests: XCTestCase {
     func testHasUniqueId() {
         let l1 = CatalogLaneModel(title: "L", books: [], moreURL: nil)

--- a/PalaceTests/CatalogUI/SideloadedLaneTests.swift
+++ b/PalaceTests/CatalogUI/SideloadedLaneTests.swift
@@ -24,6 +24,7 @@ import Combine
 
 // MARK: - Pure bridge: toCatalogContent(prepending:)
 
+@MainActor
 final class SideloadedLaneBridgeTests: XCTestCase {
 
   private func mapped(

--- a/PalaceTests/Chaos/ChaosFaultInjectionTests.swift
+++ b/PalaceTests/Chaos/ChaosFaultInjectionTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import Combine
 @testable import Palace
 
+@MainActor
 final class ChaosFaultInjectionTests: XCTestCase {
 
   private var cancellables: Set<AnyCancellable> = []

--- a/PalaceTests/Chaos/ChaosHarness.swift
+++ b/PalaceTests/Chaos/ChaosHarness.swift
@@ -53,8 +53,16 @@ final class ChaosURLProtocol: URLProtocol {
   }
 
   private static let queue = DispatchQueue(label: "ChaosURLProtocol.queue")
-  private static var _plan = Plan()
-  private static var _requestCount: Int = 0
+  private static let _planBox = LockIsolated<Plan>(Plan())
+  private static var _plan: Plan {
+    get { _planBox.value }
+    set { _planBox.value = newValue }
+  }
+  private static let _requestCountBox = LockIsolated<Int>(0)
+  private static var _requestCount: Int {
+    get { _requestCountBox.value }
+    set { _requestCountBox.value = newValue }
+  }
 
   static func setPlan(_ plan: Plan) {
     queue.sync {
@@ -272,7 +280,11 @@ enum ChaosHarness {
   // private delegate queues fire callbacks on freed state, crashing
   // libdispatch on whichever test runs next.
   private static let registryQueue = DispatchQueue(label: "ChaosHarness.registry")
-  private static var registeredSessions: [URLSession] = []
+  private static let _registeredSessionsBox = LockIsolated<[URLSession]>([])
+  private static var registeredSessions: [URLSession] {
+    get { _registeredSessionsBox.value }
+    set { _registeredSessionsBox.value = newValue }
+  }
 
   fileprivate static func _invalidateRegisteredSessions() {
     let toCancel: [URLSession] = registryQueue.sync {

--- a/PalaceTests/CodeReviewFixesTests.swift
+++ b/PalaceTests/CodeReviewFixesTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class CodeReviewFixesTests: XCTestCase {
 
     // MARK: - OAuth Param Parsing (Finding #4: base64 token truncation)

--- a/PalaceTests/Concurrency/MainActorHelpersTests.swift
+++ b/PalaceTests/Concurrency/MainActorHelpersTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class MainActorHelpersTests: XCTestCase {
 
     // MARK: - runParallel Tests

--- a/PalaceTests/Concurrency/TPPMainThreadCheckerTests.swift
+++ b/PalaceTests/Concurrency/TPPMainThreadCheckerTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPMainThreadCheckerTests: XCTestCase {
 
     // MARK: - sync Tests

--- a/PalaceTests/Contract/AudiobookPositionAdapterContractTests.swift
+++ b/PalaceTests/Contract/AudiobookPositionAdapterContractTests.swift
@@ -76,12 +76,7 @@ private final class CallLogPositionWriter: PositionWriter, @unchecked Sendable {
     }
 
     func save(_ snapshot: PositionSnapshot) async throws -> ServerPositionID? {
-        let outcome: Outcome
-        let hook: (() -> Void)?
-        lock.lock()
-        outcome = _outcome
-        hook = _onSave
-        lock.unlock()
+        let (outcome, hook): (Outcome, (() -> Void)?) = lock.withLock { (_outcome, _onSave) }
 
         log.record(
             "writer.save",

--- a/PalaceTests/Contract/AudiobookPositionAdapterContractTests.swift
+++ b/PalaceTests/Contract/AudiobookPositionAdapterContractTests.swift
@@ -195,6 +195,7 @@ private final class RecordingRegistry: NSObject, TPPBookRegistryProvider, @unche
 
 // MARK: - Tests
 
+@MainActor
 final class AudiobookPositionAdapterContractTests: XCTestCase {
 
     private let bookIdentifier = "contract-audiobook-1"

--- a/PalaceTests/Contract/BorrowOperationContractTests.swift
+++ b/PalaceTests/Contract/BorrowOperationContractTests.swift
@@ -45,8 +45,20 @@ final class BorrowOperationContractTests: XCTestCase {
     /// ContractSnapshot.assert(...) check.
     private var log: CallLog!
 
+    /// Swift 6: `fetchBook` is a non-isolated `async` closure, so it cannot
+    /// capture `self` (a non-Sendable XCTestCase) to read this per-test value.
+    /// Box it behind a lock so the closure captures the box (Sendable) instead.
+    private final class ResultBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _value: Result<TPPBook, Error>?
+        var value: Result<TPPBook, Error>? {
+            get { lock.withLock { _value } }
+            set { lock.withLock { _value = newValue } }
+        }
+    }
+
     /// Closure seams.
-    private var fetchBookResult: Result<TPPBook, Error>!
+    private let fetchBookResult = ResultBox()
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -60,7 +72,7 @@ final class BorrowOperationContractTests: XCTestCase {
         // Default success: the fetch returns the same book that was passed
         // in. Tests override per-scenario.
         let defaultBook = Self.makeBook(identifier: "BOOK-1", availability: .unlimited)
-        fetchBookResult = .success(defaultBook)
+        fetchBookResult.value = .success(defaultBook)
 
         // NOTE: BorrowOperation's `init` is gated by FEATURE_DRM_CONNECTOR
         // on the Palace target, which is set for production but NOT for
@@ -69,6 +81,10 @@ final class BorrowOperationContractTests: XCTestCase {
         // compiled framework PalaceTests links against carries the DRM
         // variant of `init`, so we call it unconditionally — same approach
         // as PalaceTests/MyBooks/BorrowOperationTests.swift.
+        // Capture Sendable collaborators as locals so the non-isolated async
+        // closures (fetchBook, attemptOIDCReauth) don't capture `self` (Swift 6).
+        let callLog = log!
+        let resultBox = fetchBookResult
         operation = BorrowOperation(
             bookRegistry: bookRegistry,
             downloadAnnouncementService: SilentAnnouncementService(),
@@ -77,12 +93,12 @@ final class BorrowOperationContractTests: XCTestCase {
             userRetryTracker: .shared,
             userAccountProvider: { [unowned self] in self.userAccount },
             adobeDRMService: AdobeDRMService.shared,
-            fetchBook: { [unowned self] url, resetCache, useToken in
-                self.log.record("fetchBook",
-                                args: ["url": url.lastPathComponent,
-                                       "resetCache": "\(resetCache)",
-                                       "useToken": "\(useToken)"])
-                switch self.fetchBookResult! {
+            fetchBook: { url, resetCache, useToken in
+                callLog.record("fetchBook",
+                               args: ["url": url.lastPathComponent,
+                                      "resetCache": "\(resetCache)",
+                                      "useToken": "\(useToken)"])
+                switch resultBox.value! {
                 case .success(let result): return result
                 case .failure(let error): throw error
                 }
@@ -96,8 +112,8 @@ final class BorrowOperationContractTests: XCTestCase {
             presentSignInModal: { [unowned self] _ in
                 self.log.record("presentSignInModal", args: [:])
             },
-            attemptOIDCReauth: { [unowned self] in
-                self.log.record("attemptOIDCReauth", args: [:])
+            attemptOIDCReauth: {
+                callLog.record("attemptOIDCReauth", args: [:])
                 return false
             }
         )
@@ -111,7 +127,7 @@ final class BorrowOperationContractTests: XCTestCase {
         userAccount = nil
         spyDelegate = nil
         operation = nil
-        fetchBookResult = nil
+        fetchBookResult.value = nil
         try super.tearDownWithError()
     }
 
@@ -123,7 +139,7 @@ final class BorrowOperationContractTests: XCTestCase {
     /// the condition (as PR #890 did) trips the snapshot diff.
     func test_borrowAsync_attemptDownloadTrue_onSuccessfulBorrow_callsStartDownload() async throws {
         let book = Self.makeBook(identifier: "F014-OK", availability: .unlimited)
-        fetchBookResult = .success(book)
+        fetchBookResult.value = .success(book)
 
         _ = try await operation.borrowAsync(book, attemptDownload: true)
 
@@ -136,7 +152,7 @@ final class BorrowOperationContractTests: XCTestCase {
     /// call startDownload. Pins the gate.
     func test_borrowAsync_attemptDownloadFalse_onSuccessfulBorrow_doesNotCallStartDownload() async throws {
         let book = Self.makeBook(identifier: "F014-NoDL", availability: .unlimited)
-        fetchBookResult = .success(book)
+        fetchBookResult.value = .success(book)
 
         _ = try await operation.borrowAsync(book, attemptDownload: false)
 
@@ -160,7 +176,7 @@ final class BorrowOperationContractTests: XCTestCase {
     func test_borrowAsync_authError_triggersRetryViaSilentReauth() async {
         let book = Self.makeBook(identifier: "AUTH-ERR", availability: .unlimited)
         let problemDoc = Self.makeProblemDoc(type: TPPProblemDocument.TypeInvalidCredentials)
-        fetchBookResult = .failure(NSError(
+        fetchBookResult.value = .failure(NSError(
             domain: "test", code: 401,
             userInfo: ["problemDocument": problemDoc as Any]
         ))
@@ -187,7 +203,7 @@ final class BorrowOperationContractTests: XCTestCase {
     func test_borrowAsync_holdResponse_doesNotCallStartDownload() async {
         let preBorrowBook = Self.makeBook(identifier: "HOLD-PRE", availability: .unlimited)
         let raceResponse = Self.makeBook(identifier: "HOLD-POST", availability: .reserved)
-        fetchBookResult = .success(raceResponse)
+        fetchBookResult.value = .success(raceResponse)
 
         do {
             _ = try await operation.borrowAsync(preBorrowBook, attemptDownload: true)
@@ -224,7 +240,7 @@ final class BorrowOperationContractTests: XCTestCase {
         userAccount.setAuthState(.loggedIn)
 
         let problemDoc = Self.makeProblemDoc(type: TPPProblemDocument.TypeInvalidCredentials)
-        fetchBookResult = .failure(NSError(
+        fetchBookResult.value = .failure(NSError(
             domain: "test", code: 401,
             userInfo: ["problemDocument": problemDoc as Any]
         ))
@@ -266,7 +282,7 @@ final class BorrowOperationContractTests: XCTestCase {
         )
         userAccount._authDefinition = AccountDetails.Authentication(auth: docAuth)
 
-        fetchBookResult = .failure(PalaceError.network(.unauthorized))
+        fetchBookResult.value = .failure(PalaceError.network(.unauthorized))
 
         do {
             _ = try await operation.borrowAsync(book, attemptDownload: false)

--- a/PalaceTests/Contract/BorrowReducerContractTests.swift
+++ b/PalaceTests/Contract/BorrowReducerContractTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BorrowReducerContractTests: XCTestCase {
 
     /// Records the state-transition contract for every (registry-state, prior-state)

--- a/PalaceTests/Contract/PositionWriterContractTests.swift
+++ b/PalaceTests/Contract/PositionWriterContractTests.swift
@@ -64,10 +64,10 @@ private final class SpyPositionNetworkAdapter: PositionNetworkAdapter, @unchecke
     }
 
     func post(_ snapshot: PositionSnapshot) async throws -> ServerPositionID {
-        lock.lock()
-        _postCount += 1
-        let id = _nextServerID
-        lock.unlock()
+        let id = lock.withLock { () -> ServerPositionID in
+            _postCount += 1
+            return _nextServerID
+        }
         // Record stable-shape args only — exact timestamps would drift
         // across runs. Record bookID + format + payload-bytes-count, which
         // is enough to catch any reordering or argument swap.
@@ -84,10 +84,7 @@ private final class SpyPositionNetworkAdapter: PositionNetworkAdapter, @unchecke
     }
 
     func fetch(bookID: String) async throws -> PositionSnapshot? {
-        let result: PositionSnapshot?
-        lock.lock()
-        result = _nextFetchResult
-        lock.unlock()
+        let result: PositionSnapshot? = lock.withLock { _nextFetchResult }
         log.record(
             "network.fetch",
             args: [

--- a/PalaceTests/Contract/PositionWriterContractTests.swift
+++ b/PalaceTests/Contract/PositionWriterContractTests.swift
@@ -152,6 +152,7 @@ private final class FrozenClock: @unchecked Sendable {
 /// Contract-snapshot tests for `RemotePositionWriter`. Each scenario drives
 /// the real writer with a spy adapter + frozen clock and locks the call
 /// sequence into the adapter as a JSON snapshot.
+@MainActor
 final class PositionWriterContractTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Contract/Reader2BookmarkContractTests.swift
+++ b/PalaceTests/Contract/Reader2BookmarkContractTests.swift
@@ -143,6 +143,7 @@ private final class NilCurrentAccountProvider: NSObject, TPPCurrentLibraryAccoun
 
 // MARK: - Tests
 
+@MainActor
 final class Reader2BookmarkContractTests: XCTestCase {
 
     private let bookIdentifier = "contract-reader2-bookmark-1"

--- a/PalaceTests/Contract/Reader2PositionAdapterContractTests.swift
+++ b/PalaceTests/Contract/Reader2PositionAdapterContractTests.swift
@@ -162,6 +162,7 @@ private final class RecordingRegistry: NSObject, TPPBookRegistryProvider, @unche
 
 // MARK: - Tests
 
+@MainActor
 final class Reader2PositionAdapterContractTests: XCTestCase {
 
     private let bookIdentifier = "contract-reader2-1"

--- a/PalaceTests/Contract/Reader2PositionResumeContractTests.swift
+++ b/PalaceTests/Contract/Reader2PositionResumeContractTests.swift
@@ -188,6 +188,7 @@ private final class RecordingResumeRegistry: NSObject, TPPBookRegistryProvider, 
 
 // MARK: - Tests
 
+@MainActor
 final class Reader2PositionResumeContractTests: XCTestCase {
 
     private let bookIdentifier = "contract-reader2-resume-1"

--- a/PalaceTests/Contract/SideloadImportContractTests.swift
+++ b/PalaceTests/Contract/SideloadImportContractTests.swift
@@ -16,6 +16,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class SideloadImportContractTests: PalaceWiringTestCase {
 
   private var tempRoot: URL!

--- a/PalaceTests/CoverageGapTests.swift
+++ b/PalaceTests/CoverageGapTests.swift
@@ -15,6 +15,7 @@ import PalaceCatalog
 
 // MARK: - Gap 1-3: Account, AccountDetails, Authentication (Account.swift)
 
+@MainActor
 final class AccountModelGapTests: XCTestCase {
 
     private var mockProvider: TPPLibraryAccountMock!
@@ -186,6 +187,7 @@ final class AccountModelGapTests: XCTestCase {
 
 // MARK: - Gap 4-5: AccountsManager (AccountsManager.swift)
 
+@MainActor
 final class AccountsManagerGapTests: XCTestCase {
 
     /// Coverage Gap: AccountsManager class — verify account lookup by UUID
@@ -240,6 +242,7 @@ final class SettingsViewModelGapTests: XCTestCase {
 
 // MARK: - Gap 7: AccountDetailViewModel (AccountDetailViewModel.swift)
 
+@MainActor
 final class AccountDetailViewModelGapTests: XCTestCase {
 
     private var mockProvider: TPPLibraryAccountMock!
@@ -348,6 +351,7 @@ final class ErrorDetailViewControllerGapTests: XCTestCase {
 
 // MARK: - Gap 11-13: adept functions (MyBooksDownloadCenter.swift)
 
+@MainActor
 final class MyBooksDownloadCenterAdeptGapTests: XCTestCase {
 
     /// Coverage Gap: adept download state — verify download state management for DRM books
@@ -400,6 +404,7 @@ final class MyBooksDownloadCenterAdeptGapTests: XCTestCase {
 // Note: DRM classes are compiled in the app target (FEATURE_DRM_CONNECTOR=1)
 // and accessible via @testable import Palace.
 
+@MainActor
 final class AdobeCertificateGapTests: XCTestCase {
 
     /// Coverage Gap: AdobeCertificate class — test expirationDate from timestamp
@@ -491,6 +496,7 @@ final class AdobeCertificateGapTests: XCTestCase {
     }
 }
 
+@MainActor
 final class AdobeDRMErrorGapTests: XCTestCase {
 
     /// Coverage Gap: AdobeDRMError enum — test error case exists
@@ -525,6 +531,7 @@ final class AdobeDRMErrorGapTests: XCTestCase {
     }
 }
 
+@MainActor
 final class AdobeDRMServiceGapTests: XCTestCase {
 
     /// Coverage Gap: AdobeDRMService class — test singleton exists

--- a/PalaceTests/CoverageGapTests2.swift
+++ b/PalaceTests/CoverageGapTests2.swift
@@ -67,6 +67,7 @@ final class AppTabRouterGapTests: XCTestCase {
 
 // MARK: - 2. TPPBookModelGapTests
 
+@MainActor
 final class TPPBookModelGapTests: XCTestCase {
 
     /// Coverage Gap: TPPBook dictionaryRepresentation — produces non-empty dict
@@ -145,6 +146,7 @@ final class TPPBookModelGapTests: XCTestCase {
 
 // MARK: - 3. TPPBadgeImageGapTests
 
+@MainActor
 final class TPPBadgeImageGapTests: XCTestCase {
 
     /// Coverage Gap: TPPBadgeImage.audiobook — assetName returns "AudiobookBadge"
@@ -176,6 +178,7 @@ final class TPPBadgeImageGapTests: XCTestCase {
 
 #if DEBUG
 
+@MainActor
 final class DebugSettingsGapTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/CoverageGapTests3.swift
+++ b/PalaceTests/CoverageGapTests3.swift
@@ -15,6 +15,7 @@ import OSLog
 
 // MARK: - 1. AudioBookmarkGapTests
 
+@MainActor
 final class AudioBookmarkGapTests: XCTestCase {
 
     override func tearDown() {
@@ -159,6 +160,7 @@ final class AudioBookmarkGapTests: XCTestCase {
 
 // MARK: - 2. DeviceLogCollectorGapTests
 
+@MainActor
 final class DeviceLogCollectorGapTests: XCTestCase {
 
     /// Coverage Gap: DeviceLogCollector.formatDate — output contains formatted dates (via collectLogs)
@@ -197,6 +199,7 @@ final class DeviceLogCollectorGapTests: XCTestCase {
 
 // MARK: - 3. TPPUserAccountGapTests
 
+@MainActor
 final class TPPUserAccountGapTests: XCTestCase {
 
     /// Coverage Gap: TPPUserAccount.sharedAccount — is accessible
@@ -259,6 +262,7 @@ final class TPPUserAccountGapTests: XCTestCase {
 
 // MARK: - 4. RemoteFeatureFlagsGapTests
 
+@MainActor
 final class RemoteFeatureFlagsGapTests: XCTestCase {
 
     /// Coverage Gap: RemoteFeatureFlags.shared — is accessible

--- a/PalaceTests/Crawl/BundledRegistrySnapshotTests.swift
+++ b/PalaceTests/Crawl/BundledRegistrySnapshotTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class BundledRegistrySnapshotTests: XCTestCase {
 
     private var tempDir: URL!

--- a/PalaceTests/Crawl/CatalogPreloaderTests.swift
+++ b/PalaceTests/Crawl/CatalogPreloaderTests.swift
@@ -30,6 +30,7 @@ private final class MockFeedPreloader: CatalogFeedPreloading, @unchecked Sendabl
 
 // MARK: - Tests
 
+@MainActor
 final class CatalogPreloaderTests: XCTestCase {
 
     // Bound every test to 30s using XCTest's built-in mechanism. The

--- a/PalaceTests/Crawl/CrawlStateTests.swift
+++ b/PalaceTests/Crawl/CrawlStateTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class CrawlStateTests: XCTestCase {
 
     // MARK: - Codable Round-Trip

--- a/PalaceTests/Crawl/CrawlableFeedAnalysisTests.swift
+++ b/PalaceTests/Crawl/CrawlableFeedAnalysisTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class CrawlableFeedAnalysisTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/Crawl/CrawlerFallbackTests.swift
+++ b/PalaceTests/Crawl/CrawlerFallbackTests.swift
@@ -10,6 +10,7 @@ import PalaceCatalog
 /// 4. First page succeeds, remaining pages fail → partial data is usable
 /// 5. Incremental crawl fails → full crawl on next attempt
 /// 6. Network completely down → returns failure (caller falls back to direct GET)
+@MainActor
 final class CrawlerFallbackTests: XCTestCase {
 
     private var fetcher: MockFallbackFetcher!

--- a/PalaceTests/Crawl/CrossDeviceBookmarkSyncTests.swift
+++ b/PalaceTests/Crawl/CrossDeviceBookmarkSyncTests.swift
@@ -11,6 +11,7 @@ import XCTest
 /// - Bookmark specs serialize correct device IDs
 /// - Server responses parse both devices' bookmarks
 /// - Conflict resolution logic handles all edge cases
+@MainActor
 final class CrossDeviceBookmarkSyncTests: XCTestCase {
 
     private let deviceA = "urn:uuid:device-A-test-001"

--- a/PalaceTests/Crawl/LibraryCatalogMergerTests.swift
+++ b/PalaceTests/Crawl/LibraryCatalogMergerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class LibraryCatalogMergerTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/Crawl/LibraryRegistryCrawlerTests.swift
+++ b/PalaceTests/Crawl/LibraryRegistryCrawlerTests.swift
@@ -115,6 +115,7 @@ private enum CrawlOutcome: Sendable, Equatable {
 
 // MARK: - Tests
 
+@MainActor
 final class LibraryRegistryCrawlerTests: XCTestCase {
 
     private var fetcher: MockCrawlerFetcher!

--- a/PalaceTests/Crawl/LiveCrawlableParsingTest.swift
+++ b/PalaceTests/Crawl/LiveCrawlableParsingTest.swift
@@ -7,6 +7,7 @@ import PalaceCatalog
 ///
 /// Uses an ephemeral URLSession that bypasses globally-registered URL protocols
 /// (including NoNetworkURLProtocol) so the hermetic test layer does not block it.
+@MainActor
 final class LiveCrawlableParsingTest: XCTestCase {
 
     /// Ephemeral session that bypasses NoNetworkURLProtocol.

--- a/PalaceTests/DRM/AdobeActivationTests.swift
+++ b/PalaceTests/DRM/AdobeActivationTests.swift
@@ -37,6 +37,7 @@ import XCTest
 // FEATURE_DRM_CONNECTOR gate. Mirrors the same approach as
 // PalaceTests/MyBooks/AdobeDRMHandlerTests.swift.
 
+@MainActor
 final class AdobeActivationTests: XCTestCase {
 
     private var drm: TPPDRMAuthorizingMock!

--- a/PalaceTests/DRM/LCPCharacterizationTests.swift
+++ b/PalaceTests/DRM/LCPCharacterizationTests.swift
@@ -38,6 +38,7 @@ import XCTest
 import PalaceCatalog
 import ReadiumLCP
 
+@MainActor
 final class LCPCharacterizationTests: XCTestCase {
 
     // MARK: - Setup / teardown

--- a/PalaceTests/DRM/LCPClientTests.swift
+++ b/PalaceTests/DRM/LCPClientTests.swift
@@ -33,6 +33,7 @@ import XCTest
 import ReadiumLCP
 import ReadiumShared
 
+@MainActor
 final class LCPClientTests: XCTestCase {
 
     // MARK: - createContext — input validation guards

--- a/PalaceTests/DRM/ResourcePropertiesLengthTests.swift
+++ b/PalaceTests/DRM/ResourcePropertiesLengthTests.swift
@@ -18,6 +18,7 @@ import XCTest
 import ReadiumShared
 @testable import Palace
 
+@MainActor
 final class ResourcePropertiesLengthTests: XCTestCase {
 
     func testLength_roundTripsLargeValueWithoutTruncation() {

--- a/PalaceTests/Date+NYPLAdditionsTests.swift
+++ b/PalaceTests/Date+NYPLAdditionsTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class Date_NYPLAdditionsTests: XCTestCase {
     func testRFC1123() {
         let date = Date(timeIntervalSince1970: 1_000_000_000)

--- a/PalaceTests/EPUBModuleTests.swift
+++ b/PalaceTests/EPUBModuleTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class EPUBModuleTests: XCTestCase {
 
     // MARK: - Initialization Tests

--- a/PalaceTests/EpubSampleFactoryTests.swift
+++ b/PalaceTests/EpubSampleFactoryTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class EpubSampleFactoryTests: XCTestCase {
 
     // MARK: - URL wrapper tests

--- a/PalaceTests/ErrorHandling/AlertModelTests.swift
+++ b/PalaceTests/ErrorHandling/AlertModelTests.swift
@@ -12,6 +12,7 @@ import XCTest
 /// Originally PP-3707 covered the retry factory; expanded here to also lock in
 /// the HalfSheetView branching contract (`secondaryButtonTitle != nil`) and the
 /// destructive-style flag.
+@MainActor
 final class AlertModelRetryTests: XCTestCase {
 
     // MARK: - Default initializer

--- a/PalaceTests/ErrorHandling/ErrorActivityTrackerTests.swift
+++ b/PalaceTests/ErrorHandling/ErrorActivityTrackerTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ErrorActivityTrackerTests: XCTestCase {
 
     // Use a fresh tracker for each test to avoid shared state pollution

--- a/PalaceTests/ErrorHandling/ErrorDetailTests.swift
+++ b/PalaceTests/ErrorHandling/ErrorDetailTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ErrorDetailTests: XCTestCase {
 
     // MARK: - Factory Method

--- a/PalaceTests/ErrorHandling/ErrorDetailViewControllerTests.swift
+++ b/PalaceTests/ErrorHandling/ErrorDetailViewControllerTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ErrorDetailViewControllerTests: XCTestCase {
 
     // MARK: - ErrorDetail Model Tests

--- a/PalaceTests/ErrorHandling/LoanExpiryHandlingTests.swift
+++ b/PalaceTests/ErrorHandling/LoanExpiryHandlingTests.swift
@@ -15,6 +15,7 @@ import PalaceCatalog
 
 // MARK: - TPPProblemDocument Loan Expiry Constant
 
+@MainActor
 final class ProblemDocumentLoanExpiryTests: XCTestCase {
 
     /// The constant must be the exact substring that Feedbooks embeds in the 500 detail field.
@@ -80,6 +81,7 @@ final class ProblemDocumentLoanExpiryTests: XCTestCase {
 
 // MARK: - Expired Loan Strings
 
+@MainActor
 final class ExpiredLoanStringsTests: XCTestCase {
 
     func testExpiredLoanTitle_isNonEmpty() {

--- a/PalaceTests/ErrorHandling/NSErrorAdditionsTests.swift
+++ b/PalaceTests/ErrorHandling/NSErrorAdditionsTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class NSErrorAdditionsTests: XCTestCase {
 
     private let testDomain = "TestDomain"

--- a/PalaceTests/ErrorHandling/PalaceErrorExtendedTests.swift
+++ b/PalaceTests/ErrorHandling/PalaceErrorExtendedTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class PalaceErrorExtendedTests: XCTestCase {
 
     // MARK: - BookRegistry Error Descriptions

--- a/PalaceTests/ErrorHandling/PalaceErrorTests.swift
+++ b/PalaceTests/ErrorHandling/PalaceErrorTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class PalaceErrorCategoryTests: XCTestCase {
 
     // MARK: - Error Descriptions

--- a/PalaceTests/ErrorHandling/TPPProblemDocumentCacheManagerTests.swift
+++ b/PalaceTests/ErrorHandling/TPPProblemDocumentCacheManagerTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPProblemDocumentCacheManagerTests: XCTestCase {
 
     private var cacheManager: TPPProblemDocumentCacheManager!

--- a/PalaceTests/ErrorHandling/TPPUserFriendlyErrorTests.swift
+++ b/PalaceTests/ErrorHandling/TPPUserFriendlyErrorTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPUserFriendlyErrorTests: XCTestCase {
 
     // MARK: - Protocol Default Implementation

--- a/PalaceTests/Extensions/ArrayExtensionsTests.swift
+++ b/PalaceTests/Extensions/ArrayExtensionsTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ArrayExtensionsTests: XCTestCase {
 
   // MARK: - Safe Subscript Getter

--- a/PalaceTests/Extensions/ColorExtensionTests.swift
+++ b/PalaceTests/Extensions/ColorExtensionTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class ColorExtensionTests: XCTestCase {
 
   /// SRS: EXT-CLR-001 — Black color is dark

--- a/PalaceTests/Extensions/DataBase64Tests.swift
+++ b/PalaceTests/Extensions/DataBase64Tests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DataBase64Tests: XCTestCase {
 
   /// SRS: EXT-B64-001 — URL-safe encoding replaces + with -

--- a/PalaceTests/Extensions/DictionaryExtensionsTests.swift
+++ b/PalaceTests/Extensions/DictionaryExtensionsTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DictionaryExtensionsTests: XCTestCase {
 
   /// SRS: EXT-DICT-001 — mapKeys transforms keys while preserving values

--- a/PalaceTests/Extensions/FloatTPPAdditionsTests.swift
+++ b/PalaceTests/Extensions/FloatTPPAdditionsTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class FloatTPPAdditionsTests: XCTestCase {
 
   // MARK: - Approximate Equality Operator (=~=)

--- a/PalaceTests/Extensions/IntExtensionsTests.swift
+++ b/PalaceTests/Extensions/IntExtensionsTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class IntExtensionsTests: XCTestCase {
 
   /// `Int.ordinal()` follows English ordinal rules: 1st/2nd/3rd, then

--- a/PalaceTests/Extensions/StringHTMLEntitiesTests.swift
+++ b/PalaceTests/Extensions/StringHTMLEntitiesTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class StringHTMLEntitiesTests: XCTestCase {
 
   // MARK: - Named Entity Decoding

--- a/PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift
+++ b/PalaceTests/FeatureFlags/RemoteFeatureFlagsSideLoadingTests.swift
@@ -19,6 +19,7 @@ import XCTest
 /// Every test constructs a fresh `RemoteFeatureFlags(defaults:)` with a
 /// per-suite `UserDefaults` so override-key state never leaks — `.shared` is
 /// never touched.
+@MainActor
 final class RemoteFeatureFlagsSideLoadingTests: XCTestCase {
 
     private var suiteName: String!

--- a/PalaceTests/Fuzz/ParserFuzzTests.swift
+++ b/PalaceTests/Fuzz/ParserFuzzTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class ParserFuzzTests: XCTestCase {
 
   // MARK: - OPDS 1.x XML

--- a/PalaceTests/HTTPStubURLProtocol.swift
+++ b/PalaceTests/HTTPStubURLProtocol.swift
@@ -8,7 +8,11 @@ final class HTTPStubURLProtocol: URLProtocol {
     }
 
     private static let handlerQueue = DispatchQueue(label: "HTTPStubURLProtocol.handlerQueue")
-    private static var requestHandlers: [(URLRequest) -> StubbedResponse?] = []
+    private static let _requestHandlers = LockIsolated<[(URLRequest) -> StubbedResponse?]>([])
+    private static var requestHandlers: [(URLRequest) -> StubbedResponse?] {
+        get { _requestHandlers.value }
+        set { _requestHandlers.value = newValue }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         return true

--- a/PalaceTests/ImageLoading/ImageCacheContinuationTests.swift
+++ b/PalaceTests/ImageLoading/ImageCacheContinuationTests.swift
@@ -19,6 +19,7 @@ import UIKit
 /// queue, enqueue the awaits so they are *guaranteed* still queued, cancel all
 /// operations, then resume the queue. Every cancelled-while-queued operation
 /// must still resume its continuation.
+@MainActor
 final class ImageCacheContinuationTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/ImageLoading/ImageLoaderTests.swift
+++ b/PalaceTests/ImageLoading/ImageLoaderTests.swift
@@ -7,6 +7,7 @@ import PalaceCatalog
 /// `TPPBookCoverRegistry` + `TPPBookCoverRegistryBridge` + `ImageCache.shared`
 /// trio at call sites. Covers cache-hit short-circuits, weak-book-reference
 /// safety on the completion bridge, and the placeholder fall-through.
+@MainActor
 final class ImageLoaderTests: XCTestCase {
 
     private var cache: MockImageCache!

--- a/PalaceTests/ImageLoading/ImageLoaderTests.swift
+++ b/PalaceTests/ImageLoading/ImageLoaderTests.swift
@@ -132,39 +132,53 @@ final class ImageLoaderTests: XCTestCase {
 
     // MARK: - Completion bridge
 
+    // Swift 6: a captured `var` mutated inside the completion (which fires on a
+    // different executor than the one that declared it) is a data race. Box it
+    // behind a lock — the write in the completion and the read after `wait`
+    // synchronize through the lock. Mirrors the @unchecked Sendable box idiom
+    // used across the test suite (e.g. AudiobookPlaytimesLifecycleTests.AccountIdBox).
+    private final class MainThreadFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _value = false
+        var value: Bool {
+            get { lock.withLock { _value } }
+            set { lock.withLock { _value = newValue } }
+        }
+    }
+
     func testCompletionBridge_thumbnail_invokesOnMainThread() {
         let book = makeBook()
         let expectation = expectation(description: "thumbnail completion fires")
-        var ranOnMain = false
+        let ranOnMain = MainThreadFlag()
 
         // Drive the call from a background queue to force the implementation
         // to hop back to main for completion (the contract the old bridge
         // guaranteed and the new ImageLoading must preserve).
         DispatchQueue.global().async { [loader] in
             loader!.thumbnailImage(for: book) { _ in
-                ranOnMain = Thread.isMainThread
+                ranOnMain.value = Thread.isMainThread
                 expectation.fulfill()
             }
         }
 
         wait(for: [expectation], timeout: 5.0)
-        XCTAssertTrue(ranOnMain, "Bridge completion must fire on the main thread")
+        XCTAssertTrue(ranOnMain.value, "Bridge completion must fire on the main thread")
     }
 
     func testCompletionBridge_cover_invokesOnMainThread() {
         let book = makeBook()
         let expectation = expectation(description: "cover completion fires")
-        var ranOnMain = false
+        let ranOnMain = MainThreadFlag()
 
         DispatchQueue.global().async { [loader] in
             loader!.coverImage(for: book) { _ in
-                ranOnMain = Thread.isMainThread
+                ranOnMain.value = Thread.isMainThread
                 expectation.fulfill()
             }
         }
 
         wait(for: [expectation], timeout: 5.0)
-        XCTAssertTrue(ranOnMain)
+        XCTAssertTrue(ranOnMain.value)
     }
 
     func testCompletionBridge_book_deallocatedBeforeCompletion_noCrash() {

--- a/PalaceTests/Integration/AccountSwitchLifecycleTests.swift
+++ b/PalaceTests/Integration/AccountSwitchLifecycleTests.swift
@@ -37,6 +37,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class AccountSwitchLifecycleTests: PalaceWiringTestCase {
 
     /// Two distinct library UUIDs so the per-library account cache keeps

--- a/PalaceTests/Integration/BookStateIntegrationTests.swift
+++ b/PalaceTests/Integration/BookStateIntegrationTests.swift
@@ -15,6 +15,7 @@ import Combine
 
 // SRS: REQ-BOOKSTATE-001 — Book state transition integration
 
+@MainActor
 final class BookStateIntegrationTests: XCTestCase {
 
     private var bookRegistry: TPPBookRegistryMock!

--- a/PalaceTests/Integration/ColdStartResumeIntegrationTests.swift
+++ b/PalaceTests/Integration/ColdStartResumeIntegrationTests.swift
@@ -31,6 +31,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class ColdStartResumeIntegrationTests: PalaceWiringTestCase {
 
     private var account: String!

--- a/PalaceTests/Integration/MockBackendIntegrationTests.swift
+++ b/PalaceTests/Integration/MockBackendIntegrationTests.swift
@@ -12,6 +12,7 @@ import PalaceCatalog
 
 // MARK: - Happy Path
 
+@MainActor
 final class MockBackendIntegrationTests: XCTestCase {
 
     private var env: MockBackendEnvironment!
@@ -62,6 +63,7 @@ final class MockBackendIntegrationTests: XCTestCase {
 
 // MARK: - Expired Credentials
 
+@MainActor
 final class MockBackendExpiredCredentialsTests: XCTestCase {
 
     private var env: MockBackendEnvironment!
@@ -101,6 +103,7 @@ final class MockBackendExpiredCredentialsTests: XCTestCase {
 
 // MARK: - Loan Limit
 
+@MainActor
 final class MockBackendLoanLimitTests: XCTestCase {
 
     private var env: MockBackendEnvironment!
@@ -135,6 +138,7 @@ final class MockBackendLoanLimitTests: XCTestCase {
 
 // MARK: - Server Down
 
+@MainActor
 final class MockBackendServerDownTests: XCTestCase {
 
     private var env: MockBackendEnvironment!
@@ -169,6 +173,7 @@ final class MockBackendServerDownTests: XCTestCase {
 
 // MARK: - Route Matching Unit Tests
 
+@MainActor
 final class MockBackendRouteMatchingTests: XCTestCase {
 
     func testRouteMatching_ExactPath() {
@@ -213,6 +218,7 @@ final class MockBackendRouteMatchingTests: XCTestCase {
 /// loans/holds feed with one reserved hold (queue position 3 of 8) plus one
 /// ready-to-borrow hold, so the populated Holds tab can be tested without real
 /// limited-copy inventory.
+@MainActor
 final class MockBackendHoldsTests: XCTestCase {
 
     private var env: MockBackendEnvironment!

--- a/PalaceTests/Keychain/TPPKeychainManagerTests.swift
+++ b/PalaceTests/Keychain/TPPKeychainManagerTests.swift
@@ -11,6 +11,7 @@ import XCTest
 @testable import Palace
 
 /// SRS: SET-001 — Keychain manager handles error status codes correctly
+@MainActor
 final class TPPKeychainManagerTests: XCTestCase {
 
     // MARK: - logKeychainError

--- a/PalaceTests/LCP/LCPAudiobooksTests.swift
+++ b/PalaceTests/LCP/LCPAudiobooksTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class LCPAudiobooksTests: XCTestCase {
 
     // MARK: - Initialization Tests
@@ -432,6 +433,7 @@ final class LCPAudiobooksTests: XCTestCase {
 
 // MARK: - LCP Audiobook URL Scheme Tests
 
+@MainActor
 final class LCPAudiobookURLSchemeTests: XCTestCase {
 
     func testReadiumLCPScheme_isCorrect() {

--- a/PalaceTests/LCP/LCPLibraryServiceTests.swift
+++ b/PalaceTests/LCP/LCPLibraryServiceTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class LCPLibraryServiceTests: XCTestCase {
 
     // MARK: - License Extension Tests
@@ -296,6 +297,7 @@ final class LCPLibraryServiceTests: XCTestCase {
 
 // MARK: - LCP DRM Fulfilled Publication Tests
 
+@MainActor
 final class DRMFulfilledPublicationTests: XCTestCase {
 
     func testDRMFulfilledPublication_storesLocalURL() {

--- a/PalaceTests/LCP/LCPPDFAcquisitionPredicateTests.swift
+++ b/PalaceTests/LCP/LCPPDFAcquisitionPredicateTests.swift
@@ -24,6 +24,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class LCPPDFAcquisitionPredicateTests: XCTestCase {
 
     // MARK: - MIME constants (mirrored from production for fixture readability)

--- a/PalaceTests/LCP/LCPPassphraseReadinessTests.swift
+++ b/PalaceTests/LCP/LCPPassphraseReadinessTests.swift
@@ -24,6 +24,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class LCPPassphraseReadinessTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/LCP/LCPSessionOrphaningTests.swift
+++ b/PalaceTests/LCP/LCPSessionOrphaningTests.swift
@@ -16,6 +16,7 @@ import CryptoSwift
 
 // MARK: - Session Identifier Stability Tests
 
+@MainActor
 final class LCPSessionIdentifierTests: XCTestCase {
 
     /// Validates that sha256-based session identifiers are deterministic.
@@ -68,6 +69,7 @@ final class LCPSessionIdentifierTests: XCTestCase {
 
 // MARK: - Registry File Existence Validation Tests
 
+@MainActor
 final class LCPOrphanedDownloadRegistryTests: XCTestCase {
 
     private var tempDir: URL!

--- a/PalaceTests/LCP/LicensesServiceTests.swift
+++ b/PalaceTests/LCP/LicensesServiceTests.swift
@@ -14,6 +14,7 @@ import PalaceCatalog
 
 #if LCP
 
+@MainActor
 final class LicensesServiceTests: XCTestCase {
 
     private var sut: TPPLicensesService!

--- a/PalaceTests/Logging/AudiobookFileLoggerTests.swift
+++ b/PalaceTests/Logging/AudiobookFileLoggerTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AudiobookFileLoggerTests: XCTestCase {
 
     // SUT and test-local logs root — injected via init to isolate from

--- a/PalaceTests/Logging/CirculationAnalyticsTests.swift
+++ b/PalaceTests/Logging/CirculationAnalyticsTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class CirculationAnalyticsTests: XCTestCase {
 
     // MARK: - Event URL Construction

--- a/PalaceTests/Logging/DeviceLogCollectorTests.swift
+++ b/PalaceTests/Logging/DeviceLogCollectorTests.swift
@@ -10,6 +10,7 @@ import PalaceLogging
 import os.log
 @testable import Palace
 
+@MainActor
 final class DeviceLogCollectorTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Logging/DeviceSpecificErrorMonitorTests.swift
+++ b/PalaceTests/Logging/DeviceSpecificErrorMonitorTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DeviceSpecificErrorMonitorTests: XCTestCase {
 
     private var sut: DeviceSpecificErrorMonitor!

--- a/PalaceTests/Logging/ErrorLogExporterTests.swift
+++ b/PalaceTests/Logging/ErrorLogExporterTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ErrorLogExporterTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Logging/LogTests.swift
+++ b/PalaceTests/Logging/LogTests.swift
@@ -10,6 +10,7 @@ import os.log
 import PalaceLogging
 @testable import Palace
 
+@MainActor
 final class LogTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Logging/PersistentLoggerTests.swift
+++ b/PalaceTests/Logging/PersistentLoggerTests.swift
@@ -10,6 +10,7 @@ import os.log
 import PalaceLogging
 @testable import Palace
 
+@MainActor
 final class PersistentLoggerTests: XCTestCase {
 
     private var sut: PersistentLogger!

--- a/PalaceTests/Logging/TPPErrorLoggerTests.swift
+++ b/PalaceTests/Logging/TPPErrorLoggerTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import Palace
 
 /// SRS: DRM-001 - Error code taxonomy and severity classification
+@MainActor
 final class TPPErrorLoggerTests: XCTestCase {
 
     // MARK: - TPPSeverity String Value Tests
@@ -379,6 +380,7 @@ final class TPPErrorLoggerTests: XCTestCase {
 
 // MARK: - ReaderError Tests
 
+@MainActor
 final class ReaderErrorTests: XCTestCase {
 
     func testFormatNotSupported_hasErrorDescription() {

--- a/PalaceTests/MetaTests/AccountsManagerIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/AccountsManagerIsolationLintTests.swift
@@ -42,6 +42,7 @@
 import Foundation
 import XCTest
 
+@MainActor
 final class AccountsManagerIsolationLintTests: XCTestCase {
 
     // MARK: - Resolution
@@ -362,6 +363,7 @@ final class AccountsManagerIsolationLintTests: XCTestCase {
     /// wiring base must be flagged; the same content WITH the base must not.
     func testWiringBaseLint_syntheticViolator() {
         let withoutBase = """
+        @MainActor
         final class RogueAccountsTests: XCTestCase {
             func testThing() {
                 let m = AccountsManager()
@@ -379,6 +381,7 @@ final class AccountsManagerIsolationLintTests: XCTestCase {
         )
 
         let withBase = """
+        @MainActor
         final class ProperAccountsTests: PalaceWiringTestCase {
             func testThing() {
                 let m = AccountsManager()

--- a/PalaceTests/MetaTests/AppContainerIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/AppContainerIsolationLintTests.swift
@@ -52,6 +52,7 @@
 import Foundation
 import XCTest
 
+@MainActor
 final class AppContainerIsolationLintTests: XCTestCase {
 
   // MARK: - Resolution

--- a/PalaceTests/MetaTests/MockIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/MockIsolationLintTests.swift
@@ -43,6 +43,7 @@
 import Foundation
 import XCTest
 
+@MainActor
 final class MockIsolationLintTests: XCTestCase {
 
   // MARK: - Resolution
@@ -299,6 +300,7 @@ final class MockIsolationLintTests: XCTestCase {
     import Combine
     import XCTest
 
+    @MainActor
     final class SyntheticInheritsTests: PalaceWiringTestCase {
         var cancellables: Set<AnyCancellable> = []
         func testSomething() {

--- a/PalaceTests/MetaTests/PoolResponsivenessProbeTests.swift
+++ b/PalaceTests/MetaTests/PoolResponsivenessProbeTests.swift
@@ -26,6 +26,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class PoolResponsivenessProbeTests: PalaceTestCase {
 
     // MARK: - Wiring: probe → detector → attributed XCTFail (RED)

--- a/PalaceTests/MetaTests/RuntimeQuiescenceGateTests.swift
+++ b/PalaceTests/MetaTests/RuntimeQuiescenceGateTests.swift
@@ -22,6 +22,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class RuntimeQuiescenceGateTests: PalaceTestCase {
 
     // MARK: - Detector proves it FIRES on a synthetic polluter

--- a/PalaceTests/MetaTests/RuntimeQuiescenceLintTests.swift
+++ b/PalaceTests/MetaTests/RuntimeQuiescenceLintTests.swift
@@ -50,6 +50,7 @@
 import Foundation
 import XCTest
 
+@MainActor
 final class RuntimeQuiescenceLintTests: XCTestCase {
 
     // MARK: - Resolution
@@ -185,6 +186,7 @@ final class RuntimeQuiescenceLintTests: XCTestCase {
     /// lint.
     func testDetector_flagsDirectXCTestCaseSubclassThatSetsFalse() {
         let bad = """
+        @MainActor
         final class FooTests: XCTestCase {
             func testBar() {
                 AccountsManager.deferInitialLoadCatalogsForTesting = false
@@ -201,6 +203,7 @@ final class RuntimeQuiescenceLintTests: XCTestCase {
     /// violations hides its own false-positives).
     func testDetector_passesQuiescenceBaseSubclassThatSetsFalse() {
         let goodPalaceTestCase = """
+        @MainActor
         final class FooTests: PalaceTestCase {
             func testBar() {
                 AccountsManager.deferInitialLoadCatalogsForTesting = false
@@ -208,6 +211,7 @@ final class RuntimeQuiescenceLintTests: XCTestCase {
         }
         """
         let goodWiring = """
+        @MainActor
         final class FooTests: PalaceWiringTestCase {
             func testBar() {
                 AccountsManager.deferInitialLoadCatalogsForTesting = false
@@ -224,6 +228,7 @@ final class RuntimeQuiescenceLintTests: XCTestCase {
     /// flagged, even if it is a direct XCTestCase subclass.
     func testDetector_passesFileThatNeverSetsFalse() {
         let clean = """
+        @MainActor
         final class FooTests: XCTestCase {
             func testBar() {
                 XCTAssertTrue(true)

--- a/PalaceTests/MetaTests/TPPUserAccountIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/TPPUserAccountIsolationLintTests.swift
@@ -22,6 +22,7 @@
 import Foundation
 import XCTest
 
+@MainActor
 final class TPPUserAccountIsolationLintTests: XCTestCase {
 
     // MARK: - Resolution

--- a/PalaceTests/MetaTests/TearDownRequiredLintTests.swift
+++ b/PalaceTests/MetaTests/TearDownRequiredLintTests.swift
@@ -63,6 +63,7 @@
 import Foundation
 import XCTest
 
+@MainActor
 final class TearDownRequiredLintTests: XCTestCase {
 
   // MARK: - Resolution
@@ -298,6 +299,7 @@ final class TearDownRequiredLintTests: XCTestCase {
     let synthetic = """
     import XCTest
 
+    @MainActor
     final class SyntheticPolluterTests: XCTestCase {
         func testFoo() {
             let manager = AccountsManager()
@@ -326,6 +328,7 @@ final class TearDownRequiredLintTests: XCTestCase {
     let inherited = """
     import XCTest
 
+    @MainActor
     final class SyntheticInheritedTests: PalaceWiringTestCase {
         func testFoo() {
             let manager = AccountsManager()
@@ -355,6 +358,7 @@ final class TearDownRequiredLintTests: XCTestCase {
     let compliant = """
     import XCTest
 
+    @MainActor
     final class SyntheticCompliantTests: XCTestCase {
         var manager: AccountsManager?
 

--- a/PalaceTests/MetaTests/UserDefaultsIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/UserDefaultsIsolationLintTests.swift
@@ -107,6 +107,7 @@ final class UserDefaultsIsolationLintTests: XCTestCase {
     func testLintCatchesSyntheticViolatorIfStrictModeEnabled() {
         let cleanInput = """
         import XCTest
+        @MainActor
         final class CleanTests: XCTestCase {
             func test_doesNotMentionTheBannedString() {
                 let defaults = testUserDefaults()
@@ -121,6 +122,7 @@ final class UserDefaultsIsolationLintTests: XCTestCase {
 
         let dirtyInput = """
         import XCTest
+        @MainActor
         final class DirtyTests: XCTestCase {
             func test_usesStandard() {
                 UserDefaults.standard.set(true, forKey: "bad")

--- a/PalaceTests/Migrations/BackupExclusionMigrationTests.swift
+++ b/PalaceTests/Migrations/BackupExclusionMigrationTests.swift
@@ -13,6 +13,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BackupExclusionMigrationTests: XCTestCase {
 
     private var sandbox: URL!

--- a/PalaceTests/Migrations/LCPKeychainMigrationTests.swift
+++ b/PalaceTests/Migrations/LCPKeychainMigrationTests.swift
@@ -14,6 +14,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class LCPKeychainMigrationTests: XCTestCase {
 
     private let suiteName = "LCPKeychainMigrationTests.suite"

--- a/PalaceTests/Migrations/SEMigrationsTests.swift
+++ b/PalaceTests/Migrations/SEMigrationsTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class SEMigrationsTests: XCTestCase {
 
     private var settings: TPPSettings!

--- a/PalaceTests/Migrations/TPPMigrationManagerTests.swift
+++ b/PalaceTests/Migrations/TPPMigrationManagerTests.swift
@@ -11,6 +11,7 @@ import XCTest
 @testable import Palace
 
 /// SRS: SET-001 — Migration version comparison drives upgrade paths
+@MainActor
 final class TPPMigrationManagerTests: XCTestCase {
 
     // MARK: - Equal versions

--- a/PalaceTests/Mocks/NYPLLibraryAccountsProviderMock.swift
+++ b/PalaceTests/Mocks/NYPLLibraryAccountsProviderMock.swift
@@ -11,6 +11,15 @@ import PalaceCatalog
 @testable import Palace
 
 class TPPLibraryAccountMock: NSObject, TPPLibraryAccountsProvider, @unchecked Sendable {
+
+    /// `@unchecked Sendable`: `TPPLibraryAccountsProvider` is `Sendable`, and this
+    /// mock HONORS that contract — its one mutable stored property
+    /// (`userAccountResolver`) is guarded by a single `NSLock`, mirroring
+    /// `TPPBookRegistryMock`. All other properties are immutable `let`s or
+    /// computed accessors, so they need no locking. Concurrency tests may share
+    /// one instance across tasks/threads.
+    private let lock = NSLock()
+
     let feedURL: URL
     let nyplAuthDocURL: URL
     let feed: OPDS2CatalogsFeed
@@ -117,8 +126,12 @@ class TPPLibraryAccountMock: NSObject, TPPLibraryAccountsProvider, @unchecked Se
     /// `TPPUserAccountMock.sharedAccount(libraryUUID:)` reads. Tests that
     /// exercise per-library isolation (see `TPPCrossLibrarySignOutTests`)
     /// assign a resolver that returns a distinct mock instance per UUID.
-    var userAccountResolver: (String) -> TPPUserAccount = { libraryUUID in
+    private var _userAccountResolver: (String) -> TPPUserAccount = { libraryUUID in
         TPPUserAccountMock.sharedAccount(libraryUUID: libraryUUID)
+    }
+    var userAccountResolver: (String) -> TPPUserAccount {
+        get { lock.withLock { _userAccountResolver } }
+        set { lock.withLock { _userAccountResolver = newValue } }
     }
 
     func userAccount(for libraryUUID: String) -> TPPUserAccount {

--- a/PalaceTests/Mocks/NYPLLibraryAccountsProviderMock.swift
+++ b/PalaceTests/Mocks/NYPLLibraryAccountsProviderMock.swift
@@ -10,7 +10,7 @@ import Foundation
 import PalaceCatalog
 @testable import Palace
 
-class TPPLibraryAccountMock: NSObject, TPPLibraryAccountsProvider {
+class TPPLibraryAccountMock: NSObject, TPPLibraryAccountsProvider, @unchecked Sendable {
     let feedURL: URL
     let nyplAuthDocURL: URL
     let feed: OPDS2CatalogsFeed

--- a/PalaceTests/Mocks/NYPLNetworkExecutorMock.swift
+++ b/PalaceTests/Mocks/NYPLNetworkExecutorMock.swift
@@ -19,23 +19,46 @@ private struct SendableResultCompletion: @unchecked Sendable {
 /// main thread during setup and only read during main-queue delivery — it is
 /// never mutated from multiple threads. The waiver documents that confinement.
 class TPPRequestExecutorMock: TPPRequestExecuting, @unchecked Sendable {
-    var requestTimeout: TimeInterval = 60
+
+    private let lock = NSLock()
+
+    private var _requestTimeout: TimeInterval = 60
+    var requestTimeout: TimeInterval {
+        get { lock.withLock { _requestTimeout } }
+        set { lock.withLock { _requestTimeout = newValue } }
+    }
 
     // table of all mock response bodies for given URLs
-    var responseBodies = [URL: String]()
+    private var _responseBodies = [URL: String]()
+    var responseBodies: [URL: String] {
+        get { lock.withLock { _responseBodies } }
+        set { lock.withLock { _responseBodies = newValue } }
+    }
 
     /// When set, ALL requests will fail with this HTTP status code.
-    var forceFailureStatusCode: Int?
+    private var _forceFailureStatusCode: Int?
+    var forceFailureStatusCode: Int? {
+        get { lock.withLock { _forceFailureStatusCode } }
+        set { lock.withLock { _forceFailureStatusCode = newValue } }
+    }
 
     /// Every URL passed to `executeRequest`, in call order. Lets tests assert
     /// that a sign-in actually FIRED the credential request (e.g. the
     /// basic/token readiness-race regression where `logIn()` used to silently
     /// no-op before `/patrons/me` was ever requested).
-    private(set) var executedRequestURLs: [URL] = []
+    private var _executedRequestURLs: [URL] = []
+    private(set) var executedRequestURLs: [URL] {
+        get { lock.withLock { _executedRequestURLs } }
+        set { lock.withLock { _executedRequestURLs = newValue } }
+    }
 
     /// Incremented in `reset()` so that stale GCD blocks from a previous
     /// test skip their completion callback.
-    private var generation: Int = 0
+    private var _generation: Int = 0
+    private var generation: Int {
+        get { lock.withLock { _generation } }
+        set { lock.withLock { _generation = newValue } }
+    }
 
     init() {
         // add here the responses of all the api calls whose flow you want to verify

--- a/PalaceTests/Mocks/NYPLNetworkExecutorMock.swift
+++ b/PalaceTests/Mocks/NYPLNetworkExecutorMock.swift
@@ -9,7 +9,16 @@
 import Foundation
 @testable import Palace
 
-class TPPRequestExecutorMock: TPPRequestExecuting {
+/// Transfers the non-Sendable completion across the `DispatchQueue.main.async`
+/// hop. Safe: it is called exactly once, on the main queue.
+private struct SendableResultCompletion: @unchecked Sendable {
+    let completion: (NYPLResult<Data>) -> Void
+}
+
+/// `@unchecked Sendable`: a test double whose mutable state is configured on the
+/// main thread during setup and only read during main-queue delivery — it is
+/// never mutated from multiple threads. The waiver documents that confinement.
+class TPPRequestExecutorMock: TPPRequestExecuting, @unchecked Sendable {
     var requestTimeout: TimeInterval = 60
 
     // table of all mock response bodies for given URLs
@@ -49,8 +58,10 @@ class TPPRequestExecutorMock: TPPRequestExecuting {
         }
 
         let capturedGeneration = generation
+        let completionBox = SendableResultCompletion(completion: completion)
         DispatchQueue.main.async { [weak self] in
             guard let self, self.generation == capturedGeneration else { return }
+            let completion = completionBox.completion
 
             guard let url = req.url else {
                 completion(.failure(NSError(domain: "Unit tests: empty url",

--- a/PalaceTests/Mocks/TPPDRMAuthorizingMock.swift
+++ b/PalaceTests/Mocks/TPPDRMAuthorizingMock.swift
@@ -9,34 +9,75 @@
 import Foundation
 @testable import Palace
 
+/// `@unchecked Sendable`: `TPPDRMAuthorizing` completions are `@Sendable`, so this
+/// mock is captured across concurrency domains in concurrent DRM tests. It HONORS
+/// that contract: every mutable stored property is guarded by a single `NSLock`
+/// (mirroring `TPPBookRegistryMock`). `let` constants and computed accessors are
+/// inherently thread-safe and are left unguarded.
 class TPPDRMAuthorizingMock: NSObject, TPPDRMAuthorizing, @unchecked Sendable {
-    var workflowsInProgress = false
+
+    private let lock = NSLock()
+
+    private var _workflowsInProgress = false
+    var workflowsInProgress: Bool {
+        get { lock.withLock { _workflowsInProgress } }
+        set { lock.withLock { _workflowsInProgress = newValue } }
+    }
+
     let deviceID = "drmDeviceID"
     let userID = "drmUserID"
 
     // MARK: - Configurable Test Properties
 
     /// Controls what `isUserAuthorized` returns. Default is `true`.
-    var isUserAuthorizedReturnValue = true
+    private var _isUserAuthorizedReturnValue = true
+    var isUserAuthorizedReturnValue: Bool {
+        get { lock.withLock { _isUserAuthorizedReturnValue } }
+        set { lock.withLock { _isUserAuthorizedReturnValue = newValue } }
+    }
 
     /// Tracks whether `authorize` was called.
-    var authorizeWasCalled = false
+    private var _authorizeWasCalled = false
+    var authorizeWasCalled: Bool {
+        get { lock.withLock { _authorizeWasCalled } }
+        set { lock.withLock { _authorizeWasCalled = newValue } }
+    }
 
     /// Counts how many times `authorize` was called.
-    var authorizeCallCount = 0
+    private var _authorizeCallCount = 0
+    var authorizeCallCount: Int {
+        get { lock.withLock { _authorizeCallCount } }
+        set { lock.withLock { _authorizeCallCount = newValue } }
+    }
 
     /// Tracks whether `deauthorize` was called.
-    var deauthorizeWasCalled = false
+    private var _deauthorizeWasCalled = false
+    var deauthorizeWasCalled: Bool {
+        get { lock.withLock { _deauthorizeWasCalled } }
+        set { lock.withLock { _deauthorizeWasCalled = newValue } }
+    }
 
     /// Counts how many times `deauthorize` was called.
-    var deauthorizeCallCount = 0
+    private var _deauthorizeCallCount = 0
+    var deauthorizeCallCount: Int {
+        get { lock.withLock { _deauthorizeCallCount } }
+        set { lock.withLock { _deauthorizeCallCount = newValue } }
+    }
 
     /// When true, `deauthorize` captures the completion instead of calling it
     /// immediately. Call `completeDeferredDeauthorize()` to fire the callback.
-    var shouldDeferDeauthorize = false
+    private var _shouldDeferDeauthorize = false
+    var shouldDeferDeauthorize: Bool {
+        get { lock.withLock { _shouldDeferDeauthorize } }
+        set { lock.withLock { _shouldDeferDeauthorize = newValue } }
+    }
 
     /// Captured deauthorization completion for simulating slow DRM callbacks.
-    private(set) var deferredDeauthCompletion: ((Bool, Error?) -> Void)?
+    private var _deferredDeauthCompletion: ((Bool, Error?) -> Void)?
+    private(set) var deferredDeauthCompletion: ((Bool, Error?) -> Void)? {
+        get { lock.withLock { _deferredDeauthCompletion } }
+        set { lock.withLock { _deferredDeauthCompletion = newValue } }
+    }
 
     func isUserAuthorized(_ userID: String!, withDevice device: String!) -> Bool {
         return isUserAuthorizedReturnValue

--- a/PalaceTests/Mocks/TPPDRMAuthorizingMock.swift
+++ b/PalaceTests/Mocks/TPPDRMAuthorizingMock.swift
@@ -9,7 +9,7 @@
 import Foundation
 @testable import Palace
 
-class TPPDRMAuthorizingMock: NSObject, TPPDRMAuthorizing {
+class TPPDRMAuthorizingMock: NSObject, TPPDRMAuthorizing, @unchecked Sendable {
     var workflowsInProgress = false
     let deviceID = "drmDeviceID"
     let userID = "drmUserID"

--- a/PalaceTests/Mocks/TPPSignInOutBusinessLogicUIDelegateMock.swift
+++ b/PalaceTests/Mocks/TPPSignInOutBusinessLogicUIDelegateMock.swift
@@ -9,7 +9,7 @@
 import Foundation
 @testable import Palace
 
-class TPPSignInOutBusinessLogicUIDelegateMock: NSObject, TPPSignInOutBusinessLogicUIDelegate {
+class TPPSignInOutBusinessLogicUIDelegateMock: NSObject, TPPSignInOutBusinessLogicUIDelegate, @unchecked Sendable {
 
     // MARK: - Call Tracking for Tests
     var didCallWillSignOut = false

--- a/PalaceTests/Mocks/TPPSignInOutBusinessLogicUIDelegateMock.swift
+++ b/PalaceTests/Mocks/TPPSignInOutBusinessLogicUIDelegateMock.swift
@@ -9,36 +9,123 @@
 import Foundation
 @testable import Palace
 
+/// `@unchecked Sendable`: this mock is shared across concurrency domains in
+/// sign-in tests, so all mutable stored state is guarded by a single `NSLock`
+/// via locked computed accessors — mirroring `TPPBookRegistryMock`. Property
+/// names, types, and `@objc` annotations are preserved so no call site changes.
 class TPPSignInOutBusinessLogicUIDelegateMock: NSObject, TPPSignInOutBusinessLogicUIDelegate, @unchecked Sendable {
 
+    private let lock = NSLock()
+
     // MARK: - Call Tracking for Tests
-    var didCallWillSignOut = false
-    var didCallDidFinishDeauthorizing = false
-    var didFinishDeauthorizingHandler: (() -> Void)?
+    private var _didCallWillSignOut = false
+    var didCallWillSignOut: Bool {
+        get { lock.withLock { _didCallWillSignOut } }
+        set { lock.withLock { _didCallWillSignOut = newValue } }
+    }
+
+    private var _didCallDidFinishDeauthorizing = false
+    var didCallDidFinishDeauthorizing: Bool {
+        get { lock.withLock { _didCallDidFinishDeauthorizing } }
+        set { lock.withLock { _didCallDidFinishDeauthorizing = newValue } }
+    }
+
+    private var _didFinishDeauthorizingHandler: (() -> Void)?
+    var didFinishDeauthorizingHandler: (() -> Void)? {
+        get { lock.withLock { _didFinishDeauthorizingHandler } }
+        set { lock.withLock { _didFinishDeauthorizingHandler = newValue } }
+    }
 
     // MARK: - Sign-In Flow Tracking
-    var didCallWillSignIn = false
-    var didCallDidCompleteSignIn = false
-    var didCallDidCancelSignIn = false
-    var didCallDidReceiveCredentials = false
-    var willSignInCallCount = 0
-    var didCompleteSignInCallCount = 0
-    var didReceiveCredentialsCallCount = 0
-    var didCompleteSignInHandler: (() -> Void)?
+    private var _didCallWillSignIn = false
+    var didCallWillSignIn: Bool {
+        get { lock.withLock { _didCallWillSignIn } }
+        set { lock.withLock { _didCallWillSignIn = newValue } }
+    }
+
+    private var _didCallDidCompleteSignIn = false
+    var didCallDidCompleteSignIn: Bool {
+        get { lock.withLock { _didCallDidCompleteSignIn } }
+        set { lock.withLock { _didCallDidCompleteSignIn = newValue } }
+    }
+
+    private var _didCallDidCancelSignIn = false
+    var didCallDidCancelSignIn: Bool {
+        get { lock.withLock { _didCallDidCancelSignIn } }
+        set { lock.withLock { _didCallDidCancelSignIn = newValue } }
+    }
+
+    private var _didCallDidReceiveCredentials = false
+    var didCallDidReceiveCredentials: Bool {
+        get { lock.withLock { _didCallDidReceiveCredentials } }
+        set { lock.withLock { _didCallDidReceiveCredentials = newValue } }
+    }
+
+    private var _willSignInCallCount = 0
+    var willSignInCallCount: Int {
+        get { lock.withLock { _willSignInCallCount } }
+        set { lock.withLock { _willSignInCallCount = newValue } }
+    }
+
+    private var _didCompleteSignInCallCount = 0
+    var didCompleteSignInCallCount: Int {
+        get { lock.withLock { _didCompleteSignInCallCount } }
+        set { lock.withLock { _didCompleteSignInCallCount = newValue } }
+    }
+
+    private var _didReceiveCredentialsCallCount = 0
+    var didReceiveCredentialsCallCount: Int {
+        get { lock.withLock { _didReceiveCredentialsCallCount } }
+        set { lock.withLock { _didReceiveCredentialsCallCount = newValue } }
+    }
+
+    private var _didCompleteSignInHandler: (() -> Void)?
+    var didCompleteSignInHandler: (() -> Void)? {
+        get { lock.withLock { _didCompleteSignInHandler } }
+        set { lock.withLock { _didCompleteSignInHandler = newValue } }
+    }
 
     // Track isLoading state transitions
-    var isLoading = false
-    var loadingStateChanges: [Bool] = []
+    private var _isLoading = false
+    var isLoading: Bool {
+        get { lock.withLock { _isLoading } }
+        set { lock.withLock { _isLoading = newValue } }
+    }
+
+    private var _loadingStateChanges: [Bool] = []
+    var loadingStateChanges: [Bool] {
+        get { lock.withLock { _loadingStateChanges } }
+        set { lock.withLock { _loadingStateChanges = newValue } }
+    }
 
     func businessLogicWillSignOut(_ businessLogic: TPPSignInBusinessLogic) {
         didCallWillSignOut = true
     }
 
     // MARK: - Sign-Out Error Tracking
-    var didCallSignOutError = false
-    var signOutErrorCallCount = 0
-    var lastSignOutErrorHTTPStatusCode: Int?
-    var signOutErrorHandler: ((Error?, Int) -> Void)?
+    private var _didCallSignOutError = false
+    var didCallSignOutError: Bool {
+        get { lock.withLock { _didCallSignOutError } }
+        set { lock.withLock { _didCallSignOutError = newValue } }
+    }
+
+    private var _signOutErrorCallCount = 0
+    var signOutErrorCallCount: Int {
+        get { lock.withLock { _signOutErrorCallCount } }
+        set { lock.withLock { _signOutErrorCallCount = newValue } }
+    }
+
+    private var _lastSignOutErrorHTTPStatusCode: Int?
+    var lastSignOutErrorHTTPStatusCode: Int? {
+        get { lock.withLock { _lastSignOutErrorHTTPStatusCode } }
+        set { lock.withLock { _lastSignOutErrorHTTPStatusCode = newValue } }
+    }
+
+    private var _signOutErrorHandler: ((Error?, Int) -> Void)?
+    var signOutErrorHandler: ((Error?, Int) -> Void)? {
+        get { lock.withLock { _signOutErrorHandler } }
+        set { lock.withLock { _signOutErrorHandler = newValue } }
+    }
 
     func businessLogic(_ logic: TPPSignInBusinessLogic,
                        didEncounterSignOutError error: Error?,
@@ -60,7 +147,11 @@ class TPPSignInOutBusinessLogicUIDelegateMock: NSObject, TPPSignInOutBusinessLog
         loadingStateChanges.append(false)
     }
 
-    var context = "Unit Tests Context"
+    private var _context = "Unit Tests Context"
+    var context: String {
+        get { lock.withLock { _context } }
+        set { lock.withLock { _context = newValue } }
+    }
 
     func businessLogicWillSignIn(_ businessLogic: TPPSignInBusinessLogic) {
         didCallWillSignIn = true
@@ -100,13 +191,33 @@ class TPPSignInOutBusinessLogicUIDelegateMock: NSObject, TPPSignInOutBusinessLog
         completion?()
     }
 
-    var username: String? = "username"
+    private var _username: String? = "username"
+    var username: String? {
+        get { lock.withLock { _username } }
+        set { lock.withLock { _username = newValue } }
+    }
 
-    var pin: String? = "pin"
+    private var _pin: String? = "pin"
+    var pin: String? {
+        get { lock.withLock { _pin } }
+        set { lock.withLock { _pin = newValue } }
+    }
 
-    var usernameTextField: UITextField?
+    private var _usernameTextField: UITextField?
+    var usernameTextField: UITextField? {
+        get { lock.withLock { _usernameTextField } }
+        set { lock.withLock { _usernameTextField = newValue } }
+    }
 
-    var PINTextField: UITextField?
+    private var _PINTextField: UITextField?
+    var PINTextField: UITextField? {
+        get { lock.withLock { _PINTextField } }
+        set { lock.withLock { _PINTextField = newValue } }
+    }
 
-    var forceEditability: Bool = false
+    private var _forceEditability: Bool = false
+    var forceEditability: Bool {
+        get { lock.withLock { _forceEditability } }
+        set { lock.withLock { _forceEditability = newValue } }
+    }
 }

--- a/PalaceTests/Mocks/TPPUserAccountMock.swift
+++ b/PalaceTests/Mocks/TPPUserAccountMock.swift
@@ -41,7 +41,6 @@ class TPPUserAccountMock: TPPUserAccount, @unchecked Sendable {
     static let testLibraryUUID = "test-library-mock"
 
     private let mockLock = NSLock()
-    private static let sharedLock = NSLock()
 
     /// Counts `removeAll()` invocations so reset tests can assert this
     /// library's credentials were cleared.
@@ -51,10 +50,14 @@ class TPPUserAccountMock: TPPUserAccount, @unchecked Sendable {
         set { mockLock.withLock { _removeAllCallCount = newValue } }
     }
 
-    private static var _shared = TPPUserAccountMock(libraryUUID: testLibraryUUID)
+    // Swift 6: a mutable `static var` is rejected even when lock-guarded via a
+    // computed wrapper (the underlying storage is still global mutable state).
+    // Hold it in a LockIsolated box (immutable `static let` binding) instead.
+    private static let _shared = LockIsolated<TPPUserAccountMock>(
+        TPPUserAccountMock(libraryUUID: testLibraryUUID))
     private static var shared: TPPUserAccountMock {
-        get { sharedLock.withLock { _shared } }
-        set { sharedLock.withLock { _shared = newValue } }
+        get { _shared.value }
+        set { _shared.value = newValue }
     }
 
     /// Tests that call `TPPUserAccountMock.sharedAccount(libraryUUID:)` get

--- a/PalaceTests/MyBooks/AdobeDRMHandlerTests.swift
+++ b/PalaceTests/MyBooks/AdobeDRMHandlerTests.swift
@@ -18,6 +18,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AdobeDRMHandlerTests: XCTestCase {
 
     private var registry: TPPBookRegistryMock!

--- a/PalaceTests/MyBooks/BackgroundDownloadHandlerTests.swift
+++ b/PalaceTests/MyBooks/BackgroundDownloadHandlerTests.swift
@@ -36,6 +36,7 @@ final class InertNoOpURLProtocol: URLProtocol {
 
 // MARK: - Tests
 
+@MainActor
 final class BackgroundDownloadHandlerTests: XCTestCase {
 
     private var handler: BackgroundDownloadHandler!

--- a/PalaceTests/MyBooks/BackgroundSessionRoutingTests.swift
+++ b/PalaceTests/MyBooks/BackgroundSessionRoutingTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BackgroundSessionRoutingTests: XCTestCase {
 
     // MARK: - Routing predicate (INV-7)

--- a/PalaceTests/MyBooks/BookContentResetServiceTests.swift
+++ b/PalaceTests/MyBooks/BookContentResetServiceTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BookContentResetServiceTests: XCTestCase {
 
     private var tempDir: URL!

--- a/PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift
+++ b/PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BookFileManagerSideloadResolutionTests: PalaceWiringTestCase {
 
   private var tempDirectory: URL!

--- a/PalaceTests/MyBooks/BookFileManagerTests.swift
+++ b/PalaceTests/MyBooks/BookFileManagerTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BookFileManagerTests: XCTestCase {
 
     private var registry: TPPBookRegistryMock!

--- a/PalaceTests/MyBooks/BorrowErrorMessageTests.swift
+++ b/PalaceTests/MyBooks/BorrowErrorMessageTests.swift
@@ -24,6 +24,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class BorrowErrorMessageTests: XCTestCase {
 
     // MARK: - Constants

--- a/PalaceTests/MyBooks/BorrowOperationTests.swift
+++ b/PalaceTests/MyBooks/BorrowOperationTests.swift
@@ -26,11 +26,15 @@ final class BorrowOperationTests: XCTestCase {
     private var book: TPPBook!
 
     /// Recorders for the closure-injected seams.
-    private var fetchBookResult: Result<TPPBook, Error>!
-    private var fetchBookCalls: [(url: URL, resetCache: Bool, useToken: Bool)] = []
+    // Swift 6: `fetchBook`/`attemptOIDCReauth` are non-isolated `async` closures
+    // and cannot capture `self` (a @MainActor, non-Sendable XCTestCase) to reach
+    // these. Box them (Sendable, lock-guarded); the async closures capture the
+    // boxes, the @MainActor closures keep capturing `self`.
+    private let fetchBookResult = LockIsolated<Result<TPPBook, Error>?>(nil)
+    private let fetchBookCalls = LockIsolated<[(url: URL, resetCache: Bool, useToken: Bool)]>([])
     private var alertCalls: [(title: String, message: String, book: TPPBook, hasRetryAction: Bool)] = []
     private var signInModalCompletions: [() -> Void] = []
-    private var oidcReauthResult: Bool = false
+    private let oidcReauthResult = LockIsolated<Bool>(false)
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -43,11 +47,11 @@ final class BorrowOperationTests: XCTestCase {
         book = TPPBookMocker.mockBook(distributorType: .EpubZip)
         // Default: borrow returns the same book (with whatever availability
         // the test sets via book.acquisition replacement before calling).
-        fetchBookResult = .success(book)
-        fetchBookCalls = []
+        fetchBookResult.value = .success(book)
+        fetchBookCalls.value = []
         alertCalls = []
         signInModalCompletions = []
-        oidcReauthResult = false
+        oidcReauthResult.value = false
 
         operation = BorrowOperation(
             bookRegistry: bookRegistry,
@@ -57,9 +61,9 @@ final class BorrowOperationTests: XCTestCase {
             userRetryTracker: .shared,
             userAccountProvider: { [unowned self] in self.userAccount },
             adobeDRMService: AdobeDRMService.shared,
-            fetchBook: { [unowned self] url, resetCache, useToken in
-                self.fetchBookCalls.append((url, resetCache, useToken))
-                switch self.fetchBookResult! {
+            fetchBook: { url, resetCache, useToken in
+                fetchBookCalls.withValue { $0.append((url, resetCache, useToken)) }
+                switch fetchBookResult.value! {
                 case .success(let result): return result
                 case .failure(let error): throw error
                 }
@@ -70,7 +74,7 @@ final class BorrowOperationTests: XCTestCase {
             presentSignInModal: { [unowned self] completion in
                 self.signInModalCompletions.append(completion)
             },
-            attemptOIDCReauth: { [unowned self] in self.oidcReauthResult }
+            attemptOIDCReauth: { oidcReauthResult.value }
         )
         operation.delegate = spyDelegate
     }
@@ -97,7 +101,7 @@ final class BorrowOperationTests: XCTestCase {
         XCTAssertEqual(result.identifier, book.identifier)
         XCTAssertEqual(bookRegistry.state(for: book.identifier), .downloadNeeded,
                        "Successful borrow with .ready/.unlimited availability must register .downloadNeeded")
-        XCTAssertEqual(fetchBookCalls.count, 1,
+        XCTAssertEqual(fetchBookCalls.value.count, 1,
                        "Borrow must hit the fetchBook closure exactly once on the success path")
         XCTAssertEqual(spyDelegate.startDownloadCalls.count, 0,
                        "attemptDownload=false must NOT call delegate.startDownload")
@@ -125,7 +129,7 @@ final class BorrowOperationTests: XCTestCase {
         // availability, simulating CM's Loan→Hold race. Easiest path: build
         // a fresh book with the right availability.
         let raceBook = makeBookWithReservedAvailability()
-        fetchBookResult = .success(raceBook)
+        fetchBookResult.value = .success(raceBook)
 
         do {
             _ = try await operation.borrowAsync(book, attemptDownload: false)
@@ -157,7 +161,7 @@ final class BorrowOperationTests: XCTestCase {
             } else {
                 XCTFail("Expected .bookRegistry(.invalidState), got \(error)")
             }
-            XCTAssertEqual(fetchBookCalls.count, 0,
+            XCTAssertEqual(fetchBookCalls.value.count, 0,
                            "No-URL guard must short-circuit BEFORE the fetchBook closure runs")
         } catch {
             XCTFail("Expected PalaceError, got \(error)")
@@ -168,7 +172,7 @@ final class BorrowOperationTests: XCTestCase {
 
     func testBorrowAsync_genericError_presentsAlertAndRethrows() async {
         struct TestError: Error {}
-        fetchBookResult = .failure(TestError())
+        fetchBookResult.value = .failure(TestError())
 
         do {
             _ = try await operation.borrowAsync(book, attemptDownload: false)
@@ -204,7 +208,7 @@ final class BorrowOperationTests: XCTestCase {
 
         // Throw the PalaceError directly so we route through the first
         // catch block (the "no originalError NSError" path).
-        fetchBookResult = .failure(PalaceError.network(.unauthorized))
+        fetchBookResult.value = .failure(PalaceError.network(.unauthorized))
 
         do {
             _ = try await operation.borrowAsync(book, attemptDownload: false)
@@ -232,7 +236,7 @@ final class BorrowOperationTests: XCTestCase {
         userAccount._credentials = nil
         userAccount._authDefinition = SyntheticAuthDef.basicNeedsAuth
 
-        fetchBookResult = .failure(PalaceError.network(.forbidden))
+        fetchBookResult.value = .failure(PalaceError.network(.forbidden))
 
         do {
             _ = try await operation.borrowAsync(book, attemptDownload: false)
@@ -256,7 +260,7 @@ final class BorrowOperationTests: XCTestCase {
     /// Locks the boundary so the item #7 predicate broadening doesn't
     /// silently absorb every network error.
     func testBorrow_NetworkUnknownError_fallsThroughToAlert() async {
-        fetchBookResult = .failure(PalaceError.network(.unknown))
+        fetchBookResult.value = .failure(PalaceError.network(.unknown))
 
         do {
             _ = try await operation.borrowAsync(book, attemptDownload: false)
@@ -294,7 +298,7 @@ final class BorrowOperationTests: XCTestCase {
         // Use a problem-doc-typed invalidCredentials to drive isAuthError
         // through the problemDoc branch (the canonical SQ-007 trigger).
         let problemDoc = Self.makeProblemDoc(type: TPPProblemDocument.TypeInvalidCredentials)
-        fetchBookResult = .failure(NSError(
+        fetchBookResult.value = .failure(NSError(
             domain: "test", code: 401,
             userInfo: ["problemDocument": problemDoc as Any]
         ))
@@ -329,7 +333,7 @@ final class BorrowOperationTests: XCTestCase {
         userAccount._authDefinition = SyntheticAuthDef.basicNeedsAuth
 
         let problemDoc = Self.makeProblemDoc(type: TPPProblemDocument.TypeInvalidCredentials)
-        fetchBookResult = .failure(NSError(
+        fetchBookResult.value = .failure(NSError(
             domain: "test", code: 401,
             userInfo: ["problemDocument": problemDoc as Any]
         ))
@@ -361,7 +365,7 @@ final class BorrowOperationTests: XCTestCase {
         userAccount._authDefinition = SyntheticAuthDef.basicNeedsAuth
 
         let problemDoc = Self.makeProblemDoc(type: TPPProblemDocument.TypeInvalidCredentials)
-        fetchBookResult = .failure(NSError(
+        fetchBookResult.value = .failure(NSError(
             domain: "test", code: 401,
             userInfo: ["problemDocument": problemDoc as Any]
         ))
@@ -393,7 +397,7 @@ final class BorrowOperationTests: XCTestCase {
         userAccount.setAuthState(.loggedIn)
 
         let problemDoc = Self.makeProblemDoc(type: TPPProblemDocument.TypeInvalidCredentials)
-        fetchBookResult = .failure(NSError(
+        fetchBookResult.value = .failure(NSError(
             domain: "test", code: 401,
             userInfo: ["problemDocument": problemDoc as Any]
         ))
@@ -449,7 +453,7 @@ final class BorrowOperationTests: XCTestCase {
         // .unregistered registry state so SQ-007 (already-has-loan) does NOT
         // fire and suppress the path — we want the live browser-reauth branch.
         let problemDoc = Self.makeProblemDoc(type: TPPProblemDocument.TypeInvalidCredentials)
-        fetchBookResult = .failure(NSError(
+        fetchBookResult.value = .failure(NSError(
             domain: "test", code: 401,
             userInfo: ["problemDocument": problemDoc as Any]
         ))

--- a/PalaceTests/MyBooks/BorrowOperationTests.swift
+++ b/PalaceTests/MyBooks/BorrowOperationTests.swift
@@ -53,6 +53,11 @@ final class BorrowOperationTests: XCTestCase {
         signInModalCompletions = []
         oidcReauthResult.value = false
 
+        // Capture the Sendable boxes as locals so the non-isolated async
+        // closures reference the boxes, not `self` (now @MainActor).
+        let fetchBookCallsBox = fetchBookCalls
+        let fetchBookResultBox = fetchBookResult
+        let oidcReauthResultBox = oidcReauthResult
         operation = BorrowOperation(
             bookRegistry: bookRegistry,
             downloadAnnouncementService: DownloadAnnouncementService(),
@@ -62,8 +67,8 @@ final class BorrowOperationTests: XCTestCase {
             userAccountProvider: { [unowned self] in self.userAccount },
             adobeDRMService: AdobeDRMService.shared,
             fetchBook: { url, resetCache, useToken in
-                fetchBookCalls.withValue { $0.append((url, resetCache, useToken)) }
-                switch fetchBookResult.value! {
+                fetchBookCallsBox.withValue { $0.append((url, resetCache, useToken)) }
+                switch fetchBookResultBox.value! {
                 case .success(let result): return result
                 case .failure(let error): throw error
                 }
@@ -74,7 +79,7 @@ final class BorrowOperationTests: XCTestCase {
             presentSignInModal: { [unowned self] completion in
                 self.signInModalCompletions.append(completion)
             },
-            attemptOIDCReauth: { oidcReauthResult.value }
+            attemptOIDCReauth: { oidcReauthResultBox.value }
         )
         operation.delegate = spyDelegate
     }

--- a/PalaceTests/MyBooks/DiskBudgetManagerTests.swift
+++ b/PalaceTests/MyBooks/DiskBudgetManagerTests.swift
@@ -17,6 +17,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DiskBudgetManagerTests: XCTestCase {
 
     private var tempDir: URL!

--- a/PalaceTests/MyBooks/DownloadAnnouncementServiceTests.swift
+++ b/PalaceTests/MyBooks/DownloadAnnouncementServiceTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DownloadAnnouncementServiceTests: XCTestCase {
 
     private var announcer: SpyAnnouncer!

--- a/PalaceTests/MyBooks/DownloadCompleteMomentTests.swift
+++ b/PalaceTests/MyBooks/DownloadCompleteMomentTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DownloadCompleteMomentTests: XCTestCase {
 
     /// Fires on the transition INTO downloadSuccessful (the celebration moment).

--- a/PalaceTests/MyBooks/DownloadCompletionParserTests.swift
+++ b/PalaceTests/MyBooks/DownloadCompletionParserTests.swift
@@ -14,6 +14,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class DownloadCompletionParserTests: XCTestCase {
 
     private var stateManager: DownloadStateManager!

--- a/PalaceTests/MyBooks/DownloadErrorInfoTests.swift
+++ b/PalaceTests/MyBooks/DownloadErrorInfoTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import Palace
 
 /// Tests for DownloadErrorInfo struct — PP-3707
+@MainActor
 final class DownloadErrorInfoTests: XCTestCase {
 
     // MARK: - Convenience Initializer (non-retryable)

--- a/PalaceTests/MyBooks/DownloadErrorRecoveryTests.swift
+++ b/PalaceTests/MyBooks/DownloadErrorRecoveryTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DownloadErrorRecoveryPolicyTests: XCTestCase {
 
     // MARK: - Retry Policy Presets

--- a/PalaceTests/MyBooks/DownloadProgressPublisherTests.swift
+++ b/PalaceTests/MyBooks/DownloadProgressPublisherTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import Combine
 @testable import Palace
 
+@MainActor
 final class DownloadProgressPublisherCoreTests: XCTestCase {
 
     private var reporter: DownloadProgressReporter!

--- a/PalaceTests/MyBooks/DownloadRMSDKHandoffTests.swift
+++ b/PalaceTests/MyBooks/DownloadRMSDKHandoffTests.swift
@@ -28,6 +28,7 @@ import XCTest
 
 #if FEATURE_DRM_CONNECTOR
 
+@MainActor
 final class DownloadRMSDKHandoffTests: XCTestCase {
 
     private var registry: TPPBookRegistryMock!
@@ -384,6 +385,7 @@ private final class RMSDKHandoffSpy: AdobeDRMHandlerDelegate {
 // target in this repo IS compiled with the flag, so production runs the
 // real suite. This branch exists so the file still compiles under a
 // noDRM build flavour.
+@MainActor
 final class DownloadRMSDKHandoffTests: XCTestCase {
 
     func testRMSDKHandoff_featureDRMConnectorDisabled_skipsSuite() {

--- a/PalaceTests/MyBooks/DownloadReconciliationLaunchOrderContractTests.swift
+++ b/PalaceTests/MyBooks/DownloadReconciliationLaunchOrderContractTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DownloadReconciliationLaunchOrderContractTests: XCTestCase {
 
     private func record(_ bookID: String, task: Int) -> PersistedDownloadRecord {

--- a/PalaceTests/MyBooks/DownloadReconciliationTests.swift
+++ b/PalaceTests/MyBooks/DownloadReconciliationTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DownloadReconciliationTests: XCTestCase {
 
     private func record(_ bookID: String, task: Int) -> PersistedDownloadRecord {

--- a/PalaceTests/MyBooks/DownloadStateManagerTests.swift
+++ b/PalaceTests/MyBooks/DownloadStateManagerTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DownloadStateManagerTests: XCTestCase {
 
     private var stateManager: DownloadStateManager!

--- a/PalaceTests/MyBooks/DownloadTaskPersistenceTests.swift
+++ b/PalaceTests/MyBooks/DownloadTaskPersistenceTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DownloadTaskPersistenceTests: XCTestCase {
 
     private var tempURL: URL!

--- a/PalaceTests/MyBooks/DownloadTransferRetryTests.swift
+++ b/PalaceTests/MyBooks/DownloadTransferRetryTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DownloadTransferRetryTests: XCTestCase {
 
     private var mockRegistry: TPPBookRegistryMock!

--- a/PalaceTests/MyBooks/LoanEvictionPolicyTests.swift
+++ b/PalaceTests/MyBooks/LoanEvictionPolicyTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class LoanEvictionPolicyTests: XCTestCase {
 
     private let now = Date(timeIntervalSince1970: 1_000_000)

--- a/PalaceTests/MyBooks/LoanRenewalServiceTests.swift
+++ b/PalaceTests/MyBooks/LoanRenewalServiceTests.swift
@@ -15,6 +15,7 @@ import PalaceAuth
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class LoanRenewalServiceTests: XCTestCase {
 
     // MARK: - Spies / stubs

--- a/PalaceTests/MyBooks/LocalBookContentServiceTests.swift
+++ b/PalaceTests/MyBooks/LocalBookContentServiceTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class LocalBookContentServiceTests: XCTestCase {
 
     private var tempDir: URL!

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterAccountIdThreadingTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterAccountIdThreadingTests.swift
@@ -71,26 +71,48 @@ final class MyBooksDownloadCenterAccountIdThreadingTests: XCTestCase {
     /// `currentAccountId` and a per-UUID `TPPUserAccountMock` map, so we
     /// can install per-account auth tokens and observe which one ends up
     /// on the resulting URLRequest.
-    private final class ControllableAccountsManagerMock: NSObject, TPPLibraryAccountsProvider {
-        var mockedCurrentAccountId: String?
-        var userAccountsByUUID: [String: TPPUserAccount] = [:]
-        var userAccountForCalls: [String] = []
+    /// Swift 6: this mock is captured into `@Sendable` closures by the
+    /// concurrent account-switch test (the switcher Task writes
+    /// `mockedCurrentAccountId` while download tasks read `currentAccountId`),
+    /// so it must be genuinely thread-safe, not merely annotated. All mutable
+    /// state is NSLock-guarded; hence `@unchecked Sendable`. This also removes a
+    /// real (previously-tolerated-under-Swift-4.2) data race in the test.
+    private final class ControllableAccountsManagerMock: NSObject, TPPLibraryAccountsProvider, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _mockedCurrentAccountId: String?
+        private var _userAccountsByUUID: [String: TPPUserAccount] = [:]
+        private var _userAccountForCalls: [String] = []
+
+        var mockedCurrentAccountId: String? {
+            get { lock.withLock { _mockedCurrentAccountId } }
+            set { lock.withLock { _mockedCurrentAccountId = newValue } }
+        }
+        var userAccountsByUUID: [String: TPPUserAccount] {
+            get { lock.withLock { _userAccountsByUUID } }
+            set { lock.withLock { _userAccountsByUUID = newValue } }
+        }
+        var userAccountForCalls: [String] {
+            get { lock.withLock { _userAccountForCalls } }
+            set { lock.withLock { _userAccountForCalls = newValue } }
+        }
 
         // The protocol surface — only the bits this test class touches
         // are filled in meaningfully. Unused fields return safe defaults.
-        var currentAccountId: String? { mockedCurrentAccountId }
+        var currentAccountId: String? { lock.withLock { _mockedCurrentAccountId } }
         var currentAccount: Account? { nil }
         var tppAccountUUID: String { AccountsManager.TPPAccountUUIDs[0] }
         func account(_ uuid: String) -> Account? { nil }
         func userAccount(for libraryUUID: String) -> TPPUserAccount {
-            userAccountForCalls.append(libraryUUID)
-            if let existing = userAccountsByUUID[libraryUUID] {
-                return existing
+            lock.withLock {
+                _userAccountForCalls.append(libraryUUID)
+                if let existing = _userAccountsByUUID[libraryUUID] {
+                    return existing
+                }
+                // Fresh placeholder for any UUID we haven't pre-installed.
+                let placeholder = TPPUserAccountMock(libraryUUID: libraryUUID)
+                _userAccountsByUUID[libraryUUID] = placeholder
+                return placeholder
             }
-            // Fresh placeholder for any UUID we haven't pre-installed.
-            let placeholder = TPPUserAccountMock(libraryUUID: libraryUUID)
-            userAccountsByUUID[libraryUUID] = placeholder
-            return placeholder
         }
         var currentUserAccount: TPPUserAccount {
             if let id = mockedCurrentAccountId {

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterAccountIdThreadingTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterAccountIdThreadingTests.swift
@@ -36,6 +36,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class MyBooksDownloadCenterAccountIdThreadingTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterEvictionTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterEvictionTests.swift
@@ -20,6 +20,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class MyBooksDownloadCenterEvictionTests: XCTestCase {
 
     private var tempDir: URL!

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterExtendedTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterExtendedTests.swift
@@ -13,6 +13,7 @@ import XCTest
 
 /// Tests for download state machine logic using mock book registry
 /// These tests verify state transitions without creating real download sessions
+@MainActor
 final class DownloadStateMachineTests: XCTestCase {
 
     private var mockBookRegistry: TPPBookRegistryMock!
@@ -118,6 +119,7 @@ final class DownloadStateMachineTests: XCTestCase {
 
 // MARK: - Disk Space Tests
 
+@MainActor
 final class DownloadDiskSpaceTests: XCTestCase {
 
     func testAvailableDiskSpace_isPositive() {
@@ -145,6 +147,7 @@ final class DownloadDiskSpaceTests: XCTestCase {
 
 /// Tests for concurrent download state management using mock registry
 /// These tests verify multiple book state tracking without network calls
+@MainActor
 final class ConcurrentDownloadStateTests: XCTestCase {
 
     private var mockBookRegistry: TPPBookRegistryMock!
@@ -210,6 +213,7 @@ final class ConcurrentDownloadStateTests: XCTestCase {
 /// Tests for download slot release when borrow results in hold or failure
 /// Bug fix: XXXX - Download queue stuck when borrow results in hold
 /// NOTE: These tests verify state transitions without network calls
+@MainActor
 final class DownloadSlotManagementTests: XCTestCase {
 
     private var mockBookRegistry: TPPBookRegistryMock!

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterIntegrationTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterIntegrationTests.swift
@@ -21,10 +21,18 @@ import PalaceCatalog
 class MockURLProtocol: URLProtocol {
 
     /// Handler closure that provides mock responses for requests
-    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+    private static let _requestHandler = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data?))?>(nil)
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))? {
+        get { _requestHandler.value }
+        set { _requestHandler.value = newValue }
+    }
 
     /// Track all requests made during tests
-    static var capturedRequests: [URLRequest] = []
+    private static let _capturedRequests = LockIsolated<[URLRequest]>([])
+    static var capturedRequests: [URLRequest] {
+        get { _capturedRequests.value }
+        set { _capturedRequests.value = newValue }
+    }
 
     override class func canInit(with request: URLRequest) -> Bool {
         // Intercept all requests in tests

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterIntegrationTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterIntegrationTests.swift
@@ -91,6 +91,7 @@ enum MockNetworkError: Error {
 
 /// Integration tests for DownloadCoordinator actor.
 /// Tests real concurrency behavior and state management.
+@MainActor
 final class DownloadCoordinatorIntegrationTests: XCTestCase {
 
     // MARK: - Concurrency Tests
@@ -300,6 +301,7 @@ final class DownloadCoordinatorIntegrationTests: XCTestCase {
 // MARK: - Download State Machine Integration Tests
 
 /// Tests for download state transitions using real MyBooksDownloadCenter behavior patterns.
+@MainActor
 final class DownloadStateMachineIntegrationTests: XCTestCase {
 
     private var mockBookRegistry: TPPBookRegistryMock!
@@ -635,6 +637,7 @@ final class DownloadStateMachineIntegrationTests: XCTestCase {
 // MARK: - Download Queue Integration Tests
 
 /// Tests for download queue management logic.
+@MainActor
 final class DownloadQueueIntegrationTests: XCTestCase {
 
     func testMaxConcurrentDownloads_limitsActiveDownloads() async {
@@ -715,6 +718,7 @@ final class DownloadQueueIntegrationTests: XCTestCase {
 // MARK: - Rights Management Detection Tests
 
 /// Tests for MIME type to rights management detection.
+@MainActor
 final class RightsManagementDetectionTests: XCTestCase {
 
     func testMimeType_adobeAdept_detectsAdobeRights() {
@@ -789,6 +793,7 @@ final class RightsManagementDetectionTests: XCTestCase {
 // MARK: - Download Progress Publisher Tests
 
 /// Tests for download progress Combine publisher.
+@MainActor
 final class DownloadProgressPublisherTests: XCTestCase {
 
     private var cancellables: Set<AnyCancellable> = []
@@ -859,6 +864,7 @@ final class DownloadProgressPublisherTests: XCTestCase {
 // MARK: - File URL Generation Tests
 
 /// Tests for book content file URL generation.
+@MainActor
 final class FileURLGenerationTests: XCTestCase {
 
     func testFileUrl_epubBook_hasEpubExtension() {
@@ -913,6 +919,7 @@ final class FileURLGenerationTests: XCTestCase {
 // MARK: - Redirect Handling Integration Tests
 
 /// Integration tests for download redirect handling.
+@MainActor
 final class RedirectHandlingIntegrationTests: XCTestCase {
 
     func testRedirect_httpsToHttp_blockedForSecurity() {
@@ -984,6 +991,7 @@ final class RedirectHandlingIntegrationTests: XCTestCase {
 // MARK: - Error Recovery Tests
 
 /// Tests for download error handling and retry logic.
+@MainActor
 final class DownloadErrorRecoveryTests: XCTestCase {
 
     private var mockBookRegistry: TPPBookRegistryMock!
@@ -1043,6 +1051,7 @@ final class DownloadErrorRecoveryTests: XCTestCase {
 // MARK: - Concurrent Book State Management Tests
 
 /// Tests for managing multiple book downloads concurrently.
+@MainActor
 final class ConcurrentBookStateTests: XCTestCase {
 
     private var mockBookRegistry: TPPBookRegistryMock!
@@ -1129,6 +1138,7 @@ final class ConcurrentBookStateTests: XCTestCase {
 // MARK: - Disk Budget Tests
 
 /// Tests for content disk budget management.
+@MainActor
 final class DiskBudgetTests: XCTestCase {
 
     func testDiskSpace_available_returnsPositiveValue() {

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterTests.swift
@@ -48,6 +48,7 @@ class MockURLSessionDownloadTask: URLSessionDownloadTask, @unchecked Sendable {
 // MARK: - Download Info Tests
 
 /// Tests for MyBooksDownloadInfo functionality - a real production struct
+@MainActor
 final class DownloadInfoTests: XCTestCase {
 
     func testDownloadInfo_creation_setsInitialValues() {
@@ -159,6 +160,7 @@ final class DownloadInfoTests: XCTestCase {
 // MARK: - Download Coordinator Tests
 
 /// Tests for the DownloadCoordinator actor - a real production actor
+@MainActor
 final class DownloadCoordinatorTests: XCTestCase {
 
     func testCoordinator_canStartDownload_withinLimit() async {
@@ -330,6 +332,7 @@ final class DownloadCoordinatorTests: XCTestCase {
 
 /// Tests for redirect handling in downloads.
 /// Verifies that auth headers are not forwarded on redirects (for No DRM open access content).
+@MainActor
 final class DownloadRedirectTests: XCTestCase {
 
     // MARK: - URLRequest Auth Header Tests

--- a/PalaceTests/MyBooks/MyBooksDownloadSessionInvalidationTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadSessionInvalidationTests.swift
@@ -14,6 +14,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class MyBooksDownloadSessionInvalidationTests: XCTestCase {
 
     /// Contract 1: `URLSession.downloadTask(with:)` on an invalidated session

--- a/PalaceTests/MyBooks/MyBooksSimplifiedBearerTokenTests.swift
+++ b/PalaceTests/MyBooks/MyBooksSimplifiedBearerTokenTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class MyBooksSimplifiedBearerTokenTests: XCTestCase {
 
     override func setUp() {

--- a/PalaceTests/MyBooks/MyBooksViewModelTests.swift
+++ b/PalaceTests/MyBooks/MyBooksViewModelTests.swift
@@ -32,6 +32,7 @@ private func makeViewModel() -> MyBooksViewModel {
 
 // MARK: - Facet Enum Tests (Real Production Enum)
 
+@MainActor
 final class FacetEnumTests: XCTestCase {
 
     func testFacet_LocalizedStrings_AreNotEmpty() {
@@ -57,6 +58,7 @@ final class FacetEnumTests: XCTestCase {
 
 // MARK: - AlertModel Tests (Real Production Struct)
 
+@MainActor
 final class AlertModelTests: XCTestCase {
 
     func testAlertModel_StoresProvidedValues() {

--- a/PalaceTests/MyBooks/OverdriveDeferredFulfillmentTests.swift
+++ b/PalaceTests/MyBooks/OverdriveDeferredFulfillmentTests.swift
@@ -23,6 +23,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class OverdriveDeferredFulfillmentTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/MyBooks/RedirectPolicyTests.swift
+++ b/PalaceTests/MyBooks/RedirectPolicyTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class RedirectPolicyTests: XCTestCase {
 
     // MARK: - Helpers

--- a/PalaceTests/MyBooks/RetryClassificationTests.swift
+++ b/PalaceTests/MyBooks/RetryClassificationTests.swift
@@ -11,6 +11,7 @@ import XCTest
 /// Tests for DownloadErrorRecovery.isRetryableForUser() — PP-3707
 /// Verifies that errors are correctly classified as retryable or non-retryable
 /// for user-facing "Retry" button presentation.
+@MainActor
 final class RetryClassificationTests: XCTestCase {
 
     // MARK: - Network Errors (Retryable)

--- a/PalaceTests/MyBooks/RightsManagementDispatcherTests.swift
+++ b/PalaceTests/MyBooks/RightsManagementDispatcherTests.swift
@@ -15,6 +15,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class RightsManagementDispatcherTests: XCTestCase {
 
     private var stateManager: DownloadStateManager!

--- a/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
+++ b/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
@@ -13,6 +13,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class SideloadedBookManagerTests: PalaceWiringTestCase {
 
   private var tempRoot: URL!

--- a/PalaceTests/MyBooks/Sideload/SideloadedBookRegistryTests.swift
+++ b/PalaceTests/MyBooks/Sideload/SideloadedBookRegistryTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class SideloadedBookRegistryTests: XCTestCase {
 
   private var tempDirectory: URL!

--- a/PalaceTests/MyBooks/TPPBookBearerTokenTests.swift
+++ b/PalaceTests/MyBooks/TPPBookBearerTokenTests.swift
@@ -14,6 +14,7 @@ import Security
 import PalaceKeychain
 @testable import Palace
 
+@MainActor
 final class TPPBookBearerTokenTests: XCTestCase {
 
     private var book: TPPBook!

--- a/PalaceTests/MyBooks/UserRetryTrackerTests.swift
+++ b/PalaceTests/MyBooks/UserRetryTrackerTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class UserRetryTrackerTests: XCTestCase {
 
     var tracker: UserRetryTracker!

--- a/PalaceTests/NYPLOPDSEntryTests.swift
+++ b/PalaceTests/NYPLOPDSEntryTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPOPDSEntryTests: XCTestCase {
 
   var entry: TPPOPDSEntry!

--- a/PalaceTests/NYPLOPDSFeedTests.swift
+++ b/PalaceTests/NYPLOPDSFeedTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPOPDSFeedTests: XCTestCase {
 
   var feed: TPPOPDSFeed!

--- a/PalaceTests/NYPLOPDSLinkTests.swift
+++ b/PalaceTests/NYPLOPDSLinkTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPOPDSLinkTests: XCTestCase {
 
   var links: [TPPOPDSLink]!

--- a/PalaceTests/NYPLXMLTests.swift
+++ b/PalaceTests/NYPLXMLTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPXMLTests: XCTestCase {
 
   func testValid() {

--- a/PalaceTests/Network/APIContractTests.swift
+++ b/PalaceTests/Network/APIContractTests.swift
@@ -36,6 +36,7 @@ enum TestFixture {
 
 // MARK: - OPDS 2 Feed Contract Tests
 
+@MainActor
 final class OPDS2FeedContractTests: XCTestCase {
 
     private func decodeFeed(from name: String) throws -> OPDS2Feed {
@@ -110,6 +111,7 @@ final class OPDS2FeedContractTests: XCTestCase {
 
 // MARK: - Problem Document Contract Tests
 
+@MainActor
 final class ProblemDocumentContractTests: XCTestCase {
 
     private var allProblems: [String: [String: Any]] = [:]
@@ -164,6 +166,7 @@ final class ProblemDocumentContractTests: XCTestCase {
 
 // MARK: - Authentication Document Contract Tests
 
+@MainActor
 final class AuthDocumentContractTests: XCTestCase {
 
     func testParseAuthDocument_ExtractsAllFields() throws {
@@ -201,6 +204,7 @@ final class AuthDocumentContractTests: XCTestCase {
 
 // MARK: - Annotation Contract Tests
 
+@MainActor
 final class AnnotationContractTests: XCTestCase {
 
     func testParseAnnotationContainer() throws {
@@ -246,6 +250,7 @@ final class AnnotationContractTests: XCTestCase {
 
 // MARK: - OPDS 1 Loans Feed Contract Tests
 
+@MainActor
 final class OPDS1LoansFeedContractTests: XCTestCase {
 
     private func parseFeed(from name: String) -> TPPOPDSFeed? {
@@ -340,6 +345,7 @@ final class OPDS1LoansFeedContractTests: XCTestCase {
 
 // MARK: - OPDS 1 Borrow Entry Contract Tests
 
+@MainActor
 final class OPDS1BorrowEntryContractTests: XCTestCase {
 
     func testParseBorrowEntry_AsSingleEntryFeed() {
@@ -413,6 +419,7 @@ final class OPDS1BorrowEntryContractTests: XCTestCase {
 
 // MARK: - Patron Profile Contract Tests
 
+@MainActor
 final class PatronProfileContractTests: XCTestCase {
 
     func testParsePatronProfile_ExtractsDRMInfo() throws {
@@ -477,6 +484,7 @@ final class PatronProfileContractTests: XCTestCase {
 
 // MARK: - OPDS 1 Hold Entries Contract Tests
 
+@MainActor
 final class OPDS1HoldEntriesContractTests: XCTestCase {
 
     private func parseHoldsFeed() -> TPPOPDSFeed? {
@@ -546,6 +554,7 @@ final class OPDS1HoldEntriesContractTests: XCTestCase {
 
 // MARK: - OPDS 1 Catalog Grouped Feed Contract Tests
 
+@MainActor
 final class OPDS1CatalogGroupedContractTests: XCTestCase {
 
     func testGroupedFeed_ParsesAsGroupedType() {
@@ -587,6 +596,7 @@ final class OPDS1CatalogGroupedContractTests: XCTestCase {
 
 // MARK: - Auth Document Variants Contract Tests
 
+@MainActor
 final class AuthDocumentVariantsContractTests: XCTestCase {
 
     func testSAMLAuthDocument_ParsesWithSAMLType() throws {
@@ -660,6 +670,7 @@ final class AuthDocumentVariantsContractTests: XCTestCase {
 
 // MARK: - OPDS 2 Search Results Contract Tests
 
+@MainActor
 final class OPDS2SearchResultsContractTests: XCTestCase {
 
     func testSearchResults_ParsesWithPagination() throws {
@@ -695,6 +706,7 @@ final class OPDS2SearchResultsContractTests: XCTestCase {
 
 // MARK: - OPDS 2 Empty Feed Contract Tests
 
+@MainActor
 final class OPDS2EmptyFeedContractTests: XCTestCase {
 
     func testEmptyFeed_ParsesWithZeroItems() throws {
@@ -709,6 +721,7 @@ final class OPDS2EmptyFeedContractTests: XCTestCase {
 
 // MARK: - OPDS 1 Revoke Response Contract Tests
 
+@MainActor
 final class OPDS1RevokeResponseContractTests: XCTestCase {
 
     func testRevokeResponse_ParsesAsSingleEntry() {
@@ -741,6 +754,7 @@ final class OPDS1RevokeResponseContractTests: XCTestCase {
 
 // MARK: - Annotation Post Response Contract Tests
 
+@MainActor
 final class AnnotationPostResponseContractTests: XCTestCase {
 
     func testAnnotationPostResponse_HasRequiredFields() throws {
@@ -765,6 +779,7 @@ final class AnnotationPostResponseContractTests: XCTestCase {
 
 // MARK: - OPDS 2 Borrow Response Contract Tests
 
+@MainActor
 final class OPDS2BorrowResponseContractTests: XCTestCase {
 
     func testBorrowResponse_ParsesPublicationMetadata() throws {

--- a/PalaceTests/Network/AccountAwareNetworkTests.swift
+++ b/PalaceTests/Network/AccountAwareNetworkTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import PalaceAuth
 @testable import Palace
 
+@MainActor
 final class AccountAwareNetworkTests: XCTestCase {
 
     override func setUp() {

--- a/PalaceTests/Network/CookiePersistenceTests.swift
+++ b/PalaceTests/Network/CookiePersistenceTests.swift
@@ -67,6 +67,7 @@ private final class TPPUserAccountCookieMock: TPPUserAccountMock, @unchecked Sen
     }
 }
 
+@MainActor
 final class CookiePersistenceTests: XCTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/Network/CredentialGuardTests.swift
+++ b/PalaceTests/Network/CredentialGuardTests.swift
@@ -21,6 +21,7 @@ import PalaceNetwork
 
 // MARK: - TokenRequest Empty Credential Guards
 
+@MainActor
 final class TokenRequestCredentialGuardTests: XCTestCase {
 
     private let tokenURL = URL(string: "https://example.com/patrons/me/token/")!
@@ -355,6 +356,7 @@ final class TokenRequestCredentialGuardTests: XCTestCase {
 
 // MARK: - Network Executor Token Refresh Guards
 
+@MainActor
 final class NetworkExecutorCredentialGuardTests: XCTestCase {
 
     private func makeExecutor() -> TPPNetworkExecutor {
@@ -598,6 +600,7 @@ final class NetworkExecutorCredentialGuardTests: XCTestCase {
 
 // MARK: - Concurrent Token Refresh Coordination
 
+@MainActor
 final class ConcurrentTokenRefreshTests: XCTestCase {
 
     private func makeExecutor() -> TPPNetworkExecutor {
@@ -676,6 +679,7 @@ final class ConcurrentTokenRefreshTests: XCTestCase {
 
 // MARK: - URLSession Configuration Tests
 
+@MainActor
 final class URLSessionCredentialStorageTests: XCTestCase {
 
     func testMakeURLSessionConfiguration_Default_DisablesCredentialStorage() {
@@ -714,6 +718,7 @@ final class URLSessionCredentialStorageTests: XCTestCase {
 
 // MARK: - Basic Auth Challenge Empty Credential Behavior
 
+@MainActor
 final class BasicAuthEmptyCredentialTests: XCTestCase {
 
     func testHandleChallenge_EmptyUsername_StillUsesCredential() {
@@ -816,6 +821,7 @@ final class BasicAuthEmptyCredentialTests: XCTestCase {
 
 // MARK: - Credential Edge Cases
 
+@MainActor
 final class CredentialEdgeCaseTests: XCTestCase {
 
     func testTokenCredential_NilBarcode_ReturnsNilUsername() {
@@ -904,6 +910,7 @@ final class CredentialEdgeCaseTests: XCTestCase {
 
 // MARK: - Token Request + Network Executor Integration
 
+@MainActor
 final class TokenRefreshIntegrationTests: XCTestCase {
 
     private func makeExecutor() -> TPPNetworkExecutor {

--- a/PalaceTests/Network/DefaultCatalogAPITests.swift
+++ b/PalaceTests/Network/DefaultCatalogAPITests.swift
@@ -13,6 +13,7 @@ import PalaceNetwork
 @testable import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class DefaultCatalogAPITests: XCTestCase {
 
     // MARK: - Properties
@@ -671,6 +672,7 @@ extension DefaultCatalogAPITests {
 /// Regression guard for the catalog "stuck state" bug. A wedged feed fetch
 /// must NOT pin the inflight dedup entry forever (which would hang every later
 /// fetch of that URL until app restart). See `InflightFeedFetches`.
+@MainActor
 final class InflightFeedFetchesTimeoutTests: XCTestCase {
 
     private actor Counter {

--- a/PalaceTests/Network/ExecutorNetworkHermeticityTests.swift
+++ b/PalaceTests/Network/ExecutorNetworkHermeticityTests.swift
@@ -24,6 +24,7 @@ import XCTest
 // per-line `// MIGRATED-DEFERRED` marker (AppContainerIsolationLint) because the
 // production shared executor IS the contract here — a makeTestAppContainer()
 // executor would not prove the PRODUCTION path is hermetic.
+@MainActor
 final class ExecutorNetworkHermeticityTests: PalaceTestCase {
 
     /// A GET to a non-stub host through the shared executor must be BLOCKED

--- a/PalaceTests/Network/ManifestFetchTests.swift
+++ b/PalaceTests/Network/ManifestFetchTests.swift
@@ -785,7 +785,7 @@ final class LCPLicenseDocumentDetectionTests: XCTestCase {
 
     /// A realistic LCP license document structure as returned by the CM
     /// for LCP audiobooks (application/vnd.readium.lcp.license.v1.0+json).
-    static let sampleLCPLicense: [String: Any] = [
+    static var sampleLCPLicense: [String: Any] { [
         "id": "urn:uuid:12345678-1234-1234-1234-123456789abc",
         "issued": "2026-03-15T10:00:00Z",
         "provider": "https://license.feedbooks.net",
@@ -833,7 +833,7 @@ final class LCPLicenseDocumentDetectionTests: XCTestCase {
             "certificate": "MIIBBase64==",
             "value": "Base64SignatureValue=="
         ]
-    ]
+    ] }
 
     func testLCPLicenseDocument_isNotDetectedAsBearerToken() {
         let token = MyBooksSimplifiedBearerToken.simplifiedBearerToken(

--- a/PalaceTests/Network/ManifestFetchTests.swift
+++ b/PalaceTests/Network/ManifestFetchTests.swift
@@ -25,6 +25,7 @@ import XCTest
 /// Verifies that the app correctly distinguishes CM bearer token responses
 /// from actual audiobook manifests. This is the core decision logic that
 /// determines whether a second network hop is needed.
+@MainActor
 final class BearerTokenResponseDetectionTests: XCTestCase {
 
     func testBearerTokenJSON_isDetectedCorrectly() {
@@ -129,6 +130,7 @@ final class BearerTokenResponseDetectionTests: XCTestCase {
 
 /// Tests the second-hop manifest fetch that uses the book-specific bearer token.
 /// Uses HTTP stub protocol to verify correct request construction and response handling.
+@MainActor
 final class FetchManifestWithBearerTokenTests: XCTestCase {
 
     private let manifestURL = URL(string: "https://distributor.example.com/manifest/book-123.json")!
@@ -404,6 +406,7 @@ final class FetchManifestWithBearerTokenTests: XCTestCase {
 /// Verifies that TPPNetworkExecutor.GET creates a URLSessionDataTask (not a download task).
 /// The old bug used download() which created URLSessionDownloadTask on a session without
 /// URLSessionDownloadDelegate, causing empty response data.
+@MainActor
 final class NetworkExecutorTaskTypeTests: XCTestCase {
 
     func testGET_createsDataTask_notDownloadTask() {
@@ -513,6 +516,7 @@ final class NetworkExecutorTaskTypeTests: XCTestCase {
 /// Step 2: App calls manifest location URL with bearer token → receives manifest
 ///
 /// These tests verify the complete chain using a stubbed executor.
+@MainActor
 final class BearerTokenFulfillFlowTests: XCTestCase {
 
     private let fulfillURL = URL(string: "https://cm.example.com/CA9876/works/6139999/fulfill/30")!
@@ -681,6 +685,7 @@ final class BearerTokenFulfillFlowTests: XCTestCase {
 /// Specifically tests that GET (data task) properly receives response bodies,
 /// while documenting that download (download task) on a non-download delegate
 /// may lose data.
+@MainActor
 final class DataReceptionComparisonTests: XCTestCase {
 
     func testGET_receivesNonEmptyBody_forValidJSON() {
@@ -781,6 +786,7 @@ final class DataReceptionComparisonTests: XCTestCase {
 /// LCP-specific failure: the CM returns a valid LCP license document (with
 /// encryption keys, rights, etc.), not an audiobook manifest. If the app
 /// incorrectly tries to parse it as a manifest, audiobook playback fails.
+@MainActor
 final class LCPLicenseDocumentDetectionTests: XCTestCase {
 
     /// A realistic LCP license document structure as returned by the CM
@@ -902,6 +908,7 @@ final class LCPLicenseDocumentDetectionTests: XCTestCase {
 /// Tests that the app routes different audiobook types through the correct
 /// code path. This prevents regression where all audiobook types fall through
 /// to fetchOpenAccessManifest regardless of their DRM type.
+@MainActor
 final class AudiobookTypeRoutingTests: XCTestCase {
 
     func testBearerTokenBook_hasExpectedIdentifiers() {
@@ -958,6 +965,7 @@ final class AudiobookTypeRoutingTests: XCTestCase {
 
 /// Verifies the file path logic used for saving and locating LCP license files.
 /// The app stores LCP licenses alongside content files with .lcpl extension.
+@MainActor
 final class LCPLicenseFilePathTests: XCTestCase {
 
     func testLCPLicenseExtension_isLcpl() {
@@ -1011,6 +1019,7 @@ final class LCPLicenseFilePathTests: XCTestCase {
 /// is broken), the bearer token detection does NOT incorrectly match it.
 /// This is a safety net: even if the routing fix fails, the app should not
 /// silently misprocess LCP license documents.
+@MainActor
 final class FetchOpenAccessManifestLCPSafetyTests: XCTestCase {
 
     func testLCPLicenseResponse_notDetectedAsBearerToken_inFetchFlow() {
@@ -1099,6 +1108,7 @@ final class FetchOpenAccessManifestLCPSafetyTests: XCTestCase {
 /// Verifies that fetchManifestWithBearerToken correctly handles the case
 /// where the manifest location URL unexpectedly returns an LCP license
 /// instead of a manifest.
+@MainActor
 final class FetchManifestWithBearerTokenLCPSafetyTests: XCTestCase {
 
     override func setUp() {
@@ -1161,6 +1171,7 @@ final class FetchManifestWithBearerTokenLCPSafetyTests: XCTestCase {
 /// Additional regression tests ensuring that TPPNetworkExecutor.GET properly
 /// receives response bodies for various content types. This prevents the
 /// original bug where URLSessionDownloadTask silently dropped response data.
+@MainActor
 final class NetworkExecutorResponseRegressionTests: XCTestCase {
 
     override func setUp() {

--- a/PalaceTests/Network/MultiLibraryTokenIsolationTests.swift
+++ b/PalaceTests/Network/MultiLibraryTokenIsolationTests.swift
@@ -78,6 +78,7 @@ private final class TwoLibraryAccountsProviderMock: NSObject, TPPLibraryAccounts
     }
 }
 
+@MainActor
 final class MultiLibraryTokenIsolationTests: XCTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/Network/NetworkCacheClearRoutingTests.swift
+++ b/PalaceTests/Network/NetworkCacheClearRoutingTests.swift
@@ -26,6 +26,7 @@ import XCTest
 import PalaceNetwork
 @testable import Palace
 
+@MainActor
 final class NetworkCacheClearRoutingTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Network/NetworkClientTests.swift
+++ b/PalaceTests/Network/NetworkClientTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceNetwork
 @testable import Palace
 
+@MainActor
 final class NetworkClientTests: XCTestCase {
 
     // MARK: - Properties
@@ -550,6 +551,7 @@ private final class HangingURLProtocol: URLProtocol {
 /// many libraries sharing one Circulation Manager host, a few stuck requests
 /// could starve every library's feed fetches. Cancelling the awaiting Task
 /// must now free the request promptly.
+@MainActor
 final class URLSessionNetworkClientCancellationTests: XCTestCase {
 
     func testSend_cancellingTask_freesRequestPromptly() async {

--- a/PalaceTests/Network/NetworkRetryTests.swift
+++ b/PalaceTests/Network/NetworkRetryTests.swift
@@ -142,9 +142,8 @@ final class NetworkRetryLogicTests: XCTestCase {
         _ = try await session.data(for: request)
 
         // 4xx errors should not be retried
-        lock.lock()
-        let finalCount = requestCount
-        lock.unlock()
+        // Swift 6: NSLock.lock()/unlock() are unavailable in async contexts.
+        let finalCount = lock.withLock { requestCount }
         XCTAssertEqual(finalCount, 1)
     }
 
@@ -168,9 +167,8 @@ final class NetworkRetryLogicTests: XCTestCase {
         defer { session.invalidateAndCancel() }
         _ = try await session.data(for: request)
 
-        lock.lock()
-        let finalCount = requestCount
-        lock.unlock()
+        // Swift 6: NSLock.lock()/unlock() are unavailable in async contexts.
+        let finalCount = lock.withLock { requestCount }
         XCTAssertEqual(finalCount, 1)
     }
 

--- a/PalaceTests/Network/NetworkRetryTests.swift
+++ b/PalaceTests/Network/NetworkRetryTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 // MARK: - Network Retry Logic Tests
 
+@MainActor
 final class NetworkRetryLogicTests: XCTestCase {
 
     // MARK: - Properties
@@ -204,6 +205,7 @@ final class NetworkRetryLogicTests: XCTestCase {
 
 // MARK: - Network Timeout Tests
 
+@MainActor
 final class NetworkTimeoutTests: XCTestCase {
 
     func testTimeout_configuration() {
@@ -233,6 +235,7 @@ final class NetworkTimeoutTests: XCTestCase {
 
 // MARK: - Offline Detection Tests
 
+@MainActor
 final class NetworkOfflineDetectionTests: XCTestCase {
 
     func testNetworkReachability_hasSharedInstance() {
@@ -284,6 +287,7 @@ final class NetworkOfflineDetectionTests: XCTestCase {
 
 // MARK: - Request Queue Tests
 
+@MainActor
 final class NetworkRequestQueueTests: XCTestCase {
 
     private var config: URLSessionConfiguration!
@@ -383,6 +387,7 @@ final class NetworkRequestQueueTests: XCTestCase {
 
 // MARK: - Network Executor Tests
 
+@MainActor
 final class TPPNetworkExecutorTests: XCTestCase {
 
     func testExecutor_usesEphemeralCaching() {

--- a/PalaceTests/Network/OPDSFormatTests.swift
+++ b/PalaceTests/Network/OPDSFormatTests.swift
@@ -10,6 +10,7 @@ import PalaceCatalog
 @testable import Palace
 
 /// SRS: NET-001 — GET/POST/PUT/DELETE execute with proper headers
+@MainActor
 class OPDSFormatTests: XCTestCase {
 
     // MARK: - Content-Type Detection

--- a/PalaceTests/Network/ReachabilityTests.swift
+++ b/PalaceTests/Network/ReachabilityTests.swift
@@ -10,6 +10,7 @@ import Network
 @testable import PalaceNetwork
 @testable import Palace
 
+@MainActor
 final class ReachabilityTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Network/SAMLCookieSyncTests.swift
+++ b/PalaceTests/Network/SAMLCookieSyncTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceNetwork
 @testable import Palace
 
+@MainActor
 final class SAMLCookieSyncTests: XCTestCase {
 
     override func setUp() {
@@ -126,6 +127,7 @@ final class SAMLCookieSyncTests: XCTestCase {
 
 // MARK: - Sign-Out Cache Clearing Tests
 
+@MainActor
 final class SignOutCacheClearingTests: XCTestCase {
 
     func testClearCache_doesNotCrash_andExecutorStaysReusable() {

--- a/PalaceTests/Network/TPPNetworkExecutorConcurrencyTests.swift
+++ b/PalaceTests/Network/TPPNetworkExecutorConcurrencyTests.swift
@@ -27,6 +27,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPNetworkExecutorConcurrencyTests: XCTestCase {
 
     private var executor: TPPNetworkExecutor!

--- a/PalaceTests/Network/TPPNetworkExecutorTests.swift
+++ b/PalaceTests/Network/TPPNetworkExecutorTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPNetworkExecutorAPITests: XCTestCase {
 
     // MARK: - Shared Instance
@@ -185,6 +186,7 @@ final class TPPNetworkExecutorAPITests: XCTestCase {
 
 // MARK: - Stubbed HTTP Tests
 
+@MainActor
 final class TPPNetworkExecutorStubbedTests: XCTestCase {
 
     private var executor: TPPNetworkExecutor!

--- a/PalaceTests/Network/TPPNetworkResponderAuthCoordinatorTests.swift
+++ b/PalaceTests/Network/TPPNetworkResponderAuthCoordinatorTests.swift
@@ -30,6 +30,7 @@ import PalaceCatalog
 @testable import Palace
 @testable import PalaceAuth
 
+@MainActor
 final class TPPNetworkResponderAuthCoordinatorTests: XCTestCase {
 
     private var responder: TPPNetworkResponder!

--- a/PalaceTests/Network/TPPNetworkResponderSizeLimitTests.swift
+++ b/PalaceTests/Network/TPPNetworkResponderSizeLimitTests.swift
@@ -25,6 +25,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPNetworkResponderSizeLimitTests: XCTestCase {
 
     private var executor: TPPNetworkExecutor!

--- a/PalaceTests/Network/TPPNetworkResponderTests.swift
+++ b/PalaceTests/Network/TPPNetworkResponderTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import Palace
 
 /// SRS: REL-003 — Token refresh retry limit prevents loops
+@MainActor
 class TPPNetworkResponderTests: XCTestCase {
 
     var responder: TPPNetworkResponder!

--- a/PalaceTests/Network/TokenRefreshAndRetryQueueTests.swift
+++ b/PalaceTests/Network/TokenRefreshAndRetryQueueTests.swift
@@ -22,6 +22,7 @@ import PalaceAuth
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TokenRefreshAndRetryQueueTests: XCTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/Network/TokenRefreshOnForegroundTests.swift
+++ b/PalaceTests/Network/TokenRefreshOnForegroundTests.swift
@@ -26,6 +26,7 @@ import PalaceAuth
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TokenRefreshOnForegroundTests: XCTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/Network/TokenRefreshTests.swift
+++ b/PalaceTests/Network/TokenRefreshTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import PalaceAuth
 @testable import Palace
 
+@MainActor
 final class TokenRefreshTests: XCTestCase {
 
     // MARK: - TokenResponse Tests
@@ -443,6 +444,7 @@ extension TokenRefreshTests {
 /// it and hangs forever. The watchdog must force-release a stuck slot while
 /// never disturbing a refresh that completed normally or a newer one in
 /// flight. These lock that contract deterministically (no real timing).
+@MainActor
 final class TokenRefreshWatchdogTests: XCTestCase {
 
     private func makeExecutor() -> TPPNetworkExecutor {

--- a/PalaceTests/Network/TokenResponseTests.swift
+++ b/PalaceTests/Network/TokenResponseTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import PalaceAuth
 @testable import Palace
 
+@MainActor
 final class TokenResponseTests: XCTestCase {
 
     // MARK: - Initialization Tests

--- a/PalaceTests/Network/URLExtensionsTests.swift
+++ b/PalaceTests/Network/URLExtensionsTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class URLExtensionsTests: XCTestCase {
 
     // MARK: - replacingScheme Tests

--- a/PalaceTests/Network/URLRequestExtensionsTests.swift
+++ b/PalaceTests/Network/URLRequestExtensionsTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class URLRequestExtensionsTests: XCTestCase {
 
     private let testURL = URL(string: "https://example.com/api")!

--- a/PalaceTests/Network/URLRequestNYPLAdditionsTests.swift
+++ b/PalaceTests/Network/URLRequestNYPLAdditionsTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class URLRequestNYPLAdditionsTests: XCTestCase {
 
     private let testURL = URL(string: "https://example.com/api/report")!

--- a/PalaceTests/Network/URLResponseAuthenticationTests.swift
+++ b/PalaceTests/Network/URLResponseAuthenticationTests.swift
@@ -10,6 +10,7 @@ import PalaceAuth
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class URLResponseAuthenticationTests: XCTestCase {
 
     private let testURL = URL(string: "https://example.com/api")!
@@ -142,6 +143,7 @@ final class URLResponseAuthenticationTests: XCTestCase {
 /// Tests for cross-domain redirect 401 handling
 /// When a request is redirected to a different domain and returns 401,
 /// we should NOT mark credentials as stale since the 401 is from a third-party.
+@MainActor
 final class CrossDomain401Tests: XCTestCase {
 
     private let palaceURL = URL(string: "https://gorgon.palaceproject.io/library/book")!
@@ -289,6 +291,7 @@ final class CrossDomain401Tests: XCTestCase {
 /// Server uses URL path conventions to classify auth errors:
 /// - /auth/recoverable/* -> client should re-authenticate
 /// - /auth/unrecoverable/* -> client should display error to user
+@MainActor
 final class AuthErrorCategoryTests: XCTestCase {
 
     private let testURL = URL(string: "https://example.com/api")!

--- a/PalaceTests/Network/URLResponseNYPLTests.swift
+++ b/PalaceTests/Network/URLResponseNYPLTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class URLResponseNYPLTests: XCTestCase {
 
     private let testURL = URL(string: "https://example.com/api")!

--- a/PalaceTests/NoNetworkURLProtocol.swift
+++ b/PalaceTests/NoNetworkURLProtocol.swift
@@ -32,7 +32,11 @@ final class NoNetworkURLProtocol: URLProtocol {
     // and after an operation; an increment means the stub blocked it, not the
     // network. Lock-guarded: protocol instances load concurrently.
     private static let interceptionLock = NSLock()
-    private static var interceptedURLs: [String] = []
+    private static let _interceptedURLs = LockIsolated<[String]>([])
+    private static var interceptedURLs: [String] {
+        get { _interceptedURLs.value }
+        set { _interceptedURLs.value = newValue }
+    }
 
     /// Count of requests intercepted so far whose absolute URL contains
     /// `substring`. Diff before/after an operation to prove THAT operation's

--- a/PalaceTests/Notifications/NotificationPayloadContractTests.swift
+++ b/PalaceTests/Notifications/NotificationPayloadContractTests.swift
@@ -30,6 +30,7 @@ private enum NotificationFixture {
 
 // MARK: - NotificationEventType Contract Tests
 
+@MainActor
 final class NotificationEventTypeContractTests: XCTestCase {
 
     /// The CM backend defines exactly 4 event types in NotificationType (StrEnum).
@@ -102,6 +103,7 @@ final class NotificationEventTypeContractTests: XCTestCase {
 
 // MARK: - Notification Payload Structure Contract Tests
 
+@MainActor
 final class NotificationPayloadContractTests: XCTestCase {
 
     private var payloads: [String: [String: Any]] = [:]

--- a/PalaceTests/Notifications/NotificationServiceStateMachineTests.swift
+++ b/PalaceTests/Notifications/NotificationServiceStateMachineTests.swift
@@ -22,6 +22,7 @@ import XCTest
 import Combine
 @testable import Palace
 
+@MainActor
 final class NotificationServiceStateMachineTests: XCTestCase {
 
     /// NYPL-fixture-backed mock: `supportsReservations == true` (the

--- a/PalaceTests/Notifications/NotificationServiceTests.swift
+++ b/PalaceTests/Notifications/NotificationServiceTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class NotificationServiceTests: XCTestCase {
 
     // MARK: - TokenData Tests

--- a/PalaceTests/Notifications/NotificationServiceTokenTests.swift
+++ b/PalaceTests/Notifications/NotificationServiceTokenTests.swift
@@ -12,6 +12,7 @@ import XCTest
 @testable import Palace
 
 /// SRS: SET-001 — Push notification token data encodes correctly for backend API
+@MainActor
 final class NotificationServiceTokenTests: XCTestCase {
 
     // MARK: - TokenData

--- a/PalaceTests/Notifications/NotificationSyncThrottleTests.swift
+++ b/PalaceTests/Notifications/NotificationSyncThrottleTests.swift
@@ -14,6 +14,7 @@ import XCTest
 /// Tests the sync throttle logic extracted from NotificationService.
 /// The real NotificationService requires UNUserNotificationCenter which
 /// can't be easily mocked, so we test the decision logic directly.
+@MainActor
 final class NotificationSyncThrottleTests: XCTestCase {
 
     override func tearDown() {
@@ -112,6 +113,7 @@ final class NotificationSyncThrottleTests: XCTestCase {
 
 // MARK: - Hold Notification Classification Tests
 
+@MainActor
 final class HoldNotificationClassificationTests: XCTestCase {
 
     func testIsHoldRelated_withTypeHold_returnsTrue() {

--- a/PalaceTests/Notifications/NotificationTokenRegistrationTests.swift
+++ b/PalaceTests/Notifications/NotificationTokenRegistrationTests.swift
@@ -23,6 +23,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class NotificationTokenRegistrationTests: XCTestCase {
 
     // MARK: - Failure paths (flag must NOT be set → retry stays possible)

--- a/PalaceTests/OPDS/OPDS1ParsingTests.swift
+++ b/PalaceTests/OPDS/OPDS1ParsingTests.swift
@@ -34,6 +34,7 @@ private enum OPDS1Fixture {
     }
 }
 
+@MainActor
 final class OPDS1ParsingTests: XCTestCase {
 
     // MARK: - Catalog feed (opds1_catalog.xml)

--- a/PalaceTests/OPDS/OPDS2ParsingTests.swift
+++ b/PalaceTests/OPDS/OPDS2ParsingTests.swift
@@ -29,6 +29,7 @@ private enum OPDS2Fixture {
     }
 }
 
+@MainActor
 final class OPDS2ParsingTests: XCTestCase {
 
     // MARK: - OPDS2Feed: typical catalog (opds2_catalog.json)

--- a/PalaceTests/OPDS/OPDSAcquisitionPathExpandedTests.swift
+++ b/PalaceTests/OPDS/OPDSAcquisitionPathExpandedTests.swift
@@ -5,6 +5,7 @@ import PalaceCatalog
 /// Tests for OPDS acquisition path resolution,
 /// TPPOPDSFeed/Entry/Link parsing from test XML resources,
 /// and dictionary roundtrip serialization.
+@MainActor
 final class OPDSAcquisitionPathExpandedTests: XCTestCase {
 
   // MARK: - Feed Parsing from Bundle Resources

--- a/PalaceTests/OPDS/OPDSParsingTests.swift
+++ b/PalaceTests/OPDS/OPDSParsingTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class OPDSParsingTests: XCTestCase {
 
     // MARK: - Test Fixtures

--- a/PalaceTests/OPDS2/OPDS2AuthenticationDocumentTests.swift
+++ b/PalaceTests/OPDS2/OPDS2AuthenticationDocumentTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class OPDS2AuthenticationDocumentTests: XCTestCase {
 
     // MARK: - Properties
@@ -325,6 +326,7 @@ final class OPDS2AuthenticationDocumentTests: XCTestCase {
 
 // MARK: - Announcement Tests
 
+@MainActor
 final class AnnouncementTests: XCTestCase {
 
     func testAnnouncement_decodesValidJSON() throws {
@@ -371,6 +373,7 @@ final class AnnouncementTests: XCTestCase {
 
 // MARK: - OPDS2LinkRel Tests
 
+@MainActor
 final class OPDS2LinkRelTests: XCTestCase {
 
     func testPasswordReset_hasCorrectRawValue() {

--- a/PalaceTests/OPDS2/OPDS2BookBridgeTests.swift
+++ b/PalaceTests/OPDS2/OPDS2BookBridgeTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class OPDS2BookBridgeTests: XCTestCase {
 
     // MARK: - Basic Metadata Mapping

--- a/PalaceTests/OPDS2/OPDS2FeedParsingTests.swift
+++ b/PalaceTests/OPDS2/OPDS2FeedParsingTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class OPDS2FeedParsingTests: XCTestCase {
 
     // MARK: - Properties
@@ -197,6 +198,7 @@ final class OPDS2FeedParsingTests: XCTestCase {
 
 // MARK: - OPDS2 Publication Tests
 
+@MainActor
 final class OPDS2PublicationTests: XCTestCase {
 
     func testPublication_hasRequiredFields() throws {
@@ -229,6 +231,7 @@ final class OPDS2PublicationTests: XCTestCase {
 
 // MARK: - OPDS2 Link Tests
 
+@MainActor
 final class OPDS2LinkTests: XCTestCase {
 
     func testLink_hasHref() throws {

--- a/PalaceTests/OPDS2/OPDS2FeedTests.swift
+++ b/PalaceTests/OPDS2/OPDS2FeedTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class OPDS2FeedTests: XCTestCase {
 
     // MARK: - Feed Parsing

--- a/PalaceTests/OPDS2/OPDS2IntegrationTests.swift
+++ b/PalaceTests/OPDS2/OPDS2IntegrationTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class OPDS2IntegrationTests: XCTestCase {
 
     private var feed: OPDS2Feed!

--- a/PalaceTests/OPDS2/OPDS2LinkAndPublicationTests.swift
+++ b/PalaceTests/OPDS2/OPDS2LinkAndPublicationTests.swift
@@ -13,6 +13,7 @@ import PalaceCatalog
 // MARK: - OPDS2Link Computed Properties Tests
 
 /// SRS: CAT-002 — OPDS 2.0 feed parsing with authentication documents
+@MainActor
 final class OPDS2LinkComputedPropertyTests: XCTestCase {
 
     // MARK: - hrefURL
@@ -185,6 +186,7 @@ final class OPDS2LinkComputedPropertyTests: XCTestCase {
 
 // MARK: - OPDS2 Availability Tests
 
+@MainActor
 final class OPDS2AvailabilityTests: XCTestCase {
 
     func testIsAvailable_AvailableState_ReturnsTrue() {
@@ -223,6 +225,7 @@ final class OPDS2AvailabilityTests: XCTestCase {
 // MARK: - OPDS2LinkArray Extension Tests
 
 /// SRS: CAT-002 — OPDS 2.0 feed parsing with authentication documents
+@MainActor
 final class OPDS2LinkArrayTests: XCTestCase {
 
     func testAllRel_MatchingLinks_ReturnsFiltered() {
@@ -281,6 +284,7 @@ final class OPDS2LinkArrayTests: XCTestCase {
 // MARK: - OPDS2Publication Tests
 
 /// SRS: CAT-002 — OPDS 2.0 feed parsing with authentication documents
+@MainActor
 final class OPDS2PublicationImageTests: XCTestCase {
 
     func testImageURL_PNGImage_ReturnsURL() {
@@ -349,6 +353,7 @@ final class OPDS2PublicationImageTests: XCTestCase {
 // silently dropping it, so audiobooks served via the lightweight feed have
 // no narrator row in the book details view (PP-4230).
 
+@MainActor
 final class OPDS2PublicationNarratorTests: XCTestCase {
 
     /// Behavioral: an OPDS2 publication JSON that includes `narrator` must
@@ -443,6 +448,7 @@ final class OPDS2PublicationNarratorTests: XCTestCase {
 // MARK: - OPDS2FullPublication Tests
 
 /// SRS: CAT-002 — OPDS 2.0 feed parsing with authentication documents
+@MainActor
 final class OPDS2FullPublicationTests: XCTestCase {
 
     private func makeFullPublication(
@@ -659,6 +665,7 @@ final class OPDS2FullPublicationTests: XCTestCase {
 // MARK: - OPDS2FullMetadata Decoding Tests
 
 /// SRS: CAT-002 — OPDS 2.0 feed parsing with authentication documents
+@MainActor
 final class OPDS2FullMetadataTests: XCTestCase {
 
     func testDecode_AtIdKey_ParsesIdentifier() throws {
@@ -729,6 +736,7 @@ final class OPDS2FullMetadataTests: XCTestCase {
 
 // MARK: - OPDS2Contributor Decoding Tests
 
+@MainActor
 final class OPDS2ContributorTests: XCTestCase {
 
     func testDecode_StringValue_ParsesAsName() throws {
@@ -755,6 +763,7 @@ final class OPDS2ContributorTests: XCTestCase {
 
 // MARK: - OPDS2Subject Decoding Tests
 
+@MainActor
 final class OPDS2SubjectTests: XCTestCase {
 
     func testDecode_StringValue_ParsesAsName() throws {
@@ -781,6 +790,7 @@ final class OPDS2SubjectTests: XCTestCase {
 
 // MARK: - OPDS2 Supporting Types Tests
 
+@MainActor
 final class OPDS2SupportingTypesTests: XCTestCase {
 
     func testPrice_CodableRoundTrip() throws {

--- a/PalaceTests/OPDS2/OPDS2PublicationExtendedTests.swift
+++ b/PalaceTests/OPDS2/OPDS2PublicationExtendedTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class OPDS2PublicationExtendedTests: XCTestCase {
 
     // MARK: - OPDS2BookBridge.relation(from:) Tests

--- a/PalaceTests/OPDS2/OPDSFeedCacheTests.swift
+++ b/PalaceTests/OPDS2/OPDSFeedCacheTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class OPDSFeedCacheTests: XCTestCase {
 
     var sut: OPDS2FeedCache!

--- a/PalaceTests/OPDS2/OPDSFeedMigrationTests.swift
+++ b/PalaceTests/OPDS2/OPDSFeedMigrationTests.swift
@@ -18,6 +18,7 @@ import PalaceCatalog
 
 // MARK: - Non-OPDS Response Handling
 
+@MainActor
 final class OPDSFeedMigrationTests: XCTestCase {
 
     // MARK: - returnBook: non-OPDS revoke response treated as success

--- a/PalaceTests/OPDS2/OPDSFeedServiceStateMachineTests.swift
+++ b/PalaceTests/OPDS2/OPDSFeedServiceStateMachineTests.swift
@@ -26,6 +26,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class OPDSFeedServiceStateMachineTests: XCTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/OPDS2/OPDSFeedServiceTests.swift
+++ b/PalaceTests/OPDS2/OPDSFeedServiceTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class OPDSFeedServiceTests: XCTestCase {
 
     // MARK: - Cancellation Tests (no network calls)
@@ -46,6 +47,7 @@ final class OPDSFeedServiceTests: XCTestCase {
 
 // MARK: - Palace Error Tests
 
+@MainActor
 final class PalaceErrorTests: XCTestCase {
 
     func testPalaceError_parsing_opdsFeedInvalid() {

--- a/PalaceTests/OPDS2/TPPContentTypeTests.swift
+++ b/PalaceTests/OPDS2/TPPContentTypeTests.swift
@@ -12,6 +12,7 @@ import PalaceCatalog
 
 // MARK: - TPPBookContentType Tests
 
+@MainActor
 final class TPPContentTypeTests: XCTestCase {
 
     // MARK: - from(mimeType:)
@@ -97,6 +98,7 @@ final class TPPContentTypeTests: XCTestCase {
 
 // MARK: - SampleType Tests
 
+@MainActor
 final class SampleTypeTests: XCTestCase {
 
     func testRawValue_ContentTypeEpubZip() {
@@ -165,6 +167,7 @@ final class SampleTypeTests: XCTestCase {
 
 // MARK: - SamplePlayerError Tests
 
+@MainActor
 final class SamplePlayerErrorTests: XCTestCase {
 
     func testNoSampleAvailable_IsError() {

--- a/PalaceTests/OPDS2/TPPOPDSGroupTests.swift
+++ b/PalaceTests/OPDS2/TPPOPDSGroupTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPOPDSGroupSwiftTests: XCTestCase {
 
   func testInitStoresProperties() {

--- a/PalaceTests/OPDS2/UnifiedOPDSServiceStateMachineTests.swift
+++ b/PalaceTests/OPDS2/UnifiedOPDSServiceStateMachineTests.swift
@@ -25,6 +25,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class UnifiedOPDSServiceStateMachineTests: XCTestCase {
 
     // MARK: - Fixtures

--- a/PalaceTests/OPDS2CatalogsFeedTests.swift
+++ b/PalaceTests/OPDS2CatalogsFeedTests.swift
@@ -11,6 +11,7 @@ import PalaceCatalog
 
 @testable import Palace
 
+@MainActor
 class OPDS2CatalogsFeedTests: XCTestCase {
 
     let testFeedUrl = Bundle.init(for: OPDS2CatalogsFeedTests.self)

--- a/PalaceTests/OPDSFeedParsingTests.swift
+++ b/PalaceTests/OPDSFeedParsingTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class OPDSFeedParsingTests: XCTestCase {
     func testParseValidOPDSFeed() {
         let bundle = Bundle(for: type(of: self))

--- a/PalaceTests/PDF/PDFExtensionsTests.swift
+++ b/PalaceTests/PDF/PDFExtensionsTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class PDFExtensionsTests: XCTestCase {
 
     // MARK: - CGSize Extension Tests

--- a/PalaceTests/PDF/PDFKitThumbnailProviderTests.swift
+++ b/PalaceTests/PDF/PDFKitThumbnailProviderTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import PDFKit
 @testable import Palace
 
+@MainActor
 final class PDFKitThumbnailProviderTests: XCTestCase {
 
     /// Build an in-memory PDF with `pageCount` US-letter pages.

--- a/PalaceTests/PDF/PalacePDFViewTests.swift
+++ b/PalaceTests/PDF/PalacePDFViewTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import PDFKit
 @testable import Palace
 
+@MainActor
 final class PalacePDFViewTests: XCTestCase {
 
     private var pdfView: PalacePDFView!

--- a/PalaceTests/PDF/TPPPDFDocumentMetadataTests.swift
+++ b/PalaceTests/PDF/TPPPDFDocumentMetadataTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import Combine
 @testable import Palace
 
+@MainActor
 final class TPPPDFDocumentMetadataTests: XCTestCase {
 
     var cancellables = Set<AnyCancellable>()

--- a/PalaceTests/PDF/TPPPDFLocationTests.swift
+++ b/PalaceTests/PDF/TPPPDFLocationTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPPDFLocationTests: XCTestCase {
 
     // MARK: - Initialization Tests

--- a/PalaceTests/PDF/TPPPDFModelTests.swift
+++ b/PalaceTests/PDF/TPPPDFModelTests.swift
@@ -13,6 +13,7 @@ import XCTest
 
 // MARK: - TPPPDFPage Tests
 
+@MainActor
 final class TPPPDFPageTests: XCTestCase {
 
     // SRS: TPPPDFPage stores page number correctly
@@ -76,6 +77,7 @@ final class TPPPDFPageTests: XCTestCase {
 
 // MARK: - TPPPDFLocation Tests
 
+@MainActor
 final class TPPPDFLocationCoverageTests: XCTestCase {
 
     // SRS: TPPPDFLocation initializes with all parameters
@@ -148,6 +150,7 @@ final class TPPPDFLocationCoverageTests: XCTestCase {
 
 // MARK: - TPPPDFPageBookmark Tests
 
+@MainActor
 final class TPPPDFPageBookmarkTests: XCTestCase {
 
     // SRS: TPPPDFPageBookmark initializes with page number
@@ -258,6 +261,7 @@ final class TPPPDFPageBookmarkTests: XCTestCase {
 
 // MARK: - TPPPDFReaderMode Tests
 
+@MainActor
 final class TPPPDFReaderModeTests: XCTestCase {
 
     // SRS: TPPPDFReaderMode reader value
@@ -309,6 +313,7 @@ final class TPPPDFReaderModeTests: XCTestCase {
 
 // MARK: - TPPPDFDocument Tests
 
+@MainActor
 final class TPPPDFDocumentTests: XCTestCase {
 
     // Post-migration: TPPPDFDocument is the non-encrypted/open-access PDF

--- a/PalaceTests/PDF/TPPPDFReaderSearchBindingTests.swift
+++ b/PalaceTests/PDF/TPPPDFReaderSearchBindingTests.swift
@@ -14,6 +14,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPPDFReaderSearchBindingTests: XCTestCase {
 
     /// Dismissing the search sheet (isPresented→false) returns to `.reader`.

--- a/PalaceTests/PalaceTestSetup.swift
+++ b/PalaceTests/PalaceTestSetup.swift
@@ -25,7 +25,11 @@ class PalaceTestSetup: NSObject {
     /// our retain, ARC drops the observer immediately after
     /// `addTestObserver(_:)` returns and `testCaseDidFinish(_:)` never
     /// fires. This `static var` retain is load-bearing.
-    private static var observer: PalaceSingletonResetObserver?
+    private static let _observer = LockIsolated<PalaceSingletonResetObserver?>(nil)
+    private static var observer: PalaceSingletonResetObserver? {
+        get { _observer.value }
+        set { _observer.value = newValue }
+    }
 
     override init() {
         super.init()

--- a/PalaceTests/PalaceTestSetup.swift
+++ b/PalaceTests/PalaceTestSetup.swift
@@ -274,9 +274,12 @@ class PalaceSingletonResetObserver: NSObject, XCTestObservation {
         let delta = post - pre
         lastObservedDeltaForTesting = delta
         if delta > 0 {
+            // Swift 6: capture the name (Sendable String) so the runActivity
+            // closure doesn't send the non-Sendable `testCase` across a boundary.
+            let testCaseName = testCase.name
             XCTContext.runActivity(named: "NotificationCenter observer leak (\(delta) net adds)") { activity in
                 let attachment = XCTAttachment(string:
-                    "Test \(testCase.name) added \(delta) NotificationCenter.default observer(s) without paired remove. " +
+                    "Test \(testCaseName) added \(delta) NotificationCenter.default observer(s) without paired remove. " +
                     "Pre=\(pre), Post=\(post). Route through an injected NotificationCenter or call " +
                     "removeObserver in tearDown."
                 )

--- a/PalaceTests/PalaceTestSetupObservationTests.swift
+++ b/PalaceTests/PalaceTestSetupObservationTests.swift
@@ -8,6 +8,7 @@ import XCTest
 /// cannot uninstall it, so they instead reset the registry between
 /// assertions and use a freshly-allocated observer for the
 /// `testCaseDidFinish` direct-call assertions.
+@MainActor
 final class PalaceTestSetupObservationTests: XCTestCase {
 
     override func setUp() {

--- a/PalaceTests/Platform/AccessibilityPreferencesTests.swift
+++ b/PalaceTests/Platform/AccessibilityPreferencesTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AccessibilityPreferencesTests: XCTestCase {
 
     private var testDefaults: UserDefaults!

--- a/PalaceTests/Platform/AccessibilityServiceTests.swift
+++ b/PalaceTests/Platform/AccessibilityServiceTests.swift
@@ -11,6 +11,7 @@ import Combine
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AccessibilityServiceTests: XCTestCase {
 
     private var service: AccessibilityService!

--- a/PalaceTests/Platform/AppLaunchTrackerExtendedTests.swift
+++ b/PalaceTests/Platform/AppLaunchTrackerExtendedTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AppLaunchTrackerExtendedTests: XCTestCase {
 
     private var tracker: AppLaunchTracker!

--- a/PalaceTests/Platform/AppLaunchTrackerTests.swift
+++ b/PalaceTests/Platform/AppLaunchTrackerTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AppLaunchTrackerTests: XCTestCase {
 
     private var tracker: AppLaunchTracker!

--- a/PalaceTests/Platform/AppLaunchTrackerWiringTests.swift
+++ b/PalaceTests/Platform/AppLaunchTrackerWiringTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AppLaunchTrackerWiringTests: XCTestCase {
 
     private var tracker: AppLaunchTracker!

--- a/PalaceTests/Platform/CrossFormatMappingTests.swift
+++ b/PalaceTests/Platform/CrossFormatMappingTests.swift
@@ -11,6 +11,7 @@ import XCTest
 @testable import Palace
 import PalaceReadingPosition
 
+@MainActor
 final class CrossFormatMappingTests: XCTestCase {
 
     // MARK: - One-to-One Mapping

--- a/PalaceTests/Platform/OfflineActionTests.swift
+++ b/PalaceTests/Platform/OfflineActionTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class OfflineActionTests: XCTestCase {
 
     // MARK: - Action Creation

--- a/PalaceTests/Platform/OfflineQueueCoordinatorTests.swift
+++ b/PalaceTests/Platform/OfflineQueueCoordinatorTests.swift
@@ -13,6 +13,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class OfflineQueueCoordinatorTests: XCTestCase {
 
     // MARK: - Fakes

--- a/PalaceTests/Platform/OfflineQueueServiceExtendedTests.swift
+++ b/PalaceTests/Platform/OfflineQueueServiceExtendedTests.swift
@@ -11,6 +11,7 @@ import Combine
 import XCTest
 @testable import Palace
 
+@MainActor
 final class OfflineQueueServiceExtendedTests: XCTestCase {
 
     private var service: OfflineQueueService!

--- a/PalaceTests/Platform/OfflineQueueServiceExtendedTests.swift
+++ b/PalaceTests/Platform/OfflineQueueServiceExtendedTests.swift
@@ -52,10 +52,12 @@ final class OfflineQueueServiceExtendedTests: XCTestCase {
     // MARK: - Queue FIFO Order
 
     func testProcessQueue_FIFO_Order() async {
-        var executedBookIDs: [String] = []
+        // Swift 6: the @Sendable executor closure can't mutate a captured local.
+        // Box it (lock-guarded) and read .value after the queue drains.
+        let executedBookIDs = LockIsolated<[String]>([])
 
         await service.setExecutor { action in
-            executedBookIDs.append(action.bookID)
+            executedBookIDs.withValue { $0.append(action.bookID) }
             return true
         }
 
@@ -70,7 +72,7 @@ final class OfflineQueueServiceExtendedTests: XCTestCase {
         await service.networkStatusChanged(isAvailable: true)
         try? await Task.sleep(nanoseconds: 500_000_000)
 
-        XCTAssertEqual(executedBookIDs, ["first", "second", "third"])
+        XCTAssertEqual(executedBookIDs.value, ["first", "second", "third"])
     }
 
     // MARK: - Queue Persistence Across "Restarts"

--- a/PalaceTests/Platform/OfflineQueueServiceTests.swift
+++ b/PalaceTests/Platform/OfflineQueueServiceTests.swift
@@ -16,7 +16,10 @@ final class OfflineQueueServiceTests: XCTestCase {
     private var service: OfflineQueueService!
     private var userDefaults: UserDefaults!
     private var cancellables: Set<AnyCancellable>!
-    private var executedActions: [OfflineAction]!
+    // Swift 6: the @Sendable executor closure appends to this from a concurrent
+    // context, so it must be a Sendable lock-guarded box rather than a captured
+    // `self` instance var. Reset per-test in setUp.
+    private let executedActions = LockIsolated<[OfflineAction]>([])
 
     override func setUp() {
         super.setUp()
@@ -24,12 +27,11 @@ final class OfflineQueueServiceTests: XCTestCase {
         userDefaults.removePersistentDomain(forName: "OfflineQueueServiceTests")
         service = OfflineQueueService(userDefaults: userDefaults)
         cancellables = Set<AnyCancellable>()
-        executedActions = []
+        executedActions.value = []
     }
 
     override func tearDown() {
         cancellables = nil
-        executedActions = nil
         userDefaults.removePersistentDomain(forName: "OfflineQueueServiceTests")
         service = nil
         userDefaults = nil
@@ -39,8 +41,8 @@ final class OfflineQueueServiceTests: XCTestCase {
     // MARK: - Helpers
 
     private func setupSuccessExecutor() async {
-        await service.setExecutor { [weak self] action in
-            self?.executedActions.append(action)
+        await service.setExecutor { action in
+            executedActions.withValue { $0.append(action) }
             return true
         }
     }
@@ -91,7 +93,7 @@ final class OfflineQueueServiceTests: XCTestCase {
         let status = await service.currentStatus()
         XCTAssertEqual(status.pendingCount, 0)
         XCTAssertEqual(status.failedCount, 0)
-        XCTAssertEqual(executedActions.count, 1)
+        XCTAssertEqual(executedActions.value.count, 1)
     }
 
     func testProcessQueueFIFOOrder() async {
@@ -106,18 +108,22 @@ final class OfflineQueueServiceTests: XCTestCase {
 
         try? await Task.sleep(nanoseconds: 200_000_000)
 
-        XCTAssertEqual(executedActions.count, 2)
-        XCTAssertEqual(executedActions[0].bookID, "book1")
-        XCTAssertEqual(executedActions[1].bookID, "book2")
+        XCTAssertEqual(executedActions.value.count, 2)
+        XCTAssertEqual(executedActions.value[0].bookID, "book1")
+        XCTAssertEqual(executedActions.value[1].bookID, "book2")
     }
 
     // MARK: - Retry
 
     func testRetryFailedAction() async {
-        var callCount = 0
+        // Swift 6: box the counter — the @Sendable executor can't mutate a
+        // captured local. withValue makes the increment-and-test atomic.
+        let callCount = LockIsolated<Int>(0)
         await service.setExecutor { _ in
-            callCount += 1
-            return callCount > 1 // Fail first, succeed second
+            callCount.withValue { count -> Bool in
+                count += 1
+                return count > 1 // Fail first, succeed second
+            }
         }
 
         let action = OfflineAction(type: .borrow, bookID: "book1", bookTitle: "Test Book", maxRetries: 3)
@@ -262,7 +268,7 @@ final class OfflineQueueServiceTests: XCTestCase {
 
         let status = await service.currentStatus()
         XCTAssertEqual(status.pendingCount, 0)
-        XCTAssertEqual(executedActions.count, 1)
+        XCTAssertEqual(executedActions.value.count, 1)
     }
 
     // MARK: - Action Properties

--- a/PalaceTests/Platform/OfflineQueueServiceTests.swift
+++ b/PalaceTests/Platform/OfflineQueueServiceTests.swift
@@ -11,6 +11,7 @@ import Combine
 import XCTest
 @testable import Palace
 
+@MainActor
 final class OfflineQueueServiceTests: XCTestCase {
 
     private var service: OfflineQueueService!

--- a/PalaceTests/Platform/PerformanceMonitorTests.swift
+++ b/PalaceTests/Platform/PerformanceMonitorTests.swift
@@ -11,6 +11,7 @@ import Combine
 import XCTest
 @testable import Palace
 
+@MainActor
 final class PerformanceMonitorTests: XCTestCase {
 
     private var monitor: PerformanceMonitor!

--- a/PalaceTests/Platform/PerformanceReportTests.swift
+++ b/PalaceTests/Platform/PerformanceReportTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class PerformanceReportTests: XCTestCase {
 
     // MARK: - Percentile Calculation

--- a/PalaceTests/Platform/PositionSyncServiceTests.swift
+++ b/PalaceTests/Platform/PositionSyncServiceTests.swift
@@ -12,6 +12,7 @@ import XCTest
 @testable import Palace
 import PalaceReadingPosition
 
+@MainActor
 final class PositionSyncServiceTests: XCTestCase {
 
     private var service: PositionSyncService!

--- a/PalaceTests/Platform/ReadingPositionTests.swift
+++ b/PalaceTests/Platform/ReadingPositionTests.swift
@@ -10,6 +10,7 @@ import XCTest
 @testable import Palace
 import PalaceReadingPosition
 
+@MainActor
 final class ReadingPositionTests: XCTestCase {
 
     // MARK: - EPUB Position

--- a/PalaceTests/PlaybackRateTests.swift
+++ b/PalaceTests/PlaybackRateTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import PalaceAudiobookToolkit
 
+@MainActor
 class PlaybackRateTests: XCTestCase {
 
   // MARK: - convert(rate:)

--- a/PalaceTests/ProblemDocumentTests.swift
+++ b/PalaceTests/ProblemDocumentTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class ProblemDocumentTests: XCTestCase {
 
     // MARK: - Problem Document Creation Tests

--- a/PalaceTests/Property/PalaceCheckPropertyTests.swift
+++ b/PalaceTests/Property/PalaceCheckPropertyTests.swift
@@ -10,6 +10,7 @@ import Foundation
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class PalaceCheckPropertyTests: XCTestCase {
 
     // MARK: - BookButtonMapper.map is total

--- a/PalaceTests/Reader/EPUBPositionTests.swift
+++ b/PalaceTests/Reader/EPUBPositionTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import ReadiumShared
 @testable import Palace
 
+@MainActor
 final class EPUBPositionTests: XCTestCase {
 
     // MARK: - TPPBookLocation Creation Tests

--- a/PalaceTests/Reader/ReaderEditingActionsTests.swift
+++ b/PalaceTests/Reader/ReaderEditingActionsTests.swift
@@ -76,7 +76,7 @@ final class ReaderEditingActionsTests: XCTestCase {
         return makeBook(identifier: "open-epub", acquisitions: [acquisition])
     }
 
-    private static let highlight = EditingAction(title: "Highlight", action: Selector("highlight"))
+    private static var highlight: EditingAction { EditingAction(title: "Highlight", action: Selector("highlight")) }
 
     // MARK: - Gating
 

--- a/PalaceTests/Reader/ReaderEditingActionsTests.swift
+++ b/PalaceTests/Reader/ReaderEditingActionsTests.swift
@@ -12,6 +12,7 @@ import PalaceCatalog
 import ReadiumNavigator
 @testable import Palace
 
+@MainActor
 final class ReaderEditingActionsTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Reader/ReaderNavBarVoiceOverTests.swift
+++ b/PalaceTests/Reader/ReaderNavBarVoiceOverTests.swift
@@ -31,6 +31,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ReaderNavBarVoiceOverTests: XCTestCase {
 
     /// Product requirement: `viewDidAppear` in `TPPBaseReaderViewController`

--- a/PalaceTests/Reader2/BookmarkBusinessLogicTests.swift
+++ b/PalaceTests/Reader2/BookmarkBusinessLogicTests.swift
@@ -10,6 +10,7 @@ import ReadiumShared
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class BookmarkBusinessLogicExtendedTests: XCTestCase {
 
     // MARK: - Properties
@@ -288,6 +289,7 @@ final class BookmarkBusinessLogicExtendedTests: XCTestCase {
 
 // MARK: - Bookmark Sync Tests
 
+@MainActor
 final class BookmarkSyncTests: XCTestCase {
 
     private var businessLogic: TPPReaderBookmarksBusinessLogic!
@@ -430,6 +432,7 @@ final class BookmarkSyncTests: XCTestCase {
 
 // MARK: - Is Bookmark Existing Tests
 
+@MainActor
 final class BookmarkExistenceTests: XCTestCase {
 
     private var businessLogic: TPPReaderBookmarksBusinessLogic!
@@ -644,6 +647,7 @@ final class BookmarkExistenceTests: XCTestCase {
 
 // MARK: - Bookmark Sorting Tests
 
+@MainActor
 final class BookmarkSortingTests: XCTestCase {
 
     private var bookRegistryMock: TPPBookRegistryMock!
@@ -762,6 +766,7 @@ final class BookmarkSortingTests: XCTestCase {
 
 // MARK: - Deletion Log Integration Tests
 
+@MainActor
 final class BookmarkDeletionLogTests: XCTestCase {
 
     private var businessLogic: TPPReaderBookmarksBusinessLogic!
@@ -974,6 +979,7 @@ final class BookmarkDeletionLogTests: XCTestCase {
 /// Tests for the re-authentication retry flow in bookmark syncing.
 /// These tests verify that the business logic properly attempts re-authentication
 /// when credentials are stale.
+@MainActor
 final class BookmarkReauthenticationTests: XCTestCase {
 
     private var businessLogic: TPPReaderBookmarksBusinessLogic!
@@ -1071,6 +1077,7 @@ final class BookmarkReauthenticationTests: XCTestCase {
 // MARK: - Device ID Matching Tests
 
 /// Tests for device ID matching behavior during bookmark sync.
+@MainActor
 final class BookmarkDeviceIdMatchingTests: XCTestCase {
 
     private var businessLogic: TPPReaderBookmarksBusinessLogic!

--- a/PalaceTests/Reader2/PositionSyncTests.swift
+++ b/PalaceTests/Reader2/PositionSyncTests.swift
@@ -10,6 +10,7 @@ import ReadiumShared
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class PositionSyncTests: XCTestCase {
 
     // MARK: - Annotations Tests
@@ -86,6 +87,7 @@ final class PositionSyncTests: XCTestCase {
 
 // MARK: - Position Persistence Tests
 
+@MainActor
 final class PositionPersistenceTests: XCTestCase {
 
     private var bookRegistryMock: TPPBookRegistryMock!
@@ -225,6 +227,7 @@ final class PositionPersistenceTests: XCTestCase {
 
 // MARK: - Sync Conflict Resolution Tests
 
+@MainActor
 final class SyncConflictResolutionTests: XCTestCase {
 
     func testConflictResolution_serverNewer_usesServer() {
@@ -289,6 +292,7 @@ final class SyncConflictResolutionTests: XCTestCase {
 /// Tests that sync preconditions correctly gate on AccountDetails.
 /// Regression: After background catalog refresh, AccountDetails became nil,
 /// causing sync to silently fail even though the user was signed in.
+@MainActor
 final class SyncPermissionTests: XCTestCase {
 
     func testSyncIsPossible_withoutCredentials_returnsFalse() {
@@ -373,6 +377,7 @@ final class SyncPermissionTests: XCTestCase {
 /// Tests that TPPLastReadPositionSynchronizer can be created and invoked
 /// from the same context as ReaderService.makeEPUBViewController.
 /// Regression: The SwiftUI EPUB path bypassed the synchronizer entirely.
+@MainActor
 final class ReaderServiceSyncTests: XCTestCase {
 
     func testLastReadPositionSynchronizer_canBeCreated() {

--- a/PalaceTests/Reader2/ReaderChromeToggleFadeTests.swift
+++ b/PalaceTests/Reader2/ReaderChromeToggleFadeTests.swift
@@ -18,6 +18,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ReaderChromeToggleFadeTests: XCTestCase {
 
     // MARK: - overlayLabelsHidden truth table

--- a/PalaceTests/Reader2/TPPBookmarkFactoryTests.swift
+++ b/PalaceTests/Reader2/TPPBookmarkFactoryTests.swift
@@ -11,6 +11,7 @@ import ReadiumShared
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPBookmarkFactoryTests: XCTestCase {
 
     // MARK: - Properties
@@ -555,6 +556,7 @@ final class TPPBookmarkFactoryTests: XCTestCase {
 
 // MARK: - Server Annotation Edge Cases
 
+@MainActor
 final class TPPBookmarkFactoryServerAnnotationEdgeCaseTests: XCTestCase {
 
     private var testBook: TPPBook!
@@ -741,6 +743,7 @@ final class TPPBookmarkFactoryServerAnnotationEdgeCaseTests: XCTestCase {
 
 // MARK: - Initialization Tests
 
+@MainActor
 final class TPPBookmarkFactoryInitTests: XCTestCase {
 
     func testInit_StoresProperties() {

--- a/PalaceTests/Reader2/TPPBookmarkR3LocationTests.swift
+++ b/PalaceTests/Reader2/TPPBookmarkR3LocationTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import ReadiumShared
 @testable import Palace
 
+@MainActor
 final class TPPBookmarkR3LocationTests: XCTestCase {
 
     // MARK: - Initialization Tests
@@ -288,6 +289,7 @@ final class TPPBookmarkR3LocationTests: XCTestCase {
 
 // MARK: - R3 Location Conversion Tests
 
+@MainActor
 final class TPPBookmarkR3ConversionTests: XCTestCase {
 
     private var publication: Publication!

--- a/PalaceTests/Reader2/TPPLastReadPositionPosterTests.swift
+++ b/PalaceTests/Reader2/TPPLastReadPositionPosterTests.swift
@@ -48,6 +48,7 @@ private actor SpyPositionWriter: PositionWriter {
     }
 }
 
+@MainActor
 final class TPPLastReadPositionPosterTests: XCTestCase {
 
     // MARK: - Properties

--- a/PalaceTests/Reader2/TPPLastReadPositionSynchronizerTests.swift
+++ b/PalaceTests/Reader2/TPPLastReadPositionSynchronizerTests.swift
@@ -210,6 +210,7 @@ enum SynchronizerTestFixtures {
 
 // MARK: - Main Test Case
 
+@MainActor
 final class TPPLastReadPositionSynchronizerTests: XCTestCase {
 
     private var sut: TPPLastReadPositionSynchronizer!
@@ -685,6 +686,7 @@ final class TPPLastReadPositionSynchronizerTests: XCTestCase {
 
 /// Tests for the real TPPLastReadPositionSynchronizer class.
 /// These tests focus on initialization and non-network functionality.
+@MainActor
 final class TPPLastReadPositionSynchronizerIntegrationTests: XCTestCase {
 
     private var mockRegistry: TPPBookRegistryMock!
@@ -796,6 +798,7 @@ final class TPPLastReadPositionSynchronizerIntegrationTests: XCTestCase {
 // MARK: - TPPBookLocation Tests
 
 /// Tests for TPPBookLocation which is used by the synchronizer.
+@MainActor
 final class TPPLastReadPositionSynchronizer_BookLocationTests: XCTestCase {
 
     func testTPPBookLocation_Creation_WithValidParameters() {
@@ -922,6 +925,7 @@ final class TPPLastReadPositionSynchronizer_BookLocationTests: XCTestCase {
 // MARK: - TPPReadiumBookmark Tests
 
 /// Tests for TPPReadiumBookmark which represents server annotations.
+@MainActor
 final class TPPLastReadPositionSynchronizer_ReadiumBookmarkTests: XCTestCase {
 
     func testReadiumBookmark_Init_WithValidParameters() {
@@ -1134,6 +1138,7 @@ final class TPPLastReadPositionSynchronizer_ReadiumBookmarkTests: XCTestCase {
 // MARK: - Sync Logic Edge Case Tests
 
 /// Focused tests on sync decision edge cases and boundary conditions.
+@MainActor
 final class TPPLastReadPositionSynchronizer_SyncLogicTests: XCTestCase {
 
     // MARK: - Complex Location String Tests
@@ -1387,6 +1392,7 @@ final class TPPLastReadPositionSynchronizer_SyncLogicTests: XCTestCase {
 // MARK: - Concurrent Access Tests
 
 /// Tests for thread safety and concurrent access patterns.
+@MainActor
 final class TPPLastReadPositionSynchronizer_ConcurrencyTests: XCTestCase {
 
     private var mockRegistry: TPPBookRegistryMock!
@@ -1525,6 +1531,7 @@ final class TPPLastReadPositionSynchronizer_ConcurrencyTests: XCTestCase {
 // MARK: - Documentation Tests
 
 /// Tests that serve as executable documentation for expected behavior.
+@MainActor
 final class TPPLastReadPositionSynchronizer_BehaviorDocumentationTests: XCTestCase {
 
     /// Documents: When server has no reading position, no sync occurs.
@@ -1639,6 +1646,7 @@ private actor SynchronizerSpyWriter: PositionWriter {
 /// an injected spy `PositionWriter`. These tests exercise the actual class
 /// (not `SyncDecisionHelper`) — they catch regressions in the delegation
 /// to `PositionWriter.load` and in the conflict-resolution wiring.
+@MainActor
 final class TPPLastReadPositionSynchronizer_WriterDelegationTests: XCTestCase {
 
     private var bookRegistryMock: TPPBookRegistryMock!

--- a/PalaceTests/Reader2/TPPReaderBlockNavigationTests.swift
+++ b/PalaceTests/Reader2/TPPReaderBlockNavigationTests.swift
@@ -13,6 +13,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPReaderBlockNavigationTests: XCTestCase {
 
   typealias BN = TPPReaderBlockNavigation

--- a/PalaceTests/Reader2/TPPReaderBookmarksReadinessTests.swift
+++ b/PalaceTests/Reader2/TPPReaderBookmarksReadinessTests.swift
@@ -33,6 +33,7 @@ import ReadiumShared
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPReaderBookmarksReadinessTests: XCTestCase {
 
     var bookmarkBusinessLogic: TPPReaderBookmarksBusinessLogic!

--- a/PalaceTests/Reader2/TPPReaderFootnoteAccessibilityTests.swift
+++ b/PalaceTests/Reader2/TPPReaderFootnoteAccessibilityTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPReaderFootnoteAccessibilityTests: XCTestCase {
 
   typealias FA = TPPReaderFootnoteAccessibility

--- a/PalaceTests/Reader2/TPPReaderPositionReportTests.swift
+++ b/PalaceTests/Reader2/TPPReaderPositionReportTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPReaderPositionReportTests: XCTestCase {
 
     // MARK: - All components present

--- a/PalaceTests/Reader2/TPPReaderSettingsTests.swift
+++ b/PalaceTests/Reader2/TPPReaderSettingsTests.swift
@@ -277,6 +277,7 @@ final class TPPReaderSettingsTests: XCTestCase {
 
 // MARK: - TPPReaderPreferencesLoad Tests
 
+@MainActor
 final class TPPReaderPreferencesLoadTests: XCTestCase {
 
     func testTPPReaderPreferencesLoad_returnsValidPreferences() {
@@ -313,6 +314,7 @@ final class TPPReaderPreferencesLoadTests: XCTestCase {
 
 // MARK: - Reader Appearance Tests
 
+@MainActor
 final class TPPReaderAppearanceTests: XCTestCase {
 
     func testBlackOnWhite_hasCorrectPropertyIndex() {
@@ -356,6 +358,7 @@ final class TPPReaderAppearanceTests: XCTestCase {
 
 // MARK: - Reader Font Tests
 
+@MainActor
 final class TPPReaderFontTests: XCTestCase {
 
     func testOriginal_hasCorrectPropertyIndex() {

--- a/PalaceTests/Reader2/TPPReadiumBookmarkTests.swift
+++ b/PalaceTests/Reader2/TPPReadiumBookmarkTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import ReadiumShared
 @testable import Palace
 
+@MainActor
 final class TPPReadiumBookmarkTests: XCTestCase {
 
     // MARK: - Initialization Tests
@@ -551,6 +552,7 @@ final class TPPReadiumBookmarkTests: XCTestCase {
 
 // MARK: - Location Matching Tests
 
+@MainActor
 final class TPPReadiumBookmarkLocationMatchingTests: XCTestCase {
 
     func testLocationMatches_matchingProgress_returnsTrue() {

--- a/PalaceTests/Reader2/Typography/FontManagerTests.swift
+++ b/PalaceTests/Reader2/Typography/FontManagerTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class FontManagerTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Reader2/Typography/ReaderThemeTests.swift
+++ b/PalaceTests/Reader2/Typography/ReaderThemeTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ReaderThemeTests: XCTestCase {
 
     // MARK: - All Cases

--- a/PalaceTests/Reader2/Typography/TypographySettingsTests.swift
+++ b/PalaceTests/Reader2/Typography/TypographySettingsTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TypographySettingsTests: XCTestCase {
 
     // MARK: - Default Initialization

--- a/PalaceTests/ReaderStreaming/StreamingReaderProgressStoreTests.swift
+++ b/PalaceTests/ReaderStreaming/StreamingReaderProgressStoreTests.swift
@@ -11,6 +11,7 @@ import CoreGraphics
 import XCTest
 @testable import Palace
 
+@MainActor
 final class StreamingReaderProgressStoreTests: XCTestCase {
 
     private var suiteName: String!

--- a/PalaceTests/RegressionGuards/AlertPresentationRawGuardLintTests.swift
+++ b/PalaceTests/RegressionGuards/AlertPresentationRawGuardLintTests.swift
@@ -36,6 +36,7 @@
 import Foundation
 import XCTest
 
+@MainActor
 final class AlertPresentationRawGuardLintTests: XCTestCase {
 
     // MARK: - Resolution

--- a/PalaceTests/RegressionGuards/FindawayChapterStatusGuardTests.swift
+++ b/PalaceTests/RegressionGuards/FindawayChapterStatusGuardTests.swift
@@ -17,6 +17,7 @@ import XCTest
 /// refactor that drops the strong ref pattern fails this suite.
 ///
 /// See PalaceTests/RegressionGuards/README.md for the full crash narrative.
+@MainActor
 final class FindawayChapterStatusGuardTests: XCTestCase {
 
     // MARK: - Documentation guard: reference-keeping pattern

--- a/PalaceTests/RegressionGuards/LCPBotanCRLGuardTests.swift
+++ b/PalaceTests/RegressionGuards/LCPBotanCRLGuardTests.swift
@@ -14,6 +14,7 @@ import ReadiumShared
 ///
 /// The fix surface: Palace/Reader2/ReaderStackConfiguration/LCP/TPPLCPClient.swift.
 /// See PalaceTests/RegressionGuards/README.md for the full crash narrative.
+@MainActor
 final class LCPBotanCRLGuardTests: XCTestCase {
 
     // MARK: - decrypt(data:using:) — empty data short-circuit

--- a/PalaceTests/RegressionGuards/iPadOnMacRMSDKGuardTests.swift
+++ b/PalaceTests/RegressionGuards/iPadOnMacRMSDKGuardTests.swift
@@ -22,6 +22,7 @@ import XCTest
 /// `docs/architecture/ws4-mac-validation-runbook.md`.
 ///
 /// See PalaceTests/RegressionGuards/README.md for the full crash narrative.
+@MainActor
 final class iPadOnMacRMSDKGuardTests: XCTestCase {
 
     func testProcessInfoExposes_isiOSAppOnMac_OnSupportedSDKs() {

--- a/PalaceTests/Security/AuthFlowSecurityTests.swift
+++ b/PalaceTests/Security/AuthFlowSecurityTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class AuthFlowSecurityTests: XCTestCase {
 
     private var session: URLSession!

--- a/PalaceTests/Security/DRMAdversarialTests.swift
+++ b/PalaceTests/Security/DRMAdversarialTests.swift
@@ -13,6 +13,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DRMAdversarialTests: XCTestCase {
 
     private var session: URLSession!

--- a/PalaceTests/Settings/DebugSettingsForceSkeletonsTests.swift
+++ b/PalaceTests/Settings/DebugSettingsForceSkeletonsTests.swift
@@ -13,6 +13,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DebugSettingsForceSkeletonsTests: XCTestCase {
 
     private var suiteName: String!

--- a/PalaceTests/Settings/DebugSettingsTests.swift
+++ b/PalaceTests/Settings/DebugSettingsTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class DebugSettingsTests: XCTestCase {
 
     private let settings = DebugSettings()

--- a/PalaceTests/Settings/DeveloperSettingsViewModelTests.swift
+++ b/PalaceTests/Settings/DeveloperSettingsViewModelTests.swift
@@ -14,6 +14,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DeveloperSettingsEngineeringTierTests: XCTestCase {
 
     // Pure decision — no view-model construction, runs everywhere. Mirrors the

--- a/PalaceTests/Settings/DownloadOnlyOnWiFiTests.swift
+++ b/PalaceTests/Settings/DownloadOnlyOnWiFiTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceNetwork
 @testable import Palace
 
+@MainActor
 final class DownloadOnlyOnWiFiTests: XCTestCase {
 
     private let settingsKey = TPPSettings.downloadOnlyOnWiFiKey

--- a/PalaceTests/Settings/SignInFormPresentationTests.swift
+++ b/PalaceTests/Settings/SignInFormPresentationTests.swift
@@ -14,6 +14,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class SignInFormPresentationTests: XCTestCase {
 
     // MARK: - ActionButtonView.titleOpacity

--- a/PalaceTests/Settings/SupportSectionDecisionTests.swift
+++ b/PalaceTests/Settings/SupportSectionDecisionTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class SupportSectionDecisionTests: XCTestCase {
 
     private let generalFallback = "support@thepalaceproject.org"

--- a/PalaceTests/Settings/TPPAccountListDataSourceTests.swift
+++ b/PalaceTests/Settings/TPPAccountListDataSourceTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPAccountListDataSourceTests: XCTestCase {
   
   // MARK: - Helpers

--- a/PalaceTests/Settings/TPPSettingsTests.swift
+++ b/PalaceTests/Settings/TPPSettingsTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import Combine
 @testable import Palace
 
+@MainActor
 final class TPPSettingsTests: XCTestCase {
 
     private var settings: TPPSettings!

--- a/PalaceTests/SignInLogic/AuthReducerTests.swift
+++ b/PalaceTests/SignInLogic/AuthReducerTests.swift
@@ -10,6 +10,7 @@ import PalaceCatalog
 /// The 413 dedicated SignInLogic tests still cover the businessLogic
 /// façade end-to-end; this file pins the transition rules in isolation
 /// so a regression in any one rule fails its own focused test.
+@MainActor
 final class AuthReducerTests: XCTestCase {
 
     // MARK: - Authentication-document loading

--- a/PalaceTests/SignInLogic/SignInModalPredicateTests.swift
+++ b/PalaceTests/SignInLogic/SignInModalPredicateTests.swift
@@ -22,6 +22,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class SignInModalPredicateTests: XCTestCase {
 
     // MARK: - shouldAutoDismiss

--- a/PalaceTests/SignInLogic/SignInModalSAMLOIDCTests.swift
+++ b/PalaceTests/SignInLogic/SignInModalSAMLOIDCTests.swift
@@ -8,6 +8,7 @@ import XCTest
 /// for SAML/OIDC so the sign-in modal is presented when needed.
 /// The handleBorrowAuthErrorIfNeeded guard must allow re-auth for
 /// genuinely expired SAML/OIDC sessions on unborrowed books.
+@MainActor
 final class SignInModalSAMLOIDCTests: XCTestCase {
 
     // MARK: - needsAuth correctness for all auth types

--- a/PalaceTests/SignInLogic/TPPAccountAuthStateTests.swift
+++ b/PalaceTests/SignInLogic/TPPAccountAuthStateTests.swift
@@ -14,6 +14,7 @@ import Combine
 
 // MARK: - Auth State Enum Tests
 
+@MainActor
 final class TPPAccountAuthStateEnumTests: XCTestCase {
 
     func testDescription_returnsCorrectStrings() {
@@ -54,6 +55,7 @@ final class TPPAccountAuthStateEnumTests: XCTestCase {
 
 // MARK: - User Account Auth State Tests
 
+@MainActor
 final class TPPUserAccountAuthStateTests: XCTestCase {
 
     private var userAccount: TPPUserAccountMock!

--- a/PalaceTests/SignInLogic/TPPAgeCheckDeepTests.swift
+++ b/PalaceTests/SignInLogic/TPPAgeCheckDeepTests.swift
@@ -45,6 +45,7 @@ private final class StubLibraryProvider: NSObject, TPPCurrentLibraryAccountProvi
 
 // MARK: - TPPAgeCheck.isValid()
 
+@MainActor
 final class TPPAgeCheckIsValidTests: XCTestCase {
 
     private var storage: TPPAgeCheckChoiceStorageMock!
@@ -122,6 +123,7 @@ final class TPPAgeCheckIsValidTests: XCTestCase {
 
 // MARK: - didCompleteAgeCheck / didFailAgeCheck
 
+@MainActor
 final class TPPAgeCheckCompletionTests: XCTestCase {
 
     private var storage: TPPAgeCheckChoiceStorageMock!
@@ -276,6 +278,7 @@ final class TPPAgeCheckCompletionTests: XCTestCase {
 
 // MARK: - verifyCurrentAccountAgeRequirement decision tree
 
+@MainActor
 final class TPPAgeCheckVerifyDecisionTests: XCTestCase {
 
     private var storage: TPPAgeCheckChoiceStorageMock!

--- a/PalaceTests/SignInLogic/TPPAuthDocumentContractTests.swift
+++ b/PalaceTests/SignInLogic/TPPAuthDocumentContractTests.swift
@@ -26,6 +26,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPAuthDocumentContractTests: XCTestCase {
 
     // MARK: - Coverage table

--- a/PalaceTests/SignInLogic/TPPBasicAuthTests.swift
+++ b/PalaceTests/SignInLogic/TPPBasicAuthTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import PalaceNetwork
 @testable import Palace
 
+@MainActor
 final class TPPBasicAuthTests: XCTestCase {
 
     // MARK: - Properties

--- a/PalaceTests/SignInLogic/TPPCredentialSnapshotCoherenceTests.swift
+++ b/PalaceTests/SignInLogic/TPPCredentialSnapshotCoherenceTests.swift
@@ -33,6 +33,7 @@ import XCTest
 import PalaceKeychain
 @testable import Palace
 
+@MainActor
 final class TPPCredentialSnapshotCoherenceTests: XCTestCase {
 
     private let testLibraryUUID = "test-coherence-\(UUID().uuidString)"

--- a/PalaceTests/SignInLogic/TPPCredentialVisibilityTests.swift
+++ b/PalaceTests/SignInLogic/TPPCredentialVisibilityTests.swift
@@ -346,6 +346,7 @@ final class TPPDRMFailureCredentialPreservationTests: XCTestCase {
 
 /// Tests for TPPUserAccount.credentialSnapshot(for:) which reads all
 /// credential state in a single barrier to prevent races.
+@MainActor
 final class TPPCredentialSnapshotTests: XCTestCase {
 
     override func tearDown() {
@@ -694,6 +695,7 @@ final class TPPSignInProfileDocEdgeCaseTests: XCTestCase {
 
 /// Tests that credential reads remain consistent even when multiple operations
 /// compete for the TPPUserAccount singleton.
+@MainActor
 final class TPPCredentialConcurrencyTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/SignInLogic/TPPCredentialsCoverageTests.swift
+++ b/PalaceTests/SignInLogic/TPPCredentialsCoverageTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPCredentialsCoverageTests: XCTestCase {
 
     // MARK: - Token Credentials

--- a/PalaceTests/SignInLogic/TPPCredentialsTests.swift
+++ b/PalaceTests/SignInLogic/TPPCredentialsTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPCredentialsTests: XCTestCase {
 
     // MARK: - Token Credential Tests

--- a/PalaceTests/SignInLogic/TPPCrossLibrarySignOutTests.swift
+++ b/PalaceTests/SignInLogic/TPPCrossLibrarySignOutTests.swift
@@ -23,7 +23,11 @@ import XCTest
 /// A user account mock that returns separate instances per library UUID,
 /// enabling tests that verify credential isolation between libraries.
 private class TPPMultiLibraryAccountMock: TPPUserAccountMock, @unchecked Sendable {
-    private static var accounts: [String: TPPUserAccountMock] = [:]
+    private static let _accounts = LockIsolated<[String: TPPUserAccountMock]>([:])
+    private static var accounts: [String: TPPUserAccountMock] {
+        get { _accounts.value }
+        set { _accounts.value = newValue }
+    }
 
     static func resetAccounts() {
         accounts.removeAll()

--- a/PalaceTests/SignInLogic/TPPDeferredAdobeActivationTests.swift
+++ b/PalaceTests/SignInLogic/TPPDeferredAdobeActivationTests.swift
@@ -262,6 +262,7 @@ final class TPPLoginNoActivationTests: XCTestCase {
 
 // MARK: - Book Adobe DRM Detection Tests
 
+@MainActor
 final class TPPBookRequiresAdobeDRMTests: XCTestCase {
 
     private static let testURL = URL(string: "https://test.example.com/borrow")!

--- a/PalaceTests/SignInLogic/TPPReauthenticatorTests.swift
+++ b/PalaceTests/SignInLogic/TPPReauthenticatorTests.swift
@@ -109,12 +109,14 @@ final class TPPReauthenticatorMockTests: XCTestCase {
     }
 
     func testMockReauthenticator_callsCompletion() {
-        var completionCallCount = 0
+        // Swift 6: the completion is @Sendable, so a captured counter var can't
+        // be mutated inside it — box it.
+        let completionCallCount = LockIsolated<Int>(0)
         mockReauthenticator.authenticateIfNeeded(userAccount, usingExistingCredentials: true) {
-            completionCallCount += 1
+            completionCallCount.withValue { $0 += 1 }
         }
         // The mock must call the completion (unlike the real implementation which needs UI)
-        XCTAssertEqual(completionCallCount, 1,
+        XCTAssertEqual(completionCallCount.value, 1,
                        "Mock reauthenticator must call the completion exactly once")
         XCTAssertTrue(mockReauthenticator.authenticateIfNeededCalled,
                       "authenticateIfNeededCalled flag must be set after completion")

--- a/PalaceTests/SignInLogic/TPPReauthenticatorTests.swift
+++ b/PalaceTests/SignInLogic/TPPReauthenticatorTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 /// Note: TPPReauthenticator requires UI presentation (SignInModalPresenter) which cannot
 /// be tested in unit tests. Use TPPReauthenticatorMockTests for testing reauthentication logic.
+@MainActor
 final class TPPReauthenticatorTests: XCTestCase {
 
     // MARK: - Properties
@@ -83,6 +84,7 @@ final class TPPReauthenticatorTests: XCTestCase {
 
 // MARK: - Mock Reauthenticator Tests
 
+@MainActor
 final class TPPReauthenticatorMockTests: XCTestCase {
 
     private var mockReauthenticator: TPPReauthenticatorMock!

--- a/PalaceTests/SignInLogic/TPPSAMLLogoutTests.swift
+++ b/PalaceTests/SignInLogic/TPPSAMLLogoutTests.swift
@@ -99,6 +99,7 @@ private enum SAMLSLOFixtures {
 
 // MARK: - Auth-document parsing
 
+@MainActor
 final class SAMLLogoutLinkParsingTests: XCTestCase {
 
     func testSAMLAuth_ParsesLogoutHref_FromAuthDocument() throws {

--- a/PalaceTests/SignInLogic/TPPSignInBusinessLogicExtendedTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInBusinessLogicExtendedTests.swift
@@ -1154,17 +1154,27 @@ class TPPNetworkErrorMock: TPPRequestExecuting {
 
 extension TPPSignInOutBusinessLogicUIDelegateMock {
     var willSignInHandler: (() -> Void)? {
-        get { objc_getAssociatedObject(self, &AssociatedKeys.willSignIn) as? () -> Void }
-        set { objc_setAssociatedObject(self, &AssociatedKeys.willSignIn, newValue, .OBJC_ASSOCIATION_RETAIN) }
+        get { objc_getAssociatedObject(self, AssociatedKeys.willSignIn) as? () -> Void }
+        set { objc_setAssociatedObject(self, AssociatedKeys.willSignIn, newValue, .OBJC_ASSOCIATION_RETAIN) }
     }
 
     var validationErrorHandler: ((Error?, String?, String?) -> Void)? {
-        get { objc_getAssociatedObject(self, &AssociatedKeys.validationError) as? (Error?, String?, String?) -> Void }
-        set { objc_setAssociatedObject(self, &AssociatedKeys.validationError, newValue, .OBJC_ASSOCIATION_RETAIN) }
+        get { objc_getAssociatedObject(self, AssociatedKeys.validationError) as? (Error?, String?, String?) -> Void }
+        set { objc_setAssociatedObject(self, AssociatedKeys.validationError, newValue, .OBJC_ASSOCIATION_RETAIN) }
     }
 }
 
-private struct AssociatedKeys {
-    static var willSignIn = "willSignIn"
-    static var validationError = "validationError"
+private enum AssociatedKeys {
+    // Swift-6 safe associated-object keys. These are used ONLY for their
+    // stable address as objc_get/setAssociatedObject keys — the String
+    // *values* were never read. A mutable `static var` is rejected under
+    // Swift 6 as global mutable state; the LockIsolated computed-var pattern
+    // does NOT work here because `&computedVar` yields a fresh temporary
+    // pointer on every access, so set/get would use different keys and the
+    // association would silently fail (verified: read-back returns nil).
+    // A `static let` heap pointer gives each key a unique, immutable,
+    // address-stable identity — the correct safe fix. Call sites drop the
+    // `&` and pass the pointer directly.
+    static let willSignIn = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+    static let validationError = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
 }

--- a/PalaceTests/SignInLogic/TPPSignInBusinessLogicExtendedTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInBusinessLogicExtendedTests.swift
@@ -1154,27 +1154,33 @@ class TPPNetworkErrorMock: TPPRequestExecuting {
 
 extension TPPSignInOutBusinessLogicUIDelegateMock {
     var willSignInHandler: (() -> Void)? {
-        get { objc_getAssociatedObject(self, AssociatedKeys.willSignIn) as? () -> Void }
-        set { objc_setAssociatedObject(self, AssociatedKeys.willSignIn, newValue, .OBJC_ASSOCIATION_RETAIN) }
+        get { objc_getAssociatedObject(self, AssociatedKeys.willSignIn.raw) as? () -> Void }
+        set { objc_setAssociatedObject(self, AssociatedKeys.willSignIn.raw, newValue, .OBJC_ASSOCIATION_RETAIN) }
     }
 
     var validationErrorHandler: ((Error?, String?, String?) -> Void)? {
-        get { objc_getAssociatedObject(self, AssociatedKeys.validationError) as? (Error?, String?, String?) -> Void }
-        set { objc_setAssociatedObject(self, AssociatedKeys.validationError, newValue, .OBJC_ASSOCIATION_RETAIN) }
+        get { objc_getAssociatedObject(self, AssociatedKeys.validationError.raw) as? (Error?, String?, String?) -> Void }
+        set { objc_setAssociatedObject(self, AssociatedKeys.validationError.raw, newValue, .OBJC_ASSOCIATION_RETAIN) }
     }
 }
 
+/// Address-stable objc associated-object key. Holds ONE immutable pointer,
+/// allocated once and never mutated — only its address is used as a key — so
+/// it is genuinely `Sendable` (the @unchecked waiver covers the fact that
+/// `UnsafeMutableRawPointer` isn't `Sendable`, which is safe here because the
+/// pointer is a `let` and its pointee is never read or written).
+private final class AssociatedKey: @unchecked Sendable {
+    let raw = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+}
+
 private enum AssociatedKeys {
-    // Swift-6 safe associated-object keys. These are used ONLY for their
-    // stable address as objc_get/setAssociatedObject keys — the String
-    // *values* were never read. A mutable `static var` is rejected under
-    // Swift 6 as global mutable state; the LockIsolated computed-var pattern
-    // does NOT work here because `&computedVar` yields a fresh temporary
-    // pointer on every access, so set/get would use different keys and the
-    // association would silently fail (verified: read-back returns nil).
-    // A `static let` heap pointer gives each key a unique, immutable,
-    // address-stable identity — the correct safe fix. Call sites drop the
-    // `&` and pass the pointer directly.
-    static let willSignIn = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
-    static let validationError = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+    // Swift-6 safe associated-object keys — used ONLY for their stable address.
+    // A mutable `static var` is rejected as global mutable state; the
+    // LockIsolated computed-var pattern does NOT work (`&computedVar` yields a
+    // fresh temporary pointer each access, so set/get key differently and the
+    // association silently fails). A bare `static let UnsafeMutableRawPointer`
+    // is address-stable but non-Sendable, so it too is rejected under Swift 6.
+    // Wrapping the immutable pointer in a Sendable holder is the correct fix.
+    static let willSignIn = AssociatedKey()
+    static let validationError = AssociatedKey()
 }

--- a/PalaceTests/SignInLogic/TPPSignInOIDCTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInOIDCTests.swift
@@ -14,6 +14,7 @@ import PalaceCatalog
 
 // MARK: - Unit Tests: AuthType & Authentication Model
 
+@MainActor
 final class OIDCAuthTypeTests: XCTestCase {
 
     func testAuthType_OidcRawValue_IsCorrect() {
@@ -64,6 +65,7 @@ final class OIDCAuthTypeTests: XCTestCase {
 
 // MARK: - Unit Tests: Authentication Properties
 
+@MainActor
 final class OIDCAuthenticationPropertyTests: XCTestCase {
 
     private var libraryMock: TPPLibraryAccountMock!
@@ -132,6 +134,7 @@ final class OIDCAuthenticationPropertyTests: XCTestCase {
 
 // MARK: - Unit Tests: OPDS Auth Document Parsing
 
+@MainActor
 final class OIDCAuthDocumentParsingTests: XCTestCase {
 
     func testAuthDocument_containsOidcType() {
@@ -184,6 +187,7 @@ final class OIDCAuthDocumentParsingTests: XCTestCase {
 
 // MARK: - Unit Tests: NSCoding Round-Trip
 
+@MainActor
 final class OIDCNSCodingTests: XCTestCase {
 
     func testOidcAuthentication_NSCodingRoundTrip_PreservesProperties() {
@@ -846,6 +850,7 @@ final class OIDCRegressionTests: XCTestCase {
 
 // MARK: - Regression Tests: UI ViewModel
 
+@MainActor
 final class OIDCViewModelRegressionTests: XCTestCase {
 
     private var libraryMock: TPPLibraryAccountMock!
@@ -1876,6 +1881,7 @@ final class OIDCViewModelSignInTests: XCTestCase {
 
 // MARK: - Tests: Network Layer OIDC 401 Handling
 
+@MainActor
 final class OIDCNetworkLayer401Tests: XCTestCase {
 
     func testOIDC_authDefinition_isNotToken() {

--- a/PalaceTests/SignInLogic/TokenRequestTests.swift
+++ b/PalaceTests/SignInLogic/TokenRequestTests.swift
@@ -10,6 +10,7 @@ import PalaceAuth
 @testable import Palace
 
 /// SRS: REL-003 — Token refresh retry limit prevents loops
+@MainActor
 class TokenRequestTests: XCTestCase {
 
     override func setUp() {

--- a/PalaceTests/Stats/BadgeDefinitionTests.swift
+++ b/PalaceTests/Stats/BadgeDefinitionTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BadgeDefinitionTests: XCTestCase {
 
   // MARK: - Test Helpers

--- a/PalaceTests/Stats/BadgeServiceTests.swift
+++ b/PalaceTests/Stats/BadgeServiceTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class BadgeServiceTests: XCTestCase {
   private var statsStore: MockStatsStore!
   private var statsService: ReadingStatsService!

--- a/PalaceTests/Stats/ReadingStatsServiceTests.swift
+++ b/PalaceTests/Stats/ReadingStatsServiceTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ReadingStatsServiceTests: XCTestCase {
 
   private var store: MockStatsStore!

--- a/PalaceTests/Stats/ReadingStatsStoreTests.swift
+++ b/PalaceTests/Stats/ReadingStatsStoreTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ReadingStatsStoreTests: XCTestCase {
   private var store: ReadingStatsStore!
   private var defaults: UserDefaults!

--- a/PalaceTests/String+NYPLAdditionsTests.swift
+++ b/PalaceTests/String+NYPLAdditionsTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class String_NYPLAdditionsTests: XCTestCase {
     func testURLEncodingQueryParam() {
         let multiASCIIWord = "Pinco Pallino".stringURLEncodedAsQueryParamValue()

--- a/PalaceTests/Support/LockIsolated.swift
+++ b/PalaceTests/Support/LockIsolated.swift
@@ -1,0 +1,53 @@
+//
+//  LockIsolated.swift
+//  PalaceTests
+//
+//  Swift 6 concurrency-safe holder for test-infrastructure state that used to
+//  live in a `static var`. Under Swift 6 language mode, a mutable `static var`
+//  is "nonisolated global shared mutable state" and is rejected — even for the
+//  serial/lock-guarded registries our test stubs rely on (HTTPStubURLProtocol
+//  handlers, stubbed sessions, mock singletons, etc.).
+//
+//  The migration pattern (chosen over `nonisolated(unsafe)`, which would merely
+//  silence the check) is:
+//
+//      // before — flagged as unsafe global mutable state:
+//      static var requestHandlers: [String: Handler] = [:]
+//
+//      // after — genuinely safe, and every existing call site is unchanged:
+//      private static let _requestHandlers = LockIsolated<[String: Handler]>([:])
+//      static var requestHandlers: [String: Handler] {
+//          get { _requestHandlers.value }
+//          set { _requestHandlers.value = newValue }
+//      }
+//
+//  The `static let` binding is immutable (safe); all mutation flows through the
+//  lock. The public `static var` is *computed* — it holds no storage of its own,
+//  so it is not global mutable state, and callers keep writing `Type.requestHandlers`.
+//
+//  `@unchecked Sendable` is sound here because every access to the wrapped value
+//  goes through `lock`, which the compiler cannot see but the type guarantees.
+import Foundation
+
+final class LockIsolated<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: Value
+
+    init(_ value: Value) {
+        self._value = value
+    }
+
+    /// Atomically read or replace the wrapped value.
+    var value: Value {
+        get { lock.withLock { _value } }
+        set { lock.withLock { _value = newValue } }
+    }
+
+    /// Perform an atomic read-modify-write against the wrapped value and return
+    /// a result. Use this when a compound mutation must not interleave (e.g.
+    /// append-then-read), which the get/set `value` pair cannot guarantee.
+    @discardableResult
+    func withValue<T>(_ body: (inout Value) throws -> T) rethrows -> T {
+        try lock.withLock { try body(&_value) }
+    }
+}

--- a/PalaceTests/Support/PalaceTestCase.swift
+++ b/PalaceTests/Support/PalaceTestCase.swift
@@ -34,6 +34,7 @@ import XCTest
 @testable import Palace
 
 /// Base XCTestCase that asserts runtime quiescence on tearDown. See header.
+@MainActor
 class PalaceTestCase: XCTestCase {
 
     /// Pre-test `NotificationCenter.default` observer count, captured in setUp.

--- a/PalaceTests/Support/PalaceWiringTestCase.swift
+++ b/PalaceTests/Support/PalaceWiringTestCase.swift
@@ -61,6 +61,7 @@ import Combine
 ///    private set so the base can drain on tearDown.
 ///  - Mint `AccountsManager` via `makeFreshAccountsManager()` rather
 ///    than `AccountsManager()` so the cancellation hook fires.
+@MainActor
 class PalaceWiringTestCase: PalaceTestCase {
 
     /// Combine subscription bag for the subclass. The base drains this

--- a/PalaceTests/Support/PalaceWiringTestCaseTests.swift
+++ b/PalaceTests/Support/PalaceWiringTestCaseTests.swift
@@ -24,6 +24,7 @@ import XCTest
 import Combine
 @testable import Palace
 
+@MainActor
 final class PalaceWiringTestCaseTests: XCTestCase {
 
     // MARK: - Probe — a minimal subclass we can drive synchronously
@@ -32,6 +33,7 @@ final class PalaceWiringTestCaseTests: XCTestCase {
     /// and `tearDownWithError` from this outer test and observe the effects.
     /// `XCTestCase`'s default no-arg `init()` is suitable for that — we never
     /// register `Probe` with the runner, we just instantiate it.
+    @MainActor
     final class Probe: PalaceWiringTestCase {
         var cancellableDrainCount: Int { return drainObservedCancellableCount }
         private(set) var drainObservedCancellableCount: Int = 0

--- a/PalaceTests/Support/SingletonResetRegistry.swift
+++ b/PalaceTests/Support/SingletonResetRegistry.swift
@@ -22,7 +22,12 @@ import Foundation
 ///
 /// Storage is an array of `(name, closure)` tuples — NOT a dictionary —
 /// because iteration order = registration order is part of the contract.
-internal class SingletonResetRegistry {
+/// `@unchecked Sendable`: all mutable stored state (`resetters`, `isIterating`)
+/// is guarded by `lock` — every read/write path acquires it before touching
+/// storage (`register`, `registeredNames`, `invokeAll`, `_removeAllForTests`).
+/// The compiler can't see the lock, but the type guarantees it, so `static let
+/// shared` is safe to share across concurrency domains.
+internal class SingletonResetRegistry: @unchecked Sendable {
     static let shared = SingletonResetRegistry()
 
     private let lock = NSLock()

--- a/PalaceTests/Support/SingletonResetRegistryTests.swift
+++ b/PalaceTests/Support/SingletonResetRegistryTests.swift
@@ -7,6 +7,7 @@ import XCTest
 /// test. The registry is process-wide; every test in this class drains the
 /// registry via `_removeAllForTests()` in `setUp` so the suite's built-in
 /// resetters do not leak into these assertions and vice-versa.
+@MainActor
 final class SingletonResetRegistryTests: XCTestCase {
 
     override func setUp() {

--- a/PalaceTests/Support/TPPUserAccountTestFactory.swift
+++ b/PalaceTests/Support/TPPUserAccountTestFactory.swift
@@ -90,7 +90,11 @@ struct TPPUserAccountTestFactory {
     /// < 10 ms on the main thread. `removeAll()` is keychain-bound, so we
     /// keep the tracked list short (one entry per test). Lock is held
     /// only across array snapshot — closures run outside the lock.
-    private final class Tracker {
+    /// `@unchecked Sendable`: the only mutable stored state (`minted`) is
+    /// guarded by `lock` — both `track` and `resetAll` acquire it before
+    /// touching the array. The compiler can't see the lock, but the type
+    /// guarantees it, so `static let shared` is safe across concurrency domains.
+    private final class Tracker: @unchecked Sendable {
         static let shared = Tracker()
 
         private let lock = NSLock()

--- a/PalaceTests/Support/TPPUserAccountTestFactoryTests.swift
+++ b/PalaceTests/Support/TPPUserAccountTestFactoryTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPUserAccountTestFactoryTests: XCTestCase {
 
     override func setUpWithError() throws {

--- a/PalaceTests/Support/TriageBotKeyAdminTests.swift
+++ b/PalaceTests/Support/TriageBotKeyAdminTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TriageBotKeyAdminTests: XCTestCase {
 
     /// In-memory stand-in for `AnthropicKeyStore` so the admin logic is tested

--- a/PalaceTests/Support/XCTestCase+testUserDefaultsTests.swift
+++ b/PalaceTests/Support/XCTestCase+testUserDefaultsTests.swift
@@ -9,6 +9,7 @@ import XCTest
 /// The "SUT" here is the helper extension itself; the file name
 /// (`XCTestCase+testUserDefaultsTests`) reflects that — the test
 /// methods exercise `testUserDefaults()` directly.
+@MainActor
 final class XCTestCase_testUserDefaultsTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
+++ b/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
@@ -22,6 +22,7 @@ import ReadiumShared
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class CrossDeviceSyncE2ETests: XCTestCase {
 
     // MARK: - Test fixtures

--- a/PalaceTests/TPPAgeCheckTests.swift
+++ b/PalaceTests/TPPAgeCheckTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class TPPAgeCheckTests: XCTestCase {
 
     // Classes/mocks needed for testing

--- a/PalaceTests/TPPBookCoverRegistryTests.swift
+++ b/PalaceTests/TPPBookCoverRegistryTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import ImageIO
 @testable import Palace
 
+@MainActor
 final class TPPBookCoverRegistryTests: XCTestCase {
 
     // MARK: - Downsample Decode Tests

--- a/PalaceTests/TPPBookCreationTests.swift
+++ b/PalaceTests/TPPBookCreationTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPBookCreationTests: XCTestCase {
     var opdsEntry: TPPOPDSEntry!
     var opdsEntryMinimal: TPPOPDSEntry!

--- a/PalaceTests/TPPBookStateTests.swift
+++ b/PalaceTests/TPPBookStateTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Palace
 
+@MainActor
 class TPPBookStateTests: XCTestCase {
 
     func testInitWithString() {

--- a/PalaceTests/TPPCachingTests.swift
+++ b/PalaceTests/TPPCachingTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceNetwork
 @testable import Palace
 
+@MainActor
 class TPPCachingTests: XCTestCase {
     var libraryCallResponse: HTTPURLResponse!
     var sufficientHeadersResponse: HTTPURLResponse!

--- a/PalaceTests/TPPConfigurationCustomRegistryTests.swift
+++ b/PalaceTests/TPPConfigurationCustomRegistryTests.swift
@@ -8,6 +8,7 @@ import XCTest
 /// behavior; a full URL is used verbatim so a developer can target an
 /// exact endpoint such as the non-crawlable `/libraries` feed that older
 /// clients parse directly.
+@MainActor
 final class TPPConfigurationCustomRegistryTests: XCTestCase {
 
   private var suiteName: String!

--- a/PalaceTests/TPPConfigurationTests.swift
+++ b/PalaceTests/TPPConfigurationTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPConfigurationTests: XCTestCase {
 
   // MARK: - Color Methods

--- a/PalaceTests/TPPJWKConversionTest.swift
+++ b/PalaceTests/TPPJWKConversionTest.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class TPPJWKConversionTest: XCTestCase {
 
     var jwkResponseData: Data!

--- a/PalaceTests/TPPOPDSAcquisitionPathTests.swift
+++ b/PalaceTests/TPPOPDSAcquisitionPathTests.swift
@@ -3,6 +3,7 @@ import PalaceCatalog
 
 @testable import Palace
 
+@MainActor
 class TPPOPDSAcquisitionPathTests: XCTestCase {
 
     var acquisitions: [TPPOPDSAcquisition]!

--- a/PalaceTests/TPPOpenSearchDescriptionExpandedTests.swift
+++ b/PalaceTests/TPPOpenSearchDescriptionExpandedTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPOpenSearchDescriptionExpandedTests: XCTestCase {
 
   // MARK: - Init with XML

--- a/PalaceTests/TPPOpenSearchDescriptionTests.swift
+++ b/PalaceTests/TPPOpenSearchDescriptionTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPOpenSearchDescriptionTests: XCTestCase {
     var searchDescr: TPPOpenSearchDescription!
 

--- a/PalaceTests/TPPReaderBookmarksBusinessLogicTests.swift
+++ b/PalaceTests/TPPReaderBookmarksBusinessLogicTests.swift
@@ -11,6 +11,7 @@ import ReadiumShared
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 class TPPReaderBookmarksBusinessLogicTests: XCTestCase {
     var bookmarkBusinessLogic: TPPReaderBookmarksBusinessLogic!
     var bookRegistryMock: TPPBookRegistryMock!

--- a/PalaceTests/TPPUserNotificationsTests.swift
+++ b/PalaceTests/TPPUserNotificationsTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import Palace
 
 /// Tests for NotificationService hold availability and badge functionality
+@MainActor
 final class TPPUserNotificationsTests: XCTestCase {
 
     override func tearDown() {

--- a/PalaceTests/UIColor+NYPLAdditionsTests.swift
+++ b/PalaceTests/UIColor+NYPLAdditionsTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class UIColor_NYPLAdditionsTests: XCTestCase {
     func testExample() throws {
         let color = UIColor(red: 0.65, green: 0.23, blue: 0.8, alpha: 0.4)

--- a/PalaceTests/UIPolish/BadgeUnlockPhaseTests.swift
+++ b/PalaceTests/UIPolish/BadgeUnlockPhaseTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class BadgeUnlockPhaseTests: XCTestCase {
 
   func testPhaseOrder_isIdleThenPopThenSettle() {

--- a/PalaceTests/UIPolish/PDFSearchEmptyStateTests.swift
+++ b/PalaceTests/UIPolish/PDFSearchEmptyStateTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class PDFSearchEmptyStateTests: XCTestCase {
 
   func testShowsNoResults_committedQueryWithZeroMatches_showsEmptyState() {

--- a/PalaceTests/UIPolish/RatingCardMotionGateTests.swift
+++ b/PalaceTests/UIPolish/RatingCardMotionGateTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class RatingCardMotionGateTests: XCTestCase {
 
   // MARK: usesScaleTransition

--- a/PalaceTests/URLRequest+NYPLTests.swift
+++ b/PalaceTests/URLRequest+NYPLTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 class URLRequest_NYPLTests: XCTestCase {
     func testAuthorizationHeaderStrip() throws {
         var req = URLRequest(url: URL(string: "https://example.org/ciccio")!)

--- a/PalaceTests/URLSession+Stubbing.swift
+++ b/PalaceTests/URLSession+Stubbing.swift
@@ -7,7 +7,11 @@ extension URLSession {
     /// `static let` form left a permanently bound session whose private
     /// delegate queue accumulated callbacks across tests and produced the
     /// `libdispatch` use-after-free described in the header comment below.
-    private static var _sharedStubbedSession: URLSession = URLSession._buildStubbedSession()
+    private static let _sharedStubbedSessionBox = LockIsolated<URLSession>(URLSession._buildStubbedSession())
+    private static var _sharedStubbedSession: URLSession {
+        get { _sharedStubbedSessionBox.value }
+        set { _sharedStubbedSessionBox.value = newValue }
+    }
 
     private static func _buildStubbedSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral

--- a/PalaceTests/URLSessionStubbingResetTests.swift
+++ b/PalaceTests/URLSessionStubbingResetTests.swift
@@ -10,6 +10,7 @@ import XCTest
 ///      implementation uses `finishTasksAndInvalidate()` precisely so a
 ///      reset call mid-test doesn't strand a completion handler on a freed
 ///      delegate queue.
+@MainActor
 final class URLSessionStubbingResetTests: XCTestCase {
 
     override func setUp() {

--- a/PalaceTests/UserProfileDocumentTests.swift
+++ b/PalaceTests/UserProfileDocumentTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Palace
 
+@MainActor
 class UserProfileDocumentTests: XCTestCase {
     let validJson = TPPFake.validUserProfileJson
 

--- a/PalaceTests/Utilities/DateExtensionTests.swift
+++ b/PalaceTests/Utilities/DateExtensionTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DateExtensionTests: XCTestCase {
 
     // MARK: - RFC339 Format Tests
@@ -118,6 +119,7 @@ final class DateExtensionTests: XCTestCase {
 
 // MARK: - Date Formatting Tests
 
+@MainActor
 final class DateFormattingTests: XCTestCase {
 
     func testShortDateFormat() {

--- a/PalaceTests/Utilities/DeviceOrientationTests.swift
+++ b/PalaceTests/Utilities/DeviceOrientationTests.swift
@@ -12,16 +12,18 @@ final class DeviceOrientationTests: XCTestCase {
 
     var orientation: DeviceOrientation!
 
-    @MainActor
-    override func setUp() {
+    override nonisolated func setUp() {
         super.setUp()
-        orientation = DeviceOrientation()
+        MainActor.assumeIsolated {
+            orientation = DeviceOrientation()
+        }
     }
 
-    @MainActor
-    override func tearDown() {
-        orientation?.stopTracking()
-        orientation = nil
+    override nonisolated func tearDown() {
+        MainActor.assumeIsolated {
+            orientation?.stopTracking()
+            orientation = nil
+        }
         super.tearDown()
     }
 

--- a/PalaceTests/Utilities/DeviceOrientationTests.swift
+++ b/PalaceTests/Utilities/DeviceOrientationTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class DeviceOrientationTests: XCTestCase {
 
     var orientation: DeviceOrientation!

--- a/PalaceTests/Utilities/EmailAddressTests.swift
+++ b/PalaceTests/Utilities/EmailAddressTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class EmailAddressTests: XCTestCase {
 
     // MARK: - Valid Emails

--- a/PalaceTests/Utilities/ExtensionCoverageTests.swift
+++ b/PalaceTests/Utilities/ExtensionCoverageTests.swift
@@ -15,6 +15,7 @@ import XCTest
 
 // MARK: - Float+TPPAdditions Tests
 
+@MainActor
 final class FloatTPPAdditionsCoverageTests: XCTestCase {
 
     // SRS: Float approximate equality returns true for equal values
@@ -76,6 +77,7 @@ final class FloatTPPAdditionsCoverageTests: XCTestCase {
 
 // MARK: - Int+Extensions Tests
 
+@MainActor
 final class IntExtensionsCoverageTests: XCTestCase {
 
     // SRS: Int ordinal returns "1st" for 1
@@ -123,6 +125,7 @@ final class IntExtensionsCoverageTests: XCTestCase {
 
 // MARK: - Dictionary+Extensions Tests
 
+@MainActor
 final class DictionaryExtensionsCoverageTests: XCTestCase {
 
     // SRS: Dictionary mapKeys transforms keys correctly
@@ -156,6 +159,7 @@ final class DictionaryExtensionsCoverageTests: XCTestCase {
 
 // MARK: - Array+Extensions Tests
 
+@MainActor
 final class ArrayExtensionsCoverageTests: XCTestCase {
 
     // SRS: Array safe subscript returns element at valid index
@@ -222,6 +226,7 @@ final class ArrayExtensionsCoverageTests: XCTestCase {
 
 // MARK: - String+Extensions Tests
 
+@MainActor
 final class StringExtensionsCoverageTests: XCTestCase {
 
     // SRS: String.isDate returns true when date1 + delay > date2
@@ -265,6 +270,7 @@ final class StringExtensionsCoverageTests: XCTestCase {
 
 // MARK: - Data+Base64 Tests
 
+@MainActor
 final class DataBase64CoverageTests: XCTestCase {
 
     // SRS: Data URL-safe base64 replaces + with -
@@ -311,6 +317,7 @@ final class DataBase64CoverageTests: XCTestCase {
 
 // MARK: - URL+Extensions Tests
 
+@MainActor
 final class URLExtensionsCoverageTests: XCTestCase {
 
     // SRS: URL replacingScheme changes http to https
@@ -346,6 +353,7 @@ final class URLExtensionsCoverageTests: XCTestCase {
 
 // MARK: - URLResponse+NYPL Tests
 
+@MainActor
 final class URLResponseNYPLCoverageTests: XCTestCase {
 
     // SRS: URLResponse isProblemDocument for application/problem+json
@@ -429,6 +437,7 @@ final class URLResponseNYPLCoverageTests: XCTestCase {
 
 // MARK: - Date+Extensions Tests
 
+@MainActor
 final class DateExtensionsCoverageTests: XCTestCase {
 
     // SRS: Date monthDayYearString formats correctly
@@ -485,6 +494,7 @@ final class DateExtensionsCoverageTests: XCTestCase {
 
 // MARK: - String+MD5 Tests
 
+@MainActor
 final class StringMD5Tests: XCTestCase {
 
     // SRS: String md5 produces correct hash for known input
@@ -540,6 +550,7 @@ final class StringMD5Tests: XCTestCase {
 
 // MARK: - UIColor+Extensions Tests
 
+@MainActor
 final class UIColorExtensionsTests: XCTestCase {
 
     // SRS: UIColor defaultLabelColor returns a color

--- a/PalaceTests/Utilities/GeneralCacheClearOnUpdateTests.swift
+++ b/PalaceTests/Utilities/GeneralCacheClearOnUpdateTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class GeneralCacheClearOnUpdateTests: XCTestCase {
 
     private let suiteName = "GeneralCacheClearOnUpdateTests"

--- a/PalaceTests/Utilities/GeneralCacheTests.swift
+++ b/PalaceTests/Utilities/GeneralCacheTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class GeneralCacheTests: XCTestCase {
 
     private var cache: GeneralCache<String, String>!

--- a/PalaceTests/Utilities/ImageCoverKeyUnificationTests.swift
+++ b/PalaceTests/Utilities/ImageCoverKeyUnificationTests.swift
@@ -14,6 +14,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class ImageCoverKeyUnificationTests: XCTestCase {
 
     func testCoverKey_cellAndPrefetch_coalesceForSmallDisplay() throws {

--- a/PalaceTests/Utilities/PalaceHapticTests.swift
+++ b/PalaceTests/Utilities/PalaceHapticTests.swift
@@ -43,6 +43,7 @@ private final class MockAccessibilityService: AccessibilityServiceProtocol, @unc
     func isHighContrastEffective() async -> Bool { false }
 }
 
+@MainActor
 final class PalaceHapticTests: XCTestCase {
 
     // MARK: - resolvedFeedback — the gating decision

--- a/PalaceTests/Utilities/PalaceMotionTests.swift
+++ b/PalaceTests/Utilities/PalaceMotionTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class PalaceMotionTests: XCTestCase {
 
     // MARK: - resolved(_:reduceMotion:) — the reduce-motion gate

--- a/PalaceTests/Utilities/PalacePressableButtonStyleTests.swift
+++ b/PalaceTests/Utilities/PalacePressableButtonStyleTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class PalacePressableButtonStyleTests: XCTestCase {
 
     // MARK: - scale(isPressed:reduceMotion:)

--- a/PalaceTests/Utilities/SafeDictionarySyncMirrorTests.swift
+++ b/PalaceTests/Utilities/SafeDictionarySyncMirrorTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class SafeDictionarySyncMirrorTests: XCTestCase {
 
     // MARK: - syncGet mirrors async set

--- a/PalaceTests/Utilities/SafeDictionaryTests.swift
+++ b/PalaceTests/Utilities/SafeDictionaryTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class SafeDictionaryTests: XCTestCase {
 
     // MARK: - Basic Operations

--- a/PalaceTests/Utilities/SkeletonTests.swift
+++ b/PalaceTests/Utilities/SkeletonTests.swift
@@ -14,6 +14,7 @@ import XCTest
 import SwiftUI
 @testable import Palace
 
+@MainActor
 final class SkeletonTests: XCTestCase {
 
   // MARK: - sweepTranslationX — the diagonal band actually travels

--- a/PalaceTests/Utilities/StringExtensionTests.swift
+++ b/PalaceTests/Utilities/StringExtensionTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class StringExtensionTests: XCTestCase {
 
     // MARK: - MD5 Hash Tests
@@ -106,6 +107,7 @@ final class StringExtensionTests: XCTestCase {
 
 // MARK: - Additional String Tests
 
+@MainActor
 final class StringNYPLAdditionsTests: XCTestCase {
 
     func testStringIsEmpty_withWhitespace() {

--- a/PalaceTests/Utilities/StringExtensionsTests.swift
+++ b/PalaceTests/Utilities/StringExtensionsTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class StringExtensionsTests: XCTestCase {
 
     // MARK: - isDate(_:moreRecentThan:with:) — happy paths

--- a/PalaceTests/Utilities/TPPBackgroundExecutorTests.swift
+++ b/PalaceTests/Utilities/TPPBackgroundExecutorTests.swift
@@ -48,6 +48,7 @@ private class MockBackgroundWorkOwner: NSObject, NYPLBackgroundWorkOwner {
 
 // MARK: - Tests
 
+@MainActor
 final class TPPBackgroundExecutorTests: XCTestCase {
 
     func testExecutorCallsSetUpWorkItem() {

--- a/PalaceTests/Utilities/TPPBookContentMetadataFilesHelperTests.swift
+++ b/PalaceTests/Utilities/TPPBookContentMetadataFilesHelperTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class TPPBookContentMetadataFilesHelperTests: XCTestCase {
 
     // MARK: - Directory for Account

--- a/PalaceTests/Utilities/TPPXMLSwiftTests.swift
+++ b/PalaceTests/Utilities/TPPXMLSwiftTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import PalaceCatalog
 @testable import Palace
 
+@MainActor
 final class TPPXMLSwiftTests: XCTestCase {
 
   // MARK: - Parsing Valid XML

--- a/PalaceTests/Utilities/URL+BackupExclusionTests.swift
+++ b/PalaceTests/Utilities/URL+BackupExclusionTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class URLBackupExclusionTests: XCTestCase {
 
     private var sandbox: URL!

--- a/PalaceTests/Utilities/URLExtensionTests.swift
+++ b/PalaceTests/Utilities/URLExtensionTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Palace
 
+@MainActor
 final class URLExtensionTests: XCTestCase {
 
     // MARK: - URL Component Tests
@@ -165,6 +166,7 @@ final class URLExtensionTests: XCTestCase {
 
 // MARK: - URL Validation Tests
 
+@MainActor
 final class URLValidationTests: XCTestCase {
 
     func testValidHTTPURL() {

--- a/PalaceTests/ViewModels/FacetViewModelTests.swift
+++ b/PalaceTests/ViewModels/FacetViewModelTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import Combine
 @testable import Palace
 
+@MainActor
 final class FacetViewModelTests: XCTestCase {
 
     private var cancellables: Set<AnyCancellable> = []

--- a/PalaceTests/ViewModels/HoldsReducerTests.swift
+++ b/PalaceTests/ViewModels/HoldsReducerTests.swift
@@ -12,7 +12,7 @@ final class HoldsReducerTests: XCTestCase {
     // MARK: - Fixtures
 
     private func makeEnv(
-        filter: @escaping (String, [TPPBook]) async -> [TPPBook] = { _, books in books }
+        filter: @escaping @Sendable (String, [TPPBook]) async -> [TPPBook] = { _, books in books }
     ) -> HoldsEnvironment {
         HoldsEnvironment(filterBooks: filter)
     }

--- a/PalaceTests/ViewModels/ViewModelComputedPropertyTests.swift
+++ b/PalaceTests/ViewModels/ViewModelComputedPropertyTests.swift
@@ -419,6 +419,7 @@ final class BookCellStateComprehensiveTests: XCTestCase {
 
 /// Tests BookButtonMapper.map() for all state combinations.
 /// SRS: BookButtonMapper is the central mapping from registry state + availability to UI state.
+@MainActor
 final class BookButtonMapperViewModelTests: XCTestCase {
 
     func testMap_Downloading_ReturnsDownloadInProgress() {

--- a/PalaceTests/VisualRegression/AnonymousBorrowFixtureTests.swift
+++ b/PalaceTests/VisualRegression/AnonymousBorrowFixtureTests.swift
@@ -140,6 +140,7 @@ final class AnonymousBorrowBaselineFixtureTests: XCTestCase {
 /// regressions introduced between 3.0.0 and the candidate. Keeping this in a
 /// separate XCTestCase makes the regression delta visible at the top of the
 /// test report.
+@MainActor
 final class AnonymousBorrowCandidateFixtureTests: XCTestCase {
 
   func test_03_catalog_titleIsPalaceBookshelf() throws {
@@ -182,6 +183,7 @@ final class AnonymousBorrowCandidateFixtureTests: XCTestCase {
 /// Failures here mean a behavior changed between versions in a way the per-version
 /// asserts didn't catch. Tolerance is set high (50px) because some shifts are
 /// content-driven (different book titles) rather than code-driven.
+@MainActor
 final class AnonymousBorrowDeltaTests: XCTestCase {
 
   func test_03_catalog_structureMatchesBetweenVersions() throws {


### PR DESCRIPTION
**Draft / measurement PR — not for merge as-is.**

Flips the PalaceTests target to Swift 6 language mode (`SWIFT_VERSION 4.2 → 6.0`) so complete actor-isolation checking runs in the test target, matching the app targets. Under Swift 4.2 the test closures compile in lenient mode; under Swift 6 the compiler enforces isolation — which would catch the @MainActor-off-main class (#1218 audiobook crashes) at compile time in tests.

Pushed purely to let CI reveal **how many existing tests trip strict-concurrency**. That error count is the input for how we tackle the migration. Follow-up commits on this branch will fix what CI surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)