### PR TITLE
feat(catalog): make top-left Palace icon static branding, not a library switcher (PP-4821)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		1246CC54E04F756C2913D438 /* LCPPDFDiskExtractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F470EA0E88BDCE56E27B86 /* LCPPDFDiskExtractTests.swift */; };
 		12695B15A63B66C4B42E9B13 /* TPPReaderFootnoteAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD60FEA388441F72F8C8D85C /* TPPReaderFootnoteAccessibilityTests.swift */; };
 		126F5079067F518749BEB335 /* TabBarModernization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919D0E3F3618D29FCDBCB3C3 /* TabBarModernization.swift */; };
+		12DF6343ACBCF6315580125B /* CatalogViewLibraryIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E0377708FBC71A366A5160 /* CatalogViewLibraryIconTests.swift */; };
 		134F3EF0E81145878D455EFF /* UserRetryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43040747774740399559510F /* UserRetryTracker.swift */; };
 		137A5C5FCEB1C3E9F22B6A99 /* TPPPDFModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3D078322CEC4B660EC470F /* TPPPDFModelTests.swift */; };
 		1387B2F9424A9B052E3B353F /* TPPLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C7D04F855F2DA251329CDD /* TPPLocalization.swift */; };
@@ -2285,6 +2286,7 @@
 		20B293519F9B55B6F4F17CC7 /* PresetCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetCard.swift; sourceTree = "<group>"; };
 		20B4FEF7030A4AB7B26D18AE /* TPPBookCoverRegistryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPBookCoverRegistryTests.swift; sourceTree = "<group>"; };
 		20D04FC64A314C81BFC4026C /* TPPObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TPPObjCExceptionCatcher.h; path = Palace/Utilities/TPPObjCExceptionCatcher.h; sourceTree = SOURCE_ROOT; };
+		20E0377708FBC71A366A5160 /* CatalogViewLibraryIconTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogViewLibraryIconTests.swift; sourceTree = "<group>"; };
 		210E954A43CCA5ECCCB12227 /* DeveloperSettingsViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeveloperSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		2126FE2D25C059240095C45C /* ReaderError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderError.swift; sourceTree = "<group>"; };
 		212B99D2258A36FD00C8BF79 /* LCPAudiobooks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LCPAudiobooks.swift; sourceTree = "<group>"; };
@@ -3900,6 +3902,7 @@
 				4057C151D980D26B04B8FC53 /* ContinueRowSectionTests.swift */,
 				B0B284DD9A4739D34937C4D0 /* CatalogViewContinueRowsIntegrationTests.swift */,
 				A6D99F654723B202B64BEDFD /* SideloadedLaneTests.swift */,
+				20E0377708FBC71A366A5160 /* CatalogViewLibraryIconTests.swift */,
 			);
 			path = CatalogUI;
 			sourceTree = "<group>";
@@ -8004,6 +8007,7 @@
 				D26888D2C9A2BB133EBD5526 /* AudiobookBearerTokenRecoveryTests.swift in Sources */,
 				AB2801CCF1699315F888F6D0 /* AudiobookContentGateTests.swift in Sources */,
 				54335D47FB665C8DAAA00BA5 /* AudiobookVendorRecoveryContractTests.swift in Sources */,
+				12DF6343ACBCF6315580125B /* CatalogViewLibraryIconTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/CatalogUI/Views/CatalogView.swift
+++ b/Palace/CatalogUI/Views/CatalogView.swift
@@ -17,12 +17,9 @@ struct CatalogView: View {
     /// `CatalogView`, not the viewmodel).
     @ObservedObject private var activeSessionsViewModel: ActiveSessionsViewModel
     @State private var currentAccountUUID: String = ""
-    @State private var showAccountDialog: Bool = false
-    @State private var showAddLibrarySheet: Bool = false
     @State private var showSearch: Bool = false
 
     private let accountsManager: AccountsManager
-    private let settings: TPPSettings
     /// Resolves `ReaderService` + `AudiobookSessionPresenter` for the
     /// resume taps. Held as an `AppContainer` so test injection can
     /// supply a spy presenter via `withAudiobookSessionPresenter(_:)`.
@@ -33,13 +30,11 @@ struct CatalogView: View {
         viewModel: CatalogViewModel,
         activeSessionsViewModel: ActiveSessionsViewModel,
         accountsManager: AccountsManager = AppContainer.production().accountsManager,
-        settings: TPPSettings = AppContainer.production().settings,
         appContainer: AppContainer = AppContainer.production()
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
         self.activeSessionsViewModel = activeSessionsViewModel
         self.accountsManager = accountsManager
-        self.settings = settings
         self.appContainer = appContainer
     }
 
@@ -55,7 +50,6 @@ struct CatalogView: View {
                 setupCurrentAccount()
                 coordinator.clearAllCatalogFilterStates()
             }
-            .sheet(isPresented: $showAddLibrarySheet) { addLibrarySheet }
             .task { await viewModel.load() }
             .onReceive(NotificationCenter.default.publisher(for: .TPPCurrentAccountDidChange)) { _ in
                 handleAccountChange()
@@ -76,14 +70,13 @@ private extension CatalogView {
                 .accessibilityIdentifier(AccessibilityID.Catalog.libraryLogo)
         }
         ToolbarItem(placement: .navigationBarLeading) {
-            Button(action: { showAccountDialog = true }, label: {
-                ImageProviders.MyBooksView.myLibraryIcon
-                    .frame(minWidth: 44, minHeight: 44)
-                    .contentShape(Rectangle())
-            })
-            .accessibilityIdentifier(AccessibilityID.Catalog.accountButton)
-            .accessibilityLabel(Strings.Generic.switchLibrary)
-            .actionSheet(isPresented: $showAccountDialog) { libraryPicker }
+            // PP-4821: the top-left Palace icon is static branding only. Library
+            // switching lives solely in Settings now, so this is a plain image —
+            // not a Button — and stays hidden from VoiceOver (no button trait, no
+            // "Switch Library" announcement).
+            ImageProviders.MyBooksView.myLibraryIcon
+                .frame(minWidth: 44, minHeight: 44)
+                .accessibilityHidden(true)
         }
 
         ToolbarItem(placement: .navigationBarTrailing) {
@@ -103,33 +96,6 @@ private extension CatalogView {
                 .accessibilityLabel(Strings.Generic.searchCatalog)
             }
         }
-    }
-
-    private var libraryPicker: ActionSheet {
-        var buttons: [ActionSheet.Button] = settings.settingsAccountsList.map { account in
-            .default(Text(account.name)) {
-                switchToAccount(account)
-            }
-        }
-        buttons.append(.default(Text(Strings.MyBooksView.addLibrary)) {
-            showAddLibrarySheet = true
-        })
-        buttons.append(.cancel())
-        return ActionSheet(
-            title: Text(Strings.MyBooksView.findYourLibrary),
-            buttons: buttons
-        )
-    }
-
-    @ViewBuilder
-    var addLibrarySheet: some View {
-        UIViewControllerWrapper(
-            TPPAccountList { account in
-                addAndSwitchToAccount(account)
-                showAddLibrarySheet = false
-            },
-            updater: { _ in }
-        )
     }
 
     @ViewBuilder
@@ -383,25 +349,6 @@ private extension CatalogView {
         coordinator.clearAllCatalogFilterStates()
 
         Task { await viewModel.handleAccountChange() }
-    }
-
-    func switchToAccount(_ account: Account) {
-        if let urlString = account.catalogUrl, let url = URL(string: urlString) {
-            settings.accountMainFeedURL = url
-        }
-
-        // Setting `currentAccount` posts `.TPPCurrentAccountDidChange` (→
-        // `onReceive` → `handleAccountChange` → SWR reload) and single-flights
-        // `driveCurrentAccountAuthDocIfNeeded()`. So no manual notification
-        // post, no direct catalog refresh, and no manual auth-doc load here.
-        accountsManager.currentAccount = account
-    }
-
-    func addAndSwitchToAccount(_ account: Account) {
-        if !settings.settingsAccountIdsList.contains(account.uuid) {
-            settings.settingsAccountIdsList.append(account.uuid)
-        }
-        switchToAccount(account)
     }
 
     // MARK: - Computed Properties

--- a/Palace/Utilities/Testing/AccessibilityIdentifiers.swift
+++ b/Palace/Utilities/Testing/AccessibilityIdentifiers.swift
@@ -51,7 +51,6 @@ public enum AccessibilityID {
         // Navigation
         public static let navigationBar = "catalog.navigationBar"
         public static let searchButton = "catalog.searchButton"
-        public static let accountButton = "catalog.accountButton"
         public static let libraryLogo = "catalog.libraryLogo"
 
         // Content

--- a/PalaceTests/CatalogUI/CatalogViewLibraryIconTests.swift
+++ b/PalaceTests/CatalogUI/CatalogViewLibraryIconTests.swift
@@ -48,10 +48,14 @@ final class CatalogViewLibraryIconTests: XCTestCase {
                       "The leading toolbar item MUST still render the Palace branding icon (no visual regression to the header)")
         XCTAssertTrue(leadingBlock.contains("accessibilityHidden(true)"),
                       "The branding icon MUST stay hidden from VoiceOver — no button trait, no switching announcement")
-        XCTAssertFalse(leadingBlock.contains("Button"),
+        // Match the control *constructors*, not the bare words — the explanatory
+        // comment in this toolbar item legitimately mentions "Button"/"tap".
+        XCTAssertFalse(leadingBlock.contains("Button("),
                        "The Palace icon MUST NOT be a Button — library switching lives in Settings now (PP-4821)")
-        XCTAssertFalse(leadingBlock.contains("actionSheet"),
+        XCTAssertFalse(leadingBlock.contains(".actionSheet("),
                        "Tapping the Palace icon MUST NOT open a library-picker action sheet")
+        XCTAssertFalse(leadingBlock.contains(".onTapGesture"),
+                       "The Palace icon MUST NOT carry a tap gesture")
     }
 
     /// The switcher's supporting machinery is gone entirely, not merely

--- a/PalaceTests/CatalogUI/CatalogViewLibraryIconTests.swift
+++ b/PalaceTests/CatalogUI/CatalogViewLibraryIconTests.swift
@@ -1,0 +1,69 @@
+//
+//  CatalogViewLibraryIconTests.swift
+//  PalaceTests
+//
+//  PP-4821 — the top-left Palace icon on the catalog screen is static branding,
+//  not a library switcher. Library switching now lives solely in Settings.
+//
+//  These are source-level contract guards, the same technique (and for the same
+//  reason) as the CatalogView guards in CatalogViewContinueRowsIntegrationTests:
+//  a SwiftUI `ToolbarContent` tree has no runtime-introspectable seam in this
+//  project (no ViewInspector), so we pin the *shape* of the leading toolbar item
+//  against the production source. If a future change re-wires the icon back into
+//  a tappable switcher, these fail loudly instead of silently regressing the
+//  single-entry-point decision.
+//
+
+import XCTest
+
+final class CatalogViewLibraryIconTests: XCTestCase {
+
+    private func catalogViewSource() throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()        // CatalogUI
+            .deletingLastPathComponent()        // PalaceTests
+            .deletingLastPathComponent()        // repo root
+            .appendingPathComponent("Palace/CatalogUI/Views/CatalogView.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// The leading (top-left) toolbar item renders the Palace branding icon as a
+    /// plain, non-interactive, VoiceOver-hidden image — NOT a Button, and it
+    /// presents no library-picker action sheet.
+    ///
+    /// Mutates: re-wrapping the icon in a `Button`, restoring the `.actionSheet`,
+    /// or dropping `.accessibilityHidden(true)` each fails a distinct assertion.
+    func testCatalogLeadingIcon_isStaticBranding_notASwitcher() throws {
+        let source = try catalogViewSource()
+
+        // Isolate the .navigationBarLeading toolbar item so the assertions can't
+        // be satisfied by (or falsely tripped by) the trailing search Button.
+        guard let leadingStart = source.range(of: "placement: .navigationBarLeading)"),
+              let trailingStart = source.range(of: "placement: .navigationBarTrailing)") else {
+            return XCTFail("CatalogView toolbar MUST declare both a leading and a trailing item")
+        }
+        let leadingBlock = String(source[leadingStart.upperBound..<trailingStart.lowerBound])
+
+        XCTAssertTrue(leadingBlock.contains("ImageProviders.MyBooksView.myLibraryIcon"),
+                      "The leading toolbar item MUST still render the Palace branding icon (no visual regression to the header)")
+        XCTAssertTrue(leadingBlock.contains("accessibilityHidden(true)"),
+                      "The branding icon MUST stay hidden from VoiceOver — no button trait, no switching announcement")
+        XCTAssertFalse(leadingBlock.contains("Button"),
+                       "The Palace icon MUST NOT be a Button — library switching lives in Settings now (PP-4821)")
+        XCTAssertFalse(leadingBlock.contains("actionSheet"),
+                       "Tapping the Palace icon MUST NOT open a library-picker action sheet")
+    }
+
+    /// The switcher's supporting machinery is gone entirely, not merely
+    /// disconnected — so a stray reference can't quietly re-arm it.
+    func testCatalogView_hasNoLibrarySwitcherMachinery() throws {
+        let source = try catalogViewSource()
+
+        XCTAssertFalse(source.contains("showAccountDialog"),
+                       "The library-switcher dialog state MUST be removed")
+        XCTAssertFalse(source.contains("AccessibilityID.Catalog.accountButton"),
+                       "The catalog account-switcher accessibility identifier MUST be removed")
+        XCTAssertFalse(source.contains("libraryPicker"),
+                       "The catalog library-picker action sheet MUST be removed")
+    }
+}


### PR DESCRIPTION
## What & why

[PP-4821](https://ebce-lyrasis.atlassian.net/browse/PP-4821) — the Palace icon in the catalog header's top-left was a `Button` that opened a library-picker action sheet. Now that Settings owns library switching/adding, that's a second, redundant entry point. This makes the catalog icon **static branding only**: a plain, non-interactive, VoiceOver-hidden image. It renders in the same place at the same size, so the header is visually unchanged.

## Acceptance criteria — verified on-sim (iPhone 17 Pro, noDRM build)

| AC | Result |
|----|--------|
| Tapping the Palace icon no longer opens the switcher; icon is not interactive | ✅ tap produces no action sheet |
| Icon continues to display top-left (no header regression) | ✅ renders unchanged |
| Switching/adding libraries remain available from Settings | ✅ Settings → LIBRARIES section + ADD LIBRARY intact (untouched by this PR) |
| VoiceOver does not identify the icon as a button or announce switching | ✅ by construction — `accessibilityHidden(true)` + no `Button` removes it from the AX tree |
| No change to Android | ✅ iOS-only diff |

## Changes

- `CatalogView.swift`: leading toolbar `Button`+`.actionSheet` → plain `myLibraryIcon` image, `accessibilityHidden(true)`.
- Removed the now-dead switcher machinery it fed: `showAccountDialog` / `showAddLibrarySheet` state + the presenting `.sheet`, `libraryPicker`, `addLibrarySheet`, `switchToAccount` / `addAndSwitchToAccount`, the injected `settings` dependency (only the switcher used it), and the unused `catalog.accountButton` accessibility id.
- `CatalogViewLibraryIconTests`: source-level contract guards pinning the leading item as a non-`Button`, action-sheet-free, `accessibilityHidden` branding image, and asserting the switcher machinery is gone. Same introspection-free technique the existing `CatalogView` contract tests use (SwiftUI `ToolbarContent` has no runtime seam in this project).

## Scope / not done

- **Scope:** catalog-screen icon only (iOS). The Settings switcher and the MyBooks/Holds tab switcher icons are intentionally untouched.
- **Deferred:** `MyBooksView`/`HoldsView` still carry the same leading switcher icon — de-duplicating those is a separate concern, out of scope here.

## Test note

Built + AC-verified via `Palace-noDRM` (shared CatalogUI source) on a fresh worktree that lacks the private Adobe RMSDK headers, so the DRM `Palace` build + full `PalaceTests` run (which compiles & executes `CatalogViewLibraryIconTests`) is delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PP-4821]: https://ebce-lyrasis.atlassian.net/browse/PP-4821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ