### PR TITLE
fix(ui): settle scroll aliasing + tab-switch flicker on catalog/lists

### DIFF
--- a/Palace/AppInfrastructure/AppTabHostView.swift
+++ b/Palace/AppInfrastructure/AppTabHostView.swift
@@ -377,14 +377,12 @@ struct AppTabHostView: View {
     /// Runs on tab selection change: pop-to-root, dismiss top VC, sync, announce.
     /// Extracted so the iOS 18+ and legacy builders share one implementation.
     func handleTabSelectionChange(to newTab: AppTab) {
-        // Respect reduce motion accessibility setting
-        if UIAccessibility.isReduceMotionEnabled {
-            appContainer.navigationCoordinatorHub.coordinator?.popToRoot()
-        } else {
-            withAnimation(.easeInOut) {
-                appContainer.navigationCoordinatorHub.coordinator?.popToRoot()
-            }
-        }
+        // Reset the stack WITHOUT animation: an animated pop-to-root here plays
+        // concurrently with SwiftUI's own cross-tab transition, and the two
+        // animations over overlapping view trees tear/flicker on rapid tab
+        // switching. Instantaneous under the tab swap reads clean. (PP — scroll/
+        // nav rendering glitches.)
+        appContainer.navigationCoordinatorHub.coordinator?.popToRoot(animated: false)
         if let appDelegate = UIApplication.shared.delegate as? TPPAppDelegate,
            let top = appDelegate.topViewController() {
             top.dismiss(animated: true)

--- a/Palace/AppInfrastructure/NavigationCoordinator.swift
+++ b/Palace/AppInfrastructure/NavigationCoordinator.swift
@@ -184,11 +184,19 @@ final class NavigationCoordinator: ObservableObject {
         pop()
     }
 
-    func popToRoot() {
+    /// Pops the entire stack back to the root.
+    ///
+    /// `animated: false` mutates the path with NO animation — used by the
+    /// tab-switch handler. An animated path collapse there runs concurrently
+    /// with SwiftUI's own cross-tab transition; the two animations play over
+    /// overlapping view trees and tear/flicker on rapid tab switching. Under a
+    /// tab swap the reset should be instantaneous (hidden by the tab
+    /// transition), so callers on that path pass `animated: false`.
+    func popToRoot(animated: Bool = true) {
         guard !path.isEmpty else { return }
         isTopRouteAudio = false
         // Respect reduce motion accessibility setting
-        if UIAccessibility.isReduceMotionEnabled {
+        if !animated || UIAccessibility.isReduceMotionEnabled {
             path.removeLast(path.count)
         } else {
             withAnimation(.easeInOut) {

--- a/Palace/Book/Models/TPPBookCoverRegistry.swift
+++ b/Palace/Book/Models/TPPBookCoverRegistry.swift
@@ -254,6 +254,20 @@ actor TPPBookCoverRegistry {
         return await placeholder(for: book, displayHeight: displayHeight)
     }
 
+    /// Target decode dimension (in pixels) for a cover shown at `displayPoints`.
+    ///
+    /// Decodes at EXACTLY the display pixel box (1:1) — NOT oversampled. Handing
+    /// SwiftUI a bitmap larger than the box it's drawn into forces Core Animation
+    /// to minify a non-mipmapped texture on every frame; as the cell scrolls the
+    /// subpixel sample position shifts each frame, which is precisely the
+    /// shimmer/aliasing seen on cover edges during scroll. A 1:1 decode makes the
+    /// blit exact. Clamped to 1200px to bound memory on very large display sizes.
+    ///
+    /// Pure + static so the sizing math is unit-testable without a decode.
+    static func decodePixels(displayPoints: CGFloat, scale: CGFloat) -> CGFloat {
+        min(displayPoints * scale, 1200)
+    }
+
     /// Fetches a cover decoded at the minimum pixel size needed for a given display size.
     /// Pass the view's point height (or width); the method converts to pixels using screen scale
     /// and clamps to a sensible max. Use this instead of `coverImage(for:)` when you know
@@ -266,7 +280,7 @@ actor TPPBookCoverRegistry {
             return await coverImage(for: book)
         }
         let scale = await MainActor.run { UIScreen.main.scale }
-        let neededPixels = min(displayPoints * scale * 1.5, 1200) // 1.5× for sharp rendering
+        let neededPixels = Self.decodePixels(displayPoints: displayPoints, scale: scale)
         let key = "\(book.identifier)_\(Int(neededPixels))px"
 
         if let cached = await imageCache.getAsync(for: key) { return cached }

--- a/Palace/Book/UI/BookDetail/BookImageView.swift
+++ b/Palace/Book/UI/BookDetail/BookImageView.swift
@@ -31,6 +31,14 @@ struct BookImageView: View {
             if let coverImage = book.coverImage ?? book.thumbnailImage {
                 Image(uiImage: coverImage)
                     .resizable()
+                    // High-quality resampling + edge antialiasing. Covers can
+                    // land at fractional-point frames inside a Lazy stack; without
+                    // these the GPU's default minification shimmers/jaggies the
+                    // cover edges as the cell scrolls. Paired with the 1:1 decode
+                    // in `TPPBookCoverRegistry.decodePixels`, this settles scroll
+                    // aliasing on cover art.
+                    .interpolation(.high)
+                    .antialiased(true)
                     .aspectRatio(contentMode: .fit)
                     .modifier(SettledCoverShadow(radius: coverShadowRadius))
                     .transition(.opacity)

--- a/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
+++ b/Palace/CatalogUI/ViewModels/CatalogViewModel.swift
@@ -497,7 +497,16 @@ final class CatalogViewModel: ObservableObject {
 // MARK: - Models
 
 struct CatalogLaneModel: Identifiable {
-  let id = UUID()
+  /// Content-derived identity: a lane IS its title + group href within a feed.
+  ///
+  /// Previously a fresh `UUID()` per instance, so every re-map (facet apply,
+  /// registry update, entry-point switch) minted brand-new identities and
+  /// `ForEach` tore down + rebuilt every lane — each horizontal ScrollView and
+  /// all its covers — instead of diffing in place, flashing the whole feed. The
+  /// codebase already treats `title` + `moreURL` as a lane's identity (the
+  /// `catalogLaneMore(title:url:)` route), so deriving `id` from them is stable
+  /// across re-maps and consistent with existing assumptions.
+  var id: String { "\(title)|\(moreURL?.absoluteString ?? "")" }
   let title: String
   let books: [TPPBook]
   let moreURL: URL?

--- a/PalaceTests/AppInfrastructure/NavigationCoordinatorTests.swift
+++ b/PalaceTests/AppInfrastructure/NavigationCoordinatorTests.swift
@@ -107,6 +107,20 @@ final class NavigationCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.path.count, 0, "Path should be empty after popToRoot")
     }
 
+    func testNavigationCoordinator_PopToRootUnanimated_ClearsEntirePath() {
+        // The tab-switch handler pops WITHOUT animation (so the reset doesn't
+        // race the TabView's own cross-tab transition and tear). The end state
+        // must still be a fully-cleared stack — same as the animated pop.
+        coordinator.push(.bookDetail(BookRoute(id: "book-1")))
+        coordinator.push(.bookDetail(BookRoute(id: "book-2")))
+        XCTAssertEqual(coordinator.path.count, 2)
+
+        coordinator.popToRoot(animated: false)
+
+        XCTAssertEqual(coordinator.path.count, 0,
+                       "popToRoot(animated: false) must clear the entire path, not no-op")
+    }
+
     func testNavigationCoordinator_PopToRoot_OnEmptyPath_DoesNotCrash() {
         // Arrange
         XCTAssertTrue(coordinator.path.isEmpty)

--- a/PalaceTests/CatalogUI/CatalogModelsTests.swift
+++ b/PalaceTests/CatalogUI/CatalogModelsTests.swift
@@ -520,28 +520,55 @@ final class CatalogLaneModelStructTests: XCTestCase {
 
     // MARK: - Identifiable Tests
 
-    func testIdentifiable_HasUniqueId() {
-        let lane1 = CatalogLaneModel(title: "Lane", books: [], moreURL: nil)
-        let lane2 = CatalogLaneModel(title: "Lane", books: [], moreURL: nil)
+    // Lane identity is CONTENT-derived (title + moreURL), NOT a per-instance
+    // UUID. This is the whole point of the fix: a re-map of the feed (facet
+    // apply, registry update, entry-point switch) rebuilds lane structs, and
+    // `ForEach(id: \.id)` must see the SAME identity for the same lane so it
+    // diffs in place instead of tearing down + rebuilding every horizontal
+    // ScrollView and its covers (the visible feed flash). If any of these
+    // regressed to `UUID()`, the equal-content cases below would fail.
 
-        // Each lane should have a unique UUID even with identical content
-        XCTAssertNotEqual(lane1.id, lane2.id)
-        // But each lane's ID must equal itself
-        XCTAssertEqual(lane1.id, lane1.id)
-        // IDs must be valid UUIDs
-        XCTAssertNotNil(UUID(uuidString: lane1.id.uuidString))
+    func testIdentity_SameTitleAndURL_ProducesEqualID() {
+        let url = URL(string: "https://library.example.org/lane/fiction/more")
+        let lane1 = CatalogLaneModel(title: "Popular Fiction", books: [], moreURL: url)
+        // Rebuilt with DIFFERENT book contents but the same title+url — a lane
+        // whose books changed on refresh is still the same lane.
+        let lane2 = CatalogLaneModel(
+            title: "Popular Fiction",
+            books: [TPPBookMocker.mockBook(identifier: "b1", title: "B1", distributorType: .EpubZip)],
+            moreURL: url
+        )
+
+        XCTAssertEqual(lane1.id, lane2.id,
+                       "Same title+moreURL must yield a STABLE id across re-maps so ForEach diffs in place")
     }
 
-    func testIdentifiable_IdIsUUID() {
-        let lane = CatalogLaneModel(title: "Test", books: [], moreURL: nil)
+    func testIdentity_DifferentTitle_ProducesDifferentID() {
+        let url = URL(string: "https://library.example.org/lane/more")
+        let fiction = CatalogLaneModel(title: "Fiction", books: [], moreURL: url)
+        let nonFiction = CatalogLaneModel(title: "Non-Fiction", books: [], moreURL: url)
 
-        // Verify ID is a valid UUID (won't throw)
-        XCTAssertNotNil(UUID(uuidString: lane.id.uuidString))
-        // ID must be stable across accesses
-        XCTAssertEqual(lane.id, lane.id)
-        // Same model should not regenerate a new ID
-        let sameLane = lane
-        XCTAssertEqual(lane.id, sameLane.id)
+        XCTAssertNotEqual(fiction.id, nonFiction.id,
+                          "Distinct lanes must have distinct identities even sharing a moreURL")
+    }
+
+    func testIdentity_DifferentMoreURL_ProducesDifferentID() {
+        let laneA = CatalogLaneModel(title: "Featured", books: [], moreURL: URL(string: "https://example.org/a"))
+        let laneB = CatalogLaneModel(title: "Featured", books: [], moreURL: URL(string: "https://example.org/b"))
+
+        XCTAssertNotEqual(laneA.id, laneB.id,
+                          "Same title but different group href are different lanes")
+    }
+
+    func testIdentity_NilMoreURL_IsStableAndDistinctFromNonNil() {
+        let noURL1 = CatalogLaneModel(title: "Sideloaded", books: [], moreURL: nil)
+        let noURL2 = CatalogLaneModel(title: "Sideloaded", books: [], moreURL: nil)
+        let withURL = CatalogLaneModel(title: "Sideloaded", books: [], moreURL: URL(string: "https://example.org/x"))
+
+        // Two nil-URL lanes with the same title collapse to one identity (stable).
+        XCTAssertEqual(noURL1.id, noURL2.id)
+        // A nil-URL lane is distinct from a same-title lane that HAS a url.
+        XCTAssertNotEqual(noURL1.id, withURL.id)
     }
 
     // MARK: - Books Collection Tests

--- a/PalaceTests/TPPBookCoverRegistryTests.swift
+++ b/PalaceTests/TPPBookCoverRegistryTests.swift
@@ -38,6 +38,30 @@ final class TPPBookCoverRegistryTests: XCTestCase {
                                     "Full-resolution decoding wastes memory and triggers iOS 26 decode bugs.")
     }
 
+    // MARK: - Decode-size (aliasing) tests
+
+    /// The cover decode target must be EXACTLY the display pixel box (1:1), not
+    /// oversampled. Oversampling then minifying a non-mipmapped bitmap every
+    /// frame is what shimmers/aliases cover edges on scroll. A 1.5× (or any >1×)
+    /// factor here would fail this test.
+    func testDecodePixels_TargetsExactDisplayPixels_NoOversample() {
+        // 150pt cell on a @3x screen → exactly 450px, not 675 (which 1.5× gave).
+        XCTAssertEqual(TPPBookCoverRegistry.decodePixels(displayPoints: 150, scale: 3), 450, accuracy: 0.001)
+        // 120pt cover on @2x → 240px.
+        XCTAssertEqual(TPPBookCoverRegistry.decodePixels(displayPoints: 120, scale: 2), 240, accuracy: 0.001)
+        // @1x is a pass-through.
+        XCTAssertEqual(TPPBookCoverRegistry.decodePixels(displayPoints: 200, scale: 1), 200, accuracy: 0.001)
+    }
+
+    /// Very large display sizes are clamped so a full-screen cover can't decode
+    /// an unbounded bitmap (memory ceiling preserved from the original code).
+    func testDecodePixels_ClampsToMemoryCeiling() {
+        // 500pt @3x = 1500px → clamped to 1200.
+        XCTAssertEqual(TPPBookCoverRegistry.decodePixels(displayPoints: 500, scale: 3), 1200, accuracy: 0.001)
+        // Just under the ceiling passes through unchanged.
+        XCTAssertEqual(TPPBookCoverRegistry.decodePixels(displayPoints: 399, scale: 3), 1197, accuracy: 0.001)
+    }
+
     /// Verify that small images are not upscaled
     func testDownsampleImage_SmallImageNotUpscaled() {
         // Arrange


### PR DESCRIPTION
## Why

High-level analysis of reported "glitchy / aliasing when scrolling catalog + lists and navigating between tabs/screens quickly" traced the symptoms to distinct causes. This lands the clear, low-risk fixes for each; visually confirmed on device (iPhone 17 Pro Max).

## What

**Aliasing — shimmery cover edges on scroll**
- `TPPBookCoverRegistry`: decode covers at the **exact display pixel box (1:1)** instead of 1.5× oversampling. Handing SwiftUI a bitmap larger than its draw box forces Core Animation to minify a non-mipmapped texture every frame; the subpixel sample shift on scroll is the shimmer. Sizing math extracted into a pure, unit-tested `decodePixels(displayPoints:scale:)`.
- `BookImageView`: add `.interpolation(.high).antialiased(true)` so fractional-frame minification resamples cleanly.

**Tab-switch flicker — rapid tab navigation**
- The tab-selection handler animated a `NavigationStack` pop-to-root that ran **concurrently with SwiftUI's own cross-tab transition** — two animations over overlapping view trees tear. Added `popToRoot(animated:)`; the tab handler now resets the stack instantly (hidden under the tab swap).

**Lane rebuild flash — facet / registry re-map**
- `CatalogLaneModel.id` was a fresh `UUID()` per instance, so every feed re-map minted new identities and `ForEach` tore down + rebuilt every lane (each horizontal ScrollView + its covers). Derive `id` from `title`+`moreURL` — the identity the `catalogLaneMore` route already uses — so `ForEach` diffs in place.

## Tests

- `decodePixels` sizing: exact 1:1 + 1200px clamp (kills the oversample mutation).
- Content-derived lane identity: same title+url → equal id; different → different; nil-url handled. **Replaces two tests that encoded the old per-instance-UUID behavior.**
- `popToRoot(animated: false)` clears the full stack.
- Affected classes green locally (55 tests); pre-push gate green on 5 classes. Full suite runs in CI here.

## Deliberately deferred (not blindly changing tuned/shipped code)

- **AdaptiveShadow 4-layer stack** — deliberate tuned design (PP-4745); a design call, not a bug.
- **Continue-lane per-frame relayout** — intrinsic to a scroll-linked collapse *feature*; rearchitecting risks the shipped UX.
- **`matchedGeometryEffect` "duplicate id"** flagged during analysis was a **false positive** — correct `if/else` source→destination pattern, one branch ever live. No change.

## Scope / risk

Rendering + animation only. No change to nav semantics, cover caching, or the Continue-lane feature. Only consumer of `CatalogLaneModel.id` is `ForEach(id:)` (needs `Hashable`; `String` works) — no production code assumed `UUID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)