### PR TITLE
feat(triage): complete PP-4831 FAQ corpus — add-library-card + formats/Kindle

### DIFF
--- a/.forgeos/intent/pp-4831-faq-addcard-formats.md
+++ b/.forgeos/intent/pp-4831-faq-addcard-formats.md
@@ -1,0 +1,35 @@
+---
+name: pp-4831-faq-addcard-formats
+created: 2026-07-22
+author: claude-opus-4-8
+---
+
+**ADR refs:** none recorded for the triage-bot area.
+
+## Context
+
+Completes PP-4831's two remaining named FAQ topics (the story's "Done when"
+listed holds, formats/Kindle, borrow limits, adding a card; holds + borrow
+limits shipped in #1309). Both answers are product-confirmed: adding a card is a
+concrete in-app flow; send-to-Kindle is confirmed **not supported** (Palace reads
+in-app; no Kindle export).
+
+## Claims
+
+- adds how_to entry `HT-2026-008-add-library-card` (anchored to
+  `settings-libraries`, reviewed 2026-07-22)
+- adds how_to entry `HT-2026-009-formats-kindle` (anchored to `my-books`,
+  reviewed 2026-07-22) stating Palace is not connected to Kindle
+- adds shouldMatch benchmark cases for both in ResponseQualityTests
+
+## Anti-claims
+
+- does NOT change the classifier, reducer, or how_to governance schema
+- does NOT add a new `ui_surface` (reuses existing `settings-libraries` /
+  `my-books` change-log anchors)
+- does NOT touch any auth / DRM / borrow / download path
+
+## Files in scope
+
+- Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+- Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResponseQualityTests.swift

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -925,6 +925,58 @@
       "visibility": "user_facing",
       "ui_surface": "my-books",
       "reviewed_at": "2026-07-21"
+    },
+    {
+      "id": "HT-2026-008-add-library-card",
+      "category": "library",
+      "kind": "how_to",
+      "symptom_keywords": [
+        "add my library card",
+        "add a library card",
+        "add my card",
+        "enter my library card",
+        "enter my barcode",
+        "sign in with my card",
+        "where do i enter my card",
+        "put in my library card",
+        "register my card"
+      ],
+      "user_facing_workaround": "To add your library card, open Settings → Libraries. If your library isn't listed yet, add it there first, then tap it and sign in with your library card number (barcode) and PIN. Once you're signed in, your loans and holds show up in Palace.",
+      "internal_reference": {
+        "jira": "PP-4831"
+      },
+      "confidence_threshold": 0.1,
+      "escalate_anyway": false,
+      "helpspot_tag": "how-to-add-library-card",
+      "trust_level": "authoritative",
+      "visibility": "user_facing",
+      "ui_surface": "settings-libraries",
+      "reviewed_at": "2026-07-22"
+    },
+    {
+      "id": "HT-2026-009-formats-kindle",
+      "category": "other",
+      "kind": "how_to",
+      "symptom_keywords": [
+        "to kindle",
+        "on kindle",
+        "use kindle",
+        "what formats",
+        "which formats",
+        "reading format",
+        "send to my ereader"
+      ],
+      "user_facing_workaround": "Palace isn't connected to Kindle — there's no \"send to Kindle\" step. You read your borrowed books right in the Palace app: ebooks open in the built-in reader and audiobooks play in the built-in player, and everything stays in Palace for the length of your loan.",
+      "internal_reference": {
+        "jira": "PP-4831"
+      },
+      "confidence_threshold": 0.1,
+      "escalate_anyway": false,
+      "helpspot_tag": "how-to-formats-kindle",
+      "trust_level": "authoritative",
+      "visibility": "user_facing",
+      "ui_surface": "my-books",
+      "reviewed_at": "2026-07-22"
     }
   ]
 }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResponseQualityTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResponseQualityTests.swift
@@ -452,6 +452,28 @@ final class ResponseQualityTests: XCTestCase {
              expect: .shouldMatch(entryId: "HT-2026-007-loan-length"),
              source: "PP-4831 FAQ — lending period is per-library"),
 
+        // === HT-2026-008 add library card (how_to) ===
+        Case(userText: "how do I add my library card",
+             category: .library, context: nil,
+             expect: .shouldMatch(entryId: "HT-2026-008-add-library-card"),
+             source: "PP-4831 FAQ — adding a card: Settings → Libraries → add + sign in with barcode/PIN"),
+
+        Case(userText: "where do I enter my barcode to sign in",
+             category: .library, context: nil,
+             expect: .shouldMatch(entryId: "HT-2026-008-add-library-card"),
+             source: "PP-4831 FAQ — where to enter the library card number"),
+
+        // === HT-2026-009 formats / send-to-Kindle (how_to) ===
+        Case(userText: "how do I send my book to Kindle",
+             category: .other, context: nil,
+             expect: .shouldMatch(entryId: "HT-2026-009-formats-kindle"),
+             source: "PP-4831 FAQ (product-confirmed not supported) — Palace isn't connected to Kindle; you read in-app"),
+
+        Case(userText: "what formats can I read in the app",
+             category: .other, context: nil,
+             expect: .shouldMatch(entryId: "HT-2026-009-formats-kindle"),
+             source: "PP-4831 FAQ — reading formats are read in-app, no Kindle export"),
+
         // how_to negative — no FAQ answer exists; must still escalate, not
         // grab a loosely-related how_to.
         Case(userText: "how do I delete my account permanently",


### PR DESCRIPTION
Completes the two FAQ topics from **PP-4831's acceptance criteria** that weren't built in #1309 (which shipped holds + borrow limits). Both answers are product-confirmed:

- **HT-2026-008-add-library-card** — concrete in-app flow: "open Settings → Libraries… tap it and sign in with your library card number (barcode) and PIN." Anchored to `settings-libraries`; keywords avoid the switch-library set.
- **HT-2026-009-formats-kindle** — **confirmed not supported**: "Palace isn't connected to Kindle — there's no 'send to Kindle' step. You read your borrowed books right in the Palace app…" Anchored to `my-books`. Keywords use `to kindle` / `on kindle` (not the nested `send to kindle` variants) so natural phrasings like "send my book to Kindle" match without tripping the nested-keyword lint.

Both carry `reviewed_at: 2026-07-22` and reuse existing UI-surface anchors, so **no change-log edit**. shouldMatch benchmark cases added for each.

**Verification:** full TriageBotCore suite green (**283/283**) — HowToGovernance, schema lint (multi-word + nested-keyword), per-kind precision/recall.

With this, none of PP-4831's named FAQ topics remain.