### PR TITLE
triage bot: category-chip chaos-QA fixes — debounce + Dynamic Type (PP-4822, PP-4823)

### DIFF
--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -76,6 +76,12 @@ public struct ConversationReducer: Sendable {
             lateBindContext(&next, context: redacted)
 
         case .userTappedCategory(let category):
+            // Debounce rapid / double taps (chaos F-001, PP-4822). Category chips
+            // are only shown while awaiting a category; once the first tap moves us
+            // to .awaitingDescription, further taps are no-ops — otherwise an eager
+            // patron appends several duplicate turns and the chat looks broken. This
+            // mirrors the Send button's debounce.
+            guard case .awaitingCategory = next.step else { return (next, effects) }
             next.step = .awaitingDescription(category: category)
             next.messages.append(.init(
                 sender: .user,

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/CategoryChipsView.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/CategoryChipsView.swift
@@ -5,6 +5,8 @@ import TriageBotCore
 struct CategoryChipsView: View {
     let onTap: (KBCategory) -> Void
 
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     private let categories: [(KBCategory, String, String)] = [
         (.audiobook, "🎧", "Audiobook"),
         (.reader, "📖", "Reading"),
@@ -15,25 +17,43 @@ struct CategoryChipsView: View {
     ]
 
     var body: some View {
-        let columns = [GridItem(.adaptive(minimum: 110), spacing: 8)]
-        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
-            ForEach(categories, id: \.0) { category, emoji, label in
-                Button { onTap(category) } label: {
-                    HStack(spacing: 6) {
-                        Text(emoji)
-                        Text(label)
-                            .font(.subheadline)
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 10)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color(.secondarySystemBackground))
-                    .clipShape(Capsule())
+        // PP-4823 (chaos F-004): the fixed-width adaptive grid squeezed chip
+        // labels into unreadable single-character columns at the largest
+        // accessibility Dynamic Type sizes. At those sizes, stack the chips one
+        // per row (full width) so labels stay legible and tappable; keep the
+        // compact adaptive grid at normal sizes.
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(categories, id: \.0) { category, emoji, label in
+                    chip(category, emoji, label)
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Category: \(label)")
+            }
+        } else {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 110), spacing: 8)],
+                      alignment: .leading, spacing: 8) {
+                ForEach(categories, id: \.0) { category, emoji, label in
+                    chip(category, emoji, label)
+                }
             }
         }
+    }
+
+    @ViewBuilder
+    private func chip(_ category: KBCategory, _ emoji: String, _ label: String) -> some View {
+        Button { onTap(category) } label: {
+            HStack(spacing: 6) {
+                Text(emoji)
+                Text(label)
+                    .font(.subheadline)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Category: \(label)")
     }
 }
 #endif

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CategoryChipDebounceTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CategoryChipDebounceTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import TriageBotCore
+
+/// PP-4822 (chaos F-001): rapid / double taps on a category chip must produce
+/// exactly one conversation turn, not several. The chip tap is debounced at the
+/// reducer — once the first tap leaves `.awaitingCategory`, further taps are
+/// no-ops (the same guarantee the Send button already has).
+final class CategoryChipDebounceTests: XCTestCase {
+
+    private func makeReducer() -> ConversationReducer {
+        let catalog = KBCatalog(version: "test", updatedAt: "2026-07-21", entries: [])
+        return ConversationReducer(knowledgeBase: KnowledgeBase(catalog: catalog))
+    }
+
+    private func startedState(_ r: ConversationReducer) -> ConversationState {
+        r.reduce(state: ConversationState(), action: .start).0
+    }
+
+    func testRapidSameCategoryTaps_produceExactlyOneTurn() {
+        let r = makeReducer()
+        var state = startedState(r)
+
+        let (afterFirst, _) = r.reduce(state: state, action: .userTappedCategory(.audiobook))
+        let countAfterFirst = afterFirst.messages.count
+        XCTAssertEqual(afterFirst.step, .awaitingDescription(category: .audiobook))
+
+        // Two more rapid taps on the same chip before the patron types anything.
+        let (afterSecond, _) = r.reduce(state: afterFirst, action: .userTappedCategory(.audiobook))
+        let (afterThird, effects) = r.reduce(state: afterSecond, action: .userTappedCategory(.audiobook))
+
+        XCTAssertEqual(afterThird.messages.count, countAfterFirst,
+                       "rapid taps must not append additional turns")
+        XCTAssertEqual(afterThird.step, .awaitingDescription(category: .audiobook),
+                       "step must stay on the first chosen category")
+        XCTAssertFalse(effects.contains { if case .emitTelemetry(let e) = $0 { return e.name == "triage_category_chosen" }; return false },
+                       "a debounced tap must not re-emit the category-chosen telemetry")
+    }
+
+    func testDifferentCategoryTapAfterFirst_isIgnored_firstWins() {
+        let r = makeReducer()
+        let (afterAudiobook, _) = r.reduce(state: startedState(r), action: .userTappedCategory(.audiobook))
+        let (afterReader, _) = r.reduce(state: afterAudiobook, action: .userTappedCategory(.reader))
+
+        XCTAssertEqual(afterReader.step, .awaitingDescription(category: .audiobook),
+                       "a second chip tap (even a different category) must not switch the flow")
+        XCTAssertEqual(afterReader.messages.count, afterAudiobook.messages.count)
+    }
+
+    func testCategoryTap_whileAwaitingCategory_stillWorks() {
+        // Guard the positive: the FIRST tap from .awaitingCategory must register.
+        let r = makeReducer()
+        let (state, effects) = r.reduce(state: startedState(r), action: .userTappedCategory(.signin))
+        XCTAssertEqual(state.step, .awaitingDescription(category: .signin))
+        XCTAssertTrue(effects.contains { if case .emitTelemetry(let e) = $0 { return e.name == "triage_category_chosen" }; return false })
+    }
+}


### PR DESCRIPTION
The two remaining category-chip findings from the triage-bot chaos pass (PP-4817). Both are first-interaction quality issues on the "Get Help" chips. Independent of the PP-4825 corpus work — these branch off `develop`.

## PP-4822 — rapid taps create duplicate turns (chaos F-001)
Category chips weren't debounced like the Send button, so an eager or double tap appended several duplicate conversation turns and the chat looked like it was stuttering. Fixed at the reducer: `.userTappedCategory` is guarded on the `.awaitingCategory` step, so once the first tap moves to `.awaitingDescription`, further taps are no-ops. First category wins; no duplicate turns, no re-emitted telemetry.
- 3 tests; guard **mutation-verified** (removing it fails the duplicate-turn test). **198/198** package tests green.

## PP-4823 — chips collapse at XXXL Dynamic Type (chaos F-004)
The fixed-width adaptive grid (`minimum: 110`) squeezed chip labels into unreadable single-character columns at the largest accessibility sizes. Now at accessibility Dynamic Type sizes the chips stack one-per-row full-width so labels stay legible + tappable; the compact adaptive grid stays at normal sizes.
- Compiles clean for iOS Simulator (`xcodebuild -scheme TriageBotUI` **BUILD SUCCEEDED**). `CategoryChipsView` is UIKit-gated, so macOS `swift test` doesn't compile it.

## ⚠️ Verification note
- **PP-4823 still needs a visual XXXL AC-verify** (DoD #12) — drive a sim at the largest Dynamic Type, open Get Help, confirm the chips render readable. Code is compile-verified but not yet screenshot-verified. PP-4822 is fully verified.
- App-scheme CI green is currently masked by develop's broken `PalaceTests` (Swift-6, fixed by #1305) — this branch's package tests run for real; the app-scheme real-green awaits #1305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)