### PR TITLE
test(triagebot): PP-4817 chaos regression journeys (redaction + chip rapid-tap)

### DIFF
--- a/.simdrive/journeys/triage-bot-category-chip-rapid-tap.yaml
+++ b/.simdrive/journeys/triage-bot-category-chip-rapid-tap.yaml
@@ -1,0 +1,67 @@
+scenario:
+  id: triage-bot-category-chip-rapid-tap
+  name: "Triage Bot — rapid-tap a category chip must not duplicate conversation turns"
+  description: >
+    Rapid-taps a triage-bot category chip 5x at the same screen location
+    with no settle time between taps, simulating a distracted/impatient
+    or fat-finger patron. The Send button (tested as a negative control
+    in the same PP-4817 chaos session) correctly debounces itself by
+    synchronously clearing/disabling on first tap; the category-chip
+    Button has no equivalent guard. See finding F-001.
+  tags: [chaos, rapid-tap, debounce, triage-bot, pp4817]
+  tier: stateful
+  blocking: false
+
+  preconditions:
+    - "Palace app cold-launched, org.thepalaceproject.palace"
+    - "Triage bot master kill-switch ON"
+
+  recording:
+    path: "~/.simdrive/recordings/chaos-rapid-tap-category-chip/recording.yaml"
+    steps: 5
+    captured_on: "2026-07-17"
+    note: "Recorded during the PP-4817 chaos pass; copy into
+      .simdrive/replays/chaos/chaos-rapid-tap-category-chip.yaml to keep."
+
+  steps:
+    - id: open_help
+      description: "Catalog -> book detail -> tap toolbar Get Help"
+      tap_target: { text: "help.button.bookDetail" }
+    - id: rapid_tap_sign_in_1
+      description: "Tap 'Sign in' chip (1/5, no settle)"
+      tap_target: { text: "Sign in" }
+    - id: rapid_tap_sign_in_2
+      description: "Tap same coords again (2/5, no settle)"
+    - id: rapid_tap_sign_in_3
+      description: "Tap same coords again (3/5, no settle)"
+    - id: rapid_tap_sign_in_4
+      description: "Tap same coords again (4/5, no settle)"
+    - id: rapid_tap_sign_in_5
+      description: "Tap same coords again (5/5, no settle)"
+    - id: observe_transcript
+      description: >
+        observe() the chat transcript. Count distinct "Sign in issue"
+        user-bubble marks (by stable_id). Expect 1; currently produces 5.
+
+  expected_invariants:
+    - "Exactly one 'Sign in issue' user bubble and one bot prompt bubble
+       appear per logical chip selection, regardless of tap repetition
+       within the debounce window."
+
+  known_failures:
+    - id: F-001
+      severity: major
+      summary: >
+        5 rapid taps produce 5 duplicate user/bot bubble pairs (5 unique
+        stable_ids each) — CategoryChipsView's Button has no debounce
+        guard, unlike SupportChatView's Send button.
+
+  structural_checks:
+    - after_step: observe_transcript
+      max_duplicate_marks:
+        text: "Sign in issue"
+        expected: 1
+      rationale: |
+        Currently fails: 5 marks match "Sign in issue" instead of 1. This
+        is the automatable regression signature for F-001 — a replay
+        harness can assert `len(marks matching text) == 1` after this step.

--- a/.simdrive/journeys/triage-bot-redaction-adversarial-input.yaml
+++ b/.simdrive/journeys/triage-bot-redaction-adversarial-input.yaml
@@ -1,0 +1,90 @@
+scenario:
+  id: triage-bot-redaction-adversarial-input
+  name: "Triage Bot — credential-shaped free text must be redacted end-to-end"
+  description: >
+    Types a single adversarial free-text string combining a prose PIN, a
+    prose password, a 14-digit barcode, a SQL-injection fragment, RTL
+    Hebrew, emoji, and a Bearer JWT into the triage-bot composer, submits
+    it, and inspects BOTH the on-screen Ticket Preview AND the actual
+    device pasteboard payload (via the post-failure "Copy details" action)
+    to prove the ContextRedactor stripped every credential shape before
+    anything could leave the device. This is the standing regression guard
+    for the gap discovered during PP-4817 chaos QA (see finding F-002).
+  tags: [chaos, security, redaction, triage-bot, pp4805, pp4806, pp4817]
+  tier: stateful
+  blocking: true
+
+  preconditions:
+    - "Palace app cold-launched, org.thepalaceproject.palace"
+    - "Triage bot master kill-switch ON (Settings > Support shows 'Get Help')"
+    - "No Mail account configured on the sim (forces the Copy-details path
+       deterministically instead of needing the Force-Submit-Failure toggle)"
+
+  recording:
+    path: "~/.simdrive/recordings/chaos-rapid-tap-category-chip/recording.yaml"
+    note: >
+      No dedicated recording exists for this exact flow yet (it was driven
+      ad hoc during the PP-4817 chaos pass, not via record_start/stop).
+      Re-record this journey with simdrive.record_start/record_stop next
+      time it is run and update this path.
+
+  steps:
+    - id: open_help
+      description: "Catalog -> book detail -> tap toolbar Get Help"
+      tap_target: { text: "help.button.bookDetail" }
+    - id: pick_category
+      description: "Tap the 'Sign in' category chip"
+      tap_target: { text: "Sign in" }
+    - id: type_adversarial_text
+      description: "Type the combined credential-shaped adversarial string"
+      type_text: >
+        my pin is 12345 and my password is hunter2abc, card
+        49925398112345, ' OR 1=1 -- אבגד 😀😀 Bearer
+        eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJyZWFsIn0.sig123456
+    - id: submit_description
+      description: "Tap the arrow.up.circle.fill submit button"
+    - id: inspect_preview
+      description: >
+        Read the Ticket Preview 'What you said' field. Every credential
+        clause must be bracket-redacted: 'my pin [REDACTED] and my password
+        [REDACTED], card [number-redacted], ... Bearer [REDACTED]'. (The
+        password clause is redacted by the password_prose pattern added in
+        #1292 to close F-002.)
+    - id: tap_send
+      description: "Tap Send on the ticket preview (expect failure on bare sim)"
+    - id: tap_copy_details
+      description: "On the 'Couldn't send' error card, tap 'Copy details'"
+    - id: read_pasteboard
+      description: >
+        Shell out: `xcrun simctl pbpaste <udid>`. Assert the literal
+        substrings "hunter2abc" and "password is hunter2abc" are ABSENT.
+        Assert "[REDACTED]" appears for the pin, password, and Bearer/JWT
+        clauses, and "[number-redacted]" for the barcode.
+
+  expected_invariants:
+    - "Every credential SHAPE in the deny-list (pin, password, barcode,
+       bearer/JWT token) is absent from both the Ticket Preview text and
+       the real pasteboard/email payload."
+    - "SQL-injection fragment, RTL Hebrew, and emoji pass through inertly
+       (not a security concern, just must not crash rendering)."
+
+  regression_history:
+    - id: F-002
+      status: fixed
+      fixed_by: "#1292 (ContextRedactor password_prose pattern)"
+      summary: >
+        "my password is X" (prose form, no ':'/'=' delimiter) previously
+        leaked -- kv_creds required a delimiter and there was no
+        password_prose analogue to pin_prose. Discovered in PP-4817 chaos QA
+        via the raw simulator pasteboard capture (not just the UI preview).
+        This journey is the standing guard against its return.
+
+  structural_checks:
+    - after_step: inspect_preview
+      required_text: ["Ticket preview", "What you said", "[REDACTED]", "[number-redacted]"]
+      forbidden_text: ["hunter2abc"]
+      rationale: |
+        The forbidden_text assertion pins F-002's fix: "hunter2abc" (the
+        prose password value) must not appear anywhere in the preview or the
+        pasteboard payload. Regressing the password_prose pattern re-breaks
+        this.


### PR DESCRIPTION
Two replayable simdrive journeys distilled from the PP-4817 triage-bot chaos pass, so the flows it exercised stay guarded on every future run:

- **triage-bot-redaction-adversarial-input.yaml** — end-to-end credential-redaction guard. Types a combined adversarial string (prose PIN, prose password, 14-digit barcode, SQLi fragment, RTL, emoji, Bearer/JWT), submits, and asserts every credential shape is absent from BOTH the Ticket Preview and the real device pasteboard (`simctl pbpaste`). The prose-password case (F-002) is now fixed by #1292; this journey is its standing regression guard.
- **triage-bot-category-chip-rapid-tap.yaml** — repro for the duplicate-turns bug (F-001, tracked as PP-4822).

YAML only — no production change. Related: PP-4817, PP-4785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)