### PR TITLE
feat(decomp): invert account-switch borrow-reauth reset via BorrowReauthResetting (Wave 3 S1)

### DIFF
--- a/.forgeos/intent/wave3-s1-borrowreauth-resetting.md
+++ b/.forgeos/intent/wave3-s1-borrowreauth-resetting.md
@@ -1,0 +1,59 @@
+# Intent: Wave 3 S1 — invert the account-switch → borrow-reauth reset (BorrowReauthResetting)
+
+**Slug:** wave3-s1-borrowreauth-resetting
+**Branch:** feat/wave3-s1-borrowreauth-resetting
+**Critical-path:** YES (money-path: account-switch borrow-reauth circuit-breaker reset)
+**Change kind:** small production seam + tests. TDD.
+
+## Context
+
+God-class decomposition Wave 3 (`docs/architecture/god-class-decomposition-plan.md`
+§3a, and the S1 decision in the Wave 3 brief) severs the mutually-coupled hub pair
+`AccountsManager` (→ PalaceAccounts) and the MyBooks download subsystem
+(→ PalaceDownloads). This PR is seam **S1**: the ONE hard, un-inverted
+Accounts→Downloads STATIC edge.
+
+`AccountsManager.cleanupActiveContentBeforeAccountSwitch(from:to:)`
+(AccountsManager.swift:995) calls the static
+`MyBooksDownloadCenter.clearAllBorrowReauthState()` on every real library switch,
+which wipes the process-global per-book borrow-reauth circuit breaker
+(`BorrowOperation.reauthTracker`). If that clear is dropped, a user who switches
+libraries after a failed borrow is silently stuck on the generic-error path with
+no reauth prompt — a money-path regression. S1 makes the edge *injected* (an
+`any BorrowReauthResetting` dependency) so the call is spy-testable and so the
+type-level Accounts→MyBooks reference dies mechanically at the 3a package move.
+
+## Claims (what this change does)
+
+1. New protocol `BorrowReauthResetting: Sendable { func clearAllBorrowReauthState() }`
+   declared in `Palace/Accounts/Library/BorrowReauthResetting.swift` (the consuming
+   package's side; moves into PalaceAccounts at 3a).
+2. New app-side adapter `DownloadCenterBorrowReauthResetter: BorrowReauthResetting`
+   in `Palace/MyBooks/DownloadCenterBorrowReauthResetter.swift`, forwarding to
+   `MyBooksDownloadCenter.clearAllBorrowReauthState()`.
+3. `AccountsManager` gains `private let borrowReauthResetter: any BorrowReauthResetting`,
+   an init param defaulting to a REAL `DownloadCenterBorrowReauthResetter()`
+   (behavior-identical; avoids churning ~135 test constructions; a no-op default is
+   FORBIDDEN because it would silently drop a money-path clear), and the :995 static
+   call becomes `borrowReauthResetter.clearAllBorrowReauthState()`.
+4. `AppContainer._buildCachedAppContainer()` passes the resetter EXPLICITLY at the
+   `AccountsManager(...)` construction (:634), per the no-default-fires house rule.
+
+## Anti-claims (explicitly NOT in scope)
+
+- NOT changing WHAT the clear does (still a global `reauthTracker.clearAll()`),
+  its call site, or its synchronous ordering before the async nav cleanup.
+- NOT inverting any other Accounts↔Downloads seam (S2/S3, the `AccountScopeProviding`
+  question, locator kills) — those are separate PRs.
+- NOT moving any type into a package (that is 3a).
+- NOT widening `AccountScopeProviding` or touching PalaceBookRegistry.
+
+## Files in scope
+
+- `Palace/Accounts/Library/BorrowReauthResetting.swift` (new, prod)
+- `Palace/MyBooks/DownloadCenterBorrowReauthResetter.swift` (new, prod)
+- `Palace/Accounts/Library/AccountsManager.swift` (edit: property + init param + :995 call)
+- `Palace/AppInfrastructure/AppContainer.swift` (edit: explicit wire at :634)
+- `PalaceTests/Accounts/BorrowReauthResettingTests.swift` (new, tests)
+- `Palace.xcodeproj/project.pbxproj` (2 prod files → both targets, 1 test file)
+- `.forgeos/intent/wave3-s1-borrowreauth-resetting.md` (this file)

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		1441E97FEA8E24E5676576B5 /* UIButton+NYPLAppearanceAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68831365CC1FF46BE9A9C2C9 /* UIButton+NYPLAppearanceAdditions.swift */; };
 		1446B886F9D2F070E2AC22A5 /* Skeleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E510DC675E5215E00B444EE /* Skeleton.swift */; };
 		145798F6215BE9E300F68AFD /* ProblemReportEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145798F5215BE9E300F68AFD /* ProblemReportEmail.swift */; };
+		149DDAD13FD460B229CDD760 /* DownloadCenterBorrowReauthResetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9381BBE0CE20B654B89FFCD /* DownloadCenterBorrowReauthResetter.swift */; };
 		149EA7BE30582B9CEF020DEC /* PalaceFeatureFlags in Frameworks */ = {isa = PBXBuildFile; productRef = FA466C796161E2DF957B24F4 /* PalaceFeatureFlags */; };
 		14D4531FA335D56645905798 /* DownloadStartReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11566537464518DD5E2536E3 /* DownloadStartReducer.swift */; };
 		14E286B1CE151643C5FF2A8B /* ReturnReducerContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D6C1AFBD65430D25345945 /* ReturnReducerContractTests.swift */; };
@@ -166,6 +167,7 @@
 		1B7C8E3D5A4F2C90B6E7D8F1 /* DiskBudgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9E0A5F7C6B4E12D8A9F0B3 /* DiskBudgetManager.swift */; };
 		1BD28F76C1C3B5B76ABC3C80 /* ReadingStreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6CA6654994D77041AE0F79 /* ReadingStreak.swift */; };
 		1BD35423CA853F6CFBB10DA8 /* PalaceNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = 8670707E3108CFD72D4569C9 /* PalaceNetwork */; };
+		1C173CB11CD63B209F95085E /* BorrowReauthResettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D32B0D46348D5770A7551C4 /* BorrowReauthResettingTests.swift */; };
 		1C1DF3E6F25FB227E234C18D /* DownloadAuthRetryHandlerAuthCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B8EE3C140BF4313428A81B /* DownloadAuthRetryHandlerAuthCoordinatorTests.swift */; };
 		1C4CC3753B75E8677FEB66B0 /* ButtonStateMonotonicClampTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB910D1F15E3A3C24D3E3247 /* ButtonStateMonotonicClampTests.swift */; };
 		1DCB0892788EDE3026D667A3 /* TPPIndeterminateProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F8E5B987D7324D570F67D0 /* TPPIndeterminateProgressView.swift */; };
@@ -836,6 +838,7 @@
 		80D9E415F5D1C5856884BDEB /* PalacePreferences in Frameworks */ = {isa = PBXBuildFile; productRef = 4E50730FA32A2D35201078B5 /* PalacePreferences */; };
 		811E00F5F755273F726941CC /* PalaceAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 3D8B27DA10A114B76EFB41A1 /* PalaceAuth */; };
 		815042A5028736B3FD358643 /* AuthDecisionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FD1DBB8243D1E1B6EC6083 /* AuthDecisionEvent.swift */; };
+		81587C22AEEAB64E6D2824BD /* BorrowReauthResetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC47AED382982103F213534 /* BorrowReauthResetting.swift */; };
 		81C26B959E33252B2BD42607 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7751F6315B6633F398F0B808 /* StringExtensionTests.swift */; };
 		81C2913BA5B150D52DAC6761 /* PerformanceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61585F7AD2A0D6CDAF2EF098 /* PerformanceMonitor.swift */; };
 		82081EC71E1591C3E61B4BF4 /* BadgesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02060A0117F26B0E56F3F606 /* BadgesView.swift */; };
@@ -1105,6 +1108,7 @@
 		B7EFBC3BEF638571AB87FD62 /* TPPAgeCheckStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45DCF5D65C3866B68D2C1EE /* TPPAgeCheckStateMachineTests.swift */; };
 		B82E5D8A62F1988332D1F9BE /* AudiobookSkipIntervalSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A379F8B76503AB9D2BB9DB48 /* AudiobookSkipIntervalSettings.swift */; };
 		B86221BBA29B2EC99494DB3C /* HostFailureTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535929C8F559713321004F38 /* HostFailureTrackerTests.swift */; };
+		B865C34CA9799A7AA0042BBF /* BorrowReauthResetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC47AED382982103F213534 /* BorrowReauthResetting.swift */; };
 		B889ECCF0F07418C40A3AEFE /* AccountsManagerStateMachineWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40B096C4C124B0219339E8E /* AccountsManagerStateMachineWiringTests.swift */; };
 		B8D7C87702A528FA7C2D47AF /* BookRegistrySyncReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED5DCD8E5494F99E3E01D1D /* BookRegistrySyncReadinessTests.swift */; };
 		B8DB7D16CE8EDE10BAD7E6E2 /* CallLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E45ABDAD5DEC345C87749C2 /* CallLog.swift */; };
@@ -1821,6 +1825,7 @@
 		EEB83DA64C1D8EC3F0CCEB08 /* AccountErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F5B74FBB8C3F4B3A64E44F /* AccountErrorReportingTests.swift */; };
 		EEEE66239B26A72D3043149B /* AuthCoordinatorTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D2803422C2006E33C1BC3E /* AuthCoordinatorTelemetryTests.swift */; };
 		EF45FA58251EA725B1A9EC42 /* ImageLoaderImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16897C4A4AB0AFFDE25449BF /* ImageLoaderImpl.swift */; };
+		EF4CC725B5E70D77890C2A03 /* DownloadCenterBorrowReauthResetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9381BBE0CE20B654B89FFCD /* DownloadCenterBorrowReauthResetter.swift */; };
 		EFADE940431FF20F6F1EF7CA /* AccountsManagerAuthDocContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928BD93AACC07042059F32C7 /* AccountsManagerAuthDocContractTests.swift */; };
 		EFD8F9BF5C9FBB1408496A64 /* PalaceBookModel in Frameworks */ = {isa = PBXBuildFile; productRef = 23ECAD584113B6C4BDFB33F6 /* PalaceBookModel */; };
 		F00D000000000000000F5501 /* MyBooksDownloadSessionInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00D000000000000000F5502 /* MyBooksDownloadSessionInvalidationTests.swift */; };
@@ -2481,6 +2486,7 @@
 		4F892EAF356E802A7E33A657 /* RatingReviewRequester.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingReviewRequester.swift; sourceTree = "<group>"; };
 		4F8D8A0D1A094920B67DC0E2 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
 		4F901D7BCF798BFF0E528D6D /* NSURL+NYPLURLAdditions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSURL+NYPLURLAdditions.swift"; sourceTree = "<group>"; };
+		4FC47AED382982103F213534 /* BorrowReauthResetting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BorrowReauthResetting.swift; sourceTree = "<group>"; };
 		500A72CE85F5DBA5FC681080 /* AudiobookTrackerExtendedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookTrackerExtendedTests.swift; sourceTree = "<group>"; };
 		502761BDE732D3752808C4C4 /* TPPBookButtonsState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookButtonsState.swift; sourceTree = "<group>"; };
 		50E92EE539A615735164856F /* RuntimeQuiescenceLintTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeQuiescenceLintTests.swift; sourceTree = "<group>"; };
@@ -2829,6 +2835,7 @@
 		9C821947A4DF5BDE2F8089DF /* PalaceTestSetupObservationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalaceTestSetupObservationTests.swift; sourceTree = "<group>"; };
 		9CEF7F7CC10FA7EDA2FBD122 /* CatalogRepositoryStaleWhileRevalidateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogRepositoryStaleWhileRevalidateTests.swift; sourceTree = "<group>"; };
 		9CF95DA87536C79B461B7A0F /* PalaceWiringTestCaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalaceWiringTestCaseTests.swift; sourceTree = "<group>"; };
+		9D32B0D46348D5770A7551C4 /* BorrowReauthResettingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BorrowReauthResettingTests.swift; sourceTree = "<group>"; };
 		9DAEBFC0D1E2F30415263750 /* BookContentResetServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookContentResetServiceTests.swift; sourceTree = "<group>"; };
 		9DAEBFC0D1E2F304152637AB /* DownloadAuthRetryHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadAuthRetryHandlerTests.swift; sourceTree = "<group>"; };
 		9DC08BFC96049300E5ADB7AD /* AccountStateMachineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountStateMachineTests.swift; sourceTree = "<group>"; };
@@ -2878,6 +2885,7 @@
 		A91FD775116643E6AF6CB27E /* TPPSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPSettingsTests.swift; sourceTree = "<group>"; };
 		A92FB0F821CDCE3D004740F4 /* TPPReturnPromptHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPReturnPromptHelper.swift; sourceTree = "<group>"; };
 		A934FABA62A6E51A6928F0DD /* PerformanceMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMonitorTests.swift; sourceTree = "<group>"; };
+		A9381BBE0CE20B654B89FFCD /* DownloadCenterBorrowReauthResetter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadCenterBorrowReauthResetter.swift; sourceTree = "<group>"; };
 		A93F9F9621CDACF700BD3B0C /* TPPAppReviewPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAppReviewPrompt.swift; sourceTree = "<group>"; };
 		A97F1FD36814FED60F937463 /* LCPAcquisitionPredicateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPAcquisitionPredicateTests.swift; sourceTree = "<group>"; };
 		A99D2B5025CDB8D6035651D6 /* LCPClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPClientTests.swift; sourceTree = "<group>"; };
@@ -4274,6 +4282,7 @@
 				7D221ADA98A856B50628D902 /* AccountsManagerFirstRunDecodeTests.swift */,
 				28F5B74FBB8C3F4B3A64E44F /* AccountErrorReportingTests.swift */,
 				A9A412ABF8C7A3A6EBC490B7 /* AccountScopeAdapterTests.swift */,
+				9D32B0D46348D5770A7551C4 /* BorrowReauthResettingTests.swift */,
 			);
 			path = Accounts;
 			sourceTree = "<group>";
@@ -4623,6 +4632,7 @@
 				994596C5FC8FAE5BC41AEB7D /* ReturnReducer.swift */,
 				0C1F974717220248950A874F /* BorrowReducerCore.swift */,
 				D132FB1FCA6430A16B5998DB /* MyBooksDownloadCenter+RegistryDownloadServicing.swift */,
+				A9381BBE0CE20B654B89FFCD /* DownloadCenterBorrowReauthResetter.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -4901,6 +4911,7 @@
 				ECB5EFDCFE78A87CFDA31A37 /* TPPSettings+AccountsList.swift */,
 				9C80B4E151496CABF2F9D0EE /* AccountsManager+ProblemReportContext.swift */,
 				19F86127F411D9B44A7A6CB3 /* AccountsManagerAccountScopeAdapter.swift */,
+				4FC47AED382982103F213534 /* BorrowReauthResetting.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -7972,6 +7983,7 @@
 				99ACB0B5B92C44F4AA5845B3 /* BookRegistryEngineTestInits.swift in Sources */,
 				C77919FC1FE8A977359429DA /* AccountScopeAdapterTests.swift in Sources */,
 				F8F19F0AC6114A6C745FB5A5 /* RegistryDownloadServicingSeamTests.swift in Sources */,
+				1C173CB11CD63B209F95085E /* BorrowReauthResettingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8530,6 +8542,8 @@
 				60C5ED69C23BFB248B1714B9 /* MyBooksDownloadCenter+RegistryDownloadServicing.swift in Sources */,
 				711421DD8E8A90F10789A56E /* TPPBookRegistry+AppConformances.swift in Sources */,
 				B00B6F2D1A05416F82D5474C /* TPPBookRegistry+ProductionInit.swift in Sources */,
+				B865C34CA9799A7AA0042BBF /* BorrowReauthResetting.swift in Sources */,
+				EF4CC725B5E70D77890C2A03 /* DownloadCenterBorrowReauthResetter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9091,6 +9105,8 @@
 				8B7831AA5CDB0202299CAF95 /* MyBooksDownloadCenter+RegistryDownloadServicing.swift in Sources */,
 				CC9C56E87FC8F66B38EF5753 /* TPPBookRegistry+AppConformances.swift in Sources */,
 				66C5BBEEAC56378BCD5C9879 /* TPPBookRegistry+ProductionInit.swift in Sources */,
+				81587C22AEEAB64E6D2824BD /* BorrowReauthResetting.swift in Sources */,
+				149DDAD13FD460B229CDD760 /* DownloadCenterBorrowReauthResetter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -267,6 +267,10 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// explicit initializer so two tests touching the current-account
     /// key cannot pollute each other. There is NO fallback once injected.
     private let defaults: UserDefaults
+    /// Injected account-switch borrow-reauth circuit-breaker reset (Wave 3 S1).
+    /// Replaces the static `MyBooksDownloadCenter.clearAllBorrowReauthState()`
+    /// call so the money-path clear is spy-testable. See `BorrowReauthResetting`.
+    private let borrowReauthResetter: any BorrowReauthResetting
     /// Lazy-resolved from AppContainer to break the singleton init cycle:
     /// AccountsManager is constructed inline by AppContainer._cached's
     /// initializer, so we cannot read AppContainer.production() during this
@@ -532,8 +536,15 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// - Parameter defaults: UserDefaults backing store for
     ///   `currentAccountIdentifierKey` reads/writes. Defaults to `.standard`
     ///   so production callers stay green; tests pass a per-suite instance.
-    init(defaults: UserDefaults = .standard) {
+    /// - Parameter borrowReauthResetter: account-switch borrow-reauth reset seam
+    ///   (Wave 3 S1). REAL default keeps every existing call site behavior-identical;
+    ///   tests inject a spy, `AppContainer` passes it explicitly.
+    init(
+        defaults: UserDefaults = .standard,
+        borrowReauthResetter: any BorrowReauthResetting = DownloadCenterBorrowReauthResetter()
+    ) {
         self.defaults = defaults
+        self.borrowReauthResetter = borrowReauthResetter
         self.settings = TPPSettings()
         self.accountSet = TPPConfiguration.customUrlHash()
             ?? (settings.useBetaLibraries
@@ -992,7 +1003,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// content before switching accounts to prevent cross-account credential leaks.
     private func cleanupActiveContentBeforeAccountSwitch(from previousId: String?, to newId: String?) {
         networkExecutor.cancelNonEssentialTasks()
-        MyBooksDownloadCenter.clearAllBorrowReauthState()
+        borrowReauthResetter.clearAllBorrowReauthState()
 
         Task { @MainActor [weak self] in
             if let coordinator = AppContainer.production().navigationCoordinatorHub.coordinator {

--- a/Palace/Accounts/Library/BorrowReauthResetting.swift
+++ b/Palace/Accounts/Library/BorrowReauthResetting.swift
@@ -1,0 +1,40 @@
+//
+//  BorrowReauthResetting.swift
+//  Palace
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+/// Inversion of the account-switch → borrow-reauth-circuit-breaker reset
+/// (god-class decomposition Wave 3, seam S1 — the ONE hard, un-inverted
+/// Accounts→Downloads static edge).
+///
+/// On every real library switch, `AccountsManager.cleanupActiveContentBefore
+/// AccountSwitch(from:to:)` must clear the process-global per-book borrow-reauth
+/// **circuit breaker** (`BorrowOperation.reauthTracker`, a `static let`). The
+/// breaker suppresses a *second* re-auth attempt for a book whose first borrow
+/// hit an auth error, so a stale, tripped breaker carried across a library
+/// switch would leave a user who switches libraries after a failed borrow
+/// silently stuck on the generic-error path with NO re-auth prompt — a
+/// money-path regression invisible to per-case unit tests (each resets the
+/// breaker in setUp). This clear MUST reset ALL books' state, not just the
+/// current book. The behavior is pinned by
+/// `AccountSwitchBorrowReauthCouplingContractTests`.
+///
+/// Declaring the protocol on the *consuming* (Accounts) side — implemented from
+/// the Downloads side above — is deliberate: at the 3a package move this file
+/// travels into `PalaceAccounts`, and SwiftPM then makes the acyclicity
+/// compiler-enforced (a packaged `AccountsManager` cannot name the app-target
+/// `MyBooksDownloadCenter`; the concrete resetter stays app-side composition).
+///
+/// `Sendable`: the resetter is stored on `AccountsManager` (`@unchecked
+/// Sendable`) and invoked from its account-switch cleanup; conformers hold no
+/// mutable state (the adapter forwards to a static), so `Sendable` is honest.
+protocol BorrowReauthResetting: Sendable {
+    /// Clears ALL books' borrow-reauth circuit-breaker state. Called on a
+    /// library switch so stale, tripped breaker entries from the previous
+    /// library cannot suppress legitimate re-auth attempts under the new one.
+    func clearAllBorrowReauthState()
+}

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -631,7 +631,13 @@ struct AppContainer: @unchecked Sendable {
         // background `loadCatalogs` the initializer dispatches. Do NOT reintroduce
         // a synchronous full-account preload here — `production()` must return
         // without paying the ~207ms (fast sim) / ~0.3-0.6s (device) full decode.
-        let accountsManager = AccountsManager()
+        // Wave 3 S1: inject the account-switch borrow-reauth circuit-breaker
+        // reset explicitly (no-default-fires house rule) rather than relying on
+        // AccountsManager's real default arg. `DownloadCenterBorrowReauthResetter`
+        // is a stateless struct that forwards to a static, so it needs no MBDC
+        // instance — no construction-order hazard even though MBDC is built later
+        // in this method.
+        let accountsManager = AccountsManager(borrowReauthResetter: DownloadCenterBorrowReauthResetter())
         // Single image-loading umbrella composed of the existing disk+memory
         // ImageCache and the TPPBookCoverRegistry actor — replaces three
         // overlapping singletons at consumer sites (Track A of the 3.2.0

--- a/Palace/MyBooks/DownloadCenterBorrowReauthResetter.swift
+++ b/Palace/MyBooks/DownloadCenterBorrowReauthResetter.swift
@@ -1,0 +1,27 @@
+//
+//  DownloadCenterBorrowReauthResetter.swift
+//  Palace
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+/// App-side adapter conforming the MyBooks download subsystem to the
+/// Accounts-declared `BorrowReauthResetting` seam (god-class decomposition
+/// Wave 3, S1). Forwards the account-switch reset to the existing static
+/// `MyBooksDownloadCenter.clearAllBorrowReauthState()`
+/// (→ `BorrowOperation.clearAllBorrowReauthState()` → `reauthTracker.clearAll()`).
+///
+/// This is the concrete `BorrowReauthResetting` `AccountsManager` receives by
+/// default and that `AppContainer` wires explicitly. It is a stateless struct
+/// that calls a static, so it needs no `MyBooksDownloadCenter` instance — which
+/// is why injecting it into `AccountsManager` (constructed before MBDC in
+/// `_buildCachedAppContainer`) has no construction-order hazard. At the 3b
+/// package move this adapter stays app-target composition; the protocol it
+/// conforms to travels into PalaceAccounts with `AccountsManager` at 3a.
+struct DownloadCenterBorrowReauthResetter: BorrowReauthResetting {
+    func clearAllBorrowReauthState() {
+        MyBooksDownloadCenter.clearAllBorrowReauthState()
+    }
+}

--- a/PalaceTests/Accounts/BorrowReauthResettingTests.swift
+++ b/PalaceTests/Accounts/BorrowReauthResettingTests.swift
@@ -1,0 +1,342 @@
+//
+//  BorrowReauthResettingTests.swift
+//  PalaceTests
+//
+//  god-class decomposition Wave 3, seam S1 — the ONE hard, un-inverted
+//  Accounts→Downloads STATIC edge, now injected via `BorrowReauthResetting`.
+//
+//  WHAT THIS PINS
+//  ==============
+//  `AccountsManager.cleanupActiveContentBeforeAccountSwitch(from:to:)` clears the
+//  process-global per-book borrow-reauth circuit breaker on every real library
+//  switch. Wave 3 S1 replaces the static
+//  `MyBooksDownloadCenter.clearAllBorrowReauthState()` call with an injected
+//  `borrowReauthResetter.clearAllBorrowReauthState()`. This suite pins:
+//
+//   1. On a real A→B switch the injected resetter is invoked EXACTLY ONCE, and
+//      the invocation is ordered BEFORE the async navigation cleanup completes
+//      (isAccountSwitching still true, i.e. the clear is synchronous in the
+//      setter, not deferred to the async Task) — spy injection.
+//   2. A redundant same-account reassignment (B→B) does NOT invoke the resetter
+//      (the switch-detection guard) — spy injection.
+//   3. A switch to a nil account (leaving a library) DOES invoke the resetter.
+//   4. END-TO-END WIRING: an `AccountsManager` using the REAL default resetter
+//      (`DownloadCenterBorrowReauthResetter`, the same one `AppContainer` wires)
+//      actually resets `BorrowOperation`'s breaker across a switch — a book whose
+//      breaker has tripped is offered re-auth AGAIN after the switch. This closes
+//      the "forgot to wire a real resetter" gap the default arg would otherwise
+//      mask: a no-op default (FORBIDDEN) or a dropped :995 call fails this test.
+//
+//  The breaker behavior itself (trip on 2nd auth-error, per-book keying, global
+//  clear) is pinned separately by the write-ahead
+//  `AccountSwitchBorrowReauthCouplingContractTests`. Contract 4 here observes it
+//  ONLY as the money-path proof that the injected/default resetter is real.
+//
+//  DETERMINISM: no sleeps, no network. The new account is NOT registered in
+//  `accountSets`, so the setter's `driveCurrentAccountAuthDocIfNeeded()` resolves
+//  nil and fires no network fetch. `fetchBook` throws synchronously; the sign-in
+//  modal completion is recorded but never invoked (no retry recursion). Per-test
+//  isolated `UserDefaults` keeps `currentAccountIdentifierKey` off `.standard`.
+//  The process-global breaker is cleared in setUp AND tearDown.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+import PalaceBookModel
+
+@MainActor
+final class BorrowReauthResettingTests: PalaceWiringTestCase {
+
+    // MARK: - Spy
+
+    /// Records how many times the account-switch reset seam fires. `@unchecked
+    /// Sendable` (the protocol requires `Sendable`); the counter is guarded by a
+    /// lock, though every invocation in these tests is synchronous on the main
+    /// thread inside the `currentAccount` setter.
+    private final class SpyBorrowReauthResetter: BorrowReauthResetting, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _callCount = 0
+        var callCount: Int { lock.withLock { _callCount } }
+        func clearAllBorrowReauthState() { lock.withLock { _callCount += 1 } }
+    }
+
+    // MARK: - Lifecycle
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Start from a clean process-global breaker so Contract 4 can't inherit a
+        // pre-tripped entry from a prior suite.
+        BorrowOperation.clearAllBorrowReauthState()
+    }
+
+    override func tearDownWithError() throws {
+        // Do not leak a tripped breaker into downstream suites.
+        BorrowOperation.clearAllBorrowReauthState()
+        // Directly-constructed (spy-path) managers aren't tracked by the base's
+        // private list, so cancel their background work here. Idempotent.
+        for manager in managersToCancel {
+            manager.cancelBackgroundWork()
+        }
+        managersToCancel.removeAll()
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Contract 1: real switch A→B invokes the resetter exactly once, before async nav cleanup
+
+    /// On a real library switch the injected resetter fires exactly once, and it
+    /// fires SYNCHRONOUSLY in the setter — before the async navigation cleanup
+    /// Task (which resets `isAccountSwitching`) has completed. We assert both
+    /// facts at the instant the synchronous assignment returns.
+    ///
+    /// Kill cases:
+    ///  - Dropping the `borrowReauthResetter.clearAllBorrowReauthState()` call
+    ///    (:995) → callCount == 0 → fail.
+    ///  - Calling it twice → callCount == 2 → fail.
+    ///  - Moving the clear into the async nav-cleanup Task → at return callCount
+    ///    would still be 0 (Task not yet run) → fail.
+    func testSwitch_AtoB_invokesResetterExactlyOnce_beforeAsyncNavCleanup() {
+        let aUUID = "urn:uuid:s1-A-\(UUID().uuidString)"
+        let bUUID = "urn:uuid:s1-B-\(UUID().uuidString)"
+        let accountB = Self.makeAccount(uuid: bUUID)
+
+        let spy = SpyBorrowReauthResetter()
+        let defaults = Self.testUserDefaults()
+        defaults.set(aUUID, forKey: currentAccountIdentifierKey)
+        let manager = makeManager(defaults: defaults, resetter: spy)
+
+        // Act — synchronous.
+        manager.currentAccount = accountB
+
+        XCTAssertEqual(spy.callCount, 1,
+                       "A real A→B switch must invoke the borrow-reauth resetter exactly once")
+        XCTAssertTrue(manager.isAccountSwitching,
+                      "The reset must fire synchronously in the setter, before the async nav cleanup resets isAccountSwitching")
+
+        AccountStateStore.shared.reset(for: aUUID)
+        AccountStateStore.shared.reset(for: bUUID)
+    }
+
+    // MARK: - Contract 2: redundant reassignment B→B does NOT invoke the resetter
+
+    /// Reassigning the SAME account is not a switch — the cleanup block (and its
+    /// breaker clear) must not run, or every redundant reassignment would wipe
+    /// in-flight breaker state.
+    ///
+    /// Kill case: dropping the `previousAccountId != newAccountId` guard on the
+    /// switch-detection block → the resetter fires on B→B → callCount == 1 → fail.
+    func testReassign_BtoB_doesNotInvokeResetter() {
+        let bUUID = "urn:uuid:s1-BB-\(UUID().uuidString)"
+        let accountB = Self.makeAccount(uuid: bUUID)
+
+        let spy = SpyBorrowReauthResetter()
+        let defaults = Self.testUserDefaults()
+        defaults.set(bUUID, forKey: currentAccountIdentifierKey)
+        let manager = makeManager(defaults: defaults, resetter: spy)
+
+        manager.currentAccount = accountB
+
+        XCTAssertEqual(spy.callCount, 0,
+                       "A redundant B→B reassignment must NOT invoke the borrow-reauth resetter")
+
+        AccountStateStore.shared.reset(for: bUUID)
+    }
+
+    // MARK: - Contract 3: switch to nil (leaving a library) invokes the resetter
+
+    /// Deselecting the current library (A→nil) is a real switch away from A and
+    /// must clear the breaker so a later reselect starts with a fresh breaker.
+    ///
+    /// Kill case: narrowing the switch-detection guard to require a non-nil NEW
+    /// account → A→nil would skip the clear → callCount == 0 → fail.
+    func testSwitch_AtoNil_invokesResetter() {
+        let aUUID = "urn:uuid:s1-Anil-\(UUID().uuidString)"
+
+        let spy = SpyBorrowReauthResetter()
+        let defaults = Self.testUserDefaults()
+        defaults.set(aUUID, forKey: currentAccountIdentifierKey)
+        let manager = makeManager(defaults: defaults, resetter: spy)
+
+        manager.currentAccount = nil
+
+        XCTAssertEqual(spy.callCount, 1,
+                       "Leaving a library (A→nil) must invoke the borrow-reauth resetter exactly once")
+
+        AccountStateStore.shared.reset(for: aUUID)
+    }
+
+    // MARK: - Contract 4: the REAL default resetter actually resets the breaker across a switch
+
+    /// End-to-end money-path proof. Using an `AccountsManager` with the REAL
+    /// default `DownloadCenterBorrowReauthResetter` (the exact resetter
+    /// `AppContainer` wires), a book whose per-book breaker has TRIPPED
+    /// (2nd auth-error borrow suppressed to a generic alert) is offered re-auth
+    /// AGAIN after a library switch — proving the default/wired resetter really
+    /// reaches `BorrowOperation.reauthTracker.clearAll()`.
+    ///
+    /// Kill cases:
+    ///  - A no-op default resetter (FORBIDDEN) → attempt 3 stays suppressed →
+    ///    sequence [modal, alert, alert] ≠ [modal, alert, modal] → fail.
+    ///  - Dropping the :995 clear call → same drift → fail.
+    func testRealDefaultResetter_acrossSwitch_reenablesReauthForTrippedBook() async {
+        let log = CallLog()
+        let userAccount = Self.noCredentialsNeedsAuthAccount()
+        let book = Self.book(identifier: "s1-reauth-reenable")
+        let op = Self.makeBorrowOperation(userAccount: userAccount,
+                                          bookIdentifier: book.identifier,
+                                          log: log)
+
+        // Trip the breaker for this book: attempt 1 → sign-in modal, attempt 2 →
+        // breaker suppresses re-auth → generic alert.
+        await Self.borrowExpectingThrow(op, book)
+        await Self.borrowExpectingThrow(op, book)
+
+        // Drive a real A→B switch on a manager using the REAL default resetter.
+        // Its `cleanupActiveContentBeforeAccountSwitch` invokes
+        // DownloadCenterBorrowReauthResetter → MyBooksDownloadCenter →
+        // BorrowOperation.clearAllBorrowReauthState() on the same process-global
+        // tracker `op` reads.
+        let aUUID = "urn:uuid:s1-C4-A-\(UUID().uuidString)"
+        let bUUID = "urn:uuid:s1-C4-B-\(UUID().uuidString)"
+        let accountB = Self.makeAccount(uuid: bUUID)
+        let defaults = Self.testUserDefaults()
+        defaults.set(aUUID, forKey: currentAccountIdentifierKey)
+        // No `resetter:` arg → the production default DownloadCenterBorrowReauthResetter.
+        let manager = makeFreshAccountsManager(defaults: defaults)
+        manager.currentAccount = accountB
+
+        // Attempt 3 for the SAME book: breaker was cleared → re-auth offered again.
+        await Self.borrowExpectingThrow(op, book)
+
+        let expected = [
+            CallRecord(method: "presentSignInModal", args: ["book": book.identifier]),
+            CallRecord(method: "presentBorrowErrorAlert", args: ["book": book.identifier]),
+            CallRecord(method: "presentSignInModal", args: ["book": book.identifier]),
+        ]
+        XCTAssertEqual(log.snapshot(), expected,
+                       "The real/default resetter must reset BorrowOperation's breaker across an account switch, so the tripped book is offered re-auth again (3rd attempt = modal, not alert)")
+
+        AccountStateStore.shared.reset(for: aUUID)
+        AccountStateStore.shared.reset(for: bUUID)
+    }
+
+    // MARK: - Manager helper (spy injection)
+
+    /// Construct a fresh `AccountsManager` with an injected resetter and per-test
+    /// defaults, pinning the background-loadCatalogs opt-out (like the base's
+    /// `makeFreshAccountsManager`) and registering it for teardown cancellation.
+    private func makeManager(defaults: UserDefaults, resetter: any BorrowReauthResetting) -> AccountsManager {
+        #if DEBUG
+        AccountsManager.deferInitialLoadCatalogsForTesting = true
+        #endif
+        let manager = AccountsManager(defaults: defaults, borrowReauthResetter: resetter)
+        managersToCancel.append(manager)
+        return manager
+    }
+
+    /// Directly-constructed managers (spy path) aren't tracked by the base's
+    /// private list; `tearDownWithError` cancels their background work.
+    private var managersToCancel: [AccountsManager] = []
+
+    // MARK: - Account / book fixtures
+
+    /// Minimal account from a link-less publication; its `metadata.id` becomes the
+    /// account UUID. No `authentication_document` link → any drive is network-free.
+    private static func makeAccount(uuid: String) -> Account {
+        let metadata = OPDS2Publication.Metadata(
+            updated: Date(),
+            description: "S1 borrow-reauth resetter",
+            id: uuid,
+            title: "S1 Account \(uuid.suffix(6))"
+        )
+        let publication = OPDS2Publication(links: [], metadata: metadata, images: nil)
+        return Account(publication: publication, imageCache: MockImageCache())
+    }
+
+    private static func book(identifier: String) -> TPPBook {
+        TPPBookMocker.mockBook(identifier: identifier, title: "Title-\(identifier)")
+    }
+
+    // MARK: - BorrowOperation harness (for Contract 4 — mirrors the write-ahead coupling suite)
+
+    /// A no-credentials account whose auth definition `needsAuth`, so a borrow
+    /// auth-error routes into the sign-in-modal recovery arm.
+    private static func noCredentialsNeedsAuthAccount() -> TPPUserAccountMock {
+        let account = TPPUserAccountMock()
+        account._credentials = nil
+        account._authDefinition = SyntheticBasicNeedsAuthS1.authentication
+        return account
+    }
+
+    /// Builds a `BorrowOperation` whose closure seams record into `log`. The
+    /// no-credentials + needs-auth account + a `fetchBook` that throws
+    /// `.network(.unauthorized)` route every borrow into the "no creds → sign-in
+    /// modal" arm, gated by the per-book circuit breaker. The modal completion is
+    /// recorded, never invoked — no retry recursion.
+    private static func makeBorrowOperation(
+        userAccount: TPPUserAccountMock,
+        bookIdentifier: String,
+        log: CallLog
+    ) -> BorrowOperation {
+        let callLog = log
+        let capturedBookId = bookIdentifier
+        let account = userAccount
+        let authError = PalaceError.network(.unauthorized)
+
+        return BorrowOperation(
+            bookRegistry: TPPBookRegistryMock(),
+            downloadAnnouncementService: DownloadAnnouncementService(),
+            errorActivityTracker: .shared,
+            debugSettings: DebugSettings(),
+            userRetryTracker: .shared,
+            userAccountProvider: { account },
+            adobeDRMService: AdobeDRMService.shared,
+            fetchBook: { _, _, _ in
+                throw authError
+            },
+            presentBorrowErrorAlert: { _, _, _, _, book, _ in
+                callLog.record("presentBorrowErrorAlert", args: ["book": book.identifier])
+            },
+            presentSignInModal: { _ in
+                callLog.record("presentSignInModal", args: ["book": capturedBookId])
+            },
+            attemptOIDCReauth: { false }
+        )
+    }
+
+    /// Drive one borrow and swallow the expected rethrow (auth-error borrows
+    /// always rethrow — both `.routeToReauth` and `.showGenericError` throw).
+    private static func borrowExpectingThrow(_ op: BorrowOperation, _ book: TPPBook) async {
+        do {
+            _ = try await op.borrowAsync(book, attemptDownload: false)
+            XCTFail("Auth-error borrow for '\(book.identifier)' must rethrow, not succeed")
+        } catch {
+            // expected
+        }
+    }
+}
+
+// MARK: - Local auth-definition fixture
+
+/// Basic-auth `AccountDetails.Authentication` (`needsAuth == true`,
+/// `isBrowserBased == false`) — routes borrow auth-errors into the
+/// no-credentials sign-in-modal arm. The OPDS2 memberwise init is internal to
+/// PalaceCatalog, so JSON round-trip is the supported construction path.
+private enum SyntheticBasicNeedsAuthS1 {
+    static var authentication: AccountDetails.Authentication {
+        let json = """
+        {
+          "type": "http://opds-spec.org/auth/basic",
+          "description": "Basic auth",
+          "labels": {"login": "Barcode", "password": "PIN"}
+        }
+        """
+        let docAuth = try! JSONDecoder().decode(
+            OPDS2AuthenticationDocument.Authentication.self,
+            from: Data(json.utf8)
+        )
+        return AccountDetails.Authentication(auth: docAuth)
+    }
+}

--- a/PalaceTests/Accounts/BorrowReauthResettingTests.swift
+++ b/PalaceTests/Accounts/BorrowReauthResettingTests.swift
@@ -73,14 +73,10 @@ final class BorrowReauthResettingTests: PalaceWiringTestCase {
     }
 
     override func tearDownWithError() throws {
-        // Do not leak a tripped breaker into downstream suites.
+        // Do not leak a tripped breaker into downstream suites. Manager
+        // background-work cancellation is handled by the base (every manager is
+        // minted via `makeFreshAccountsManager`).
         BorrowOperation.clearAllBorrowReauthState()
-        // Directly-constructed (spy-path) managers aren't tracked by the base's
-        // private list, so cancel their background work here. Idempotent.
-        for manager in managersToCancel {
-            manager.cancelBackgroundWork()
-        }
-        managersToCancel.removeAll()
         try super.tearDownWithError()
     }
 
@@ -105,7 +101,7 @@ final class BorrowReauthResettingTests: PalaceWiringTestCase {
         let spy = SpyBorrowReauthResetter()
         let defaults = Self.testUserDefaults()
         defaults.set(aUUID, forKey: currentAccountIdentifierKey)
-        let manager = makeManager(defaults: defaults, resetter: spy)
+        let manager = makeFreshAccountsManager(defaults: defaults, borrowReauthResetter: spy)
 
         // Act — synchronous.
         manager.currentAccount = accountB
@@ -134,7 +130,7 @@ final class BorrowReauthResettingTests: PalaceWiringTestCase {
         let spy = SpyBorrowReauthResetter()
         let defaults = Self.testUserDefaults()
         defaults.set(bUUID, forKey: currentAccountIdentifierKey)
-        let manager = makeManager(defaults: defaults, resetter: spy)
+        let manager = makeFreshAccountsManager(defaults: defaults, borrowReauthResetter: spy)
 
         manager.currentAccount = accountB
 
@@ -157,7 +153,7 @@ final class BorrowReauthResettingTests: PalaceWiringTestCase {
         let spy = SpyBorrowReauthResetter()
         let defaults = Self.testUserDefaults()
         defaults.set(aUUID, forKey: currentAccountIdentifierKey)
-        let manager = makeManager(defaults: defaults, resetter: spy)
+        let manager = makeFreshAccountsManager(defaults: defaults, borrowReauthResetter: spy)
 
         manager.currentAccount = nil
 
@@ -221,24 +217,6 @@ final class BorrowReauthResettingTests: PalaceWiringTestCase {
         AccountStateStore.shared.reset(for: aUUID)
         AccountStateStore.shared.reset(for: bUUID)
     }
-
-    // MARK: - Manager helper (spy injection)
-
-    /// Construct a fresh `AccountsManager` with an injected resetter and per-test
-    /// defaults, pinning the background-loadCatalogs opt-out (like the base's
-    /// `makeFreshAccountsManager`) and registering it for teardown cancellation.
-    private func makeManager(defaults: UserDefaults, resetter: any BorrowReauthResetting) -> AccountsManager {
-        #if DEBUG
-        AccountsManager.deferInitialLoadCatalogsForTesting = true
-        #endif
-        let manager = AccountsManager(defaults: defaults, borrowReauthResetter: resetter)
-        managersToCancel.append(manager)
-        return manager
-    }
-
-    /// Directly-constructed managers (spy path) aren't tracked by the base's
-    /// private list; `tearDownWithError` cancels their background work.
-    private var managersToCancel: [AccountsManager] = []
 
     // MARK: - Account / book fixtures
 

--- a/PalaceTests/Support/PalaceWiringTestCase.swift
+++ b/PalaceTests/Support/PalaceWiringTestCase.swift
@@ -215,6 +215,26 @@ class PalaceWiringTestCase: PalaceTestCase {
         return manager
     }
 
+    /// DI-aware overload that also injects the account-switch borrow-reauth reset
+    /// seam (`BorrowReauthResetting`, Wave 3 S1). Routes bare `AccountsManager`
+    /// construction through this whitelisted helper so a spy-injected switch test
+    /// still gets the `loadCatalogs` opt-out pin + tearDown cancellation, keeping
+    /// it off the `AccountsManagerIsolationLint` bare-construction ban.
+    @discardableResult
+    nonisolated func makeFreshAccountsManager(
+        defaults: UserDefaults,
+        borrowReauthResetter: any BorrowReauthResetting,
+        _ configure: (AccountsManager) -> Void = { _ in }
+    ) -> AccountsManager {
+        #if DEBUG
+        AccountsManager.deferInitialLoadCatalogsForTesting = true
+        #endif
+        let manager = AccountsManager(defaults: defaults, borrowReauthResetter: borrowReauthResetter)
+        configure(manager)
+        managersToCancelOnTearDown.append(manager)
+        return manager
+    }
+
     // MARK: - Disk-cache cleanup
 
     /// Remove every on-disk catalog/auth/crawl cache file in the test

--- a/scripts/godclass-loc-baseline.txt
+++ b/scripts/godclass-loc-baseline.txt
@@ -24,8 +24,16 @@
 #     replacing one declaration line with a 5-line explanatory comment + the plain
 #     declaration. Verified extraction-mechanical: no logic added (git diff = comment
 #     + protocol-keyword change only).
+# Wave 3 S1 (+11 on AccountsManager, 2321 -> 2332): the account-switch borrow-reauth
+#   circuit-breaker reset was INVERTED behind the injected `BorrowReauthResetting` seam
+#   (new `private let borrowReauthResetter` + its init param + a 3-line doc). This is the
+#   decomposition inversion itself, not reliability accretion — the residual growth is a
+#   stored dependency + minimal docs (the rationale lives in the new, unfrozen
+#   BorrowReauthResetting.swift). Nets strongly NEGATIVE at the 3a package move, when the
+#   MyBooksDownloadCenter static call site and its cluster leave the hub. Re-baselined by
+#   the exact delta; the freeze still catches any further unrelated growth.
 2764 Palace/Audiobooks/AudiobookSessionManager.swift
-2321 Palace/Accounts/Library/AccountsManager.swift
+2332 Palace/Accounts/Library/AccountsManager.swift
 2170 Palace/MyBooks/MyBooksDownloadCenter.swift
 1378 Palace/Book/UI/BookDetail/BookDetailViewModel.swift
 1124 Palace/SignInLogic/TPPSignInBusinessLogic.swift


### PR DESCRIPTION
## What

God-class decomposition **Wave 3, seam S1** — inverts the ONE hard, un-inverted
`Accounts → Downloads` static edge behind an injected `BorrowReauthResetting`
seam. **Critical-path (money-path):** the account-switch borrow-reauth
circuit-breaker reset.

On every real library switch, `AccountsManager.cleanupActiveContentBefore
AccountSwitch` cleared the process-global per-book borrow-reauth circuit breaker
(`BorrowOperation.reauthTracker`) via the static
`MyBooksDownloadCenter.clearAllBorrowReauthState()`. If that clear is ever
dropped, a user who switches libraries after a failed borrow is silently stuck
on the generic-error path with no re-auth prompt. This PR makes the edge
**injected** so the clear is spy-testable and the `Accounts → MyBooks` type
reference is reduced to the init default-arg expression, which dies mechanically
at the 3a package move.

## Changes

- **New** `Palace/Accounts/Library/BorrowReauthResetting.swift` —
  `protocol BorrowReauthResetting: Sendable`, declared on the *consuming*
  (Accounts) side; travels into `PalaceAccounts` at 3a (acyclicity becomes
  compiler-enforced there).
- **New** `Palace/MyBooks/DownloadCenterBorrowReauthResetter.swift` — app-side
  adapter forwarding to `MyBooksDownloadCenter.clearAllBorrowReauthState()`.
- `AccountsManager` — new `private let borrowReauthResetter`; `:995` becomes
  `borrowReauthResetter.clearAllBorrowReauthState()`; init param defaults to a
  **REAL** `DownloadCenterBorrowReauthResetter()` (behavior-identical for ~135
  test constructions; a no-op default would silently drop a money-path clear and
  is forbidden).
- `AppContainer._buildCachedAppContainer` — wires the resetter **explicitly**
  (no-default-fires house rule); no construction-order hazard (adapter calls a
  static, needs no MBDC instance).
- `scripts/godclass-loc-baseline.txt` — AccountsManager re-baselined +11
  (2321 → 2332) with a documented justification, per the Wave 1a/2a/2b precedent
  for decomposition-mechanical growth. `.shared` and locator ratchets
  unchanged / down.
- pbxproj — 2 new prod files added to **both** `Palace` and `Palace-noDRM`; the
  test file to `PalaceTests`.

## Tests (`PalaceTests/Accounts/BorrowReauthResettingTests.swift`)

1. Spy-injected: real A→B switch invokes the resetter **exactly once**, ordered
   **before** the async nav cleanup (`isAccountSwitching` still true).
2. B→B reassignment does **not** invoke the resetter (guard mutant).
3. A→nil (leaving a library) **does** invoke the resetter.
4. **End-to-end money-path proof:** an `AccountsManager` using the REAL default
   resetter actually resets `BorrowOperation`'s breaker across a switch — a
   tripped book is re-offered re-auth (`[modal, alert, modal]`), observed
   behaviorally through `borrowAsync`. Closes the "forgot to wire a real
   resetter" gap the default arg would otherwise mask.

**Mutation:** neutering the `:995` clear fails 3 of 4 tests (B→B correctly
unaffected). Kill confirmed on the load-bearing line.

## Verification

- `Palace` + `Palace-noDRM` clean builds green (fresh derivedDataPath);
  noDRM installs and launches on the simulator (no crash — Findaway lesson).
- 4/4 new tests green; full-suite CI-parity run
  (`-retry-tests-on-failure -test-iterations 3`) executed.
- Ratchet gates pass: godclass-loc-freeze, shared-read-count,
  appcontainer-locator-count.
- SoD review: architect + qa_test + blast_radius (heka).

## Scope / not done

- **S1 only.** S2 (`DownloadAccountScopeProviding` / credential surface), S3
  (locator kills in the switch-cleanup path), and the 3a/3b package moves are
  separate PRs per the Wave 3 brief.
- The byte-identical check against the write-ahead
  `AccountSwitchBorrowReauthCouplingContractTests` happens once both that suite
  and this land (it is not yet on develop).

Wave 3 seam S1. Do not merge until CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
