### PR TITLE
ci(release-gates): wire the 3.2.0-retro gates to fire on release→main PRs

### DIFF
--- a/.forgeos/crash-triage/README.md
+++ b/.forgeos/crash-triage/README.md
@@ -1,0 +1,39 @@
+# Pre-GA crash-triage ledger
+
+The **Release Gates** workflow (`.github/workflows/release-gates.yml`, gate 2)
+runs `scripts/check-pre-ga-crash-triage.py` on every PR into `main`. It pulls
+the release version's FATAL Crashlytics signatures (via
+`scripts/crashlytics-triage-export.py`, reusing the sentinel's Firebase access)
+and BLOCKS the release if a signature that FIRST appeared in this release is
+still un-triaged.
+
+This closes the 3.2.0 gap: the saveSync-deadlock crash had events on the pre-GA
+RC builds, but nobody triaged them until a week after GA.
+
+## When the gate fires
+
+A FATAL signature whose `firstSeenVersion` equals the release version is
+un-triaged. Look at it on the Crashlytics board and decide, then record it:
+
+- **Fix it** — cut/adjust the release to carry the fix.
+- **Triage it** — you've assessed it and are shipping anyway (known, low-volume,
+  a fix is already riding the next release, etc.). Record it here.
+
+## Triage file format
+
+One file per version: `<version>.txt` (e.g. `3.2.0.txt`). One entry per line:
+
+```
+<issue-id>   <ticket-or-reason>
+# lines beginning with '#' are comments
+8afb1c66ce5dde59b8774424240af778   PP-4819 — fixed in 3.2.1 hotfix
+```
+
+A signature is triaged if its Crashlytics issue id (full, or as a prefix) is the
+first token of a line here.
+
+## Firebase-outage contract
+
+If the Firebase service account is missing or the fetch fails, the export is
+empty and the gate PASSES — a Crashlytics outage must not block a release. The
+manual maintainer triage is the backstop for that window.

--- a/.forgeos/release-waivers/README.md
+++ b/.forgeos/release-waivers/README.md
@@ -1,0 +1,33 @@
+# Release fix-reconciliation waivers
+
+The **Release Gates** workflow (`.github/workflows/release-gates.yml`, gate 1)
+runs `scripts/check-release-fix-reconciliation.py` on every PR into `main`. It
+diffs the release branch against `origin/develop` (by patch-id, via `git
+cherry`) and BLOCKS the release if a crash / critical-path fix on develop has no
+equivalent on the release and is not waived here.
+
+## When the gate fires
+
+It found a commit on develop that (a) touches a critical-path file AND (b) reads
+as a fix, that is NOT on the release you're promoting. For each one, decide:
+
+- **Cherry-pick it into the release** — it belongs in this ship. (Preferred for
+  anything crash-related.)
+- **Waive it** — it is intentionally held for a later release. Record it here so
+  the exclusion is a deliberate, audited decision, not silence.
+
+## Waiver file format
+
+One file per release: `<release>.txt` where `<release>` is the release ref with
+`/` replaced by `-` (e.g. `release-3.2.1.txt`, `hotfix-3.2.1.txt`). One entry
+per line:
+
+```
+<sha-or-#pr>   <reason>
+# lines beginning with '#' (followed by non-digit) are comments
+62e12d56c      shipping in 3.3.0 — not needed on this hotfix line
+#1097          same fix, deliberately deferred
+```
+
+A candidate is reconciled if its abbreviated SHA, full SHA, or `#<pr>` is the
+first token of a line here.

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -1,0 +1,132 @@
+name: Release Gates
+
+# Fires the two release-process gates from the 3.2.0 crash retro (PP-4819) on
+# every PR into `main` — i.e. every release/X.Y.Z and hotfix/X.Y.Z promotion —
+# so a release can't ship while it is missing a crash fix that already landed
+# on develop, or while a crash signature it introduced sits un-triaged on the
+# RC/TestFlight builds.
+#
+#   1. fix-reconciliation  (HARD, pure git — no external deps)
+#        diff the release branch (PR head) against origin/develop for
+#        crash/critical-path fixes that have no patch-equivalent on the release
+#        and are not waived. This is the gate that would have caught 3.2.0
+#        shipping without the saveSync-deadlock fix (#1097).
+#
+#   2. pre-ga-crash-triage (HARD on real findings, SOFT on Firebase outage)
+#        pull the release version's FATAL Crashlytics signatures and block if
+#        any signature that FIRST appeared in this release is un-triaged. A
+#        Firebase outage / missing service account emits an empty export and
+#        passes (the sentinel's "an outage must not block a release" contract);
+#        the manual maintainer triage is the backstop for that window.
+#
+# Waivers / triage ledgers (leave an audit trail for every deliberate exclusion):
+#   .forgeos/release-waivers/<release>.txt   — `<sha-or-#pr> <reason>` per line
+#   .forgeos/crash-triage/<version>.txt      — `<issue-id> <ticket-or-reason>` per line
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      release_ref:
+        description: "Release ref to check (default: current branch)"
+        required: false
+      develop_ref:
+        description: "Integration ref to reconcile against"
+        required: false
+        default: "origin/develop"
+
+concurrency:
+  group: release-gates-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fix-reconciliation:
+    name: Release fix-reconciliation (crash/critical-path)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (full history — the gate diffs against origin/develop)
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Resolve release ref
+        id: refs
+        run: |
+          if [[ -n "${{ github.event.inputs.release_ref }}" ]]; then
+            echo "release_ref=${{ github.event.inputs.release_ref }}" >> "$GITHUB_OUTPUT"
+          elif [[ -n "${{ github.event.pull_request.head.sha }}" ]]; then
+            echo "release_ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_ref=HEAD" >> "$GITHUB_OUTPUT"
+          fi
+          DEV="${{ github.event.inputs.develop_ref }}"
+          echo "develop_ref=${DEV:-origin/develop}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure develop is fetched
+        run: git fetch origin develop --quiet || true
+
+      - name: Run fix-reconciliation gate
+        run: |
+          python3 scripts/check-release-fix-reconciliation.py \
+            --release-ref "${{ steps.refs.outputs.release_ref }}" \
+            --develop-ref "${{ steps.refs.outputs.develop_ref }}"
+
+  pre-ga-crash-triage:
+    name: Pre-GA crash triage (new-in-release FATAL)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Firebase REST deps
+        run: pip install pyjwt cryptography
+
+      - name: Write Firebase service account
+        # Same secret + fall-through contract as crashlytics-sentinel.yml: a
+        # missing service account warns and the export comes back empty, so the
+        # gate passes rather than blocking a release on a CI-config gap.
+        env:
+          FIREBASE_SA: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [[ -n "$FIREBASE_SA" ]]; then
+            mkdir -p ~/.palace
+            printf '%s' "$FIREBASE_SA" > ~/.palace/firebase-service-account.json
+            echo "Service account written."
+          else
+            echo "::warning::FIREBASE_SERVICE_ACCOUNT secret not set; crash-triage export will be empty (gate passes)."
+          fi
+
+      - name: Resolve release version from pbxproj
+        id: version
+        run: |
+          # The release version being promoted is the MARKETING_VERSION in the
+          # project. Grab the first (all Palace configs share one value).
+          VERSION=$(grep -m1 -E 'MARKETING_VERSION = [0-9]' Palace.xcodeproj/project.pbxproj \
+                    | sed -E 's/.*MARKETING_VERSION = ([0-9.]+);/\1/')
+          echo "Release version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Export current FATAL Crashlytics signatures
+        run: |
+          python3 scripts/crashlytics-triage-export.py --days 90 --page-size 50 > crash-export.json
+          echo "--- export ---"; cat crash-export.json
+
+      - name: Run pre-GA crash-triage gate
+        run: |
+          python3 scripts/check-pre-ga-crash-triage.py \
+            --release-version "${{ steps.version.outputs.version }}" \
+            --issues-json crash-export.json

--- a/scripts/crashlytics-triage-export.py
+++ b/scripts/crashlytics-triage-export.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+crashlytics-triage-export.py — emit current FATAL Crashlytics issues in the JSON
+shape that check-pre-ga-crash-triage.py consumes.
+
+This is the bridge that wires the pre-GA crash-triage gate to live Crashlytics
+data. It REUSES the sentinel's Firebase auth + fetch (scripts/crashlytics-sentinel.py)
+so there is exactly one Crashlytics-access implementation in the repo — this
+script only reshapes the sentinel's normalized issues into the gate's schema.
+
+The sentinel's fetch is FATAL-filtered, so every emitted row is a FATAL crash;
+`errorType` is set to "FATAL" for all of them.
+
+Field mapping (sentinel normalized -> triage-gate schema):
+    issue_id            -> id
+    title               -> title
+    (implicit FATAL)    -> errorType
+    first_seen_version  -> firstSeenVersion
+    events_count        -> eventsCount
+    impacted_users      -> impactedUsersCount
+
+USAGE
+    crashlytics-triage-export.py [--days N] [--page-size N] [--snapshot FILE] > export.json
+    check-pre-ga-crash-triage.py --release-version 3.2.0 --issues-json export.json
+
+    --snapshot FILE  Use a raw Crashlytics API payload from disk instead of a
+                     live fetch (offline / tests). It is normalized through the
+                     same sentinel code path as the live fetch.
+
+FAILURE CONTRACT
+    On any Firebase auth / network error (or a missing service account) the
+    underlying sentinel fetch returns [] with a warning on stderr, so this
+    emits {"issues": []}. The triage gate then finds nothing to block on — a
+    Firebase outage MUST NOT block a release (matching the sentinel's
+    "outage must not page" contract). The manual maintainer triage is the
+    backstop for that window. The gate is HARD only on real, fetched,
+    un-triaged new-in-release signatures.
+
+EXIT CODES
+    0  export emitted (possibly empty).
+    2  the sentinel module could not be loaded (repo/layout error).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_sentinel():
+    """Load the hyphenated crashlytics-sentinel.py as an importable module."""
+    path = Path(__file__).with_name("crashlytics-sentinel.py")
+    spec = importlib.util.spec_from_file_location("crashlytics_sentinel", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load sentinel at {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def to_triage_shape(normalized: list[dict]) -> list[dict]:
+    """Map the sentinel's normalized issues to the triage gate's schema.
+
+    Pure transform — no I/O — so it is unit-testable without Firebase.
+    """
+    out: list[dict] = []
+    for item in normalized:
+        issue_id = item.get("issue_id") or item.get("id") or ""
+        if not issue_id:
+            continue
+        out.append({
+            "id": issue_id,
+            "title": item.get("title", ""),
+            "errorType": "FATAL",  # the sentinel fetch is FATAL-filtered
+            "firstSeenVersion": item.get("first_seen_version", ""),
+            "eventsCount": int(item.get("events_count", 0) or 0),
+            "impactedUsersCount": int(item.get("impacted_users", 0) or 0),
+        })
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--days", type=int, default=90,
+                        help="Lookback window for the topIssues query (default 90 — "
+                             "wide enough to catch a new-in-release signature seen "
+                             "across the RC/TestFlight window).")
+    parser.add_argument("--page-size", type=int, default=50,
+                        help="Number of top FATAL issues to fetch (default 50 — "
+                             "broader than the sentinel's top-10 so a new-in-release "
+                             "crash below the top-10 isn't missed).")
+    parser.add_argument("--snapshot", type=Path,
+                        help="Raw Crashlytics API payload to use instead of a live "
+                             "fetch (offline / tests).")
+    args = parser.parse_args(argv)
+
+    try:
+        sentinel = _load_sentinel()
+    except ImportError as exc:
+        print(f"[crashlytics-triage-export] ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.snapshot:
+        normalized = sentinel.load_snapshot(args.snapshot)
+    else:
+        normalized = sentinel.fetch_top_issues_from_firebase(
+            days=args.days, page_size=args.page_size)
+
+    print(json.dumps({"issues": to_triage_shape(normalized)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/tests/test_crashlytics_triage_export.py
+++ b/scripts/tests/test_crashlytics_triage_export.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Tests for crashlytics-triage-export.py — the bridge that reshapes the sentinel's
+normalized Crashlytics issues into the pre-GA crash-triage gate's schema.
+
+The Firebase fetch is not exercised here (that path is the sentinel's, and hits
+the network); these tests pin the pure transform + the end-to-end snapshot path
+(raw API payload -> sentinel.load_snapshot -> export shape -> the gate can read it).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+EXPORT = SCRIPTS / "crashlytics-triage-export.py"
+GATE = SCRIPTS / "check-pre-ga-crash-triage.py"
+
+
+def _load_export_module():
+    spec = importlib.util.spec_from_file_location(
+        "crashlytics_triage_export", EXPORT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- pure transform -------------------------------------------------------
+
+def test_to_triage_shape_maps_fields():
+    mod = _load_export_module()
+    normalized = [{
+        "issue_id": "8afb1c66",
+        "title": "BookRegistrySync.saveSync",
+        "first_seen_version": "3.2.0",
+        "events_count": 8,
+        "impacted_users": 6,
+    }]
+    out = mod.to_triage_shape(normalized)
+    assert out == [{
+        "id": "8afb1c66",
+        "title": "BookRegistrySync.saveSync",
+        "errorType": "FATAL",
+        "firstSeenVersion": "3.2.0",
+        "eventsCount": 8,
+        "impactedUsersCount": 6,
+    }]
+
+
+def test_to_triage_shape_drops_idless_rows():
+    mod = _load_export_module()
+    out = mod.to_triage_shape([{"title": "no id", "events_count": 3}])
+    assert out == []
+
+
+def test_to_triage_shape_coerces_missing_counts_to_zero():
+    mod = _load_export_module()
+    out = mod.to_triage_shape([{"issue_id": "x", "first_seen_version": "3.2.0"}])
+    assert out[0]["eventsCount"] == 0
+    assert out[0]["impactedUsersCount"] == 0
+    assert out[0]["errorType"] == "FATAL"
+
+
+# --- end-to-end: snapshot -> export -> gate reads it ----------------------
+
+def test_snapshot_export_feeds_the_gate(tmp_path: Path):
+    """A raw API-shaped snapshot flows through the export into a JSON the gate
+    consumes and blocks on (the real 3.2.0 saveSync scenario)."""
+    # Raw payload shaped like the Crashlytics report the sentinel normalizes.
+    raw = {"issues": [{
+        "id": "8afb1c66ce5dde59b8774424240af778",
+        "title": "BookRegistrySync.saveSync reentrancy deadlock",
+        "firstSeenVersion": "3.2.0",
+        "eventsCount": 8,
+        "impactedUsers": 6,
+    }]}
+    snap = tmp_path / "raw.json"
+    snap.write_text(json.dumps(raw))
+
+    export = subprocess.run(
+        [sys.executable, str(EXPORT), "--snapshot", str(snap)],
+        capture_output=True, text=True)
+    assert export.returncode == 0, export.stderr
+    payload = json.loads(export.stdout)
+    assert payload["issues"], "export should carry the FATAL signature"
+    assert payload["issues"][0]["firstSeenVersion"] == "3.2.0"
+
+    export_file = tmp_path / "export.json"
+    export_file.write_text(export.stdout)
+
+    # Un-triaged -> the gate BLOCKS.
+    gate = subprocess.run(
+        [sys.executable, str(GATE),
+         "--release-version", "3.2.0", "--issues-json", str(export_file)],
+        capture_output=True, text=True)
+    assert gate.returncode == 1, gate.stderr + gate.stdout
+    assert "8afb1c66" in gate.stderr
+
+
+def test_missing_snapshot_is_empty_export(tmp_path: Path):
+    """A nonexistent snapshot (mirrors a Firebase outage → empty fetch) yields
+    an empty export, so the gate has nothing to block on (soft-fail contract)."""
+    export = subprocess.run(
+        [sys.executable, str(EXPORT), "--snapshot", str(tmp_path / "nope.json")],
+        capture_output=True, text=True)
+    assert export.returncode == 0, export.stderr
+    assert json.loads(export.stdout) == {"issues": []}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Wire the release gates so they actually fire

The two gates from #1281 (the 3.2.0 crash retro) existed but nothing invoked them — a loaded gun no one pulled. This wires them into CI.

### New workflow: `.github/workflows/release-gates.yml`
Triggers on **PR → `main`** (every release/hotfix promotion) + `workflow_dispatch`. Two jobs:

**1. fix-reconciliation** (HARD, ubuntu, pure git)
Diffs the release branch vs `origin/develop` for un-ported crash/critical-path fixes. **Dry-run against the real `3.2.0` tag flags #1097 (the saveSync-deadlock fix) at the top** — it would have caught 3.2.0 shipping without it.

**2. pre-ga-crash-triage** (HARD on real findings, SOFT on Firebase outage)
New bridge `scripts/crashlytics-triage-export.py` reuses the sentinel's Firebase auth + fetch to emit the release version's FATAL signatures in the gate's schema; `check-pre-ga-crash-triage.py` blocks on any new-in-release signature that's un-triaged. Missing service account / fetch failure → empty export → **passes** (the sentinel's "an outage must not block a release" contract; manual triage is the backstop).

### Also
- `.forgeos/release-waivers/` + `.forgeos/crash-triage/` ledger dirs with READMEs documenting the waive/triage audit-trail format.
- Pytest for the export transform + end-to-end snapshot→export→gate path.

### Verification
- Export pytest **5/5**; all **23** gate pytests green; workflow is valid YAML.
- Gate-1 fires correctly against a real release ref (proof it catches the actual 3.2.0 miss).
- Reuses the *existing* Firebase access pattern (`FIREBASE_SERVICE_ACCOUNT` secret + sentinel) — no new secrets.

### ⚠️ One human step left (flagged, can't do in code)
Making these **required status checks** on `main` is a repo branch-protection setting (UI/admin). The workflow runs on every release→main PR now, but must be added to main's required checks to actually *block* merge. Until then it's advisory-but-visible.

Companion to #1281 (built the gates) / #1279 (the hotfix they'd have prevented needing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)