### PR TITLE
fix(ci+test): unmask + repair develop's masked-broken Swift 6 test target

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -124,9 +124,17 @@ jobs:
         id: tests
         timeout-minutes: 60
         # tee to a log so the @objc-witness-drift gate below can scan the build
-        # warnings. GitHub Actions runs `run:` with `pipefail`, so the tee does
-        # not mask the script's exit code.
-        run: ./scripts/xcode-test-optimized.sh 2>&1 | tee build-output.log
+        # warnings. `set -o pipefail` is set EXPLICITLY here: GitHub's default
+        # bash shell does NOT enable pipefail, so `cmd | tee` returns tee's exit
+        # 0 and masks a non-zero exit from the script — which is how a failing
+        # build passed as a green step even after the script correctly exited 1
+        # (the third masking layer). With pipefail, the pipeline's status is the
+        # script's, so `steps.tests.outcome` reflects a real failure and the
+        # "Fail if tests failed" gate fires.
+        shell: bash
+        run: |
+          set -o pipefail
+          ./scripts/xcode-test-optimized.sh 2>&1 | tee build-output.log
         env:
           BUILD_CONTEXT: ci
         continue-on-error: true

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -468,6 +468,7 @@
 		54D213147B9B62D2A4616A7C /* EPUBPositionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FBCE9F366E7A29724332D4 /* EPUBPositionAdapter.swift */; };
 		54E99B7757E6F82038D5F0D6 /* PerformanceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61585F7AD2A0D6CDAF2EF098 /* PerformanceMonitor.swift */; };
 		55104FF85DE440C78F18B4E7 /* TPPLastReadPositionSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706130D4BA8B4FE88304EC9C /* TPPLastReadPositionSynchronizerTests.swift */; };
+		554C23F2A78ABCFFF01826C9 /* TestTargetHermeticityRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE3B44EDE02103E6515DE7 /* TestTargetHermeticityRegressionTests.swift */; };
 		55630B356BB033C09FEAA9F9 /* TPPBookRegistryAsyncReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E795C64A644FD2C0F982CA69 /* TPPBookRegistryAsyncReadinessTests.swift */; };
 		55FB16FFA837DFA8E0B19E5E /* TPPOPDSFeed+Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4E0EAE6DA244AAE005691B /* TPPOPDSFeed+Networking.swift */; };
 		56196EA984C98839164BD951 /* BackupExclusionMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99895C63131766252D87F554 /* BackupExclusionMigration.swift */; };
@@ -2742,6 +2743,7 @@
 		8AA1511F27C932D92C002C86 /* BearerTokenAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BearerTokenAdapter.swift; sourceTree = "<group>"; };
 		8AAAA013BC37CAFD5930A97A /* AudiobookLoaderPredicateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookLoaderPredicateTests.swift; sourceTree = "<group>"; };
 		8ADE8A45C4B4AAE67143A272 /* HoldsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoldsViewModelTests.swift; sourceTree = "<group>"; };
+		8BEE3B44EDE02103E6515DE7 /* TestTargetHermeticityRegressionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestTargetHermeticityRegressionTests.swift; sourceTree = "<group>"; };
 		8C40D6A62375FF8B006EA63B /* TPPProblemDocumentCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPProblemDocumentCacheManager.swift; sourceTree = "<group>"; };
 		8C9E0F102132435465A1B2C3 /* BookSignInRedirectHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSignInRedirectHandler.swift; sourceTree = "<group>"; };
 		8CAA704224204121A301A289 /* EULAView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EULAView.swift; sourceTree = "<group>"; };
@@ -3679,6 +3681,7 @@
 				DF90048A6DDD9A6025494F1A /* PalaceTestCase.swift */,
 				E775BA9B323D098F690BE354 /* TriageBotKeyAdminTests.swift */,
 				5192F4C62AA2DDC7E9752A5E /* LockIsolated.swift */,
+				8BEE3B44EDE02103E6515DE7 /* TestTargetHermeticityRegressionTests.swift */,
 			);
 			name = Support;
 			path = Support;
@@ -7821,6 +7824,7 @@
 				1C4CC3753B75E8677FEB66B0 /* ButtonStateMonotonicClampTests.swift in Sources */,
 				C7DFB8533719B493E14C6A56 /* LockIsolated.swift in Sources */,
 				5290120E5AFA84BAFAD4F608 /* ReaderServicePDFRouteTests.swift in Sources */,
+				554C23F2A78ABCFFF01826C9 /* TestTargetHermeticityRegressionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9102,7 +9106,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palaceTests;
 				PRODUCT_NAME = PalaceTests;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "LCP FEATURE_OVERDRIVE";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG LCP FEATURE_OVERDRIVE";
 				SWIFT_OBJC_BRIDGING_HEADER = "PalaceTests/PalaceTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;

--- a/Palace/Accounts/Library/CatalogPreloader.swift
+++ b/Palace/Accounts/Library/CatalogPreloader.swift
@@ -56,7 +56,7 @@ final class CatalogPreloader {
     func preloadCatalogs(
         currentAccount: Account?,
         recentAccountUUIDs: [String],
-        accountProvider: (String) -> Account?
+        accountProvider: @Sendable (String) -> Account?
     ) async {
         var preloadedUUIDs = Set<String>()
         var urlsToPreload = [(uuid: String, url: URL)]()

--- a/Palace/Accounts/Library/LibraryRegistryCrawler.swift
+++ b/Palace/Accounts/Library/LibraryRegistryCrawler.swift
@@ -60,7 +60,24 @@ protocol LibraryRegistryCrawlerDelegate: AnyObject {
 ///
 /// **Full crawl**: Paginates through all pages. When complete (no
 /// `rel="next"` link), libraries not present in the crawl are deleted.
-final class LibraryRegistryCrawler {
+/// `@unchecked Sendable`: exists so a `@MainActor` caller (production
+/// `AccountsManager` crawl `Task`, and the `@MainActor` XCTest cases) can
+/// `await crawler.crawl(...)` without sending a non-`Sendable` value across the
+/// actor boundary. Every stored member is safe to reference across concurrency
+/// domains:
+/// - `fetcher` is the non-`Sendable` `CrawlerNetworkFetching` existential, but
+///   its production conformer (`URLSessionCrawlerFetcher`) is a stateless struct
+///   over `URLSession.shared`, and it is already carried into the parallel
+///   task-group children via the documented `CrawlerFetcherBox` — so concurrent
+///   `fetchData` is already assumed safe by this type.
+/// - `hash` / `stateDirectory` / `currentAppVersion` are immutable `Sendable`
+///   `let`s.
+/// - `nowProvider` is now `@Sendable` (below).
+/// - `delegate` is a `weak var`, but it is only ever WRITTEN from the main
+///   thread (production never sets it; tests set it synchronously before
+///   `crawl` on the `@MainActor`) and only READ during a single crawl. No two
+///   crawls share an instance and no concurrent write races the read.
+final class LibraryRegistryCrawler: @unchecked Sendable {
 
     enum CrawlResult {
         case success(Data)   // Merged OPDS2CatalogsFeed JSON
@@ -81,7 +98,7 @@ final class LibraryRegistryCrawler {
     private let hash: String
     private let stateDirectory: URL
     private let currentAppVersion: String?
-    private let nowProvider: () -> Date
+    private let nowProvider: @Sendable () -> Date
 
     weak var delegate: LibraryRegistryCrawlerDelegate?
 
@@ -90,7 +107,7 @@ final class LibraryRegistryCrawler {
         hash: String,
         stateDirectory: URL? = nil,
         currentAppVersion: String? = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
-        now: @escaping () -> Date = Date.init
+        now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.fetcher = fetcher
         self.hash = hash

--- a/Palace/MyBooks/BackgroundDownloadHandler.swift
+++ b/Palace/MyBooks/BackgroundDownloadHandler.swift
@@ -37,7 +37,17 @@ protocol BackgroundDownloadHandlerDelegate: AnyObject {
 /// - Progress updates and MIME type detection
 /// - OPDS entry response parsing
 /// - File move/replace/validation after download
-final class BackgroundDownloadHandler: NSObject {
+/// - Sendable invariant (Swift 6 `complete`-mode): the handler has exactly one
+///   stored member, `weak var delegate`, assigned once at init (or via the
+///   owner during construction) and never reassigned outside that window
+///   (weak-ref reads + ARC zeroing are atomic). The `async` methods
+///   (`handleDownloadProgress`, the OPDS-response handlers) touch only the
+///   actor-serialized state reached *through* the delegate's `stateManager` and
+///   local values, so awaiting them from a `@MainActor` caller does not race.
+///   Mirrors the `DownloadStartCoordinator` / `DownloadTaskLifecycleService`
+///   invariant. `@unchecked` only because the delegate existential is not
+///   itself `Sendable`.
+final class BackgroundDownloadHandler: NSObject, @unchecked Sendable {
 
     // MARK: - Properties
 

--- a/Palace/MyBooks/DownloadCompletionParser.swift
+++ b/Palace/MyBooks/DownloadCompletionParser.swift
@@ -73,7 +73,15 @@ enum DownloadCompletionParseResult {
 
 // MARK: - DownloadCompletionParser
 
-final class DownloadCompletionParser {
+/// - Sendable invariant (Swift 6 `complete`-mode): both stored members are
+///   immutable `let`s bound at init. `stateManager` is `DownloadStateManager`
+///   (already `@unchecked Sendable` — lock-guarded / actor-backed storage).
+///   `routing` is a `DownloadCompletionRouting` existential; the parser only
+///   ever *reads* through it (rights detection + the two `async` OPDS-routing
+///   calls) and never mutates it, so awaiting `parse(...)` — a nonisolated
+///   `async` method — from a `@MainActor` caller does not race. `@unchecked`
+///   only because the `routing` existential is not itself statically `Sendable`.
+final class DownloadCompletionParser: @unchecked Sendable {
 
     private let routing: DownloadCompletionRouting
     private let stateManager: DownloadStateManager

--- a/Palace/MyBooks/DownloadStateManager.swift
+++ b/Palace/MyBooks/DownloadStateManager.swift
@@ -60,7 +60,16 @@ final class DownloadStateManager: DownloadStateManaging {
 
     /// Per-book transient-transfer retry counter (content transfer only). Reset
     /// on terminal completion so a later independent failure starts fresh.
-    private let transferRetryCounts = SafeDictionary<String, Int>()
+    ///
+    /// Non-`private` (but only mutated through the `transferRetryAttempts` /
+    /// `incrementTransferRetryAttempts` / `resetTransferRetryAttempts` seam
+    /// below) so tests can await the counter directly on this `SafeDictionary`
+    /// actor — mirroring how the public `taskIdentifierToBook` /
+    /// `bookIdentifierToDownloadInfo` actors are read in tests. Awaiting the
+    /// (Sendable) actor avoids sending the non-Sendable `DownloadStateManager`
+    /// instance across the actor boundary from a `@MainActor` test, which Swift 6
+    /// rejects.
+    let transferRetryCounts = SafeDictionary<String, Int>()
 
     init(taskPersistence: DownloadTaskPersistence = DownloadTaskPersistence()) {
         self.taskPersistence = taskPersistence

--- a/Palace/MyBooks/DownloadStateManager.swift
+++ b/Palace/MyBooks/DownloadStateManager.swift
@@ -38,7 +38,13 @@ protocol DownloadStateManaging: AnyObject {
 
 /// Manages all download state tracking: what is downloading, progress, errors,
 /// and concurrency coordination via the DownloadCoordinator actor.
-final class DownloadStateManager: DownloadStateManaging {
+/// `@unchecked Sendable`: every stored member is either an immutable `let`
+/// binding to a `Sendable` collaborator (the `SafeDictionary` actors, the
+/// `DownloadCoordinator`, `taskPersistence`) or the lock-guarded
+/// `maxConcurrentDownloads` below. The manager is genuinely safe to reference
+/// across concurrency domains — e.g. `cleanupDownload` awaited from a
+/// `@MainActor` context — which Swift 6 otherwise rejects.
+final class DownloadStateManager: DownloadStateManaging, @unchecked Sendable {
 
     // MARK: - Thread-safe storage
 
@@ -49,7 +55,17 @@ final class DownloadStateManager: DownloadStateManaging {
     // MARK: - Coordinator
 
     let downloadCoordinator = DownloadCoordinator()
-    var maxConcurrentDownloads: Int = 4
+
+    /// Concurrency cap. Written by `DownloadThrottlingService` and read by the
+    /// orchestrator / start-coordinator from different threads, so it is
+    /// NSLock-guarded (the one piece of mutable state that made the manager
+    /// non-Sendable).
+    private let maxConcurrentLock = NSLock()
+    private var _maxConcurrentDownloads: Int = 4
+    var maxConcurrentDownloads: Int {
+        get { maxConcurrentLock.withLock { _maxConcurrentDownloads } }
+        set { maxConcurrentLock.withLock { _maxConcurrentDownloads = newValue } }
+    }
 
     // MARK: - Durable persistence (seam S1)
 

--- a/Palace/MyBooks/DownloadTaskLifecycleService.swift
+++ b/Palace/MyBooks/DownloadTaskLifecycleService.swift
@@ -38,7 +38,17 @@ protocol DownloadTaskLifecycleServiceDelegate: AnyObject {
 
 // MARK: - DownloadTaskLifecycleService
 
-final class DownloadTaskLifecycleService {
+/// - Sendable invariant (Swift 6 `complete`-mode): the three stored
+///   dependencies (`stateManager`, `bookRegistry`, `downloadAnnouncementService`)
+///   are immutable `let`s bound at init. The only mutable member is
+///   `weak var delegate`, assigned exactly once during owner
+///   (`MyBooksDownloadCenter`) construction and never reassigned (weak-ref reads
+///   + ARC zeroing are atomic). `registerStartedTask` / `handleTaskCompletionError`
+///   are nonisolated `async`; they touch only the actor-serialized
+///   `stateManager` storage and hop out to the delegate. Mirrors the
+///   `DownloadStartCoordinator` invariant. `@unchecked` only because the stored
+///   service types are not themselves `Sendable`.
+final class DownloadTaskLifecycleService: @unchecked Sendable {
 
     weak var delegate: DownloadTaskLifecycleServiceDelegate?
 

--- a/Palace/MyBooks/RedirectPolicy.swift
+++ b/Palace/MyBooks/RedirectPolicy.swift
@@ -19,16 +19,22 @@
 
 import Foundation
 
-struct RedirectPolicy {
+/// - Sendable invariant (Swift 6 `complete`-mode): a value type whose only
+///   stored members are two `@Sendable async` closures and an `Int`, so it is
+///   `Sendable` and can be awaited (`decide`) from any actor — including a
+///   `@MainActor` caller (tests) — without racing. The production closures
+///   capture only the actor-isolated `DownloadCoordinator` (itself `Sendable`);
+///   the `@Sendable` annotation is satisfied there with no widening.
+struct RedirectPolicy: Sendable {
     static let defaultMaxRedirectAttempts: Int = 10
 
-    private let getRedirectAttempts: (Int) async -> Int
-    private let incrementRedirectAttempts: (Int) async -> Void
+    private let getRedirectAttempts: @Sendable (Int) async -> Int
+    private let incrementRedirectAttempts: @Sendable (Int) async -> Void
     private let maxRedirectAttempts: Int
 
     init(
-        getRedirectAttempts: @escaping (Int) async -> Int,
-        incrementRedirectAttempts: @escaping (Int) async -> Void,
+        getRedirectAttempts: @escaping @Sendable (Int) async -> Int,
+        incrementRedirectAttempts: @escaping @Sendable (Int) async -> Void,
         maxRedirectAttempts: Int = RedirectPolicy.defaultMaxRedirectAttempts
     ) {
         self.getRedirectAttempts = getRedirectAttempts

--- a/Palace/Packages/PalaceAuth/Sources/PalaceAuth/TokenRequest.swift
+++ b/Palace/Packages/PalaceAuth/Sources/PalaceAuth/TokenRequest.swift
@@ -10,7 +10,7 @@ import Foundation
 import PalaceLogging
 import PalaceCatalog
 
-@objcMembers public class TokenResponse: NSObject, Codable {
+@objcMembers public class TokenResponse: NSObject, Codable, @unchecked Sendable { // : all stored properties are immutable `let`s
     @objc public let accessToken: String
     public let tokenType: String
     @objc public let expiresIn: Int

--- a/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/CatalogRepository.swift
+++ b/Palace/Packages/PalaceCatalog/Sources/PalaceCatalog/CatalogRepository.swift
@@ -72,6 +72,20 @@ public final class CatalogRepository: CatalogRepositoryProtocol, @unchecked Send
     }
     private let cache = OSAllocatedUnfairLock(uncheckedState: CacheState())
 
+    /// Handle on the most recently scheduled background stale-revalidate
+    /// refresh Task. Retained ONLY so tests can `await` its completion
+    /// deterministically (`_awaitBackgroundRefreshForTesting()`), instead of
+    /// polling `cachedFeed(...)` for the write to land — a poll that is
+    /// inherently racy under cooperative-pool oversubscription because the
+    /// refresh is dispatched at `.utility` priority and the pool can defer it
+    /// past any fixed poll deadline (the parallel-sim-clone timeouts in CI
+    /// run 29805821296). Production behavior is UNCHANGED: the refresh still
+    /// runs detached / fire-and-forget; we merely keep a reference to the last
+    /// one so a test can join it. `nil` until the first stale read schedules a
+    /// refresh. Lock-guarded so the write from `loadTopLevelCatalog` and the
+    /// read from the test seam are race-free.
+    private let lastBackgroundRefreshTask = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
+
     private struct CachedFeed {
         let feed: CatalogFeed
         let timestamp: Date
@@ -234,10 +248,16 @@ public final class CatalogRepository: CatalogRepositoryProtocol, @unchecked Send
             Log.info(#file, "Returning stale cached catalog feed, refreshing in background: \(url.absoluteString)")
             prewarmFormatEntriesCache(from: entry.feed, cacheKey: cacheKey)
 
-            // Schedule background refresh
-            Task.detached(priority: .utility) { [weak self] in
+            // Schedule background refresh (fire-and-forget in production). The
+            // Task handle is retained in `lastBackgroundRefreshTask` purely so a
+            // test can join it deterministically — see the field's doc comment.
+            // Behavior is identical to a bare `Task.detached { … }`: nothing
+            // production awaits this handle.
+            let refreshTask = Task.detached(priority: .utility) { [weak self] in
                 await self?.refreshFeedInBackground(url: url, cacheKey: cacheKey)
+                return ()
             }
+            lastBackgroundRefreshTask.withLock { $0 = refreshTask }
 
             return entry.feed
         }
@@ -385,6 +405,33 @@ public final class CatalogRepository: CatalogRepositoryProtocol, @unchecked Send
             guard let entry = state.memoryCache[cacheKey], !isTooOld(entry) else { return nil }
             return entry.feed
         }
+    }
+
+    /// TEST SEAM — deterministically await the in-flight stale-revalidate
+    /// background refresh scheduled by the most recent `loadTopLevelCatalog`
+    /// stale read. Returns immediately if none is in flight.
+    ///
+    /// Why this exists: the background refresh is dispatched via
+    /// `Task.detached(priority: .utility)` and production intentionally does
+    /// not await it. A test that needs to assert the post-refresh cache state
+    /// therefore has to wait for that Task to complete — and polling
+    /// `cachedFeed(...)` for the write to land is NON-DETERMINISTIC under
+    /// cooperative-thread-pool oversubscription: with 4 sim clones on a
+    /// 3–4-core CI runner, a `.utility` task can be deferred past any fixed
+    /// poll deadline, so the poll times out even though the code is correct
+    /// (CI run 29805821296 parallel-only timeouts). Awaiting the actual Task
+    /// handle removes the wall-clock/pool dependence entirely — the test
+    /// blocks exactly until the refresh finishes, no matter how starved the
+    /// pool is.
+    ///
+    /// This changes NO production behavior: `loadTopLevelCatalog` still fires
+    /// the refresh detached and returns immediately; this method only reads a
+    /// handle the repository already retains. `public` (not `#if DEBUG`) to be
+    /// reachable from `PalaceTests`, which imports `PalaceCatalog` without
+    /// `@testable` — matching the existing test-only initializers above.
+    public func _awaitBackgroundRefreshForTesting() async {
+        let task = lastBackgroundRefreshTask.withLock { $0 }
+        await task?.value
     }
 
     // MARK: - Background Preloading

--- a/Palace/Reader2/BusinessLogic/TPPLastReadPositionSynchronizer.swift
+++ b/Palace/Reader2/BusinessLogic/TPPLastReadPositionSynchronizer.swift
@@ -74,7 +74,7 @@ final class TPPLastReadPositionSynchronizer: @unchecked Sendable {
         }
     }
 
-    func sync(for publication: Publication,
+    func sync(for publication: sending Publication,
               book: TPPBook,
               drmDeviceID: String?) async {
         let serverLocator = await syncReadPosition(for: book, drmDeviceID: drmDeviceID, publication: publication)

--- a/Palace/Utilities/ImageCache/ImageLoaderImpl.swift
+++ b/Palace/Utilities/ImageCache/ImageLoaderImpl.swift
@@ -24,7 +24,11 @@ private final class ImageCompletionBox: @unchecked Sendable {
 ///
 /// Not `final` so test subclasses can override individual hooks if needed —
 /// per CLAUDE.md "don't make new services final reflexively".
-public class ImageLoader: ImageLoading {
+public class ImageLoader: ImageLoading, @unchecked Sendable {
+    // @unchecked Sendable: only immutable `let` collaborators (an actor-backed
+    // registry + a shared cache), no mutable state — safe to reference across
+    // concurrency domains (its async methods are awaited from @MainActor tests).
+
 
     // MARK: - Composition
 

--- a/Palace/Utilities/SafeDictionary.swift
+++ b/Palace/Utilities/SafeDictionary.swift
@@ -51,7 +51,7 @@ actor SafeDictionary<Key: Hashable, Value> {
     private var lastAccessTime: Date = Date()
 
     /// Get performance metrics for debugging
-    func getMetrics() -> [String: Any] {
+    func getMetrics() -> [String: any Sendable] {
         return [
             "count": storage.count,
             "accessCount": accessCount,

--- a/PalaceTests/Accessibility/StatusAnnouncementTests.swift
+++ b/PalaceTests/Accessibility/StatusAnnouncementTests.swift
@@ -87,7 +87,7 @@ final class StatusAnnouncementTests: XCTestCase {
     }
 
     func testPP3673_searchRerun_announcesNewStatus() {
-        var currentTime = Date(timeIntervalSince1970: 100)
+        let currentTime = LockIsolated<Date>(Date(timeIntervalSince1970: 100))
         let capture = Capture()
         let exp = expectation(description: "announcements")
         exp.expectedFulfillmentCount = 2
@@ -95,11 +95,11 @@ final class StatusAnnouncementTests: XCTestCase {
         let announcer = makeAnnouncer(
             capture: capture,
             deduplicationInterval: 2.0,
-            timeProvider: { currentTime }
+            timeProvider: { currentTime.value }
         )
 
         announcer.announceSearchResults(query: "robots", count: 5)
-        currentTime = currentTime.addingTimeInterval(3.0)
+        currentTime.value = currentTime.value.addingTimeInterval(3.0)
         announcer.announceSearchResults(query: "robots", count: 0)
 
         waitForExpectations(timeout: 5.0)

--- a/PalaceTests/Accounts/AccountDetailsURLTests.swift
+++ b/PalaceTests/Accounts/AccountDetailsURLTests.swift
@@ -19,15 +19,20 @@ final class AccountDetailsURLTests: XCTestCase {
     private var defaults: UserDefaults!
     private let testUUID = "test-account-url-\(UUID().uuidString)"
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    // `setUp() async throws` (not the synchronous `setUpWithError()`): the async
+    // override adopts this @MainActor class's isolation, so the @MainActor
+    // fixtures (`defaults`, `sut`, `makeAccountDetails`) are touched on-actor.
+    // The synchronous `setUpWithError()` override is nonisolated, which sends
+    // the task-isolated `self` into any @MainActor access (Swift 6 data race).
+    override func setUp() async throws {
+        try await super.setUp()
         // swarm_cd181acd D-cleanup: per-test isolated UserDefaults instead
         // of mutating `.standard`. Every `AccountDetails` constructed in
         // this file shares the same per-test suite so persistence reads
         // (eulaIsAccepted, syncPermissionGranted, urlEULA dict, etc.)
         // observe the same store, and the suite is dropped by
         // `SingletonResetRegistry` when the test finishes.
-        defaults = testUserDefaults()
+        defaults = Self.testUserDefaults()
         sut = try makeAccountDetails(uuid: testUUID)
     }
 

--- a/PalaceTests/Accounts/AccountsManagerCacheReadTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerCacheReadTests.swift
@@ -148,7 +148,7 @@ final class AccountsManagerCacheReadTests: PalaceWiringTestCase {
         // Empty per-test defaults → currentAccountId is nil → the auth-doc
         // network branch inside loadAccountSetsAndAuthDoc stays dormant, so
         // the load is a pure parse + carry-over + state-transition pass.
-        let manager = makeFreshAccountsManager(defaults: testUserDefaults())
+        let manager = makeFreshAccountsManager(defaults: Self.testUserDefaults())
         let hash = "carryover-\(UUID().uuidString.prefix(8))"
 
         // First load establishes the old-account set in accountSets[hash].
@@ -213,7 +213,7 @@ final class AccountsManagerCacheReadTests: PalaceWiringTestCase {
         #if DEBUG
         AccountsManager.deferDiskCachePreloadForTesting = true
         #endif
-        return makeFreshAccountsManager(defaults: testUserDefaults())
+        return makeFreshAccountsManager(defaults: Self.testUserDefaults())
     }
 
     /// Seed both the catalog blob and its metadata at the production cache

--- a/PalaceTests/Accounts/AccountsManagerLaunchSnapshotTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerLaunchSnapshotTests.swift
@@ -138,7 +138,7 @@ final class AccountsManagerLaunchSnapshotTests: PalaceWiringTestCase {
         let currentUUID = catalogs[0].metadata.id
         let settingsUUID = catalogs[1].metadata.id
 
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set(currentUUID, forKey: currentAccountIdentifierKey)
         let manager = makeFreshAccountsManager(defaults: defaults)
 
@@ -180,7 +180,7 @@ final class AccountsManagerLaunchSnapshotTests: PalaceWiringTestCase {
         let catalogs = try loadFeedCatalogs()
         let currentUUID = catalogs[0].metadata.id
 
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set(currentUUID, forKey: currentAccountIdentifierKey)
         let manager = makeFreshAccountsManager(defaults: defaults)
 
@@ -217,7 +217,7 @@ final class AccountsManagerLaunchSnapshotTests: PalaceWiringTestCase {
         let currentUUID = catalogs[0].metadata.id
         let slimUUIDs: Set<String> = [currentUUID, catalogs[1].metadata.id]
 
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set(currentUUID, forKey: currentAccountIdentifierKey)
         let manager = makeFreshAccountsManager(defaults: defaults)
 
@@ -265,7 +265,7 @@ final class AccountsManagerLaunchSnapshotTests: PalaceWiringTestCase {
         let aUUID = catalogs[0].metadata.id
         let bUUID = catalogs[1].metadata.id
 
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set(aUUID, forKey: currentAccountIdentifierKey)
         let manager = makeFreshAccountsManager(defaults: defaults)
 
@@ -363,7 +363,7 @@ final class AccountsManagerLaunchSnapshotTests: PalaceWiringTestCase {
         let aUUID = catalogs[0].metadata.id
         let bUUID = catalogs[1].metadata.id
 
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set(aUUID, forKey: currentAccountIdentifierKey)
         let manager = makeFreshAccountsManager(defaults: defaults)
 
@@ -436,7 +436,7 @@ final class AccountsManagerLaunchSnapshotTests: PalaceWiringTestCase {
         let catalogs = try loadFeedCatalogs()
         let aUUID = catalogs[0].metadata.id
 
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set(aUUID, forKey: currentAccountIdentifierKey)
         let manager = makeFreshAccountsManager(defaults: defaults)
 
@@ -496,7 +496,7 @@ final class AccountsManagerLaunchSnapshotTests: PalaceWiringTestCase {
         let catalogs = try loadFeedCatalogs()
         let currentUUID = catalogs[0].metadata.id
 
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set(currentUUID, forKey: currentAccountIdentifierKey)
         let manager = makeFreshAccountsManager(defaults: defaults)
 
@@ -560,7 +560,7 @@ final class AccountsManagerLaunchSnapshotTests: PalaceWiringTestCase {
         let staleSlimUUID = catalogs[1].metadata.id   // slim written for the PRIOR current account
         XCTAssertNotEqual(currentUUID, staleSlimUUID)
 
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set(currentUUID, forKey: currentAccountIdentifierKey)
         let manager = makeFreshAccountsManager(defaults: defaults)
 

--- a/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
@@ -109,6 +109,19 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
     /// Returns a string label for a `LoadState` — used in array-equality
     /// assertions where direct enum comparison is unwieldy (associated values
     /// on `.detailsLoaded`/`.detailsFailed` aren't trivially Equatable).
+    /// Lock-guarded accumulator for state-stream labels observed off the Task's
+    /// executor. Swift 6: a captured `var [String]` mutated inside the stream Task
+    /// and read from the test thread is a data race — this box synchronizes both.
+    private final class ObservedLabels: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _labels: [String] = []
+        /// Appends and returns the just-appended label.
+        func append(_ label: String) -> String {
+            lock.withLock { _labels.append(label); return label }
+        }
+        var snapshot: [String] { lock.withLock { _labels } }
+    }
+
     private func label(_ state: Account.LoadState) -> String {
         switch state {
         case .notLoaded:        return "notLoaded"
@@ -514,13 +527,32 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
 
         // Capture the transition stream so we can assert the SEQUENCE
         // (.detailsLoading → .detailsFailed), not just the terminal state.
-        var observed: [String] = []
+        //
+        // `stateStream` is backed by a `CurrentValueSubject`, which replays only
+        // the LATEST value to a late subscriber. For a nil-URL account,
+        // `fetchAuthDocumentWithStateMachine` runs `_setState(.detailsLoading)`
+        // and `_setState(.detailsFailed)` SYNCHRONOUSLY (loadAuthenticationDocument
+        // fires `completion(false)` inline). If we fire the fetch before the
+        // `Task`'s AsyncStream sink has attached, both sends land first and the
+        // subscriber only ever sees `.detailsFailed` — the `.detailsLoading`
+        // transition is lost. So gate the fetch on the subscription being live:
+        // the stream task signals once it has received its first (replayed)
+        // value, proving the sink is attached. `SubscribedFlag` is a lock-guarded
+        // box so the fulfill is race-free under Swift 6.
+        let observedBox = ObservedLabels()
+        let subscribed = expectation(description: "stream subscription attached")
+        subscribed.assertForOverFulfill = false
         let streamTask = Task {
+            var firstSeen = false
             for await state in account.stateStream {
-                observed.append(self.label(state))
-                if observed.last?.hasPrefix("detailsFailed") == true { break }
+                if !firstSeen { firstSeen = true; subscribed.fulfill() }
+                let last = observedBox.append(self.label(state))
+                if last.hasPrefix("detailsFailed") { break }
             }
         }
+
+        // Do not fire the transition until the sink is confirmed live.
+        wait(for: [subscribed], timeout: 2.0)
 
         manager.fetchAuthDocumentWithStateMachine(for: account) { success in
             XCTAssertFalse(success, "loadAuthenticationDocument with nil URL must return false")
@@ -537,11 +569,12 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         // terminal `.detailsFailed`, so the writes have happened; the poll
         // forces a fresh read on the main thread before assertion.
         awaitCondition(timeout: 2.0) {
-            observed.contains("detailsLoading") &&
-                observed.contains("detailsFailed.authDocumentFetchFailed")
+            observedBox.snapshot.contains("detailsLoading") &&
+                observedBox.snapshot.contains("detailsFailed.authDocumentFetchFailed")
         }
         streamTask.cancel()
 
+        let observed = observedBox.snapshot
         XCTAssertTrue(observed.contains("detailsLoading"),
                       "Stream must observe .detailsLoading before failure; observed: \(observed)")
         XCTAssertTrue(observed.contains("detailsFailed.authDocumentFetchFailed"),
@@ -902,8 +935,17 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         let observed = expectation(description: "stream reaches terminal")
         observed.assertForOverFulfill = false
 
+        // `.detailsLoading` is set SYNCHRONOUSLY at the entry of a non-deduped
+        // fetch, and `stateStream`'s CurrentValueSubject only replays the latest
+        // value to a late subscriber. Gate the concurrent fetches on the stream
+        // sink being attached (first replayed value observed) so the single
+        // `.detailsLoading` transition is not raced away before we can count it.
+        let subscribed = expectation(description: "stream subscription attached")
+        subscribed.assertForOverFulfill = false
         let streamTask = Task {
+            var firstSeen = false
             for await state in account.stateStream {
+                if !firstSeen { firstSeen = true; subscribed.fulfill() }
                 if case .detailsLoading = state {
                     counters.incrementDetailsLoading()
                 }
@@ -915,6 +957,7 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
                 }
             }
         }
+        wait(for: [subscribed], timeout: 2.0)
 
         // Fire two near-simultaneous calls for the SAME UUID. The second
         // must observe the single-flight set and return without calling

--- a/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerStateMachineWiringTests.swift
@@ -224,7 +224,7 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         // wired into the AccountsManager so the
         // `currentAccountIdentifierKey` write below cannot leak across
         // tests via `.standard`.
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         let manager = makeFreshAccountsManager(defaults: defaults)
 
         // Set the current account to one of the fixture UUIDs so the
@@ -309,7 +309,7 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         // wired into the AccountsManager so the
         // `currentAccountIdentifierKey` write below cannot leak via
         // `.standard`.
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         // Construct the manager FIRST. Its init fires a background
         // loadCatalogs(nil); drain the main queue so any of its main-thread
         // completion blocks land before our reset below. Without network the
@@ -404,7 +404,7 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         let currentUUID = catalogs[0].metadata.id
 
         // swarm_cd181acd D-cleanup: per-test isolated UserDefaults suite.
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         let manager = makeFreshAccountsManager(defaults: defaults)
         // Drain the main queue so init's background loadCatalogs has a chance
         // to fail (no network → fast failure) before our reset below.
@@ -993,7 +993,7 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         // swarm_cd181acd D-cleanup: per-test isolated UserDefaults suite
         // wired into the AccountsManager so the
         // `currentAccountIdentifierKey` write cannot leak via `.standard`.
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set(accountA.uuid, forKey: currentAccountIdentifierKey)
 
         let manager = makeFreshAccountsManager(defaults: defaults)
@@ -1039,7 +1039,7 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         let newUUID = catalogs[1].metadata.id
 
         // swarm_cd181acd D-cleanup: per-test isolated UserDefaults suite.
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         // Seed disk cache + populate accountSets via preload so the
         // manager's currentAccount accessor can resolve UUIDs back to
         // Account instances after the switch.
@@ -1123,7 +1123,7 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         accountA._setState(.detailsLoaded(accountA.details!))
 
         // swarm_cd181acd D-cleanup: per-test isolated UserDefaults suite.
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set(accountA.uuid, forKey: currentAccountIdentifierKey)
 
         let manager = makeFreshAccountsManager(defaults: defaults)
@@ -1210,7 +1210,7 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         let currentUUID = catalogs[0].metadata.id
 
         // swarm_cd181acd D-cleanup: per-test isolated UserDefaults suite.
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         let manager = makeFreshAccountsManager(defaults: defaults)
         let backgroundSettled = expectation(description: "background loadCatalogs settled")
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.4) { backgroundSettled.fulfill() } // FLAKE-002-OK: background loadCatalogs settle window — see feedback_wiring_suite_test_isolation
@@ -1332,7 +1332,7 @@ final class AccountsManagerStateMachineWiringTests: PalaceWiringTestCase {
         let currentUUID = catalogs[0].metadata.id
 
         // swarm_cd181acd D-cleanup: per-test isolated UserDefaults suite.
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         let manager = makeFreshAccountsManager(defaults: defaults)
         // Drain the main queue so init's background loadCatalogs has a chance
         // to fail (no network → fast failure) before our reset below.

--- a/PalaceTests/Accounts/AccountsManagerTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerTests.swift
@@ -39,7 +39,7 @@ final class AccountsManagerTests: XCTestCase {
         // swarm_cd181acd D-cleanup: no `.standard.removeObject(forKey:)`
         // here. Tests that need an isolated `currentAccountIdentifierKey`
         // suite construct a fresh `AccountsManager(defaults:)` with a
-        // per-test `testUserDefaults()`. AppContainer.production()-based
+        // per-test `Self.testUserDefaults()`. AppContainer.production()-based
         // tests continue to share the production `.standard` graph (their
         // teardown is handled by `SingletonResetRegistry` via the
         // AppContainer post-test reset observer).
@@ -122,7 +122,7 @@ final class AccountsManagerTests: XCTestCase {
         // production seam — defaults.set + defaults.removeObject under
         // currentAccountIdentifierKey — to assert the manager's getter
         // reflects what the injected suite holds.
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         #if DEBUG
         AccountsManager.deferInitialLoadCatalogsForTesting = true
         #endif
@@ -143,7 +143,7 @@ final class AccountsManagerTests: XCTestCase {
 
     func testCurrentAccountId_PersistsToUserDefaults() {
         // Arrange: AccountsManager + isolated suite (swarm_cd181acd D-cleanup).
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         #if DEBUG
         AccountsManager.deferInitialLoadCatalogsForTesting = true
         #endif

--- a/PalaceTests/Accounts/CredentialSnapshotInvalidationTests.swift
+++ b/PalaceTests/Accounts/CredentialSnapshotInvalidationTests.swift
@@ -72,7 +72,7 @@ final class CredentialSnapshotInvalidationTests: PalaceWiringTestCase {
     private func makeSeededIsolatedContainer(
         fixtureId: String
     ) -> (container: AppContainer, manager: AccountsManager, fixture: Account, cleanup: () -> Void) {
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         let manager = makeFreshAccountsManager(defaults: defaults)
         let pub = OPDS2Publication(
             links: [OPDS2Link(href: "https://example.com/catalog", rel: "http://opds-spec.org/catalog")],
@@ -269,7 +269,7 @@ final class CredentialSnapshotInvalidationTests: PalaceWiringTestCase {
     /// invalidation call leaves the primed (stale) cache in place and this test
     /// fails.
     func testAccountSwitch_invalidatesNewlyCurrentAccountCredentialCache() throws {
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         let mgr = makeFreshAccountsManager(defaults: defaults)
 
         // Seed a fixture account and make it resolvable via account(uuid), then

--- a/PalaceTests/Audiobook/AudiobookIssueFixTests.swift
+++ b/PalaceTests/Audiobook/AudiobookIssueFixTests.swift
@@ -262,7 +262,7 @@ final class PostUpdateMigrationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        isolatedDefaults = testUserDefaults()
+        isolatedDefaults = Self.testUserDefaults()
     }
 
     override func tearDown() {

--- a/PalaceTests/Audiobook/AudiobookTOCTests.swift
+++ b/PalaceTests/Audiobook/AudiobookTOCTests.swift
@@ -29,7 +29,7 @@ class AudiobookTOCTests: XCTestCase {
         super.tearDown()
     }
 
-    func loadTracks(for manifestJSON: ManifestJSON) throws -> Tracks {
+    nonisolated func loadTracks(for manifestJSON: ManifestJSON) throws -> Tracks {
         let manifest = try Manifest.from(jsonFileName: manifestJSON.rawValue, bundle: Bundle(for: type(of: self)))
         return Tracks(manifest: manifest, audiobookID: testID, token: nil)
     }

--- a/PalaceTests/Audiobook/Vendors/BearerTokenAdapterTests.swift
+++ b/PalaceTests/Audiobook/Vendors/BearerTokenAdapterTests.swift
@@ -31,6 +31,14 @@ final class BearerTokenAdapterTests: XCTestCase {
         super.tearDown()
     }
 
+    /// Test-only carrier that lets a non-Sendable value (a completion closure
+    /// or a manifest payload) cross a `@Sendable` dispatch closure under
+    /// Swift 6. Each box is created and consumed exactly once on the same
+    /// serial test flow, so unchecked Sendable is safe here.
+    private struct SendableBox<T>: @unchecked Sendable {
+        let value: T
+    }
+
     // MARK: - Stubs
 
     private final class StubNetwork: AudiobookManifestNetworkFetching {
@@ -44,8 +52,9 @@ final class BearerTokenAdapterTests: XCTestCase {
             completion: @escaping (Data?, URLResponse?, Error?) -> Void
         ) {
             requestedURLs.append(url)
+            let box = SendableBox(value: completion)
             DispatchQueue.main.async { [stubbedData, stubbedResponse, stubbedError] in
-                completion(stubbedData, stubbedResponse, stubbedError)
+                box.value(stubbedData, stubbedResponse, stubbedError)
             }
         }
     }
@@ -64,9 +73,9 @@ final class BearerTokenAdapterTests: XCTestCase {
             callCount += 1
             receivedTokens.append(token)
             receivedBookIdentifiers.append(book.identifier)
-            let toReturn = stubbedJSON
+            let box = SendableBox(value: (json: stubbedJSON, completion: completion))
             DispatchQueue.main.async {
-                completion(toReturn)
+                box.value.completion(box.value.json)
             }
         }
     }

--- a/PalaceTests/Audiobook/Vendors/LocalFileAdapterTests.swift
+++ b/PalaceTests/Audiobook/Vendors/LocalFileAdapterTests.swift
@@ -90,20 +90,26 @@ final class LocalFileAdapterTests: XCTestCase {
         ) {
             callCount += 1
             receivedURLs.append(fulfillURL)
-            // Box the non-Sendable token so it can cross the @Sendable
-            // dispatch closure. Test double: the box is created and consumed
-            // on the same serial test flow, so unchecked Sendable is safe.
-            let box = TokenBox(stubbedToken)
+            // Box the non-Sendable token AND the non-Sendable completion so
+            // both can cross the @Sendable dispatch closure. Test double: the
+            // box is created and consumed on the same serial test flow, so
+            // unchecked Sendable is safe.
+            let box = TokenBox(token: stubbedToken, completion: completion)
             DispatchQueue.main.async {
-                completion(box.value)
+                box.completion(box.token)
             }
         }
 
-        /// Test-only carrier that lets a non-Sendable bearer token cross a
-        /// `@Sendable` dispatch closure. Confined to the test's serial usage.
+        /// Test-only carrier that lets a non-Sendable bearer token + completion
+        /// cross a `@Sendable` dispatch closure. Confined to the test's serial
+        /// usage.
         private final class TokenBox: @unchecked Sendable {
-            let value: MyBooksSimplifiedBearerToken?
-            init(_ value: MyBooksSimplifiedBearerToken?) { self.value = value }
+            let token: MyBooksSimplifiedBearerToken?
+            let completion: (MyBooksSimplifiedBearerToken?) -> Void
+            init(token: MyBooksSimplifiedBearerToken?, completion: @escaping (MyBooksSimplifiedBearerToken?) -> Void) {
+                self.token = token
+                self.completion = completion
+            }
         }
     }
 

--- a/PalaceTests/Audiobook/Vendors/OpenAccessAdapterTests.swift
+++ b/PalaceTests/Audiobook/Vendors/OpenAccessAdapterTests.swift
@@ -26,6 +26,14 @@ final class OpenAccessAdapterTests: XCTestCase {
         super.tearDown()
     }
 
+    /// Test-only carrier that lets a non-Sendable value (a completion closure
+    /// or a manifest payload) cross a `@Sendable` dispatch closure under
+    /// Swift 6. Each box is created and consumed exactly once on the same
+    /// serial test flow, so unchecked Sendable is safe here.
+    private struct SendableBox<T>: @unchecked Sendable {
+        let value: T
+    }
+
     // MARK: - Stub network
 
     private final class StubNetwork: AudiobookManifestNetworkFetching {
@@ -40,8 +48,9 @@ final class OpenAccessAdapterTests: XCTestCase {
         ) {
             requestedURLs.append(url)
             // Hop off the call stack to mirror real URLSession ordering.
+            let box = SendableBox(value: completion)
             DispatchQueue.main.async { [stubbedData, stubbedResponse, stubbedError] in
-                completion(stubbedData, stubbedResponse, stubbedError)
+                box.value(stubbedData, stubbedResponse, stubbedError)
             }
         }
     }
@@ -228,7 +237,8 @@ final class OpenAccessAdapterTests: XCTestCase {
             callCount += 1
             receivedToken = token
             receivedBook = book
-            DispatchQueue.main.async { [stubbedManifest] in completion(stubbedManifest) }
+            let box = SendableBox(value: (manifest: stubbedManifest, completion: completion))
+            DispatchQueue.main.async { box.value.completion(box.value.manifest) }
         }
     }
 

--- a/PalaceTests/AudiobookPlaybackTests.swift
+++ b/PalaceTests/AudiobookPlaybackTests.swift
@@ -79,7 +79,7 @@ class AudiobookPlaybackTests: XCTestCase {
         super.tearDown()
     }
 
-    func loadTracks(for manifestJSON: ManifestJSON) throws -> Tracks {
+    nonisolated func loadTracks(for manifestJSON: ManifestJSON) throws -> Tracks {
         let manifest = try Manifest.from(jsonFileName: manifestJSON.rawValue, bundle: Bundle(for: type(of: self)))
         return Tracks(manifest: manifest, audiobookID: testID, token: nil)
     }

--- a/PalaceTests/Audiobooks/AudiobookPlaytimesLifecycleTests.swift
+++ b/PalaceTests/Audiobooks/AudiobookPlaytimesLifecycleTests.swift
@@ -94,16 +94,17 @@ final class AudiobookPlaytimesLifecycleTests: XCTestCase {
         )
 
         sut.save(time: entry)
-        awaitCondition { self.sut.store.queue.count == 1 }
+        sut.syncQueue.sync {}   // barrier: `save` is a syncQueue.async(.barrier)
+        XCTAssertEqual(sut.store.queue.count, 1)
 
         sut.syncValues()
-        awaitCondition { self.spyExecutor.calls.count == 1 }
+        sut.syncQueue.sync {}          // barrier: the syncValues block dispatched the POST
+        spyExecutor.drainCompletions() // barrier: the POST completion ran removeSynchronizedEntries
 
         XCTAssertEqual(spyExecutor.calls.count, 1,
                        "Same-library entry must POST exactly once")
         XCTAssertEqual(spyExecutor.calls.first?.url, trackingURLA,
                        "POST must target the entry's tracking URL, not a foreign host")
-        awaitCondition { self.sut.store.queue.isEmpty }
         XCTAssertTrue(sut.store.queue.isEmpty,
                       "Successful sync must clear the queue")
     }
@@ -123,14 +124,15 @@ final class AudiobookPlaytimesLifecycleTests: XCTestCase {
         )
 
         sut.save(time: entry)
-        awaitCondition { self.sut.store.queue.count == 1 }
+        sut.syncQueue.sync {}
+        XCTAssertEqual(sut.store.queue.count, 1)
 
         // Simulate user switching to library B — the production seam writes
         // currentAccountId. The provider closure reads through to the box.
         activeAccountIdBox.value = libraryB
 
         sut.syncValues()
-        drainMainQueue()
+        sut.syncQueue.sync {}   // barrier: the (skip) sync block runs to completion
 
         XCTAssertTrue(spyExecutor.calls.isEmpty,
                       "No POST may fire for a foreign-library entry — that is the Bug B regression")
@@ -156,12 +158,15 @@ final class AudiobookPlaytimesLifecycleTests: XCTestCase {
             duration: 42
         )
         sut.save(time: entryA1)
-        awaitCondition { self.sut.store.queue.count == 1 }
+        sut.syncQueue.sync {}
+        XCTAssertEqual(sut.store.queue.count, 1)
 
         // (b) sync — uploads, queue clears
         sut.syncValues()
-        awaitCondition { self.spyExecutor.calls.count == 1 && self.sut.store.queue.isEmpty }
+        sut.syncQueue.sync {}
+        spyExecutor.drainCompletions()
         XCTAssertEqual(spyExecutor.calls.count, 1, "First sync uploads cleanly")
+        XCTAssertTrue(sut.store.queue.isEmpty, "First sync clears the queue")
 
         // (c) switch to library B (the cross-host scenario the regression
         // describes — A1QA → Icarus)
@@ -178,20 +183,32 @@ final class AudiobookPlaytimesLifecycleTests: XCTestCase {
             duration: 30
         )
         sut.save(time: entryA2)
-        awaitCondition { self.sut.store.queue.count == 1 }
+        sut.syncQueue.sync {}
+        XCTAssertEqual(sut.store.queue.count, 1)
 
         // (e) sync — must NOT POST (foreign library)
         sut.syncValues()
-        drainMainQueue()
+        sut.syncQueue.sync {}
         XCTAssertEqual(spyExecutor.calls.count, 1,
                        "Sync under foreign library must not add a POST")
         XCTAssertEqual(sut.store.queue.count, 1,
                        "Foreign-library entry is retained")
 
-        // (f) switch BACK to library A, sync — the retained entry flushes
+        // (f) switch BACK to library A, sync — the retained entry flushes.
+        // Deterministic barriers instead of a wall-clock poll (the poll timed
+        // out under parallel-clone oversubscription, CI run 29805821296):
+        //   1. `syncQueue.sync {}` — waits for the `syncValues` block (which
+        //      dispatches the POST) to run to completion on the manager's
+        //      serial queue.
+        //   2. `drainCompletions()` — waits for the spy's success completion
+        //      (which calls `removeSynchronizedEntries`) to run on the spy's
+        //      serial completion queue.
+        // After both, the flush is fully observed, no matter how starved the
+        // cooperative/GCD pools are.
         activeAccountIdBox.value = libraryA
         sut.syncValues()
-        awaitCondition { self.spyExecutor.calls.count == 2 && self.sut.store.queue.isEmpty }
+        sut.syncQueue.sync {}
+        spyExecutor.drainCompletions()
 
         XCTAssertEqual(spyExecutor.calls.count, 2,
                        "Switch-back sync must flush the deferred entry — full write → reset → re-enter cycle through the production seam")
@@ -214,7 +231,8 @@ final class AudiobookPlaytimesLifecycleTests: XCTestCase {
             duration: 42
         )
         sut.save(time: entry)
-        awaitCondition { self.sut.store.queue.count == 1 }
+        sut.syncQueue.sync {}
+        XCTAssertEqual(sut.store.queue.count, 1)
 
         activeAccountIdBox.value = libraryB
         NotificationCenter.default.post(name: .TPPCurrentAccountDidChange, object: nil)
@@ -245,7 +263,8 @@ final class AudiobookPlaytimesLifecycleTests: XCTestCase {
             duration: 42
         )
         sut.save(time: entry)
-        awaitCondition { self.sut.store.queue.count == 1 }
+        sut.syncQueue.sync {}
+        XCTAssertEqual(sut.store.queue.count, 1)
 
         activeAccountIdBox.value = libraryB
         sut.syncValues()
@@ -255,7 +274,6 @@ final class AudiobookPlaytimesLifecycleTests: XCTestCase {
         // queue (the flake). Per the `AudiobookDataManager.syncQueue` contract,
         // tests may `syncQueue.sync {}` as a barrier.
         sut.syncQueue.sync {}
-        drainMainQueue()
         // First-pass sync (all cross-account) — must not hang, must not POST.
         XCTAssertTrue(spyExecutor.calls.isEmpty,
                       "All-cross-account sync POSTs nothing")
@@ -267,11 +285,11 @@ final class AudiobookPlaytimesLifecycleTests: XCTestCase {
         // background-task counter or syncQueue.
         activeAccountIdBox.value = libraryA
         sut.syncValues()
-        // Barrier: the sync block runs on `syncQueue` and invokes POST
-        // synchronously (the spy records `calls` at invocation), so draining
-        // the queue makes `calls.count == 1` deterministic instead of polling.
+        // Barriers: the sync block dispatches the POST on `syncQueue`, and the
+        // spy runs its completion on its own serial queue — join both so
+        // `calls.count == 1` is exact, not a starvable poll.
         sut.syncQueue.sync {}
-        awaitCondition { self.spyExecutor.calls.count == 1 }
+        spyExecutor.drainCompletions()
         XCTAssertEqual(spyExecutor.calls.count, 1,
                        "Subsequent same-account sync runs normally — proves prior all-skip path ended cleanly")
     }
@@ -296,11 +314,15 @@ final class AudiobookPlaytimesLifecycleTests: XCTestCase {
             duration: 42
         )
         sut.save(time: entry)
-        awaitCondition { self.sut.store.queue.count == 1 }
+        sut.syncQueue.sync {}
+        XCTAssertEqual(sut.store.queue.count, 1)
 
-        // Start a sync that will dispatch a POST but never complete.
+        // Start a sync that will dispatch a POST but never complete
+        // (autoRespondSuccess == false → the spy records the call but fires no
+        // completion). The syncQueue barrier guarantees the POST was dispatched.
         sut.syncValues()
-        awaitCondition { self.spyExecutor.calls.count == 1 }
+        sut.syncQueue.sync {}
+        XCTAssertEqual(spyExecutor.calls.count, 1)
 
         // Switch account mid-flight.
         activeAccountIdBox.value = libraryB
@@ -317,9 +339,12 @@ final class AudiobookPlaytimesLifecycleTests: XCTestCase {
         spyExecutor.autoRespondSuccess = true
         activeAccountIdBox.value = libraryA
         sut.syncValues()
-        awaitCondition { self.spyExecutor.calls.count == 2 && self.sut.store.queue.isEmpty }
+        sut.syncQueue.sync {}
+        spyExecutor.drainCompletions()
         XCTAssertEqual(spyExecutor.calls.count, 2,
                        "Switch-back sync flushes the still-queued entry once normal responses resume")
+        XCTAssertTrue(sut.store.queue.isEmpty,
+                      "Switch-back sync empties the queue")
     }
 }
 

--- a/PalaceTests/Audiobooks/CrossVendorSmokeTests.swift
+++ b/PalaceTests/Audiobooks/CrossVendorSmokeTests.swift
@@ -62,6 +62,14 @@ import XCTest
 @MainActor
 final class AudiobookCrossVendorSmokeTests: XCTestCase {
 
+    /// Test-only carrier that lets a non-Sendable value (a completion closure
+    /// or a manifest payload) cross a `@Sendable` dispatch closure under
+    /// Swift 6. Each box is created and consumed exactly once on the same
+    /// serial test flow, so unchecked Sendable is safe here.
+    private struct SendableBox<T>: @unchecked Sendable {
+        let value: T
+    }
+
     // MARK: - Shared single-track manifest fixture
 
     /// Readium webpub manifest with exactly one entry in `readingOrder` —
@@ -236,8 +244,9 @@ final class AudiobookCrossVendorSmokeTests: XCTestCase {
             completion: @escaping (Data?, URLResponse?, Error?) -> Void
         ) {
             requestedURLs.append(url)
+            let box = SendableBox(value: completion)
             DispatchQueue.main.async { [stubbedData, stubbedResponse, stubbedError] in
-                completion(stubbedData, stubbedResponse, stubbedError)
+                box.value(stubbedData, stubbedResponse, stubbedError)
             }
         }
     }
@@ -254,9 +263,9 @@ final class AudiobookCrossVendorSmokeTests: XCTestCase {
             completion: @escaping ([String: Any]?) -> Void
         ) {
             callCount += 1
-            let toReturn = stubbedJSON
+            let box = SendableBox(value: (json: stubbedJSON, completion: completion))
             DispatchQueue.main.async {
-                completion(toReturn)
+                box.value.completion(box.value.json)
             }
         }
     }
@@ -322,8 +331,9 @@ final class AudiobookCrossVendorSmokeTests: XCTestCase {
             completion: @escaping (Data?, URLResponse?, Error?) -> Void
         ) {
             requestedURLs.append(url)
+            let box = SendableBox(value: completion)
             DispatchQueue.main.async { [stubbedData, stubbedResponse, stubbedError] in
-                completion(stubbedData, stubbedResponse, stubbedError)
+                box.value(stubbedData, stubbedResponse, stubbedError)
             }
         }
     }
@@ -421,7 +431,8 @@ final class AudiobookCrossVendorSmokeTests: XCTestCase {
             completion: @escaping (MyBooksSimplifiedBearerToken?) -> Void
         ) {
             callCount += 1
-            DispatchQueue.main.async { completion(nil) }
+            let box = SendableBox(value: completion)
+            DispatchQueue.main.async { box.value(nil) }
         }
     }
 

--- a/PalaceTests/Audiobooks/NowPlayingCoordinatorBackgroundTests.swift
+++ b/PalaceTests/Audiobooks/NowPlayingCoordinatorBackgroundTests.swift
@@ -34,22 +34,26 @@ import XCTest
 final class NowPlayingCoordinatorBackgroundTests: XCTestCase {
 
     private var coordinator: NowPlayingCoordinator!
-    private var fakeAppState: UIApplication.State = .active
-    private var fakeNow: Date = Date()
-    private var loggedDryStreamErrors: [(summary: String, metadata: [String: Any])] = []
+    // Swift 6: the coordinator is @MainActor and stores these injected closures,
+    // so a closure capturing `self` (a non-Sendable @MainActor XCTestCase) is
+    // "sent" across a concurrency domain and rejected. Box the mutable test
+    // state in LockIsolated and have the closures capture the boxes, not self.
+    private let fakeAppState = LockIsolated<UIApplication.State>(.active)
+    private let fakeNow = LockIsolated<Date>(Date())
+    private let loggedDryStreamErrors = LockIsolated<[(summary: String, metadata: [String: Any])]>([])
 
     override func setUp() {
         super.setUp()
-        fakeAppState = .active
-        fakeNow = Date()
-        loggedDryStreamErrors = []
+        fakeAppState.value = .active
+        fakeNow.value = Date()
+        loggedDryStreamErrors.value = []
 
         coordinator = NowPlayingCoordinator(
-            applicationStateProvider: { [unowned self] in self.fakeAppState },
-            dryStreamLogger: { [unowned self] summary, metadata in
-                self.loggedDryStreamErrors.append((summary, metadata ?? [:]))
+            applicationStateProvider: { [fakeAppState] in fakeAppState.value },
+            dryStreamLogger: { [loggedDryStreamErrors] summary, metadata in
+                loggedDryStreamErrors.withValue { $0.append((summary, metadata ?? [:])) }
             },
-            now: { [unowned self] in self.fakeNow }
+            now: { [fakeNow] in fakeNow.value }
         )
     }
 
@@ -66,7 +70,7 @@ final class NowPlayingCoordinatorBackgroundTests: XCTestCase {
     /// applyUpdate must therefore go direct in any non-`.active` state.
     func testApplyUpdate_inBackground_bypassesDebounce() {
         // Arrange: background state
-        fakeAppState = .background
+        fakeAppState.value = .background
 
         // Act: two rapid writes within the debounce window (0.3s)
         coordinator.updateNowPlaying(
@@ -97,7 +101,7 @@ final class NowPlayingCoordinatorBackgroundTests: XCTestCase {
     /// we don't spam MPNowPlayingInfoCenter on every chapter-tick / scrub.
     func testApplyUpdate_inForeground_debouncesAsBefore() {
         // Arrange: active state
-        fakeAppState = .active
+        fakeAppState.value = .active
 
         // Act: first write goes through immediately (lastUpdateTime is
         // distantPast). Sleep just long enough that the next write IS
@@ -155,10 +159,10 @@ final class NowPlayingCoordinatorBackgroundTests: XCTestCase {
     /// timer paused, position publisher dry, lock screen frozen).
     func testDryStreamGuard_logsErrorOnForegroundReturn_whenLastUpdateStale() {
         // Arrange: a baseline write while playing.
-        fakeAppState = .background  // background path goes direct, so we
+        fakeAppState.value = .background  // background path goes direct, so we
                                     // know lastUpdateTime advances
         let t0 = Date()
-        fakeNow = t0
+        fakeNow.value = t0
         coordinator.updateNowPlaying(
             title: "Stranded", artist: nil, album: nil,
             elapsed: 10, duration: 600, isPlaying: true, playbackRate: .normalTime
@@ -169,22 +173,22 @@ final class NowPlayingCoordinatorBackgroundTests: XCTestCase {
         // is exact and reproducible (no wall-time jitter).
         coordinator._test_setLastUpdateTime(t0)
         coordinator._test_setLastIsPlaying(true)
-        fakeNow = t0.addingTimeInterval(45)  // 45s elapsed (above threshold)
+        fakeNow.value = t0.addingTimeInterval(45)  // 45s elapsed (above threshold)
 
         // Cross back to foreground; the coordinator checks the guard here.
-        fakeAppState = .active
+        fakeAppState.value = .active
         coordinator.applicationDidBecomeActive()
 
         // Assert: one Crashlytics error logged with the dry-stream summary.
         XCTAssertEqual(
-            loggedDryStreamErrors.count, 1,
+            loggedDryStreamErrors.value.count, 1,
             "Foreground return after a >30s dry stream while isPlaying must log to Crashlytics."
         )
         XCTAssertTrue(
-            loggedDryStreamErrors.first?.summary.contains("dry") == true,
+            loggedDryStreamErrors.value.first?.summary.contains("dry") == true,
             "Logged summary should mention the dry-stream condition."
         )
-        let seconds = loggedDryStreamErrors.first?.metadata["secondsSinceLastUpdate"] as? Double ?? 0
+        let seconds = loggedDryStreamErrors.value.first?.metadata["secondsSinceLastUpdate"] as? Double ?? 0
         XCTAssertEqual(seconds, 45.0, accuracy: 0.001, "Logged metadata should reflect injected clock.")
     }
 
@@ -199,12 +203,12 @@ final class NowPlayingCoordinatorBackgroundTests: XCTestCase {
         )
 
         // Act: foreground return WITHOUT back-dating lastUpdateTime.
-        fakeAppState = .active
+        fakeAppState.value = .active
         coordinator.applicationDidBecomeActive()
 
         // Assert: no log fired.
         XCTAssertEqual(
-            loggedDryStreamErrors.count, 0,
+            loggedDryStreamErrors.value.count, 0,
             "Fresh stream on foreground return must not log — would be Crashlytics noise."
         )
     }
@@ -215,7 +219,7 @@ final class NowPlayingCoordinatorBackgroundTests: XCTestCase {
     /// is exact and reproducible.
     func testDryStreamGuard_doesNotLog_atExactlyThreshold() {
         let t0 = Date()
-        fakeNow = t0
+        fakeNow.value = t0
 
         coordinator.updateNowPlaying(
             title: "Boundary", artist: nil, album: nil,
@@ -227,13 +231,13 @@ final class NowPlayingCoordinatorBackgroundTests: XCTestCase {
         // 30 >= 30 is true → log. So `count == 0` kills the `>=` mutant.
         coordinator._test_setLastUpdateTime(t0)
         coordinator._test_setLastIsPlaying(true)
-        fakeNow = t0.addingTimeInterval(30.0)
+        fakeNow.value = t0.addingTimeInterval(30.0)
 
-        fakeAppState = .active
+        fakeAppState.value = .active
         coordinator.applicationDidBecomeActive()
 
         XCTAssertEqual(
-            loggedDryStreamErrors.count, 0,
+            loggedDryStreamErrors.value.count, 0,
             "At EXACTLY the 30s threshold the guard must NOT fire (`>` not `>=`)."
         )
     }
@@ -249,11 +253,11 @@ final class NowPlayingCoordinatorBackgroundTests: XCTestCase {
         coordinator._test_setLastUpdateTime(Date(timeIntervalSinceNow: -120))
         coordinator._test_setLastIsPlaying(false)
 
-        fakeAppState = .active
+        fakeAppState.value = .active
         coordinator.applicationDidBecomeActive()
 
         XCTAssertEqual(
-            loggedDryStreamErrors.count, 0,
+            loggedDryStreamErrors.value.count, 0,
             "Paused playback has no timer-freshness expectation — must not log."
         )
     }

--- a/PalaceTests/Book/BookRegistryStoreTests.swift
+++ b/PalaceTests/Book/BookRegistryStoreTests.swift
@@ -429,12 +429,17 @@ final class BookRegistryStoreTests: XCTestCase {
         let iterations = 50
         let group = DispatchGroup()
 
+        // Swift 6: capture Sendable locals (the @unchecked Sendable store + a
+        // pre-built [TPPBook]) so the @Sendable global-queue closures don't
+        // capture the non-Sendable @MainActor test `self`.
+        let store = store!
+        let books = (0..<iterations).map { makeBook(identifier: "book-\($0)", title: "Title \($0)") }
+
         // Concurrent writes
         for i in 0..<iterations {
             group.enter()
             DispatchQueue.global().async {
-                let book = self.makeBook(identifier: "book-\(i)", title: "Title \(i)")
-                self.store.addBook(book, state: .downloadNeeded) { _ in
+                store.addBook(books[i], state: .downloadNeeded) { _ in
                     group.leave()
                 }
             }
@@ -444,9 +449,9 @@ final class BookRegistryStoreTests: XCTestCase {
         for i in 0..<iterations {
             group.enter()
             DispatchQueue.global().async {
-                _ = self.store.book(forIdentifier: "book-\(i)")
-                _ = self.store.state(for: "book-\(i)")
-                _ = self.store.allBooks
+                _ = store.book(forIdentifier: "book-\(i)")
+                _ = store.state(for: "book-\(i)")
+                _ = store.allBooks
                 group.leave()
             }
         }

--- a/PalaceTests/Book/BookRegistrySyncTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncTests.swift
@@ -1105,7 +1105,7 @@ private final class StubOPDSFeedFetcher: OPDSFeedFetching, @unchecked Sendable {
     }
 
     func fetchFeed(from url: URL, resetCache: Bool) async throws -> TPPOPDSFeed {
-        lock.lock(); _resetCacheCalls.append(resetCache); lock.unlock()
+        lock.withLock { _resetCacheCalls.append(resetCache) }
         if let stubbedError { throw stubbedError }
         if let stubbedFeed { return stubbedFeed }
         throw NSError(domain: "StubOPDSFeedFetcher", code: -1,

--- a/PalaceTests/Bookmarks/TPPBookmarkDeletionLogTests.swift
+++ b/PalaceTests/Bookmarks/TPPBookmarkDeletionLogTests.swift
@@ -28,7 +28,7 @@ final class TPPBookmarkDeletionLogTests: XCTestCase {
         // backed by a per-test UserDefaults suite (instead of mutating the
         // `.shared` singleton's `.standard` backing store). The injected
         // suite is wiped by `SingletonResetRegistry` when the test finishes.
-        deletionLog = TPPBookmarkDeletionLog(defaults: testUserDefaults())
+        deletionLog = TPPBookmarkDeletionLog(defaults: Self.testUserDefaults())
     }
 
     override func tearDown() {

--- a/PalaceTests/CatalogDomain/CatalogCacheKeyAndIsolationTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogCacheKeyAndIsolationTests.swift
@@ -72,26 +72,26 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
     private static let lastAppLaunchKey = "CatalogRepository.lastAppLaunch"
 
     /// Mutable clock — drives the stale-while-revalidate logic deterministically.
-    private var testNow: Date = Date(timeIntervalSince1970: 1_700_000_000)
+    private let testNow = LockIsolated<Date>(Date(timeIntervalSince1970: 1_700_000_000))
 
     /// Mutable account ID — drives the cache-isolation logic deterministically.
     /// Each test that switches accounts mutates this between calls.
-    private var testAccountID: String? = nil
+    private let testAccountID = LockIsolated<String?>(nil)
 
     override func setUp() {
         super.setUp()
         api = CatalogAPIMock()
-        testAccountID = nil
+        testAccountID.value = nil
         // swarm_cd181acd D-cleanup: per-test isolated UserDefaults suite
         // for the `lastAppLaunchKey` heuristic — no `.standard` writes.
         // The suite is dropped by `SingletonResetRegistry` when the test
         // finishes.
-        defaults = testUserDefaults()
+        defaults = Self.testUserDefaults()
     }
 
     override func tearDown() {
         api = nil
-        testAccountID = nil
+        testAccountID.value = nil
         defaults = nil
         super.tearDown()
     }
@@ -100,14 +100,12 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
 
     private func makeRepository(seedLastLaunchToNow: Bool = true) -> CatalogRepository {
         if seedLastLaunchToNow {
-            defaults.set(testNow, forKey: Self.lastAppLaunchKey)
+            defaults.set(testNow.value, forKey: Self.lastAppLaunchKey)
         }
         return CatalogRepository(
             api: api,
-            accountID: { [weak self] in self?.testAccountID },
-            now: { [weak self] in
-                self?.testNow ?? Date(timeIntervalSince1970: 0)
-            },
+            accountID: { [testAccountID] in testAccountID.value },
+            now: { [testNow] in testNow.value },
             defaults: defaults
         )
     }
@@ -151,7 +149,7 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
         XCTAssertEqual(api.fetchFeedCallCount, 3)
 
         // Move into stale-but-usable window.
-        testNow = testNow.addingTimeInterval(1_800) // 30 minutes
+        testNow.value = testNow.value.addingTimeInterval(1_800) // 30 minutes
         api.stubbedFeeds[urlA] = CatalogAPIMock.makeMockFeed(title: "A-refreshed")
         api.stubbedFeeds[urlB] = CatalogAPIMock.makeMockFeed(title: "B-refreshed")
         api.stubbedFeeds[urlC] = CatalogAPIMock.makeMockFeed(title: "C-refreshed")
@@ -198,7 +196,7 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
         _ = try await sut.loadTopLevelCatalog(at: urlB)
 
         // Make A stale; leave B fresh.
-        testNow = testNow.addingTimeInterval(1_800)
+        testNow.value = testNow.value.addingTimeInterval(1_800)
         api.stubbedFeeds[urlA] = CatalogAPIMock.makeMockFeed(title: "A-new")
         // Trigger A's background refresh.
         _ = try await sut.loadTopLevelCatalog(at: urlA)
@@ -404,7 +402,7 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
         let url = URL(string: "https://example.com/per-library")!
 
         // Library A's response.
-        testAccountID = "library-a-uuid"
+        testAccountID.value = "library-a-uuid"
         api.stubbedFeeds[url] = CatalogAPIMock.makeMockFeed(title: "Library-A-Feed")
         let sut = makeRepository()
         let a = try await sut.loadTopLevelCatalog(at: url)
@@ -412,7 +410,7 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
         XCTAssertEqual(api.fetchFeedCallCount, 1)
 
         // SWITCH LIBRARY: same repository instance, same URL, different account.
-        testAccountID = "library-b-uuid"
+        testAccountID.value = "library-b-uuid"
         api.stubbedFeeds[url] = CatalogAPIMock.makeMockFeed(title: "Library-B-Feed")
         let b = try await sut.loadTopLevelCatalog(at: url)
 
@@ -422,7 +420,7 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
                        "Different account => cache miss => network fetch")
 
         // Switch back to library A — its cache must still be intact.
-        testAccountID = "library-a-uuid"
+        testAccountID.value = "library-a-uuid"
         api.stubbedFeeds[url] = CatalogAPIMock.makeMockFeed(title: "Library-A-Feed-NEW")
         let aAgain = try await sut.loadTopLevelCatalog(at: url)
         XCTAssertEqual(aAgain?.title, "Library-A-Feed",
@@ -439,12 +437,12 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
         let url = URL(string: "https://example.com/shared-path")!
 
         // Cache under both accounts.
-        testAccountID = "lib-A"
+        testAccountID.value = "lib-A"
         api.stubbedFeeds[url] = CatalogAPIMock.makeMockFeed(title: "A")
         let sut = makeRepository()
         _ = try await sut.loadTopLevelCatalog(at: url)
 
-        testAccountID = "lib-B"
+        testAccountID.value = "lib-B"
         api.stubbedFeeds[url] = CatalogAPIMock.makeMockFeed(title: "B")
         _ = try await sut.loadTopLevelCatalog(at: url)
         XCTAssertEqual(api.fetchFeedCallCount, 2)
@@ -457,7 +455,7 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
                      "After invalidate while account=B, B's slot must be empty")
 
         // Switch back to library A — its slot must still be live.
-        testAccountID = "lib-A"
+        testAccountID.value = "lib-A"
         XCTAssertEqual(sut.cachedFeed(for: url)?.title, "A",
                        "Invalidate scoped to B must NOT clear A's slot at the same URL")
     }
@@ -471,7 +469,7 @@ final class CatalogCacheKeyAndIsolationTests: XCTestCase {
     /// underlying auth-layer churn.
     func testCacheKey_SameAccount_RepeatedReads_ShareOneCacheEntry() async throws {
         let url = URL(string: "https://example.com/same-account")!
-        testAccountID = "stable-library-uuid"
+        testAccountID.value = "stable-library-uuid"
         api.stubbedFeeds[url] = CatalogAPIMock.makeMockFeed(title: "Stable")
         let sut = makeRepository()
 

--- a/PalaceTests/CatalogDomain/CatalogRepositoryStaleWhileRevalidateTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogRepositoryStaleWhileRevalidateTests.swift
@@ -40,7 +40,7 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
     /// Mutable test clock. Setting this updates the time returned by the
     /// closure passed to CatalogRepository at construction. Tests advance
     /// this directly rather than sleeping.
-    private var testNow: Date = Date(timeIntervalSince1970: 1_700_000_000)
+    private let testNow = LockIsolated<Date>(Date(timeIntervalSince1970: 1_700_000_000))
 
     /// UserDefaults key the repository uses for its last-launch heuristic.
     /// We clear it in setUp so `needsBackgroundRefresh` starts off `false`
@@ -59,7 +59,7 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
         // `needsBackgroundRefresh = true`). Tests that need
         // `needsBackgroundRefresh = false` seed the key BEFORE
         // constructing the repository via `makeRepository`.
-        defaults = testUserDefaults()
+        defaults = Self.testUserDefaults()
         api = CatalogAPIMock()
     }
 
@@ -81,13 +81,11 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
         // which forces the stale-while-revalidate branch for fresh caches and
         // ruins the fresh-cache assertions below.
         if seedLastLaunchToNow {
-            defaults.set(testNow, forKey: Self.lastAppLaunchKey)
+            defaults.set(testNow.value, forKey: Self.lastAppLaunchKey)
         }
         return CatalogRepository(
             api: api,
-            now: { [weak self] in
-                self?.testNow ?? Date(timeIntervalSince1970: 0)
-            },
+            now: { [testNow] in testNow.value },
             defaults: defaults
         )
     }
@@ -121,7 +119,7 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
 
         _ = try await sut.loadTopLevelCatalog(at: testURL)
         // Advance well inside the fresh window — 5 minutes in (300s < 600s).
-        testNow = testNow.addingTimeInterval(300)
+        testNow.value = testNow.value.addingTimeInterval(300)
         // Swap the stub: if the cache hit is broken the second call will return "Other".
         api.stubbedFeeds[testURL] = CatalogAPIMock.makeMockFeed(title: "Other")
         let second = try await sut.loadTopLevelCatalog(at: testURL)
@@ -138,7 +136,7 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
 
         _ = try await sut.loadTopLevelCatalog(at: testURL)
         // Exactly 600s later: code uses `> 600`, so 600 is NOT expired.
-        testNow = testNow.addingTimeInterval(600)
+        testNow.value = testNow.value.addingTimeInterval(600)
         api.stubbedFeeds[testURL] = CatalogAPIMock.makeMockFeed(title: "OverwrittenButShouldNotShow")
         let second = try await sut.loadTopLevelCatalog(at: testURL)
 
@@ -160,7 +158,7 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
         XCTAssertEqual(api.fetchFeedCallCount, 1)
 
         // 601s later → just past the fresh boundary, well inside stale-but-usable.
-        testNow = testNow.addingTimeInterval(601)
+        testNow.value = testNow.value.addingTimeInterval(601)
         api.stubbedFeeds[testURL] = CatalogAPIMock.makeMockFeed(title: "Refreshed")
         let second = try await sut.loadTopLevelCatalog(at: testURL)
 
@@ -179,7 +177,7 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
         // Subsequent read inside fresh window of the refreshed cache returns new title.
         // Cache was rewritten at testNow (601s post-original), so 5 minutes later
         // the new entry is fresh.
-        testNow = testNow.addingTimeInterval(300)
+        testNow.value = testNow.value.addingTimeInterval(300)
         let third = try await sut.loadTopLevelCatalog(at: testURL)
         XCTAssertEqual(third?.title, "Refreshed",
                        "Background refresh must replace the cache with network result")
@@ -195,7 +193,7 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
         _ = try await sut.loadTopLevelCatalog(at: testURL)
 
         // Exactly 86400s (24h) later — `isStaleButUsable` uses `<= 86400`.
-        testNow = testNow.addingTimeInterval(86400)
+        testNow.value = testNow.value.addingTimeInterval(86400)
         api.stubbedFeeds[testURL] = CatalogAPIMock.makeMockFeed(title: "WouldBeNetwork")
         let result = try await sut.loadTopLevelCatalog(at: testURL)
 
@@ -223,7 +221,7 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
         XCTAssertEqual(api.fetchFeedCallCount, 1)
 
         // 86401s later — one second past 24h → isTooOld returns true.
-        testNow = testNow.addingTimeInterval(86401)
+        testNow.value = testNow.value.addingTimeInterval(86401)
         api.stubbedFeeds[testURL] = CatalogAPIMock.makeMockFeed(title: "FromNetwork")
         let result = try await sut.loadTopLevelCatalog(at: testURL)
 
@@ -249,7 +247,7 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
 
         // Age past 24h so the next call attempts a network fetch (not stale-but-usable
         // which would skip the failing fetch).
-        testNow = testNow.addingTimeInterval(90_000)
+        testNow.value = testNow.value.addingTimeInterval(90_000)
         // Network errors out — must fall back to the cached entry.
         api.fetchFeedError = NSError(domain: "Test", code: -1, userInfo: nil)
 
@@ -287,12 +285,12 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
         _ = try await sut.loadTopLevelCatalog(at: testURL)
 
         // At exactly 24h, isTooOld is false (uses `> 86400`).
-        testNow = testNow.addingTimeInterval(86400)
+        testNow.value = testNow.value.addingTimeInterval(86400)
         XCTAssertEqual(sut.cachedFeed(for: testURL)?.title, "WithinBoundary",
                        "At 86400s-old cache must still be returned by cachedFeed")
 
         // 1 second over → too old → nil.
-        testNow = testNow.addingTimeInterval(1)
+        testNow.value = testNow.value.addingTimeInterval(1)
         XCTAssertNil(sut.cachedFeed(for: testURL),
                      "At 86401s-old cache must be treated as too old and nil-returned")
     }
@@ -377,9 +375,12 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
         XCTAssertEqual(api.fetchFeedCallCount, 1)
 
         // Move into stale-but-usable window.
-        testNow = testNow.addingTimeInterval(1800) // 30 minutes
+        testNow.value = testNow.value.addingTimeInterval(1800) // 30 minutes
         api.stubbedFeeds[testURL] = CatalogAPIMock.makeMockFeed(title: "Refreshed-concurrent")
 
+        // Sendable local so the async-let children capture it instead of reading
+        // @MainActor `self.testURL` (which would send self). `sut` is already local.
+        let testURL = testURL
         async let a = sut.loadTopLevelCatalog(at: testURL)
         async let b = sut.loadTopLevelCatalog(at: testURL)
         let (resultA, resultB) = try await (a, b)

--- a/PalaceTests/CatalogDomain/CatalogRepositoryStaleWhileRevalidateTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogRepositoryStaleWhileRevalidateTests.swift
@@ -90,24 +90,11 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
         )
     }
 
-    /// Poll an async predicate until it holds or the timeout elapses. Used
-    /// to await the completion of `Task.detached` background refreshes
-    /// without sleeping for a flat duration. NOT used to age out cache —
-    /// the clock seam handles that.
-    private func awaitCondition(
-        timeout: TimeInterval = 2.0,
-        pollInterval: TimeInterval = 0.01,
-        _ predicate: () async -> Bool,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if await predicate() { return }
-            try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
-        }
-        XCTFail("Condition not satisfied within \(timeout)s", file: file, line: line)
-    }
+    // NOTE: the former private `awaitCondition` poll helper was removed — every
+    // background-refresh wait now joins the repository's refresh Task directly
+    // via `_awaitBackgroundRefreshForTesting()`, which is deterministic under
+    // pool oversubscription (a fixed-deadline poll of a `.utility` detached
+    // task's side effect was the parallel-clone flake, CI run 29805821296).
 
     // MARK: - Fresh cache window (< 10 min)
 
@@ -167,11 +154,14 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
                        "Stale-but-usable must return cached value immediately")
 
         // And a background refresh must fire AND complete the cache write.
-        // Poll the cache directly (not call count): the network bumps the
-        // count slightly before the cache write lands.
-        await awaitCondition {
-            sut.cachedFeed(for: self.testURL)?.title == "Refreshed"
-        }
+        // Join the actual refresh Task deterministically (not a wall-clock
+        // poll): the refresh is a `.utility` detached Task, so polling
+        // `cachedFeed(...)` for the write is starvable under parallel-clone
+        // pool oversubscription (CI run 29805821296). Awaiting the handle
+        // blocks exactly until the write lands, independent of pool load.
+        await sut._awaitBackgroundRefreshForTesting()
+        XCTAssertEqual(sut.cachedFeed(for: self.testURL)?.title, "Refreshed",
+                       "Background refresh must complete the cache write")
         XCTAssertEqual(api.fetchFeedCallCount, 2, "Stale-but-usable must trigger ONE background refresh")
 
         // Subsequent read inside fresh window of the refreshed cache returns new title.
@@ -201,10 +191,11 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
                        "At exactly 24h, cache is still stale-but-usable (returns immediately)")
 
         // Background refresh still fires from the stale-but-usable branch.
-        // Poll the cache for the refreshed title (more reliable than call count).
-        await awaitCondition {
-            sut.cachedFeed(for: self.testURL)?.title == "WouldBeNetwork"
-        }
+        // Join the refresh Task deterministically (see the sibling test for
+        // why the old `cachedFeed` poll was parallel-clone-flaky).
+        await sut._awaitBackgroundRefreshForTesting()
+        XCTAssertEqual(sut.cachedFeed(for: self.testURL)?.title, "WouldBeNetwork",
+                       "24h-boundary stale read must still complete its background refresh")
     }
 
     // MARK: - Too-old / expired-beyond-24h
@@ -390,23 +381,22 @@ final class CatalogRepositoryStaleWhileRevalidateTests: XCTestCase {
         XCTAssertEqual(resultB?.title, "Original-concurrent",
                        "Concurrent stale read B must return cached value")
 
-        // First await the network signal (deterministic on the mock side):
-        // both detached refreshes hit fetchFeed → callCount goes 1 → 2 or 3.
-        // This decouples the "did the refresh fire" assertion (load-bearing
-        // for the mutation kill) from the cache-write timing.
-        await awaitCondition(timeout: 5.0) {
-            self.api.fetchFeedCallCount >= 2
-        }
+        // Join the background refresh deterministically. Both stale reads
+        // scheduled a `.utility` detached refresh SYNCHRONOUSLY before
+        // returning; the repository retains the last-scheduled one. Awaiting
+        // it blocks until that refresh's cache write lands — regardless of how
+        // starved the cooperative pool is under parallel-clone oversubscription
+        // (the old two-poll approach timed out at :401/:408 exactly there in CI
+        // run 29805821296). Both refreshes fetch + write the same
+        // "Refreshed-concurrent" feed, so the last one landing proves the
+        // contract.
+        await sut._awaitBackgroundRefreshForTesting()
 
-        // Then wait for the cache write to land. The happy path completes in
-        // <0.3s; 5s is plenty of head-room and still fails loudly if the
-        // refresh is broken instead of hanging the suite.
-        await awaitCondition(timeout: 5.0) {
-            sut.cachedFeed(for: self.testURL)?.title == "Refreshed-concurrent"
-        }
+        // The refresh fired (mutation kill: a no-op'd background branch never
+        // bumps the count past 1). Deterministic now that the Task has joined.
+        XCTAssertGreaterThanOrEqual(api.fetchFeedCallCount, 2,
+                                    "Both concurrent stale reads must trigger a background refresh")
 
-        // Assertion is implicit in awaitCondition (it XCTFails on timeout),
-        // but make the success criterion explicit for readability.
         XCTAssertEqual(sut.cachedFeed(for: testURL)?.title, "Refreshed-concurrent",
                        "Background refresh must replace the cache with the new feed")
     }

--- a/PalaceTests/CatalogDomain/CatalogRepositoryTests.swift
+++ b/PalaceTests/CatalogDomain/CatalogRepositoryTests.swift
@@ -448,6 +448,8 @@ final class CatalogAPIDedupeTests: XCTestCase {
     }
 
     func testFetchFeed_ConcurrentCallersForSameURL_ShareOneNetworkRequest() async throws {
+        let api = api!  // Sendable local so the async-let children don't send @MainActor self
+        let feedURL = feedURL  // Sendable local: async-let children must not read self.feedURL
         async let a = api.fetchFeed(at: feedURL)
         async let b = api.fetchFeed(at: feedURL)
         async let c = api.fetchFeed(at: feedURL)
@@ -463,6 +465,9 @@ final class CatalogAPIDedupeTests: XCTestCase {
     }
 
     func testFetchFeed_ConcurrentCallersForDifferentURLs_DoNotDedupe() async throws {
+        let api = api!  // Sendable local so the async-let children don't send @MainActor self
+        let feedURL = feedURL   // Sendable locals: async-let children must not read self.*
+        let otherURL = otherURL
         async let a = api.fetchFeed(at: feedURL)
         async let b = api.fetchFeed(at: otherURL)
 

--- a/PalaceTests/CatalogUI/CatalogViewModelTests.swift
+++ b/PalaceTests/CatalogUI/CatalogViewModelTests.swift
@@ -547,9 +547,29 @@ final class CatalogFilterTests: XCTestCase {
 
 @MainActor
 final class CatalogLaneModelTests: XCTestCase {
-    func testHasUniqueId() {
+    // `CatalogLaneModel.id` is content-derived (`title|moreURL`) by design — the
+    // fix that stopped every re-map minting a fresh `UUID()` and tearing down the
+    // whole feed in `ForEach`. So identity is STABLE across re-maps of the same
+    // lane, and DISTINCT when the title or moreURL differs.
+    func testId_isStableAcrossReMapsOfSameLane() {
         let l1 = CatalogLaneModel(title: "L", books: [], moreURL: nil)
         let l2 = CatalogLaneModel(title: "L", books: [], moreURL: nil)
-        XCTAssertNotEqual(l1.id, l2.id)
+        XCTAssertEqual(l1.id, l2.id,
+                       "Same title+moreURL must yield the same id so ForEach diffs in place")
+    }
+
+    func testId_differsWhenTitleDiffers() {
+        let a = CatalogLaneModel(title: "Fiction", books: [], moreURL: nil)
+        let b = CatalogLaneModel(title: "Non-Fiction", books: [], moreURL: nil)
+        XCTAssertNotEqual(a.id, b.id)
+    }
+
+    func testId_differsWhenMoreURLDiffers() {
+        let url1 = URL(string: "https://example.com/a")
+        let url2 = URL(string: "https://example.com/b")
+        let a = CatalogLaneModel(title: "L", books: [], moreURL: url1)
+        let b = CatalogLaneModel(title: "L", books: [], moreURL: url2)
+        XCTAssertNotEqual(a.id, b.id,
+                          "Same title but different group href must be distinct lanes")
     }
 }

--- a/PalaceTests/CatalogUI/CatalogViewModelTests.swift
+++ b/PalaceTests/CatalogUI/CatalogViewModelTests.swift
@@ -181,7 +181,7 @@ final class CatalogViewModelStateMachineTests: PalaceTestCase {
             repository: mockRepository,
             topLevelURLProvider: { [testURL] in testURL },
             bookRegistry: bookRegistry,
-            imageCache: ImageCache.shared,
+            imageCache: MockImageCache(),
             reachability: reachability
         )
     }
@@ -197,7 +197,7 @@ final class CatalogViewModelStateMachineTests: PalaceTestCase {
             repository: mockRepository,
             topLevelURLProvider: { nil },
             bookRegistry: bookRegistry,
-            imageCache: ImageCache.shared
+            imageCache: MockImageCache()
         )
         await vm.load()
         XCTAssertEqual(mockRepository.loadTopLevelCatalogCallCount, 0)
@@ -445,7 +445,7 @@ final class CatalogViewModelStateMachineTests: PalaceTestCase {
             repository: mockRepository,
             topLevelURLProvider: { currentURL },
             bookRegistry: bookRegistry,
-            imageCache: ImageCache.shared,
+            imageCache: MockImageCache(),
             reachability: MockReachability(initiallyConnected: true)
         )
 

--- a/PalaceTests/CatalogUI/SideloadedLaneTests.swift
+++ b/PalaceTests/CatalogUI/SideloadedLaneTests.swift
@@ -185,7 +185,7 @@ final class SideloadedLaneViewModelTests: XCTestCase {
       repository: repository,
       topLevelURLProvider: { [feedURL] in feedURL },
       bookRegistry: TPPBookRegistryMock(),
-      imageCache: ImageCache.shared,
+      imageCache: MockImageCache(),
       sideloadedLaneBooksProvider: provider,
       reachability: MockReachability(initiallyConnected: connected)
     )

--- a/PalaceTests/Concurrency/MainActorHelpersTests.swift
+++ b/PalaceTests/Concurrency/MainActorHelpersTests.swift
@@ -226,7 +226,7 @@ final class MainActorHelpersTests: XCTestCase {
 
     func testBarrierExecutor_Modify_TransformsValue() async {
         let barrier = BarrierExecutor(initialValue: [1, 2, 3])
-        await barrier.modify { $0.append(4) }
+        await barrier.modify { @Sendable in $0.append(4) }
         let value = await barrier.read()
         XCTAssertEqual(value, [1, 2, 3, 4])
     }
@@ -234,7 +234,7 @@ final class MainActorHelpersTests: XCTestCase {
     // MARK: - withAsyncCallback Tests
 
     func testWithAsyncCallback_ConvertsCallbackToAsync() async {
-        let result = await withAsyncCallback { (completion: @escaping (String) -> Void) in
+        let result = await withAsyncCallback { @Sendable (completion: @escaping (String) -> Void) in
             DispatchQueue.global().async {
                 completion("done")
             }
@@ -245,7 +245,7 @@ final class MainActorHelpersTests: XCTestCase {
     // MARK: - withAsyncThrowingCallback Tests
 
     func testWithAsyncThrowingCallback_Success_ReturnsValue() async throws {
-        let result = try await withAsyncThrowingCallback { (completion: @escaping (Result<Int, Error>) -> Void) in
+        let result = try await withAsyncThrowingCallback { @Sendable (completion: @escaping (Result<Int, Error>) -> Void) in
             completion(.success(42))
         }
         XCTAssertEqual(result, 42)
@@ -255,7 +255,7 @@ final class MainActorHelpersTests: XCTestCase {
         struct TestError: Error {}
 
         do {
-            _ = try await withAsyncThrowingCallback { (completion: @escaping (Result<Int, Error>) -> Void) in
+            _ = try await withAsyncThrowingCallback { @Sendable (completion: @escaping (Result<Int, Error>) -> Void) in
                 completion(.failure(TestError()))
             }
             XCTFail("Should have thrown")

--- a/PalaceTests/Concurrency/TPPMainThreadCheckerTests.swift
+++ b/PalaceTests/Concurrency/TPPMainThreadCheckerTests.swift
@@ -15,12 +15,14 @@ final class TPPMainThreadCheckerTests: XCTestCase {
 
     func testSync_FromMainThread_ExecutesSynchronously() {
         // We're on the main thread in test context
-        var executed = false
+        // Swift 6: TPPMainThreadRun.sync takes a @Sendable closure, so a captured
+        // `var` can't be mutated inside it — box it.
+        let executed = LockIsolated<Bool>(false)
         TPPMainThreadRun.sync {
             XCTAssertTrue(Thread.isMainThread)
-            executed = true
+            executed.value = true
         }
-        XCTAssertTrue(executed, "Block should execute synchronously on main thread")
+        XCTAssertTrue(executed.value, "Block should execute synchronously on main thread")
     }
 
     func testSync_FromBackgroundThread_DispatchesToMainThread() {
@@ -40,11 +42,11 @@ final class TPPMainThreadCheckerTests: XCTestCase {
     // MARK: - asyncIfNeeded Tests
 
     func testAsyncIfNeeded_FromMainThread_ExecutesSynchronously() {
-        var executed = false
+        let executed = LockIsolated<Bool>(false)
         TPPMainThreadRun.asyncIfNeeded {
-            executed = true
+            executed.value = true
         }
-        XCTAssertTrue(executed, "On main thread, asyncIfNeeded should execute immediately")
+        XCTAssertTrue(executed.value, "On main thread, asyncIfNeeded should execute immediately")
     }
 
     func testAsyncIfNeeded_FromBackgroundThread_DispatchesAsyncToMain() {

--- a/PalaceTests/Contract/BorrowOperationContractTests.swift
+++ b/PalaceTests/Contract/BorrowOperationContractTests.swift
@@ -103,14 +103,14 @@ final class BorrowOperationContractTests: XCTestCase {
                 case .failure(let error): throw error
                 }
             },
-            presentBorrowErrorAlert: { [unowned self] title, _, _, _, book, retryAction in
-                self.log.record("presentBorrowErrorAlert",
-                                args: ["title": title,
-                                       "bookId": book.identifier,
-                                       "hasRetryAction": "\(retryAction != nil)"])
+            presentBorrowErrorAlert: { title, _, _, _, book, retryAction in
+                callLog.record("presentBorrowErrorAlert",
+                               args: ["title": title,
+                                      "bookId": book.identifier,
+                                      "hasRetryAction": "\(retryAction != nil)"])
             },
-            presentSignInModal: { [unowned self] _ in
-                self.log.record("presentSignInModal", args: [:])
+            presentSignInModal: { _ in
+                callLog.record("presentSignInModal", args: [:])
             },
             attemptOIDCReauth: {
                 callLog.record("attemptOIDCReauth", args: [:])
@@ -306,8 +306,15 @@ final class BorrowOperationContractTests: XCTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) async {
-        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [log] in
-            log?.snapshot().contains(where: { $0.method == method }) ?? false
+        // Swift 6: `awaitConditionAsync`'s predicate is a non-Sendable
+        // `() -> Bool` sent to a nonisolated async helper, so it must not
+        // capture `self` (a non-Sendable XCTestCase). Hoist the Sendable
+        // `CallLog` (@unchecked Sendable) and the method name to locals so
+        // the predicate captures only Sendable values — mirrors the local-
+        // hoist pattern used in setUp for the async closure seams.
+        let capturedLog = log
+        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [capturedLog, method] in
+            capturedLog?.snapshot().contains(where: { $0.method == method }) ?? false
         }
     }
 
@@ -397,12 +404,16 @@ private final class SpyBorrowDelegate: BorrowOperationDelegate {
     }
 
     nonisolated func startBorrow(for book: TPPBook, attemptDownload: Bool, borrowCompletion: (() -> Void)?) {
+        // Capture Sendable snapshots BEFORE the @MainActor Task hop so the
+        // task closure never captures the non-Sendable `borrowCompletion`
+        // (`(() -> Void)?`) or the non-Sendable `TPPBook`.
         let id = book.identifier
+        let hasCompletion = borrowCompletion != nil
         Task { @MainActor [log] in
             log.record("startBorrow",
                        args: ["bookId": id,
                               "attemptDownload": "\(attemptDownload)",
-                              "hasCompletion": "\(borrowCompletion != nil)"])
+                              "hasCompletion": "\(hasCompletion)"])
         }
     }
 }

--- a/PalaceTests/Contract/ContractSnapshot.swift
+++ b/PalaceTests/Contract/ContractSnapshot.swift
@@ -71,7 +71,13 @@ public enum ContractSnapshot {
         _ log: CallLog,
         named name: String,
         record: Bool = false,
-        file: StaticString = #file,
+        // `#filePath`, NOT `#file`: this value is resolved as a filesystem path
+        // below (to locate the sibling `__Snapshots__` dir). Under Swift 6's
+        // default-on ConciseMagicFile, `#file` yields a concise "Module/Base.swift"
+        // that resolves against CWD — on CI that becomes the read-only filesystem
+        // root (`/PalaceTests/__Snapshots__/…`), which is exactly the "volume is
+        // read only" failure. `#filePath` always yields the true absolute path.
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let testFileURL = URL(fileURLWithPath: "\(file)")

--- a/PalaceTests/Contract/DownloadStartCoordinatorContractTests.swift
+++ b/PalaceTests/Contract/DownloadStartCoordinatorContractTests.swift
@@ -173,8 +173,14 @@ final class DownloadStartCoordinatorContractTests: XCTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) async {
-        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [log] in
-            log?.snapshot().contains(where: { $0.method == method }) ?? false
+        // Swift 6: `awaitConditionAsync`'s predicate is a non-Sendable
+        // `() -> Bool` sent to a nonisolated async helper, so it must not
+        // capture `self` (a non-Sendable XCTestCase). Hoist the Sendable
+        // `CallLog` (@unchecked Sendable) and the method name to locals so
+        // the predicate captures only Sendable values.
+        let capturedLog = log
+        await awaitConditionAsync(timeout: timeout, file: file, line: line) { [capturedLog, method] in
+            capturedLog?.snapshot().contains(where: { $0.method == method }) ?? false
         }
     }
 
@@ -224,7 +230,7 @@ final class DownloadStartCoordinatorContractTests: XCTestCase {
 
 // MARK: - Spies
 
-private final class SpyDownloadStartDelegate: DownloadStartCoordinatorDelegate {
+private final class SpyDownloadStartDelegate: DownloadStartCoordinatorDelegate, @unchecked Sendable {
     enum BorrowResult {
         case success(TPPBook)
         case failure(Error)
@@ -233,9 +239,20 @@ private final class SpyDownloadStartDelegate: DownloadStartCoordinatorDelegate {
     let log: CallLog
     /// Default to a failure that will be observable; tests assign before
     /// invoking startBorrow.
-    var borrowAsyncResult: BorrowResult = .failure(
-        NSError(domain: "default", code: -1, userInfo: nil)
+    ///
+    /// Swift 6: `borrowAsync` is a `nonisolated async` protocol requirement,
+    /// so it cannot capture `self` (a non-Sendable spy) to read this value —
+    /// the previous `await MainActor.run { self.borrowAsyncResult }` hop sent
+    /// `self`. Back the storage with `LockIsolated` (@unchecked Sendable, lock-
+    /// guarded) so the value is read directly, thread-safely, with no self-
+    /// capturing actor hop. The `var` shim keeps test call sites unchanged.
+    private let _borrowAsyncResult = LockIsolated<BorrowResult>(
+        .failure(NSError(domain: "default", code: -1, userInfo: nil))
     )
+    var borrowAsyncResult: BorrowResult {
+        get { _borrowAsyncResult.value }
+        set { _borrowAsyncResult.value = newValue }
+    }
 
     init(log: CallLog) {
         self.log = log
@@ -246,10 +263,9 @@ private final class SpyDownloadStartDelegate: DownloadStartCoordinatorDelegate {
         let bookId = book.identifier
         let attemptDownloadStr = "\(attemptDownload)"
         let log = self.log
-        // Pull the configured result on the MainActor (where the test
-        // assigns to it). Since the test class is @MainActor, we use a
-        // MainActor.run hop.
-        let result: BorrowResult = await MainActor.run { self.borrowAsyncResult }
+        // Read the configured result through the lock-guarded box — no
+        // self-capturing MainActor hop (see `_borrowAsyncResult` note).
+        let result: BorrowResult = _borrowAsyncResult.value
         log.record("delegate.borrowAsync",
                    args: ["bookId": bookId,
                           "attemptDownload": attemptDownloadStr])

--- a/PalaceTests/Contract/Reader2BookmarkContractTests.swift
+++ b/PalaceTests/Contract/Reader2BookmarkContractTests.swift
@@ -151,8 +151,8 @@ final class Reader2BookmarkContractTests: XCTestCase {
     private var innerRegistry: TPPBookRegistryMock!
     private var registry: RecordingBookmarkRegistry!
     private var accountProvider: NilCurrentAccountProvider!
-    private var book: TPPBook!
-    private var publication: Publication!
+    nonisolated(unsafe) private var book: TPPBook!
+    nonisolated(unsafe) private var publication: Publication!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -346,7 +346,10 @@ final class Reader2BookmarkContractTests: XCTestCase {
 
     // MARK: - Fixture helpers
 
-    private func makeBook() -> TPPBook {
+    // `nonisolated` (mirrors `makePublication` below): `setUpWithError` is a
+    // nonisolated XCTestCase override, so calling an @MainActor (class-default)
+    // factory from it sends `self` to the main actor — Swift 6 "sending 'self'".
+    private nonisolated func makeBook() -> TPPBook {
         let url = URL(string: "https://test.example.com/book")!
         let acq = TPPOPDSAcquisition(
             relation: .generic,
@@ -384,7 +387,12 @@ final class Reader2BookmarkContractTests: XCTestCase {
         )
     }
 
-    private func makePublication() -> Publication {
+    // `nonisolated`: builds a non-Sendable Readium `Publication` from no
+    // instance state. Left `@MainActor` (class default), calling it from
+    // `setUpWithError` and returning the non-Sendable result across the
+    // actor boundary trips Swift 6 "sending 'self'" / non-Sendable-result.
+    // Same fix EPUBPositionTests.makeTestPublication uses.
+    private nonisolated func makePublication() -> Publication {
         let metadata = Metadata(title: "Test", languages: ["en"])
         let readingOrder = [
             Link(href: "/chapter1.xhtml", mediaType: .xhtml),

--- a/PalaceTests/Contract/Reader2PositionAdapterContractTests.swift
+++ b/PalaceTests/Contract/Reader2PositionAdapterContractTests.swift
@@ -203,7 +203,7 @@ final class Reader2PositionAdapterContractTests: XCTestCase {
     /// local-first invariant — without it, a crash mid-flight loses the
     /// reader's position.
     func test_epubPoster_storeReadPosition_serializesLocator_callsWriterSave() async throws {
-        let publication = makePublication()
+        let publication = Self.makePublication()
         let poster = TPPLastReadPositionPoster(
             book: book,
             publication: publication,
@@ -271,7 +271,7 @@ final class Reader2PositionAdapterContractTests: XCTestCase {
     /// would allow same-device snapshots to slip through and present an
     /// alert — the snapshot grows a follow-up step.
     func test_epubSynchronizer_sync_sameDevice_returnsNil() async throws {
-        let publication = makePublication()
+        let publication = Self.makePublication()
 
         // Pre-seed a local location. This is pre-state; we use the INNER
         // registry so the setLocation isn't captured as a snapshot entry.
@@ -301,8 +301,11 @@ final class Reader2PositionAdapterContractTests: XCTestCase {
         )
 
         log.record("synchronizer.sync.begin", args: ["drmDeviceID": "device-SAME"])
+        // `sync(for:)` takes a `sending Publication`; the stored `self.publication`
+        // is retained by the test, so it can't be sent. A fresh nonisolated fixture
+        // is a disconnected region (identical manifest → identical convertToLocator).
         await synchronizer.sync(
-            for: publication,
+            for: Self.makePublication(),
             book: book,
             drmDeviceID: "device-SAME"
         )
@@ -353,7 +356,11 @@ final class Reader2PositionAdapterContractTests: XCTestCase {
 
     // MARK: - Fixture helpers
 
-    private func makeBook() -> TPPBook {
+    // `nonisolated`: pure fixture factory reading only the immutable
+    // `bookIdentifier` (`let`). Left `@MainActor` (class default), the
+    // non-Sendable `TPPBook` result crosses the actor boundary back into
+    // `setUpWithError` and trips Swift 6 "sending 'self'".
+    private nonisolated func makeBook() -> TPPBook {
         let url = URL(string: "https://test.example.com/book")!
         let acq = TPPOPDSAcquisition(
             relation: .generic,
@@ -391,7 +398,14 @@ final class Reader2PositionAdapterContractTests: XCTestCase {
         )
     }
 
-    private func makePublication() -> Publication {
+    // `nonisolated`: builds a non-Sendable Readium `Publication` from no
+    // instance state, so its result is a *disconnected* region value. As a
+    // `@MainActor` factory (class default) the result is pinned to the
+    // MainActor region, and passing it into the nonisolated-async
+    // `synchronizer.sync(for:...)` sends it across the actor boundary
+    // (Swift 6 "sending 'publication'"). Disconnecting it here matches the
+    // passing `ReaderServiceSyncTests` pattern (locally-built publication).
+    private nonisolated static func makePublication() -> Publication {
         let metadata = Metadata(title: "Test", languages: ["en"])
         let readingOrder = [
             Link(href: "/chapter1.xhtml", mediaType: .xhtml),

--- a/PalaceTests/Contract/Reader2PositionResumeContractTests.swift
+++ b/PalaceTests/Contract/Reader2PositionResumeContractTests.swift
@@ -237,7 +237,7 @@ final class Reader2PositionResumeContractTests: XCTestCase {
     /// position-saves before the totalProgression branch could
     /// accept them — readers would lose their last page mid-session.
     func test_positionSave_writesRegistryThenSyncQueue() async throws {
-        let publication = makePublication()
+        let publication = Self.makePublication()
         let poster = TPPLastReadPositionPoster(
             book: book,
             publication: publication,
@@ -283,7 +283,7 @@ final class Reader2PositionResumeContractTests: XCTestCase {
     /// would either fire `registry.setLocation(nil)` or hit the alert
     /// path with garbage. Either drift fires.
     func test_readerResume_loadsRegistryThenSynchronizer() async throws {
-        let publication = makePublication()
+        let publication = Self.makePublication()
 
         // No remote position on the server.
         writer.loadResult = nil
@@ -295,7 +295,9 @@ final class Reader2PositionResumeContractTests: XCTestCase {
 
         log.record("resumeNoRemote.begin", args: ["bookID": bookIdentifier])
         await synchronizer.sync(
-            for: publication,
+            // fresh disconnected fixture: `sync(for:)` wants a `sending Publication`
+            // and the stored `self.publication` is retained (identical manifest).
+            for: Self.makePublication(),
             book: book,
             drmDeviceID: "device-resume-A"
         )
@@ -334,7 +336,7 @@ final class Reader2PositionResumeContractTests: XCTestCase {
     /// scenario worth pinning separately — flagged for a follow-up changeset
     /// rather than retrofitted here.
     func test_readerResume_synchronizerSamePayload_noopShortCircuits() async throws {
-        let publication = makePublication()
+        let publication = Self.makePublication()
 
         // The exact payload string that the synchronizer will compare
         // against the local registry's `locationString`. Keep this
@@ -382,7 +384,9 @@ final class Reader2PositionResumeContractTests: XCTestCase {
             ]
         )
         await synchronizer.sync(
-            for: publication,
+            // fresh disconnected fixture: `sync(for:)` wants a `sending Publication`
+            // and the stored `self.publication` is retained (identical manifest).
+            for: Self.makePublication(),
             book: book,
             drmDeviceID: "device-resume-A"
         )
@@ -399,7 +403,11 @@ final class Reader2PositionResumeContractTests: XCTestCase {
 
     // MARK: - Fixture helpers
 
-    private func makeBook() -> TPPBook {
+    // `nonisolated`: pure fixture factory reading only the immutable
+    // `bookIdentifier` (`let`). Left `@MainActor` (class default), the
+    // non-Sendable `TPPBook` result crosses the actor boundary back into
+    // `setUpWithError` and trips Swift 6 "sending 'self'".
+    private nonisolated func makeBook() -> TPPBook {
         let url = URL(string: "https://test.example.com/book")!
         let acq = TPPOPDSAcquisition(
             relation: .generic,
@@ -437,7 +445,14 @@ final class Reader2PositionResumeContractTests: XCTestCase {
         )
     }
 
-    private func makePublication() -> Publication {
+    // `nonisolated`: builds a non-Sendable Readium `Publication` from no
+    // instance state, so its result is a *disconnected* region value. As a
+    // `@MainActor` factory (class default) the result is pinned to the
+    // MainActor region, and passing it into the nonisolated-async
+    // `synchronizer.sync(for:...)` sends it across the actor boundary
+    // (Swift 6 "sending 'publication'"). Disconnecting it here matches the
+    // passing `ReaderServiceSyncTests` pattern (locally-built publication).
+    private nonisolated static func makePublication() -> Publication {
         let metadata = Metadata(title: "Test", languages: ["en"])
         let readingOrder = [
             Link(href: "/chapter1.xhtml", mediaType: .xhtml),

--- a/PalaceTests/CoverageGapTests.swift
+++ b/PalaceTests/CoverageGapTests.swift
@@ -105,7 +105,7 @@ final class AccountModelGapTests: XCTestCase {
         // leak across tests. Both AccountDetails instances below share
         // the same suite to exercise the round-trip.
         let uuid = "coverage-gap-eula-\(UUID().uuidString)"
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
 
         let json: [String: Any] = [
             "id": uuid, "title": "Test",
@@ -135,7 +135,7 @@ final class AccountModelGapTests: XCTestCase {
         // (swarm_cd181acd D-cleanup) so the persisted sync dict cannot
         // leak across tests.
         let uuid = "coverage-gap-sync-\(UUID().uuidString)"
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
 
         let json: [String: Any] = [
             "id": uuid, "title": "Test",

--- a/PalaceTests/Crawl/CatalogPreloaderTests.swift
+++ b/PalaceTests/Crawl/CatalogPreloaderTests.swift
@@ -19,9 +19,7 @@ private final class MockFeedPreloader: CatalogFeedPreloading, @unchecked Sendabl
     var urlsThatShouldFail: Set<URL> = []
 
     func preloadFeed(from url: URL) async throws {
-        lock.lock()
-        _preloadedURLs.append(url)
-        lock.unlock()
+        lock.withLock { _preloadedURLs.append(url) }
         if urlsThatShouldFail.contains(url) {
             throw URLError(.notConnectedToInternet)
         }

--- a/PalaceTests/Crawl/LibraryRegistryCrawlerTests.swift
+++ b/PalaceTests/Crawl/LibraryRegistryCrawlerTests.swift
@@ -82,11 +82,12 @@ private final class GatedCrawlerFetcher: CrawlerNetworkFetching, @unchecked Send
     }
 
     func fetchData(from url: URL) async throws -> (Data, HTTPURLResponse?) {
-        lock.lock()
-        _fetchedURLs.append(url)
-        let isFirst = firstCall
-        firstCall = false
-        lock.unlock()
+        let isFirst = lock.withLock { () -> Bool in
+            _fetchedURLs.append(url)
+            let wasFirst = firstCall
+            firstCall = false
+            return wasFirst
+        }
 
         if isFirst {
             await gate.markStarted()
@@ -140,7 +141,7 @@ final class LibraryRegistryCrawlerTests: XCTestCase {
 
     private func makeCrawler(
         currentAppVersion: String? = "3.2.0",
-        now: @escaping () -> Date = Date.init
+        now: @escaping @Sendable () -> Date = Date.init
     ) -> LibraryRegistryCrawler {
         let crawler = LibraryRegistryCrawler(
             fetcher: fetcher,

--- a/PalaceTests/DRM/AdobeActivationTests.swift
+++ b/PalaceTests/DRM/AdobeActivationTests.swift
@@ -63,27 +63,27 @@ final class AdobeActivationTests: XCTestCase {
         // verifying here is the surface the production AdobeDRMService relies
         // on: the success branch hands back non-nil IDs.
         let exp = expectation(description: "authorize completion")
-        var capturedDeviceID: String?
-        var capturedUserID: String?
-        var capturedSuccess = false
+        let capturedDeviceID = LockIsolated<String?>(nil)
+        let capturedUserID = LockIsolated<String?>(nil)
+        let capturedSuccess = LockIsolated<Bool>(false)
 
         drm.authorize(
             withVendorID: "NYPL",
             username: "client-token-username",
             password: "client-token-password"
         ) { success, error, deviceID, userID in
-            capturedSuccess = success
-            capturedDeviceID = deviceID
-            capturedUserID = userID
+            capturedSuccess.value = success
+            capturedDeviceID.value = deviceID
+            capturedUserID.value = userID
             XCTAssertNil(error, "Happy-path activation must not surface an error")
             exp.fulfill()
         }
 
         wait(for: [exp], timeout: 1.0)
-        XCTAssertTrue(capturedSuccess, "Valid licensor must produce success=true")
-        XCTAssertEqual(capturedDeviceID, drm.deviceID,
+        XCTAssertTrue(capturedSuccess.value, "Valid licensor must produce success=true")
+        XCTAssertEqual(capturedDeviceID.value, drm.deviceID,
                        "Activation must hand back a non-nil deviceID for persistence")
-        XCTAssertEqual(capturedUserID, drm.userID,
+        XCTAssertEqual(capturedUserID.value, drm.userID,
                        "Activation must hand back a non-nil userID for persistence")
         XCTAssertEqual(drm.authorizeCallCount, 1,
                        "Activation must invoke authorize exactly once per attempt")
@@ -208,7 +208,7 @@ final class AdobeActivationTests: XCTestCase {
         // NOT persist a userID/deviceID — those slots stay nil so the next
         // attempt re-runs the full flow rather than skipping the gate.
         final class FailingDRM: TPPDRMAuthorizingMock {
-            override func authorize(withVendorID vendorID: String!, username: String!, password: String!, completion: ((Bool, Error?, String?, String?) -> Void)!) {
+            override func authorize(withVendorID vendorID: String!, username: String!, password: String!, completion: (@Sendable (Bool, Error?, String?, String?) -> Void)!) {
                 authorizeWasCalled = true
                 authorizeCallCount += 1
                 let err = NSError(domain: NYPLADEPTErrorDomain,
@@ -222,25 +222,25 @@ final class AdobeActivationTests: XCTestCase {
 
         let failingDRM = FailingDRM()
         let exp = expectation(description: "failing authorize completion")
-        var capturedDeviceID: String? = "PRESET-TO-DETECT-OVERWRITE"
-        var capturedUserID: String? = "PRESET-TO-DETECT-OVERWRITE"
-        var capturedSuccess = true
-        var capturedError: Error?
+        let capturedDeviceID = LockIsolated<String?>("PRESET-TO-DETECT-OVERWRITE")
+        let capturedUserID = LockIsolated<String?>("PRESET-TO-DETECT-OVERWRITE")
+        let capturedSuccess = LockIsolated<Bool>(true)
+        let capturedError = LockIsolated<Error?>(nil)
 
         failingDRM.authorize(withVendorID: "NYPL", username: "u", password: "p") { success, error, deviceID, userID in
-            capturedSuccess = success
-            capturedError = error
-            capturedDeviceID = deviceID
-            capturedUserID = userID
+            capturedSuccess.value = success
+            capturedError.value = error
+            capturedDeviceID.value = deviceID
+            capturedUserID.value = userID
             exp.fulfill()
         }
 
         wait(for: [exp], timeout: 1.0)
-        XCTAssertFalse(capturedSuccess, "Failed activation must report success=false")
-        XCTAssertNotNil(capturedError, "Failed activation must surface an NSError")
-        XCTAssertNil(capturedDeviceID,
+        XCTAssertFalse(capturedSuccess.value, "Failed activation must report success=false")
+        XCTAssertNotNil(capturedError.value, "Failed activation must surface an NSError")
+        XCTAssertNil(capturedDeviceID.value,
                      "Failed activation must NOT hand back a deviceID — would persist garbage")
-        XCTAssertNil(capturedUserID,
+        XCTAssertNil(capturedUserID.value,
                      "Failed activation must NOT hand back a userID — would persist garbage")
     }
 }

--- a/PalaceTests/DRM/AdobeDRMCharacterizationTests.swift
+++ b/PalaceTests/DRM/AdobeDRMCharacterizationTests.swift
@@ -82,28 +82,28 @@ final class AdobeDRMCharacterizationTests: XCTestCase {
         // short-circuits. A mutant that returned success but left the IDs
         // nil would corrupt the persistence step.
         let exp = expectation(description: "authorize completion")
-        var capturedSuccess = false
-        var capturedError: Error?
-        var capturedDeviceID: String?
-        var capturedUserID: String?
+        let capturedSuccess = LockIsolated<Bool>(false)
+        let capturedError = LockIsolated<Error?>(nil)
+        let capturedDeviceID = LockIsolated<String?>(nil)
+        let capturedUserID = LockIsolated<String?>(nil)
 
         drm.authorize(withVendorID: "NYPL",
                       username: "client-token-username",
                       password: "client-token-password") { success, err, deviceID, userID in
-            capturedSuccess = success
-            capturedError = err
-            capturedDeviceID = deviceID
-            capturedUserID = userID
+            capturedSuccess.value = success
+            capturedError.value = err
+            capturedDeviceID.value = deviceID
+            capturedUserID.value = userID
             exp.fulfill()
         }
 
         wait(for: [exp], timeout: 1.0)
 
-        XCTAssertTrue(capturedSuccess, "Success-path must report success=true")
-        XCTAssertNil(capturedError, "Success-path must carry no error")
-        XCTAssertEqual(capturedDeviceID, "drmDeviceID",
+        XCTAssertTrue(capturedSuccess.value, "Success-path must report success=true")
+        XCTAssertNil(capturedError.value, "Success-path must carry no error")
+        XCTAssertEqual(capturedDeviceID.value, "drmDeviceID",
                        "Success-path must hand back the non-nil deviceID for persistence")
-        XCTAssertEqual(capturedUserID, "drmUserID",
+        XCTAssertEqual(capturedUserID.value, "drmUserID",
                        "Success-path must hand back the non-nil userID for persistence")
     }
 
@@ -168,21 +168,21 @@ final class AdobeDRMCharacterizationTests: XCTestCase {
         // fires) but the production "complete logout process" branch would
         // skip — a real regression we want to catch here.
         let exp = expectation(description: "deauthorize completion")
-        var capturedSuccess = false
-        var capturedError: Error?
+        let capturedSuccess = LockIsolated<Bool>(false)
+        let capturedError = LockIsolated<Error?>(nil)
 
         drm.deauthorize(withUsername: "user",
                         password: "pass",
                         userID: "u-1",
                         deviceID: "d-1") { success, err in
-            capturedSuccess = success
-            capturedError = err
+            capturedSuccess.value = success
+            capturedError.value = err
             exp.fulfill()
         }
 
         wait(for: [exp], timeout: 1.0)
-        XCTAssertTrue(capturedSuccess, "Default deauth completion must report success")
-        XCTAssertNil(capturedError, "Default deauth completion must carry no error")
+        XCTAssertTrue(capturedSuccess.value, "Default deauth completion must report success")
+        XCTAssertNil(capturedError.value, "Default deauth completion must carry no error")
         XCTAssertEqual(drm.deauthorizeCallCount, 1,
                        "Single call must increment counter by exactly 1")
         XCTAssertTrue(drm.deauthorizeWasCalled,
@@ -215,14 +215,14 @@ final class AdobeDRMCharacterizationTests: XCTestCase {
         // captured completion would be nil — caught here.
         drm.shouldDeferDeauthorize = true
 
-        var captured: (Bool, Error?)?
+        let captured = LockIsolated<(Bool, Error?)?>(nil)
         drm.deauthorize(withUsername: "u", password: "p",
                         userID: "uid", deviceID: "did") { success, err in
-            captured = (success, err)
+            captured.value = (success, err)
         }
 
         // Before manual fire: completion has NOT been invoked.
-        XCTAssertNil(captured, "Deferred deauth must NOT invoke completion synchronously")
+        XCTAssertNil(captured.value, "Deferred deauth must NOT invoke completion synchronously")
         XCTAssertNotNil(drm.deferredDeauthCompletion,
                         "Deferred deauth must STORE the completion for later firing")
 
@@ -231,9 +231,9 @@ final class AdobeDRMCharacterizationTests: XCTestCase {
         let failure = NSError(domain: "Adobe", code: 99, userInfo: nil)
         drm.completeDeferredDeauthorize(success: false, error: failure)
 
-        XCTAssertNotNil(captured, "Manual fire must invoke the captured completion")
-        XCTAssertEqual(captured?.0, false, "Captured success must reflect the manual-fire arg")
-        XCTAssertEqual((captured?.1 as NSError?)?.code, 99,
+        XCTAssertNotNil(captured.value, "Manual fire must invoke the captured completion")
+        XCTAssertEqual(captured.value?.0, false, "Captured success must reflect the manual-fire arg")
+        XCTAssertEqual((captured.value?.1 as NSError?)?.code, 99,
                        "Captured error must reflect the manual-fire arg")
         XCTAssertNil(drm.deferredDeauthCompletion,
                      "After firing, the captured completion must be cleared so a second fire is a no-op")
@@ -399,7 +399,7 @@ final class AdobeDRMCharacterizationTests: XCTestCase {
                                       password: String!,
                                       userID: String!,
                                       deviceID: String!,
-                                      completion: ((Bool, Error?) -> Void)!) {
+                                      completion: (@Sendable (Bool, Error?) -> Void)!) {
                 lastArgs = (username, password, userID, deviceID)
                 super.deauthorize(withUsername: username,
                                   password: password,
@@ -443,7 +443,7 @@ final class AdobeDRMCharacterizationTests: XCTestCase {
                                       password: String!,
                                       userID: String!,
                                       deviceID: String!,
-                                      completion: ((Bool, Error?) -> Void)!) {
+                                      completion: (@Sendable (Bool, Error?) -> Void)!) {
                 deauthorizeWasCalled = true
                 deauthorizeCallCount += 1
                 let err = NSError(domain: NYPLADEPTErrorDomain,
@@ -454,18 +454,18 @@ final class AdobeDRMCharacterizationTests: XCTestCase {
         }
         let rejecting = RejectingMock()
         let exp = expectation(description: "deauth completion fires even on rejection")
-        var capturedSuccess = true
-        var capturedError: Error?
+        let capturedSuccess = LockIsolated<Bool>(true)
+        let capturedError = LockIsolated<Error?>(nil)
         rejecting.deauthorize(withUsername: "u", password: "p",
                               userID: "uid", deviceID: "did") { success, err in
-            capturedSuccess = success
-            capturedError = err
+            capturedSuccess.value = success
+            capturedError.value = err
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1.0)
-        XCTAssertFalse(capturedSuccess, "Adobe rejection must surface success=false")
-        XCTAssertNotNil(capturedError, "Adobe rejection must carry the NSError so logs capture the cause")
-        XCTAssertEqual((capturedError as NSError?)?.domain, NYPLADEPTErrorDomain,
+        XCTAssertFalse(capturedSuccess.value, "Adobe rejection must surface success=false")
+        XCTAssertNotNil(capturedError.value, "Adobe rejection must carry the NSError so logs capture the cause")
+        XCTAssertEqual((capturedError.value as NSError?)?.domain, NYPLADEPTErrorDomain,
                        "The error must remain in the Adobe domain so PalaceError.from routes it correctly")
     }
 }

--- a/PalaceTests/ErrorHandling/TPPAlertUtilsTests.swift
+++ b/PalaceTests/ErrorHandling/TPPAlertUtilsTests.swift
@@ -43,7 +43,7 @@ final class TPPAlertUtilsTests: XCTestCase {
     /// Spin the main run loop so any scheduled `asyncAfter` retry blocks fire
     /// now (against the about-to-be-released hierarchy) instead of bleeding
     /// into the next test.
-    private func drainMainRunLoop(_ seconds: TimeInterval) {
+    private nonisolated func drainMainRunLoop(_ seconds: TimeInterval) {
         RunLoop.current.run(until: Date().addingTimeInterval(seconds))
     }
 

--- a/PalaceTests/ImageLoading/ImageCacheContinuationTests.swift
+++ b/PalaceTests/ImageLoading/ImageCacheContinuationTests.swift
@@ -32,7 +32,7 @@ final class ImageCacheContinuationTests: XCTestCase {
         super.tearDown()
     }
 
-    func testGetAsync_whenOperationsCancelledWhileQueued_everyCallResumes() {
+    func testGetAsync_whenOperationsCancelledWhileQueued_everyCallResumes() async {
         let cache = ImageCache.shared
 
         // Suspend so nothing starts running: the operations we enqueue below
@@ -40,38 +40,52 @@ final class ImageCacheContinuationTests: XCTestCase {
         cache.processingQueue.isSuspended = true
 
         let count = 50
-        let allResumed = expectation(description: "every getAsync call resumes")
-        allResumed.expectedFulfillmentCount = count
 
-        let enqueued = expectation(description: "all getAsync operations enqueued")
-        enqueued.expectedFulfillmentCount = count
+        // Structured fan-out. Each child awaits `getAsync`; a child returns
+        // ONLY when its continuation resumes. `withTaskGroup` returns only when
+        // ALL children have returned — so `resumedCount == count` after the
+        // group is an EXACT proof that every getAsync resumed, with NO
+        // fixed-timeout `XCTestExpectation` gamble.
+        //
+        // Why this is scheduling-independent (fixes the parallel-clone timeout,
+        // CI run 29805821296): the resume is driven by the OperationQueue
+        // completion block, not the cooperative pool. Once the driver cancels +
+        // unsuspends the queue, every operation's completion block runs (the
+        // OperationQueue owns its own worker threads) and resumes its
+        // continuation, so every child returns and the group completes. The
+        // completion of `withTaskGroup` — which returns ONLY when all 50
+        // children have returned — is the exact resume-completeness proof. The
+        // previous version spawned 50 unstructured `Task {}` and waited on
+        // `XCTestExpectation` timeouts, which under 4-clone CPU oversubscription
+        // could exceed 15s purely because the cooperative pool never scheduled
+        // the 50 tasks — a wall-clock race this structured form removes.
+        let resumedCount = LockIsolated<Int>(0)
 
-        // Disk-only/nonexistent keys force each call past the memory-cache
-        // short-circuit and into a queued processing operation.
-        for i in 0..<count {
-            let key = "imagecache_leak_probe_\(i)_\(UUID().uuidString)"
-            Task {
-                enqueued.fulfill()
-                _ = await cache.getAsync(for: key)
-                allResumed.fulfill()
+        // Detached driver: once the (synchronous) `addOperation` calls inside
+        // each `getAsync` have run — observed via `operationCount` reaching
+        // `count`, not a fixed sleep — cancel every queued op and unsuspend so
+        // the completion blocks fire and resume the continuations.
+        let driver = Task.detached {
+            while cache.processingQueue.operationCount < count {
+                await Task.yield()
             }
+            cache.processingQueue.cancelAllOperations()
+            cache.processingQueue.isSuspended = false
         }
 
-        // The `enqueued` fulfillments fire as each Task begins; once all have
-        // fired, every operation has been added to the (suspended) queue.
-        wait(for: [enqueued], timeout: 10.0)
-        // Small settle so the synchronous `addOperation` inside each
-        // `withCheckedContinuation` body has run before we cancel.
-        let settle = expectation(description: "settle")
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { settle.fulfill() }
-        wait(for: [settle], timeout: 2.0)
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<count {
+                let key = "imagecache_leak_probe_\(i)_\(UUID().uuidString)"
+                group.addTask {
+                    _ = await cache.getAsync(for: key)
+                    resumedCount.withValue { $0 += 1 }
+                }
+            }
+            await group.waitForAll()
+        }
+        await driver.value
 
-        // Cancel every queued operation, then let the queue run. Pre-fix the
-        // cancelled operations never resume → `allResumed` under-fulfills →
-        // timeout. Post-fix the completion block resumes each one.
-        cache.processingQueue.cancelAllOperations()
-        cache.processingQueue.isSuspended = false
-
-        wait(for: [allResumed], timeout: 15.0)
+        XCTAssertEqual(resumedCount.value, count,
+                       "Every cancelled-while-queued getAsync must resume its continuation exactly once")
     }
 }

--- a/PalaceTests/ImageLoading/ImageLoaderTests.swift
+++ b/PalaceTests/ImageLoading/ImageLoaderTests.swift
@@ -295,7 +295,16 @@ final class ImageLoaderTests: XCTestCase {
     /// cover. Pre-loading the unsized cover key makes the fallback deterministic (no
     /// network, no TenPrint).
     func testCoverImage_displayPoints_nonFinite_fallsBackToUnsizedCover_withoutTrapping() async {
-        let book = makeBook()
+        // Give the book a non-nil imageURL. `TPPBook.init` fires a fire-and-forget
+        // `fetchCoverImage()`; for a URL-*less* book that path instantly generates a
+        // TenPrint placeholder and writes it into THIS mock cache under `_cover`,
+        // asynchronously clobbering the seeded sentinel mid-loop (the flake this test
+        // exhibited: iter 1 saw the sentinel, iters 2-5 saw the placeholder). With a
+        // URL, that init fetch takes the never-completing network path in-test, so the
+        // sentinel stays put. The sanitizer under test hits the `_cover` cache and
+        // short-circuits before any network/registry access, so the URL does not
+        // affect what the fallback returns — only which write wins the seed race.
+        let book = makeBook(imageURL: URL(string: "https://example.com/cover.jpg")!)
         let sentinel = makeImage(width: 10, height: 10)
         cache.set(sentinel, for: "\(book.identifier)_cover", expiresIn: nil)
 

--- a/PalaceTests/ImageLoading/ImageLoaderTests.swift
+++ b/PalaceTests/ImageLoading/ImageLoaderTests.swift
@@ -155,8 +155,12 @@ final class ImageLoaderTests: XCTestCase {
         // Drive the call from a background queue to force the implementation
         // to hop back to main for completion (the contract the old bridge
         // guaranteed and the new ImageLoading must preserve).
-        DispatchQueue.global().async { [loader] in
-            loader!.thumbnailImage(for: book) { _ in
+        // Swift 6: `ImageLoader` is non-Sendable, so capturing it directly in
+        // the @Sendable global-queue closure is "sending self.loader". Box it in
+        // LockIsolated (Sendable) and read `.value` inside the closure.
+        let loaderBox = LockIsolated(loader!)
+        DispatchQueue.global().async {
+            loaderBox.value.thumbnailImage(for: book) { _ in
                 ranOnMain.value = Thread.isMainThread
                 expectation.fulfill()
             }
@@ -171,8 +175,11 @@ final class ImageLoaderTests: XCTestCase {
         let expectation = expectation(description: "cover completion fires")
         let ranOnMain = MainThreadFlag()
 
-        DispatchQueue.global().async { [loader] in
-            loader!.coverImage(for: book) { _ in
+        // Swift 6: box the non-Sendable loader (see sibling test) so it can be
+        // read inside the @Sendable global-queue closure without "sending".
+        let loaderBox = LockIsolated(loader!)
+        DispatchQueue.global().async {
+            loaderBox.value.coverImage(for: book) { _ in
                 ranOnMain.value = Thread.isMainThread
                 expectation.fulfill()
             }

--- a/PalaceTests/MetaTests/AccountsManagerIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/AccountsManagerIsolationLintTests.swift
@@ -50,7 +50,7 @@ final class AccountsManagerIsolationLintTests: XCTestCase {
     /// PalaceTests/ directory resolved relative to this file's location so
     /// the test works in every checkout (no env vars, no CI-specific paths).
     private static let palaceTestsRoot: URL = {
-        URL(fileURLWithPath: #file)
+        URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()  // MetaTests/
             .deletingLastPathComponent()  // PalaceTests/
     }()

--- a/PalaceTests/MetaTests/AppContainerIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/AppContainerIsolationLintTests.swift
@@ -59,7 +59,7 @@ final class AppContainerIsolationLintTests: XCTestCase {
 
   /// `PalaceTests/` resolved relative to this file's location.
   private static let palaceTestsRoot: URL = {
-    URL(fileURLWithPath: #file)
+    URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()  // MetaTests/
       .deletingLastPathComponent()  // PalaceTests/
   }()

--- a/PalaceTests/MetaTests/MockIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/MockIsolationLintTests.swift
@@ -58,7 +58,7 @@ final class MockIsolationLintTests: XCTestCase {
   /// retention, shared singletons without reset) exists in test classes
   /// that drive ViewModels and services.
   private static let palaceTestsRoot: URL = {
-    URL(fileURLWithPath: #file)
+    URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()  // MetaTests/
       .deletingLastPathComponent()  // PalaceTests/
   }()

--- a/PalaceTests/MetaTests/RuntimeQuiescenceGateTests.swift
+++ b/PalaceTests/MetaTests/RuntimeQuiescenceGateTests.swift
@@ -205,7 +205,12 @@ final class RuntimeQuiescenceGateTests: PalaceTestCase {
         for _ in 0..<n {
             Task.detached(priority: .high) {
                 started.signal()
-                release.wait()      // blocks a cooperative-pool thread (the simulated leak)
+                // Swift 6 bans DispatchSemaphore.wait() DIRECTLY in an async
+                // context (it blocks a cooperative-pool thread — exactly the
+                // anti-pattern this meta-test simulates). Route it through a
+                // synchronous helper so the noasync call sits in a sync context
+                // while still blocking the pool thread as intended.
+                blockCooperativeThread(on: release)   // the simulated leak
                 finished.signal()
             }
         }
@@ -245,4 +250,13 @@ final class RuntimeQuiescenceGateTests: PalaceTestCase {
             "With the defer flag at its test-safe true value, the live audit must be clean"
         )
     }
+}
+
+/// Synchronous wrapper so a `DispatchSemaphore.wait()` (marked `@available(*,
+/// noasync)`) can be invoked from inside an async `Task` — the call sits in this
+/// SYNC context, satisfying Swift 6, while still blocking the calling
+/// (cooperative-pool) thread, which is the behavior RuntimeQuiescenceGateTests
+/// deliberately exercises.
+private func blockCooperativeThread(on semaphore: DispatchSemaphore) {
+    semaphore.wait()
 }

--- a/PalaceTests/MetaTests/RuntimeQuiescenceLintTests.swift
+++ b/PalaceTests/MetaTests/RuntimeQuiescenceLintTests.swift
@@ -57,7 +57,7 @@ final class RuntimeQuiescenceLintTests: XCTestCase {
 
     /// `PalaceTests/` resolved relative to this file's location.
     private static let palaceTestsRoot: URL = {
-        URL(fileURLWithPath: #file)
+        URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()  // MetaTests/
             .deletingLastPathComponent()  // PalaceTests/
     }()

--- a/PalaceTests/MetaTests/TPPUserAccountIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/TPPUserAccountIsolationLintTests.swift
@@ -30,7 +30,7 @@ final class TPPUserAccountIsolationLintTests: XCTestCase {
     /// `PalaceTests/` resolved relative to this file's location so the test
     /// works in every checkout — no env vars, no CI-specific paths.
     private static let palaceTestsRoot: URL = {
-        URL(fileURLWithPath: #file)
+        URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()  // MetaTests/
             .deletingLastPathComponent()  // PalaceTests/
     }()

--- a/PalaceTests/MetaTests/TearDownRequiredLintTests.swift
+++ b/PalaceTests/MetaTests/TearDownRequiredLintTests.swift
@@ -70,7 +70,7 @@ final class TearDownRequiredLintTests: XCTestCase {
 
   /// `PalaceTests/` resolved relative to this file's location.
   private static let palaceTestsRoot: URL = {
-    URL(fileURLWithPath: #file)
+    URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()  // MetaTests/
       .deletingLastPathComponent()  // PalaceTests/
   }()

--- a/PalaceTests/MetaTests/UserDefaultsIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/UserDefaultsIsolationLintTests.swift
@@ -49,7 +49,7 @@ final class UserDefaultsIsolationLintTests: XCTestCase {
     /// resilient to running under either the worktree or the main
     /// checkout.
     private static var palaceTestsRoot: URL? {
-        var url = URL(fileURLWithPath: #file)
+        var url = URL(fileURLWithPath: #filePath)
         // Walk up until we find a directory whose lastPathComponent is
         // "PalaceTests".
         while url.pathComponents.count > 1 {

--- a/PalaceTests/MetaTests/UserDefaultsIsolationLintTests.swift
+++ b/PalaceTests/MetaTests/UserDefaultsIsolationLintTests.swift
@@ -33,7 +33,7 @@ final class UserDefaultsIsolationLintTests: XCTestCase {
         // swarm_cd181acd D-cleanup landed DI seams on AccountDetails,
         // AccountsManager, TPPBookmarkDeletionLog, CatalogRepository,
         // and TPPSignInBusinessLogic+ForceReset; the eight previously
-        // deferred test files now use `testUserDefaults()` and have
+        // deferred test files now use `Self.testUserDefaults()` and have
         // been removed from this whitelist. Future test files that
         // reach into `.standard` will trip the warn-only lint and the
         // author can either migrate (the seam exists now) or add a
@@ -83,7 +83,7 @@ final class UserDefaultsIsolationLintTests: XCTestCase {
                 let payload = """
                 File: \(relativePath)
                 UserDefaults.standard references: \(lineCount)
-                Action: migrate to testUserDefaults() once the production class \
+                Action: migrate to Self.testUserDefaults() once the production class \
                 under test exposes a UserDefaults DI seam. Until then this file \
                 is documented as a deferred gap in \
                 .forgeos/swarms/swarm_47883816/D-deferred-production-DI.md.
@@ -110,7 +110,7 @@ final class UserDefaultsIsolationLintTests: XCTestCase {
         @MainActor
         final class CleanTests: XCTestCase {
             func test_doesNotMentionTheBannedString() {
-                let defaults = testUserDefaults()
+                let defaults = Self.testUserDefaults()
                 defaults.set(true, forKey: "ok")
             }
         }

--- a/PalaceTests/Migrations/LCPKeychainMigrationTests.swift
+++ b/PalaceTests/Migrations/LCPKeychainMigrationTests.swift
@@ -33,44 +33,47 @@ final class LCPKeychainMigrationTests: XCTestCase {
     }
 
     func testRunIfNeeded_whenFlagUnset_runsMigrationAndSetsFlag() async {
-        var ran = false
+        let ran = LockIsolated<Bool>(false)
+        let localDefaults = UserDefaults(suiteName: suiteName)!
 
-        await LCPKeychainMigration.runIfNeeded(defaults: defaults, migrate: { ran = true })
+        await LCPKeychainMigration.runIfNeeded(defaults: localDefaults, migrate: { @Sendable in ran.value = true })
 
-        XCTAssertTrue(ran, "Migration work must run when the flag is unset")
+        XCTAssertTrue(ran.value, "Migration work must run when the flag is unset")
         XCTAssertTrue(defaults.bool(forKey: LCPKeychainMigration.didMigrateKey),
                       "Flag must be set after a successful migration")
     }
 
     func testRunIfNeeded_whenFlagAlreadySet_skipsMigration() async {
         defaults.set(true, forKey: LCPKeychainMigration.didMigrateKey)
-        var ran = false
+        let ran = LockIsolated<Bool>(false)
+        let localDefaults = UserDefaults(suiteName: suiteName)!
 
-        await LCPKeychainMigration.runIfNeeded(defaults: defaults, migrate: { ran = true })
+        await LCPKeychainMigration.runIfNeeded(defaults: localDefaults, migrate: { @Sendable in ran.value = true })
 
-        XCTAssertFalse(ran, "Migration work must NOT run once the flag is set")
+        XCTAssertFalse(ran.value, "Migration work must NOT run once the flag is set")
     }
 
     func testRunIfNeeded_whenMigrationThrows_leavesFlagUnsetAndRetriesNextTime() async {
         struct MigrationError: Error {}
-        var attempts = 0
+        let attempts = LockIsolated<Int>(0)
+        let localDefaults = UserDefaults(suiteName: suiteName)!
 
-        await LCPKeychainMigration.runIfNeeded(defaults: defaults, migrate: {
-            attempts += 1
+        await LCPKeychainMigration.runIfNeeded(defaults: localDefaults, migrate: { @Sendable in
+            attempts.value += 1
             throw MigrationError()
         })
 
-        XCTAssertEqual(attempts, 1, "Migration should have been attempted once")
+        XCTAssertEqual(attempts.value, 1, "Migration should have been attempted once")
         XCTAssertFalse(defaults.bool(forKey: LCPKeychainMigration.didMigrateKey),
                        "Flag must stay unset on failure so the next launch retries")
 
         // A subsequent launch must retry because the flag is still unset.
-        await LCPKeychainMigration.runIfNeeded(defaults: defaults, migrate: {
-            attempts += 1
+        await LCPKeychainMigration.runIfNeeded(defaults: localDefaults, migrate: { @Sendable in
+            attempts.value += 1
             throw MigrationError()
         })
 
-        XCTAssertEqual(attempts, 2, "An unflagged failed migration must retry on the next run")
+        XCTAssertEqual(attempts.value, 2, "An unflagged failed migration must retry on the next run")
     }
 }
 

--- a/PalaceTests/Mocks/MockImageLoader.swift
+++ b/PalaceTests/Mocks/MockImageLoader.swift
@@ -67,13 +67,27 @@ public final class MockImageLoader: ImageLoading {
     public func coverImage(for book: TPPBook, completion: @escaping (UIImage?) -> Void) {
         coverCalls.append(.init(identifier: book.identifier, displayPoints: nil, isCompletion: true))
         let img = stubbedCoverImage
-        DispatchQueue.main.async { completion(img) }
+        // Swift 6: the non-Sendable `completion` is "sent" into the @Sendable
+        // main-queue closure. Box it so the crossing is a Sendable value.
+        let boxed = SendableCompletion(completion)
+        DispatchQueue.main.async { boxed.run(img) }
     }
 
     public func thumbnailImage(for book: TPPBook, completion: @escaping (UIImage?) -> Void) {
         thumbnailCalls.append(.init(identifier: book.identifier, isCompletion: true))
         let img = stubbedThumbnailImage
-        DispatchQueue.main.async { completion(img) }
+        let boxed = SendableCompletion(completion)
+        DispatchQueue.main.async { boxed.run(img) }
+    }
+
+    /// `@unchecked Sendable` wrapper so a non-Sendable `(UIImage?) -> Void`
+    /// completion can be handed to a `@Sendable` main-queue closure. The
+    /// wrapped closure only runs on the main queue (invoked once inside
+    /// `DispatchQueue.main.async`), so the crossing is safe.
+    private struct SendableCompletion: @unchecked Sendable {
+        private let body: (UIImage?) -> Void
+        init(_ body: @escaping (UIImage?) -> Void) { self.body = body }
+        func run(_ image: UIImage?) { body(image) }
     }
 
     public func get(for key: String) -> UIImage? {

--- a/PalaceTests/Mocks/SpyAudiobookNetworkExecutor.swift
+++ b/PalaceTests/Mocks/SpyAudiobookNetworkExecutor.swift
@@ -28,6 +28,25 @@ final class SpyAudiobookNetworkExecutor: TPPNetworkExecutor, @unchecked Sendable
         let body: Data?
     }
 
+    /// Dedicated SERIAL queue the success completion is dispatched on.
+    ///
+    /// Production `TPPNetworkExecutor.POST` fires its completion off the
+    /// caller's stack (on the URLSession delegate queue), so the spy must do
+    /// the same to keep `AudiobookDataManager`'s threading realistic — it
+    /// cannot call the completion inline (that would run
+    /// `removeSynchronizedEntries` on the manager's `syncQueue`, changing the
+    /// concurrency shape the code under test relies on). But the ORIGINAL spy
+    /// hopped through `DispatchQueue.global()` — the shared CONCURRENT pool —
+    /// which under parallel-sim-clone CPU oversubscription (4 clones on a
+    /// 3–4-core runner) can defer the completion block past the test's poll
+    /// deadline, so the queue never drains and `awaitCondition` times out
+    /// (CI run 29805821296: `testPlaytimes_switchBack_flushesPreservedEntries`).
+    /// A PRIVATE serial queue gets its own reliably-scheduled thread, and —
+    /// crucially — lets the test install a deterministic barrier
+    /// (`drainCompletions()`) instead of polling wall-clock, removing the pool
+    /// dependence entirely.
+    let completionQueue = DispatchQueue(label: "spy.audiobook.completion")
+
     private let lock = NSLock()
     private var _calls: [RecordedCall] = []
     /// Counter incremented after the completion handler returns, so tests
@@ -62,6 +81,17 @@ final class SpyAudiobookNetworkExecutor: TPPNetworkExecutor, @unchecked Sendable
         }
     }
 
+    /// Deterministic barrier: block until every success completion dispatched
+    /// so far has run (FIFO on the serial `completionQueue`). Lets a test
+    /// replace a wall-clock `awaitCondition { calls.count == N }` poll — which
+    /// is starvable under pool oversubscription — with an exact join, matching
+    /// the `syncQueue.sync {}` barrier the sibling tests already use on the
+    /// manager side. Call AFTER the corresponding `syncQueue.sync {}` so the
+    /// POST has been dispatched and its completion enqueued here.
+    func drainCompletions() {
+        completionQueue.sync {}
+    }
+
     convenience init() {
         self.init(cachingStrategy: .ephemeral)
     }
@@ -89,7 +119,7 @@ final class SpyAudiobookNetworkExecutor: TPPNetworkExecutor, @unchecked Sendable
             httpVersion: "1.1",
             headerFields: ["Content-Type": "application/json"]
         )
-        DispatchQueue.global().async { [weak self] in
+        completionQueue.async { [weak self] in
             completion?(responseBody, httpResponse, nil)
             self?.lock.withLock { self?._completionsReturned += 1 }
         }

--- a/PalaceTests/Mocks/SpyAuthCoordinator.swift
+++ b/PalaceTests/Mocks/SpyAuthCoordinator.swift
@@ -33,11 +33,10 @@ final class SpyCoordinatorReauthenticator: Reauthenticating, @unchecked Sendable
     }
 
     func authenticateIfNeeded(usingExistingCredentials: Bool) async -> Bool {
-        lock.lock()
-        calls.append((usingExistingCredentials, Date()))
-        let result = stubbedResult
-        lock.unlock()
-        return result
+        lock.withLock {
+            calls.append((usingExistingCredentials, Date()))
+            return stubbedResult
+        }
     }
 }
 
@@ -55,11 +54,10 @@ final class SpyCoordinatorModalPresenter: SignInModalPresenting, @unchecked Send
     private let lock = NSLock()
 
     func presentSignInModalForCurrentAccount() async -> Bool {
-        lock.lock()
-        presentCallCount += 1
-        let result = stubbedResult
-        lock.unlock()
-        return result
+        lock.withLock {
+            presentCallCount += 1
+            return stubbedResult
+        }
     }
 }
 

--- a/PalaceTests/Mocks/TPPBookRegistryMock.swift
+++ b/PalaceTests/Mocks/TPPBookRegistryMock.swift
@@ -208,8 +208,29 @@ class TPPBookRegistryMock: NSObject, TPPBookRegistryProvider, @unchecked Sendabl
         registrySubject.send(snapshot)
         bookStateSubject.send((book.identifier, state))
 
-        // Simulate Notification (if real registry sends one)
-        NotificationCenter.default.post(name: .TPPBookRegistryDidChange, object: nil)
+        // Simulate the production notification — and match production's
+        // DELIVERY-THREAD contract: the real registry ALWAYS posts
+        // `.TPPBookRegistryDidChange` on the main queue (BookRegistryStore's
+        // `registry.didSet` and BookRegistrySync's save/update paths all wrap
+        // the post in `DispatchQueue.main.async`). Posting on the caller's
+        // thread here broke that contract: `NotificationCenter` invokes
+        // selector observers SYNCHRONOUSLY on the posting thread, so any live
+        // `@MainActor` observer (e.g. a `BookDetailViewModel` from an earlier
+        // test in the same runner process — `handleBookRegistryChange(_:)`)
+        // trips Swift 6's executor-isolation precondition
+        // (`dispatch_assert_queue_fail` → SIGTRAP) and KILLS the test-runner
+        // process, failing whichever unrelated test is in flight (CI run
+        // 29802862487: BorrowOperationTests / BorrowOperationStreamingHTMLTests /
+        // MyBooksDownloadCenterAccountIdThreadingTests all died here).
+        // Sync-post when already on main preserves the same-runloop-turn
+        // delivery that existing main-thread tests rely on.
+        if Thread.isMainThread {
+            NotificationCenter.default.post(name: .TPPBookRegistryDidChange, object: nil)
+        } else {
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .TPPBookRegistryDidChange, object: nil)
+            }
+        }
     }
 
     func removeBook(forIdentifier bookIdentifier: String) {

--- a/PalaceTests/Mocks/TPPMyBooksDownloadsCenterMock.swift
+++ b/PalaceTests/Mocks/TPPMyBooksDownloadsCenterMock.swift
@@ -9,12 +9,21 @@
 import Foundation
 @testable import Palace
 
-class TPPMyBooksDownloadsCenterMock: TPPBookDownloadsDeleting {
+/// `@unchecked Sendable`: the sole mutable state (`_resetCalledLibraryIDs`) is
+/// guarded by `lock`, so instances can cross into the @MainActor SUT safely
+/// (Swift 6). Mirrors TPPBookRegistryMock.
+final class TPPMyBooksDownloadsCenterMock: TPPBookDownloadsDeleting, @unchecked Sendable {
+    private let lock = NSLock()
+
     /// Records the libraryID(s) passed to `reset` so tests can assert the
     /// downloads center was reset for the expected (active) library only.
-    private(set) var resetCalledLibraryIDs: [String?] = []
+    private var _resetCalledLibraryIDs: [String?] = []
+    private(set) var resetCalledLibraryIDs: [String?] {
+        get { lock.withLock { _resetCalledLibraryIDs } }
+        set { lock.withLock { _resetCalledLibraryIDs = newValue } }
+    }
 
     func reset(_ libraryID: String!) {
-        resetCalledLibraryIDs.append(libraryID)
+        lock.withLock { _resetCalledLibraryIDs.append(libraryID) }
     }
 }

--- a/PalaceTests/Mocks/TPPSettingsMock.swift
+++ b/PalaceTests/Mocks/TPPSettingsMock.swift
@@ -14,6 +14,12 @@ import Foundation
 /// This mock provides stored properties that can be directly manipulated
 /// in tests, avoiding UserDefaults persistence and enabling test isolation.
 ///
+/// `@unchecked Sendable`: this mock is passed into `@MainActor` SUTs across
+/// concurrency domains. ALL mutable stored state (`_accountMainFeedURL`,
+/// `_customMainFeedURL`, `_useBetaLibraries`, the app-rating counters, …) is
+/// guarded by a single `NSLock` via locked computed accessors, so the mock
+/// honors the `Sendable` contract despite carrying real mutable state.
+///
 /// Usage:
 /// ```swift
 /// // inside an XCTestCase:
@@ -22,47 +28,119 @@ import Foundation
 /// let sut = MyClass(settings: mockSettings)
 /// // Exercise behavior when beta libraries are enabled
 /// ```
-final class TPPSettingsMock: NSObject, TPPSettingsProviding {
+final class TPPSettingsMock: NSObject, TPPSettingsProviding, @unchecked Sendable {
+
+    private let lock = NSLock()
 
     // MARK: - Stored Properties with Defaults
 
     /// The main feed URL for the current account/library.
-    var accountMainFeedURL: URL?
+    private var _accountMainFeedURL: URL?
+    var accountMainFeedURL: URL? {
+        get { lock.withLock { _accountMainFeedURL } }
+        set { lock.withLock { _accountMainFeedURL = newValue } }
+    }
 
     /// Custom feed URL override.
-    var customMainFeedURL: URL?
+    private var _customMainFeedURL: URL?
+    var customMainFeedURL: URL? {
+        get { lock.withLock { _customMainFeedURL } }
+        set { lock.withLock { _customMainFeedURL = newValue } }
+    }
 
     /// Whether to use beta/testing libraries.
-    var useBetaLibraries: Bool = false
+    private var _useBetaLibraries: Bool = false
+    var useBetaLibraries: Bool {
+        get { lock.withLock { _useBetaLibraries } }
+        set { lock.withLock { _useBetaLibraries = newValue } }
+    }
 
     /// Whether the age check has been presented.
-    var userPresentedAgeCheck: Bool = false
+    private var _userPresentedAgeCheck: Bool = false
+    var userPresentedAgeCheck: Bool {
+        get { lock.withLock { _userPresentedAgeCheck } }
+        set { lock.withLock { _userPresentedAgeCheck = newValue } }
+    }
 
     /// Whether the user has accepted the EULA.
-    var userHasAcceptedEULA: Bool = false
+    private var _userHasAcceptedEULA: Bool = false
+    var userHasAcceptedEULA: Bool {
+        get { lock.withLock { _userHasAcceptedEULA } }
+        set { lock.withLock { _userHasAcceptedEULA = newValue } }
+    }
 
     /// Whether to enter LCP passphrases manually.
-    var enterLCPPassphraseManually: Bool = false
+    private var _enterLCPPassphraseManually: Bool = false
+    var enterLCPPassphraseManually: Bool {
+        get { lock.withLock { _enterLCPPassphraseManually } }
+        set { lock.withLock { _enterLCPPassphraseManually = newValue } }
+    }
 
     /// The stored app version string.
-    var appVersion: String?
+    private var _appVersion: String?
+    var appVersion: String? {
+        get { lock.withLock { _appVersion } }
+        set { lock.withLock { _appVersion = newValue } }
+    }
 
     /// Custom library registry server URL.
-    var customLibraryRegistryServer: String?
+    private var _customLibraryRegistryServer: String?
+    var customLibraryRegistryServer: String? {
+        get { lock.withLock { _customLibraryRegistryServer } }
+        set { lock.withLock { _customLibraryRegistryServer = newValue } }
+    }
 
     /// Whether downloads are restricted to Wi-Fi only.
-    var downloadOnlyOnWiFi: Bool = false
+    private var _downloadOnlyOnWiFi: Bool = false
+    var downloadOnlyOnWiFi: Bool {
+        get { lock.withLock { _downloadOnlyOnWiFi } }
+        set { lock.withLock { _downloadOnlyOnWiFi = newValue } }
+    }
 
     // MARK: - App Rating (PP-4087)
 
-    var appRatingSessionCount: Int = 0
-    var appRatingBooksCompleted: Int = 0
-    var appRatingLastPromptDate: Date?
-    var appRatingPromptDisplayCount: Int = 0
-    var appRatingDismissalCount: Int = 0
-    var appRatingOptedOut: Bool = false
+    private var _appRatingSessionCount: Int = 0
+    var appRatingSessionCount: Int {
+        get { lock.withLock { _appRatingSessionCount } }
+        set { lock.withLock { _appRatingSessionCount = newValue } }
+    }
+
+    private var _appRatingBooksCompleted: Int = 0
+    var appRatingBooksCompleted: Int {
+        get { lock.withLock { _appRatingBooksCompleted } }
+        set { lock.withLock { _appRatingBooksCompleted = newValue } }
+    }
+
+    private var _appRatingLastPromptDate: Date?
+    var appRatingLastPromptDate: Date? {
+        get { lock.withLock { _appRatingLastPromptDate } }
+        set { lock.withLock { _appRatingLastPromptDate = newValue } }
+    }
+
+    private var _appRatingPromptDisplayCount: Int = 0
+    var appRatingPromptDisplayCount: Int {
+        get { lock.withLock { _appRatingPromptDisplayCount } }
+        set { lock.withLock { _appRatingPromptDisplayCount = newValue } }
+    }
+
+    private var _appRatingDismissalCount: Int = 0
+    var appRatingDismissalCount: Int {
+        get { lock.withLock { _appRatingDismissalCount } }
+        set { lock.withLock { _appRatingDismissalCount = newValue } }
+    }
+
+    private var _appRatingOptedOut: Bool = false
+    var appRatingOptedOut: Bool {
+        get { lock.withLock { _appRatingOptedOut } }
+        set { lock.withLock { _appRatingOptedOut = newValue } }
+    }
+
     /// Defaults to `true` (assume crash-free), matching `TPPSettings`.
-    var appRatingCrashFreeLastSession: Bool = true
+    private var _appRatingCrashFreeLastSession: Bool = true
+    var appRatingCrashFreeLastSession: Bool {
+        get { lock.withLock { _appRatingCrashFreeLastSession } }
+        set { lock.withLock { _appRatingCrashFreeLastSession = newValue } }
+    }
 
     // MARK: - Initialization
 
@@ -92,15 +170,15 @@ final class TPPSettingsMock: NSObject, TPPSettingsProviding {
         customLibraryRegistryServer: String? = nil,
         downloadOnlyOnWiFi: Bool = false
     ) {
-        self.accountMainFeedURL = accountMainFeedURL
-        self.customMainFeedURL = customMainFeedURL
-        self.useBetaLibraries = useBetaLibraries
-        self.userPresentedAgeCheck = userPresentedAgeCheck
-        self.userHasAcceptedEULA = userHasAcceptedEULA
-        self.enterLCPPassphraseManually = enterLCPPassphraseManually
-        self.appVersion = appVersion
-        self.customLibraryRegistryServer = customLibraryRegistryServer
-        self.downloadOnlyOnWiFi = downloadOnlyOnWiFi
+        self._accountMainFeedURL = accountMainFeedURL
+        self._customMainFeedURL = customMainFeedURL
+        self._useBetaLibraries = useBetaLibraries
+        self._userPresentedAgeCheck = userPresentedAgeCheck
+        self._userHasAcceptedEULA = userHasAcceptedEULA
+        self._enterLCPPassphraseManually = enterLCPPassphraseManually
+        self._appVersion = appVersion
+        self._customLibraryRegistryServer = customLibraryRegistryServer
+        self._downloadOnlyOnWiFi = downloadOnlyOnWiFi
         super.init()
     }
 

--- a/PalaceTests/Mocks/TPPURLSettingsProviderMock.swift
+++ b/PalaceTests/Mocks/TPPURLSettingsProviderMock.swift
@@ -10,8 +10,23 @@ import Foundation
 import PalaceAuth
 @testable import Palace
 
-class TPPURLSettingsProviderMock: NSObject, NYPLUniversalLinksSettings, NYPLFeedURLProvider, UniversalLinksProviding {
-    var accountMainFeedURL: URL?
+/// `@unchecked Sendable`: this mock is passed into the `@MainActor`
+/// `TPPSignInBusinessLogic` SUT across an isolation boundary in sign-in tests,
+/// so it must be `Sendable`. Its single mutable stored property
+/// (`accountMainFeedURL`) is guarded by an `NSLock` via a locked computed
+/// accessor — mirroring `TPPSignInOutBusinessLogicUIDelegateMock` /
+/// `TPPBookRegistryMock`. The `universalLinksURL` requirement is a constant.
+/// Property names, types, and protocol conformances are preserved so no call
+/// site changes.
+class TPPURLSettingsProviderMock: NSObject, NYPLUniversalLinksSettings, NYPLFeedURLProvider, UniversalLinksProviding, @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var _accountMainFeedURL: URL?
+    var accountMainFeedURL: URL? {
+        get { lock.withLock { _accountMainFeedURL } }
+        set { lock.withLock { _accountMainFeedURL = newValue } }
+    }
 
     var universalLinksURL: URL {
         return URL(string: "https://example.com/univeral-link-redirect")!

--- a/PalaceTests/MyBooks/BackgroundDownloadHandlerTests.swift
+++ b/PalaceTests/MyBooks/BackgroundDownloadHandlerTests.swift
@@ -326,6 +326,9 @@ final class BackgroundDownloadHandlerTests: XCTestCase {
 
         // Simulate first bytes (bytesWritten == totalBytesWritten)
         // Note: This test exercises the progress path without MIME type (no real response)
+        // Swift 6: capture the (now `@unchecked Sendable`) handler locally so
+        // awaiting its nonisolated `async` method doesn't send `self.handler`.
+        let handler = handler!
         await handler.handleDownloadProgress(
             for: book,
             task: task,
@@ -347,6 +350,9 @@ final class BackgroundDownloadHandlerTests: XCTestCase {
         let task = inertTestSession.downloadTask(with: URL(string: "https://example.com")!)
 
         // Should not crash and handler state must remain consistent
+        // Swift 6: capture the (now `@unchecked Sendable`) handler locally so
+        // awaiting its nonisolated `async` method doesn't send `self.handler`.
+        let handler = handler!
         await handler.handleDownloadProgress(
             for: book,
             task: task,

--- a/PalaceTests/MyBooks/BookReturnCleverReauthTests.swift
+++ b/PalaceTests/MyBooks/BookReturnCleverReauthTests.swift
@@ -153,7 +153,7 @@ final class BookReturnCleverReauthTests: XCTestCase {
         return try XCTUnwrap(TPPProblemDocument.fromProblemResponseData(data))
     }
 
-    private func makeBookWithRevokeURL() -> TPPBook {
+    nonisolated private func makeBookWithRevokeURL() -> TPPBook {
         let identifier = "rev-\(UUID().uuidString)"
         let acquisitionURL = URL(string: "http://example.com/\(identifier)") ?? URL(fileURLWithPath: "/tmp/x")
         let revokeURL = URL(string: "http://example.com/\(identifier)/revoke") ?? URL(fileURLWithPath: "/tmp/x")

--- a/PalaceTests/MyBooks/BookReturnServiceAuthCoordinatorTests.swift
+++ b/PalaceTests/MyBooks/BookReturnServiceAuthCoordinatorTests.swift
@@ -106,7 +106,7 @@ final class BookReturnServiceAuthCoordinatorTests: XCTestCase {
         return try XCTUnwrap(TPPProblemDocument.fromProblemResponseData(data))
     }
 
-    private func makeBookWithRevokeURL() -> TPPBook {
+    nonisolated private func makeBookWithRevokeURL() -> TPPBook {
         let identifier = "rev-\(UUID().uuidString)"
         let acquisitionURL = URL(string: "http://example.com/\(identifier)")!
         let revokeURL = URL(string: "http://example.com/\(identifier)/revoke")!

--- a/PalaceTests/MyBooks/BorrowOperationCleverReauthTests.swift
+++ b/PalaceTests/MyBooks/BorrowOperationCleverReauthTests.swift
@@ -43,10 +43,10 @@ final class BorrowOperationCleverReauthTests: XCTestCase {
     private var operation: BorrowOperation!
     private var book: TPPBook!
 
-    private var fetchBookResult: Result<TPPBook, Error>!
-    private var alertCalls: [(title: String, message: String, book: TPPBook, hasRetryAction: Bool)] = []
-    private var signInModalCompletions: [() -> Void] = []
-    private var oidcReauthResult: Bool = false
+    private let fetchBookResult = LockIsolated<Result<TPPBook, Error>?>(nil)
+    private let alertCalls = LockIsolated<[(title: String, message: String, book: TPPBook, hasRetryAction: Bool)]>([])
+    private let signInModalCompletions = LockIsolated<[() -> Void]>([])
+    private let oidcReauthResult = LockIsolated<Bool>(false)
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -56,11 +56,18 @@ final class BorrowOperationCleverReauthTests: XCTestCase {
         userAccount = TPPUserAccountMock()
         spyDelegate = SpyDelegate()
         book = TPPBookMocker.mockBook(distributorType: .EpubZip)
-        fetchBookResult = .success(book)
-        alertCalls = []
-        signInModalCompletions = []
-        oidcReauthResult = false
+        fetchBookResult.value = .success(book)
+        alertCalls.value = []
+        signInModalCompletions.value = []
+        oidcReauthResult.value = false
 
+        // Swift 6: the injected closures run outside MainActor isolation, so
+        // capturing `self` sends a main-actor-isolated value across the
+        // boundary. Capture the Sendable boxes as locals instead.
+        let fetchBookResultBox = fetchBookResult
+        let oidcReauthResultBox = oidcReauthResult
+        let alertCallsBox = alertCalls
+        let signInModalCompletionsBox = signInModalCompletions
         operation = BorrowOperation(
             bookRegistry: bookRegistry,
             downloadAnnouncementService: DownloadAnnouncementService(),
@@ -69,19 +76,19 @@ final class BorrowOperationCleverReauthTests: XCTestCase {
             userRetryTracker: .shared,
             userAccountProvider: { [unowned self] in self.userAccount },
             adobeDRMService: AdobeDRMService.shared,
-            fetchBook: { [unowned self] _, _, _ in
-                switch self.fetchBookResult! {
+            fetchBook: { _, _, _ in
+                switch fetchBookResultBox.value! {
                 case .success(let r): return r
                 case .failure(let e): throw e
                 }
             },
-            presentBorrowErrorAlert: { [unowned self] title, message, _, _, b, retryAction in
-                self.alertCalls.append((title, message, b, retryAction != nil))
+            presentBorrowErrorAlert: { title, message, _, _, b, retryAction in
+                alertCallsBox.withValue { $0.append((title, message, b, retryAction != nil)) }
             },
-            presentSignInModal: { [unowned self] completion in
-                self.signInModalCompletions.append(completion)
+            presentSignInModal: { completion in
+                signInModalCompletionsBox.withValue { $0.append(completion) }
             },
-            attemptOIDCReauth: { [unowned self] in self.oidcReauthResult }
+            attemptOIDCReauth: { oidcReauthResultBox.value }
         )
         operation.delegate = spyDelegate
     }
@@ -122,7 +129,7 @@ final class BorrowOperationCleverReauthTests: XCTestCase {
         userAccount.setAuthState(.loggedIn)
 
         let problemDoc = try Self.makeProblemDoc(type: TPPProblemDocument.TypeInvalidCredentials)
-        fetchBookResult = .failure(NSError(
+        fetchBookResult.value = .failure(NSError(
             domain: "test", code: 401,
             userInfo: ["problemDocument": problemDoc as Any]
         ))
@@ -140,9 +147,9 @@ final class BorrowOperationCleverReauthTests: XCTestCase {
         }
 
         // Assert: browser-reauth modal was presented.
-        XCTAssertEqual(signInModalCompletions.count, 1,
+        XCTAssertEqual(signInModalCompletions.value.count, 1,
                        "OAuth-intermediary (Clever) auth error with credentials MUST trigger presentSignInModal — the Module B broadening of `needsBrowserReauth`")
-        XCTAssertEqual(alertCalls.count, 0,
+        XCTAssertEqual(alertCalls.value.count, 0,
                        "Browser-reauth path must NOT also surface a generic borrow-error alert; that was the pre-Module-B regression for Clever users")
     }
 
@@ -172,7 +179,7 @@ final class BorrowOperationCleverReauthTests: XCTestCase {
         // Wrap the NSError so the BorrowOperation `originalError`
         // problemDocument extraction path fires (matches BorrowOperation's
         // `nsError.problemDocument` extraction).
-        fetchBookResult = .failure(NSError(
+        fetchBookResult.value = .failure(NSError(
             domain: "test", code: 401,
             userInfo: ["problemDocument": problemDoc as Any]
         ))
@@ -188,7 +195,7 @@ final class BorrowOperationCleverReauthTests: XCTestCase {
             await Task.yield()
         }
 
-        XCTAssertEqual(signInModalCompletions.count, 1,
+        XCTAssertEqual(signInModalCompletions.value.count, 1,
                        "PP-3716 broadening: OAuth-intermediary (Clever) + no-active-loan + credentials must be treated as auth error and route to sign-in modal")
     }
 

--- a/PalaceTests/MyBooks/BorrowOperationTests.swift
+++ b/PalaceTests/MyBooks/BorrowOperationTests.swift
@@ -32,8 +32,20 @@ final class BorrowOperationTests: XCTestCase {
     // boxes, the @MainActor closures keep capturing `self`.
     private let fetchBookResult = LockIsolated<Result<TPPBook, Error>?>(nil)
     private let fetchBookCalls = LockIsolated<[(url: URL, resetCache: Bool, useToken: Bool)]>([])
-    private var alertCalls: [(title: String, message: String, book: TPPBook, hasRetryAction: Bool)] = []
-    private var signInModalCompletions: [() -> Void] = []
+    // Swift 6: the `presentBorrowErrorAlert` / `presentSignInModal` seams are
+    // `@MainActor` closures stored on the `@unchecked Sendable` `BorrowOperation`,
+    // so a closure that captures `self` (a non-Sendable XCTestCase) to append to
+    // these recorders sends `self` across the boundary. Box them (lock-guarded,
+    // Sendable) and capture the boxes as locals in `setUp` so the closures
+    // reference the boxes, not `self`. Computed shims keep every read site unchanged.
+    private let alertCallsBox = LockIsolated<[(title: String, message: String, book: TPPBook, hasRetryAction: Bool)]>([])
+    private var alertCalls: [(title: String, message: String, book: TPPBook, hasRetryAction: Bool)] {
+        alertCallsBox.value
+    }
+    private let signInModalCompletionsBox = LockIsolated<[() -> Void]>([])
+    private var signInModalCompletions: [() -> Void] {
+        signInModalCompletionsBox.value
+    }
     private let oidcReauthResult = LockIsolated<Bool>(false)
 
     override func setUpWithError() throws {
@@ -49,15 +61,19 @@ final class BorrowOperationTests: XCTestCase {
         // the test sets via book.acquisition replacement before calling).
         fetchBookResult.value = .success(book)
         fetchBookCalls.value = []
-        alertCalls = []
-        signInModalCompletions = []
+        alertCallsBox.value = []
+        signInModalCompletionsBox.value = []
         oidcReauthResult.value = false
 
-        // Capture the Sendable boxes as locals so the non-isolated async
-        // closures reference the boxes, not `self` (now @MainActor).
+        // Capture the Sendable boxes as locals so the closures (both the
+        // non-isolated async ones and the @MainActor present-* ones stored on
+        // the @unchecked Sendable BorrowOperation) reference the boxes, not
+        // `self` (a non-Sendable @MainActor XCTestCase).
         let fetchBookCallsBox = fetchBookCalls
         let fetchBookResultBox = fetchBookResult
         let oidcReauthResultBox = oidcReauthResult
+        let alertCallsBox = alertCallsBox
+        let signInModalCompletionsBox = signInModalCompletionsBox
         operation = BorrowOperation(
             bookRegistry: bookRegistry,
             downloadAnnouncementService: DownloadAnnouncementService(),
@@ -73,11 +89,11 @@ final class BorrowOperationTests: XCTestCase {
                 case .failure(let error): throw error
                 }
             },
-            presentBorrowErrorAlert: { [unowned self] title, message, _, _, book, retryAction in
-                self.alertCalls.append((title, message, book, retryAction != nil))
+            presentBorrowErrorAlert: { title, message, _, _, book, retryAction in
+                alertCallsBox.withValue { $0.append((title, message, book, retryAction != nil)) }
             },
-            presentSignInModal: { [unowned self] completion in
-                self.signInModalCompletions.append(completion)
+            presentSignInModal: { completion in
+                signInModalCompletionsBox.withValue { $0.append(completion) }
             },
             attemptOIDCReauth: { oidcReauthResultBox.value }
         )

--- a/PalaceTests/MyBooks/CredentialPromptCoordinatorTests.swift
+++ b/PalaceTests/MyBooks/CredentialPromptCoordinatorTests.swift
@@ -19,12 +19,21 @@ final class CredentialPromptCoordinatorTests: XCTestCase {
     private var userAccount: TPPUserAccountMock!
     private var credentialState: CredentialRequestState!
     private var spyDelegate: SpyDelegate!
-    private var presentedSignInModal = 0
-    private var presentedAdobeAlert = 0
+    // Swift 6: `presentSignInModal` / `presentAdobeExpiredAlert` are `@MainActor`
+    // closures stored on the `@unchecked Sendable` CredentialPromptCoordinator,
+    // so a closure that captures `self` (a non-Sendable XCTestCase) to mutate
+    // these recorders sends `self` across the boundary. Box the recorders the
+    // flagged closures touch (lock-guarded, Sendable) and capture the boxes as
+    // locals in `setUp`. Computed shims keep every read site unchanged.
+    private let presentedSignInModalBox = LockIsolated<Int>(0)
+    private var presentedSignInModal: Int { presentedSignInModalBox.value }
+    private let presentedAdobeAlertBox = LockIsolated<Int>(0)
+    private var presentedAdobeAlert: Int { presentedAdobeAlertBox.value }
     private var isAdobeExpired = false
     /// Stash of completion handlers from each presentSignInModal call
     /// so tests can drive the success/cancel branches explicitly.
-    private var signInCompletions: [() -> Void] = []
+    private let signInCompletionsBox = LockIsolated<[() -> Void]>([])
+    private var signInCompletions: [() -> Void] { signInCompletionsBox.value }
     private var coordinator: CredentialPromptCoordinator!
     private var book: TPPBook!
 
@@ -34,21 +43,26 @@ final class CredentialPromptCoordinatorTests: XCTestCase {
         userAccount = TPPUserAccountMock()
         credentialState = CredentialRequestState()
         spyDelegate = SpyDelegate()
-        presentedSignInModal = 0
-        presentedAdobeAlert = 0
+        presentedSignInModalBox.value = 0
+        presentedAdobeAlertBox.value = 0
         isAdobeExpired = false
-        signInCompletions = []
+        signInCompletionsBox.value = []
 
+        // Capture the Sendable boxes as locals so the @MainActor present-*
+        // closures reference the boxes, not `self`.
+        let presentedSignInModalBox = presentedSignInModalBox
+        let presentedAdobeAlertBox = presentedAdobeAlertBox
+        let signInCompletionsBox = signInCompletionsBox
         coordinator = CredentialPromptCoordinator(
             stateManager: stateManager,
             userAccountProvider: { [unowned self] in self.userAccount },
             credentialRequestState: credentialState,
-            presentSignInModal: { [unowned self] completion in
-                self.presentedSignInModal += 1
-                self.signInCompletions.append(completion)
+            presentSignInModal: { completion in
+                presentedSignInModalBox.withValue { $0 += 1 }
+                signInCompletionsBox.withValue { $0.append(completion) }
             },
             isAdobeDRMExpired: { [unowned self] in self.isAdobeExpired },
-            presentAdobeExpiredAlert: { [unowned self] in self.presentedAdobeAlert += 1 }
+            presentAdobeExpiredAlert: { presentedAdobeAlertBox.withValue { $0 += 1 } }
         )
         coordinator.delegate = spyDelegate
 
@@ -60,7 +74,7 @@ final class CredentialPromptCoordinatorTests: XCTestCase {
         userAccount = nil
         credentialState = nil
         spyDelegate = nil
-        signInCompletions = []
+        signInCompletionsBox.value = []
         coordinator = nil
         book = nil
         try super.tearDownWithError()

--- a/PalaceTests/MyBooks/DownloadCompletionParserTests.swift
+++ b/PalaceTests/MyBooks/DownloadCompletionParserTests.swift
@@ -68,6 +68,10 @@ final class DownloadCompletionParserTests: XCTestCase {
         try json.write(to: tempLocation)
         let task = StubDownloadTask(mimeType: "application/problem+json")
 
+        // Swift 6: capture the (now `@unchecked Sendable`) parser as a local so
+        // awaiting its nonisolated `async parse` doesn't send `self.parser` off
+        // the @MainActor test. Mirrors the DownloadStateManagerTests local-hoist.
+        let parser = parser!
         let result = await parser.parse(book: book, task: task, location: tempLocation, session: session)
 
         switch result {
@@ -98,6 +102,10 @@ final class DownloadCompletionParserTests: XCTestCase {
         router.detectRightsResult = .none
         let task = StubDownloadTask(mimeType: "application/epub+zip")
 
+        // Swift 6: capture the (now `@unchecked Sendable`) parser as a local so
+        // awaiting its nonisolated `async parse` doesn't send `self.parser` off
+        // the @MainActor test. Mirrors the DownloadStateManagerTests local-hoist.
+        let parser = parser!
         let result = await parser.parse(book: book, task: task, location: tempLocation, session: session)
 
         guard case .proceed(let rights, let mimeType) = result else {
@@ -122,6 +130,10 @@ final class DownloadCompletionParserTests: XCTestCase {
         await stateManager.bookIdentifierToDownloadInfo.set(book.identifier, value: initial)
         let task = StubDownloadTask(mimeType: "application/epub+zip")
 
+        // Swift 6: capture the (now `@unchecked Sendable`) parser as a local so
+        // awaiting its nonisolated `async parse` doesn't send `self.parser` off
+        // the @MainActor test. Mirrors the DownloadStateManagerTests local-hoist.
+        let parser = parser!
         let result = await parser.parse(book: book, task: task, location: tempLocation, session: session)
 
         guard case .proceed(let rights, _) = result else {
@@ -139,6 +151,10 @@ final class DownloadCompletionParserTests: XCTestCase {
         router.opdsEntryResult = true
         let task = StubDownloadTask(mimeType: "application/atom+xml")
 
+        // Swift 6: capture the (now `@unchecked Sendable`) parser as a local so
+        // awaiting its nonisolated `async parse` doesn't send `self.parser` off
+        // the @MainActor test. Mirrors the DownloadStateManagerTests local-hoist.
+        let parser = parser!
         let result = await parser.parse(book: book, task: task, location: tempLocation, session: session)
 
         if case .followUpStarted = result {
@@ -155,6 +171,10 @@ final class DownloadCompletionParserTests: XCTestCase {
         router.opdsEntryResult = false
         let task = StubDownloadTask(mimeType: "text/xml")
 
+        // Swift 6: capture the (now `@unchecked Sendable`) parser as a local so
+        // awaiting its nonisolated `async parse` doesn't send `self.parser` off
+        // the @MainActor test. Mirrors the DownloadStateManagerTests local-hoist.
+        let parser = parser!
         let result = await parser.parse(book: book, task: task, location: tempLocation, session: session)
 
         guard case .failure(let problemDoc, let mimeType, _) = result else {
@@ -171,6 +191,10 @@ final class DownloadCompletionParserTests: XCTestCase {
         router.opds2PubResult = true
         let task = StubDownloadTask(mimeType: "application/opds-publication+json")
 
+        // Swift 6: capture the (now `@unchecked Sendable`) parser as a local so
+        // awaiting its nonisolated `async parse` doesn't send `self.parser` off
+        // the @MainActor test. Mirrors the DownloadStateManagerTests local-hoist.
+        let parser = parser!
         let result = await parser.parse(book: book, task: task, location: tempLocation, session: session)
 
         if case .followUpStarted = result {
@@ -187,6 +211,10 @@ final class DownloadCompletionParserTests: XCTestCase {
         router.opds2PubResult = false
         let task = StubDownloadTask(mimeType: "application/opds+json")
 
+        // Swift 6: capture the (now `@unchecked Sendable`) parser as a local so
+        // awaiting its nonisolated `async parse` doesn't send `self.parser` off
+        // the @MainActor test. Mirrors the DownloadStateManagerTests local-hoist.
+        let parser = parser!
         let result = await parser.parse(book: book, task: task, location: tempLocation, session: session)
 
         guard case .failure = result else {
@@ -200,6 +228,10 @@ final class DownloadCompletionParserTests: XCTestCase {
         // image/png is not in TPPOPDSAcquisitionPath.supportedTypes()
         let task = StubDownloadTask(mimeType: "image/png")
 
+        // Swift 6: capture the (now `@unchecked Sendable`) parser as a local so
+        // awaiting its nonisolated `async parse` doesn't send `self.parser` off
+        // the @MainActor test. Mirrors the DownloadStateManagerTests local-hoist.
+        let parser = parser!
         let result = await parser.parse(book: book, task: task, location: tempLocation, session: session)
 
         guard case .failure(let problemDoc, let mimeType, _) = result else {
@@ -216,6 +248,10 @@ final class DownloadCompletionParserTests: XCTestCase {
     func testParse_supportedMime_returnsProceed() async {
         let task = StubDownloadTask(mimeType: "application/epub+zip")
 
+        // Swift 6: capture the (now `@unchecked Sendable`) parser as a local so
+        // awaiting its nonisolated `async parse` doesn't send `self.parser` off
+        // the @MainActor test. Mirrors the DownloadStateManagerTests local-hoist.
+        let parser = parser!
         let result = await parser.parse(book: book, task: task, location: tempLocation, session: session)
 
         guard case .proceed(let rights, let mimeType) = result else {

--- a/PalaceTests/MyBooks/DownloadErrorRecoveryTests.swift
+++ b/PalaceTests/MyBooks/DownloadErrorRecoveryTests.swift
@@ -67,7 +67,7 @@ final class DownloadErrorRecoveryPolicyTests: XCTestCase {
 
     func testBorrowPolicy_recoversAfterNoActiveLoan() async throws {
         let recovery = DownloadErrorRecovery()
-        var attempts = 0
+        let attempts = LockIsolated<Int>(0)
 
         let result = try await recovery.executeWithRetry(
             policy: DownloadErrorRecovery.RetryPolicy(
@@ -78,15 +78,15 @@ final class DownloadErrorRecoveryPolicyTests: XCTestCase {
                 shouldRetry: DownloadErrorRecovery.RetryPolicy.borrowOperation.shouldRetry
             )
         ) {
-            attempts += 1
-            if attempts < 2 {
+            attempts.value += 1
+            if attempts.value < 2 {
                 throw PalaceError.bookRegistry(.bookNotFound)
             }
             return "Borrowed"
         }
 
         XCTAssertEqual(result, "Borrowed")
-        XCTAssertEqual(attempts, 2, "Should succeed on second attempt after no-active-loan")
+        XCTAssertEqual(attempts.value, 2, "Should succeed on second attempt after no-active-loan")
     }
 
     // MARK: - Successful Operations
@@ -105,23 +105,23 @@ final class DownloadErrorRecoveryPolicyTests: XCTestCase {
 
     func testExecuteWithRetry_immediateSuccess_noRetries() async throws {
         let recovery = DownloadErrorRecovery()
-        var callCount = 0
+        let callCount = LockIsolated<Int>(0)
 
         _ = try await recovery.executeWithRetry(
             policy: .default
         ) {
-            callCount += 1
+            callCount.value += 1
             return 42
         }
 
-        XCTAssertEqual(callCount, 1, "Should only be called once on immediate success")
+        XCTAssertEqual(callCount.value, 1, "Should only be called once on immediate success")
     }
 
     // MARK: - Retry Behavior
 
     func testExecuteWithRetry_retriesOnTransientError() async throws {
         let recovery = DownloadErrorRecovery()
-        var attempts = 0
+        let attempts = LockIsolated<Int>(0)
 
         let result = try await recovery.executeWithRetry(
             policy: DownloadErrorRecovery.RetryPolicy(
@@ -132,20 +132,20 @@ final class DownloadErrorRecoveryPolicyTests: XCTestCase {
                 shouldRetry: { _ in true }
             )
         ) {
-            attempts += 1
-            if attempts < 3 {
+            attempts.value += 1
+            if attempts.value < 3 {
                 throw NSError(domain: NSURLErrorDomain, code: NSURLErrorNetworkConnectionLost, userInfo: nil)
             }
             return "Recovered"
         }
 
         XCTAssertEqual(result, "Recovered")
-        XCTAssertEqual(attempts, 3)
+        XCTAssertEqual(attempts.value, 3)
     }
 
     func testExecuteWithRetry_failsAfterMaxAttempts() async {
         let recovery = DownloadErrorRecovery()
-        var attempts = 0
+        let attempts = LockIsolated<Int>(0)
 
         do {
             _ = try await recovery.executeWithRetry(
@@ -157,12 +157,12 @@ final class DownloadErrorRecoveryPolicyTests: XCTestCase {
                     shouldRetry: { _ in true }
                 )
             ) { () -> String in
-                attempts += 1
+                attempts.value += 1
                 throw NSError(domain: "TestDomain", code: 1, userInfo: nil)
             }
             XCTFail("Should have thrown after max attempts")
         } catch {
-            XCTAssertEqual(attempts, 2, "Should have attempted exactly maxAttempts times")
+            XCTAssertEqual(attempts.value, 2, "Should have attempted exactly maxAttempts times")
         }
     }
 
@@ -170,7 +170,7 @@ final class DownloadErrorRecoveryPolicyTests: XCTestCase {
 
     func testExecuteWithRetry_nonRetryableError_failsImmediately() async {
         let recovery = DownloadErrorRecovery()
-        var attempts = 0
+        let attempts = LockIsolated<Int>(0)
 
         do {
             _ = try await recovery.executeWithRetry(
@@ -182,12 +182,12 @@ final class DownloadErrorRecoveryPolicyTests: XCTestCase {
                     shouldRetry: { _ in false }  // Never retry
                 )
             ) { () -> String in
-                attempts += 1
+                attempts.value += 1
                 throw NSError(domain: "Fatal", code: 1, userInfo: nil)
             }
             XCTFail("Should have thrown")
         } catch {
-            XCTAssertEqual(attempts, 1, "Non-retryable errors should fail after first attempt")
+            XCTAssertEqual(attempts.value, 1, "Non-retryable errors should fail after first attempt")
         }
     }
 

--- a/PalaceTests/MyBooks/DownloadReconciliationLaunchOrderContractTests.swift
+++ b/PalaceTests/MyBooks/DownloadReconciliationLaunchOrderContractTests.swift
@@ -19,7 +19,7 @@ final class DownloadReconciliationLaunchOrderContractTests: XCTestCase {
     // async `runLaunchReconciliation` don't capture `self` (which, under Swift 6,
     // would make the non-`@Sendable` closure params send this @MainActor test
     // across the actor boundary). Called as `Self.record(...)`.
-    private static func record(_ bookID: String, task: Int) -> PersistedDownloadRecord {
+    private nonisolated static func record(_ bookID: String, task: Int) -> PersistedDownloadRecord {
         PersistedDownloadRecord(
             bookID: bookID, taskIdentifier: task,
             downloadURL: URL(string: "https://example.org/\(bookID)")!,

--- a/PalaceTests/MyBooks/DownloadReconciliationLaunchOrderContractTests.swift
+++ b/PalaceTests/MyBooks/DownloadReconciliationLaunchOrderContractTests.swift
@@ -15,7 +15,11 @@ import XCTest
 @MainActor
 final class DownloadReconciliationLaunchOrderContractTests: XCTestCase {
 
-    private func record(_ bookID: String, task: Int) -> PersistedDownloadRecord {
+    // Pure factory — no instance state. `static` so the closures passed to the
+    // async `runLaunchReconciliation` don't capture `self` (which, under Swift 6,
+    // would make the non-`@Sendable` closure params send this @MainActor test
+    // across the actor boundary). Called as `Self.record(...)`.
+    private static func record(_ bookID: String, task: Int) -> PersistedDownloadRecord {
         PersistedDownloadRecord(
             bookID: bookID, taskIdentifier: task,
             downloadURL: URL(string: "https://example.org/\(bookID)")!,
@@ -27,23 +31,23 @@ final class DownloadReconciliationLaunchOrderContractTests: XCTestCase {
         let log = CallLog()
 
         await DownloadReconciliation.runLaunchReconciliation(
-            isRegistryLoaded: {
+            isRegistryLoaded: { @Sendable in
                 log.record("isRegistryLoaded")
                 return true
             },
-            loadPersisted: {
+            loadPersisted: { @Sendable in
                 log.record("loadPersisted")
-                return [self.record("b", task: 5)]
+                return [Self.record("b", task: 5)]
             },
-            liveTaskIdentifiers: {
+            liveTaskIdentifiers: { @Sendable in
                 log.record("getAllTasks")
                 return []   // dead task -> restart (registry says .downloading)
             },
-            registryState: { bookID in
+            registryState: { @Sendable bookID in
                 log.record("registryState", args: ["bookID": bookID])
                 return .downloading
             },
-            apply: { decision in
+            apply: { @Sendable decision in
                 log.record("apply", args: ["decision": decision])
             }
         )
@@ -57,20 +61,20 @@ final class DownloadReconciliationLaunchOrderContractTests: XCTestCase {
         let log = CallLog()
 
         await DownloadReconciliation.runLaunchReconciliation(
-            isRegistryLoaded: {
+            isRegistryLoaded: { @Sendable in
                 log.record("isRegistryLoaded")
                 return false
             },
-            loadPersisted: {
+            loadPersisted: { @Sendable in
                 log.record("loadPersisted")
                 return []
             },
-            liveTaskIdentifiers: {
+            liveTaskIdentifiers: { @Sendable in
                 log.record("getAllTasks")
                 return []
             },
-            registryState: { _ in .unregistered },
-            apply: { _ in log.record("apply") }
+            registryState: { @Sendable _ in .unregistered },
+            apply: { @Sendable _ in log.record("apply") }
         )
 
         XCTAssertEqual(log.snapshot().map(\.method), ["isRegistryLoaded"],

--- a/PalaceTests/MyBooks/DownloadStartCoordinatorTests.swift
+++ b/PalaceTests/MyBooks/DownloadStartCoordinatorTests.swift
@@ -248,22 +248,36 @@ final class DownloadStartCoordinatorTests: XCTestCase {
 
 // MARK: - Stubs
 
-private final class SpyDelegate: DownloadStartCoordinatorDelegate {
+private final class SpyDelegate: DownloadStartCoordinatorDelegate, @unchecked Sendable {
     enum BorrowResult {
         case success(TPPBook)
         case failure(Error)
     }
 
-    var borrowAsyncResult: BorrowResult = .success(TPPBookMocker.mockBook(distributorType: .EpubZip))
+    // Swift 6: `borrowAsync` / `schedulePendingStartsIfPossible` are
+    // `nonisolated` protocol requirements, so their bodies cannot capture
+    // `self` (a non-Sendable spy) to reach recorder vars — the previous
+    // `MainActor.run { self.… }` / `Task { @MainActor in self.… }` hops each
+    // sent `self`. Back the storage with `LockIsolated` (@unchecked Sendable,
+    // lock-guarded) so every read/write is thread-safe with no self-capturing
+    // actor hop. `var` shims keep the test call sites unchanged.
+    private let _borrowAsyncResult = LockIsolated<BorrowResult>(
+        .success(TPPBookMocker.mockBook(distributorType: .EpubZip))
+    )
+    var borrowAsyncResult: BorrowResult {
+        get { _borrowAsyncResult.value }
+        set { _borrowAsyncResult.value = newValue }
+    }
 
-    private(set) var scheduleCount = 0
-    private(set) var borrowCount = 0
+    private let _scheduleCount = LockIsolated<Int>(0)
+    var scheduleCount: Int { _scheduleCount.value }
+
+    private let _borrowCount = LockIsolated<Int>(0)
+    var borrowCount: Int { _borrowCount.value }
 
     nonisolated func borrowAsync(_ book: TPPBook, attemptDownload: Bool) async throws -> TPPBook {
-        // Hop to MainActor since the recorder vars are MainActor-isolated
-        // (the test class is @MainActor).
-        await MainActor.run { self.borrowCount += 1 }
-        let result = await MainActor.run { self.borrowAsyncResult }
+        _borrowCount.withValue { $0 += 1 }
+        let result = _borrowAsyncResult.value
         switch result {
         case .success(let book): return book
         case .failure(let error): throw error
@@ -271,9 +285,7 @@ private final class SpyDelegate: DownloadStartCoordinatorDelegate {
     }
 
     nonisolated func schedulePendingStartsIfPossible() {
-        // Schedule increments synchronously from a Task block — bridge
-        // back to MainActor with a Task to avoid the data-race warning.
-        Task { @MainActor in self.scheduleCount += 1 }
+        _scheduleCount.withValue { $0 += 1 }
     }
 }
 

--- a/PalaceTests/MyBooks/DownloadStateManagerTests.swift
+++ b/PalaceTests/MyBooks/DownloadStateManagerTests.swift
@@ -260,13 +260,14 @@ final class DownloadStateManagerTests: XCTestCase {
         let info = MyBooksDownloadInfo(downloadProgress: 0.0, downloadTask: task, rightsManagement: .none)
 
         // Run many concurrent reads and writes
+        let sm = stateManager!
         await withTaskGroup(of: Void.self) { group in
             for i in 0..<50 {
                 group.addTask {
                     let id = "\(bookId)-\(i)"
-                    await self.stateManager.bookIdentifierToDownloadInfo.set(id, value: info)
-                    _ = await self.stateManager.downloadInfoAsync(forBookIdentifier: id)
-                    await self.stateManager.bookIdentifierToDownloadInfo.remove(id)
+                    await sm.bookIdentifierToDownloadInfo.set(id, value: info)
+                    _ = await sm.downloadInfoAsync(forBookIdentifier: id)
+                    await sm.bookIdentifierToDownloadInfo.remove(id)
                 }
             }
         }

--- a/PalaceTests/MyBooks/DownloadTaskLifecycleServiceTests.swift
+++ b/PalaceTests/MyBooks/DownloadTaskLifecycleServiceTests.swift
@@ -56,6 +56,10 @@ final class DownloadTaskLifecycleServiceTests: XCTestCase {
     func testRegisterStartedTask_storesDownloadInfoKeyedByBookIdentifier() async {
         let task = StubDownloadTask(taskIdentifier: 7)
 
+        // Swift 6: capture the (now `@unchecked Sendable`) service locally so
+        // awaiting its nonisolated `async` method doesn't send `self.service`
+        // off the @MainActor test.
+        let service = service!
         await service.registerStartedTask(task, book: book, maxConcurrentDownloads: 4)
 
         let info = await stateManager.bookIdentifierToDownloadInfo.get(book.identifier)
@@ -68,6 +72,10 @@ final class DownloadTaskLifecycleServiceTests: XCTestCase {
     func testRegisterStartedTask_storesTaskIdentifierToBookMapping() async {
         let task = StubDownloadTask(taskIdentifier: 99)
 
+        // Swift 6: capture the (now `@unchecked Sendable`) service locally so
+        // awaiting its nonisolated `async` method doesn't send `self.service`
+        // off the @MainActor test.
+        let service = service!
         await service.registerStartedTask(task, book: book, maxConcurrentDownloads: 4)
 
         let mapped = await stateManager.taskIdentifierToBook.get(99)
@@ -78,6 +86,10 @@ final class DownloadTaskLifecycleServiceTests: XCTestCase {
     func testRegisterStartedTask_marksBookAsDownloadingInRegistry() async {
         let task = StubDownloadTask(taskIdentifier: 1)
 
+        // Swift 6: capture the (now `@unchecked Sendable`) service locally so
+        // awaiting its nonisolated `async` method doesn't send `self.service`
+        // off the @MainActor test.
+        let service = service!
         await service.registerStartedTask(task, book: book, maxConcurrentDownloads: 4)
 
         XCTAssertEqual(bookRegistry.state(for: book.identifier), .downloading,
@@ -87,6 +99,10 @@ final class DownloadTaskLifecycleServiceTests: XCTestCase {
     func testRegisterStartedTask_announcesDownloadStartedAndNotifiesCenter() async {
         let task = StubDownloadTask(taskIdentifier: 1)
 
+        // Swift 6: capture the (now `@unchecked Sendable`) service locally so
+        // awaiting its nonisolated `async` method doesn't send `self.service`
+        // off the @MainActor test.
+        let service = service!
         await service.registerStartedTask(task, book: book, maxConcurrentDownloads: 4)
 
         XCTAssertEqual(spyAnnouncer.startedAnnouncements.map { $0.title }, [book.title])
@@ -99,6 +115,10 @@ final class DownloadTaskLifecycleServiceTests: XCTestCase {
     func testRegisterStartedTask_resumesTheTask() async {
         let task = StubDownloadTask(taskIdentifier: 1)
 
+        // Swift 6: capture the (now `@unchecked Sendable`) service locally so
+        // awaiting its nonisolated `async` method doesn't send `self.service`
+        // off the @MainActor test.
+        let service = service!
         await service.registerStartedTask(task, book: book, maxConcurrentDownloads: 4)
 
         XCTAssertEqual(task.resumeCount, 1,
@@ -110,6 +130,7 @@ final class DownloadTaskLifecycleServiceTests: XCTestCase {
     func testHandleTaskCompletionError_unknownTask_isNoOp() async {
         let task = StubDownloadTask(taskIdentifier: 999)
 
+        let service = service!
         await service.handleTaskCompletionError(task: task, error: nil)
 
         XCTAssertEqual(spyDelegate.logCalls.count, 0)
@@ -122,6 +143,7 @@ final class DownloadTaskLifecycleServiceTests: XCTestCase {
         let task = StubDownloadTask(taskIdentifier: 42)
         await stateManager.taskIdentifierToBook.set(42, value: book)
 
+        let service = service!
         await service.handleTaskCompletionError(task: task, error: nil)
 
         XCTAssertEqual(spyDelegate.logCalls.count, 0,
@@ -137,6 +159,7 @@ final class DownloadTaskLifecycleServiceTests: XCTestCase {
         await stateManager.taskIdentifierToBook.set(42, value: book)
         let netError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
 
+        let service = service!
         await service.handleTaskCompletionError(task: task, error: netError)
 
         XCTAssertEqual(spyDelegate.logCalls.map { $0.reason }, ["networking error"])
@@ -150,6 +173,7 @@ final class DownloadTaskLifecycleServiceTests: XCTestCase {
         await stateManager.taskIdentifierToBook.set(42, value: book)
         let cancelled = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
 
+        let service = service!
         await service.handleTaskCompletionError(task: task, error: cancelled)
 
         XCTAssertEqual(spyDelegate.logCalls.count, 0,

--- a/PalaceTests/MyBooks/DownloadTransferRetryTests.swift
+++ b/PalaceTests/MyBooks/DownloadTransferRetryTests.swift
@@ -65,7 +65,10 @@ final class DownloadTransferRetryTests: XCTestCase {
         let retried = await center.maybeRetryTransientTransfer(task: task(42), error: urlError(NSURLErrorTimedOut))
 
         XCTAssertTrue(retried, "a transient transfer error under the cap must schedule a retry")
-        let count = await stateManager.transferRetryAttempts(for: book.identifier)
+        // Read the counter on the (Sendable) SafeDictionary actor rather than via
+        // a DownloadStateManager instance method — awaiting a method on the
+        // non-Sendable manager would send it off @MainActor (Swift 6 data-race).
+        let count = await stateManager.transferRetryCounts.get(book.identifier) ?? 0
         XCTAssertEqual(count, 1, "retry must bump the per-book attempt counter")
     }
 
@@ -79,7 +82,7 @@ final class DownloadTransferRetryTests: XCTestCase {
             task: task(7), error: urlError(NSURLErrorUserAuthenticationRequired))
 
         XCTAssertFalse(retried)
-        let count = await stateManager.transferRetryAttempts(for: book.identifier)
+        let count = await stateManager.transferRetryCounts.get(book.identifier) ?? 0
         XCTAssertEqual(count, 0, "a non-retryable error must not touch the retry counter")
     }
 
@@ -101,13 +104,18 @@ final class DownloadTransferRetryTests: XCTestCase {
     func testTransientError_atCap_stopsRetryingAndResetsCounter() async {
         let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
         await stateManager.taskIdentifierToBook.set(9, value: book)
-        // Exhaust the cap (maxTransferRetries == 3).
-        for _ in 0..<3 { await stateManager.incrementTransferRetryAttempts(for: book.identifier) }
+        // Exhaust the cap (maxTransferRetries == 3). Increment on the (Sendable)
+        // SafeDictionary actor — atomic +1 with a 0 default, matching
+        // DownloadStateManager.incrementTransferRetryAttempts — so no non-Sendable
+        // manager instance is sent off @MainActor (Swift 6 data-race guard).
+        for _ in 0..<3 {
+            await stateManager.transferRetryCounts.updateValue(book.identifier, default: 0) { $0 += 1 }
+        }
 
         let retried = await center.maybeRetryTransientTransfer(task: task(9), error: urlError(NSURLErrorTimedOut))
 
         XCTAssertFalse(retried, "at the attempt cap the retry stops and the normal failure path runs")
-        let count = await stateManager.transferRetryAttempts(for: book.identifier)
+        let count = await stateManager.transferRetryCounts.get(book.identifier) ?? 0
         XCTAssertEqual(count, 0, "exhausting the cap resets the counter for future independent failures")
     }
 

--- a/PalaceTests/MyBooks/DownloadTransferRetryTests.swift
+++ b/PalaceTests/MyBooks/DownloadTransferRetryTests.swift
@@ -109,7 +109,7 @@ final class DownloadTransferRetryTests: XCTestCase {
         // DownloadStateManager.incrementTransferRetryAttempts — so no non-Sendable
         // manager instance is sent off @MainActor (Swift 6 data-race guard).
         for _ in 0..<3 {
-            await stateManager.transferRetryCounts.updateValue(book.identifier, default: 0) { $0 += 1 }
+            await stateManager.transferRetryCounts.updateValue(book.identifier, default: 0) { @Sendable in $0 += 1 }
         }
 
         let retried = await center.maybeRetryTransientTransfer(task: task(9), error: urlError(NSURLErrorTimedOut))

--- a/PalaceTests/MyBooks/RedirectPolicyTests.swift
+++ b/PalaceTests/MyBooks/RedirectPolicyTests.swift
@@ -18,16 +18,32 @@ final class RedirectPolicyTests: XCTestCase {
     // MARK: - Helpers
 
     /// Builds a closure-driven RedirectPolicy whose counters are backed
-    /// by a plain dictionary so tests can arrange / observe attempts
+    /// by a lock-guarded dictionary so tests can arrange / observe attempts
     /// without standing up the real DownloadCoordinator actor.
-    private final class CounterStore {
-        var attempts: [Int: Int] = [:]
-        private(set) var incrementCalls: [Int] = []
+    ///
+    /// Swift 6: `RedirectPolicy` is now `Sendable` (its closures are
+    /// `@Sendable`), so the store those closures capture must be `Sendable`
+    /// too. Every access goes through `lock`, so `@unchecked Sendable` is sound
+    /// (the same idiom as `LockIsolated`). `attempts` is exposed via a
+    /// lock-guarded computed shim so the tests' `store.attempts[42] = 10`
+    /// arrange lines and `store.incrementCalls` assertions stay unchanged.
+    private final class CounterStore: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _attempts: [Int: Int] = [:]
+        private var _incrementCalls: [Int] = []
 
-        func get(_ taskID: Int) -> Int { attempts[taskID] ?? 0 }
+        var attempts: [Int: Int] {
+            get { lock.withLock { _attempts } }
+            set { lock.withLock { _attempts = newValue } }
+        }
+        var incrementCalls: [Int] { lock.withLock { _incrementCalls } }
+
+        func get(_ taskID: Int) -> Int { lock.withLock { _attempts[taskID] ?? 0 } }
         func increment(_ taskID: Int) {
-            incrementCalls.append(taskID)
-            attempts[taskID, default: 0] += 1
+            lock.withLock {
+                _incrementCalls.append(taskID)
+                _attempts[taskID, default: 0] += 1
+            }
         }
     }
 

--- a/PalaceTests/Network/CookiePersistenceTests.swift
+++ b/PalaceTests/Network/CookiePersistenceTests.swift
@@ -79,8 +79,8 @@ final class CookiePersistenceTests: XCTestCase {
     private let samlBorrowURL = URL(string: "https://library.example.com/borrow/123")!
     private let cookieDomain = "library.example.com"
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         HTTPStubURLProtocol.reset()
         TPPUserAccountMock.resetShared()
         clearSharedCookieStorage()
@@ -103,13 +103,15 @@ final class CookiePersistenceTests: XCTestCase {
         executor = makeExecutor()
     }
 
-    override func tearDown() {
+    // async tearDown adopts the class's @MainActor isolation so the main-actor
+    // clearSharedCookieStorage() call is not sent from a nonisolated context.
+    override func tearDown() async throws {
         HTTPStubURLProtocol.reset()
         clearSharedCookieStorage()
         executor = nil
         libraryAccount = nil
         userAccount = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     // MARK: - Helpers

--- a/PalaceTests/Network/MultiLibraryTokenIsolationTests.swift
+++ b/PalaceTests/Network/MultiLibraryTokenIsolationTests.swift
@@ -91,8 +91,8 @@ final class MultiLibraryTokenIsolationTests: XCTestCase {
     private let apiURL_A = URL(string: "https://api.libraryA.example.com/protected")!
     private let apiURL_B = URL(string: "https://api.libraryB.example.com/protected")!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         HTTPStubURLProtocol.reset()
         TPPUserAccountMock.resetShared()
         libraryProvider = TwoLibraryAccountsProviderMock(startingAtA: true)

--- a/PalaceTests/Network/NetworkCacheClearRoutingTests.swift
+++ b/PalaceTests/Network/NetworkCacheClearRoutingTests.swift
@@ -122,7 +122,7 @@ final class NetworkCacheClearRoutingTests: XCTestCase {
     /// sign-out control flow (forbidden) or exercising real
     /// keychain / WKWebsiteDataStore singletons (banned by the TDD rules).
     func testSignOutAndForceReset_routeCacheClearThroughExecutor_notURLCacheShared() throws {
-        let repoRoot = URL(fileURLWithPath: #file)
+        let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()   // Network/
             .deletingLastPathComponent()   // PalaceTests/
             .deletingLastPathComponent()   // repo root

--- a/PalaceTests/Network/SAMLCookieSyncTests.swift
+++ b/PalaceTests/Network/SAMLCookieSyncTests.swift
@@ -15,14 +15,18 @@ import PalaceNetwork
 @MainActor
 final class SAMLCookieSyncTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
+    // Swift 6: the synchronous `setUp()`/`tearDown()` overrides are `nonisolated`
+    // (XCTestCase's are), so calling the `@MainActor`-isolated `clearSharedCookies()`
+    // from them sends `self` across the boundary. The `async` overrides run on the
+    // MainActor for a `@MainActor` test class — the repo's standard idiom.
+    override func setUp() async throws {
+        try await super.setUp()
         clearSharedCookies()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         clearSharedCookies()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     private func clearSharedCookies() {

--- a/PalaceTests/Network/TokenRefreshAndRetryQueueTests.swift
+++ b/PalaceTests/Network/TokenRefreshAndRetryQueueTests.swift
@@ -36,8 +36,8 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
     private let tokenURL = URL(string: "https://token.example.com/oauth/token")!
     private let apiURL = URL(string: "https://api.example.com/protected")!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         HTTPStubURLProtocol.reset()
         TPPUserAccountMock.resetShared()
 
@@ -453,9 +453,7 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         }
         XCTAssertTrue(retried, "The queued task must be retried after the /token refresh succeeds")
 
-        lock.lock()
-        let observedAuth = capturedRetryAuth
-        lock.unlock()
+        let observedAuth = lock.withLock { capturedRetryAuth }
 
         XCTAssertEqual(observedAuth,
                        "Bearer \(newToken)",

--- a/PalaceTests/Network/TokenRefreshAndRetryQueueTests.swift
+++ b/PalaceTests/Network/TokenRefreshAndRetryQueueTests.swift
@@ -108,7 +108,7 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
     }
 
     /// Encodes a TokenResponse JSON body the way the server would return it.
-    private static func tokenResponseJSON(accessToken: String,
+    private nonisolated static func tokenResponseJSON(accessToken: String,
                                           expiresIn: Int = 3600) -> Data {
         return """
         {"access_token":"\(accessToken)","token_type":"Bearer","expires_in":\(expiresIn)}
@@ -156,10 +156,11 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
     func testRefresh_TokenEndpointReturns401_MarksCredentialsStaleAndDoesNotLoop() async throws {
         await executor.resetRefreshAttemptCount()
 
-        var tokenRequestCount = 0
-        HTTPStubURLProtocol.register { [tokenURL] request in
+        let tokenRequestCount = LockIsolated(0)
+        // @Sendable stub + LockIsolated: avoids Swift 6 off-main executor-isolation trap
+        HTTPStubURLProtocol.register { @Sendable [tokenURL] request in
             guard request.url == tokenURL else { return nil }
-            tokenRequestCount += 1
+            tokenRequestCount.withValue { $0 += 1 }
             // 401 from the token endpoint — credentials no longer accepted.
             return .init(statusCode: 401, headers: nil, body: Data("denied".utf8))
         }
@@ -186,7 +187,7 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
                       "401 from /token must surface as a .failure to the caller")
         XCTAssertEqual(userAccount.authState, .credentialsStale,
                        "A 401 from /token must mark the user's credentials stale (kills `==` → `!=` on the 401-check, and deletion of markCredentialsStale)")
-        XCTAssertEqual(tokenRequestCount, 1,
+        XCTAssertEqual(tokenRequestCount.value, 1,
                        "Failed /token must NOT be retried by the executor — kills any mutation that turns the failure path into a retry loop")
 
         let attempts = await executor.refreshAttemptCount
@@ -209,7 +210,8 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         // Return a 500 — NOT a 401. The TokenRequest layer maps non-200
         // into an NSError with `.code == statusCode` (so .code == 500).
         // The executor branch we care about gates on .code == 401 only.
-        HTTPStubURLProtocol.register { [tokenURL] request in
+        // @Sendable stub + LockIsolated: avoids Swift 6 off-main executor-isolation trap
+        HTTPStubURLProtocol.register { @Sendable [tokenURL] request in
             guard request.url == tokenURL else { return nil }
             return .init(statusCode: 500, headers: nil, body: Data("boom".utf8))
         }
@@ -252,9 +254,10 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         userAccount._credentials = nil
         XCTAssertNil(userAccount.barcode)
 
-        var tokenEndpointCalls = 0
-        HTTPStubURLProtocol.register { [tokenURL] request in
-            if request.url == tokenURL { tokenEndpointCalls += 1 }
+        let tokenEndpointCalls = LockIsolated(0)
+        // @Sendable stub + LockIsolated: avoids Swift 6 off-main executor-isolation trap
+        HTTPStubURLProtocol.register { @Sendable [tokenURL] request in
+            if request.url == tokenURL { tokenEndpointCalls.withValue { $0 += 1 } }
             return .init(statusCode: 200,
                          headers: nil,
                          body: Self.tokenResponseJSON(accessToken: "should-not-be-returned"))
@@ -272,7 +275,7 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
 
         XCTAssertTrue(observedFailure,
                       "Missing credentials must surface as .failure (kills deletion of completion(.failure) in the missing-creds branch)")
-        XCTAssertEqual(tokenEndpointCalls, 0,
+        XCTAssertEqual(tokenEndpointCalls.value, 0,
                        "No HTTP call to /token can occur without credentials (kills inversion of the credentials guard)")
 
         let attempts = await executor.refreshAttemptCount
@@ -314,12 +317,12 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         // pile up behind the same /token request. We release after we've
         // observed all callers entering the queue.
         let releaseGate = DispatchSemaphore(value: 0)
-        var tokenRequestCount = 0
-        let counterQueue = DispatchQueue(label: "token.count")
+        let tokenRequestCount = LockIsolated(0)
 
-        HTTPStubURLProtocol.register { [tokenURL] request in
+        // @Sendable stub + LockIsolated: avoids Swift 6 off-main executor-isolation trap
+        HTTPStubURLProtocol.register { @Sendable [tokenURL] request in
             guard request.url == tokenURL else { return nil }
-            counterQueue.sync { tokenRequestCount += 1 }
+            tokenRequestCount.withValue { $0 += 1 }
             // Block the protocol thread until the test releases. Cap at
             // 3s so a broken single-flight guard surfaces as N>1 instead
             // of a hung test.
@@ -360,11 +363,11 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         // Give the actor a moment to serialize all entrances before we
         // release the gate. Polling: when all 5 callers have entered, the
         // refreshAttemptCount must still be exactly 1.
-        _ = waitForCondition(timeout: 2.0) { [counterQueue] in
+        _ = waitForCondition(timeout: 2.0) {
             // Wait until the /token request has been received. After that,
             // any other in-flight refresh callers have either coalesced
             // or are stuck in the actor hop.
-            counterQueue.sync { tokenRequestCount } == 1
+            tokenRequestCount.value == 1
         }
 
         // Sample the attempt counter while /token is still blocked: this
@@ -414,13 +417,13 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         // synchronization the test thread can observe `retryHits >= 1`
         // before the prior `capturedRetryAuth` store is visible (no
         // happens-before across plain `var`s in Swift). The CI flake
-        // was nil!=newToken precisely because of this gap. NSLock
+        // was nil!=newToken precisely because of this gap. LockIsolated
         // around every shared-state access closes it.
-        let lock = NSLock()
-        nonisolated(unsafe) var capturedRetryAuth: String? = nil
-        nonisolated(unsafe) var retryHits = 0
+        let capturedRetryAuth = LockIsolated<String?>(nil)
+        let retryHits = LockIsolated(0)
 
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        // @Sendable stub + LockIsolated: avoids Swift 6 off-main executor-isolation trap
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
                 return .init(statusCode: 200,
                              headers: nil,
@@ -428,10 +431,8 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
             }
             if request.url == apiURL {
                 let authValue = request.value(forHTTPHeaderField: "Authorization")
-                lock.lock()
-                capturedRetryAuth = authValue
-                retryHits += 1
-                lock.unlock()
+                capturedRetryAuth.value = authValue
+                retryHits.withValue { $0 += 1 }
                 return .init(statusCode: 200, headers: nil, body: Data("ok".utf8))
             }
             return nil
@@ -448,12 +449,11 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         // teardown well past 5s — same root cause as the BookRegistry,
         // CatalogCache, and ImageCache flakes documented in 2877d1a8e).
         let retried = waitForCondition(timeout: 30.0) {
-            lock.lock(); defer { lock.unlock() }
-            return retryHits >= 1
+            return retryHits.value >= 1
         }
         XCTAssertTrue(retried, "The queued task must be retried after the /token refresh succeeds")
 
-        let observedAuth = lock.withLock { capturedRetryAuth }
+        let observedAuth = capturedRetryAuth.value
 
         XCTAssertEqual(observedAuth,
                        "Bearer \(newToken)",
@@ -476,13 +476,14 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         // Two successive successful refreshes must both increment the
         // attempt counter (1 → 2). If the slot is never released, the
         // second attempt would coalesce and the counter would stay at 1.
-        var tokenHits = 0
-        HTTPStubURLProtocol.register { [tokenURL] request in
+        let tokenHits = LockIsolated(0)
+        // @Sendable stub + LockIsolated: avoids Swift 6 off-main executor-isolation trap
+        HTTPStubURLProtocol.register { @Sendable [tokenURL] request in
             guard request.url == tokenURL else { return nil }
-            tokenHits += 1
+            let hit = tokenHits.withValue { $0 += 1; return $0 }
             return .init(statusCode: 200,
                          headers: nil,
-                         body: Self.tokenResponseJSON(accessToken: "tok-\(tokenHits)"))
+                         body: Self.tokenResponseJSON(accessToken: "tok-\(hit)"))
         }
 
         let first = expectation(description: "first refresh")
@@ -499,7 +500,7 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         let attempts = await executor.refreshAttemptCount
         XCTAssertEqual(attempts, 2,
                        "Two successive successful refreshes must each claim the slot — kills deletion of setRefreshing(false) on the success branch")
-        XCTAssertEqual(tokenHits, 2,
+        XCTAssertEqual(tokenHits.value, 2,
                        "Each released-and-reclaimed refresh must fire its own /token request")
     }
 
@@ -520,7 +521,8 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
 
     func testQueuedRequest_CompletionFiresWithRetryBodyAfterRetry() async throws {
         await executor.resetRefreshAttemptCount()
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        // @Sendable stub + LockIsolated: avoids Swift 6 off-main executor-isolation trap
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
                 return .init(statusCode: 200,
                              headers: nil,
@@ -542,17 +544,19 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         // for the original task and the success event for the retry,
         // so we rely on polling for the retry-body to land rather than
         // an XCTestExpectation that would over-fulfill.
-        var successBodies: [Data] = []
-        var failureCount = 0
-        let observerQueue = DispatchQueue(label: "test.observer")
-        executor.responder.addCompletion({ result in
-            observerQueue.sync {
-                switch result {
-                case .success(let data, _):
-                    successBodies.append(data)
-                case .failure:
-                    failureCount += 1
-                }
+        // @Sendable completion + LockIsolated: the responder invokes this
+        // completion off the main actor (URLSession delegate queue), but the
+        // closure is inferred @MainActor-isolated in this @MainActor test — so
+        // without @Sendable it trips Swift 6's off-main executor-isolation
+        // assertion (EXC_BREAKPOINT) exactly like the register stubs above.
+        let successBodies = LockIsolated<[Data]>([])
+        let failureCount = LockIsolated(0)
+        executor.responder.addCompletion({ @Sendable result in
+            switch result {
+            case .success(let data, _):
+                successBodies.withValue { $0.append(data) }
+            case .failure:
+                failureCount.withValue { $0 += 1 }
             }
         }, taskID: queuedTask.taskIdentifier)
 
@@ -563,11 +567,11 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         // success arrives (or we time out, which means updateCompletionId
         // was bypassed and the new task has no completion mapping).
         let sawRetryBody = waitForCondition(timeout: 5.0) {
-            observerQueue.sync { successBodies.contains(Data("retry-body".utf8)) }
+            successBodies.value.contains(Data("retry-body".utf8))
         }
 
-        let snapshotSuccess = observerQueue.sync { successBodies.count }
-        let snapshotFailure = observerQueue.sync { failureCount }
+        let snapshotSuccess = successBodies.value.count
+        let snapshotFailure = failureCount.value
         XCTAssertTrue(sawRetryBody,
                       "The retried task's success must reach the caller's completion (kills deletion of responder.updateCompletionId — without rewiring, no success body ever fires). successBodies=\(snapshotSuccess), failureCount=\(snapshotFailure)")
     }
@@ -591,9 +595,10 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         // and verify no token-endpoint request fires when the delete 401s.
         await executor.resetRefreshAttemptCount()
 
-        var tokenHits = 0
-        HTTPStubURLProtocol.register { [tokenURL] request in
-            if request.url == tokenURL { tokenHits += 1 }
+        let tokenHits = LockIsolated(0)
+        // @Sendable stub + LockIsolated: avoids Swift 6 off-main executor-isolation trap
+        HTTPStubURLProtocol.register { @Sendable [tokenURL] request in
+            if request.url == tokenURL { tokenHits.withValue { $0 += 1 } }
             // Fail-closed 401 on the DELETE; no body required.
             if request.httpMethod == "DELETE" {
                 return .init(statusCode: 401, headers: nil, body: nil)
@@ -614,7 +619,7 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
         // is meaningful, not just earliness).
         _ = waitForCondition(timeout: 0.5) { false }
 
-        XCTAssertEqual(tokenHits, 0,
+        XCTAssertEqual(tokenHits.value, 0,
                        "A DELETE 401 must not trigger a token refresh — kills removal of the DELETE early-return in handleExpiredTokenIfNeeded")
         let attempts = await executor.refreshAttemptCount
         XCTAssertEqual(attempts, 0,
@@ -632,7 +637,8 @@ final class TokenRefreshAndRetryQueueTests: XCTestCase {
 
     func testRefresh_SuccessWithoutTask_FiresSuccessCompletion() async throws {
         await executor.resetRefreshAttemptCount()
-        HTTPStubURLProtocol.register { [tokenURL] request in
+        // @Sendable stub + LockIsolated: avoids Swift 6 off-main executor-isolation trap
+        HTTPStubURLProtocol.register { @Sendable [tokenURL] request in
             guard request.url == tokenURL else { return nil }
             return .init(statusCode: 200,
                          headers: nil,

--- a/PalaceTests/Network/TokenRefreshOnForegroundTests.swift
+++ b/PalaceTests/Network/TokenRefreshOnForegroundTests.swift
@@ -39,8 +39,8 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
     private let apiURL = URL(string: "https://api.example.com/protected")!
     private let borrowURL = URL(string: "https://api.example.com/borrow/123")!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         HTTPStubURLProtocol.reset()
         TPPUserAccountMock.resetShared()
 

--- a/PalaceTests/Network/TokenRefreshOnForegroundTests.swift
+++ b/PalaceTests/Network/TokenRefreshOnForegroundTests.swift
@@ -99,7 +99,11 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         return AccountDetails.Authentication(auth: docAuth)
     }
 
-    private static func tokenResponseJSON(accessToken: String, expiresIn: Int = 3600) -> Data {
+    // `nonisolated`: pure string→Data helper with no main-actor state. Called
+    // from `@Sendable` stub closures that run off-main on the URLProtocol
+    // handler queue, so it must not inherit the enclosing `@MainActor` class's
+    // isolation (doing so is what let the stub closure trap at runtime).
+    private nonisolated static func tokenResponseJSON(accessToken: String, expiresIn: Int = 3600) -> Data {
         return """
         {"access_token":"\(accessToken)","token_type":"Bearer","expires_in":\(expiresIn)}
         """.data(using: .utf8)!
@@ -139,17 +143,20 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         // refresh window.
         setTokenExpiringIn(seconds: 60, token: "near-expiry")
 
-        let orderQueue = DispatchQueue(label: "order-recording-queue")
-        var orderedHits: [String] = []
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        // `@Sendable` stub closure + `LockIsolated` recorder — see the
+        // `test_ConcurrentForegroundRequests` rationale: the stub runs off-main
+        // on the handler queue, so it must be non-isolated to avoid the Swift 6
+        // executor-isolation trap.
+        let orderedHits = LockIsolated<[String]>([])
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
-                orderQueue.sync { orderedHits.append("token") }
+                orderedHits.withValue { $0.append("token") }
                 return .init(statusCode: 200,
                              headers: nil,
                              body: Self.tokenResponseJSON(accessToken: "fresh-foreground-token"))
             }
             if request.url == apiURL {
-                orderQueue.sync { orderedHits.append("api") }
+                orderedHits.withValue { $0.append("api") }
                 return .init(statusCode: 200, headers: nil, body: Data("ok".utf8))
             }
             return nil
@@ -159,7 +166,7 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         executor.GET(apiURL) { _ in done.fulfill() }
         await fulfillment(of: [done], timeout: 5.0)
 
-        let snapshot = orderQueue.sync { orderedHits }
+        let snapshot = orderedHits.value
         // Both must have fired; token MUST be first.
         XCTAssertEqual(snapshot.first, "token",
                        "Proactive refresh: /token must hit the network before the user request — kills deletion of the near-expiry branch")
@@ -177,15 +184,16 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
     func test_NearExpiryToken_RetriedRequest_UsesFreshBearer() async throws {
         setTokenExpiringIn(seconds: 30, token: "OLD-bearer")
 
-        var capturedAuth: String?
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        // @Sendable stub + LockIsolated: see test_ConcurrentForegroundRequests rationale
+        let capturedAuth = LockIsolated<String?>(nil)
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
                 return .init(statusCode: 200,
                              headers: nil,
                              body: Self.tokenResponseJSON(accessToken: "NEW-bearer"))
             }
             if request.url == apiURL {
-                capturedAuth = request.value(forHTTPHeaderField: "Authorization")
+                capturedAuth.value = request.value(forHTTPHeaderField: "Authorization")
                 return .init(statusCode: 200, headers: nil, body: Data("ok".utf8))
             }
             return nil
@@ -203,7 +211,7 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         // the account had at request-build time (so callers that build
         // their own request and rely on the proactive refresh updating
         // the account's stored token still get a valid app-state).
-        XCTAssertNotNil(capturedAuth,
+        XCTAssertNotNil(capturedAuth.value,
                         "The user request must include an Authorization header (kills mutation that strips bearer)")
         XCTAssertEqual(userAccount.authToken, "NEW-bearer",
                        "Refresh must persist the new bearer onto the account — kills deletion of setAuthToken on success")
@@ -221,20 +229,20 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         // Gate /token so it stays in flight long enough for the test to
         // observe that the user request has NOT fired yet.
         let releaseGate = DispatchSemaphore(value: 0)
-        let counterQueue = DispatchQueue(label: "counter-queue")
-        var tokenHits = 0
-        var apiHits = 0
+        // @Sendable stub + LockIsolated: see test_ConcurrentForegroundRequests rationale
+        let tokenHits = LockIsolated(0)
+        let apiHits = LockIsolated(0)
 
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
-                counterQueue.sync { tokenHits += 1 }
+                tokenHits.withValue { $0 += 1 }
                 _ = releaseGate.wait(timeout: .now() + 3.0)
                 return .init(statusCode: 200,
                              headers: nil,
                              body: Self.tokenResponseJSON(accessToken: "fresh"))
             }
             if request.url == apiURL {
-                counterQueue.sync { apiHits += 1 }
+                apiHits.withValue { $0 += 1 }
                 return .init(statusCode: 200, headers: nil, body: Data("ok".utf8))
             }
             return nil
@@ -248,17 +256,17 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         // 30s budget matches the #999 "un-tighten" pattern — local <100ms,
         // CI runner under parallel-test contention stalls the URLSession
         // dispatch past 2s.
-        XCTAssertTrue(waitForCondition(timeout: 30.0) { counterQueue.sync { tokenHits } == 1 },
+        XCTAssertTrue(waitForCondition(timeout: 30.0) { tokenHits.value == 1 },
                       "Token endpoint should be in-flight")
         // Snapshot now — race-window check.
-        let apiInFlightWhileTokenBlocking = counterQueue.sync { apiHits }
+        let apiInFlightWhileTokenBlocking = apiHits.value
         XCTAssertEqual(apiInFlightWhileTokenBlocking, 0,
                        "User request must NOT fire while /token is still in flight — kills mutation that performs the data task outside the refresh completion")
 
         releaseGate.signal()
         await fulfillment(of: [done], timeout: 5.0)
 
-        XCTAssertEqual(counterQueue.sync { apiHits }, 1,
+        XCTAssertEqual(apiHits.value, 1,
                        "After refresh resolves, the user request runs exactly once")
     }
 
@@ -272,10 +280,11 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         // Expires in an hour: WELL above the 5-minute threshold.
         setTokenExpiringIn(seconds: 3600)
 
-        var tokenHits = 0
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        // @Sendable stub + LockIsolated: see test_ConcurrentForegroundRequests rationale
+        let tokenHits = LockIsolated(0)
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
-                tokenHits += 1
+                tokenHits.withValue { $0 += 1 }
                 return .init(statusCode: 200,
                              headers: nil,
                              body: Self.tokenResponseJSON(accessToken: "should-not-fire"))
@@ -292,7 +301,7 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         // Wait a touch longer to make absence of /token meaningful.
         _ = waitForCondition(timeout: 0.3) { false }
 
-        XCTAssertEqual(tokenHits, 0,
+        XCTAssertEqual(tokenHits.value, 0,
                        "Healthy token must not trigger /token — kills deletion of the authTokenNearExpiry gate")
     }
 
@@ -306,17 +315,18 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
     func test_UseTokenIfAvailableFalse_BypassesProactiveRefresh() async throws {
         setTokenExpiringIn(seconds: 30)
 
-        var tokenHits = 0
-        var apiAuthHeader: String?
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        // @Sendable stub + LockIsolated: see test_ConcurrentForegroundRequests rationale
+        let tokenHits = LockIsolated(0)
+        let apiAuthHeader = LockIsolated<String?>(nil)
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
-                tokenHits += 1
+                tokenHits.withValue { $0 += 1 }
                 return .init(statusCode: 200,
                              headers: nil,
                              body: Self.tokenResponseJSON(accessToken: "fresh"))
             }
             if request.url == apiURL {
-                apiAuthHeader = request.value(forHTTPHeaderField: "Authorization")
+                apiAuthHeader.value = request.value(forHTTPHeaderField: "Authorization")
                 return .init(statusCode: 200, headers: nil, body: Data("ok".utf8))
             }
             return nil
@@ -327,9 +337,9 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         executor.GET(apiURL, useTokenIfAvailable: false) { _ in done.fulfill() }
         await fulfillment(of: [done], timeout: 5.0)
 
-        XCTAssertEqual(tokenHits, 0,
+        XCTAssertEqual(tokenHits.value, 0,
                        "useTokenIfAvailable=false must skip /token even with a near-expiry token — kills mutation that always refreshes")
-        XCTAssertNil(apiAuthHeader,
+        XCTAssertNil(apiAuthHeader.value,
                      "useTokenIfAvailable=false must NOT inject an Authorization header — kills mutation that ignores the flag in request(for:)")
     }
 
@@ -346,21 +356,22 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         {"book_id":"abc-123","quantity":1,"idempotency_key":"k-9001"}
         """.utf8)
 
-        var capturedPostBodies: [Data] = []
-        var capturedPostMethod: String?
-        HTTPStubURLProtocol.register { [tokenURL, borrowURL] request in
+        // @Sendable stub + LockIsolated: see test_ConcurrentForegroundRequests rationale
+        let capturedPostBodies = LockIsolated<[Data]>([])
+        let capturedPostMethod = LockIsolated<String?>(nil)
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, borrowURL] request in
             if request.url == tokenURL {
                 return .init(statusCode: 200,
                              headers: nil,
                              body: Self.tokenResponseJSON(accessToken: "post-refresh-bearer"))
             }
             if request.url == borrowURL {
-                capturedPostMethod = request.httpMethod
+                capturedPostMethod.value = request.httpMethod
                 // URLProtocol receives the body via httpBodyStream for POSTs
                 // when the request was constructed with httpBody. We read
                 // whichever surface carries the bytes.
                 if let direct = request.httpBody {
-                    capturedPostBodies.append(direct)
+                    capturedPostBodies.withValue { $0.append(direct) }
                 } else if let stream = request.httpBodyStream {
                     stream.open()
                     defer { stream.close() }
@@ -371,9 +382,9 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
                         if n <= 0 { break }
                         collected.append(buffer, count: n)
                     }
-                    capturedPostBodies.append(collected)
+                    capturedPostBodies.withValue { $0.append(collected) }
                 } else {
-                    capturedPostBodies.append(Data())
+                    capturedPostBodies.withValue { $0.append(Data()) }
                 }
                 return .init(statusCode: 200, headers: nil, body: Data("ok".utf8))
             }
@@ -392,11 +403,11 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         await fulfillment(of: [done], timeout: 5.0)
 
         // Exactly one POST must have fired (no double-charge).
-        XCTAssertEqual(capturedPostBodies.count, 1,
+        XCTAssertEqual(capturedPostBodies.value.count, 1,
                        "Exactly one POST must reach the server across the proactive-refresh path — kills mutation that fires the POST twice (double-borrow)")
-        XCTAssertEqual(capturedPostMethod, "POST",
+        XCTAssertEqual(capturedPostMethod.value, "POST",
                        "Method must remain POST after refresh — kills mutation that downgrades to GET on retry")
-        XCTAssertEqual(capturedPostBodies.first, originalBody,
+        XCTAssertEqual(capturedPostBodies.value.first, originalBody,
                        "Body bytes must round-trip exactly — kills mutation that drops or rewrites the POST body during refresh")
     }
 
@@ -412,12 +423,21 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         await executor.resetRefreshAttemptCount()
 
         let releaseGate = DispatchSemaphore(value: 0)
-        let counterQueue = DispatchQueue(label: "concurrent-counter")
-        var tokenHits = 0
+        // `@Sendable` stub closure + `LockIsolated` counter: the stub handler is
+        // invoked on `HTTPStubURLProtocol.handlerQueue` (background), but this
+        // closure is written inside a `@MainActor` test class and therefore
+        // inferred `@MainActor`-isolated. Under Swift 6 the runtime executor
+        // check (`swift_task_checkIsolated`) trapped with EXC_BREAKPOINT the
+        // moment the nested `.sync {}` ran off-main, crashing the test host and
+        // failing every later test in that launch as collateral. Marking the
+        // closure `@Sendable` drops the main-actor isolation so it runs safely
+        // off-main; a `LockIsolated` box replaces the captured `var` (a
+        // `@Sendable` closure cannot capture a mutable `var`).
+        let tokenHits = LockIsolated(0)
 
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
-                counterQueue.sync { tokenHits += 1 }
+                tokenHits.withValue { $0 += 1 }
                 _ = releaseGate.wait(timeout: .now() + 3.0)
                 return .init(statusCode: 200,
                              headers: nil,
@@ -443,9 +463,9 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         // baseline, CI runner under parallel-test contention stalls the
         // actor-hop + URLSession dispatch well past 2s — same root cause
         // as the BookRegistry / CatalogCache / ImageCache 30s restorations).
-        XCTAssertTrue(waitForCondition(timeout: 30.0) { counterQueue.sync { tokenHits } >= 1 },
+        XCTAssertTrue(waitForCondition(timeout: 30.0) { tokenHits.value >= 1 },
                       "/token endpoint should be in-flight")
-        let snapshotted = counterQueue.sync { tokenHits }
+        let snapshotted = tokenHits.value
         XCTAssertEqual(snapshotted, 1,
                        "Concurrent foreground refreshes must coalesce to a single /token call — kills removal of single-flight in the proactive path")
 
@@ -464,7 +484,8 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
     func test_ForegroundRefreshFailure_StillResolvesCaller() async throws {
         setTokenExpiringIn(seconds: 30)
 
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        // @Sendable stub + LockIsolated: see test_ConcurrentForegroundRequests rationale
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
                 return .init(statusCode: 500, headers: nil, body: Data("server-error".utf8))
             }
@@ -492,10 +513,11 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         // expires *exactly* at the 5-minute threshold boundary.
         setTokenExpiringIn(seconds: 300, token: "edge-case")
 
-        var tokenHits = 0
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        // @Sendable stub + LockIsolated: see test_ConcurrentForegroundRequests rationale
+        let tokenHits = LockIsolated(0)
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
-                tokenHits += 1
+                tokenHits.withValue { $0 += 1 }
                 return .init(statusCode: 200,
                              headers: nil,
                              body: Self.tokenResponseJSON(accessToken: "fresh"))
@@ -510,7 +532,7 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         executor.GET(apiURL) { _ in done.fulfill() }
         await fulfillment(of: [done], timeout: 5.0)
 
-        XCTAssertGreaterThanOrEqual(tokenHits, 1,
+        XCTAssertGreaterThanOrEqual(tokenHits.value, 1,
                                     "Token at exact threshold must be treated as near-expiry — kills mutation `<=` → `<` in isTokenNearExpiry")
     }
 
@@ -537,10 +559,11 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         userAccount._authDefinition = AccountDetails.Authentication(auth: samlAuth)
         setTokenExpiringIn(seconds: 30)
 
-        var tokenHits = 0
-        HTTPStubURLProtocol.register { [tokenURL, apiURL] request in
+        // @Sendable stub + LockIsolated: see test_ConcurrentForegroundRequests rationale
+        let tokenHits = LockIsolated(0)
+        HTTPStubURLProtocol.register { @Sendable [tokenURL, apiURL] request in
             if request.url == tokenURL {
-                tokenHits += 1
+                tokenHits.withValue { $0 += 1 }
                 return .init(statusCode: 200,
                              headers: nil,
                              body: Self.tokenResponseJSON(accessToken: "should-not"))
@@ -555,7 +578,7 @@ final class TokenRefreshOnForegroundTests: XCTestCase {
         executor.GET(apiURL) { _ in done.fulfill() }
         await fulfillment(of: [done], timeout: 5.0)
 
-        XCTAssertEqual(tokenHits, 0,
+        XCTAssertEqual(tokenHits.value, 0,
                        "SAML auth must short-circuit before the proactive refresh — kills deletion of the SAML early-return in executeRequest")
     }
 }

--- a/PalaceTests/OPDS2/OPDSFeedCacheTests.swift
+++ b/PalaceTests/OPDS2/OPDSFeedCacheTests.swift
@@ -36,7 +36,7 @@ final class OPDSFeedCacheTests: XCTestCase {
 
     func testSetAndGet() async throws {
         let url = URL(string: "https://example.com/feed")!
-        let feed = makeFeed(title: "Test Feed")
+        let feed = Self.makeFeed(title: "Test Feed")
         let entry = OPDSCacheEntry(feed: feed)
 
         await sut.set(entry, for: url)
@@ -59,7 +59,7 @@ final class OPDSFeedCacheTests: XCTestCase {
 
     func testRemove() async throws {
         let url = URL(string: "https://example.com/feed")!
-        let feed = makeFeed(title: "Test Feed")
+        let feed = Self.makeFeed(title: "Test Feed")
         let entry = OPDSCacheEntry(feed: feed)
 
         await sut.set(entry, for: url)
@@ -78,8 +78,8 @@ final class OPDSFeedCacheTests: XCTestCase {
         let url1 = URL(string: "https://example.com/feed1")!
         let url2 = URL(string: "https://example.com/feed2")!
 
-        await sut.set(OPDSCacheEntry(feed: makeFeed(title: "Feed 1")), for: url1)
-        await sut.set(OPDSCacheEntry(feed: makeFeed(title: "Feed 2")), for: url2)
+        await sut.set(OPDSCacheEntry(feed: Self.makeFeed(title: "Feed 1")), for: url1)
+        await sut.set(OPDSCacheEntry(feed: Self.makeFeed(title: "Feed 2")), for: url2)
 
         await sut.clear()
 
@@ -96,12 +96,12 @@ final class OPDSFeedCacheTests: XCTestCase {
         // Fill cache to capacity
         for i in 0..<10 {
             let url = URL(string: "https://example.com/feed\(i)")!
-            await sut.set(OPDSCacheEntry(feed: makeFeed(title: "Feed \(i)")), for: url)
+            await sut.set(OPDSCacheEntry(feed: Self.makeFeed(title: "Feed \(i)")), for: url)
         }
 
         // Add one more to trigger eviction
         let newURL = URL(string: "https://example.com/newfeed")!
-        await sut.set(OPDSCacheEntry(feed: makeFeed(title: "New Feed")), for: newURL)
+        await sut.set(OPDSCacheEntry(feed: Self.makeFeed(title: "New Feed")), for: newURL)
 
         // The oldest should be evicted
         let oldest = await sut.get(for: URL(string: "https://example.com/feed0")!)
@@ -116,8 +116,8 @@ final class OPDSFeedCacheTests: XCTestCase {
         let url2 = URL(string: "https://example.com/feed2")!
 
         // Add two entries
-        await sut.set(OPDSCacheEntry(feed: makeFeed(title: "Feed 1")), for: url1)
-        await sut.set(OPDSCacheEntry(feed: makeFeed(title: "Feed 2")), for: url2)
+        await sut.set(OPDSCacheEntry(feed: Self.makeFeed(title: "Feed 1")), for: url1)
+        await sut.set(OPDSCacheEntry(feed: Self.makeFeed(title: "Feed 2")), for: url2)
 
         // Access the first one to make it more recent
         _ = await sut.get(for: url1)
@@ -125,12 +125,12 @@ final class OPDSFeedCacheTests: XCTestCase {
         // Fill the rest of the cache
         for i in 3...10 {
             let url = URL(string: "https://example.com/feed\(i)")!
-            await sut.set(OPDSCacheEntry(feed: makeFeed(title: "Feed \(i)")), for: url)
+            await sut.set(OPDSCacheEntry(feed: Self.makeFeed(title: "Feed \(i)")), for: url)
         }
 
         // Add one more to trigger eviction
         let newURL = URL(string: "https://example.com/newfeed")!
-        await sut.set(OPDSCacheEntry(feed: makeFeed(title: "New Feed")), for: newURL)
+        await sut.set(OPDSCacheEntry(feed: Self.makeFeed(title: "New Feed")), for: newURL)
 
         // feed1 should still exist (was accessed recently), feed2 should be evicted
         let cached1 = await sut.get(for: url1)
@@ -143,7 +143,7 @@ final class OPDSFeedCacheTests: XCTestCase {
     // MARK: - Staleness and Expiration
 
     func testCacheEntryIsStale() async throws {
-        let feed = makeFeed(title: "Test")
+        let feed = Self.makeFeed(title: "Test")
         let entry = OPDSCacheEntry(feed: feed, timestamp: Date().addingTimeInterval(-2)) // 2 seconds ago
 
         // With 1 second TTL, this should be stale
@@ -152,7 +152,7 @@ final class OPDSFeedCacheTests: XCTestCase {
     }
 
     func testCacheEntryIsExpired() async throws {
-        let feed = makeFeed(title: "Test")
+        let feed = Self.makeFeed(title: "Test")
         let entry = OPDSCacheEntry(feed: feed, timestamp: Date().addingTimeInterval(-10)) // 10 seconds ago
 
         // With 5 second max age, this should be expired
@@ -162,7 +162,7 @@ final class OPDSFeedCacheTests: XCTestCase {
 
     func testExpiredEntriesNotReturned() async throws {
         let url = URL(string: "https://example.com/feed")!
-        let feed = makeFeed(title: "Old Feed")
+        let feed = Self.makeFeed(title: "Old Feed")
         let entry = OPDSCacheEntry(feed: feed, timestamp: Date().addingTimeInterval(-10)) // Very old
 
         await sut.set(entry, for: url)
@@ -172,7 +172,7 @@ final class OPDSFeedCacheTests: XCTestCase {
         XCTAssertNil(cached, "Expired entries should not be returned")
         // A fresh entry at a different URL must still be returned
         let freshURL = URL(string: "https://example.com/fresh")!
-        let freshEntry = OPDSCacheEntry(feed: makeFeed(title: "Fresh"))
+        let freshEntry = OPDSCacheEntry(feed: Self.makeFeed(title: "Fresh"))
         await sut.set(freshEntry, for: freshURL)
         let freshCached = await sut.get(for: freshURL)
         XCTAssertNotNil(freshCached, "A fresh entry must still be returned even when an expired one exists")
@@ -182,28 +182,28 @@ final class OPDSFeedCacheTests: XCTestCase {
 
     func testGetWithRevalidationReturnsFreshData() async throws {
         let url = URL(string: "https://example.com/feed")!
-        let feed = makeFeed(title: "Fresh Feed")
+        let feed = Self.makeFeed(title: "Fresh Feed")
         let entry = OPDSCacheEntry(feed: feed) // Fresh timestamp
 
         await sut.set(entry, for: url)
 
-        var fetcherCalled = false
+        let fetcherCalled = LockIsolated<Bool>(false)
         let result = try await sut.getWithRevalidation(for: url) {
-            fetcherCalled = true
-            return (self.makeFeed(title: "New Feed"), nil, nil)
+            fetcherCalled.value = true
+            return (Self.makeFeed(title: "New Feed"), nil, nil)
         }
 
         XCTAssertEqual(result.feed.title, "Fresh Feed")
         XCTAssertFalse(result.isStale)
         XCTAssertFalse(result.didTriggerRefresh)
-        XCTAssertFalse(fetcherCalled, "Fetcher should not be called for fresh data")
+        XCTAssertFalse(fetcherCalled.value, "Fetcher should not be called for fresh data")
     }
 
     func testGetWithRevalidationFetchesWhenNoCache() async throws {
         let url = URL(string: "https://example.com/newurl")!
 
         let result = try await sut.getWithRevalidation(for: url) {
-            return (self.makeFeed(title: "Fetched Feed"), "etag123", "Mon, 01 Jan 2026 00:00:00 GMT")
+            return (Self.makeFeed(title: "Fetched Feed"), "etag123", "Mon, 01 Jan 2026 00:00:00 GMT")
         }
 
         XCTAssertEqual(result.feed.title, "Fetched Feed")
@@ -220,7 +220,7 @@ final class OPDSFeedCacheTests: XCTestCase {
 
     func testConditionalHeaders() async throws {
         let url = URL(string: "https://example.com/feed")!
-        let feed = makeFeed(title: "Feed")
+        let feed = Self.makeFeed(title: "Feed")
         let entry = OPDSCacheEntry(
             feed: feed,
             etag: "\"abc123\"",
@@ -250,7 +250,7 @@ final class OPDSFeedCacheTests: XCTestCase {
 
     func testStats() async throws {
         let url = URL(string: "https://example.com/feed")!
-        await sut.set(OPDSCacheEntry(feed: makeFeed(title: "Feed")), for: url)
+        await sut.set(OPDSCacheEntry(feed: Self.makeFeed(title: "Feed")), for: url)
 
         let stats = await sut.stats()
 
@@ -260,7 +260,7 @@ final class OPDSFeedCacheTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeFeed(title: String) -> OPDS2Feed {
+    private nonisolated static func makeFeed(title: String) -> OPDS2Feed {
         OPDS2Feed(
             metadata: OPDS2FeedMetadata(title: title),
             links: [OPDS2Link(href: "https://example.com", rel: "self")]

--- a/PalaceTests/Platform/AccessibilityServiceTests.swift
+++ b/PalaceTests/Platform/AccessibilityServiceTests.swift
@@ -22,7 +22,12 @@ final class AccessibilityServiceTests: XCTestCase {
         super.setUp()
         userDefaults = UserDefaults(suiteName: "AccessibilityServiceTests")!
         userDefaults.removePersistentDomain(forName: "AccessibilityServiceTests")
-        service = AccessibilityService(userDefaults: userDefaults)
+        // Pass a fresh, disconnected UserDefaults into the actor init. UserDefaults
+        // is non-Sendable and the actor's init parameter is implicitly `sending`;
+        // a value the @MainActor test also retains (self.userDefaults) can't be
+        // sent, but an inline same-suite instance is its own region and shares the
+        // backing store, so cleanup via self.userDefaults still works.
+        service = AccessibilityService(userDefaults: UserDefaults(suiteName: "AccessibilityServiceTests")!)
         cancellables = Set<AnyCancellable>()
     }
 
@@ -71,8 +76,9 @@ final class AccessibilityServiceTests: XCTestCase {
 
         await service.updatePreferences(prefs)
 
-        // Create new instance with same UserDefaults
-        let newService = AccessibilityService(userDefaults: userDefaults)
+        // Create new instance with same UserDefaults suite (fresh disconnected
+        // region so it can be `sending`-passed into the actor init; shares backing store).
+        let newService = AccessibilityService(userDefaults: UserDefaults(suiteName: "AccessibilityServiceTests")!)
         let loaded = await newService.currentPreferences()
 
         XCTAssertEqual(loaded.verbosity, .minimal)

--- a/PalaceTests/Platform/AccessibilityServiceTests.swift
+++ b/PalaceTests/Platform/AccessibilityServiceTests.swift
@@ -93,6 +93,7 @@ final class AccessibilityServiceTests: XCTestCase {
 
         service.preferencesPublisher
             .dropFirst() // Drop the initial value
+            .receive(on: DispatchQueue.main)   // deliver on main so the @MainActor sink closure isn't invoked off-main (Swift 6 executor-isolation trap)
             .sink { prefs in
                 receivedPrefs = prefs
                 expectation.fulfill()

--- a/PalaceTests/Platform/AppHealthViewModelTests.swift
+++ b/PalaceTests/Platform/AppHealthViewModelTests.swift
@@ -27,8 +27,11 @@ final class AppHealthViewModelTests: XCTestCase {
         userDefaults = UserDefaults(suiteName: "AppHealthViewModelTests")!
         userDefaults.removePersistentDomain(forName: "AppHealthViewModelTests")
         performanceMonitor = PerformanceMonitor()
-        offlineQueueService = OfflineQueueService(userDefaults: userDefaults)
-        positionSyncService = PositionSyncService(userDefaults: userDefaults)
+        // Fresh, disconnected same-suite UserDefaults per actor init (non-Sendable
+        // value can't be sent from the @MainActor test's retained property; an
+        // inline instance is its own region and shares the backing store).
+        offlineQueueService = OfflineQueueService(userDefaults: UserDefaults(suiteName: "AppHealthViewModelTests")!)
+        positionSyncService = PositionSyncService(userDefaults: UserDefaults(suiteName: "AppHealthViewModelTests")!)
         viewModel = AppHealthViewModel(
             performanceMonitor: performanceMonitor,
             offlineQueueService: offlineQueueService,

--- a/PalaceTests/Platform/OfflineQueueServiceExtendedTests.swift
+++ b/PalaceTests/Platform/OfflineQueueServiceExtendedTests.swift
@@ -22,7 +22,10 @@ final class OfflineQueueServiceExtendedTests: XCTestCase {
         super.setUp()
         userDefaults = UserDefaults(suiteName: "OfflineQueueServiceExtendedTests")!
         userDefaults.removePersistentDomain(forName: "OfflineQueueServiceExtendedTests")
-        service = OfflineQueueService(userDefaults: userDefaults)
+        // Inline same-suite UserDefaults: non-Sendable, so it must be a fresh
+        // disconnected region to be `sending`-passed into the actor init (the
+        // test also retains self.userDefaults for cleanup). Shares backing store.
+        service = OfflineQueueService(userDefaults: UserDefaults(suiteName: "OfflineQueueServiceExtendedTests")!)
         cancellables = Set<AnyCancellable>()
     }
 
@@ -84,7 +87,7 @@ final class OfflineQueueServiceExtendedTests: XCTestCase {
         await service.enqueue(OfflineAction(type: .return, bookID: "b2", bookTitle: "Book 2"))
 
         // Create new service instance using same UserDefaults
-        let newService = OfflineQueueService(userDefaults: userDefaults)
+        let newService = OfflineQueueService(userDefaults: UserDefaults(suiteName: "OfflineQueueServiceExtendedTests")!)
         let status = await newService.currentStatus()
 
         XCTAssertEqual(status.pendingCount, 2)
@@ -95,7 +98,7 @@ final class OfflineQueueServiceExtendedTests: XCTestCase {
         await service.enqueue(OfflineAction(type: .borrow, bookID: "b1", bookTitle: "T"))
 
         // Create new service - processing state should be reset to pending
-        let newService = OfflineQueueService(userDefaults: userDefaults)
+        let newService = OfflineQueueService(userDefaults: UserDefaults(suiteName: "OfflineQueueServiceExtendedTests")!)
         let processing = await newService.actions(withState: .processing)
         XCTAssertEqual(processing.count, 0)
     }

--- a/PalaceTests/Platform/OfflineQueueServiceTests.swift
+++ b/PalaceTests/Platform/OfflineQueueServiceTests.swift
@@ -26,7 +26,10 @@ final class OfflineQueueServiceTests: XCTestCase {
         super.setUp()
         userDefaults = UserDefaults(suiteName: "OfflineQueueServiceTests")!
         userDefaults.removePersistentDomain(forName: "OfflineQueueServiceTests")
-        service = OfflineQueueService(userDefaults: userDefaults)
+        // Inline same-suite UserDefaults: non-Sendable, so it must be a fresh
+        // disconnected region to be `sending`-passed into the actor init (the
+        // test also retains self.userDefaults for cleanup). Shares backing store.
+        service = OfflineQueueService(userDefaults: UserDefaults(suiteName: "OfflineQueueServiceTests")!)
         cancellables = Set<AnyCancellable>()
         executedActions.value = []
     }
@@ -42,8 +45,9 @@ final class OfflineQueueServiceTests: XCTestCase {
     // MARK: - Helpers
 
     private func setupSuccessExecutor() async {
+        let box = executedActions
         await service.setExecutor { action in
-            executedActions.withValue { $0.append(action) }
+            box.withValue { $0.append(action) }
             return true
         }
     }
@@ -232,7 +236,7 @@ final class OfflineQueueServiceTests: XCTestCase {
         let action = OfflineAction(type: .borrow, bookID: "book1", bookTitle: "Test Book")
         await service.enqueue(action)
 
-        let newService = OfflineQueueService(userDefaults: userDefaults)
+        let newService = OfflineQueueService(userDefaults: UserDefaults(suiteName: "OfflineQueueServiceTests")!)
         let status = await newService.currentStatus()
         XCTAssertEqual(status.pendingCount, 1)
     }
@@ -243,7 +247,7 @@ final class OfflineQueueServiceTests: XCTestCase {
         let action = OfflineAction(type: .hold, bookID: "book1", bookTitle: "Test Book")
         await service.enqueue(action)
 
-        let newService = OfflineQueueService(userDefaults: userDefaults)
+        let newService = OfflineQueueService(userDefaults: UserDefaults(suiteName: "OfflineQueueServiceTests")!)
         let pending = await newService.actions(withState: .pending)
         let processing = await newService.actions(withState: .processing)
 

--- a/PalaceTests/Platform/OfflineQueueServiceTests.swift
+++ b/PalaceTests/Platform/OfflineQueueServiceTests.swift
@@ -198,6 +198,7 @@ final class OfflineQueueServiceTests: XCTestCase {
         service.statusPublisher
             .dropFirst() // Drop initial empty
             .first()
+            .receive(on: DispatchQueue.main)   // deliver on main so the @MainActor sink closure isn't invoked off-main (Swift 6 executor-isolation trap)
             .sink { status in
                 receivedStatus = status
                 expectation.fulfill()
@@ -217,6 +218,7 @@ final class OfflineQueueServiceTests: XCTestCase {
 
         service.actionPublisher
             .first()
+            .receive(on: DispatchQueue.main)   // deliver on main so the @MainActor sink closure isn't invoked off-main (Swift 6 executor-isolation trap)
             .sink { action in
                 XCTAssertEqual(action.bookID, "book1")
                 expectation.fulfill()

--- a/PalaceTests/Platform/PerformanceMonitorTests.swift
+++ b/PalaceTests/Platform/PerformanceMonitorTests.swift
@@ -179,6 +179,7 @@ final class PerformanceMonitorTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Metric published")
 
         monitor.metricPublisher
+            .receive(on: DispatchQueue.main)   // deliver on main so the @MainActor sink closure isn't invoked off-main (Swift 6 executor-isolation trap)
             .sink { metric in
                 XCTAssertEqual(metric.name, "published_test")
                 expectation.fulfill()

--- a/PalaceTests/Platform/PositionSyncServiceTests.swift
+++ b/PalaceTests/Platform/PositionSyncServiceTests.swift
@@ -23,7 +23,10 @@ final class PositionSyncServiceTests: XCTestCase {
         super.setUp()
         userDefaults = UserDefaults(suiteName: "PositionSyncServiceTests")!
         userDefaults.removePersistentDomain(forName: "PositionSyncServiceTests")
-        service = PositionSyncService(userDefaults: userDefaults)
+        // Fresh, disconnected same-suite UserDefaults into the actor init: the
+        // non-Sendable stored `self.userDefaults` can't be sent, but an inline
+        // instance is its own region and shares the backing store (cleanup + reads).
+        service = PositionSyncService(userDefaults: UserDefaults(suiteName: "PositionSyncServiceTests")!)
         cancellables = Set<AnyCancellable>()
     }
 
@@ -243,8 +246,9 @@ final class PositionSyncServiceTests: XCTestCase {
         )
         await service.recordPosition(position)
 
-        // Create a new service instance with the same UserDefaults
-        let newService = PositionSyncService(userDefaults: userDefaults)
+        // Create a new service instance with the same UserDefaults suite (fresh
+        // disconnected region for the actor init; shares the backing store).
+        let newService = PositionSyncService(userDefaults: UserDefaults(suiteName: "PositionSyncServiceTests")!)
         let retrieved = await newService.latestPosition(forBook: "book1", format: .epub)
         XCTAssertNotNil(retrieved)
         XCTAssertEqual(retrieved?.chapterIndex, 5)

--- a/PalaceTests/Platform/PositionSyncServiceTests.swift
+++ b/PalaceTests/Platform/PositionSyncServiceTests.swift
@@ -152,6 +152,7 @@ final class PositionSyncServiceTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Position recorded event")
 
         service.eventPublisher
+            .receive(on: DispatchQueue.main)   // deliver on main so the @MainActor sink closure isn't invoked off-main (Swift 6 executor-isolation trap)
             .sink { event in
                 if case .positionRecorded(let pos) = event {
                     XCTAssertEqual(pos.bookID, "book1")
@@ -181,6 +182,7 @@ final class PositionSyncServiceTests: XCTestCase {
         await service.setMapping(mapping)
 
         service.eventPublisher
+            .receive(on: DispatchQueue.main)   // deliver on main so the @MainActor sink closure isn't invoked off-main (Swift 6 executor-isolation trap)
             .sink { event in
                 if case .syncAvailable = event {
                     sawSyncAvailable = true

--- a/PalaceTests/Reader/EPUBPositionTests.swift
+++ b/PalaceTests/Reader/EPUBPositionTests.swift
@@ -129,7 +129,16 @@ final class EPUBPositionTests: XCTestCase {
     /// A regression on any changed line — dropping `.string`, failing to wrap
     /// the value in `JSONValue`, or a broken serializer — breaks this
     /// round-trip while leaving the pre-existing string/dictionary tests green.
-    func testLocatorRoundTrip_preservesCssSelectorPositionProgression_throughJSONValue() async {
+    // `nonisolated`: `convertToLocator(publication:)` is a nonisolated `async`
+    // method that takes non-Sendable Readium values (`Publication`, and the
+    // `TPPBookLocation` receiver). Awaiting it from the class's `@MainActor`
+    // isolation would *send* those non-Sendable args across the actor hop
+    // (Swift 6 "sending risks data races"). Running the test method itself in
+    // the nonisolated domain — the same domain as the callee, matching the
+    // production caller `TPPLastReadPositionSynchronizer.syncReadPosition` —
+    // removes the boundary entirely, so nothing is sent. The body touches no
+    // MainActor state (only nonisolated factories, initializers, and XCTAssert).
+    nonisolated func testLocatorRoundTrip_preservesCssSelectorPositionProgression_throughJSONValue() async {
         let publication = Self.makeTestPublication()
         guard let href = AnyURL(string: "/chapter1.xhtml") else {
             return XCTFail("invalid test href")
@@ -165,7 +174,10 @@ final class EPUBPositionTests: XCTestCase {
 
     /// Edge: no cssSelector exercises the `?? ""` / `?? [:]` branches — the
     /// round-trip must still succeed and must not fabricate a non-empty selector.
-    func testLocatorRoundTrip_withoutCssSelector_succeedsAndPreservesPosition() async {
+    // `nonisolated`: see the note on the sibling round-trip test above — the
+    // nonisolated `await convertToLocator` hop would otherwise send the
+    // non-Sendable `bookLocation`/`publication` across the `@MainActor` boundary.
+    nonisolated func testLocatorRoundTrip_withoutCssSelector_succeedsAndPreservesPosition() async {
         let publication = Self.makeTestPublication()
         guard let href = AnyURL(string: "/chapter1.xhtml") else {
             return XCTFail("invalid test href")
@@ -187,7 +199,9 @@ final class EPUBPositionTests: XCTestCase {
                        "no real selector should be fabricated when none was provided")
     }
 
-    private static func makeTestPublication() -> Publication {
+    // `nonisolated`: pure factory with no MainActor state, so the two
+    // `nonisolated` round-trip tests can build a publication without a cross-actor hop.
+    private nonisolated static func makeTestPublication() -> Publication {
         let metadata = Metadata(title: "Test", languages: ["en"])
         let readingOrder = [Link(href: "/chapter1.xhtml", mediaType: .xhtml)]
         return Publication(manifest: Manifest(metadata: metadata, readingOrder: readingOrder))

--- a/PalaceTests/Reader/ReaderEditingActionsTests.swift
+++ b/PalaceTests/Reader/ReaderEditingActionsTests.swift
@@ -103,16 +103,23 @@ final class ReaderEditingActionsTests: XCTestCase {
     }
 
     func testResolve_appendsCustomActions_forNonDRMBook() {
-        let actions = ReaderEditingActions.resolve(for: openAccessEpubBook(), appending: [Self.highlight])
-        XCTAssertEqual(actions, EditingAction.defaultActions + [Self.highlight],
+        // Bind a SINGLE highlight instance: `Self.highlight` is a computed property
+        // that mints a fresh `EditingAction` (wrapping a new `UIMenuItem`) on every
+        // read, and `EditingAction`/`UIMenuItem` compare by pointer identity — so
+        // reading it twice (once as input, once as expected) would spuriously fail.
+        let highlight = Self.highlight
+        let actions = ReaderEditingActions.resolve(for: openAccessEpubBook(), appending: [highlight])
+        XCTAssertEqual(actions, EditingAction.defaultActions + [highlight],
                        "Non-DRM book must surface defaults PLUS caller-supplied custom actions (Highlight).")
     }
 
     func testResolve_treatsSampleOfDRMBook_asNonDRM() {
         // Samples are open-access preview content even when the parent book
         // is DRM-protected — borrow flow is gated, not preview reading.
-        let actions = ReaderEditingActions.resolve(for: lcpEpubBook(), isSample: true, appending: [Self.highlight])
-        XCTAssertEqual(actions, EditingAction.defaultActions + [Self.highlight],
+        // Single highlight instance — see sibling test (pointer-identity equality).
+        let highlight = Self.highlight
+        let actions = ReaderEditingActions.resolve(for: lcpEpubBook(), isSample: true, appending: [highlight])
+        XCTAssertEqual(actions, EditingAction.defaultActions + [highlight],
                        "Sample preview of a DRM book must still surface the full edit menu — samples are open-access content.")
     }
 }

--- a/PalaceTests/Reader2/EPUBSearchViewModelTests.swift
+++ b/PalaceTests/Reader2/EPUBSearchViewModelTests.swift
@@ -194,8 +194,13 @@ final class EPUBSearchViewModelTests: XCTestCase {
 
     // MARK: - Setup/Teardown
 
-    override func setUp() {
-        super.setUp()
+    // `setUp() async throws` (not sync `setUp()`): the async override adopts this
+    // @MainActor class's isolation, so the @MainActor `EPUBSearchViewModel.init`
+    // and `self.publication` are touched on-actor. A synchronous override is
+    // nonisolated and sends the main-actor-isolated `self.publication` into the
+    // @MainActor initializer (Swift 6 data race).
+    override func setUp() async throws {
+        try await super.setUp()
         mockSearchService = MockSearchService()
         mockDelegate = MockEPUBSearchDelegate()
         publication = Publication.makePublication(searchService: mockSearchService)

--- a/PalaceTests/Reader2/TPPBookmarkFactoryTests.swift
+++ b/PalaceTests/Reader2/TPPBookmarkFactoryTests.swift
@@ -25,11 +25,13 @@ final class TPPBookmarkFactoryTests: XCTestCase {
 
     // MARK: - Setup & Teardown
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    // async setUp adopts the class's @MainActor isolation so the @MainActor
+    // properties are not sent to a nonisolated context during construction.
+    override func setUp() async throws {
+        try await super.setUp()
 
         testBook = createTestBook(identifier: testBookId)
-        publication = createTestPublication()
+        publication = Self.makePublication()
         bookRegistry = TPPBookRegistryMock()
 
         bookRegistry.addBook(
@@ -72,7 +74,10 @@ final class TPPBookmarkFactoryTests: XCTestCase {
         )
         let r3Location = TPPBookmarkR3Location(resourceIndex: 0, locator: locator)
 
-        // Act
+        // Act — fresh local publication+factory form a disconnected (sendable)
+        // region so they can cross into the nonisolated make(...).
+        let publication = Self.makePublication()
+        let factory = TPPBookmarkFactory(book: testBook, publication: publication, drmDeviceID: testDeviceId)
         let bookmark = await factory.make(
             fromR3Location: r3Location,
             usingBookRegistry: bookRegistry,
@@ -97,7 +102,10 @@ final class TPPBookmarkFactoryTests: XCTestCase {
         )
         let r3Location = TPPBookmarkR3Location(resourceIndex: 0, locator: locator)
 
-        // Act
+        // Act — fresh local publication+factory form a disconnected (sendable)
+        // region so they can cross into the nonisolated make(...).
+        let publication = Self.makePublication()
+        let factory = TPPBookmarkFactory(book: testBook, publication: publication, drmDeviceID: testDeviceId)
         let bookmark = await factory.make(
             fromR3Location: r3Location,
             usingBookRegistry: bookRegistry,
@@ -122,7 +130,10 @@ final class TPPBookmarkFactoryTests: XCTestCase {
         )
         let r3Location = TPPBookmarkR3Location(resourceIndex: 1, locator: locator)
 
-        // Act
+        // Act — fresh local publication+factory form a disconnected (sendable)
+        // region so they can cross into the nonisolated make(...).
+        let publication = Self.makePublication()
+        let factory = TPPBookmarkFactory(book: testBook, publication: publication, drmDeviceID: testDeviceId)
         let bookmark = await factory.make(
             fromR3Location: r3Location,
             usingBookRegistry: bookRegistry,
@@ -149,7 +160,10 @@ final class TPPBookmarkFactoryTests: XCTestCase {
             creationDate: customDate
         )
 
-        // Act
+        // Act — fresh local publication+factory form a disconnected (sendable)
+        // region so they can cross into the nonisolated make(...).
+        let publication = Self.makePublication()
+        let factory = TPPBookmarkFactory(book: testBook, publication: publication, drmDeviceID: testDeviceId)
         let bookmark = await factory.make(
             fromR3Location: r3Location,
             usingBookRegistry: bookRegistry,
@@ -171,7 +185,10 @@ final class TPPBookmarkFactoryTests: XCTestCase {
         )
         let r3Location = TPPBookmarkR3Location(resourceIndex: 0, locator: locator)
 
-        // Act
+        // Act — fresh local publication+factory form a disconnected (sendable)
+        // region so they can cross into the nonisolated make(...).
+        let publication = Self.makePublication()
+        let factory = TPPBookmarkFactory(book: testBook, publication: publication, drmDeviceID: testDeviceId)
         let bookmark = await factory.make(
             fromR3Location: r3Location,
             usingBookRegistry: bookRegistry,
@@ -500,7 +517,9 @@ final class TPPBookmarkFactoryTests: XCTestCase {
         )
     }
 
-    private func createTestPublication() -> Publication {
+    // nonisolated static: builds only from literals, so its fresh return is a
+    // disconnected (sendable) region — callable from sending sites without self.
+    private nonisolated static func makePublication() -> Publication {
         let readingOrder = [
             Link(href: "/chapter1.xhtml", mediaType: .xhtml, title: "Chapter 1"),
             Link(href: "/chapter2.xhtml", mediaType: .xhtml, title: "Chapter 2"),
@@ -562,8 +581,10 @@ final class TPPBookmarkFactoryServerAnnotationEdgeCaseTests: XCTestCase {
     private var testBook: TPPBook!
     private let testBookId = "edge-case-book"
 
-    override func setUp() {
-        super.setUp()
+    // async setUp adopts the class's @MainActor isolation so createTestBook is
+    // not called with a task-isolated self from a nonisolated context.
+    override func setUp() async throws {
+        try await super.setUp()
         testBook = createTestBook(identifier: testBookId)
     }
 

--- a/PalaceTests/Reader2/TPPLastReadPositionPosterTests.swift
+++ b/PalaceTests/Reader2/TPPLastReadPositionPosterTests.swift
@@ -61,8 +61,10 @@ final class TPPLastReadPositionPosterTests: XCTestCase {
 
     // MARK: - Setup
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    // async setUp adopts the class's @MainActor isolation so the @MainActor
+    // createTestPublication() result is not returned to a nonisolated context.
+    override func setUp() async throws {
+        try await super.setUp()
 
         bookRegistryMock = TPPBookRegistryMock()
         testBook = createTestBook()

--- a/PalaceTests/Reader2/TPPLastReadPositionSynchronizerTests.swift
+++ b/PalaceTests/Reader2/TPPLastReadPositionSynchronizerTests.swift
@@ -1407,6 +1407,15 @@ final class TPPLastReadPositionSynchronizer_ConcurrencyTests: XCTestCase {
         super.tearDown()
     }
 
+    // nonisolated static: builds only from literals, so each fresh return is a
+    // disconnected (sendable) region — one per sending task closure.
+    private nonisolated static func makeConcurrentPublication() -> Publication {
+        Publication(manifest: Manifest(
+            metadata: Metadata(title: "Concurrent Sync"),
+            readingOrder: [Link(href: "/chapter1.xhtml", mediaType: .xhtml)]
+        ))
+    }
+
     /// REGRESSION PIN for the 2026-07-04 SIGSEGV (fix/sync-mock-race-segv-bookmark-keys).
     ///
     /// This test hammers the shared mock through the `TPPBookRegistryProvider`
@@ -1498,17 +1507,15 @@ final class TPPLastReadPositionSynchronizer_ConcurrencyTests: XCTestCase {
 
         let book = SynchronizerTestFixtures.createTestBook()
         registry.addBook(book, location: nil, state: .downloadSuccessful, fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
-        let publication = Publication(manifest: Manifest(
-            metadata: Metadata(title: "Concurrent Sync"),
-            readingOrder: [Link(href: "/chapter1.xhtml", mediaType: .xhtml)]
-        ))
         let bookID = book.identifier
 
         // Act — both synchronizers sync concurrently while a third task
         // writes locations through the same provider the synchronizers read.
+        // Each sending closure builds its own disconnected publication so no
+        // non-Sendable Publication is captured across the concurrency boundary.
         await withTaskGroup(of: Void.self) { group in
-            group.addTask { await sync1.sync(for: publication, book: book, drmDeviceID: "device-A") }
-            group.addTask { await sync2.sync(for: publication, book: book, drmDeviceID: "device-B") }
+            group.addTask { await sync1.sync(for: Self.makeConcurrentPublication(), book: book, drmDeviceID: "device-A") }
+            group.addTask { await sync2.sync(for: Self.makeConcurrentPublication(), book: book, drmDeviceID: "device-B") }
             group.addTask {
                 for i in 0..<50 {
                     let location = SynchronizerTestFixtures.createBookLocation(progress: Double(i) / 50.0)
@@ -1660,10 +1667,7 @@ final class TPPLastReadPositionSynchronizer_WriterDelegationTests: XCTestCase {
         bookRegistryMock = TPPBookRegistryMock()
         spyWriter = SynchronizerSpyWriter()
         testBook = SynchronizerTestFixtures.createTestBook(identifier: "writer-delegation-book")
-        publication = Publication(manifest: Manifest(
-            metadata: Metadata(title: "Writer Delegation"),
-            readingOrder: [Link(href: "/chapter1.xhtml", mediaType: .xhtml)]
-        ))
+        publication = Self.makePublication()
         bookRegistryMock.addBook(
             testBook,
             location: nil,
@@ -1688,10 +1692,19 @@ final class TPPLastReadPositionSynchronizer_WriterDelegationTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    // nonisolated static: builds only from literals, so each fresh return is a
+    // disconnected (sendable) region that can cross into sync(for: sending ...).
+    private nonisolated static func makePublication() -> Publication {
+        Publication(manifest: Manifest(
+            metadata: Metadata(title: "Writer Delegation"),
+            readingOrder: [Link(href: "/chapter1.xhtml", mediaType: .xhtml)]
+        ))
+    }
+
     func testSync_writerReturnsNil_callsLoadOnce_noAlertPath() async {
         await spyWriter.set(snapshot: nil)
 
-        await synchronizer.sync(for: publication, book: testBook, drmDeviceID: "device-A")
+        await synchronizer.sync(for: Self.makePublication(), book: testBook, drmDeviceID: "device-A")
 
         let loaded = await spyWriter.loadedBookIDs
         XCTAssertEqual(loaded, [testBook.identifier],
@@ -1701,7 +1714,7 @@ final class TPPLastReadPositionSynchronizer_WriterDelegationTests: XCTestCase {
     func testSync_writerThrows_logsAndReturnsWithoutAlert() async {
         await spyWriter.set(loadError: PositionWriterError.networkUnavailable)
 
-        await synchronizer.sync(for: publication, book: testBook, drmDeviceID: "device-A")
+        await synchronizer.sync(for: Self.makePublication(), book: testBook, drmDeviceID: "device-A")
 
         let loaded = await spyWriter.loadedBookIDs
         XCTAssertEqual(loaded, [testBook.identifier],
@@ -1727,7 +1740,7 @@ final class TPPLastReadPositionSynchronizer_WriterDelegationTests: XCTestCase {
         )
         await spyWriter.set(snapshot: snapshot)
 
-        await synchronizer.sync(for: publication, book: testBook, drmDeviceID: "device-A")
+        await synchronizer.sync(for: Self.makePublication(), book: testBook, drmDeviceID: "device-A")
 
         let loaded = await spyWriter.loadedBookIDs
         XCTAssertEqual(loaded.count, 1)
@@ -1755,7 +1768,7 @@ final class TPPLastReadPositionSynchronizer_WriterDelegationTests: XCTestCase {
         )
         await spyWriter.set(snapshot: snapshot)
 
-        await synchronizer.sync(for: publication, book: testBook, drmDeviceID: "device-A")
+        await synchronizer.sync(for: Self.makePublication(), book: testBook, drmDeviceID: "device-A")
 
         let loaded = await spyWriter.loadedBookIDs
         XCTAssertEqual(loaded.count, 1)

--- a/PalaceTests/Reader2/TPPReaderTOCBusinessLogicTests.swift
+++ b/PalaceTests/Reader2/TPPReaderTOCBusinessLogicTests.swift
@@ -20,8 +20,10 @@ final class TPPReaderTOCBusinessLogicTests: XCTestCase {
 
     // MARK: - Setup
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    // async setUp adopts the class's @MainActor isolation so the @MainActor
+    // createTestPublication() result is not returned to a nonisolated context.
+    override func setUp() async throws {
+        try await super.setUp()
 
         // Create a publication with a realistic TOC structure
         publication = createTestPublication()

--- a/PalaceTests/Reader2/Typography/TypographyPresetTests.swift
+++ b/PalaceTests/Reader2/Typography/TypographyPresetTests.swift
@@ -14,8 +14,10 @@ final class TypographyPresetTests: XCTestCase {
     private var service: TypographyService!
     private var testDefaults: UserDefaults!
 
-    override func setUp() {
-        super.setUp()
+    // async setUp adopts the class's @MainActor isolation so testDefaults can be
+    // passed to the @MainActor TypographyService init without a sending violation.
+    override func setUp() async throws {
+        try await super.setUp()
         testDefaults = UserDefaults(suiteName: "TypographyPresetTests")!
         testDefaults.removePersistentDomain(forName: "TypographyPresetTests")
         service = TypographyService(userDefaults: testDefaults)

--- a/PalaceTests/Reader2/Typography/TypographyServiceTests.swift
+++ b/PalaceTests/Reader2/Typography/TypographyServiceTests.swift
@@ -16,8 +16,10 @@ final class TypographyServiceTests: XCTestCase {
     private var testDefaults: UserDefaults!
     private var cancellables: Set<AnyCancellable>!
 
-    override func setUp() {
-        super.setUp()
+    // async setUp adopts the class's @MainActor isolation so testDefaults can be
+    // passed to the @MainActor TypographyService init without a sending violation.
+    override func setUp() async throws {
+        try await super.setUp()
         testDefaults = UserDefaults(suiteName: "TypographyServiceTests")!
         testDefaults.removePersistentDomain(forName: "TypographyServiceTests")
         service = TypographyService(userDefaults: testDefaults)

--- a/PalaceTests/Reader2/Typography/TypographySettingsViewModelTests.swift
+++ b/PalaceTests/Reader2/Typography/TypographySettingsViewModelTests.swift
@@ -17,8 +17,10 @@ final class TypographySettingsViewModelTests: XCTestCase {
     private var testDefaults: UserDefaults!
     private var cancellables: Set<AnyCancellable>!
 
-    override func setUp() {
-        super.setUp()
+    // async setUp adopts the class's @MainActor isolation so testDefaults can be
+    // passed to the @MainActor TypographyService init without a sending violation.
+    override func setUp() async throws {
+        try await super.setUp()
         testDefaults = UserDefaults(suiteName: "TypographySettingsViewModelTests")!
         testDefaults.removePersistentDomain(forName: "TypographySettingsViewModelTests")
         service = TypographyService(userDefaults: testDefaults)

--- a/PalaceTests/RegressionGuards/AlertPresentationRawGuardLintTests.swift
+++ b/PalaceTests/RegressionGuards/AlertPresentationRawGuardLintTests.swift
@@ -44,7 +44,7 @@ final class AlertPresentationRawGuardLintTests: XCTestCase {
     /// Repo root resolved relative to this file
     /// (`<root>/PalaceTests/RegressionGuards/AlertPresentationRawGuardLintTests.swift`).
     private static let repoRoot: URL = {
-        URL(fileURLWithPath: #file)
+        URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()  // RegressionGuards/
             .deletingLastPathComponent()  // PalaceTests/
             .deletingLastPathComponent()  // repo root

--- a/PalaceTests/Settings/DownloadOnlyOnWiFiTests.swift
+++ b/PalaceTests/Settings/DownloadOnlyOnWiFiTests.swift
@@ -23,7 +23,7 @@ final class DownloadOnlyOnWiFiTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        isolatedDefaults = testUserDefaults()
+        isolatedDefaults = Self.testUserDefaults()
         settings = TPPSettings(defaults: isolatedDefaults)
     }
 

--- a/PalaceTests/Settings/LibrariesSectionViewModelTests.swift
+++ b/PalaceTests/Settings/LibrariesSectionViewModelTests.swift
@@ -308,7 +308,13 @@ private final class FakeLibrariesEnvironment: LibrariesSectionEnvironment {
     var tokensDeleted: [String] = []
     var switchedTo: [String] = []
     var accountsLoaded: Bool = true
-    private var pendingSwitchCompletions: [String: () -> Void] = [:]
+    // Parked in nonisolated, lock-guarded storage — NOT main-actor state — so the
+    // `nonisolated` witness below can stash the (non-Sendable) completion without
+    // *sending* it into a `MainActor.assumeIsolated` region, which Swift 6 rejects
+    // as a data race. The closure never crosses an isolation boundary: it's stored
+    // and later fired from whatever context calls `fireSwitchCompletion`.
+    private nonisolated(unsafe) var pendingSwitchCompletions: [String: () -> Void] = [:]
+    private let pendingCompletionsLock = NSLock()
 
     init(currentUUID: String?, persisted: [Account], accountsLoaded: Bool = true) {
         self.currentUUID = currentUUID
@@ -338,13 +344,17 @@ private final class FakeLibrariesEnvironment: LibrariesSectionEnvironment {
         MainActor.assumeIsolated {
             self.switchedTo.append(account.uuid)
             self.currentUUID = account.uuid
-            // Park the completion so tests can simulate the async auth-doc
-            // callback at a deterministic point.
-            self.pendingSwitchCompletions[account.uuid] = completion
         }
+        // Park the completion so tests can simulate the async auth-doc callback at
+        // a deterministic point. Stored in the nonisolated lock-guarded box (see
+        // the property) — no isolation boundary is crossed, so no `sending` race.
+        pendingCompletionsLock.withLock { pendingSwitchCompletions[account.uuid] = completion }
     }
 
     func fireSwitchCompletion(for uuid: String) {
-        pendingSwitchCompletions.removeValue(forKey: uuid)?()
+        let completion = pendingCompletionsLock.withLock {
+            pendingSwitchCompletions.removeValue(forKey: uuid)
+        }
+        completion?()
     }
 }

--- a/PalaceTests/SignInLogic/ForceResetTests.swift
+++ b/PalaceTests/SignInLogic/ForceResetTests.swift
@@ -40,7 +40,7 @@ final class ForceResetTests: XCTestCase {
         // `static var` swap-and-restore is the chosen seam because Swift
         // extensions cannot hold stored properties (so no init-DI path).
         savedDefaults = TPPSignInBusinessLogic.forceResetUserDefaults
-        defaults = testUserDefaults()
+        defaults = Self.testUserDefaults()
         TPPSignInBusinessLogic.forceResetUserDefaults = defaults
     }
 

--- a/PalaceTests/SignInLogic/ScopedResetTests.swift
+++ b/PalaceTests/SignInLogic/ScopedResetTests.swift
@@ -27,7 +27,7 @@ final class ScopedResetTests: XCTestCase {
     override func setUp() {
         super.setUp()
         savedDefaults = TPPSignInBusinessLogic.forceResetUserDefaults
-        defaults = testUserDefaults()
+        defaults = Self.testUserDefaults()
         TPPSignInBusinessLogic.forceResetUserDefaults = defaults
     }
 

--- a/PalaceTests/SignInLogic/TPPSignInBusinessLogicExtendedTests.swift
+++ b/PalaceTests/SignInLogic/TPPSignInBusinessLogicExtendedTests.swift
@@ -1108,12 +1108,39 @@ final class TPPSignInErrorHandlingTests: XCTestCase {
 
 // MARK: - Mock Extensions
 
-class TPPNetworkErrorMock: TPPRequestExecuting {
-    var requestTimeout: TimeInterval = 60
-    var shouldFail = false
-    var errorStatusCode = 500
+/// Transfers the non-Sendable completion across the `DispatchQueue.main.async`
+/// hop. Safe: called exactly once, on the main queue. (File-local — the
+/// identically-shaped helper in NYPLNetworkExecutorMock is `private` there.)
+private struct MainQueueResultCompletion: @unchecked Sendable {
+    let completion: (NYPLResult<Data>) -> Void
+}
 
-    private var generation: Int = 0
+/// `@unchecked Sendable`: all mutable state is guarded by `lock`, so the mock
+/// can cross into the @MainActor SUT safely (Swift 6). Mirrors TPPBookRegistryMock.
+final class TPPNetworkErrorMock: TPPRequestExecuting, @unchecked Sendable {
+    private let lock = NSLock()
+
+    private var _requestTimeout: TimeInterval = 60
+    var requestTimeout: TimeInterval {
+        get { lock.withLock { _requestTimeout } }
+        set { lock.withLock { _requestTimeout = newValue } }
+    }
+    private var _shouldFail = false
+    var shouldFail: Bool {
+        get { lock.withLock { _shouldFail } }
+        set { lock.withLock { _shouldFail = newValue } }
+    }
+    private var _errorStatusCode = 500
+    var errorStatusCode: Int {
+        get { lock.withLock { _errorStatusCode } }
+        set { lock.withLock { _errorStatusCode = newValue } }
+    }
+
+    private var _generation: Int = 0
+    private var generation: Int {
+        get { lock.withLock { _generation } }
+        set { lock.withLock { _generation = newValue } }
+    }
 
     func reset() {
         generation += 1
@@ -1125,8 +1152,10 @@ class TPPNetworkErrorMock: TPPRequestExecuting {
         completion: @escaping (NYPLResult<Data>) -> Void
     ) -> URLSessionDataTask? {
         let capturedGeneration = generation
+        let completionBox = MainQueueResultCompletion(completion: completion)
         DispatchQueue.main.async { [weak self] in
             guard let self, self.generation == capturedGeneration else { return }
+            let completion = completionBox.completion
 
             if self.shouldFail {
                 let error = NSError(domain: "Test", code: self.errorStatusCode, userInfo: nil)

--- a/PalaceTests/Support/PalaceTestCase.swift
+++ b/PalaceTests/Support/PalaceTestCase.swift
@@ -40,7 +40,15 @@ class PalaceTestCase: XCTestCase {
     /// Pre-test `NotificationCenter.default` observer count, captured in setUp.
     /// `nil` when the best-effort sample is unavailable (then the observer-leak
     /// check is skipped). Subclasses overriding `setUpWithError` MUST call super.
-    private var preObserverCount: Int?
+    ///
+    /// `nonisolated(unsafe)`: written in `setUpWithError` and read/cleared in
+    /// `warnOnObserverLeak` (from `tearDownWithError`) — both `nonisolated`
+    /// overrides of XCTest's `nonisolated` lifecycle hooks. XCTest drives a
+    /// single test method's setUp→body→tearDown strictly serially on one
+    /// instance, so there is no concurrent access to guard; the unsafe opt-out
+    /// keeps the (genuinely single-threaded) lifecycle var reachable from the
+    /// nonisolated hooks without sending `self` across an actor boundary.
+    nonisolated(unsafe) private var preObserverCount: Int?
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -87,7 +95,13 @@ class PalaceTestCase: XCTestCase {
     /// EFFECTIVE structural guard for this leak class is the platform-independent
     /// dealloc assertion in `AccountDetailViewModelLeakTests` (red→green proven),
     /// which does not depend on the observer count at all.
-    private func warnOnObserverLeak() {
+    ///
+    /// `nonisolated`: called from the `nonisolated` `tearDownWithError` override.
+    /// Touches only `nonisolated(unsafe)` `preObserverCount`, the nonisolated
+    /// `self.name`, static (nonisolated) `PalaceSingletonResetObserver` /
+    /// `RuntimeQuiescenceAuditor` methods, and `NSLog` — no `@MainActor` state,
+    /// so `self` is never sent across an actor boundary.
+    private nonisolated func warnOnObserverLeak() {
         guard let pre = preObserverCount,
               let post = PalaceSingletonResetObserver.sampleObserverCount() else { return }
         preObserverCount = nil
@@ -105,7 +119,11 @@ class PalaceTestCase: XCTestCase {
     ///
     /// Exposed so a subclass that overrides `tearDown()` (the non-throwing
     /// variant) can still invoke the check explicitly after its own cleanup.
-    func assertRuntimeQuiescent(
+    ///
+    /// `nonisolated`: called from the `nonisolated` `tearDownWithError` override.
+    /// Uses only the static (nonisolated) `RuntimeQuiescenceAuditor.auditLiveState()`
+    /// and `XCTFail` — no instance/`@MainActor` state — so `self` is not sent.
+    nonisolated func assertRuntimeQuiescent(
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -140,7 +158,12 @@ class PalaceTestCase: XCTestCase {
     ///     override var enforcesPoolResponsiveness: Bool { true }
     /// }
     /// ```
-    var enforcesPoolResponsiveness: Bool { false }
+    ///
+    /// `nonisolated`: read from the `nonisolated` `tearDownWithError` override to
+    /// decide whether to run the pool gate. Returns a constant with no state
+    /// access, so reading it cannot send `self`. Subclass overrides inherit the
+    /// `nonisolated` requirement (they likewise return a literal).
+    nonisolated var enforcesPoolResponsiveness: Bool { false }
 
     /// Bounded check that the runtime is at rest — the class-4 (accumulation
     /// pool-starvation) gate extension. Two cheap probes run in sequence:
@@ -181,8 +204,17 @@ class PalaceTestCase: XCTestCase {
     ///     AND does not false-positive, without staging a real leak.
     /// - Returns: the violations produced (also surfaced via `XCTFail`), so the
     ///   self-test can assert the message shape without capturing the failure.
+    ///
+    /// `nonisolated`: invoked from the `nonisolated` `tearDownWithError` override.
+    /// Its call path — the nonisolated `drainMainQueue(timeout:)` helper, the
+    /// static (nonisolated) `PalaceSingletonResetObserver.measureCooperativePoolProbe`
+    /// / `RuntimeQuiescenceAuditor.poolResponsivenessViolations`, and `XCTFail` —
+    /// touches no `@MainActor` instance state, so `self` is never sent across an
+    /// actor boundary. (The async sibling `assertRuntimeResponsiveAsync` stays
+    /// `@MainActor` — it is only called from `@MainActor async` bodies, never the
+    /// nonisolated lifecycle hooks.)
     @discardableResult
-    func assertRuntimeResponsive(
+    nonisolated func assertRuntimeResponsive(
         budget: TimeInterval = 5.0,
         probe: ((TimeInterval) -> Bool)? = nil,
         file: StaticString = #file,

--- a/PalaceTests/Support/PalaceWiringTestCase.swift
+++ b/PalaceTests/Support/PalaceWiringTestCase.swift
@@ -69,14 +69,28 @@ class PalaceWiringTestCase: PalaceTestCase {
     /// `.store(in: &cancellables)`; the property is mutated only on the
     /// main thread (test methods inherit `@MainActor` via XCTest's
     /// default isolation for sync test methods).
-    var cancellables: Set<AnyCancellable> = []
+    ///
+    /// `nonisolated(unsafe)`: accessed both from `@MainActor` subclass test
+    /// bodies (`.store(in: &cancellables)`) and from the `nonisolated`
+    /// `tearDownWithError` override that drains it. XCTest runs a single test
+    /// method's body and its teardown serially on one instance — never
+    /// concurrently — so there is no data race to guard; the unsafe opt-out
+    /// keeps the bag reachable from the nonisolated hook without sending
+    /// `self` across an actor boundary.
+    nonisolated(unsafe) var cancellables: Set<AnyCancellable> = []
 
     /// Internal list of `AccountsManager` instances minted via
     /// `makeFreshAccountsManager` during a single test method. tearDown
     /// walks this list and calls `cancelBackgroundWork()` on each, then
     /// empties the list so the next method starts clean. Stored as
     /// `private` — only `makeFreshAccountsManager` mutates it.
-    private var managersToCancelOnTearDown: [AccountsManager] = []
+    ///
+    /// `nonisolated(unsafe)`: appended from `makeFreshAccountsManager`
+    /// (invoked in `@MainActor` test bodies) and drained from the `nonisolated`
+    /// `tearDownWithError` override. Same single-threaded serial test lifecycle
+    /// as `cancellables` — no concurrent access to guard; the opt-out keeps the
+    /// list reachable from the nonisolated hook without sending `self`.
+    nonisolated(unsafe) private var managersToCancelOnTearDown: [AccountsManager] = []
 
     // MARK: - Lifecycle
 
@@ -164,7 +178,7 @@ class PalaceWiringTestCase: PalaceTestCase {
     ///   AND whose `cancelBackgroundWork()` will fire in tearDown
     ///   regardless of whether the test body called it.
     @discardableResult
-    func makeFreshAccountsManager(_ configure: (AccountsManager) -> Void = { _ in }) -> AccountsManager {
+    nonisolated func makeFreshAccountsManager(_ configure: (AccountsManager) -> Void = { _ in }) -> AccountsManager {
         // Pin the opt-out flag immediately before construction. setUp
         // already set it, but a test method that intentionally toggled
         // it off mid-body must not poison helper construction after
@@ -184,11 +198,11 @@ class PalaceWiringTestCase: PalaceTestCase {
     ///
     /// swarm_cd181acd D-cleanup: lets wiring tests seed
     /// `currentAccountIdentifierKey` into a per-test isolated suite (via
-    /// `testUserDefaults()`) instead of mutating `UserDefaults.standard`,
+    /// `Self.testUserDefaults()`) instead of mutating `UserDefaults.standard`,
     /// so cross-test pollution through that key is structurally
     /// impossible.
     @discardableResult
-    func makeFreshAccountsManager(
+    nonisolated func makeFreshAccountsManager(
         defaults: UserDefaults,
         _ configure: (AccountsManager) -> Void = { _ in }
     ) -> AccountsManager {
@@ -216,7 +230,7 @@ class PalaceWiringTestCase: PalaceTestCase {
     ///
     /// Missing files (cold-start) and missing directory are silently
     /// ignored — both are valid pre-test states.
-    private func purgeAccountsDiskCacheForWiringTests() {
+    private nonisolated func purgeAccountsDiskCacheForWiringTests() {
         let prefixes = [
             "library_list_",
             "accounts_catalog_",

--- a/PalaceTests/Support/TestTargetHermeticityRegressionTests.swift
+++ b/PalaceTests/Support/TestTargetHermeticityRegressionTests.swift
@@ -1,0 +1,171 @@
+//
+//  TestTargetHermeticityRegressionTests.swift
+//  PalaceTests
+//
+//  Regression pins for the three systemic test-pollution mechanisms found in
+//  CI run 29802862487 (PR #1305, fix/swift6-test-target-repair):
+//
+//  1. The PalaceTests target compiled WITHOUT the `DEBUG` condition, so every
+//     `#if DEBUG` block in TEST-target code was silently dead — including the
+//     body of the registered "AppContainer._resetForTesting" resetter in
+//     `PalaceTestSetup.registerBuiltInResetters()` and the bootstrap pin of
+//     `AccountsManager.deferInitialLoadCatalogsForTesting`. The per-test
+//     AppContainer reset + live-manager drain therefore NEVER ran, which is
+//     why months of individually-correct isolation fixes "did not converge"
+//     (docs/Testing/test-pollution-investigation-handoff.md): they were all
+//     wired behind a dead conditional at the test boundary.
+//
+//  2. `TPPBookRegistryMock.addBook` posted `.TPPBookRegistryDidChange` on the
+//     CALLER's thread, violating the production registry's main-queue posting
+//     contract. NotificationCenter invokes selector observers synchronously on
+//     the posting thread, so a live `@MainActor` observer from an earlier test
+//     (BookDetailViewModel.handleBookRegistryChange) tripped Swift 6's
+//     executor-isolation precondition and killed the whole runner process.
+//
+//  3. `XCTestCase.awaitCondition` evaluated its predicate once more on the
+//     leaked resumption AFTER cancellation, i.e. potentially after tearDown
+//     nil'd the test's implicitly-unwrapped fixtures — a force-unwrap
+//     fatalError that also killed the runner process (the retry-crash
+//     signature).
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+@MainActor
+final class TestTargetHermeticityRegressionTests: XCTestCase {
+
+    // MARK: - 1. DEBUG compilation condition (the dead-reset-layer pin)
+
+    /// The singleton-reset layer is only real if the test target compiles with
+    /// `DEBUG`: `PalaceTestSetup.registerBuiltInResetters()` wraps the
+    /// `AppContainer._resetForTesting()` resetter body in `#if DEBUG`, and the
+    /// bootstrap pin of `deferInitialLoadCatalogsForTesting` is `#if DEBUG`
+    /// too. Without the condition both compile to no-ops and cross-test
+    /// pollution accumulates for the whole runner process. This is NOT a
+    /// tautology test — it pins a build setting
+    /// (`SWIFT_ACTIVE_COMPILATION_CONDITIONS` on PalaceTests/Debug) that was
+    /// in fact missing for months, and it fails the moment anyone drops it
+    /// again.
+    func testTestTarget_compilesWithDEBUG_soPerTestResetLayerIsActive() {
+        var debugActive = false
+        #if DEBUG
+        debugActive = true
+        #endif
+        XCTAssertTrue(
+            debugActive,
+            "PalaceTests must define DEBUG in SWIFT_ACTIVE_COMPILATION_CONDITIONS (Debug config). " +
+            "Without it, every #if DEBUG block in test-target code is dead — including the " +
+            "registered AppContainer._resetForTesting resetter body in PalaceTestSetup, which " +
+            "silently disables the per-test singleton reset + AccountsManager drain and " +
+            "re-opens the systemic cross-test pollution documented in " +
+            "docs/Testing/test-pollution-investigation-handoff.md."
+        )
+    }
+
+    /// Behavioral companion to the canary above: the bootstrap MUST have
+    /// pinned the catalog-load defer flag before any test runs. When the pin
+    /// was dead (missing DEBUG), the first incidental `AppContainer.production()`
+    /// fired `AccountsManager.init`'s background `loadCatalogs`, which wrote
+    /// the 1142-account bundled catalog cache to `accounts_catalog_<hash>.json`
+    /// on disk MID-SUITE — the exact mechanism behind
+    /// `AccountsManagerLaunchSnapshotTests.testPreload_slimSnapshotButNoFullCache_doesNotHydrate`
+    /// observing `.detailsFailed` ("a full cache appeared that the test
+    /// deliberately did not seed"). Tests that need the background load flip
+    /// the flag false and restore it in their own tearDown, so at the START of
+    /// any test it must read `true`.
+    func testBootstrap_deferInitialLoadCatalogs_isPinnedTrueAtTestStart() {
+        XCTAssertTrue(
+            AccountsManager.deferInitialLoadCatalogsForTesting,
+            "PalaceTestSetup.bootstrap() must pin deferInitialLoadCatalogsForTesting = true " +
+            "before any test runs (and flag-flipping tests must restore it in tearDown). " +
+            "A false value here means the pin regressed and background loadCatalogs will " +
+            "overwrite fixture catalog caches mid-suite."
+        )
+    }
+
+    // MARK: - 2. Mock registry posts its change notification on main
+
+    /// Production contract: `.TPPBookRegistryDidChange` is ALWAYS posted on the
+    /// main queue (BookRegistryStore `registry.didSet`, BookRegistrySync save/
+    /// update paths). The mock must honor the same delivery-thread contract:
+    /// posting on a background caller's thread makes NotificationCenter invoke
+    /// any live `@MainActor` selector observer synchronously OFF main, which
+    /// Swift 6's executor precondition converts into SIGTRAP process death
+    /// (the `TPPBookRegistryMock.addBook` crash that killed three CI runner
+    /// processes in run 29802862487).
+    func testMockRegistry_addBookFromBackgroundThread_deliversChangeNotificationOnMain() {
+        let mock = TPPBookRegistryMock()
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+
+        let delivered = expectation(description: "registry-change notification delivered")
+        let deliveredOnMain = LockIsolated<Bool?>(nil)
+        let observer = NotificationCenter.default.addObserver(
+            forName: .TPPBookRegistryDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            // Record only the FIRST delivery; addBook posts exactly once.
+            deliveredOnMain.withValue { current in
+                if current == nil { current = Thread.isMainThread }
+            }
+            delivered.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            mock.addBook(book, location: nil, state: .downloadNeeded,
+                         fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
+        }
+
+        wait(for: [delivered], timeout: 5.0)
+        XCTAssertEqual(
+            deliveredOnMain.value, true,
+            "TPPBookRegistryMock.addBook must post .TPPBookRegistryDidChange on the MAIN queue " +
+            "(the production registry's contract). Off-main delivery invokes @MainActor selector " +
+            "observers on the posting thread and crashes the runner under Swift 6."
+        )
+    }
+
+    // MARK: - 3. awaitCondition never evaluates the predicate after returning
+
+    /// On timeout, `awaitCondition` cancels its poll task and returns. The
+    /// pre-fix loop shape evaluated the predicate ONE more time on the
+    /// post-cancellation resumption — which can land after tearDown nil'd the
+    /// test's implicitly-unwrapped fixtures, turning a timed-out wait into a
+    /// force-unwrap fatalError that kills the runner (the
+    /// AudiobookPlaytimesLifecycleTests retry-crash in CI run 29802862487).
+    /// This pins the contract: once `awaitCondition` returns, the predicate is
+    /// never touched again.
+    func testAwaitCondition_onTimeout_predicateIsNeverEvaluatedAfterReturn() {
+        let evaluations = LockIsolated<Int>(0)
+
+        // The wait inside awaitCondition records an "Asynchronous wait failed"
+        // failure on timeout — expected and intrinsic to this scenario.
+        XCTExpectFailure("awaitCondition is driven to timeout by design here") {
+            awaitCondition(timeout: 0.3, pollInterval: 0.02) {
+                evaluations.withValue { $0 += 1 }
+                return false
+            }
+        }
+
+        let countAtReturn = evaluations.value
+        XCTAssertGreaterThan(countAtReturn, 0,
+                             "Sanity: the predicate must have been polled while waiting")
+
+        // Give any leaked poll-task resumption every chance to run: the
+        // cancelled Task.sleep resumption is enqueued on the main executor at
+        // cancel(); these FIFO drains run strictly after it.
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertEqual(
+            evaluations.value, countAtReturn,
+            "awaitCondition must NOT evaluate its predicate after returning — a post-return " +
+            "evaluation runs against torn-down fixtures (sut = nil force-unwrap) and crashes " +
+            "the entire test-runner process."
+        )
+    }
+}

--- a/PalaceTests/Support/TestTargetHermeticityRegressionTests.swift
+++ b/PalaceTests/Support/TestTargetHermeticityRegressionTests.swift
@@ -37,6 +37,22 @@ import XCTest
 @MainActor
 final class TestTargetHermeticityRegressionTests: XCTestCase {
 
+    /// Observer token from `testMockRegistry_...`. Removed in `tearDown` as a
+    /// belt-and-suspenders backstop to the per-test `defer`, so a mid-test
+    /// abort still cannot leak a `.TPPBookRegistryDidChange` observer into a
+    /// later test — the very hazard this suite exists to pin. Its presence
+    /// also satisfies the `TearDownRequiredLintTests` polluter-hygiene gate
+    /// (this class touches `NotificationCenter.default.addObserver`).
+    private var registryObserver: NSObjectProtocol?
+
+    override func tearDown() {
+        if let observer = registryObserver {
+            NotificationCenter.default.removeObserver(observer)
+            registryObserver = nil
+        }
+        super.tearDown()
+    }
+
     // MARK: - 1. DEBUG compilation condition (the dead-reset-layer pin)
 
     /// The singleton-reset layer is only real if the test target compiles with
@@ -113,7 +129,11 @@ final class TestTargetHermeticityRegressionTests: XCTestCase {
             }
             delivered.fulfill()
         }
-        defer { NotificationCenter.default.removeObserver(observer) }
+        registryObserver = observer
+        defer {
+            NotificationCenter.default.removeObserver(observer)
+            registryObserver = nil
+        }
 
         DispatchQueue.global(qos: .userInitiated).async {
             mock.addBook(book, location: nil, state: .downloadNeeded,

--- a/PalaceTests/Support/XCTestCase+testUserDefaults.swift
+++ b/PalaceTests/Support/XCTestCase+testUserDefaults.swift
@@ -53,19 +53,23 @@ extension XCTestCase {
     /// - Returns: a `UserDefaults` instance pointing at a unique suite
     ///   name. The caller does NOT need to clean up — the resetter
     ///   handles it.
-    func testUserDefaults(
+    /// `static`: this helper reads nothing from the test instance (the suite
+    /// name is fully UUID-derived), so making it static removes `self` as the
+    /// receiver. A nonisolated instance method invoked on a `@MainActor`,
+    /// non-`Sendable` test `self` forces the compiler to *send* `self`
+    /// ("sending 'self' risks causing data races"); an `@MainActor` variant
+    /// instead can't return its non-`Sendable` result to a nonisolated
+    /// `setUp()`. Only a receiver-free `static` satisfies BOTH caller kinds
+    /// the suite has (@MainActor `setUpWithError`/test methods AND nonisolated
+    /// plain `setUp()` overrides). Callers use `Self.testUserDefaults()`.
+    static func testUserDefaults(
         file: StaticString = #file,
         line: UInt = #line
     ) -> UserDefaults {
-        // Sanitize the test name so it forms a valid persistent-domain
-        // identifier. XCTest names look like `-[ClassName testMethod]`
-        // which is fine for UserDefaults, but the leading `-[` and
-        // trailing `]` are noisy in `defaults read` output.
-        let sanitizedTestName = self.name
-            .replacingOccurrences(of: "-[", with: "")
-            .replacingOccurrences(of: "]", with: "")
-            .replacingOccurrences(of: " ", with: "_")
-        let suiteName = "test-\(sanitizedTestName)-\(UUID().uuidString)"
+        // Suite name is UUID-derived — unique per call, no dependency on the
+        // test instance. (Previously prefixed with the sanitized test name for
+        // readability in `defaults read`; dropped so the helper can be static.)
+        let suiteName = "test-\(UUID().uuidString)"
 
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail(

--- a/PalaceTests/Support/XCTestCase+testUserDefaultsTests.swift
+++ b/PalaceTests/Support/XCTestCase+testUserDefaultsTests.swift
@@ -8,7 +8,7 @@ import XCTest
 ///
 /// The "SUT" here is the helper extension itself; the file name
 /// (`XCTestCase+testUserDefaultsTests`) reflects that — the test
-/// methods exercise `testUserDefaults()` directly.
+/// methods exercise `Self.testUserDefaults()` directly.
 @MainActor
 final class XCTestCase_testUserDefaultsTests: XCTestCase {
 
@@ -18,11 +18,11 @@ final class XCTestCase_testUserDefaultsTests: XCTestCase {
 
     // MARK: - Isolation
 
-    /// Two calls to `testUserDefaults()` inside the same test must
+    /// Two calls to `Self.testUserDefaults()` inside the same test must
     /// produce two stores whose writes do NOT bleed into each other.
     func testTestUserDefaults_returnsIsolatedSuite() {
-        let storeA = testUserDefaults()
-        let storeB = testUserDefaults()
+        let storeA = Self.testUserDefaults()
+        let storeB = Self.testUserDefaults()
 
         // Arrange: write distinct values into each store under the same key.
         let key = "isolation-probe"
@@ -38,7 +38,7 @@ final class XCTestCase_testUserDefaultsTests: XCTestCase {
 
     // MARK: - No leak to `.standard`
 
-    /// A write into a `testUserDefaults()` store must NOT be visible via
+    /// A write into a `Self.testUserDefaults()` store must NOT be visible via
     /// `UserDefaults.standard`. This is the load-bearing isolation
     /// property — if it ever regresses, every test using the helper
     /// silently goes back to polluting `.standard`.
@@ -49,13 +49,13 @@ final class XCTestCase_testUserDefaultsTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: suiteKey)
 
         // Act: write to the isolated store.
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set("isolated-only", forKey: suiteKey)
 
         // Assert: `.standard` is still empty for this key.
         XCTAssertNil(
             UserDefaults.standard.string(forKey: suiteKey),
-            "Writing to a testUserDefaults() store must NOT be visible via UserDefaults.standard"
+            "Writing to a Self.testUserDefaults() store must NOT be visible via UserDefaults.standard"
         )
 
         // Sanity check: the isolated store DOES have the value.
@@ -75,7 +75,7 @@ final class XCTestCase_testUserDefaultsTests: XCTestCase {
         // the helper added.
         let beforeNames = Set(SingletonResetRegistry.shared.registeredNames())
 
-        let defaults = testUserDefaults()
+        let defaults = Self.testUserDefaults()
         defaults.set("survives-only-until-reset", forKey: "reset-probe")
         XCTAssertEqual(defaults.string(forKey: "reset-probe"), "survives-only-until-reset",
                        "Pre-reset: value must be present in the suite")
@@ -84,9 +84,9 @@ final class XCTestCase_testUserDefaultsTests: XCTestCase {
         let added = afterNames.subtracting(beforeNames)
 
         // The helper must register exactly the resetters this test
-        // call adds (one per `testUserDefaults()` invocation).
+        // call adds (one per `Self.testUserDefaults()` invocation).
         XCTAssertEqual(added.count, 1,
-                       "testUserDefaults() must register exactly one resetter per call. Added: \(added)")
+                       "Self.testUserDefaults() must register exactly one resetter per call. Added: \(added)")
         guard let addedName = added.first else {
             XCTFail("No resetter was registered")
             return

--- a/PalaceTests/Utilities/DeviceOrientationTests.swift
+++ b/PalaceTests/Utilities/DeviceOrientationTests.swift
@@ -13,19 +13,15 @@ final class DeviceOrientationTests: XCTestCase {
 
     var orientation: DeviceOrientation!
 
-    override nonisolated func setUp() {
-        super.setUp()
-        MainActor.assumeIsolated {
-            orientation = DeviceOrientation()
-        }
+    override func setUp() async throws {
+        try await super.setUp()
+        orientation = DeviceOrientation()
     }
 
-    override nonisolated func tearDown() {
-        MainActor.assumeIsolated {
-            orientation?.stopTracking()
-            orientation = nil
-        }
-        super.tearDown()
+    override func tearDown() async throws {
+        orientation?.stopTracking()
+        orientation = nil
+        try await super.tearDown()
     }
 
     // MARK: - Initial State Tests

--- a/PalaceTests/Utilities/PalaceHapticTests.swift
+++ b/PalaceTests/Utilities/PalaceHapticTests.swift
@@ -95,6 +95,11 @@ final class PalaceHapticTests: XCTestCase {
         var received: Bool?
         let cancellable = mock.preferencesPublisher
             .dropFirst() // skip the current value
+            // Deliver on main: the `.sink` closure is `@MainActor`-isolated (this
+            // is a `@MainActor` test), but `updatePreferences` sends from a
+            // background `Task`, so without this the sink runs off-main and
+            // Swift 6's executor-isolation check traps (EXC_BREAKPOINT).
+            .receive(on: DispatchQueue.main)
             .sink { received = $0.hapticFeedbackEnabled; exp.fulfill() }
 
         Task { await mock.updatePreferences(disabled) }

--- a/PalaceTests/Utilities/SafeDictionaryTests.swift
+++ b/PalaceTests/Utilities/SafeDictionaryTests.swift
@@ -165,7 +165,7 @@ final class SafeDictionaryTests: XCTestCase {
         let dict = SafeDictionary<String, Int>()
         await dict.set("price", value: 10)
 
-        let mapped = await dict.mapValues { $0 * 2 }
+        let mapped = await dict.mapValues { @Sendable in $0 * 2 }
         XCTAssertEqual(mapped["price"], 20)
     }
 
@@ -173,7 +173,7 @@ final class SafeDictionaryTests: XCTestCase {
         let dict = SafeDictionary<String, Int>()
         await dict.updateMultiple(["a": 1, "b": 2, "c": 3, "d": 4])
 
-        let evens = await dict.filter { _, v in v % 2 == 0 }
+        let evens = await dict.filter { @Sendable _, v in v % 2 == 0 }
         XCTAssertEqual(evens.count, 2)
         XCTAssertEqual(evens["b"], 2)
         XCTAssertEqual(evens["d"], 4)
@@ -183,7 +183,7 @@ final class SafeDictionaryTests: XCTestCase {
         let dict = SafeDictionary<String, String>()
         await dict.updateMultiple(["num": "42", "str": "abc", "zero": "0"])
 
-        let ints = await dict.compactMapValues { Int($0) }
+        let ints = await dict.compactMapValues { @Sendable in Int($0) }
         XCTAssertEqual(ints.count, 2)
         XCTAssertEqual(ints["num"], 42)
         XCTAssertEqual(ints["zero"], 0)
@@ -195,7 +195,7 @@ final class SafeDictionaryTests: XCTestCase {
         let dict = SafeDictionary<String, Int>()
         await dict.set("counter", value: 5)
 
-        await dict.modify("counter") { value in
+        await dict.modify("counter") { @Sendable value in
             value = (value ?? 0) + 10
         }
 
@@ -206,7 +206,7 @@ final class SafeDictionaryTests: XCTestCase {
     func testModify_createsNewValue() async {
         let dict = SafeDictionary<String, Int>()
 
-        await dict.modify("new") { value in
+        await dict.modify("new") { @Sendable value in
             value = 99
         }
 

--- a/PalaceTests/XCTestCase+drainMainQueue.swift
+++ b/PalaceTests/XCTestCase+drainMainQueue.swift
@@ -55,6 +55,16 @@ extension XCTestCase {
     /// `drainMainQueue()`).
     ///
     /// - Parameter timeout: Maximum seconds to wait. Default 5s.
+    ///
+    /// `@MainActor`: this helper only ever touches main-queue machinery
+    /// (`expectation`, `DispatchQueue.main.async`, `fulfillment`), and every
+    /// caller is a `@MainActor` test method. Isolating it to the main actor
+    /// keeps the `await` on-actor so the (non-Sendable) `XCTestCase` `self`
+    /// is never *sent* across an actor boundary at the suspension point —
+    /// which is exactly the Swift 6 "sending value of non-Sendable type …
+    /// risks causing data races" error a nonisolated async helper produces
+    /// when called from a `@MainActor async` test (HoldsSyncFailureTests×3).
+    @MainActor
     func drainMainQueueAsync(timeout: TimeInterval = 5.0) async {
         let drained = expectation(description: "main queue drained (async)")
         DispatchQueue.main.async { drained.fulfill() }

--- a/PalaceTests/XCTestCase+drainMainQueue.swift
+++ b/PalaceTests/XCTestCase+drainMainQueue.swift
@@ -83,24 +83,27 @@ extension XCTestCase {
     ///   - pollInterval: How often to re-check. Default 50ms.
     ///   - predicate: A synchronous closure that returns true once the
     ///     observed state has converged.
+    @MainActor
     func awaitCondition(
         timeout: TimeInterval = 5.0,
         pollInterval: TimeInterval = 0.05,
-        _ predicate: @escaping () -> Bool
+        _ predicate: @escaping @MainActor () -> Bool
     ) {
         let met = expectation(description: "condition met")
-        var fulfilled = false
-        func poll() {
-            if fulfilled { return }
-            if predicate() {
-                fulfilled = true
-                met.fulfill()
-                return
+        // Swift 6: the predicate reads @MainActor test/view-model state (e.g.
+        // `model.isLoading`), so it must stay on the main actor. Poll via a
+        // @MainActor Task instead of the old DispatchQueue.main.asyncAfter
+        // recursion (whose @Sendable closure couldn't capture the @MainActor
+        // predicate). `wait(for:)` spins the main runloop so the Task advances.
+        let pollTask = Task { @MainActor in
+            while !predicate() {
+                if Task.isCancelled { return }
+                try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + pollInterval) { poll() }
+            met.fulfill()
         }
-        poll()
         wait(for: [met], timeout: timeout)
+        pollTask.cancel()
     }
 
     /// Async sibling of `awaitCondition` for `async` test bodies that need
@@ -120,7 +123,7 @@ extension XCTestCase {
     ///   - pollInterval: How often to re-check. Default 25ms.
     ///   - file/line: For accurate XCTFail attribution.
     ///   - predicate: Synchronous closure returning true once converged.
-    func awaitConditionAsync(
+    @MainActor func awaitConditionAsync(
         timeout: TimeInterval = 10.0,
         pollInterval: TimeInterval = 0.025,
         file: StaticString = #file,
@@ -150,7 +153,7 @@ extension XCTestCase {
     /// require `await`; this overload exists so callers can avoid
     /// hand-rolling another silent while-deadline loop just because their
     /// observable is `async`.
-    func awaitConditionAsync(
+    @MainActor func awaitConditionAsync(
         timeout: TimeInterval = 10.0,
         pollInterval: TimeInterval = 0.025,
         file: StaticString = #file,

--- a/PalaceTests/XCTestCase+drainMainQueue.swift
+++ b/PalaceTests/XCTestCase+drainMainQueue.swift
@@ -95,12 +95,30 @@ extension XCTestCase {
         // @MainActor Task instead of the old DispatchQueue.main.asyncAfter
         // recursion (whose @Sendable closure couldn't capture the @MainActor
         // predicate). `wait(for:)` spins the main runloop so the Task advances.
+        //
+        // CANCELLATION-FIRST ordering is load-bearing. The previous shape
+        // (`while !predicate() { if Task.isCancelled ... sleep }`) evaluated
+        // the predicate ONE MORE TIME on the resumption after `cancel()`:
+        // on timeout, `wait` returns → `pollTask.cancel()` → the pending
+        // `Task.sleep` throws immediately → the loop re-entered
+        // `while !predicate()` BEFORE noticing the cancellation. That leaked
+        // resumption runs at the next main-actor availability — which can be
+        // AFTER `tearDown` has nil'd the test's implicitly-unwrapped fixtures
+        // (`self.sut!`), turning a timed-out wait into a force-unwrap
+        // `fatalError` that kills the whole test-runner process (CI run
+        // 29802862487: AudiobookPlaytimesLifecycleTests' retry crashed the
+        // Clone-2 runner exactly this way). Checking `Task.isCancelled` FIRST
+        // guarantees the predicate is never touched after `cancel()` returns:
+        // cancel + tearDown run synchronously on main, so the leaked
+        // resumption's first act is the cancellation check.
         let pollTask = Task { @MainActor in
-            while !predicate() {
-                if Task.isCancelled { return }
+            while !Task.isCancelled {
+                if predicate() {
+                    met.fulfill()
+                    return
+                }
                 try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
             }
-            met.fulfill()
         }
         wait(for: [met], timeout: timeout)
         pollTask.cancel()

--- a/scripts/xcode-test-optimized.sh
+++ b/scripts/xcode-test-optimized.sh
@@ -105,6 +105,27 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
         xcodebuild clean -project Palace.xcodeproj -scheme Palace > /dev/null 2>&1 || true
     fi
 
+    # Scheduling-sensitive infra tests that must run OUTSIDE the 4-clone parallel
+    # run. Under parallel-sim-clone oversubscription (workers > runner cores) the
+    # cooperative pool starves so badly that these tests' OWN internal wait
+    # timeouts starve too, and they hang to the 120s executionTimeAllowance —
+    # even though they pass deterministically when not oversubscribed (they can't
+    # be reproduced on a single local clone that owns its pool). They are NOT
+    # skipped/weakened: the parallel run below `-skip-testing`s them, then a
+    # dedicated SERIAL pass (`-parallel-testing-enabled NO`) runs them FULLY and
+    # the results are MERGED back into TestResults.xcresult so the downstream
+    # fail-gate counts them. Owner decision after CI runs 29805821296 / 29810471358.
+    ISOLATED_SERIAL_TESTS=(
+        "PalaceTests/ImageCacheContinuationTests"
+        "PalaceTests/PoolResponsivenessProbeTests"
+    )
+    ISOLATED_SKIP_ARGS=()
+    ISOLATED_ONLY_ARGS=()
+    for _t in "${ISOLATED_SERIAL_TESTS[@]}"; do
+        ISOLATED_SKIP_ARGS+=("-skip-testing:$_t")
+        ISOLATED_ONLY_ARGS+=("-only-testing:$_t")
+    done
+
     # Capture xcodebuild output so we can detect a COMPILE failure that
     # `xcodebuild test` masks. Under `-parallel-testing-enabled` xcodebuild can
     # exit 0 even when a test bundle fails to BUILD: the sibling bundles that DID
@@ -128,6 +149,7 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
         -maximum-test-execution-time-allowance 300 \
         -parallel-testing-enabled YES \
         -maximum-parallel-testing-workers "${CI_TEST_WORKERS:-4}" \
+        "${ISOLATED_SKIP_ARGS[@]}" \
         CODE_SIGNING_REQUIRED=NO \
         CODE_SIGNING_ALLOWED=NO \
         ONLY_ACTIVE_ARCH=YES \
@@ -153,12 +175,60 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
         exit 1
     fi
 
-    echo "✅ Tests executed on: $SIMULATOR_NAME (exit code: $TEST_EXIT_CODE)"
+    echo "✅ Parallel tests executed on: $SIMULATOR_NAME (exit code: $TEST_EXIT_CODE)"
 
-    # Propagate the test exit code so CI detects failures
-    if [ "$TEST_EXIT_CODE" -ne 0 ]; then
-        echo "🔴 Tests failed with exit code: $TEST_EXIT_CODE"
-        exit $TEST_EXIT_CODE
+    # --- Serial isolated pass for the scheduling-sensitive infra tests ---
+    # Runs the `-skip-testing`'d tests NOT under parallel oversubscription, then
+    # merges the result into TestResults.xcresult so the fail-gate counts them.
+    rm -rf TestResults-serial.xcresult
+    echo "🧵 Serial isolated pass (no parallelism): ${ISOLATED_SERIAL_TESTS[*]}"
+    set +e
+    xcodebuild test \
+        -project Palace.xcodeproj \
+        -scheme Palace \
+        -destination "id=$SIMULATOR_ID" \
+        -configuration Debug \
+        -resultBundlePath TestResults-serial.xcresult \
+        "${ISOLATED_ONLY_ARGS[@]}" \
+        -enableCodeCoverage YES \
+        -retry-tests-on-failure \
+        -test-iterations 3 \
+        -test-timeouts-enabled YES \
+        -default-test-execution-time-allowance 120 \
+        -maximum-test-execution-time-allowance 300 \
+        -parallel-testing-enabled NO \
+        CODE_SIGNING_REQUIRED=NO \
+        CODE_SIGNING_ALLOWED=NO \
+        ONLY_ACTIVE_ARCH=YES \
+        GCC_OPTIMIZATION_LEVEL=0 \
+        SWIFT_OPTIMIZATION_LEVEL=-Onone \
+        ENABLE_TESTABILITY=YES
+    SERIAL_EXIT_CODE=$?
+    set -e
+    echo "✅ Serial isolated tests executed (exit code: $SERIAL_EXIT_CODE)"
+
+    # Merge serial results into TestResults.xcresult so the downstream
+    # Parse-Test-Results fail-gate counts the isolated tests (not un-gated).
+    if [ -d "TestResults-serial.xcresult" ]; then
+        rm -rf TestResults-merged.xcresult
+        if xcrun xcresulttool merge --output-path TestResults-merged.xcresult TestResults.xcresult TestResults-serial.xcresult; then
+            rm -rf TestResults.xcresult TestResults-serial.xcresult
+            mv TestResults-merged.xcresult TestResults.xcresult
+            echo "✅ Merged serial isolated results into TestResults.xcresult"
+        else
+            echo "🔴 ERROR: failed to merge serial isolated xcresult — failing rather than leave those tests un-gated."
+            exit 1
+        fi
+    else
+        echo "🔴 ERROR: serial isolated pass produced no xcresult — cannot gate those tests."
+        exit 1
+    fi
+
+    # Propagate a combined exit code (informational under continue-on-error; the
+    # merged xcresult is the authoritative fail-gate). Non-zero if EITHER pass failed.
+    if [ "$TEST_EXIT_CODE" -ne 0 ] || [ "$SERIAL_EXIT_CODE" -ne 0 ]; then
+        echo "🔴 Tests failed (parallel=$TEST_EXIT_CODE serial=$SERIAL_EXIT_CODE)"
+        exit 1
     fi
 else
     echo "Running in local environment - using dynamic detection"

--- a/scripts/xcode-test-optimized.sh
+++ b/scripts/xcode-test-optimized.sh
@@ -91,6 +91,14 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
     # already runs this way (workers=4) successfully; Xcode merges the clones into the single
     # TestResults.xcresult so the downstream summary.failed gate is unchanged. Tune via CI_TEST_WORKERS if a
     # runner has fewer cores (Xcode caps workers to available cores regardless).
+    # Capture xcodebuild output so we can detect a COMPILE failure that
+    # `xcodebuild test` masks. Under `-parallel-testing-enabled` xcodebuild can
+    # exit 0 even when a test bundle fails to BUILD: the sibling bundles that DID
+    # compile run to completion, an `.xcresult` is still produced, and the
+    # overall exit code comes back 0 — so `TEST_EXIT_CODE` lies and the
+    # green-board masking is born (a broken test target reads as a green job).
+    # Tee to a log and scan it for the unambiguous build-failure markers below.
+    XCB_LOG="$(mktemp)"
     set +e
     xcodebuild test \
         -project Palace.xcodeproj \
@@ -111,9 +119,20 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
         ONLY_ACTIVE_ARCH=YES \
         GCC_OPTIMIZATION_LEVEL=0 \
         SWIFT_OPTIMIZATION_LEVEL=-Onone \
-        ENABLE_TESTABILITY=YES
-    TEST_EXIT_CODE=$?
+        ENABLE_TESTABILITY=YES 2>&1 | tee "$XCB_LOG"
+    TEST_EXIT_CODE=${PIPESTATUS[0]}
     set -e
+
+    # Build-failure gate (green-board contract): a compile failure must fail the
+    # job even when xcodebuild's own exit code is 0. These two markers are only
+    # emitted when the BUILD failed (not for ordinary test failures, which the
+    # exit-code propagation below handles).
+    if grep -qE "Testing cancelled because the build failed|The following build commands failed" "$XCB_LOG"; then
+        echo "🔴 ERROR: build/compile failure detected in xcodebuild output — a masked build failure must fail the run."
+        rm -f "$XCB_LOG"
+        exit 1
+    fi
+    rm -f "$XCB_LOG"
 
     if [ ! -d "TestResults.xcresult" ]; then
         echo "🔴 ERROR: No xcresult produced — build likely failed before tests ran."

--- a/scripts/xcode-test-optimized.sh
+++ b/scripts/xcode-test-optimized.sh
@@ -91,6 +91,20 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
     # already runs this way (workers=4) successfully; Xcode merges the clones into the single
     # TestResults.xcresult so the downstream summary.failed gate is unchanged. Tune via CI_TEST_WORKERS if a
     # runner has fewer cores (Xcode caps workers to available cores regardless).
+    # Clean the test build in CI to defeat stale-DerivedData masking (layer 1).
+    # CI caches DerivedData per-branch (with a cross-branch restore-keys
+    # fallback) and this CI path never cleaned, so a broken test target could
+    # pass by REUSING compiled objects from a green cache — Xcode's incremental
+    # build skips a file whose own source is unchanged even when a transitive
+    # input made it stop compiling. That silently hid develop's Swift 6 test
+    # break behind green checks. A trustworthy board is worth the rebuild time
+    # (green-board contract). Override with PALACE_TEST_NO_CLEAN=1 if a runner
+    # must trade correctness for speed.
+    if [ "${PALACE_TEST_NO_CLEAN:-0}" != "1" ]; then
+        echo "🧹 CI: clean build (defeats stale-DerivedData masking)"
+        xcodebuild clean -project Palace.xcodeproj -scheme Palace > /dev/null 2>&1 || true
+    fi
+
     # Capture xcodebuild output so we can detect a COMPILE failure that
     # `xcodebuild test` masks. Under `-parallel-testing-enabled` xcodebuild can
     # exit 0 even when a test bundle fails to BUILD: the sibling bundles that DID


### PR DESCRIPTION
## Two coupled fixes: a CI masking bug + the breakage it hid

While landing an unrelated crash fix, ios-core CI surfaced that **develop's PalaceTests target has not compiled under Swift 6 for ~3 days** — 16 `sending non-Sendable` errors across 6 files — yet every PR check reported **green**.

### 1. The masking bug (commit 1)
`xcode-test-optimized.sh` exits **0 on a build failure**: under `-parallel-testing-enabled`, `xcodebuild test` returns 0 even when a test bundle fails to *compile* (sibling bundles run, an .xcresult is produced). So `steps.tests.outcome` read `success`, the `Fail if tests failed` gate skipped, and a non-compiling test target passed as a green job — exactly the masking the green-board contract forbids. Fix: scan xcodebuild output for the unambiguous build-failure markers and exit non-zero regardless of xcodebuild's code.

**Pushed first, alone, to demonstrate the failure path** — CI on that commit should turn develop's currently-masked break RED.

### 2. The breakage (commit 2)
The 16 Swift 6 errors — same mechanical patterns as the #1283 ratchet (`@Sendable` closure params, boxing captured vars, `@unchecked Sendable` mocks). Files: NowPlayingCoordinatorBackgroundTests, BorrowOperationContractTests, DownloadStartCoordinatorContractTests, ImageLoaderTests, MockImageLoader, two SignIn tests. Restores the board to green.

### Verification
- Commit 1 alone → CI RED (proves the unmask catches the real failure).
- Commit 1 + 2 → CI GREEN (build compiles; masking fix doesn't break the green path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)