### PR TITLE
feat(ci): STARVE-001 gate — stop new parallel-clone deadline-poll flakes at PR time

### DIFF
--- a/.github/workflows/tooling-checks.yml
+++ b/.github/workflows/tooling-checks.yml
@@ -7,6 +7,8 @@ name: Tooling Checks
 #   1. bash -n on every committed shell script  (catches syntax breaks)
 #   2. pytest on the detector suite              (catches detector logic regressions)
 #   3. the pre-commit hook fixture test          (catches hook-wiring regressions)
+# A second job (flake-lint) diff-scopes the STARVE-001 test-flakiness gate against
+# the PR's base branch — blocks NEW parallel-clone-starvation deadline-polls.
 on: [ pull_request, workflow_dispatch ]
 concurrency:
   group: tooling-checks-${{ github.event.pull_request.number || github.ref }}
@@ -139,3 +141,37 @@ jobs:
           else
             echo "No contributor-surface gate — skipping."
           fi
+
+  # Diff-scoped test-flakiness gate. Separate job because it needs the PR's base
+  # branch fetched (fetch-depth: 0 + an explicit base fetch) to diff against —
+  # the tooling-integrity job runs shallow. Fails the PR if a changed test file
+  # ADDS a fixed-deadline wait on async work (STARVE-001 / recurrence class
+  # `parallel-clone-starvation`): those starve under the 2 parallel sim clones on
+  # the macOS test runner and fail all 3 `-retry-tests-on-failure` iterations.
+  # Scoped to ADDED lines only, so it never chokes on the ~675 legacy occurrences.
+  flake-lint:
+    runs-on: ubuntu-latest
+    env:
+      # PR target branch (develop for the overwhelming majority); default to
+      # develop for a manual workflow_dispatch run that has no base_ref.
+      BASE: ${{ github.base_ref || 'develop' }}
+    steps:
+      - name: Checkout (full history so the base merge-base is reachable)
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Fetch PR base branch
+        run: git fetch --no-tags origin "+refs/heads/${BASE}:refs/remotes/origin/${BASE}"
+
+      # Flag NEW deadline-poll waits on lines this PR adds vs its base. The
+      # linter's --changed mode is diff-scoped (added lines of PalaceTests/*.swift
+      # only) and exits 1 on a hit. No Xcode/simulator needed.
+      - name: STARVE-001 — no new deadline-poll waits in changed tests
+        run: python3 scripts/lint-test-quality.py --changed "origin/${BASE}"

--- a/docs/Testing/Test_Patterns.md
+++ b/docs/Testing/Test_Patterns.md
@@ -741,30 +741,99 @@ func testRealKeychain() throws {
 
 ### 10.1 Flaky Async Tests
 
-**Problem:** Tests pass locally but fail in CI due to timing.
+**Problem:** A test waits on fire-and-forget async work (a detached `Task`, a
+background `loadCatalogs` crawl, a reauth dispatch) by arming an
+`XCTestExpectation` and blocking on a *fixed wall-clock deadline* —
+`fulfillment(of:timeout:)`, `wait(for:timeout:)`, `waitForExpectations(timeout:)`.
+It passes locally and fails in CI.
 
-**Solution:** Use explicit expectations with appropriate timeouts.
+**Why the deadline poll fails — parallel-clone starvation.** CI does not run one
+test process. `scripts/xcode-test-optimized.sh` runs the whole scheme under
+`-retry-tests-on-failure -test-iterations 3` with **two sim clones in parallel**
+on a shared macOS runner (3–4 cores). A detached `.utility`/`.background` Task is
+scheduled on the cooperative thread pool; when two clones oversubscribe the pool,
+that Task can be deferred *past* any fixed timeout. The deadline fires before the
+work runs, the expectation never fulfills, and the test fails. Retry does not save
+it: the parallel load **persists across all 3 iterations**, so a deadline-poll test
+that loses the CPU race loses it three times and stays red. Run serially it is
+green every time — which is the tell for this class. This is recurrence class
+[`parallel-clone-starvation`](../regressions/recurrence-classes.md) (fixed in
+#1319/#1321), and it is why the "Good" example that used to live here —
+`await fulfillment(of: [expectation], timeout: 5.0)` — was **the anti-pattern**,
+not the fix. A timeout is a guess about a CPU race; the linter's `STARVE-001` rule
+blocks it on any newly-added test line.
+
+**Solution — a deterministic Task-join seam.** Don't guess a deadline; *join the
+actual work unit*. The production code retains the fire-and-forget `Task` handle in
+an XCTest-gated array and exposes an `_await…ForTesting() async` that awaits the
+handles. The test `await`s that — it blocks exactly until the work finishes, no
+matter how starved the pool is, so there is no clock to lose.
+
+The retention must be gated so a RELEASE build never populates the array:
 
 ```swift
-// Bad
-func testAsync() async {
-    await viewModel.load()
-    XCTAssertTrue(viewModel.isLoaded) // May fail if async completion not awaited
+// Production code (the class under test)
+private static let _isRunningUnderXCTest =
+    ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+
+private let _tasksLock = NSLock()
+private var _trackedTasks: [Task<Void, Never>] = []
+
+private func trackForTesting(_ task: Task<Void, Never>) {
+    guard Self._isRunningUnderXCTest else { return }   // no-op in RELEASE
+    _tasksLock.lock(); _trackedTasks.append(task); _tasksLock.unlock()
 }
 
-// Good
-func testAsync() async {
-    let expectation = XCTestExpectation(description: "Load completes")
-
-    viewModel.$isLoaded
-        .filter { $0 }
-        .sink { _ in expectation.fulfill() }
-        .store(in: &cancellables)
-
-    await viewModel.load()
-    await fulfillment(of: [expectation], timeout: 5.0)
+/// Test-only deterministic JOIN seam — awaits the ACTUAL fire-and-forget work
+/// instead of polling a wall-clock deadline. `nonisolated` + a synchronous
+/// lock-guarded snapshot so an @MainActor test can await it without sending a
+/// non-Sendable self across the isolation boundary.
+nonisolated func _awaitTrackedWorkForTesting() async {
+    _tasksLock.lock(); let tasks = _trackedTasks; _tasksLock.unlock()
+    for task in tasks { _ = await task.value }
 }
 ```
+
+```swift
+// Bad — deadline poll; starves under 2 parallel sim clones, fails all 3 retries
+func testAsync() async {
+    let expectation = XCTestExpectation(description: "Load completes")
+    viewModel.$isLoaded.filter { $0 }.sink { _ in expectation.fulfill() }
+        .store(in: &cancellables)
+    await viewModel.load()
+    await fulfillment(of: [expectation], timeout: 5.0)   // ← STARVE-001
+}
+
+// Good — join the real work unit; no clock, so no race to lose
+func testAsync() async {
+    await viewModel.load()                     // fires the detached Task, returns
+    await viewModel._awaitTrackedWorkForTesting()  // blocks until it actually finishes
+    XCTAssertTrue(viewModel.isLoaded)
+}
+```
+
+**Real seams already in the tree — model new code on these, don't reinvent:**
+
+- `AccountsManager._awaitAllCrawlTasksForTesting()` — joins the off-main
+  first-run `loadCatalogs` decode → `fetchFromNetwork` kickoff (`nonisolated`,
+  snapshots the first-run task list under a lock, awaits each handle).
+- `CatalogRepository._awaitAllBackgroundRefreshesForTesting()` — joins every
+  background stale-while-revalidate refresh armed via
+  `_trackRefreshTasksForTesting()` (the single-handle
+  `_awaitBackgroundRefreshForTesting()` joins only the most recent).
+- `TokenRefreshInterceptor._awaitAuthDispatchForTesting()` — joins the reauth
+  dispatch chain (coordinator refresh → modal present → per-book state flip →
+  retry), re-snapshotting until the task set stops growing.
+
+Each is gated on `ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"]
+!= nil` so RELEASE behavior is byte-identical to the bare fire-and-forget spawn it
+replaces — the tracking array only ever populates under XCTest, and production
+never calls the await seam.
+
+> If you genuinely must wait on a *bounded, cancellable* dependency (a real I/O
+> op with its own timeout, not fire-and-forget async), that is the rare legitimate
+> `wait(for:timeout:)` — annotate the line `// STARVE-001-OK: <reason>` so the
+> gate stays honest. Everything else joins the Task.
 
 ### 10.2 Singleton State Leakage
 

--- a/scripts/lint-test-quality.py
+++ b/scripts/lint-test-quality.py
@@ -7,9 +7,18 @@ Run as a pre-commit check or CI gate to prevent low-quality tests.
 
 Usage:
     python3 scripts/lint-test-quality.py [--fix] [--file PATH]
+    python3 scripts/lint-test-quality.py --changed [BASE]   # CI diff gate
+    python3 scripts/lint-test-quality.py --diff <PATH|->     # diff from file/stdin
 
-    --fix   Show suggested replacements (does not auto-apply)
-    --file  Lint a single file instead of all PalaceTests/
+    --fix      Show suggested replacements (does not auto-apply)
+    --file     Lint a single file instead of all PalaceTests/
+    --changed  DIFF-SCOPED STARVE-001 gate: flag NEW parallel-clone-starvation
+               deadline-poll waits on lines this PR ADDS vs BASE (default
+               origin/develop). Scoped to added lines so it never chokes on the
+               ~675 legacy occurrences. Wired into tooling-checks.yml.
+    --diff     Same gate, reading a pre-computed unified diff (file path or `-`
+               for stdin) instead of shelling out to git.
+    --quiet    Suppress the "no violations" success line (diff modes only).
 """
 
 import re
@@ -89,7 +98,11 @@ FLAKE_PATTERNS = [
     # listing. Tracking as Phase 2 follow-up per cs_2e842c4e and cs_6afc8b96
     # QA reviewer findings (rev_9cbd0540, rev_5acda1bf).
     (r'\b(Thread\.sleep|usleep|nanosleep)\b|(?<![\w.])sleep\(\s*\d',
-     "FLAKE-001: Raw sleep in test. Use XCTestExpectation, drainMainQueue, or awaitCondition.",
+     "FLAKE-001: Raw sleep in test. Replace with a deterministic Task-join seam "
+     "(retain the fire-and-forget Task under an XCTest gate and await its handle — "
+     "e.g. AccountsManager._awaitAllCrawlTasksForTesting) or drainMainQueue / "
+     "awaitCondition. Do NOT reach for a fixed-timeout XCTestExpectation — that is "
+     "the deadline-poll shape that starves under parallel sim clones (see STARVE-001).",
      False),
 
     # asyncAfter used as sleep-disguised-as-expectation. Matches an
@@ -131,7 +144,174 @@ ALLOWLIST_COMMENT_RE = {
     'FLAKE-002': re.compile(r'//\s*FLAKE-002-OK'),
     'FLAKE-003': re.compile(r'//\s*FLAKE-003-OK'),
     'MISSING-001': re.compile(r'//\s*MISSING-001-OK'),
+    'STARVE-001': re.compile(r'//\s*STARVE-001-OK'),
 }
+
+# ---------------------------------------------------------------------------
+# STARVE-001 — parallel-clone deadline-poll starvation (DIFF-SCOPED ONLY).
+#
+# The recurrence class `parallel-clone-starvation`
+# (docs/regressions/recurrence-classes.md): a test that waits on
+# fire-and-forget async via a FIXED wall-clock deadline
+# (`wait(for:timeout:)`, `fulfillment(of:timeout:)`,
+# `waitForExpectations(timeout:)`) loses the CPU race under 2+ parallel sim
+# clones on the CI macOS runner and fails all 3 `-retry-tests-on-failure`
+# iterations, because the load persists across iterations. Fixed in #1319/#1321
+# by replacing the deadline poll with a deterministic Task-join seam (retain the
+# fire-and-forget Task under an XCTest gate, expose `_await…ForTesting() async`,
+# await the handle). Real seams to model new code on:
+#   * AccountsManager._awaitAllCrawlTasksForTesting()
+#   * CatalogRepository._awaitAllBackgroundRefreshesForTesting()
+#   * TokenRefreshInterceptor._awaitAuthDispatchForTesting()
+#
+# CRITICAL SCOPING: this rule runs ONLY over ADDED lines in a diff, NEVER over a
+# full-tree scan. There are ~675 legacy deadline-poll occurrences in PalaceTests;
+# flagging them all would wall the board red and destroy the signal (green-board
+# contract). We gate reintroduction on NEW lines only — legacy debt is migrated
+# separately, not by this linter.
+#
+# Per-line escape hatch: `// STARVE-001-OK: <reason>` on the matched line (for a
+# genuinely bounded expectation that is NOT waiting on fire-and-forget async —
+# e.g. an integration test with a real, cancellable I/O bound).
+STARVE_PATTERNS = [
+    re.compile(r'\bwait\(for:'),
+    re.compile(r'\bfulfillment\(of:'),
+    re.compile(r'\bwaitForExpectations\(\s*timeout:'),
+]
+
+STARVE_DETAIL = (
+    "STARVE-001: NEW fixed-deadline wait on async work — starves under parallel "
+    "sim clones and fails all 3 CI retries (recurrence class "
+    "`parallel-clone-starvation`, docs/regressions/recurrence-classes.md). Replace "
+    "the wall-clock deadline with a deterministic Task-join seam: retain the "
+    "fire-and-forget Task in an XCTest-gated array (guard on "
+    "ProcessInfo.processInfo.environment[\"XCTestConfigurationFilePath\"] != nil), "
+    "expose `_await…ForTesting() async`, and await THAT. Model on "
+    "AccountsManager._awaitAllCrawlTasksForTesting / "
+    "CatalogRepository._awaitAllBackgroundRefreshesForTesting / "
+    "TokenRefreshInterceptor._awaitAuthDispatchForTesting. If this wait is on a "
+    "genuinely bounded/cancellable dependency (not fire-and-forget), annotate the "
+    "line with `// STARVE-001-OK: <reason>`."
+)
+
+
+def _is_test_swift(path: str) -> bool:
+    """True for a Swift file under the test target. Scoped to `PalaceTests/`
+    (where all XCTest lives) so the diff gate never trips on production code
+    that happens to contain a matching token."""
+    return path.endswith('.swift') and (
+        path.startswith('PalaceTests/') or '/PalaceTests/' in path
+    )
+
+
+class _AddedLine:
+    __slots__ = ('path', 'line_no', 'text')
+
+    def __init__(self, path: str, line_no: int, text: str):
+        self.path = path
+        self.line_no = line_no
+        self.text = text
+
+
+def parse_added_lines(diff_text: str) -> List["_AddedLine"]:
+    """Parse a unified diff and return the ADDED lines (post-image `+` lines,
+    excluding the `+++` file header) with their post-image line numbers.
+
+    Self-contained (no dependency on the detector-lib hunk parser) so
+    lint-test-quality.py stays a standalone script. Context (` `) and removed
+    (`-`) lines are intentionally ignored — STARVE-001 fires only on genuinely
+    NEW code, so a pre-existing deadline-poll appearing as diff context never
+    trips it.
+    """
+    added: List[_AddedLine] = []
+    cur_path = None
+    new_lineno = 0
+    hunk_re = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@')
+    for raw in diff_text.split('\n'):
+        if raw.startswith('+++ '):
+            # `+++ b/path` (or `+++ path`, or `/dev/null` for a deletion).
+            p = raw[4:].strip()
+            if p == '/dev/null':
+                cur_path = None
+            else:
+                if p.startswith('b/'):
+                    p = p[2:]
+                cur_path = p
+            continue
+        if raw.startswith('--- '):
+            continue
+        m = hunk_re.match(raw)
+        if m:
+            new_lineno = int(m.group(1))
+            continue
+        if raw.startswith('+'):
+            if cur_path is not None:
+                added.append(_AddedLine(cur_path, new_lineno, raw[1:]))
+            new_lineno += 1
+        elif raw.startswith('-'):
+            # Removed line: does not advance the post-image counter.
+            continue
+        elif raw.startswith(' '):
+            new_lineno += 1
+        # Any other line (diff/index/@@-less) leaves the counter alone.
+    return added
+
+
+def lint_starvation_diff(diff_text: str) -> List[Violation]:
+    """DIFF-SCOPED STARVE-001 scan: flag NEW deadline-poll waits on added lines
+    of changed test files. Never scans the full tree (see the module note)."""
+    findings: List[Violation] = []
+    for al in parse_added_lines(diff_text):
+        if not _is_test_swift(al.path):
+            continue
+        stripped = al.text.strip()
+        if stripped.startswith('//'):
+            continue
+        if ALLOWLIST_COMMENT_RE['STARVE-001'].search(al.text):
+            continue
+        if any(pat.search(al.text) for pat in STARVE_PATTERNS):
+            findings.append(Violation(
+                file=al.path,
+                line=al.line_no,
+                method='<added line>',
+                rule='STARVE-001',
+                detail=STARVE_DETAIL,
+            ))
+    return findings
+
+
+def _git_diff(base: str) -> str:
+    """Compute the unified diff of the current checkout vs `base`, scoped to the
+    test target. Tries three-dot (merge-base, correct for PRs) first, falling
+    back to two-dot for shallow/edge checkouts where the merge-base is absent."""
+    import subprocess
+    for spec in (f'{base}...HEAD', base):
+        try:
+            out = subprocess.run(
+                ['git', 'diff', spec, '--', 'PalaceTests'],
+                capture_output=True, text=True, check=True,
+            )
+            return out.stdout
+        except subprocess.CalledProcessError:
+            continue
+    return ''
+
+
+def run_diff_gate(diff_text: str, quiet: bool = False) -> int:
+    """Run the diff-scoped STARVE-001 gate over `diff_text`; print findings and
+    return the process exit code (1 on any hit, else 0)."""
+    findings = lint_starvation_diff(diff_text)
+    if not findings:
+        if not quiet:
+            print("STARVE-001: no new deadline-poll waits in changed test files.")
+        return 0
+    print(f"STARVE-001: {len(findings)} new deadline-poll wait(s) in changed test files:")
+    print("=" * 70)
+    for v in findings:
+        print(f"  {v.file}:{v.line} — {v.rule}")
+    print()
+    print(findings[0].detail)
+    return 1
 
 # Generic line-level lint-ignore marker. A line carrying
 #   // lint-ignore: FLUFF-003
@@ -394,6 +574,25 @@ def lint_file(filepath: str) -> List[Violation]:
     return violations
 
 def main():
+    # DIFF-SCOPED STARVE-001 gate. Runs ONLY the parallel-clone-starvation rule
+    # over ADDED lines of changed test files — the CI gate wired into
+    # .github/workflows/tooling-checks.yml. Kept as a separate, early-return code
+    # path so it never touches the full-tree scan below (which would drown on the
+    # ~675 legacy deadline-poll occurrences). Two entry points:
+    #   --diff <path|->   parse a unified diff from a file (or `-`/stdin)
+    #   --changed [BASE]  compute `git diff BASE...HEAD` (default origin/develop)
+    quiet = '--quiet' in sys.argv
+    if '--diff' in sys.argv:
+        idx = sys.argv.index('--diff')
+        src = sys.argv[idx + 1] if idx + 1 < len(sys.argv) else '-'
+        diff_text = sys.stdin.read() if src == '-' else open(src).read()
+        sys.exit(run_diff_gate(diff_text, quiet=quiet))
+    if '--changed' in sys.argv:
+        idx = sys.argv.index('--changed')
+        nxt = sys.argv[idx + 1] if idx + 1 < len(sys.argv) else ''
+        base = nxt if (nxt and not nxt.startswith('-')) else 'origin/develop'
+        sys.exit(run_diff_gate(_git_diff(base), quiet=quiet))
+
     fix_mode = '--fix' in sys.argv
     # `--per-file` emits one line per violation: <relpath>:<line>:<rule>
     # That gives verify-pr.sh a machine-parseable per-file view so it can

--- a/scripts/tests/test_lint_test_quality.py
+++ b/scripts/tests/test_lint_test_quality.py
@@ -1,0 +1,325 @@
+"""Contract tests for scripts/lint-test-quality.py — with a focus on the
+DIFF-SCOPED STARVE-001 rule (recurrence class `parallel-clone-starvation`).
+
+STARVE-001 blocks NEWLY-INTRODUCED fixed-deadline waits on async work
+(`fulfillment(of:timeout:)`, `wait(for:timeout:)`, `waitForExpectations(timeout:)`)
+because they starve under the 2 parallel sim clones on the CI macOS runner and
+fail all 3 `-retry-tests-on-failure` iterations. It runs over ADDED diff lines
+ONLY — never the full tree — so it does not wall the board red on the ~675 legacy
+occurrences (green-board contract).
+
+The green-board contract (CLAUDE.md "CI/CD reliability" #4) requires BOTH:
+  * a violation-path assertion (the rule FIRES on a real violation), AND
+  * a CLEAN-DIFF pass assertion (a diff the rule should accept does NOT block).
+Both are pinned below, plus scoping guards (context lines, comments, allow-list,
+non-test paths) and a regression check that the pre-existing full-scan rules
+(MISSING-001 etc.) are untouched and that STARVE-001 never leaks into full-scan.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO / "scripts" / "lint-test-quality.py"
+
+
+# --- module import (hyphenated filename → importlib) ------------------------
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("lint_test_quality", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_LTQ = _load_module()
+
+
+# --- diff fixtures ----------------------------------------------------------
+
+def _new_file_diff(path: str, added_lines: list[str]) -> str:
+    """A unified diff that ADDS `path` as a new file with `added_lines`."""
+    body = "".join(f"+{l}\n" for l in added_lines)
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        "new file mode 100644\n"
+        "index 0000000..1111111\n"
+        "--- /dev/null\n"
+        f"+++ b/{path}\n"
+        f"@@ -0,0 +1,{len(added_lines)} @@\n"
+        f"{body}"
+    )
+
+
+# A fire-and-forget async test that waits on a fixed deadline — the violation.
+_VIOLATION_LINES = [
+    "import XCTest",
+    "final class BarTests: XCTestCase {",
+    "  func testAsync() async {",
+    "    let e = XCTestExpectation(description: \"load\")",
+    "    viewModel.$isLoaded.filter { $0 }.sink { _ in e.fulfill() }.store(in: &bag)",
+    "    await viewModel.load()",
+    "    await fulfillment(of: [e], timeout: 5)",
+    "  }",
+    "}",
+]
+
+# The corrected form — joins the real work via a Task-join seam. Clean.
+_CLEAN_LINES = [
+    "import XCTest",
+    "final class BarTests: XCTestCase {",
+    "  func testAsync() async {",
+    "    await viewModel.load()",
+    "    await viewModel._awaitTrackedWorkForTesting()",
+    "    XCTAssertTrue(viewModel.isLoaded)",
+    "  }",
+    "}",
+]
+
+
+def _run_diff(diff_text: str) -> subprocess.CompletedProcess:
+    """Invoke the linter's diff gate, feeding the diff on stdin (`--diff -`)."""
+    # --quiet suppresses only the "no violations" success line; a real
+    # violation still prints, so the clean path emits nothing and the
+    # `"STARVE-001" not in stdout` assertion is unambiguous.
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--diff", "-", "--quiet"],
+        input=diff_text, capture_output=True, text=True, cwd=_REPO,
+    )
+
+
+# --- (i) violation-path: STARVE-001 FIRES ----------------------------------
+
+def test_starve001_flags_fulfillment_deadline_on_added_line():
+    diff = _new_file_diff("PalaceTests/Foo/BarTests.swift", _VIOLATION_LINES)
+    r = _run_diff(diff)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "STARVE-001" in r.stdout
+    assert "PalaceTests/Foo/BarTests.swift" in r.stdout
+
+
+@pytest.mark.parametrize("wait_line", [
+    "    await fulfillment(of: [e], timeout: 5)",
+    "    wait(for: [e], timeout: 5.0)",
+    "    waitForExpectations(timeout: 3)",
+])
+def test_starve001_flags_each_deadline_shape(wait_line):
+    diff = _new_file_diff(
+        "PalaceTests/X/YTests.swift",
+        ["func testX() {", wait_line, "}"],
+    )
+    r = _run_diff(diff)
+    assert r.returncode == 1, r.stdout
+    assert "STARVE-001" in r.stdout
+
+
+# --- (ii) CLEAN-DIFF pass: the mandatory green-board assertion --------------
+
+def test_starve001_clean_taskjoin_diff_passes():
+    """A changed test file that joins the real work via a Task-join seam (no
+    fixed deadline) must NOT trip the rule — the clean-diff pass the green-board
+    contract requires so an accepted interface never blocks."""
+    diff = _new_file_diff("PalaceTests/Foo/BarTests.swift", _CLEAN_LINES)
+    r = _run_diff(diff)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "STARVE-001" not in r.stdout
+
+
+def test_starve001_pure_sync_assertions_diff_passes():
+    diff = _new_file_diff(
+        "PalaceTests/Foo/SyncTests.swift",
+        ["func testTotal() {", "  XCTAssertEqual(cart.total, 15.99)", "}"],
+    )
+    r = _run_diff(diff)
+    assert r.returncode == 0, r.stdout
+
+
+# --- scoping guards (no false positives) -----------------------------------
+
+def test_starve001_allowlist_comment_suppresses():
+    diff = _new_file_diff(
+        "PalaceTests/Foo/IntegrationTests.swift",
+        ["func testIO() {",
+         "  wait(for: [e], timeout: 5) // STARVE-001-OK: real bounded I/O op",
+         "}"],
+    )
+    r = _run_diff(diff)
+    assert r.returncode == 0, r.stdout
+
+
+def test_starve001_ignores_commented_out_line():
+    diff = _new_file_diff(
+        "PalaceTests/Foo/CommentTests.swift",
+        ["func testX() {",
+         "  // await fulfillment(of: [e], timeout: 5)  <- migrated away",
+         "  await sut._awaitTrackedWorkForTesting()",
+         "}"],
+    )
+    r = _run_diff(diff)
+    assert r.returncode == 0, r.stdout
+
+
+def test_starve001_scoped_to_test_files_not_production():
+    """A `wait(for:` added in a production Palace/ file is out of scope — the
+    rule is about test-side deadline polls, not production code."""
+    diff = _new_file_diff("Palace/Foo/Bar.swift",
+                          ["func f() { wait(for: [e], timeout: 5) }"])
+    r = _run_diff(diff)
+    assert r.returncode == 0, r.stdout
+
+
+def test_starve001_ignores_preexisting_context_line():
+    """A legacy deadline-poll that appears only as diff CONTEXT (space-prefixed,
+    unchanged) must NOT flag — the rule fires on genuinely NEW lines only, so a
+    PR editing a neighbor of a legacy poll is not blocked on it."""
+    diff = (
+        "diff --git a/PalaceTests/Foo/BarTests.swift b/PalaceTests/Foo/BarTests.swift\n"
+        "--- a/PalaceTests/Foo/BarTests.swift\n"
+        "+++ b/PalaceTests/Foo/BarTests.swift\n"
+        "@@ -10,3 +10,4 @@ final class BarTests {\n"
+        "   await fulfillment(of: [e], timeout: 5)\n"   # context (space) — legacy
+        "+  XCTAssertTrue(sut.isLoaded)\n"              # the only ADDED line
+        "   }\n"
+        " }\n"
+    )
+    r = _run_diff(diff)
+    assert r.returncode == 0, r.stdout
+
+
+# --- unit level: parser + detector -----------------------------------------
+
+def test_parse_added_lines_tracks_only_plus_lines_with_line_numbers():
+    diff = (
+        "diff --git a/PalaceTests/A.swift b/PalaceTests/A.swift\n"
+        "--- a/PalaceTests/A.swift\n"
+        "+++ b/PalaceTests/A.swift\n"
+        "@@ -5,2 +5,3 @@\n"
+        " context\n"          # line 5
+        "-removed\n"          # does not advance post-image counter
+        "+added-one\n"        # line 6
+        "+added-two\n"        # line 7
+    )
+    added = _LTQ.parse_added_lines(diff)
+    texts = [(a.path, a.line_no, a.text) for a in added]
+    assert ("PalaceTests/A.swift", 6, "added-one") in texts
+    assert ("PalaceTests/A.swift", 7, "added-two") in texts
+    assert all(a.text not in ("context", "removed") for a in added)
+
+
+def test_lint_starvation_diff_returns_violation_objects():
+    diff = _new_file_diff("PalaceTests/Foo/BarTests.swift", _VIOLATION_LINES)
+    findings = _LTQ.lint_starvation_diff(diff)
+    assert len(findings) == 1
+    assert findings[0].rule == "STARVE-001"
+    assert findings[0].file == "PalaceTests/Foo/BarTests.swift"
+
+
+# --- (iii) existing rules untouched ----------------------------------------
+
+def test_full_scan_missing001_still_fires(tmp_path):
+    """A pre-existing rule (MISSING-001) still blocks in the default --file scan,
+    proving the STARVE additions didn't disturb the established gate."""
+    f = tmp_path / "NoAssertTests.swift"
+    f.write_text(
+        "import XCTest\n"
+        "final class NoAssertTests: XCTestCase {\n"
+        "  func testDoesNothing() {\n"
+        "    let x = Foo()\n"
+        "    x.doWork()\n"
+        "  }\n"
+        "}\n"
+    )
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--file", str(f)],
+        capture_output=True, text=True, cwd=_REPO,
+    )
+    assert r.returncode == 1, r.stdout
+    assert "MISSING-001" in r.stdout
+
+
+def test_full_scan_never_emits_starve001(tmp_path):
+    """STARVE-001 is diff-only: a full-tree/--file scan of a file FULL of
+    deadline polls must NOT emit it (that is exactly the 675-legacy wall the
+    scoping avoids)."""
+    f = tmp_path / "LegacyPollTests.swift"
+    f.write_text(
+        "import XCTest\n"
+        "final class LegacyPollTests: XCTestCase {\n"
+        "  func testA() async {\n"
+        "    let e = XCTestExpectation(description: \"x\")\n"
+        "    await fulfillment(of: [e], timeout: 5)\n"
+        "    XCTAssertTrue(true)\n"
+        "  }\n"
+        "}\n"
+    )
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--file", str(f)],
+        capture_output=True, text=True, cwd=_REPO,
+    )
+    assert "STARVE-001" not in r.stdout
+
+
+# --- --changed git entry point (the actual CI invocation) ------------------
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def test_changed_mode_end_to_end_flags_new_poll(tmp_path):
+    """Exercise the real CI entry point: a throwaway git repo with a base commit
+    and a branch that ADDS a deadline-poll test file. `--changed <base>` must
+    diff against base and block."""
+    repo = tmp_path / "repo"
+    (repo / "PalaceTests" / "Foo").mkdir(parents=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@t.io")
+    _git(repo, "config", "user.name", "t")
+    # Base commit: a clean test file.
+    tf = repo / "PalaceTests" / "Foo" / "BarTests.swift"
+    tf.write_text("\n".join(_CLEAN_LINES) + "\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True
+    ).stdout.strip()
+    # Change: introduce a deadline poll.
+    tf.write_text("\n".join(_VIOLATION_LINES) + "\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add poll")
+
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--changed", base_sha],
+        capture_output=True, text=True, cwd=repo,
+    )
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "STARVE-001" in r.stdout
+
+
+def test_changed_mode_end_to_end_clean_passes(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "PalaceTests" / "Foo").mkdir(parents=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@t.io")
+    _git(repo, "config", "user.name", "t")
+    tf = repo / "PalaceTests" / "Foo" / "BarTests.swift"
+    tf.write_text("// baseline\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True
+    ).stdout.strip()
+    tf.write_text("\n".join(_CLEAN_LINES) + "\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add clean test")
+
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--changed", base_sha],
+        capture_output=True, text=True, cwd=repo,
+    )
+    assert r.returncode == 0, r.stdout + r.stderr


### PR DESCRIPTION
## Why
The 2026-07-22 de-flake campaign root-caused 4 CI flake classes but nothing *prevents* new ones. Two gaps: (1) the existing `lint-test-quality.py` detector was wired into nothing (only ran via a local opt-in `verify-pr.sh`); (2) `docs/Testing/Test_Patterns.md` §10.1 actively **taught** the anti-pattern (its "good" example was `fulfillment(of:timeout:)`, the exact deadline-poll that starves under 2 parallel sim clones).

## What
- **`STARVE-001`** rule in `scripts/lint-test-quality.py` — flags newly-added `wait(for:` / `fulfillment(of:` / `waitForExpectations(timeout:` in changed test files. **Diff-scoped to added lines only** so it never wall-of-reds the ~675 legacy sites; `// STARVE-001-OK:` escape hatch per line.
- **CI wiring** — new fast ubuntu `flake-lint` job in `.github/workflows/tooling-checks.yml` (diff vs base, no Xcode).
- **Doc fix** — `Test_Patterns.md` §10.1 rewritten to explain parallel-clone starvation and teach the deterministic Task-join seam, quoting the three real seams.
- Retargeted the FLAKE-001 remediation text off the starvation pattern.

## Verification
- `scripts/tests/test_lint_test_quality.py` (16 new tests incl. the mandatory **clean-diff pass** assertion); `python3 -m pytest scripts/tests/ -q` → **339 passed**.
- Dry-run `--changed origin/develop` on this branch → **0 false positives**.

This is the ratchet that keeps the wall-clock-wait burndown (swarm `swarm_ad0b4c65`) at zero once drained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)