### PR TITLE
feat(flags): Firebase-gate in-app playback nav + split continuation cards into their own flag

### DIFF
--- a/Palace/AppInfrastructure/FirebaseManager.swift
+++ b/Palace/AppInfrastructure/FirebaseManager.swift
@@ -68,6 +68,7 @@ final class FirebaseManager: @unchecked Sendable {
         case triageBotTicketSubmissionEnabled = "triage_bot_ticket_submission_enabled"
         case triageBotAIFallbackEnabled = "triage_bot_ai_fallback_enabled"
         case inAppPlaybackNavEnabled = "in_app_playback_nav_enabled"
+        case continuationCardsEnabled = "continuation_cards_enabled"
         case sideLoadingEnabled = "side_loading_enabled"
         // App-rating prompt (Epic PP-4086). Master switch + tunable thresholds.
         case appRatingPromptEnabled = "app_rating_prompt_enabled"
@@ -122,6 +123,7 @@ final class FirebaseManager: @unchecked Sendable {
             RemoteConfigKey.triageBotTicketSubmissionEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.triageBotAIFallbackEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.inAppPlaybackNavEnabled.rawValue: NSNumber(value: false),
+            RemoteConfigKey.continuationCardsEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.sideLoadingEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.appRatingPromptEnabled.rawValue: NSNumber(value: true),
             RemoteConfigKey.appRatingMinSessions.rawValue: NSNumber(value: RatingConfig.fallback.minSessions),

--- a/Palace/CatalogUI/Views/CatalogContentView.swift
+++ b/Palace/CatalogUI/Views/CatalogContentView.swift
@@ -27,15 +27,17 @@ struct CatalogContentView: View {
     var bookRegistry: TPPBookRegistryProvider = AppContainer.production().bookRegistry
 
     /// Subscribes to the developer-settings local override so the view
-    /// re-renders the moment the dev toggle flips. The actual gating
-    /// decision delegates to `RemoteFeatureFlags.shared
-    /// .isInAppPlaybackNavEnabled`, which combines the override (wins
-    /// when set) with the Firebase Remote Config `in_app_playback_nav_enabled`
-    /// value (fallback). Reading the @AppStorage value inside
-    /// `inAppPlaybackNavEnabled` registers the SwiftUI observation
-    /// against the same UserDefaults key the dev toggle writes to.
-    @AppStorage("RemoteFeatureFlags.inAppPlaybackNavLocalOverride")
-    private var inAppPlaybackNavLocalOverride: Bool = false
+    /// re-renders the moment the dev toggle flips. The actual gating decision
+    /// delegates to `RemoteFeatureFlags.shared.isContinuationCardsEnabled`,
+    /// which combines the override (wins when set) with the Firebase Remote
+    /// Config `continuation_cards_enabled` value (fallback). Reading the
+    /// @AppStorage value inside `continuationCardsEnabled` registers the
+    /// SwiftUI observation against the same UserDefaults key the dev toggle
+    /// writes to. NOTE: the continuation cards are gated separately from the
+    /// in-app mini-player (`inAppPlaybackNavEnabled`) so they roll out
+    /// independently.
+    @AppStorage("RemoteFeatureFlags.continuationCardsLocalOverride")
+    private var continuationCardsLocalOverride: Bool = false
 
     /// Chevron "pin": when `false` the lane is manually pinned collapsed and
     /// ignores the scroll; when `true` (default) the scroll position drives it.
@@ -49,18 +51,19 @@ struct CatalogContentView: View {
     /// catalog body. See `ContinueCollapseModel`.
     @State private var continueCollapse = ContinueCollapseModel()
 
-    private var inAppPlaybackNavEnabled: Bool {
-        _ = inAppPlaybackNavLocalOverride  // trigger SwiftUI observation
-        return RemoteFeatureFlags.shared.isInAppPlaybackNavEnabled
+    private var continuationCardsEnabled: Bool {
+        _ = continuationCardsLocalOverride  // trigger SwiftUI observation
+        return RemoteFeatureFlags.shared.isContinuationCardsEnabled
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Feature-flagged (in_app_playback_nav_enabled): hides the
+            // Feature-flagged (continuation_cards_enabled): hides the
             // Continue Reading / Continue Listening hero rows when off.
-            // The viewmodel still runs (subscriptions stay live so the
-            // flag flip is instant); only the rendering is gated.
-            if inAppPlaybackNavEnabled {
+            // Gated independently of the in-app mini-player. The viewmodel
+            // still runs (subscriptions stay live so the flag flip is
+            // instant); only the rendering is gated.
+            if continuationCardsEnabled {
                 ContinueRowSection(
                     viewModel: activeSessions,
                     onResumeReading: onResumeReading,

--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -55,8 +55,13 @@ final class RemoteFeatureFlags: @unchecked Sendable {
         /// polish 2026-06-02): Continue Reading/Listening hero rows on
         /// the Catalog top, the persistent mini-player chrome above the
         /// tab bar, and the tap-to-resume routing that wires both to
-        /// `AudiobookSessionPresenter`. Default OFF — the feature is
-        /// opt-in via the developer settings toggle until broad rollout.
+        /// `AudiobookSessionPresenter`. **Default OFF — Firebase-gated.**
+        /// Production users get the legacy toolkit player until Firebase
+        /// Remote Config sets `in_app_playback_nav_enabled = true` (a global
+        /// or staged/condition-based rollout the team controls without
+        /// shipping a build). Precedence is UserDefaults local override
+        /// (dev-menu toggle / QA) > Firebase remote (default false) — see
+        /// `isInAppPlaybackNavEnabled`.
         case inAppPlaybackNavEnabled = "in_app_playback_nav_enabled"
         /// Gates every side-loading surface (swarm_495a88d9 — PP-2677 /
         /// PP-2678 / PP-2679): the Settings "Side Loading" import screen and
@@ -84,6 +89,8 @@ final class RemoteFeatureFlags: @unchecked Sendable {
             case .appRatingPromptEnabled:
                 return true
             default:
+                // Includes `.inAppPlaybackNavEnabled`: default OFF in-app —
+                // Firebase Remote Config turns it on (see isInAppPlaybackNavEnabled).
                 return false
             }
         }
@@ -365,15 +372,21 @@ final class RemoteFeatureFlags: @unchecked Sendable {
     /// persistent mini-player above the tab bar, and the tap-to-resume
     /// routing that wires both to `AudiobookSessionPresenter`.
     ///
-    /// **GA (2026-07): now the standard experience — no longer gated on
-    /// Remote Config.** Returns `true` by default. A developer-settings
-    /// local override is still honored so QA can force the legacy player
-    /// path for comparison; absent that override, the feature is always on.
+    /// **Default OFF — Firebase-gated (2026-07).** Production users get the
+    /// legacy toolkit player until Firebase Remote Config enables the
+    /// feature; this lets the team turn it on (globally or via a staged /
+    /// condition-based rollout) — and roll it back — without shipping a
+    /// build. The registered Remote Config default is `false`.
+    ///
+    /// Override precedence:
+    ///   1. UserDefaults local override (dev-menu toggle / QA) — wins so QA
+    ///      can force either player regardless of the production rollout.
+    ///   2. Firebase Remote Config (`isFeatureEnabled`, default `false`).
     var isInAppPlaybackNavEnabled: Bool {
         if let override = defaults.object(forKey: Self.inAppPlaybackNavLocalOverrideKey) as? Bool {
             return override
         }
-        return true
+        return isFeatureEnabled(.inAppPlaybackNavEnabled)
     }
 
     /// UserDefaults override that lets QA / a developer force side loading on

--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -63,6 +63,14 @@ final class RemoteFeatureFlags: @unchecked Sendable {
         /// (dev-menu toggle / QA) > Firebase remote (default false) — see
         /// `isInAppPlaybackNavEnabled`.
         case inAppPlaybackNavEnabled = "in_app_playback_nav_enabled"
+        /// Gates ONLY the Continue Reading / Continue Listening hero rows at the
+        /// top of the Catalog (the "continuation" cards). Split out from
+        /// `inAppPlaybackNavEnabled` so the cards and the in-app player can be
+        /// rolled out independently — e.g. ship the in-app mini-player without
+        /// the continuation cards, or vice versa. **Default OFF — Firebase-gated**
+        /// (same posture as `inAppPlaybackNavEnabled`); see
+        /// `isContinuationCardsEnabled`.
+        case continuationCardsEnabled = "continuation_cards_enabled"
         /// Gates every side-loading surface (swarm_495a88d9 — PP-2677 /
         /// PP-2678 / PP-2679): the Settings "Side Loading" import screen and
         /// the catalog side-loaded lane. Test-only capability for exercising
@@ -116,6 +124,8 @@ final class RemoteFeatureFlags: @unchecked Sendable {
                 return .triageBotAIFallbackEnabled
             case .inAppPlaybackNavEnabled:
                 return .inAppPlaybackNavEnabled
+            case .continuationCardsEnabled:
+                return .continuationCardsEnabled
             case .sideLoadingEnabled:
                 return .sideLoadingEnabled
             case .appRatingPromptEnabled:
@@ -387,6 +397,27 @@ final class RemoteFeatureFlags: @unchecked Sendable {
             return override
         }
         return isFeatureEnabled(.inAppPlaybackNavEnabled)
+    }
+
+    /// UserDefaults override for the continuation cards, independent of the
+    /// in-app playback-nav override. Settable from the developer settings.
+    static let continuationCardsLocalOverrideKey = "RemoteFeatureFlags.continuationCardsLocalOverride"
+
+    /// Whether the Continue Reading / Continue Listening hero rows are shown at
+    /// the top of the Catalog. Split from `isInAppPlaybackNavEnabled` so the
+    /// continuation cards and the in-app mini-player roll out independently.
+    ///
+    /// **Default OFF — Firebase-gated.** The cards are hidden until Firebase
+    /// Remote Config sets `continuation_cards_enabled = true` (global or staged).
+    ///
+    /// Override precedence (mirrors `isInAppPlaybackNavEnabled`):
+    ///   1. UserDefaults local override (dev-menu toggle / QA) — wins.
+    ///   2. Firebase Remote Config (`isFeatureEnabled`, default `false`).
+    var isContinuationCardsEnabled: Bool {
+        if let override = defaults.object(forKey: Self.continuationCardsLocalOverrideKey) as? Bool {
+            return override
+        }
+        return isFeatureEnabled(.continuationCardsEnabled)
     }
 
     /// UserDefaults override that lets QA / a developer force side loading on

--- a/Palace/Settings/DeveloperSettings/DeveloperSettingsView.swift
+++ b/Palace/Settings/DeveloperSettings/DeveloperSettingsView.swift
@@ -113,6 +113,7 @@ struct DeveloperSettingsView: View {
     @ViewBuilder private var featureFlagsSection: some View {
         Section(header: Text("Feature Flags")) {
             DevToggleRow(title: "In-App Playback Navigation", isOn: $viewModel.inAppPlaybackNavEnabled)
+            DevToggleRow(title: "Continuation Cards", isOn: $viewModel.continuationCardsEnabled)
             DevToggleRow(title: "Force Rating Prompt Eligible", isOn: $viewModel.appRatingForceEligible)
             DevActionRow(title: "Trigger Rating Prompt Now", color: .blue) {
                 viewModel.triggerRatingPromptNow()

--- a/Palace/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
+++ b/Palace/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
@@ -87,6 +87,10 @@ final class DeveloperSettingsViewModel: ObservableObject {
         didSet { overrideDefaults.set(inAppPlaybackNavEnabled, forKey: RemoteFeatureFlags.inAppPlaybackNavLocalOverrideKey) }
     }
 
+    @Published var continuationCardsEnabled: Bool {
+        didSet { overrideDefaults.set(continuationCardsEnabled, forKey: RemoteFeatureFlags.continuationCardsLocalOverrideKey) }
+    }
+
     @Published var appRatingForceEligible: Bool {
         didSet { overrideDefaults.set(appRatingForceEligible, forKey: RemoteFeatureFlags.appRatingForceEligibleLocalOverrideKey) }
     }
@@ -155,6 +159,7 @@ final class DeveloperSettingsViewModel: ObservableObject {
         self.anthropicKeyStatus = triageBotKeyAdmin.hasStoredKey ? "Stored" : "Not set"
 
         self.inAppPlaybackNavEnabled = featureFlags.isInAppPlaybackNavEnabled
+        self.continuationCardsEnabled = featureFlags.isContinuationCardsEnabled
         self.appRatingForceEligible = featureFlags.isAppRatingForceEligible
 
         self.customRegistryInput = settings.customLibraryRegistryServer ?? ""

--- a/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
+++ b/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
@@ -169,4 +169,65 @@ final class RemoteFeatureFlagsTests: XCTestCase {
         }
         XCTAssertEqual(value, 42, "withTimeout must return the operation's result when it completes within the bound")
     }
+
+    // MARK: - In-App Playback Navigation (Firebase-gated, default OFF)
+    //
+    // The in-app playback-nav feature is OFF by default and enabled via
+    // Firebase Remote Config (the team turns it on — globally or via a staged
+    // rollout — without shipping a build). Precedence: local dev override
+    // (QA) > Firebase Remote Config (registered default false).
+
+    /// Fresh, isolated UserDefaults suite so the local-override key can't bleed
+    /// across tests or into `.standard`.
+    private func makeInAppNavFlags() -> (flags: RemoteFeatureFlags, suite: UserDefaults, name: String) {
+        let name = "test.inAppPlaybackNav.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: name)!
+        return (RemoteFeatureFlags(defaults: suite), suite, name)
+    }
+
+    /// No local override and no Firebase server value (the unit-test state):
+    /// the feature is OFF and reflects the Remote Config flag rather than a
+    /// hardcoded constant. Reverting the getter to `return true` (the prior GA
+    /// behavior) fails the first assertion.
+    func testInAppPlaybackNav_noOverride_defaultsOff() {
+        let (flags, suite, name) = makeInAppNavFlags()
+        defer { suite.removePersistentDomain(forName: name) }
+
+        XCTAssertFalse(flags.isInAppPlaybackNavEnabled,
+                       "Absent a local override or Firebase value, in-app playback nav must default OFF (Firebase-gated)")
+        XCTAssertEqual(flags.isInAppPlaybackNavEnabled,
+                       flags.isFeatureEnabled(.inAppPlaybackNavEnabled),
+                       "Without a local override, the getter must reflect the Remote Config flag, not a constant")
+    }
+
+    /// A local override of `true` forces the feature ON regardless of the OFF
+    /// default — QA/dev can preview the in-app player before the rollout.
+    /// Kills a mutant that ignores the override and returns the (false in tests)
+    /// Remote Config value.
+    func testInAppPlaybackNav_localOverrideTrue_forcesOn() {
+        let (flags, suite, name) = makeInAppNavFlags()
+        defer { suite.removePersistentDomain(forName: name) }
+
+        suite.set(true, forKey: RemoteFeatureFlags.inAppPlaybackNavLocalOverrideKey)
+        XCTAssertTrue(flags.isInAppPlaybackNavEnabled,
+                      "A local override of true must force the feature ON")
+    }
+
+    /// A local override of `false` forces the legacy player even if Firebase
+    /// would enable the feature. Kills the prior hardcoded `return true`.
+    func testInAppPlaybackNav_localOverrideFalse_forcesOff() {
+        let (flags, suite, name) = makeInAppNavFlags()
+        defer { suite.removePersistentDomain(forName: name) }
+
+        suite.set(false, forKey: RemoteFeatureFlags.inAppPlaybackNavLocalOverrideKey)
+        XCTAssertFalse(flags.isInAppPlaybackNavEnabled,
+                       "A local override of false must force the feature OFF (legacy toolkit player)")
+    }
+
+    /// The registered production default is OFF — pins the Firebase-gated
+    /// posture so a regression to on-by-default is caught.
+    func testInAppPlaybackNav_featureFlagDefault_isOff() {
+        XCTAssertFalse(RemoteFeatureFlags.FeatureFlag.inAppPlaybackNavEnabled.defaultValue,
+                       "in-app playback nav default must be OFF — Firebase Remote Config turns it on")
+    }
 }

--- a/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
+++ b/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
@@ -230,4 +230,68 @@ final class RemoteFeatureFlagsTests: XCTestCase {
         XCTAssertFalse(RemoteFeatureFlags.FeatureFlag.inAppPlaybackNavEnabled.defaultValue,
                        "in-app playback nav default must be OFF — Firebase Remote Config turns it on")
     }
+
+    // MARK: - Continuation Cards (Firebase-gated, default OFF, independent flag)
+    //
+    // The Continue Reading/Listening hero rows are gated by their OWN flag,
+    // split from in-app playback nav so the cards and the mini-player roll out
+    // independently. Same posture: default OFF, Firebase enables, local override
+    // wins.
+
+    func testContinuationCards_noOverride_defaultsOff() {
+        let (flags, suite, name) = makeInAppNavFlags()
+        defer { suite.removePersistentDomain(forName: name) }
+
+        XCTAssertFalse(flags.isContinuationCardsEnabled,
+                       "Absent a local override or Firebase value, continuation cards must default OFF")
+        XCTAssertEqual(flags.isContinuationCardsEnabled,
+                       flags.isFeatureEnabled(.continuationCardsEnabled),
+                       "Without a local override, the getter must reflect the Remote Config flag, not a constant")
+    }
+
+    func testContinuationCards_localOverrideTrue_forcesOn() {
+        let (flags, suite, name) = makeInAppNavFlags()
+        defer { suite.removePersistentDomain(forName: name) }
+
+        suite.set(true, forKey: RemoteFeatureFlags.continuationCardsLocalOverrideKey)
+        XCTAssertTrue(flags.isContinuationCardsEnabled,
+                      "A local override of true must force the continuation cards ON")
+    }
+
+    func testContinuationCards_localOverrideFalse_forcesOff() {
+        let (flags, suite, name) = makeInAppNavFlags()
+        defer { suite.removePersistentDomain(forName: name) }
+
+        suite.set(false, forKey: RemoteFeatureFlags.continuationCardsLocalOverrideKey)
+        XCTAssertFalse(flags.isContinuationCardsEnabled,
+                       "A local override of false must force the continuation cards OFF")
+    }
+
+    func testContinuationCards_featureFlagDefault_isOff() {
+        XCTAssertFalse(RemoteFeatureFlags.FeatureFlag.continuationCardsEnabled.defaultValue,
+                       "continuation cards default must be OFF — Firebase Remote Config turns it on")
+    }
+
+    /// The split's core guarantee: the two flags are independent. Forcing the
+    /// continuation cards ON while forcing in-app playback nav OFF (and vice
+    /// versa) must be honored — one does not leak into the other. A mutant that
+    /// re-pointed either getter at the wrong override key fails here.
+    func testFlags_continuationAndInAppNav_areIndependent() {
+        let (flags, suite, name) = makeInAppNavFlags()
+        defer { suite.removePersistentDomain(forName: name) }
+
+        suite.set(true, forKey: RemoteFeatureFlags.continuationCardsLocalOverrideKey)
+        suite.set(false, forKey: RemoteFeatureFlags.inAppPlaybackNavLocalOverrideKey)
+        XCTAssertTrue(flags.isContinuationCardsEnabled,
+                      "continuation ON must not be suppressed by in-app-nav OFF")
+        XCTAssertFalse(flags.isInAppPlaybackNavEnabled,
+                       "in-app-nav OFF must be honored independently of continuation ON")
+
+        suite.set(false, forKey: RemoteFeatureFlags.continuationCardsLocalOverrideKey)
+        suite.set(true, forKey: RemoteFeatureFlags.inAppPlaybackNavLocalOverrideKey)
+        XCTAssertFalse(flags.isContinuationCardsEnabled,
+                       "continuation OFF must be honored independently of in-app-nav ON")
+        XCTAssertTrue(flags.isInAppPlaybackNavEnabled,
+                      "in-app-nav ON must not be suppressed by continuation OFF")
+    }
 }


### PR DESCRIPTION
Two related feature-flag changes for the in-app playback / continuation surfaces. Both default **OFF** and are enabled via Firebase Remote Config (local dev override wins for QA).

## 1. Firebase-gate in-app playback nav (`in_app_playback_nav_enabled`)
The GA change (#1257) hardcoded `isInAppPlaybackNavEnabled` to `return true`, detaching it from Remote Config. This restores control: the getter reads `isFeatureEnabled(.inAppPlaybackNavEnabled)` (registered default `false`) when no local override is set, so the team can enable/disable the in-app mini-player + player presentation for production via Firebase — no build required.

## 2. Split continuation cards into their own flag (`continuation_cards_enabled`)
`inAppPlaybackNavEnabled` previously gated **two** separable surfaces: the Continue Reading/Listening cards AND the mini-player/player. Now:
- **`continuation_cards_enabled`** → the Continue cards (`CatalogContentView`).
- **`in_app_playback_nav_enabled`** → the mini-player (`AppTabHostView`) + audiobook player presentation (`AudiobookSessionManager`).

They're independent, so any combination is valid:
| in-app-nav | continuation | result |
|---|---|---|
| ON | OFF | mini-player, no Continue cards |
| OFF | ON | Continue cards; listen-card tap opens the **legacy** player |
| ON | ON | full current experience |
| OFF | OFF | legacy player, no cards (default) |

New "Continuation Cards" developer-settings toggle sits alongside "In-App Playback Navigation".

## ⚠️ Behavior change
Effectively **reverts the #1257 GA to Firebase-gated**: once shipped, production reverts to the legacy player + no continuation cards until you set the flags on in Remote Config. Line up the two Remote Config parameters (`in_app_playback_nav_enabled`, `continuation_cards_enabled`) before the release, or prod ships with both off.

## Tests
`RemoteFeatureFlagsTests`: per-flag default-OFF + local-override precedence for both flags, plus an **independence test** (continuation ON + in-app-nav OFF, and the reverse) proving neither flag leaks into the other. Local test-target compile is blocked by #1283's Swift-6 ratchet under Xcode 26.3 (unrelated); CI on Xcode 26 is the gate — the app target builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)