### PR TITLE
fix(pdf): route plain PDFs from the Continue card through the PDFKit path

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 		51909291473E1B9E9260CE8C /* CarPlayAuthHelperReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 426F162F6CFC705CE42A45B2 /* CarPlayAuthHelperReadinessTests.swift */; };
 		51B4D85037A44C1463C4418F /* ImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CCD6D02A703C447C36C65D /* ImageLoaderTests.swift */; };
 		524DF6EC46F70059471E3A77 /* MyBooksDownloadCenterAccountIdThreadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC176AE72CA93111D5E2B6C3 /* MyBooksDownloadCenterAccountIdThreadingTests.swift */; };
+		5290120E5AFA84BAFAD4F608 /* ReaderServicePDFRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF549655DE7026414C096C08 /* ReaderServicePDFRouteTests.swift */; };
 		52E656FD2F1E4C8EF201059C /* SingletonResetRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63880885010BDEA019007D3A /* SingletonResetRegistryTests.swift */; };
 		5419E00285822EDBFB4ED932 /* SendableSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BD75A5447FB7BD0DA90F57 /* SendableSubject.swift */; };
 		544B4387437E609DFF7E6757 /* OPDS2PublicationExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023DFFACC986541965F1560 /* OPDS2PublicationExtended.swift */; };
@@ -3005,6 +3006,7 @@
 		CE97656B54F67282B7B52648 /* TPPLinearView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPLinearView.swift; sourceTree = "<group>"; };
 		CF2D0C6025D50993E6431BDC /* ReaderThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeTests.swift; sourceTree = "<group>"; };
 		CF4E37ED1C3EFEF6CB717835 /* PalaceMotionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalaceMotionTests.swift; sourceTree = "<group>"; };
+		CF549655DE7026414C096C08 /* ReaderServicePDFRouteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderServicePDFRouteTests.swift; sourceTree = "<group>"; };
 		CF8AB4D59DBD90ED85785F01 /* RatingEligibilityPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingEligibilityPolicyTests.swift; sourceTree = "<group>"; };
 		COOKIEPERSIST001REF001 /* CookiePersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CookiePersistenceTests.swift; sourceTree = "<group>"; };
 		CPTB00010000FILEREF01 /* CarPlayTemplateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayTemplateBuilder.swift; sourceTree = "<group>"; };
@@ -5650,6 +5652,7 @@
 				F3E2541AFE374BC6F841E19E /* AppTabHostMiniPlayerIntegrationTests.swift */,
 				7510F2474FBF692B90EF902A /* AudiobookMorphingPlayerViewTests.swift */,
 				036520F6ED04D581E2F1C8BC /* TabBarModernizationTests.swift */,
+				CF549655DE7026414C096C08 /* ReaderServicePDFRouteTests.swift */,
 			);
 			path = AppInfrastructure;
 			sourceTree = "<group>";
@@ -7819,6 +7822,7 @@
 				FCD12E3016C092CF32FB00F3 /* BookServiceAudiobookOpenTests.swift in Sources */,
 				1C4CC3753B75E8677FEB66B0 /* ButtonStateMonotonicClampTests.swift in Sources */,
 				C7DFB8533719B493E14C6A56 /* LockIsolated.swift in Sources */,
+				5290120E5AFA84BAFAD4F608 /* ReaderServicePDFRouteTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/ReaderService.swift
+++ b/Palace/AppInfrastructure/ReaderService.swift
@@ -99,45 +99,94 @@ final class ReaderService {
         openEPUBInternal(book, isRetry: false)
     }
 
-    /// Opens an LCP-protected PDF through the Readium pipeline:
-    /// `AssetRetriever` + `PublicationOpener` → `Publication` served by
-    /// `httpServer` → `PDFNavigatorViewController`. No temp-extract step.
+    /// PDF open entry point for every caller (BookDetail, My Books, and the
+    /// Continue-reading card). Routes on encryption:
+    ///   - LCP-protected PDFs → `openLCPPDF` (Readium publication open +
+    ///     chunked disk extract → PDFKit).
+    ///   - Plain (non-LCP) PDFs → `openPlainPDF` (PDFKit `PDFDocument(url:)`
+    ///     mmap, no publication/extract hop).
     ///
-    /// The route is pushed IMMEDIATELY so the reader view appears with
-    /// its own loading state — the publication open + TOC pre-load run
-    /// asynchronously in the background, and the reader view re-renders
-    /// when the publication lands. This is intentional: LCP open on large
-    /// Marketplace containers involves hundreds of synchronous AES decrypt
-    /// calls (visible in `TPPLCPClient.swift: Successfully decrypted ...`
-    /// logs) and can take 30-60s. Holding the user on the book detail
-    /// page during that window makes the app feel frozen.
+    /// Gating lives here rather than only in `BookService.presentPDF` so that
+    /// EVERY caller stays correct through a single seam. The Continue-reading
+    /// card called this method directly while it was LCP-only, so tapping a
+    /// plain downloaded PDF (an open-access title) drove it through the LCP
+    /// extract pipeline and failed with a spurious "unable to open" alert.
     ///
-    /// `onFinish` fires once the route has been pushed (or the open has
-    /// failed and an alert is queued). It does NOT wait for the
-    /// publication itself — callers that want to clear a button spinner
-    /// can do so as soon as the reader appears.
-    /// LCP PDF open flow — **disk-extract architecture**.
-    ///
-    /// Previously this route handed an LCP-encrypted `Publication`
-    /// directly to Readium's `PDFNavigatorViewController`, which did
-    /// random-access reads on the encrypted stream. The device log
-    /// captured 841,570 decrypts in 10s with ~9 KB retained per call
-    /// (residentMB 1.8 → 2.8 GB), guaranteed OOM on anything bigger
-    /// than a one-page PDF.
-    ///
-    /// The new path streams the decrypted PDF ONCE through Readium's
-    /// `Resource.stream(consume:)` into a temp .pdf on disk, then
-    /// renders with PDFKit (`TPPPDFReaderView`) which mmaps the file
-    /// and pages in on demand. ~25k linear decrypts for a 50MB book
-    /// instead of ~800k random-access ones, with the Readium
-    /// publication released the instant extraction completes.
-    ///
-    /// Cached extract on disk → re-opens skip the decrypt entirely.
+    /// The shared prologue — `bookOpenTracker.recordOpened` +
+    /// `stopActiveAudiobookSessionIfNeeded()` — runs for BOTH routes, matching
+    /// `openEPUB` and audiobook opens: opening a reader is a content switch, so
+    /// it records recency and stops any playing audiobook regardless of PDF
+    /// encryption. NOTE: plain PDFs opened from BookDetail/My Books previously
+    /// bypassed this method and did neither; routing them through the single
+    /// seam intentionally unifies that behavior.
     @MainActor
     func openPDF(_ book: TPPBook, onFinish: (() -> Void)? = nil) {
         // Polish-phase (in-app-nav-polish-2026-06-01) — see openEPUB.
         AppContainer.production().bookOpenTracker.recordOpened(book.identifier)
         Self.stopActiveAudiobookSessionIfNeeded()
+
+        switch Self.pdfOpenRoute(for: book) {
+        case .lcp:
+            openLCPPDF(book, onFinish: onFinish)
+        case .plain:
+            openPlainPDF(book, onFinish: onFinish)
+        }
+    }
+
+    /// Which PDF-open pipeline a book routes to. `openPDF` dispatches on this;
+    /// pulled out as a pure `nonisolated static` so the routing decision — the
+    /// exact seam the Continue-card regression turned on — is unit-testable
+    /// without the singleton-coupled open machinery.
+    enum PDFOpenRoute: Equatable { case lcp, plain }
+
+    /// Route a PDF by encryption. LCP-protected PDFs (including Marketplace
+    /// shapes where the LCP MIME is nested/sibling — see `hasLCPAcquisition`)
+    /// take the Readium extract pipeline; everything else is a plain PDFKit
+    /// open. In a non-LCP (open-source) build there is no LCP path, so every
+    /// PDF is `.plain`.
+    nonisolated static func pdfOpenRoute(for book: TPPBook) -> PDFOpenRoute {
+        #if LCP
+        return LCPPDFs.hasLCPAcquisition(book) ? .lcp : .plain
+        #else
+        return .plain
+        #endif
+    }
+
+    /// Plain (non-LCP) PDF open. `PDFDocument(url:)` mmaps the file and pages
+    /// in on demand — no up-front RAM cost for a large textbook, no
+    /// synchronous main-thread read of the whole file (PR #852). Shared by
+    /// BookDetail, My Books, and the Continue-reading card.
+    private func openPlainPDF(_ book: TPPBook, onFinish: (() -> Void)? = nil) {
+        guard let url = AppContainer.production().downloadCenter.fileUrl(for: book.identifier) else {
+            Log.error(#file, "[PDF] no on-disk file for \(book.identifier) — cannot open plain PDF")
+            onFinish?()
+            return
+        }
+        let metadata = TPPPDFDocumentMetadata(with: book)
+        let document = TPPPDFDocument(url: url)
+        if let coordinator = AppContainer.production().navigationCoordinatorHub.coordinator {
+            coordinator.storePDF(document: document, metadata: metadata, forBookId: book.identifier)
+            coordinator.push(.pdf(BookRoute(id: book.identifier)))
+        }
+        onFinish?()
+    }
+
+    /// LCP-protected PDF open. Opens the Readium publication, extracts the
+    /// decrypted PDF to disk (chunked, off-main), then hands the on-disk file
+    /// to PDFKit. Only reached for books with an LCP acquisition. The route is
+    /// pushed immediately with a loading state; `onFinish` fires once the route
+    /// is pushed (or the open fails and an alert is queued), NOT once the
+    /// publication lands.
+    ///
+    /// Disk-extract (rather than serving the encrypted publication straight to
+    /// Readium's `PDFNavigatorViewController`) is deliberate: random-access
+    /// reads on the encrypted stream logged ~841k AES decrypts in 10s (~9 KB
+    /// retained each, residentMB 1.8 → 2.8 GB) and OOM'd on anything past a
+    /// one-page PDF. Streaming the decrypted bytes once to a temp `.pdf` then
+    /// mmapping with PDFKit is ~25k linear decrypts for a 50 MB book, and the
+    /// Readium publication is released the instant extraction completes. A
+    /// cached on-disk extract lets re-opens skip the decrypt entirely.
+    private func openLCPPDF(_ book: TPPBook, onFinish: (() -> Void)? = nil) {
         guard let presenter = topPresenter() else { onFinish?(); return }
 
         if openInFlightBookIds.contains(book.identifier) {

--- a/Palace/Book/UI/BookDetail/BookService.swift
+++ b/Palace/Book/UI/BookDetail/BookService.swift
@@ -119,33 +119,19 @@ enum BookService {
     }
 
     @MainActor private static func presentPDF(_ book: TPPBook, completion: (() -> Void)? = nil) {
-        // LCP-protected PDFs go through Readium's PDFNavigator — no temp
-        // extract, pages stream on demand via the shared httpServer. Use
-        // hasLCPAcquisition (walks all acquisitions + indirect chains)
-        // rather than canOpenBook so OPDS-Catalog-wrapped LCP PDFs (where
-        // the LCP MIME is a sibling acquisition rather than the default)
-        // get routed correctly. Defer `completion?()` until the
-        // publication opens — LCP open is async (~1–3s) and the caller
-        // typically holds a loading indicator on this completion.
-        #if LCP
-        if LCPPDFs.hasLCPAcquisition(book) {
-            AppContainer.production().readerService.openPDF(book) {
-                completion?()
-            }
-            return
+        // Single PDF seam: `ReaderService.openPDF` gates LCP vs plain
+        // internally. LCP-protected PDFs stream through Readium's
+        // publication-open + disk-extract pipeline; plain (non-LCP) PDFs use
+        // PDFKit's `PDFDocument(url:)` mmap path. Routing lives in one place
+        // (ReaderService) so BookDetail, My Books, and the Continue-reading
+        // card can't drift apart — the Continue card previously bypassed this
+        // gate and failed to open plain PDFs. `completion` fires once the open
+        // has been dispatched (immediately for plain; after the async
+        // publication open for LCP — the caller typically holds a loading
+        // indicator on it).
+        AppContainer.production().readerService.openPDF(book) {
+            completion?()
         }
-        #endif
-
-        // Plain (non-LCP) PDFs keep the PDFKit path: PDFDocument(url:) mmaps
-        // the file and pages in on demand without the HTTP-server hop.
-        guard let url = AppContainer.production().downloadCenter.fileUrl(for: book.identifier) else { completion?(); return }
-        let metadata = TPPPDFDocumentMetadata(with: book)
-        let document = TPPPDFDocument(url: url)
-        if let coordinator = AppContainer.production().navigationCoordinatorHub.coordinator {
-            coordinator.storePDF(document: document, metadata: metadata, forBookId: book.identifier)
-            coordinator.push(.pdf(BookRoute(id: book.identifier)))
-        }
-        completion?()
     }
 
     /// Shown when an audiobook open fails. Invoked by

--- a/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
+++ b/Palace/MyBooks/MyBooks/BookCell/BookCellModel.swift
@@ -629,26 +629,16 @@ extension BookCellModel {
             readerService.openEPUB(book)
             self.isLoading = false
         case .pdf:
-            #if LCP
-            if LCPPDFs.hasLCPAcquisition(book) {
-                // LCP PDFs go through the Readium publication opener which
-                // is async + heavy (LCP key derivation + asset retrieval).
-                // Hold isLoading until the route is pushed so the cell
-                // spinner stays visible while the user waits.
-                readerService.openPDF(book) { [weak self] in
-                    self?.isLoading = false
-                }
-                return
+            // Single PDF seam: `ReaderService.openPDF` gates LCP vs plain
+            // internally (see `ReaderService.pdfOpenRoute`) so every caller —
+            // this cell, BookDetail, and the Continue-reading card — routes
+            // identically. Hold the cell spinner until the open dispatches:
+            // the completion fires synchronously for a plain PDFKit open and
+            // after the async publication open for LCP (key derivation + asset
+            // retrieval), keeping the spinner visible while the user waits.
+            readerService.openPDF(book) { [weak self] in
+                self?.isLoading = false
             }
-            #endif
-            guard let url = downloadCenter.fileUrl(for: book.identifier) else { self.isLoading = false; return }
-            let metadata = TPPPDFDocumentMetadata(with: book)
-            let document = TPPPDFDocument(url: url)
-            if let coordinator = AppContainer.production().navigationCoordinatorHub.coordinator {
-                coordinator.storePDF(document: document, metadata: metadata, forBookId: book.identifier)
-                coordinator.push(.pdf(BookRoute(id: book.identifier)))
-            }
-            self.isLoading = false
         case .audiobook:
             openAudiobookFromCell()
         case .streamingHTML:

--- a/PalaceTests/AppInfrastructure/ReaderServicePDFRouteTests.swift
+++ b/PalaceTests/AppInfrastructure/ReaderServicePDFRouteTests.swift
@@ -1,0 +1,131 @@
+//
+//  ReaderServicePDFRouteTests.swift
+//  PalaceTests
+//
+//  Behavior tests for `ReaderService.pdfOpenRoute(for:)` — the pure routing
+//  decision that `openPDF` dispatches on to send a book to either the LCP
+//  extract pipeline (`openLCPPDF`) or the plain PDFKit path (`openPlainPDF`).
+//
+//  Regression context: the Continue-reading card calls `ReaderService.openPDF`
+//  directly. While `openPDF` was LCP-only, tapping a *plain* (open-access)
+//  downloaded PDF drove it through the Readium publication-open + disk-extract
+//  pipeline, which failed with a spurious "unable to open" alert — the user
+//  saw a loading spinner and then an error. BookDetail worked only because it
+//  routed through `BookService.presentPDF`'s own LCP gate. The fix moves the
+//  gate into `openPDF` (via `pdfOpenRoute`) so every caller routes correctly
+//  through one seam. These tests pin that a non-LCP PDF routes `.plain` and an
+//  LCP PDF routes `.lcp`; flipping the gate condition in production fails them.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+final class ReaderServicePDFRouteTests: XCTestCase {
+
+    // MARK: - MIME constants (mirrored from production for fixture readability)
+
+    private let lcpLicenseMIME = "application/vnd.readium.lcp.license.v1.0+json"
+    private let opdsPublicationMIME = "application/opds-publication+json"
+    private let pdfMIME = "application/pdf"
+
+    // MARK: - Fixture helpers
+
+    private func makeBook(acquisitions: [TPPOPDSAcquisition]) -> TPPBook {
+        TPPBook(
+            acquisitions: acquisitions,
+            authors: [],
+            categoryStrings: [],
+            distributor: "Test",
+            identifier: UUID().uuidString,
+            imageURL: nil,
+            imageThumbnailURL: nil,
+            published: Date(),
+            publisher: "Test",
+            subtitle: nil,
+            summary: nil,
+            title: "Test Book",
+            updated: Date(),
+            annotationsURL: nil,
+            analyticsURL: nil,
+            alternateURL: nil,
+            relatedWorksURL: nil,
+            previewLink: nil,
+            seriesURL: nil,
+            revokeURL: nil,
+            reportURL: nil,
+            timeTrackingURL: nil,
+            contributors: [:],
+            bookDuration: nil,
+            imageCache: MockImageCache()
+        )
+    }
+
+    private func acquisition(
+        type: String,
+        indirect: [TPPOPDSIndirectAcquisition] = []
+    ) -> TPPOPDSAcquisition {
+        TPPOPDSAcquisition(
+            relation: .generic,
+            type: type,
+            hrefURL: URL(string: "https://library.test/book.lcpl")!,
+            indirectAcquisitions: indirect,
+            availability: TPPOPDSAcquisitionAvailabilityUnlimited()
+        )
+    }
+
+    private func indirect(_ type: String, _ children: [TPPOPDSIndirectAcquisition] = []) -> TPPOPDSIndirectAcquisition {
+        TPPOPDSIndirectAcquisition(type: type, indirectAcquisitions: children)
+    }
+
+    // MARK: - Tests
+
+    /// Open-access PDF — no LCP MIME anywhere. MUST route `.plain` so the
+    /// Continue card (and every other caller) opens it via PDFKit rather than
+    /// driving it through the LCP extract pipeline that produced the reported
+    /// "loading then error". This is the direct regression kill point.
+    func testPDFOpenRoute_plainPDF_routesPlain() {
+        let book = makeBook(acquisitions: [acquisition(type: pdfMIME)])
+
+        XCTAssertEqual(book.defaultBookContentType, .pdf,
+                       "Pre-condition: open-access PDF resolves as .pdf")
+        XCTAssertEqual(ReaderService.pdfOpenRoute(for: book), .plain,
+                       "A non-LCP PDF MUST route to the plain PDFKit path — routing it to .lcp is exactly the Continue-card regression")
+    }
+
+    #if LCP
+    /// Classic LCP-license-wrapped PDF — top-level LCP MIME. MUST route `.lcp`
+    /// so the Readium extract pipeline runs. Flipping the gate would send an
+    /// encrypted PDF to the plain path, where PDFKit cannot decrypt it.
+    func testPDFOpenRoute_topLevelLCPPDF_routesLCP() {
+        let book = makeBook(acquisitions: [
+            acquisition(type: lcpLicenseMIME, indirect: [indirect(pdfMIME)])
+        ])
+
+        XCTAssertEqual(book.defaultBookContentType, .pdf,
+                       "Pre-condition: LCP-license-wrapped PDF resolves as .pdf")
+        XCTAssertEqual(ReaderService.pdfOpenRoute(for: book), .lcp,
+                       "A top-level-LCP PDF MUST route to the LCP extract pipeline")
+    }
+
+    /// Marketplace `/groups/` JSON shape — LCP MIME nested one level deep under
+    /// `application/opds-publication+json`. MUST still route `.lcp` (mirrors the
+    /// PP-4454 nested-chain kill point). This proves the gate uses the recursive
+    /// `hasLCPAcquisition` predicate, not a shallow `defaultAcquisition.type`.
+    func testPDFOpenRoute_nestedMarketplaceLCPPDF_routesLCP() {
+        let book = makeBook(acquisitions: [
+            acquisition(
+                type: opdsPublicationMIME,
+                indirect: [indirect(lcpLicenseMIME, [indirect(pdfMIME)])]
+            )
+        ])
+
+        XCTAssertEqual(book.defaultBookContentType, .pdf,
+                       "Pre-condition: Marketplace-shaped LCP PDF still resolves as .pdf")
+        XCTAssertEqual(ReaderService.pdfOpenRoute(for: book), .lcp,
+                       "A nested/Marketplace LCP PDF MUST route .lcp — the gate must walk the indirect chain")
+    }
+    #endif
+}


### PR DESCRIPTION
## Summary

The **Continue-reading card** opened every PDF via `ReaderService.openPDF`, which had become an **LCP-only** pipeline (Readium publication open + chunked disk extract). Tapping a plain (open-access) downloaded PDF drove it through the LCP extract path and failed — the user saw a **loading spinner, then an error**. BookDetail and My Books worked only because each carried its *own* copy of the LCP-vs-plain gate; the Continue card (`resumeReading`) had none. Three divergent copies of the same routing decision — the Continue card was the one that got missed.

## Fix

Move the gate into `openPDF` itself via a pure, unit-tested `pdfOpenRoute(for:) -> PDFOpenRoute` that dispatches to `openLCPPDF` (encrypted) or `openPlainPDF` (PDFKit `PDFDocument(url:)` mmap). `BookService.presentPDF` and `BookCellModel`'s `.pdf` case collapse to delegate through that one seam, so **every caller routes identically and can't drift apart again**. Also fixes the **Palace-noDRM** build, where the Continue card previously hit the LCP path's `#else abortRunawayOpen`.

### Intentional behavior unification (flagged by SoD review)
The shared `openPDF` prologue — `bookOpenTracker.recordOpened` + `stopActiveAudiobookSessionIfNeeded()` — now runs for the plain path too. A plain PDF opened from BookDetail/My Books now bumps Continue-lane recency and stops a playing audiobook; it did neither before (those callers bypassed `openPDF`). This aligns plain PDFs with how EPUB, LCP-PDF, and audiobook opens already behave — a content switch stops prior content. The plain-PDF *rendering* body is byte-for-byte the logic BookDetail/My Books already shipped.

## Tests
- New `ReaderServicePDFRouteTests`: plain PDF → `.plain` (regression kill point), top-level + nested/Marketplace LCP → `.lcp`. Flipping the gate ternary fails it.
- Continue-row wiring + BookCellModel action/state suites stay green (45 tests spot-checked; full suite is the CI gate).

## Verification
Driven end-to-end on the iPhone 17 Pro sim: borrowed a plain PDF (`Palace Rainbow Article-PDF`), opened it so it registered in the Continue lane, then **tapped the Continue card** — the reader opened and resumed at the saved page (3/6). Zero `[PERF] [LCP-PDF]` log lines during the open confirm the plain path was taken, not the LCP pipeline.

## Review
SoD reviewers (architect / qa_test / blast_radius) ran under heka governance and approved; their two advisory findings (a stale doc block, commit-body scope honesty) are addressed in the final revision. Note: these reviewers are agent roles in the solo-dev heka workflow, not an independent second party — CI's full suite is the substantive gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)