### PR TITLE
fix(deflake): fix the AccountsManager pollution tail (disk-cache lock-jam + auth-doc main-hop)

### DIFF
--- a/PalaceTests/PalaceTestSetup.swift
+++ b/PalaceTests/PalaceTestSetup.swift
@@ -121,6 +121,35 @@ class PalaceTestSetup: NSObject {
     private static func registerBuiltInResetters() {
         let registry = SingletonResetRegistry.shared
 
+        // Purge the on-disk catalog/auth caches after EVERY test — not just
+        // `PalaceWiringTestCase` subclasses (which do their own purge). A test that
+        // flips `deferInitialLoadCatalogsForTesting` back to `false` (e.g.
+        // AppContainerResetTests) lets the background `loadCatalogs` write the
+        // ~1142-account bundled catalog to `accounts_catalog_<hash>.json`. If that
+        // file survives the boundary, the NEXT test's `preloadAccountsFromDiskCacheSync`
+        // parses all 1142 under CPU starvation, holding the `accountSetsLock` barrier
+        // long enough to hang a later `performRead` (`account(uuid:)`) to the 120s
+        // execution allowance — the AccountsManager-suite lock-jam flakes that hit
+        // even Accounts-unrelated PRs. Registered FIRST so the stale file is gone
+        // before `AppContainer._resetForTesting` recreates + preloads. Mirrors the
+        // prefix list `AccountsManager.clearCache()` uses at runtime.
+        registry.register("AccountsDiskCache.purge") {
+            let prefixes = [
+                "library_list_", "accounts_catalog_", "accounts_catalog_metadata_",
+                "authentication_document_", "crawl_state_",
+            ]
+            let fm = FileManager.default
+            guard let appSupport = try? fm.url(for: .applicationSupportDirectory,
+                                               in: .userDomainMask,
+                                               appropriateFor: nil, create: false),
+                  let files = try? fm.contentsOfDirectory(at: appSupport,
+                                                          includingPropertiesForKeys: nil)
+            else { return }
+            for file in files where prefixes.contains(where: { file.lastPathComponent.hasPrefix($0) }) {
+                try? fm.removeItem(at: file)
+            }
+        }
+
         registry.register("AppContainer._resetForTesting") {
             #if DEBUG
             // Module B's `Palace/AppInfrastructure/AppContainer.swift`

--- a/PalaceTests/PalaceTestSetup.swift
+++ b/PalaceTests/PalaceTestSetup.swift
@@ -137,6 +137,27 @@ class PalaceTestSetup: NSObject {
             #endif
         }
 
+        // Drain EVERY live AccountsManager's background work at the boundary —
+        // not just the shared one AppContainer recreates. The root of the
+        // order-dependent Accounts-suite flakes is a pending `DispatchQueue.main.async`
+        // auth-doc drive (from `preloadAccountsFromDiskCacheSync`'s deferred
+        // `driveCurrentAccountAuthDocIfNeeded()`) enqueued at EVERY AccountsManager
+        // init — including foreign instances built by test helpers. It is NOT a
+        // Task, so `cancelBackgroundWork()` can't stop it; left un-flushed it fires
+        // on a later runloop turn INSIDE the next test and writes a fixture library
+        // UUID's `.detailsLoading`/`.detailsFailed` into it. `cancelAndDrainBackgroundWork`
+        // (invoked per live instance by `_drainAllLiveInstancesForTesting`) PUMPS
+        // the main run loop (bounded) so every such pending hop fires NOW, inside
+        // the boundary — after `AppContainer._resetForTesting` above (so the
+        // just-recreated shared instance is included) and BEFORE the store reset
+        // below (so any flushed late-write is then wiped). This is the missing wire:
+        // the drain existed but ran only in one bespoke test, never per-boundary.
+        registry.register("AccountsManager._drainAllLiveInstancesForTesting") {
+            #if DEBUG
+            AccountsManager._drainAllLiveInstancesForTesting()
+            #endif
+        }
+
         registry.register("AccountStateStore.shared._resetAllForTesting") {
             AccountStateStore.shared._resetAllForTesting()
         }

--- a/scripts/xcode-test-optimized.sh
+++ b/scripts/xcode-test-optimized.sh
@@ -126,6 +126,17 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
         ISOLATED_ONLY_ARGS+=("-only-testing:$_t")
     done
 
+    # Retry/iteration args. CI default is 3 iterations + retry-on-failure (a
+    # test passing any of 3 counts as pass — flake safety net). A caller can set
+    # CI_TEST_ITERATIONS=1 for a single-pass repro (ci-parity-local.sh --fast) —
+    # but xcodebuild REJECTS `-test-iterations 1` ("must be more than 1
+    # iteration"), so at 1 we OMIT both flags (a bare `xcodebuild test` runs each
+    # test once). Only >1 gets the retry+iterations pair.
+    RETRY_ITER_ARGS=()
+    if [ "${CI_TEST_ITERATIONS:-3}" -gt 1 ]; then
+        RETRY_ITER_ARGS=(-retry-tests-on-failure -test-iterations "${CI_TEST_ITERATIONS:-3}")
+    fi
+
     # Capture xcodebuild output so we can detect a COMPILE failure that
     # `xcodebuild test` masks. Under `-parallel-testing-enabled` xcodebuild can
     # exit 0 even when a test bundle fails to BUILD: the sibling bundles that DID
@@ -142,8 +153,7 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
         -configuration Debug \
         -resultBundlePath TestResults.xcresult \
         -enableCodeCoverage YES \
-        -retry-tests-on-failure \
-        -test-iterations "${CI_TEST_ITERATIONS:-3}" \
+        ${RETRY_ITER_ARGS[@]+"${RETRY_ITER_ARGS[@]}"} \
         -test-timeouts-enabled YES \
         -default-test-execution-time-allowance 120 \
         -maximum-test-execution-time-allowance 300 \
@@ -191,8 +201,7 @@ if [ "${BUILD_CONTEXT:-}" == "ci" ]; then
         -resultBundlePath TestResults-serial.xcresult \
         "${ISOLATED_ONLY_ARGS[@]}" \
         -enableCodeCoverage YES \
-        -retry-tests-on-failure \
-        -test-iterations "${CI_TEST_ITERATIONS:-3}" \
+        ${RETRY_ITER_ARGS[@]+"${RETRY_ITER_ARGS[@]}"} \
         -test-timeouts-enabled YES \
         -default-test-execution-time-allowance 120 \
         -maximum-test-execution-time-allowance 300 \
@@ -257,8 +266,7 @@ else
                 -configuration Debug \
                 -resultBundlePath TestResults.xcresult \
                 -enableCodeCoverage YES \
-                -retry-tests-on-failure \
-                -test-iterations "${CI_TEST_ITERATIONS:-3}" \
+                ${RETRY_ITER_ARGS[@]+"${RETRY_ITER_ARGS[@]}"} \
                 -parallel-testing-enabled YES \
                 -maximum-parallel-testing-workers 4 \
                 CODE_SIGNING_REQUIRED=NO \
@@ -288,8 +296,7 @@ else
             -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
             -configuration Debug \
             -resultBundlePath TestResults.xcresult \
-            -retry-tests-on-failure \
-            -test-iterations "${CI_TEST_ITERATIONS:-3}" \
+            ${RETRY_ITER_ARGS[@]+"${RETRY_ITER_ARGS[@]}"} \
             -enableCodeCoverage YES \
             -parallel-testing-enabled YES \
             -maximum-parallel-testing-workers 4 \


### PR DESCRIPTION
Fixes the residual systemic AccountsManager-pollution tail — the deadline-poll/hang flakes that hit **every** PR (even Accounts-unrelated ones like the jira tooling PR) and that the test-pollution handoff documented as non-converging.

## Two mechanisms, both closed

**1. Disk-cache lock-jam (the 120s hangs).** A test that flips `deferInitialLoadCatalogsForTesting` back to `false` (e.g. AppContainerResetTests) lets the background `loadCatalogs` write the ~1142-account bundled catalog to `accounts_catalog_<hash>.json`. That file is only purged by `PalaceWiringTestCase` subclasses — for a plain `XCTestCase` (AccountsManagerTests) it survives the boundary, so the next test's `preloadAccountsFromDiskCacheSync` parses all 1142 under CPU starvation, holding the `accountSetsLock` barrier long enough to hang a later `account(uuid:)` `performRead` to the 120s allowance. → **Purge the disk cache in the GLOBAL per-test reset registry**, first (before AppContainer recreates + preloads).

**2. Leaked auth-doc main-hop.** Every AccountsManager init enqueues a pending `DispatchQueue.main.async` auth-doc drive that isn't a Task (uncancellable) and fires inside the next test. The pumping drain that flushes it (`_drainAllLiveInstancesForTesting`) existed but was wired into one bespoke test. → **Wire it into the per-test boundary** (after AppContainer reset, before store reset).

Also fixes a bug in the `--fast` mode of the CI-parity harness (`-test-iterations 1` is rejected by xcodebuild → omit the flag).

## Validation
The **CI-parity harness reproduced this locally** (2 AccountsManager failures + a 120s hang under 3-core pressure), and **passes cleanly twice** after the fix — with `--fast` (1 iteration, no retry) which is *more* sensitive than CI's 3-iteration retry. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)