### PR TITLE
fix(registry): purge .bak + quarantine sidecars on sign-out (port of 3.2.3 build 490)

### DIFF
--- a/Palace/Packages/PalaceBookRegistry/Sources/PalaceBookRegistry/BookRegistrySync.swift
+++ b/Palace/Packages/PalaceBookRegistry/Sources/PalaceBookRegistry/BookRegistrySync.swift
@@ -788,7 +788,13 @@ final class BookRegistrySync: @unchecked Sendable {
       } catch {
         Log.error(#file, "Error deleting registry data: \(error.localizedDescription)")
       }
+      // Also drop the sidecars (last-good `.bak` + `.corrupt-<ts>` quarantine
+      // copies). Deleting only the primary left the signed-out patron's whole
+      // shelf readable on disk and recoverable into the next patron's session
+      // at the same library. Ported from the 3.2.3 build-490 hotfix.
+      RegistryFileRecovery.purgeSidecars(for: registryUrl)
     }
+    needsRebuildFromServer = false
   }
 
   /// Decides whether a sync() reconciliation should skip deleting books that

--- a/Palace/Packages/PalaceBookRegistry/Sources/PalaceBookRegistry/RegistryFileRecovery.swift
+++ b/Palace/Packages/PalaceBookRegistry/Sources/PalaceBookRegistry/RegistryFileRecovery.swift
@@ -172,6 +172,34 @@ enum RegistryFileRecovery {
     try FileManager.default.moveItem(at: tempURL, to: backup)
   }
 
+  /// Deletes every sidecar this type creates for `registryURL`: the last-good
+  /// `.bak` backup and any `.corrupt-<timestamp>` quarantine copies.
+  ///
+  /// Called from `BookRegistrySync.reset(_:)` — the sign-out / force-reset /
+  /// "delete server data" path — which otherwise removed only the PRIMARY file.
+  /// Leaving the sidecars behind kept a signed-out patron's entire shelf
+  /// (titles, identifiers, reading positions) readable on disk indefinitely,
+  /// kept `onDiskHasRecords` true after sign-out, and left the corrupt-primary
+  /// recovery path able to restore the PREVIOUS patron's books into the next
+  /// patron's session at the same library (same account UUID → same path).
+  ///
+  /// Best-effort and silent: reset is a cleanup path, and a sidecar that is
+  /// already absent (or unreadable) must not fail the sign-out.
+  static func purgeSidecars(for registryURL: URL) {
+    let fileManager = FileManager.default
+    try? fileManager.removeItem(at: backupURL(for: registryURL))
+
+    // Quarantine copies are `registry.json.corrupt-<unix-timestamp>`, so there
+    // may be several from repeated corruption. Match on the prefix rather than
+    // reconstructing timestamps we no longer know.
+    let directory = registryURL.deletingLastPathComponent()
+    let quarantinePrefix = registryURL.lastPathComponent + ".corrupt-"
+    guard let entries = try? fileManager.contentsOfDirectory(atPath: directory.path) else { return }
+    for entry in entries where entry.hasPrefix(quarantinePrefix) {
+      try? fileManager.removeItem(at: directory.appendingPathComponent(entry))
+    }
+  }
+
   /// The records recoverable from the `.bak` backup, or `nil` when there is no
   /// backup, it is unreadable, corrupt, or valid-but-empty. Only a NON-empty
   /// valid backup is a usable recovery source.

--- a/PalaceTests/Book/BookRegistrySyncTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncTests.swift
@@ -402,6 +402,48 @@ final class BookRegistrySyncTests: XCTestCase {
         XCTAssertNil(syncManager.syncUrl)
     }
 
+    /// The registry has two on-disk SIDECARS next to `registry.json`: the
+    /// last-good `.bak` written before every good save, and `.corrupt-<ts>`
+    /// quarantine copies. `reset(_:)` — the sign-out / force-reset / "delete
+    /// server data" path — deleted only the PRIMARY, so a signed-out patron's
+    /// entire shelf (titles, identifiers, reading positions) stayed readable on
+    /// disk indefinitely. It also kept `RegistryFileRecovery.onDiskHasRecords`
+    /// true after sign-out, and left the corrupt-primary recovery path able to
+    /// restore the PREVIOUS patron's books into the next patron's session at
+    /// the same library (same account UUID → same registry path).
+    ///
+    /// Verified live on the 3.2.3 hotfix line: after sign-out + relaunch,
+    /// `registry.json` was gone but `registry.json.bak` still held all 9 of the
+    /// signed-out patron's records. Ported here from build 490.
+    func test_reset_removesBackupAndQuarantineSidecars() throws {
+        let (account, url) = makeIsolatedAccount()
+        defer { cleanupAccount(url) }
+
+        let book = makeBook(identifier: "r-sidecar")
+        let record = TPPBookRegistryRecord(book: book, state: .downloadNeeded)
+        try writeRegistryFile(records: [record.dictionaryRepresentation], to: url)
+
+        let backup = RegistryFileRecovery.backupURL(for: url)
+        try Data(contentsOf: url).write(to: backup)
+        let quarantine = RegistryFileRecovery.quarantineURL(
+            for: url,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        try Data("{ truncated".utf8).write(to: quarantine)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backup.path), "setup: .bak present")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: quarantine.path), "setup: quarantine present")
+
+        syncManager.reset(account)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path),
+                       "reset must delete the primary registry file")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path),
+                       "reset must delete the last-good .bak — otherwise a signed-out patron's shelf persists on disk and can be recovered into the next patron's session")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: quarantine.path),
+                       "reset must prune quarantined corrupt registry copies rather than accumulate them forever")
+    }
+
     // MARK: - checkIfBookFileExists
 
     func test_checkIfBookFileExists_returnsFalseForUnknownBook() {

--- a/PalaceTests/Book/RegistryFileRecoveryTests.swift
+++ b/PalaceTests/Book/RegistryFileRecoveryTests.swift
@@ -238,4 +238,51 @@ final class RegistryFileRecoveryTests: XCTestCase {
     XCTAssertNil(RegistryFileRecovery.recoverFromBackup(for: url),
                  "a corrupt backup must not be offered as a recovery source")
   }
+
+  // MARK: - purgeSidecars (sign-out / reset cleanup)
+
+  /// `reset(_:)` used to delete only the PRIMARY, leaving the signed-out
+  /// patron's whole shelf readable in the `.bak` — and recoverable into the
+  /// next patron's session at the same library. `purgeSidecars` must remove the
+  /// backup AND every accumulated quarantine copy, while leaving unrelated
+  /// files in the directory alone.
+  func testPurgeSidecars_removesBackupAndAllQuarantineCopies_leavingUnrelatedFiles() throws {
+    let url = registryURL()
+    write(versionedPayload(records: [recordDict(id: "keep")], version: 1), to: url)
+    write(versionedPayload(records: [recordDict(id: "leaked")], version: 1),
+          to: RegistryFileRecovery.backupURL(for: url))
+
+    // Two quarantine copies from repeated corruption — both must go.
+    let q1 = RegistryFileRecovery.quarantineURL(for: url, timestamp: Date(timeIntervalSince1970: 1_700_000_000))
+    let q2 = RegistryFileRecovery.quarantineURL(for: url, timestamp: Date(timeIntervalSince1970: 1_700_000_999))
+    write(Data("{ truncated".utf8), to: q1)
+    write(Data("{ truncated".utf8), to: q2)
+
+    // An unrelated neighbour that must survive.
+    let unrelated = url.deletingLastPathComponent().appendingPathComponent("other.json")
+    write(Data("{}".utf8), to: unrelated)
+
+    RegistryFileRecovery.purgeSidecars(for: url)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: RegistryFileRecovery.backupURL(for: url).path),
+                   "the last-good .bak must be deleted — it holds the signed-out patron's shelf")
+    XCTAssertFalse(FileManager.default.fileExists(atPath: q1.path),
+                   "quarantine copies must be pruned, not accumulated forever")
+    XCTAssertFalse(FileManager.default.fileExists(atPath: q2.path),
+                   "ALL quarantine copies must be pruned, not just the first match")
+    XCTAssertTrue(FileManager.default.fileExists(atPath: unrelated.path),
+                  "purgeSidecars must not touch unrelated files in the registry directory")
+  }
+
+  /// Cleanup path: purging when nothing is on disk must be a silent no-op, so a
+  /// sign-out never fails on an already-clean directory.
+  func testPurgeSidecars_withNoSidecarsPresent_isSilentNoOp() {
+    let url = registryURL()
+    write(versionedPayload(records: [recordDict(id: "solo")], version: 1), to: url)
+
+    RegistryFileRecovery.purgeSidecars(for: url)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
+                  "purgeSidecars must not delete the primary registry file")
+  }
 }


### PR DESCRIPTION
## What this is

`BookRegistrySync.reset(_:)` — the **sign-out** / force-reset / "delete server data" path — deletes only the primary `registry.json`. The sidecars added by the registry-resilience work (#1212) are left behind, so a **signed-out patron's entire shelf stays readable on disk indefinitely**.

Found while regression-testing the 3.2.3 hotfix line, and **verified live there**: after sign-out + relaunch, `registry.json` was gone but `registry.json.bak` still held all 9 of the signed-out patron's records (titles, identifiers, reading positions). With the fix, the registry directory is empty.

**develop has the identical defect independently** — it writes the `.bak` (`writeBackup`) but never purges it — so 3.3.0 ships it unless fixed here.

## Why this is a port, not a forward-port

Wave 2b moved these files into `Palace/Packages/PalaceBookRegistry/`, so the hotfix's `Palace/Book/Models/` change doesn't apply. Behavior and tests are identical to [build 490 on `main`](https://github.com/ThePalaceProject/ios-core/pull/1346).

## Change

New `RegistryFileRecovery.purgeSidecars(for:)` removes the `.bak` and every `.corrupt-<ts>` quarantine copy (prefix-matched — repeated corruption can leave several). Best-effort and silent: a cleanup path must not fail sign-out on an already-absent sidecar. `reset(_:)` calls it and clears `needsRebuildFromServer`.

## Severity — low, but worth fixing before it ships

- Data stays inside the app sandbox; the directory is `excludeFromBackup()`.
- An **absent** primary classifies `.empty` (no `.bak` recovery), so an ordinary sign-out → sign-in-as-someone-else does **not** resurface the old shelf.
- The cross-patron resurrection path is narrow: new patron at the same library saves zero books (so the `.bak` is still the old patron's) **and** the primary then corrupts.

It's fixed because it's cheap and the data-retention behavior is plainly wrong, not because there's evidence of patron harm — no support tickets found.

## Tests

- `testPurgeSidecars_removesBackupAndAllQuarantineCopies_leavingUnrelatedFiles` — two quarantine copies + an unrelated neighbour that must survive
- `testPurgeSidecars_withNoSidecarsPresent_isSilentNoOp`
- `test_reset_removesBackupAndQuarantineSidecars` — integration through the real `reset(_:)`

**59 tests across both suites: 0 failures.** `check-blast-radius` + `check-superpartner-spectrum` exit 0.

## Scope / not done

Sign-out cleanup only — no change to save/load, the INV-1 empty-save guard, or recovery behavior. The `.bak` write + fsync on every non-empty registry save remains an unmeasured perf risk on large shelves (pre-existing, separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
