### PR TITLE
fix(regression): use rf separator constants in the campaign report (drift fix)

### DIFF
--- a/scripts/generate-regression-campaign-report.py
+++ b/scripts/generate-regression-campaign-report.py
@@ -184,7 +184,7 @@ def _evidence_links(row: Dict[str, str], assets_root: Optional[str]) -> str:
     raw = _g(row, "evidence_paths")
     if not raw:
         return '<span class="muted">no evidence</span>'
-    parts = [p.strip() for p in raw.split(";") if p.strip()]
+    parts = [p.strip() for p in raw.split(rf.EVIDENCE_SEP) if p.strip()]
     out = []
     for p in parts:
         href = f"{assets_root.rstrip('/')}/{p}" if assets_root else p
@@ -237,9 +237,9 @@ def _render_gallery(rows, assets_root):
     pairs = []
     for r in rows:
         sp = _g(r, "screenshot_pair")
-        if not sp or "|" not in sp:
+        if not sp or rf.SCREENSHOT_SEP not in sp:
             continue
-        base, cand = (sp.split("|", 1) + [""])[:2]
+        base, cand = (sp.split(rf.SCREENSHOT_SEP, 1) + [""])[:2]
         def src(p):
             p = p.strip()
             if not p:


### PR DESCRIPTION
Small, zero-risk latent-bug fix from the tooling review.

`generate-regression-campaign-report.py` already imports `regression_findings as rf` — the module that owns the findings-CSV schema — and `rc-report.py` already parses via `rf.EVIDENCE_SEP` / `rf.SCREENSHOT_SEP`. But the campaign report **hardcoded** `";"` and `"|"` when splitting evidence paths and screenshot pairs. If `rf` ever changes a separator, the writer and this reader would disagree silently.

Swapped the three literals for the `rf` constants (values identical today).

**Verified byte-identical:** regenerating the report from the sample CSV before vs after produces the same 7469-byte output; `test_regression_campaign_report` passes.

**Not done:** the `SEVERITY_COLORS` vocab hoist — the generators' dicts genuinely differ (the campaign one has an extra `""` fallback), so unifying would change empty-severity row colors. That edge-case reconciliation is deliberately out of scope; this PR is the safe, byte-identical half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)