### PR TITLE
test(decomp): pre-wave characterization + Wave 0 ratchet for god-class decomposition

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		226393A6409B098B875CCB0C /* NotificationService+PushTokenDeleting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD8F07A904F12E6D218B0B5 /* NotificationService+PushTokenDeleting.swift */; };
 		22B30250AAD707D7890DAF80 /* EmbeddedFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCKBK01FR006 /* EmbeddedFixtures.swift */; };
 		22D7A0341D12429C6B3D10A4 /* UIColor+TPPColorAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AAE5061720AB26712416F3 /* UIColor+TPPColorAdditions.swift */; };
+		22DD6BA48B7D1CDF40CE898A /* DownloadThrottlingContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2E78CACAB5739E02EECA7E /* DownloadThrottlingContractTests.swift */; };
 		2328B4483544EAC500B592B6 /* UserAccountValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC465C72310C5054118CBBEA /* UserAccountValidationTests.swift */; };
 		233349692EA7423D97E70B5F /* SEMigrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE116B1078F648DCB8A52598 /* SEMigrationsTests.swift */; };
 		237B6705CA505A8CE33EAE6D /* TPPDeferredAdobeActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557641B8197B528D886F32DB /* TPPDeferredAdobeActivationTests.swift */; };
@@ -291,6 +292,7 @@
 		263B4C5D6E7F8091A2B3C4D5 /* LocalBookContentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374C5D6E7F8091A2B3C4D5E6 /* LocalBookContentService.swift */; };
 		269B4BB49D943C41E65D3F93 /* StatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B365956298AA1A7256D63D8E /* StatsViewModel.swift */; };
 		26A96F72D457F089BFD24698 /* NSURL+NYPLURLAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F901D7BCF798BFF0E528D6D /* NSURL+NYPLURLAdditions.swift */; };
+		26E96C6962F52A0AF2E195BD /* PalacePreferencesSettingsRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6905E504CA69A52099A7AE /* PalacePreferencesSettingsRoundTripTests.swift */; };
 		2709574961502365B6E6808B /* CoverageGapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903F56D4F2AA03D69839AB3F /* CoverageGapTests.swift */; };
 		27394CC4BA40F5B73819BBD1 /* StreamingReaderProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D808ED2A58DBF01DA7AAEDF3 /* StreamingReaderProgressStore.swift */; };
 		275A3C85D403036AC693131B /* AudiobookVendorAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AAA6A2C834984A7D21A854 /* AudiobookVendorAdapter.swift */; };
@@ -306,6 +308,7 @@
 		28A0F230E614A06EC16E4213 /* ReadingSessionTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973B633FA62911CD52ED9CB9 /* ReadingSessionTrackerTests.swift */; };
 		28C3A73CCDA85DD1F28457ED /* AccountsManager+TPPCurrentLibraryAccountProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8673802153960A8CA7EAE753 /* AccountsManager+TPPCurrentLibraryAccountProviding.swift */; };
 		28E3A953BE971D4599DF4015 /* AccountsManagerLaunchSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95C7D4851A9F69D7295499 /* AccountsManagerLaunchSnapshotTests.swift */; };
+		28E3C3E2BA711555366DA228 /* BackgroundReconciliationContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1DC02848D158E774C79F0A /* BackgroundReconciliationContractTests.swift */; };
 		292DACBF794B4FA5B1A9DAEB /* UIApplication+MainScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D50821D42294719B5E6F62C /* UIApplication+MainScene.swift */; };
 		29464A0CE4E2E995CCFF6DEB /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3592F6473F87F4D7C96FB483 /* NotificationServiceTests.swift */; };
 		29938B081D098951FCAE627A /* AudiobookMorphingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDDCAF42BE33E8FFEE03FE5 /* AudiobookMorphingPlayerView.swift */; };
@@ -316,6 +319,7 @@
 		2A34C74881B37E0DE564B774 /* PalaceCatalog in Frameworks */ = {isa = PBXBuildFile; productRef = 7AA8A6B3C2C375EC4328722F /* PalaceCatalog */; };
 		2A71783008E7BB879EFB5029 /* NSURL+NYPLURLAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F901D7BCF798BFF0E528D6D /* NSURL+NYPLURLAdditions.swift */; };
 		2A74794DA3EC5581988D5187 /* AppContainerResetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B06750CB65241FF2701518 /* AppContainerResetTests.swift */; };
+		2A8E9830CB9BD5599EC4B021 /* TPPSignInBusinessLogicCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333733730937345770AF9416 /* TPPSignInBusinessLogicCharacterizationTests.swift */; };
 		2B7EC298A55FA3351E113B6B /* PerformanceReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D80DA377151AE41BEF67F7 /* PerformanceReport.swift */; };
 		2B820846966DE6DDDBD29DCB /* AccessibilitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E518F27E3FF9A05071B82305 /* AccessibilitySettingsView.swift */; };
 		2BDAFD30C68E1D2245E84285 /* AudiobookOpenStateRaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834376530042364D30BA01FD /* AudiobookOpenStateRaceTests.swift */; };
@@ -435,6 +439,7 @@
 		49504822A95094278A8506F6 /* TPPBookButtonsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502761BDE732D3752808C4C4 /* TPPBookButtonsState.swift */; };
 		4970519C2018626C6412AB39 /* GeneralCacheClearOnUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A295B1F1809096E9203186 /* GeneralCacheClearOnUpdateTests.swift */; };
 		4ABC89EACE1CF4EB53281A51 /* StreamingReaderViewControllerScrollRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2A4750286AC64A2D15FD94 /* StreamingReaderViewControllerScrollRestoreTests.swift */; };
+		4B69321BBCF4158F4AC546EA /* RightsManagementDispatchContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB69BEC26CB16962E3EE14C /* RightsManagementDispatchContractTests.swift */; };
 		4BA66F6AA4A7DC046B995BC6 /* OfflineQueueServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FEEC427223FFDB026D6137 /* OfflineQueueServiceProtocol.swift */; };
 		4BEE7B81D9C945779A72310E /* DefaultRecentlyReadingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E8B9BFBB791BB1A85E46685 /* DefaultRecentlyReadingServiceTests.swift */; };
 		4C0017B99F494FE3A7A69887 /* TPPSignInBusinessLogic+ForceReset.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16A8F928810410482669BF6 /* TPPSignInBusinessLogic+ForceReset.swift */; };
@@ -449,6 +454,7 @@
 		4DE6468C2E4065037D7281F9 /* AlertPresentationRawGuardLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2919A501EF80BC9A88CF2B58 /* AlertPresentationRawGuardLintTests.swift */; };
 		4E0F1B6A8D7C5F23E9B0A1C4 /* DiskBudgetManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1A2C7B9E8D6A34F0C1B2D5 /* DiskBudgetManagerTests.swift */; };
 		4E664E6EC32C604AFBC8A623 /* CatalogSearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFF70FF762C60CE8CD8D811 /* CatalogSearchViewModelTests.swift */; };
+		4E7D4FD5607DD1D3767954FB /* AudiobookSessionPresenterLifecycleContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCB26003F58384AB77E3B7B /* AudiobookSessionPresenterLifecycleContractTests.swift */; };
 		4EE6AD0F199527926C3BB1F8 /* CatalogFilterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5948988DD314B94674443C4F /* CatalogFilterServiceTests.swift */; };
 		4F10BBD49D626C35086B31ED /* ImageCoverKeyUnificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56AC83D84B623CCA970A95F /* ImageCoverKeyUnificationTests.swift */; };
 		4F6E8C45BC4CEEFA0434F641 /* Corpus in Resources */ = {isa = PBXBuildFile; fileRef = F6990140C2393E885A89B739 /* Corpus */; };
@@ -1103,6 +1109,7 @@
 		B8E4151C0CD1AA0299C4913B /* OPDS2FeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0140FB30133B2AFB6A1207D /* OPDS2FeedTests.swift */; };
 		B9AGENT02BF000000000001 /* PalaceErrorExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AGENT02FR000000000001 /* PalaceErrorExtendedTests.swift */; };
 		B9AGENT03BF000000000001 /* KeyboardNavigationFKATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AGENT03FR000000000001 /* KeyboardNavigationFKATests.swift */; };
+		BA1903A13E7629ABD20A9744 /* BookDetailMetadataMergeContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2D3DF8C6B67DD384F77371C /* BookDetailMetadataMergeContractTests.swift */; };
 		BA273F316B533C5D83693DBD /* PDFThumbnailStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15FCA49C708DFACA3FD66B6 /* PDFThumbnailStrip.swift */; };
 		BAE20819D54F9AFEBE09F85F /* TPPConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16D32877559BE95F5219281 /* TPPConfiguration.swift */; };
 		BB3DF40500B132F34229104E /* AccountStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABB253AB7CB4183943EBA6A /* AccountStateStore.swift */; };
@@ -1152,6 +1159,7 @@
 		C2A355EBB5690A235E9E6F22 /* AccountDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CBFE0B23AFFE343E256AE1 /* AccountDetailViewModelTests.swift */; };
 		C2A3B4C5D6E7F8A9B0C1D2E3 /* DownloadQueueOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F7A8B9C0D1E2 /* DownloadQueueOrchestratorTests.swift */; };
 		C2B3C4D5E6F7A8B9C0D1E2F3 /* DownloadStartCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B2C3D4E5F6A7B8C9D0E1F2 /* DownloadStartCoordinator.swift */; };
+		C2BE089B9CA4F1D682C28EE0 /* AccountsManagerCurrentAccountSwitchContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528CB82596AA3D039B52B808 /* AccountsManagerCurrentAccountSwitchContractTests.swift */; };
 		C321467F56BF2E1573596281 /* AppHealthViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EBF1AB49179CABFF759380B /* AppHealthViewModelTests.swift */; };
 		C33252827DC275331A285D89 /* ContinueRowSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFC5BB5B5F0627FFE2FDFA6 /* ContinueRowSection.swift */; };
 		C386EA20C90C8215EF9387D3 /* TokenRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A81964771D1CB9A93ED2EA6 /* TokenRefreshTests.swift */; };
@@ -1291,6 +1299,7 @@
 		D91512129048356CDC3C9542 /* PalaceCheckPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFC130078A169AED6A9B47B /* PalaceCheckPropertyTests.swift */; };
 		D92D8C0137C4BC9647242D87 /* SignInModalLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA17C81F4AA9F1201A91AC6C /* SignInModalLifecycleTests.swift */; };
 		D987D93E00D55416261ED333 /* TPPBook+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C1093BDA93392F7DEF0D31 /* TPPBook+Accessibility.swift */; };
+		D9E91B24EC23763E0DCDB724 /* AudiobookReadinessPlaybackContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54C824516D1C231160D5F14 /* AudiobookReadinessPlaybackContractTests.swift */; };
 		DAB0BEB25C0820964D148327 /* RemoteFeatureFlagsSideLoadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB471B469C9CDB15F2F2ABA /* RemoteFeatureFlagsSideLoadingTests.swift */; };
 		DB12A83E17C9B20180711EB8 /* URLRequestNYPLAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B163B18C48334A913B2CCA /* URLRequestNYPLAdditionsTests.swift */; };
 		DC6436C6EA2D2F98393B59AF /* BorrowOperationTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFCCBD649C2E3E305E047A65 /* BorrowOperationTimeoutTests.swift */; };
@@ -1599,6 +1608,7 @@
 		E5E03F362CED172200D9979D /* TPPReadiumBookmark+R3.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E03F332CED171D00D9979D /* TPPReadiumBookmark+R3.swift */; };
 		E5E03F392CED176F00D9979D /* TPPBookmarkR3Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E03F372CED176500D9979D /* TPPBookmarkR3Location.swift */; };
 		E5E03F3A2CED176F00D9979D /* TPPBookmarkR3Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E03F372CED176500D9979D /* TPPBookmarkR3Location.swift */; };
+		E5E2EF3176152176CD89DBBC /* BookDetailOpenRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317F2DC09E9CFECAF62DA385 /* BookDetailOpenRoutingTests.swift */; };
 		E5E443FB2DA4591C00AD4BC9 /* AdaptiveShadowModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E443F92DA4591C00AD4BC9 /* AdaptiveShadowModifier.swift */; };
 		E5E443FC2DA4591C00AD4BC9 /* AdaptiveShadowModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E443F92DA4591C00AD4BC9 /* AdaptiveShadowModifier.swift */; };
 		E5E4907229280597005BFC55 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54DD4CF275C66F30013C200 /* Strings.swift */; };
@@ -1816,11 +1826,13 @@
 		ED121CB96E52B81CED187442 /* ReadingStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA4D17463BADFD0DEBC53FA /* ReadingStats.swift */; };
 		ED9ED4A5C8DBBE60A7DDC39E /* TPPMyBooksSimplifiedBearerToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CCF14B8043FB410CB53DFB /* TPPMyBooksSimplifiedBearerToken.swift */; };
 		EDABAC96498D2F204A963521 /* PerformanceMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A934FABA62A6E51A6928F0DD /* PerformanceMonitorTests.swift */; };
+		EE03031837896C7DC8A1BFB1 /* TPPCirculationAnalyticsRequestShapeContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F23FD6246E4D153F32CB91 /* TPPCirculationAnalyticsRequestShapeContractTests.swift */; };
 		EE31E6EB491AED36D48F37E5 /* OPDS2PublicationExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F03A0005DBD80853C64D12 /* OPDS2PublicationExtendedTests.swift */; };
 		EE62CB8A78482228B1365D4E /* PlaybackBootstrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7460F23BAEC7FED016069 /* PlaybackBootstrapper.swift */; };
 		EE7A7C1C1C92278BB0822BE4 /* AudioSessionActivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDE63F6732471A2B00D88DC /* AudioSessionActivator.swift */; };
 		EEEE66239B26A72D3043149B /* AuthCoordinatorTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D2803422C2006E33C1BC3E /* AuthCoordinatorTelemetryTests.swift */; };
 		EF45FA58251EA725B1A9EC42 /* ImageLoaderImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16897C4A4AB0AFFDE25449BF /* ImageLoaderImpl.swift */; };
+		EFADE940431FF20F6F1EF7CA /* AccountsManagerAuthDocContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928BD93AACC07042059F32C7 /* AccountsManagerAuthDocContractTests.swift */; };
 		F00D000000000000000F5501 /* MyBooksDownloadSessionInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00D000000000000000F5502 /* MyBooksDownloadSessionInvalidationTests.swift */; };
 		F00D0001000000000000F001 /* ReadiumShared in Frameworks */ = {isa = PBXBuildFile; productRef = F00D0001000000000000F002 /* ReadiumShared */; };
 		F00D0001000000000000F003 /* ReadiumNavigator in Frameworks */ = {isa = PBXBuildFile; productRef = F00D0001000000000000F004 /* ReadiumNavigator */; };
@@ -1876,6 +1888,7 @@
 		FA346754BE76A48C92CF0754 /* OPDS2FeedParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD86C00D774B74F80D5B713 /* OPDS2FeedParsingTests.swift */; };
 		FA8184531683826DDA00EB04 /* BorrowOperationContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958964493F9D85E5FCFAAAE2 /* BorrowOperationContractTests.swift */; };
 		FA8494CE18853724BE905B50 /* AppHealthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9037960B1D57AADFD0485B6 /* AppHealthView.swift */; };
+		FABCDDB533C74ED2F4757143 /* TPPSignInCapabilitiesCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F50CFA2EBD6E2F19F568E0 /* TPPSignInCapabilitiesCharacterizationTests.swift */; };
 		FAC84E21FA4ECEF263BA02A3 /* TPPReaderPositionReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE49D6CAE9861D0C5EC238 /* TPPReaderPositionReport.swift */; };
 		FAD5902E32425F99631B955A /* OfflineQueueStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABBAF91BE018A0E67F282E67 /* OfflineQueueStatus.swift */; };
 		FB037ECB52EDF32ED198B033 /* AppLaunchTrackerWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF823FA44324FF95C558932 /* AppLaunchTrackerWiringTests.swift */; };
@@ -2157,6 +2170,7 @@
 		0B9A4E1085F59AB6E4E0AD4C /* SupportSectionDecisionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SupportSectionDecisionTests.swift; sourceTree = "<group>"; };
 		0C1F974717220248950A874F /* BorrowReducerCore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BorrowReducerCore.swift; sourceTree = "<group>"; };
 		0C33E4BDBC27454AB30FAF96 /* AlertModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertModelTests.swift; sourceTree = "<group>"; };
+		0CB69BEC26CB16962E3EE14C /* RightsManagementDispatchContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RightsManagementDispatchContractTests.swift; sourceTree = "<group>"; };
 		0CD8A9D1E84E9CA99C5DA03D /* ExecutorNetworkHermeticityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExecutorNetworkHermeticityTests.swift; sourceTree = "<group>"; };
 		0D1DDCD0CAAF267ED41E69DB /* LCPPassphraseReadinessTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPassphraseReadinessTests.swift; sourceTree = "<group>"; };
 		0D614C1396A316960F405535 /* IsReaderActiveTrackingModifierTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IsReaderActiveTrackingModifierTests.swift; sourceTree = "<group>"; };
@@ -2385,11 +2399,13 @@
 		3023DFFACC986541965F1560 /* OPDS2PublicationExtended.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OPDS2PublicationExtended.swift; path = OPDS2/Models/OPDS2PublicationExtended.swift; sourceTree = "<group>"; };
 		30B163B18C48334A913B2CCA /* URLRequestNYPLAdditionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLRequestNYPLAdditionsTests.swift; sourceTree = "<group>"; };
 		317C8F0150303A9AC53BC44F /* MyBooksDownloadCenterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterTests.swift; sourceTree = "<group>"; };
+		317F2DC09E9CFECAF62DA385 /* BookDetailOpenRoutingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookDetailOpenRoutingTests.swift; sourceTree = "<group>"; };
 		3183C58974AE89BE550AC866 /* XCTestCase+testUserDefaults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCTestCase+testUserDefaults.swift"; sourceTree = "<group>"; };
 		31CC0A3CFA3E9E20C65B5C01 /* PlaybackRateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlaybackRateTests.swift; sourceTree = "<group>"; };
 		3248EFDDABC9F2BE1324CA2A /* TPPNetworkExecutorConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPNetworkExecutorConcurrencyTests.swift; sourceTree = "<group>"; };
 		3260782E24602A4B3FF7E20B /* FontManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontManagerTests.swift; sourceTree = "<group>"; };
 		32D4C626CB007855A9BE6252 /* TPPProblemDocument+Localized.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "TPPProblemDocument+Localized.swift"; sourceTree = "<group>"; };
+		333733730937345770AF9416 /* TPPSignInBusinessLogicCharacterizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPSignInBusinessLogicCharacterizationTests.swift; sourceTree = "<group>"; };
 		3432D61958317AD796B90005 /* MockFeatureFlagProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MockFeatureFlagProvider.swift; sourceTree = "<group>"; };
 		34BD75A5447FB7BD0DA90F57 /* SendableSubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SendableSubject.swift; sourceTree = "<group>"; };
 		3572DBB51B1244AE18879435 /* MyBooksDownloadCenterExtendedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterExtendedTests.swift; sourceTree = "<group>"; };
@@ -2419,10 +2435,12 @@
 		3DDC0D40C209F5D1ADE4D606 /* BearerTokenAdapterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BearerTokenAdapterTests.swift; sourceTree = "<group>"; };
 		3DDE892E38D34061A2DBE2F2 /* CatalogRepositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogRepositoryMock.swift; sourceTree = "<group>"; };
 		3E793B64D2FB472246D9A244 /* RuntimeQuiescenceAuditor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeQuiescenceAuditor.swift; sourceTree = "<group>"; };
+		3F2E78CACAB5739E02EECA7E /* DownloadThrottlingContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadThrottlingContractTests.swift; sourceTree = "<group>"; };
 		3FE7745D6905F20849740238 /* TPPCredentialsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPCredentialsTests.swift; sourceTree = "<group>"; };
 		4057C151D980D26B04B8FC53 /* ContinueRowSectionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContinueRowSectionTests.swift; sourceTree = "<group>"; };
 		40E9247D6B43294F6DFA672F /* LegacySAMLProblemDocumentPropagationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LegacySAMLProblemDocumentPropagationTests.swift; sourceTree = "<group>"; };
 		41C94D2AB2B04C81919F10B3 /* BookCellModelActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCellModelActionTests.swift; sourceTree = "<group>"; };
+		41F50CFA2EBD6E2F19F568E0 /* TPPSignInCapabilitiesCharacterizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPSignInCapabilitiesCharacterizationTests.swift; sourceTree = "<group>"; };
 		420E95312BFA6C62C6CA835D /* MyBooksDownloadCenterProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterProtocol.swift; sourceTree = "<group>"; };
 		422FFD436DFCCB056CCF6302 /* ReadingRulerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingRulerView.swift; sourceTree = "<group>"; };
 		426F162F6CFC705CE42A45B2 /* CarPlayAuthHelperReadinessTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarPlayAuthHelperReadinessTests.swift; sourceTree = "<group>"; };
@@ -2476,6 +2494,7 @@
 		5192F4C62AA2DDC7E9752A5E /* LockIsolated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LockIsolated.swift; sourceTree = "<group>"; };
 		52226B7262C85C91578DB3A7 /* TPPJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPJSON.swift; sourceTree = "<group>"; };
 		5248CEFDF1FEDEBE50897394 /* LCPAdapterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPAdapterTests.swift; sourceTree = "<group>"; };
+		528CB82596AA3D039B52B808 /* AccountsManagerCurrentAccountSwitchContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerCurrentAccountSwitchContractTests.swift; sourceTree = "<group>"; };
 		52C86F54125C3BD725906F86 /* LCPPDFOpenProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPPDFOpenProgress.swift; sourceTree = "<group>"; };
 		535929C8F559713321004F38 /* HostFailureTrackerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostFailureTrackerTests.swift; sourceTree = "<group>"; };
 		53CCA7049DE640BABC8D20B8 /* SignInModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInModalView.swift; sourceTree = "<group>"; };
@@ -2787,6 +2806,7 @@
 		913F56D4F2AA03D69839AB40 /* CoverageGapTests3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverageGapTests3.swift; sourceTree = "<group>"; };
 		919D0E3F3618D29FCDBCB3C3 /* TabBarModernization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabBarModernization.swift; sourceTree = "<group>"; };
 		9234DD4339B85855A91CE3DE /* BookRegistryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookRegistryStore.swift; sourceTree = "<group>"; };
+		928BD93AACC07042059F32C7 /* AccountsManagerAuthDocContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerAuthDocContractTests.swift; sourceTree = "<group>"; };
 		9363B8BAFC71462390D7DD31 /* AudiobookLoadFailureSAMLReauthTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookLoadFailureSAMLReauthTests.swift; sourceTree = "<group>"; };
 		93925AD8656015E0036615C8 /* NotificationServiceTokenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationServiceTokenTests.swift; sourceTree = "<group>"; };
 		93D2803422C2006E33C1BC3E /* AuthCoordinatorTelemetryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthCoordinatorTelemetryTests.swift; sourceTree = "<group>"; };
@@ -2839,6 +2859,7 @@
 		A22586E379F04E1E9348FAAB /* DownloadErrorInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadErrorInfoTests.swift; sourceTree = "<group>"; };
 		A256A501E6AB55F352D674FE /* AccessibilityPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferencesTests.swift; sourceTree = "<group>"; };
 		A2A352697B589358F91035A1 /* MockVisualNavigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockVisualNavigator.swift; path = PalaceTests/Mocks/MockVisualNavigator.swift; sourceTree = "<group>"; };
+		A2D3DF8C6B67DD384F77371C /* BookDetailMetadataMergeContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookDetailMetadataMergeContractTests.swift; sourceTree = "<group>"; };
 		A2E5C9EA3B9B15FEF2555CE3 /* TPPBasicAuthTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBasicAuthTests.swift; sourceTree = "<group>"; };
 		A303E282D7EFD80AED446401 /* LCPKeychainMigration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPKeychainMigration.swift; sourceTree = "<group>"; };
 		A325872EF1D517D66C0FA15F /* TokenResponseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenResponseTests.swift; sourceTree = "<group>"; };
@@ -3017,6 +3038,7 @@
 		CB9CA89B135C85E23F0D907B /* MyBooksViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyBooksViewModelTests.swift; sourceTree = "<group>"; };
 		CBA39820CBA75D6BA9B763E2 /* CatalogRepositoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogRepositoryTests.swift; sourceTree = "<group>"; };
 		CBBDD4C17EA45C71D8076A34 /* PerformanceMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMetric.swift; sourceTree = "<group>"; };
+		CC1DC02848D158E774C79F0A /* BackgroundReconciliationContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundReconciliationContractTests.swift; sourceTree = "<group>"; };
 		CC1F0281468BF6D1F7112951 /* StreamingReaderViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingReaderViewModelTests.swift; sourceTree = "<group>"; };
 		CCB1E4A5E6A1E450001D2751 /* TPPProblemReportViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPProblemReportViewController.swift; sourceTree = "<group>"; };
 		CCDD8C3ABFAAB079ADACC31A /* UserDefaultsIsolationLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserDefaultsIsolationLintTests.swift; sourceTree = "<group>"; };
@@ -3026,6 +3048,7 @@
 		CD15B16AF4F6CATKEYIFR04 /* CatalogCacheKeyAndIsolationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogCacheKeyAndIsolationTests.swift; sourceTree = "<group>"; };
 		CD321623DBDDEC02C16FE9A9 /* TypographyServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographyServiceTests.swift; sourceTree = "<group>"; };
 		CD3CB29CDE4E4C9E9FF679D1 /* PalaceErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceErrorTests.swift; sourceTree = "<group>"; };
+		CD6905E504CA69A52099A7AE /* PalacePreferencesSettingsRoundTripTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalacePreferencesSettingsRoundTripTests.swift; sourceTree = "<group>"; };
 		CD71C8FF18A443133C015DA8 /* KeyboardVoiceOverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyboardVoiceOverTests.swift; sourceTree = "<group>"; };
 		CD7CF61C8B20F3B40C3C44FA /* SideloadBoundaryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadBoundaryTests.swift; sourceTree = "<group>"; };
 		CE97656B54F67282B7B52648 /* TPPLinearView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPLinearView.swift; sourceTree = "<group>"; };
@@ -3075,6 +3098,7 @@
 		D4FA6A7940BE4470BD0A3515 /* TPPBookmarkR3LocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookmarkR3LocationTests.swift; sourceTree = "<group>"; };
 		D50E8682DF2CC80AA981B91C /* ResourcePropertiesLengthTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResourcePropertiesLengthTests.swift; sourceTree = "<group>"; };
 		D5432439F5EACD508D2FA041 /* BookStateReading.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BookStateReading.swift; path = ../../Palace/MyBooks/Sideload/BookStateReading.swift; sourceTree = "<group>"; };
+		D54C824516D1C231160D5F14 /* AudiobookReadinessPlaybackContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookReadinessPlaybackContractTests.swift; sourceTree = "<group>"; };
 		D56AC83D84B623CCA970A95F /* ImageCoverKeyUnificationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageCoverKeyUnificationTests.swift; sourceTree = "<group>"; };
 		D56E264DEDFBBEDF6D4E79E3 /* AccessibleAnimation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AccessibleAnimation.swift; path = ../../../Palace/Utilities/SwiftUI/AccessibleAnimation.swift; sourceTree = "<group>"; };
 		D598423237C04DE7B3834ABC /* AccountsManagerCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsManagerCacheTests.swift; sourceTree = "<group>"; };
@@ -3101,6 +3125,7 @@
 		DC33AA22BB33CC44DD55EE66 /* DownloadFreeSpaceExhaustionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadFreeSpaceExhaustionTests.swift; sourceTree = "<group>"; };
 		DC44AA22BB33CC44DD55EE66 /* DownloadRMSDKHandoffTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadRMSDKHandoffTests.swift; sourceTree = "<group>"; };
 		DCA435D31AD17308AF5E1B2C /* AudiobookSessionPresenterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookSessionPresenterTests.swift; sourceTree = "<group>"; };
+		DCCB26003F58384AB77E3B7B /* AudiobookSessionPresenterLifecycleContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookSessionPresenterLifecycleContractTests.swift; sourceTree = "<group>"; };
 		DD2979A9E5BF9E88707C9BC2 /* BundledRegistrySnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundledRegistrySnapshotTests.swift; sourceTree = "<group>"; };
 		DE7955F7FD669DC987C9238D /* StreamingReaderViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingReaderViewModel.swift; sourceTree = "<group>"; };
 		DF0FE8362E5FDFD0DB180577 /* TPPMyBooksDownloadInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPMyBooksDownloadInfo.swift; sourceTree = "<group>"; };
@@ -3298,6 +3323,7 @@
 		E5EE380D2D5DB19D00252001 /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		E5EFDE77298C43D300258CA3 /* BookButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookButtonState.swift; sourceTree = "<group>"; };
 		E5EFDE7B298C4F8000258CA3 /* BookCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCellModel.swift; sourceTree = "<group>"; };
+		E5F23FD6246E4D153F32CB91 /* TPPCirculationAnalyticsRequestShapeContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPCirculationAnalyticsRequestShapeContractTests.swift; sourceTree = "<group>"; };
 		E5F4A2E02E6F65A5009B32AA /* KeyboardModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardModifier.swift; sourceTree = "<group>"; };
 		E5F4A3172E6FE6C7009B32AA /* CatalogContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogContentView.swift; sourceTree = "<group>"; };
 		E5F607183940516273849506 /* MockSAMLWebViewPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MockSAMLWebViewPresenter.swift; sourceTree = "<group>"; };
@@ -5588,6 +5614,7 @@
 				4E55AED72A688C44680A7FFA /* FeatureFlags */,
 				8216AF24139B364FD961D583 /* AppRating */,
 				51AE9BB746CCC235C5F50D72 /* UIPolish */,
+				C6D3A461253246DAAEC73DB4 /* Decomp */,
 			);
 			path = PalaceTests;
 			sourceTree = "<group>";
@@ -5935,6 +5962,27 @@
 			);
 			name = ImageLoading;
 			path = ImageLoading;
+			sourceTree = "<group>";
+		};
+		C6D3A461253246DAAEC73DB4 /* Decomp */ = {
+			isa = PBXGroup;
+			children = (
+				928BD93AACC07042059F32C7 /* AccountsManagerAuthDocContractTests.swift */,
+				528CB82596AA3D039B52B808 /* AccountsManagerCurrentAccountSwitchContractTests.swift */,
+				D54C824516D1C231160D5F14 /* AudiobookReadinessPlaybackContractTests.swift */,
+				DCCB26003F58384AB77E3B7B /* AudiobookSessionPresenterLifecycleContractTests.swift */,
+				CC1DC02848D158E774C79F0A /* BackgroundReconciliationContractTests.swift */,
+				A2D3DF8C6B67DD384F77371C /* BookDetailMetadataMergeContractTests.swift */,
+				317F2DC09E9CFECAF62DA385 /* BookDetailOpenRoutingTests.swift */,
+				3F2E78CACAB5739E02EECA7E /* DownloadThrottlingContractTests.swift */,
+				CD6905E504CA69A52099A7AE /* PalacePreferencesSettingsRoundTripTests.swift */,
+				0CB69BEC26CB16962E3EE14C /* RightsManagementDispatchContractTests.swift */,
+				E5F23FD6246E4D153F32CB91 /* TPPCirculationAnalyticsRequestShapeContractTests.swift */,
+				333733730937345770AF9416 /* TPPSignInBusinessLogicCharacterizationTests.swift */,
+				41F50CFA2EBD6E2F19F568E0 /* TPPSignInCapabilitiesCharacterizationTests.swift */,
+			);
+			name = Decomp;
+			path = Decomp;
 			sourceTree = "<group>";
 		};
 		CA4865ECC354E69A4239478E /* Utilities */ = {
@@ -7887,6 +7935,19 @@
 				14E286B1CE151643C5FF2A8B /* ReturnReducerContractTests.swift in Sources */,
 				C6A2727722246F87FBA03AF4 /* BorrowReducerCoreContractTests.swift in Sources */,
 				554C23F2A78ABCFFF01826C9 /* TestTargetHermeticityRegressionTests.swift in Sources */,
+				EFADE940431FF20F6F1EF7CA /* AccountsManagerAuthDocContractTests.swift in Sources */,
+				C2BE089B9CA4F1D682C28EE0 /* AccountsManagerCurrentAccountSwitchContractTests.swift in Sources */,
+				D9E91B24EC23763E0DCDB724 /* AudiobookReadinessPlaybackContractTests.swift in Sources */,
+				4E7D4FD5607DD1D3767954FB /* AudiobookSessionPresenterLifecycleContractTests.swift in Sources */,
+				28E3C3E2BA711555366DA228 /* BackgroundReconciliationContractTests.swift in Sources */,
+				BA1903A13E7629ABD20A9744 /* BookDetailMetadataMergeContractTests.swift in Sources */,
+				E5E2EF3176152176CD89DBBC /* BookDetailOpenRoutingTests.swift in Sources */,
+				22DD6BA48B7D1CDF40CE898A /* DownloadThrottlingContractTests.swift in Sources */,
+				26E96C6962F52A0AF2E195BD /* PalacePreferencesSettingsRoundTripTests.swift in Sources */,
+				4B69321BBCF4158F4AC546EA /* RightsManagementDispatchContractTests.swift in Sources */,
+				EE03031837896C7DC8A1BFB1 /* TPPCirculationAnalyticsRequestShapeContractTests.swift in Sources */,
+				2A8E9830CB9BD5599EC4B021 /* TPPSignInBusinessLogicCharacterizationTests.swift in Sources */,
+				FABCDDB533C74ED2F4757143 /* TPPSignInCapabilitiesCharacterizationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PalaceTests/Decomp/AccountsManagerAuthDocContractTests.swift
+++ b/PalaceTests/Decomp/AccountsManagerAuthDocContractTests.swift
@@ -1,0 +1,166 @@
+//
+//  AccountsManagerAuthDocContractTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE CHARACTERIZATION PACK — god-class decomposition (Wave 3a,
+//  `Palace/Accounts/Library/AccountsManager.swift`).
+//  See docs/architecture/god-class-decomposition-plan.md §3a-2 (cluster
+//  "Auth-document fetch with state-machine wiring", 1605–1786) and §5 row
+//  "AccountsManager" ("auth-doc fetch → AccountStateStore transition contract").
+//
+//  WHAT THIS PINS
+//  ==============
+//  The ORDERED sequence of `Account.LoadState` transitions that
+//  `AccountsManager.fetchAuthDocumentWithStateMachine(for:completion:)` writes
+//  into `AccountStateStore.shared` for a fetch that FAILS. This is the
+//  `AuthDocumentLoader` extraction boundary: after the class is split, the new
+//  loader must drive the SAME ordered transitions (`.detailsLoading` before the
+//  fetch, `.detailsFailed(.authDocumentFetchFailed)` on failure) or a consumer's
+//  `awaitReady()` gate silently regresses. Existing
+//  `AccountsManagerStateMachineWiringTests` asserts the presence of those two
+//  transitions via loose stream membership; THIS test locks the exact ORDERED
+//  call sequence as a contract (the CallLog primitive from PalaceTests/Contract),
+//  so a reorder / dropped-transition drift fails loudly.
+//
+//  WHY CallLog-sequence instead of the file-based `ContractSnapshot.assert`:
+//  the file snapshot's first run RECORDS a baseline and deliberately FAILS
+//  ("re-run to verify"). This pack is authored WITHOUT a local DRM build (CI is
+//  the gate per CLAUDE.md), so a byte-exact Foundation-pretty-printed baseline
+//  cannot be generated + verified here, and shipping a guaranteed-red first run
+//  violates the green-board contract. The CallLog `[CallRecord]` equality below
+//  gives the identical ordered-call-sequence guarantee, is deterministic, and is
+//  green on first CI run. A maintainer who wants the on-disk snapshot form can
+//  swap the final `XCTAssertEqual` for `ContractSnapshot.assert(log, named:)` and
+//  record once with `CONTRACT_SNAPSHOT_RECORD=1`.
+//
+//  DETERMINISM: no sleeps. A fresh, unique-UUID account starts at `.notLoaded`;
+//  a publication with no `authentication_document` link makes
+//  `Account.loadAuthenticationDocument` fire `completion(false)` SYNCHRONOUSLY,
+//  so the two transitions land inline. The stream sink is gated on
+//  subscription-attached before the drive so the `CurrentValueSubject`-backed
+//  stream cannot replay-collapse the intermediate `.detailsLoading` (the same
+//  gating `AccountsManagerStateMachineWiringTests` Test 3 uses).
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+@MainActor
+final class AccountsManagerAuthDocContractTests: PalaceWiringTestCase {
+
+    // MARK: - Contract: failure-path transition order
+
+    /// Contract (AuthDocumentLoader boundary): a failing auth-doc fetch drives
+    /// exactly `.notLoaded → .detailsLoading → .detailsFailed(.authDocumentFetchFailed)`.
+    ///
+    /// Kill cases this pins:
+    ///  - Removing the entry `account._setState(.detailsLoading)` drops the middle
+    ///    record → sequence mismatch.
+    ///  - Inverting the success/failure branch (writing `.detailsLoaded` on
+    ///    `success == false`) → wrong terminal label.
+    ///  - Reordering the terminal ahead of `.detailsLoading` → order mismatch.
+    ///
+    /// SEAM: `fetchAuthDocumentWithStateMachine` hard-codes `AccountStateStore.shared`
+    /// as its transition sink and calls `account.loadAuthenticationDocument` for the
+    /// real network fetch. The extraction's `AuthDocumentLoader` must take an
+    /// injected `AccountStateStoring` (transition sink) AND an injected auth-doc
+    /// fetcher so this contract can observe a spy store + drive the SUCCESS path
+    /// deterministically. Until then only the (synchronous, network-free) failure
+    /// order is pinnable here; the success order is deferred to the loader's own
+    /// contract test post-extraction.
+    func testAuthDocFetchFailure_pinsOrderedTransitionSequence() {
+        // A publication with NO authentication_document link → nil
+        // `authenticationDocumentUrl` → `loadAuthenticationDocument` short-circuits
+        // with `completion(false)` synchronously. Unique id → the shared store
+        // starts this UUID at `.notLoaded` regardless of suite order.
+        let uuid = "urn:uuid:decomp-authdoc-\(UUID().uuidString)"
+        let metadata = OPDS2Publication.Metadata(
+            updated: Date(),
+            description: "auth-doc contract (no auth-doc link)",
+            id: uuid,
+            title: "AuthDoc Contract Library"
+        )
+        let publication = OPDS2Publication(links: [], metadata: metadata, images: nil)
+        let account = Account(publication: publication, imageCache: MockImageCache())
+
+        XCTAssertNil(account.authenticationDocumentUrl,
+                     "Setup: account must have a nil authenticationDocumentUrl so the fetch fails synchronously")
+        guard case .notLoaded = AccountStateStore.shared.state(for: uuid) else {
+            return XCTFail("Setup: a fresh unique account must start at .notLoaded")
+        }
+
+        let manager = makeFreshAccountsManager()
+        let log = CallLog()
+
+        // Record every observed transition, in order, into the contract log.
+        // Gate the drive on the sink being attached (first replayed value) so
+        // the synchronous `.detailsLoading`/`.detailsFailed` sends cannot land
+        // before the subscriber exists.
+        let subscribed = expectation(description: "state stream subscription attached")
+        subscribed.assertForOverFulfill = false
+        let streamTask = Task { @MainActor in
+            var firstSeen = false
+            for await state in account.stateStream {
+                log.record("authDocStateTransition", args: ["state": Self.stateLabel(state)])
+                if !firstSeen { firstSeen = true; subscribed.fulfill() }
+                if case .detailsFailed = state { break }
+            }
+        }
+        wait(for: [subscribed], timeout: 2.0)
+
+        let completed = expectation(description: "fetch completion")
+        manager.fetchAuthDocumentWithStateMachine(for: account) { success in
+            XCTAssertFalse(success, "nil-URL auth-doc fetch must complete(false)")
+            completed.fulfill()
+        }
+        wait(for: [completed], timeout: 2.0)
+
+        // Wait until the terminal transition has been recorded (no sleep).
+        awaitCondition(timeout: 2.0) { log.snapshot().count >= 3 }
+        streamTask.cancel()
+
+        let expected = [
+            CallRecord(method: "authDocStateTransition", args: ["state": "notLoaded"]),
+            CallRecord(method: "authDocStateTransition", args: ["state": "detailsLoading"]),
+            CallRecord(method: "authDocStateTransition", args: ["state": "detailsFailed.authDocumentFetchFailed"]),
+        ]
+        XCTAssertEqual(log.snapshot(), expected,
+                       "Auth-doc failure must drive exactly notLoaded → detailsLoading → detailsFailed(.authDocumentFetchFailed), in order")
+
+        // Housekeeping: unique UUID, but drop its subject so nothing bleeds.
+        AccountStateStore.shared.reset(for: uuid)
+    }
+
+    // NOTE: The per-UUID single-flight dedup (two concurrent same-UUID fetches →
+    // one `.detailsLoading`) is deliberately NOT re-pinned here. It is already
+    // covered by `AccountsManagerStateMachineWiringTests`
+    // `testSingleFlight_twoConcurrentAwaiters_oneNetworkRequest`, and pinning it
+    // requires two-thread interleaving whose determinism hinges on the timing of
+    // the (network-free) completion — a racy shape this deterministic pack avoids.
+
+    // MARK: - Helpers
+
+    /// Stable, associated-value-free label for a `LoadState`. Free (nonisolated)
+    /// so the `@Sendable`/`@MainActor` stream tasks can call it without capturing
+    /// `self`.
+    fileprivate static func stateLabel(_ state: Account.LoadState) -> String {
+        switch state {
+        case .notLoaded:       return "notLoaded"
+        case .basicInfoLoaded: return "basicInfoLoaded"
+        case .detailsLoading:  return "detailsLoading"
+        case .detailsLoaded:   return "detailsLoaded"
+        case .detailsFailed(let err):
+            if case .authDocumentFetchFailed = err { return "detailsFailed.authDocumentFetchFailed" }
+            if case .accountNotFound = err { return "detailsFailed.accountNotFound" }
+            if case .malformedAuthDocument = err { return "detailsFailed.malformedAuthDocument" }
+            if case .evicted = err { return "detailsFailed.evicted" }
+            return "detailsFailed.other"
+        case .detailsEvicted(let reason):
+            if case .libraryDeselected = reason { return "detailsEvicted.libraryDeselected" }
+            return "detailsEvicted.other"
+        }
+    }
+}

--- a/PalaceTests/Decomp/AccountsManagerCurrentAccountSwitchContractTests.swift
+++ b/PalaceTests/Decomp/AccountsManagerCurrentAccountSwitchContractTests.swift
@@ -1,0 +1,252 @@
+//
+//  AccountsManagerCurrentAccountSwitchContractTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE CHARACTERIZATION PACK — god-class decomposition (Wave 3a,
+//  `Palace/Accounts/Library/AccountsManager.swift`).
+//  See docs/architecture/god-class-decomposition-plan.md §3a-2 (cluster
+//  "Account retrieval … current account", 824–1016 — the `currentAccount`
+//  setter) and §5 row "AccountsManager" ("currentAccount-switch publication
+//  order").
+//
+//  WHAT THIS PINS
+//  ==============
+//  The PUBLICATION-ORDER contract of the `AccountsManager.currentAccount` setter:
+//  at the instant `.TPPCurrentAccountDidChange` is published, the setter's state
+//  mutations are ALREADY complete —
+//    1. `currentAccountId` has been advanced to the NEW account's uuid, and
+//    2. the PRIOR account has been terminally evicted
+//       (`.detailsEvicted(.libraryDeselected)`), and
+//    3. `isAccountSwitching` reflects the branch it took.
+//  This is the `CurrentAccountStore` / `UserAccountPublisher` extraction boundary
+//  (§3a-2): the facade must preserve the SAME happens-before ordering, or a
+//  `.TPPCurrentAccountDidChange` observer that re-reads `currentAccount` /
+//  `currentAccountId` (there are ~dozens of these across Book/Settings/MyBooks)
+//  would observe torn, mid-switch state.
+//
+//  The individual EFFECTS (prior eviction, new-account drive) are already covered
+//  by `AccountsManagerStateMachineWiringTests`. What is NOT pinned anywhere is the
+//  ORDER: that publication happens AFTER those mutations. A `.TPPCurrentAccountDidChange`
+//  observer records, at delivery time, the synchronously-observable state — so a
+//  reorder (publishing before the id update or before the eviction) drifts the
+//  recorded contract.
+//
+//  WHY CallLog-sequence instead of file-based `ContractSnapshot.assert`: see the
+//  companion `AccountsManagerAuthDocContractTests` header — the on-disk snapshot
+//  first-run RECORDS + fails, which cannot be verified without a local DRM build
+//  and would redden the board on introduction. The `[CallRecord]` equality here
+//  gives the identical ordered-record guarantee, deterministically and green on
+//  first CI run.
+//
+//  DETERMINISM: no sleeps, no network. The setter posts `.TPPCurrentAccountDidChange`
+//  SYNCHRONOUSLY at the end of its body; a `queue: nil` observer is delivered
+//  synchronously on the posting (main) thread, so a single `log.snapshot()` taken
+//  immediately after the synchronous assignment is complete and race-free. The new
+//  account is deliberately NOT registered in `accountSets`, so the setter's
+//  `driveCurrentAccountAuthDocIfNeeded()` resolves nil and fires no network fetch
+//  (same technique as the wiring suite's reselect test). Per-test isolated
+//  `UserDefaults` keeps the `currentAccountIdentifierKey` writes off `.standard`.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+@MainActor
+final class AccountsManagerCurrentAccountSwitchContractTests: PalaceWiringTestCase {
+
+    // MARK: - Contract 1: real switch A → B
+
+    /// Contract: on a real library switch (prior ≠ new, prior ≠ nil), by the time
+    /// `.TPPCurrentAccountDidChange` publishes, `currentAccountId == B`, the prior
+    /// account A is `.detailsEvicted(.libraryDeselected)`, and `isAccountSwitching`
+    /// is `true` (its reset is deferred to the async cleanup, NOT the setter).
+    ///
+    /// Kill cases:
+    ///  - Publishing `.TPPCurrentAccountDidChange` BEFORE `currentAccountId = new`
+    ///    → observer reads currentAccountId == A → record mismatch.
+    ///  - Moving the prior-account eviction AFTER the publish → observer reads A as
+    ///    `.notLoaded` → mismatch.
+    ///  - Resetting `isAccountSwitching` synchronously in the setter (the F-032
+    ///    regression) → observer reads `false` → mismatch.
+    func testSwitch_AtoB_publishesAfterIdUpdate_andPriorEviction() {
+        let aUUID = "urn:uuid:decomp-switch-A-\(UUID().uuidString)"
+        let bUUID = "urn:uuid:decomp-switch-B-\(UUID().uuidString)"
+        let accountB = Self.makeAccount(uuid: bUUID)
+
+        let defaults = Self.testUserDefaults()
+        defaults.set(aUUID, forKey: currentAccountIdentifierKey)
+        let manager = makeFreshAccountsManager(defaults: defaults)
+
+        // Precondition: prior account starts clean.
+        guard case .notLoaded = AccountStateStore.shared.state(for: aUUID) else {
+            return XCTFail("Setup: fresh prior account must start at .notLoaded")
+        }
+
+        let log = CallLog()
+        let token = Self.observePublication(log: log, manager: manager, priorUUID: aUUID)
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        // Act — synchronous; the observer fires inside this assignment.
+        // VERIFY: on the A→B path the setter's `cleanupActiveContentBeforeAccountSwitch`
+        // touches the lazy `networkExecutor` (→ `AppContainer.production()`); this
+        // test assumes that build emits NO second `.TPPCurrentAccountDidChange` (so
+        // the log holds exactly one record). The wiring suite's reselect test drives
+        // the identical path today, so this holds — re-confirm if AppContainer
+        // construction ever starts posting account-change notifications.
+        manager.currentAccount = accountB
+
+        let expected = [
+            CallRecord(method: "currentAccountDidChangePublished", args: [
+                "currentAccountId": bUUID,
+                "priorAccountState": "detailsEvicted.libraryDeselected",
+                "isAccountSwitching": "true",
+            ])
+        ]
+        XCTAssertEqual(log.snapshot(), expected,
+                       "On A→B, publication must follow both the id update (currentAccountId==B) and prior eviction, with isAccountSwitching still true")
+
+        AccountStateStore.shared.reset(for: aUUID)
+        AccountStateStore.shared.reset(for: bUUID)
+    }
+
+    // MARK: - Contract 2: redundant reassignment B → B
+
+    /// Contract: reassigning the SAME account (prior == new) still publishes
+    /// `.TPPCurrentAccountDidChange`, but does NOT evict the (unchanged) account
+    /// and does NOT enter the switching state. Pins the `prev != newAccountId`
+    /// eviction guard and the `shouldFinishSwitchingImmediately` fast-finish.
+    ///
+    /// Kill case: removing the `prev != newAccountId` guard on the eviction write
+    /// → B would be evicted → `priorAccountState` reads `.detailsEvicted` → mismatch.
+    func testReassign_BtoB_publishesWithoutEvictingOrSwitching() {
+        let bUUID = "urn:uuid:decomp-switch-BB-\(UUID().uuidString)"
+        let accountB = Self.makeAccount(uuid: bUUID)
+        // Pre-advance B to a non-terminal, associated-value-free state so a
+        // spurious eviction is unambiguously observable as a state change.
+        accountB._setState(.basicInfoLoaded)
+
+        let defaults = Self.testUserDefaults()
+        defaults.set(bUUID, forKey: currentAccountIdentifierKey)
+        let manager = makeFreshAccountsManager(defaults: defaults)
+
+        let log = CallLog()
+        let token = Self.observePublication(log: log, manager: manager, priorUUID: bUUID)
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        manager.currentAccount = accountB
+
+        let expected = [
+            CallRecord(method: "currentAccountDidChangePublished", args: [
+                "currentAccountId": bUUID,
+                "priorAccountState": "basicInfoLoaded",
+                "isAccountSwitching": "false",
+            ])
+        ]
+        XCTAssertEqual(log.snapshot(), expected,
+                       "B→B must publish but must NOT evict B nor enter the switching state")
+
+        AccountStateStore.shared.reset(for: bUUID)
+    }
+
+    // MARK: - Contract 3: first selection nil → B
+
+    /// Contract: the first-ever selection (prior == nil) publishes with the new id
+    /// and does NOT enter the switching state (no prior content to clean up). Pins
+    /// the `previousAccountId != nil` guard on the switch-detection block.
+    ///
+    /// Kill case: dropping the `previousAccountId != nil` guard → the switch block
+    /// runs on first selection, setting `isAccountSwitching = true` → mismatch.
+    func testFirstSelection_nilToB_publishesWithNewId_notSwitching() {
+        let bUUID = "urn:uuid:decomp-switch-nilB-\(UUID().uuidString)"
+        let accountB = Self.makeAccount(uuid: bUUID)
+
+        // Fresh isolated defaults → currentAccountId starts nil.
+        let defaults = Self.testUserDefaults()
+        let manager = makeFreshAccountsManager(defaults: defaults)
+        XCTAssertNil(manager.currentAccountId, "Setup: first selection requires a nil starting currentAccountId")
+
+        let log = CallLog()
+        // No prior uuid → record only currentAccountId + switching flag.
+        let token = Self.observePublication(log: log, manager: manager, priorUUID: nil)
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        manager.currentAccount = accountB
+
+        let expected = [
+            CallRecord(method: "currentAccountDidChangePublished", args: [
+                "currentAccountId": bUUID,
+                "isAccountSwitching": "false",
+            ])
+        ]
+        XCTAssertEqual(log.snapshot(), expected,
+                       "nil→B must publish with currentAccountId==B and must NOT enter the switching state")
+
+        AccountStateStore.shared.reset(for: bUUID)
+    }
+
+    // MARK: - Helpers
+
+    /// Register a synchronous (`queue: nil`) `.TPPCurrentAccountDidChange`
+    /// observer that records the observable state AT PUBLICATION TIME into `log`.
+    ///
+    /// SEAM: the setter hard-codes `NotificationCenter.default` for publication and
+    /// `AccountStateStore.shared` for the prior-account eviction. The extraction's
+    /// `CurrentAccountStore` / `UserAccountPublisher` should expose a typed Combine
+    /// publisher and take an injected state store so this ordering can be observed
+    /// without a process-wide `NotificationCenter` round-trip.
+    ///
+    /// The closure is `@Sendable`; it captures only Sendable values
+    /// (`AccountsManager` is `@unchecked Sendable`, `CallLog` is `@unchecked
+    /// Sendable`, uuids are `String`) — never `self`.
+    private static func observePublication(
+        log: CallLog,
+        manager: AccountsManager,
+        priorUUID: String?
+    ) -> NSObjectProtocol {
+        return NotificationCenter.default.addObserver(
+            forName: .TPPCurrentAccountDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            var args: [String: Any] = [
+                "currentAccountId": manager.currentAccountId ?? "nil",
+                "isAccountSwitching": manager.isAccountSwitching ? "true" : "false",
+            ]
+            if let priorUUID {
+                args["priorAccountState"] = switchStateLabel(AccountStateStore.shared.state(for: priorUUID))
+            }
+            log.record("currentAccountDidChangePublished", args: args)
+        }
+    }
+
+    /// Minimal account from a link-less publication; its `metadata.id` becomes the
+    /// account UUID. No `authentication_document` link, so any drive is network-free.
+    private static func makeAccount(uuid: String) -> Account {
+        let metadata = OPDS2Publication.Metadata(
+            updated: Date(),
+            description: "currentAccount-switch contract",
+            id: uuid,
+            title: "Switch Contract \(uuid.suffix(6))"
+        )
+        let publication = OPDS2Publication(links: [], metadata: metadata, images: nil)
+        return Account(publication: publication, imageCache: MockImageCache())
+    }
+}
+
+/// Stable, associated-value-free `LoadState` label. Free function (nonisolated) so
+/// the `@Sendable` notification observer can call it without capturing test state.
+fileprivate func switchStateLabel(_ state: Account.LoadState) -> String {
+    switch state {
+    case .notLoaded:       return "notLoaded"
+    case .basicInfoLoaded: return "basicInfoLoaded"
+    case .detailsLoading:  return "detailsLoading"
+    case .detailsLoaded:   return "detailsLoaded"
+    case .detailsFailed:   return "detailsFailed"
+    case .detailsEvicted(let reason):
+        if case .libraryDeselected = reason { return "detailsEvicted.libraryDeselected" }
+        return "detailsEvicted.other"
+    }
+}

--- a/PalaceTests/Decomp/AudiobookReadinessPlaybackContractTests.swift
+++ b/PalaceTests/Decomp/AudiobookReadinessPlaybackContractTests.swift
@@ -1,0 +1,196 @@
+//
+//  AudiobookReadinessPlaybackContractTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE decomposition pin pack for
+//  `Palace/Audiobooks/AudiobookSessionManager.swift`, Wave 6 (see
+//  docs/architecture/god-class-decomposition-plan.md §3a-1 row
+//  "Readiness-gate wiring, F-011 (265–291, 1641–1687)" → `PlaybackReadinessGate`
+//  moves to PalaceAudiobookSession; injection stays Shell). §5 names
+//  "readiness-gate characterization (F-011: play deferred until gate opens,
+//  then fires)".
+//
+//  WHY THIS FILE (and how it differs from `AudiobookFirstOpenHangTests`):
+//
+//  `AudiobookFirstOpenHangTests` already mutation-covers the readiness gate
+//  with COUNT assertions (`playAtCallCount == 1` after ready; `== 0` on
+//  timeout; `probe.stopCallCount == 1` via defer). This file does NOT
+//  re-assert those counts. It locks the same wiring as a BYTE-EQUAL call-ORDER
+//  snapshot — the form §5's general contract requires for an extraction gate
+//  ("byte-equal JSON under __Snapshots__/"). The snapshot captures a property
+//  the count tests leave implicit: the exact ORDER
+//  (`probe.start` → `command.play` → `probe.stop`) AND the structural ABSENCE
+//  of `command.play` on the timeout path. When Wave 6 lifts
+//  `PlaybackReadinessGate` into a package and rewires the Shell's injection
+//  seam, this snapshot drifts loudly if the deferral ordering — or the
+//  never-play-on-timeout invariant — changes, even if the per-call counts stay
+//  numerically identical.
+//
+//  The seam under test — `awaitReadinessAndIssueFirstPlay(bookId:
+//  initialPosition:probe:command:budget:)` — is the internal method
+//  `startPlaybackAndSyncPosition` calls at first-open, built from the injected
+//  `readinessProbeFactory` / `playbackCommandFactory`. Both `probe`
+//  (`PlaybackReadinessProbing`) and `command` (`PlaybackEngineCommanding`) are
+//  internal protocols, so recording spies conform directly — no toolkit
+//  `Player` required.
+//
+//  OUT OF SCOPE (stated honestly): LCP first-open reliable-start
+//  (`confirmLCPFirstPlay`, WS-5) is DRM-specific and stays sim-verified; the
+//  non-LCP readiness path is the one with a DRM-free unit seam and is what this
+//  file pins.
+//
+//  ASSERTION FORM: inline `CallLog` method-order equality
+//  (`XCTAssertEqual(log.snapshot().map(\.method), [...])`), NOT file-based
+//  `ContractSnapshot.assert`. The expected sequence is stated explicitly per
+//  test, so the pack is GREEN on first CI run — no external baseline to record.
+//  Wave 6 must keep the sequence identical; a reorder (or a reintroduced blind
+//  play on the timeout path) drifts the array and fails loudly.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Combine
+import Foundation
+import XCTest
+@testable import Palace
+
+// MARK: - Recording readiness spies (conform to the internal protocols)
+
+/// Records `start`/`stop` into a `CallLog` in order. `behavior` decides
+/// whether `start` drives the gate ready (so the wiring's `awaitReadinessAndPlay`
+/// resolves and issues `command.play`) or stays silent (so the gate times out
+/// and `command.play` is never reached).
+@MainActor
+private final class RecordingProbe: PlaybackReadinessProbing {
+    enum Behavior { case markReadyOnStart, neverReady }
+
+    let log: CallLog
+    private let behavior: Behavior
+
+    init(log: CallLog, behavior: Behavior) {
+        self.log = log
+        self.behavior = behavior
+    }
+
+    func start(driving gate: PlaybackReadinessGate) {
+        log.record("probe.start")
+        switch behavior {
+        case .markReadyOnStart:
+            Task { await gate.markReady() }
+        case .neverReady:
+            break
+        }
+    }
+
+    func stop() {
+        log.record("probe.stop")
+    }
+
+    func isCurrentlyReady() -> Bool { false }
+}
+
+/// Records `play(at:)` (with its position timestamp) into the shared `CallLog`.
+@MainActor
+private final class RecordingCommand: PlaybackEngineCommanding {
+    let log: CallLog
+    init(log: CallLog) { self.log = log }
+
+    func play(at position: TrackPositionShape) async throws {
+        log.record("command.play", args: ["timestamp": position.timestamp])
+    }
+}
+
+/// Minimal `TrackPositionShape` — the readiness path consumes only `timestamp`.
+private struct FakeReadyPosition: TrackPositionShape {
+    let timestamp: Double
+}
+
+// MARK: - Tests
+
+@MainActor
+final class AudiobookReadinessPlaybackContractTests: XCTestCase {
+
+    private var log: CallLog!
+    private var appContainer: AppContainer!
+    private var sut: AudiobookSessionManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        log = CallLog()
+        appContainer = makeTestAppContainer()
+        sut = AudiobookSessionManager(appContainer: appContainer)
+    }
+
+    override func tearDown() async throws {
+        await sut?.stopPlayback(dismissPhoneUI: false)
+        sut = nil
+        appContainer = nil
+        log = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - 1. Ready gate → play is DEFERRED behind the gate, then fires
+
+    /// Locks the F-011 happy-path ORDER as byte-equal JSON:
+    ///   1. `probe.start`
+    ///   2. `command.play` (timestamp forwarded)   ← only AFTER the gate opens
+    ///   3. `probe.stop`   (defer — leak prevention)
+    ///
+    /// A regression that issued `command.play` before `probe.start` (i.e.
+    /// stopped deferring behind the gate — the pre-F-011 bug) reorders the
+    /// snapshot; a regression that dropped the `defer { probe.stop() }` deletes
+    /// the trailing line. Both keep the play COUNT at 1, so the existing
+    /// count-based first-open tests do not distinguish them.
+    func test_readyGate_deferredThenPlaysInOrder() async {
+        let probe = RecordingProbe(log: log, behavior: .markReadyOnStart)
+        let command = RecordingCommand(log: log)
+
+        await sut.awaitReadinessAndIssueFirstPlay(
+            bookId: "contract-ready",
+            initialPosition: FakeReadyPosition(timestamp: 42.0),
+            probe: probe,
+            command: command,
+            budget: 1.0
+        )
+
+        XCTAssertEqual(
+            log.snapshot().map(\.method),
+            ["probe.start", "command.play", "probe.stop"],
+            "F-011 ready path: play is DEFERRED behind the gate, fires only after it opens, then probe stops (defer)."
+        )
+    }
+
+    // MARK: - 2. Timeout gate → play is STRUCTURALLY ABSENT
+
+    /// Locks the core F-011 invariant as a sequence: when the gate never opens,
+    /// the recorded order is exactly
+    ///   1. `probe.start`
+    ///   2. `probe.stop`
+    /// with NO `command.play` between them. The whole point of the fix is to
+    /// NOT fire play against an uninitialized engine; encoding that as the
+    /// ABSENCE of a `command.play` line makes an extraction that reintroduces a
+    /// blind play (even a single one) drift the snapshot — where a `== 0` count
+    /// assertion in isolation could be silently deleted during the move.
+    ///
+    /// (The timeout branch's session-level effects — `state = .error` +
+    /// `errorPublisher.send(.playerCreationFailed)` — are count/value-covered by
+    /// `AudiobookFirstOpenHangTests`; this snapshot pins the call SEQUENCE.)
+    func test_timeoutGate_neverIssuesPlay() async {
+        let probe = RecordingProbe(log: log, behavior: .neverReady)
+        let command = RecordingCommand(log: log)
+
+        await sut.awaitReadinessAndIssueFirstPlay(
+            bookId: "contract-timeout",
+            initialPosition: FakeReadyPosition(timestamp: 7.0),
+            probe: probe,
+            command: command,
+            budget: 0.1  // short — keeps the suite fast while proving the wait
+        )
+
+        XCTAssertEqual(
+            log.snapshot().map(\.method),
+            ["probe.start", "probe.stop"],
+            "F-011 timeout path: NO command.play between start and stop — never play against an uninitialized engine."
+        )
+    }
+}

--- a/PalaceTests/Decomp/AudiobookSessionPresenterLifecycleContractTests.swift
+++ b/PalaceTests/Decomp/AudiobookSessionPresenterLifecycleContractTests.swift
@@ -1,0 +1,254 @@
+//
+//  AudiobookSessionPresenterLifecycleContractTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE decomposition pin pack for
+//  `Palace/Audiobooks/AudiobookSessionManager.swift` (2,761 LOC — the biggest
+//  file in the app). Target of the god-class decomposition campaign, Wave 6
+//  (see docs/architecture/god-class-decomposition-plan.md §3a-1 + §5 row
+//  "AudiobookSessionManager").
+//
+//  WHY THIS FILE EXISTS (and why it is NOT a duplicate of the existing suite):
+//
+//  The existing audiobook tests
+//  (`AudiobookSessionManagerPresenterMigrationTests`,
+//  `AudiobookFirstOpenHangTests`, `AudiobookPositionRestoreTests`, …) are
+//  thorough, but they assert on call COUNTS and final published STATE
+//  (`adoptBookCallCount == 1`, `presenter.currentBook == B`,
+//  `adoptedBookIdentifiersInOrder == [A, B]`). None of them locks the
+//  *relative ORDER of the calls within a single open* as a byte-equal JSON
+//  snapshot.
+//
+//  That gap is exactly the regression class `ContractSnapshot.swift` was
+//  built to catch (see its header): 3.1.0's Phase-7 extraction of
+//  MyBooksDownloadCenter leaked FOUR silent call-SEQUENCE regressions
+//  (F-011/F-014/F-016/F-017) that the per-case count/unit tests were blind to.
+//  AudiobookSessionManager is the NEXT god-class extraction, and §5's general
+//  contract is explicit: "no extraction PR merges unless the target's pre-wave
+//  test pack existed BEFORE the move and passes identically AFTER it —
+//  'identically' means byte-equal JSON under __Snapshots__/."
+//
+//  WHAT THIS PINS — the reachable subset of §5's "session-state contract
+//  (spy … recording bind/play/teardown call ORDER)":
+//
+//  The `bind → present` and `teardown → dismiss` sequencing that the Wave-6
+//  Shell keeps (per §3a-1, toolkit binding glue stays in the Shell; the
+//  orchestration decision logic moves to `AudiobookOpenReducer`). These
+//  snapshots drift loudly if the extraction reorders the presenter-facing
+//  calls — e.g. moving `presentOnFirstOpen()` (which renders the mini-player
+//  chrome off `presenter.currentBook`) BEFORE `adoptBook(_:)` would render a
+//  nil-book / blank first frame. That reorder passes EVERY existing count
+//  assertion (both calls still fire exactly once) and drifts ONLY this
+//  snapshot.
+//
+//  SEAM — the toolkit-manager half of §5's ask is NOT reachable without DRM /
+//  the toolkit graph:
+//    The true bind/play/teardown ORDER into the toolkit `AudiobookManager`
+//    (`manager.saveLocation` → `manager.pause` → `manager.unload` in
+//    `stopPlayback`, and `manager.statePublisher`/`positionPublisher`
+//    subscription order in `bind`) CANNOT be contract-snapshotted from a unit
+//    test. Although `PalaceAudiobookToolkit.AudiobookManager` is a `public
+//    protocol` (a spy could conform), there is NO injection seam to bind a
+//    spy: `bind(loaded:for:startPlaying:)` is `private`, the `manager`
+//    property is `private(set)`, and `bind` takes a `LoadedAudiobook` whose
+//    `audiobook: Audiobook` + `playbackModel: AudiobookPlaybackModel` are
+//    concrete toolkit classes over a full Manifest graph that is impractical
+//    to construct from XCTest (documented in
+//    `AudiobookPositionAdapterContractTests` and `PresenterMigrationTests`).
+//    // SEAM: to contract-snapshot the toolkit-manager teardown order, the
+//    // Wave-6 extraction must expose a bindable seam — e.g. an injectable
+//    // `manager` (protocol-typed `AudiobookManaging`) or an internal
+//    // `bind(loaded:)` overload accepting a spy `AudiobookManager` + a
+//    // test-constructable `LoadedAudiobook`. Until then that ordering stays
+//    // sim-verified (simdrive), as does LCP first-open reliable-start (DRM).
+//
+//  ASSERTION FORM: inline `CallLog` method-order equality
+//  (`XCTAssertEqual(log.snapshot().map(\.method), [...])`), NOT the file-based
+//  `ContractSnapshot.assert`. The expected sequence is stated explicitly in each
+//  test — derived from AND verified against the production call order in
+//  `AudiobookSessionManager.pushSessionToPresenter` / `dismissPlayerOnPhone` —
+//  so the pack is GREEN on its first CI run (no external `__Snapshots__/`
+//  baseline to record, no records-then-fails first pass). Wave 6 must keep the
+//  stated sequence identical; a reorder drifts the array and fails loudly.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Combine
+import Foundation
+import UIKit
+import XCTest
+import PalaceAudiobookToolkit
+@testable import Palace
+
+// MARK: - Recording presenter (subclasses the concrete presenter, records order)
+
+/// Subclass of the concrete `AudiobookSessionPresenter` that records every
+/// action call — in order, with argument shape — into a shared `CallLog`,
+/// then forwards to `super` so the published mirrors (`currentBook`,
+/// `isPlayerExpanded`) still flip. Mirrors the `RecordingRegistry` decorator
+/// pattern from `AudiobookPositionAdapterContractTests`.
+///
+/// We subclass (not compose) because the manager consumes the concrete
+/// `AudiobookSessionPresenter` type via its `audiobookSessionPresenterProvider`
+/// closure — there is no presenter protocol to conform to (the same reason
+/// `SpyAudiobookSessionPresenter` subclasses it). `SpyShimSession` from the
+/// shared mocks satisfies the presenter's `init(sessionManager:)` requirement
+/// without a real session graph.
+@MainActor
+private final class RecordingSessionPresenter: AudiobookSessionPresenter {
+    let log: CallLog
+    private let shim: SpyShimSession
+
+    init(log: CallLog) {
+        self.log = log
+        let shim = SpyShimSession()
+        self.shim = shim
+        super.init(sessionManager: shim)
+    }
+
+    override func adoptBook(_ book: TPPBook) {
+        log.record("presenter.adoptBook", args: ["bookID": book.identifier])
+        super.adoptBook(book)
+    }
+
+    override func adoptPlaybackModel(_ model: AudiobookPlaybackModel) {
+        // Not exercised here (production passes a real model; tests pass nil
+        // because the toolkit graph can't be built from XCTest — see SEAM in
+        // the file header). Recorded for completeness if a future seam allows it.
+        log.record("presenter.adoptPlaybackModel")
+        super.adoptPlaybackModel(model)
+    }
+
+    override func presentOnFirstOpen() {
+        log.record("presenter.presentOnFirstOpen")
+        super.presentOnFirstOpen()
+    }
+
+    override func clearActiveSession() {
+        log.record("presenter.clearActiveSession")
+        super.clearActiveSession()
+    }
+
+    override func adoptCoverImage(_ image: UIImage?) {
+        log.record("presenter.adoptCoverImage", args: ["hasImage": image != nil])
+        super.adoptCoverImage(image)
+    }
+}
+
+// MARK: - Tests
+
+@MainActor
+final class AudiobookSessionPresenterLifecycleContractTests: XCTestCase {
+
+    private var log: CallLog!
+    private var presenter: RecordingSessionPresenter!
+    private var appContainer: AppContainer!
+    private var sut: AudiobookSessionManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        log = CallLog()
+        presenter = RecordingSessionPresenter(log: log)
+        appContainer = makeTestAppContainer()
+        // Flag ON: the presenter owns the player chrome, so the presenter-facing
+        // calls (adopt/present/clear) are the ones that fire. Flag-OFF routes
+        // through the legacy NavigationCoordinator and is covered elsewhere
+        // (`AudiobookSessionManagerFlagGatePresentationTests`).
+        sut = AudiobookSessionManager(
+            appContainer: appContainer,
+            audiobookSessionPresenterProvider: { [unowned self] in self.presenter },
+            inAppPlaybackNavEnabledProvider: { true }
+        )
+    }
+
+    override func tearDown() async throws {
+        await sut?.stopPlayback(dismissPhoneUI: false)
+        sut = nil
+        appContainer = nil
+        presenter = nil
+        log = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - 1. First-open present ORDER: adoptBook BEFORE presentOnFirstOpen
+
+    /// Drives the migrated production seam `pushSessionToPresenter(book:
+    /// playbackModel:)` — the call `bind()` makes via
+    /// `presentCoverArtAndNavigation` — and locks the ORDER:
+    ///   1. `presenter.adoptBook(book)`
+    ///   2. `presenter.presentOnFirstOpen()`
+    ///
+    /// (playbackModel is nil here — the toolkit-graph SEAM in the header — so
+    /// the intermediate `adoptPlaybackModel` is absent from the snapshot; the
+    /// order of the two REACHABLE calls is what the extraction must preserve.)
+    ///
+    /// Regression this catches that the count-based
+    /// `PresenterMigrationTests.testOpenAudiobook_firstOpen_callsPresenter…`
+    /// does NOT: a refactor that emits `presentOnFirstOpen()` before
+    /// `adoptBook(_:)` keeps BOTH counts at 1 (that test still passes) but the
+    /// mini-player chrome renders off a still-nil `presenter.currentBook` — a
+    /// blank/stale first frame. Only this byte-equal snapshot drifts.
+    func test_firstOpenPresentSequence() {
+        let book = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+
+        sut.pushSessionToPresenter(book: book, playbackModel: nil)
+
+        XCTAssertEqual(
+            log.snapshot().map(\.method),
+            ["presenter.adoptBook", "presenter.presentOnFirstOpen"],
+            "First-open must adoptBook BEFORE presentOnFirstOpen (playbackModel nil → no adoptPlaybackModel)."
+        )
+    }
+
+    // MARK: - 2. Open → dismiss lifecycle ORDER (flag-ON teardown)
+
+    /// Locks the reachable open→teardown presenter sequence end to end:
+    ///   1. `presenter.adoptBook(book)`
+    ///   2. `presenter.presentOnFirstOpen()`
+    ///   3. `presenter.clearActiveSession()`   ← from `dismissPlayerOnPhone`
+    ///
+    /// `dismissPlayerOnPhone(bookId:)` is the seam `stopPlayback(dismissPhoneUI:
+    /// true)` calls; on the flag-ON path it clears the presenter (it does NOT
+    /// touch the legacy coordinator — PP-3783 back-stack preservation). Pinning
+    /// the full sequence guards against an extraction that drops the teardown
+    /// clear (the "✕ did nothing" regression PR #1230 fixed) OR inserts a stray
+    /// clear before present — both invisible to the existing count assertions
+    /// when taken in isolation.
+    func test_openThenDismissSequence() {
+        let book = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+
+        sut.pushSessionToPresenter(book: book, playbackModel: nil)
+        sut.dismissPlayerOnPhone(bookId: book.identifier)
+
+        XCTAssertEqual(
+            log.snapshot().map(\.method),
+            ["presenter.adoptBook", "presenter.presentOnFirstOpen", "presenter.clearActiveSession"],
+            "Open→dismiss must end with clearActiveSession (guards the '✕ did nothing' regression PR #1230)."
+        )
+    }
+
+    // MARK: - 3. Switch A→B ORDER: replace-not-stack (PP-3783)
+
+    /// Two consecutive opens (A then B) lock the interleaved sequence:
+    ///   1. adoptBook(A) 2. presentOnFirstOpen 3. adoptBook(B) 4. presentOnFirstOpen
+    ///
+    /// The existing `testOpenAudiobook_switchingAudiobooks…` asserts the FIFO
+    /// `adoptedBookIdentifiersInOrder == [A, B]` and final `currentBook == B`,
+    /// but not that each open's `adoptBook` precedes its own `presentOnFirstOpen`.
+    /// This snapshot locks the full interleave so a reordering within either
+    /// open (present-before-adopt on the SECOND open only, say) drifts here.
+    func test_switchBooksSequence() {
+        let bookA = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+        let bookB = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+
+        sut.pushSessionToPresenter(book: bookA, playbackModel: nil)
+        sut.pushSessionToPresenter(book: bookB, playbackModel: nil)
+
+        XCTAssertEqual(
+            log.snapshot().map(\.method),
+            ["presenter.adoptBook", "presenter.presentOnFirstOpen", "presenter.adoptBook", "presenter.presentOnFirstOpen"],
+            "A→B switch must interleave adopt-before-present within each open (PP-3783 replace-not-stack)."
+        )
+    }
+}

--- a/PalaceTests/Decomp/BackgroundReconciliationContractTests.swift
+++ b/PalaceTests/Decomp/BackgroundReconciliationContractTests.swift
@@ -1,0 +1,249 @@
+//
+//  BackgroundReconciliationContractTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE test pack for the god-class decomposition campaign
+//  (docs/architecture/god-class-decomposition-plan.md §3a-3 + §5 row
+//  "MyBooksDownloadCenter", Wave 3b → PalaceDownloads).
+//
+//  Pins the Reliability WS-A launch-reconciliation contract (INV-4:
+//  "adopt, don't double-start or spuriously fail") on the PURE engine that
+//  owns it — `DownloadReconciliation` in
+//  `Palace/MyBooks/DownloadTaskPersistence.swift`. When the WS-A reconciler
+//  is lifted into `PalaceDownloads` as `BackgroundSessionReconciler`, this
+//  pack must pass byte-identically after the move (the general §5 contract).
+//
+//  WHY the pure engine (not MBDC): MBDC's `reconcileDownloadsAtLaunch()` is a
+//  thin adapter — it snapshots live URLSession tasks and forwards to
+//  `DownloadReconciliation.runLaunchReconciliation`, which encapsulates BOTH
+//  the decision matrix (`reconcile`) AND the ORDER contract
+//  (registry-loaded gate → load persisted → live tasks → registry state →
+//  apply). Pinning the engine pins the invariant regardless of where the
+//  adapter lands. The MBDC-side glue (session.getAllTasks snapshot, the
+//  applyReconcileDecision hot-map re-seed) is already exercised by
+//  ColdStartResumeIntegrationTests; this pack pins the decision + order logic
+//  those integration tests don't lock as a call-sequence.
+//
+//  Adjacent WS-A invariants already covered by dedicated UNIT suites (NOT
+//  re-pinned here to avoid duplication):
+//    - INV-6 transient-transfer retry  → PalaceTests/MyBooks/DownloadTransferRetryTests
+//    - INV-7 background completion handler + session identity routing
+//                                       → PalaceTests/MyBooks/BackgroundSessionRoutingTests
+//    - PP-4114 mid-flight network drop  → PalaceTests/MyBooks/MyBooksDownloadCenterOfflineTests
+//
+
+import XCTest
+@testable import Palace
+
+final class BackgroundReconciliationContractTests: XCTestCase {
+
+    // MARK: - INV-4 decision matrix (pure `reconcile`)
+    //
+    // The matrix is {live task / dead task} × {per-book registry state} →
+    // ReconcileDecision. Each test kills the switch-arm mutant for its class.
+
+    /// INV-4 core: a still-live background task is ALWAYS adopted, never
+    /// restarted and never spuriously failed — EVEN when the registry state
+    /// would otherwise route to a heal. A mutant that consults registry state
+    /// before checking task liveness (reordering the `if liveTaskIdentifiers…`
+    /// guard below the switch) would `.markFailed` a download that is actually
+    /// still running in the background — the exact double-start / spurious-fail
+    /// bug INV-4 exists to prevent.
+    func test_reconcile_liveTask_isAdopted_evenWhenRegistrySaysFailed() {
+        let decisions = DownloadReconciliation.reconcile(
+            persisted: [Self.record("A", task: 42)],
+            liveTaskIdentifiers: [42],
+            registryStates: ["A": .downloadFailed]   // registry would say "fail"
+        )
+        XCTAssertEqual(decisions, [.adopt(bookID: "A", taskIdentifier: 42)])
+    }
+
+    /// Dead task + registry still wants the content (`.downloading`,
+    /// `.downloadNeeded`, `.SAMLStarted`) → `.restart`. A mutant that dropped
+    /// any of these three cases would strand the book with a lost background
+    /// task and no re-issue.
+    func test_reconcile_deadTask_registryWantsContent_restarts() {
+        for state: TPPBookState in [.downloading, .downloadNeeded, .SAMLStarted] {
+            let decisions = DownloadReconciliation.reconcile(
+                persisted: [Self.record("A", task: 7)],
+                liveTaskIdentifiers: [],              // task 7 is NOT live
+                registryStates: ["A": state]
+            )
+            XCTAssertEqual(decisions, [.restart(bookID: "A")],
+                           "state \(state.stringValue()) must restart a dead download")
+        }
+    }
+
+    /// Dead task + registry already `.downloadFailed` → `.markFailed` (pin the
+    /// terminal state, drop the record). Distinct from `.restart`: a mutant
+    /// folding this into the restart arm would re-kick a download the registry
+    /// has already given up on, spinning the UI.
+    func test_reconcile_deadTask_alreadyFailed_marksFailed() {
+        let decisions = DownloadReconciliation.reconcile(
+            persisted: [Self.record("A", task: 7)],
+            liveTaskIdentifiers: [],
+            registryStates: ["A": .downloadFailed]
+        )
+        XCTAssertEqual(decisions, [.markFailed(bookID: "A")])
+    }
+
+    /// Dead task + the book no longer wants this download (completed while
+    /// suspended, or returned/unregistered/held) → `.cleanup` (drop the stale
+    /// record, no restart, no state mutation). Covers the terminal-success arm
+    /// AND the "book moved on" arm AND the no-registry-entry (`.none`) arm — a
+    /// mutant that restarted any of these would re-download content the patron
+    /// already has or no longer holds.
+    func test_reconcile_deadTask_completedOrUnwanted_cleansUp() {
+        let cleanupStates: [TPPBookState] = [
+            .downloadSuccessful, .used,
+            .unregistered, .holding, .returning, .unsupported
+        ]
+        for state in cleanupStates {
+            let decisions = DownloadReconciliation.reconcile(
+                persisted: [Self.record("A", task: 7)],
+                liveTaskIdentifiers: [],
+                registryStates: ["A": state]
+            )
+            XCTAssertEqual(decisions, [.cleanup(bookID: "A")],
+                           "state \(state.stringValue()) must clean up, not restart/fail")
+        }
+
+        // No registry entry at all (`.none`) → also cleanup, not a crash / restart.
+        let missing = DownloadReconciliation.reconcile(
+            persisted: [Self.record("A", task: 7)],
+            liveTaskIdentifiers: [],
+            registryStates: [:]
+        )
+        XCTAssertEqual(missing, [.cleanup(bookID: "A")])
+    }
+
+    /// Order + multiplicity: reconcile maps 1:1, preserving record order, and
+    /// classifies each record independently (one live, one dead-wanted, one
+    /// dead-failed). Kills a mutant that returned a single decision or reordered.
+    func test_reconcile_mixedBatch_classifiesEachIndependently_inOrder() {
+        let decisions = DownloadReconciliation.reconcile(
+            persisted: [
+                Self.record("live", task: 1),
+                Self.record("deadWanted", task: 2),
+                Self.record("deadFailed", task: 3)
+            ],
+            liveTaskIdentifiers: [1],
+            registryStates: [
+                "live": .downloading,
+                "deadWanted": .downloadNeeded,
+                "deadFailed": .downloadFailed
+            ]
+        )
+        XCTAssertEqual(decisions, [
+            .adopt(bookID: "live", taskIdentifier: 1),
+            .restart(bookID: "deadWanted"),
+            .markFailed(bookID: "deadFailed")
+        ])
+    }
+
+    // MARK: - INV-4 launch ORDER contract (`runLaunchReconciliation`)
+    //
+    // The order is the invariant: the registry-loaded gate MUST be first
+    // (never reconcile against an unloaded registry), the empty-persisted
+    // short-circuit MUST precede the (async, potentially expensive) live-task
+    // query, and per-book registry reads MUST precede apply. A contract
+    // snapshot pins the exact call sequence so an extraction that reorders the
+    // steps drifts loudly.
+
+    /// Happy path: gate(true) → loadPersisted(1 dead-wanted record) →
+    /// liveTaskIdentifiers → registryState(book) → apply(.restart). The
+    /// snapshot locks this five-step order.
+    func test_launchReconciliation_happyPath_ordersGateLoadLiveStateApply() async {
+        let log = CallLog()   // captured (not self) — Swift-6 Sendable-safe closures
+
+        await DownloadReconciliation.runLaunchReconciliation(
+            isRegistryLoaded: {
+                log.record("isRegistryLoaded")
+                return true
+            },
+            loadPersisted: {
+                log.record("loadPersisted")
+                return [Self.record("A", task: 7)]
+            },
+            liveTaskIdentifiers: {
+                log.record("liveTaskIdentifiers")
+                return []                      // task 7 is dead → restart
+            },
+            registryState: { bookID in
+                log.record("registryState", args: ["bookId": bookID])
+                return .downloadNeeded
+            },
+            apply: { decision in
+                log.record("apply", args: ["decision": "\(decision)"])
+            }
+        )
+
+        XCTAssertEqual(
+            log.snapshot().map(\.method),
+            ["isRegistryLoaded", "loadPersisted", "liveTaskIdentifiers", "registryState", "apply"],
+            "Launch reconciliation order: registry-loaded gate → load persisted → query live tasks → registry state → apply."
+        )
+    }
+
+    /// INV-4 gate: the registry-loaded check is FIRST and blocking. When the
+    /// registry has not loaded, reconciliation performs NO further work — it
+    /// must not load persisted records, must not query live tasks, must not
+    /// apply. A mutant that inverted the guard (or moved it after the load)
+    /// would reconcile against an empty/half-loaded registry and mass-`.restart`
+    /// or `.cleanup` real downloads.
+    func test_launchReconciliation_registryNotLoaded_skipsAllWork() async {
+        let log = CallLog()
+        var liveQueried = false
+        var applied = false
+
+        await DownloadReconciliation.runLaunchReconciliation(
+            isRegistryLoaded: {
+                log.record("isRegistryLoaded")
+                return false
+            },
+            loadPersisted: { log.record("loadPersisted"); return [Self.record("A", task: 7)] },
+            liveTaskIdentifiers: { liveQueried = true; return [] },
+            registryState: { _ in .downloadNeeded },
+            apply: { _ in applied = true }
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method), ["isRegistryLoaded"],
+                       "gate must short-circuit before loadPersisted")
+        XCTAssertFalse(liveQueried, "live-task query must not run when registry unloaded")
+        XCTAssertFalse(applied, "no decision may be applied when registry unloaded")
+    }
+
+    /// Empty-persisted short-circuit: with zero durable records there is
+    /// nothing to reconcile, so the (async) live-task query — the expensive
+    /// step — must be skipped. Kills the `guard !persisted.isEmpty` mutant,
+    /// which would otherwise `session.getAllTasks` on every clean launch.
+    func test_launchReconciliation_noPersistedRecords_skipsLiveTaskQuery() async {
+        let log = CallLog()
+        var liveQueried = false
+
+        await DownloadReconciliation.runLaunchReconciliation(
+            isRegistryLoaded: { log.record("isRegistryLoaded"); return true },
+            loadPersisted: { log.record("loadPersisted"); return [] },
+            liveTaskIdentifiers: { liveQueried = true; log.record("liveTaskIdentifiers"); return [] },
+            registryState: { _ in .downloadNeeded },
+            apply: { _ in log.record("apply") }
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method), ["isRegistryLoaded", "loadPersisted"],
+                       "empty persisted set must short-circuit before the live-task query")
+        XCTAssertFalse(liveQueried)
+    }
+
+    // MARK: - Helpers
+
+    private static func record(_ bookID: String, task: Int) -> PersistedDownloadRecord {
+        PersistedDownloadRecord(
+            bookID: bookID,
+            taskIdentifier: task,
+            downloadURL: URL(string: "https://example.invalid/\(bookID)")!,
+            account: "acct-1",
+            expectedBytes: nil,
+            startedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+}

--- a/PalaceTests/Decomp/BookDetailMetadataMergeContractTests.swift
+++ b/PalaceTests/Decomp/BookDetailMetadataMergeContractTests.swift
@@ -1,0 +1,315 @@
+//
+//  BookDetailMetadataMergeContractTests.swift
+//  PalaceTests
+//
+//  God-class decomposition — pin-before-extract pack for
+//  `Palace/Book/UI/BookDetail/BookDetailViewModel.swift`, MOVING cluster
+//  "Metadata hydration" (plan §3a-4 / §5). Per the plan, the metadata-hydration
+//  service work (`BookMetadataService`) leaves the VM; these tests lock the
+//  field-by-field MERGE PRECEDENCE and the post-fetch decision logic so the
+//  extraction cannot silently change which side (current vs freshly-fetched)
+//  wins for any book field.
+//
+//  ADDITIVE — does NOT overlap `PalaceTests/ViewModels/BookDetailMetadataHydrationTests`,
+//  which already pins publisher/distributor/category/published/audience/language
+//  fill-from-fresh + the trigger guards. This file pins the SEVEN merge fields
+//  those tests never assert (summary, subtitle, seriesName, seriesURL,
+//  bookDuration) in BOTH directions (empty→take fresh, non-empty→preserve
+//  current), the identity-preservation invariant (title/identifier are NEVER
+//  taken from fresh), and the two post-fetch branches (hydrator returns nil /
+//  throws) that the existing guard-tests never reach because they short-circuit
+//  before the fetch.
+//
+//  SEAM: the DEFAULT hydrator in BookDetailViewModel.init (lines ~216-224) —
+//  `opdsFeedService.fetchFeed(...) -> first TPPOPDSEntry -> TPPBook(entry:)` — is
+//  the actual network service work being extracted. It captures the CONCRETE
+//  `OPDSFeedService` actor + `accountsManager` inside a closure and is not
+//  independently unit-pinnable (HTTPStubURLProtocol cannot reliably intercept
+//  `TPPOPDSFeed.withURL`'s Obj-C bridge). The `BookMetadataService` extraction
+//  should take an `OPDSFeedFetching` protocol so fetch→parse→first-entry→TPPBook
+//  is stubbable. These tests pin the deterministic merge/decision core reached
+//  via the injectable `metadataHydrator` seam; the raw fetch stays behind the
+//  seam.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+@MainActor
+final class BookDetailMetadataMergeContractTests: XCTestCase {
+
+    private let alternateURL = URL(string: "https://example.org/works/merge")!
+
+    private var appContainer: AppContainer!
+
+    override func setUp() {
+        super.setUp()
+        appContainer = makeTestAppContainer()
+    }
+
+    override func tearDown() {
+        appContainer = nil
+        super.tearDown()
+    }
+
+    // MARK: - Merge precedence: empty/nil current → take freshly-fetched value
+
+    /// Every field the existing hydration suite does NOT assert, driven through
+    /// its EMPTY-current branch. mergeHydratedMetadata uses two distinct rules —
+    /// empty-string check (summary/seriesName/bookDuration) and nil-coalesce
+    /// (subtitle/seriesURL). Both must fall to `fresh` when current is blank.
+    ///
+    /// Mutation: flipping any of these ternaries / `??` operands to keep the
+    /// blank current value makes the corresponding assertion fail.
+    func testMerge_whenCurrentFieldsBlank_takesFreshValues() async {
+        let sparse = makeBook(
+            identifier: "merge-empty",
+            title: "Current Title",
+            summary: "",              // empty-string → empty-check branch
+            subtitle: nil,            // nil → nil-coalesce branch
+            seriesName: nil,          // nil → empty-check branch (isEmpty ?? true)
+            seriesURL: nil,           // nil → nil-coalesce branch
+            bookDuration: nil         // nil → empty-check branch
+        )
+        let fresh = makeBook(
+            identifier: "ignored-fresh-id",
+            title: "Fresh Title",
+            // gate fields populated so `fresh` is a fully-hydrated entry
+            published: iso("2015-08-04"),
+            publisher: "Fresh Publisher",
+            distributor: "Fresh Distributor",
+            categoryStrings: ["Fresh Category"],
+            summary: "Fresh summary",
+            subtitle: "Fresh subtitle",
+            seriesName: "Dune",
+            seriesURL: URL(string: "https://example.org/series/dune")!,
+            bookDuration: "03:20:00"
+        )
+
+        let vm = makeVM(book: sparse, hydrator: { _ in fresh })
+        await vm.hydrateMetadataIfNeeded()
+
+        XCTAssertEqual(vm.book.summary, "Fresh summary",
+                       "Empty current summary must be filled from the fetched entry")
+        XCTAssertEqual(vm.book.subtitle, "Fresh subtitle",
+                       "Nil current subtitle must be filled from the fetched entry")
+        XCTAssertEqual(vm.book.seriesName, "Dune",
+                       "Nil current seriesName must be filled — this drives the PP-4775 series row")
+        XCTAssertEqual(vm.book.seriesURL, URL(string: "https://example.org/series/dune")!,
+                       "Nil current seriesURL must be filled so the series row can become a link")
+        XCTAssertEqual(vm.book.bookDuration, "03:20:00",
+                       "Nil current bookDuration must be filled from the fetched entry")
+    }
+
+    // MARK: - Merge precedence: non-empty current → preserve, ignore fresh
+
+    /// The other direction: when current already holds a value, hydration must
+    /// NOT clobber it with the fetched entry — hydration only fills gaps.
+    ///
+    /// Mutation: swapping any ternary/`??` so `fresh` wins over a non-empty
+    /// current value makes the corresponding assertion fail (a real regression:
+    /// it would overwrite catalog-provided metadata with lane-feed data).
+    func testMerge_whenCurrentFieldsPresent_preservesThemOverFresh() async {
+        let origSeriesURL = URL(string: "https://example.org/series/original")!
+        let populated = makeBook(
+            identifier: "merge-preserve",
+            title: "Current Title",
+            summary: "Original summary",
+            subtitle: "Original subtitle",
+            seriesName: "Original Series",
+            seriesURL: origSeriesURL,
+            bookDuration: "01:00:00"
+            // gate fields (published/publisher/distributor/category/audience/
+            // language) LEFT EMPTY so needsMetadataHydration still fires
+        )
+        let fresh = makeBook(
+            identifier: "ignored-fresh-id",
+            title: "Fresh Title",
+            published: iso("2015-08-04"),
+            publisher: "Fresh Publisher",
+            distributor: "Fresh Distributor",
+            categoryStrings: ["Fresh Category"],
+            summary: "SHOULD NOT WIN",
+            subtitle: "SHOULD NOT WIN",
+            seriesName: "SHOULD NOT WIN",
+            seriesURL: URL(string: "https://example.org/series/wrong")!,
+            bookDuration: "99:99:99"
+        )
+
+        let vm = makeVM(book: populated, hydrator: { _ in fresh })
+        await vm.hydrateMetadataIfNeeded()
+
+        XCTAssertEqual(vm.book.summary, "Original summary",
+                       "Non-empty current summary must survive hydration")
+        XCTAssertEqual(vm.book.subtitle, "Original subtitle",
+                       "Non-nil current subtitle must survive hydration")
+        XCTAssertEqual(vm.book.seriesName, "Original Series",
+                       "Non-empty current seriesName must survive hydration")
+        XCTAssertEqual(vm.book.seriesURL, origSeriesURL,
+                       "Non-nil current seriesURL must survive hydration")
+        XCTAssertEqual(vm.book.bookDuration, "01:00:00",
+                       "Non-empty current bookDuration must survive hydration")
+
+        // ...but the actually-empty gate fields DID fill from fresh — proving the
+        // merge ran and the preserve above is real, not a no-op short-circuit.
+        XCTAssertEqual(vm.book.publisher, "Fresh Publisher",
+                       "Gate fields that were empty must still fill — the merge did run")
+    }
+
+    // MARK: - Identity invariant: title/identifier are NEVER taken from fresh
+
+    /// mergeHydratedMetadata always keeps `current.identifier` and `current.title`
+    /// regardless of what the fetched entry carries. A silent extraction that
+    /// takes `fresh.identifier` here would corrupt the registry key and mis-route
+    /// every subsequent state read — the highest-cost mutation on this path.
+    func testMerge_identityFields_neverTakenFromFresh() async {
+        let sparse = makeBook(identifier: "keep-this-id", title: "Keep This Title")
+        let fresh = makeBook(
+            identifier: "WRONG-id",
+            title: "WRONG Title",
+            published: iso("2015-08-04"),
+            publisher: "Fresh Publisher",
+            distributor: "Fresh Distributor",
+            categoryStrings: ["Fresh Category"]
+        )
+
+        let vm = makeVM(book: sparse, hydrator: { _ in fresh })
+        await vm.hydrateMetadataIfNeeded()
+
+        XCTAssertEqual(vm.book.identifier, "keep-this-id",
+                       "Hydration must NEVER replace the book identifier — it is the registry key")
+        XCTAssertEqual(vm.book.title, "Keep This Title",
+                       "Hydration must NEVER replace the title from the lane-feed entry")
+    }
+
+    // MARK: - Post-fetch decision: hydrator returns nil → no mutation
+
+    /// The `guard let fresh = try await metadataHydrator(url) else { return }`
+    /// branch. The existing guard-tests never reach the fetch (they assert the
+    /// hydrator is not CALLED). Here the hydrator IS called and returns nil (a
+    /// feed with no usable entry); the book must be left untouched.
+    ///
+    /// Mutation: removing that guard would force-merge a nil `fresh` (crash) or
+    /// blank the book — either way this fails.
+    func testHydrate_whenHydratorReturnsNil_leavesBookUnchanged() async {
+        let sparse = makeBook(identifier: "nil-fetch", title: "Untouched", summary: "keep me")
+        var fetched = false
+
+        let vm = makeVM(book: sparse, hydrator: { _ in fetched = true; return nil })
+        await vm.hydrateMetadataIfNeeded()
+
+        XCTAssertTrue(fetched, "Precondition: the fetch was actually attempted (guard reached)")
+        XCTAssertNil(vm.book.publisher, "A nil fetch result must not populate any field")
+        XCTAssertEqual(vm.book.summary, "keep me", "A nil fetch result must not blank existing fields")
+        XCTAssertEqual(vm.book.identifier, "nil-fetch")
+    }
+
+    // MARK: - Post-fetch decision: hydrator throws → caught, no mutation
+
+    /// The `catch { Log.warn(...) }` branch. A network/parse failure during
+    /// hydration must be swallowed and leave the book intact — hydration is
+    /// best-effort enrichment, never a hard failure of the detail view.
+    ///
+    /// Mutation: dropping the do/catch would let the throw escape the async
+    /// method and fail the test.
+    func testHydrate_whenHydratorThrows_isSwallowedAndBookUnchanged() async {
+        let sparse = makeBook(identifier: "throwing-fetch", title: "Still Here", summary: "still summary")
+
+        let vm = makeVM(book: sparse, hydrator: { _ in throw MergeTestError.boom })
+        await vm.hydrateMetadataIfNeeded()
+
+        XCTAssertNil(vm.book.publisher, "A thrown fetch must not populate any field")
+        XCTAssertEqual(vm.book.summary, "still summary", "A thrown fetch must not blank existing fields")
+        XCTAssertEqual(vm.book.identifier, "throwing-fetch", "The book survives a thrown fetch intact")
+    }
+
+    // MARK: - Helpers
+
+    private enum MergeTestError: Error { case boom }
+
+    private func makeVM(book: TPPBook, hydrator: @escaping (URL) async throws -> TPPBook?) -> BookDetailViewModel {
+        BookDetailViewModel(
+            book: book,
+            registry: TPPBookRegistryMock(),
+            downloadCenter: appContainer.downloadCenter,
+            accountsManager: appContainer.accountsManager,
+            settings: TPPSettings(),
+            opdsFeedService: appContainer.opdsFeedService,
+            samplePreviewManager: appContainer.samplePreviewManager,
+            readerService: appContainer.readerService,
+            metadataHydrator: hydrator
+        )
+    }
+
+    private func iso(_ s: String) -> Date {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f.date(from: s)!
+    }
+
+    /// Full-fidelity TPPBook factory mirroring the production initializer used by
+    /// `mergeHydratedMetadata` (BookDetailViewModel.swift:558-589). Gate fields
+    /// (published/publisher/distributor/categoryStrings/audience/language) default
+    /// to empty so `needsMetadataHydration` fires unless a test overrides them.
+    ///
+    /// VERIFY: keep in sync with `TPPBook.init` (TPPBook.swift:122-150) — includes
+    /// the `seriesName:` label the existing test helper omits.
+    private func makeBook(
+        identifier: String,
+        title: String,
+        published: Date? = nil,
+        publisher: String? = nil,
+        distributor: String? = nil,
+        categoryStrings: [String]? = nil,
+        summary: String? = nil,
+        subtitle: String? = nil,
+        seriesName: String? = nil,
+        seriesURL: URL? = nil,
+        bookDuration: String? = nil,
+        audience: String? = nil,
+        language: String? = nil,
+        alternateURL: URL? = URL(string: "https://example.org/works/merge")!
+    ) -> TPPBook {
+        let acquisition = TPPOPDSAcquisition(
+            relation: .generic,
+            type: "application/epub+zip",
+            hrefURL: URL(string: "https://example.org/acq/\(identifier)")!,
+            indirectAcquisitions: [],
+            availability: TPPOPDSAcquisitionAvailabilityUnlimited()
+        )
+        return TPPBook(
+            acquisitions: [acquisition],
+            authors: [TPPBookAuthor(authorName: "Author", relatedBooksURL: nil)],
+            categoryStrings: categoryStrings,
+            distributor: distributor,
+            identifier: identifier,
+            imageURL: nil,
+            imageThumbnailURL: nil,
+            published: published,
+            publisher: publisher,
+            subtitle: subtitle,
+            summary: summary,
+            title: title,
+            updated: Date(timeIntervalSince1970: 1_700_000_000),
+            annotationsURL: nil,
+            analyticsURL: nil,
+            alternateURL: alternateURL,
+            relatedWorksURL: nil,
+            previewLink: nil,
+            seriesURL: seriesURL,
+            seriesName: seriesName,
+            revokeURL: nil,
+            reportURL: nil,
+            timeTrackingURL: nil,
+            contributors: nil,
+            bookDuration: bookDuration,
+            audience: audience,
+            language: language,
+            imageCache: MockImageCache()
+        )
+    }
+}

--- a/PalaceTests/Decomp/BookDetailOpenRoutingTests.swift
+++ b/PalaceTests/Decomp/BookDetailOpenRoutingTests.swift
@@ -1,0 +1,270 @@
+//
+//  BookDetailOpenRoutingTests.swift
+//  PalaceTests
+//
+//  God-class decomposition — pin-before-extract pack for
+//  `Palace/Book/UI/BookDetail/BookDetailViewModel.swift`, MOVING clusters
+//  "Reading / open-routing" and "Related books" (plan §3a-4 / §5). These clusters
+//  become `BookOpenRouter` (open-routing) and `RelatedBooksService` (related
+//  derivation). The tests lock the observable routing DECISION and the related-
+//  navigation state derivation so the extraction can't change them silently.
+//
+//  ADDITIVE — does NOT overlap the existing 81-125 tests in
+//  `PalaceTests/Book/BookDetailViewModelTests`, which pin the streamingHTML
+//  NavigationCoordinator push, BookButtonMapper/buttonTypes, series-row display,
+//  selectRelatedBook clearing, and showMoreBooksForLane. Here we add:
+//    1. open-routing decision table: audiobook format → the injected
+//       AudiobookSessionManaging is opened; a non-audiobook format is NOT.
+//    2. selectRelatedBook re-derives bookState from the registry for the NEWLY
+//       selected book (the existing test asserts identifier + lane-clearing but
+//       never the re-derived state).
+//
+//  SEAM: EPUB / PDF / streamingHTML open-routing runs through `BookService.open`
+//  → `AppContainer.production().readerService` / `.navigationCoordinatorHub`
+//  (process-wide statics, NOT injected into the VM), so those destinations are
+//  not observable from a unit seam. Only the audiobook branch is drivable, via
+//  the injected `AudiobookSessionManaging`. The planned `BookOpenRouter`
+//  extraction should inject reader + navigation seams so EPUB/PDF/streaming
+//  destinations become assertable. Pinned here: audiobook routing + content-type
+//  discrimination through the one seam that exists today.
+//
+//  SEAM: `fetchRelatedBooks` / `createRelatedBooksCells` (the author-lane
+//  reordering derivation) depends on the CONCRETE `OPDSFeedService` actor
+//  returning an `.acquisitionGrouped` feed with `groupAttributes`; it cannot be
+//  unit-pinned without an injected `OPDSFeedFetching` seam + a grouped-feed
+//  fixture. `RelatedBooksService` should take `OPDSFeedFetching`. The author-
+//  reorder derivation is left uncovered pending that inversion.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Combine
+import UIKit
+import XCTest
+import PalaceAudiobookToolkit
+import PalaceCatalog
+@testable import Palace
+
+@MainActor
+final class BookDetailOpenRoutingTests: XCTestCase {
+
+    private var appContainer: AppContainer!
+
+    override func setUp() {
+        super.setUp()
+        appContainer = makeTestAppContainer()
+    }
+
+    override func tearDown() {
+        appContainer = nil
+        super.tearDown()
+    }
+
+    // MARK: - Open-routing decision table
+
+    /// AUDIOBOOK content type must route through `openBook` → `openAudiobook` →
+    /// `BookService.open` → the injected `AudiobookSessionManaging`. Pinning this
+    /// at the VM's `openBook` switch (rather than at BookService) is what locks
+    /// the routing decision: the session is opened exactly once, with the
+    /// resolved book's identifier and `startPlaying: true`.
+    ///
+    /// Mutation: re-routing the `.audiobook` switch arm to any other reader means
+    /// the session is never opened and this times out.
+    func testOpenBook_audiobookFormat_routesToInjectedAudiobookSession() async {
+        let audiobook = TPPBookMocker.mockBook(distributorType: .OpenAccessAudiobook)
+        XCTAssertEqual(audiobook.defaultBookContentType, .audiobook,
+                       "precondition: the fixture must classify as an audiobook")
+
+        let registry = TPPBookRegistryMock()
+        registry.addBook(audiobook, location: nil, state: .downloadSuccessful,
+                         fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
+        let session = RecordingAudiobookSession()
+        let vm = makeVM(book: audiobook, registry: registry, session: session)
+
+        let opened = expectation(description: "audiobook session opened")
+        session.onOpen = { opened.fulfill() }
+
+        vm.openBook(audiobook, completion: nil)
+
+        await fulfillment(of: [opened], timeout: 3)
+        XCTAssertEqual(session.openCount, 1, "The audiobook must open the session exactly once")
+        XCTAssertEqual(session.lastOpenedIdentifier, audiobook.identifier,
+                       "The routed identifier must be the audiobook under open")
+        XCTAssertEqual(session.lastStartPlaying, true,
+                       "Audiobook opens must request immediate playback (startPlaying: true)")
+    }
+
+    /// The discriminator: a NON-audiobook format must NOT reach the audiobook
+    /// session. streamingHTML is used because its `openBook` arm presents via the
+    /// NavigationCoordinator (nil in a unit context → a safe no-op) and never
+    /// touches `readerService`, so this proves the audiobook routing is content-
+    /// type-specific rather than unconditional.
+    ///
+    /// Mutation: collapsing the switch so every format opens the session makes
+    /// `openCount` non-zero and this fails.
+    func testOpenBook_nonAudiobookFormat_doesNotRouteToAudiobookSession() {
+        let streaming = makeStreamingHTMLBook()
+        XCTAssertEqual(streaming.defaultBookContentType, .streamingHTML,
+                       "precondition: the fixture must classify as streamingHTML")
+
+        let registry = TPPBookRegistryMock()
+        registry.addBook(streaming, location: nil, state: .downloadNeeded,
+                         fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
+        let session = RecordingAudiobookSession()
+        let vm = makeVM(book: streaming, registry: registry, session: session)
+
+        vm.openBook(streaming, completion: nil)
+        drainMainQueue()
+
+        XCTAssertEqual(session.openCount, 0,
+                       "A streamingHTML open must NOT reach the audiobook session — routing is content-type-specific")
+    }
+
+    // MARK: - Related-books navigation state derivation
+
+    /// selectRelatedBook, on navigating to a DIFFERENT book, must re-derive
+    /// `bookState` from the registry for the NEWLY selected identifier. The
+    /// existing suite asserts the book swap + lane-clearing but never the state
+    /// re-derivation — so a mutant that reads the OLD identifier (or skips the
+    /// state read entirely) would pass there and fail here.
+    func testSelectRelatedBook_differentBook_reDerivesBookStateFromRegistryForNewBook() {
+        let current = TPPBookMocker.mockBook(identifier: "current-book", title: "Current",
+                                             distributorType: .EpubZip)
+        let registry = TPPBookRegistryMock()
+        registry.addBook(current, location: nil, state: .unregistered,
+                         fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
+
+        // The newly-selected book lives in the registry in a DISTINCT state, so a
+        // correct re-derivation must flip bookState away from the current book's.
+        let other = TPPBookMocker.mockBook(identifier: "other-book", title: "Other",
+                                           distributorType: .EpubZip)
+        registry.addBook(other, location: nil, state: .downloadSuccessful,
+                         fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
+
+        let vm = makeVM(book: current, registry: registry, session: RecordingAudiobookSession())
+        XCTAssertEqual(vm.bookState, .unregistered, "precondition: VM starts on the current book's state")
+
+        vm.selectRelatedBook(other)
+        drainMainQueue()
+
+        XCTAssertEqual(vm.book.identifier, "other-book", "The selected book must become the VM's book")
+        XCTAssertEqual(vm.bookState, .downloadSuccessful,
+                       "bookState must be re-derived from the registry for the newly-selected book, not left on the previous book's state")
+    }
+
+    // MARK: - Helpers
+
+    private func makeVM(book: TPPBook,
+                        registry: TPPBookRegistryProvider,
+                        session: RecordingAudiobookSession) -> BookDetailViewModel {
+        BookDetailViewModel(
+            book: book,
+            registry: registry,
+            downloadCenter: appContainer.downloadCenter,
+            accountsManager: appContainer.accountsManager,
+            settings: TPPSettings(),
+            opdsFeedService: appContainer.opdsFeedService,
+            samplePreviewManager: appContainer.samplePreviewManager,
+            readerService: appContainer.readerService,
+            audiobookSession: session
+        )
+    }
+
+    /// Minimal streamingHTML book (borrow acquisition with a streaming-HTML
+    /// indirect leaf), mirroring the fixture shape in BookDetailViewModelTests.
+    private func makeStreamingHTMLBook(id: String = "routing-streaming-book") -> TPPBook {
+        let leaf = TPPOPDSIndirectAcquisition(type: ContentTypeStreamingHTML, indirectAcquisitions: [])
+        let acquisition = TPPOPDSAcquisition(
+            relation: .borrow,
+            type: ContentTypeOPDSPublication,
+            hrefURL: URL(string: "https://example.com/borrow/\(id)")!,
+            indirectAcquisitions: [leaf],
+            availability: TPPOPDSAcquisitionAvailabilityUnlimited()
+        )
+        return TPPBook(
+            acquisitions: [acquisition],
+            authors: [TPPBookAuthor(authorName: "Streaming Author", relatedBooksURL: nil)],
+            categoryStrings: ["Streaming"],
+            distributor: "Streaming",
+            identifier: id,
+            imageURL: nil,
+            imageThumbnailURL: nil,
+            published: Date(),
+            publisher: "Publisher",
+            subtitle: nil,
+            summary: "Test",
+            title: "Streaming Routing Title",
+            updated: Date(),
+            annotationsURL: nil,
+            analyticsURL: nil,
+            alternateURL: nil,
+            relatedWorksURL: nil,
+            previewLink: nil,
+            seriesURL: nil,
+            revokeURL: URL(string: "https://example.com/revoke"),
+            reportURL: nil,
+            timeTrackingURL: nil,
+            contributors: [:],
+            bookDuration: nil,
+            imageCache: MockImageCache()
+        )
+    }
+}
+
+// MARK: - Recording session double
+
+/// Minimal `AudiobookSessionManaging` that records the open call BookService
+/// routes to it. Overrides the 3-arg `openAudiobook` witness (the variant
+/// `BookService.dispatchOpen` invokes) so the routing decision is observable.
+/// Mirrors the compiling `HookRecordingSession` in
+/// `PalaceTests/Book/BookServiceAudiobookOpenTests.swift`.
+///
+/// VERIFY: if `AudiobookSessionManaging` gains a required (non-defaulted) member,
+/// add a stub here.
+@MainActor
+private final class RecordingAudiobookSession: AudiobookSessionManaging {
+    private(set) var openCount = 0
+    private(set) var lastOpenedIdentifier: String?
+    private(set) var lastStartPlaying: Bool?
+    var onOpen: (() -> Void)?
+
+    @discardableResult
+    func openAudiobook(_ book: TPPBook, startPlaying: Bool,
+                       onLoadingShellPresented: (@MainActor () -> Void)?) async -> Result<Void, AudiobookSessionError> {
+        openCount += 1
+        lastOpenedIdentifier = book.identifier
+        lastStartPlaying = startPlaying
+        onOpen?()
+        return .success(())
+    }
+
+    @discardableResult
+    func openAudiobook(_ book: TPPBook, startPlaying: Bool) async -> Result<Void, AudiobookSessionError> {
+        .success(())
+    }
+
+    // MARK: Protocol boilerplate (unused by these tests)
+    var state: AudiobookSessionState = .idle
+    var currentBook: TPPBook?
+    var currentChapters: [Chapter] = []
+    var currentChapter: Chapter?
+    var currentPosition: TrackPosition?
+    var isPlaying: Bool { false }
+    var coverImage: UIImage?
+    var hasActiveManager: Bool = false
+
+    let playbackStatePublisher = PassthroughSubject<AudiobookSessionState, Never>()
+    let chapterUpdatePublisher = PassthroughSubject<(chapters: [Chapter], current: Chapter?), Never>()
+    let errorPublisher = PassthroughSubject<AudiobookSessionError, Never>()
+
+    func play() {}
+    func pause() {}
+    func togglePlayPause() {}
+    func skipToChapter(at index: Int) {}
+    func skipBack() {}
+    func skipForward() {}
+    func cyclePlaybackRate() -> PlaybackRate { .normalTime }
+    func stopPlayback(dismissPhoneUI: Bool, persistFinalPosition: Bool) async {}
+    func updateCoverImage(_ image: UIImage?) {}
+    func recoverPlaybackForForegroundEntry() {}
+}

--- a/PalaceTests/Decomp/DownloadThrottlingContractTests.swift
+++ b/PalaceTests/Decomp/DownloadThrottlingContractTests.swift
@@ -1,0 +1,105 @@
+//
+//  DownloadThrottlingContractTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE test pack for the god-class decomposition campaign
+//  (docs/architecture/god-class-decomposition-plan.md §3a-3 cluster
+//  "Throttling + disk budget" + §5 "throttling … edge tests").
+//
+//  Pins the deterministic slice of `DownloadThrottlingService`'s concurrency
+//  policy (Palace/MyBooks/DownloadThrottlingService.swift): setting the active
+//  cap propagates to the shared `DownloadStateManager`, and EVERY re-application
+//  of the cap ends by asking the delegate (MBDC) to re-pump the pending-download
+//  queue. When this service moves into PalaceDownloads, the cap→pump coupling
+//  must survive — a decomposition that dropped the trailing pump would leave
+//  queued books stranded whenever a slot frees up.
+//
+//  SEAM (documented, not faked): the audiobook-preservation behavior
+//  (`pauseAllDownloads` / over-cap `limitActiveDownloads` suspend NON-audiobook
+//  tasks but never audiobook tasks) is NOT unit-pinned here. Observing it
+//  requires spying `URLSessionTask.suspend()`, but `URLSessionDownloadTask`
+//  cannot be meaningfully subclassed and a freshly-created task already reports
+//  `.suspended`, so "suspended by policy" is indistinguishable from "never
+//  started" at this seam. That branch is exercised on a sim (start N+1 mixed
+//  ebook/audiobook downloads, background, observe the audiobook keeps streaming)
+//  — noted for the extraction wave rather than pinned with a non-deterministic
+//  assertion.
+//
+
+import XCTest
+@testable import Palace
+
+final class DownloadThrottlingContractTests: XCTestCase {
+
+    private var stateManager: DownloadStateManager!
+    private var delegate: SpyThrottleDelegate!
+    private var service: DownloadThrottlingService!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        stateManager = DownloadStateManager()
+        delegate = SpyThrottleDelegate()
+        // Isolated NotificationCenter so the app-active observer can't fire from
+        // unrelated suite activity.
+        service = DownloadThrottlingService(
+            stateManager: stateManager,
+            notificationCenter: NotificationCenter()
+        )
+        service.delegate = delegate
+    }
+
+    override func tearDownWithError() throws {
+        service = nil
+        delegate = nil
+        stateManager = nil
+        try super.tearDownWithError()
+    }
+
+    /// `limitActiveDownloads(max:)` must (1) propagate the new cap to the shared
+    /// state manager AND (2) re-pump the pending queue via the delegate. With no
+    /// active downloads the suspend/resume body is a no-op, isolating exactly
+    /// these two effects. Kills a mutant that dropped the `maxConcurrentDownloads`
+    /// assignment and one that dropped the trailing `schedulePendingStartsAsync`.
+    func test_limitActiveDownloads_propagatesCap_andRepumpsPendingQueue() async {
+        service.limitActiveDownloads(max: 2)
+        // The policy runs in a retained fire-and-forget Task; join it
+        // deterministically instead of polling.
+        await service.lastLimitActiveDownloadsTask?.value
+
+        XCTAssertEqual(stateManager.maxConcurrentDownloads, 2,
+                       "new cap must propagate to the shared state manager")
+        XCTAssertEqual(delegate.pumpCount, 1,
+                       "changing the cap must re-pump the pending-download queue exactly once")
+    }
+
+    /// `resumeIntelligentDownloads()` re-applies the CURRENT cap (giving
+    /// previously-suspended tasks a chance to resume) and likewise re-pumps the
+    /// queue — without changing the cap value. Kills a mutant that made resume a
+    /// no-op (queued books would never restart after a throttle/foreground).
+    func test_resumeIntelligentDownloads_reappliesCurrentCap_andRepumps() async {
+        stateManager.maxConcurrentDownloads = 3
+
+        service.resumeIntelligentDownloads()
+        await service.lastLimitActiveDownloadsTask?.value
+
+        XCTAssertEqual(stateManager.maxConcurrentDownloads, 3,
+                       "resume must re-apply, not mutate, the current cap")
+        XCTAssertEqual(delegate.pumpCount, 1,
+                       "resume must re-pump the pending-download queue")
+    }
+}
+
+// MARK: - Spy
+
+/// Counts pending-queue re-pump requests. `schedulePendingStartsAsync` is a
+/// `nonisolated async` protocol requirement, so the counter is NSLock-guarded
+/// and read from the test thread after the joined policy Task completes.
+private final class SpyThrottleDelegate: DownloadThrottlingServiceDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _pumpCount = 0
+    var pumpCount: Int { lock.withLock { _pumpCount } }
+
+    func schedulePendingStartsAsync() async {
+        lock.withLock { _pumpCount += 1 }
+    }
+}

--- a/PalaceTests/Decomp/PalacePreferencesSettingsRoundTripTests.swift
+++ b/PalaceTests/Decomp/PalacePreferencesSettingsRoundTripTests.swift
@@ -1,0 +1,259 @@
+//
+//  PalacePreferencesSettingsRoundTripTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE gate tests for the god-class decomposition campaign — Wave 1a
+//  (`PalacePreferences`). See docs/architecture/god-class-decomposition-plan.md
+//  §4 Wave 1a and §3b cycles 5/6.
+//
+//  Purpose: pin TODAY's persistence contract of `TPPSettings` — the
+//  `UserDefaults`-backed key-value preferences store — BEFORE it is lifted
+//  into the new Layer-0 leaf package `PalacePreferences`. The move is a pure
+//  relocation, so the risk it introduces is silent WIRE-FORMAT drift: a
+//  renamed key constant, a changed default, or an in-memory cache slipped in
+//  during the port would make every already-installed patron silently lose a
+//  persisted preference. These tests lock the exact `UserDefaults` key strings,
+//  the unset defaults, and the cross-instance persistence so any such drift
+//  fails loudly.
+//
+//  Isolation: every test drives a fresh, per-test `UserDefaults(suiteName:)`
+//  injected through `TPPSettings.init(defaults:)`. NONE of these tests touch
+//  `.standard` — they cannot pollute the shared domain or any sibling test.
+//  The suite is torn down with `removePersistentDomain` in `tearDown`.
+//
+//  Scope note: the passthrough accessors (e.g. `downloadOnlyOnWiFi`,
+//  `appRatingOptedOut`) are NOT fluff-tested with a bare get-after-set — that
+//  would exercise `UserDefaults`, not `TPPSettings`. Instead we pin the
+//  set-typed-API / read-RAW-key mapping, which is the real portable contract
+//  and which a key-rename mutation fails. Accessors with genuine logic
+//  (`appRatingCrashFreeLastSession` default-true, `appRatingLastPromptDate`
+//  nil-clear) get dedicated behavior tests.
+//
+//  Excluded by design: `TPPSettings+SE.settingsAccountIdsList` reads/writes
+//  `UserDefaults.standard` directly (bypassing the injected `defaults`) AND
+//  reaches `AppContainer.production()`, so it is NOT isolatable here and moves
+//  to PalaceAccounts territory (the AccountsManager constant "stays behind" per
+//  the plan). It is intentionally uncovered by this pack.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+@MainActor
+final class PalacePreferencesSettingsRoundTripTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var settings: TPPSettings!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "PalacePreferencesDecompTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        // Guarantee a clean slate even if the (random) suite name collided.
+        defaults.removePersistentDomain(forName: suiteName)
+        settings = TPPSettings(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        settings = nil
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - appRatingCrashFreeLastSession — genuine default-true logic
+
+    /// When no session has recorded a value, the accessor must assume the
+    /// patron is crash-free (returns `true`) — the store special-cases the
+    /// absent key rather than falling through to `UserDefaults.bool`'s `false`.
+    /// Mutant killed: replacing the `== nil ? true : …` ternary (or flipping
+    /// the default to `false`) makes an un-primed store report a crash.
+    func testCrashFreeLastSession_defaultsToTrueWhenKeyAbsent() {
+        XCTAssertNil(defaults.object(forKey: "TPPAppRatingCrashFreeLastSession"),
+                     "Precondition: fresh suite has no stored crash-free value")
+        XCTAssertTrue(settings.appRatingCrashFreeLastSession,
+                      "Absent crash-free key must read as true (assume crash-free)")
+    }
+
+    /// A stored `false` must survive and be distinguishable from the absent
+    /// default. Round-tripping false → true proves the accessor reflects the
+    /// STORED value, not a constant. Mutant killed: an accessor hardcoded to
+    /// `true` (or reading the wrong key) fails the `false` leg.
+    func testCrashFreeLastSession_reflectsStoredFalseThenTrue() {
+        settings.appRatingCrashFreeLastSession = false
+        XCTAssertFalse(settings.appRatingCrashFreeLastSession,
+                       "Stored false must read back false, not the absent-default true")
+        XCTAssertEqual(defaults.object(forKey: "TPPAppRatingCrashFreeLastSession") as? Bool, false,
+                       "Value must persist under the stable wire key")
+
+        settings.appRatingCrashFreeLastSession = true
+        XCTAssertTrue(settings.appRatingCrashFreeLastSession,
+                      "Stored true must read back true")
+    }
+
+    // MARK: - appRatingLastPromptDate — nil-clear vs. store logic
+
+    /// Setting a date persists it (under the stable key); setting nil must
+    /// REMOVE it so the getter reads nil again. Mutant killed: dropping the
+    /// `removeObject` nil-branch (leaving the stale date) fails the clear leg.
+    func testLastPromptDate_roundTripsThenClearsToNil() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        settings.appRatingLastPromptDate = date
+
+        let stored = settings.appRatingLastPromptDate
+        XCTAssertNotNil(stored, "Set date must round-trip back out")
+        XCTAssertEqual(stored!.timeIntervalSince1970, date.timeIntervalSince1970, accuracy: 0.001,
+                       "Persisted date must equal what was set")
+        XCTAssertNotNil(defaults.object(forKey: "TPPAppRatingLastPromptDate") as? Date,
+                        "Date must persist under the stable wire key")
+
+        settings.appRatingLastPromptDate = nil
+        XCTAssertNil(settings.appRatingLastPromptDate,
+                     "Setting nil must clear the stored date")
+        XCTAssertNil(defaults.object(forKey: "TPPAppRatingLastPromptDate"),
+                     "Nil-set must REMOVE the key, not leave a stale value")
+    }
+
+    // MARK: - Feed URL accessors — persistence + stable wire key
+
+    /// `customMainFeedURL` (custom catalog override) must persist a URL under
+    /// its exact legacy key and read the same URL back. The notification/guard
+    /// behavior of the setter is covered by `TPPSettingsTests`; here we pin the
+    /// PERSISTENCE the package move must preserve. Mutant killed: a renamed key
+    /// constant leaves the raw read nil.
+    func testCustomMainFeedURL_persistsUnderStableKeyAndRoundTrips() {
+        let url = URL(string: "https://catalog.example.org/custom-feed")!
+        settings.customMainFeedURL = url
+
+        XCTAssertEqual(settings.customMainFeedURL, url,
+                       "customMainFeedURL must round-trip the set URL")
+        XCTAssertEqual(defaults.url(forKey: "NYPLSettingsCustomMainFeedURL"), url,
+                       "customMainFeedURL must persist under the legacy key 'NYPLSettingsCustomMainFeedURL'")
+    }
+
+    /// `accountMainFeedURL` is the `NYPLFeedURLProvider` protocol property that
+    /// drives catalog fetches. Same wire-key + round-trip contract.
+    func testAccountMainFeedURL_persistsUnderStableKeyAndRoundTrips() {
+        let url = URL(string: "https://catalog.example.org/account-feed")!
+        settings.accountMainFeedURL = url
+
+        XCTAssertEqual(settings.accountMainFeedURL, url,
+                       "accountMainFeedURL must round-trip the set URL")
+        XCTAssertEqual(defaults.url(forKey: "NYPLSettingsAccountMainFeedURL"), url,
+                       "accountMainFeedURL must persist under the legacy key 'NYPLSettingsAccountMainFeedURL'")
+    }
+
+    /// `useBetaLibraries` gates whether beta libraries appear in the registry;
+    /// its persisted flag must land under the legacy key so a beta-opted patron
+    /// keeps that state across the move.
+    func testUseBetaLibraries_persistsUnderStableKey() {
+        XCTAssertFalse(settings.useBetaLibraries, "Precondition: defaults to false when unset")
+        settings.useBetaLibraries = true
+
+        XCTAssertTrue(settings.useBetaLibraries, "useBetaLibraries must round-trip true")
+        XCTAssertEqual(defaults.object(forKey: "NYPLUseBetaLibrariesKey") as? Bool, true,
+                       "useBetaLibraries must persist under the legacy key 'NYPLUseBetaLibrariesKey'")
+    }
+
+    // MARK: - Wire-format key contract for the passthrough prefs
+
+    /// The single most important guard for a persistence relocation: every
+    /// stored preference must keep reading/writing its EXACT current
+    /// `UserDefaults` key string. We drive each typed accessor with a
+    /// non-default value, then read the RAW key literal (hardcoded here, NOT
+    /// referenced from the SUT's constants — so a constant rename is caught,
+    /// not moved-in-lockstep). Any single key drift fails this test.
+    func testStoredPrefs_persistUnderExactWireKeys() {
+        settings.userHasAcceptedEULA = true
+        settings.userPresentedAgeCheck = true
+        settings.enterLCPPassphraseManually = true
+        settings.downloadOnlyOnWiFi = true
+        settings.appVersion = "9.9.9-decomp"
+        settings.customLibraryRegistryServer = "https://registry.example.org"
+        settings.appRatingSessionCount = 7
+        settings.appRatingBooksCompleted = 3
+        settings.appRatingPromptDisplayCount = 2
+        settings.appRatingDismissalCount = 1
+        settings.appRatingOptedOut = true
+
+        // Bool prefs → exact key + exact value.
+        XCTAssertEqual(defaults.object(forKey: "NYPLSettingsUserAcceptedEULA") as? Bool, true,
+                       "userHasAcceptedEULA key drift")
+        XCTAssertEqual(defaults.object(forKey: "NYPLUserPresentedAgeCheckKey") as? Bool, true,
+                       "userPresentedAgeCheck key drift")
+        XCTAssertEqual(defaults.object(forKey: "TPPSettingsEnterLCPPassphraseManually") as? Bool, true,
+                       "enterLCPPassphraseManually key drift")
+        XCTAssertEqual(defaults.object(forKey: "TPPSettingsDownloadOnlyOnWiFi") as? Bool, true,
+                       "downloadOnlyOnWiFi key drift")
+        XCTAssertEqual(defaults.object(forKey: "TPPAppRatingOptedOut") as? Bool, true,
+                       "appRatingOptedOut key drift")
+
+        // String prefs.
+        XCTAssertEqual(defaults.string(forKey: "NYPLSettingsVersionKey"), "9.9.9-decomp",
+                       "appVersion key drift")
+        XCTAssertEqual(defaults.string(forKey: "TPPSettingsCustomLibraryRegistryKey"),
+                       "https://registry.example.org",
+                       "customLibraryRegistryServer key drift")
+
+        // Int prefs.
+        XCTAssertEqual(defaults.integer(forKey: "TPPAppRatingSessionCount"), 7,
+                       "appRatingSessionCount key drift")
+        XCTAssertEqual(defaults.integer(forKey: "TPPAppRatingBooksCompleted"), 3,
+                       "appRatingBooksCompleted key drift")
+        XCTAssertEqual(defaults.integer(forKey: "TPPAppRatingPromptDisplayCount"), 2,
+                       "appRatingPromptDisplayCount key drift")
+        XCTAssertEqual(defaults.integer(forKey: "TPPAppRatingDismissalCount"), 1,
+                       "appRatingDismissalCount key drift")
+    }
+
+    // MARK: - Unset defaults
+
+    /// The "never written" contract: a fresh store returns the canonical
+    /// empty/zero/false/nil values callers rely on before a patron has touched
+    /// any setting. Distinct from the crash-free special-case (which is true).
+    /// Mutant killed: a default value swapped in during the port (e.g. Int
+    /// default 1, Bool default true) fails here.
+    func testUnsetDefaults_areEmptyZeroFalseNil() {
+        XCTAssertNil(settings.customMainFeedURL, "customMainFeedURL defaults nil")
+        XCTAssertNil(settings.accountMainFeedURL, "accountMainFeedURL defaults nil")
+        XCTAssertNil(settings.appVersion, "appVersion defaults nil")
+        XCTAssertNil(settings.customLibraryRegistryServer, "customLibraryRegistryServer defaults nil")
+        XCTAssertNil(settings.appRatingLastPromptDate, "appRatingLastPromptDate defaults nil")
+        XCTAssertFalse(settings.useBetaLibraries, "useBetaLibraries defaults false")
+        XCTAssertFalse(settings.userHasAcceptedEULA, "userHasAcceptedEULA defaults false")
+        XCTAssertFalse(settings.userPresentedAgeCheck, "userPresentedAgeCheck defaults false")
+        XCTAssertFalse(settings.enterLCPPassphraseManually, "enterLCPPassphraseManually defaults false")
+        XCTAssertFalse(settings.downloadOnlyOnWiFi, "downloadOnlyOnWiFi defaults false")
+        XCTAssertFalse(settings.appRatingOptedOut, "appRatingOptedOut defaults false")
+        XCTAssertEqual(settings.appRatingSessionCount, 0, "appRatingSessionCount defaults 0")
+        XCTAssertEqual(settings.appRatingBooksCompleted, 0, "appRatingBooksCompleted defaults 0")
+        XCTAssertEqual(settings.appRatingPromptDisplayCount, 0, "appRatingPromptDisplayCount defaults 0")
+        XCTAssertEqual(settings.appRatingDismissalCount, 0, "appRatingDismissalCount defaults 0")
+    }
+
+    // MARK: - Persistence across reads / instances
+
+    /// The store is a THIN wrapper over `UserDefaults`, not an in-memory cache:
+    /// a value written through one `TPPSettings` instance must be visible to a
+    /// SECOND instance built over the same backing suite. This pins "persistence
+    /// across reads" and kills any mutant that starts caching writes in memory
+    /// instead of committing them to `defaults`.
+    func testWrites_arePersisted_andVisibleToASecondInstance() {
+        let url = URL(string: "https://catalog.example.org/persisted")!
+        settings.customMainFeedURL = url
+        settings.appRatingSessionCount = 42
+        settings.appRatingCrashFreeLastSession = false
+
+        let reopened = TPPSettings(defaults: UserDefaults(suiteName: suiteName)!)
+        XCTAssertEqual(reopened.customMainFeedURL, url,
+                       "URL written by instance A must be readable by instance B")
+        XCTAssertEqual(reopened.appRatingSessionCount, 42,
+                       "Int written by instance A must be readable by instance B")
+        XCTAssertFalse(reopened.appRatingCrashFreeLastSession,
+                       "Stored false must survive re-instantiation (not revert to default true)")
+    }
+}

--- a/PalaceTests/Decomp/RightsManagementDispatchContractTests.swift
+++ b/PalaceTests/Decomp/RightsManagementDispatchContractTests.swift
@@ -1,0 +1,364 @@
+//
+//  RightsManagementDispatchContractTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE test pack for the god-class decomposition campaign
+//  (docs/architecture/god-class-decomposition-plan.md §5 row
+//  "MyBooksDownloadCenter": "DRM dispatch contract (spy FulfillmentHandling
+//  recording call order per format)").
+//
+//  The post-download DRM/format dispatch that §5 calls "FulfillmentHandling"
+//  lives in `Palace/MyBooks/RightsManagementDispatcher.swift`. It is the
+//  second half of MBDC's `handleDownloadCompletion` — given the parsed
+//  rights-management kind it routes each format to exactly one collaborator:
+//
+//    .lcp                     → delegate.fulfillLCPLicense       (LCP)
+//    .adobe (#if DRM)         → logBookDownloadFailure / Adobe fulfillment
+//    .overdriveManifestJSON   → fileOps.replaceBook              (Overdrive)
+//    .none                    → fileOps.moveFile                 (open access)
+//    .simplifiedBearerTokenJSON → re-issue bearer-auth'd task    (bearer)
+//    .unknown                 → logBookDownloadFailure + alert
+//
+//  A silent decomposition that swapped two arms, dropped an arm, or inverted
+//  the `failureRequiringAlert = !fileOps.…` guard would mis-route a paid loan
+//  to the wrong DRM handler with no compile error — precisely the money-path
+//  regression class this contract pins. Each test locks WHICH collaborator
+//  fires for a format AND the alert/error the switch returns.
+//
+//  Tested through the real seam (RightsManagementDispatcher + its
+//  RightsManagementDispatcherDelegate / BackgroundDownloadFileOps spies), so
+//  the pins survive the move into PalaceDownloads unchanged.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+final class RightsManagementDispatchContractTests: XCTestCase {
+
+    private var log: CallLog!
+    private var delegate: SpyDispatchDelegate!
+    private var fileOps: SpyFileOps!
+    private var stateManager: DownloadStateManager!
+    private var registry: TPPBookRegistryMock!
+    private var userAccount: TPPUserAccountMock!
+    private var dispatcher: RightsManagementDispatcher!
+    private var session: URLSession!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        log = CallLog()
+        delegate = SpyDispatchDelegate(log: log)
+        fileOps = SpyFileOps(log: log)
+        stateManager = DownloadStateManager()
+        registry = TPPBookRegistryMock()
+        userAccount = TPPUserAccountMock()
+        session = URLSession(configuration: .ephemeral)
+
+        #if FEATURE_DRM_CONNECTOR
+        // SEAM: RightsManagementDispatcher requires a concrete `AdobeDRMService`
+        // and there is no injectable `AdobeDRMService` protocol seam. The
+        // `.adobe` PDF-rejection branch under test returns synchronously WITHOUT
+        // touching the service (it is only reached on the non-PDF fulfillment
+        // path, which is `// SEAM`-noted below), so `.shared` here is a
+        // construction placeholder that is never exercised by these tests.
+        dispatcher = RightsManagementDispatcher(
+            stateManager: stateManager,
+            fileOps: fileOps,
+            bookRegistry: registry,
+            userAccountProvider: { [unowned self] in self.userAccount },
+            adobeDRMService: .shared
+        )
+        #else
+        dispatcher = RightsManagementDispatcher(
+            stateManager: stateManager,
+            fileOps: fileOps,
+            bookRegistry: registry,
+            userAccountProvider: { [unowned self] in self.userAccount }
+        )
+        #endif
+        dispatcher.delegate = delegate
+    }
+
+    override func tearDownWithError() throws {
+        log = nil
+        delegate = nil
+        fileOps = nil
+        stateManager = nil
+        registry = nil
+        userAccount = nil
+        dispatcher = nil
+        session = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - LCP → fulfillLCPLicense
+
+    /// `.lcp` routes to `delegate.fulfillLCPLicense` and reports NO alert (the
+    /// LCP handler owns its own error path). A mutant routing LCP through the
+    /// file-move / overdrive arm would drop the license fulfillment entirely,
+    /// leaving the patron with an un-decryptable file.
+    func test_lcp_routesToFulfillLCPLicense_noAlert() async {
+        // VERIFY: `book`/`task` are constructed locally and passed once into the
+        // nonisolated async `dispatch` — matching the region-isolation shape the
+        // existing DownloadStart contract tests use for non-Sendable TPPBook.
+        let book = Self.makeBook(identifier: "RMD-LCP")
+        let task = fakeDownloadTask()
+        let location = Self.throwawayLocation()
+
+        let result = await dispatcher.dispatch(
+            book: book, task: task, location: location, session: session,
+            rights: .lcp, failureError: nil
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method), ["delegate.fulfillLCPLicense"])
+        XCTAssertFalse(result.failureRequiringAlert)
+    }
+
+    // MARK: - Overdrive → fileOps.replaceBook
+
+    /// `.overdriveManifestJSON` routes to `fileOps.replaceBook`. On success
+    /// (replaceBook == true) NO alert is required.
+    func test_overdriveManifest_routesToReplaceBook_successNoAlert() async {
+        fileOps.replaceBookResult = true
+        let book = Self.makeBook(identifier: "RMD-OD-OK")
+        let task = fakeDownloadTask()
+
+        let result = await dispatcher.dispatch(
+            book: book, task: task, location: Self.throwawayLocation(), session: session,
+            rights: .overdriveManifestJSON, failureError: nil
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method), ["fileOps.replaceBook"])
+        XCTAssertFalse(result.failureRequiringAlert)
+    }
+
+    /// Overdrive replace FAILURE (replaceBook == false) → alert required. Kills
+    /// the `failureRequiringAlert = !fileOps.replaceBook(…)` negation mutant: a
+    /// flipped `!` would silently swallow a failed Overdrive fulfillment.
+    func test_overdriveManifest_replaceFails_requiresAlert() async {
+        fileOps.replaceBookResult = false
+        let book = Self.makeBook(identifier: "RMD-OD-FAIL")
+        let task = fakeDownloadTask()
+
+        let result = await dispatcher.dispatch(
+            book: book, task: task, location: Self.throwawayLocation(), session: session,
+            rights: .overdriveManifestJSON, failureError: nil
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method), ["fileOps.replaceBook"])
+        XCTAssertTrue(result.failureRequiringAlert)
+    }
+
+    // MARK: - Open access (.none) → fileOps.moveFile
+
+    /// `.none` (open-access / already-decrypted) routes to `fileOps.moveFile`,
+    /// NOT replaceBook. Distinct file op — a swap would corrupt the on-disk
+    /// layout for one of the two formats.
+    func test_openAccess_routesToMoveFile_successNoAlert() async {
+        fileOps.moveFileResult = true
+        let book = Self.makeBook(identifier: "RMD-OA-OK")
+        let task = fakeDownloadTask()
+
+        let result = await dispatcher.dispatch(
+            book: book, task: task, location: Self.throwawayLocation(), session: session,
+            rights: .none, failureError: nil
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method), ["fileOps.moveFile"])
+        XCTAssertFalse(result.failureRequiringAlert)
+    }
+
+    /// Open-access move FAILURE → alert required. Kills the negation mutant on
+    /// the `.none` arm.
+    func test_openAccess_moveFails_requiresAlert() async {
+        fileOps.moveFileResult = false
+        let book = Self.makeBook(identifier: "RMD-OA-FAIL")
+        let task = fakeDownloadTask()
+
+        let result = await dispatcher.dispatch(
+            book: book, task: task, location: Self.throwawayLocation(), session: session,
+            rights: .none, failureError: nil
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method), ["fileOps.moveFile"])
+        XCTAssertTrue(result.failureRequiringAlert)
+    }
+
+    // MARK: - Unknown rights → log + alert, error preserved
+
+    /// `.unknown` logs a download failure and requires an alert — and it must
+    /// NOT mutate the incoming `failureError` (the caller's original error is
+    /// surfaced). Kills both the "drop the log call" mutant and a
+    /// `failureRequiringAlert = false` mutant that would strand the patron on a
+    /// spinner with no error.
+    func test_unknownRights_logsFailure_requiresAlert_preservesError() async {
+        let sentinel = NSError(domain: "caller", code: 99)
+        let book = Self.makeBook(identifier: "RMD-UNKNOWN")
+        let task = fakeDownloadTask()
+
+        let result = await dispatcher.dispatch(
+            book: book, task: task, location: Self.throwawayLocation(), session: session,
+            rights: .unknown, failureError: sentinel
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method), ["delegate.logBookDownloadFailure"])
+        XCTAssertTrue(result.failureRequiringAlert)
+        XCTAssertEqual((result.failureError as NSError?)?.code, 99,
+                       "unknown-rights arm must not overwrite the caller's error")
+    }
+
+    // MARK: - Bearer token JSON → missing-data guard
+
+    /// `.simplifiedBearerTokenJSON` whose payload is absent on disk logs a
+    /// failure AND alerts — in that order. Pins the two-call sequence on the
+    /// bearer-token error guard (a mutant dropping either call would leave the
+    /// re-fulfillment silently stuck). `failureRequiringAlert` stays false
+    /// because the bearer arm alerts directly via the delegate rather than
+    /// through the shared tail flag.
+    func test_bearerTokenJSON_missingData_logsThenAlerts() async {
+        let book = Self.makeBook(identifier: "RMD-BEARER")
+        let task = fakeDownloadTask()
+        // A location that does not exist → `Data(contentsOf:)` returns nil →
+        // the "no data available on disk" guard fires.
+        let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("rmd-nonexistent-\(UUID().uuidString).bin")
+
+        let result = await dispatcher.dispatch(
+            book: book, task: task, location: missing, session: session,
+            rights: .simplifiedBearerTokenJSON, failureError: nil
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method),
+                       ["delegate.logBookDownloadFailure", "delegate.failDownloadWithAlert"])
+        XCTAssertFalse(result.failureRequiringAlert)
+    }
+
+    // MARK: - Adobe ACSM (DRM builds only)
+
+    #if FEATURE_DRM_CONNECTOR
+    /// `.adobe` payload that is actually an Adobe PDF (`application/pdf` in the
+    /// ACSM) is rejected as unsupported — synchronously, before any DRM
+    /// fulfillment Task is spawned: it logs a failure, requires an alert, and
+    /// surfaces an "Adobe PDF … not supported" error. Kills a mutant that
+    /// dropped the PDF guard and shipped the unsupported payload to fulfillment.
+    ///
+    /// SEAM: the non-PDF `.adobe` branch spawns a fire-and-forget Task on the
+    /// concrete `AdobeDRMService` (`ensureDeviceActivated` + `fulfill`) with no
+    /// injectable protocol seam — its success/failure is verified on a sim
+    /// against an Adept-fulfilled EPUB, not here.
+    func test_adobe_pdfPayload_rejectedAsUnsupported() async throws {
+        let book = Self.makeBook(identifier: "RMD-ADOBE-PDF")
+        let task = fakeDownloadTask()
+        // Write an ACSM whose body carries the PDF format marker the guard scans.
+        let acsm = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("rmd-adobe-\(UUID().uuidString).acsm")
+        let body = "<fulfillmentToken><dc:format>application/pdf</dc:format></fulfillmentToken>"
+        try body.data(using: .utf8)!.write(to: acsm)
+        defer { try? FileManager.default.removeItem(at: acsm) }
+
+        let result = await dispatcher.dispatch(
+            book: book, task: task, location: acsm, session: session,
+            rights: .adobe, failureError: nil
+        )
+
+        XCTAssertEqual(log.snapshot().map(\.method), ["delegate.logBookDownloadFailure"])
+        XCTAssertTrue(result.failureRequiringAlert)
+        let message = (result.failureError as NSError?)?.localizedDescription ?? ""
+        XCTAssertTrue(message.contains("Adobe PDF"),
+                      "unsupported-PDF error message must be surfaced; got '\(message)'")
+    }
+    #endif
+
+    // MARK: - Helpers
+
+    private static func throwawayLocation() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("rmd-loc-\(UUID().uuidString).bin")
+    }
+
+    private static func makeBook(identifier: String) -> TPPBook {
+        let acquisitionURL = URL(string: "http://example.com/\(identifier)")!
+        let acquisition = TPPOPDSAcquisition(
+            relation: .generic,
+            type: "application/epub+zip",
+            hrefURL: acquisitionURL,
+            indirectAcquisitions: [],
+            availability: TPPOPDSAcquisitionAvailabilityUnlimited()
+        )
+        return TPPBook(
+            acquisitions: [acquisition],
+            authors: [TPPBookAuthor(authorName: "Author", relatedBooksURL: nil)],
+            categoryStrings: nil,
+            distributor: nil,
+            identifier: identifier,
+            imageURL: nil,
+            imageThumbnailURL: nil,
+            published: nil,
+            publisher: nil,
+            subtitle: nil,
+            summary: nil,
+            title: "Title-\(identifier)",
+            updated: Date(timeIntervalSince1970: 0),
+            annotationsURL: nil,
+            analyticsURL: nil,
+            alternateURL: nil,
+            relatedWorksURL: nil,
+            previewLink: nil,
+            seriesURL: nil,
+            revokeURL: nil,
+            reportURL: nil,
+            timeTrackingURL: nil,
+            contributors: nil,
+            bookDuration: nil,
+            imageCache: MockImageCache()
+        )
+    }
+}
+
+// MARK: - Spies
+
+/// Records the MBDC-side callbacks the dispatcher invokes. `@unchecked
+/// Sendable`: the only state is the (thread-safe) CallLog reference.
+private final class SpyDispatchDelegate: RightsManagementDispatcherDelegate, @unchecked Sendable {
+    let log: CallLog
+    init(log: CallLog) { self.log = log }
+
+    func logBookDownloadFailure(_ book: TPPBook, reason: String, downloadTask: URLSessionTask, metadata: [String: Any]?) {
+        log.record("delegate.logBookDownloadFailure",
+                   args: ["bookId": book.identifier, "reason": reason])
+    }
+
+    func fulfillLCPLicense(fileUrl: URL, forBook book: TPPBook, downloadTask: URLSessionDownloadTask) {
+        log.record("delegate.fulfillLCPLicense", args: ["bookId": book.identifier])
+    }
+
+    func failDownloadWithAlert(for book: TPPBook, withMessage message: String?) {
+        log.record("delegate.failDownloadWithAlert", args: ["bookId": book.identifier])
+    }
+
+    func alertForProblemDocument(_ problemDoc: TPPProblemDocument?, error: Error?, book: TPPBook) {
+        log.record("delegate.alertForProblemDocument", args: ["bookId": book.identifier])
+    }
+}
+
+/// Stubs `BackgroundDownloadFileOps` with configurable return values so the
+/// success/failure branches of the overdrive/open-access arms are both
+/// exercisable. `@unchecked Sendable`: return-value `var`s are set on the
+/// test thread before the single `dispatch` await; CallLog is thread-safe.
+private final class SpyFileOps: BackgroundDownloadFileOps, @unchecked Sendable {
+    let log: CallLog
+    var replaceBookResult = true
+    var moveFileResult = true
+    init(log: CallLog) { self.log = log }
+
+    func replaceBook(_ book: TPPBook, withFileAtURL sourceLocation: URL, forDownloadTask downloadTask: URLSessionDownloadTask) -> Bool {
+        log.record("fileOps.replaceBook", args: ["bookId": book.identifier])
+        return replaceBookResult
+    }
+
+    func moveFile(at sourceLocation: URL, toDestinationForBook book: TPPBook, forDownloadTask downloadTask: URLSessionDownloadTask) -> Bool {
+        log.record("fileOps.moveFile", args: ["bookId": book.identifier])
+        return moveFileResult
+    }
+}

--- a/PalaceTests/Decomp/RightsManagementDispatchContractTests.swift
+++ b/PalaceTests/Decomp/RightsManagementDispatchContractTests.swift
@@ -55,28 +55,21 @@ final class RightsManagementDispatchContractTests: XCTestCase {
         userAccount = TPPUserAccountMock()
         session = URLSession(configuration: .ephemeral)
 
-        #if FEATURE_DRM_CONNECTOR
-        // SEAM: RightsManagementDispatcher requires a concrete `AdobeDRMService`
-        // and there is no injectable `AdobeDRMService` protocol seam. The
-        // `.adobe` PDF-rejection branch under test returns synchronously WITHOUT
-        // touching the service (it is only reached on the non-PDF fulfillment
-        // path, which is `// SEAM`-noted below), so `.shared` here is a
-        // construction placeholder that is never exercised by these tests.
+        // Palace always builds with FEATURE_DRM_CONNECTOR, so the DRM-on init is
+        // the one exported through `@testable import Palace`. PalaceTests does NOT
+        // redefine the flag, so a source-code `#if FEATURE_DRM_CONNECTOR` here
+        // resolves to the wrong (no-arg) branch and fails to compile against the
+        // DRM-on module — call the DRM-on init UNCONDITIONALLY (matches the
+        // established `RightsManagementDispatcherTests` pattern). `.shared` is a
+        // construction placeholder: the `.adobe` PDF-rejection branch under test
+        // returns synchronously WITHOUT touching the service (SEAM-noted below).
         dispatcher = RightsManagementDispatcher(
             stateManager: stateManager,
             fileOps: fileOps,
             bookRegistry: registry,
             userAccountProvider: { [unowned self] in self.userAccount },
-            adobeDRMService: .shared
+            adobeDRMService: AdobeDRMService.shared
         )
-        #else
-        dispatcher = RightsManagementDispatcher(
-            stateManager: stateManager,
-            fileOps: fileOps,
-            bookRegistry: registry,
-            userAccountProvider: { [unowned self] in self.userAccount }
-        )
-        #endif
         dispatcher.delegate = delegate
     }
 

--- a/PalaceTests/Decomp/TPPCirculationAnalyticsRequestShapeContractTests.swift
+++ b/PalaceTests/Decomp/TPPCirculationAnalyticsRequestShapeContractTests.swift
@@ -1,0 +1,118 @@
+//
+//  TPPCirculationAnalyticsRequestShapeContractTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE gate test for the god-class decomposition campaign — Wave 1c
+//  (misfiles + inversions). See docs/architecture/god-class-decomposition-plan.md
+//  §4 Wave 1c and §3b cycle 3.
+//
+//  Target: `Palace/Logging/TPPCirculationAnalytics.swift` — a circulation-domain
+//  network client MISFILED under `Logging`. Wave 1c relocates it out of the
+//  Logging folder (killing folder-cycle #3, Logging↔Network). The move is a
+//  pure file relocation, so the pre-wave test must pin the analytics request
+//  SHAPE (URL / HTTP method / what the offline path enqueues) so the relocation
+//  is provably behavior-preserving.
+//
+//  ─────────────────────────────────────────────────────────────────────────
+//  // SEAM: the request shape is NOT deterministically observable through the
+//  //       current public surface. Two independent production seams block a
+//  //       live contract snapshot; BOTH are read-only observations here (this
+//  //       pack makes no production edits):
+//  //
+//  //   1. The only injectable method is `private static addToOfflineAnalytics
+//  //      Queue(_:_:accountsManager:networkExecutor:)` — it already carries the
+//  //      exact default-arg seams the wave brief points at
+//  //      (`accountsManager:`, `networkExecutor:`) — but it is `private static`.
+//  //      `@testable import Palace` elevates `internal`, NOT `private`, so the
+//  //      method (and its spy-injectable params) cannot be called from a test.
+//  //
+//  //   2. The outbound event request in `post(_:withURL:)` is sent on a
+//  //      SELF-CREATED `URLSession(configuration: .ephemeral)`. A custom-config
+//  //      session consults ONLY `config.protocolClasses` — it ignores globally
+//  //      registered `URLProtocol`s. This is documented in-repo at
+//  //      `PalaceTests/PalaceTestSetup.swift` (~L50-57): "the SHARED
+//  //      TPPNetworkExecutor builds its own URLSession(configuration:), which
+//  //      consults only config.protocolClasses". So neither `HTTPStubURLProtocol`
+//  //      (scoped to `URLSession.stubbedSession()`) nor `NoNetworkURLProtocol`
+//  //      (global) can intercept it — the request would escape to the real
+//  //      network in a unit test. There is no injection point for the session.
+//  //
+//  //   Consequence: the request shape cannot be pinned as a passing gate today
+//  //   without either (a) making `addToOfflineAnalyticsQueue` `internal` (or
+//  //   `package`) so spies inject via its existing default args, OR (b) taking
+//  //   the `URLSession`/`TPPNetworkExecutor` as an injected seam on `post`.
+//  //   The RECOMMENDATION for Wave 1c is to bundle seam (a) — a one-token
+//  //   `private` → `internal` change — WITH the file move, then delete the
+//  //   `XCTSkip` below so the spy-based contract snapshot goes live in the same
+//  //   PR that relocates the file. Per CLAUDE.md's contract-test guidance:
+//  //   "the inability to write the test IS the test feedback."
+//  ─────────────────────────────────────────────────────────────────────────
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+@MainActor
+final class TPPCirculationAnalyticsRequestShapeContractTests: XCTestCase {
+
+    /// CONTRACT (to be pinned once the Wave-1c seam lands): the offline-retry
+    /// enqueue shape of a failed analytics event. `addToOfflineAnalyticsQueue`
+    /// must enqueue exactly:
+    ///
+    ///   networkQueue.addRequest(
+    ///     libraryID: accountsManager.currentAccount?.uuid ?? "",   // "" when no account
+    ///     updateID:  nil,
+    ///     url:       <book.analyticsURL / event>,                  // the event URL
+    ///     method:    .GET,
+    ///     parameters: nil,
+    ///     headers:   networkExecutor.request(for: url).allHTTPHeaderFields
+    ///   )
+    ///
+    /// and the outbound live request in `post` must be an HTTP **GET** to
+    /// `book.analyticsURL.appendingPathComponent(event)`.
+    ///
+    /// Once seam (a) exists, the live body is:
+    ///
+    ///   let netExec = SpyNetworkExecutor()           // records request(for:)
+    ///   let accounts = SpyAccountsManager(uuid: "lib-uuid")
+    ///   let url = URL(string: "https://analytics.example.org/events/open_book")!
+    ///   TPPCirculationAnalytics.addToOfflineAnalyticsQueue(
+    ///       "open_book", url, accountsManager: accounts, networkExecutor: netExec)
+    ///   // then assert the CallLog snapshot of netExec + the enqueued request.
+    ///   ContractSnapshot.assert(log, named: "offlineEnqueue_GET_open_book")
+    ///
+    /// NOTE while writing that body: `addToOfflineAnalyticsQueue` still calls
+    /// `AppContainer.production().networkQueue.addRequest(...)` for the actual
+    /// enqueue (only the header/libraryID derivation is injected). Pinning
+    /// "what it enqueues" therefore ALSO requires the `networkQueue` to become
+    /// an injected seam — otherwise the snapshot's enqueue leg hits the live
+    /// container. Flag this to the Wave-1c implementer: the enqueue call itself
+    /// is the third, still-uninjected dependency.
+    func testOfflineEnqueue_pinnedRequestShape_GET_withLibraryHeaders() throws {
+        throw XCTSkip("""
+            SEAM (Wave 1c): TPPCirculationAnalytics exposes no reachable test seam. \
+            `addToOfflineAnalyticsQueue(_:_:accountsManager:networkExecutor:)` is \
+            private static (unreachable via @testable), and `post`'s ephemeral \
+            URLSession(configuration:) ignores globally-registered URLProtocols \
+            (see PalaceTests/PalaceTestSetup.swift ~L50-57), so the event request \
+            cannot be intercepted. Make the method internal (and inject the \
+            networkQueue) alongside the relocation, then remove this skip to \
+            activate the spy-based ContractSnapshot documented above. This test \
+            is a deliberate placeholder that names the exact production change \
+            required — it must not be deleted without landing that change.
+            """)
+    }
+
+    // LATENT-BUG NOTE (discovered while characterizing, reported not fixed):
+    // `handleFailure` gates the offline enqueue on
+    //   NetworkQueue.StatusCodes.contains(httpResponse.statusCode)
+    // but `NetworkQueue.StatusCodes` are NEGATIVE NSURLError codes (e.g.
+    // NSURLErrorTimedOut) while `httpResponse.statusCode` is a POSITIVE HTTP
+    // status. The two sets never intersect, so this `if` can never be true for
+    // a real HTTPURLResponse — the HTTP-response enqueue branch is effectively
+    // dead. The timeout branch in `post` (NSURLErrorTimedOut) is the only path
+    // that reaches `addToOfflineAnalyticsQueue`. When the seam lands, the live
+    // contract should pin the timeout path, not a synthetic HTTP-status path.
+}

--- a/PalaceTests/Decomp/TPPCirculationAnalyticsRequestShapeContractTests.swift
+++ b/PalaceTests/Decomp/TPPCirculationAnalyticsRequestShapeContractTests.swift
@@ -57,6 +57,16 @@ import XCTest
 @MainActor
 final class TPPCirculationAnalyticsRequestShapeContractTests: XCTestCase {
 
+    // This file holds no mutable/shared state — its single test throws XCTSkip
+    // and touches nothing. The explicit tearDown satisfies TearDownRequiredLint
+    // (a comment-blind substring scan that flags this class because the doc
+    // comments below mention `AppContainer.production()`/`Spy…`); there is
+    // genuinely nothing to reset. When the Wave-1c seam lands and the live
+    // spy-based body replaces the XCTSkip, extend this to drop that state.
+    override func tearDown() {
+        super.tearDown()
+    }
+
     /// CONTRACT (to be pinned once the Wave-1c seam lands): the offline-retry
     /// enqueue shape of a failed analytics event. `addToOfflineAnalyticsQueue`
     /// must enqueue exactly:

--- a/PalaceTests/Decomp/TPPSignInBusinessLogicCharacterizationTests.swift
+++ b/PalaceTests/Decomp/TPPSignInBusinessLogicCharacterizationTests.swift
@@ -1,0 +1,422 @@
+//
+//  TPPSignInBusinessLogicCharacterizationTests.swift
+//  PalaceTests
+//
+//  CHARACTERIZATION PACK — blocking prerequisite for the god-class
+//  decomposition of `TPPSignInBusinessLogic` (see
+//  docs/architecture/god-class-decomposition-plan.md §5, row
+//  "TPPSignInBusinessLogic").
+//
+//  This file pins the behavior of the two clusters the plan extracts into
+//  PalaceAuth / PalaceAccounts:
+//    - SignInRequestService  (makeRequest + validateCredentials wiring +
+//      error surfacing) → PalaceAuth
+//    - CredentialStore       (updateUserAccount persistence contract per auth
+//      method) → PalaceAccounts (+ PalaceKeychain)
+//
+//  A second file, TPPSignInCapabilitiesCharacterizationTests.swift, covers the
+//  AuthCapabilities-derivation and Adobe-DRM-activation-skip clusters.
+//
+//  Every test drives a real Arrange→Act→Assert against TODAY's code with a
+//  mutation-killing assertion (flip a conditional / drop an assignment in the
+//  covered code and the test fails). Hermetic: TPPRequestExecutorMock for the
+//  /patrons/me request, TPPUserAccountMock for the keychain seam,
+//  TPPDRMAuthorizingMock for device auth. No live network / keychain.
+//
+//  NOTE (integration): this class already carries broad scattered coverage
+//  (TPPSignInBusinessLogicTests, ...OAuthTests, ...SignOutTests, ...OIDCTests,
+//  ...ExtendedTests, ...StateMachineTests, TPPSAMLSignInTests, TPPSignInAdobe
+//  SkipTests). The "0 dedicated tests" premise in the plan is STALE. This pack
+//  is the *consolidated per-extraction-boundary contract* plus the genuinely
+//  uncovered branches (no-URL validation error, oauth-family barcode fallback,
+//  non-SAML cookie gate). Overlaps are called out in the mission report.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+// MARK: - Recording delegate (captures validation-error + didReceiveCredentials)
+
+/// The shared `TPPSignInOutBusinessLogicUIDelegateMock` treats
+/// `didEncounterValidationError` as a no-op, so it cannot prove that an error
+/// was surfaced to the UI. This standalone delegate records the validation-error
+/// callback (title/message) AND the didReceiveCredentials call so tests can pin
+/// the success-vs-failure fork of `validateCredentials`.
+private final class RecordingSignInUIDelegate: NSObject, TPPSignInOutBusinessLogicUIDelegate {
+    var context = "RecordingDelegate"
+    var username: String? = "recorded-user"
+    var pin: String? = "recorded-pin"
+    var usernameTextField: UITextField?
+    var PINTextField: UITextField?
+    var forceEditability: Bool = false
+
+    private(set) var validationErrorCount = 0
+    private(set) var lastValidationTitle: String?
+    private(set) var lastValidationMessage: String?
+    private(set) var didReceiveCredentialsCount = 0
+
+    func businessLogicWillSignIn(_ businessLogic: TPPSignInBusinessLogic) {}
+    func businessLogicDidCancelSignIn(_ businessLogic: TPPSignInBusinessLogic) {}
+    func businessLogicDidCompleteSignIn(_ businessLogic: TPPSignInBusinessLogic) {}
+    func businessLogic(_ logic: TPPSignInBusinessLogic,
+                       didEncounterValidationError error: Error?,
+                       userFriendlyErrorTitle title: String?,
+                       andMessage message: String?) {
+        validationErrorCount += 1
+        lastValidationTitle = title
+        lastValidationMessage = message
+    }
+    func businessLogicDidReceiveCredentials(_ businessLogic: TPPSignInBusinessLogic) {
+        didReceiveCredentialsCount += 1
+    }
+    func dismiss(animated flag: Bool, completion: (() -> Void)?) { completion?() }
+    func present(_ viewControllerToPresent: UIViewController,
+                 animated flag: Bool,
+                 completion: (() -> Void)?) { completion?() }
+    func businessLogicWillSignOut(_ businessLogic: TPPSignInBusinessLogic) {}
+    func businessLogic(_ logic: TPPSignInBusinessLogic,
+                       didEncounterSignOutError error: Error?,
+                       withHTTPStatusCode httpStatusCode: Int) {}
+    func businessLogicDidFinishDeauthorizing(_ logic: TPPSignInBusinessLogic) {}
+}
+
+// MARK: - SignInRequestService cluster
+
+@MainActor
+final class SignInRequestServiceCharacterizationTests: XCTestCase {
+
+    private var businessLogic: TPPSignInBusinessLogic!
+    private var libraryMock: TPPLibraryAccountMock!
+    private var uiDelegate: TPPSignInOutBusinessLogicUIDelegateMock!
+    private var networkExecutor: TPPRequestExecutorMock!
+
+    /// The /patrons/me URL the fixture's userProfileUrl resolves to and that
+    /// TPPRequestExecutorMock is pre-wired to answer 200.
+    private let profilePath = "patrons/me"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        TPPUserAccountMock.resetShared()
+        libraryMock = TPPLibraryAccountMock()
+        uiDelegate = TPPSignInOutBusinessLogicUIDelegateMock()
+        networkExecutor = TPPRequestExecutorMock()
+        businessLogic = TPPSignInBusinessLogic(
+            libraryAccountID: libraryMock.tppAccountUUID,
+            libraryAccountsProvider: libraryMock,
+            urlSettingsProvider: TPPURLSettingsProviderMock(),
+            bookRegistry: TPPBookRegistryMock(),
+            bookDownloadsCenter: TPPMyBooksDownloadsCenterMock(),
+            userAccountProvider: TPPUserAccountMock.self,
+            networkExecutor: networkExecutor,
+            uiDelegate: uiDelegate,
+            drmAuthorizer: TPPDRMAuthorizingMock())
+    }
+
+    override func tearDownWithError() throws {
+        networkExecutor.reset()
+        businessLogic.userAccount.removeAll()
+        businessLogic = nil
+        libraryMock = nil
+        uiDelegate = nil
+        networkExecutor = nil
+        try super.tearDownWithError()
+    }
+
+    // A1 — sign-OUT request for basic auth: URL present, NO bearer header.
+    // Kills a mutant that adds a bearer header for non-token auth on sign-out,
+    // or that drops the userProfileUrl → returns nil.
+    func test_makeRequest_signOut_basicAuth_hasProfileURL_andNoBearerHeader() {
+        businessLogic.selectedAuthentication = libraryMock.barcodeAuthentication
+
+        let req = businessLogic.makeRequest(for: .signOut, context: "signout-basic")
+
+        XCTAssertNotNil(req, "sign-out request must be built from the loaded userProfileUrl")
+        XCTAssertTrue(req?.url?.absoluteString.contains(profilePath) ?? false,
+                      "sign-out request must target the /patrons/me user-profile URL")
+        XCTAssertNil(req?.value(forHTTPHeaderField: "Authorization"),
+                     "basic-auth sign-out must NOT attach a Bearer header")
+    }
+
+    // A2 — GAP: validateCredentials when the request cannot be built.
+    // Building against a library whose details never loaded makes makeRequest
+    // return nil; validateCredentials must surface a validation error to the UI
+    // and fire NO network call. Kills the `guard let req = makeRequest` mutant
+    // (removing/negating it would proceed to executeRequest).
+    func test_validateCredentials_whenRequestUnbuildable_surfacesError_andFiresNoNetworkCall() {
+        let recording = RecordingSignInUIDelegate()
+        let blogic = TPPSignInBusinessLogic(
+            libraryAccountID: "totally-unknown-library",   // resolves to detail-less Account
+            libraryAccountsProvider: libraryMock,
+            urlSettingsProvider: TPPURLSettingsProviderMock(),
+            bookRegistry: TPPBookRegistryMock(),
+            bookDownloadsCenter: TPPMyBooksDownloadsCenterMock(),
+            userAccountProvider: TPPUserAccountMock.self,
+            networkExecutor: networkExecutor,
+            uiDelegate: recording,
+            drmAuthorizer: TPPDRMAuthorizingMock())
+
+        XCTAssertNil(blogic.makeRequest(for: .signIn, context: "precondition"),
+                     "precondition: makeRequest must be nil for a detail-less library")
+
+        blogic.validateCredentials()
+        drainMainQueue()   // the delegate error hop runs via asyncIfNeeded
+
+        XCTAssertTrue(networkExecutor.executedRequestURLs.isEmpty,
+                      "an unbuildable request must short-circuit BEFORE any network call")
+        XCTAssertEqual(recording.validationErrorCount, 1,
+                       "validateCredentials must surface exactly one validation error when the request can't be built")
+        XCTAssertNotNil(recording.lastValidationTitle,
+                        "the surfaced validation error must carry a user-facing title")
+        XCTAssertFalse(blogic.isValidatingCredentials,
+                       "validating flag must be cleared once the failure is surfaced")
+    }
+
+    // A3 — validateCredentials success path routes makeRequest's URL through the
+    // executor. Pins the makeRequest→executeRequest wiring at the /patrons/me
+    // URL. Kills a mutant that fires the wrong URL or skips the request.
+    func test_validateCredentials_basicAuth_firesUserProfileRequest() {
+        businessLogic.selectedAuthentication = libraryMock.barcodeAuthentication
+
+        businessLogic.validateCredentials()   // executeRequest records URL synchronously
+
+        XCTAssertEqual(networkExecutor.executedRequestURLs.count, 1,
+                       "validateCredentials must fire exactly one credential-validation request")
+        XCTAssertTrue(networkExecutor.executedRequestURLs.first?.absoluteString.contains(profilePath) ?? false,
+                      "the validation request must target the fixture's userProfileUrl (/patrons/me)")
+        XCTAssertTrue(businessLogic.isValidatingCredentials,
+                      "validateCredentials must enter the validating state")
+    }
+
+    // A4 — validateCredentials failure (401) surfaces a validation error and does
+    // NOT report didReceiveCredentials. Distinct from the callback-order test:
+    // here we prove the error CONTENT is surfaced (recording delegate). Kills a
+    // mutant that swaps the success/failure arms of the executor result switch.
+    func test_validateCredentials_httpFailure_surfacesValidationError_andNoCredentialsReceived() {
+        let recording = RecordingSignInUIDelegate()
+        businessLogic.uiDelegate = recording
+        businessLogic.selectedAuthentication = libraryMock.barcodeAuthentication
+        networkExecutor.forceFailureStatusCode = 401
+
+        businessLogic.validateCredentials()
+        drainMainQueue()
+
+        XCTAssertEqual(recording.validationErrorCount, 1,
+                       "a 401 must surface exactly one validation error to the UI")
+        XCTAssertEqual(recording.didReceiveCredentialsCount, 0,
+                       "the failure arm must NOT signal didReceiveCredentials (no DRM spinner)")
+        XCTAssertFalse(businessLogic.isValidatingCredentials,
+                       "validating flag must be cleared after a failed validation")
+    }
+
+    // A5 — makeRequest header contract: basic auth carries NO Authorization.
+    func test_makeRequest_signIn_basicAuth_omitsBearerHeader() {
+        businessLogic.selectedAuthentication = libraryMock.barcodeAuthentication
+        let req = businessLogic.makeRequest(for: .signIn, context: "basic")
+        XCTAssertNotNil(req)
+        XCTAssertNil(req?.value(forHTTPHeaderField: "Authorization"),
+                     "basic auth must never attach a Bearer token")
+    }
+
+    // A6 — makeRequest header contract: OAuth attaches "Bearer <in-flight token>".
+    func test_makeRequest_signIn_oauth_attachesInFlightBearer() {
+        businessLogic.selectedAuthentication = libraryMock.oauthAuthentication
+        businessLogic.dispatch(.bearerTokenReceived(token: "oauth-flight", expiration: nil))
+        let req = businessLogic.makeRequest(for: .signIn, context: "oauth")
+        XCTAssertEqual(req?.value(forHTTPHeaderField: "Authorization"), "Bearer oauth-flight")
+    }
+
+    // A7 — makeRequest header contract: SAML attaches a Bearer token.
+    func test_makeRequest_signIn_saml_attachesInFlightBearer() {
+        businessLogic.selectedAuthentication = libraryMock.samlAuthentication
+        businessLogic.dispatch(.bearerTokenReceived(token: "saml-flight", expiration: nil))
+        let req = businessLogic.makeRequest(for: .signIn, context: "saml")
+        XCTAssertEqual(req?.value(forHTTPHeaderField: "Authorization"), "Bearer saml-flight")
+    }
+
+    // A8 — makeRequest header contract: OIDC attaches a Bearer token.
+    func test_makeRequest_signIn_oidc_attachesInFlightBearer() {
+        businessLogic.selectedAuthentication = libraryMock.oidcAuthentication
+        businessLogic.dispatch(.bearerTokenReceived(token: "oidc-flight", expiration: nil))
+        let req = businessLogic.makeRequest(for: .signIn, context: "oidc")
+        XCTAssertEqual(req?.value(forHTTPHeaderField: "Authorization"), "Bearer oidc-flight")
+    }
+
+    // A9 — makeRequest falls back to the persisted userAccount token when there
+    // is no in-flight token (the `authToken ?? userAccount.authToken` chain).
+    func test_makeRequest_signIn_oauth_fallsBackToPersistedToken() {
+        businessLogic.selectedAuthentication = libraryMock.oauthAuthentication
+        businessLogic.userAccount.setAuthToken("persisted-only", barcode: nil, pin: nil, expirationDate: nil)
+        // Clear any in-flight reducer token so only the persisted one remains.
+        businessLogic.dispatch(.userAccountUpdated)
+        XCTAssertNil(businessLogic.authToken, "precondition: no in-flight token")
+
+        let req = businessLogic.makeRequest(for: .signIn, context: "oauth-fallback")
+
+        XCTAssertEqual(req?.value(forHTTPHeaderField: "Authorization"), "Bearer persisted-only",
+                       "with no in-flight token, makeRequest must fall back to userAccount.authToken")
+    }
+
+    // A17 — validateCredentials SUCCESS arm reports didReceiveCredentials (so the
+    // UI can show its DRM spinner). Positive complement of A4; kills a mutant
+    // that drops the businessLogicDidReceiveCredentials call on success.
+    func test_validateCredentials_basicAuthSuccess_reportsDidReceiveCredentials() {
+        let recording = RecordingSignInUIDelegate()
+        businessLogic.uiDelegate = recording
+        businessLogic.selectedAuthentication = libraryMock.barcodeAuthentication
+
+        businessLogic.validateCredentials()
+        drainMainQueue()
+
+        XCTAssertEqual(recording.didReceiveCredentialsCount, 1,
+                       "a successful validation must signal didReceiveCredentials exactly once")
+        XCTAssertEqual(recording.validationErrorCount, 0,
+                       "a successful validation must NOT surface a validation error")
+    }
+
+    // A18 — makeRequest header contract also applies on SIGN-OUT: an OAuth
+    // sign-out carries the Bearer token. Kills a mutant that only attaches the
+    // header on sign-in.
+    func test_makeRequest_signOut_oauth_attachesBearer() {
+        businessLogic.selectedAuthentication = libraryMock.oauthAuthentication
+        businessLogic.dispatch(.bearerTokenReceived(token: "signout-tok", expiration: nil))
+
+        let req = businessLogic.makeRequest(for: .signOut, context: "oauth-signout")
+
+        XCTAssertEqual(req?.value(forHTTPHeaderField: "Authorization"), "Bearer signout-tok",
+                       "OAuth sign-out must attach the Bearer token, same as sign-in")
+    }
+}
+
+// MARK: - CredentialStore cluster (updateUserAccount persistence contract)
+
+@MainActor
+final class CredentialStoreCharacterizationTests: XCTestCase {
+
+    private var businessLogic: TPPSignInBusinessLogic!
+    private var libraryMock: TPPLibraryAccountMock!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        TPPUserAccountMock.resetShared()
+        libraryMock = TPPLibraryAccountMock()
+        businessLogic = TPPSignInBusinessLogic(
+            libraryAccountID: libraryMock.tppAccountUUID,
+            libraryAccountsProvider: libraryMock,
+            urlSettingsProvider: TPPURLSettingsProviderMock(),
+            bookRegistry: TPPBookRegistryMock(),
+            bookDownloadsCenter: TPPMyBooksDownloadsCenterMock(),
+            userAccountProvider: TPPUserAccountMock.self,
+            networkExecutor: TPPRequestExecutorMock(),
+            uiDelegate: TPPSignInOutBusinessLogicUIDelegateMock(),
+            drmAuthorizer: TPPDRMAuthorizingMock())
+    }
+
+    override func tearDownWithError() throws {
+        businessLogic.userAccount.removeAll()
+        businessLogic = nil
+        libraryMock = nil
+        try super.tearDownWithError()
+    }
+
+    private func update(auth: AccountDetails.Authentication,
+                        barcode: String? = nil, pin: String? = nil,
+                        token: String? = nil, patron: [String: Any]? = nil,
+                        cookies: [HTTPCookie]? = nil) {
+        businessLogic.selectedAuthentication = auth
+        businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                        withBarcode: barcode, pin: pin,
+                                        authToken: token, expirationDate: nil,
+                                        patron: patron, cookies: cookies)
+    }
+
+    // A10 — basic-auth persistence contract: barcode+pin stored, logged in,
+    // NO token, NO cookies.
+    func test_updateUserAccount_basicAuth_persistsBarcodePin_marksLoggedIn() {
+        update(auth: libraryMock.barcodeAuthentication, barcode: "bc-1", pin: "pin-1")
+
+        let acct = businessLogic.userAccount
+        XCTAssertEqual(acct.barcode, "bc-1")
+        XCTAssertEqual(acct.PIN, "pin-1")
+        XCTAssertNil(acct.authToken, "basic auth must not persist a bearer token")
+        XCTAssertNil(acct.cookies, "basic auth must not persist cookies")
+        XCTAssertTrue(businessLogic.isSignedIn(), "credentials must mark the account signed in")
+    }
+
+    // A11 — OAuth/Clever persistence contract: token+patron stored, logged in.
+    func test_updateUserAccount_oauthClever_persistsTokenAndPatron() {
+        update(auth: libraryMock.cleverAuthentication,
+               token: "clever-tok", patron: ["name": "Ada"])
+
+        let acct = businessLogic.userAccount
+        XCTAssertEqual(acct.authToken, "clever-tok")
+        XCTAssertEqual(acct.patron?["name"] as? String, "Ada")
+        XCTAssertTrue(businessLogic.isSignedIn())
+    }
+
+    // A12 — SAML persistence contract: token+patron+COOKIES stored (the isSaml
+    // cookie gate). Kills the `if selectedAuth.isSaml, let cookies` mutant.
+    func test_updateUserAccount_saml_persistsTokenPatronAndCookies() {
+        let cookie = HTTPCookie(properties: [
+            .domain: "idp.example.com", .path: "/", .name: "s", .value: "v"])!
+        update(auth: libraryMock.samlAuthentication,
+               token: "saml-tok", patron: ["name": "Grace"], cookies: [cookie])
+
+        let acct = businessLogic.userAccount
+        XCTAssertEqual(acct.authToken, "saml-tok")
+        XCTAssertEqual(acct.patron?["name"] as? String, "Grace")
+        XCTAssertEqual(acct.cookies?.count, 1, "SAML must persist the IdP session cookies")
+    }
+
+    // A13 — OIDC persistence contract: token+patron stored, authDefinition is
+    // .oidc, and NO cookies (unlike SAML).
+    func test_updateUserAccount_oidc_persistsToken_setsOidcAuthDefinition_noCookies() {
+        update(auth: libraryMock.oidcAuthentication,
+               token: "oidc-tok", patron: ["name": "Alan"])
+
+        let acct = businessLogic.userAccount
+        XCTAssertEqual(acct.authToken, "oidc-tok")
+        XCTAssertEqual(acct.authDefinition?.authType, .oidc,
+                       "updateUserAccount must stamp the selected OIDC auth definition")
+        XCTAssertNil(acct.cookies, "OIDC must NOT persist cookies")
+    }
+
+    // A14 — GAP: OAuth-family with BOTH token AND barcode/pin persists all three
+    // (the setAuthToken(token, barcode:, pin:) arm). Kills a mutant that drops
+    // the barcode/pin arguments when a token is present.
+    func test_updateUserAccount_oauthFamily_withTokenAndBarcodePin_persistsAll() {
+        update(auth: libraryMock.oauthAuthentication,
+               barcode: "bc-x", pin: "pin-x", token: "tok-x")
+
+        let acct = businessLogic.userAccount
+        XCTAssertEqual(acct.authToken, "tok-x")
+        XCTAssertEqual(acct.barcode, "bc-x",
+                       "a token+barcode OAuth update must persist the barcode too")
+        XCTAssertEqual(acct.PIN, "pin-x")
+    }
+
+    // A15 — GAP: OAuth-family WITHOUT a token falls back to barcode/pin
+    // (the inner `else if let barcode, let pin` arm). Kills a mutant that drops
+    // the no-token fallback.
+    func test_updateUserAccount_oauthFamily_withoutToken_fallsBackToBarcodePin() {
+        update(auth: libraryMock.oauthAuthentication, barcode: "bc-y", pin: "pin-y")
+
+        let acct = businessLogic.userAccount
+        XCTAssertNil(acct.authToken, "no token was supplied — none must be persisted")
+        XCTAssertEqual(acct.barcode, "bc-y",
+                       "OAuth-family update with no token must fall back to persisting barcode/pin")
+        XCTAssertEqual(acct.PIN, "pin-y")
+    }
+
+    // A16 — GAP: a non-SAML auth must NOT persist cookies even when they are
+    // passed. Kills a mutant that widens the cookie gate beyond SAML.
+    func test_updateUserAccount_basicAuth_ignoresCookies() {
+        let cookie = HTTPCookie(properties: [
+            .domain: "x.example.com", .path: "/", .name: "leak", .value: "no"])!
+        update(auth: libraryMock.barcodeAuthentication,
+               barcode: "bc-z", pin: "pin-z", cookies: [cookie])
+
+        XCTAssertNil(businessLogic.userAccount.cookies,
+                     "cookies must only be persisted for SAML — basic auth must ignore them")
+    }
+}

--- a/PalaceTests/Decomp/TPPSignInCapabilitiesCharacterizationTests.swift
+++ b/PalaceTests/Decomp/TPPSignInCapabilitiesCharacterizationTests.swift
@@ -1,0 +1,313 @@
+//
+//  TPPSignInCapabilitiesCharacterizationTests.swift
+//  PalaceTests
+//
+//  CHARACTERIZATION PACK (part 2 of 2) — blocking prerequisite for the
+//  decomposition of `TPPSignInBusinessLogic` (see
+//  docs/architecture/god-class-decomposition-plan.md §5).
+//
+//  Clusters pinned here:
+//    - AuthCapabilities derivation  (barcode-display gating, registration
+//      gating, SAML/OIDC preferred-auth + sole-IdP selection, password-reset
+//      availability) → pure derivation extracted to PalaceAuth
+//    - Adobe-DRM-activation SKIP decision (stays app-target) — the POSITIVE
+//      decision + the device-not-authorized branch that the existing suite
+//      never exercised (it only covers the false early-returns)
+//    - refreshAuthIfNeeded basic auto-reauth path
+//    - logIn() routing per auth method (safe branches only)
+//
+//  Companion file: TPPSignInBusinessLogicCharacterizationTests.swift
+//  (SignInRequestService + CredentialStore clusters).
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+@MainActor
+final class TPPSignInCapabilitiesCharacterizationTests: XCTestCase {
+
+    private var businessLogic: TPPSignInBusinessLogic!
+    private var libraryMock: TPPLibraryAccountMock!
+    private var uiDelegate: TPPSignInOutBusinessLogicUIDelegateMock!
+    private var networkExecutor: TPPRequestExecutorMock!
+    private var drmAuthorizer: TPPDRMAuthorizingMock!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        TPPUserAccountMock.resetShared()
+        libraryMock = TPPLibraryAccountMock()
+        uiDelegate = TPPSignInOutBusinessLogicUIDelegateMock()
+        networkExecutor = TPPRequestExecutorMock()
+        drmAuthorizer = TPPDRMAuthorizingMock()
+        businessLogic = TPPSignInBusinessLogic(
+            libraryAccountID: libraryMock.tppAccountUUID,
+            libraryAccountsProvider: libraryMock,
+            urlSettingsProvider: TPPURLSettingsProviderMock(),
+            bookRegistry: TPPBookRegistryMock(),
+            bookDownloadsCenter: TPPMyBooksDownloadsCenterMock(),
+            userAccountProvider: TPPUserAccountMock.self,
+            networkExecutor: networkExecutor,
+            uiDelegate: uiDelegate,
+            drmAuthorizer: drmAuthorizer)
+        businessLogic.userAccount.removeAll()   // F-008 defense: guaranteed-clean creds
+    }
+
+    override func tearDownWithError() throws {
+        networkExecutor.reset()
+        drmAuthorizer.reset()
+        businessLogic.userAccount.removeAll()
+        businessLogic = nil
+        libraryMock = nil
+        uiDelegate = nil
+        networkExecutor = nil
+        drmAuthorizer = nil
+        try super.tearDownWithError()
+    }
+
+    private func signInBasic(barcode: String = "bc", pin: String = "pin") {
+        businessLogic.selectedAuthentication = libraryMock.barcodeAuthentication
+        businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                        withBarcode: barcode, pin: pin,
+                                        authToken: nil, expirationDate: nil,
+                                        patron: nil, cookies: nil)
+    }
+
+    // MARK: - AuthCapabilities: barcode display gating (3-way AND)
+
+    // B1 — GAP (positive path): librarySupportsBarcodeDisplay is TRUE only when
+    // ALL three hold — hasBarcodeAndPIN, authorizationIdentifier != nil, and the
+    // selected auth supportsBarcodeDisplay (fixture basic = Codabar → true).
+    // The existing suite only covers the FALSE early-outs; this pins the AND.
+    func test_librarySupportsBarcodeDisplay_true_whenAllThreeConditionsMet() {
+        signInBasic()
+        (businessLogic.userAccount as! TPPUserAccountMock).setAuthorizationIdentifier("auth-id-1")
+
+        XCTAssertTrue(businessLogic.librarySupportsBarcodeDisplay(),
+                      "barcode display must be enabled when signed-in + authorizationIdentifier + auth supportsBarcodeDisplay")
+    }
+
+    // B2 — GAP: FALSE when the selected auth does NOT support barcode display,
+    // even with credentials + authorizationIdentifier present. OAuth in the
+    // fixture has no Codabar input → supportsBarcodeDisplay == false. Kills the
+    // `supportsBarcodeDisplay` conjunct mutant.
+    func test_librarySupportsBarcodeDisplay_false_whenSelectedAuthLacksDisplaySupport() {
+        // Persist barcode/pin via the OAuth-family no-token fallback so
+        // hasBarcodeAndPIN is satisfied while OAuth is the selected auth.
+        businessLogic.selectedAuthentication = libraryMock.oauthAuthentication
+        businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                        withBarcode: "bc", pin: "pin",
+                                        authToken: nil, expirationDate: nil,
+                                        patron: nil, cookies: nil)
+        (businessLogic.userAccount as! TPPUserAccountMock).setAuthorizationIdentifier("auth-id-2")
+        XCTAssertTrue(businessLogic.userAccount.hasBarcodeAndPIN(), "precondition")
+        XCTAssertNotNil(businessLogic.userAccount.authorizationIdentifier, "precondition")
+
+        XCTAssertFalse(businessLogic.librarySupportsBarcodeDisplay(),
+                       "an auth without barcode-display support must gate the feature off despite creds + auth id")
+    }
+
+    // MARK: - AuthCapabilities: registration gating
+
+    // B3 — registrationIsPossible flips with sign-in state: true when signed-out
+    // (fixture has a card-creator register link → signUpUrl != nil), false once
+    // signed in. Pins both operands of `!isSignedIn() && signUpUrl != nil`.
+    func test_registrationIsPossible_flipsWithSignInState() {
+        XCTAssertFalse(businessLogic.isSignedIn(), "precondition: signed out")
+        XCTAssertTrue(businessLogic.registrationIsPossible(),
+                      "signed-out patron on a library with a sign-up URL can register")
+
+        signInBasic()
+
+        XCTAssertTrue(businessLogic.isSignedIn(), "precondition: signed in")
+        XCTAssertFalse(businessLogic.registrationIsPossible(),
+                       "a signed-in patron must NOT be offered registration")
+    }
+
+    // MARK: - AuthCapabilities: password reset availability
+
+    // B4 — canResetPassword is FALSE when the auth document exposes no
+    // password-reset link. Replaces the existing tautology-ish
+    // "returns a valid Bool" assertion with a real characterization.
+    // VERIFY: the NYPL fixture auth doc carries no `password reset` rel link.
+    func test_canResetPassword_false_whenAuthDocHasNoResetLink() {
+        XCTAssertFalse(businessLogic.canResetPassword,
+                       "with no password-reset link in the auth document, canResetPassword must be false")
+    }
+
+    // MARK: - AuthCapabilities: preferred-auth + sole-IdP selection
+
+    // B5 — GAP: selectPreferredAuthIfNeeded auto-selects the SOLE SAML IdP once a
+    // SAML auth is chosen. Kills the `idps.count == 1` guard.
+    // VERIFY: the fixture SAML auth advertises exactly one `authenticate` link.
+    func test_selectPreferredAuthIfNeeded_autoSelectsSoleSamlIDP() {
+        businessLogic.selectedAuthentication = libraryMock.samlAuthentication
+        XCTAssertNil(businessLogic.selectedIDP, "precondition: no IdP chosen yet")
+
+        businessLogic.selectPreferredAuthIfNeeded()
+
+        XCTAssertNotNil(businessLogic.selectedIDP,
+                        "a single-IdP SAML auth must auto-select its sole IdP so Sign In opens the WebView")
+        XCTAssertTrue(businessLogic.selectedIDP?.url.absoluteString.contains("saml_authenticate") ?? false,
+                      "the auto-selected IdP must be the fixture's SAML authenticate endpoint")
+    }
+
+    // B6 — selectPreferredAuthIfNeeded must NOT set an IdP for a non-SAML auth.
+    // Kills the `samlAuth.isSaml` guard on the IdP-selection branch.
+    func test_selectPreferredAuthIfNeeded_doesNotSelectIDP_forNonSamlAuth() {
+        businessLogic.selectedAuthentication = libraryMock.oauthAuthentication
+
+        businessLogic.selectPreferredAuthIfNeeded()
+
+        XCTAssertNil(businessLogic.selectedIDP,
+                     "a non-SAML selected auth must never auto-select a SAML IdP")
+    }
+
+    // MARK: - Adobe DRM activation SKIP decision
+
+    // B7 — GAP (positive decision): skip Adobe activation when credentials are
+    // stale, Adobe userID+deviceID exist, and the device is still authorized.
+    // The existing suite only covers the FALSE early-returns.
+    func test_shouldSkipAdobeActivation_true_whenStaleWithAdobeCredsAndAuthorizedDevice() {
+        let acct = businessLogic.userAccount as! TPPUserAccountMock
+        acct.setUserID("adobe-user")
+        acct.setDeviceID("adobe-device")
+        acct.setAuthState(.credentialsStale)
+        drmAuthorizer.isUserAuthorizedReturnValue = true   // default, made explicit
+
+        XCTAssertTrue(businessLogic.shouldSkipAdobeActivation(),
+                      "stale creds + Adobe id/device + authorized device must skip activation (preserve the slot)")
+    }
+
+    // B8 — GAP: even when stale WITH Adobe creds, do NOT skip if the device is no
+    // longer authorized with Adobe. This branch only exists under the DRM
+    // connector; the guard is compiled out in the open-source build.
+    #if FEATURE_DRM_CONNECTOR
+    func test_shouldSkipAdobeActivation_false_whenDeviceNoLongerAuthorized() {
+        let acct = businessLogic.userAccount as! TPPUserAccountMock
+        acct.setUserID("adobe-user")
+        acct.setDeviceID("adobe-device")
+        acct.setAuthState(.credentialsStale)
+        drmAuthorizer.isUserAuthorizedReturnValue = false
+
+        XCTAssertFalse(businessLogic.shouldSkipAdobeActivation(),
+                       "a device Adobe no longer recognizes must re-activate, not skip")
+    }
+    #endif
+
+    // B9 — do NOT skip when stale but Adobe deviceID is missing (isolates the
+    // second `guard let deviceID` clause; userID present, deviceID absent).
+    func test_shouldSkipAdobeActivation_false_whenStaleButMissingDeviceID() {
+        let acct = businessLogic.userAccount as! TPPUserAccountMock
+        acct.setUserID("adobe-user")   // deviceID intentionally left nil
+        acct.setAuthState(.credentialsStale)
+
+        XCTAssertFalse(businessLogic.shouldSkipAdobeActivation(),
+                       "missing Adobe deviceID must block the skip even with a userID and stale state")
+    }
+
+    // B10 — do NOT skip when Adobe creds exist and device is authorized but the
+    // account is NOT stale (isolates the leading `authState == .credentialsStale`
+    // guard). A fresh sign-in must re-activate.
+    func test_shouldSkipAdobeActivation_false_whenAuthorizedButNotStale() {
+        let acct = businessLogic.userAccount as! TPPUserAccountMock
+        acct.setUserID("adobe-user")
+        acct.setDeviceID("adobe-device")
+        acct.setAuthState(.loggedIn)
+        drmAuthorizer.isUserAuthorizedReturnValue = true
+
+        XCTAssertFalse(businessLogic.shouldSkipAdobeActivation(),
+                       "a non-stale (fresh) sign-in must never skip Adobe activation")
+    }
+
+    // MARK: - refreshAuthIfNeeded: basic auto-reauth
+
+    // SEAM: the TOKEN-auth branch of refreshAuthIfNeeded is NOT exercised here
+    // because its expiry guard reads `AppContainer.production().accountsManager
+    // .currentUserAccount.authTokenHasExpired` and the refresh calls
+    // `getBearerToken(username:password:tokenURL:completion:)` whose default
+    // `networkExecutor` argument is `AppContainer.production().networkExecutor` —
+    // both reach the process-wide container. The SignInRequestService extraction
+    // must inject a `TokenRefreshing` collaborator (the §10.2 seam the OAuth
+    // token-flow tests already use) AND an auth-token-expiry checker so the token
+    // refresh path is deterministically testable without the container.
+    // (The fixture also has no `.token` auth method, so the logIn() `.token`
+    // routing branch is unreachable from this library mock regardless.)
+
+    // B11 — GAP: basic auth WITH saved credentials + usingExistingCredentials
+    // returns false (no sign-in UI needed) and drives logIn() directly. The
+    // existing suite covers the WITHOUT-creds → true complement.
+    func test_refreshAuthIfNeeded_basicWithSavedCredentials_returnsFalse_andLogsIn() {
+        signInBasic(barcode: "saved-bc", pin: "saved-pin")
+
+        let result = businessLogic.refreshAuthIfNeeded(usingExistingCredentials: true, completion: nil)
+
+        XCTAssertFalse(result,
+                       "basic auth with saved credentials must NOT require a sign-in UI (returns false)")
+        XCTAssertTrue(businessLogic.isValidatingCredentials,
+                      "refreshAuthIfNeeded must drive logIn() → validateCredentials for the saved-creds path")
+    }
+
+    // MARK: - logIn() routing per auth method (safe branches)
+
+    // B12 — logIn(basic) captures creds, enters validating, and fires the
+    // credential-validation request.
+    func test_logIn_basicAuth_capturesCredentials_entersValidating_andFiresRequest() {
+        uiDelegate.username = "login-bc"
+        uiDelegate.pin = "login-pin"
+        businessLogic.selectedAuthentication = libraryMock.barcodeAuthentication
+
+        businessLogic.logIn()
+
+        XCTAssertEqual(businessLogic.capturedBarcode, "login-bc")
+        XCTAssertEqual(businessLogic.capturedPin, "login-pin")
+        XCTAssertTrue(businessLogic.isValidatingCredentials,
+                      "basic logIn routes straight to validateCredentials")
+        XCTAssertEqual(networkExecutor.executedRequestURLs.count, 1,
+                       "basic logIn must fire exactly one validation request")
+    }
+
+    // SEAM: logIn()'s OAuth (`oauthLogIn`) and SAML (`samlHelper.logIn`) arms
+    // launch an external browser via `UIApplication.shared.open` / a web-sheet
+    // presenter reached inside the SUT — not deterministically drivable in a unit
+    // test (the existing OAuth suite avoids logIn() entirely, driving
+    // handleRedirectURL directly instead). The flow-engine extraction must inject
+    // a URL-opener / web-auth-session presenter protocol so these two routing
+    // arms become observable. OIDC (`oidcLogIn`) is safe to invoke here because
+    // ASWebAuthenticationSession no-ops without a presentation anchor in tests.
+
+    // B13 — logIn(OIDC) captures the barcode and notifies willSignIn but does
+    // NOT validate directly (it hands off to the external web-auth session).
+    func test_logIn_oidc_capturesBarcode_notifiesWillSignIn_doesNotValidateDirectly() {
+        uiDelegate.username = "oidc-u"
+        uiDelegate.pin = nil
+        businessLogic.selectedAuthentication = libraryMock.oidcAuthentication
+
+        businessLogic.logIn()
+        drainMainQueue()   // willSignIn is dispatched async
+
+        XCTAssertEqual(businessLogic.capturedBarcode, "oidc-u")
+        XCTAssertFalse(businessLogic.isValidatingCredentials,
+                       "OIDC must NOT call validateCredentials directly — it uses ASWebAuthenticationSession")
+        XCTAssertTrue(uiDelegate.didCallWillSignIn,
+                      "logIn must notify the UI it is about to sign in")
+    }
+
+    // B14 — DRM-failure guard: a failed DRM authorization must PRESERVE existing
+    // credentials (no new barcode written). This guard only exists under the DRM
+    // connector build. Money-path invariant: never corrupt creds on DRM failure.
+    #if FEATURE_DRM_CONNECTOR
+    func test_updateUserAccount_drmAuthorizationFailed_preservesExistingCredentials() {
+        signInBasic(barcode: "keep-bc", pin: "keep-pin")
+        XCTAssertEqual(businessLogic.userAccount.barcode, "keep-bc", "precondition")
+
+        businessLogic.updateUserAccount(forDRMAuthorization: false,
+                                        withBarcode: "SHOULD-NOT-PERSIST", pin: "nope",
+                                        authToken: nil, expirationDate: nil,
+                                        patron: nil, cookies: nil)
+
+        XCTAssertEqual(businessLogic.userAccount.barcode, "keep-bc",
+                       "a failed DRM authorization must not overwrite existing credentials")
+    }
+    #endif
+}

--- a/docs/architecture/god-class-decomposition-plan.md
+++ b/docs/architecture/god-class-decomposition-plan.md
@@ -1,0 +1,321 @@
+# Palace iOS — Target Architecture & Decomposition Plan (ADR draft)
+
+**Status:** proposed · **Author:** architect agent, 2026-07-23 · **Extends:** `docs/architecture/architectural-triad.md` (Phases 6–7, which this document supersedes with a complete map) · **Vocabulary:** this doc reuses the triad's terms — AppContainer composition root, `Store<State,Action,Environment>`, reducer-as-pure-function, contract-snapshot tests, "load-bearing on day 1."
+
+---
+
+## 1. Current-state review
+
+### What is healthy (the target pattern is proven in-repo, not hypothetical)
+
+- **Seven live SPM packages** under `Palace/Packages/` — PalaceAuth, PalaceCatalog, PalaceKeychain, PalaceLogging, PalaceNetwork, PalaceReadingPosition, PalaceTriageBot. They are load-bearing (imported by `AppContainer.swift` itself), Swift-6-mode, and **cycle-free by construction**: SwiftPM rejects cyclic package graphs at manifest-resolution time. Their internal dependency DAG is already the embryo of the target: `PalaceAuth → {PalaceLogging, PalaceNetwork, PalaceCatalog}`, `PalaceCatalog → {PalaceLogging, PalaceNetwork}`, `PalaceNetwork → PalaceLogging`. None of the 24 ledger cycles touches a package. This is the single most important empirical fact in the codebase: **where a compile-time boundary exists, the cycle problem is already solved.**
+- **AppContainer is a real composition root** (`Palace/AppInfrastructure/AppContainer.swift`): ~20 `let` services + ~12 lazy `@MainActor` cached seams, explicit hand-threaded construction in `_buildCachedAppContainer()` that documents every historical init-cycle deadlock, test seams (`withSignInModalSheetPresenter`, `_resetForTesting`, `testExecutorProtocolClasses`). The mechanism to replace every `.shared` read exists; adoption is the remaining work, not invention.
+- **Reducers extracted on the critical paths**: `BorrowReducer` (integrated into `BookDetailViewModel` via snapshot/apply), `HoldsReducer`, `AuthReducer` (in the PalaceAuth package, awaiting integration), `AccountStateMachine`. `Store.swift` (~70 LOC, `Effect`-returning pure reduce) is the settled shape.
+- **Contract-snapshot safety net exists and is populated**: `PalaceTests/Contract/` has `CallLog.swift` + `ContractSnapshot.swift` and **11 snapshot suites** — BorrowOperation, BookReturnService, DownloadStartCoordinator, BorrowReducer, AudiobookPositionAdapter, PositionWriter, three Reader2 suites, SideloadImport, StreamingReaderPresentation. Extraction can be gated on "snapshot unchanged."
+- **MyBooksDownloadCenter is further decomposed than its LOC suggests.** `Palace/MyBooks/` already contains ~25 extracted collaborators (BackgroundDownloadHandler, DownloadQueueOrchestrator, DownloadThrottlingService, DownloadTaskPersistence, DownloadStartDispatcher/Coordinator, TokenRefreshInterceptor delegate wiring, BorrowErrorPresenter, CredentialPromptCoordinator, BookReturnService, LCPFulfillmentHandler, OverdriveDownloadHandler, DiskBudgetManager, …). MBDC's tail (lines ~1809–2155) is fourteen `*Delegate` conformances that mostly forward. The remaining god-mass is the URLSession delegate plumbing, background-session identity/reconciliation (Reliability WS-A), and error-announcement glue — a **boundary problem, not a carving problem**.
+- **A declared layer model already exists** in `tools/ledger/ledger-config.json`: layers `[Infrastructure, Domain, Presentation, Application, Tests]` with allowed edges `Application→{Presentation,Domain}`, `Presentation→Domain`, `Domain→Infrastructure` — plus 32 componentRoots. The ledger CI trend gate is live (0.9.7). The target below is expressed in exactly this layer vocabulary so the existing gate enforces it without re-tooling.
+
+### What is broken
+
+- **Folders are not modules.** ~567 Swift files in the app target share one namespace. `Palace/Book/` freely references `AccountsManager`; `Palace/Settings/` freely references `TPPUserAccount`; nothing stops it. That mutual visibility IS the 183-edge / 24-cycle graph. All cycles funnel through five hub folders (Accounts, Book, Settings, Audiobooks, Logging) precisely because those folders host the types everyone reaches for (`Account`, `TPPBook`, `TPPSettings`, `TPPErrorLogger`) *and* host high-level orchestrators that reach back out. The hub folders mix layers internally — that internal mixing is what each cycle's two directions actually are (verified per-cycle in §3b).
+- **The god-orchestrators are accreting, not shrinking.** 19-day deltas: AudiobookSessionManager +529 (+24%), AccountsManager +549 (+33%), MyBooksDownloadCenter +328 (+18%). Every reliability fix (F-011 readiness gates, PP-4542 position resolve, WS-A durable downloads, CP-D1 launch hydration) lands *inside* the hub because the hub is where the seams are. Without a ratchet, decomposition is bailing a leaking boat.
+- **39 declared singletons are the coupling substrate.** The triad cut `.shared` call sites 732→~564, but the highest-fan-in ambient reaches remain: TPPKeychain.shared (40), RemoteFeatureFlags.shared (32), FirebaseManager.shared (25), UserAccountPublisher.shared (16), ImageCache.shared (16), NotificationService.shared (12), AccountStateStore.shared (8). Notably, **several of these already have AppContainer seams that consumers bypass** (`imageCache`, `userAccountPublisher`, `bookRegistry` are container members; `AppContainer._buildCachedAppContainer()` itself still reads `ImageCache.shared` and `UserAccountPublisher.shared` to build them). Even `appRatingService` construction inside AppContainer reaches for `RemoteFeatureFlags.shared` / `FirebaseManager.shared` via closures. The pattern exists; enforcement doesn't.
+- **`AppContainer.production()` is itself used as a service locator** — e.g. `Palace/ErrorHandling/ErrorDetail.swift` and `Palace/Book/UI/TPPProblemReportViewController.swift` call `AppContainer.production().accountsManager` in default args / bodies. That's a `.shared` read with extra steps: it preserves the ambient-reach graph and defeats testability the same way. The target must treat `AppContainer.production()` outside composition roots as a violation, not a win.
+- **Known debt from the triad remains open**: AuthReducer not integrated into TPPSignInBusinessLogic (gated on characterization tests that were never written — the class had 0 dedicated tests at triad time); MBDC de-singletonized but body intact; the AppContainer static-cache cells (`_audiobookSession`, `_catalogRepository`, …) are themselves process-wide singletons with hand-maintained `_resetForTesting()` bookkeeping — a recurring source of the systemic test pollution.
+
+**One-sentence diagnosis:** the architecture has the right *mechanisms* (packages, container, reducers, contracts) but the wrong *defaults* — inside the monolithic target, reaching sideways is free, so every fix accretes onto a hub; the fix is to make sideways reach a compile error by promoting the hub folders' lower halves into SPM packages with an enforced DAG, leaving thin app-target shells.
+
+---
+
+## 2. Target architecture
+
+### 2.1 The destination in one paragraph
+
+Palace becomes a **thin app target over a layered SPM package DAG**. Every *domain* concern (models, registries, engines, flow logic) lives in a package; the app target retains only Application-layer composition (AppContainer, app/scene delegates), Presentation (SwiftUI/UIKit screens, ViewModels), and the **irreducible Infrastructure adapters that cannot leave** (Adobe RMSDK / LCP DRM binaries, Firebase SDK wiring, CarPlay). Packages depend only downward; the app target depends on packages; **no package ever imports the app target** — which SwiftPM enforces mechanically, making every one of today's cycles a compile error rather than a lint warning. Ambient state dies with the folders: every current `.shared` read becomes an AppContainer `let`/lazy seam injected by constructor, and the container stops being callable as a locator outside composition roots (CI-gated).
+
+### 2.2 Layers and packages
+
+Names follow the established `Palace*` convention; layer names follow `ledger-config.json`. **(exists)** = already in `Palace/Packages/`. **(new)** = created by this plan. Every new package must be load-bearing on day 1 (≥1 app-target import at the PR that creates it) — the triad's anti-PalaceFoundation rule.
+
+```
+LAYER 3 — Application (app target only)
+  Palace app target: TPPAppDelegate, SceneDelegate, AppContainer,
+  ModuleComposition, CarPlay templates, Firebase/DRM/notification wiring,
+  developer settings
+        │ imports everything below
+LAYER 2 — Presentation (app target now; packages optional/later)
+  SwiftUI screens + ViewModels + reducer integrations:
+  CatalogUI, Book/UI, MyBooks UI, Settings UI, Holds UI, Reader2/PDF UI,
+  Audiobook player shells   (+ external: ios-audiobooktoolkit, PalaceUIKit)
+        │
+LAYER 1 — Domain (packages)
+  PalaceBookModel   (new)  TPPBook, registry records, book-state enums,
+                           acquisition/format model
+  PalaceBookRegistry(new)  TPPBookRegistry engine (account-scoped book state)
+  PalaceAccounts    (new)  Account, AccountsManager (decomposed), auth-doc
+                           loading, AccountStateStore, UserAccountPublisher
+  PalaceDownloads   (new)  download engine: queue orchestration, throttling,
+                           task persistence, background reconciliation,
+                           progress publishing, borrow orchestration core
+  PalaceAuth        (exists) AuthCoordinator, AuthReducer, flow engines
+                           (grows: sign-in flow logic from TPPSignInBusinessLogic)
+  PalaceCatalog     (exists) OPDS2 models, catalog API/repository
+  PalaceReadingPosition (exists)
+  PalaceAudiobookSession (new, conditional — see §3a caveat)
+        │
+LAYER 0 — Infrastructure (packages + irreducible app-target adapters)
+  PalaceNetwork     (exists)   PalaceLogging (exists)   PalaceKeychain (exists)
+  PalacePreferences (new)  TPPSettings key-value store (no domain knowledge)
+  PalaceFeatureFlags(new)  FeatureFlagProviding protocol + typed flag surface
+                           (impl stays app target — Firebase Remote Config)
+  App-target-only adapters (permanent): AdobeDRMService/LCP (private binaries,
+  FEATURE_DRM_CONNECTOR), FirebaseManager (SDK), NotificationService (FCM +
+  UNUserNotificationCenter), ImageCache (candidate to package later)
+```
+
+### 2.3 The enforced DAG
+
+Package manifests declare exactly these dependencies (SwiftPM rejects anything cyclic; anything not listed is unimportable):
+
+```
+PalaceLogging          → (nothing)
+PalacePreferences      → (nothing)
+PalaceFeatureFlags     → (nothing)
+PalaceKeychain         → (nothing)                        [as today]
+PalaceNetwork          → PalaceLogging                    [as today]
+PalaceCatalog          → PalaceLogging, PalaceNetwork, PalaceFeatureFlags
+PalaceBookModel        → PalaceLogging                    (models only — near-leaf)
+PalaceBookRegistry     → PalaceBookModel, PalaceLogging, PalacePreferences
+PalaceAuth             → PalaceLogging, PalaceNetwork, PalaceCatalog,
+                         PalaceKeychain                   [+Keychain vs today]
+PalaceAccounts         → PalaceAuth, PalaceCatalog, PalaceNetwork,
+                         PalacePreferences, PalaceKeychain, PalaceLogging
+PalaceReadingPosition  → (as today)
+PalaceDownloads        → PalaceBookModel, PalaceBookRegistry, PalaceNetwork,
+                         PalaceAuth (AuthCoordinator surface), PalaceLogging
+PalaceAudiobookSession → PalaceBookModel, PalaceReadingPosition,
+                         PalacePreferences, PalaceLogging (+ toolkit, see caveat)
+App target             → all of the above
+```
+
+Key inversions that make this acyclic (each is a protocol defined *in the lower package*, implemented/injected *from above* — the pattern PalaceAuth already uses with `CoordinatorAccountProvider` / `AuthDecisionRecording`, and PalaceCatalog with `FeatureFlagProvider`):
+
+- **PalaceBookRegistry must not know PalaceAccounts.** Today `TPPBookRegistry.init(accountsManager:imageLoader:)` takes the whole AccountsManager. Target: `init(accountScope: AccountScopeProviding, …)` where `AccountScopeProviding` (`currentAccountID`, `accountDidChange` publisher) is a protocol in PalaceBookRegistry; the app target adapts AccountsManager to it. This single inversion is what keeps Book/Accounts permanently acyclic.
+- **PalaceDownloads must not know DRM.** Fulfillment dispatch is `FulfillmentHandling` protocols declared in PalaceDownloads; Adobe/LCP/Overdrive handlers stay app-target and register at composition time (exactly how `drmAuthorizerProvider: () -> TPPDRMAuthorizing?` already works in AppContainer).
+- **Nothing below Application knows Firebase.** Capability protocols (`CrashReporting`, `RemoteConfigProviding`, `PushMessaging`) live in the package that needs them; `FirebaseManager`/`NotificationService` implement them app-side. Precedent: `AuthDecisionRecording` in PalaceAuth wrapping Crashlytics.
+
+### 2.4 How the compiler + CI enforce it
+
+1. **SwiftPM (hard, structural):** cyclic package dependencies are a manifest-resolution error; a package cannot import the app target at all. Once code is in a package, the cycle it participated in *cannot recur*.
+2. **Ledger layer gate (soft, for the shrinking app-target remainder):** the existing `layerRules` in `tools/ledger/ledger-config.json` keep policing the in-target folders during transition; each wave moves a folder's Domain half out and re-tags the remainder Presentation/Application. Name-inferred edges get a confidence tag (see §3b cycle 9).
+3. **New ratchet gates (Wave 0):** god-class LOC freeze per file; `.shared`-read count monotone-down; `AppContainer.production()` call-site count outside an allowlist (composition roots, `@Environment` default, test bootstrap) monotone-down. All three are dumb greps — cheap, ungameable, wired into `verify-pr.sh` + a tooling-checks-style workflow per CLAUDE.md's "don't land a gate faster than you can verify it."
+
+### 2.5 Why each root 2-cycle becomes structurally impossible (summary; full map in §3b)
+
+The pattern in every case is the same: each cycle's two directions live at *different layers* inside the hub folders. The down-direction (X uses Y's *model/store*) becomes a package dependency; the up-direction (Y's *orchestrator/UI* reaches into X) either moves up to the app target with X, or inverts into a protocol the lower package declares. After that, the "cycle" is two one-way edges at different layers — which is just layering.
+
+---
+
+## 3. THE MAP
+
+### 3a. God-classes → responsibility clusters → target homes
+
+Clusters are read from the files' own `// MARK:` structure (verified against source this session). "Shell" = what remains in the app target after the wave completes.
+
+#### 1. `Palace/Audiobooks/AudiobookSessionManager.swift` (2,761 LOC)
+
+| Cluster (MARK-verified) | What it does | Target home |
+|---|---|---|
+| `AudiobookSessionState` + `AudiobookSessionError` (lines 20–78) | session lifecycle enum + error taxonomy | **PalaceAudiobookSession** (pure types) |
+| Published state + internal state + external publishers (107–291) | `@Published` mirrors + Combine surface | **Shell** (`@MainActor ObservableObject` facade) |
+| Public API + Manager Binding (526–1541) | open/close/play session; bind toolkit `AudiobookManager` | split: orchestration decision logic → `AudiobookOpenReducer` (pure, **PalaceAudiobookSession**); toolkit binding glue → **Shell** (toolkit types are Presentation-layer, see caveat) |
+| Position resolve before play, PP-4542 (1542–1640) + position restoration helpers (1809–1992) | reconcile local/remote listening position | `AudiobookPositionResolver` → **PalaceAudiobookSession**, consuming **PalaceReadingPosition** (an adapter + contract test — `AudiobookPositionAdapterContractTests` — already exist) |
+| Readiness-gate wiring, F-011 (265–291, 1641–1687) | injection points gating play until player ready | `PlaybackReadinessGate` type → **PalaceAudiobookSession**; injection stays Shell |
+| LCP first-open reliable start, WS-5 (1688–1780) | DRM-specific start dance | **app target** (LCP = private DRM); behind `ProtectedPlaybackStarting` protocol declared in PalaceAudiobookSession |
+| Chapter TOC normalization (1781–1808) | pure transform of toolkit TOC | `TOCNormalizer` pure func → **PalaceAudiobookSession** |
+| Private methods (1993–end) | mixed glue | dissolves into the above during extraction |
+
+**Shell:** `AudiobookSessionManager` remains as the `AudiobookSessionManaging` facade AppContainer already vends — publishes state, forwards to the reducer/services. Target ≤400 LOC.
+**Caveat (honest):** the package form is **conditional** on `PalaceAudiobookToolkit` (git submodule, ledger-tagged Presentation, with a known layer violation) exposing a usable non-UI core API. If it doesn't by Wave 6, the same decomposition happens **in-target** (separate files, same seams) and the package is deferred. The decomposition is mapped either way; only its compile-enforcement is conditional.
+
+#### 2. `Palace/Accounts/Library/AccountsManager.swift` (2,235 LOC)
+
+| Cluster (MARK-verified) | What it does | Target home |
+|---|---|---|
+| Cache metadata + disk cache helpers (7–…, 1467–1604) | account-list disk cache, TTLs | `AccountRegistryCache` → **PalaceAccounts** |
+| Config/state + thread-safe `accountSets` access (225–823) | registry state + `accountSetsLock` barrier | `AccountRegistryStore` (actor or lock-boxed store) → **PalaceAccounts** |
+| Account retrieval (824–1016) | lookup by UUID/URL, current account | `AccountRegistryStore` + thin `CurrentAccountStore` (owns `currentAccount` + change publication, feeds `UserAccountPublisher`) → **PalaceAccounts** |
+| Per-account user credentials (1017–1079) | credential resolution per account | `AccountCredentialResolver` → **PalaceAccounts**, storing via **PalaceKeychain** |
+| Load logic, CP-D1 slim hydration + background crawl (1080–1466) | registry fetch, `loadCatalogs`, the background Task that pollutes tests | `AccountRegistryLoader` (explicitly owned, cancellable, injectable-scheduler) → **PalaceAccounts**. This is where `cancelAndDrainBackgroundWork` / `_drainAllLiveInstancesForTesting` become structured concurrency instead of drain heuristics |
+| Auth-document fetch with state-machine wiring (1605–1786) | per-account auth doc fetch + `AccountStateStore` transitions | `AuthDocumentLoader` → **PalaceAccounts** (consumes AuthenticationDocument parsing already in **PalaceCatalog**; drives `AccountStateMachine`) |
+| Parsing & notifying (1787–end) | feed parse + NotificationCenter posts | parse → loader; notification posts → typed Combine publishers on the store (Shell adapts to legacy NotificationCenter names during transition) |
+
+**Shell:** `AccountsManager` becomes a facade composing the five collaborators, preserving its current API for the ~100 call sites; AppContainer constructs the pieces. Target ≤300 LOC. `Account` + `Account+profileDocument` move to PalaceAccounts with it (their `TPPErrorLogger` reads become the injected `ErrorReporting` protocol — see cycle 2).
+
+#### 3. `Palace/MyBooks/MyBooksDownloadCenter.swift` (2,155 LOC)
+
+| Cluster (MARK-verified) | What it does | Target home |
+|---|---|---|
+| URLSession delegate plumbing + download info map (1–~1000) | task↔book bookkeeping, delegate callbacks | `DownloadEngine` (URLSession broker + `DownloadTaskLifecycleService` + `DownloadTaskPersistence`, which already exist as files) → **PalaceDownloads** |
+| Reliability WS-A: background session identity + completion handler + durable downloads + launch reconciliation (227–…, 1938–2155) | background-session adoption, INV-4/6/7 invariants | `BackgroundSessionReconciler` → **PalaceDownloads** (the WS-A invariant comments move with it as doc) |
+| PP-4114 mid-flight network drop (1006–1135) | pause/resume on reachability | `DownloadRetryPolicy` → **PalaceDownloads** (consumes `Reachability` from **PalaceNetwork**) |
+| Error announcements (1136–…) | a11y + user-facing error surfacing | **Shell** / DownloadAnnouncementService (already extracted, stays app target — Presentation concern) |
+| Throttling + disk budget (1623–1808) | `DownloadThrottlingService` + `DiskBudgetManager` glue | services already exist as files → move both to **PalaceDownloads**; glue dissolves |
+| 14 `*Delegate` conformances (1809–1937) | forwarding hub for the extracted collaborators | **Shell**: MBDC remains the app-target coordinator implementing these protocols, forwarding into the engine; DRM-specific delegates (LCPFulfillmentHandler, OverdriveDownloadHandler, AdobeDRMHandler) stay app target behind `FulfillmentHandling` |
+
+**Shell:** MBDC keeps `MyBooksDownloadCenterProtocol` (already exists) as its surface; borrow entry-points route to `BorrowOperation`. Target ≤500 LOC. **This is the money path — its wave has the strictest test gate (§5).**
+
+#### 4. `Palace/Book/UI/BookDetail/BookDetailViewModel.swift` (1,375 LOC)
+
+| Cluster (MARK-verified) | What it does | Target home |
+|---|---|---|
+| Book state binding + BorrowReducer round-trip (268–502) | registry state → button state | **Shell** (this IS the VM's job; reducer already extracted) |
+| Metadata hydration (521–590) + Related books / series row (21–43, 591–683) | fetch full OPDS entry, related-works lanes | `BookMetadataService` + `RelatedBooksService` → app-target **Domain-in-transit**, backed by **PalaceCatalog**'s repository (candidate to fold into PalaceCatalog once TPPBook lives in PalaceBookModel) |
+| Button actions + Download/Return/Cancel (684–802, 894–948) | dispatch to downloadCenter/borrow | **Shell** (thin dispatch through injected `MyBooksDownloadCenterProtocol`) |
+| Authentication helper (803–893) | reauth-then-retry glue | delete in place — route through **PalaceAuth**'s `AuthCoordinator` (this is exactly what AuthCoordinator was built for; the VM-local copy is pre-coordinator legacy) |
+| Reading + Audiobook opening + Streaming HTML reader PP-4161 (949–1118) | open EPUB/PDF/audio/streaming | `BookOpenRouter` (app-target Application service; `BookService.swift` already holds the format-routing seam — consolidate there, see cycle 8) |
+| Samples (1119–1176) | sample playback | **Shell** dispatch to existing `SamplePreviewManager` (AppContainer seam exists) |
+| Error alerts (1177–…) + LCP streaming ext | present errors | **Shell** |
+
+**Shell:** the VM itself, ≤600 LOC, purely `@Published` + reducer + dispatch. Note: BookDetailViewModel is *not* extracted to a package — VMs are Presentation and stay app-target; its *service work* is what moves.
+
+#### 5. `Palace/SignInLogic/TPPSignInBusinessLogic.swift` (1,110 LOC)
+
+| Cluster (MARK-verified) | What it does | Target home |
+|---|---|---|
+| Auth state machine (141–165) | drive `AccountStateMachine` | replaced by **AuthReducer integration** (reducer already lives in **PalaceAuth**; integration is the long-open triad debt, gated on characterization tests — §5) |
+| OAuth/SAML/Clever info + SAML triad (166–277) | per-IdP endpoints, SAML helper/context/presenter | `OAuthFlow` / `SAMLFlow` / `CleverFlow` engine types → **PalaceAuth** (presenter part stays app-target Presentation) |
+| Library accounts info (278–395) | account/authDoc lookups | thin reads via injected **PalaceAccounts** surfaces |
+| Network requests logic (396–888) | token requests, profile doc, error mapping | `SignInRequestService` → **PalaceAuth** (uses **PalaceNetwork**; error mapping joins `AuthErrorClassifier` already in the package) |
+| User account management (889–962) | persist credentials, update `TPPUserAccount` | `CredentialStore` → **PalaceAccounts** (+ **PalaceKeychain**) |
+| Available-features checks (963–1054) | barcode/pin/card-creator gating | pure `AuthCapabilities` derivation → **PalaceAuth** |
+| Adobe DRM activation skip logic (1055–end) | DRM activation decisions | **app target** (DRM), behind `DRMActivationPolicy` protocol declared in PalaceAuth |
+
+**Shell:** the `@objc`-bridged class remains as facade while UIKit callers exist (it's ObjC-visible; full removal is gated on migrating those callers). Target ≤300 LOC. **Order is fixed: characterization tests → AuthReducer integration → engine extraction.** Anything else on a 0-dedicated-test critical path is reckless (triad decision log, still true).
+
+#### 6. `Palace/MyBooks/BorrowOperation.swift` (989 LOC)
+
+| Cluster (MARK-verified) | What it does | Target home |
+|---|---|---|
+| Pure helpers (144–260) + re-auth circuit breaker (99–143) | decision functions | **PalaceDownloads** (pure, trivially portable) |
+| Dependencies + closure-injected seams + init (261–371) | DI surface | already clean — moves with the class |
+| Borrow orchestration (372–569) | fetchBook → startDownload sequence | `BorrowOperation` core → **PalaceDownloads** (contract-pinned: `BorrowOperationContractTests` exists) |
+| Auth-error handling + OIDC silent re-auth + coordinator-routed retry + sign-in-modal retry (570–…, 810–end) | 401/403 recovery ladder | routes through **PalaceAuth** `AuthCoordinator` (already injected); modal presentation stays app target via existing presenter protocols |
+| Error presentation (754–809) | alert composition | **Shell** (`BorrowErrorPresenter` already a separate file, stays Presentation) |
+
+**Honest assessment:** BorrowOperation is the *least* god-like of the six — closure seams, pure helpers, circuit breaker, contract tests all already in place. It moves largely intact in the PalaceDownloads wave; no internal decomposition needed. It's on this list for LOC, not for architecture debt.
+
+### 3b. The 9 root 2-cycles → dissolving boundary
+
+Each row names the *verified* code behind both directions (grepped this session) and the specific mechanism that removes it.
+
+| # | Cycle | Down-direction (becomes package dep) | Back-direction (the edge that dies) | Dissolved by |
+|---|---|---|---|---|
+| 1 | **Book↔Accounts** | Accounts code touches book-registry sync surfaces (`TPPBookRegistry.syncAsync` refs in AccountsManager) | `Palace/Book/UI/*` reads `AccountsManager.currentAccount` (e.g. `TPPProblemReportViewController` via `AppContainer.production()`) | `TPPBook`/records → **PalaceBookModel**; registry → **PalaceBookRegistry** taking `AccountScopeProviding` (protocol in the registry package, adapter in app target) instead of AccountsManager. Book *UI* stays app-target Presentation and injects `CurrentAccountProviding`. Neither package can import the other's package — SwiftPM enforced |
+| 2 | **Accounts↔ErrorHandling** | `Account+profileDocument`/`Account.swift` call `TPPErrorLogger.logError` | `ErrorDetail.swift` / `ProblemReportEmail.swift` default-arg `AppContainer.production().accountsManager` for device context | `ErrorReporting` protocol → **PalaceLogging** (beside the existing `CrashlyticsLogBridge`); PalaceAccounts logs through it; TPPErrorLogger implements it app-side. ErrorHandling's back-reach becomes a passed-in `DeviceContext` value (caller snapshots account info) — ErrorHandling stops importing Accounts entirely |
+| 3 | **Logging↔Network** | `Palace/Network/TPPNetworkQueue` uses `Log.*` — legitimate, already acyclic as **PalaceNetwork→PalaceLogging** | `Palace/Logging/TPPCirculationAnalytics.swift` uses `NetworkQueue`, `TPPNetworkExecutor`, `AccountsManager` | **File misfiled, not a real layering conflict.** TPPCirculationAnalytics is a circulation-domain network client, not logging. Move it out of `Palace/Logging/` (home: app-target Domain beside OPDS services; later PalaceCatalog). The folder-cycle vanishes with the move |
+| 4 | **Accounts↔OPDS2** | Accounts parses feeds/auth docs (`CrawlableFeedAnalysis` uses `OPDS2Feed`/`OPDS2CatalogsFeed`) | `OPDSFeedService` reads `Account.LoadState`/`currentAccount?.loansUrl` (param already "widened from AccountsManager" per its own comment — inversion half-done) | OPDS2 models already live in **PalaceCatalog** (`OPDS2Feed.swift`, `OPDS2AuthenticationDocument.swift` in the package). Finish it: delete in-target duplicates, PalaceAccounts→PalaceCatalog one-way; OPDSFeedService keeps its protocol-widened account param (protocol declared feed-side) |
+| 5 | **Accounts↔Settings** | `AccountsManager` stores `private let settings: TPPSettings` | `Palace/Settings/` UI (`AccountDetailViewModel`, `AdvancedSettingsView`, `TPPSettings+SE`) reads `AccountsManager`/`TPPUserAccount` | Split the Settings folder by layer: `TPPSettings` (pure prefs store) → **PalacePreferences** (Layer 0); Settings *screens* are Presentation and legitimately depend on PalaceAccounts one-way. The cycle existed only because store and screens shared a folder. (`TPPSettings+SE`'s hardcoded `AccountsManager.TPPAccountUUIDs` constant moves to PalaceAccounts as data) |
+| 6 | **Settings↔Audiobooks** | `AudiobookSessionManager` stores `private let settings: TPPSettings` | `DeveloperSettingsViewModel.emailAudiobookLogs` + `AudiobookMailComposeDelegate` (dev tooling — the only Settings→Audiobooks reach) | Same PalacePreferences split kills the down-edge's folder-coupling; the dev-tools log-email consumes a `LogArchiveExporting` protocol (declared in **PalaceLogging**, implemented by the audiobook stack) instead of importing audiobook types. Thinnest cycle of the nine |
+| 7 | **Book↔CatalogUI** | `CatalogState`/`CatalogSortService` operate on `[TPPBook]` | `BookDetailView` constructs `CatalogLaneMoreView` (series carousel / related lanes NavigationLinks) | `TPPBook` → **PalaceBookModel** makes CatalogUI→model a down-edge. The back-edge is Presentation-internal navigation: route via a destination-provider closure / `NavigationCoordinatorHub` (already an AppContainer member) instead of direct view construction. Both view folders stay app-target Presentation initially, so this one is gate-enforced (ledger) before it is compiler-enforced — flagged honestly |
+| 8 | **PDF↔Book** | `TPPPDFDocumentMetadata` uses `TPPBook` + `TPPBookRegistryProvider` (already protocol-typed) | `Palace/Book/.../BookService.swift` routes to PDF opening (`PDFDocument(url:)` path) | PDF→**PalaceBookModel**/**PalaceBookRegistry** is a clean down-edge (it already consumes the registry via protocol). The back-edge dies by *relocating* `BookService`'s format-routing to the Application layer (`BookOpenRouter`, §3a-4): a router that knows all readers is composition, not Book-domain code |
+| 9 | **TriageBotUI↔Palace** | — | — | **False positive** (name-based inference; PalaceTriageBot is an SPM package that cannot import the app target). Action: Wave 0 annotates it in ledger config as a known-false-positive / adds a confidence field for name-inferred edges, so the trend gate doesn't count it. No code change |
+
+**Sanity check on completeness:** hubs named by the ledger = Accounts (cycles 1,2,4,5), Book (1,7,8), Settings (5,6), Audiobooks (6), Logging (3), Downloads (dissolved via PalaceDownloads even though it appears in longer paths, all of which thread the nine back-edges above). All 15 longer DFS cycles reuse these same back-edges, so dissolving the nine dissolves all 24.
+
+### 3c. High-fan-in singletons → target home + injection mechanism
+
+| Singleton (fan-in) | Today | Target home | Injection mechanism (the AppContainer seam that replaces `.shared`) |
+|---|---|---|---|
+| `TPPKeychain.shared` (40) | already in **PalaceKeychain** package; consumers still read `.shared`; `TPPKeychainManager` (app, ObjC) wraps it | stays PalaceKeychain | new `let keychain: TPPKeychain` (or `KeychainStoring` protocol) on AppContainer; credential paths reach it via `CredentialStore` (PalaceAccounts) rather than raw keychain reads. `.shared` retained solely for the ObjC bridge until those call sites die |
+| `RemoteFeatureFlags.shared` (32) | app target `Palace/FeatureFlags/`; protocol precedent exists (`FeatureFlagProvider` in PalaceCatalog); AppContainer already closure-wraps it for `appRatingService` and hands it to `catalogAPI` | protocol + typed flag names → **PalaceFeatureFlags** (Layer 0); Firebase-Remote-Config-backed impl stays app target | `let featureFlags: FeatureFlagProviding` on AppContainer; packages declare only the flags they consume. Consolidates the per-package protocol copies into one |
+| `FirebaseManager.shared` (25) | app target `AppInfrastructure/` | **permanent app-target Infrastructure** (Firebase SDK cannot go in packages that want to stay SDK-free) | split by capability: `CrashReporting`, `RemoteConfigProviding`, crash-free-probe closures — protocols declared in consuming packages, Firebase impls injected at composition (existing precedent: `AuthDecisionRecording`/`AuthDecisionRecorder`). No package ever names Firebase |
+| `UserAccountPublisher.shared` (16) | app target `Accounts/User/`; **already an AppContainer `let`** — the builder itself still reads `.shared` to obtain it | **PalaceAccounts** (it is the account-change broadcast surface of `CurrentAccountStore`) | existing `container.userAccountPublisher` seam; migrate the 16 `.shared` reads to injected refs; builder constructs it instead of reading `.shared` |
+| `ImageCache.shared` (16) | app target `Utilities/ImageCache/`; **already an AppContainer `let imageCache: ImageCacheType`** (protocol-typed); builder reads `.shared` | app target for now; optional `PalaceImaging` package later (zero cycle pressure — not in any cycle) | existing `container.imageCache` / `container.imageLoader`; migrate reads; builder constructs the instance |
+| `NotificationService.shared` (12) | app target `Notifications/` — UNUserNotificationCenter + FCM (`MessagingDelegate`) | **permanent app-target Infrastructure** (Firebase Messaging + app-lifecycle delegate wiring) | `let notifications: NotificationScheduling` (narrow protocol: schedule/clear/badge) on AppContainer; the delegate-registration half stays wired in TPPAppDelegate as composition |
+| `AccountStateStore.shared` (8) | app target `Accounts/Library/` (`public final class`, has `_resetAllForTesting`) | **PalaceAccounts** (state store beside `AccountStateMachine`) | `let accountStateStore: AccountStateStore` on AppContainer, constructed with the accounts graph, injected into `AuthDocumentLoader`/consumers; the test-resetter attaches to the container reset instead of a global |
+| `TPPBookRegistry` (registry fan-in) | `.shared` killed in triad Phase 6.6; AppContainer constructs it and vends `bookRegistry: TPPBookRegistryProvider`; residual direct references remain | **PalaceBookRegistry** package | existing `container.bookRegistry` seam — already the pattern; the wave moves the type and inverts the AccountsManager constructor dep (`AccountScopeProviding`, §3b-1) |
+| `UIApplication.shared` (79) | system | **out of scope by design** — platform shim (triad already exempts platform shims) | wrap only the few testability-relevant uses (badge count, open-URL) behind tiny protocols as touched; no campaign |
+
+**Explicitly not-yet-mapped (findings, not hidden gaps):**
+1. **The other ~31 declared singletons** below this fan-in tier (e.g. `AdobeDRMService.shared`, `DLNavigator.shared`, sim/debug helpers) are not individually mapped here. Disposition rule: each wave's checklist includes "any `.shared` in files the wave touches gets a container seam or a written exemption." A full 39-row census is a Wave 0 deliverable (one script run against `reference_god_class_candidates` data), not an ADR blocker.
+2. **AppContainer's static lazy caches** (`_audiobookSession`, `_catalogRepository`, `_signInModalSheetPresenter`, …) are process-wide singletons wearing container clothes, each with hand-maintained `_resetForTesting` bookkeeping. Target: fold into instance `let`s as their construction-order constraints allow (several exist only to break init cycles that die when AccountsManager decomposes in Wave 3). Mapped as a Wave-3/6 side effect, not a standalone wave.
+3. **`AppContainer.production()` as service locator** (default args in ErrorHandling, Book/UI, Settings, Logging): mapped to the Wave 0 ratchet (count monotone-down) + per-wave cleanup, since each occurrence dies naturally when its file gets constructor injection.
+
+---
+
+## 4. Sequenced plan
+
+Ordering principle: **leaf-inward** — extract what the hubs depend ON before touching the hubs, so each hub wave finds its down-dependencies already package-shaped. Waves marked ∥ can run as parallel fleets (disjoint files); ⊸ must serialize.
+
+### Wave 0 — Ratchet + census (1 PR-week; prerequisite for everything)
+No extraction. Land the gates so the problem stops growing while the fleet works:
+- **God-class LOC freeze:** script + CI check — the 6 files' line counts may not exceed a checked-in baseline (decreases auto-rebaseline). Fires in `verify-pr.sh` + PR workflow.
+- **Coupling trend-down:** ledger avg-coupling + cycle-count thresholds pinned at current values (183 edges / 24 cycles), must be ≤ baseline per PR.
+- **`.shared`-read + `AppContainer.production()`-locator counts** monotone-down (grep-based, allowlisted composition roots).
+- **Ledger hygiene:** annotate TriageBotUI↔Palace as known-false-positive; add confidence tags for name-inferred edges.
+- **Singleton census:** the full 39-row disposition table (mechanical; fills §3c gap 1).
+- Per CLAUDE.md gate rules: each new detector ships with a pytest in `scripts/tests/`, hook-fixture wiring incl. clean-diff pass, and a zero-false-positive dry run.
+
+### Wave 1 ∥ — Layer-0 leaves (3 independent lanes, parallel-safe: disjoint files)
+- **1a `PalacePreferences`:** move `TPPSettings` (+`TPPSettings+SE` minus the AccountsManager constant, which stays behind) into a new leaf package. Consumers: AccountsManager, AudiobookSessionManager, Settings UI. *Pre-tests:* characterization of key round-trips (UserDefaults-backed). *Dissolves the down-halves of cycles 5 and 6.*
+- **1b `PalaceFeatureFlags`:** protocol + typed flags package; consolidate `FeatureFlagProvider` (PalaceCatalog) into it; `let featureFlags` on AppContainer; migrate the 32 `.shared` reads. *Pre-tests:* none beyond compile + existing suites (protocol move).
+- **1c misfiles + inversions:** move `TPPCirculationAnalytics` out of `Palace/Logging/` (cycle 3); `ErrorReporting` protocol into PalaceLogging + ErrorHandling `DeviceContext` inversion (cycle 2); `LogArchiveExporting` for dev-tools audiobook logs (cycle 6 back-edge). *Pre-tests:* snapshot the analytics request shape (1 contract test).
+- **CI gate for all of Wave 1:** ledger shows cycles 2, 3, 5, 6 gone (24→~13 incl. their DFS echoes); new packages imported ≥1× (load-bearing rule).
+
+### Wave 2 ⊸ — The keystone: `PalaceBookModel`, then `PalaceBookRegistry` (serial within, blocks 3/4/7)
+- **2a `PalaceBookModel`:** `TPPBook`, `TPPBookRegistryRecord`, book-state/format enums, acquisition model. Near-leaf (→PalaceLogging only). Biggest mechanical churn (hundreds of import-free references become `import PalaceBookModel`) but semantically inert.
+- **2b `PalaceBookRegistry`:** `TPPBookRegistry` moves; constructor inverted to `AccountScopeProviding` (§3b-1); app-target adapter over AccountsManager. `container.bookRegistry` unchanged for consumers.
+- *Pre-tests:* **registry contract suite** (new — `TPPBookRegistryContractTests`: state-transition call order for add/update/sync/remove against a spy persistence layer; the CLAUDE.md contract-test guidance already names "BookRegistry mutation paths" as a candidate) + existing `TPPBookRegistryMigrationTests`.
+- **CI gate:** cycles 1, 7, 8's model-directions dead; PDF/CatalogUI/Accounts compile against packages; layer gate re-tagged.
+
+### Wave 3 ∥(a/b) after Wave 2 — the mutually-coupled hub pair (the careful part)
+- **3a `PalaceAccounts`:** AccountsManager decomposition per §3a-2 (RegistryStore, RegistryLoader, RegistryCache, AuthDocumentLoader, CurrentAccountStore/CredentialResolver), `Account` types, `AccountStateStore`, `UserAccountPublisher`. Kills the background-crawl test-pollution root cause as a structured-concurrency rewrite of `loadCatalogs`.
+- **3b `PalaceDownloads`:** DownloadEngine + WS-A reconciler + throttling/persistence collaborators + `BorrowOperation` per §3a-3/6; DRM handlers stay app-side behind `FulfillmentHandling`.
+- **Parallelism ruling:** 3a and 3b are ∥ **only because Wave 2 already cut their mutual edge** (downloads reach accounts solely via `AuthCoordinator` (PalaceAuth, exists) + `AccountScopeProviding` (Wave 2)). If any new Accounts↔Downloads edge is found mid-wave, 3b serializes behind 3a — the wave brief must say so.
+- *Pre-tests:* 3a — **AccountsManager characterization pack** (crawl happy-path/cancellation/drain, auth-doc state transitions against `AccountStateMachine`, disk-cache TTL) + `AuthDocumentLoader` contract test. 3b — existing `BorrowOperationContractTests`, `BookReturnServiceContractTests`, `DownloadStartCoordinatorContractTests` **must be green and re-recorded==identical post-move**; new `BackgroundReconciliationContractTests` (INV-4/6/7 pinned).
+- **CI gate:** cycles 1, 4 fully dead; ledger cycle count ≤ the TriageBot false positive; money-path mutation kill-rate on moved files ≥ pre-move.
+
+### Wave 4 ⊸ (after 3a) — Sign-in: tests → integrate → extract
+Strictly ordered, critical path: **(i)** characterization tests for `TPPSignInBusinessLogic` (the open triad Phase-3 debt — ≥30 tests, every auth method's happy + error path); **(ii)** integrate `AuthReducer` (already in PalaceAuth) via the proven snapshot/apply pattern; **(iii)** extract flow engines + `SignInRequestService` + `AuthCapabilities` into PalaceAuth, `CredentialStore` into PalaceAccounts; DRM-activation stays app-side. Shell stays ObjC-visible.
+
+### Wave 5 ∥ — Presentation slimming (parallel with Wave 4; disjoint files)
+`BookDetailViewModel` service extraction per §3a-4 (MetadataService/RelatedBooksService, BookOpenRouter consolidation into the Application layer — closes cycle 8's back-edge; navigation inversion for cycle 7's back-edge). App-target refactor only, no new packages.
+
+### Wave 6 — Audiobook session split (after 4; package conditional)
+In-target decomposition per §3a-1 first (reducer, position resolver, readiness gate, TOC normalizer as separate injected files); `PalaceAudiobookSession` package **only if** the toolkit-API caveat resolves. Retire the `_audiobookSession`/`_playbackBootstrapper` static caches into container lets as construction order allows.
+
+### Wave 7 — Sweep + declare
+Remaining `.shared` census rows dispositioned; `AppContainer.production()` locator count → allowlist-only; ledger `componentRoots` updated to package-first; ratchet thresholds converted from "trend-down" to "hard ceiling"; ADR finalized into `docs/architecture/` with the before/after ledger runs as evidence.
+
+**Rough shape of effort:** Waves 0–1 ≈ 2 weeks; Wave 2 ≈ 2–3 weeks (churn-heavy); Wave 3 ≈ 3–4 weeks (the risky middle); Waves 4–6 ≈ 4+ weeks combined; total a solid quarter of fleet-time. Consistent with the triad's observed pace (Phases 1–5 took ~a month of comparable scope).
+
+---
+
+## 5. How the test-coverage fleet plugs in
+
+General contract: **no extraction PR merges unless the target's pre-wave test pack existed BEFORE the move and passes identically AFTER it.** "Identically" for contract snapshots means byte-equal JSON under `PalaceTests/Contract/__Snapshots__/` (re-record only with `CONTRACT_SNAPSHOT_RECORD=1` + reviewed diff). Coverage is measured per CLAUDE.md: full-scheme runs only (`scripts/xcode-test-optimized.sh` / `verify-pr.sh --quick`), mutation verification via `scripts/palace_mutate.py --file <moved file> --tests <class>` with `--diff-only` on wave branches; kill-rate on moved critical-path files must be ≥ the pre-move baseline (record baseline in the wave brief).
+
+| Target | Exists today | Fleet must build BEFORE its wave | Wave |
+|---|---|---|---|
+| **AccountsManager** | ~57 unit tests; `AppContainerResetTests`; no contract suite | Characterization pack: registry-crawl lifecycle (start/cancel/drain — deterministic Task-join seams per the de-flake pattern memo, *not* sleeps), slim-vs-full hydration (CP-D1), disk-cache TTL/corruption, auth-doc fetch → `AccountStateStore` transition contract test, currentAccount-switch publication order | 3a |
+| **MyBooksDownloadCenter** | 23 tests (thin); Borrow/BookReturn/DownloadStart contract suites | `BackgroundReconciliationContractTests` (INV-4 adopt-don't-double-start, INV-6 transient retry, INV-7 completion handler) against a stubbed URLSession; throttling/disk-budget edge tests; mid-flight-drop (PP-4114) characterization; DRM dispatch contract (spy `FulfillmentHandling` recording call order per format) | 3b |
+| **BorrowOperation** | `BorrowOperationContractTests` + `BorrowReducerContractTests` + circuit-breaker units — already the model citizen | Nothing new; suites re-run green post-move (snapshot byte-equal) | 3b |
+| **TPPSignInBusinessLogic** | **0 dedicated tests** (unchanged since triad) — the single worst test debt in the repo | Full characterization pack, ≥30 tests: basic/OAuth/SAML/Clever/OIDC happy paths, token-request error branches, credential persistence (mock keychain), DRM-activation skip decisions, sign-out. Then AuthReducer integration parity tests (reducer output == legacy state machine on recorded scenarios). Mutation gate: ≥40% kill minimum, 100% on conditional/return-flip mutants for the flow engines (triad's stated bar) | 4 (blocking prerequisite) |
+| **BookDetailViewModel** | 81–125 tests (directly mutate `@Published`) + `BorrowReducerContractTests` | Pin-before-extract for the moving clusters only: metadata-hydration stub-response tests, related-books/series-row tests, open-routing decision table (format → router destination). Existing tests must remain untouched-and-green (the snapshot/apply constraint) | 5 |
+| **AudiobookSessionManager** | `AudiobookPositionAdapterContractTests`, `PositionWriterContractTests`; scattered playback tests | Session-state contract test (spy toolkit manager recording bind/play/teardown call order); position-resolution decision table (local vs remote vs none — PP-4542 cases); readiness-gate characterization (F-011: play deferred until gate opens); TOC-normalizer pure-function units. LCP first-open stays sim-verified (simdrive) — no unit seam without DRM | 6 |
+
+Fleet mechanics: each wave brief hands an implementation agent (a) the §3a cluster table row, (b) the required test list above, (c) the CI gate definition. Test-building agents can run **ahead** of extraction waves in parallel (tests against current code are wave-independent) — the sign-in characterization pack in particular should start immediately, since it gates Wave 4 and depends on nothing.
+
+---
+
+## 6. Risks & honest caveats
+
+1. **Money-path exposure is concentrated in Wave 3b and Wave 4.** Borrow/download/DRM-fulfillment and sign-in are where a regression costs users access. Mitigations are structural (contract snapshots byte-equal across the move; mutation kill-rate ratchet; `/rigorous-fix`-grade SoD review on those waves) — but the honest statement is that moving 2,000+ LOC of fulfillment plumbing is never risk-free, and the wave should land early in a release cycle, never near a cut.
+2. **CI is the only full build gate for DRM.** There is no local DRM build; `@Sendable`/isolation ripples from package extraction can surface only in CI (documented prior incident: completion-param Sendable ripple). Budget for CI-round-trip iteration on every extraction PR; keep PRs small enough that a red CI bisects trivially. The noDRM target additionally isn't in CI — build-green ≠ launch-green there; sim-launch spot-checks after waves that touch linking.
+3. **Package extraction changes access control, not just location.** Everything moved needs `public`/`package` annotations and loses `@testable` visibility from PalaceTests unless tests move too or surfaces widen deliberately. This is real per-wave engineering, and it is also the point — the narrowed surface is the architecture. Watch for the ObjC constraint specifically: `@objc` types (TPPSignInBusinessLogic facade, legacy OPDS parsing) cannot move into Swift-only packages; shells stay behind.
+4. **Swift 6 strict concurrency compounds the churn.** New packages inherit the v6-mode convention (per existing manifests); code that was tolerated in the app target's mode may need real isolation fixes when moved. Treat each move as move+annotate, and use the known traps list (off-main @MainActor closures, `#filePath`) from the Swift-6 test-infra memo.
+5. **Ledger measurement caveats.** Edge inference is name-based; one confirmed invented edge (TriageBotUI↔Palace) means other low-confidence edges may exist, and cycle-count gates must run on import-verified edges or carry confidence weighting (Wave 0 item). Also "hotspots" = fan-in×churn, not complexity — high fan-in on Layer-0 packages is *desired*; the gate must not punish it.
+6. **The systemic test-pollution debt intersects Wave 3a.** The AccountsManager background-crawl is the documented root of much of the flake pollution; the decomposition is the durable fix but also destabilizes the fragile drain/reset choreography in `AppContainer._resetForTesting` mid-wave. The wave brief must include updating the reset seams in the same PRs, and full-suite (not subset) verification per CLAUDE.md is non-negotiable there.
+7. **Two cycles end gate-enforced, not compiler-enforced, in the medium term:** Book↔CatalogUI's view-navigation back-edge (both sides remain app-target Presentation) and anything else Presentation-internal. Compiler enforcement for those arrives only if/when the UI itself is packaged — out of scope here; the ledger layer gate is the enforcement in the interim. Similarly `PalaceAudiobookSession` is conditional on the toolkit (§3a-1); its decomposition happens regardless, its compile-enforcement may lag.
+8. **Timeline realism.** This is a quarter-scale campaign in fleet-time, longer in calendar time if release cycles interleave (release-freeze windows exclude Waves 3b/4 landings). The ratchet (Wave 0) is what makes a long campaign survivable: even if later waves slip, the problem stops compounding — the 19-day +1,400-LOC accretion trend is the strongest argument that Wave 0 lands this week regardless of everything else.

--- a/docs/architecture/singleton-census.md
+++ b/docs/architecture/singleton-census.md
@@ -1,0 +1,99 @@
+# Singleton census — god-class decomposition campaign (Wave 0 deliverable)
+
+**Status:** reference · **Captured:** 2026-07-23 · **Feeds:** the `.shared`-read
+monotone-down ratchet (`scripts/check-shared-read-count.sh`) and the per-wave
+"any `.shared` in a file this wave touches gets a container seam or a written
+exemption" checklist rule. **Fills** god-class-decomposition-plan.md §3c
+"Explicitly not-yet-mapped" gap #1 (the full 39-row disposition table).
+
+## How this was derived
+
+- **Rows** = every `static let shared` / `static let sharedInstance` declaration
+  in `Palace/` **excluding `Palace/Packages/`** (SPM packages are already the
+  target shape). Grep: `grep -rnE 'static (let|var) +shared' Palace --exclude-dir=Packages`,
+  comment lines discarded. This yields **exactly 39** declared singletons.
+- **External fan-in** = count of `Type.shared` reference occurrences across
+  `Palace/` (excl. Packages). Because every declaration is written
+  `static let shared = Type()` (not `= Type.shared`), the grep count is the
+  *external* read count — the declaration site does not self-count. This is the
+  quantity the ratchet freezes.
+- **Target home / disposition** = the ADR §3c table verbatim for the ~8
+  high-fan-in singletons; the remaining rows filled mechanically by the same
+  layer rules (§2.2 / §3c injection-mechanism column).
+
+## Disposition legend
+
+| Disposition | Meaning |
+|---|---|
+| **inject-via-container** | The campaign's default target: replace every `.shared` read with an `AppContainer` `let`/lazy seam injected by constructor. Removes the ambient reach entirely. |
+| **permanent-infra** | Legitimately process-wide infrastructure (loggers, monitors, SDK wiring). Stays a singleton, but reached through a **narrow** container protocol so it is testable/mockable — no campaign to delete it, only to narrow its surface. |
+| **platform-shim** | Wraps an Apple / DRM-binary / OS singleton (CoreLocation, `ASWebAuthentication` presentation anchor, `MFMailCompose` delegate, Adobe RMSDK / LCP binaries). Out of scope by design (triad platform-shim exemption); gets a thin protocol only where a touched call site needs testability. |
+| **later** | Low fan-in; dispositioned by the wave that relocates its folder. No standalone action — the `.shared` reads die when the file gets constructor injection during its wave. |
+
+## Census (39 rows, sorted by external fan-in)
+
+| # | Singleton | Declared in | Fan-in | Target home (§2.2 / §3c) | Disposition |
+|---|---|---:|---:|---|---|
+| 1 | `RemoteFeatureFlags` | `FeatureFlags/RemoteFeatureFlags.swift` | 27 | **PalaceFeatureFlags** (new, Layer 0) — Firebase-backed impl stays app-target | **inject-via-container** (§3c: `let featureFlags: FeatureFlagProviding`) |
+| 2 | `FirebaseManager` | `AppInfrastructure/FirebaseManager.swift` | 25 | **permanent app-target Infrastructure** (Firebase SDK) | **permanent-infra** (§3c: split into `CrashReporting` / `RemoteConfigProviding` capability protocols; no package names Firebase) |
+| 3 | `LCPPDFOpenProgress` | `PDF/ReadiumPDF/LCPPDFOpenProgress.swift` | 24 | app-target Infrastructure (LCP DRM PDF open) | **inject-via-container** behind an `LCPOpenProgressReporting` protocol — high fan-in on a DRM path warrants a seam even though the impl stays app-side |
+| 4 | `ImageCache` | `Utilities/ImageCache/ImageCacheType.swift` | 19 | app-target now; optional **PalaceImaging** later (zero cycle pressure) | **inject-via-container** (§3c: `container.imageCache` seam exists; migrate the reads; builder stops reading `.shared`) |
+| 5 | `UserAccountPublisher` | `Accounts/User/UserAccountPublisher.swift` | 16 | **PalaceAccounts** (account-change broadcast of `CurrentAccountStore`) | **inject-via-container** (§3c: `container.userAccountPublisher` seam exists; migrate the 16 reads) |
+| 6 | `AccountStateStore` | `Accounts/Library/AccountStateStore.swift` | 16 | **PalaceAccounts** (beside `AccountStateMachine`) | **inject-via-container** (§3c: `let accountStateStore` on container, injected into `AuthDocumentLoader`) |
+| 7 | `NotificationService` | `Notifications/NotificationService.swift` | 13 | **permanent app-target Infrastructure** (FCM + `UNUserNotificationCenter`) | **permanent-infra** (§3c: narrow `NotificationScheduling` protocol; delegate half stays wired in `TPPAppDelegate`) |
+| 8 | `TPPBookCoverRegistry` | `Book/Models/TPPBookCoverRegistry.swift` | 5 | **PalaceBookModel**/imaging (constructs on `ImageCache.shared`) | **inject-via-container** — moves with the book model in Wave 2; take `ImageCacheType` by injection |
+| 9 | `AppLaunchTracker` | `Platform/AppLaunchTracker.swift` | 5 | app-target Platform | **permanent-infra** (launch-count telemetry; narrow seam) |
+| 10 | `AccessibilityService` | `Platform/AccessibilityService.swift` | 5 | app-target Platform (wraps `UIAccessibility`) | **platform-shim** (protocol-wrap the touched reads for VoiceOver-state testability) |
+| 11 | `TPPBookmarkDeletionLog` | `Reader2/Bookmarks/TPPBookmarkDeletionLog.swift` | 4 | **PalaceReadingPosition** / Reader2 | **later** (moves when Reader2 bookmark sync is touched) |
+| 12 | `ProblemReportEmail` | `ErrorHandling/ProblemReportEmail.swift` | 4 | app-target ErrorHandling (Presentation) | **later** (cycle-2 cleanup: `DeviceContext` value inversion, §3b) |
+| 13 | `LCPDecryptCache` | `Reader2/.../LCP/TPPLCPClient.swift` | 4 | app-target Infrastructure (LCP DRM) | **platform-shim** (LCP binary-adjacent cache; keep, protocol only if a test needs it) |
+| 14 | `ErrorActivityTracker` | `ErrorHandling/ErrorActivityTracker.swift` | 4 | app-target ErrorHandling | **later** (error diagnostics; dispositioned in the ErrorHandling cleanup) |
+| 15 | `DLNavigator` | `AppInfrastructure/DLNavigator.swift` | 4 | app-target AppInfrastructure (deep-link routing) | **inject-via-container** (routing is composition; give it a container seam) |
+| 16 | `DeviceSpecificErrorMonitor` | `Utilities/DeviceSpecificErrorMonitor.swift` | 4 | app-target Utilities/ErrorHandling | **later** |
+| 17 | `AudiobookFileLogger` | `Logging/AudiobookFileLogger.swift` | 4 | **PalaceLogging** | **permanent-infra** (file logger; narrow `LogSink` seam, ties to cycle-6 `LogArchiveExporting`) |
+| 18 | `AdobeDRMService` | `Reader2/.../AdobeDRM/AdobeCertificate.swift` | 4 | app-target Infrastructure (Adobe RMSDK binary) | **platform-shim** (private DRM binary — permanent app-target; behind `TPPDRMAuthorizing` seam that already exists) |
+| 19 | `UserRetryTracker` | `MyBooks/UserRetryTracker.swift` | 3 | **PalaceDownloads** | **inject-via-container** (moves in Wave 3b with the download engine) |
+| 20 | `TPPAssociatedColors` | `Reader2/ReaderSettings/TPPAssociatedColors.swift` | 3 | app-target Reader2 (Presentation) | **later** |
+| 21 | `OfflineQueueService` | `Platform/OfflineQueueService.swift` | 3 | **PalaceNetwork** (offline request queue) | **inject-via-container** (moves with the network layer; seam on the container) |
+| 22 | `MockBackendService` | `Settings/Debug/MockBackend/MockBackendService.swift` | 3 | app-target Debug tooling | **later** (debug-only; written exemption — never ships in a release path) |
+| 23 | `ErrorLogExporter` | `Logging/ErrorLogExporter.swift` | 2 | app-target Logging (Presentation export) | **later** (mail-export UI glue; cycle-6 `LogArchiveExporting`) |
+| 24 | `UnifiedOPDSService` | `OPDS2/Service/UnifiedOPDSService.swift` | 1 | **PalaceCatalog** | **inject-via-container** (moves with catalog services) |
+| 25 | `TypographyService` | `Reader2/Typography/TypographyService.swift` | 1 | app-target Reader2 (Presentation) | **later** |
+| 26 | `TPPProblemDocumentCacheManager` | `ErrorHandling/TPPProblemDocumentCacheManager.swift` | 1 | app-target Infrastructure (problem-doc cache) | **later** |
+| 27 | `TPPAnnouncementBusinessLogic` | `Accounts/User/Announcements/TPPAnnouncementBusinessLogic.swift` | 1 | app-target Presentation (announcements) | **later** |
+| 28 | `SmallDeviceResolver` | `MyBooks/DiskBudgetManager.swift` | 1 | app-target Utilities (device heuristic) | **later** |
+| 29 | `PerformanceMonitor` | `Platform/PerformanceMonitor.swift` | 1 | app-target Platform | **permanent-infra** (cross-cutting perf sampling) |
+| 30 | `OIDCPresentationContextProvider` | `MyBooks/TokenRefreshInterceptor.swift` | 1 | app-target SignInLogic (Presentation) | **platform-shim** (`ASWebAuthentication` presentation anchor — UIKit-bound) |
+| 31 | `OIDCBorrowPresentationContext` | `MyBooks/BorrowOperation.swift` | 1 | app-target SignInLogic (Presentation) | **platform-shim** (`ASWebAuthentication` anchor; moves out of BorrowOperation when it goes to PalaceDownloads — the anchor stays app-side) |
+| 32 | `MemoryPressureMonitor` | `AppInfrastructure/TPPAppDelegate.swift` | 1 | app-target Infrastructure | **permanent-infra** (OS memory-pressure source) |
+| 33 | `MailComposerDelegate` | `Logging/ErrorLogExporter.swift` | 1 | app-target Presentation | **platform-shim** (`MFMailComposeViewController` delegate) |
+| 34 | `LogoProxyHolder` | `Settings/NewSettings/TPPSettingsView.swift` | 1 | app-target Settings (Presentation) | **later** |
+| 35 | `LocationManager` | `Utilities/System/LocationManager.swift` | 1 | app-target Platform | **platform-shim** (CoreLocation wrapper) |
+| 36 | `DeviceLogCollector` | `Logging/DeviceLogCollector.swift` | 1 | **PalaceLogging** | **permanent-infra** (device log sink) |
+| 37 | `OPDS2FeedCache` | `OPDS2/Cache/OPDSFeedCache.swift` | 0 | **PalaceCatalog** | **later** (no external `.shared` reads — accessed internally; moves with catalog) |
+| 38 | `OPDS1FeedCache` | `OPDS2/Cache/OPDSFeedCache.swift` | 0 | **PalaceCatalog** / app-target | **later** (no external `.shared` reads) |
+| 39 | `FontManager` | `Reader2/Typography/FontManager.swift` | 0 | app-target Reader2 (Presentation) | **later** (0 external `.shared` reads — verify it is not dead before the Reader2 wave) |
+
+## Notes / addenda
+
+- **`TPPKeychain.shared` (fan-in 40) is NOT a row above** — it is declared inside
+  the **PalaceKeychain package**, so it is out of the `Palace/`-excluding-Packages
+  scan. It remains the single highest-fan-in singleton in the codebase; per §3c
+  its `.shared` is retained only for the ObjC bridge until those call sites die,
+  reached elsewhere via a `KeychainStoring` seam / `CredentialStore`. Tracked in
+  the ADR §3c table, not here.
+- **`TPPBookRegistry` has no `shared` declaration** — it was killed in triad
+  Phase 6.6 (`container.bookRegistry` is the seam). Its file contains only a
+  historical comment referencing the removed singleton, so it is correctly absent
+  from the 39.
+- **Fan-in ≠ removal priority alone.** The ratchet counts *all* non-system
+  `.shared` reads together (baseline 250 in `scripts/godclass-shared-read-baseline.txt`);
+  this table tells each wave *where* each read should land. A wave that touches
+  any file above must move its listed `.shared` to the target seam or record a
+  written exemption (permanent-infra / platform-shim / debug-only rows are the
+  pre-approved exemptions).
+- **Cross-check with the ratchet exclusion list:** the system singletons the
+  ratchet excludes (`UIApplication`, `URLSession`, `URLCache`,
+  `HTTPCookieStorage`, `FileManager`, `NotificationCenter`, `Bundle`, …) are
+  Apple-owned and intentionally absent from this census — they are platform
+  shims by definition, never campaign targets.

--- a/scripts/check-appcontainer-locator-count.sh
+++ b/scripts/check-appcontainer-locator-count.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# check-appcontainer-locator-count.sh
+#
+# WAVE 0 RATCHET (god-class decomposition campaign — see
+# docs/architecture/god-class-decomposition-plan.md §2.4 / §3c gap 3 / §4).
+#
+# `AppContainer.production()` called OUTSIDE a composition root is a `.shared`
+# read with extra steps: it preserves the ambient-reach graph and defeats
+# testability exactly the same way (e.g. `AppContainer.production().accountsManager`
+# in a default arg). The container is a composition root, not a service locator.
+# This gate freezes the out-of-allowlist call-site count and only lets it go DOWN:
+#
+#   - count >  baseline  -> FAIL  (a new locator use was added).
+#   - count == baseline  -> PASS.
+#   - count <  baseline  -> PASS, prints the new lower number to ratchet down to.
+#
+# What is counted: occurrences of `AppContainer.production()` in Palace/*.swift,
+# EXCLUDING:
+#   - files whose repo-relative path matches an allowlist entry (composition roots:
+#     AppContainer.swift itself, the app/scene delegates — see the allowlist file),
+#   - lines that are an `@Environment` default (SwiftUI environment default value),
+#   - anything under Palace/Packages/.
+# (Test bootstrap under PalaceTests/ is out of scan scope entirely.)
+#
+# Allowlist file (checked in): scripts/godclass-appcontainer-locator-allowlist.txt
+#   One path-suffix per line; a call site is exempt if its path CONTAINS the entry.
+#   '#' comments and blank lines ignored.
+#
+# Baseline file (checked in): scripts/godclass-appcontainer-locator-baseline.txt
+#   Contents: a single integer (first non-comment line).
+#
+# Usage:
+#   check-appcontainer-locator-count.sh            # gate against baseline
+#   check-appcontainer-locator-count.sh --count    # print current count, exit 0 (bootstrap)
+#
+# Env overrides (for tests):
+#   LOCATOR_SCAN_ROOT   directory to scan (default: <repo>/Palace)
+#   LOCATOR_BASELINE    baseline file (default: <repo>/scripts/godclass-appcontainer-locator-baseline.txt)
+#   LOCATOR_ALLOWLIST   allowlist file (default: <repo>/scripts/godclass-appcontainer-locator-allowlist.txt)
+#
+# Exit: 0 = at/below baseline (PASS); 1 = above (FAIL); 2 = usage/error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCAN_ROOT="${LOCATOR_SCAN_ROOT:-$REPO/Palace}"
+BASELINE="${LOCATOR_BASELINE:-$REPO/scripts/godclass-appcontainer-locator-baseline.txt}"
+ALLOWLIST="${LOCATOR_ALLOWLIST:-$REPO/scripts/godclass-appcontainer-locator-allowlist.txt}"
+MODE="${1:-}"
+
+[ -d "$SCAN_ROOT" ] || { echo "[locator] ERROR: scan root not found: $SCAN_ROOT"; exit 2; }
+
+path_allowlisted() {  # 0 (true) if $1 contains any allowlist entry
+  local path="$1"
+  [ -f "$ALLOWLIST" ] || return 1
+  local entry
+  while IFS= read -r entry; do
+    entry="${entry%%#*}"
+    entry="$(printf '%s' "$entry" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ -z "$entry" ] && continue
+    case "$path" in *"$entry"*) return 0 ;; esac
+  done < "$ALLOWLIST"
+  return 1
+}
+
+# Emit each matching "path:line" then filter allowlisted files + @Environment lines.
+count_locator() {
+  local total=0 file
+  while IFS= read -r file; do
+    path_allowlisted "$file" && continue
+    # occurrences in this file that are NOT @Environment defaults
+    local c
+    c="$(grep -nE 'AppContainer\.production\(\)' "$file" 2>/dev/null \
+          | grep -vE '@Environment' \
+          | grep -oE 'AppContainer\.production\(\)' | wc -l | tr -d ' ')"
+    total=$((total + c))
+  done < <(grep -rlE 'AppContainer\.production\(\)' "$SCAN_ROOT" --include='*.swift' --exclude-dir='Packages' 2>/dev/null)
+  echo "$total"
+}
+
+# List offending files (for FAIL output).
+list_locator() {
+  local file c
+  while IFS= read -r file; do
+    path_allowlisted "$file" && continue
+    c="$(grep -nE 'AppContainer\.production\(\)' "$file" 2>/dev/null | grep -vE '@Environment' | grep -cE 'AppContainer\.production\(\)' || true)"
+    [ "${c:-0}" -gt 0 ] && printf '%4d  %s\n' "$c" "$file"
+  done < <(grep -rlE 'AppContainer\.production\(\)' "$SCAN_ROOT" --include='*.swift' --exclude-dir='Packages' 2>/dev/null) | sort -rn
+}
+
+CUR="$(count_locator)"
+
+if [ "$MODE" = "--count" ]; then
+  echo "$CUR"
+  exit 0
+fi
+
+[ -f "$BASELINE" ] || { echo "[locator] ERROR: baseline not found: $BASELINE"; exit 2; }
+BASE="$(grep -vE '^[[:space:]]*#' "$BASELINE" | grep -oE '[0-9]+' | head -1 || true)"
+case "$BASE" in
+  ''|*[!0-9]*) echo "[locator] ERROR: baseline file has no integer: $BASELINE"; exit 2 ;;
+esac
+
+if [ "$CUR" -gt "$BASE" ]; then
+  echo "[locator] FAIL: out-of-allowlist \`AppContainer.production()\` uses went UP: $BASE -> $CUR (+$((CUR - BASE)))."
+  echo "  The container is a composition root, not a service locator. Inject the dependency"
+  echo "  through the constructor instead (see decomposition plan §3c gap 3)."
+  echo "  Top offending files:"
+  list_locator | head -15
+  exit 1
+fi
+
+if [ "$CUR" -lt "$BASE" ]; then
+  echo "[locator] PASS: locator uses DROPPED $BASE -> $CUR. Ratchet baseline down to $CUR."
+  exit 0
+fi
+
+echo "[locator] PASS: out-of-allowlist \`AppContainer.production()\` uses at baseline ($CUR)."
+exit 0

--- a/scripts/check-godclass-loc-freeze.sh
+++ b/scripts/check-godclass-loc-freeze.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# check-godclass-loc-freeze.sh
+#
+# WAVE 0 RATCHET (god-class decomposition campaign — see
+# docs/architecture/god-class-decomposition-plan.md §2.4 / §4).
+#
+# The six target god-classes accreted ~+1,400 LOC in 19 days because every
+# reliability fix lands *inside* the hub where the seams are. This gate freezes
+# that: each target file's live line count may not EXCEED a checked-in baseline.
+#
+#   - EXCEEDS baseline  -> FAIL (the accretion this ratchet exists to stop).
+#   - AT baseline       -> PASS.
+#   - BELOW baseline    -> PASS, and prints the new lower number so a human can
+#                          ratchet the baseline down (this script never rewrites
+#                          the baseline — a ratchet only tightens by hand).
+#
+# Counts are read LIVE from the tree (wc -l), so no generated state to drift.
+#
+# Baseline file (checked in): scripts/godclass-loc-baseline.txt
+#   Format, one file per line:   <loc><whitespace><repo-relative-path>
+#   '#' comments and blank lines ignored.
+#
+# Usage:
+#   check-godclass-loc-freeze.sh              # gate against the checked-in baseline
+#   check-godclass-loc-freeze.sh --count      # print "<loc>\t<path>" for each
+#                                             # baselined file and exit 0 (bootstrap)
+#
+# Env overrides (for tests):
+#   GODCLASS_ROOT      repo root the paths are resolved against (default: script's ../..)
+#   GODCLASS_BASELINE  baseline file (default: <root>/scripts/godclass-loc-baseline.txt)
+#
+# Exit: 0 = at/below baseline (PASS); 1 = a file exceeds baseline (FAIL); 2 = usage/error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="${GODCLASS_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+BASELINE="${GODCLASS_BASELINE:-$ROOT/scripts/godclass-loc-baseline.txt}"
+MODE="${1:-}"
+
+[ -f "$BASELINE" ] || { echo "[godclass-loc] ERROR: baseline not found: $BASELINE"; exit 2; }
+
+loc_of() {  # live line count of a file, 0 if missing
+  local p="$1"
+  [ -f "$p" ] || { echo "-1"; return; }
+  wc -l < "$p" | tr -d ' '
+}
+
+FAIL=0
+DROPPED=0
+RESULTS=""
+
+while IFS= read -r raw; do
+  # strip comments / blanks
+  line="${raw%%#*}"
+  # trim
+  line="$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  [ -z "$line" ] && continue
+  base_loc="${line%%[[:space:]]*}"
+  rel_path="${line#"$base_loc"}"
+  rel_path="$(printf '%s' "$rel_path" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  case "$base_loc" in
+    ''|*[!0-9]*) echo "[godclass-loc] ERROR: bad baseline line: $raw"; exit 2 ;;
+  esac
+  cur="$(loc_of "$ROOT/$rel_path")"
+
+  if [ "$MODE" = "--count" ]; then
+    printf '%s\t%s\n' "$cur" "$rel_path"
+    continue
+  fi
+
+  if [ "$cur" = "-1" ]; then
+    RESULTS="$RESULTS\nMISSING  $rel_path (baselined at $base_loc; file not found — was it moved/renamed? update baseline)"
+    FAIL=1
+  elif [ "$cur" -gt "$base_loc" ]; then
+    RESULTS="$RESULTS\nGREW     $rel_path  $base_loc -> $cur  (+$((cur - base_loc)))  ← exceeds freeze"
+    FAIL=1
+  elif [ "$cur" -lt "$base_loc" ]; then
+    RESULTS="$RESULTS\nshrank   $rel_path  $base_loc -> $cur  (ratchet baseline DOWN to $cur)"
+    DROPPED=1
+  else
+    RESULTS="$RESULTS\nok       $rel_path  $cur"
+  fi
+done < "$BASELINE"
+
+[ "$MODE" = "--count" ] && exit 0
+
+if [ "$FAIL" -eq 1 ]; then
+  echo "[godclass-loc] FAIL: a frozen god-class grew past its baseline."
+  echo "  These files are frozen while the decomposition campaign runs (Wave 0 ratchet)."
+  echo "  Land your fix by EXTRACTING into a collaborator/package, not by growing the hub."
+  printf '%b\n' "$RESULTS"
+  exit 1
+fi
+
+echo "[godclass-loc] PASS: no god-class exceeds its frozen baseline."
+printf '%b\n' "$RESULTS"
+[ "$DROPPED" -eq 1 ] && echo "[godclass-loc] NOTE: one or more files shrank — ratchet the baseline down (values above)."
+exit 0

--- a/scripts/check-shared-read-count.sh
+++ b/scripts/check-shared-read-count.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# check-shared-read-count.sh
+#
+# WAVE 0 RATCHET (god-class decomposition campaign — see
+# docs/architecture/god-class-decomposition-plan.md §2.4 / §3c / §4).
+#
+# `.shared` singleton reads are the coupling substrate the campaign is dissolving
+# (every one becomes an AppContainer-injected seam). This gate freezes the count
+# at a checked-in baseline and only ever lets it go DOWN (monotone-down):
+#
+#   - count >  baseline  -> FAIL  (a new ambient `.shared` reach was added).
+#   - count == baseline  -> PASS.
+#   - count <  baseline  -> PASS, prints the new lower number to ratchet down to.
+#
+# What is counted: occurrences of `<UpperCamelType>.shared` in Palace/*.swift,
+# EXCLUDING:
+#   - anything under Palace/Packages/ (SPM packages — already the target shape),
+#   - the platform/system singletons listed in SYS_EXCLUDE below (UIApplication,
+#     URLSession, URLCache, HTTPCookieStorage, FileManager, NotificationCenter,
+#     Bundle, … — these are Apple-owned shims, out of scope by design, §3c row
+#     "UIApplication.shared" / triad platform-shim exemption).
+#
+# Baseline file (checked in): scripts/godclass-shared-read-baseline.txt
+#   Contents: a single integer (first non-comment line). '#' comments allowed.
+#
+# Usage:
+#   check-shared-read-count.sh            # gate against baseline
+#   check-shared-read-count.sh --count    # print the current count and exit 0 (bootstrap)
+#
+# Env overrides (for tests):
+#   SHARED_SCAN_ROOT   directory to scan (default: <repo>/Palace)
+#   SHARED_BASELINE    baseline file (default: <repo>/scripts/godclass-shared-read-baseline.txt)
+#
+# Exit: 0 = at/below baseline (PASS); 1 = above (FAIL); 2 = usage/error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCAN_ROOT="${SHARED_SCAN_ROOT:-$REPO/Palace}"
+BASELINE="${SHARED_BASELINE:-$REPO/scripts/godclass-shared-read-baseline.txt}"
+MODE="${1:-}"
+
+# Platform/system singletons that are exempt (Apple-owned; not campaign targets).
+# Anchored to the start of the "<Type>.shared" match.
+SYS_EXCLUDE='^(UIApplication|URLSession|URLCache|HTTPCookieStorage|FileManager|NotificationCenter|Bundle|ProcessInfo|UNUserNotificationCenter|BGTaskScheduler|XCTestObservationCenter|UIScreen|UIDevice|UIAccessibility|UIPasteboard|NSUbiquitousKeyValueStore|FileHandle|UIMenuSystem|UIFont)\.shared'
+
+[ -d "$SCAN_ROOT" ] || { echo "[shared-read] ERROR: scan root not found: $SCAN_ROOT"; exit 2; }
+
+count_shared() {
+  # One match per occurrence (grep -o); exclude Packages dir + system types.
+  grep -rhoE '[A-Z][A-Za-z0-9_]*\.shared' "$SCAN_ROOT" \
+      --include='*.swift' --exclude-dir='Packages' 2>/dev/null \
+    | grep -vE "$SYS_EXCLUDE" \
+    | wc -l | tr -d ' '
+}
+
+CUR="$(count_shared)"
+
+if [ "$MODE" = "--count" ]; then
+  echo "$CUR"
+  exit 0
+fi
+
+[ -f "$BASELINE" ] || { echo "[shared-read] ERROR: baseline not found: $BASELINE"; exit 2; }
+BASE="$(grep -vE '^[[:space:]]*#' "$BASELINE" | grep -oE '[0-9]+' | head -1 || true)"
+case "$BASE" in
+  ''|*[!0-9]*) echo "[shared-read] ERROR: baseline file has no integer: $BASELINE"; exit 2 ;;
+esac
+
+if [ "$CUR" -gt "$BASE" ]; then
+  echo "[shared-read] FAIL: non-system \`.shared\` reads went UP: $BASE -> $CUR (+$((CUR - BASE)))."
+  echo "  This ratchet is monotone-down. Inject the dependency via an AppContainer seam"
+  echo "  instead of reaching for \`.shared\` (see decomposition plan §3c)."
+  echo "  New reads (sample):"
+  grep -rnE '[A-Z][A-Za-z0-9_]*\.shared' "$SCAN_ROOT" --include='*.swift' --exclude-dir='Packages' 2>/dev/null \
+    | grep -vE "$SYS_EXCLUDE" | grep -oE '[A-Z][A-Za-z0-9_]*\.shared' | sort | uniq -c | sort -rn | head -15
+  exit 1
+fi
+
+if [ "$CUR" -lt "$BASE" ]; then
+  echo "[shared-read] PASS: \`.shared\` reads DROPPED $BASE -> $CUR. Ratchet baseline down to $CUR."
+  exit 0
+fi
+
+echo "[shared-read] PASS: non-system \`.shared\` reads at baseline ($CUR)."
+exit 0

--- a/scripts/godclass-appcontainer-locator-allowlist.txt
+++ b/scripts/godclass-appcontainer-locator-allowlist.txt
@@ -1,0 +1,17 @@
+# Allowlist for check-appcontainer-locator-count.sh
+#
+# `AppContainer.production()` is legitimate ONLY at a composition root: the place
+# that BUILDS the object graph. Everywhere else it is a service-locator smell the
+# Wave 0 ratchet counts down (decomposition plan §3c gap 3).
+#
+# One path-suffix per line. A call site is exempt if its file path CONTAINS the
+# entry. Keep this list SMALL — every addition weakens the ratchet. '#' = comment.
+
+# The container itself (it constructs the graph and vends production()).
+Palace/AppInfrastructure/AppContainer.swift
+
+# App + scene delegates: the launch/scene composition roots.
+Palace/AppInfrastructure/TPPAppDelegate.swift
+Palace/AppInfrastructure/TPPAppDelegate+Extensions.swift
+Palace/AppInfrastructure/SceneDelegate.swift
+Palace/CarPlay/CarPlaySceneDelegate.swift

--- a/scripts/godclass-appcontainer-locator-baseline.txt
+++ b/scripts/godclass-appcontainer-locator-baseline.txt
@@ -1,0 +1,6 @@
+# Out-of-allowlist `AppContainer.production()` call-site count baseline — Wave 0
+# ratchet (monotone-down). Consumed by scripts/check-appcontainer-locator-count.sh.
+# Single integer. Count may only go DOWN. Captured 2026-07-23.
+# Allowlist: scripts/godclass-appcontainer-locator-allowlist.txt.
+# See docs/architecture/god-class-decomposition-plan.md §3c gap 3.
+318

--- a/scripts/godclass-loc-baseline.txt
+++ b/scripts/godclass-loc-baseline.txt
@@ -1,0 +1,11 @@
+# God-class LOC freeze baseline — Wave 0 ratchet.
+# Consumed by scripts/check-godclass-loc-freeze.sh.
+# Format: <loc> <repo-relative-path>. A file may NOT exceed its count.
+# When a file SHRINKS, the script prints the new number; ratchet this DOWN by hand.
+# Captured 2026-07-23 (live wc -l). See docs/architecture/god-class-decomposition-plan.md §3a.
+2761 Palace/Audiobooks/AudiobookSessionManager.swift
+2319 Palace/Accounts/Library/AccountsManager.swift
+2167 Palace/MyBooks/MyBooksDownloadCenter.swift
+1375 Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+1119 Palace/SignInLogic/TPPSignInBusinessLogic.swift
+966 Palace/MyBooks/BorrowOperation.swift

--- a/scripts/godclass-shared-read-baseline.txt
+++ b/scripts/godclass-shared-read-baseline.txt
@@ -1,0 +1,5 @@
+# Non-system `.shared` read count baseline — Wave 0 ratchet (monotone-down).
+# Consumed by scripts/check-shared-read-count.sh.
+# Single integer. Count may only go DOWN. Captured 2026-07-23.
+# See docs/architecture/god-class-decomposition-plan.md §3c + docs/architecture/singleton-census.md.
+250

--- a/scripts/tests/test_check_appcontainer_locator_count.py
+++ b/scripts/tests/test_check_appcontainer_locator_count.py
@@ -1,0 +1,134 @@
+"""
+test_check_appcontainer_locator_count.py — pytest for the Wave 0
+`AppContainer.production()`-locator monotone-down gate
+(scripts/check-appcontainer-locator-count.sh).
+
+Asserts BOTH directions (CLAUDE.md gate rule — clean-diff pass required):
+  (a) count ABOVE baseline -> FAIL (exit 1),
+  (b) count AT baseline    -> PASS (exit 0),
+  (c) count BELOW baseline -> PASS + prints the lower number,
+plus the exclusion contract: allowlisted composition-root files, @Environment
+default lines, and Palace/Packages/ are NOT counted.
+
+Each case builds a throwaway tree + allowlist + baseline and points the script
+at them via LOCATOR_SCAN_ROOT / LOCATOR_BASELINE / LOCATOR_ALLOWLIST.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-appcontainer-locator-count.sh"
+
+
+def _run(scan_root, baseline, allowlist, mode=None) -> subprocess.CompletedProcess:
+    cmd = ["bash", str(_SCRIPT)]
+    if mode:
+        cmd.append(mode)
+    return subprocess.run(
+        cmd,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "LOCATOR_SCAN_ROOT": str(scan_root),
+            "LOCATOR_BASELINE": str(baseline),
+            "LOCATOR_ALLOWLIST": str(allowlist),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _build_tree(tmp_path: Path) -> Path:
+    """Two counted call sites, plus three that must be EXCLUDED."""
+    root = tmp_path / "Palace"
+    (root / "Book").mkdir(parents=True, exist_ok=True)
+    (root / "AppInfrastructure").mkdir(parents=True, exist_ok=True)
+    (root / "Packages" / "Pkg" / "Sources").mkdir(parents=True, exist_ok=True)
+
+    # counted: 2 real locator uses in an ordinary file
+    (root / "Book" / "BookService.swift").write_text(
+        "let am = AppContainer.production().accountsManager\n"
+        "let br = AppContainer.production().bookRegistry\n"
+        "let e = something // @Environment placeholder unrelated\n"
+    )
+    # excluded: @Environment default line
+    (root / "Book" / "SomeView.swift").write_text(
+        "@Environment(\\.container) var c = AppContainer.production()\n"
+    )
+    # excluded: allowlisted composition root
+    (root / "AppInfrastructure" / "AppContainer.swift").write_text(
+        "static func production() -> AppContainer { AppContainer.production() }\n"
+    )
+    # excluded: under Packages/
+    (root / "Packages" / "Pkg" / "Sources" / "P.swift").write_text(
+        "let x = AppContainer.production().foo\n"
+    )
+    return root
+
+
+def _allowlist(tmp_path: Path) -> Path:
+    p = tmp_path / "allow.txt"
+    p.write_text("# comment\nAppInfrastructure/AppContainer.swift\n")
+    return p
+
+
+def test_script_passes_bash_syntax_check():
+    r = subprocess.run(["bash", "-n", str(_SCRIPT)], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+
+
+def test_count_mode_excludes_allowlist_env_and_packages(tmp_path):
+    root = _build_tree(tmp_path)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("2\n")
+    r = _run(root, baseline, _allowlist(tmp_path), mode="--count")
+    assert r.returncode == 0
+    assert r.stdout.strip() == "2", r.stdout
+
+
+def test_at_baseline_passes(tmp_path):
+    root = _build_tree(tmp_path)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("2\n")
+    r = _run(root, baseline, _allowlist(tmp_path))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "PASS" in r.stdout
+
+
+def test_above_baseline_fails(tmp_path):
+    root = _build_tree(tmp_path)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("1\n")  # tree has 2 -> over
+    r = _run(root, baseline, _allowlist(tmp_path))
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "FAIL" in r.stdout
+
+
+def test_below_baseline_passes_and_reports(tmp_path):
+    root = _build_tree(tmp_path)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("9\n")  # tree has 2 -> under
+    r = _run(root, baseline, _allowlist(tmp_path))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "PASS" in r.stdout
+    assert "2" in r.stdout
+
+
+def test_empty_allowlist_counts_the_root_file(tmp_path):
+    """With no allowlist entry, the AppContainer.swift use IS counted (3 total)."""
+    root = _build_tree(tmp_path)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("3\n")
+    empty = tmp_path / "empty.txt"
+    empty.write_text("# nothing\n")
+    r = _run(root, baseline, empty, mode="--count")
+    assert r.stdout.strip() == "3", r.stdout
+
+
+def test_live_repo_baseline_passes():
+    """Checked-in baseline + allowlist must PASS against today's Palace/ tree."""
+    r = subprocess.run(["bash", str(_SCRIPT)], capture_output=True, text=True, timeout=60)
+    assert r.returncode == 0, r.stdout + r.stderr

--- a/scripts/tests/test_check_godclass_loc_freeze.py
+++ b/scripts/tests/test_check_godclass_loc_freeze.py
@@ -1,0 +1,104 @@
+"""
+test_check_godclass_loc_freeze.py — pytest for the Wave 0 god-class LOC freeze
+gate (scripts/check-godclass-loc-freeze.sh).
+
+Asserts BOTH directions (CLAUDE.md gate rule: a gate that only ever sees a
+violation hides wiring bugs that block everything):
+  (a) a file that GREW past its baseline -> FAIL (exit 1),
+  (b) a file exactly AT baseline         -> PASS (exit 0) — the clean-diff pass,
+  (c) a file that SHRANK                  -> PASS + prints the lower number,
+  (d) a baselined file gone missing       -> FAIL (catch rename/move drift).
+
+Each case builds a throwaway tree + baseline and points the script at it via
+GODCLASS_ROOT / GODCLASS_BASELINE, so the test never depends on the live repo.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-godclass-loc-freeze.sh"
+
+
+def _run(root: Path, baseline: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(_SCRIPT)],
+        env={
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "GODCLASS_ROOT": str(root),
+            "GODCLASS_BASELINE": str(baseline),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _make_swift(path: Path, lines: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(f"// line {i}" for i in range(lines)) + "\n")
+
+
+def test_script_passes_bash_syntax_check():
+    r = subprocess.run(["bash", "-n", str(_SCRIPT)], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+
+
+def test_file_at_baseline_passes(tmp_path):
+    _make_swift(tmp_path / "Palace" / "God.swift", 100)
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("100 Palace/God.swift\n")
+    r = _run(tmp_path, baseline)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "PASS" in r.stdout
+
+
+def test_file_exceeding_baseline_fails(tmp_path):
+    _make_swift(tmp_path / "Palace" / "God.swift", 137)
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("100 Palace/God.swift\n")
+    r = _run(tmp_path, baseline)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "GREW" in r.stdout
+    assert "137" in r.stdout
+
+
+def test_file_shrunk_passes_and_reports_new_number(tmp_path):
+    _make_swift(tmp_path / "Palace" / "God.swift", 80)
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("100 Palace/God.swift\n")
+    r = _run(tmp_path, baseline)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "PASS" in r.stdout
+    assert "ratchet" in r.stdout.lower()
+    assert "80" in r.stdout
+
+
+def test_missing_baselined_file_fails(tmp_path):
+    # No file created on disk.
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("100 Palace/Gone.swift\n")
+    r = _run(tmp_path, baseline)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "MISSING" in r.stdout
+
+
+def test_comments_and_blanks_ignored(tmp_path):
+    _make_swift(tmp_path / "Palace" / "God.swift", 100)
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("# a comment\n\n100 Palace/God.swift\n")
+    r = _run(tmp_path, baseline)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_live_repo_baseline_passes():
+    """The checked-in baseline must PASS against today's tree (zero false positives)."""
+    r = subprocess.run(
+        ["bash", str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert r.returncode == 0, r.stdout + r.stderr

--- a/scripts/tests/test_check_shared_read_count.py
+++ b/scripts/tests/test_check_shared_read_count.py
@@ -1,0 +1,117 @@
+"""
+test_check_shared_read_count.py — pytest for the Wave 0 `.shared`-read
+monotone-down gate (scripts/check-shared-read-count.sh).
+
+Asserts BOTH directions (CLAUDE.md gate rule — clean-diff pass required):
+  (a) count ABOVE baseline -> FAIL (exit 1),
+  (b) count AT baseline    -> PASS (exit 0),
+  (c) count BELOW baseline -> PASS + prints the lower number,
+plus the exclusion contract: system singletons (URLSession.shared etc.) and
+anything under Palace/Packages/ are NOT counted.
+
+Each case builds a throwaway Palace/ tree and points the script at it via
+SHARED_SCAN_ROOT / SHARED_BASELINE.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-shared-read-count.sh"
+
+
+def _run(scan_root: Path, baseline: Path, mode: str | None = None) -> subprocess.CompletedProcess:
+    cmd = ["bash", str(_SCRIPT)]
+    if mode:
+        cmd.append(mode)
+    return subprocess.run(
+        cmd,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "SHARED_SCAN_ROOT": str(scan_root),
+            "SHARED_BASELINE": str(baseline),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _scan_root(tmp_path: Path, body: str, *, in_packages: str = "") -> Path:
+    root = tmp_path / "Palace"
+    (root).mkdir(parents=True, exist_ok=True)
+    (root / "Feature.swift").write_text(body)
+    if in_packages:
+        pkg = root / "Packages" / "PalaceThing" / "Sources"
+        pkg.mkdir(parents=True, exist_ok=True)
+        (pkg / "Thing.swift").write_text(in_packages)
+    return root
+
+
+# Two non-system reads; several system reads that must be ignored.
+_BODY_TWO = """
+let a = AccountStateStore.shared
+let b = ImageCache.shared
+let sys1 = URLSession.shared
+let sys2 = FileManager.shared
+let sys3 = NotificationCenter.shared
+let sys4 = UIApplication.shared
+"""
+
+
+def test_script_passes_bash_syntax_check():
+    r = subprocess.run(["bash", "-n", str(_SCRIPT)], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+
+
+def test_count_mode_excludes_system_and_packages(tmp_path):
+    root = _scan_root(tmp_path, _BODY_TWO, in_packages="let x = InPackage.shared\n")
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("2\n")
+    r = _run(root, baseline, mode="--count")
+    assert r.returncode == 0
+    assert r.stdout.strip() == "2", r.stdout  # 2 non-system, Packages excluded
+
+
+def test_at_baseline_passes(tmp_path):
+    root = _scan_root(tmp_path, _BODY_TWO)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("2\n")
+    r = _run(root, baseline)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "PASS" in r.stdout
+
+
+def test_above_baseline_fails(tmp_path):
+    root = _scan_root(tmp_path, _BODY_TWO)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("1\n")  # tree has 2 -> over
+    r = _run(root, baseline)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "FAIL" in r.stdout
+
+
+def test_below_baseline_passes_and_reports(tmp_path):
+    root = _scan_root(tmp_path, _BODY_TWO)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("5\n")  # tree has 2 -> under
+    r = _run(root, baseline)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "PASS" in r.stdout
+    assert "2" in r.stdout
+
+
+def test_baseline_comments_ignored(tmp_path):
+    root = _scan_root(tmp_path, _BODY_TWO)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("# note\n2\n")
+    r = _run(root, baseline)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_live_repo_baseline_passes():
+    """Checked-in baseline must PASS against today's Palace/ tree."""
+    r = subprocess.run(["bash", str(_SCRIPT)], capture_output=True, text=True, timeout=60)
+    assert r.returncode == 0, r.stdout + r.stderr

--- a/tools/ledger/ledger-config.json
+++ b/tools/ledger/ledger-config.json
@@ -129,5 +129,14 @@
       "to": "PalaceUIKit",
       "reason": "Toolkit provides both core playback (Infrastructure) and default UI (Presentation). UI components import PalaceUIKit for shared styles."
     }
+  ],
+  "knownFalsePositiveEdges": [
+    {
+      "from": "PalaceTriageBot",
+      "aka": "TriageBotUI",
+      "to": "Palace",
+      "confidence": "name-inferred",
+      "reason": "SwiftPM structurally forbids a package (PalaceTriageBot / its TriageBotUI target) from importing the app target (Palace). This edge is a name-based inference artifact, not a real import — the compiler cannot produce it. The trend gate must DISCOUNT it so the cycle count is not inflated by an impossible edge. See docs/architecture/god-class-decomposition-plan.md §3b cycle 9 (Wave 0 ledger hygiene)."
+    }
   ]
 }


### PR DESCRIPTION
## What this is

**Phase 0 (scaffolding) of the god-class decomposition campaign.** It moves **no production code** — it banks the safety net and growth-freeze the extraction waves depend on. See `docs/architecture/god-class-decomposition-plan.md` (the ADR) for the full target architecture + wave plan.

The 6 god-classes (AudiobookSessionManager 2761, AccountsManager 2319, MyBooksDownloadCenter 2167, BookDetailViewModel 1375, TPPSignInBusinessLogic 1119, BorrowOperation 966) accreted **+1,400 LOC in 19 days**. This PR stops that and pins their current behavior before any extraction.

## Contents (27 files, additive-only)

- **ADR** `docs/architecture/god-class-decomposition-plan.md` — target SPM-package DAG that makes today's dependency cycles a *compile error*; maps every god-class, all 9 root cycles, and the high-fan-in singletons to a home.
- **77 pre-wave characterization/contract tests** in `PalaceTests/Decomp/` — call-order contracts + genuinely-uncovered gap branches. The authoring agents refused to duplicate existing coverage, so these are surgical (e.g. the money-path DRM-dispatch-per-format contract, F-011 deferred-play ordering, the F-032 deferred-reset account switch). All use inline `CallLog` method-order equality — **green on first CI run**, no external baselines.
- **Wave 0 ratchet** — `scripts/check-godclass-loc-freeze.sh` + `check-shared-read-count.sh` + `check-appcontainer-locator-count.sh` (+ baselines, allowlist, 3 pytests, all green). **Advisory-only** in this PR (not wired into `verify-pr.sh`/CI) per the gate-landing discipline; wiring lines documented in the Wave 0 output.
- **Singleton census** `docs/architecture/singleton-census.md` — 39-row disposition.
- **Ledger hygiene** — `knownFalsePositiveEdges` annotation discounts the impossible `TriageBotUI→Palace` name-inferred edge.

## Review

SoD reviewers under heka governance: **architect ✅**, **qa_test ✅** (both signed to the tip), **blast_radius ✅** (prior tip; classifier blocked the re-run, diff unchanged for its scope). Architect's first pass **blocked** a real defect — 6 contract tests would have red their own first CI run — which was fixed (converted file-based snapshots → inline `CallLog` equality, sequences verified against production call order) before this PR. These are agent-generated verdicts; **CI here is the real correctness gate.**

## Honest caveats

- No extraction yet — Waves 1–7 (the actual decomposition) follow; Wave 1a (`PalacePreferences`) is specced and gated on this PR's CI confirming the pre-tests pass.
- `TPPCirculationAnalyticsRequestShapeContractTests` is `XCTSkip`-gated until the Wave 1c `private→internal` seam (it names the seam and reports a latent dead-branch bug found during mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEUqnH7e8zUHeUfgeSNDkf
