### PR TITLE
feat(triagebot,debug): failure-injection toggle to make error+retry simdrive-verifiable (PP-4808/PP-4813)

### DIFF
--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -330,6 +330,29 @@ final class RemoteFeatureFlags: @unchecked Sendable {
         #endif
     }
 
+    #if DEBUG
+    /// DEBUG-only override that forces ticket submission to fail on demand, so
+    /// QA / simdrive / the chaos run can drive the error+retry UI (AC-8/9). On
+    /// a bare simulator `MFMailComposeViewController.canSendMail()` is false and
+    /// both gateway branches fall back to the always-succeeding clipboard
+    /// gateway, so the "Couldn't send / Try again / Copy details / Start over"
+    /// card is otherwise unreachable on-screen. Never present in release builds.
+    static let triageBotForceSubmitFailureLocalOverrideKey = "RemoteFeatureFlags.triageBotForceSubmitFailureLocalOverride"
+
+    /// When true, `TriageBotFactory` injects a gateway that always throws a
+    /// `.transport` failure so the real `.error` recovery card is reachable.
+    /// Defaults OFF. Honored via the tappable developer toggle OR the
+    /// `-TriageBotForceSubmitFailure 1` launch argument (auto-mapped into
+    /// UserDefaults' NSArgumentDomain), so a headless simdrive/chaos run can
+    /// force the failure without tapping through Settings. DEBUG-only.
+    var isTriageBotForceSubmitFailureEnabled: Bool {
+        if let override = defaults.object(forKey: Self.triageBotForceSubmitFailureLocalOverrideKey) as? Bool {
+            return override
+        }
+        return defaults.bool(forKey: "TriageBotForceSubmitFailure")
+    }
+    #endif
+
     /// UserDefaults override that lets QA / a developer toggle the
     /// in-app playback nav feature without a Firebase round-trip.
     /// Settable from `TPPDeveloperSettingsTableViewController`. Falls

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Debug/ForcedFailureTicketGateway.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Debug/ForcedFailureTicketGateway.swift
@@ -1,0 +1,65 @@
+#if DEBUG
+import Foundation
+
+/// DEBUG-only `TicketGateway` that always fails, so QA / simdrive / the chaos
+/// run can drive the ticket-submission error+retry UI (AC-8/9) on a bare
+/// simulator.
+///
+/// **Why this exists.** On a bare simulator `MFMailComposeViewController
+/// .canSendMail()` is false, so both the email and clipboard gateway branches
+/// resolve to `ClipboardTicketGateway`, which always succeeds. Without this,
+/// there was no way to reach the "Couldn't send / Try again / Copy details /
+/// Start over" failure card on-screen — AC-8/9 were only covered by
+/// unit/reducer tests, never driven in the UI.
+///
+/// The host (`TriageBotFactory`) injects this in place of the real gateway
+/// only when the "Force ticket submission failure" developer toggle (or the
+/// `-TriageBotForceSubmitFailure 1` launch argument) is on. It throws a
+/// `ForcedSubmissionError`, which conforms to `SubmissionFailureConvertible`,
+/// so the ViewModel maps it exactly like a real gateway error — the injected
+/// failure lands on the genuine production `.error` recovery path (or the
+/// cancel-restores-preview path), never a fake one.
+///
+/// Compiled only in DEBUG builds (`#if DEBUG`); no trace of it exists in
+/// release.
+public struct ForcedFailureTicketGateway: TicketGateway {
+    /// Which failure to inject.
+    /// - `.transport`: a real failure — lands on the `.error` recovery card
+    ///   (Try again / Copy details / Start over). This is the AC-8/9 path.
+    /// - `.userCancelled`: exercises the "cancel restores the preview" path.
+    public enum Mode: Sendable {
+        case transport
+        case userCancelled
+    }
+
+    private let mode: Mode
+
+    public init(mode: Mode = .transport) {
+        self.mode = mode
+    }
+
+    public func submit(_ draft: TicketDraft) async throws -> TicketReceipt {
+        throw ForcedSubmissionError(mode: mode)
+    }
+}
+
+/// Error thrown by ``ForcedFailureTicketGateway``. Conforms to
+/// `SubmissionFailureConvertible` so it maps through the exact same path the
+/// ViewModel uses for real gateway errors — no special-casing, no fake UI.
+public struct ForcedSubmissionError: Error, SubmissionFailureConvertible {
+    public let mode: ForcedFailureTicketGateway.Mode
+
+    public init(mode: ForcedFailureTicketGateway.Mode) {
+        self.mode = mode
+    }
+
+    public var asSubmissionFailure: SubmissionFailure {
+        switch mode {
+        case .transport:
+            return .transport(detail: "DEBUG: forced ticket-submission failure (developer toggle)")
+        case .userCancelled:
+            return .userCancelled
+        }
+    }
+}
+#endif

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ForcedFailureTicketGatewayTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ForcedFailureTicketGatewayTests.swift
@@ -1,0 +1,134 @@
+#if DEBUG
+import XCTest
+@testable import TriageBotCore
+
+/// PP-4808/PP-4813 — the DEBUG-only failure-injection gateway. On a bare
+/// simulator `canSendMail()` is false, so the real gateways fall back to the
+/// always-succeeding clipboard gateway and the error+retry card (AC-8/9) is
+/// unreachable on-screen. `ForcedFailureTicketGateway` makes submission fail on
+/// demand; this pins that (a) it always throws, (b) the thrown error maps to
+/// the intended `SubmissionFailure`, and (c) threading that failure through the
+/// real reducer lands on the genuine `.error` recovery card carrying the failed
+/// draft (transport) or restores the preview (userCancelled) — the exact
+/// production paths, not a fake.
+final class ForcedFailureTicketGatewayTests: XCTestCase {
+
+    private func makeReducer() -> ConversationReducer {
+        // The .ticketSubmissionFailed path never consults the KB, so an empty
+        // catalog is sufficient to drive the failure → recovery transition.
+        let catalog = KBCatalog(version: "test", updatedAt: "2026-07-16", entries: [])
+        return ConversationReducer(knowledgeBase: KnowledgeBase(catalog: catalog))
+    }
+
+    private func makeDraft(_ description: String = "won't play") -> TicketDraft {
+        TicketDraft(
+            userDescription: description,
+            category: .audiobook,
+            context: ContextSnapshot(appVersion: "3.3.0", appBuild: "500", osVersion: "26", deviceModel: "iPhone17,2")
+        )
+    }
+
+    // MARK: - Gateway always throws + maps correctly
+
+    func testTransportMode_throwsErrorMappingToTransportFailure() async {
+        let gateway = ForcedFailureTicketGateway(mode: .transport)
+        do {
+            _ = try await gateway.submit(makeDraft())
+            XCTFail("Forced-failure gateway must never succeed")
+        } catch let error as SubmissionFailureConvertible {
+            guard case .transport(let detail) = error.asSubmissionFailure else {
+                return XCTFail(".transport mode must map to a .transport SubmissionFailure")
+            }
+            XCTAssertFalse(detail.isEmpty, "Transport detail must carry something for Copy details")
+        } catch {
+            XCTFail("Thrown error must be SubmissionFailureConvertible, got \(error)")
+        }
+    }
+
+    func testUserCancelledMode_throwsErrorMappingToUserCancelled() async {
+        let gateway = ForcedFailureTicketGateway(mode: .userCancelled)
+        do {
+            _ = try await gateway.submit(makeDraft())
+            XCTFail("Forced-failure gateway must never succeed")
+        } catch let error as SubmissionFailureConvertible {
+            XCTAssertEqual(error.asSubmissionFailure, .userCancelled)
+        } catch {
+            XCTFail("Thrown error must be SubmissionFailureConvertible, got \(error)")
+        }
+    }
+
+    func testDefaultMode_isTransport() async {
+        let gateway = ForcedFailureTicketGateway()
+        do {
+            _ = try await gateway.submit(makeDraft())
+            XCTFail("Forced-failure gateway must never succeed")
+        } catch let error as SubmissionFailureConvertible {
+            guard case .transport = error.asSubmissionFailure else {
+                return XCTFail("Default mode must be .transport")
+            }
+        } catch {
+            XCTFail("Thrown error must be SubmissionFailureConvertible, got \(error)")
+        }
+    }
+
+    // MARK: - Injected failure lands on the real reducer recovery path
+
+    /// The full injection chain, minus the ViewModel's Task plumbing: gateway
+    /// throws → error is mapped via SubmissionFailureConvertible (exactly what
+    /// TriageBotViewModel does) → reducer receives `.ticketSubmissionFailed`
+    /// from a `.submitting` state and lands on `.error` carrying the draft.
+    func testInjectedTransportFailure_landsReducerInErrorCarryingFailedDraft() async {
+        let gateway = ForcedFailureTicketGateway(mode: .transport)
+        let draft = makeDraft()
+
+        // Gateway throws; map like the ViewModel does.
+        var mapped: SubmissionFailure?
+        do {
+            _ = try await gateway.submit(draft)
+            return XCTFail("Gateway must throw")
+        } catch {
+            mapped = (error as? SubmissionFailureConvertible)?.asSubmissionFailure
+                ?? .transport(detail: error.localizedDescription)
+        }
+        guard let failure = mapped else { return XCTFail("Failure must be mapped") }
+
+        let reducer = makeReducer()
+        let submitting = ConversationState(step: .submitting(ticket: draft))
+        let (next, _) = reducer.reduce(state: submitting, action: .ticketSubmissionFailed(failure))
+
+        guard case .error(_, let failedDraft) = next.step else {
+            return XCTFail("A transport failure must land on .error, got \(next.step)")
+        }
+        XCTAssertEqual(failedDraft, draft, "The error step must carry the exact failed draft for Retry / Copy details")
+        // The error card must be present so the UI can render Retry / Copy / Start over.
+        XCTAssertTrue(
+            next.messages.contains { if case .errorActions = $0.kind { return true } else { return false } },
+            "The reducer must append an errorActions card driving the AC-8/9 affordances"
+        )
+    }
+
+    /// The `.userCancelled` injection drives the cancel-restores-preview path.
+    func testInjectedUserCancelled_restoresPreviewToDrafting() async {
+        let gateway = ForcedFailureTicketGateway(mode: .userCancelled)
+        let draft = makeDraft()
+
+        var mapped: SubmissionFailure?
+        do {
+            _ = try await gateway.submit(draft)
+            return XCTFail("Gateway must throw")
+        } catch {
+            mapped = (error as? SubmissionFailureConvertible)?.asSubmissionFailure
+        }
+        guard let failure = mapped else { return XCTFail("Failure must be mapped") }
+
+        let reducer = makeReducer()
+        let submitting = ConversationState(step: .submitting(ticket: draft))
+        let (next, _) = reducer.reduce(state: submitting, action: .ticketSubmissionFailed(failure))
+
+        guard case .drafting(let restored) = next.step else {
+            return XCTFail("A user cancel must restore the preview to .drafting, got \(next.step)")
+        }
+        XCTAssertEqual(restored, draft, "Cancel must restore the exact draft preview")
+    }
+}
+#endif

--- a/Palace/Settings/DeveloperSettings/DeveloperSettingsView.swift
+++ b/Palace/Settings/DeveloperSettings/DeveloperSettingsView.swift
@@ -82,6 +82,9 @@ struct DeveloperSettingsView: View {
             DevToggleRow(title: "Enabled (master)", isOn: $viewModel.triageBotEnabled)
             DevToggleRow(title: "Ticket Submission (Email)", isOn: $viewModel.triageBotTicketSubmissionEnabled)
             DevToggleRow(title: "AI Fallback (Claude)", isOn: $viewModel.triageBotAIFallbackEnabled)
+            #if DEBUG
+            DevToggleRow(title: "Force Submit Failure (debug)", isOn: $viewModel.triageBotForceSubmitFailure)
+            #endif
             DevDisclosureValueRow(
                 title: "Anthropic API Key",
                 value: viewModel.anthropicKeyStatus

--- a/Palace/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
+++ b/Palace/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
@@ -69,6 +69,15 @@ final class DeveloperSettingsViewModel: ObservableObject {
         didSet { overrideDefaults.set(triageBotAIFallbackEnabled, forKey: RemoteFeatureFlags.triageBotAIFallbackLocalOverrideKey) }
     }
 
+    #if DEBUG
+    /// DEBUG-only: force ticket submission to fail so QA / simdrive / the chaos
+    /// run can reach the error+retry card (AC-8/9). See RemoteFeatureFlags
+    /// `triageBotForceSubmitFailureLocalOverrideKey`.
+    @Published var triageBotForceSubmitFailure: Bool {
+        didSet { overrideDefaults.set(triageBotForceSubmitFailure, forKey: RemoteFeatureFlags.triageBotForceSubmitFailureLocalOverrideKey) }
+    }
+    #endif
+
     /// "Stored" / "Not set" trailing status for the Anthropic key row.
     @Published var anthropicKeyStatus: String
 
@@ -140,6 +149,9 @@ final class DeveloperSettingsViewModel: ObservableObject {
         self.triageBotEnabled = featureFlags.isTriageBotEnabled
         self.triageBotTicketSubmissionEnabled = featureFlags.isTriageBotTicketSubmissionEnabled
         self.triageBotAIFallbackEnabled = featureFlags.isTriageBotAIFallbackEnabled
+        #if DEBUG
+        self.triageBotForceSubmitFailure = featureFlags.isTriageBotForceSubmitFailureEnabled
+        #endif
         self.anthropicKeyStatus = triageBotKeyAdmin.hasStoredKey ? "Stored" : "Not set"
 
         self.inAppPlaybackNavEnabled = featureFlags.isInAppPlaybackNavEnabled

--- a/Palace/Support/TriageBotFactory.swift
+++ b/Palace/Support/TriageBotFactory.swift
@@ -98,6 +98,25 @@ enum TriageBotFactory {
             gateway = ClipboardTicketGateway()
         }
 
+        // PP-4808/PP-4813: DEBUG-only failure injection. On a bare simulator
+        // canSendMail() is false, so the gateways above both resolve to the
+        // always-succeeding ClipboardTicketGateway — the error+retry UI (AC-8/9)
+        // was unreachable on-screen. When the "Force ticket submission failure"
+        // developer toggle (or `-TriageBotForceSubmitFailure 1`) is on, swap in a
+        // gateway that always throws `.transport`, landing on the real
+        // ErrorActionsCard path. Entirely inside `#if DEBUG` — release builds
+        // never see this override read or the forced gateway.
+        let effectiveGateway: TicketGateway
+        #if DEBUG
+        if RemoteFeatureFlags.shared.isTriageBotForceSubmitFailureEnabled {
+            effectiveGateway = ForcedFailureTicketGateway(mode: .transport)
+        } else {
+            effectiveGateway = gateway
+        }
+        #else
+        effectiveGateway = gateway
+        #endif
+
         // Telemetry sink: OSLog for local/dev visibility, Firebase Analytics in
         // release builds (PP-4814). Both forward only enumerable id/count/enum
         // parameters — FirebaseTriageTelemetrySink runs TelemetryContract so no
@@ -112,7 +131,7 @@ enum TriageBotFactory {
         return makeViewModel(
             reducer: reducer,
             contextProvider: contextProvider,
-            gateway: gateway,
+            gateway: effectiveGateway,
             sink: sink,
             fallbackClassifier: fallbackClassifier
         )


### PR DESCRIPTION
## What

DEBUG-only failure-injection hook so the triage bot's ticket-submission error+retry UX (AC-8/9) can be driven on-screen in simdrive and the chaos run.

- **`ForcedFailureTicketGateway`** (TriageBotCore, `#if DEBUG`) — a `TicketGateway` that always throws. `.transport` mode maps (via `SubmissionFailureConvertible`) to a `.transport` `SubmissionFailure` and lands on the real `ErrorActionsCard` recovery path; `.userCancelled` mode drives the cancel-restores-preview path.
- **`RemoteFeatureFlags.isTriageBotForceSubmitFailureEnabled`** (`#if DEBUG`) — honored via a tappable Developer Settings toggle ("Force Submit Failure (debug)", in the existing Triage Bot section) OR the `-TriageBotForceSubmitFailure 1` launch argument for headless runs.
- **`TriageBotFactory`** injects the forced gateway only when the flag is on, inside `#if DEBUG`.

## Why

The simdrive AC gate could **not** reach the "Couldn't send / Try again / Copy details / Start over" failure UI. On a bare simulator `MFMailComposeViewController.canSendMail()` is false, so both the email and clipboard gateway branches in `TriageBotFactory` resolve to `ClipboardTicketGateway`, which **always succeeds**. There was no toggle/env/launch-arg to force a `.transport` failure, so AC-8/9 were only ever covered by unit/reducer tests (`EmailGatewayFailureMappingTests`), never driven on-screen. This unblocks the chaos run's failure scenarios and the simdrive AC-verify pass for the error+retry card.

The injected failure lands on the **exact production reducer path** (the real `ErrorActionsCard`), not a fake UI.

## Release safety

The entire injection path is `#if DEBUG` — the flag read, the factory wiring, the gateway type, the Dev Settings toggle, and the ViewModel mirror. Release builds never see any of it. Verified: `swift build -c release` on the package compiles the gateway out cleanly.

## Tests

New `ForcedFailureTicketGatewayTests` (TriageBotCore, `#if DEBUG`, macOS-runnable under `swift test`):
- gateway always throws in both modes; thrown error maps to the intended `SubmissionFailure`;
- threading the injected failure through the **real** `ConversationReducer` lands `.error` carrying the exact failed draft **and** appends the `errorActions` card (AC-8/9 affordances);
- `.userCancelled` injection restores the preview to `.drafting`.

`swift test --package-path Palace/Packages/PalaceTriageBot`: **191 tests, 0 failures** (includes the 5 new tests; existing `EmailGatewayFailureMappingTests` stay green — they're iOS/MessageUI-gated and run on the CI simulator). Host toggle wiring (RemoteFeatureFlags / TriageBotFactory / Developer Settings) is CI-gated, not built in this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
