### PR TITLE
fix(triagebot,security): redact prose-stated passwords (PP-4817 chaos F-002)

### DIFF
--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/ContextRedactor.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/ContextRedactor.swift
@@ -194,6 +194,20 @@ public struct ContextRedactor: Sendable {
             regex: #"(?i)\b(pin|passcode)\b[^\d\n]{0,10}\d{3,8}\b"#,
             replacement: "$1 [REDACTED]"
         ),
+        // Password stated in prose without a delimiter ("my password is hunter2").
+        // The delimited "password: X" / "password=X" forms are caught by
+        // `kv_creds`; this covers the "<keyword> is|was <token>" prose form a
+        // patron naturally types in a support chat (PP-4817 chaos F-002: a prose
+        // password leaked into the ticket + real clipboard payload). Requiring an
+        // explicit "is"/"was" linker keeps benign phrases safe — "password reset",
+        // "forgot my password", "password not working" have no linker and are
+        // untouched; only "<keyword> is/was <token>" is redacted (privacy >
+        // utility, so an occasional "password is wrong" losing "wrong" is fine).
+        RedactionPattern(
+            label: "password_prose",
+            regex: #"(?i)\b(password|passwd|passphrase|pwd)\b\s+(?:is|was)\s+\S{3,}"#,
+            replacement: "$1 [REDACTED]"
+        ),
         // Standalone 10-14 digit library barcode / card number typed inline.
         // Word-boundaried so 4-digit years and 3-digit error codes survive.
         // The negative lookahead carves out exactly a 13-digit 978/979 ISBN —

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/FreeTextRedactionTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/FreeTextRedactionTests.swift
@@ -69,6 +69,19 @@ final class FreeTextRedactionTests: XCTestCase {
         XCTAssertEqual(redactor.redactLine(input), input)
     }
 
+    func testRedactsPasswordStatedInProse() {
+        // PP-4817 chaos F-002: a prose password (no ':' / '=') leaked into the
+        // ticket + the real clipboard payload. The "is|was <token>" prose form
+        // must be stripped, mirroring pin_prose.
+        let output = redactor.redactLine("hey my password is hunter2abc thanks")
+        XCTAssertFalse(output.contains("hunter2abc"), "A prose-stated password must be stripped")
+    }
+
+    func testRedactsPasswdWasStatedInProse() {
+        let output = redactor.redactLine("the passwd was Tr0ub4dor3000 yesterday")
+        XCTAssertFalse(output.contains("Tr0ub4dor3000"), "A 'passwd was <token>' prose password must be stripped")
+    }
+
     // MARK: - standalone 10-14 digit barcode / card number
 
     func testRedactsStandaloneBarcodeDigits() {


### PR DESCRIPTION
## Blocker (from the PP-4817 chaos pass)
Typing **"my password is X"** in prose (no `:` / `=`) leaked the password unredacted into the ticket **and** the real clipboard payload — proven via raw `simctl pbpaste`, not just a screenshot. The redactor had `pin_prose` but **no `password_prose`**; `kv_creds` only catches the delimited `password:`/`password=` forms.

## Fix
Add a `password_prose` pattern — `(?i)\b(password|passwd|passphrase|pwd)\b\s+(?:is|was)\s+\S{3,}` -> `$1 [REDACTED]`. Requiring an explicit **is/was** linker keeps benign support phrases safe: "password reset", "forgot my password", "password not working" have no linker and are untouched (privacy > utility for the rare "password is wrong" case).

## Tests
- `testRedactsPasswordStatedInProse` / `testRedactsPasswdWasStatedInProse` — prose passwords stripped.
- Existing `testPassword_decoy_leavesPasswordResetProseUntouched` still passes.
- `swift test` -> **195 tests, 0 failures**.

Critical-path (credential redaction) — should merge before the triage-bot flag-flip. PP-4785 / PP-4817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)