### PR TITLE
perf(ci): fix DerivedData cache churn + path filters + local clean gating

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -1,5 +1,14 @@
 name: Unit Tests
-on: [ pull_request, workflow_dispatch ]
+on:
+  pull_request:
+    # Skip the full macOS build/test job for changes that cannot regress runtime
+    # behavior. scripts/** is deliberately NOT ignored — the test invocation lives
+    # there. Mirrors verify-pr.sh's docs-only fast-path.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.simdrive/**'
+  workflow_dispatch:
 concurrency:
   group: unit-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -11,6 +20,10 @@ jobs:
 
   build-and-test:
     runs-on: macos-15
+    # Cap the whole job. The test step has its own 60-min bound, but the ~15
+    # post-processing steps (xcresult parse, snapshot find, Pages deploy) are
+    # unbounded — a hang there could otherwise burn the 360-min default.
+    timeout-minutes: 90
     permissions:
       contents: write
       pull-requests: write
@@ -46,25 +59,31 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          # Key on the branch name + run number so each run has a unique key
-          # (always saves) but restores from the latest cache for this branch.
-          # We deliberately do NOT key on pbxproj — every file-add edit
-          # invalidated the entire cache, forcing ~50min cold rebuilds that
-          # blew the job timeout before tests could even start.
-          key: ${{ runner.os }}-deriveddata-${{ github.head_ref || github.ref_name }}-${{ github.run_number }}
+          # Key on the branch name only (NOT run_number). A run_number suffix made
+          # every run save a fresh ~1.8 GiB cache that never key-hit again, so the
+          # repo blew GitHub's 10 GiB cache cap and LRU-evicted the warm caches —
+          # producing 25-46 min cold rebuilds. Branch-only keying updates ONE cache
+          # per branch in place (actions/cache skips save on an exact key hit, so
+          # this warms once then reuses). We deliberately do NOT key on pbxproj —
+          # every file-add edit would invalidate the whole cache.
+          # Tradeoff: within a long-lived branch the cache isn't re-saved (exact
+          # hit skips save), and develop's base cache freezes at its first snapshot
+          # — a dedicated develop-push cache-warm job is the proper follow-up. Even
+          # frozen, a weeks-old DerivedData saves most recompilation vs a cold run.
+          key: ${{ runner.os }}-deriveddata-${{ github.head_ref || github.ref_name }}
           restore-keys: |
-            ${{ runner.os }}-deriveddata-${{ github.head_ref || github.ref_name }}-
-            ${{ runner.os }}-deriveddata-develop-
+            ${{ runner.os }}-deriveddata-${{ github.head_ref || github.ref_name }}
+            ${{ runner.os }}-deriveddata-develop
             ${{ runner.os }}-deriveddata-
             
       - name: Cache Test History
         uses: actions/cache@v6
         with:
           path: .test-history
-          key: test-history-${{ github.head_ref || github.ref_name }}-${{ github.run_number }}
+          key: test-history-${{ github.head_ref || github.ref_name }}
           restore-keys: |
-            test-history-${{ github.head_ref || github.ref_name }}-
-            test-history-develop-
+            test-history-${{ github.head_ref || github.ref_name }}
+            test-history-develop
             test-history-
             
       # Fast, DRM-free gate for the PalaceTriageBot SPM package. Runs the

--- a/scripts/xcode-test-optimized.sh
+++ b/scripts/xcode-test-optimized.sh
@@ -15,6 +15,21 @@ set -euo pipefail
 
 echo "Running optimized unit tests for Palace..."
 
+# Opt-in clean. The local paths below ran `xcodebuild clean` UNCONDITIONALLY,
+# discarding warm DerivedData and forcing a full cold rebuild (tens of minutes)
+# on every "CI-parity" local run. Off by default — set PALACE_TEST_CLEAN=1 (or
+# pass --clean) only when you actually suspect a stale-artifact / arch conflict.
+CLEAN_BUILD="${PALACE_TEST_CLEAN:-0}"
+for arg in "$@"; do
+    [ "$arg" = "--clean" ] && CLEAN_BUILD=1
+done
+maybe_clean() {
+    if [ "$CLEAN_BUILD" = "1" ]; then
+        echo "Cleaning build folder (PALACE_TEST_CLEAN / --clean set)..."
+        xcodebuild clean -project Palace.xcodeproj -scheme Palace > /dev/null 2>&1
+    fi
+}
+
 # Clean up any previous test results
 rm -rf TestResults.xcresult
 
@@ -124,8 +139,7 @@ else
 
     if [ -z "$SIMULATOR_ID" ]; then
         echo "❌ No available iPhone simulator found, trying fallback..."
-        # Clean build folder first
-        xcodebuild clean -project Palace.xcodeproj -scheme Palace > /dev/null 2>&1
+        maybe_clean
         
         # Fallback to name-based approach with common simulators
         # Updated for Xcode 26 / iOS 26 compatibility
@@ -161,8 +175,9 @@ else
         done
     else
         echo "Using iPhone simulator ID: $SIMULATOR_ID"
-        # Clean build folder to avoid architecture conflicts
-        xcodebuild clean -project Palace.xcodeproj -scheme Palace > /dev/null 2>&1
+        # Clean only when explicitly requested (arch-conflict recovery); default
+        # reuses warm DerivedData for a fast incremental local run.
+        maybe_clean
         
         xcodebuild test \
             -project Palace.xcodeproj \


### PR DESCRIPTION
Wave 3 of the tooling review — the biggest wall-clock returns.

## The headline: DerivedData cache churn

The cache was keyed on `…-${{ github.run_number }}`, so **every run saved a fresh ~1.8 GiB cache that never key-hit again**. The repo climbed past GitHub's 10 GiB cache cap and LRU-evicted the warm caches — which is why warm runs are 8-12 min but cold ones hit **25-46 min**. Fix: key on branch name only. `actions/cache` skips the save on an exact key hit, so each branch warms **one** cache and reuses it; new branches restore from `develop`'s via restore-keys. Same fix applied to the Test History cache.

**Honest tradeoff (noted in the YAML comment):** within a long-lived branch the cache isn't re-saved mid-branch, and `develop`'s base cache freezes at its first snapshot. Even frozen, a weeks-old DerivedData saves most recompilation vs a cold run — and the proper follow-up is a develop-push cache-warm job (deferred; needs a CI run to validate).

## Also here

- **Path filters** — `paths-ignore: ['**.md','docs/**','.simdrive/**']` so a docs / replay-corpus PR no longer spins the full 8-45 min macOS job. `scripts/**` stays **in** (the test script lives there).
- **90-min job timeout** — the ~15 post-processing steps (xcresult parse, snapshot find, Pages deploy) were unbounded; only the test step had its own 60-min cap.
- **Local `xcodebuild clean` gated** — `xcode-test-optimized.sh` ran an unconditional clean on the local path, cold-rebuilding on every "CI-parity" run. Now opt-in via `PALACE_TEST_CLEAN=1` / `--clean` (default off). **CI is unaffected** — it takes the `BUILD_CONTEXT=ci` path, which never cleaned.

## Verification

YAML parses (path-filters + `workflow_dispatch` preserved, timeout present, branch-only keys); `bash -n` clean; flag defaults off and flips on for both `--clean` and the env var. This PR's own CI run is the live test of the cache change.

## Scope

CI config + local test-runner only — **no product code, no test logic**. Deferred to focused follow-ups: the develop cache-warm job and the `palace_mutate` per-mutant timeout/grading fix (both need a CI/mutation run to validate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)