### PR TITLE
fix(triage): Sent-state 'Ask another question' + readable reference at XXXL (PP-4844, PP-4845)

### DIFF
--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/CategoryChipsView.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/CategoryChipsView.swift
@@ -3,6 +3,13 @@ import SwiftUI
 import TriageBotCore
 
 struct CategoryChipsView: View {
+    /// PP-4844: chips are only a live affordance while the conversation is
+    /// actually awaiting a category. Once the log moves on (a ticket was sent,
+    /// the flow advanced), the earlier chip row is historical — tapping it is a
+    /// reducer no-op. Render those inactive chips dimmed + disabled so they
+    /// don't look tappable, and hide them from VoiceOver so a patron isn't
+    /// promised six categories that do nothing.
+    var isActive: Bool = true
     let onTap: (KBCategory) -> Void
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -53,7 +60,10 @@ struct CategoryChipsView: View {
             .clipShape(Capsule())
         }
         .buttonStyle(.plain)
+        .disabled(!isActive)
+        .opacity(isActive ? 1.0 : 0.5)
         .accessibilityLabel("Category: \(label)")
+        .accessibilityHidden(!isActive)
     }
 }
 #endif

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/SupportChatView.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/SupportChatView.swift
@@ -103,7 +103,11 @@ public struct SupportChatView: View {
         case .text(let text):
             ChatBubble(text: text, sender: message.sender)
         case .categoryChips:
-            CategoryChipsView { category in
+            // PP-4844: chips are only live while the reducer is awaiting a
+            // category. Any earlier chip row (e.g. still on-screen after a
+            // ticket was sent) is historical — pass isActive: false so it
+            // renders dimmed + disabled instead of looking tappable-but-dead.
+            CategoryChipsView(isActive: chipsAreLive) { category in
                 viewModel.send(.userTappedCategory(category))
             }
         case .kbMatch(let entryId):
@@ -135,6 +139,21 @@ public struct SupportChatView: View {
                 handleErrorAction(action)
             }
         }
+    }
+
+    /// Category chips are a live affordance only while the reducer is actually
+    /// awaiting a category. In every other step an on-screen chip row is a
+    /// historical turn whose taps are reducer no-ops (PP-4844).
+    private var chipsAreLive: Bool {
+        if case .awaitingCategory = viewModel.state.step { return true }
+        return false
+    }
+
+    /// The terminal "Sent" state. The ticket is filed and there's no text input
+    /// — without an explicit affordance the patron is stranded (PP-4844).
+    private var isSentTerminalStep: Bool {
+        if case .sent = viewModel.state.step { return true }
+        return false
     }
 
     private struct InputBarConfig {
@@ -203,6 +222,18 @@ public struct SupportChatView: View {
             }
             .padding(.horizontal)
             .padding(.vertical, 8)
+        } else if isSentTerminalStep {
+            // PP-4844: the ticket is filed and there's no text field, so the
+            // only recovery used to be closing + reopening the Help sheet.
+            // Give the patron a first-class way to keep going. This dispatches
+            // the reducer's existing reset action (.userTappedStartOver), which
+            // clears state back to a fresh category prompt.
+            BotUI.PrimaryButton(title: "Ask another question", systemImage: "plus.bubble") {
+                viewModel.send(.userTappedStartOver)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .accessibilityHint("Starts a new question. Your sent ticket is unaffected.")
         }
     }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TicketPreviewCard.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TicketPreviewCard.swift
@@ -269,8 +269,11 @@ struct TicketReceiptCard: View {
             Text("Reference: \(receipt.ticketId)")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
+                // PP-4845: at the largest accessibility Dynamic Type this line
+                // middle-truncated ("Referen…645573") so the patron couldn't
+                // read their ticket reference — their only handle on the filed
+                // ticket. Let it wrap like every other line on the receipt.
+                .fixedSize(horizontal: false, vertical: true)
             Text("Support will reply within 1 business day.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)


### PR DESCRIPTION
Fixes **PP-4844** and **PP-4845** (from the chaos QA pass).

**PP-4844** — the 'Sent' confirmation was a dead-end: the topic chips stayed at full opacity but did nothing and the input field was gone. Now the post-send chips render dimmed + `.disabled()` + VoiceOver-hidden, and the terminal 'Sent' state shows an **'Ask another question'** button wired to the existing `.userTappedStartOver` reset — a patron can start fresh without closing/reopening the sheet.

**PP-4845** — the ticket 'Reference:' line truncated with a middle-ellipsis at the largest Dynamic Type. Removed the `lineLimit(1)`/`.truncationMode`, added `.fixedSize` so it wraps and the full reference is readable.

Compile-verified (`xcodebuild -scheme TriageBotUI` BUILD SUCCEEDED). No view-test harness in the package; the reset action is already covered by `ConversationReducerTests.testStartOver_fromError_...`. Coordinator will simdrive-verify the combined UI.

Note: touches `CategoryChipsView` (adds an `isActive` param) — needs to reconcile with the pending pill-fix re-land on the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)