### PR TITLE
chore(decomp): Wave 2b fast-follows — ADR doc + purity gate fail-closed + @_spi test seams

### DIFF
--- a/Palace/Packages/PalaceBookRegistry/Sources/PalaceBookRegistry/TPPBookRegistry.swift
+++ b/Palace/Packages/PalaceBookRegistry/Sources/PalaceBookRegistry/TPPBookRegistry.swift
@@ -727,7 +727,7 @@ public class TPPBookRegistry: @unchecked Sendable {
     /// Deliberately does NOT await the account switch-back debounce
     /// (`asyncAfter` ~line 160): that is a UX timer, not fire-and-forget work;
     /// tests asserting switch-back drive it explicitly.
-    public func _awaitPendingWritesForTesting() async {
+    @_spi(Testing) public func _awaitPendingWritesForTesting() async {
         await store._awaitPendingWritesForTesting()
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
             DispatchQueue.main.async { cont.resume() }
@@ -741,7 +741,7 @@ public class TPPBookRegistry: @unchecked Sendable {
     /// write), THEN drain the disk-write queue (so those writes have flushed).
     /// Deterministic replacement for a `.TPPBookRegistryDidChange` deadline wait
     /// in the account-capture persistence contract tests (STARVE-001).
-    public func _awaitPendingPersistenceForTesting() async {
+    @_spi(Testing) public func _awaitPendingPersistenceForTesting() async {
         await _awaitPendingWritesForTesting()
         await syncEngine._awaitPendingDiskWritesForTesting()
     }

--- a/PalaceTests/BookRegistry/TPPBookRegistryIntegrationTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryIntegrationTests.swift
@@ -33,7 +33,7 @@ import XCTest
 import Combine
 @testable import Palace
 import PalaceBookModel
-import PalaceBookRegistry
+@_spi(Testing) import PalaceBookRegistry
 
 // MARK: - TPPBookRegistry State Management Integration Tests
 

--- a/PalaceTests/BookRegistry/TPPBookRegistryPersistenceTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryPersistenceTests.swift
@@ -34,7 +34,7 @@ import XCTest
 import Combine
 @testable import Palace
 import PalaceBookModel
-@testable import PalaceBookRegistry
+@_spi(Testing) @testable import PalaceBookRegistry
 
 @MainActor
 class TPPBookRegistryPersistenceTests: PalaceWiringTestCase {

--- a/PalaceTests/BookRegistry/TPPBookRegistryTests.swift
+++ b/PalaceTests/BookRegistry/TPPBookRegistryTests.swift
@@ -20,7 +20,7 @@ import XCTest
 import Combine
 @testable import Palace
 import PalaceBookModel
-import PalaceBookRegistry
+@_spi(Testing) import PalaceBookRegistry
 
 // MARK: - TPPBookRegistryRecord Persistence Tests
 

--- a/PalaceTests/Contract/TPPBookRegistryAccountCaptureContractTests.swift
+++ b/PalaceTests/Contract/TPPBookRegistryAccountCaptureContractTests.swift
@@ -36,7 +36,7 @@ import XCTest
 import PalaceCatalog
 import PalaceBookModel
 @testable import Palace
-@testable import PalaceBookRegistry
+@_spi(Testing) @testable import PalaceBookRegistry
 
 @MainActor
 final class TPPBookRegistryAccountCaptureContractTests: PalaceWiringTestCase {

--- a/PalaceTests/Contract/TPPBookRegistryFacadeContractTests.swift
+++ b/PalaceTests/Contract/TPPBookRegistryFacadeContractTests.swift
@@ -48,7 +48,7 @@ import Combine
 import UIKit
 @testable import Palace
 import PalaceBookModel
-@testable import PalaceBookRegistry
+@_spi(Testing) @testable import PalaceBookRegistry
 
 @MainActor
 final class TPPBookRegistryFacadeContractTests: PalaceWiringTestCase {

--- a/docs/architecture/god-class-decomposition-plan.md
+++ b/docs/architecture/god-class-decomposition-plan.md
@@ -85,7 +85,18 @@ PalaceKeychain         → (nothing)                        [as today]
 PalaceNetwork          → PalaceLogging                    [as today]
 PalaceCatalog          → PalaceLogging, PalaceNetwork, PalaceFeatureFlags
 PalaceBookModel        → PalaceLogging                    (models only — near-leaf)
-PalaceBookRegistry     → PalaceBookModel, PalaceLogging, PalacePreferences
+PalaceBookRegistry     → PalaceBookModel, PalaceCatalog, PalaceLogging
+                         [as shipped in Wave 2b — deviates from this ADR's
+                         original DAG, which named PalacePreferences instead
+                         of PalaceCatalog: the extracted cluster (TPPBookRegistry
+                         + BookRegistryStore/Sync + BookmarkManager +
+                         RegistryFileRecovery) has zero TPPSettings references,
+                         so PalacePreferences was dropped; it DOES need
+                         PalaceCatalog for TPPOPDSFeed/TPPOPDSEntry + the
+                         OPDSFeedFetching seam, which already live there
+                         (PalaceBookModel already depends on PalaceCatalog, so
+                         this stays layer-clean). See
+                         Palace/Packages/PalaceBookRegistry/Package.swift.]
 PalaceAuth             → PalaceLogging, PalaceNetwork, PalaceCatalog,
                          PalaceKeychain                   [+Keychain vs today]
 PalaceAccounts         → PalaceAuth, PalaceCatalog, PalaceNetwork,

--- a/scripts/check-bookregistry-package-purity.sh
+++ b/scripts/check-bookregistry-package-purity.sh
@@ -48,7 +48,11 @@ fi
 # Swift comments (`//`, `///`, `/* */`) and string literals before matching, and
 # require a word-boundary hit on the residue. A naive grep would flag the gate's
 # own documentation.
-FINDINGS="$(FORBIDDEN="$FORBIDDEN" SCAN_ROOT="$SCAN_ROOT" python3 - <<'PY' 2>/dev/null || true
+PY_STDERR="$(mktemp)"
+trap 'rm -f "$PY_STDERR"' EXIT
+
+set +e
+FINDINGS="$(FORBIDDEN="$FORBIDDEN" SCAN_ROOT="$SCAN_ROOT" python3 - 2>"$PY_STDERR" <<'PY'
 import os, re, sys
 forbidden = os.environ["FORBIDDEN"]
 root = os.environ["SCAN_ROOT"]
@@ -99,6 +103,16 @@ for dirpath, _, files in os.walk(root):
 sys.stdout.write("\n".join(hits))
 PY
 )"
+PY_EXIT=$?
+set -e
+
+if [ "$PY_EXIT" -ne 0 ]; then
+  echo "[bookregistry-purity] FAIL: the python3 scanner crashed (exit $PY_EXIT) instead of"
+  echo "  producing findings. A crashed scanner is NOT the same as zero findings — failing"
+  echo "  closed rather than silently passing. Interpreter stderr:"
+  sed 's/^/  /' "$PY_STDERR"
+  exit 1
+fi
 
 if [ -n "$FINDINGS" ]; then
   echo "[bookregistry-purity] FAIL: PalaceBookRegistry/Sources references the app-target"

--- a/scripts/tests/test_check_bookregistry_package_purity.py
+++ b/scripts/tests/test_check_bookregistry_package_purity.py
@@ -16,6 +16,8 @@ BOOKREGISTRY_SCAN_ROOT so it never touches the real repo tree.
 
 from __future__ import annotations
 
+import os
+import stat
 import subprocess
 from pathlib import Path
 
@@ -23,11 +25,11 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _SCRIPT = _REPO_ROOT / "scripts" / "check-bookregistry-package-purity.sh"
 
 
-def _run(scan_root: Path) -> subprocess.CompletedProcess:
+def _run(scan_root: Path, path: str = "/usr/bin:/bin:/usr/sbin:/sbin") -> subprocess.CompletedProcess:
     return subprocess.run(
         ["bash", str(_SCRIPT)],
         env={
-            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "PATH": path,
             "BOOKREGISTRY_SCAN_ROOT": str(scan_root),
         },
         capture_output=True,
@@ -150,6 +152,41 @@ def test_forbidden_symbol_in_string_literal_passes(tmp_path):
         f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
     )
     assert "PASS" in result.stdout
+
+
+def test_python_crash_fails_closed(tmp_path):
+    """If the embedded python3 scanner itself crashes (bad interpreter, syntax
+    error, whatever), the gate must FAIL, not silently pass. Previously the
+    heredoc was wrapped in `2>/dev/null || true`, so a python crash produced
+    an empty FINDINGS string indistinguishable from "clean package" ->
+    fail-open. Simulate a crash by shadowing `python3` on PATH with a stub
+    that always exits non-zero, then assert the gate fails closed with a
+    message that names the crash (not a false "PASS")."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "Clean.swift").write_text("import Foundation\nstruct Clean {}\n")
+
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        "echo 'boom: simulated interpreter crash' >&2\n"
+        "exit 137\n"
+    )
+    fake_python.chmod(fake_python.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    result = _run(root, path=f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin")
+
+    assert result.returncode != 0, (
+        f"expected the gate to fail closed when python3 crashes, got exit "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "PASS" not in result.stdout, (
+        "gate must never report PASS when the scanner itself crashed "
+        f"(fail-open regression)\nstdout: {result.stdout!r}"
+    )
+    assert "crash" in result.stdout.lower() or "crash" in result.stderr.lower()
 
 
 def test_forbidden_symbol_in_code_after_a_comment_line_is_flagged(tmp_path):


### PR DESCRIPTION
## Summary
Three low-risk cleanup items agreed after Wave 2b (PR #1341) merged to develop:

1. **ADR DAG doc correction.** `docs/architecture/god-class-decomposition-plan.md`'s PalaceBookRegistry dependency line now matches what actually shipped: `PalaceBookModel, PalaceCatalog, PalaceLogging` (PalacePreferences dropped — zero TPPSettings refs; PalaceCatalog added — TPPOPDSFeed/TPPOPDSEntry live there), with an inline note on the deviation. Verified against `Palace/Packages/PalaceBookRegistry/Package.swift`.

2. **Fail-closed the package-purity gate.** `scripts/check-bookregistry-package-purity.sh`'s embedded python3 scanner was wrapped in `2>/dev/null || true`, so an interpreter crash produced empty findings indistinguishable from a clean pass (fail-open). Now the script captures the python exit code separately and FAILs the gate (exit 1, with the captured stderr) if the scanner itself crashed, while preserving no-op/PASS/FAIL semantics for the real cases. Added `test_python_crash_fails_closed` to `scripts/tests/test_check_bookregistry_package_purity.py`, which shadows `python3` on PATH with a stub that exits 137 and asserts the gate now fails closed.

3. **Tightened two test-only seams to `@_spi(Testing)`.** `TPPBookRegistry._awaitPendingWritesForTesting()` and `_awaitPendingPersistenceForTesting()` (drain-only, production never calls them) moved from bare `public` to `@_spi(Testing) public` per the Wave 2b brief. Updated the 5 PalaceTests files that call these seams to `@_spi(Testing) import PalaceBookRegistry` (or `@_spi(Testing) @testable import`). `BookRegistryStore`/`BookRegistrySync`'s sibling seams were already `internal` and are unaffected.

## Verification
- `bash -n scripts/check-bookregistry-package-purity.sh` — OK
- `python3 -m pytest scripts/tests/test_check_bookregistry_package_purity.py -q` — 8 passed
- `bash scripts/check-bookregistry-package-purity.sh` — PASS against the real package
- Full detector suite `python3 -m pytest scripts/tests/ -q` — 380 passed
- `build-for-testing` (Palace scheme, fresh derivedDataPath) — `** TEST BUILD SUCCEEDED **`
- Seam-calling suites (TPPBookRegistryFacadeContractTests, TPPBookRegistryAccountCaptureContractTests, TPPBookRegistrySyncContractTests, TPPBookRegistryRebuildRefusalContractTests, TPPBookRegistryPersistenceTests, TPPBookRegistryMigrationTests, BookRegistryStoreTests, BookRegistrySyncTests, TPPBookRegistryLargeCorpusTests, TPPBookRegistryAtomicWriteTests, TPPBookRegistryLoadReentrancyTests, TPPBookRegistryPublisherTests, TPPBookRegistryThreadSafetyTests) — all green
- `PalaceTests/Contract/__Snapshots__/` — `git status` clean (byte-identical, no re-record)
- `heka2` architect + blast_radius reviews recorded and approved at tip (`review:architect`, `review:blast_radius` both `passed:true` in the local ledger)
- Native `pre-push-test-gate.sh` git hook: 6 targeted classes green before push was allowed

## Test plan
- [x] CI green on this PR (full scheme, both bundles)
- [x] Confirm `PalaceTests/Contract/__Snapshots__/` stays untouched in CI diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)