### PR TITLE
feat(readium): upgrade swift-toolkit 3.9.0 → 3.11.0 (PP-4848)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -10000,7 +10000,7 @@
 			repositoryURL = "https://github.com/readium/swift-toolkit.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.9.0;
+				version = 3.11.0;
 			};
 		};
 		E77D02232931357400544180 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {
@@ -10024,7 +10024,7 @@
 			repositoryURL = "https://github.com/stephencelis/SQLite.swift.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.15.0;
+				minimumVersion = 0.16.0;
 			};
 		};
 		E7D51772BFB94BFBA1AE8862 /* XCRemoteSwiftPackageReference "std-uritemplate-swift" */ = {

--- a/Palace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Palace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6b3d05989d7ed978a5123126bc368d7901ded954f588f07dd50a100a638360e5",
+  "originHash" : "420c0e58206155635d276e368be5122475ea4d34bc6d3543dfd406fb5c18b6c7",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
-        "version" : "1.9.0"
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
       "state" : {
-        "revision" : "0c08856385fe24f7b76d8c51842d78a196e8e817",
-        "version" : "0.15.5"
+        "revision" : "964c300fb0736699ce945c9edb56ecd62eba27a3",
+        "version" : "0.16.0"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/readium/swift-toolkit.git",
       "state" : {
-        "revision" : "de07026e9f825a5791f27a7ac4cd6bb1a784ab8d",
-        "version" : "3.9.0"
+        "revision" : "d82f44f4f05d87add9e22a8b75abbd61dce745dd",
+        "version" : "3.11.0"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "6c7915e16f729857aec3e99068c361e58a00ed68",
-        "version" : "2.13.4"
+        "revision" : "8d6ad267714cac3ae747cefdd21f7a6665006e1f",
+        "version" : "2.13.7"
       }
     },
     {

--- a/Palace/Reader2/ReaderStackConfiguration/LCP/TPPLCPClient.swift
+++ b/Palace/Reader2/ReaderStackConfiguration/LCP/TPPLCPClient.swift
@@ -222,6 +222,16 @@ class TPPLCPClient: ReadiumLCP.LCPClient {
 
         return result
     }
+
+    /// PP-4848 (Readium 3.11): `LCPClient` now requires this. Readium ships a
+    /// hardcoded default list, but forwarding the value liblcp actually reports
+    /// is what lets Readium surface the correct "profile not supported" error
+    /// for a license whose profile the embedded `R2LCPClient` can't handle,
+    /// instead of failing opaquely. `R2LCPClient.getSupportedLCPProfileURIs()`
+    /// returns an optional; an empty list is the honest "none advertised" value.
+    func getSupportedLCPProfileURIs() -> [String] {
+        R2LCPClient.getSupportedLCPProfileURIs() ?? []
+    }
 }
 
 extension TPPLCPClient {

--- a/PalaceTests/DRM/LCPClientTests.swift
+++ b/PalaceTests/DRM/LCPClientTests.swift
@@ -32,6 +32,7 @@ import XCTest
 @testable import Palace
 import ReadiumLCP
 import ReadiumShared
+import R2LCPClient
 
 @MainActor
 final class LCPClientTests: XCTestCase {
@@ -230,6 +231,32 @@ final class LCPClientTests: XCTestCase {
                 "findOneValidPassphrase must return nil on garbage license JSON (\(garbage.prefix(40))) — never crash, never return a bogus passphrase"
             )
         }
+    }
+
+    // MARK: - getSupportedLCPProfileURIs — PP-4848 (Readium 3.11) facade forwarding
+
+    func test_getSupportedLCPProfileURIs_forwardsLiblcpAdvertisedProfiles() {
+        // PP-4848: Readium 3.11 added getSupportedLCPProfileURIs() to the
+        // LCPClient protocol WITH a hardcoded default implementation. The
+        // facade must NOT rely on that default — it must forward the set the
+        // embedded liblcp (R2LCPClient) actually advertises, so ReadiumLCP can
+        // raise the correct "profile not supported" error for a license whose
+        // profile this liblcp build can't handle (AC #2). If the override were
+        // dropped, the facade would silently fall back to Readium's default
+        // list — which could claim support liblcp doesn't have.
+        let client = TPPLCPClient()
+        let facade = client.getSupportedLCPProfileURIs()
+        let liblcp = R2LCPClient.getSupportedLCPProfileURIs() ?? []
+
+        // Forwarding contract: facade == exactly what liblcp reports. Kills the
+        // "return Readium's default" and "return []" mutants.
+        XCTAssertEqual(facade, liblcp,
+                       "Facade must forward R2LCPClient.getSupportedLCPProfileURIs() verbatim, not Readium's hardcoded default")
+        // Sanity: this liblcp build advertises the standard production profile.
+        XCTAssertFalse(facade.isEmpty,
+                       "liblcp must advertise at least one supported LCP profile")
+        XCTAssertTrue(facade.contains("http://readium.org/lcp/profile-1.0"),
+                      "The standard LCP production profile 1.0 must be advertised by this liblcp build")
     }
 }
 


### PR DESCRIPTION
## What & why

[PP-4848](https://ebce-lyrasis.atlassian.net/browse/PP-4848) — upgrade the Readium swift-toolkit **3.9.0 → 3.11.0** (crossing 3.10 + 3.11). Picks up upstream fixes relevant to Palace: the **AudioNavigator memory leak**, EPUB font CORS handling + footnote detection, EPUB HREF fragment/query preservation, and the **LCP device-ID moving to the Keychain** (survives delete/reinstall, stops burning device-registration slots).

**Companion submodule PR:** ThePalaceProject/ios-audiobooktoolkit **#199** (the toolkit is a second swift-toolkit consumer; its `exactVersion` pin must match or SPM resolution fails). This PR bumps the submodule pointer to that branch's commit.

## Changes

- **Both SPM graphs → 3.11.0**: `Palace.xcodeproj` pin + regenerated `Package.resolved`, and the `ios-audiobooktoolkit` submodule pointer (`08f7045 → 06afaac`, PR #199).
- **Forced transitive bump — SQLite.swift `0.15.x → 0.16.0`**: swift-toolkit 3.11 requires `sqlite.swift 0.16.x`; Palace directly pinned `0.15.x`, so resolution failed without this. Palace's only SQLite consumer is `TPPNetworkQueue` (offline-retry queue); it builds unchanged against 0.16 (stable query-builder API, already `@preconcurrency import`ed).
- **`TPPLCPClient.getSupportedLCPProfileURIs()`** — 3.11 adds this as a required `LCPClient` protocol method (witness-table dispatched; ReadiumLCP calls it at `LicenseValidation.swift:267`). Readium ships a hardcoded default, but we forward `R2LCPClient.getSupportedLCPProfileURIs() ?? []` so ReadiumLCP surfaces the correct "profile not supported" error for a license this liblcp build can't handle. Matches Readium's own documented facade recipe.
- **No custom `LCPPassphraseRepository`** exists → the 3.10 `addPassphrase` signature change needs no Palace work; device-ID→Keychain is entirely internal to Readium.

### Also in `Package.resolved` (transitive, semver-minor)
`CryptoSwift 1.9.0 → 1.10.0` (used on the LCP path, `String.sha256()`) and `SwiftSoup 2.13.4 → 2.13.7`. Both stable across the minor bump; DRM build + on-sim EPUB read passed.

## Verification

- ✅ **DRM `Palace` build SUCCEEDED** at 3.11.0 + SQLite 0.16 (no source changes beyond the facade; no `@preconcurrency`/`Sendable` regressions).
- ✅ **Integration test** `test_getSupportedLCPProfileURIs_forwardsLiblcpAdvertisedProfiles` passes against the **real `R2LCPClient`** binary (DRM test target) — pins facade == liblcp's advertised set, non-empty, includes `profile-1.0`; kills the "return Readium default"/"return []" mutants.
- ✅ **On-sim (DRM 3.11.0)**: launch → live catalog → **borrow → download → open EPUB → Readium 3.11 renders** cover/front-matter/body prose with correct fonts, justification, pagination; reader UI functional.
- ✅ SoD reviewed: architect + qa_test + blast-radius all approved (heka ledger, at tip).

## Deferred to the DRM QA regression matrix (must run green before ship)
LCP-**protected** loan borrow→unlock→open (this PR exercised only open-access EPUB + the facade unit test), footnote tap-handling, TOC/Media-Overlays hrefs with spaces/fragments, custom text-selection menu (simdrive can't drive the WebKit selection gesture), and **audiobook playback + memory-leak** verification (needs Instruments over an extended session — the AudioNavigator fix is upstream).

## Merge ordering
Land submodule **#199** to a durable ref before/with this PR; do **not** delete the `chore/readium-3.11.0` branch pre-merge or its commit `06afaac` could be GC'd and break this PR's `git submodule update` in CI.

## Scope / not done
- **Not done:** did NOT adopt the new optional APIs (`AudioSessionManaging`, `LCPService.addPassphrase` preloading) — out of scope per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PP-4848]: https://ebce-lyrasis.atlassian.net/browse/PP-4848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ