### PR TITLE
feat(decomp): Downloads-owned account-context seams (Wave 3 S2)

### DIFF
--- a/.forgeos/intent/wave3-s2-download-account-context.md
+++ b/.forgeos/intent/wave3-s2-download-account-context.md
@@ -1,0 +1,59 @@
+# Intent — Wave 3 S2: Downloads-owned account-context seams
+
+**Slug:** wave3-s2-download-account-context
+**Branch:** feat/wave3-s2-download-account-context
+**Base:** chore/forward-port-main-to-develop @ 2a5c4cbd7 (stacked on #1348; S1 #1345 already landed)
+**Critical path:** YES — auth / credentials / download-file scoping.
+
+## Claims (what this diff does)
+
+1. Declares three **Downloads-owned** protocols + two package-local mirror enums in a new
+   app-target file `Palace/MyBooks/DownloadAccountContext.swift`, inverting the
+   Downloads→Accounts coupling **without** widening the registry's `AccountScopeProviding`
+   (PalaceBookRegistry stays untouched — Wave 3 §2 decision):
+   - `DownloadAccountScopeProviding: Sendable` — `currentAccountID`, `currentAccountAuthSurfaceHosts`
+   - `DownloadCredentialsProviding: Sendable` — `currentUserAccount()`, `userAccount(forAccount:)`
+   - `DownloadUserAccount: AnyObject, Sendable` — the credential/auth surface Downloads reads
+   - `DownloadReauthStrategy` (mirrors `AccountDetails.Authentication.ReauthStrategy`)
+   - `DownloadAuthState` (mirrors `TPPAccountAuthState`)
+2. `extension TPPUserAccount: DownloadUserAccount` (new file) with **exhaustive-switch** enum
+   adapters — a new upstream `ReauthStrategy`/`TPPAccountAuthState` case becomes a COMPILE error
+   here, not silent drift (§5 risk 3).
+3. `AccountsManagerDownloadContextAdapter` (new, `Palace/Accounts/Library/`) conforming to the two
+   providing protocols over the concrete `AccountsManager`. App-target composition; never leaks
+   `Account`/`AccountsManager`/`TPPUserAccount` as named types across the protocol boundary.
+4. AppContainer vends the adapter via a computed `downloadAccountContext` seam (stateless wrapper
+   over `self.accountsManager`; no new stored property, no init churn).
+5. Proves the seam by retyping the **smallest** consumer — `BookFileManager` — off the concrete
+   `AccountsManager` onto `any DownloadAccountScopeProviding`. Behavior byte-identical
+   (`currentAccountID` maps to `accountsManager.currentAccountId`, the exact defaults-backed read
+   BookFileManager used).
+
+## Anti-claims (what this diff deliberately does NOT do)
+
+- Does NOT widen or touch `AccountScopeProviding` / PalaceBookRegistry.
+- Does NOT retype `MyBooksDownloadCenter` (~15 read sites), BorrowOperation, the B7 closures, or
+  any other Downloads consumer — **DEFERRED to a follow-up PR** (interim adoption is incremental,
+  §2). Only `BookFileManager` is retyped here.
+- Does NOT move any type into a SwiftPM package (that is 3a/3b).
+- Does NOT change any runtime behavior — the retype and adapters are pure indirection.
+
+## Files in scope
+
+- NEW `Palace/MyBooks/DownloadAccountContext.swift`
+- NEW `Palace/Accounts/User/TPPUserAccount+DownloadUserAccount.swift`
+- NEW `Palace/Accounts/Library/AccountsManagerDownloadContextAdapter.swift`
+- NEW `PalaceTests/MyBooks/DownloadAccountContextAdapterTests.swift`
+- EDIT `Palace/AppInfrastructure/AppContainer.swift` (computed `downloadAccountContext`)
+- EDIT `Palace/MyBooks/BookFileManager.swift` (dep retype)
+- EDIT call sites passing `accountsManager:` to `BookFileManager(...)` — 3 prod + test sites
+  (wrap concrete `AccountsManager` in the adapter, or drop the redundant production default arg).
+
+## Signature deviations from the brief (verified against reality)
+
+- `DownloadUserAccount.authState` renamed to **`downloadAuthState`** — `TPPUserAccount` already
+  declares `var authState: TPPAccountAuthState`; a same-named `DownloadAuthState` property is an
+  invalid redeclaration. The mirror member is therefore `downloadAuthState`.
+- Adapter `currentAccountID` maps to `accountsManager.currentAccountId` (defaults-backed), NOT
+  `currentAccount?.uuid` — that is the exact read `BookFileManager` funnelled through; the two
+  diverge during a switch and only `currentAccountId` preserves behavior.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 		51B4D85037A44C1463C4418F /* ImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CCD6D02A703C447C36C65D /* ImageLoaderTests.swift */; };
 		524DF6EC46F70059471E3A77 /* MyBooksDownloadCenterAccountIdThreadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC176AE72CA93111D5E2B6C3 /* MyBooksDownloadCenterAccountIdThreadingTests.swift */; };
 		5290120E5AFA84BAFAD4F608 /* ReaderServicePDFRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF549655DE7026414C096C08 /* ReaderServicePDFRouteTests.swift */; };
+		52CD9C9FE87B37BDF0802E1D /* DownloadAccountContextAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B176B6F96E196C5CB2940D94 /* DownloadAccountContextAdapterTests.swift */; };
 		52E656FD2F1E4C8EF201059C /* SingletonResetRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63880885010BDEA019007D3A /* SingletonResetRegistryTests.swift */; };
 		5419E00285822EDBFB4ED932 /* SendableSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BD75A5447FB7BD0DA90F57 /* SendableSubject.swift */; };
 		54335D47FB665C8DAAA00BA5 /* AudiobookVendorRecoveryContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170477A29A88A56DDCF7CC50 /* AudiobookVendorRecoveryContractTests.swift */; };
@@ -500,6 +501,7 @@
 		585E75B6C33D67733D044B74 /* TPPSettingsAuthBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB91C36D9DC90CDAC98FA568 /* TPPSettingsAuthBridge.swift */; };
 		5884A9AE2BB0DE1946609A0B /* MockIsolationLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F5CC426CE615EF41ABC2E8 /* MockIsolationLintTests.swift */; };
 		58915F3DB0E19C97F3154DD3 /* ReaderEditingActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0446DDEE241612C3A2146A6 /* ReaderEditingActions.swift */; };
+		58961A9372B38C65858022FF /* TPPUserAccount+DownloadUserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E4C73FA0E390F45512CCD7 /* TPPUserAccount+DownloadUserAccount.swift */; };
 		58AF4A75D388F83A1F5B140B /* LCPLibraryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8568424DF6517B247D048D5D /* LCPLibraryServiceTests.swift */; };
 		592CA096DBCC547AD2470AD2 /* IsReaderActiveTrackingModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0E5A429454281B98614AA0 /* IsReaderActiveTrackingModifier.swift */; };
 		5944697470D242E08CB939D5 /* AccountsManagerCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D598423237C04DE7B3834ABC /* AccountsManagerCacheTests.swift */; };
@@ -587,6 +589,7 @@
 		6A6738A956F9F5305F33478C /* PositionWriterContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFAE8C1C6326EB2344FD99E /* PositionWriterContractTests.swift */; };
 		6A7C8D9E0F102132435465A0 /* BorrowErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596B7C8D9E0F10213243546F /* BorrowErrorPresenter.swift */; };
 		6A7C8D9E0F102132435465A8 /* BookSignInRedirectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B8D9E0F102132435465A1B9 /* BookSignInRedirectHandlerTests.swift */; };
+		6A926C1D3AC9D74518F44338 /* TPPUserAccount+DownloadUserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E4C73FA0E390F45512CCD7 /* TPPUserAccount+DownloadUserAccount.swift */; };
 		6AC0B57C7401ADE5ECFCD1F2 /* StringHTMLEntitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06784DE00D5161E7071843F0 /* StringHTMLEntitiesTests.swift */; };
 		6AD629A88EADF90A1230E517 /* Account+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7531D0BC80AF1F317534E80 /* Account+State.swift */; };
 		6B4524A7B4E7B404AB95EE4A /* AudiobookSessionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C03DB276DAE8ED383D25A /* AudiobookSessionPresenter.swift */; };
@@ -791,6 +794,7 @@
 		73FE59B37F16D1DD6CA6002A /* SignInModalSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8829DAED777C8EBAB199D77 /* SignInModalSheetPresenter.swift */; };
 		746E262BBCF7858203AD0E94 /* TokenRefreshInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085A2D3663F363348BE14190 /* TokenRefreshInterceptor.swift */; };
 		74E2FBEE352BB19421EABD2A /* AccountDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5171A2D51228EEF05D37CA /* AccountDetailsTests.swift */; };
+		750415F0CCAA268608A4422F /* AccountsManagerDownloadContextAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7171C65212AB50506BA53D3 /* AccountsManagerDownloadContextAdapter.swift */; };
 		7523580830BDE54F1195D17A /* stduritemplate in Frameworks */ = {isa = PBXBuildFile; productRef = 5E5E92EBF42CB6D733C398B0 /* stduritemplate */; };
 		75251AA51940997697E902BA /* StreamingReaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7846827A6CC273AC21EFC4D0 /* StreamingReaderViewController.swift */; };
 		75470B1D0B012E3D9C94E2F7 /* TPPAccountAuthStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84A55CE7F9823DCEFBAE90 /* TPPAccountAuthStateTests.swift */; };
@@ -1018,6 +1022,7 @@
 		A940C5845CFB8B9A7422E3DE /* PalaceFeatureFlags in Frameworks */ = {isa = PBXBuildFile; productRef = 7F1CB28D175A6A63406EF061 /* PalaceFeatureFlags */; };
 		A961D381DEBCF6341C9C7AA2 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA10178BD2885EBF24673F3 /* FontManager.swift */; };
 		A9701CD50E8850215EA9FD69 /* ReadingRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422FFD436DFCCB056CCF6302 /* ReadingRulerView.swift */; };
+		A99ED22868A0A1698801FDB0 /* AccountsManagerDownloadContextAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7171C65212AB50506BA53D3 /* AccountsManagerDownloadContextAdapter.swift */; };
 		AA225D8E76E146A5132FEA43 /* LCPKeychainMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A303E282D7EFD80AED446401 /* LCPKeychainMigration.swift */; };
 		AAAA00032ECCC53200CDA626 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = AAAA00012ECCC53200CDA626 /* SnapshotTesting */; };
 		AAB502EE6AB7156C9D7D5C19 /* NetworkRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F31B83CAB15F0245AEEE83C /* NetworkRetryTests.swift */; };
@@ -1203,6 +1208,7 @@
 		C7BA5AA8F4F0099226CE67F5 /* StreamingReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7955F7FD669DC987C9238D /* StreamingReaderViewModel.swift */; };
 		C7DFB8533719B493E14C6A56 /* LockIsolated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5192F4C62AA2DDC7E9752A5E /* LockIsolated.swift */; };
 		C7E59C3E09A16D6F9B65233F /* IntExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5A0D270E8AC2DDFBC62044 /* IntExtensionsTests.swift */; };
+		C8876BE8C4B5606146B6488C /* DownloadAccountContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A731B2809097BED1D69F274 /* DownloadAccountContext.swift */; };
 		C89594A0D21089924B82E71D /* TypographyServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1B8AF7EB40C9DE22ED5ED0 /* TypographyServiceProtocol.swift */; };
 		C8DC8F9202D050EEFBC61B4C /* SettingsSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551562029D888E2A48F22A52 /* SettingsSkeletonView.swift */; };
 		C911BB897D0420A06D49D6CA /* AnonymousBorrowFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB73BECBC7822AE7F95B941B /* AnonymousBorrowFixtureTests.swift */; };
@@ -1802,6 +1808,7 @@
 		E7FD4E52286CCF2C00D26A3B /* TPPPDFLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FD4E51286CCF2C00D26A3B /* TPPPDFLocation.swift */; };
 		E7FD4E54286CD0E000D26A3B /* TPPPDFLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FD4E53286CD0E000D26A3B /* TPPPDFLocationView.swift */; };
 		E7FFEAA62A745F600006030A /* ULID in Frameworks */ = {isa = PBXBuildFile; productRef = E7FFEAA52A745F600006030A /* ULID */; };
+		E80C5E70F16BB4B46EEDA432 /* DownloadAccountContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A731B2809097BED1D69F274 /* DownloadAccountContext.swift */; };
 		E80FAD5EFA9DBAF8CE8A1D18 /* UIView+TPPViewAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581C6B05F79FEB7A95DD4BA5 /* UIView+TPPViewAdditions.swift */; };
 		E861F14A001F228C7E96F790 /* KeyboardVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD71C8FF18A443133C015DA8 /* KeyboardVoiceOverTests.swift */; };
 		E91B4ADED23243A6914C3DEA /* PDFExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EA8E55783D47B7A773164F /* PDFExtensionsTests.swift */; };
@@ -2165,6 +2172,7 @@
 		091A2B3C4D5E6F708192A3B4 /* TPPCredentialSnapshotCoherenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPCredentialSnapshotCoherenceTests.swift; sourceTree = "<group>"; };
 		09CAC3762A717783DDE755DD /* AudiobookSessionManagerShutdownTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookSessionManagerShutdownTests.swift; sourceTree = "<group>"; };
 		09CF38F572AE4A88961FCA46 /* AudiobookIssueFixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookIssueFixTests.swift; sourceTree = "<group>"; };
+		0A731B2809097BED1D69F274 /* DownloadAccountContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadAccountContext.swift; sourceTree = "<group>"; };
 		0A8D27C47B505B4D77B12221 /* RatingCardMotionGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingCardMotionGateTests.swift; sourceTree = "<group>"; };
 		0ABB253AB7CB4183943EBA6A /* AccountStateStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountStateStore.swift; sourceTree = "<group>"; };
 		0B60466B2029331616A708B4 /* RatingPromptPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingPromptPresenter.swift; sourceTree = "<group>"; };
@@ -2759,6 +2767,7 @@
 		80D24086CF8BC2C596888CDA /* BookReturnServiceContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookReturnServiceContractTests.swift; sourceTree = "<group>"; };
 		80EA8E55783D47B7A773164F /* PDFExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFExtensionsTests.swift; sourceTree = "<group>"; };
 		810C0A1999902FEEE96BD07D /* AccountAuthSurfaceHostsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountAuthSurfaceHostsTests.swift; sourceTree = "<group>"; };
+		81E4C73FA0E390F45512CCD7 /* TPPUserAccount+DownloadUserAccount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "TPPUserAccount+DownloadUserAccount.swift"; sourceTree = "<group>"; };
 		8207C4AC28B2FA1774B6E827 /* AppLaunchTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchTrackerTests.swift; sourceTree = "<group>"; };
 		820FFFB90AD6CB0A124F6420 /* BookCellModelStreamingHTMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookCellModelStreamingHTMLTests.swift; sourceTree = "<group>"; };
 		821943DED462B52FCCF8555A /* ErrorLogging.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorLogging.swift; sourceTree = "<group>"; };
@@ -2940,6 +2949,7 @@
 		B004B00FB1D06292BE7578B9 /* ImageCacheContinuationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageCacheContinuationTests.swift; sourceTree = "<group>"; };
 		B0B284DD9A4739D34937C4D0 /* CatalogViewContinueRowsIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogViewContinueRowsIntegrationTests.swift; sourceTree = "<group>"; };
 		B16FBDE7626549B79736A665 /* TPPCredentialIsolationE2ETests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPCredentialIsolationE2ETests.swift; sourceTree = "<group>"; };
+		B176B6F96E196C5CB2940D94 /* DownloadAccountContextAdapterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadAccountContextAdapterTests.swift; sourceTree = "<group>"; };
 		B1A2B3C4D5E6F7A8B9C0D1E2 /* RedirectPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectPolicy.swift; sourceTree = "<group>"; };
 		B2024455DC09E38D5FA3CE21 /* CirculationAnalyticsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CirculationAnalyticsTests.swift; sourceTree = "<group>"; };
 		B2D4C9FAC4974D7D0F087712 /* LibrariesSectionViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LibrariesSectionViewModelTests.swift; sourceTree = "<group>"; };
@@ -2970,6 +2980,7 @@
 		B57489E1C2CE2DD11EFC1C03 /* CatalogModelsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogModelsTests.swift; sourceTree = "<group>"; };
 		B5D6A3DE24CC45D98F02DC98 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		B6EA859EE89F1644E98E4186 /* BackgroundSessionRoutingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundSessionRoutingTests.swift; sourceTree = "<group>"; };
+		B7171C65212AB50506BA53D3 /* AccountsManagerDownloadContextAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerDownloadContextAdapter.swift; sourceTree = "<group>"; };
 		B79DD7FF880843F7BE282614 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		B7A89DC26D262DB004F837CA /* DownloadReconciliationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadReconciliationTests.swift; sourceTree = "<group>"; };
 		B83C63AD7FC1676713DBCC77 /* CatalogDomainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogDomainTests.swift; sourceTree = "<group>"; };
@@ -4645,6 +4656,7 @@
 				0C1F974717220248950A874F /* BorrowReducerCore.swift */,
 				D132FB1FCA6430A16B5998DB /* MyBooksDownloadCenter+RegistryDownloadServicing.swift */,
 				A9381BBE0CE20B654B89FFCD /* DownloadCenterBorrowReauthResetter.swift */,
+				0A731B2809097BED1D69F274 /* DownloadAccountContext.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -4924,6 +4936,7 @@
 				9C80B4E151496CABF2F9D0EE /* AccountsManager+ProblemReportContext.swift */,
 				19F86127F411D9B44A7A6CB3 /* AccountsManagerAccountScopeAdapter.swift */,
 				4FC47AED382982103F213534 /* BorrowReauthResetting.swift */,
+				B7171C65212AB50506BA53D3 /* AccountsManagerDownloadContextAdapter.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -4942,6 +4955,7 @@
 				E75423242AFC381E008CB7EF /* UserProfileDocument+Links.swift */,
 				84756EEE7935063418887357 /* NYPLADEPT+TPPDRMAuthorizing.swift */,
 				2DA2444F7FCEF34F2D7BE23B /* TPPUserAccount+TPPUserAccountReadingWriting.swift */,
+				81E4C73FA0E390F45512CCD7 /* TPPUserAccount+DownloadUserAccount.swift */,
 			);
 			path = User;
 			sourceTree = "<group>";
@@ -5934,6 +5948,7 @@
 				060E761D281D979E3359C83A /* LoanRenewalServiceTests.swift */,
 				AA3C44FFE90B7C54E0D99025 /* RegistryDownloadServicingSeamTests.swift */,
 				9B0842274F19EF54B4FC5686 /* BookFileManagerAccountScopingTests.swift */,
+				B176B6F96E196C5CB2940D94 /* DownloadAccountContextAdapterTests.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -8004,6 +8019,7 @@
 				D26888D2C9A2BB133EBD5526 /* AudiobookBearerTokenRecoveryTests.swift in Sources */,
 				AB2801CCF1699315F888F6D0 /* AudiobookContentGateTests.swift in Sources */,
 				54335D47FB665C8DAAA00BA5 /* AudiobookVendorRecoveryContractTests.swift in Sources */,
+				52CD9C9FE87B37BDF0802E1D /* DownloadAccountContextAdapterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8564,6 +8580,9 @@
 				B00B6F2D1A05416F82D5474C /* TPPBookRegistry+ProductionInit.swift in Sources */,
 				B865C34CA9799A7AA0042BBF /* BorrowReauthResetting.swift in Sources */,
 				EF4CC725B5E70D77890C2A03 /* DownloadCenterBorrowReauthResetter.swift in Sources */,
+				C8876BE8C4B5606146B6488C /* DownloadAccountContext.swift in Sources */,
+				58961A9372B38C65858022FF /* TPPUserAccount+DownloadUserAccount.swift in Sources */,
+				A99ED22868A0A1698801FDB0 /* AccountsManagerDownloadContextAdapter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9127,6 +9146,9 @@
 				66C5BBEEAC56378BCD5C9879 /* TPPBookRegistry+ProductionInit.swift in Sources */,
 				81587C22AEEAB64E6D2824BD /* BorrowReauthResetting.swift in Sources */,
 				149DDAD13FD460B229CDD760 /* DownloadCenterBorrowReauthResetter.swift in Sources */,
+				E80C5E70F16BB4B46EEDA432 /* DownloadAccountContext.swift in Sources */,
+				6A926C1D3AC9D74518F44338 /* TPPUserAccount+DownloadUserAccount.swift in Sources */,
+				750415F0CCAA268608A4422F /* AccountsManagerDownloadContextAdapter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountsManagerDownloadContextAdapter.swift
+++ b/Palace/Accounts/Library/AccountsManagerDownloadContextAdapter.swift
@@ -1,0 +1,58 @@
+//
+//  AccountsManagerDownloadContextAdapter.swift
+//  Palace
+//
+//  Adapts the concrete `AccountsManager` to the Downloads-owned account-context
+//  seams (`DownloadAccountScopeProviding` + `DownloadCredentialsProviding`) —
+//  the B-side inversion of the Accounts↔Downloads hub pair (god-class
+//  decomposition Wave 3, S2). App-target composition: it is the only place the
+//  Downloads protocols and the concrete `AccountsManager` are named together.
+//  No `Account` / `AccountsManager` / `TPPUserAccount` type crosses the protocol
+//  boundary — only `String?`, `Set<String>`, and `any DownloadUserAccount` do.
+//
+//  `@unchecked Sendable`: the sole stored property is an immutable `let` to the
+//  process-lifetime `AccountsManager` (itself `@unchecked Sendable`). This
+//  adapter adds no mutable state, so it inherits the same thread-safety
+//  invariant — the same pattern as `AccountsManagerAccountScopeAdapter`.
+//
+
+import Foundation
+
+final class AccountsManagerDownloadContextAdapter: DownloadAccountScopeProviding,
+                                                   DownloadCredentialsProviding,
+                                                   @unchecked Sendable {
+    private let accountsManager: AccountsManager
+
+    init(accountsManager: AccountsManager) {
+        self.accountsManager = accountsManager
+    }
+
+    // MARK: - DownloadAccountScopeProviding
+
+    /// The defaults-backed `currentAccountId`, NOT `currentAccount?.uuid`. This
+    /// is the exact read `BookFileManager.fileUrl(for:)` funnelled through: a
+    /// download file must resolve under the selected library even before that
+    /// library's `Account` object has materialized (the two diverge during a
+    /// switch / pre-hydration; only `currentAccountId` preserves behavior).
+    var currentAccountID: String? {
+        accountsManager.currentAccountId
+    }
+
+    /// The current library's auth-surface hosts (empty when the auth doc has
+    /// not loaded — the cold-launch fallback signal). Mirrors the ambient
+    /// `AppContainer.production().accountsManager.currentAccount?.authSurfaceHosts`
+    /// reach the download 401-classification path performs today.
+    var currentAccountAuthSurfaceHosts: Set<String> {
+        accountsManager.currentAccount?.authSurfaceHosts ?? []
+    }
+
+    // MARK: - DownloadCredentialsProviding
+
+    func currentUserAccount() -> any DownloadUserAccount {
+        accountsManager.currentUserAccount
+    }
+
+    func userAccount(forAccount accountID: String) -> any DownloadUserAccount {
+        accountsManager.userAccount(for: accountID)
+    }
+}

--- a/Palace/Accounts/User/TPPUserAccount+DownloadUserAccount.swift
+++ b/Palace/Accounts/User/TPPUserAccount+DownloadUserAccount.swift
@@ -1,0 +1,57 @@
+//
+//  TPPUserAccount+DownloadUserAccount.swift
+//  Palace
+//
+//  App-side conformance of `TPPUserAccount` to the Downloads-owned
+//  `DownloadUserAccount` seam (god-class decomposition Wave 3, S2). This is
+//  composition glue: it imports both the concrete account type and the
+//  Downloads protocol. At the package split it stays app-target — it is the one
+//  place `TPPUserAccount` (→ PalaceAccounts at 3a) and `DownloadUserAccount`
+//  (→ PalaceDownloads at 3b) are named together.
+//
+//  The mirror-enum adapters below are EXHAUSTIVE switches over the real
+//  `AccountDetails.Authentication.ReauthStrategy` and `TPPAccountAuthState`, so
+//  a new upstream case is a COMPILE error here, not a silent fallthrough (Wave
+//  3 §5 risk 3). Do not replace them with a `default:` clause.
+//
+
+import Foundation
+
+extension TPPUserAccount: DownloadUserAccount {
+
+    /// Matches the download path's `authDefinition?.isSaml == true` reads —
+    /// nil auth definition means "not SAML".
+    var isSaml: Bool { authDefinition?.isSaml == true }
+
+    /// Matches the download path's `authDefinition?.isOidc == true` reads.
+    var isOidc: Bool { authDefinition?.isOidc == true }
+
+    /// Maps `authDefinition?.reauthStrategy` (defaulting to `.none` when no auth
+    /// definition is loaded, exactly as the download path's
+    /// `?? .none` reads) through an exhaustive switch.
+    var reauthStrategy: DownloadReauthStrategy {
+        guard let strategy = authDefinition?.reauthStrategy else { return .none }
+        switch strategy {
+        case .browser: return .browser
+        case .tokenRefresh: return .tokenRefresh
+        case .credentialPrompt: return .credentialPrompt
+        case .none: return .none
+        }
+    }
+
+    /// Maps the live `authState` (`TPPAccountAuthState`) through an exhaustive
+    /// switch. See the property doc on `DownloadUserAccount.downloadAuthState`
+    /// for why this is not named `authState`.
+    var downloadAuthState: DownloadAuthState {
+        switch authState {
+        case .loggedOut: return .loggedOut
+        case .loggedIn: return .loggedIn
+        case .credentialsStale: return .credentialsStale
+        }
+    }
+
+    // needsAuth, hasCredentials(), markCredentialsStale(), authToken,
+    // setAuthToken(_:barcode:pin:expirationDate:), cookies, setCookies(_:),
+    // barcode, PIN, username, userID, deviceID are all already members of
+    // TPPUserAccount with matching signatures and satisfy the protocol directly.
+}

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -309,7 +309,7 @@ struct AppContainer: @unchecked Sendable {
         let manager = SideloadedBookManager(
             bookRegistry: self.bookRegistry,
             sideloadedRegistry: self.sideloadedBookRegistry,
-            bookFileManager: BookFileManager()
+            bookFileManager: BookFileManager(accountScope: self.downloadAccountContext)
         )
         return AppContainer._sideloadedBookManager.withLock { slot in
             if let existing = slot { return existing }
@@ -884,6 +884,21 @@ struct AppContainer: @unchecked Sendable {
         AccountsManager.deferInitialLoadCatalogsForTesting = true
     }
     #endif
+}
+
+// MARK: - Downloads account-context seam (Wave 3 S2)
+
+extension AppContainer {
+    /// Vends the Downloads-owned account-context adapter over this container's
+    /// `accountsManager` (god-class decomposition Wave 3, S2). Stateless
+    /// wrapper — computed, so it needs no stored property and no init churn, and
+    /// every container (production or a test container) yields an adapter scoped
+    /// to its OWN `accountsManager`. Consumed by `BookFileManager` (and, at the
+    /// deferred follow-up, `MyBooksDownloadCenter`) in place of the concrete
+    /// `AccountsManager`.
+    var downloadAccountContext: AccountsManagerDownloadContextAdapter {
+        AccountsManagerDownloadContextAdapter(accountsManager: accountsManager)
+    }
 }
 
 // MARK: - SwiftUI Environment Integration

--- a/Palace/MyBooks/BookFileManager.swift
+++ b/Palace/MyBooks/BookFileManager.swift
@@ -26,7 +26,11 @@ import PalaceBookRegistry
 class BookFileManager {
 
     private let bookRegistry: TPPBookRegistryProvider
-    private let accountsManager: AccountsManager
+    /// Account-scope read seam (god-class decomposition Wave 3, S2). Was the
+    /// concrete `AccountsManager`; now the Downloads-owned
+    /// `DownloadAccountScopeProviding` so this type carries no Accounts
+    /// dependency into PalaceDownloads at 3b. Only `currentAccountID` is read.
+    private let accountScope: any DownloadAccountScopeProviding
     private let fileManager: FileManager
     /// Test-only override for the per-account content directory lookup.
     /// Production passes nil so `contentDirectoryURL(_:)` resolves the
@@ -47,13 +51,13 @@ class BookFileManager {
 
     init(
         bookRegistry: TPPBookRegistryProvider = AppContainer.production().bookRegistry,
-        accountsManager: AccountsManager = AppContainer.production().accountsManager,
+        accountScope: any DownloadAccountScopeProviding = AppContainer.production().downloadAccountContext,
         fileManager: FileManager = .default,
         directoryProvider: ((String?) -> URL?)? = nil,
         sideloadedIdentifiersProvider: @escaping () -> Set<String> = { AppContainer.production().sideloadedBookRegistry.identifiers }
     ) {
         self.bookRegistry = bookRegistry
-        self.accountsManager = accountsManager
+        self.accountScope = accountScope
         self.fileManager = fileManager
         self.directoryProvider = directoryProvider
         self.sideloadedIdentifiersProvider = sideloadedIdentifiersProvider
@@ -65,7 +69,7 @@ class BookFileManager {
     /// under the current account. Returns nil if the book is unknown or the
     /// content directory can't be created.
     func fileUrl(for identifier: String) -> URL? {
-        fileUrl(for: identifier, account: accountsManager.currentAccountId)
+        fileUrl(for: identifier, account: accountScope.currentAccountID)
     }
 
     func fileUrl(for identifier: String, account: String?) -> URL? {

--- a/Palace/MyBooks/DiskBudgetManager.swift
+++ b/Palace/MyBooks/DiskBudgetManager.swift
@@ -90,7 +90,7 @@ final class DiskBudgetManager {
         self.accountsManager = accountsManager
         self.bookFileManager = bookFileManager ?? BookFileManager(
             bookRegistry: bookRegistry,
-            accountsManager: accountsManager,
+            accountScope: AccountsManagerDownloadContextAdapter(accountsManager: accountsManager),
             fileManager: fileManager
         )
         self.fileManager = fileManager

--- a/Palace/MyBooks/DownloadAccountContext.swift
+++ b/Palace/MyBooks/DownloadAccountContext.swift
@@ -1,0 +1,116 @@
+//
+//  DownloadAccountContext.swift
+//  Palace
+//
+//  Downloads-owned account-context seams (god-class decomposition Wave 3, S2).
+//
+//  These protocols invert the Downloads→Accounts read coupling (the B-side of
+//  the Accounts↔Downloads hub pair) WITHOUT widening PalaceBookRegistry's
+//  `AccountScopeProviding`. The only member Downloads shares with the registry
+//  protocol is `currentAccountID`; everything else here is credential/auth
+//  *capability* the registry must never see. Hanging that on a registry-owned
+//  protocol would make PalaceBookRegistry the accidental home of download-auth
+//  concerns and force every registry consumer to compile against them — so
+//  Wave 3 §2 keeps the surfaces split. PalaceBookRegistry is untouched.
+//
+//  These declarations are app-target today and MOVE INTO PalaceDownloads at 3b
+//  (protocol declared in the consuming/lower package, implemented from above —
+//  the same inversion shape as 2b's `AccountScopeProviding`). What crosses the
+//  boundary is deliberately narrow: value queries (`isSaml`/`needsAuth`/
+//  `reauthStrategy`/`isOidc`) plus the 401-recovery writeback
+//  (`markCredentialsStale`/`setAuthToken`/`setCookies`). What does NOT cross as
+//  named types: `Account`, `AccountDetails`, `AccountsManager`, `TPPUserAccount`
+//  — the `authDefinition` object never crosses (reduced to the 4 value queries),
+//  which is what keeps 3b package-legal without moving `TPPUserAccount`.
+//
+
+import Foundation
+
+/// Account-scope reads the download subsystem needs (per-account file
+/// isolation + auth-surface host classification). Value-only.
+protocol DownloadAccountScopeProviding: Sendable {
+    /// The current library's identifier. Backs per-account download-file
+    /// scoping (`BookFileManager.fileUrl(for:)`) and the account-switch reset
+    /// guards. Semantically the defaults-backed `currentAccountId`, not a
+    /// resolved-`Account` uuid — a book file must resolve under the selected
+    /// library even before its `Account` object has materialized.
+    var currentAccountID: String? { get }
+
+    /// Hosts that constitute the current account's auth surface (auth-doc,
+    /// catalog, loans, home page), lowercased at the producer. Empty set is the
+    /// cold-launch signal (auth doc not yet loaded) — consumers must fall back
+    /// to legacy behavior rather than false-block. Kills the ambient
+    /// `AppContainer.production().accountsManager.currentAccount?.authSurfaceHosts`
+    /// locator reaches in the download 401-classification path (B6).
+    var currentAccountAuthSurfaceHosts: Set<String> { get }
+}
+
+/// Resolves the credential-bearing account the download subsystem authenticates
+/// against — current library or a captured library UUID (capture-at-start
+/// discipline for operations that outlive a library switch).
+protocol DownloadCredentialsProviding: Sendable {
+    func currentUserAccount() -> any DownloadUserAccount
+    func userAccount(forAccount accountID: String) -> any DownloadUserAccount
+}
+
+/// The credential/auth capability surface the download subsystem reads and
+/// writes on a per-library account. `TPPUserAccount` conforms app-side. This is
+/// a *capability* boundary (unlike 2b's value-only registry boundary): the
+/// writeback members are the 401-recovery path and must cross.
+protocol DownloadUserAccount: AnyObject, Sendable {
+    // Value queries (replace the `authDefinition` object — it never crosses).
+    var needsAuth: Bool { get }
+    var isSaml: Bool { get }
+    var isOidc: Bool { get }
+    var reauthStrategy: DownloadReauthStrategy { get }
+
+    /// Mirror of `TPPAccountAuthState`. Named `downloadAuthState` rather than
+    /// `authState` because `TPPUserAccount` already declares
+    /// `var authState: TPPAccountAuthState` — a same-named property of a
+    /// different type would be an invalid redeclaration.
+    var downloadAuthState: DownloadAuthState { get }
+
+    // Credential presence + 401-recovery writeback (capability boundary).
+    func hasCredentials() -> Bool
+    func markCredentialsStale()
+
+    var authToken: String? { get }
+    func setAuthToken(_ token: String, barcode: String?, pin: String?, expirationDate: Date?)
+
+    var cookies: [HTTPCookie]? { get }
+    func setCookies(_ cookies: [HTTPCookie])
+
+    // Identity fields the download/DRM path stamps into requests.
+    var barcode: String? { get }
+    var PIN: String? { get }
+    var username: String? { get }
+    var userID: String? { get }
+    var deviceID: String? { get }
+}
+
+/// Package-local mirror of `AccountDetails.Authentication.ReauthStrategy`. The
+/// app-side adapter maps the real enum here via an EXHAUSTIVE switch, so a new
+/// upstream case is a compile error rather than silent `.none` drift (Wave 3
+/// §5 risk 3).
+enum DownloadReauthStrategy: Equatable, Sendable {
+    /// Browser-based sign-in flow (SAML IdP, OIDC provider).
+    case browser
+    /// Programmatic token refresh via tokenURL (OAuth, basic-token).
+    case tokenRefresh
+    /// Username/password credential prompt.
+    case credentialPrompt
+    /// No re-auth possible (anonymous, COPPA, unknown).
+    case none
+}
+
+/// Package-local mirror of `TPPAccountAuthState`. The app-side adapter maps the
+/// real `@objc` enum here via an EXHAUSTIVE switch (do NOT move the `@objc`
+/// enum into the package). A new upstream case is a compile error here.
+enum DownloadAuthState: Equatable, Sendable {
+    /// No credentials stored; Adobe DRM deactivated.
+    case loggedOut
+    /// Fully authenticated; Adobe DRM activated.
+    case loggedIn
+    /// Session/token expired but Adobe DRM still valid (e.g. SAML cookie expiry).
+    case credentialsStale
+}

--- a/Palace/MyBooks/LocalBookContentService.swift
+++ b/Palace/MyBooks/LocalBookContentService.swift
@@ -43,7 +43,7 @@ class LocalBookContentService {
         self.accountsManager = accountsManager
         self.bookFileManager = bookFileManager ?? BookFileManager(
             bookRegistry: bookRegistry,
-            accountsManager: accountsManager,
+            accountScope: AccountsManagerDownloadContextAdapter(accountsManager: accountsManager),
             fileManager: fileManager
         )
         self.fileManager = fileManager

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -410,7 +410,7 @@ private final class DownloadFailureMetadataBox: @unchecked Sendable {
         // per-account directory without standing up a custom BookFileManager.
         self.bookFileManager = bookFileManager ?? BookFileManager(
             bookRegistry: bookRegistry,
-            accountsManager: accountsManager,
+            accountScope: AccountsManagerDownloadContextAdapter(accountsManager: accountsManager),
             directoryProvider: directoryProvider
         )
         // DiskBudgetManager pulls from the same registry + accounts manager

--- a/PalaceTests/Contract/SideloadBoundaryTests.swift
+++ b/PalaceTests/Contract/SideloadBoundaryTests.swift
@@ -133,7 +133,7 @@ final class SideloadBoundaryTests: PalaceWiringTestCase {
     let isolatedDefaults = UserDefaults(suiteName: "SideloadBoundary-\(UUID().uuidString)") ?? .standard
     let bookFileManager = BookFileManager(
       bookRegistry: spyLoanRegistry,
-      accountsManager: makeFreshAccountsManager(defaults: isolatedDefaults),
+      accountScope: AccountsManagerDownloadContextAdapter(accountsManager: makeFreshAccountsManager(defaults: isolatedDefaults)),
       fileManager: .default,
       directoryProvider: { [contentRoot] account in contentRoot!.appendingPathComponent("acct-\(account ?? "nil")") },
       sideloadedIdentifiersProvider: { [] }

--- a/PalaceTests/Contract/SideloadImportContractTests.swift
+++ b/PalaceTests/Contract/SideloadImportContractTests.swift
@@ -54,7 +54,7 @@ final class SideloadImportContractTests: PalaceWiringTestCase {
     let isolatedDefaults = UserDefaults(suiteName: "SideloadContract-\(UUID().uuidString)") ?? .standard
     let bookFileManager = BookFileManager(
       bookRegistry: recordingRegistry,
-      accountsManager: makeFreshAccountsManager(defaults: isolatedDefaults),
+      accountScope: AccountsManagerDownloadContextAdapter(accountsManager: makeFreshAccountsManager(defaults: isolatedDefaults)),
       fileManager: .default,
       directoryProvider: { [contentRoot] account in contentRoot!.appendingPathComponent("acct-\(account ?? "nil")") },
       sideloadedIdentifiersProvider: { [] }

--- a/PalaceTests/MyBooks/BookContentResetServiceTests.swift
+++ b/PalaceTests/MyBooks/BookContentResetServiceTests.swift
@@ -118,7 +118,6 @@ private final class SpyBookFileManager: BookFileManager {
         self.tempDir = tempDir
         super.init(
             bookRegistry: bookRegistry,
-            accountsManager: AppContainer.production().accountsManager,
             fileManager: .default
         )
     }

--- a/PalaceTests/MyBooks/BookFileManagerAccountScopingTests.swift
+++ b/PalaceTests/MyBooks/BookFileManagerAccountScopingTests.swift
@@ -98,7 +98,7 @@ final class BookFileManagerAccountScopingTests: PalaceWiringTestCase {
     ) -> BookFileManager {
         BookFileManager(
             bookRegistry: registry,
-            accountsManager: accountsManager,
+            accountScope: AccountsManagerDownloadContextAdapter(accountsManager: accountsManager),
             fileManager: .default,
             directoryProvider: Self.echoingDirectoryProvider(),
             sideloadedIdentifiersProvider: { sideloadedIdentifiers }

--- a/PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift
+++ b/PalaceTests/MyBooks/BookFileManagerSideloadResolutionTests.swift
@@ -83,7 +83,7 @@ final class BookFileManagerSideloadResolutionTests: PalaceWiringTestCase {
 
     return BookFileManager(
       bookRegistry: registry,
-      accountsManager: accountsManager,
+      accountScope: AccountsManagerDownloadContextAdapter(accountsManager: accountsManager),
       fileManager: .default,
       directoryProvider: { account in
         dir.appendingPathComponent("acct-\(account ?? "nil")")

--- a/PalaceTests/MyBooks/BookFileManagerTests.swift
+++ b/PalaceTests/MyBooks/BookFileManagerTests.swift
@@ -26,7 +26,6 @@ final class BookFileManagerTests: XCTestCase {
         testAccountId = "bookfilemanager-test-\(UUID().uuidString)"
         sut = BookFileManager(
             bookRegistry: registry,
-            accountsManager: AppContainer.production().accountsManager,
             fileManager: .default
         )
     }

--- a/PalaceTests/MyBooks/DownloadAccountContextAdapterTests.swift
+++ b/PalaceTests/MyBooks/DownloadAccountContextAdapterTests.swift
@@ -1,0 +1,227 @@
+//
+//  DownloadAccountContextAdapterTests.swift
+//  PalaceTests
+//
+//  Wave 3 S2 — the Downloads-owned account-context seams. Pins:
+//    1. `AccountsManagerDownloadContextAdapter` — every provider member returns
+//       the right value over a concrete `AccountsManager` (currentAccountID is
+//       the DEFAULTS-backed currentAccountId, not currentAccount?.uuid;
+//       currentUserAccount()/userAccount(forAccount:) return AccountsManager's
+//       per-library instances; auth-surface hosts are empty pre-hydration).
+//    2. `TPPUserAccount`'s `DownloadUserAccount` conformance — the exhaustive
+//       enum-mapping adapters (`reauthStrategy`, `downloadAuthState`, isSaml,
+//       isOidc) map every real case correctly. A mutant that swaps a case or
+//       collapses the switch fails at least one row.
+//
+//  DETERMINISM: `currentAccountId` is controlled through an isolated
+//  `UserDefaults` suite (same key the setter writes); no heavy `currentAccount`
+//  setter is driven, so no static singletons are touched. Enum mapping is
+//  exercised against `TPPUserAccountMock` (keychain-free stored authDefinition /
+//  authState), so no keychain, no network, no main-async side effects.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+@MainActor
+final class DownloadAccountContextAdapterTests: PalaceWiringTestCase {
+
+    private var defaults: UserDefaults!
+    private var accountsManager: AccountsManager!
+
+    private let accountA = "s2-adapter-A-\(UUID().uuidString)"
+    private let accountB = "s2-adapter-B-\(UUID().uuidString)"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        defaults = Self.testUserDefaults()
+        defaults.set(accountA, forKey: currentAccountIdentifierKey)
+        accountsManager = makeFreshAccountsManager(defaults: defaults)
+    }
+
+    override func tearDownWithError() throws {
+        accountsManager = nil
+        defaults = nil
+        try super.tearDownWithError()
+    }
+
+    private func makeAdapter() -> AccountsManagerDownloadContextAdapter {
+        AccountsManagerDownloadContextAdapter(accountsManager: accountsManager)
+    }
+
+    // MARK: - DownloadAccountScopeProviding
+
+    /// `currentAccountID` must be the defaults-backed `currentAccountId` — the
+    /// exact read BookFileManager funnelled through. Kill case: a mutant that
+    /// reads `currentAccount?.uuid` returns nil here (no Account is loaded), so
+    /// per-account download scoping would break at cold launch.
+    func testCurrentAccountID_isDefaultsBackedCurrentAccountId() {
+        let adapter = makeAdapter()
+        XCTAssertEqual(adapter.currentAccountID, accountA,
+                       "currentAccountID must read the defaults-backed currentAccountId, not a resolved Account uuid")
+    }
+
+    /// Flipping the current library (A → B) re-points `currentAccountID`. Pins
+    /// the per-account isolation the download-file scoping depends on.
+    func testCurrentAccountID_followsAccountSwitch() {
+        let adapter = makeAdapter()
+        XCTAssertEqual(adapter.currentAccountID, accountA)
+
+        defaults.set(accountB, forKey: currentAccountIdentifierKey)
+        XCTAssertEqual(adapter.currentAccountID, accountB,
+                       "After the current library flips A→B, currentAccountID must follow")
+    }
+
+    /// Pre-hydration (no `Account` object materialized for the current uuid),
+    /// the auth-surface hosts are the empty cold-launch signal — consumers must
+    /// fall back to legacy behavior rather than false-block. Kill case: a mutant
+    /// that force-unwraps `currentAccount` or returns a non-empty default.
+    func testAuthSurfaceHosts_emptyWhenNoAccountLoaded() {
+        let adapter = makeAdapter()
+        XCTAssertTrue(adapter.currentAccountAuthSurfaceHosts.isEmpty,
+                      "With no Account loaded, auth-surface hosts must be empty (cold-launch fallback signal)")
+    }
+
+    // MARK: - DownloadCredentialsProviding
+
+    /// `currentUserAccount()` must return AccountsManager's current per-library
+    /// instance — not a fresh account. Identity matters: the download path reads
+    /// and WRITES credentials through it (401 recovery), so it must be the same
+    /// instance every other reader sees.
+    func testCurrentUserAccount_returnsAccountsManagerCurrentInstance() {
+        let adapter = makeAdapter()
+        let viaAdapter = adapter.currentUserAccount() as AnyObject
+        let direct = accountsManager.currentUserAccount as AnyObject
+        XCTAssertTrue(viaAdapter === direct,
+                      "currentUserAccount() must return the SAME instance AccountsManager vends")
+    }
+
+    /// `userAccount(forAccount:)` must resolve the per-library instance for the
+    /// captured uuid (the capture-at-start path for operations that outlive a
+    /// switch), identical to `AccountsManager.userAccount(for:)`.
+    func testUserAccountForAccount_returnsPerLibraryInstance() {
+        let adapter = makeAdapter()
+        let viaAdapter = adapter.userAccount(forAccount: accountA) as AnyObject
+        let direct = accountsManager.userAccount(for: accountA) as AnyObject
+        XCTAssertTrue(viaAdapter === direct,
+                      "userAccount(forAccount:) must resolve the same per-library instance as AccountsManager.userAccount(for:)")
+    }
+
+    // MARK: - TPPUserAccount: DownloadUserAccount — enum mapping (exhaustive)
+
+    /// `reauthStrategy` must map every real `ReauthStrategy` case correctly, via
+    /// the account's `authDefinition`. This is the mirror-enum drift guard
+    /// (§5 risk 3): the adapter switch is exhaustive, so a new upstream case is
+    /// a compile error; this test pins that each EXISTING case maps right.
+    func testReauthStrategyMapping_coversEveryAuthType() throws {
+        let cases: [(AccountDetails.AuthType, DownloadReauthStrategy)] = [
+            (.saml, .browser),
+            (.oidc, .browser),
+            (.oauthIntermediary, .tokenRefresh),
+            (.token, .tokenRefresh),
+            (.basic, .credentialPrompt),
+            (.anonymous, .none),
+            (.coppa, .none)
+        ]
+        for (authType, expected) in cases {
+            let account: DownloadUserAccount = try makeMockAccount(authType: authType)
+            XCTAssertEqual(account.reauthStrategy, expected,
+                           "authType \(authType.rawValue) must map to \(expected)")
+        }
+    }
+
+    /// A nil `authDefinition` (cold launch, before sign-in) must map to `.none`
+    /// — matching the download path's `?? .none` reads.
+    func testReauthStrategyMapping_nilAuthDefinition_isNone() {
+        let account: DownloadUserAccount = TPPUserAccountMock()
+        account.markCredentialsStale() // no-op without creds; ensures no authDefinition
+        XCTAssertEqual(account.reauthStrategy, .none,
+                       "No authDefinition must map to .none, never crash or a wrong strategy")
+    }
+
+    /// `isSaml` / `isOidc` must be true for exactly their own auth type and
+    /// false for the rest — the download path's `authDefinition?.isSaml == true`
+    /// reads reduced onto the protocol.
+    func testIsSamlIsOidc_areTypeSpecific() throws {
+        let saml: DownloadUserAccount = try makeMockAccount(authType: .saml)
+        XCTAssertTrue(saml.isSaml); XCTAssertFalse(saml.isOidc)
+
+        let oidc: DownloadUserAccount = try makeMockAccount(authType: .oidc)
+        XCTAssertTrue(oidc.isOidc); XCTAssertFalse(oidc.isSaml)
+
+        let basic: DownloadUserAccount = try makeMockAccount(authType: .basic)
+        XCTAssertFalse(basic.isSaml); XCTAssertFalse(basic.isOidc)
+    }
+
+    /// `downloadAuthState` must map every `TPPAccountAuthState` case. Exhaustive
+    /// switch → compile error on a new case; this pins the existing three.
+    func testDownloadAuthStateMapping_coversEveryState() {
+        let loggedOut = TPPUserAccountMock()
+        loggedOut.setAuthState(.loggedOut)
+        XCTAssertEqual((loggedOut as DownloadUserAccount).downloadAuthState, .loggedOut)
+
+        let loggedIn = TPPUserAccountMock()
+        loggedIn.setAuthState(.loggedIn)
+        XCTAssertEqual((loggedIn as DownloadUserAccount).downloadAuthState, .loggedIn)
+
+        let stale = TPPUserAccountMock()
+        stale.setAuthState(.loggedIn)
+        stale.markCredentialsStale()
+        XCTAssertEqual((stale as DownloadUserAccount).downloadAuthState, .credentialsStale)
+    }
+
+    // MARK: - TPPUserAccount: DownloadUserAccount — value pass-through
+
+    /// The identity + credential fields exposed through the protocol existential
+    /// must reflect the underlying account. Kill case: a conformance that mapped
+    /// the wrong field (e.g. userID→deviceID) would fail here.
+    func testIdentityFields_passThroughUnderlyingAccount() {
+        let mock = TPPUserAccountMock()
+        mock.credentials = .barcodeAndPin(barcode: "patron-barcode", pin: "1234")
+        mock.setUserID("user-42")
+        mock.setDeviceID("device-99")
+
+        let account: DownloadUserAccount = mock
+        XCTAssertEqual(account.barcode, "patron-barcode")
+        XCTAssertEqual(account.username, "patron-barcode", "username mirrors barcode")
+        XCTAssertEqual(account.PIN, "1234")
+        XCTAssertEqual(account.userID, "user-42")
+        XCTAssertEqual(account.deviceID, "device-99")
+        XCTAssertTrue(account.hasCredentials())
+    }
+
+    /// The 401-recovery writeback crosses the capability boundary: writing a
+    /// fresh token through the protocol existential must land on the account and
+    /// flip its state to loggedIn (mirrors TPPUserAccount.setAuthToken).
+    func testSetAuthToken_writesThroughProtocol() {
+        let mock = TPPUserAccountMock()
+        let account: DownloadUserAccount = mock
+        account.setAuthToken("fresh-token", barcode: "b", pin: "p", expirationDate: nil)
+        XCTAssertEqual(account.authToken, "fresh-token",
+                       "setAuthToken through the DownloadUserAccount surface must persist on the account")
+        XCTAssertEqual(account.downloadAuthState, .loggedIn,
+                       "A fresh token must flip auth state to loggedIn (clears any stale flag)")
+    }
+
+    // MARK: - Helpers
+
+    /// Builds a keychain-free `TPPUserAccountMock` carrying an
+    /// `AccountDetails.Authentication` of the requested type (decoded via the
+    /// OPDS2 auth-document JSON path — the memberwise init is module-internal).
+    private func makeMockAccount(authType: AccountDetails.AuthType) throws -> TPPUserAccountMock {
+        let json = """
+        { "type": "\(authType.rawValue)", "description": "s2 fixture",
+          "labels": {"login": "x", "password": "y"} }
+        """
+        let docAuth = try JSONDecoder().decode(
+            OPDS2AuthenticationDocument.Authentication.self,
+            from: Data(json.utf8)
+        )
+        let mock = TPPUserAccountMock()
+        mock.authDefinition = AccountDetails.Authentication(auth: docAuth)
+        return mock
+    }
+}

--- a/PalaceTests/MyBooks/DownloadFreeSpaceExhaustionTests.swift
+++ b/PalaceTests/MyBooks/DownloadFreeSpaceExhaustionTests.swift
@@ -57,7 +57,7 @@ final class DownloadFreeSpaceExhaustionTests: XCTestCase {
         diskBudget = DiskBudgetManager(
             bookRegistry: registry,
             accountsManager: AppContainer.production().accountsManager,
-            bookFileManager: BookFileManager(bookRegistry: registry, accountsManager: AppContainer.production().accountsManager),
+            bookFileManager: BookFileManager(bookRegistry: registry),
             fileManager: .default
         )
     }

--- a/PalaceTests/MyBooks/LocalBookContentServiceTests.swift
+++ b/PalaceTests/MyBooks/LocalBookContentServiceTests.swift
@@ -167,7 +167,6 @@ private final class SpyBookFileManager: BookFileManager {
         self.tempDir = tempDir
         super.init(
             bookRegistry: bookRegistry,
-            accountsManager: AppContainer.production().accountsManager,
             fileManager: .default
         )
     }

--- a/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
+++ b/PalaceTests/MyBooks/Sideload/SideloadedBookManagerTests.swift
@@ -70,7 +70,7 @@ final class SideloadedBookManagerTests: PalaceWiringTestCase {
     let root = contentRoot!
     return BookFileManager(
       bookRegistry: registry,
-      accountsManager: accountsManager,
+      accountScope: AccountsManagerDownloadContextAdapter(accountsManager: accountsManager),
       fileManager: .default,
       directoryProvider: { account in root.appendingPathComponent("acct-\(account ?? "nil")") },
       sideloadedIdentifiersProvider: { [] }
@@ -225,7 +225,7 @@ final class SideloadedBookManagerTests: PalaceWiringTestCase {
     // so the import cannot resolve a copy destination → `.destinationUnavailable`.
     let bfm = BookFileManager(
       bookRegistry: registry,
-      accountsManager: accountsManager,
+      accountScope: AccountsManagerDownloadContextAdapter(accountsManager: accountsManager),
       fileManager: .default,
       directoryProvider: { _ in nil },
       sideloadedIdentifiersProvider: { [] }


### PR DESCRIPTION
## Wave 3 S2 — Downloads-owned account-context seams

Second concrete PR of the Accounts↔Downloads god-class decomposition (Wave 3). Inverts the **Downloads→Accounts** read coupling (the B-side of the hub pair) by declaring **Downloads-owned** protocols instead of widening PalaceBookRegistry's `AccountScopeProviding` — the decision-complete Wave 3 brief §2 ruling. **PalaceBookRegistry / `AccountScopeProviding` are untouched.**

Stacked on #1348 (`chore/forward-port-main-to-develop`); retargets to `develop` when #1348 merges. **Do not merge yet.**

### What lands
- **`Palace/MyBooks/DownloadAccountContext.swift`** (new, app-target now → PalaceDownloads at 3b):
  - `DownloadAccountScopeProviding` — `currentAccountID`, `currentAccountAuthSurfaceHosts`
  - `DownloadCredentialsProviding` — `currentUserAccount()`, `userAccount(forAccount:)`
  - `DownloadUserAccount` — the credential/auth capability surface Downloads reads + the 401-recovery writeback (`markCredentialsStale`/`setAuthToken`/`setCookies`)
  - `DownloadReauthStrategy` / `DownloadAuthState` — package-local mirror enums
- **`extension TPPUserAccount: DownloadUserAccount`** (new) — maps the real `ReauthStrategy`/`TPPAccountAuthState` via **exhaustive switches** (a new upstream case is a compile error, not silent drift — §5 risk 3).
- **`AccountsManagerDownloadContextAdapter`** (new) — conforms the concrete `AccountsManager` to the two providing protocols; app-target composition. No `Account`/`AccountsManager`/`TPPUserAccount` named type crosses the protocol boundary.
- **AppContainer** vends the adapter via a computed `downloadAccountContext` seam (stateless; no stored-property/init churn).
- **`BookFileManager` retyped** off the concrete `AccountsManager` onto `any DownloadAccountScopeProviding` — the smallest consumer, proving the seam end-to-end. `currentAccountID` maps to the exact defaults-backed `currentAccountId` read it funnelled through → behavior byte-identical. 3 prod callers + ~8 test sites rewrapped through the adapter.

### Signature deviations from the brief (verified against reality)
- `DownloadUserAccount.authState` → **`downloadAuthState`**: `TPPUserAccount` already declares `authState: TPPAccountAuthState`; a same-named member is an invalid redeclaration.
- Adapter `currentAccountID` → **`accountsManager.currentAccountId`** (defaults-backed), **not** `currentAccount?.uuid` — the two diverge during a switch / pre-hydration, and only `currentAccountId` preserves BookFileManager's cold-launch scoping. (Deliberately different from `AccountsManagerAccountScopeAdapter`, which uses the PP-4129 capture-discipline uuid for the registry seam.)

### Deferred (follow-up PR)
- **The MyBooksDownloadCenter retype (~15 read sites):** `currentUserAccount` resolvers, `userAccount(for:)` capture path, and the `authSurfaceHosts` locators at MBDC `:480`/`:611` — plus the B7 `() -> TPPUserAccount` closures. Interim adoption is incremental (§2); each retype is mechanical and separately verifiable; MBDC moves at 3b.
- **Reviewer-recommended tests to add with that retype** (all three SoD reviewers converged, non-blocking here because these members have no live consumer yet): a **populated** `currentAccountAuthSurfaceHosts` test (this PR covers only the empty cold-launch fallback — the exact surface behind the Icarus cross-host-logout wall-failure) and a `setCookies`-through-protocol writeback test for symmetry with the existing `setAuthToken` test.

### Verification
- **Both targets build clean** (Palace + Palace-noDRM, fresh `-derivedDataPath`).
- Touched suites green: **61 + 37 tests, 0 failures** (incl. the new 8-test `DownloadAccountContextAdapterTests`).
- Meta-lints green: TearDownRequiredLint, AppContainerIsolationLint, AccountsManagerIsolationLint.
- **Mutation 100% (2/2)** on the enum-mapping file; adapter is pure delegation (no mutation points; behavior pinned by identity/switch tests).
- Locator ratchet PASS (313→309); shared-read PASS (224); **zero contract-snapshot drift**.
- SoD review: **architect + qa_test + blast_radius all APPROVED** (fresh identities, 0 concerns/fails).

**Not done:** no type moves into a SwiftPM package (that is 3a/3b); no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
