### PR TITLE
fix(audiobooks): first-open download visibility + speed chip restores on reopen

### DIFF
--- a/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
@@ -268,7 +268,17 @@ struct AudiobookMorphingPlayerView: View {
         .overlay(alignment: .bottom) { toastOverlay }
         .accessibilityElement(children: .contain)
         .onAppear {
-            currentRate = audiobookSession.currentPlaybackRate
+            // Only adopt the session rate once a manager is bound. On a fresh
+            // cold open the player mounts (loading shell) BEFORE bind, so a bare
+            // `currentPlaybackRate` read here returns the default 1.0× and would
+            // pin the speed chip at 1.0× for the whole session even though the
+            // toolkit restored the patron's persisted rate. The bind-time
+            // `.onChange` below re-syncs once the real rate is known.
+            currentRate = Self.displayRate(
+                sessionRate: audiobookSession.currentPlaybackRate,
+                isBound: audiobookSession.hasActiveManager,
+                fallback: currentRate
+            )
             // Announce the screen transition + move VoiceOver focus to the title
             // (mirrors toolkit AudiobookPlayerView.onAppear).
             NotificationCenter.default.post(
@@ -278,6 +288,21 @@ struct AudiobookMorphingPlayerView: View {
             UIAccessibility.post(notification: .layoutChanged, argument: nil)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                 isTitleFocused = true
+            }
+        }
+        // Re-sync the speed chip when the player binds. `presenter.playbackModel`
+        // goes non-nil exactly at bind (`adoptPlaybackModel`), by which point the
+        // manager is set and `currentPlaybackRate` returns the toolkit's restored
+        // (persisted, global) rate — so the chip matches what's actually playing
+        // instead of the pre-bind 1.0× default. Fires only on a real bind; a
+        // mini→expand re-open (model already bound) is handled by `.onAppear`.
+        .onChange(of: presenter.playbackModel != nil) { _, isBound in
+            if isBound {
+                currentRate = Self.displayRate(
+                    sessionRate: audiobookSession.currentPlaybackRate,
+                    isBound: true,
+                    fallback: currentRate
+                )
             }
         }
         .onChange(of: presenter.toastMessage) { _, newValue in
@@ -709,6 +734,20 @@ struct AudiobookMorphingPlayerView: View {
     /// the view's buffering-window timer.
     nonisolated static func shouldSurfaceLoadTimeout(isLoaded: Bool, isDownloading: Bool) -> Bool {
         !isLoaded && !isDownloading
+    }
+
+    /// Resolves the rate the speed chip should display. Only adopts the session's
+    /// rate once a manager is bound — pre-bind, `currentPlaybackRate` returns the
+    /// default 1.0× (no player yet), which must NOT overwrite the chip, or a
+    /// freshly-reopened book (whose persisted rate the toolkit restores on bind)
+    /// would show 1.0× while playing faster. When bound, the session rate is the
+    /// source of truth. Pure so the sync decision is unit-tested for both phases.
+    nonisolated static func displayRate(
+        sessionRate: PlaybackRate,
+        isBound: Bool,
+        fallback: PlaybackRate
+    ) -> PlaybackRate {
+        isBound ? sessionRate : fallback
     }
 
     @ViewBuilder

--- a/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
@@ -656,50 +656,156 @@ struct AudiobookMorphingPlayerView: View {
 
     // MARK: - Loading overlay (toolkit `LoadingView` / `LoadingErrorView` parity)
 
+    /// The four mutually-exclusive presentations of the loading overlay. Pulled
+    /// out of `loadingOverlay`'s inline branching so the decision is a pure,
+    /// mutation-testable function (`loadingOverlayState`) instead of a tangle of
+    /// view-side `if`s — matching the `nonisolated static` predicate pattern used
+    /// across the audiobook session code.
+    enum LoadingOverlayState: Equatable {
+        /// Player is loaded — no overlay.
+        case hidden
+        /// Content is still downloading (the pre-bind PP-4542 `.lcpa` wait, or a
+        /// post-bind track download). Show a determinate "Downloading… NN%" state
+        /// — NOT the shimmer skeleton (which is opaque and occluded the download
+        /// bar, so a healthy multi-minute download read as a hang) and NOT the
+        /// load-error overlay (a download in flight is not a load failure).
+        case downloading
+        /// The 30s load timeout fired while the player was neither loaded nor
+        /// downloading — surface the error + retry.
+        case loadError
+        /// Brief "materializing" shimmer for the load window before we know
+        /// whether content is downloading (or the toolkit is buffering a
+        /// locally-present book). Also the QA `forceSkeletons` inspection state.
+        case skeleton
+    }
+
+    /// Pure decision for which loading presentation to show. Kept free of view
+    /// state so it can be unit-tested for every combination.
+    ///
+    /// `forceSkeletons` (the PP-4797 QA override, a compile-time `false` in
+    /// release) always wins so the skeleton can be inspected on the sim — the
+    /// real `!isLoaded` window is shorter than simdrive's observe latency.
+    /// Otherwise: a loaded player shows nothing; an in-flight download shows the
+    /// determinate downloading state (BEFORE the load-error check, so a slow
+    /// download never trips the 30s error); a timed-out non-downloading load
+    /// shows the error; everything else is the transient skeleton.
+    nonisolated static func loadingOverlayState(
+        isLoaded: Bool,
+        isDownloading: Bool,
+        loadingTimedOut: Bool,
+        forceSkeletons: Bool
+    ) -> LoadingOverlayState {
+        if forceSkeletons { return .skeleton }
+        guard !isLoaded else { return .hidden }
+        if isDownloading { return .downloading }
+        if loadingTimedOut { return .loadError }
+        return .skeleton
+    }
+
+    /// Whether the 30s load-error timer, once fired, should actually surface the
+    /// error. A download in flight is healthy progress, not a load failure, so
+    /// the timeout is suppressed while `isDownloading` — the download has its own
+    /// bound (the PP-4542 180s content wait) and must not be short-circuited by
+    /// the view's buffering-window timer.
+    nonisolated static func shouldSurfaceLoadTimeout(isLoaded: Bool, isDownloading: Bool) -> Bool {
+        !isLoaded && !isDownloading
+    }
+
     @ViewBuilder
     private var loadingOverlay: some View {
-        // `|| DebugSettings.forceSkeletons` (the PP-4797 QA override, a
-        // compile-time `false` in release) holds the loading skeleton up over a
-        // loaded player so it can be inspected on the sim — the real
-        // `!isLoaded` window is shorter than simdrive's observe latency on a
-        // warm manifest, so this is the DoD-#12 fixture seam for this state.
-        if !audiobookSession.isLoaded || DebugSettings.forceSkeletons {
-            if loadingTimedOut {
-                ZStack {
-                    Color.black.opacity(0.5).ignoresSafeArea()
-                    VStack(spacing: 16) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .font(.system(size: 40)).foregroundStyle(.yellow)
-                        Text(Strings.Generic.audiobookLoadErrorTitle)
-                            .foregroundStyle(.white).font(.headline)
-                        Text(Strings.Generic.audiobookLoadErrorMessage)
-                            .foregroundStyle(.white).multilineTextAlignment(.center)
-                            .padding(.horizontal, 32)
-                        Button {
-                            loadingTimedOut = false
-                            audiobookSession.play()
-                        } label: {
-                            Text(Strings.Generic.audiobookRetry)
-                                .fontWeight(.semibold).foregroundStyle(.black)
-                                .padding(.horizontal, 32).padding(.vertical, 10)
-                                .background(Color.white).cornerRadius(8)
+        switch Self.loadingOverlayState(
+            isLoaded: audiobookSession.isLoaded,
+            isDownloading: presenter.isDownloading,
+            loadingTimedOut: loadingTimedOut,
+            forceSkeletons: DebugSettings.forceSkeletons
+        ) {
+        case .hidden:
+            EmptyView()
+        case .downloading:
+            playerDownloadingOverlay
+        case .loadError:
+            ZStack {
+                Color.black.opacity(0.5).ignoresSafeArea()
+                VStack(spacing: 16) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 40)).foregroundStyle(.yellow)
+                    Text(Strings.Generic.audiobookLoadErrorTitle)
+                        .foregroundStyle(.white).font(.headline)
+                    Text(Strings.Generic.audiobookLoadErrorMessage)
+                        .foregroundStyle(.white).multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+                    Button {
+                        loadingTimedOut = false
+                        audiobookSession.play()
+                    } label: {
+                        Text(Strings.Generic.audiobookRetry)
+                            .fontWeight(.semibold).foregroundStyle(.black)
+                            .padding(.horizontal, 32).padding(.vertical, 10)
+                            .background(Color.white).cornerRadius(8)
+                    }
+                }
+            }
+            .accessibilityElement(children: .contain)
+        case .skeleton:
+            playerLoadingSkeleton
+                .onAppear {
+                    // Arm the 30s timeout; reset on (re)appear (mirrors toolkit).
+                    // Suppressed while a download is in flight (see
+                    // `shouldSurfaceLoadTimeout`) so a healthy multi-minute
+                    // content download can't false-trip the load-error overlay.
+                    loadingTimedOut = false
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
+                        if Self.shouldSurfaceLoadTimeout(
+                            isLoaded: audiobookSession.isLoaded,
+                            isDownloading: presenter.isDownloading
+                        ) {
+                            loadingTimedOut = true
                         }
                     }
                 }
-                .accessibilityElement(children: .contain)
-            } else {
-                playerLoadingSkeleton
-                    .onAppear {
-                        // Arm the 30s timeout; reset on (re)appear (mirrors toolkit).
-                        loadingTimedOut = false
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
-                            if !audiobookSession.isLoaded {
-                                loadingTimedOut = true
-                            }
-                        }
-                    }
-            }
         }
+    }
+
+    /// Determinate "Downloading…" state shown while the `.lcpa` content is still
+    /// landing (or tracks are downloading post-bind). Reuses the real cover +
+    /// title so it reads as the player materializing, and shows both a
+    /// percentage bar AND an always-animated indeterminate track — the latter so
+    /// it never reads as frozen even if the fulfillment layer reports progress
+    /// coarsely (a single 0→1 jump at completion). Opaque background matches the
+    /// player chrome (follows system appearance).
+    private var playerDownloadingOverlay: some View {
+        ZStack {
+            Color(.systemBackground).ignoresSafeArea()
+            VStack(spacing: 24) {
+                Spacer(minLength: 24)
+                coverImageOrPlaceholder
+                    .aspectRatio(1, contentMode: .fit)
+                    .frame(maxWidth: 240)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .shadow(color: .black.opacity(0.25), radius: 12, y: 6)
+                titleAuthorFull
+                    .padding(.horizontal, 24)
+                VStack(spacing: 10) {
+                    ProgressView(value: Double(min(max(presenter.overallDownloadProgress, 0), 1)), total: 1.0)
+                        .progressViewStyle(.linear)
+                        .tint(.accentColor)
+                        .frame(maxWidth: 260)
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.mini)
+                        Text("\(Strings.Generic.audiobookDownloading) \(Int(presenter.overallDownloadProgress * 100))%")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                Spacer(minLength: 24)
+            }
+            .padding(.horizontal, 24)
+        }
+        .transition(.opacity)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(Strings.Generic.audiobookDownloading), \(Int(presenter.overallDownloadProgress * 100))%")
     }
 
     /// Skeleton lockup shown while the audiobook loads — replaces the old

--- a/PalaceTests/AppInfrastructure/AudiobookMorphingPlayerViewTests.swift
+++ b/PalaceTests/AppInfrastructure/AudiobookMorphingPlayerViewTests.swift
@@ -222,6 +222,29 @@ final class AudiobookMorphingPlayerViewTests: XCTestCase {
                        "A loaded player never surfaces the timeout")
     }
 
+    // MARK: - Speed-chip rate sync (exit/return label mismatch)
+
+    /// Once a manager is bound, the chip adopts the session's (restored,
+    /// persisted) rate — regardless of the stale fallback. This is the fix for
+    /// the speed label reading 1.0× after exit/return while audio plays faster.
+    func testDisplayRate_boundAdoptsSessionRate() {
+        XCTAssertEqual(
+            V.displayRate(sessionRate: .doubleTime, isBound: true, fallback: .normalTime),
+            .doubleTime,
+            "A bound player must show the session's actual rate, not the stale chip fallback")
+    }
+
+    /// Pre-bind, the session rate is the meaningless 1.0× default (no player yet)
+    /// — the chip must KEEP its fallback rather than be pinned to that default,
+    /// so the bind-time re-sync can later show the real restored rate. Kills a
+    /// mutation that swaps the ternary (would clobber the chip with 1.0×).
+    func testDisplayRate_unboundKeepsFallback() {
+        XCTAssertEqual(
+            V.displayRate(sessionRate: .normalTime, isBound: false, fallback: .doubleTime),
+            .doubleTime,
+            "Pre-bind, the chip keeps its fallback — the default session rate must not overwrite it")
+    }
+
     // MARK: - Timecode formatter (relocated when the dead mini-player view was removed)
 
     /// Pure `TimeInterval` -> "MM:SS" / "H:MM:SS" formatter, relocated onto the

--- a/PalaceTests/AppInfrastructure/AudiobookMorphingPlayerViewTests.swift
+++ b/PalaceTests/AppInfrastructure/AudiobookMorphingPlayerViewTests.swift
@@ -153,6 +153,75 @@ final class AudiobookMorphingPlayerViewTests: XCTestCase {
                           "Deeper upward pull must resist further (monotonic resistance)")
     }
 
+    // MARK: - Loading overlay state decision (PP-4542 skeleton-occlusion fix)
+
+    /// A loaded player shows no overlay — regardless of the other flags.
+    func testLoadingOverlayState_loadedIsHidden() {
+        XCTAssertEqual(
+            V.loadingOverlayState(isLoaded: true, isDownloading: false, loadingTimedOut: false, forceSkeletons: false),
+            .hidden,
+            "A loaded, non-downloading player has no loading overlay")
+        XCTAssertEqual(
+            V.loadingOverlayState(isLoaded: true, isDownloading: true, loadingTimedOut: true, forceSkeletons: false),
+            .hidden,
+            "Once loaded, neither a lingering download flag nor a stale timeout resurrects the overlay")
+    }
+
+    /// The core fix: while content is downloading (and not yet loaded) the overlay
+    /// is the DETERMINATE downloading state — NOT the opaque shimmer skeleton that
+    /// previously occluded the progress bar and read as a hang. Downloading also
+    /// wins over a fired 30s timeout, so a slow-but-healthy download never shows
+    /// the load-error overlay. Kills a branch-reorder that checks `loadingTimedOut`
+    /// (or falls through to `.skeleton`) before `isDownloading`.
+    func testLoadingOverlayState_downloadingBeatsSkeletonAndTimeout() {
+        XCTAssertEqual(
+            V.loadingOverlayState(isLoaded: false, isDownloading: true, loadingTimedOut: false, forceSkeletons: false),
+            .downloading,
+            "An in-flight download shows the determinate downloading state, not the shimmer skeleton")
+        XCTAssertEqual(
+            V.loadingOverlayState(isLoaded: false, isDownloading: true, loadingTimedOut: true, forceSkeletons: false),
+            .downloading,
+            "A download in flight is healthy progress — it must win over a fired load timeout, never the error overlay")
+    }
+
+    /// A genuine load timeout (not loaded, NOT downloading, timer fired) surfaces
+    /// the error+retry. Kills dropping the `loadingTimedOut` branch.
+    func testLoadingOverlayState_timeoutWithoutDownloadIsLoadError() {
+        XCTAssertEqual(
+            V.loadingOverlayState(isLoaded: false, isDownloading: false, loadingTimedOut: true, forceSkeletons: false),
+            .loadError,
+            "A stalled, non-downloading load that fired the 30s timer shows the load-error overlay")
+    }
+
+    /// The transient load window (not loaded, not downloading, timer not yet
+    /// fired) is the skeleton. The QA `forceSkeletons` override forces the
+    /// skeleton even over a loaded/downloading player so it can be inspected.
+    func testLoadingOverlayState_skeletonDefaultAndForceOverride() {
+        XCTAssertEqual(
+            V.loadingOverlayState(isLoaded: false, isDownloading: false, loadingTimedOut: false, forceSkeletons: false),
+            .skeleton,
+            "The brief pre-download load window is the shimmer skeleton")
+        XCTAssertEqual(
+            V.loadingOverlayState(isLoaded: true, isDownloading: true, loadingTimedOut: false, forceSkeletons: true),
+            .skeleton,
+            "forceSkeletons is the QA inspection override — it wins over every other flag")
+    }
+
+    /// The 30s load-error timer must be suppressed while a download is in flight:
+    /// a healthy multi-minute content download is not a load failure. Only a
+    /// not-loaded AND not-downloading state surfaces the timeout. This is what
+    /// stops a >30s LCP `.lcpa` download from false-tripping the error overlay.
+    func testShouldSurfaceLoadTimeout_onlyWhenNotLoadedAndNotDownloading() {
+        XCTAssertTrue(V.shouldSurfaceLoadTimeout(isLoaded: false, isDownloading: false),
+                      "A stalled, non-downloading load surfaces the timeout")
+        XCTAssertFalse(V.shouldSurfaceLoadTimeout(isLoaded: false, isDownloading: true),
+                       "A download in flight must NOT surface the load-error timeout")
+        XCTAssertFalse(V.shouldSurfaceLoadTimeout(isLoaded: true, isDownloading: false),
+                       "A loaded player has nothing to time out")
+        XCTAssertFalse(V.shouldSurfaceLoadTimeout(isLoaded: true, isDownloading: true),
+                       "A loaded player never surfaces the timeout")
+    }
+
     // MARK: - Timecode formatter (relocated when the dead mini-player view was removed)
 
     /// Pure `TimeInterval` -> "MM:SS" / "H:MM:SS" formatter, relocated onto the


### PR DESCRIPTION
Two audiobook morphing-player UX bugs, both in `AudiobookMorphingPlayerView`, reported together.

## Bug 1 — first-open loading screen looks hung (LCP)

A freshly-borrowed LCP audiobook is marked `.downloadSuccessful` the instant its `.lcpl` license lands while the real `.lcpa` content keeps downloading; tapping Listen enters the PP-4542 content-wait (up to 180s). The opaque shimmer **skeleton** (`!isLoaded`) is layered *over* the whole player via `.overlay { loadingOverlay }`, hiding the `downloadBar` that #1276's `showDownloadProgress` feeds — so a healthy multi-minute download read as a hang. The skeleton also armed a 30s timer that false-tripped an "Audiobook load error / Retry" overlay on any download over 30s.

**Fix:** skeleton flashes only for the initial materialize, then swaps to a determinate **"Downloading… NN%"** state (real cover + title + byte-level URLSession progress + an always-animated spinner) the instant a download is in flight; the 30s load-error timer is suppressed while downloading. Pure `loadingOverlayState` / `shouldSurfaceLoadTimeout` seams with unit coverage.

## Bug 2 — speed chip wrong after exit/return

The chip's `currentRate` was snapshotted only in `.onAppear`, which on a fresh cold open fires pre-bind (manager nil → 1.0× default). The toolkit restores the persisted global rate on bind, so audio played at e.g. 1.5× while the chip stayed at 1.0×.

**Fix:** re-sync the chip at bind (`presenter.playbackModel` goes non-nil at `adoptPlaybackModel`, manager set, `currentPlaybackRate` returns the restored rate). Pure `displayRate(sessionRate:isBound:fallback:)` seam — adopt only once bound. Audio was already correct; this fixes the label.

## Verification
- CI build gate (fresh worktree can't compile LCP/DRM locally) + unit tests (`AudiobookMorphingPlayerViewTests`, all decision seams).
- simdrive pass on the morphing player (in-app-nav ON): speed set → exit → return shows the correct chip; loading→downloading swap.

## Deferred
- in-app-nav-**OFF** production-default legacy path still shows a bare caller spinner during the same 180s wait — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)