### PR TITLE
test(ci): close the detector scan-vs-diff test gap + fix two silently-skipped gates

### DIFF
--- a/scripts/check-no-committed-signing.sh
+++ b/scripts/check-no-committed-signing.sh
@@ -58,7 +58,7 @@ RELEVANT_ADDED="$(printf '%s\n' "$DIFF" | awk '
 
 # DEVELOPMENT_TEAM: trailing ';' (pbxproj) OR end-of-line (xcconfig has no ';').
 FINDINGS="$(printf '%s\n' "$RELEVANT_ADDED" | grep -nE \
-  'CODE_SIGN_STYLE[[:space:]]*=[[:space:]]*Automatic|DEVELOPMENT_TEAM[[:space:]]*=[[:space:]]*[A-Z0-9]{10}[[:space:]]*(;|$)|PROVISIONING_PROFILE[[:space:]]*=[[:space:]]*"?[0-9a-fA-F]{8}-[0-9a-fA-F-]{27}' \
+  'CODE_SIGN_STYLE[[:space:]]*=[[:space:]]*Automatic|DEVELOPMENT_TEAM[[:space:]]*=[[:space:]]*"?[A-Z0-9]{10}"?[[:space:]]*(;|$)|PROVISIONING_PROFILE[[:space:]]*=[[:space:]]*"?[0-9a-fA-F]{8}-[0-9a-fA-F-]{27}' \
   2>/dev/null || true)"
 
 # Drop allowlisted lines.

--- a/scripts/tests/test_check_no_committed_signing.sh
+++ b/scripts/tests/test_check_no_committed_signing.sh
@@ -77,5 +77,13 @@ cat > "$TMP/selftest.diff" <<'EOF'
 EOF
 "$DET" "$TMP/selftest.diff" >/dev/null 2>&1; [ $? -eq 0 ] && ok "signing strings in non-build file ignored (no self-block)" || bad "path-blind: flagged a non-build file"
 
+# 10 — QUOTED team id in a pbxproj (Xcode emits `DEVELOPMENT_TEAM = "ABCDE12345";`
+#      in some configs) -> BLOCK. The unquoted rule missed this form.
+cat > "$TMP/quoted.diff" <<'EOF'
++++ b/Palace.xcodeproj/project.pbxproj
++				DEVELOPMENT_TEAM = "88CBA74T8K";
+EOF
+"$DET" "$TMP/quoted.diff" >/dev/null 2>&1; [ $? -eq 1 ] && ok "quoted DEVELOPMENT_TEAM blocked" || bad "quoted team id slipped through"
+
 echo "[test_check_no_committed_signing] $PASS passed / $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_detectors_diff_mode.py
+++ b/scripts/tests/test_detectors_diff_mode.py
@@ -1,0 +1,115 @@
+"""Diff-mode contract tests for the Phase-3.5 class-scan detectors.
+
+The pre-commit hook (`scripts/pre-commit-phase35-detectors.sh`) wires these five
+detectors as **`--diff`** — it feeds each one `git diff --cached` and blocks (or
+warns) on a finding. Their existing pytests, however, exercise only **`--scan`**
+mode, which "sidesteps the diff-narrowing rule" (per those tests' own docstrings).
+That left the production interface — the `--diff` path with its file-narrowing and
+post-image reconstruction — with no violation-path coverage: a regression there
+would silently turn a blocking gate into a no-op while the pytest board stayed green
+(exactly the failure the green-board contract rule #4 warns about).
+
+This module pins that interface. For each detector it builds a real
+`git diff --cached` that ADDS a known-violation fixture at a production `Palace/`
+path — byte-for-byte the input the hook produces — and asserts the detector fires.
+A companion empty-diff case proves the `--diff` path does not false-positive on a
+no-op (the clean-path half of the contract).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO / "scripts"
+_FIXTURES = _SCRIPTS / "tests" / "fixtures"
+
+# script | fixtures subdir | violation fixture | prod-relative dir | finding token | mode
+_CASES = [
+    ("check-foreign-host-401-scoping.py",           "foreign_host_401",    "violation_missing_guard.swift",      "Palace/Network",           "FH-1",    "block"),
+    ("check-completion-nil-error-suppression.py",    "completion_nil_error","violation_string_literals.swift",    "Palace/SignInLogic",       "D3-1",    "block"),
+    ("check-nserror-problemdoc-preservation.py",     "nserror_problemdoc",  "violation_dropped_problemdoc.swift", "Palace/Network",           "D4-1",    "block"),
+    ("check-swiftui-placeholder-a11y.py",            "swiftui_a11y",        "violation.swift",                    "Palace/CatalogUI",         "PP-4421", "warn"),
+    ("check-notification-center-observer-storage.py","notification_center", "violation_unstored_observer.swift",  "Palace/AppInfrastructure", "D5-1",    "warn"),
+]
+
+_IDS = [c[0].removeprefix("check-").removesuffix(".py") for c in _CASES]
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _staged_repo(tmp_path: Path, subdir: str, violation: str, prod_dir: str):
+    """Create a throwaway git repo with the violation fixture staged at its
+    production path, and return (repo, diff_file) where diff_file holds the
+    `git diff --cached` text the pre-commit hook would feed the detector."""
+    repo = tmp_path / "repo"
+    dest = repo / prod_dir
+    dest.mkdir(parents=True)
+    shutil.copy(_FIXTURES / subdir / violation, dest / violation)
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    diff = subprocess.run(
+        ["git", "diff", "--cached"], cwd=repo, capture_output=True, text=True
+    ).stdout
+    diff_file = tmp_path / "staged.diff"
+    diff_file.write_text(diff)
+    return repo, diff_file
+
+
+def _run_diff(script: str, repo: Path, diff_file: Path) -> subprocess.CompletedProcess:
+    # cwd=repo so the detector resolves the added file on disk too, whether it
+    # reconstructs the post-image from the diff or reads the source directly.
+    return subprocess.run(
+        [sys.executable, str(_SCRIPTS / script), "--diff", str(diff_file), "--quiet"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize("script,subdir,violation,prod_dir,token,mode", _CASES, ids=_IDS)
+def test_detector_fires_in_diff_mode(tmp_path, script, subdir, violation, prod_dir, token, mode):
+    """A staged violation must make the detector exit non-zero in --diff mode and
+    name its finding — the production `diff` wiring, previously untested."""
+    repo, diff_file = _staged_repo(tmp_path, subdir, violation, prod_dir)
+    r = _run_diff(script, repo, diff_file)
+    assert r.returncode != 0, (
+        f"{script} did NOT fire in --diff mode (exit {r.returncode}); "
+        f"the {mode}-mode gate would silently pass this violation.\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+    assert token in (r.stdout + r.stderr), (
+        f"{script}: expected finding token {token!r} in output, got:\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+
+
+@pytest.mark.parametrize("script", [c[0] for c in _CASES], ids=_IDS)
+def test_detector_clean_on_empty_diff(tmp_path, script):
+    """The clean-path half: an empty diff must exit 0 — the --diff path must not
+    block/warn on a no-op (guards against a narrowing regression that flips to
+    always-fire)."""
+    diff_file = tmp_path / "empty.diff"
+    diff_file.write_text("")
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPTS / script), "--diff", str(diff_file), "--quiet"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert r.returncode == 0, (
+        f"{script} did not pass a clean (empty) diff (exit {r.returncode})\n"
+        f"stdout: {r.stdout!r}\nstderr: {r.stderr!r}"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -197,6 +197,12 @@ echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
 echo "Changed files: $(echo "$CHANGED_SWIFT" | wc -l | tr -d ' ') production, $(echo "$CHANGED_TEST_SWIFT" | wc -l | tr -d ' ') test"
 echo ""
 
+# Mark the start of this run so the coverage-floor step (find -newer) matches
+# only THIS run's xcresult. Without it, `find -newer /tmp/.verify-pr-start`
+# errors on the missing marker → XCRESULT="" → the gate silently records
+# "No xcresult found (skipped)" and has never actually enforced a floor.
+touch /tmp/.verify-pr-start 2>/dev/null || true
+
 # Docs-only fast-path: skip build/test/lint/coverage/mutation/a11y when no
 # source files changed. Honest pass records, written to JSON report and stdout
 # the same as the full battery would emit, just with explicit "skipped" detail.


### PR DESCRIPTION
Wave 2 of the tooling review — **restore the green-board contract's teeth**. Three gates that pass without enforcing anything.

## 1. The scan-vs-diff test gap (the big one)

The pre-commit hook wires five Phase-3.5 class-scan detectors as **`--diff`** (it feeds each `git diff --cached` and blocks/warns on a finding). Their pytests only exercised **`--scan`**, which explicitly "sidesteps the diff-narrowing rule" — so the production interface (file-narrowing + post-image reconstruction) had **no violation coverage**. `completion-nil-error-suppression` (block) and `swiftui-placeholder-a11y` (warn) had **zero** `--diff` tests. A narrowing regression would silently turn a blocking gate into a no-op with the board green — exactly the failure the contract's rule #4 warns about.

New `scripts/tests/test_detectors_diff_mode.py`: for each detector, build a real `git diff --cached` that adds a known-violation fixture at a `Palace/` path (byte-for-byte the hook's input) and assert the detector fires (non-zero exit + finding token), plus an empty-diff clean case. **10 new tests.**

## 2. Quoted `DEVELOPMENT_TEAM` slipped the signing gate

`check-no-committed-signing.sh` required the 10-char team id immediately after `=`, so `DEVELOPMENT_TEAM = "88CBA74T8K";` (the quoted form Xcode emits) wasn't caught — while `PROVISIONING_PROFILE` already allowed the quote. Added `"?` + test case 10. **Verified teeth:** the pre-fix detector exits `0` on a quoted team id; post-fix exits `1`.

## 3. verify-pr coverage floor never ran

The coverage step keyed off `find -newer /tmp/.verify-pr-start`, but nothing created that marker — so the find errored, `XCRESULT` was empty, and it recorded "No xcresult found (skipped)" every run. Now created at run start.

## Verification

Full tooling suite **323 passed** (+10). `bash -n` clean on all edited scripts. Before/after teeth demonstrated for the signing fix.

## Scope

Test + gate-correctness only — **no product code**. Retro release gates are already wired (#1295); local `settings.local.json` items (heka `|| true` no-op, `SKIP_PRE_PUSH_TESTS` allowlist) are machine-local and handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)