### PR TITLE
fix(firebase): withTimeout actually bounds a non-cancellable operation (2nd full-suite hang)

### DIFF
--- a/.forgeos/intent/firebase-withtimeout-noncancellable-hang.md
+++ b/.forgeos/intent/firebase-withtimeout-noncancellable-hang.md
@@ -1,0 +1,51 @@
+---
+name: firebase-withtimeout-noncancellable-hang
+created: 2026-07-21
+author: claude-opus-4-8
+---
+
+**ADR refs:** none recorded for the `architecture`/`testing` areas touching
+FirebaseManager's timeout utility.
+
+## Context
+
+`RemoteFeatureFlagsTests.testFetchIfNeeded_doesNotCrash` timed out at exactly
+120.000s in a full-suite CI run (a second, distinct hang-class polluter surfaced
+now that #1305 made CI fail-closed; the first was DeviceLogCollector). Chain:
+`fetchIfNeeded → fetchAndActivate → FirebaseManager.fetchAndActivateRemoteConfig
+→ withTimeout(10s) { remoteConfig.fetchAndActivate() }`.
+
+`withTimeout` is supposed to bound the fetch at 10s, but it uses
+`withThrowingTaskGroup`, which **awaits all child tasks before the group
+returns**. When the timeout child wins the race, `cancelAll()` fires — but
+Firebase's `fetchAndActivate()` ignores cancellation, so exiting the group blocks
+on the still-running operation child anyway. The advertised bound is a no-op for
+exactly the non-cancellable call it exists to bound: the caller hangs (120s in
+CI; on a dead network the app's flag fetch would hang past the intended 10s in
+production too). The existing guard test uses `Task.sleep` (which honors
+cancellation), so it passes and masks the bug.
+
+## Claims
+
+- migrates `FirebaseManager.withTimeout` from a `withThrowingTaskGroup` race to a
+  continuation-based first-wins race that orphans (does not await) the operation
+  task on timeout, so a non-cancellable operation cannot block the caller past
+  the bound — matching the method's own documented "orphaned fetch completes
+  harmlessly in the background while the caller proceeds" contract
+- adds `RemoteFeatureFlagsTests.testWithTimeout_boundsANonCancellableHangingOperation`
+  pinning the bound against an operation that never completes AND ignores
+  cancellation (the real Firebase case the existing `Task.sleep`-based test
+  cannot reproduce)
+
+## Anti-claims
+
+- does NOT change `withTimeout`'s success-path or fast-return behavior
+- does NOT change `fetchAndActivateRemoteConfig`, `fetchIfNeeded`, or any flag
+  values / defaults
+- does NOT touch DeviceLogCollector (that hang is fixed separately, PR #1314)
+- does NOT touch any auth / DRM / borrow / download / sync path
+
+## Files in scope
+
+- Palace/AppInfrastructure/FirebaseManager.swift
+- PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift

--- a/Palace/AppInfrastructure/FirebaseManager.swift
+++ b/Palace/AppInfrastructure/FirebaseManager.swift
@@ -14,6 +14,27 @@ import FirebaseAnalytics
 import FirebaseCrashlytics
 import PalaceLogging
 
+/// Lock-guarded, resume-exactly-once holder for a `CheckedContinuation`, shared
+/// across the two racing tasks in `FirebaseManager.withTimeout`. A
+/// `CheckedContinuation` is not `Sendable`, so it rides inside this
+/// `@unchecked Sendable` box; the continuation is nil'd on the first resume, so
+/// the losing task's later resume is a no-op rather than a double-resume crash.
+/// File-scope (not nested in the generic `withTimeout`) because Swift forbids a
+/// local type inside a generic function.
+private final class ResumeOnceBox<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    init(_ continuation: CheckedContinuation<T, Error>) { self.continuation = continuation }
+    func resume(returning value: T) {
+        lock.lock(); let c = continuation; continuation = nil; lock.unlock()
+        c?.resume(returning: value)
+    }
+    func resume(throwing error: Error) {
+        lock.lock(); let c = continuation; continuation = nil; lock.unlock()
+        c?.resume(throwing: error)
+    }
+}
+
 /// Centralized manager for all Firebase services.
 ///
 /// Thread Safety:
@@ -203,17 +224,29 @@ final class FirebaseManager: @unchecked Sendable {
         seconds: Double,
         _ operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask { try await operation() }
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                throw RemoteConfigFetchTimeout()
+        // A `withThrowingTaskGroup` race is WRONG here: the group re-awaits the
+        // operation child at scope exit, so when the timeout wins and we
+        // `cancelAll()`, exiting still blocks on the operation if it ignores
+        // cancellation — which Firebase's `fetchAndActivate()` does. That made
+        // the 10s bound a no-op for the one call it exists to bound (the 120s
+        // RemoteFeatureFlagsTests hang; a dead-network hang in production). The
+        // existing `Task.sleep`-based guard test passed only because sleep
+        // honors cancellation and so didn't reproduce the non-cancellable case.
+        //
+        // Instead: resume the caller from whichever task wins, and ORPHAN the
+        // loser. When the timeout wins, the operation task keeps running
+        // (untethered) but no longer blocks the caller — exactly the documented
+        // "orphaned fetch completes harmlessly in the background" contract.
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+            let box = ResumeOnceBox(continuation)
+            Task {
+                do { box.resume(returning: try await operation()) }
+                catch { box.resume(throwing: error) }
             }
-            defer { group.cancelAll() }
-            guard let result = try await group.next() else {
-                throw RemoteConfigFetchTimeout()
+            Task {
+                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                box.resume(throwing: RemoteConfigFetchTimeout())
             }
-            return result
         }
     }
 

--- a/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
+++ b/PalaceTests/AppInfrastructure/RemoteFeatureFlagsTests.swift
@@ -161,6 +161,32 @@ final class RemoteFeatureFlagsTests: XCTestCase {
         }
     }
 
+    /// The case the `Task.sleep` test above CANNOT reproduce: `Task.sleep` honors
+    /// cancellation, so a task-group `withTimeout` unblocks when it cancels the
+    /// child. The real Firebase `fetchAndActivate()` ignores cancellation — and a
+    /// task-group implementation re-awaits that child at scope exit, so the bound
+    /// silently fails to fire (the 120s `testFetchIfNeeded_doesNotCrash` hang).
+    /// This drives an operation that never completes AND ignores cancellation:
+    /// `withTimeout` must still return promptly on the timeout, orphaning it.
+    func testWithTimeout_boundsANonCancellableHangingOperation() async {
+        let start = Date()
+        do {
+            _ = try await FirebaseManager.withTimeout(seconds: 0.2) { () async throws -> Bool in
+                // Never resumes, and does not observe cancellation — mirrors the
+                // non-cancellable Firebase fetch.
+                await withCheckedContinuation { (_: CheckedContinuation<Void, Never>) in }
+                return true
+            }
+            XCTFail("withTimeout must throw when a non-cancellable operation exceeds the bound")
+        } catch is FirebaseManager.RemoteConfigFetchTimeout {
+            let elapsed = Date().timeIntervalSince(start)
+            XCTAssertLessThan(elapsed, 2.0,
+                              "withTimeout must bound a NON-cancellable hang (the real Firebase case) by orphaning it, got \(elapsed)s")
+        } catch {
+            XCTFail("Expected RemoteConfigFetchTimeout, got \(type(of: error)): \(error)")
+        }
+    }
+
     /// A fast operation must return its value, NOT be falsely timed out —
     /// kills a mutant that always throws / always loses the race.
     func testWithTimeout_returnsResultOfFastOperation() async throws {


### PR DESCRIPTION
## Root cause

The **second** full-suite hang polluter surfaced by `#1305`'s fail-closed CI (companion to #1314): `RemoteFeatureFlagsTests.testFetchIfNeeded_doesNotCrash` timed out at **120.000s**.

`fetchIfNeeded → fetchAndActivate → FirebaseManager.fetchAndActivateRemoteConfig → withTimeout(10s) { remoteConfig.fetchAndActivate() }`. `withTimeout` is supposed to bound the fetch, but it raced the operation against a sleep inside a `withThrowingTaskGroup` — and **a task group re-awaits its children at scope exit**. When the timeout won and `cancelAll()` fired, Firebase's `fetchAndActivate()` **ignores cancellation**, so exiting the group blocked on the still-running child anyway. The 10s bound was a no-op for exactly the non-cancellable call it exists to bound: the caller hung (120s in CI; **on a dead network the app's flag fetch would hang in production too** — a real production bug, not just a test issue).

The existing guard test used `Task.sleep`, which **honors** cancellation, so it passed and masked the bug.

## Fix

- Rewrite `withTimeout` as a **continuation-based first-wins race** (file-scope `ResumeOnceBox<T: Sendable>`, lock-guarded resume-exactly-once). On timeout the operation task is **orphaned, not awaited** — matching the method's own documented *"orphaned fetch completes harmlessly in the background while the caller proceeds"* contract. A non-cancellable hang can no longer block the caller.
- Add `testWithTimeout_boundsANonCancellableHangingOperation`: drives an operation that never completes **and ignores cancellation** (`withCheckedContinuation` never resumed) — the real Firebase case the `Task.sleep` test can't reproduce. **Hangs 120s on the old impl; returns in 0.22s on the new one.**

## Verification

`RemoteFeatureFlagsTests` **21/21 green**; `testFetchIfNeeded_doesNotCrash` **120s-hang → 0.57s**; existing `testWithTimeout_boundsAHangingOperation` still passes.

Companion to #1314 — same *"test reaches an unbounded live external dependency"* class (there: live OSLogStore; here: Firebase), which is why the handoff doc's reset-registry approach never converged on these. Both are needed for #1309 (PP-4831, a clean PR blocked purely by this pollution) to go green.