### PR TITLE
fix(audiobooks): Findaway Now-Playing crash on iOS 26 — 3.2.2 hotfix (PP-4873)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -8735,7 +8735,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 487;
+				CURRENT_PROJECT_VERSION = 488;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8758,7 +8758,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.1;
+				MARKETING_VERSION = 3.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -8793,7 +8793,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 487;
+				CURRENT_PROJECT_VERSION = 488;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8816,7 +8816,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.1;
+				MARKETING_VERSION = 3.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -8981,7 +8981,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 487;
+				CURRENT_PROJECT_VERSION = 488;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -9007,7 +9007,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.1;
+				MARKETING_VERSION = 3.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -9041,7 +9041,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 487;
+				CURRENT_PROJECT_VERSION = 488;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -9068,7 +9068,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.1;
+				MARKETING_VERSION = 3.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.thepalaceproject.palace;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "App Store";


### PR DESCRIPTION
Fixes the iOS-26 audiobook crash on **Findaway** titles — PP-4873, Crashlytics 4a92d371 (147 crashes / 11 patrons, still OPEN, first seen 3.2.0).

## Root cause (verified against the shipped 3.2.1 binary)
FindawayPlayer.playbackRate's getter force-unwrapped `PlaybackRate(rawValue: Int(rate * 100))!`. On iOS 26 the Findaway engine reports an idle / out-of-range rate during bind (before playback starts) whose Int(rate*100) is not an exact PlaybackRate case, so init(rawValue:) returned nil and the `!` aborted the process when Now Playing updated. It is **not** a concurrency crash — the Crashlytics `block_destroy_helper.46` frame was a symbolication artifact (nearest surviving symbol in the stripped toolkit binary). Pinned recreation-free by disassembling the shipped Palace-3.2.1.487 binary from ios-binaries.

## The fix (toolkit-only, minimal)
Both force-unwraps in the getter now fall back to `?? .normalTime`. **No Palace app-code change** — this PR is only a submodule bump to the toolkit hotfix commit, plus a regression test.

- Toolkit diff (2 lines + regression test): https://github.com/ThePalaceProject/ios-audiobooktoolkit/compare/8b0fffc2...d8d9226
- develop / 3.3.0 already carries this fix (via **PP-4518** / 81b91da1); the 3.2.x submodule pin was cut 4 days before it landed. This is the minimal 3.2.2 backport.

## Merge policy
Hotfix to `main` via a **merge commit (--no-ff), NOT squash** (per the release-merge policy), then forward-port to develop.

## Verification
Root cause confirmed from the shipped binary + git lineage. Local build/test verification is running; final confirmation is TestFlight then Crashlytics (the crash is data/timing-dependent and does not reproduce in a local Debug/-O build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
