### PR TITLE
ci: dormant package-purity gates for Wave 3a/3b (PalaceAccounts / PalaceDownloads)

### DIFF
--- a/scripts/check-palaceaccounts-package-purity.sh
+++ b/scripts/check-palaceaccounts-package-purity.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# check-palaceaccounts-package-purity.sh
+#
+# DORMANT gate for the future `PalaceAccounts` package (Wave 3a — see
+# docs/architecture/god-class-decomposition-plan.md and the Wave 3 brief:
+# extract PalaceAccounts off AccountsManager, seam-injecting the app-target
+# reaches it has today).
+#
+# Once that package exists, its `Sources/` must NEVER reach back into the
+# app-target coupling surface it was extracted to escape — that would
+# recreate exactly the coupling the whole god-class decomposition campaign
+# exists to dissolve. This gate asserts ZERO occurrences, anywhere under
+# `Palace/Packages/PalaceAccounts/Sources`, of:
+#
+#   AppContainer | MyBooksDownloadCenter | ImageCache.shared |
+#   TPPBookCoverRegistry | FirebaseManager
+#
+# It is DORMANT today: the package does not exist yet (Wave 3a has not landed
+# as of this writing), so the gate NO-OPs cleanly (exit 0, explains why) until
+# `Palace/Packages/PalaceAccounts/Sources` appears. Once the package is
+# extracted, this gate goes live automatically on the very next commit that
+# touches it — no further wiring required.
+#
+# Env overrides (for tests):
+#   PALACEACCOUNTS_SCAN_ROOT   directory to scan (default:
+#                               <repo>/Palace/Packages/PalaceAccounts/Sources)
+#
+# Usage: check-palaceaccounts-package-purity.sh
+# Exit: 0 = package doesn't exist yet (no-op) OR zero forbidden references (PASS)
+#       1 = a forbidden reference was found (FAIL)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCAN_ROOT="${PALACEACCOUNTS_SCAN_ROOT:-$REPO/Palace/Packages/PalaceAccounts/Sources}"
+
+FORBIDDEN='AppContainer|MyBooksDownloadCenter|ImageCache\.shared|TPPBookCoverRegistry|FirebaseManager'
+
+if [ ! -d "$SCAN_ROOT" ]; then
+  echo "[palaceaccounts-purity] NO-OP: $SCAN_ROOT does not exist yet (Wave 3a package not extracted) — gate is dormant."
+  exit 0
+fi
+
+# Match CODE references only, not documentation. The extracted package's
+# boundary docs legitimately NAME these types (e.g. "no `AppContainer` type
+# crosses this boundary", "the package holds no edge to `FirebaseManager`") —
+# the invariant is about code coupling (imports / type usage), never prose. So
+# strip Swift comments (`//`, `///`, `/* */`) and string literals before
+# matching, and require a word-boundary hit on the residue. A naive grep would
+# flag the gate's own documentation.
+PY_STDERR="$(mktemp)"
+trap 'rm -f "$PY_STDERR"' EXIT
+
+set +e
+FINDINGS="$(FORBIDDEN="$FORBIDDEN" SCAN_ROOT="$SCAN_ROOT" python3 - 2>"$PY_STDERR" <<'PY'
+import os, re, sys
+forbidden = os.environ["FORBIDDEN"]
+root = os.environ["SCAN_ROOT"]
+pat = re.compile(r'\b(' + forbidden + r')\b')
+
+def strip(src):
+    # Blank out //-line-comments, /* */ block comments, and "..." string
+    # literals, preserving newlines so line numbers stay accurate.
+    out = []
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == '"':                       # string literal
+            out.append(' '); i += 1
+            while i < n and src[i] != '"':
+                if src[i] == '\\' and i + 1 < n:
+                    out.append('  '); i += 2; continue
+                out.append('\n' if src[i] == '\n' else ' '); i += 1
+            if i < n:
+                out.append(' '); i += 1
+        elif c == '/' and i + 1 < n and src[i+1] == '/':   # // or /// line comment
+            while i < n and src[i] != '\n':
+                out.append(' '); i += 1
+        elif c == '/' and i + 1 < n and src[i+1] == '*':   # /* */ block comment
+            out.append('  '); i += 2
+            while i + 1 < n and not (src[i] == '*' and src[i+1] == '/'):
+                out.append('\n' if src[i] == '\n' else ' '); i += 1
+            if i + 1 < n:
+                out.append('  '); i += 2
+        else:
+            out.append(c); i += 1
+    return ''.join(out)
+
+hits = []
+for dirpath, _, files in os.walk(root):
+    for f in files:
+        if not f.endswith('.swift'):
+            continue
+        p = os.path.join(dirpath, f)
+        try:
+            code = strip(open(p, encoding='utf-8', errors='replace').read())
+        except OSError:
+            continue
+        for ln, line in enumerate(code.splitlines(), 1):
+            m = pat.search(line)
+            if m:
+                hits.append(f"{p}:{ln}: {m.group(1)}")
+sys.stdout.write("\n".join(hits))
+PY
+)"
+PY_EXIT=$?
+set -e
+
+if [ "$PY_EXIT" -ne 0 ]; then
+  echo "[palaceaccounts-purity] FAIL: the python3 scanner crashed (exit $PY_EXIT) instead of"
+  echo "  producing findings. A crashed scanner is NOT the same as zero findings — failing"
+  echo "  closed rather than silently passing. Interpreter stderr:"
+  sed 's/^/  /' "$PY_STDERR"
+  exit 1
+fi
+
+if [ -n "$FINDINGS" ]; then
+  echo "[palaceaccounts-purity] FAIL: PalaceAccounts/Sources references the app-target"
+  echo "  coupling surface it was extracted to escape:"
+  printf '%s\n' "$FINDINGS"
+  echo ""
+  echo "  Fix: seam-inject instead of reaching back into AppContainer /"
+  echo "  MyBooksDownloadCenter / ImageCache.shared / TPPBookCoverRegistry /"
+  echo "  FirebaseManager from the extracted package (see the Wave 3 plan)."
+  exit 1
+fi
+
+echo "[palaceaccounts-purity] PASS: $SCAN_ROOT has zero forbidden app-target references."
+exit 0

--- a/scripts/check-palacedownloads-package-purity.sh
+++ b/scripts/check-palacedownloads-package-purity.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# check-palacedownloads-package-purity.sh
+#
+# DORMANT gate for the future `PalaceDownloads` package (Wave 3b — see
+# docs/architecture/god-class-decomposition-plan.md and the Wave 3 brief:
+# extract PalaceDownloads, consuming the S2 protocols instead of naming the
+# app-target types directly).
+#
+# Once that package exists, its `Sources/` must NEVER reach back into the
+# app-target coupling surface it was extracted to escape — that would
+# recreate exactly the coupling the whole god-class decomposition campaign
+# exists to dissolve. This gate asserts ZERO occurrences, anywhere under
+# `Palace/Packages/PalaceDownloads/Sources`, of:
+#
+#   AccountsManager | TPPUserAccount | AppContainer | LCPAudiobooks | AdobeDRM
+#
+# It is DORMANT today: the package does not exist yet (Wave 3b has not landed
+# as of this writing), so the gate NO-OPs cleanly (exit 0, explains why) until
+# `Palace/Packages/PalaceDownloads/Sources` appears. Once the package is
+# extracted, this gate goes live automatically on the very next commit that
+# touches it — no further wiring required.
+#
+# Env overrides (for tests):
+#   PALACEDOWNLOADS_SCAN_ROOT   directory to scan (default:
+#                                <repo>/Palace/Packages/PalaceDownloads/Sources)
+#
+# Usage: check-palacedownloads-package-purity.sh
+# Exit: 0 = package doesn't exist yet (no-op) OR zero forbidden references (PASS)
+#       1 = a forbidden reference was found (FAIL)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCAN_ROOT="${PALACEDOWNLOADS_SCAN_ROOT:-$REPO/Palace/Packages/PalaceDownloads/Sources}"
+
+FORBIDDEN='AccountsManager|TPPUserAccount|AppContainer|LCPAudiobooks|AdobeDRM'
+
+if [ ! -d "$SCAN_ROOT" ]; then
+  echo "[palacedownloads-purity] NO-OP: $SCAN_ROOT does not exist yet (Wave 3b package not extracted) — gate is dormant."
+  exit 0
+fi
+
+# Match CODE references only, not documentation. The extracted package's
+# boundary docs legitimately NAME these types (e.g. "no `AccountsManager` type
+# crosses this boundary", "the package holds no edge to `AdobeDRM`") — the
+# invariant is about code coupling (imports / type usage), never prose. So
+# strip Swift comments (`//`, `///`, `/* */`) and string literals before
+# matching, and require a word-boundary hit on the residue. A naive grep would
+# flag the gate's own documentation.
+PY_STDERR="$(mktemp)"
+trap 'rm -f "$PY_STDERR"' EXIT
+
+set +e
+FINDINGS="$(FORBIDDEN="$FORBIDDEN" SCAN_ROOT="$SCAN_ROOT" python3 - 2>"$PY_STDERR" <<'PY'
+import os, re, sys
+forbidden = os.environ["FORBIDDEN"]
+root = os.environ["SCAN_ROOT"]
+pat = re.compile(r'\b(' + forbidden + r')\b')
+
+def strip(src):
+    # Blank out //-line-comments, /* */ block comments, and "..." string
+    # literals, preserving newlines so line numbers stay accurate.
+    out = []
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == '"':                       # string literal
+            out.append(' '); i += 1
+            while i < n and src[i] != '"':
+                if src[i] == '\\' and i + 1 < n:
+                    out.append('  '); i += 2; continue
+                out.append('\n' if src[i] == '\n' else ' '); i += 1
+            if i < n:
+                out.append(' '); i += 1
+        elif c == '/' and i + 1 < n and src[i+1] == '/':   # // or /// line comment
+            while i < n and src[i] != '\n':
+                out.append(' '); i += 1
+        elif c == '/' and i + 1 < n and src[i+1] == '*':   # /* */ block comment
+            out.append('  '); i += 2
+            while i + 1 < n and not (src[i] == '*' and src[i+1] == '/'):
+                out.append('\n' if src[i] == '\n' else ' '); i += 1
+            if i + 1 < n:
+                out.append('  '); i += 2
+        else:
+            out.append(c); i += 1
+    return ''.join(out)
+
+hits = []
+for dirpath, _, files in os.walk(root):
+    for f in files:
+        if not f.endswith('.swift'):
+            continue
+        p = os.path.join(dirpath, f)
+        try:
+            code = strip(open(p, encoding='utf-8', errors='replace').read())
+        except OSError:
+            continue
+        for ln, line in enumerate(code.splitlines(), 1):
+            m = pat.search(line)
+            if m:
+                hits.append(f"{p}:{ln}: {m.group(1)}")
+sys.stdout.write("\n".join(hits))
+PY
+)"
+PY_EXIT=$?
+set -e
+
+if [ "$PY_EXIT" -ne 0 ]; then
+  echo "[palacedownloads-purity] FAIL: the python3 scanner crashed (exit $PY_EXIT) instead of"
+  echo "  producing findings. A crashed scanner is NOT the same as zero findings — failing"
+  echo "  closed rather than silently passing. Interpreter stderr:"
+  sed 's/^/  /' "$PY_STDERR"
+  exit 1
+fi
+
+if [ -n "$FINDINGS" ]; then
+  echo "[palacedownloads-purity] FAIL: PalaceDownloads/Sources references the app-target"
+  echo "  coupling surface it was extracted to escape:"
+  printf '%s\n' "$FINDINGS"
+  echo ""
+  echo "  Fix: consume the S2 protocols instead of naming AccountsManager /"
+  echo "  TPPUserAccount / AppContainer / LCPAudiobooks / AdobeDRM directly from"
+  echo "  the extracted package (see the Wave 3 plan)."
+  exit 1
+fi
+
+echo "[palacedownloads-purity] PASS: $SCAN_ROOT has zero forbidden app-target references."
+exit 0

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -128,6 +128,28 @@ if [[ -f "$REPO_ROOT_M1/scripts/check-bookregistry-package-purity.sh" ]]; then
   fi
 fi
 
+# DORMANT Wave 3a gate: PalaceAccounts/Sources package purity. Whole-tree
+# scan (not diff-based) but a no-op today — the package doesn't exist until
+# Wave 3a extracts it — so it's cheap to run unconditionally. See
+# scripts/check-palaceaccounts-package-purity.sh.
+if [[ -f "$REPO_ROOT_M1/scripts/check-palaceaccounts-package-purity.sh" ]]; then
+  if ! _pa_out=$(bash "$REPO_ROOT_M1/scripts/check-palaceaccounts-package-purity.sh" 2>&1); then
+    echo "$_pa_out" >&2
+    M1_FAIL=$((M1_FAIL + 1))
+  fi
+fi
+
+# DORMANT Wave 3b gate: PalaceDownloads/Sources package purity. Whole-tree
+# scan (not diff-based) but a no-op today — the package doesn't exist until
+# Wave 3b extracts it — so it's cheap to run unconditionally. See
+# scripts/check-palacedownloads-package-purity.sh.
+if [[ -f "$REPO_ROOT_M1/scripts/check-palacedownloads-package-purity.sh" ]]; then
+  if ! _pd_out=$(bash "$REPO_ROOT_M1/scripts/check-palacedownloads-package-purity.sh" 2>&1); then
+    echo "$_pd_out" >&2
+    M1_FAIL=$((M1_FAIL + 1))
+  fi
+fi
+
 m1_enforce "$M1_FAIL"
 
 # Friendly nudge — non-blocking. Only print if anything is staged at all.

--- a/scripts/tests/test_check_palaceaccounts_package_purity.py
+++ b/scripts/tests/test_check_palaceaccounts_package_purity.py
@@ -1,0 +1,207 @@
+"""
+test_check_palaceaccounts_package_purity.py — pytest for the DORMANT
+`PalaceAccounts` package-purity gate (scripts/check-palaceaccounts-package-purity.sh).
+
+Asserts the full gate-rule contract required by CLAUDE.md rule #4 even though
+the gate's real target package (Wave 3a) does not exist yet:
+
+  (a) package dir absent  -> NO-OP, exit 0 (today's actual repo state — the
+      gate must not block anything before the package is extracted),
+  (b) package dir present + a forbidden reference -> FAIL, exit 1,
+  (c) package dir present + clean -> PASS, exit 0.
+
+Each case points the script at a throwaway scan root via
+PALACEACCOUNTS_SCAN_ROOT so it never touches the real repo tree.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-palaceaccounts-package-purity.sh"
+
+
+def _run(scan_root: Path, path: str = "/usr/bin:/bin:/usr/sbin:/sbin") -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(_SCRIPT)],
+        env={
+            "PATH": path,
+            "PALACEACCOUNTS_SCAN_ROOT": str(scan_root),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_missing_package_dir_is_a_noop(tmp_path):
+    """Today's actual repo state: the package hasn't been extracted yet. The
+    gate MUST NOT block — it should no-op cleanly with exit 0."""
+    missing_root = tmp_path / "Palace" / "Packages" / "PalaceAccounts" / "Sources"
+    result = _run(missing_root)
+    assert result.returncode == 0, (
+        f"expected no-op exit 0 for a nonexistent package dir, got "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "NO-OP" in result.stdout
+
+
+def test_forbidden_reference_is_flagged(tmp_path):
+    """Once the package exists, a reference back into the app-target coupling
+    surface (AppContainer here) MUST fail the gate."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "AccountsStore.swift").write_text(
+        "import Foundation\n"
+        "struct AccountsStore {\n"
+        "    let container = AppContainer.production()\n"
+        "}\n"
+    )
+    result = _run(root)
+    assert result.returncode == 1, (
+        f"expected exit 1 for a forbidden reference, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "AppContainer" in result.stdout
+
+
+def test_each_forbidden_symbol_is_flagged(tmp_path):
+    """Every symbol in the forbidden list fires independently."""
+    forbidden_symbols = [
+        "AppContainer",
+        "MyBooksDownloadCenter",
+        "ImageCache",
+        "TPPBookCoverRegistry",
+        "FirebaseManager",
+    ]
+    for symbol in forbidden_symbols:
+        root = tmp_path / symbol / "Sources"
+        root.mkdir(parents=True)
+        if symbol == "ImageCache":
+            (root / "Thing.swift").write_text("let x = ImageCache.shared.thing\n")
+        else:
+            (root / "Thing.swift").write_text(f"let x = {symbol}.thing\n")
+        result = _run(root)
+        assert result.returncode == 1, (
+            f"{symbol}: expected exit 1, got {result.returncode}\n"
+            f"stdout: {result.stdout!r}"
+        )
+        assert symbol in result.stdout
+
+
+def test_clean_package_passes(tmp_path):
+    """A package that only depends on its own inverted seam (e.g. a protocol)
+    — no forbidden app-target reference — MUST pass."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "AccountsStore.swift").write_text(
+        "import Foundation\n"
+        "protocol AccountsCoverImageProviding {\n"
+        "    func image(for accountID: String) -> Data?\n"
+        "}\n"
+        "struct AccountsStore {\n"
+        "    let images: AccountsCoverImageProviding\n"
+        "}\n"
+    )
+    result = _run(root)
+    assert result.returncode == 0, (
+        f"expected exit 0 for a clean package, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "PASS" in result.stdout
+
+
+def test_forbidden_symbol_in_doc_comment_passes(tmp_path):
+    """The extracted package's boundary docs legitimately NAME these types
+    (e.g. "no `AppContainer` type crosses this boundary"). The invariant is
+    about CODE coupling, not prose — a comment mention MUST NOT be flagged, or
+    the gate would fail on its own documentation (the Wave 2b regression)."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "AccountsCoverImageProviding.swift").write_text(
+        "import Foundation\n"
+        "/// Value-only: no `AppContainer` or `MyBooksDownloadCenter` type ever\n"
+        "/// crosses this boundary. The package holds no edge to `ImageCache.shared`,\n"
+        "/// `TPPBookCoverRegistry`, or `FirebaseManager`.\n"
+        "/* block comment naming FirebaseManager too */\n"
+        "protocol AccountsCoverImageProviding {\n"
+        "    func image(for accountID: String) -> Data?  // adapter reads AppContainer app-side\n"
+        "}\n"
+    )
+    result = _run(root)
+    assert result.returncode == 0, (
+        f"expected exit 0 — forbidden names appear ONLY in comments, got "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "PASS" in result.stdout
+
+
+def test_forbidden_symbol_in_string_literal_passes(tmp_path):
+    """A forbidden name inside a string literal is not a code coupling edge."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "Log.swift").write_text(
+        'let msg = "resolved via AppContainer.production() on the app side"\n'
+        "let n = 1\n"
+    )
+    result = _run(root)
+    assert result.returncode == 0, (
+        f"expected exit 0 — forbidden name is in a string literal, got "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "PASS" in result.stdout
+
+
+def test_python_crash_fails_closed(tmp_path):
+    """If the embedded python3 scanner itself crashes (bad interpreter, syntax
+    error, whatever), the gate must FAIL, not silently pass. Simulate a crash
+    by shadowing `python3` on PATH with a stub that always exits non-zero,
+    then assert the gate fails closed with a message that names the crash
+    (not a false "PASS")."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "Clean.swift").write_text("import Foundation\nstruct Clean {}\n")
+
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        "echo 'boom: simulated interpreter crash' >&2\n"
+        "exit 137\n"
+    )
+    fake_python.chmod(fake_python.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    result = _run(root, path=f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin")
+
+    assert result.returncode != 0, (
+        f"expected the gate to fail closed when python3 crashes, got exit "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "PASS" not in result.stdout, (
+        "gate must never report PASS when the scanner itself crashed "
+        f"(fail-open regression)\nstdout: {result.stdout!r}"
+    )
+    assert "crash" in result.stdout.lower() or "crash" in result.stderr.lower()
+
+
+def test_forbidden_symbol_in_code_after_a_comment_line_is_flagged(tmp_path):
+    """Comment-stripping must not mask a REAL code reference elsewhere in the
+    file — a doc comment naming the type PLUS actual code usage still fails."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "Sync.swift").write_text(
+        "/// This package must not touch AppContainer.\n"
+        "import Foundation\n"
+        "let leaked = AppContainer.production()\n"
+    )
+    result = _run(root)
+    assert result.returncode == 1, (
+        f"expected exit 1 — real code reference despite a comment, got "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "AppContainer" in result.stdout

--- a/scripts/tests/test_check_palacedownloads_package_purity.py
+++ b/scripts/tests/test_check_palacedownloads_package_purity.py
@@ -1,0 +1,208 @@
+"""
+test_check_palacedownloads_package_purity.py — pytest for the DORMANT
+`PalaceDownloads` package-purity gate (scripts/check-palacedownloads-package-purity.sh).
+
+Asserts the full gate-rule contract required by CLAUDE.md rule #4 even though
+the gate's real target package (Wave 3b) does not exist yet:
+
+  (a) package dir absent  -> NO-OP, exit 0 (today's actual repo state — the
+      gate must not block anything before the package is extracted),
+  (b) package dir present + a forbidden reference -> FAIL, exit 1,
+  (c) package dir present + clean -> PASS, exit 0.
+
+Each case points the script at a throwaway scan root via
+PALACEDOWNLOADS_SCAN_ROOT so it never touches the real repo tree.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-palacedownloads-package-purity.sh"
+
+
+def _run(scan_root: Path, path: str = "/usr/bin:/bin:/usr/sbin:/sbin") -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(_SCRIPT)],
+        env={
+            "PATH": path,
+            "PALACEDOWNLOADS_SCAN_ROOT": str(scan_root),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_missing_package_dir_is_a_noop(tmp_path):
+    """Today's actual repo state: the package hasn't been extracted yet. The
+    gate MUST NOT block — it should no-op cleanly with exit 0."""
+    missing_root = tmp_path / "Palace" / "Packages" / "PalaceDownloads" / "Sources"
+    result = _run(missing_root)
+    assert result.returncode == 0, (
+        f"expected no-op exit 0 for a nonexistent package dir, got "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "NO-OP" in result.stdout
+
+
+def test_forbidden_reference_is_flagged(tmp_path):
+    """Once the package exists, a reference back into the app-target coupling
+    surface (AppContainer here) MUST fail the gate."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "DownloadsStore.swift").write_text(
+        "import Foundation\n"
+        "struct DownloadsStore {\n"
+        "    let container = AppContainer.production()\n"
+        "}\n"
+    )
+    result = _run(root)
+    assert result.returncode == 1, (
+        f"expected exit 1 for a forbidden reference, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "AppContainer" in result.stdout
+
+
+def test_each_forbidden_symbol_is_flagged(tmp_path):
+    """Every symbol in the forbidden list fires independently."""
+    forbidden_symbols = [
+        "AccountsManager",
+        "TPPUserAccount",
+        "AppContainer",
+        "LCPAudiobooks",
+        "AdobeDRM",
+    ]
+    for symbol in forbidden_symbols:
+        root = tmp_path / symbol / "Sources"
+        root.mkdir(parents=True)
+        (root / "Thing.swift").write_text(f"let x = {symbol}.thing\n")
+        result = _run(root)
+        assert result.returncode == 1, (
+            f"{symbol}: expected exit 1, got {result.returncode}\n"
+            f"stdout: {result.stdout!r}"
+        )
+        assert symbol in result.stdout
+
+
+def test_clean_package_passes(tmp_path):
+    """A package that only depends on its own inverted seam (e.g. the S2
+    protocols) — no forbidden app-target reference — MUST pass."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "DownloadsStore.swift").write_text(
+        "import Foundation\n"
+        "protocol DownloadAccountScopeProviding {\n"
+        "    var currentAccountID: String { get }\n"
+        "}\n"
+        "protocol DownloadDRMFulfilling {\n"
+        "    func fulfill(url: URL) async throws -> URL\n"
+        "}\n"
+        "struct DownloadsStore {\n"
+        "    let scope: DownloadAccountScopeProviding\n"
+        "    let drm: DownloadDRMFulfilling\n"
+        "}\n"
+    )
+    result = _run(root)
+    assert result.returncode == 0, (
+        f"expected exit 0 for a clean package, got {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "PASS" in result.stdout
+
+
+def test_forbidden_symbol_in_doc_comment_passes(tmp_path):
+    """The extracted package's boundary docs legitimately NAME these types
+    (e.g. "no `AccountsManager` type crosses this boundary"). The invariant is
+    about CODE coupling, not prose — a comment mention MUST NOT be flagged, or
+    the gate would fail on its own documentation (the Wave 2b regression)."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "DownloadAccountScopeProviding.swift").write_text(
+        "import Foundation\n"
+        "/// Value-only: no `AccountsManager`, `TPPUserAccount`, or `AppContainer`\n"
+        "/// type ever crosses this boundary. The package holds no edge to\n"
+        "/// `LCPAudiobooks` or `AdobeDRM`.\n"
+        "/* block comment naming AdobeDRM too */\n"
+        "protocol DownloadAccountScopeProviding {\n"
+        "    var currentAccountID: String { get }  // adapter reads AccountsManager app-side\n"
+        "}\n"
+    )
+    result = _run(root)
+    assert result.returncode == 0, (
+        f"expected exit 0 — forbidden names appear ONLY in comments, got "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "PASS" in result.stdout
+
+
+def test_forbidden_symbol_in_string_literal_passes(tmp_path):
+    """A forbidden name inside a string literal is not a code coupling edge."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "Log.swift").write_text(
+        'let msg = "resolved via AccountsManager.shared on the app side"\n'
+        "let n = 1\n"
+    )
+    result = _run(root)
+    assert result.returncode == 0, (
+        f"expected exit 0 — forbidden name is in a string literal, got "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "PASS" in result.stdout
+
+
+def test_python_crash_fails_closed(tmp_path):
+    """If the embedded python3 scanner itself crashes (bad interpreter, syntax
+    error, whatever), the gate must FAIL, not silently pass. Simulate a crash
+    by shadowing `python3` on PATH with a stub that always exits non-zero,
+    then assert the gate fails closed with a message that names the crash
+    (not a false "PASS")."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "Clean.swift").write_text("import Foundation\nstruct Clean {}\n")
+
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        "echo 'boom: simulated interpreter crash' >&2\n"
+        "exit 137\n"
+    )
+    fake_python.chmod(fake_python.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    result = _run(root, path=f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin")
+
+    assert result.returncode != 0, (
+        f"expected the gate to fail closed when python3 crashes, got exit "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "PASS" not in result.stdout, (
+        "gate must never report PASS when the scanner itself crashed "
+        f"(fail-open regression)\nstdout: {result.stdout!r}"
+    )
+    assert "crash" in result.stdout.lower() or "crash" in result.stderr.lower()
+
+
+def test_forbidden_symbol_in_code_after_a_comment_line_is_flagged(tmp_path):
+    """Comment-stripping must not mask a REAL code reference elsewhere in the
+    file — a doc comment naming the type PLUS actual code usage still fails."""
+    root = tmp_path / "Sources"
+    root.mkdir(parents=True)
+    (root / "Sync.swift").write_text(
+        "/// This package must not touch AccountsManager.\n"
+        "import Foundation\n"
+        "let leaked = AccountsManager.shared\n"
+    )
+    result = _run(root)
+    assert result.returncode == 1, (
+        f"expected exit 1 — real code reference despite a comment, got "
+        f"{result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "AccountsManager" in result.stdout

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -537,6 +537,40 @@ else
   record "bookregistry_package_purity" "pass" "check-bookregistry-package-purity.sh not found (skipped)"
 fi
 
+# 3b4. DORMANT Wave 3a gate — PalaceAccounts/Sources package purity.
+# Whole-tree scan (not diff-based), but a no-op until the package is
+# extracted. See `scripts/check-palaceaccounts-package-purity.sh`.
+echo "--- PalaceAccounts package purity (dormant — Wave 3a) ---"
+if [ "$MUTATION_ONLY" = "true" ]; then
+  record "palaceaccounts_package_purity" "pass" "Skipped (--mutation-only)"
+elif [ -f scripts/check-palaceaccounts-package-purity.sh ]; then
+  PA_OUT=$(bash scripts/check-palaceaccounts-package-purity.sh 2>&1)
+  if [ "$?" -eq 0 ]; then
+    record "palaceaccounts_package_purity" "pass" "$(echo "$PA_OUT" | head -1)"
+  else
+    record "palaceaccounts_package_purity" "fail" "$(echo "$PA_OUT" | grep -m1 FAIL)"
+  fi
+else
+  record "palaceaccounts_package_purity" "pass" "check-palaceaccounts-package-purity.sh not found (skipped)"
+fi
+
+# 3b5. DORMANT Wave 3b gate — PalaceDownloads/Sources package purity.
+# Whole-tree scan (not diff-based), but a no-op until the package is
+# extracted. See `scripts/check-palacedownloads-package-purity.sh`.
+echo "--- PalaceDownloads package purity (dormant — Wave 3b) ---"
+if [ "$MUTATION_ONLY" = "true" ]; then
+  record "palacedownloads_package_purity" "pass" "Skipped (--mutation-only)"
+elif [ -f scripts/check-palacedownloads-package-purity.sh ]; then
+  PD_OUT=$(bash scripts/check-palacedownloads-package-purity.sh 2>&1)
+  if [ "$?" -eq 0 ]; then
+    record "palacedownloads_package_purity" "pass" "$(echo "$PD_OUT" | head -1)"
+  else
+    record "palacedownloads_package_purity" "fail" "$(echo "$PD_OUT" | grep -m1 FAIL)"
+  fi
+else
+  record "palacedownloads_package_purity" "pass" "check-palacedownloads-package-purity.sh not found (skipped)"
+fi
+
 # 3c. Adjacency staleness (M1 universal-rigor-floor gate, warn-only)
 # Greps comments in the surviving codebase for references to removed/renamed
 # declarations in the diff. Always passes; counts warnings.


### PR DESCRIPTION
Two DORMANT CI gates that go live automatically when Wave 3a/3b extract the PalaceAccounts / PalaceDownloads packages — asserting neither package reaches back into the app-target coupling it was extracted to escape.

- `check-palaceaccounts-package-purity.sh` — 0 refs to AppContainer / MyBooksDownloadCenter / ImageCache.shared / TPPBookCoverRegistry / FirebaseManager under PalaceAccounts/Sources.
- `check-palacedownloads-package-purity.sh` — 0 refs to AccountsManager / TPPUserAccount / AppContainer / LCPAudiobooks / AdobeDRM under PalaceDownloads/Sources.

Both clone the shipped bookregistry-purity gate exactly: comment/string-aware (a boundary doc naming a type doesn't trip it), fail-closed on interpreter error, and NO-OP (exit 0) while the package dirs don't exist yet — so they're inert today and activate on the extraction PRs. Each has a 7-case pytest (mirrors the bookregistry gate); wired into pre-commit + verify-pr; tooling-checks.yml auto-collects them. scripts/ only, no production change.

Verified: bash -n clean; pytest scripts/tests/ → 396 passed; both gates dry-run NO-OP on the current tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)