### PR TITLE
fix(triage): send-consent gate + Sent-state recovery + reference wrap + 1-line chips (PP-4843/4844/4845 + pill)

### DIFF
--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
@@ -83,19 +83,31 @@ public struct ConversationState: Equatable, Sendable {
     public var context: ContextSnapshot?
     public var lastClassification: ClassificationResult?
     public var inputText: String
+    /// PP-4843 send-consent gate. `true` means the reducer has just presented a
+    /// FRESH ticket preview and the patron has not yet been shown to have seen
+    /// it — a `.userConfirmedTicketSubmit` that arrives while this is `true` is a
+    /// same-burst rapid double-tap that skipped past the preview, so it is
+    /// suppressed rather than silently filing a ticket the patron never reviewed.
+    /// The preview card clears it by dispatching `.ticketPreviewPresented` on
+    /// appear. Defaults to `false` so a directly-constructed drafting state (and
+    /// every pre-PP-4843 flow) sends normally — only reducer-driven fresh
+    /// previews arm the gate.
+    public var pendingSendConsent: Bool
 
     public init(
         step: Step = .welcome,
         messages: [ConversationMessage] = [],
         context: ContextSnapshot? = nil,
         lastClassification: ClassificationResult? = nil,
-        inputText: String = ""
+        inputText: String = "",
+        pendingSendConsent: Bool = false
     ) {
         self.step = step
         self.messages = messages
         self.context = context
         self.lastClassification = lastClassification
         self.inputText = inputText
+        self.pendingSendConsent = pendingSendConsent
     }
 }
 
@@ -142,6 +154,13 @@ public enum ConversationAction: Equatable, Sendable {
     case userEditedDescription(String)
     /// PP-4807 preview editor: explicit include/omit for the log excerpt.
     case userOmittedLogs(Bool)
+    /// PP-4843: the ticket preview card became visible to the patron (its
+    /// `onAppear`). Clears the send-consent gate so a deliberate Send is
+    /// honored. Because this only fires once the view has actually laid out —
+    /// a runloop turn AFTER the escalation — it does NOT fire in the middle of
+    /// a synchronous rapid-tap burst, which is what lets the reducer tell a
+    /// deliberate confirm apart from a same-burst accidental one.
+    case ticketPreviewPresented
     case userConfirmedTicketSubmit
     case userCancelledTicketSubmit
     case ticketSubmitted(TicketReceipt)

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -475,8 +475,30 @@ public struct ConversationReducer: Sendable {
                 tagSuffix: "escalate-after-guided-flow-abandoned"
             )
 
+        case .ticketPreviewPresented:
+            // PP-4843: the preview card is now on screen and the patron can
+            // read it — release the send-consent gate so a deliberate Send
+            // goes through. Idempotent and safe from any state.
+            next.pendingSendConsent = false
+
         case .userConfirmedTicketSubmit:
             guard case .drafting(let draft) = next.step else { return (next, effects) }
+            // PP-4843 (chaos rapid-tap): on a short conversation the preview's
+            // own Send button renders at the same screen position the message
+            // Send arrow occupied before the auto-scroll, so a rapid burst that
+            // began as message-submit taps bleeds a confirm tap onto the
+            // just-appeared preview before the patron ever saw it. The reducer
+            // arms `pendingSendConsent` whenever it presents a FRESH preview and
+            // only the card's `.ticketPreviewPresented` (fired on a later
+            // runloop turn) clears it — so a confirm that arrives while the gate
+            // is still armed is that same-burst accidental tap. Suppress it: the
+            // patron must actually see the preview before a ticket is filed.
+            // Mirrors the PP-4822 category-chip debounce class. (A directly
+            // constructed drafting state defaults to an un-armed gate, so
+            // deliberate single-tap sends are unaffected.)
+            if next.pendingSendConsent {
+                return (next, effects)
+            }
             // Chaos-qa F-002: drop the ticketPreview from the message log
             // when leaving .drafting so the user doesn't see active Send /
             // Cancel buttons stacked next to the eventual "Sent" receipt.
@@ -662,6 +684,9 @@ public struct ConversationReducer: Sendable {
             )
             next.step = .drafting(ticket: enriched)
             next.inputText = ""
+            // PP-4843: the follow-up answer presents a fresh preview — arm the
+            // send-consent gate so a rapid tap after answering can't skip it.
+            next.pendingSendConsent = true
             // Append a user-side message showing what they answered (or a
             // "(skipped)" marker) so the chat history reads naturally.
             if let answer, !answer.isEmpty {
@@ -832,6 +857,10 @@ public struct ConversationReducer: Sendable {
             )))
         } else {
             next.step = .drafting(ticket: draft)
+            // PP-4843: arm the send-consent gate — the patron must be shown to
+            // have seen this fresh preview (.ticketPreviewPresented) before a
+            // confirm is honored.
+            next.pendingSendConsent = true
             next.messages.append(.init(
                 sender: .bot,
                 kind: .text("I haven't seen exactly that before — let me file a ticket so support can look. Here's what I'll send:")
@@ -883,6 +912,8 @@ public struct ConversationReducer: Sendable {
             )))
         } else {
             next.step = .drafting(ticket: draft)
+            // PP-4843: arm the send-consent gate for this fresh preview too.
+            next.pendingSendConsent = true
             next.messages.append(.init(
                 sender: .bot,
                 kind: .text("That didn't fix it. I'll file a ticket with the exact steps you tried so support can pick up where we left off.")

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/CategoryChipsView.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/CategoryChipsView.swift
@@ -36,7 +36,10 @@ struct CategoryChipsView: View {
                 }
             }
         } else {
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 110), spacing: 8)],
+            // Wider adaptive minimum so the grid drops to ~2 columns on phones
+            // narrower than a Max — at 110pt the third column wrapped "Audiobook"
+            // / "Download" onto two lines. (Re-land of the pill-label fix.)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 155), spacing: 8)],
                       alignment: .leading, spacing: 8) {
                 ForEach(categories, id: \.0) { category, emoji, label in
                     chip(category, emoji, label)
@@ -52,6 +55,10 @@ struct CategoryChipsView: View {
                 Text(emoji)
                 Text(label)
                     .font(.subheadline)
+                    // Never wrap a chip label to a second line; shrink a hair only
+                    // if a chip is ever too narrow for the label.
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.9)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/CategoryChipsView.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/CategoryChipsView.swift
@@ -3,6 +3,13 @@ import SwiftUI
 import TriageBotCore
 
 struct CategoryChipsView: View {
+    /// PP-4844: chips are only a live affordance while the conversation is
+    /// actually awaiting a category. Once the log moves on (a ticket was sent,
+    /// the flow advanced), the earlier chip row is historical — tapping it is a
+    /// reducer no-op. Render those inactive chips dimmed + disabled so they
+    /// don't look tappable, and hide them from VoiceOver so a patron isn't
+    /// promised six categories that do nothing.
+    var isActive: Bool = true
     let onTap: (KBCategory) -> Void
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -53,7 +60,10 @@ struct CategoryChipsView: View {
             .clipShape(Capsule())
         }
         .buttonStyle(.plain)
+        .disabled(!isActive)
+        .opacity(isActive ? 1.0 : 0.5)
         .accessibilityLabel("Category: \(label)")
+        .accessibilityHidden(!isActive)
     }
 }
 #endif

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/SupportChatView.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/SupportChatView.swift
@@ -103,7 +103,11 @@ public struct SupportChatView: View {
         case .text(let text):
             ChatBubble(text: text, sender: message.sender)
         case .categoryChips:
-            CategoryChipsView { category in
+            // PP-4844: chips are only live while the reducer is awaiting a
+            // category. Any earlier chip row (e.g. still on-screen after a
+            // ticket was sent) is historical — pass isActive: false so it
+            // renders dimmed + disabled instead of looking tappable-but-dead.
+            CategoryChipsView(isActive: chipsAreLive) { category in
                 viewModel.send(.userTappedCategory(category))
             }
         case .kbMatch(let entryId):
@@ -135,6 +139,21 @@ public struct SupportChatView: View {
                 handleErrorAction(action)
             }
         }
+    }
+
+    /// Category chips are a live affordance only while the reducer is actually
+    /// awaiting a category. In every other step an on-screen chip row is a
+    /// historical turn whose taps are reducer no-ops (PP-4844).
+    private var chipsAreLive: Bool {
+        if case .awaitingCategory = viewModel.state.step { return true }
+        return false
+    }
+
+    /// The terminal "Sent" state. The ticket is filed and there's no text input
+    /// — without an explicit affordance the patron is stranded (PP-4844).
+    private var isSentTerminalStep: Bool {
+        if case .sent = viewModel.state.step { return true }
+        return false
     }
 
     private struct InputBarConfig {
@@ -203,6 +222,18 @@ public struct SupportChatView: View {
             }
             .padding(.horizontal)
             .padding(.vertical, 8)
+        } else if isSentTerminalStep {
+            // PP-4844: the ticket is filed and there's no text field, so the
+            // only recovery used to be closing + reopening the Help sheet.
+            // Give the patron a first-class way to keep going. This dispatches
+            // the reducer's existing reset action (.userTappedStartOver), which
+            // clears state back to a fresh category prompt.
+            BotUI.PrimaryButton(title: "Ask another question", systemImage: "plus.bubble") {
+                viewModel.send(.userTappedStartOver)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .accessibilityHint("Starts a new question. Your sent ticket is unaffected.")
         }
     }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/SupportChatView.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/SupportChatView.swift
@@ -279,6 +279,8 @@ public struct SupportChatView: View {
             viewModel.send(.userOmittedLogs(omit))
         case .editDescription(let text):
             viewModel.send(.userEditedDescription(text))
+        case .presented:
+            viewModel.send(.ticketPreviewPresented)
         }
     }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TicketPreviewCard.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TicketPreviewCard.swift
@@ -12,6 +12,10 @@ struct TicketPreviewCard: View {
         case omitLogs(Bool)
         /// PP-4807: the user edited the description before sending.
         case editDescription(String)
+        /// PP-4843: fired from onAppear once the preview is actually on screen.
+        /// Releases the reducer's send-consent gate so a rapid Send burst can't
+        /// auto-confirm a preview the patron never saw.
+        case presented
     }
 
     let draft: TicketDraft
@@ -98,6 +102,10 @@ struct TicketPreviewCard: View {
                 descriptionText = draft.userDescription
                 didSeed = true
             }
+            // PP-4843: acknowledge the preview is on screen — a later runloop
+            // turn than the tap burst that presented it, so it releases the
+            // send-consent gate only after the patron could actually see it.
+            onAction(.presented)
         }
     }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TicketPreviewCard.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TicketPreviewCard.swift
@@ -269,8 +269,11 @@ struct TicketReceiptCard: View {
             Text("Reference: \(receipt.ticketId)")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
+                // PP-4845: at the largest accessibility Dynamic Type this line
+                // middle-truncated ("Referen…645573") so the patron couldn't
+                // read their ticket reference — their only handle on the filed
+                // ticket. Let it wrap like every other line on the receipt.
+                .fixedSize(horizontal: false, vertical: true)
             Text("Support will reply within 1 business day.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ConversationReducerTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ConversationReducerTests.swift
@@ -124,6 +124,13 @@ final class ConversationReducerTests: XCTestCase {
         }
         XCTAssertNil(draft.matchedEntryId, "Novel symptom must not pin a matched entry")
 
+        // PP-4843: a reducer-driven preview arrives with the send-consent gate
+        // armed. The patron seeing the card (its onAppear) dispatches
+        // .ticketPreviewPresented, which releases the gate so a deliberate Send
+        // is honored. Without this the confirm below would be treated as a
+        // same-burst rapid double-tap and suppressed.
+        (state, _) = reducer.reduce(state: state, action: .ticketPreviewPresented)
+
         let (submitting, effects) = reducer.reduce(state: state, action: .userConfirmedTicketSubmit)
         state = submitting
 
@@ -142,6 +149,83 @@ final class ConversationReducerTests: XCTestCase {
             return XCTFail("Expected .sent after ticketSubmitted, got \(afterReceipt.step)")
         }
         XCTAssertEqual(stored.ticketId, "HS-99999")
+    }
+
+    // MARK: - PP-4843 send-consent gate (chaos rapid-tap on Send)
+
+    /// Chaos PP-4843 (MAJOR): on a short conversation the preview's own Send
+    /// button renders where the message Send arrow was, so a rapid tap burst
+    /// (tap #1 submits the message, tap #2 lands on the just-appeared confirm)
+    /// filed a ticket the patron never saw. The reducer arms a send-consent
+    /// gate on the fresh preview; a confirm that arrives in the SAME burst —
+    /// with no intervening .ticketPreviewPresented — must be a no-op that
+    /// leaves the patron on the preview, NOT sent.
+    func testRapidSubmitThenConfirm_inSameBurst_staysOnPreview_doesNotFileTicket_PP4843() {
+        let reducer = makeReducer()
+        var (state, _) = reducer.reduce(state: ConversationState(), action: .start)
+        (state, _) = reducer.reduce(state: state, action: .contextLoaded(ContextSnapshot(
+            appVersion: "3.0.3", appBuild: "478", osVersion: "26.4.2", deviceModel: "iPhone17,2"
+        )))
+        (state, _) = reducer.reduce(state: state, action: .userTappedCategory(.reader))
+        (state, _) = reducer.reduce(state: state, action: .inputChanged("something the knowledge base has never encountered before"))
+
+        // Tap #1 — the message submit. A novel symptom escalates straight to the
+        // preview (no matched entry, no follow-up), arming the consent gate.
+        let (drafted, _) = reducer.reduce(state: state, action: .userSubmittedDescription)
+        guard case .drafting = drafted.step else {
+            return XCTFail("Novel symptom should land on the ticket preview, got \(drafted.step)")
+        }
+        XCTAssertTrue(drafted.pendingSendConsent, "A fresh reducer-driven preview must arm the send-consent gate")
+
+        // Tap #2 — same burst, lands on the confirm button before the patron saw it.
+        let (afterRapidConfirm, effects) = reducer.reduce(state: drafted, action: .userConfirmedTicketSubmit)
+
+        guard case .drafting = afterRapidConfirm.step else {
+            return XCTFail("A same-burst rapid confirm must NOT leave the preview; got \(afterRapidConfirm.step)")
+        }
+        XCTAssertFalse(
+            effects.contains { if case .submitTicket = $0 { return true }; return false },
+            "A rapid confirm the patron never consented to must not file a ticket"
+        )
+        XCTAssertTrue(
+            afterRapidConfirm.messages.contains { if case .ticketPreview = $0.kind { return true }; return false },
+            "The preview card must remain so the patron can actually review it"
+        )
+    }
+
+    /// PP-4843 regression / positive path: once the patron has actually seen the
+    /// preview (the card's onAppear dispatches .ticketPreviewPresented, clearing
+    /// the gate), a deliberate Send must file the ticket normally.
+    func testSubmit_thenPreviewPresented_thenDeliberateConfirm_filesTicket_PP4843() {
+        let reducer = makeReducer()
+        var (state, _) = reducer.reduce(state: ConversationState(), action: .start)
+        (state, _) = reducer.reduce(state: state, action: .contextLoaded(ContextSnapshot(
+            appVersion: "3.0.3", appBuild: "478", osVersion: "26.4.2", deviceModel: "iPhone17,2"
+        )))
+        (state, _) = reducer.reduce(state: state, action: .userTappedCategory(.reader))
+        (state, _) = reducer.reduce(state: state, action: .inputChanged("something the knowledge base has never encountered before"))
+        (state, _) = reducer.reduce(state: state, action: .userSubmittedDescription)
+        guard case .drafting = state.step else {
+            return XCTFail("Novel symptom should land on the ticket preview, got \(state.step)")
+        }
+
+        // The preview became visible — the gate releases.
+        (state, _) = reducer.reduce(state: state, action: .ticketPreviewPresented)
+        XCTAssertFalse(state.pendingSendConsent, "Presenting the preview must release the send-consent gate")
+
+        // A deliberate Send now goes through.
+        let (submitting, effects) = reducer.reduce(state: state, action: .userConfirmedTicketSubmit)
+        guard case .submitting = submitting.step else {
+            return XCTFail("A confirm after the preview was seen must submit, got \(submitting.step)")
+        }
+        XCTAssertTrue(
+            effects.contains { if case .submitTicket = $0 { return true }; return false },
+            "A consented Send must emit the submitTicket effect"
+        )
+        XCTAssertFalse(
+            submitting.messages.contains { if case .ticketPreview = $0.kind { return true }; return false },
+            "The preview is removed once submission is in flight (F-002 contract)"
+        )
     }
 
     // Chaos-qa F-002 regression: the ticketPreview message MUST be removed


### PR DESCRIPTION
Integrated fix for the coupled chatbot chaos-QA findings (the redaction fix is separate in #1311).

## What's in it
- **PP-4843 (major) — Send consent-bypass.** Reducer gate: a fresh ticket preview arms `pendingSendConsent`; confirm-send is a no-op until `TicketPreviewCard.onAppear` fires `.ticketPreviewPresented` (a later runloop turn than the tap burst that presented it). Rapid Send taps now stay on the preview; a deliberate Send after the preview is visible still files normally. **The reducer guard and its UI companion are in this one PR on purpose — the reducer change alone would leave the gate permanently armed and break all ticket sending.**
- **PP-4844 (major) — Sent dead-end.** Post-send chips render dimmed + disabled + VoiceOver-hidden; the terminal 'Sent' state shows an **'Ask another question'** button wired to the existing `.userTappedStartOver` reset.
- **PP-4845 (minor) — reference truncation.** The 'Reference:' line wraps (removed `lineLimit(1)`/middle-truncation) so the full ID is readable at XXXL.
- **Pill re-land (PP-4823 follow-up).** #1310 merged a pre-pill snapshot, so `CategoryChipsView` was back to the wrapping `minimum: 110`; restored the 2-column + `lineLimit(1)` layout so 'Audiobook'/'Download' don't wrap. Reconciled with PP-4844's new `isActive` dimming.

## Validation
- Package suite **258/258 green** (`swift test`) — includes the send-consent reducer tests (rapid-burst stays on preview; deliberate confirm files) and the 100-iteration determinism scripts.
- **TriageBotUI iOS build SUCCEEDED.**
- **Simdrive end-to-end verify in progress** — confirming the gate releases (a normal Send actually reaches 'Sent'), the rapid-tap stays on preview, 'Ask another question' resets, chips are 1-line, and the reference wraps at XXXL. Will post the result before merge.

Supersedes #1312 (its PP-4844/4845 commits are included here) and carries `fix/pp-4843-send-consent`. Merge order: this + #1311, in any order (no shared files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)