### PR TITLE
ci: delete a PR's Actions caches when it closes (keep active branches warm)

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,0 +1,45 @@
+name: Cleanup PR caches
+
+# When a PR closes (merged or not), its DerivedData / test-history caches —
+# scoped to refs/pull/<N>/merge — become dead weight. The repo's Actions cache
+# is capped at 10 GiB and each DerivedData cache is ~1.9 GiB, so a handful of
+# stale PR caches push the repo over the cap and GitHub LRU-evicts caches that
+# ACTIVE branches still need (cold rebuilds). Proactively deleting a closed PR's
+# own caches means eviction hits dead entries first, keeping live branches warm.
+#
+# Delete-only + best-effort — this workflow can never fail a build; a delete that
+# 404s (already evicted) is ignored.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write   # required to delete caches
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Delete this PR's caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          echo "Looking for caches scoped to $PR_REF ..."
+          ids=$(gh cache list -R "$REPO" --limit 200 --json id,ref \
+                  --jq ".[] | select(.ref == \"$PR_REF\") | .id" 2>/dev/null || true)
+          if [ -z "$ids" ]; then
+            echo "No caches to clean for $PR_REF."
+            exit 0
+          fi
+          for id in $ids; do
+            if gh cache delete -R "$REPO" "$id" 2>/dev/null; then
+              echo "deleted cache $id"
+            else
+              echo "could not delete $id (already evicted?) — ignoring"
+            fi
+          done


### PR DESCRIPTION
Deferred follow-up from the tooling review — but **not** the develop cache-warm job the review suggested. Evidence changed the fix.

## Why not the warm job

Live `gh cache list` shows #1299 is working (new caches are branch-only keyed), but the repo is **still at 11.1 GiB — over the 10 GiB cap** because 5+ active branch caches × 1.9 GiB each exceed it. A develop cache-warm job would **add** another 1.9 GiB cache and *worsen* the pressure. GitHub then LRU-evicts caches that active branches still need → cold rebuilds.

## The actual fix

Delete a PR's caches **when it closes**. Each PR's DerivedData + test-history caches are scoped to `refs/pull/<N>/merge` and are dead weight once the PR closes. Removing them means eviction pressure falls on dead entries first, keeping live branches warm.

- Delete-only + best-effort → **can never fail a build**; a 404 (already evicted) is ignored.
- Scoped strictly to the closing PR's own `refs/pull/<N>/merge` ref — **never** touches develop/main caches.

## Verification

Ran the core selector against the **live** repo: for the just-merged #1301 it matched exactly its two caches (`macOS-deriveddata-fix/palace-mutate-timeout-grading` + `test-history-…`, ~3.9 GiB of now-dead weight) and returned **empty** for develop/main refs. YAML validated.

## Scope

New cleanup workflow only — no change to build/test/cache-save logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)