### PR TITLE
fix(audiobook): full-player X fully closes the player (stops + dismisses), not minimize

### DIFF
--- a/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
@@ -387,12 +387,13 @@ struct AudiobookMorphingPlayerView: View {
         ZStack {
             grabber
             HStack {
-                // Explicit close: collapses the full player to the mini-bar
-                // (playback continues). The only other way down is the
-                // non-obvious pull-down gesture, so this gives the full player a
-                // discoverable exit. Occupies the slot the Help entry point used
-                // to hold — Help now lives on book-detail + sign-in only.
-                Button { setExpanded(false) } label: {
+                // Explicit close: fully dismisses the player — stops playback,
+                // saves the position, and removes BOTH the full player and the
+                // mini-bar (not a minimize). The only other exit is the
+                // non-obvious pull-down-to-minimize gesture, so this ✕ is the
+                // discoverable way out. In the slot the Help entry point used to
+                // hold — Help now lives on book-detail + sign-in only.
+                Button { presenter.closePlayer() } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: 18, weight: .medium))
                         .frame(width: 44, height: 44)

--- a/Palace/Audiobooks/AudiobookSessionPresenter.swift
+++ b/Palace/Audiobooks/AudiobookSessionPresenter.swift
@@ -253,6 +253,14 @@ class AudiobookSessionPresenter: ObservableObject {
         isCollapsed = false
     }
 
+    /// Full close from the ✕ on the full player — ends the session and dismisses
+    /// BOTH the full player and the mini-bar (unlike `minimize()`, which only
+    /// hides the full player and keeps the mini-bar). Playback stops and the
+    /// final position is persisted so the patron can resume later from My Books.
+    func closePlayer() {
+        Task { await sessionManager.stopPlayback(dismissPhoneUI: true, persistFinalPosition: true) }
+    }
+
     /// No-op in the resize-overlay morph: the floating pill is GONE — the mini
     /// bar is already the smallest chrome state, so there is nothing further to
     /// collapse into. Left as a no-op (rather than deleted) so the mini bar's


### PR DESCRIPTION
Follow-up to #1288. The full-player X only **minimized** to the mini-bar; make it **fully close** — stop playback, persist the position, and remove both the full player and the mini-bar.

- New `AudiobookSessionPresenter.closePlayer()` -> `sessionManager.stopPlayback(dismissPhoneUI: true, persistFinalPosition: true)` (the canonical stop+dismiss path, same one `dismissPlayerOnPhone` uses). Position is saved so the patron resumes from My Books.
- The X button now calls `presenter.closePlayer()` instead of `setExpanded(false)`.
- Matches the presenter comment that already said "dismiss is via the X".

Host UI/presenter is CI-gated (build validates); the close is exercised on-sim in the audiobook/triage simdrive pass.

Related: #1288 (added the X), PP-4785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)