### PR TITLE
feat(accounts): owned, joinable catalog crawl — PP-4754 root-fix (re-land #1349)

### DIFF
--- a/.forgeos/intent/deflake-loadcatalogs.md
+++ b/.forgeos/intent/deflake-loadcatalogs.md
@@ -1,0 +1,52 @@
+---
+name: deflake-loadcatalogs
+created: 2026-07-28
+author: claude-opus-4-8
+---
+
+**ADR refs:** none recorded for the touched accounts area in the local ledger;
+this implements the Wave-3 brief §4 3a-(2) rewrite (PP-4754 root fix) as a
+standalone change ahead of 3a. Front-runs, does not contradict, prior decisions.
+
+PP-4754 root-cause de-flake: convert AccountsManager's leaky detached/GCD
+background catalog-crawl work into owned, cancellable, deterministically-joinable
+Tasks so the test-boundary drain is COMPLETE (no un-awaitable write channel
+survives a test), and add a wall-clock-free join seam for tests. Production crawl
+work (what it does, its ordering, snapshot writes, priorities, detachedness) is
+behavior-identical; only ownership/cancellability/test-joinability change.
+
+## Claims
+
+- adds file `Palace/Accounts/Library/CatalogCrawlScheduler.swift` with `CrawlTaskScheduler` (injectable spawn seam) and `OwnedCrawlTaskRegistry` (self-pruning owned-task registry)
+- adds field `ownedCrawlTasks` (OwnedCrawlTaskRegistry) to `AccountsManager`
+- adds field `crawlScheduler` (CrawlTaskScheduler) to `AccountsManager`, injected via a defaulted `init` param
+- adds public function `_awaitCatalogLoadForTesting(maxRounds:)` on `AccountsManager` (async, XCTest-gated Task-join, no wall-clock)
+- adds field `_ownedCrawlTaskCountForTesting` on `AccountsManager`
+- adds private function `spawnOwnedCrawlTask(priority:detached:firstRun:_:)` on `AccountsManager` routing every crawl spawn site through the registry
+- migrates the init background-load arm from a `#if DEBUG` Task.detached / `#else` GCD split to a single owned `spawnOwnedCrawlTask` spawn (RELEASE: GCD -> detached Task, same .utility QoS)
+- migrates the two untracked network-executor completions in `fallbackFetchFromNetwork` and `fallbackDirectRefresh` into owned Tasks bridging the callback via the async-throwing `GET`
+- removes `_trackCrawlTask`
+- removes `_trackedCrawlTasks`
+- adds function `spawnOwnedCrawlTask` on `AccountsManager`
+- migrates `cancelBackgroundWork` and `cancelAndDrainBackgroundWork` to drain the owned registry
+- migrates `PalaceWiringTestCase.tearDownWithError` per-manager `cancelBackgroundWork()` to `cancelAndDrainBackgroundWork()`
+
+## Anti-claims
+
+- does NOT change what the crawl does (same registry crawl, pagination, preload, snapshot bytes, `.TPPCatalogDidLoad` posts, stale-while-revalidate branch order)
+- does NOT change the public surface of `AccountsManager` beyond the defaulted `crawlScheduler` init param and the two new test-only seams (all 159 existing `AccountsManager(` constructions compile unchanged)
+- keeps the existing observation surfaces unchanged in name and semantics (`_backgroundFetchTaskWasExplicitlyCancelled`, `_backgroundFetchTaskHandleIsNil`, `_injectBackgroundFetchTaskForTesting`, `fetchFromNetworkCountForTesting`, `_awaitAllCrawlTasksForTesting`, `deferInitialLoadCatalogsForTesting`)
+- keeps `deferInitialLoadCatalogsForTesting` (not deleted)
+- does NOT touch Wave-3 seams (S1 breaker inversion, S2 download protocols, S3 de-locatoring); `networkExecutor` lazy var stays as-is
+- does NOT change `AppContainer._resetForTesting`'s structure (comment-only update)
+
+## Files in scope
+
+- Palace/Accounts/Library/CatalogCrawlScheduler.swift
+- Palace/Accounts/Library/AccountsManager.swift
+- Palace/AppInfrastructure/AppContainer.swift
+- PalaceTests/Support/PalaceWiringTestCase.swift
+- PalaceTests/Accounts/CatalogCrawlSchedulerTests.swift
+- PalaceTests/Accounts/AccountsManagerCatalogLoadJoinTests.swift
+- Palace.xcodeproj/project.pbxproj
+- scripts/godclass-loc-baseline.txt

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		1441E97FEA8E24E5676576B5 /* UIButton+NYPLAppearanceAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68831365CC1FF46BE9A9C2C9 /* UIButton+NYPLAppearanceAdditions.swift */; };
 		1446B886F9D2F070E2AC22A5 /* Skeleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E510DC675E5215E00B444EE /* Skeleton.swift */; };
 		145798F6215BE9E300F68AFD /* ProblemReportEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145798F5215BE9E300F68AFD /* ProblemReportEmail.swift */; };
+		146E571D95091CB8EDE2B624 /* CatalogCrawlScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692DF9B78A5B64F59033D35C /* CatalogCrawlScheduler.swift */; };
 		149DDAD13FD460B229CDD760 /* DownloadCenterBorrowReauthResetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9381BBE0CE20B654B89FFCD /* DownloadCenterBorrowReauthResetter.swift */; };
 		149EA7BE30582B9CEF020DEC /* PalaceFeatureFlags in Frameworks */ = {isa = PBXBuildFile; productRef = FA466C796161E2DF957B24F4 /* PalaceFeatureFlags */; };
 		14D4531FA335D56645905798 /* DownloadStartReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11566537464518DD5E2536E3 /* DownloadStartReducer.swift */; };
@@ -440,6 +441,7 @@
 		48CDA3BE961ED5B184FEC215 /* DownloadStartDispatcherContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76AF4A0119E7C4C70E3E4574 /* DownloadStartDispatcherContractTests.swift */; };
 		49504822A95094278A8506F6 /* TPPBookButtonsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502761BDE732D3752808C4C4 /* TPPBookButtonsState.swift */; };
 		4970519C2018626C6412AB39 /* GeneralCacheClearOnUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A295B1F1809096E9203186 /* GeneralCacheClearOnUpdateTests.swift */; };
+		49B679EE821164E16AF43BCF /* CatalogCrawlSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822C34E7CB9D9E06317B7722 /* CatalogCrawlSchedulerTests.swift */; };
 		4ABC89EACE1CF4EB53281A51 /* StreamingReaderViewControllerScrollRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2A4750286AC64A2D15FD94 /* StreamingReaderViewControllerScrollRestoreTests.swift */; };
 		4B69321BBCF4158F4AC546EA /* RightsManagementDispatchContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB69BEC26CB16962E3EE14C /* RightsManagementDispatchContractTests.swift */; };
 		4BA66F6AA4A7DC046B995BC6 /* OfflineQueueServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FEEC427223FFDB026D6137 /* OfflineQueueServiceProtocol.swift */; };
@@ -455,6 +457,7 @@
 		4DE364F5D585D79C2FCFF132 /* TPPBook+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C1093BDA93392F7DEF0D31 /* TPPBook+Accessibility.swift */; };
 		4DE6468C2E4065037D7281F9 /* AlertPresentationRawGuardLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2919A501EF80BC9A88CF2B58 /* AlertPresentationRawGuardLintTests.swift */; };
 		4E0F1B6A8D7C5F23E9B0A1C4 /* DiskBudgetManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1A2C7B9E8D6A34F0C1B2D5 /* DiskBudgetManagerTests.swift */; };
+		4E3744149885D84DD020BB3B /* AccountsManagerCatalogLoadJoinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64CF3480F3F5C70A6227526 /* AccountsManagerCatalogLoadJoinTests.swift */; };
 		4E664E6EC32C604AFBC8A623 /* CatalogSearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFF70FF762C60CE8CD8D811 /* CatalogSearchViewModelTests.swift */; };
 		4E7D4FD5607DD1D3767954FB /* AudiobookSessionPresenterLifecycleContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCB26003F58384AB77E3B7B /* AudiobookSessionPresenterLifecycleContractTests.swift */; };
 		4EE6AD0F199527926C3BB1F8 /* CatalogFilterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5948988DD314B94674443C4F /* CatalogFilterServiceTests.swift */; };
@@ -1139,6 +1142,7 @@
 		BED408AC57A5DB39579B5FEA /* TPPBookRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5550F79A349D3D7ADE48B5E1 /* TPPBookRegistryTests.swift */; };
 		BF0FD554A5AA86C241E2CA9F /* StatsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCA63D51A4176FB08ED1941 /* StatsTab.swift */; };
 		BF2B5B79D36596C9F06C43A5 /* ReadingStatsServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCA7B3D060EF65547DF53DA /* ReadingStatsServiceProtocol.swift */; };
+		BF6754FDD3EBF7514C3CD5B5 /* CatalogCrawlScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692DF9B78A5B64F59033D35C /* CatalogCrawlScheduler.swift */; };
 		BF6A7B8C9D0E1F2A3B4C5D6E /* DownloadThrottlingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5F6A7B8C9D0E1F2A3B4C5D /* DownloadThrottlingService.swift */; };
 		BKTST00012F27000000BF02 /* TPPBookContentTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BKTST00012F27000000FR02 /* TPPBookContentTypeTests.swift */; };
 		BKTST00012F27000000BF04 /* TPPBookSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BKTST00012F27000000FR04 /* TPPBookSerializationTests.swift */; };
@@ -2577,6 +2581,7 @@
 		68831365CC1FF46BE9A9C2C9 /* UIButton+NYPLAppearanceAdditions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIButton+NYPLAppearanceAdditions.swift"; sourceTree = "<group>"; };
 		68DD067CA8C1F43B32DF167B /* AudiobookContentGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookContentGateTests.swift; sourceTree = "<group>"; };
 		68E0A5661D94D658E8CDD19F /* BundledRegistrySnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundledRegistrySnapshot.swift; sourceTree = "<group>"; };
+		692DF9B78A5B64F59033D35C /* CatalogCrawlScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogCrawlScheduler.swift; sourceTree = "<group>"; };
 		6A40759C732F4FC1B0587021 /* ErrorActivityTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorActivityTracker.swift; sourceTree = "<group>"; };
 		6A6CA6654994D77041AE0F79 /* ReadingStreak.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStreak.swift; sourceTree = "<group>"; };
 		6A7081A2B3C4D5E6F7081929 /* BookReturnService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookReturnService.swift; sourceTree = "<group>"; };
@@ -2762,6 +2767,7 @@
 		8207C4AC28B2FA1774B6E827 /* AppLaunchTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchTrackerTests.swift; sourceTree = "<group>"; };
 		820FFFB90AD6CB0A124F6420 /* BookCellModelStreamingHTMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookCellModelStreamingHTMLTests.swift; sourceTree = "<group>"; };
 		821943DED462B52FCCF8555A /* ErrorLogging.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorLogging.swift; sourceTree = "<group>"; };
+		822C34E7CB9D9E06317B7722 /* CatalogCrawlSchedulerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogCrawlSchedulerTests.swift; sourceTree = "<group>"; };
 		82958AC044A81FB84416B2BD /* AudiobookFirstOpenHangTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookFirstOpenHangTests.swift; sourceTree = "<group>"; };
 		834376530042364D30BA01FD /* AudiobookOpenStateRaceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookOpenStateRaceTests.swift; sourceTree = "<group>"; };
 		83A12F5637D02B11F6E2EC36 /* FakeStreamingReaderProgressStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FakeStreamingReaderProgressStore.swift; sourceTree = "<group>"; };
@@ -2874,6 +2880,7 @@
 		A4B5C6D7E8F9A0B1C2D3E4F5 /* DownloadCancellationHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadCancellationHandlerTests.swift; sourceTree = "<group>"; };
 		A556E4218D9D8BDC19019BFA /* TPPBookTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookTests.swift; sourceTree = "<group>"; };
 		A5A6C8FEE9804D8B9B969537 /* CatalogLaneRowViewAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogLaneRowViewAccessibilityTests.swift; sourceTree = "<group>"; };
+		A64CF3480F3F5C70A6227526 /* AccountsManagerCatalogLoadJoinTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountsManagerCatalogLoadJoinTests.swift; sourceTree = "<group>"; };
 		A6D99F654723B202B64BEDFD /* SideloadedLaneTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadedLaneTests.swift; sourceTree = "<group>"; };
 		A7531D0BC80AF1F317534E80 /* Account+State.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Account+State.swift"; sourceTree = "<group>"; };
 		A77E63314ED6F70CC68C0DA0 /* AudiobookAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookAccessibilityTests.swift; sourceTree = "<group>"; };
@@ -4295,6 +4302,8 @@
 				28F5B74FBB8C3F4B3A64E44F /* AccountErrorReportingTests.swift */,
 				A9A412ABF8C7A3A6EBC490B7 /* AccountScopeAdapterTests.swift */,
 				9D32B0D46348D5770A7551C4 /* BorrowReauthResettingTests.swift */,
+				822C34E7CB9D9E06317B7722 /* CatalogCrawlSchedulerTests.swift */,
+				A64CF3480F3F5C70A6227526 /* AccountsManagerCatalogLoadJoinTests.swift */,
 			);
 			path = Accounts;
 			sourceTree = "<group>";
@@ -4924,6 +4933,7 @@
 				9C80B4E151496CABF2F9D0EE /* AccountsManager+ProblemReportContext.swift */,
 				19F86127F411D9B44A7A6CB3 /* AccountsManagerAccountScopeAdapter.swift */,
 				4FC47AED382982103F213534 /* BorrowReauthResetting.swift */,
+				692DF9B78A5B64F59033D35C /* CatalogCrawlScheduler.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -8004,6 +8014,8 @@
 				D26888D2C9A2BB133EBD5526 /* AudiobookBearerTokenRecoveryTests.swift in Sources */,
 				AB2801CCF1699315F888F6D0 /* AudiobookContentGateTests.swift in Sources */,
 				54335D47FB665C8DAAA00BA5 /* AudiobookVendorRecoveryContractTests.swift in Sources */,
+				49B679EE821164E16AF43BCF /* CatalogCrawlSchedulerTests.swift in Sources */,
+				4E3744149885D84DD020BB3B /* AccountsManagerCatalogLoadJoinTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8564,6 +8576,7 @@
 				B00B6F2D1A05416F82D5474C /* TPPBookRegistry+ProductionInit.swift in Sources */,
 				B865C34CA9799A7AA0042BBF /* BorrowReauthResetting.swift in Sources */,
 				EF4CC725B5E70D77890C2A03 /* DownloadCenterBorrowReauthResetter.swift in Sources */,
+				146E571D95091CB8EDE2B624 /* CatalogCrawlScheduler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9127,6 +9140,7 @@
 				66C5BBEEAC56378BCD5C9879 /* TPPBookRegistry+ProductionInit.swift in Sources */,
 				81587C22AEEAB64E6D2824BD /* BorrowReauthResetting.swift in Sources */,
 				149DDAD13FD460B229CDD760 /* DownloadCenterBorrowReauthResetter.swift in Sources */,
+				BF6754FDD3EBF7514C3CD5B5 /* CatalogCrawlScheduler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -192,7 +192,9 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
 ///   - `inflightAuthDocFetches`  → read/written only under `inflightAuthDocLock`.
 ///   - `userAccounts`, `lastKnownCurrentUserAccount`  → read/written only under
 ///     `userAccountsLock`.
-///   - `_trackedCrawlTasks`  → read/written only under `_trackedCrawlTasksLock`.
+///   - `_trackedFirstRunTasks`  → read/written only under `_trackedCrawlTasksLock`.
+///   - `ownedCrawlTasks`  → an `OwnedCrawlTaskRegistry`, internally synchronized;
+///     `crawlScheduler`  → immutable `Sendable` `let` bound once from `init`.
 ///   - `isAccountSwitching`  → storage moved into the lock-backed
 ///     `AccountsManagerBoolFlag` holder (`_isAccountSwitching`), so its `Bool`
 ///     set/get is serialized by the holder's own `NSLock`; the public
@@ -277,6 +279,14 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// class's init. The lazy var is first accessed *after* AppContainer
     /// finishes constructing, so the cached instance is ready.
     private lazy var networkExecutor: TPPNetworkExecutor = AppContainer.production().networkExecutor
+    /// Injectable background-crawl spawn seam (see `CatalogCrawlScheduler`).
+    /// Immutable `Sendable` `let`; `.production` by default, recording under test.
+    private let crawlScheduler: CrawlTaskScheduler
+    /// Owns every background catalog-crawl Task — production included (PP-4754):
+    /// the previously fire-and-forget crawl now has an owner the reset
+    /// choreography cancels + awaits, so no un-drainable write channel survives a
+    /// test boundary. Self-pruning + internally synchronized.
+    private let ownedCrawlTasks = OwnedCrawlTaskRegistry()
     private var accountSet: String
     private var accountSets = [String: [Account]]()
     /// O(1) `uuid → Account` index derived from `accountSets`, kept in lockstep
@@ -342,9 +352,8 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
 
     #if DEBUG
     /// Test-only opt-out from the post-init background `loadCatalogs` spawn.
-    /// When `true`, `AccountsManager.init()` skips the
-    /// `DispatchQueue.global(qos: .utility).async { loadCatalogs(...) }`
-    /// dispatch — eliminating the cross-test race where lingering background
+    /// When `true`, `AccountsManager.init()` skips the owned background
+    /// `loadCatalogs` Task spawn — eliminating the cross-test race where lingering background
     /// work from a previously-constructed AccountsManager instance writes
     /// through to `accountSets` / `AccountStateStore.shared` mid-test.
     ///
@@ -436,40 +445,20 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     }
     #endif
 
-    /// Registry of the unstructured background `Task`s spawned by
-    /// `loadCatalogs` → `fetchFromNetwork` / `refreshInBackground` (the
-    /// registry crawl, pagination, and catalog-preload). These are independent
-    /// tasks — NOT children of `backgroundFetchTask` — so `cancelBackgroundWork()`
-    /// did not previously cancel them. When a test constructed an
-    /// `AccountsManager` under `deferInitialLoadCatalogsForTesting = false`
-    /// (e.g. `AppContainerResetTests`), these tasks outlived the test and the
-    /// cooperative-cancel of `backgroundFetchTask`, leaking a live multi-page
-    /// network crawl into whatever test ran next — the root of the intermittent
-    /// cross-test CI crashes (a different victim each run).
-    ///
-    /// `_trackCrawlTask` no-ops outside an XCTest process (the runtime gate
-    /// below), so release / TestFlight / dev-sim builds never append — the
-    /// array stays empty and there is no storage cost or unbounded growth. The
-    /// only consumer that drains/cancels the list is `cancelBackgroundWork()`,
-    /// which is itself `#if DEBUG` and only invoked under `_resetForTesting()`
-    /// / wiring-suite tearDown. Using the XCTest env-var gate rather than
-    /// `#if DEBUG` on these production call sites keeps the crawl-spawn paths
-    /// free of conditional compilation (blast-radius BR-2).
+    /// PP-4754: every background catalog-crawl `Task` (init load, first-run,
+    /// crawl, pagination, refresh, the wrapped fallback GETs, preload) is spawned
+    /// through `spawnOwnedCrawlTask` into `ownedCrawlTasks` — production included,
+    /// no XCTest/`#if DEBUG` bookkeeping on the spawn path — so the reset
+    /// choreography cancels + awaits every one, closing the last un-drainable
+    /// write channel that leaked a live crawl into the next test.
     private static let _isRunningUnderXCTest =
         ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    /// Guards `_trackedFirstRunTasks`.
     private let _trackedCrawlTasksLock = NSLock()
-    private var _trackedCrawlTasks: [Task<Void, Never>] = []
-    /// The subset of tracked tasks that are `loadCatalogs` FIRST-RUN tasks (the
-    /// detached bundled-decode → synchronous `fetchFromNetwork` kickoff). Guarded
-    /// by `_trackedCrawlTasksLock`. Populated only under XCTest (same env gate as
-    /// `_trackedCrawlTasks`). The deterministic-join seam
-    /// `_awaitAllCrawlTasksForTesting()` awaits ONLY these — NOT the downstream
-    /// live network crawl the first-run task spawns via `fetchFromNetwork` (that
-    /// hits the real registry and would reintroduce wall-clock nondeterminism).
-    /// By the time a first-run task's `.value` resolves, its synchronous
-    /// `fetchFromNetwork` call has already returned (bumping
-    /// `_fetchFromNetworkCount`), so joining the first-run task alone is a
-    /// deterministic barrier for the decode + fetch-fired observations.
+    /// Subset of owned tasks that are `loadCatalogs` FIRST-RUN tasks. Populated
+    /// only under XCTest (byte-identical to the prior `_trackFirstRunTask` gate).
+    /// The narrow `_awaitAllCrawlTasksForTesting()` seam joins ONLY these (see it
+    /// for why); the broad `_awaitCatalogLoadForTesting()` joins the whole set.
     private var _trackedFirstRunTasks: [Task<Void, Never>] = []
 
     /// Resolves the build-time bundled registry snapshot resource. Production
@@ -494,60 +483,74 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
         return _fetchFromNetworkCount
     }
 
-    /// Register a spawned background crawl task so `cancelBackgroundWork()` can
-    /// cancel it. No-op outside an XCTest process.
-    private func _trackCrawlTask(_ task: Task<Void, Never>) {
-        guard Self._isRunningUnderXCTest else { return }
-        _trackedCrawlTasksLock.lock()
-        _trackedCrawlTasks.append(task)
-        _trackedCrawlTasksLock.unlock()
+    /// Spawn a background crawl `Task` through `crawlScheduler` and register it in
+    /// `ownedCrawlTasks` so the reset choreography can cancel + await it.
+    /// `detached`/`priority` preserve each call site's exact semantics + QoS;
+    /// `firstRun` also records it in the narrow-join subset (XCTest only). A
+    /// `defer` self-prunes the token as the task unwinds, bounding the live set.
+    @discardableResult
+    private func spawnOwnedCrawlTask(
+        priority: TaskPriority,
+        detached: Bool,
+        firstRun: Bool = false,
+        _ operation: @escaping @Sendable () async -> Void
+    ) -> Task<Void, Never> {
+        let token = UUID()
+        let registry = ownedCrawlTasks
+        let owned: @Sendable () async -> Void = {
+            defer { registry.complete(token) }
+            await operation()
+        }
+        let task = detached
+            ? crawlScheduler.spawnDetached(priority, owned)
+            : crawlScheduler.spawn(priority, owned)
+        ownedCrawlTasks.register(token, task)
+        if firstRun { _trackFirstRunTask(task) }
+        return task
     }
 
-    /// Register a `loadCatalogs` FIRST-RUN task. Appends to BOTH the general
-    /// crawl registry (so `cancelBackgroundWork()` cancels it, identical to
-    /// `_trackCrawlTask`) AND the first-run subset the deterministic-join seam
-    /// awaits. No-op outside an XCTest process — production never populates
-    /// either list, so RELEASE behavior is byte-identical to a bare
-    /// `_trackCrawlTask` (which is itself a no-op in RELEASE).
+    /// Record a `loadCatalogs` FIRST-RUN task in the narrow-join subset. No-op
+    /// outside XCTest (the whole-set drain uses `ownedCrawlTasks`, not this).
     private func _trackFirstRunTask(_ task: Task<Void, Never>) {
         guard Self._isRunningUnderXCTest else { return }
         _trackedCrawlTasksLock.lock()
-        _trackedCrawlTasks.append(task)
         _trackedFirstRunTasks.append(task)
         _trackedCrawlTasksLock.unlock()
     }
 
-    /// Test-only deterministic JOIN seam. Snapshots the currently-tracked
-    /// FIRST-RUN tasks under the lock and `await`s each to completion, so a test
-    /// can join the ACTUAL off-main first-run work (bundled decode → synchronous
-    /// `fetchFromNetwork` kickoff) spawned by `loadCatalogs` instead of polling a
-    /// wall-clock deadline. Under CI's parallel sim clones a fixed-deadline poll
-    /// starves (the detached `.utility` task loses the CPU race) and fails on all
-    /// 3 retries; awaiting the real handle removes the clock entirely.
-    ///
-    /// Awaits ALL tracked first-run tasks (not just the most-recent), so a
-    /// dedupe-break that erroneously spawns a SECOND first-run task is also
-    /// joined — `testSecondConcurrentLoad` can then assert the decode ran exactly
-    /// once after every first-run task has finished. It deliberately does NOT
-    /// await the downstream live network crawl that `fetchFromNetwork` spawns
-    /// (which hits the real registry and would reintroduce nondeterministic
-    /// latency); the first-run task's synchronous `fetchFromNetwork` call has
+    /// Test-only whole-quiescence JOIN seam (PP-4754). Grows-until-stable: awaits
+    /// every owned crawl `Task`, re-snapshotting to catch tasks the wave spawned
+    /// (crawl → pagination/fallback → preload is a finite chain) until none is
+    /// new or `maxRounds` is hit. NO wall-clock — pure Task-join, so it never
+    /// starves under parallel CI clones (STARVE-001-clean) and never blocks main
+    /// (it suspends). No-op outside XCTest.
+    nonisolated func _awaitCatalogLoadForTesting(maxRounds: Int = 8) async {
+        guard Self._isRunningUnderXCTest else { return }
+        var awaited = Set<UUID>()
+        for _ in 0..<maxRounds {
+            let fresh = ownedCrawlTasks.snapshot().filter { !awaited.contains($0.0) }
+            if fresh.isEmpty { return }
+            for (token, task) in fresh {
+                _ = await task.value
+                awaited.insert(token)
+            }
+        }
+    }
+
+    /// Test-only quiescence assertion helper: number of live owned crawl tasks.
+    var _ownedCrawlTaskCountForTesting: Int { ownedCrawlTasks.count }
+
+    /// Test-only NARROW deterministic JOIN seam. Awaits every tracked FIRST-RUN
+    /// task (bundled decode → synchronous `fetchFromNetwork` kickoff) instead of
+    /// polling a wall-clock deadline that starves under parallel CI clones. It
+    /// deliberately does NOT await the downstream live crawl `fetchFromNetwork`
+    /// spawns — the first-run task's synchronous `fetchFromNetwork` call has
     /// already returned (bumping `_fetchFromNetworkCount`) by the time its
-    /// `.value` resolves, so joining the first-run task alone suffices.
-    ///
-    /// `nonisolated` + a synchronous lock-guarded snapshot: the manager is only
-    /// touched synchronously here (the `Task<Void, Never>` handles are Sendable),
-    /// so awaiting this from an `@MainActor` test never "sends" the non-Sendable
-    /// manager across an isolation boundary. Behavior-identical to a no-op in
-    /// RELEASE — the first-run-tasks array only ever populates under XCTest (the
-    /// `_trackFirstRunTask` env gate), and production never calls this method. It
-    /// only READS/awaits existing handles; it spawns no work and mutates no
-    /// production state.
-    /// Synchronous lock-guarded snapshot of the tracked first-run tasks. Split
-    /// out of the `async` join seam because `NSLock.lock()`/`.unlock()` are
-    /// unavailable from an async context (Swift 6 forbids them even when the
-    /// critical section never spans a suspension point). The `await` happens in
-    /// the caller, strictly after the lock is released here.
+    /// `.value` resolves, so joining the first-run task alone suffices for the
+    /// decode + fetch-fired observations. (For whole-quiescence use
+    /// `_awaitCatalogLoadForTesting`.) No-op in RELEASE — the array only
+    /// populates under XCTest. Snapshot-then-await-without-a-lock (Swift 6 bans
+    /// `NSLock.lock()` across an await).
     nonisolated private func _snapshotFirstRunTasksForTesting() -> [Task<Void, Never>] {
         _trackedCrawlTasksLock.lock()
         defer { _trackedCrawlTasksLock.unlock() }
@@ -571,12 +574,16 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// - Parameter borrowReauthResetter: account-switch borrow-reauth reset seam
     ///   (Wave 3 S1). REAL default keeps every existing call site behavior-identical;
     ///   tests inject a spy, `AppContainer` passes it explicitly.
+    /// - Parameter crawlScheduler: injectable background-crawl spawn seam
+    ///   (PP-4754). `.production` keeps every call site behavior-identical.
     init(
         defaults: UserDefaults = .standard,
-        borrowReauthResetter: any BorrowReauthResetting = DownloadCenterBorrowReauthResetter()
+        borrowReauthResetter: any BorrowReauthResetting = DownloadCenterBorrowReauthResetter(),
+        crawlScheduler: CrawlTaskScheduler = .production
     ) {
         self.defaults = defaults
         self.borrowReauthResetter = borrowReauthResetter
+        self.crawlScheduler = crawlScheduler
         self.settings = TPPSettings()
         self.accountSet = TPPConfiguration.customUrlHash()
             ?? (settings.useBetaLibraries
@@ -629,20 +636,23 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             // explicitly. Production never takes this branch.
             return
         }
-        // DEBUG-only arm: use `Task.detached` so the background work is
-        // cancellable from `cancelBackgroundWork()` (called by
-        // `AppContainer._resetForTesting()`). Production uses
-        // `DispatchQueue.global(qos: .utility).async`. Both arms run at
-        // `.utility` (bumped from `.background` in CP-D3) so the cold-launch
-        // registry crawl is not starved behind lower-priority work — and so
-        // DEBUG tests exercise the same QoS as production. swarm_4b64e4e0 Fix 2.
-        backgroundFetchTask = Task.detached(priority: .utility) { [weak self] in
+        #endif
+        // Unified background-load arm (both configs) — PP-4754. Routed through
+        // `spawnOwnedCrawlTask` so the crawl is OWNED (cancellable + drainable at
+        // a test boundary). RELEASE previously used a bare
+        // `DispatchQueue.global(qos: .utility).async` (untracked); it now spawns
+        // the SAME detached `.utility` work DEBUG has exercised for months. This
+        // ownership unification is the single deliberate production-visible
+        // delta; the crawl work (`loadCatalogs`) is unchanged. DEBUG keeps a
+        // separate `backgroundFetchTask` handle for the injection + cancellation
+        // observation seams; RELEASE lets the registry own it.
+        let initialLoadTask = spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
             self?.loadCatalogs(completion: nil)
         }
+        #if DEBUG
+        backgroundFetchTask = initialLoadTask
         #else
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            self?.loadCatalogs(completion: nil)
-        }
+        _ = initialLoadTask
         #endif
     }
 
@@ -818,13 +828,12 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
         // conditional compilation on the production path). Production always
         // refreshes; tests seed slim snapshots explicitly.
         guard !Self._isRunningUnderXCTest else { return }
-        let task = Task.detached(priority: .utility) { [weak self] in
+        spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
             guard let self, !Task.isCancelled else { return }
             guard let data = self.readCachedAccountsCatalogData(hash: hash) else { return }
             guard !Task.isCancelled else { return }
             self.writeSlimSnapshot(fromFullCatalogData: data, hash: hash)
         }
-        _trackCrawlTask(task)
     }
 
     /// Carve the current + settings accounts out of the full catalog blob and
@@ -1311,7 +1320,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
         // `_trackCrawlTask` so `cancelBackgroundWork()` cancels it — which
         // keeps the `Task.isCancelled` guard below meaningful (mirrors the
         // crawl tasks spawned inside `fetchFromNetwork`).
-        let firstRunTask = Task.detached(priority: .utility) { [weak self] in
+        spawnOwnedCrawlTask(priority: .utility, detached: true, firstRun: true) { [weak self] in
             guard let self = self else { return }
 
             // 2.5. Bundled snapshot fast-path. The `Task.isCancelled` guard
@@ -1339,7 +1348,6 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             Log.debug(#file, "Loading catalogs from network for hash \(hash)…")
             self.fetchFromNetwork(targetUrl: targetUrl, hash: hash)
         }
-        _trackFirstRunTask(firstRunTask)
     }
 
     /// Fetches catalog data using the first-page fast path:
@@ -1365,7 +1373,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
             return
         }
-        let crawlTask = Task(priority: .userInitiated) { [weak self] in
+        spawnOwnedCrawlTask(priority: .userInitiated, detached: false) { [weak self] in
             guard let self = self else { return }
             Log.debug(#file, "Fetching catalogs via first-page fast path for hash \(hash)")
 
@@ -1405,7 +1413,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
                 // via a documented box (used strictly sequentially — see
                 // `CrawlerHandoffBox`). `firstPage`/`targetUrl` are Sendable.
                 let crawlerBox = CrawlerHandoffBox(crawler: crawler)
-                let paginationTask = Task(priority: .utility) { [weak self] in
+                self.spawnOwnedCrawlTask(priority: .utility, detached: false) { [weak self] in
                     guard let self = self else { return }
 
                     let remainingResult = await crawlerBox.crawler.crawlRemainingPages(
@@ -1425,7 +1433,6 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
                     }
                     self.triggerCatalogPreload()
                 }
-                self._trackCrawlTask(paginationTask)
 
             case .noChanges:
                 self.callAndClearLoadingHandlers(for: hash, true)
@@ -1435,34 +1442,32 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
                 self.fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
             }
         }
-        _trackCrawlTask(crawlTask)
     }
 
     /// Fallback direct GET when crawler fails on first launch.
+    ///
+    /// PP-4754: the GET completion used to be a fire-and-forget closure the
+    /// test-boundary drain could not await (the last un-drainable write channel).
+    /// It now runs inside an OWNED `spawnOwnedCrawlTask` bridging the callback GET
+    /// via the existing `ContinuationGuard`-protected `async throws` `GET` (so
+    /// the continuation resumes exactly once even on a -999 cancel). The
+    /// post-await `Task.isCancelled` guard drops a late response instead of
+    /// late-writing `AccountStateStore.shared` into the next test — now that the
+    /// task is owned+cancelled, this fully supersedes the prior DEBUG
+    /// `_explicitCancelCalled` completion guard.
     private func fallbackFetchFromNetwork(targetUrl: URL, hash: String) {
-        networkExecutor.GET(targetUrl, useTokenIfAvailable: false) { [weak self] result in
+        spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
             guard let self = self else { return }
-            #if DEBUG
-            // Test-pollution guard: a completion for a manager the test-boundary
-            // drain already cancelled must not late-write AccountStateStore.shared
-            // into a subsequent test. This network completion is untracked (not a
-            // `_trackCrawlTask` Task, so the drain's cooperative-cancellation
-            // observation misses it) — without this guard its `cacheAccountsCatalogData`
-            // / `loadAccountSetsAndAuthDoc` writes can land on a later runloop turn,
-            // after the next test's AccountStateStore reset, keyed by a fixture-shared
-            // library UUID. Mirrors the `fetchAuthDocumentWithStateMachine` guards.
-            // Production is UNAFFECTED: `_explicitCancelCalled` is `#if DEBUG` and set
-            // only by `cancelBackgroundWork()` (reachable only from `_resetForTesting()`).
-            if self._explicitCancelCalled { return }
-            #endif
-            switch result {
-            case .success(let data, _):
+            do {
+                let (data, _) = try await self.networkExecutor.GET(targetUrl, useTokenIfAvailable: false)
+                if Task.isCancelled { return }
                 self.cacheAccountsCatalogData(data, hash: hash)
                 self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { success in
                     NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
                     self.callAndClearLoadingHandlers(for: hash, success)
                 }
-            case .failure(let error, _):
+            } catch {
+                if Task.isCancelled { return }
                 Log.error(#file, "Failed to load catalogs from network: \(error.localizedDescription)")
                 if let data = self.readCachedAccountsCatalogData(hash: hash) {
                     Log.info(#file, "Using cached catalog data as fallback after network failure")
@@ -1487,7 +1492,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
             return
         }
-        let refreshTask = Task(priority: .utility) { [weak self] in
+        spawnOwnedCrawlTask(priority: .utility, detached: false) { [weak self] in
             guard let self = self else { return }
             Log.debug(#file, "Starting background refresh (crawl) for catalog hash \(hash)")
 
@@ -1532,34 +1537,23 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
                 self.fallbackDirectRefresh(targetUrl: targetUrl, hash: hash)
             }
         }
-        _trackCrawlTask(refreshTask)
     }
 
-    /// Fallback to direct GET when crawlable endpoint fails.
+    /// Fallback to direct GET when crawlable endpoint fails. PP-4754: owned +
+    /// drainable, bridging the callback GET via the `ContinuationGuard`-protected
+    /// `async throws` `GET` — see `fallbackFetchFromNetwork` for the rationale.
     private func fallbackDirectRefresh(targetUrl: URL, hash: String) {
-        networkExecutor.GET(targetUrl, useTokenIfAvailable: false) { [weak self] result in
+        spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
             guard let self = self else { return }
-            #if DEBUG
-            // Test-pollution guard: a completion for a manager the test-boundary
-            // drain already cancelled must not late-write AccountStateStore.shared
-            // into a subsequent test. This network completion is untracked (not a
-            // `_trackCrawlTask` Task, so the drain's cooperative-cancellation
-            // observation misses it) — without this guard its `cacheAccountsCatalogData`
-            // / `loadAccountSetsAndAuthDoc` writes can land on a later runloop turn,
-            // after the next test's AccountStateStore reset, keyed by a fixture-shared
-            // library UUID. Mirrors the `fetchAuthDocumentWithStateMachine` guards.
-            // Production is UNAFFECTED: `_explicitCancelCalled` is `#if DEBUG` and set
-            // only by `cancelBackgroundWork()` (reachable only from `_resetForTesting()`).
-            if self._explicitCancelCalled { return }
-            #endif
-            switch result {
-            case .success(let data, _):
+            do {
+                let (data, _) = try await self.networkExecutor.GET(targetUrl, useTokenIfAvailable: false)
+                if Task.isCancelled { return }
                 Log.info(#file, "Fallback direct refresh successful for hash \(hash)")
                 self.cacheAccountsCatalogData(data, hash: hash)
                 self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { _ in
                     NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
                 }
-            case .failure(let error, _):
+            } catch {
                 Log.debug(#file, "Fallback direct refresh also failed for hash \(hash): \(error.localizedDescription)")
             }
         }
@@ -1567,7 +1561,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
 
     /// Triggers catalog feed preloading for active accounts.
     private func triggerCatalogPreload() {
-        let preloadTask = Task(priority: .utility) { [weak self] in
+        spawnOwnedCrawlTask(priority: .utility, detached: false) { [weak self] in
             guard let self = self else { return }
             await self.catalogPreloader.preloadCatalogs(
                 currentAccount: self.currentAccount,
@@ -1575,7 +1569,6 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
                 accountProvider: { self.account($0) }
             )
         }
-        _trackCrawlTask(preloadTask)
     }
 
     // MARK: – Disk cache helpers
@@ -2194,7 +2187,13 @@ extension AccountsManager {
     /// `AppContainer._resetForTesting()`. swarm_4b64e4e0 Fix 2 — closes the
     /// H1 finding from swarm_f88ae9e3 A.
     ///
-    /// Residual race window (documented intentional): if `loadCatalogs` is
+    /// This is the COOPERATIVE cancel — it returns immediately. The SYNCHRONOUS
+    /// `cancelAndDrainBackgroundWork()` (which `_resetForTesting()` actually
+    /// calls at every boundary) awaits the full owned set, which drains the
+    /// previously un-awaitable fallback-GET channel. Kept for the
+    /// idempotent/observation-surface tests.
+    ///
+    /// Residual race window (NARROWED to one boundary): if `loadCatalogs` is
     /// already past the post-await `Task.isCancelled` check inside
     /// `fetchFromNetwork`, the network response still lands in `accountSets`
     /// on the OLD AccountsManager instance — but the OLD instance is no
@@ -2211,19 +2210,17 @@ extension AccountsManager {
         _explicitCancelCalled = true
         backgroundFetchTask?.cancel()
         backgroundFetchTask = nil
-        // Cancel the unstructured crawl / pagination / preload tasks spawned by
-        // loadCatalogs. These are independent of backgroundFetchTask, so
-        // without this they leak a live registry crawl past the test boundary
-        // and pollute the next test (the intermittent cross-test CI crash).
+        // Cancel every OWNED crawl / pagination / refresh / fallback-GET /
+        // preload task spawned by loadCatalogs — without this they leak a live
+        // crawl past the test boundary and pollute the next test. Each task
+        // self-prunes its token as it unwinds, so cancelAll() does not clear the
+        // map — the drain then awaits whatever is still live.
+        ownedCrawlTasks.cancelAll()
+        // Drop the first-run subset so the narrow join seam does not re-await an
+        // already-cancelled task.
         _trackedCrawlTasksLock.lock()
-        let crawlTasks = _trackedCrawlTasks
-        _trackedCrawlTasks.removeAll()
-        // Clear the first-run subset too — its handles are a subset of
-        // `_trackedCrawlTasks` (cancelled above), so dropping them here keeps the
-        // deterministic-join seam from re-awaiting an already-cancelled task.
         _trackedFirstRunTasks.removeAll()
         _trackedCrawlTasksLock.unlock()
-        crawlTasks.forEach { $0.cancel() }
         networkExecutor.cancelNonEssentialTasks()
     }
 
@@ -2253,14 +2250,16 @@ extension AccountsManager {
     /// `AppContainer._resetForTesting()` (every test boundary) so the fix is
     /// global across ALL flag-false crawl spawners, not a per-test patch.
     func cancelAndDrainBackgroundWork(timeout: TimeInterval = 3.0) {
-        // Capture the in-flight tasks BEFORE cancelBackgroundWork() clears them.
-        _trackedCrawlTasksLock.lock()
-        let crawlTasks = _trackedCrawlTasks
-        _trackedCrawlTasksLock.unlock()
+        // Capture the FULL owned set BEFORE cancelBackgroundWork() cancels it —
+        // including the newly-wrapped fallback GET tasks, so the last
+        // un-drainable write channel is now awaited, not missed.
+        // `backgroundFetchTask` is also awaited to cover a test-INJECTED task
+        // not in the registry (an owned task awaited twice returns immediately).
+        let ownedTasks = ownedCrawlTasks.snapshot().map { $0.1 }
         let fetchTask = backgroundFetchTask
-        let tasksToDrain = crawlTasks + [fetchTask].compactMap { $0 }
+        let tasksToDrain = ownedTasks + [fetchTask].compactMap { $0 }
 
-        cancelBackgroundWork() // requests cancellation, nils handles, clears list
+        cancelBackgroundWork() // requests cancellation, nils the handle
 
         if tasksToDrain.isEmpty {
             // No tracked Tasks, but init may have enqueued a DispatchQueue.main.async

--- a/Palace/Accounts/Library/CatalogCrawlScheduler.swift
+++ b/Palace/Accounts/Library/CatalogCrawlScheduler.swift
@@ -1,0 +1,124 @@
+//
+//  CatalogCrawlScheduler.swift
+//  Palace
+//
+//  Owned-task infrastructure for AccountsManager's background catalog-crawl
+//  work (PP-4754 root-cause de-flake). Splits two collaborators out of the
+//  AccountsManager god class:
+//
+//   - `CrawlTaskScheduler`: the injectable spawn seam. Production spawns real
+//     structured/detached Tasks; tests inject a recording scheduler to pin the
+//     scheduling contract (site order + priority + detachedness) that a refactor
+//     could otherwise silently drift.
+//   - `OwnedCrawlTaskRegistry`: a self-pruning registry that gives every
+//     background crawl Task a real owner. ALWAYS populated (production included)
+//     so the test-boundary drain is COMPLETE — no fire-and-forget write channel
+//     survives a test to pollute the next one (the systemic flake class this
+//     change closes). Bounded because each task removes its own token on
+//     completion.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+
+/// Injectable spawn seam for AccountsManager's background catalog-crawl Tasks.
+///
+/// Two arms preserve each call site's exact detached-vs-inheriting semantics and
+/// priority: the init / first-run / slim-refresh sites spawn `detached` at
+/// `.utility`; the `fetchFromNetwork` crawl spawns an inheriting `Task` at
+/// `.userInitiated`; pagination / refresh / preload spawn inheriting `Task`s at
+/// `.utility`. `production` is the live implementation; a test can substitute a
+/// recording scheduler that captures `(priority, detached)` per spawn to assert
+/// the cold-launch scheduling contract.
+struct CrawlTaskScheduler: Sendable {
+  /// Spawn an inheriting `Task` at `priority`.
+  var spawn: @Sendable (TaskPriority, @escaping @Sendable () async -> Void) -> Task<Void, Never>
+  /// Spawn a context-free `Task.detached` at `priority`.
+  var spawnDetached: @Sendable (TaskPriority, @escaping @Sendable () async -> Void) -> Task<Void, Never>
+
+  static let production = CrawlTaskScheduler(
+    spawn: { priority, operation in
+      Task(priority: priority) { await operation() }
+    },
+    spawnDetached: { priority, operation in
+      Task.detached(priority: priority) { await operation() }
+    }
+  )
+}
+
+/// Self-pruning owned-task registry for AccountsManager's background crawl work.
+///
+/// Every background Task the manager spawns is registered here under a fresh
+/// token and self-removes on completion (the caller wraps the operation in a
+/// `defer { registry.complete(token) }`). The registry is populated in
+/// production too — this is the ownership change at the heart of PP-4754: a
+/// crawl that used to be fire-and-forget now has an owner that
+/// `cancelBackgroundWork()` can cancel and `cancelAndDrainBackgroundWork()` can
+/// await. Growth is bounded because each task prunes its own token, so the live
+/// set only ever holds genuinely in-flight work.
+///
+/// `@unchecked Sendable` invariant: the only mutable state (`tasks`,
+/// `completedBeforeInsert`) is read and written exclusively under `lock` (an
+/// immutable `NSLock`); the wrapped `Task<Void, Never>` handles are themselves
+/// `Sendable`.
+///
+/// Insert-vs-complete race: a spawned Task can finish — and run its
+/// `complete(_:)` defer — BEFORE the spawning code calls `register(_:_:)` (the
+/// task is created, then registered). A naive registry would then insert a
+/// handle for an already-finished task and never prune it. The `completedBeforeInsert`
+/// tombstone set closes this: if `complete` runs first it records the token as a
+/// tombstone; `register` then sees the tombstone, clears it, and skips the
+/// insert. Even if this guard were absent the leak would be benign for the join
+/// (awaiting a finished task returns immediately) — the tombstone only bounds
+/// memory, which is why it is safe and cheap.
+final class OwnedCrawlTaskRegistry: @unchecked Sendable {
+  private let lock = NSLock()
+  private var tasks: [UUID: Task<Void, Never>] = [:]
+  private var completedBeforeInsert: Set<UUID> = []
+
+  /// Register a freshly-spawned task under `token`. Called AFTER the task is
+  /// created, so it must reconcile with a `complete(_:)` that may already have
+  /// run (see the tombstone rationale on the type).
+  func register(_ token: UUID, _ task: Task<Void, Never>) {
+    lock.lock(); defer { lock.unlock() }
+    if completedBeforeInsert.remove(token) != nil {
+      // The task already finished before we got here — nothing to track.
+      return
+    }
+    tasks[token] = task
+  }
+
+  /// Self-prune: called from the spawned task's own completion `defer`.
+  func complete(_ token: UUID) {
+    lock.lock(); defer { lock.unlock() }
+    if tasks.removeValue(forKey: token) == nil {
+      // Completed before `register` inserted us — leave a tombstone so the
+      // pending `register` skips the insert.
+      completedBeforeInsert.insert(token)
+    }
+  }
+
+  /// Request cancellation of every live task. Does not clear the map —
+  /// each task's `complete(_:)` defer prunes it as it unwinds, which is what the
+  /// drain then awaits.
+  func cancelAll() {
+    lock.lock()
+    let live = Array(tasks.values)
+    lock.unlock()
+    for task in live { task.cancel() }
+  }
+
+  /// Snapshot of the live `(token, task)` pairs for the deterministic drain /
+  /// join. Callers await OUTSIDE the lock (no lock is ever held across `await`).
+  func snapshot() -> [(UUID, Task<Void, Never>)] {
+    lock.lock(); defer { lock.unlock() }
+    return tasks.map { ($0.key, $0.value) }
+  }
+
+  /// Count of live owned tasks — for test quiescence assertions.
+  var count: Int {
+    lock.lock(); defer { lock.unlock() }
+    return tasks.count
+  }
+}

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -786,18 +786,21 @@ struct AppContainer: @unchecked Sendable {
     ///      (`AppContainerResetTests`); the safe default between tests is
     ///      `true`, matching `PalaceTestSetup.bootstrap()`.
     ///
-    /// Residual race window (DOCUMENTED INTENTIONAL):
-    /// Step 2's cancellation is cooperative. If the prior AccountsManager's
-    /// `fetchFromNetwork` Task is mid-await on `crawler.crawlFirstPage`, the
-    /// completion still fires and writes through to `accountSets` on the OLD
-    /// instance — but the OLD instance is no longer reachable from
-    /// `production()`, so the write is observable only by code paths that
-    /// held a strong reference to the prior `accountsManager` (none in
-    /// production; vanishingly few in tests). The next test gets a clean
-    /// `production()` graph regardless. This window is the brief moment
-    /// between cancel-request and Task cancellation observation; on a
-    /// 100Mbps link with the bundled snapshot path, < 50ms in 99% of cases.
-    /// Acceptable per swarm_4b64e4e0 outcome.md user direction.
+    /// Residual race window (NARROWED — PP-4754):
+    /// Step 2 no longer relies on cooperative cancellation alone. Every
+    /// background crawl Task — including the previously un-drainable fallback
+    /// GET completions — is now OWNED by `AccountsManager.ownedCrawlTasks`, and
+    /// `cancelAndDrainBackgroundWork()` (called below) synchronously awaits the
+    /// full owned set before returning. So a `fetchFromNetwork` Task mid-await
+    /// on `crawler.crawlFirstPage` is drained to completion (its post-await
+    /// `Task.isCancelled` guard drops the write) inside this boundary rather
+    /// than landing on the OLD instance a few ms later. The one remaining
+    /// window: a crawl that passes its `Task.isCancelled` guard concurrently
+    /// with the cancel can spawn a successor (pagination/preload) that is
+    /// neither in the drained snapshot nor yet cancelled — it is caught at the
+    /// NEXT boundary by `_drainAllLiveInstancesForTesting()`. Strictly narrower
+    /// than the pre-change fire-and-forget behavior; no write survives past that
+    /// next boundary's store reset.
     ///
     /// swarm_4b64e4e0 Fix 2 — DEBUG-only test seam. Not callable from
     /// production code (compile-time gated). The function is `internal` so

--- a/PalaceTests/Accounts/AccountsManagerCatalogLoadJoinTests.swift
+++ b/PalaceTests/Accounts/AccountsManagerCatalogLoadJoinTests.swift
@@ -1,0 +1,272 @@
+//
+//  AccountsManagerCatalogLoadJoinTests.swift
+//  PalaceTests
+//
+//  PP-4754 root-fix tests for the OWNED, deterministically-joinable catalog
+//  crawl. Drives the real cold-load spawn chain fully OFFLINE (the test host
+//  routes `URLSession.shared` + the network executor through
+//  `NoNetworkURLProtocol`, so both the registry crawler and the fallback GET
+//  fail fast) and asserts:
+//
+//   1. The whole-set join seam `_awaitCatalogLoadForTesting()` drives every
+//      owned crawl Task — init/first-run → crawl → fallback GET — to quiescence
+//      with NO wall-clock (grow-until-stable Task-join). After it returns, the
+//      owned set is empty.
+//   2. The scheduling contract: the first-run task is a detached `.utility`
+//      spawn, the crawl an inheriting `.userInitiated` spawn, and — the crux of
+//      the fix — the fallback GET is now an OWNED detached `.utility` spawn
+//      (previously a fire-and-forget closure the drain could not await).
+//   3. Drain completeness: `cancelAndDrainBackgroundWork()` leaves the owned set
+//      empty — the wrapped fallback GET is awaited, not leaked past the boundary.
+//
+//  Isolation is inherited from `PalaceWiringTestCase` (per-test singleton reset,
+//  `deferInitialLoadCatalogsForTesting`, tearDown drain, disk-cache purge).
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+@testable import Palace
+
+@MainActor
+final class AccountsManagerCatalogLoadJoinTests: PalaceWiringTestCase {
+
+    // MARK: - Fixtures
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("catalog_join_tests_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    /// Zero-catalog OPDS 2.0 feed so the bundled decode does no per-account work.
+    private func writeStubSnapshot() throws -> URL {
+        let payload = #"{"metadata":{"title":"PP-4754 stub"},"catalogs":[],"links":[]}"#
+        let url = tempDir
+            .appendingPathComponent("\(BundledRegistrySnapshot.resourceName).\(BundledRegistrySnapshot.resourceExtension)")
+        try payload.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    /// Isolated defaults so `currentAccountIdentifierKey` can't resolve a real
+    /// account and flip the manager onto the warm memory path.
+    private func isolatedDefaults() -> UserDefaults {
+        let name = "pp4754.join.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    // MARK: - 1 + 2. Whole-set join reaches quiescence; scheduling contract
+
+    func testColdLoad_awaitCatalogLoad_drivesOwnedChainToQuiescence() async throws {
+        let snapshotURL = try writeStubSnapshot()
+        let resolver = StubSnapshotResolver(snapshotURL: snapshotURL)
+        let recorder = RecordingCrawlScheduler()
+
+        let manager = makeFreshAccountsManager(
+            defaults: isolatedDefaults(),
+            crawlScheduler: recorder.scheduler()
+        ) {
+            $0.snapshotResourceResolver = resolver
+        }
+
+        // deferInitialLoadCatalogsForTesting is pinned true by the helper, so
+        // init spawned nothing — the ONLY spawns are the ones this call drives.
+        XCTAssertEqual(manager._ownedCrawlTaskCountForTesting, 0,
+                       "precondition: opt-out construction spawns no crawl task")
+
+        manager.loadCatalogs(completion: nil)
+
+        // Deterministic whole-set join — no wall-clock. Grows until stable across
+        // the finite first-run → crawl → fallback chain.
+        await manager._awaitCatalogLoadForTesting()
+
+        XCTAssertEqual(manager._ownedCrawlTaskCountForTesting, 0,
+                       "after the join every owned crawl task must have drained (grow-until-stable reached quiescence)")
+
+        // Scheduling contract: first-run detached .utility → crawl inheriting
+        // .userInitiated → fallback GET detached .utility (the crux: the fallback
+        // is now OWNED, so it appears here at all).
+        let spawns = recorder.spawns
+        XCTAssertGreaterThanOrEqual(spawns.count, 3,
+                                    "cold offline load must spawn first-run, crawl, and the fallback GET")
+        XCTAssertEqual(spawns[0], .init(priority: .utility, detached: true),
+                       "first spawn is the first-run task (detached .utility)")
+        XCTAssertEqual(spawns[1], .init(priority: .userInitiated, detached: false),
+                       "second spawn is the fetchFromNetwork crawl (inheriting .userInitiated)")
+        XCTAssertEqual(spawns[2], .init(priority: .utility, detached: true),
+                       "third spawn is the wrapped fallback GET (owned detached .utility) — the previously un-drainable write channel")
+    }
+
+    // MARK: - 3. Drain completeness for the wrapped fallback GET
+
+    func testColdLoad_cancelAndDrain_leavesOwnedSetEmpty() async throws {
+        let snapshotURL = try writeStubSnapshot()
+        let resolver = StubSnapshotResolver(snapshotURL: snapshotURL)
+        let recorder = RecordingCrawlScheduler()
+
+        let manager = makeFreshAccountsManager(
+            defaults: isolatedDefaults(),
+            crawlScheduler: recorder.scheduler()
+        ) {
+            $0.snapshotResourceResolver = resolver
+        }
+
+        manager.loadCatalogs(completion: nil)
+        // Let the chain fully materialize (first-run → crawl → fallback) so the
+        // fallback GET is actually owned when we drain — the join is the
+        // deterministic barrier that guarantees it spawned.
+        await manager._awaitCatalogLoadForTesting()
+        // Positional (not `.contains`, which the first-run spawn's identical
+        // signature would also satisfy): the 3rd spawn IS the fallback GET.
+        let spawns = recorder.spawns
+        XCTAssertGreaterThanOrEqual(spawns.count, 3, "sanity: first-run + crawl + fallback GET all spawned")
+        XCTAssertEqual(spawns[2], .init(priority: .utility, detached: true),
+                       "sanity: the 3rd spawn is the owned fallback GET")
+
+        // The synchronous drain must leave nothing live — a fire-and-forget
+        // fallback completion (the pre-fix behavior) would survive this.
+        manager.cancelAndDrainBackgroundWork()
+        XCTAssertEqual(manager._ownedCrawlTaskCountForTesting, 0,
+                       "cancelAndDrainBackgroundWork must leave the owned set empty — the wrapped fallback GET is drained, not leaked")
+    }
+
+    // MARK: - 4. Live-drain arm: an in-flight owned task is awaited by the drain
+
+    /// Exercises the LIVE drain arm directly (not the join-first path): a crawl
+    /// task held in-flight on a cancellation-aware gate is snapshotted by
+    /// `cancelAndDrainBackgroundWork`, cancelled, and awaited to completion — so
+    /// the owned set is empty on return. A drain that skipped the await (or
+    /// never cancelled) would leave the gated task live. The gate resumes on
+    /// cancellation, so no wall-clock is involved.
+    func testCancelAndDrain_awaitsInFlightGatedOwnedTask() async throws {
+        let snapshotURL = try writeStubSnapshot()
+        let resolver = StubSnapshotResolver(snapshotURL: snapshotURL)
+        let gate = SpawnGate()
+
+        let manager = makeFreshAccountsManager(
+            defaults: isolatedDefaults(),
+            crawlScheduler: gate.scheduler()
+        ) {
+            $0.snapshotResourceResolver = resolver
+        }
+
+        manager.loadCatalogs(completion: nil)
+        // The first-run task is registered synchronously by spawnOwnedCrawlTask
+        // and immediately suspends on the gate → in-flight, before doing any work.
+        XCTAssertGreaterThanOrEqual(manager._ownedCrawlTaskCountForTesting, 1,
+                                    "an owned crawl task must be in-flight (gated) before the drain")
+
+        // Drain: snapshot (non-empty) → cancel (the gate resumes on cancellation)
+        // → await to completion. Must return with the owned set empty.
+        manager.cancelAndDrainBackgroundWork()
+        XCTAssertEqual(manager._ownedCrawlTaskCountForTesting, 0,
+                       "cancelAndDrainBackgroundWork must cancel + await the in-flight owned task, not return while it is still live")
+    }
+}
+
+// MARK: - Test helpers
+
+/// `BundleResourceResolving` stub handing back a tiny fixture feed.
+private final class StubSnapshotResolver: BundleResourceResolving, @unchecked Sendable {
+    private let snapshotURL: URL?
+    init(snapshotURL: URL?) { self.snapshotURL = snapshotURL }
+    func resourceURL(forName name: String, extension ext: String) -> URL? {
+        guard name == BundledRegistrySnapshot.resourceName,
+              ext == BundledRegistrySnapshot.resourceExtension else { return nil }
+        return snapshotURL
+    }
+}
+
+/// A `CrawlTaskScheduler` that suspends every spawned op on a cancellation-aware
+/// gate BEFORE it runs, so a test can hold an owned task in-flight and then
+/// exercise the live drain arm. The gate resumes when the surrounding task is
+/// cancelled (via `withTaskCancellationHandler`), so `cancelAndDrainBackgroundWork`
+/// unblocks + drains it with no wall-clock wait.
+private final class SpawnGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private var opened = false
+
+    func scheduler() -> CrawlTaskScheduler {
+        // Suspend on the gate, then ALWAYS run `op` — it is the registry's
+        // self-pruning wrapper (`defer { complete(token) }` around the real crawl
+        // body), so skipping it on cancel would leak the token. The crawl body's
+        // own `Task.isCancelled` checks make it return fast when cancelled.
+        CrawlTaskScheduler(
+            spawn: { [self] priority, op in
+                Task(priority: priority) { await self.gate(); await op() }
+            },
+            spawnDetached: { [self] priority, op in
+                Task.detached(priority: priority) { await self.gate(); await op() }
+            }
+        )
+    }
+
+    /// Suspends until `open()` is called or the surrounding task is cancelled.
+    private func gate() async {
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+                lock.lock()
+                if opened { lock.unlock(); c.resume(); return }
+                continuations.append(c)
+                lock.unlock()
+            }
+        } onCancel: {
+            resumeAll()
+        }
+    }
+
+    /// Release every gated op (and any future one). Idempotent; resumes each
+    /// registered continuation exactly once.
+    func open() { resumeAll() }
+
+    private func resumeAll() {
+        lock.lock()
+        let pending = continuations
+        continuations = []
+        opened = true
+        lock.unlock()
+        pending.forEach { $0.resume() }
+    }
+}
+
+/// Records each crawl spawn's `(priority, detached)` and delegates to real
+/// Tasks so the offline chain still runs to completion.
+private final class RecordingCrawlScheduler: @unchecked Sendable {
+    struct Spawn: Equatable {
+        let priority: TaskPriority
+        let detached: Bool
+    }
+    private let lock = NSLock()
+    private var _spawns: [Spawn] = []
+    var spawns: [Spawn] { lock.lock(); defer { lock.unlock() }; return _spawns }
+
+    func scheduler() -> CrawlTaskScheduler {
+        CrawlTaskScheduler(
+            spawn: { [self] priority, op in
+                record(priority, detached: false)
+                return Task(priority: priority) { await op() }
+            },
+            spawnDetached: { [self] priority, op in
+                record(priority, detached: true)
+                return Task.detached(priority: priority) { await op() }
+            }
+        )
+    }
+
+    private func record(_ priority: TaskPriority, detached: Bool) {
+        lock.lock(); _spawns.append(Spawn(priority: priority, detached: detached)); lock.unlock()
+    }
+}

--- a/PalaceTests/Accounts/CatalogCrawlSchedulerTests.swift
+++ b/PalaceTests/Accounts/CatalogCrawlSchedulerTests.swift
@@ -1,0 +1,212 @@
+//
+//  CatalogCrawlSchedulerTests.swift
+//  PalaceTests
+//
+//  Unit tests for the PP-4754 owned-crawl infrastructure split out of
+//  AccountsManager: `OwnedCrawlTaskRegistry` (self-pruning, insert-vs-complete
+//  race guard) and `CrawlTaskScheduler` (the two-arm injectable spawn seam).
+//
+//  These are pure, offline, network-free tests — no AccountsManager, no crawl,
+//  no wall-clock. They pin the registry's ownership invariants (the thing that
+//  makes the test-boundary drain complete) and the scheduler's spawn contract.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import Palace
+
+final class CatalogCrawlSchedulerTests: XCTestCase {
+
+    // MARK: - OwnedCrawlTaskRegistry: self-pruning
+
+    /// A registered task that later `complete`s prunes its token — the live set
+    /// returns to zero. Kills a mutant that drops the `removeValue` in
+    /// `complete`.
+    func test_registerThenComplete_prunesTokenToZero() {
+        let registry = OwnedCrawlTaskRegistry()
+        let token = UUID()
+        let task = Task<Void, Never> {}
+
+        registry.register(token, task)
+        XCTAssertEqual(registry.count, 1, "register must add the token to the live set")
+
+        registry.complete(token)
+        XCTAssertEqual(registry.count, 0, "complete must prune the token from the live set")
+    }
+
+    /// Insert-vs-complete race: when `complete` runs BEFORE `register` (the task
+    /// finished before the spawning code registered it), the tombstone must make
+    /// `register` skip the insert so no finished handle leaks. Kills a mutant
+    /// that removes the `completedBeforeInsert` tombstone guard in `register`
+    /// (without it, count would be 1 — a permanently-leaked finished task).
+    func test_completeBeforeRegister_tombstoneSkipsInsert() {
+        let registry = OwnedCrawlTaskRegistry()
+        let token = UUID()
+        let task = Task<Void, Never> {}
+
+        // Completion beats the (still-pending) registration.
+        registry.complete(token)
+        XCTAssertEqual(registry.count, 0, "a completion with no prior registration must not add anything")
+
+        // The late registration must observe the tombstone and skip the insert.
+        registry.register(token, task)
+        XCTAssertEqual(registry.count, 0,
+                       "register must skip a token already tombstoned by an earlier complete — else a finished task leaks forever")
+    }
+
+    /// Completing a LIVE token must not leave a spurious tombstone — a later
+    /// re-registration of that token must succeed. Kills the mutant that flips
+    /// `complete`'s `tasks.removeValue(...) == nil` to `!= nil` (which would
+    /// tombstone a token it just successfully removed, silently dropping a
+    /// subsequent registration of that token).
+    func test_completeOfLiveToken_leavesNoTombstoneForReuse() {
+        let registry = OwnedCrawlTaskRegistry()
+        let token = UUID()
+
+        registry.register(token, Task<Void, Never> {})
+        registry.complete(token)               // removes the live task
+        XCTAssertEqual(registry.count, 0)
+
+        // Re-registering the same token must succeed — a spurious tombstone from
+        // the mutated `complete` would make this insert be skipped.
+        registry.register(token, Task<Void, Never> {})
+        XCTAssertEqual(registry.count, 1,
+                       "complete() of a live token must not leave a tombstone that blocks re-registration")
+    }
+
+    /// Two distinct tokens are tracked independently — completing one does not
+    /// prune the other. Guards against a mutant that clears the whole map on any
+    /// completion.
+    func test_independentTokens_pruneIndependently() {
+        let registry = OwnedCrawlTaskRegistry()
+        let a = UUID(), b = UUID()
+        registry.register(a, Task<Void, Never> {})
+        registry.register(b, Task<Void, Never> {})
+        XCTAssertEqual(registry.count, 2)
+
+        registry.complete(a)
+        XCTAssertEqual(registry.count, 1, "completing one token must leave the other live")
+
+        let liveTokens = Set(registry.snapshot().map { $0.0 })
+        XCTAssertEqual(liveTokens, [b], "the surviving token must be the one not completed")
+    }
+
+    // MARK: - OwnedCrawlTaskRegistry: cancellation
+
+    /// `cancelAll()` cancels every live task. Kills a mutant that no-ops
+    /// cancelAll (the suspended task would never observe cancellation and the
+    /// await below would hang the test).
+    func test_cancelAll_cancelsEveryLiveTask() async {
+        let registry = OwnedCrawlTaskRegistry()
+        let suspicious = Task<Void, Never> {
+            // Suspends until cancelled; `Task.sleep` throws on cancel so `try?`
+            // lets it complete cleanly. No wall-clock dependence — the value is
+            // `.max` and only cancellation ends the sleep.
+            try? await Task.sleep(nanoseconds: .max)
+        }
+        registry.register(UUID(), suspicious)
+
+        registry.cancelAll()
+        _ = await suspicious.value
+
+        XCTAssertTrue(suspicious.isCancelled,
+                      "cancelAll must request cancellation of every registered task")
+    }
+
+    /// `snapshot()` returns the live (token, task) pairs so the drain can await
+    /// them. Confirms the returned handle is the one registered.
+    func test_snapshot_returnsRegisteredHandles() {
+        let registry = OwnedCrawlTaskRegistry()
+        let token = UUID()
+        let task = Task<Void, Never> {}
+        registry.register(token, task)
+
+        let snap = registry.snapshot()
+        XCTAssertEqual(snap.count, 1)
+        XCTAssertEqual(snap.first?.0, token, "snapshot must return the registered token")
+    }
+
+    // MARK: - CrawlTaskScheduler: two-arm spawn contract
+
+    /// The production `spawn` arm runs the supplied operation to completion.
+    func test_productionSpawn_runsOperation() async {
+        let ran = TestFlag()
+        let task = CrawlTaskScheduler.production.spawn(.utility) {
+            ran.set()
+        }
+        _ = await task.value
+        XCTAssertTrue(ran.value, "production.spawn must execute the operation")
+    }
+
+    /// The production `spawnDetached` arm runs the supplied operation to
+    /// completion.
+    func test_productionSpawnDetached_runsOperation() async {
+        let ran = TestFlag()
+        let task = CrawlTaskScheduler.production.spawnDetached(.userInitiated) {
+            ran.set()
+        }
+        _ = await task.value
+        XCTAssertTrue(ran.value, "production.spawnDetached must execute the operation")
+    }
+
+    /// A recording scheduler captures the (priority, detached) of each spawn AND
+    /// still runs the operation — the exact seam a characterization test uses to
+    /// pin the crawl scheduling contract. Proves both arms record distinctly.
+    func test_recordingScheduler_capturesPriorityAndArm() async {
+        let recorder = RecordingScheduler()
+        let scheduler = recorder.scheduler()
+
+        let ran1 = TestFlag(), ran2 = TestFlag()
+        let t1 = scheduler.spawn(.userInitiated) { ran1.set() }
+        let t2 = scheduler.spawnDetached(.utility) { ran2.set() }
+        _ = await t1.value
+        _ = await t2.value
+
+        XCTAssertTrue(ran1.value && ran2.value, "recording scheduler must still run the operations")
+        XCTAssertEqual(recorder.spawns, [
+            .init(priority: .userInitiated, detached: false),
+            .init(priority: .utility, detached: true),
+        ], "recording scheduler must capture each spawn's priority and detached arm in order")
+    }
+}
+
+// MARK: - Test helpers
+
+/// Thread-safe one-shot flag so `@Sendable` operation closures can signal they
+/// ran without data races.
+private final class TestFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = false
+    var value: Bool { lock.lock(); defer { lock.unlock() }; return _value }
+    func set() { lock.lock(); _value = true; lock.unlock() }
+}
+
+/// A `CrawlTaskScheduler` that records each spawn's `(priority, detached)` and
+/// delegates to the production spawns so the operation still runs.
+private final class RecordingScheduler: @unchecked Sendable {
+    struct Spawn: Equatable {
+        let priority: TaskPriority
+        let detached: Bool
+    }
+    private let lock = NSLock()
+    private var _spawns: [Spawn] = []
+    var spawns: [Spawn] { lock.lock(); defer { lock.unlock() }; return _spawns }
+
+    func scheduler() -> CrawlTaskScheduler {
+        CrawlTaskScheduler(
+            spawn: { [self] priority, op in
+                record(priority, detached: false)
+                return Task(priority: priority) { await op() }
+            },
+            spawnDetached: { [self] priority, op in
+                record(priority, detached: true)
+                return Task.detached(priority: priority) { await op() }
+            }
+        )
+    }
+
+    private func record(_ priority: TaskPriority, detached: Bool) {
+        lock.lock(); _spawns.append(Spawn(priority: priority, detached: detached)); lock.unlock()
+    }
+}

--- a/PalaceTests/Support/PalaceWiringTestCase.swift
+++ b/PalaceTests/Support/PalaceWiringTestCase.swift
@@ -139,15 +139,22 @@ class PalaceWiringTestCase: PalaceTestCase {
         // managers.
         cancellables.removeAll()
 
-        // Cancel background work on every helper-minted manager. We
+        // Cancel AND DRAIN background work on every helper-minted manager. We
         // capture the list locally and clear the stored property first
         // so a re-entrant tearDown (shouldn't happen, but) sees an empty
-        // list. `cancelBackgroundWork()` is idempotent — already-cancelled
-        // managers ignore the second call.
+        // list. `cancelAndDrainBackgroundWork()` is idempotent — already-drained
+        // managers return immediately.
+        //
+        // Drain (not just cancel): a bare `cancelBackgroundWork()` returns while
+        // a just-cancelled crawl is still mid-flight, which then bleeds into the
+        // NEXT method of THIS same class (the per-class boundary drain in
+        // `AppContainer._resetForTesting()` only covers cross-CLASS bleed). The
+        // synchronous drain here awaits the full owned set — including the
+        // wrapped fallback GETs — so nothing survives the method boundary.
         let managers = managersToCancelOnTearDown
         managersToCancelOnTearDown.removeAll()
         for manager in managers {
-            manager.cancelBackgroundWork()
+            manager.cancelAndDrainBackgroundWork()
         }
 
         // Symmetry with setUp: wipe the on-disk OPDS2 catalog cache so
@@ -230,6 +237,26 @@ class PalaceWiringTestCase: PalaceTestCase {
         AccountsManager.deferInitialLoadCatalogsForTesting = true
         #endif
         let manager = AccountsManager(defaults: defaults, borrowReauthResetter: borrowReauthResetter)
+        configure(manager)
+        managersToCancelOnTearDown.append(manager)
+        return manager
+    }
+
+    /// DI-aware overload that injects the background-crawl spawn seam
+    /// (`CrawlTaskScheduler`, PP-4754). Lets a test install a recording scheduler
+    /// to pin the crawl scheduling contract while keeping the same opt-out flag
+    /// pin + tearDown drain as the other helpers (so it stays off the
+    /// `AccountsManagerIsolationLint` bare-construction ban).
+    @discardableResult
+    nonisolated func makeFreshAccountsManager(
+        defaults: UserDefaults,
+        crawlScheduler: CrawlTaskScheduler,
+        _ configure: (AccountsManager) -> Void = { _ in }
+    ) -> AccountsManager {
+        #if DEBUG
+        AccountsManager.deferInitialLoadCatalogsForTesting = true
+        #endif
+        let manager = AccountsManager(defaults: defaults, crawlScheduler: crawlScheduler)
         configure(manager)
         managersToCancelOnTearDown.append(manager)
         return manager


### PR DESCRIPTION
Re-lands PR #1349 (the PP-4754 loadCatalogs root-fix) onto develop.

**Why a second PR:** #1349 merged into the forward-port branch (`chore/forward-port-main-to-develop`), but that branch's own merge to develop (#1348, commit 28958d206) used the pre-de-flake tip `99b3d38fb` — so the de-flake commit `4a37aa14c` was stranded one commit ahead. This PR carries exactly that one commit to develop.

**Already vetted:** identical code to #1349 — 3 SoD reviewers approved, full CI-parity 3-iter zero-restart verified, and CI green on the merged tip (tested alongside the boundedCompletion fix, which is now on develop). This PR's diff is exactly the de-flake; it merges clean onto develop (verified, no conflicts).

Closes the largest PP-4754 root cause. See PP-4754.