### PR TITLE
fix(catalog): a newly-opened ebook updates the Continue lane over an audiobook

### DIFF
--- a/Palace/MyBooks/RecentlyReadingService.swift
+++ b/Palace/MyBooks/RecentlyReadingService.swift
@@ -116,12 +116,18 @@ final class DefaultRecentlyReadingService: RecentlyReadingService {
             if acquisition.relation == .sample || acquisition.relation == .preview {
                 return nil
             }
-            // No saved location → no Continue Reading entry; user hasn't
-            // opened this book yet.
-            guard let location = bookRegistry.location(forIdentifier: book.identifier) else {
-                return nil
-            }
-            let parsed = parseLocation(location, fallbackUpdated: book.updated, now: now)
+            // Include a book the patron actually opened even if its reading
+            // position hasn't persisted yet: the reader saves location
+            // asynchronously, so right after an open the tracker has a
+            // wall-clock open time while `location` is still nil. Audiobooks
+            // already qualify on open-time alone (see `recentlyOpenedAudiobook`),
+            // so gating ebooks on a saved location made a freshly-opened ebook
+            // fail to supersede a Continue-slot audiobook until some unrelated
+            // refresh. Exclude only books with neither a saved location NOR a
+            // recorded open (i.e. genuinely never opened).
+            let openedAt = bookOpenTracker?.lastOpened(book.identifier)
+            let location = bookRegistry.location(forIdentifier: book.identifier)
+            guard location != nil || openedAt != nil else { return nil }
             // Polish-phase last-read accuracy fix
             // (in-app-nav-polish-2026-06-01): prefer the BookOpenTracker's
             // wall-clock open time over parsed location timestamp /
@@ -131,15 +137,15 @@ final class DefaultRecentlyReadingService: RecentlyReadingService {
             // so the Continue Reading row shows the book with the
             // newest catalog entry, NOT the book the user actually
             // opened most recently.
-            let openedAt = bookOpenTracker?.lastOpened(book.identifier)
-            let lastReadAt = openedAt ?? parsed.lastReadAt
+            let parsed = location.map { parseLocation($0, fallbackUpdated: book.updated, now: now) }
+            let lastReadAt = openedAt ?? parsed?.lastReadAt ?? book.updated
             return ContinueReadingItem(
                 bookId: book.identifier,
                 book: book,
                 contentType: contentType,
                 lastReadAt: lastReadAt,
-                progressFraction: parsed.progressFraction,
-                progressLabel: parsed.progressLabel
+                progressFraction: parsed?.progressFraction,
+                progressLabel: parsed?.progressLabel
             )
         }
 

--- a/PalaceTests/MyBooks/DefaultRecentlyReadingServiceTests.swift
+++ b/PalaceTests/MyBooks/DefaultRecentlyReadingServiceTests.swift
@@ -114,6 +114,37 @@ final class DefaultRecentlyReadingServiceTests: XCTestCase {
                        "Books with no saved location MUST be excluded")
     }
 
+    // MARK: - Test 4b: includes a just-opened ebook whose location hasn't persisted yet
+
+    func testRecentlyReading_includesOpenedEbookWithoutSavedLocation_viaTracker() {
+        // Regression (Continue-lane ebook-vs-audiobook): a freshly-opened ebook
+        // has a BookOpenTracker open-time but NO saved location yet (the reader
+        // persists position asynchronously). It MUST still appear on the Continue
+        // row and, with a newer open-time, sort ahead of an older ebook — so
+        // opening a new ebook supersedes a Continue-slot audiobook instead of
+        // being filtered out. Audiobooks already qualify on open-time alone; this
+        // pins the same for ebooks.
+        let now = Date(timeIntervalSince1970: 1_720_000_000)
+        let older = now.addingTimeInterval(-3600)
+
+        let freshNoLocation = makeEpub(id: "FRESH")     // just opened; location not persisted
+        let olderWithLocation = makeEpub(id: "OLDER")
+
+        registry.myBooks = [freshNoLocation, olderWithLocation]
+        registry.addBook(freshNoLocation, location: nil, state: .downloadSuccessful)
+        registry.addBook(olderWithLocation, location: makeLocation(timestamp: older), state: .downloadSuccessful)
+
+        let tracker = StubBookOpenTracker(openTimes: ["FRESH": now, "OLDER": older])
+        let service = DefaultRecentlyReadingService(bookRegistry: registry, bookOpenTracker: tracker)
+
+        let result = service.recentlyReading()
+
+        XCTAssertEqual(result.map { $0.bookId }, ["FRESH", "OLDER"],
+                       "A just-opened ebook (tracker open-time, no saved location yet) MUST appear and sort ahead of an older-opened ebook")
+        XCTAssertEqual(result.first?.lastReadAt, now,
+                       "Its lastReadAt MUST be the fresh open-time so it supersedes a Continue-slot audiobook")
+    }
+
     // MARK: - Test 5: empty registry returns empty (no crash)
 
     func testRecentlyReading_emptyRegistryReturnsEmpty() {


### PR DESCRIPTION
## Bug
With an audiobook in the "Continue" slot, opening a new **ebook** did not update the Continue lane — it kept showing the audiobook.

## Root cause
An asymmetry in `DefaultRecentlyReadingService.recentlyReading()`: audiobooks qualify for Continue on open-time alone, but ebooks were gated on a **persisted reading location** (`guard let location = … else { return nil }`). The reader saves position asynchronously, so at the `.palaceBookOpenedDidRecord` refresh that fires right after an open, the fresh ebook has a `BookOpenTracker` open-time but **no location yet** → filtered out → the audiobook keeps the slot (and the later location-save posts a notification this view model does not observe, so it stays stuck).

## Fix
Consult the open-tracker **before** the location gate; include a book with a saved location **OR** a recorded open-time, using the open-time as `lastReadAt` when the location isnt there yet. The fresh ebook (newer open-time) then supersedes the audiobook on the refresh that already fires. Symmetric with the audiobook path; no dependency on the missing location-save notification.

## Test
`DefaultRecentlyReadingServiceTests.testRecentlyReading_includesOpenedEbookWithoutSavedLocation_viaTracker` — an EPUB with a tracker open-time but no location is included and sorts ahead of an older ebook. The existing `testRecentlyReading_excludesBooksWithoutSavedLocation` still passes (no tracker injected → still excluded). Host code, CI-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)