### PR TITLE
test(triagebot): redaction corpus + release-time leak-check automation (PP-4806)

### DIFF
--- a/Palace/Packages/PalaceTriageBot/Package.swift
+++ b/Palace/Packages/PalaceTriageBot/Package.swift
@@ -51,6 +51,10 @@ let package = Package(
         .testTarget(
             name: "TriageBotCoreTests",
             dependencies: ["TriageBotCore"],
+            // PP-4806: synthetic redaction corpus. Copied verbatim so the
+            // deny-list guard (RedactionCorpusTests) can enumerate the
+            // captured-payload fixtures at runtime via Bundle.module.
+            resources: [.copy("Fixtures")],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         // iOS-adapter tests. Depends on TriageBotIOS (ClaudeFallbackClassifier)

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/README.md
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/README.md
@@ -1,0 +1,41 @@
+# Redaction corpus — SYNTHETIC fixtures (PP-4806)
+
+**Every value in these `*.txt` files is hand-authored and FAKE.** No real
+patron credential, barcode, token, cookie, or PIN appears here. The strings are
+*shaped* like the secrets the HelpSpot forensic (PR #1278 / PP-4805) found
+leaking — Bearer/JWT tokens, `Basic` auth, `Set-Cookie` values, 3-8 digit PINs
+adjacent to "pin/passcode", 10-14 digit card barcodes, `password:`/`access_token`
+key-value pairs — so that `ContextRedactor` has a realistic, sensitive-flow
+payload to prove itself against.
+
+## What these are
+
+Each file mimics the `recentLogLines` a Palace device diagnostic would capture
+during one sensitive flow:
+
+| File | Flow |
+|------|------|
+| `signin_basic.txt` | Basic-auth (barcode + PIN) library sign-in |
+| `signin_saml_oauth.txt` | SAML web / OAuth web sign-in (cookies, bearer, id_token) |
+| `borrow.txt` | Borrow / loan creation |
+| `download.txt` | LCP / Adobe fulfillment + download |
+| `audiobook.txt` | Findaway / AudioEngine audiobook playback |
+
+## Standing guard
+
+`RedactionCorpusTests` runs `ContextRedactor` over every line here and asserts a
+**credential deny-list survives nothing** — no un-redacted Bearer/JWT, `pin:
+<digits>`, raw barcode, `password:`, cookie value, or `access_token=`. It also
+asserts the RAW (pre-redaction) corpus DOES trip the deny-list, so the gate can
+never pass by degenerating into a corpus of harmless text.
+
+`scripts/triage-corpus-check.sh` re-runs that guard at release time and can
+`--self-test` (inject a raw leak, prove the gate goes red, clean up).
+
+## DEFERRED — live device capture
+
+These synthetic fixtures are the *framework*. Capturing REAL (already-fake-account)
+device payloads from the sensitive flows on a running sim/device is deferred to
+the simdrive / chaos QA runs (PP-4813 / PP-4817). When those land, real captures
+drop in here alongside (or replacing) these synthetic files and the same
+deny-list guard covers them unchanged.

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/audiobook.txt
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/audiobook.txt
@@ -1,0 +1,7 @@
+# SYNTHETIC — hand-authored, all values FAKE. See Fixtures/README.md.
+2026-07-16T15:30:00Z [Audiobook] Findaway session for "A Fake Audiobook"
+2026-07-16T15:30:00Z [Audiobook] AudioEngine license request Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdWRpbyI6ImZha2UifQ.FAKEaudioSIG
+2026-07-16T15:30:01Z [Audiobook] fulfillment json {"access_token":"FAKE-audio-access.aaa.bbb","expires_in":3600}
+2026-07-16T15:30:01Z [Audiobook] patron note: passcode 246810 not accepted for barcode 21234000099887
+2026-07-16T15:30:02Z [Audiobook] session Cookie: PLAYSESSION=FAKEplay-abcdef123; path=/
+2026-07-16T15:30:02Z [Audiobook] listener patron-bob@example.org account 0a1b2c3d-4e5f-6789-abcd-ef0123456789

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/borrow.txt
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/borrow.txt
@@ -1,0 +1,6 @@
+# SYNTHETIC — hand-authored, all values FAKE. See Fixtures/README.md.
+2026-07-16T15:01:00Z [Borrow] patron tapped Borrow on "A Fake Title" isbn 9780306406157
+2026-07-16T15:01:00Z [Network] PUT /works/12345/borrow Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJsb2FuIjoiZmFrZSJ9.FAKEborrowSIG Cookie: JSESSIONID=FAKEjsess-borrow-456
+2026-07-16T15:01:01Z [Borrow] fulfillment link https://circulation.example.org/loans/98765?access_token=FAKE-loan-token-abcdef
+2026-07-16T15:01:01Z [Borrow] patron note: card 24000000778899 won't let me borrow, pin 1357
+2026-07-16T15:01:02Z [Borrow] loan uuid 11112222-3333-4444-5555-666677778888 recorded ok

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/download.txt
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/download.txt
@@ -1,0 +1,7 @@
+# SYNTHETIC — hand-authored, all values FAKE. See Fixtures/README.md.
+2026-07-16T15:10:00Z [Download] starting LCP fulfillment for loan 98765
+2026-07-16T15:10:00Z [Network] GET /fulfill Authorization: Bearer eyJhbGciOiJFUzI1NiJ9.eyJmdWxmaWxsIjoiZmFrZSJ9.FAKEdlSIG
+2026-07-16T15:10:01Z [Download] LCP passphrase retrieval client_secret=FAKE-lcp-secret-xyz789 api_key=FAKE-apikey-qwerty01
+2026-07-16T15:10:01Z [Download] Set-Cookie: authsession=FAKEauth-Zm9vYmFyMTIzNA; Secure
+2026-07-16T15:10:02Z [Download] Adobe device auth token=FAKE-adobe-token-abc123def456
+2026-07-16T15:10:02Z [Download] progress 45% for device 99998888-7777-6666-5555-444433332222

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/signin_basic.txt
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/signin_basic.txt
@@ -1,0 +1,8 @@
+# SYNTHETIC — hand-authored, all values FAKE. See Fixtures/README.md.
+2026-07-16T14:22:01Z [SignIn] basic-auth attempt for library "Morton Public Library"
+2026-07-16T14:22:01Z [Network] POST /patrons/me Authorization: Basic ZmFrZXVzZXI6ZmFrZXBhc3N3b3JkOTk5 Content-Type: application/json
+2026-07-16T14:22:01Z [SignIn] patron entered barcode: 21234000012345 pin: 4821
+2026-07-16T14:22:02Z [SignIn] free-text note: my pin is 4821 and it keeps failing
+2026-07-16T14:22:02Z [Network] 401 Unauthorized from https://circulation.example.org/patrons/me
+2026-07-16T14:22:03Z [SignIn] patron retried with password: hunter2-swordfish-fake
+2026-07-16T14:22:03Z [SignIn] account uuid ABCDEF12-3456-7890-ABCD-EF1234567890 patron patron-jane@example.com

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/signin_saml_oauth.txt
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/signin_saml_oauth.txt
@@ -1,0 +1,8 @@
+# SYNTHETIC — hand-authored, all values FAKE. See Fixtures/README.md.
+2026-07-16T14:25:10Z [SAML] web sign-in started for "Statewide Digital Library (SAML)"
+2026-07-16T14:25:11Z [SAML] Set-Cookie: simpleSAMLSessionID=FAKEsess-abc123def456; path=/; HttpOnly
+2026-07-16T14:25:11Z [SAML] Set-Cookie: PHPSESSID=FAKEphp789xyz001; path=/
+2026-07-16T14:25:12Z [OAuth] callback palace://oauth?access_token=ya29.FAKE-access-abcdef123&refresh_token=FAKE-refresh-zzz999&state=ok
+2026-07-16T14:25:12Z [OAuth] stored session: Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWtlIn0.FAKEsigABCDEF
+2026-07-16T14:25:13Z [OAuth] raw id_token eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJmYWtlIn0.FAKEsigRS123
+2026-07-16T14:25:13Z [Network] x-api-key: sk-live-FAKEapikey123456

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/RedactionCorpusTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/RedactionCorpusTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+@testable import TriageBotCore
+
+/// PP-4806 — the standing redaction regression guard.
+///
+/// PR #1278 (PP-4805) landed `ContextRedactor`; this test proves that redactor
+/// against a realistic, sensitive-flow *corpus* (`Fixtures/*.txt`) rather than a
+/// handful of inline strings, and — crucially — is designed to be rebuilt each
+/// release so a newly-introduced log line that leaks a secret FAILS the release
+/// rather than shipping.
+///
+/// The corpus is currently SYNTHETIC (hand-authored, fake values). Capturing
+/// real device payloads from the sensitive flows on a running sim is deferred to
+/// the simdrive / chaos QA runs (PP-4813 / PP-4817) — when those land, the real
+/// captures drop into `Fixtures/` and this same guard covers them unchanged.
+///
+/// Design: a credential **deny-list** of secret *shapes*. Each pattern is
+/// written so it matches a RAW secret but never a redaction placeholder
+/// (`[REDACTED]`, `[jwt-redacted]`, `[number-redacted]`, …). We assert twice:
+///   1. the RAW corpus TRIPS the deny-list (proves the fixtures are actually
+///      adversarial — the gate cannot pass by degenerating into harmless text);
+///   2. the REDACTED corpus trips NOTHING (the actual regression guard).
+final class RedactionCorpusTests: XCTestCase {
+    private let redactor = ContextRedactor()
+
+    /// Redact a line, honoring the `TRIAGE_CORPUS_DISABLE_REDACTION` escape hatch
+    /// used by `scripts/triage-corpus-check.sh --self-test` to prove this guard
+    /// actually fails when redaction stops working (a gate nobody has seen fail
+    /// is not a gate). Unset in normal runs → real redaction.
+    private func redact(_ line: String) -> String {
+        if ProcessInfo.processInfo.environment["TRIAGE_CORPUS_DISABLE_REDACTION"] == "1" {
+            return line
+        }
+        return redactor.redactLine(line)
+    }
+
+    // MARK: - Credential deny-list
+
+    /// A secret shape that must never survive redaction. `regex` is applied
+    /// case-insensitively to redacted text; every pattern is authored so a
+    /// redaction placeholder (which always begins `[`) can never match.
+    private struct DenyPattern {
+        let label: String
+        let regex: String
+    }
+
+    private static let denyList: [DenyPattern] = [
+        // OAuth / bearer scheme token (charset excludes '[' so "Bearer [REDACTED]" is safe)
+        DenyPattern(label: "bearer_token", regex: #"(?i)\bBearer\s+[A-Za-z0-9._\-]{12,}"#),
+        // HTTP Basic auth credential
+        DenyPattern(label: "basic_auth", regex: #"(?i)\bBasic\s+[A-Za-z0-9+/=]{12,}"#),
+        // Standalone JWT (eyJ header . payload [. signature])
+        DenyPattern(label: "jwt", regex: #"\beyJ[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]{4,}"#),
+        // PIN as key=value / key: value
+        DenyPattern(label: "pin_kv", regex: #"(?i)\bpin\s*[:=]\s*\d{3,8}"#),
+        // PIN / passcode stated in prose ("my pin is 4821")
+        DenyPattern(label: "pin_prose", regex: #"(?i)\b(?:pin|passcode)\b[^\d\n]{0,10}\d{3,8}"#),
+        // password: <token>  (value must not be a "[…]" placeholder)
+        DenyPattern(label: "password_kv", regex: #"(?i)\b(?:password|passwd)\s*[:=]\s*(?!\[)\S{3,}"#),
+        // access_token / refresh_token / client_secret / api_key = <token>, incl. JSON quoting
+        DenyPattern(
+            label: "token_kv",
+            regex: #"(?i)\b(?:access_token|refresh_token|client_secret|api_?key)\b\s*["']?\s*[:=]\s*["']?(?!\[)[A-Za-z0-9._\-]{4,}"#
+        ),
+        // bare `token=<value>` credential
+        DenyPattern(label: "generic_token_kv", regex: #"(?i)\btoken\s*[:=]\s*(?!\[)[A-Za-z0-9._\-]{6,}"#),
+        // x-api-key request header
+        DenyPattern(label: "x_api_key", regex: #"(?i)x-api-key:\s*(?!\[)\S{4,}"#),
+        // Authorization: <non-scheme value> (scheme tokens caught by bearer/basic above)
+        DenyPattern(label: "auth_header", regex: #"(?i)Authorization:\s*(?!\[)(?!Bearer\b)(?!Basic\b)\S{4,}"#),
+        // Cookie / Set-Cookie name=value (value not a placeholder)
+        DenyPattern(label: "cookie_value", regex: #"(?i)\b(?:Set-Cookie|Cookie):\s*[A-Za-z0-9_.\-]+=(?!\[)[^;\s]{3,}"#),
+        // Standalone 10-14 digit card barcode, carving out a 978/979 ISBN
+        DenyPattern(label: "barcode", regex: #"\b(?!97[89]\d{10}\b)\d{10,14}\b"#),
+    ]
+
+    // MARK: - Corpus loading
+
+    /// Every fixture file: (name, full text). Fails loudly if the corpus is
+    /// missing or empty — a silently-empty corpus is a broken gate, not a pass.
+    private func loadCorpus(file: StaticString = #filePath, line: UInt = #line) -> [(name: String, text: String)] {
+        guard let dir = Bundle.module.url(forResource: "Fixtures", withExtension: nil) else {
+            XCTFail("Fixtures/ resource directory not found in test bundle", file: file, line: line)
+            return []
+        }
+        let urls = (try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil
+        )) ?? []
+        let corpus: [(String, String)] = urls
+            .filter { $0.pathExtension == "txt" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .compactMap { url in
+                guard let text = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+                return (url.lastPathComponent, text)
+            }
+        XCTAssertFalse(corpus.isEmpty, "Redaction corpus is empty — no *.txt fixtures loaded", file: file, line: line)
+        return corpus
+    }
+
+    private func firstDenyHit(in text: String) -> (label: String, match: String)? {
+        for pattern in Self.denyList {
+            guard let expr = try? NSRegularExpression(pattern: pattern.regex, options: [.caseInsensitive]) else {
+                continue
+            }
+            let range = NSRange(text.startIndex..<text.endIndex, in: text)
+            if let m = expr.firstMatch(in: text, options: [], range: range),
+               let r = Range(m.range, in: text) {
+                return (pattern.label, String(text[r]))
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Tests
+
+    /// The regression guard: nothing on the deny-list may survive redaction of
+    /// any line in any fixture.
+    func testRedactedCorpus_leaksNoCredentialShapes() {
+        let corpus = loadCorpus()
+        for (name, text) in corpus {
+            for (index, rawLine) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+                let line = String(rawLine)
+                if line.hasPrefix("#") || line.trimmingCharacters(in: .whitespaces).isEmpty { continue }
+                let redacted = redact(line)
+                if let hit = firstDenyHit(in: redacted) {
+                    XCTFail(
+                        "\(name):\(index + 1) leaked a \(hit.label) after redaction: '\(hit.match)'\n  redacted line: \(redacted)"
+                    )
+                }
+            }
+        }
+    }
+
+    /// The corpus is genuinely adversarial: the RAW (pre-redaction) corpus MUST
+    /// trip the deny-list. Without this, a corpus of harmless text would pass
+    /// `testRedactedCorpus_leaksNoCredentialShapes` and the gate would be inert.
+    func testRawCorpus_containsCredentialShapes_soGuardIsMeaningful() {
+        let corpus = loadCorpus()
+        var hitLabels = Set<String>()
+        for (_, text) in corpus {
+            for rawLine in text.split(separator: "\n") {
+                let line = String(rawLine)
+                if line.hasPrefix("#") { continue }
+                if let hit = firstDenyHit(in: line) { hitLabels.insert(hit.label) }
+            }
+        }
+        // Every sensitive flow must contribute at least one real secret shape,
+        // and collectively the corpus must exercise the high-value patterns.
+        for required in ["bearer_token", "jwt", "pin_kv", "password_kv", "token_kv", "cookie_value", "barcode", "basic_auth"] {
+            XCTAssertTrue(
+                hitLabels.contains(required),
+                "Corpus does not exercise the '\(required)' secret shape — the guard would not cover it. Present: \(hitLabels.sorted())"
+            )
+        }
+    }
+
+    /// The deny-list itself is correct: it fires on a raw secret and clears once
+    /// that secret is redacted. This pins the gate's own behavior so a future
+    /// edit that neuters a deny pattern (e.g. anchors it to only match `[…]`)
+    /// fails here rather than silently letting leaks through the corpus test.
+    func testDenyList_firesOnRawSecret_andClearsAfterRedaction() {
+        let leak = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJyZWFsIn0.leakedSIGNATURE9999"
+        XCTAssertNotNil(firstDenyHit(in: leak), "Deny-list must fire on a raw Bearer/JWT leak")
+        XCTAssertNil(firstDenyHit(in: redactor.redactLine(leak)), "Deny-list must clear once the secret is redacted")
+
+        let rawPin = "patron note: my pin is 4821 thanks"
+        XCTAssertNotNil(firstDenyHit(in: rawPin), "Deny-list must fire on a raw prose PIN")
+        XCTAssertNil(firstDenyHit(in: redactor.redactLine(rawPin)), "Deny-list must clear once the PIN is redacted")
+    }
+}

--- a/scripts/triage-corpus-check.sh
+++ b/scripts/triage-corpus-check.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# triage-corpus-check.sh
+#
+# Release-time credential-leak gate for the TriageBot redaction corpus (PP-4806).
+#
+# Re-runs the standing deny-list guard (RedactionCorpusTests) over the synthetic
+# captured-payload corpus in
+#   Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/
+# so that a log line newly introduced anywhere in the sensitive flows (sign-in /
+# borrow / download / audiobook) that leaks a patron secret through
+# ContextRedactor FAILS the release instead of shipping.
+#
+# The corpus is SYNTHETIC today; real device captures from the simdrive / chaos
+# QA runs (PP-4813 / PP-4817) drop into Fixtures/ later and this gate covers them
+# unchanged.
+#
+# Usage:
+#   scripts/triage-corpus-check.sh              # run the deny-list guard
+#   scripts/triage-corpus-check.sh --self-test  # ALSO prove the gate goes red on
+#                                               # an injected raw leak, then clean up
+#
+# Exit 0 = corpus clean (and, with --self-test, the gate provably fails on a leak).
+# Exit 1 = a credential shape survived redaction (or the self-test gate did NOT
+#          go red on an injected leak — a broken gate).
+# Exit 2 = usage / environment error.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKG_PATH="$REPO_ROOT/Palace/Packages/PalaceTriageBot"
+FIXTURES_DIR="$PKG_PATH/Tests/TriageBotCoreTests/Fixtures"
+TEST_FILTER="RedactionCorpusTests"
+
+SELF_TEST=0
+for arg in "$@"; do
+  case "$arg" in
+    --self-test) SELF_TEST=1 ;;
+    -h|--help) sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "[triage-corpus] unknown argument: $arg"; exit 2 ;;
+  esac
+done
+
+if ! command -v swift >/dev/null 2>&1; then
+  echo "[triage-corpus] swift toolchain not found on PATH"; exit 2
+fi
+if [ ! -d "$PKG_PATH" ]; then
+  echo "[triage-corpus] package not found at $PKG_PATH"; exit 2
+fi
+if [ ! -d "$FIXTURES_DIR" ]; then
+  echo "[triage-corpus] fixtures dir not found at $FIXTURES_DIR"; exit 2
+fi
+
+run_guard() {
+  swift test --package-path "$PKG_PATH" --filter "$TEST_FILTER" 2>&1
+}
+
+echo "[triage-corpus] running redaction deny-list guard over $(find "$FIXTURES_DIR" -name '*.txt' | wc -l | tr -d ' ') fixture file(s)…"
+if run_guard | tee /tmp/triage-corpus-guard.log | grep -qE "Test Suite '$TEST_FILTER' passed"; then
+  echo "[triage-corpus] PASS — no credential shape survived redaction."
+else
+  echo "[triage-corpus] FAIL — a credential shape survived redaction (see output above)."
+  exit 1
+fi
+
+if [ "$SELF_TEST" -eq 1 ]; then
+  # Prove the gate is live: if redaction ever STOPS stripping the secret shapes
+  # the corpus contains, the guard must go RED. We simulate that leak by running
+  # the same guard with redaction disabled (TRIAGE_CORPUS_DISABLE_REDACTION=1,
+  # honored by RedactionCorpusTests) — the raw corpus then flows straight into
+  # the deny-list, which must fire. A gate nobody has seen fail is not a gate.
+  echo "[triage-corpus] --self-test: disabling redaction to prove the guard goes RED on an un-redacted corpus…"
+  if TRIAGE_CORPUS_DISABLE_REDACTION=1 run_guard | grep -qE "Test Suite '$TEST_FILTER' passed"; then
+    echo "[triage-corpus] SELF-TEST FAIL — guard PASSED with redaction disabled. The deny-list is inert; a real leak would ship."
+    exit 1
+  fi
+  echo "[triage-corpus] SELF-TEST PASS — guard correctly went RED when redaction was disabled (deny-list is live)."
+fi
+
+echo "[triage-corpus] done."
+exit 0


### PR DESCRIPTION
## What & why (PP-4806)

PR #1278 (PP-4805) landed `ContextRedactor`, which strips patron credentials
(PIN/password/tokens/cookies/JWT/barcode) from ticket text. PP-4806 requires
**proving** that redaction against realistic captured device output **and**
rebuilding that corpus each release so a newly-introduced log line that leaks a
secret fails the release rather than shipping.

This PR delivers the framework + automation + a synthetic corpus. Live real-payload
capture is explicitly deferred (see below).

## What's here

**1. Synthetic captured-payload corpus** — `Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/`
Hand-authored, **all-fake** diagnostic output mimicking the sensitive flows:
`signin_basic.txt`, `signin_saml_oauth.txt`, `borrow.txt`, `download.txt`,
`audiobook.txt`. Each carries the credential shapes the HelpSpot forensic found —
Bearer/JWT, `Basic`, 3-8 digit PINs adjacent to `pin/passcode`, 10-14 digit
barcodes, `password:`/`access_token`/`client_secret` kv-pairs, `Set-Cookie`
values. `Fixtures/README.md` marks the whole corpus SYNTHETIC until live capture lands.

**2. Deny-list leak test** — `RedactionCorpusTests`
Runs `ContextRedactor` over every fixture line and asserts a credential
**deny-list survives nothing**. Three assertions:
- `testRedactedCorpus_leaksNoCredentialShapes` — the standing regression guard.
- `testRawCorpus_containsCredentialShapes_soGuardIsMeaningful` — the RAW corpus
  MUST trip the deny-list, so the gate can't pass by degenerating into harmless text.
- `testDenyList_firesOnRawSecret_andClearsAfterRedaction` — pins the deny-list's
  own fire-then-clear behavior.

**3. Release-time automation** — `scripts/triage-corpus-check.sh`
Re-runs the guard over the current corpus at release time. `--self-test` disables
redaction (`TRIAGE_CORPUS_DISABLE_REDACTION=1`) to prove the guard goes RED — a
repeatable, baked-in "this gate can fail" proof on every release run.

## Proof the gate catches a leak (a gate nobody has seen fail is not a gate)

- **Redaction weakened → RED.** Temporarily neutering the standalone-barcode
  redaction pattern turned the guard red with precise diagnostics:
  `borrow.txt:5 leaked a barcode after redaction: '24000000778899'` and
  `audiobook.txt:5 leaked a barcode ... '21234000099887'`. Redactor restored, corpus green.
- **`--self-test` → RED.** With redaction disabled the guard fails as designed;
  the script reports `SELF-TEST PASS — guard correctly went RED`.
- Overlapping coverage is a feature: neutering the Bearer pattern alone stayed
  green because JWT + `Authorization:` redaction still stripped those lines.

## Validation

- `swift test --package-path Palace/Packages/PalaceTriageBot` → **189 tests, 0 failures** (incl. the 3 new corpus tests).
- `bash -n scripts/triage-corpus-check.sh` → clean (also auto-covered by `tooling-checks.yml`'s shell-syntax sweep).
- `RedactionCorpusTests` lives in the `TriageBotCoreTests` target, so it runs in CI with the rest of the package — the standing guard is always on.

## Deferred (NOT in this PR)

Capturing **REAL** device payloads (from already-fake test accounts) on a running
sim/device — that needs a live simdrive/chaos session and is folded into the QA
runs (**PP-4813 / PP-4817**). Real captures drop into `Fixtures/` later and this
same deny-list guard covers them unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)