### PR TITLE
test(decomp): Wave 3 write-ahead — Accounts↔Downloads coupling pins (PR-W3-pre)

### DIFF
--- a/.forgeos/intent/wave3-writeahead-tests.md
+++ b/.forgeos/intent/wave3-writeahead-tests.md
@@ -1,0 +1,60 @@
+# Intent: Wave 3 write-ahead coupling tests (Accounts ↔ Downloads)
+
+**Slug:** wave3-writeahead-tests
+**Branch:** feat/wave3-writeahead-tests
+**Critical-path:** YES (borrow / download / account-switch / auth)
+**Change kind:** TESTS ONLY — no production `Palace/**` edits.
+
+## Context
+
+God-class decomposition Wave 3 (`docs/architecture/god-class-decomposition-plan.md`
+§3a-2/§3a-3, §4 Wave 3, §5) splits the mutually-coupled hub pair
+`AccountsManager` (→ PalaceAccounts) and the MyBooks download subsystem
+(→ PalaceDownloads). These write-ahead characterization/contract tests pin the
+CURRENT bidirectional coupling behavior at the seams Wave 3 will sever, so the
+later extraction is provably behavior-neutral.
+
+Existing coverage already pins large parts of the coupling (verified this
+session): the Downloads→Accounts current-account **capture-once** seam
+(`MyBooksDownloadCenterAccountIdThreadingTests`), per-library credential/registry
+isolation across a switch (`AccountSwitchLifecycleTests`), and the
+account-switch **publication order** of the `currentAccount` setter
+(`PalaceTests/Decomp/AccountsManagerCurrentAccountSwitchContractTests`). This
+work adds ONLY the genuinely-unpinned coupling seams.
+
+## Claims (what the new tests assert)
+
+1. **Accounts→Downloads static edge — borrow reauth circuit breaker.**
+   `AccountsManager.cleanupActiveContentBeforeAccountSwitch` (line ~994) calls
+   `MyBooksDownloadCenter.clearAllBorrowReauthState()` →
+   `BorrowOperation.clearAllBorrowReauthState()`. The behavioral contract: a book
+   whose per-book borrow-reauth circuit breaker has tripped (2nd auth-error
+   borrow is suppressed to a generic error) gets a FRESH reauth attempt after
+   `clearAllBorrowReauthState()` — i.e. account switch resets the breaker.
+   Driven through the real `BorrowOperation.borrowAsync` with closure spy seams.
+
+2. **Downloads→Accounts read edge — per-account download-file scoping.**
+   `BookFileManager.fileUrl(for:)` resolves the on-disk path under
+   `accountsManager.currentAccountId`; changing the current account changes the
+   resolved directory (files follow the current library). The sideloaded-content
+   isolation EXCEPTION: a `sideload-`-prefixed id resolves under the fixed
+   `SideloadedBookRegistry.sideloadContentAccountID` regardless of the current
+   account, so a library switch cannot orphan sideloaded files.
+
+## Anti-claims (explicitly NOT in scope)
+
+- NOT re-pinning capture-once / bearerAuthorized threading (already covered).
+- NOT re-pinning the `currentAccount` setter publication order (already covered).
+- NOT testing the non-injectable setter side-effects that reach static
+  singletons (`ImageCache.shared`, `TPPBookCoverRegistry.shared`,
+  `networkExecutor` via `AppContainer.production()`) — those are recorded as
+  needed production seams in the coupling map, not worked around.
+- NO production code changes. If a seam can't be tested without one, it is
+  documented, not added.
+
+## Files in scope (test target only)
+
+- `PalaceTests/Contract/AccountSwitchBorrowReauthCouplingContractTests.swift` (new)
+- `PalaceTests/MyBooks/BookFileManagerAccountScopingTests.swift` (new)
+- `docs/architecture/wave3-coupling-map.md` (new; doc)
+- `.forgeos/intent/wave3-writeahead-tests.md` (this file)

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -425,6 +425,7 @@
 		460ADECAE6DF8B66F16BB9A8 /* DownloadCompleteMomentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5995564B8E8B92FA04E7C75 /* DownloadCompleteMomentTests.swift */; };
 		46221C45145B8DE90E9A166F /* DownloadStartCoordinatorContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5090C9BA8767EBE657172BD /* DownloadStartCoordinatorContractTests.swift */; };
 		46D82B974AA50B5FF3AABA1F /* AudiobookLoaderDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D831302F218AC0EE46308A0 /* AudiobookLoaderDispatchTests.swift */; };
+		46E0E670ECA43B1BE1769CA7 /* AccountSwitchBorrowReauthCouplingContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE04BB7BA065CC171F20537B /* AccountSwitchBorrowReauthCouplingContractTests.swift */; };
 		4714FCCE477E3480FCAB241C /* BadgeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C927D5FB4DCC629EEF09DE4C /* BadgeServiceTests.swift */; };
 		47E7D42D22FE22D4C9489931 /* SignInModalSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8829DAED777C8EBAB199D77 /* SignInModalSheetPresenter.swift */; };
 		483261822C71A1A249B7F279 /* ContinueRowSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4057C151D980D26B04B8FC53 /* ContinueRowSectionTests.swift */; };
@@ -1853,6 +1854,7 @@
 		F3D0B1820DA683D0A25A3D50 /* DownloadTransferRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645A5614EC730C72D2EAA1B1 /* DownloadTransferRetryTests.swift */; };
 		F44DED83ED7B4324B4C605D6 /* CarPlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2634B33D2AE74BF5948971BA /* CarPlayTests.swift */; };
 		F4565465A1B2C3D4E5F6071A /* OverdriveDownloadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3465465A1B2C3D4E5F60829 /* OverdriveDownloadHandler.swift */; };
+		F4CD3922F3950DEEFCDBFEAA /* BookFileManagerAccountScopingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0842274F19EF54B4FC5686 /* BookFileManagerAccountScopingTests.swift */; };
 		F516D06B9979F4625E8BD312 /* PalacePDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060B04F768844865F55ED1A1 /* PalacePDFView.swift */; };
 		F54239DDA912F713D8B6695D /* PalaceAudiobookToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E7F9BABE2A8E6811001697DE /* PalaceAudiobookToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F58124F59C1F78CADB673820 /* TriageBotKeyAdminTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E775BA9B323D098F690BE354 /* TriageBotKeyAdminTests.swift */; };
@@ -2819,6 +2821,7 @@
 		9A35DE944F78A26A081622BA /* TPPReaderPageListBusinessLogicTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReaderPageListBusinessLogicTests.swift; sourceTree = "<group>"; };
 		9A399B178C9ECF3F62C62172 /* AccountsManagerIsolationLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerIsolationLintTests.swift; sourceTree = "<group>"; };
 		9A586098465213BD58E11860 /* PDFReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderTests.swift; sourceTree = "<group>"; };
+		9B0842274F19EF54B4FC5686 /* BookFileManagerAccountScopingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookFileManagerAccountScopingTests.swift; sourceTree = "<group>"; };
 		9B3391CCE50BC961BC7A5726 /* TPPMigrationManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPMigrationManagerTests.swift; sourceTree = "<group>"; };
 		9B55BD3620F51707395548D0 /* TPPCredentialsCoverageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPCredentialsCoverageTests.swift; sourceTree = "<group>"; };
 		9B97ED224E7C43B89FBBEE5A /* GeneralCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCacheTests.swift; sourceTree = "<group>"; };
@@ -3045,6 +3048,7 @@
 		CD6905E504CA69A52099A7AE /* PalacePreferencesSettingsRoundTripTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalacePreferencesSettingsRoundTripTests.swift; sourceTree = "<group>"; };
 		CD71C8FF18A443133C015DA8 /* KeyboardVoiceOverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyboardVoiceOverTests.swift; sourceTree = "<group>"; };
 		CD7CF61C8B20F3B40C3C44FA /* SideloadBoundaryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadBoundaryTests.swift; sourceTree = "<group>"; };
+		CE04BB7BA065CC171F20537B /* AccountSwitchBorrowReauthCouplingContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountSwitchBorrowReauthCouplingContractTests.swift; sourceTree = "<group>"; };
 		CE97656B54F67282B7B52648 /* TPPLinearView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPLinearView.swift; sourceTree = "<group>"; };
 		CF2D0C6025D50993E6431BDC /* ReaderThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeTests.swift; sourceTree = "<group>"; };
 		CF4E37ED1C3EFEF6CB717835 /* PalaceMotionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalaceMotionTests.swift; sourceTree = "<group>"; };
@@ -5696,6 +5700,7 @@
 				857910362707D0E957D559D1 /* TPPBookRegistrySyncContractTests.swift */,
 				BC0A032C501D578FE2D25C40 /* TPPBookRegistryAccountCaptureContractTests.swift */,
 				FE80265D45D506F30737A616 /* TPPBookRegistryRebuildRefusalContractTests.swift */,
+				CE04BB7BA065CC171F20537B /* AccountSwitchBorrowReauthCouplingContractTests.swift */,
 			);
 			name = Contract;
 			path = Contract;
@@ -5908,6 +5913,7 @@
 				5575A14D947C09A968459FF1 /* LoanEvictionPolicyTests.swift */,
 				060E761D281D979E3359C83A /* LoanRenewalServiceTests.swift */,
 				AA3C44FFE90B7C54E0D99025 /* RegistryDownloadServicingSeamTests.swift */,
+				9B0842274F19EF54B4FC5686 /* BookFileManagerAccountScopingTests.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -7972,6 +7978,8 @@
 				99ACB0B5B92C44F4AA5845B3 /* BookRegistryEngineTestInits.swift in Sources */,
 				C77919FC1FE8A977359429DA /* AccountScopeAdapterTests.swift in Sources */,
 				F8F19F0AC6114A6C745FB5A5 /* RegistryDownloadServicingSeamTests.swift in Sources */,
+				46E0E670ECA43B1BE1769CA7 /* AccountSwitchBorrowReauthCouplingContractTests.swift in Sources */,
+				F4CD3922F3950DEEFCDBFEAA /* BookFileManagerAccountScopingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PalaceTests/Contract/AccountSwitchBorrowReauthCouplingContractTests.swift
+++ b/PalaceTests/Contract/AccountSwitchBorrowReauthCouplingContractTests.swift
@@ -1,0 +1,288 @@
+//
+//  AccountSwitchBorrowReauthCouplingContractTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE CHARACTERIZATION PACK — god-class decomposition Wave 3, the
+//  mutually-coupled hub pair Accounts ↔ Downloads
+//  (docs/architecture/god-class-decomposition-plan.md §3a-2/§3a-3, §4 Wave 3).
+//
+//  WHAT THIS PINS
+//  ==============
+//  The ONE hard, un-inverted Accounts→Downloads STATIC edge in the account-switch
+//  path. `AccountsManager.cleanupActiveContentBeforeAccountSwitch(from:to:)`
+//  (AccountsManager.swift ~994) calls, synchronously on every real library
+//  switch:
+//
+//      MyBooksDownloadCenter.clearAllBorrowReauthState()
+//        → BorrowOperation.clearAllBorrowReauthState()   (MBDC+Async.swift:27,
+//                                                          BorrowOperation.swift:141)
+//
+//  which wipes the process-wide per-book borrow-reauth **circuit breaker**
+//  (`BorrowOperation.reauthTracker`, a `static let`). Its OBSERVABLE effect —
+//  the contract Wave 3 must preserve when this static call becomes a cross-PACKAGE
+//  call (AccountsManager → PalaceAccounts, BorrowOperation → PalaceDownloads) —
+//  is a change in what `BorrowOperation.borrowAsync` DOES on a repeat auth-error:
+//
+//    • 1st auth-error borrow for a book → reauth is attempted
+//      (`presentSignInModal` seam fires; no generic error alert).
+//    • 2nd auth-error borrow for the SAME book (breaker tripped) → reauth is
+//      SUPPRESSED and the generic error alert is shown instead
+//      (`presentBorrowErrorAlert` seam fires; BorrowOperation.swift:626 guard).
+//    • After `clearAllBorrowReauthState()` (what an account switch triggers) →
+//      the SAME book is offered reauth AGAIN — the breaker was reset.
+//
+//  If the extraction dropped, reordered, or narrowed that clear (e.g. cleared
+//  only the current book instead of ALL books, or stopped calling it), a user
+//  who switches libraries after a failed borrow would be silently stuck on the
+//  generic-error path with no reauth prompt — a money-path regression invisible
+//  to the per-case unit tests (which each reset the breaker in setUp).
+//
+//  WHY A CONTRACT SNAPSHOT (ordered seam sequence) rather than count asserts:
+//  the coupling IS an ordering of decisions across repeated calls
+//  (attempt → suppress → reset → attempt). ContractSnapshot locks the exact
+//  ORDER + argument shape of the seam calls, so a refactor that changes WHICH
+//  recovery path fires for a repeat borrow drifts the snapshot loudly. This is
+//  the sanctioned form for the "clearAllBorrowReauthState becomes cross-package"
+//  seam (§5 general contract: byte-equal JSON under __Snapshots__/).
+//
+//  DETERMINISM: no network, no UIKit, no sleeps. `fetchBook` is a closure that
+//  throws `PalaceError.network(.unauthorized)`; the sign-in-modal completion is
+//  recorded but NEVER invoked, so there is no retry recursion. Books use fixed
+//  identifiers so snapshot args are stable across runs. The global breaker is
+//  cleared in setUp AND tearDown so the suite neither inherits nor leaks state.
+//
+//  RECIPE PROVENANCE: the no-credentials + needs-auth + 401 arm is the exact
+//  path pinned (single-attempt) by
+//  `PalaceTests/MyBooks/BorrowOperationTests.testBorrow_401Network...
+//  presentsSignInModal`. This suite adds ONLY the cross-attempt breaker + reset
+//  semantics that no existing test pins.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+import PalaceBookModel
+
+@MainActor
+final class AccountSwitchBorrowReauthCouplingContractTests: XCTestCase {
+
+    private var log: CallLog!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // The reauth breaker is a process-wide static — start every scenario
+        // from a clean breaker so a prior test can't pre-trip it.
+        BorrowOperation.clearAllBorrowReauthState()
+        log = CallLog()
+    }
+
+    override func tearDownWithError() throws {
+        // Do not leak a tripped breaker into downstream suites.
+        BorrowOperation.clearAllBorrowReauthState()
+        log = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Contract 1: breaker trips on the 2nd auth-error for the same book
+
+    /// First auth-error borrow → reauth (`presentSignInModal`). Second for the
+    /// same book → breaker suppresses reauth → generic error alert
+    /// (`presentBorrowErrorAlert`). This is the state the account switch clears.
+    ///
+    /// Kill cases:
+    ///  - Removing the circuit-breaker guard (BorrowOperation.swift:626) → the
+    ///    2nd attempt would ALSO present the sign-in modal → sequence
+    ///    [presentSignInModal, presentSignInModal] ≠ snapshot.
+    ///  - Never marking the breaker → same drift.
+    func testRepeatAuthErrorSameBook_secondAttemptSuppressedToGenericAlert() async {
+        let account = Self.noCredentialsNeedsAuthAccount()
+        let book = Self.book(identifier: "reauth-coupling-C1")
+        let op = makeOperation(userAccount: account, bookIdentifier: book.identifier, log: log)
+
+        await borrowExpectingThrow(op, book)   // attempt 1 → reauth
+        await borrowExpectingThrow(op, book)   // attempt 2 → breaker → generic alert
+
+        ContractSnapshot.assert(log, named: "repeatSameBook_tripsBreaker")
+    }
+
+    // MARK: - Contract 2: account switch (clearAll) re-enables reauth
+
+    /// THE coupling contract. After the breaker has tripped for a book, calling
+    /// `clearAllBorrowReauthState()` — exactly what
+    /// `AccountsManager.cleanupActiveContentBeforeAccountSwitch` invokes on a
+    /// library switch — must re-offer reauth for that book.
+    ///
+    /// Kill cases:
+    ///  - `clearAllBorrowReauthState()` no-op'd / dropped from the switch path →
+    ///    the 3rd attempt stays suppressed → [modal, alert, alert] ≠ snapshot.
+    func testClearAllAfterBreakerTripped_reenablesReauthForSameBook() async {
+        let account = Self.noCredentialsNeedsAuthAccount()
+        let book = Self.book(identifier: "reauth-coupling-C2")
+        let op = makeOperation(userAccount: account, bookIdentifier: book.identifier, log: log)
+
+        await borrowExpectingThrow(op, book)   // attempt 1 → reauth (modal)
+        await borrowExpectingThrow(op, book)   // attempt 2 → breaker → alert
+
+        // Simulate the account switch's Downloads-side cleanup.
+        BorrowOperation.clearAllBorrowReauthState()
+
+        await borrowExpectingThrow(op, book)   // attempt 3 → reauth AGAIN (modal)
+
+        ContractSnapshot.assert(log, named: "clearAll_reenablesReauth")
+    }
+
+    // MARK: - Contract 3: clearAll is a GLOBAL wipe (all books, not just current)
+
+    /// Two independent books each trip their own breaker. A SINGLE
+    /// `clearAllBorrowReauthState()` must reset BOTH — the switch clears the
+    /// whole tracker, not one entry. Pins `reauthTracker.clearAll()` semantics
+    /// (BorrowOperation.swift:121/142).
+    ///
+    /// Kill case:
+    ///  - Replacing `clearAll()` with a single-book `clear(currentBookId)` → book
+    ///    B's post-clear attempt would stay suppressed → the final two records
+    ///    would read [modal(A), alert(B)] instead of [modal(A), modal(B)].
+    func testClearAll_resetsBreakerForEveryBook_notJustOne() async {
+        let account = Self.noCredentialsNeedsAuthAccount()
+        let bookA = Self.book(identifier: "reauth-coupling-C3-A")
+        let bookB = Self.book(identifier: "reauth-coupling-C3-B")
+        let opA = makeOperation(userAccount: account, bookIdentifier: bookA.identifier, log: log)
+        let opB = makeOperation(userAccount: account, bookIdentifier: bookB.identifier, log: log)
+
+        await borrowExpectingThrow(opA, bookA) // modal(A)
+        await borrowExpectingThrow(opA, bookA) // alert(A) — A tripped
+        await borrowExpectingThrow(opB, bookB) // modal(B)
+        await borrowExpectingThrow(opB, bookB) // alert(B) — B tripped
+
+        BorrowOperation.clearAllBorrowReauthState() // one global wipe
+
+        await borrowExpectingThrow(opA, bookA) // modal(A) — reset
+        await borrowExpectingThrow(opB, bookB) // modal(B) — reset (proves GLOBAL)
+
+        ContractSnapshot.assert(log, named: "clearAll_isGlobalAcrossBooks")
+    }
+
+    // MARK: - Contract 4: the breaker is keyed PER-BOOK (isolation, no clear)
+
+    /// Contrast to Contract 3: WITHOUT any clear, a tripped breaker on book A
+    /// must NOT suppress book B's FIRST auth-error borrow. Pins that the tracker
+    /// keys on `book.identifier` (BorrowOperation.swift:118–120) — the property
+    /// that makes the account-switch's global clear meaningful rather than moot.
+    ///
+    /// Kill case:
+    ///  - Keying the breaker on a constant / ignoring the book id → book B's
+    ///    first attempt would be suppressed → [modal(A), alert(A), alert(B)]
+    ///    instead of [modal(A), alert(A), modal(B)].
+    func testBreakerIsPerBook_trippedABookDoesNotSuppressAnother() async {
+        let account = Self.noCredentialsNeedsAuthAccount()
+        let bookA = Self.book(identifier: "reauth-coupling-C4-A")
+        let bookB = Self.book(identifier: "reauth-coupling-C4-B")
+        let opA = makeOperation(userAccount: account, bookIdentifier: bookA.identifier, log: log)
+        let opB = makeOperation(userAccount: account, bookIdentifier: bookB.identifier, log: log)
+
+        await borrowExpectingThrow(opA, bookA) // modal(A)
+        await borrowExpectingThrow(opA, bookA) // alert(A) — A tripped
+
+        await borrowExpectingThrow(opB, bookB) // modal(B) — B's FIRST attempt, unaffected
+
+        ContractSnapshot.assert(log, named: "breakerIsPerBook")
+    }
+
+    // MARK: - Operation factory
+
+    /// Builds a `BorrowOperation` whose closure seams record into `log`. The
+    /// no-credentials + needs-auth account + a `fetchBook` that throws
+    /// `.network(.unauthorized)` route every borrow into
+    /// `handleBorrowAuthErrorIfNeeded`'s "no creds → sign-in modal" arm
+    /// (BorrowOperation.swift:699), gated by the per-book circuit breaker.
+    ///
+    /// `presentSignInModal` receives no book argument, so the book identifier is
+    /// captured at build time (`bookIdentifier`) for a stable snapshot record.
+    /// The modal completion is stored, never called — no retry recursion.
+    private func makeOperation(
+        userAccount: TPPUserAccountMock,
+        bookIdentifier: String,
+        log: CallLog
+    ) -> BorrowOperation {
+        let callLog = log
+        let capturedBookId = bookIdentifier
+        let account = userAccount
+        let authError = PalaceError.network(.unauthorized)
+
+        let operation = BorrowOperation(
+            bookRegistry: TPPBookRegistryMock(),
+            downloadAnnouncementService: DownloadAnnouncementService(),
+            errorActivityTracker: .shared,
+            debugSettings: DebugSettings(),
+            userRetryTracker: .shared,
+            userAccountProvider: { account },
+            adobeDRMService: AdobeDRMService.shared,
+            fetchBook: { _, _, _ in
+                throw authError
+            },
+            presentBorrowErrorAlert: { _, _, _, _, book, _ in
+                callLog.record("presentBorrowErrorAlert", args: ["book": book.identifier])
+            },
+            presentSignInModal: { _ in
+                callLog.record("presentSignInModal", args: ["book": capturedBookId])
+            },
+            attemptOIDCReauth: { false }
+        )
+        return operation
+    }
+
+    /// Drive one borrow and swallow the expected rethrow. Every auth-error
+    /// borrow rethrows (`.routeToReauth` / `.showGenericError` both throw).
+    private func borrowExpectingThrow(_ op: BorrowOperation, _ book: TPPBook) async {
+        do {
+            _ = try await op.borrowAsync(book, attemptDownload: false)
+            XCTFail("Auth-error borrow for '\(book.identifier)' must rethrow, not succeed")
+        } catch {
+            // expected — the routing decision is what the snapshot pins, via seams.
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// A no-credentials account whose auth definition `needsAuth`, so a borrow
+    /// auth-error routes into the sign-in-modal recovery arm.
+    private static func noCredentialsNeedsAuthAccount() -> TPPUserAccountMock {
+        let account = TPPUserAccountMock()
+        account._credentials = nil
+        account._authDefinition = SyntheticBasicNeedsAuth.authentication
+        return account
+    }
+
+    /// Deterministic-identifier book with a real default-acquisition href so
+    /// `borrowAsync` reaches `fetchBook` (BorrowOperation.swift:382 guard).
+    private static func book(identifier: String) -> TPPBook {
+        TPPBookMocker.mockBook(identifier: identifier, title: "Title-\(identifier)")
+    }
+}
+
+// MARK: - Local auth-definition fixture
+
+/// Basic-auth `AccountDetails.Authentication` (`needsAuth == true`,
+/// `isBrowserBased == false`) — routes borrow auth-errors into the
+/// no-credentials sign-in-modal arm rather than the browser/OIDC arm. The
+/// OPDS2 memberwise init is internal to PalaceCatalog, so JSON round-trip is
+/// the supported construction path (same technique as the per-file
+/// `SyntheticAuthDef` fixtures in the MyBooks suites).
+private enum SyntheticBasicNeedsAuth {
+    static var authentication: AccountDetails.Authentication {
+        let json = """
+        {
+          "type": "http://opds-spec.org/auth/basic",
+          "description": "Basic auth",
+          "labels": {"login": "Barcode", "password": "PIN"}
+        }
+        """
+        let docAuth = try! JSONDecoder().decode(
+            OPDS2AuthenticationDocument.Authentication.self,
+            from: Data(json.utf8)
+        )
+        return AccountDetails.Authentication(auth: docAuth)
+    }
+}

--- a/PalaceTests/Contract/__Snapshots__/AccountSwitchBorrowReauthCouplingContractTests/breakerIsPerBook.json
+++ b/PalaceTests/Contract/__Snapshots__/AccountSwitchBorrowReauthCouplingContractTests/breakerIsPerBook.json
@@ -1,0 +1,20 @@
+[
+  {
+    "args" : {
+      "book" : "reauth-coupling-C4-A"
+    },
+    "method" : "presentSignInModal"
+  },
+  {
+    "args" : {
+      "book" : "reauth-coupling-C4-A"
+    },
+    "method" : "presentBorrowErrorAlert"
+  },
+  {
+    "args" : {
+      "book" : "reauth-coupling-C4-B"
+    },
+    "method" : "presentSignInModal"
+  }
+]

--- a/PalaceTests/Contract/__Snapshots__/AccountSwitchBorrowReauthCouplingContractTests/clearAll_isGlobalAcrossBooks.json
+++ b/PalaceTests/Contract/__Snapshots__/AccountSwitchBorrowReauthCouplingContractTests/clearAll_isGlobalAcrossBooks.json
@@ -1,0 +1,38 @@
+[
+  {
+    "args" : {
+      "book" : "reauth-coupling-C3-A"
+    },
+    "method" : "presentSignInModal"
+  },
+  {
+    "args" : {
+      "book" : "reauth-coupling-C3-A"
+    },
+    "method" : "presentBorrowErrorAlert"
+  },
+  {
+    "args" : {
+      "book" : "reauth-coupling-C3-B"
+    },
+    "method" : "presentSignInModal"
+  },
+  {
+    "args" : {
+      "book" : "reauth-coupling-C3-B"
+    },
+    "method" : "presentBorrowErrorAlert"
+  },
+  {
+    "args" : {
+      "book" : "reauth-coupling-C3-A"
+    },
+    "method" : "presentSignInModal"
+  },
+  {
+    "args" : {
+      "book" : "reauth-coupling-C3-B"
+    },
+    "method" : "presentSignInModal"
+  }
+]

--- a/PalaceTests/Contract/__Snapshots__/AccountSwitchBorrowReauthCouplingContractTests/clearAll_reenablesReauth.json
+++ b/PalaceTests/Contract/__Snapshots__/AccountSwitchBorrowReauthCouplingContractTests/clearAll_reenablesReauth.json
@@ -1,0 +1,20 @@
+[
+  {
+    "args" : {
+      "book" : "reauth-coupling-C2"
+    },
+    "method" : "presentSignInModal"
+  },
+  {
+    "args" : {
+      "book" : "reauth-coupling-C2"
+    },
+    "method" : "presentBorrowErrorAlert"
+  },
+  {
+    "args" : {
+      "book" : "reauth-coupling-C2"
+    },
+    "method" : "presentSignInModal"
+  }
+]

--- a/PalaceTests/Contract/__Snapshots__/AccountSwitchBorrowReauthCouplingContractTests/repeatSameBook_tripsBreaker.json
+++ b/PalaceTests/Contract/__Snapshots__/AccountSwitchBorrowReauthCouplingContractTests/repeatSameBook_tripsBreaker.json
@@ -1,0 +1,14 @@
+[
+  {
+    "args" : {
+      "book" : "reauth-coupling-C1"
+    },
+    "method" : "presentSignInModal"
+  },
+  {
+    "args" : {
+      "book" : "reauth-coupling-C1"
+    },
+    "method" : "presentBorrowErrorAlert"
+  }
+]

--- a/PalaceTests/MyBooks/BookFileManagerAccountScopingTests.swift
+++ b/PalaceTests/MyBooks/BookFileManagerAccountScopingTests.swift
@@ -1,0 +1,222 @@
+//
+//  BookFileManagerAccountScopingTests.swift
+//  PalaceTests
+//
+//  PRE-WAVE CHARACTERIZATION PACK — god-class decomposition Wave 3, the
+//  mutually-coupled hub pair Accounts ↔ Downloads
+//  (docs/architecture/god-class-decomposition-plan.md §3a-2/§3a-3, §4 Wave 3).
+//
+//  WHAT THIS PINS
+//  ==============
+//  The Downloads→Accounts READ edge for per-account download-file isolation.
+//  `BookFileManager` (extracted from MyBooksDownloadCenter; owns the on-disk
+//  geometry for downloaded books) resolves a book's file URL under the CURRENT
+//  library by reading `accountsManager.currentAccountId`:
+//
+//      func fileUrl(for identifier: String) -> URL? {
+//          fileUrl(for: identifier, account: accountsManager.currentAccountId)  // BookFileManager.swift:67
+//      }
+//
+//  Wave 3 moves `BookFileManager` into **PalaceDownloads**, which must NOT know
+//  `AccountsManager` (the whole point of the hub split). The dependency has to
+//  invert to an injected account-scope provider (`AccountScopeProviding`
+//  `currentAccountID`, per §3b-1 / §2.3) rather than the concrete
+//  `AccountsManager`. These tests pin the CURRENT behavior the inversion must
+//  reproduce byte-for-byte:
+//
+//    1. The resolved download-file directory FOLLOWS the current account — flip
+//       `currentAccountId` A→B and the same book resolves to a different
+//       per-account directory. (Two accounts never co-mingle their downloads.)
+//    2. The sideloaded-content ISOLATION EXCEPTION: a `sideload-`-prefixed id
+//       whose identifier is in the sideloaded set resolves under the FIXED
+//       `SideloadedBookRegistry.sideloadContentAccountID`, IGNORING the current
+//       account — so a library switch cannot orphan a sideloaded book's file
+//       (BookFileManager.swift:92–96, sideloading-plan.md R6).
+//
+//  Existing `BookFileManagerTests` only exercises the EXPLICIT-account overloads
+//  (`fileUrl(for:account:)`) — it never drives the `currentAccountId`-reading
+//  convenience nor the sideload override. Those two coupling seams are the
+//  genuinely-unpinned surface this file adds; there is no overlap.
+//
+//  DETERMINISM / ISOLATION: `currentAccountId` is controlled purely through an
+//  isolated `UserDefaults` suite seeded at `currentAccountIdentifierKey` (the
+//  same key the setter writes) — NO heavy `currentAccount` setter is driven, so
+//  no static singletons (`ImageCache.shared`, network executor) are touched. A
+//  `directoryProvider` closure maps account → a temp URL that embeds the account
+//  string, so the account the path resolved under is directly observable without
+//  a real Application Support directory. No network, no keychain, no sleeps.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+import PalaceBookModel
+
+@MainActor
+final class BookFileManagerAccountScopingTests: PalaceWiringTestCase {
+
+    private var registry: TPPBookRegistryMock!
+    private var defaults: UserDefaults!
+    private var accountsManager: AccountsManager!
+
+    private let accountA = "wave3-filescope-A-\(UUID().uuidString)"
+    private let accountB = "wave3-filescope-B-\(UUID().uuidString)"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        registry = TPPBookRegistryMock()
+        defaults = Self.testUserDefaults()
+        // Start "current library == A".
+        defaults.set(accountA, forKey: currentAccountIdentifierKey)
+        accountsManager = makeFreshAccountsManager(defaults: defaults)
+    }
+
+    override func tearDownWithError() throws {
+        registry = nil
+        accountsManager = nil
+        defaults = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    /// A `directoryProvider` that echoes the resolved account into a stable temp
+    /// path, so a test can read back WHICH account the file URL resolved under.
+    /// Returns nil for a nil account (matches production's "no directory").
+    private static func echoingDirectoryProvider() -> (String?) -> URL? {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("wave3-filescope-\(UUID().uuidString)")
+        return { account in
+            guard let account else { return nil }
+            return root.appendingPathComponent(account).appendingPathComponent("content")
+        }
+    }
+
+    private func makeManager(
+        sideloadedIdentifiers: Set<String> = []
+    ) -> BookFileManager {
+        BookFileManager(
+            bookRegistry: registry,
+            accountsManager: accountsManager,
+            fileManager: .default,
+            directoryProvider: Self.echoingDirectoryProvider(),
+            sideloadedIdentifiersProvider: { sideloadedIdentifiers }
+        )
+    }
+
+    /// The account-directory component embedded in a resolved file URL. The
+    /// echoing provider lays out `<root>/<account>/content/<hash>.<ext>`, so the
+    /// account is the grandparent directory of the file.
+    private func resolvedAccount(in url: URL) -> String {
+        url.deletingLastPathComponent()        // .../<account>/content
+            .deletingLastPathComponent()        // .../<account>
+            .lastPathComponent
+    }
+
+    // MARK: - 1. File path follows the CURRENT account
+
+    /// The `fileUrl(for:)` convenience resolves under `currentAccountId`. Pins the
+    /// Downloads→Accounts read that Wave 3 inverts to an injected scope provider.
+    ///
+    /// Kill case: a mutant that hard-codes the account or reads a fixed string
+    /// instead of `accountsManager.currentAccountId` would resolve under the
+    /// wrong (or a constant) directory.
+    func testFileUrlConvenience_resolvesUnderCurrentAccount() throws {
+        let book = TPPBookMocker.mockBook(identifier: "scope-current-1", title: "Title scope-current-1")
+        registry.addBook(book, state: .downloadSuccessful)
+        let sut = makeManager()
+
+        let url = try XCTUnwrap(sut.fileUrl(for: "scope-current-1"),
+                                "Convenience overload must resolve a URL for a registered book under the current account")
+        XCTAssertEqual(resolvedAccount(in: url), accountA,
+                       "fileUrl(for:) must resolve under the CURRENT account (A) — this is the currentAccountId read Wave 3 inverts")
+    }
+
+    /// Switching the current library (A → B) re-points the SAME book's download
+    /// file to B's per-account directory. Two libraries never share a download
+    /// path. Pins the per-account isolation the extraction must preserve.
+    ///
+    /// Kill case: a mutant that captures the account once (or ignores
+    /// currentAccountId) would keep resolving under A after the switch.
+    func testFileUrlConvenience_followsAccountSwitch_AtoB() throws {
+        let book = TPPBookMocker.mockBook(identifier: "scope-switch-1", title: "Title scope-switch-1")
+        registry.addBook(book, state: .downloadSuccessful)
+        let sut = makeManager()
+
+        let urlUnderA = try XCTUnwrap(sut.fileUrl(for: "scope-switch-1"))
+        XCTAssertEqual(resolvedAccount(in: urlUnderA), accountA)
+
+        // Simulate a library switch by advancing the same key the setter writes.
+        defaults.set(accountB, forKey: currentAccountIdentifierKey)
+
+        let urlUnderB = try XCTUnwrap(sut.fileUrl(for: "scope-switch-1"))
+        XCTAssertEqual(resolvedAccount(in: urlUnderB), accountB,
+                       "After the current library flips A→B, the SAME book must resolve under B's directory — downloads follow the current account")
+        XCTAssertNotEqual(urlUnderA, urlUnderB,
+                          "A and B must yield DISTINCT download paths — per-account isolation, no cross-library co-mingling")
+        // File stem (hashed identifier) is account-independent; only the
+        // account directory differs.
+        XCTAssertEqual(urlUnderA.lastPathComponent, urlUnderB.lastPathComponent,
+                       "Only the per-account directory changes across a switch — the hashed file name is stable")
+    }
+
+    // MARK: - 2. Sideloaded content is pinned to the fixed sideload account
+
+    /// The isolation EXCEPTION: a registered sideloaded id resolves under the
+    /// fixed `sideloadContentAccountID`, NOT the current account — so a library
+    /// switch can't orphan its file. Pins BookFileManager.swift:92–96.
+    ///
+    /// Kill cases:
+    ///  - Dropping the sideload override → the file resolves under the current
+    ///    account (A) and is orphaned when the user switches libraries.
+    ///  - Dropping the membership check → a normal id that merely carries the
+    ///    prefix would be mis-pinned (covered by the negative test below).
+    func testSideloadedBook_pinsToFixedSideloadAccount_ignoringCurrentAccount() throws {
+        let sideloadId = "sideload-\(UUID().uuidString)"
+        let book = TPPBookMocker.mockBook(identifier: sideloadId, title: "Title \(sideloadId)")
+        registry.addBook(book, state: .downloadSuccessful)
+        // Current library is A, but the book is a registered sideloaded id.
+        let sut = makeManager(sideloadedIdentifiers: [sideloadId])
+
+        let url = try XCTUnwrap(sut.fileUrl(for: sideloadId))
+        XCTAssertEqual(resolvedAccount(in: url), SideloadedBookRegistry.sideloadContentAccountID,
+                       "A registered sideloaded id must resolve under the FIXED sideload account, ignoring current account A — a library switch must not orphan it")
+        XCTAssertNotEqual(resolvedAccount(in: url), accountA,
+                          "Sideloaded content must NOT be scoped to the current library")
+    }
+
+    /// Sideloaded content stays pinned to the fixed account even AFTER a library
+    /// switch — the property that makes sideloaded books readable across any
+    /// current library.
+    func testSideloadedBook_staysPinned_acrossAccountSwitch() throws {
+        let sideloadId = "sideload-\(UUID().uuidString)"
+        let book = TPPBookMocker.mockBook(identifier: sideloadId, title: "Title \(sideloadId)")
+        registry.addBook(book, state: .downloadSuccessful)
+        let sut = makeManager(sideloadedIdentifiers: [sideloadId])
+
+        let underA = try XCTUnwrap(sut.fileUrl(for: sideloadId))
+        defaults.set(accountB, forKey: currentAccountIdentifierKey)
+        let underB = try XCTUnwrap(sut.fileUrl(for: sideloadId))
+
+        XCTAssertEqual(underA, underB,
+                       "A sideloaded book's file path must be identical before and after a library switch — pinned to the fixed sideload account")
+        XCTAssertEqual(resolvedAccount(in: underB), SideloadedBookRegistry.sideloadContentAccountID)
+    }
+
+    /// Negative boundary: a `sideload-`-prefixed id that is NOT in the
+    /// sideloaded set must fall through to normal per-account scoping (the
+    /// membership check is defense-in-depth, BookFileManager.swift:92–93).
+    /// Guards against a mutant that pins on the prefix alone.
+    func testPrefixedButUnregistered_fallsBackToCurrentAccount() throws {
+        let notReallySideloaded = "sideload-not-registered-\(UUID().uuidString)"
+        let book = TPPBookMocker.mockBook(identifier: notReallySideloaded, title: "Title \(notReallySideloaded)")
+        registry.addBook(book, state: .downloadSuccessful)
+        // Empty sideloaded set → the prefix alone must NOT trigger the override.
+        let sut = makeManager(sideloadedIdentifiers: [])
+
+        let url = try XCTUnwrap(sut.fileUrl(for: notReallySideloaded))
+        XCTAssertEqual(resolvedAccount(in: url), accountA,
+                       "A prefixed id absent from the sideloaded set must scope to the CURRENT account — the override requires BOTH prefix AND membership")
+    }
+}

--- a/docs/architecture/wave3-coupling-map.md
+++ b/docs/architecture/wave3-coupling-map.md
@@ -1,0 +1,115 @@
+# Wave 3 coupling map — Accounts ↔ Downloads (verified)
+
+**Status:** write-ahead characterization scouting for god-class-decomposition
+**Wave 3** (`docs/architecture/god-class-decomposition-plan.md` §3a-2/§3a-3, §4
+Wave 3, §5). **Author:** test-coverage fleet, 2026-07-27. **Scope:** tests +
+this doc only — no production change.
+
+This maps the ACTUAL bidirectional coupling between `AccountsManager`
+(→ PalaceAccounts, Wave 3a) and the MyBooks download subsystem
+(→ PalaceDownloads, Wave 3b), grepped and read against source this session, so
+the extraction is provably behavior-neutral. Line numbers are from
+`origin/develop` @ `4ce91283f`.
+
+## Headline finding: the coupling is ASYMMETRIC and mostly already inverted
+
+The Downloads side already reaches Accounts almost entirely through
+**closure seams** (`userAccountProvider: () -> TPPUserAccount`), the exact
+inversion Wave 3 wants. The load-bearing, still-concrete coupling reduces to a
+handful of `currentAccountId` / `currentUserAccount` reads plus **one** hard
+static back-call from Accounts into Downloads. Wave 3's real work is (a) a single
+`AccountScopeProviding` protocol for the `currentAccountId` reads, and (b) a
+new reset-notification seam for the one static back-call — NOT a large carving.
+
+The plan's §3a-3 "3a/3b are ∥ only because Wave 2 already cut their mutual edge"
+holds with **one caveat** (see Seam S1): the account-switch → borrow-reauth-reset
+static call is a live Accounts→Downloads edge that Wave 2 did **not** cut. It
+must invert before 3a and 3b can land independently, or 3b serializes behind 3a.
+
+---
+
+## A. Accounts → Downloads (the back-edges)
+
+| # | Site (file:line) | What it does | Status |
+|---|---|---|---|
+| **A1** | `Accounts/Library/AccountsManager.swift:994` → `MyBooks/MyBooksDownloadCenter+Async.swift:27` → `MyBooks/BorrowOperation.swift:141` | `cleanupActiveContentBeforeAccountSwitch` calls the STATIC `MyBooksDownloadCenter.clearAllBorrowReauthState()` on every real library switch, wiping the process-wide per-book borrow-reauth circuit breaker. | **PINNED** (new `AccountSwitchBorrowReauthCouplingContractTests`). **Un-inverted static — needs a seam (S1).** |
+| A2 | `Accounts/Library/AccountsManager.swift:993` (via lazy `networkExecutor`, decl :274 = `AppContainer.production().networkExecutor`) | Account switch cancels non-essential in-flight tasks (incl. downloads). | Covered at the executor level by `AccountSwitchLifecycleTests` + `AccountSwitchCleanupTests`. Reaches `AppContainer.production()` — see S3. |
+| A3 | `Accounts/Library/AccountsManager.swift:1131` (doc) | Comment: MyBooksDownloadCenter observes `hasCredentials` transitions on the account. | Advisory only; no direct call. |
+
+The account-switch cleanup also fires (same setter, `currentAccount.didSet` @ :910):
+`ImageCache.shared.evictDecodedImages()` (:913), `TPPBookCoverRegistry.shared.resetHostFailures()`
+(:917), `AccountStateStore.shared.setState(.detailsEvicted…)` (:953), and an async
+`AppContainer.production().navigationCoordinatorHub` pop-to-root (:997). These are
+**not** Downloads coupling but are the static reaches that block a clean
+`CurrentAccountStore` extraction test (see S3). The setter's **publication order**
+is already pinned by `PalaceTests/Decomp/AccountsManagerCurrentAccountSwitchContractTests`.
+
+## B. Downloads → Accounts (the forward reads)
+
+| # | Site (file:line) | What it does | Status |
+|---|---|---|---|
+| B1 | `MyBooks/BookFileManager.swift:67` (`fileUrl(for:)` → `accountsManager.currentAccountId`); stored dep :28/:49 | Per-account download-file directory: the on-disk path follows the current library; sideloaded ids pin to the fixed sideload account (:92–96). | **PINNED** (new `BookFileManagerAccountScopingTests`). Needs S2. |
+| B2 | `MyBooks/MyBooksDownloadCenter.swift:784` (`captureCurrentAccountId` → `accountsManager.currentAccountId`) | Capture-at-start of `currentAccountId`, threaded through the whole download → bearer-auth path (fixes spurious login modal on mid-download library swap). | **Already PINNED** (`MyBooksDownloadCenterAccountIdThreadingTests`, 7 cases incl. concurrency). Needs S2. |
+| B3 | `MyBooks/MyBooksDownloadCenter.swift:105–107` (`userAccount` → `accountsManager.currentUserAccount`); :114–119 (`userAccount(forCapturedId:)` → `accountsManager.userAccount(for:)`) | Legacy resolver-fallback + captured-id resolution for download credentials. | Thin delegators; the coordinator-level capture (B2) is the tested surface. Needs S2. |
+| B4 | `MyBooks/MyBooksDownloadCenter.swift:1778` (`reset(account:)`: `if accountsManager.currentAccountId == account`) | Content-reset only clears the pending-removal marker when resetting the CURRENT account. | Not separately pinned (needs a full MBDC). Needs S2. |
+| B5 | `MyBooks/MyBooksDownloadCenter.swift:1992` (`account: accountsManager.currentAccountId ?? ""`) | Current-account id stamped into a registry/announce call. | Not separately pinned. Needs S2. |
+| B6 | `MyBooks/MyBooksDownloadCenter.swift:479, 610` (`AppContainer.production().accountsManager.currentAccount?.authSurfaceHosts`) | Foreign-host guard for the auth-error classifier — locator reach, NOT the injected `accountsManager`. | Needs S2 **and** S3 (kills a `AppContainer.production()` locator). |
+| B7 | Closure-inverted, **already seam-clean**: `BorrowOperation.swift:229`, `BookReturnService.swift:96`, `BorrowErrorPresenter.swift:98`, `CredentialPromptCoordinator.swift:60`, `RightsManagementDispatcher.swift:78`, `BookSignInRedirectHandler.swift:63`, `DownloadAuthRetryHandler.swift:90` (all `userAccountProvider: () -> TPPUserAccount`) | Per-flow current-account resolution. | No inversion needed — these already take a closure. They move to PalaceDownloads intact. |
+
+---
+
+## Production SEAMS the Wave 3 extraction will need
+
+These are the DI seams that do **not** exist yet. Each is a place a test could
+not exercise the coupling without a production change — recorded here rather than
+added (tests-only rule). This is the analogue of the four missing seams the
+Wave 2b contract work surfaced.
+
+- **S1 — `BorrowReauthResetting` (NEW; not in the plan).** `AccountsManager`'s
+  account-switch cleanup calls `MyBooksDownloadCenter.clearAllBorrowReauthState()`
+  as a hard STATIC (A1). Once AccountsManager is in PalaceAccounts and
+  BorrowOperation is in PalaceDownloads, PalaceAccounts cannot name the download
+  type. Introduce a narrow protocol (e.g. `protocol BorrowReauthResetting { func
+  clearAllBorrowReauthState() }`) declared in **PalaceAccounts** (or a shared
+  lower layer) and injected into the account-switch cleanup; the download
+  subsystem registers the impl at composition. **This edge was NOT cut by Wave 2**
+  — until S1 exists, Wave 3b's borrow-reauth-reset behavior is coupled to 3a, so
+  either land S1 first or serialize 3b behind 3a (per §3a-3's own escape clause).
+  Behavior to preserve is locked by `AccountSwitchBorrowReauthCouplingContractTests`.
+
+- **S2 — `AccountScopeProviding` (named in plan §3b-1/§2.3, scope wider than
+  stated).** The plan introduces `AccountScopeProviding` (`currentAccountID`,
+  `accountDidChange`) for `PalaceBookRegistry`. Wave 3 needs the SAME protocol to
+  cover every Downloads→Accounts read (B1–B6), replacing the concrete
+  `accountsManager: AccountsManager` dependency in `BookFileManager` and
+  `MyBooksDownloadCenter` with `currentAccountId` (and `userAccount(for:)` /
+  `currentUserAccount` for the credential reads). Confirm the protocol surface is
+  widened from the registry-only `{currentAccountID, accountDidChange}` to also
+  vend `userAccount(for:) -> TPPUserAccount` and `currentUserAccount`, or split
+  into `AccountScopeProviding` + `AccountCredentialProviding`.
+
+- **S3 — de-locator the account-switch cleanup + MBDC host guard.** The
+  `currentAccount` setter's cleanup reaches `ImageCache.shared`,
+  `TPPBookCoverRegistry.shared`, `AccountStateStore.shared`, and
+  `AppContainer.production().{networkExecutor,navigationCoordinatorHub}` directly
+  (A2 + §A note), and MBDC reads `AppContainer.production().accountsManager` for
+  the foreign-host guard (B6). These block a deterministic spy-based test of the
+  cleanup ORDERING (why `AccountsManagerCurrentAccountSwitchContractTests` observes
+  via `NotificationCenter` rather than injected spies, and why this suite pins the
+  Downloads coupling through `BorrowOperation` directly rather than the setter).
+  The `CurrentAccountStore` extraction should take these as injected collaborators
+  (`ImageCaching`, cover-registry, `NetworkTaskCancelling`, nav hub) so the
+  post-extraction facade's cleanup order becomes spy-testable.
+
+## What this write-ahead pack locks (so the extraction is provably neutral)
+
+| Suite (new) | Direction | Pins |
+|---|---|---|
+| `PalaceTests/Contract/AccountSwitchBorrowReauthCouplingContractTests` | Accounts→Downloads (A1) | Ordered seam sequence across repeat borrows: 1st auth-error → reauth; 2nd (same book) → breaker suppresses to generic error; `clearAllBorrowReauthState()` (what a switch calls) re-enables; the wipe is GLOBAL across books; the breaker is keyed per-book. 4 byte-equal JSON snapshots. |
+| `PalaceTests/MyBooks/BookFileManagerAccountScopingTests` | Downloads→Accounts (B1) | Download-file path follows `currentAccountId` (A→B re-points the same book); sideloaded content pins to the fixed sideload account across a switch; prefix-without-membership falls back to per-account scoping. 5 unit assertions. |
+
+Already-covered coupling (verified this session; NOT duplicated): capture-once /
+bearer-auth threading (B2, `MyBooksDownloadCenterAccountIdThreadingTests`),
+per-library credential + registry isolation across a switch
+(`AccountSwitchLifecycleTests`), and the `currentAccount` setter publication
+order (`Decomp/AccountsManagerCurrentAccountSwitchContractTests`).

--- a/docs/architecture/wave3-coupling-map.md
+++ b/docs/architecture/wave3-coupling-map.md
@@ -113,3 +113,65 @@ bearer-auth threading (B2, `MyBooksDownloadCenterAccountIdThreadingTests`),
 per-library credential + registry isolation across a switch
 (`AccountSwitchLifecycleTests`), and the `currentAccount` setter publication
 order (`Decomp/AccountsManagerCurrentAccountSwitchContractTests`).
+
+---
+
+## Post-2b refresh (2026-07-27)
+
+Re-verified against `origin/develop` @ `c231b5a43` (Wave 2b, PR #1341, landed
+after this map was first written). Rebased `feat/wave3-writeahead-tests` onto
+this tip — **conflict-free**, no test edits needed, both new suites still pass
+(byte-equal contract snapshots, unchanged). Facts below are grepped/read from
+current source this session, not carried over from the pre-2b draft.
+
+- **Line drift.** The A1 static call site is now
+  `AccountsManager.swift:995` (was `:994` pre-2b — a one-line shift from an
+  intervening edit, not a behavior change):
+  `MyBooksDownloadCenter.clearAllBorrowReauthState()`, still fired
+  unconditionally from `cleanupActiveContentBeforeAccountSwitch`. The B1 read
+  moved to `BookFileManager.swift:68` (was `:67`):
+  `accountsManager.currentAccountId` inside `fileUrl(for:)`. The breaker
+  itself, `BorrowOperation.clearAllBorrowReauthState()`, is now at `:142` (was
+  `:141`). All three are pure line-number churn — the pinned call-order and
+  seam sequence in both new suites are unaffected.
+
+- **Cycle-1 Accounts→registry down-edge is now COMMENT-ONLY.** Pre-2b,
+  `AccountsManager` had a live code edge into the book registry; Wave 2b's
+  `PalaceBookRegistry` extraction + `AccountScopeProviding` inversion cut it.
+  `AccountsManager.swift` today has exactly one `import PalaceBookRegistry`
+  (for the adapter conformance, in the separate
+  `AccountsManagerAccountScopeAdapter.swift`) and two remaining mentions of
+  `TPPBookRegistry`/`BookRegistrySync`, both inside doc comments (`:369-370`,
+  `:1049`) — no live call. The registry now depends on Accounts only through
+  the protocol; Accounts does not reach back into the registry in code.
+
+- **`AccountScopeProviding` shipped 4-member**, confirmed at
+  `Palace/Packages/PalaceBookRegistry/Sources/PalaceBookRegistry/AccountScopeProviding.swift`:
+  `currentAccountID: String?`, `accountDidChangePublisher:
+  AnyPublisher<Void, Never>`, `hasCredentials(forAccount:) -> Bool`,
+  `loansURL(forAccount:) async throws -> URL?`. This **supersedes §S2 above**:
+  the decision (made during 2b) is AGAINST widening this shared protocol for
+  Downloads' B1–B6 reads. `AccountScopeProviding` stays value-only
+  (registry-only consumer); Wave 3b's S2 introduces its own
+  Downloads-owned protocol(s) (`DownloadAccountScopeProviding` /
+  `DownloadCredentialsProviding`) rather than extending this one — a
+  capability-boundary split, not a shared surface.
+
+- **Sequencing refinement: S1/A1 structurally blocks 3a only, not 3b.**
+  Restated from the original §S1: a packaged `AccountsManager` (3a) cannot
+  name the app-target `MyBooksDownloadCenter` type, so A1 must invert before
+  3a can extract. 3b (packaging the Downloads side) does **not** have the same
+  hard blocker — the MBDC shell can stay app-target with a static forwarder
+  into package-side `BorrowOperation`, so 3b alone would still compile without
+  S1. S1 still lands first regardless: it is small, removes the one edge that
+  would otherwise force a serialization decision mid-wave, and makes the
+  account-switch cleanup ordering spy-testable (feeds S3). This refines, not
+  reverses, the original "serialize 3b behind 3a" framing — the constraint is
+  narrower than first stated.
+
+No other divergences found. The pinned suites
+(`AccountSwitchBorrowReauthCouplingContractTests`,
+`BookFileManagerAccountScopingTests`) remain valid unmodified against
+post-2b source.
+
+<!-- audit-verified -->


### PR DESCRIPTION
## Summary
- Write-ahead characterization pack for the Wave 3 god-class decomposition (Accounts↔Downloads coupling extraction, `docs/architecture/god-class-decomposition-plan.md` §4 Wave 3): locks current behavior BEFORE the actual 3a/3b extraction PRs land, so those PRs are provably behavior-neutral.
- `PalaceTests/Contract/AccountSwitchBorrowReauthCouplingContractTests.swift` — contract-snapshot test pinning the ordered seam sequence of `AccountsManager.cleanupActiveContentBeforeAccountSwitch` → `MyBooksDownloadCenter.clearAllBorrowReauthState()` → `BorrowOperation`'s per-book borrow-reauth circuit breaker (the one hard, un-inverted Accounts→Downloads static edge Wave 2 did not cut).
- `PalaceTests/MyBooks/BookFileManagerAccountScopingTests.swift` — unit tests pinning `BookFileManager.fileUrl(for:)`'s account-scoped download-file path resolution, including the sideloaded-content pin-to-fixed-account override.
- `docs/architecture/wave3-coupling-map.md` — post-Wave-2b refresh appendix: line drift, confirmation that `AccountScopeProviding` shipped 4-member (supersedes the original S2 widening proposal — Downloads gets its own protocol instead), the Accounts→registry down-edge now being comment-only, and the sequencing refinement that S1/A1 structurally blocks Wave 3a only, not 3b.

**Zero production `Palace/` source change** — test files + snapshots + doc + pbxproj registration only.

## Test plan
- [x] Rebased cleanly onto post-Wave-2b `develop` (`c231b5a43`, PR #1341) — conflict-free, no test edits needed.
- [x] Fresh `-derivedDataPath` `build-for-testing` succeeded; no import changes needed (both suites already import `XCTest, PalaceCatalog, @testable Palace, PalaceBookModel` — no `PalaceBookRegistry` import required).
- [x] Both new suites run twice: run 1 recorded contract snapshots, run 2 asserted against them — `** TEST EXECUTE SUCCEEDED **` both times, 9/9 tests passing.
- [x] `git status PalaceTests/Contract/__Snapshots__/` clean after both runs.
- [x] Required meta-lints (`TearDownRequiredLintTests`, `AppContainerIsolationLintTests`) pass.
- [x] Independent architect + blast-radius review via `/forge-review` — both APPROVED (heka ledger, tip `44f9273a2`).

**Not done:** no production seams (S1/S2/S3 from the coupling map) implemented — those are the actual Wave 3a/3b extraction PRs this pack precedes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)