### PR TITLE
fix(deflake): filter holds synchronously — remove global-queue pool-exhaustion victim

### DIFF
--- a/Palace/Holds/HoldsViewModel.swift
+++ b/Palace/Holds/HoldsViewModel.swift
@@ -107,14 +107,19 @@ final class HoldsViewModel: ObservableObject {
         }
 
         let environment = HoldsEnvironment(filterBooks: { query, books in
-            await withCheckedContinuation { continuation in
-                DispatchQueue.global(qos: .userInitiated).async {
-                    let filtered = books.filter {
-                        $0.title.localizedCaseInsensitiveContains(query) ||
-                            ($0.authors?.localizedCaseInsensitiveContains(query) ?? false)
-                    }
-                    continuation.resume(returning: filtered)
-                }
+            // Filter in-place. This runs on the reducer effect's `@Sendable`
+            // (off-main) task, so it never blocks the UI, and a holds list is
+            // tiny — an in-memory title/author substring match. The previous
+            // implementation bridged this through `withCheckedContinuation` +
+            // `DispatchQueue.global(qos:).async`, which made a trivial filter a
+            // VICTIM of global-queue thread-pool exhaustion: under full-suite CI
+            // load, when leaked blocking work saturates the global pool, the
+            // enqueued filter block never runs and `sendAwait(.searchQueryChanged)`
+            // hangs to the 120s execution allowance (the HoldsViewModel flake).
+            // A synchronous filter has no queue dependency and cannot starve.
+            books.filter {
+                $0.title.localizedCaseInsensitiveContains(query) ||
+                    ($0.authors?.localizedCaseInsensitiveContains(query) ?? false)
             }
         })
         self.store = Store(


### PR DESCRIPTION
`HoldsViewModelTests.testFilterBooks_CaseInsensitive` hung 120s under full-suite CI load (surfaced on #1323's run, after the AccountsManager pollution was fixed).

**Cause:** `HoldsViewModel`'s `env.filterBooks` bridged a *trivial* in-memory title/author filter through `withCheckedContinuation` + `DispatchQueue.global(qos:).async`. The reducer effect awaiting it already runs on a `@Sendable` (off-main) task, so the background hop bought nothing — but it made the filter a **victim of global-queue thread-pool exhaustion**: when leaked blocking work saturates the global pool under load, the enqueued filter block never runs and `sendAwait(.searchQueryChanged)` hangs to the 120s allowance.

**Fix:** filter in-place (a holds list is tiny; no queue dependency → cannot starve). Behavior-identical filter result. HoldsViewModelTests pass 23/23.

**Not done:** the pool-exhaustion *source* — this removes one victim; chasing the source needs reproduction of a low-frequency flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)