### PR TITLE
ci: ban raw NSOperation closure literals (#1338 regression guard) + dormant BookRegistry purity gate

### DIFF
--- a/scripts/check-addoperation-literal-ban.py
+++ b/scripts/check-addoperation-literal-ban.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+check-addoperation-literal-ban.py — ban raw `NSOperation`-family closure
+LITERALS in the app target (`Palace/**/*.swift`).
+
+Catches the #1338 regression class: an Xcode 26.2 / Swift 6.2 ClangImporter
+bug caches the imported Swift type of the canonical clang block type
+`void (^)(void)` the FIRST time any WebKit block declaration is type-checked
+in a given `swift-frontend` process. WebKit's headers annotate blocks with
+`NS_SWIFT_UI_ACTOR` (`@MainActor`) while Foundation's `-addOperationWithBlock:`
+/ `-addExecutionBlock:` / `completionBlock` use `NS_SWIFT_SENDABLE` — both are
+`swift_attr` sugar over the SAME canonical block type. Once the ClangImporter
+has cached `@MainActor @Sendable () -> Void` for that type, every LATER
+structurally-identical block parameter in the same process (batch or WMO)
+surfaces as `@MainActor` too — including Foundation's operation-queue APIs. A
+`@MainActor`-typed closure LITERAL passed directly to one of those APIs gets a
+`dispatch_assert_queue(main)` prologue and SIGTRAPs
+(`swift_task_checkIsolated` -> `dispatch_assert_queue_fail`) the instant the
+queue runs it off-main. Which files are affected depends only on
+frontend-batch membership, so an unrelated file-set change can flip a
+previously-fine file. See `Palace/Utilities/ImageCache/ImageCache.swift`'s
+class-header comment for the full forensic (the #1338 bootstrap crash).
+
+The fix is NOT to avoid these APIs — it is to hoist the closure into an
+explicitly-typed `let` binding BEFORE handing it to the API. The closure's
+type then comes from the `let` ANNOTATION (e.g. `@Sendable () -> Void`), not
+the poisonable imported parameter type; passing that typed value to even a
+poisoned parameter is a safe conversion with no runtime isolation assertion.
+
+    let work: @Sendable () -> Void = { ... }
+    queue.addOperation(work)                     // APPROVED — named value
+
+    queue.addOperation { ... }                    // BANNED — literal
+    operation.addExecutionBlock { ... }           // BANNED — literal
+    BlockOperation { ... }                        // BANNED — literal
+    BlockOperation(block: { ... })                // BANNED — literal
+    operation.completionBlock = { ... }           // BANNED — literal assign
+
+Scope: diff-ADDED lines only, `Palace/**/*.swift` (app target). Test/mock/
+preview/scripts dirs are excluded — mirrors
+`check-completion-nil-error-suppression.py`'s `_NON_PROD_PATH_SUBSTRINGS`.
+
+False-positive escape hatch: `// no-addoperation-literal-ban: <reason>` on the
+violating line or any of the 3 preceding lines (mirrors the sibling
+detectors' `// no-nil-error-suppression:` convention).
+
+Flags (mirror the sibling pre-commit detectors):
+  --diff <file>        Unified-diff input. `-` or omit for stdin.
+  --scan <repo-root>   Walk `<root>/Palace/**/*.swift` directly instead of a
+                       diff (whole-tree dry run / bootstrap).
+  --severity-floor LVL Block at LVL or higher (low|medium|high). Default high.
+  --no-block           Print findings, always exit 0.
+  --quiet              Suppress trailing summary line on stderr.
+  --dry-run            Parse only; never exit non-zero on findings.
+
+Exit codes:
+  0  — no findings at or above the severity floor (default: high)
+  1  — at least one finding at or above the floor
+  2  — argument or I/O error
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from _checklib import at_or_above, iter_hunk_lines, read_diff
+
+_at_or_above = at_or_above
+
+# --- Detection patterns ------------------------------------------------------
+#
+# Each pattern matches a closure LITERAL (`{`) passed/assigned directly to one
+# of the banned NSOperation-family APIs. A NAMED value (identifier, no `{`
+# immediately following) never matches — that is the approved hoisted form.
+# `(?!s)` on addOperation keeps `.addOperations(` (plural, array API — out of
+# scope) from matching. Patterns are matched against the whole reconstructed
+# source (not line-by-line) so a literal whose opening `{` sits just after a
+# line break (e.g. `.addOperation(\n    {`) is still caught — `\s` matches
+# newlines too.
+
+_RE_ADD_OPERATION = re.compile(r"\.addOperation(?!s)\s*\(?\s*\{")
+_RE_ADD_EXECUTION_BLOCK = re.compile(r"\.addExecutionBlock\s*\(?\s*\{")
+_RE_BLOCK_OPERATION = re.compile(r"\bBlockOperation\s*(?:\(\s*block\s*:\s*)?\{")
+_RE_COMPLETION_BLOCK_ASSIGN = re.compile(r"\.completionBlock\s*=\s*\{")
+
+_PATTERNS: tuple[tuple[str, re.Pattern, str], ...] = (
+    ("addOperation", _RE_ADD_OPERATION,
+     "`.addOperation { ... }` trailing-closure LITERAL"),
+    ("addExecutionBlock", _RE_ADD_EXECUTION_BLOCK,
+     "`.addExecutionBlock { ... }` closure LITERAL"),
+    ("BlockOperation", _RE_BLOCK_OPERATION,
+     "`BlockOperation { ... }` / `BlockOperation(block: { ... })` closure LITERAL"),
+    ("completionBlock", _RE_COMPLETION_BLOCK_ASSIGN,
+     "`.completionBlock = { ... }` closure LITERAL assignment"),
+)
+
+_RE_NO_BAN_ANNOTATION = re.compile(
+    r"//\s*no-addoperation-literal-ban\b", re.IGNORECASE
+)
+
+# Non-prod path substrings — mirrors check-blast-radius.py /
+# check-completion-nil-error-suppression.py.
+_NON_PROD_PATH_SUBSTRINGS = (
+    "PalaceTests/",
+    "Tests/",
+    "TestSupport/",
+    "Utilities/Testing/",
+    "Preview Content/",
+    "Mocks/",
+    ".forgeos/",
+    "scripts/_fixtures/",
+    "scripts/tests/",
+)
+
+
+def _is_non_prod_swift(path: str) -> bool:
+    return any(s in path for s in _NON_PROD_PATH_SUBSTRINGS)
+
+
+# --- Findings ----------------------------------------------------------------
+
+@dataclass
+class _Finding:
+    code: str
+    severity: str
+    file_path: str
+    line_no: int
+    description: str
+
+    def render(self) -> str:
+        return (f"{self.file_path}:{self.line_no}: "
+                f"{self.code}: {self.severity}: {self.description}")
+
+
+def _line_no_at_offset(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def _has_annotation(lines: list[str], call_line: int) -> bool:
+    start = max(1, call_line - 3)
+    for ln in range(start, call_line + 1):
+        if ln < 1 or ln > len(lines):
+            continue
+        if _RE_NO_BAN_ANNOTATION.search(lines[ln - 1]):
+            return True
+    return False
+
+
+def _scan_file(rel_path: str, source: str) -> list[_Finding]:
+    """Find all banned-literal call sites in `source`. Line-no sorted."""
+    if _is_non_prod_swift(rel_path):
+        return []
+    if not rel_path.endswith(".swift"):
+        return []
+
+    lines = source.splitlines()
+    findings: list[_Finding] = []
+    for _name, rx, desc in _PATTERNS:
+        for m in rx.finditer(source):
+            line_no = _line_no_at_offset(source, m.start())
+            if _has_annotation(lines, line_no):
+                continue
+            findings.append(_Finding(
+                code="AOB-1",
+                severity="high",
+                file_path=rel_path,
+                line_no=line_no,
+                description=(
+                    f"{desc} — Xcode 26.2 ClangImporter @MainActor-poisoning "
+                    "risk (#1338: a WebKit block declaration anywhere in the "
+                    "same compile batch flips this literal's inferred type to "
+                    "@MainActor, and it SIGTRAPs off-main). Hoist into "
+                    "`let work: @Sendable () -> Void = { ... }` and pass "
+                    "`work` instead."
+                ),
+            ))
+
+    findings.sort(key=lambda f: (f.file_path, f.line_no))
+    return findings
+
+
+# --- Diff mode ---------------------------------------------------------------
+
+def _scan_diff(diff_text: str, repo_root: Path) -> list[_Finding]:
+    """Scan a unified diff: per touched file, reconstruct or read the
+    post-image and emit findings whose line numbers fall on ADDED lines.
+    """
+    touched: dict[str, set[int]] = {}
+    for dl in iter_hunk_lines(diff_text):
+        if dl.kind != "+":
+            continue
+        if not dl.file_path.endswith(".swift"):
+            continue
+        if _is_non_prod_swift(dl.file_path):
+            continue
+        touched.setdefault(dl.file_path, set()).add(dl.line_no)
+
+    out: list[_Finding] = []
+    for rel_path, added_lines in touched.items():
+        on_disk = repo_root / rel_path
+        if on_disk.is_file():
+            try:
+                source = on_disk.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+        else:
+            source = _reconstruct_post_image(diff_text, rel_path)
+            if source is None:
+                continue
+        file_findings = _scan_file(rel_path, source)
+        for f in file_findings:
+            if f.line_no in added_lines:
+                out.append(f)
+    return out
+
+
+def _reconstruct_post_image(diff_text: str, target_path: str) -> str | None:
+    """Reconstruct a synthetic post-image when the file isn't on disk (e.g.
+    scanning a standalone diff file against a throwaway/no-checkout root)."""
+    rows: dict[int, str] = {}
+    found = False
+    for dl in iter_hunk_lines(diff_text):
+        if dl.file_path != target_path:
+            continue
+        if dl.kind not in ("+", " "):
+            continue
+        rows[dl.line_no] = dl.text
+        found = True
+    if not found:
+        return None
+    if not rows:
+        return ""
+    max_line = max(rows)
+    out_lines = [rows.get(i, "") for i in range(1, max_line + 1)]
+    return "\n".join(out_lines)
+
+
+# --- Scan mode ----------------------------------------------------------------
+
+def _scan_repo(repo_root: Path) -> list[_Finding]:
+    out: list[_Finding] = []
+    palace_dir = repo_root / "Palace"
+    if not palace_dir.is_dir():
+        palace_dir = repo_root
+    for root, _dirs, files in os.walk(palace_dir):
+        for name in files:
+            if not name.endswith(".swift"):
+                continue
+            full = Path(root) / name
+            try:
+                rel = str(full.relative_to(repo_root))
+            except ValueError:
+                rel = str(full)
+            if _is_non_prod_swift(rel):
+                continue
+            try:
+                source = full.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            out.extend(_scan_file(rel, source))
+    return out
+
+
+# --- CLI -----------------------------------------------------------------
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check-addoperation-literal-ban.py",
+        description=(
+            "Ban raw NSOperation-family closure LITERALS "
+            "(.addOperation {, .addExecutionBlock {, BlockOperation {, "
+            ".completionBlock = {) in Palace/**/*.swift — Xcode 26.2 "
+            "ClangImporter @MainActor-poisoning risk (#1338)."
+        ),
+    )
+    parser.add_argument("--diff", default=None,
+                        help="Unified-diff input file. `-` or omit for stdin.")
+    parser.add_argument("--scan", default=None,
+                        help="Repo root to walk directly instead of a diff.")
+    parser.add_argument("--severity-floor", default="high",
+                        choices=("low", "medium", "high"),
+                        help="Block at LVL or above (default: high).")
+    parser.add_argument("--no-block", action="store_true",
+                        help="Print findings, always exit 0.")
+    parser.add_argument("--quiet", action="store_true",
+                        help="Suppress summary line on stderr.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print findings; do not exit non-zero.")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.scan:
+            findings = _scan_repo(Path(args.scan).resolve())
+        else:
+            diff_text = read_diff(args.diff)
+            repo_root = Path.cwd()
+            findings = _scan_diff(diff_text, repo_root)
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover - safety net
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    blocking: list[_Finding] = []
+    for f in sorted(findings, key=lambda x: (x.file_path, x.line_no, x.code)):
+        if _at_or_above(f.severity, args.severity_floor):
+            blocking.append(f)
+        print(f.render())
+
+    if not args.quiet:
+        msg = (f"\n{len(findings)} addOperation-literal-ban finding(s); "
+               f"{len(blocking)} at/above floor={args.severity_floor}")
+        print(msg, file=sys.stderr)
+
+    if args.no_block or args.dry_run:
+        return 0
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-bookregistry-package-purity.sh
+++ b/scripts/check-bookregistry-package-purity.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# check-bookregistry-package-purity.sh
+#
+# DORMANT gate for the future `PalaceBookRegistry` package (Wave 2b — see
+# docs/architecture/god-class-decomposition-plan.md and the Wave 2b brief:
+# extract PalaceBookRegistry + invert Accounts via `AccountScopeProviding`).
+#
+# Once that package exists, its `Sources/` must NEVER reach back into the
+# app-target coupling surface it was extracted to escape — that would
+# recreate exactly the `.shared` / `AppContainer`-locator coupling the whole
+# god-class decomposition campaign exists to dissolve. This gate asserts ZERO
+# occurrences, anywhere under `Palace/Packages/PalaceBookRegistry/Sources`, of:
+#
+#   AccountsManager | TPPUserAccount | AppContainer | MyBooksDownloadCenter |
+#   LCPAudiobooks | NotificationService
+#
+# It is DORMANT today: the package does not exist yet (Wave 2b has not landed
+# as of this writing), so the gate NO-OPs cleanly (exit 0, explains why) until
+# `Palace/Packages/PalaceBookRegistry/Sources` appears. Once the package is
+# extracted, this gate goes live automatically on the very next commit that
+# touches it — no further wiring required.
+#
+# Env overrides (for tests):
+#   BOOKREGISTRY_SCAN_ROOT   directory to scan (default:
+#                            <repo>/Palace/Packages/PalaceBookRegistry/Sources)
+#
+# Usage: check-bookregistry-package-purity.sh
+# Exit: 0 = package doesn't exist yet (no-op) OR zero forbidden references (PASS)
+#       1 = a forbidden reference was found (FAIL)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCAN_ROOT="${BOOKREGISTRY_SCAN_ROOT:-$REPO/Palace/Packages/PalaceBookRegistry/Sources}"
+
+FORBIDDEN='AccountsManager|TPPUserAccount|AppContainer|MyBooksDownloadCenter|LCPAudiobooks|NotificationService'
+
+if [ ! -d "$SCAN_ROOT" ]; then
+  echo "[bookregistry-purity] NO-OP: $SCAN_ROOT does not exist yet (Wave 2b package not extracted) — gate is dormant."
+  exit 0
+fi
+
+FINDINGS="$(grep -rnE "$FORBIDDEN" "$SCAN_ROOT" --include='*.swift' 2>/dev/null || true)"
+
+if [ -n "$FINDINGS" ]; then
+  echo "[bookregistry-purity] FAIL: PalaceBookRegistry/Sources references the app-target"
+  echo "  coupling surface it was extracted to escape:"
+  printf '%s\n' "$FINDINGS"
+  echo ""
+  echo "  Fix: invert the dependency (e.g. AccountScopeProviding) instead of reaching back"
+  echo "  into AccountsManager / TPPUserAccount / AppContainer / MyBooksDownloadCenter /"
+  echo "  LCPAudiobooks / NotificationService from the extracted package (see the Wave 2b plan)."
+  exit 1
+fi
+
+echo "[bookregistry-purity] PASS: $SCAN_ROOT has zero forbidden app-target references."
+exit 0

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -117,6 +117,17 @@ if [[ -f "$REPO_ROOT_M1/scripts/check-doc-hygiene.sh" ]]; then
   fi
 fi
 
+# DORMANT Wave 2b gate: PalaceBookRegistry/Sources package purity. Whole-tree
+# scan (not diff-based) but a no-op today — the package doesn't exist until
+# Wave 2b extracts it — so it's cheap to run unconditionally. See
+# scripts/check-bookregistry-package-purity.sh.
+if [[ -f "$REPO_ROOT_M1/scripts/check-bookregistry-package-purity.sh" ]]; then
+  if ! _br_out=$(bash "$REPO_ROOT_M1/scripts/check-bookregistry-package-purity.sh" 2>&1); then
+    echo "$_br_out" >&2
+    M1_FAIL=$((M1_FAIL + 1))
+  fi
+fi
+
 m1_enforce "$M1_FAIL"
 
 # Friendly nudge — non-blocking. Only print if anything is staged at all.

--- a/scripts/pre-commit-phase35-detectors.sh
+++ b/scripts/pre-commit-phase35-detectors.sh
@@ -47,6 +47,7 @@ DETECTORS=(
   "SWIFTUI_PLACEHOLDER_A11Y|check-swiftui-placeholder-a11y.py|warn|diff"
   "NOTIFICATION_CENTER_OBSERVER_STORAGE|check-notification-center-observer-storage.py|warn|diff"
   "UNSYNCHRONIZED_SENDABLE_MOCK|check-unsynchronized-sendable-mock.py|block|scan"
+  "ADDOPERATION_LITERAL_BAN|check-addoperation-literal-ban.py|block|diff"
 )
 
 OVERALL_EXIT=0

--- a/scripts/tests/fixtures/addoperation_literal_ban/clean_addoperations_plural.swift
+++ b/scripts/tests/fixtures/addoperation_literal_ban/clean_addoperations_plural.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// `addOperations` (plural, array API) is out of scope for this ban — it does
+/// not take a trailing closure and is not part of the #1338 predicate.
+final class CleanAddOperationsPlural {
+    func schedule() {
+        let op1 = BlockOperation()
+        let op2 = BlockOperation()
+        OperationQueue().addOperations([op1, op2], waitUntilFinished: false)
+    }
+}

--- a/scripts/tests/fixtures/addoperation_literal_ban/clean_annotation_escape.swift
+++ b/scripts/tests/fixtures/addoperation_literal_ban/clean_annotation_escape.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// A literal that is DELIBERATELY exempted via the escape-hatch annotation.
+/// Only use this when a maintainer has verified the isolation is safe for
+/// this specific call site (e.g. it always runs on `@MainActor` already).
+final class CleanAnnotationEscape {
+    func schedule() {
+        // no-addoperation-literal-ban: this queue is main-only by construction
+        OperationQueue.main.addOperation {
+            print("intentionally allowed literal")
+        }
+    }
+}

--- a/scripts/tests/fixtures/addoperation_literal_ban/clean_hoisted_all_forms.swift
+++ b/scripts/tests/fixtures/addoperation_literal_ban/clean_hoisted_all_forms.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// APPROVED form (mirrors Palace/Utilities/ImageCache/ImageCache.swift): every
+/// closure is hoisted into an explicitly-typed `let` binding BEFORE being
+/// handed to the NSOperation-family API, rather than written inline as a
+/// trailing-closure literal. The bound value's type comes from the `let`
+/// annotation, not the poisonable imported parameter type, so passing it to
+/// any of these APIs is safe under the #1338 ClangImporter bug.
+final class CleanHoistedAllForms {
+    private let processingQueue = OperationQueue()
+
+    func schedule() {
+        let work: @Sendable () -> Void = {
+            print("hoisted addOperation work")
+        }
+        processingQueue.addOperation(work)
+
+        let operation = BlockOperation()
+
+        let executionBlock: @Sendable () -> Void = {
+            print("hoisted execution block")
+        }
+        operation.addExecutionBlock(executionBlock)
+
+        let completion: @Sendable () -> Void = {
+            print("hoisted completion")
+        }
+        operation.completionBlock = completion
+
+        processingQueue.addOperation(operation)
+    }
+}

--- a/scripts/tests/fixtures/addoperation_literal_ban/violation_add_execution_block.swift
+++ b/scripts/tests/fixtures/addoperation_literal_ban/violation_add_execution_block.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+final class ViolationAddExecutionBlock {
+    func schedule() {
+        let operation = BlockOperation()
+        operation.addExecutionBlock {
+            print("execution block literal — banned")
+        }
+    }
+}

--- a/scripts/tests/fixtures/addoperation_literal_ban/violation_addoperation_trailing_closure.swift
+++ b/scripts/tests/fixtures/addoperation_literal_ban/violation_addoperation_trailing_closure.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// PP-1338-class violation: a raw trailing-closure literal handed directly to
+/// `addOperation`. Under Xcode 26.2's ClangImporter @MainActor-poisoning bug
+/// this literal's inferred type can flip to `@MainActor`, and it SIGTRAPs the
+/// instant `processingQueue` runs it off-main.
+final class ViolationAddOperationTrailingClosure {
+    private let processingQueue = OperationQueue()
+
+    func schedule() {
+        processingQueue.addOperation {
+            print("work done inline — banned literal")
+        }
+    }
+}

--- a/scripts/tests/fixtures/addoperation_literal_ban/violation_block_operation_init.swift
+++ b/scripts/tests/fixtures/addoperation_literal_ban/violation_block_operation_init.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+final class ViolationBlockOperationInit {
+    func schedule() {
+        let operation = BlockOperation {
+            print("BlockOperation trailing-closure literal — banned")
+        }
+        OperationQueue().addOperation(operation)
+    }
+}

--- a/scripts/tests/fixtures/addoperation_literal_ban/violation_block_operation_labeled.swift
+++ b/scripts/tests/fixtures/addoperation_literal_ban/violation_block_operation_labeled.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+final class ViolationBlockOperationLabeled {
+    func schedule() {
+        let operation = BlockOperation(block: {
+            print("labeled block literal — banned")
+        })
+        OperationQueue().addOperation(operation)
+    }
+}

--- a/scripts/tests/fixtures/addoperation_literal_ban/violation_completion_block_assign.swift
+++ b/scripts/tests/fixtures/addoperation_literal_ban/violation_completion_block_assign.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+final class ViolationCompletionBlockAssign {
+    func schedule() {
+        let operation = BlockOperation()
+        operation.completionBlock = {
+            print("completion literal assigned directly — banned")
+        }
+        OperationQueue().addOperation(operation)
+    }
+}

--- a/scripts/tests/test_check_addoperation_literal_ban.py
+++ b/scripts/tests/test_check_addoperation_literal_ban.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+test_check_addoperation_literal_ban.py — self-verify the AOB-1 detector
+(scripts/check-addoperation-literal-ban.py).
+
+Runs the detector via `--scan` against the sibling per-shape Swift fixtures
+and asserts the predicate fires on each of the four banned literal forms
+(`.addOperation {`, `.addExecutionBlock {`, `BlockOperation {` /
+`BlockOperation(block: {`, `.completionBlock = {`) while passing the
+approved hoisted-`let`-binding form, the `// no-addoperation-literal-ban:`
+escape hatch, and the out-of-scope `addOperations` (plural) API. Guards the
+#1338 regression class (Xcode 26.2 ClangImporter @MainActor-poisoning of
+NSOperation-family closure literals — see
+Palace/Utilities/ImageCache/ImageCache.swift).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-addoperation-literal-ban.py"
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "addoperation_literal_ban"
+
+
+def _run_scan(scan_root: Path) -> tuple[int, str, str]:
+    """Invoke the detector in --scan mode; return (rc, stdout, stderr)."""
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--scan", str(scan_root), "--quiet"],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+        timeout=30,
+    )
+    return (result.returncode, result.stdout, result.stderr)
+
+
+def _isolate(tmp_path: Path, fixture_name: str) -> Path:
+    """Copy ONE fixture into a tmp Palace/ tree so --scan sees only it."""
+    src = _FIXTURE_DIR / fixture_name
+    assert src.is_file(), f"missing fixture: {src}"
+    palace = tmp_path / "Palace"
+    palace.mkdir()
+    dst = palace / fixture_name
+    dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    return tmp_path
+
+
+# --- Violation fixtures — each of the four banned literal forms ------------
+
+def test_violation_addoperation_trailing_closure_is_flagged(tmp_path):
+    """`.addOperation { ... }` — the canonical #1338 shape. MUST flag AOB-1."""
+    root = _isolate(tmp_path, "violation_addoperation_trailing_closure.swift")
+    rc, out, err = _run_scan(root)
+    assert rc != 0, f"expected non-zero exit, got 0. stdout={out!r}"
+    assert "AOB-1" in out, f"expected AOB-1 finding. stdout={out!r}"
+    assert "high" in out, f"expected high severity. stdout={out!r}"
+    assert "violation_addoperation_trailing_closure.swift" in out
+
+
+def test_violation_add_execution_block_is_flagged(tmp_path):
+    """`.addExecutionBlock { ... }` — MUST flag AOB-1."""
+    root = _isolate(tmp_path, "violation_add_execution_block.swift")
+    rc, out, err = _run_scan(root)
+    assert rc != 0, f"expected non-zero exit, got 0. stdout={out!r}"
+    assert "AOB-1" in out
+    assert "violation_add_execution_block.swift" in out
+
+
+def test_violation_block_operation_init_is_flagged(tmp_path):
+    """`BlockOperation { ... }` (trailing-closure init) — MUST flag AOB-1."""
+    root = _isolate(tmp_path, "violation_block_operation_init.swift")
+    rc, out, err = _run_scan(root)
+    assert rc != 0, f"expected non-zero exit, got 0. stdout={out!r}"
+    assert "AOB-1" in out
+    assert "violation_block_operation_init.swift" in out
+
+
+def test_violation_block_operation_labeled_is_flagged(tmp_path):
+    """`BlockOperation(block: { ... })` — MUST flag AOB-1."""
+    root = _isolate(tmp_path, "violation_block_operation_labeled.swift")
+    rc, out, err = _run_scan(root)
+    assert rc != 0, f"expected non-zero exit, got 0. stdout={out!r}"
+    assert "AOB-1" in out
+    assert "violation_block_operation_labeled.swift" in out
+
+
+def test_violation_completion_block_assign_is_flagged(tmp_path):
+    """`.completionBlock = { ... }` — MUST flag AOB-1."""
+    root = _isolate(tmp_path, "violation_completion_block_assign.swift")
+    rc, out, err = _run_scan(root)
+    assert rc != 0, f"expected non-zero exit, got 0. stdout={out!r}"
+    assert "AOB-1" in out
+    assert "violation_completion_block_assign.swift" in out
+
+
+# --- Clean fixtures ---------------------------------------------------------
+
+def test_clean_hoisted_all_forms_passes(tmp_path):
+    """The CANONICAL fix (ImageCache.swift pattern): every closure is bound to
+    an explicitly-typed `let` before being handed to the API. MUST pass with
+    exit 0 and no AOB-1 finding."""
+    root = _isolate(tmp_path, "clean_hoisted_all_forms.swift")
+    rc, out, err = _run_scan(root)
+    assert rc == 0, f"expected exit 0, got {rc}. stdout={out!r} stderr={err!r}"
+    assert "AOB-1" not in out
+
+
+def test_clean_annotation_escape_hatch_passes(tmp_path):
+    """`// no-addoperation-literal-ban: <reason>` on the preceding line MUST
+    suppress the finding."""
+    root = _isolate(tmp_path, "clean_annotation_escape.swift")
+    rc, out, err = _run_scan(root)
+    assert rc == 0, f"expected exit 0, got {rc}. stdout={out!r} stderr={err!r}"
+    assert "AOB-1" not in out
+
+
+def test_clean_addoperations_plural_passes(tmp_path):
+    """`addOperations` (plural, array API) is out of scope — MUST NOT flag."""
+    root = _isolate(tmp_path, "clean_addoperations_plural.swift")
+    rc, out, err = _run_scan(root)
+    assert rc == 0, f"expected exit 0, got {rc}. stdout={out!r} stderr={err!r}"
+    assert "AOB-1" not in out
+
+
+def test_clean_empty_diff_passes(tmp_path):
+    """`--diff` path on a no-op (empty) diff must exit 0 — the clean-diff half
+    of the CLAUDE.md gate-rule contract (a wiring bug that always-fires would
+    be invisible to a violation-only fixture)."""
+    diff_file = tmp_path / "empty.diff"
+    diff_file.write_text("")
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--diff", str(diff_file), "--quiet"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"empty diff must pass, got exit {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+
+
+def test_diff_scoped_ignores_unrelated_added_lines(tmp_path):
+    """A diff that adds an unrelated Swift line elsewhere in the SAME file as
+    a pre-existing (not newly-added) literal must NOT flag it — the detector
+    is diff-scoped (only lines this diff ADDS), not whole-file scan-on-touch."""
+    diff_text = """diff --git a/Palace/Foo/Existing.swift b/Palace/Foo/Existing.swift
+--- a/Palace/Foo/Existing.swift
++++ b/Palace/Foo/Existing.swift
+@@ -1,4 +1,5 @@
+ import Foundation
+ queue.addOperation {
+     print("pre-existing literal, not part of this diff")
+ }
++let unrelated = 1
+"""
+    diff_file = tmp_path / "unrelated.diff"
+    diff_file.write_text(diff_text)
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--diff", str(diff_file), "--quiet"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"expected exit 0 (only an unrelated line was added), got "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "AOB-1" not in result.stdout
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_check_bookregistry_package_purity.py
+++ b/scripts/tests/test_check_bookregistry_package_purity.py
@@ -1,0 +1,111 @@
+"""
+test_check_bookregistry_package_purity.py — pytest for the DORMANT
+`PalaceBookRegistry` package-purity gate (scripts/check-bookregistry-package-purity.sh).
+
+Asserts the full gate-rule contract required by CLAUDE.md rule #4 even though
+the gate's real target package (Wave 2b) does not exist yet:
+
+  (a) package dir absent  -> NO-OP, exit 0 (today's actual repo state — the
+      gate must not block anything before the package is extracted),
+  (b) package dir present + a forbidden reference -> FAIL, exit 1,
+  (c) package dir present + clean -> PASS, exit 0.
+
+Each case points the script at a throwaway scan root via
+BOOKREGISTRY_SCAN_ROOT so it never touches the real repo tree.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-bookregistry-package-purity.sh"
+
+
+def _run(scan_root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(_SCRIPT)],
+        env={
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "BOOKREGISTRY_SCAN_ROOT": str(scan_root),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_missing_package_dir_is_a_noop(tmp_path):
+    """Today's actual repo state: the package hasn't been extracted yet. The
+    gate MUST NOT block — it should no-op cleanly with exit 0."""
+    missing_root = tmp_path / "Palace" / "Packages" / "PalaceBookRegistry" / "Sources"
+    result = _run(missing_root)
+    assert result.returncode == 0, (
+        f"expected no-op exit 0 for a nonexistent package dir, got "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "NO-OP" in result.stdout
+
+
+def test_forbidden_reference_is_flagged(tmp_path):
+    """Once the package exists, a reference back into the app-target coupling
+    surface (AppContainer here) MUST fail the gate."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "BookRegistryStore.swift").write_text(
+        "import Foundation\n"
+        "struct BookRegistryStore {\n"
+        "    let container = AppContainer.production()\n"
+        "}\n"
+    )
+    result = _run(root)
+    assert result.returncode == 1, (
+        f"expected exit 1 for a forbidden reference, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "AppContainer" in result.stdout
+
+
+def test_each_forbidden_symbol_is_flagged(tmp_path):
+    """Every symbol in the forbidden list fires independently."""
+    forbidden_symbols = [
+        "AccountsManager",
+        "TPPUserAccount",
+        "AppContainer",
+        "MyBooksDownloadCenter",
+        "LCPAudiobooks",
+        "NotificationService",
+    ]
+    for symbol in forbidden_symbols:
+        root = tmp_path / symbol / "Sources"
+        root.mkdir(parents=True)
+        (root / "Thing.swift").write_text(f"let x = {symbol}.thing\n")
+        result = _run(root)
+        assert result.returncode == 1, (
+            f"{symbol}: expected exit 1, got {result.returncode}\n"
+            f"stdout: {result.stdout!r}"
+        )
+        assert symbol in result.stdout
+
+
+def test_clean_package_passes(tmp_path):
+    """A package that only depends on its own inverted seam (e.g.
+    AccountScopeProviding) — no forbidden app-target reference — MUST pass."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "BookRegistryStore.swift").write_text(
+        "import Foundation\n"
+        "protocol AccountScopeProviding {\n"
+        "    var currentAccountID: String { get }\n"
+        "}\n"
+        "struct BookRegistryStore {\n"
+        "    let scope: AccountScopeProviding\n"
+        "}\n"
+    )
+    result = _run(root)
+    assert result.returncode == 0, (
+        f"expected exit 0 for a clean package, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "PASS" in result.stdout

--- a/scripts/tests/test_detectors_diff_mode.py
+++ b/scripts/tests/test_detectors_diff_mode.py
@@ -36,6 +36,7 @@ _CASES = [
     ("check-nserror-problemdoc-preservation.py",     "nserror_problemdoc",  "violation_dropped_problemdoc.swift", "Palace/Network",           "D4-1",    "block"),
     ("check-swiftui-placeholder-a11y.py",            "swiftui_a11y",        "violation.swift",                    "Palace/CatalogUI",         "PP-4421", "warn"),
     ("check-notification-center-observer-storage.py","notification_center", "violation_unstored_observer.swift",  "Palace/AppInfrastructure", "D5-1",    "warn"),
+    ("check-addoperation-literal-ban.py",             "addoperation_literal_ban", "violation_addoperation_trailing_closure.swift", "Palace/Utilities", "AOB-1", "block"),
 ]
 
 _IDS = [c[0].removeprefix("check-").removesuffix(".py") for c in _CASES]

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -520,6 +520,23 @@ else
   record "doc_hygiene" "pass" "check-doc-hygiene.sh not found (skipped)"
 fi
 
+# 3b3. DORMANT Wave 2b gate — PalaceBookRegistry/Sources package purity.
+# Whole-tree scan (not diff-based), but a no-op until the package is
+# extracted. See `scripts/check-bookregistry-package-purity.sh`.
+echo "--- BookRegistry package purity (dormant — Wave 2b) ---"
+if [ "$MUTATION_ONLY" = "true" ]; then
+  record "bookregistry_package_purity" "pass" "Skipped (--mutation-only)"
+elif [ -f scripts/check-bookregistry-package-purity.sh ]; then
+  BR_OUT=$(bash scripts/check-bookregistry-package-purity.sh 2>&1)
+  if [ "$?" -eq 0 ]; then
+    record "bookregistry_package_purity" "pass" "$(echo "$BR_OUT" | head -1)"
+  else
+    record "bookregistry_package_purity" "fail" "$(echo "$BR_OUT" | grep -m1 FAIL)"
+  fi
+else
+  record "bookregistry_package_purity" "pass" "check-bookregistry-package-purity.sh not found (skipped)"
+fi
+
 # 3c. Adjacency staleness (M1 universal-rigor-floor gate, warn-only)
 # Greps comments in the surviving codebase for references to removed/renamed
 # declarations in the diff. Always passes; counts warnings.
@@ -678,6 +695,8 @@ run_phase35_detector "notification_center_observer_storage" "check-notification-
   "No NotificationCenter observer registered without storage/removal" "diff"
 run_phase35_detector "unsynchronized_sendable_mock" "check-unsynchronized-sendable-mock.py" "block" \
   "No unsynchronized @unchecked Sendable mock driven by concurrent tests" "scan"
+run_phase35_detector "addoperation_literal_ban" "check-addoperation-literal-ban.py" "block" \
+  "No raw NSOperation-family closure literal (#1338 ClangImporter @MainActor-poisoning risk)" "diff"
 
 # 4. Coverage floors
 echo "--- Coverage Floors ---"


### PR DESCRIPTION
Follow-up to #1338. Adds two detectors (scripts/ only — no production code):

**1. `check-addoperation-literal-ban.py` — the #1338 regression guard.** Diff-scoped; bans raw closure *literals* passed directly to `addOperation {` / `addExecutionBlock {` / `BlockOperation {` / `.completionBlock = {` in `Palace/**`. These flip to `@MainActor` on an unlucky compiler batch under the Xcode-26 WebKit/ClangImporter bug and SIGTRAP off-main (root cause of #1338). The approved hoisted form (`let work: @Sendable () -> Void = { … }; queue.addOperation(work)`) is never flagged. Escape hatch: `// no-addoperation-literal-ban: <reason>`. Wired into pre-commit + verify-pr; 10-case pytest + clean-diff-passes fixture assertion; zero false positives on the current tree.

**2. `check-bookregistry-package-purity.sh` — dormant Wave 2b gate.** Asserts the future `PalaceBookRegistry` package has zero refs to AccountsManager/TPPUserAccount/AppContainer/MyBooksDownloadCenter/LCPAudiobooks/NotificationService. No-ops cleanly until the package exists (Wave 2b).

Verification: `bash -n` clean; `pytest scripts/tests/` 376 passed; hook fixture 6 assertions pass; detector dry-run on current tree exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)