### PR TITLE
refactor(accounts): de-locator the account-switch cleanup path — Wave 3 S3

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -851,6 +851,7 @@
 		81587C22AEEAB64E6D2824BD /* BorrowReauthResetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC47AED382982103F213534 /* BorrowReauthResetting.swift */; };
 		81C26B959E33252B2BD42607 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7751F6315B6633F398F0B808 /* StringExtensionTests.swift */; };
 		81C2913BA5B150D52DAC6761 /* PerformanceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61585F7AD2A0D6CDAF2EF098 /* PerformanceMonitor.swift */; };
+		82030623B66F1E97D4ABBE03 /* AccountSwitchDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C353AC0344431D385FC89E6 /* AccountSwitchDependencies.swift */; };
 		82081EC71E1591C3E61B4BF4 /* BadgesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02060A0117F26B0E56F3F606 /* BadgesView.swift */; };
 		82193678E858613CE236C800 /* DeveloperSettingsRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DAE1616595EBC6566A5AAE /* DeveloperSettingsRows.swift */; };
 		831E5553911B54588D3628EC /* AppContainerWithSignInModalSheetPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81CEAD2E6B1E066814D228A /* AppContainerWithSignInModalSheetPresenterTests.swift */; };
@@ -1221,6 +1222,7 @@
 		C9C0443BDCA64CFA42558EE0 /* PalaceBookRegistry in Frameworks */ = {isa = PBXBuildFile; productRef = 1F6FCF4928205B68989B8F7E /* PalaceBookRegistry */; };
 		CA166E125C49407BA91617D7 /* CatalogState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85803B918D5A471B9C0B98D0 /* CatalogState.swift */; };
 		CB0E52E82642EB6B2E1C7BA9 /* NowPlayingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9B49899F1C10F43D4FAAD8 /* NowPlayingCoordinator.swift */; };
+		CB5A9D76695146A98175489C /* AccountSwitchDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C353AC0344431D385FC89E6 /* AccountSwitchDependencies.swift */; };
 		CBCB444F4C168A9CCF792BFA /* AudiobookTrackerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500A72CE85F5DBA5FC681080 /* AudiobookTrackerExtendedTests.swift */; };
 		CC24969C17E24D89872DE10E /* MyBooksSimplifiedBearerTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12BEBBCCBA734E42BB9C6C03 /* MyBooksSimplifiedBearerTokenTests.swift */; };
 		CC749CBF2B6975993AC29B7D /* ReturnReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994596C5FC8FAE5BC41AEB7D /* ReturnReducer.swift */; };
@@ -2391,6 +2393,7 @@
 		2B222C03630C4B2984C38A28 /* EmailAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailAddressTests.swift; sourceTree = "<group>"; };
 		2B75E0B61DBA872395691E65 /* AppAdvancedSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppAdvancedSettingsView.swift; sourceTree = "<group>"; };
 		2BD8F07A904F12E6D218B0B5 /* NotificationService+PushTokenDeleting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NotificationService+PushTokenDeleting.swift"; sourceTree = "<group>"; };
+		2C353AC0344431D385FC89E6 /* AccountSwitchDependencies.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountSwitchDependencies.swift; sourceTree = "<group>"; };
 		2C4E96DEEFAA4607B343D65D /* DownloadErrorRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadErrorRecoveryTests.swift; sourceTree = "<group>"; };
 		2D2B47621D08F1ED007F7764 /* PalaceTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PalaceTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		2D2B47691D08F264007F7764 /* UpdateCheckUpToDate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UpdateCheckUpToDate.json; sourceTree = "<group>"; };
@@ -4950,6 +4953,7 @@
 				4FC47AED382982103F213534 /* BorrowReauthResetting.swift */,
 				B7171C65212AB50506BA53D3 /* AccountsManagerDownloadContextAdapter.swift */,
 				692DF9B78A5B64F59033D35C /* CatalogCrawlScheduler.swift */,
+				2C353AC0344431D385FC89E6 /* AccountSwitchDependencies.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -8600,6 +8604,7 @@
 				58961A9372B38C65858022FF /* TPPUserAccount+DownloadUserAccount.swift in Sources */,
 				A99ED22868A0A1698801FDB0 /* AccountsManagerDownloadContextAdapter.swift in Sources */,
 				146E571D95091CB8EDE2B624 /* CatalogCrawlScheduler.swift in Sources */,
+				82030623B66F1E97D4ABBE03 /* AccountSwitchDependencies.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9167,6 +9172,7 @@
 				6A926C1D3AC9D74518F44338 /* TPPUserAccount+DownloadUserAccount.swift in Sources */,
 				750415F0CCAA268608A4422F /* AccountsManagerDownloadContextAdapter.swift in Sources */,
 				BF6754FDD3EBF7514C3CD5B5 /* CatalogCrawlScheduler.swift in Sources */,
+				CB5A9D76695146A98175489C /* AccountSwitchDependencies.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountSwitchDependencies.swift
+++ b/Palace/Accounts/Library/AccountSwitchDependencies.swift
@@ -1,0 +1,83 @@
+//
+//  AccountSwitchDependencies.swift
+//  Palace
+//
+//  god-class decomposition — Wave 3 seam S3.
+//
+//  The ambient collaborators the `AccountsManager.currentAccount` setter and its
+//  `cleanupActiveContentBeforeAccountSwitch(from:to:)` path used to reach for
+//  directly — the shared image cache, the shared cover-registry circuit breaker,
+//  the shared account-state store, the composition root's network executor, and the
+//  composition root's navigation coordinator hub. Bundled into a frozen, `Sendable`
+//  deps struct injected at construction — the `RegistryExternalDependencies`
+//  precedent (Wave 2b) — so that:
+//
+//    * a packaged `AccountsManager` (the Wave 3a `PalaceAccounts` move) names none
+//      of these app-target singletons directly, and
+//    * the account-switch cleanup ORDER becomes spy-observable — each seam is a
+//      recordable double instead of a process-wide singleton mutation a test can
+//      only observe through a `NotificationCenter` round-trip.
+//
+//  Provider CLOSURES preserve the LAZY resolution the originals had where the
+//  original read was deferred: `networkExecutorProvider` keeps the documented
+//  init-cycle deferral (the manager is built INSIDE the composition root's
+//  dispatch_once, so resolving the executor eagerly at init re-enters + traps), and
+//  `popToRootForAccountSwitch` keeps the `@MainActor` navigation hop.
+//
+//  The `production` binding lives at the composition root — the one place allowed to
+//  resolve these singletons — so this file carries no edge to the container / image
+//  caches / cover registry and is already the shape the 3a package move needs.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import PalaceBookModel
+
+/// Frozen bundle of the account-switch cleanup collaborators, injected into
+/// `AccountsManager` at construction. `Sendable` so the cleanup Task can capture it
+/// by value (the pop-to-root hop must survive regardless of the manager's lifetime,
+/// exactly as the prior composition-root-based hop did).
+struct AccountSwitchDependencies: Sendable {
+    /// Decoded-image cache. `evictDecodedImages()` runs on a real library switch
+    /// (the new library has different covers); also the cache every
+    /// `Account(publication:imageCache:)` the manager builds is backed by.
+    let imageCache: ImageCacheType
+
+    /// Per-uuid account load-state store. Read/written by the setter's prior-account
+    /// eviction and by the hydrate / auth-doc-drive guards. Injected as the concrete
+    /// instance for S3 (the type itself moves into `PalaceAccounts` at 3a).
+    let accountStateStore: AccountStateStore
+
+    /// Resets the cover-fetch circuit breaker so a host that tripped while the prior
+    /// library was active does not keep cover fetches suppressed for the new library
+    /// (was the shared cover registry's `resetHostFailures()`).
+    let resetCoverCircuitBreaker: @Sendable () -> Void
+
+    /// Lazily resolves the shared network executor. DEFERRED because `AccountsManager`
+    /// is constructed inline inside `AppContainer`'s dispatch_once — resolving the
+    /// executor eagerly at init would re-enter that lock and trap. Resolved once,
+    /// cached behind the manager's `lazy var networkExecutor`.
+    let networkExecutorProvider: @Sendable () -> TPPNetworkExecutor
+
+    /// Main-actor navigation cleanup before an account switch: pop the active
+    /// navigation stack to root (when non-empty) then wait the documented settle
+    /// interval before the switch's `isAccountSwitching` flag is cleared. Encapsulates
+    /// the coordinator lookup + the pop decision so the whole hop is a single spy
+    /// point; the production binding resolves the coordinator via the composition root.
+    let popToRootForAccountSwitch: @MainActor @Sendable () async -> Void
+
+    init(
+        imageCache: ImageCacheType,
+        accountStateStore: AccountStateStore,
+        resetCoverCircuitBreaker: @escaping @Sendable () -> Void,
+        networkExecutorProvider: @escaping @Sendable () -> TPPNetworkExecutor,
+        popToRootForAccountSwitch: @escaping @MainActor @Sendable () async -> Void
+    ) {
+        self.imageCache = imageCache
+        self.accountStateStore = accountStateStore
+        self.resetCoverCircuitBreaker = resetCoverCircuitBreaker
+        self.networkExecutorProvider = networkExecutorProvider
+        self.popToRootForAccountSwitch = popToRootForAccountSwitch
+    }
+}

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -273,12 +273,14 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// Replaces the static `MyBooksDownloadCenter.clearAllBorrowReauthState()`
     /// call so the money-path clear is spy-testable. See `BorrowReauthResetting`.
     private let borrowReauthResetter: any BorrowReauthResetting
-    /// Lazy-resolved from AppContainer to break the singleton init cycle:
-    /// AccountsManager is constructed inline by AppContainer._cached's
-    /// initializer, so we cannot read AppContainer.production() during this
-    /// class's init. The lazy var is first accessed *after* AppContainer
-    /// finishes constructing, so the cached instance is ready.
-    private lazy var networkExecutor: TPPNetworkExecutor = AppContainer.production().networkExecutor
+    /// Wave 3 S3 — account-switch cleanup collaborators injected as a frozen bundle so the setter /
+    /// cleanup invert the ambient singleton REACHES (spy-observable); the concrete TPPNetworkExecutor TYPE edge survives, so 3a must still introduce a NetworkExecuting protocol to fully unblock the PalaceAccounts move.
+    private let switchDeps: AccountSwitchDependencies
+    /// Lazy-resolved through the injected provider to break the singleton init cycle:
+    /// AccountsManager is constructed inline by AppContainer._cached's initializer, so
+    /// we cannot resolve the executor during init. First accessed *after* AppContainer
+    /// finishes constructing; resolved exactly once, then cached here.
+    private lazy var networkExecutor: TPPNetworkExecutor = switchDeps.networkExecutorProvider()
     /// Injectable background-crawl spawn seam (see `CatalogCrawlScheduler`).
     /// Immutable `Sendable` `let`; `.production` by default, recording under test.
     private let crawlScheduler: CrawlTaskScheduler
@@ -576,14 +578,18 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     ///   tests inject a spy, `AppContainer` passes it explicitly.
     /// - Parameter crawlScheduler: injectable background-crawl spawn seam
     ///   (PP-4754). `.production` keeps every call site behavior-identical.
+    /// - Parameter switchDependencies: account-switch cleanup seams (Wave 3 S3);
+    ///   `.production` binds the live collaborators (behavior-identical), tests spy.
     init(
         defaults: UserDefaults = .standard,
         borrowReauthResetter: any BorrowReauthResetting = DownloadCenterBorrowReauthResetter(),
-        crawlScheduler: CrawlTaskScheduler = .production
+        crawlScheduler: CrawlTaskScheduler = .production,
+        switchDependencies: AccountSwitchDependencies = .production
     ) {
         self.defaults = defaults
         self.borrowReauthResetter = borrowReauthResetter
         self.crawlScheduler = crawlScheduler
+        self.switchDeps = switchDependencies
         self.settings = TPPSettings()
         self.accountSet = TPPConfiguration.customUrlHash()
             ?? (settings.useBetaLibraries
@@ -712,7 +718,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
         do {
             let feed = try OPDS2CatalogsFeed.fromData(data)
             let accounts = feed.catalogs.map {
-                Account(publication: $0, imageCache: ImageCache.shared)
+                Account(publication: $0, imageCache: switchDeps.imageCache)
             }
             guard !accounts.isEmpty else { return false }
             // CP-D1 (Finding 5): the slim snapshot is written from the
@@ -731,7 +737,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             }
             storeSlimAccounts(accounts)
             for account in accounts {
-                if case .notLoaded = AccountStateStore.shared.state(for: account.uuid) {
+                if case .notLoaded = switchDeps.accountStateStore.state(for: account.uuid) {
                     account._setState(.basicInfoLoaded)
                 }
             }
@@ -774,7 +780,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
         do {
             let feed = try OPDS2CatalogsFeed.fromData(cachedData)
             let accounts = feed.catalogs.map {
-                Account(publication: $0, imageCache: ImageCache.shared)
+                Account(publication: $0, imageCache: switchDeps.imageCache)
             }
             mutateAccountSets { $0[hash] = accounts }
             // Account state-machine wiring (3.2.0): Phase 1 — drive every
@@ -783,7 +789,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             // critical-path readers `awaitReady()` continue blocking until
             // the auth-doc transition completes.
             for account in accounts {
-                if case .notLoaded = AccountStateStore.shared.state(for: account.uuid) {
+                if case .notLoaded = switchDeps.accountStateStore.state(for: account.uuid) {
                     account._setState(.basicInfoLoaded)
                 }
             }
@@ -963,11 +969,11 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
                 cleanupActiveContentBeforeAccountSwitch(from: previousAccountId, to: newAccountId)
                 // Evict decoded cover images — the new library has different covers.
                 // Keeps compressed JPEG cache on disk for fast re-decode if user switches back.
-                ImageCache.shared.evictDecodedImages()
+                switchDeps.imageCache.evictDecodedImages()
                 // Reset the cover-fetch circuit breaker: a host that tripped while
                 // the prior library was active must not keep cover fetches
                 // suppressed for the newly selected library.
-                TPPBookCoverRegistry.shared.resetHostFailures()
+                switchDeps.resetCoverCircuitBreaker()
             }
 
             self.currentAccount?.hasUpdatedToken = false
@@ -1003,7 +1009,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             // Re-entering the same UUID later overwrites the marker through
             // the `.basicInfoLoaded` path on the next preload/loadCatalogs.
             if let prev = previousAccountId, prev != newAccountId {
-                AccountStateStore.shared.setState(
+                switchDeps.accountStateStore.setState(
                     .detailsEvicted(.libraryDeselected(uuid: prev)),
                     for: prev
                 )
@@ -1046,18 +1052,12 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
         networkExecutor.cancelNonEssentialTasks()
         borrowReauthResetter.clearAllBorrowReauthState()
 
+        // Capture the injected nav-pop seam BY VALUE so the hop fires regardless of
+        // the manager's lifetime (matching the prior composition-root-based pop). The
+        // seam encapsulates the coordinator lookup + `shouldPopToRoot` + settle.
+        let popToRoot = switchDeps.popToRootForAccountSwitch
         Task { @MainActor [weak self] in
-            if let coordinator = AppContainer.production().navigationCoordinatorHub.coordinator {
-                let pathCount = coordinator.path.count
-                Log.debug(#file, "  Navigation path has \(pathCount) items")
-
-                if Self.shouldPopToRoot(navigationPathCount: pathCount) {
-                    Log.info(#file, "  🔄 Popping to root to clean up active content before account switch")
-                    coordinator.popToRoot()
-
-                    try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
-                }
-            }
+            await popToRoot()
             // Reset flag AFTER async cleanup completes — not in the setter (F-032)
             self?.isAccountSwitching = false
         }
@@ -1832,7 +1832,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             // a fetch that landed just before cancellation must not resurrect the
             // now-non-current account.
             if AccountsManager.fetchCompletionMayWriteTerminal(
-                currentState: AccountStateStore.shared.state(for: account.uuid)
+                currentState: switchDeps.accountStateStore.state(for: account.uuid)
             ) {
                 if success, let details = account.details {
                     account._setState(.detailsLoaded(details))
@@ -1860,7 +1860,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// the library-switch path.
     internal func driveCurrentAccountAuthDocIfNeeded() {
         guard let account = currentAccount else { return }
-        switch AccountStateStore.shared.state(for: account.uuid) {
+        switch switchDeps.accountStateStore.state(for: account.uuid) {
         case .detailsLoaded:
             return // terminal — `awaitReady()` awaiters resolve via the loaded details
         case .detailsEvicted(.libraryDeselected):
@@ -1956,7 +1956,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
                    let slim = slimAccount(publication.metadata.id) {
                     return slim
                 }
-                return Account(publication: publication, imageCache: ImageCache.shared)
+                return Account(publication: publication, imageCache: switchDeps.imageCache)
             }
 
             // Carry over authenticationDocument (and thus details) from old
@@ -1970,7 +1970,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
                     }
                     // Evict cached logo if the thumbnail URL changed
                     if old.logoUrl != newAccount.logoUrl {
-                        ImageCache.shared.remove(for: newAccount.uuid)
+                        switchDeps.imageCache.remove(for: newAccount.uuid)
                     }
                 }
             }
@@ -1993,7 +1993,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
                     // mock-data publication could in principle land here
                     // with an authDoc that fails to construct details.
                     newAccount._setState(.detailsLoaded(details))
-                } else if case .notLoaded = AccountStateStore.shared.state(for: newAccount.uuid) {
+                } else if case .notLoaded = switchDeps.accountStateStore.state(for: newAccount.uuid) {
                     // CP-D1: preserve any state the slim launch snapshot already
                     // advanced this uuid to. The slim current-account drive can
                     // reach `.detailsLoading`/`.detailsLoaded` BEFORE this async

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -8,6 +8,7 @@ import PalaceNetwork
 import PalaceCatalog // swarm_27c181b5 A5: shared CatalogRepository / DefaultCatalogAPI accessor
 import PalaceBookModel
 import PalaceBookRegistry
+import PalaceLogging
 
 // Swift 6 `complete` — `@unchecked Sendable` invariant: every stored member is
 // an immutable `let` established once at the composition root and only read
@@ -637,7 +638,16 @@ struct AppContainer: @unchecked Sendable {
         // is a stateless struct that forwards to a static, so it needs no MBDC
         // instance — no construction-order hazard even though MBDC is built later
         // in this method.
-        let accountsManager = AccountsManager(borrowReauthResetter: DownloadCenterBorrowReauthResetter())
+        // Wave 3 S3: inject the account-switch cleanup collaborators as a frozen
+        // bundle (the `RegistryExternalDependencies` precedent) rather than letting
+        // the setter / cleanup reach for the shared singletons directly. `.production`
+        // resolves them at the composition root — its network-executor + nav-hub
+        // reads are DEFERRED in closures, so evaluating it here does not re-enter this
+        // dispatch_once. Passed explicitly (no-default-fires house rule).
+        let accountsManager = AccountsManager(
+            borrowReauthResetter: DownloadCenterBorrowReauthResetter(),
+            switchDependencies: .production
+        )
         // Single image-loading umbrella composed of the existing disk+memory
         // ImageCache and the TPPBookCoverRegistry actor — replaces three
         // overlapping singletons at consumer sites (Track A of the 3.2.0
@@ -917,5 +927,41 @@ extension EnvironmentValues {
     var appContainer: AppContainer {
         get { self[AppContainerKey.self] }
         set { self[AppContainerKey.self] = newValue }
+    }
+}
+
+// MARK: - Account-switch cleanup deps (Wave 3 S3)
+
+extension AccountSwitchDependencies {
+    /// The live account-switch cleanup collaborators, resolved at the composition
+    /// root. This is the ONE legitimate binding site for these singletons — the
+    /// account-switch cleanup used to reach for them inline. The network-executor and
+    /// nav-hub reads are wrapped in closures so they resolve LAZILY (first account
+    /// switch), never during the `production()` dispatch_once that constructs the
+    /// manager — preserving the documented init-cycle deferral.
+    static var production: AccountSwitchDependencies {
+        AccountSwitchDependencies(
+            imageCache: ImageCache.shared,
+            accountStateStore: .shared,
+            resetCoverCircuitBreaker: { TPPBookCoverRegistry.shared.resetHostFailures() },
+            networkExecutorProvider: { AppContainer.production().networkExecutor },
+            popToRootForAccountSwitch: { await AppContainer.popToRootForAccountSwitch() }
+        )
+    }
+}
+
+extension AppContainer {
+    /// Main-actor navigation cleanup for an account switch: pop the active navigation
+    /// stack to root when it is non-empty, then wait the documented settle interval.
+    /// Extracted verbatim from the manager's prior inline cleanup Task so the seam is
+    /// a single spy point while the production behavior is byte-for-byte identical.
+    @MainActor
+    fileprivate static func popToRootForAccountSwitch() async {
+        guard let coordinator = AppContainer.production().navigationCoordinatorHub.coordinator else { return }
+        Log.debug(#file, "  Navigation path has \(coordinator.path.count) items")
+        guard AccountsManager.shouldPopToRoot(navigationPathCount: coordinator.path.count) else { return }
+        Log.info(#file, "  🔄 Popping to root to clean up active content before account switch")
+        coordinator.popToRoot()
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
     }
 }

--- a/Palace/Packages/PalaceBookModel/Sources/PalaceBookModel/ImageCacheType.swift
+++ b/Palace/Packages/PalaceBookModel/Sources/PalaceBookModel/ImageCacheType.swift
@@ -7,6 +7,13 @@ public protocol ImageCacheType: Sendable {
     func remove(for key: String)
     func clear()
     func warmMemoryCache(for keys: [String]) async
+    /// Drop the decoded (in-memory) image representations while keeping the
+    /// compressed on-disk cache, so a re-decode is fast. Called on an account
+    /// switch (the new library has different covers). Wave 3 S3 promoted this
+    /// from a concrete `ImageCache`-only method to the protocol so the
+    /// account-switch cleanup can invoke it through the injected `ImageCacheType`
+    /// seam instead of reaching for `ImageCache.shared`.
+    func evictDecodedImages()
 }
 
 public extension ImageCacheType {

--- a/Palace/Packages/PalaceBookModel/Sources/PalaceBookModel/TPPBookImageContext.swift
+++ b/Palace/Packages/PalaceBookModel/Sources/PalaceBookModel/TPPBookImageContext.swift
@@ -39,4 +39,5 @@ final class NullImageCache: ImageCacheType {
     func remove(for key: String) {}
     func clear() {}
     func warmMemoryCache(for keys: [String]) async {}
+    func evictDecodedImages() {}
 }

--- a/PalaceTests/Decomp/AccountsManagerCurrentAccountSwitchContractTests.swift
+++ b/PalaceTests/Decomp/AccountsManagerCurrentAccountSwitchContractTests.swift
@@ -51,7 +51,9 @@
 //
 
 import XCTest
+import UIKit
 import PalaceCatalog
+import PalaceBookModel
 @testable import Palace
 
 @MainActor
@@ -187,6 +189,139 @@ final class AccountsManagerCurrentAccountSwitchContractTests: PalaceWiringTestCa
         AccountStateStore.shared.reset(for: bUUID)
     }
 
+    // MARK: - Contract 4: spy-order cleanup sequence (Wave 3 S3)
+
+    /// Contract: on a real switch A → B, the setter drives its cleanup
+    /// collaborators in a FIXED order —
+    ///   cancelNonEssentialTasks → clearAllBorrowReauthState → evictDecodedImages
+    ///   → resetCoverCircuitBreaker → (account-state eviction of A) → popToRoot
+    ///   → isAccountSwitching reset.
+    /// Every seam is now an injected double recording into one `CallLog`, so the
+    /// ORDER is pinned directly against spies instead of inferred through a
+    /// `NotificationCenter` round-trip. The account-state eviction is a store
+    /// mutation (the injected `AccountStateStore` instance is not a `CallLog` spy),
+    /// so it is pinned by its effect + its synchronous position between the cover
+    /// reset and the async nav pop; `isAccountSwitching`'s deferred reset is pinned
+    /// by the true-before / false-after state assertions.
+    ///
+    /// Kill cases (each flips this test red):
+    ///  - Reordering any two of the four synchronous seam calls.
+    ///  - Moving `evictDecodedImages` / `resetCoverCircuitBreaker` before the
+    ///    `cleanupActiveContentBeforeAccountSwitch` call (they'd precede
+    ///    cancel/borrow-clear in the log).
+    ///  - Dropping the prior-account eviction → A stays `.notLoaded`.
+    ///  - Resetting `isAccountSwitching` synchronously in the setter (F-032) →
+    ///    the true-before assertion fails.
+    ///  - Firing the nav pop synchronously → it appears in the pre-yield log.
+    func testSwitch_AtoB_drivesCleanupSeamsInOrder() async {
+        let aUUID = "urn:uuid:decomp-s3-A-\(UUID().uuidString)"
+        let bUUID = "urn:uuid:decomp-s3-B-\(UUID().uuidString)"
+        let accountB = Self.makeAccount(uuid: bUUID)
+
+        let log = CallLog()
+        let stateStore = AccountStateStore() // fresh, isolated — not `.shared`
+        let spyExecutor = SpyAccountSwitchNetworkExecutor(log: log)
+        let spyImageCache = SpySwitchImageCache(log: log)
+        let spyBorrow = SpySwitchBorrowReauthResetter(log: log)
+
+        let deps = AccountSwitchDependencies(
+            imageCache: spyImageCache,
+            accountStateStore: stateStore,
+            resetCoverCircuitBreaker: { log.record("resetCoverCircuitBreaker") },
+            networkExecutorProvider: { spyExecutor },
+            popToRootForAccountSwitch: { log.record("popToRoot") }
+        )
+
+        let defaults = Self.testUserDefaults()
+        defaults.set(aUUID, forKey: currentAccountIdentifierKey)
+        let manager = makeFreshAccountsManager(
+            defaults: defaults,
+            borrowReauthResetter: spyBorrow,
+            switchDependencies: deps
+        )
+
+        guard case .notLoaded = stateStore.state(for: aUUID) else {
+            return XCTFail("Setup: fresh prior account must start at .notLoaded in the injected store")
+        }
+
+        // Act — synchronous portion runs inline on the main actor.
+        manager.currentAccount = accountB
+
+        // Synchronous cleanup order: cancel + borrow-clear (inside
+        // cleanupActiveContentBeforeAccountSwitch) then image evict + cover reset.
+        XCTAssertEqual(log.snapshot().map(\.method),
+                       ["cancelNonEssentialTasks", "clearAllBorrowReauthState",
+                        "evictDecodedImages", "resetCoverCircuitBreaker"],
+                       "synchronous cleanup seams must fire in this exact order")
+        // Prior account A terminally evicted in the injected store (synchronous).
+        XCTAssertEqual(switchStateLabel(stateStore.state(for: aUUID)),
+                       "detailsEvicted.libraryDeselected",
+                       "prior account A must be evicted before control returns")
+        // Nav pop is deferred to the async cleanup Task — not yet fired.
+        XCTAssertFalse(log.snapshot().contains { $0.method == "popToRoot" },
+                       "nav pop-to-root must be deferred to the async cleanup, not synchronous")
+        // isAccountSwitching reset is deferred (F-032).
+        XCTAssertTrue(manager.isAccountSwitching,
+                      "isAccountSwitching must still be true synchronously (reset is deferred)")
+
+        // Let the @MainActor cleanup Task run (nav pop then flag reset).
+        for _ in 0..<1000 {
+            if log.snapshot().contains(where: { $0.method == "popToRoot" }),
+               !manager.isAccountSwitching { break }
+            await Task.yield()
+        }
+
+        XCTAssertEqual(log.snapshot().map(\.method),
+                       ["cancelNonEssentialTasks", "clearAllBorrowReauthState",
+                        "evictDecodedImages", "resetCoverCircuitBreaker", "popToRoot"],
+                       "full cleanup order: nav pop must follow every synchronous seam")
+        XCTAssertFalse(manager.isAccountSwitching,
+                       "isAccountSwitching must be reset only AFTER the async nav cleanup completes")
+    }
+
+    /// Contract: first selection nil → B takes NO cleanup path — none of the
+    /// switch seams fire (no prior content to clean up). Pins the
+    /// `previousAccountId != nil` guard against the injected spies.
+    ///
+    /// Kill case: dropping the `previousAccountId != nil` guard → cancel / evict /
+    /// cover reset / nav pop would fire on first selection → non-empty log.
+    func testFirstSelection_nilToB_drivesNoCleanupSeams() async {
+        let bUUID = "urn:uuid:decomp-s3-nilB-\(UUID().uuidString)"
+        let accountB = Self.makeAccount(uuid: bUUID)
+
+        let log = CallLog()
+        let stateStore = AccountStateStore()
+        let spyExecutor = SpyAccountSwitchNetworkExecutor(log: log)
+        let spyImageCache = SpySwitchImageCache(log: log)
+        let spyBorrow = SpySwitchBorrowReauthResetter(log: log)
+
+        let deps = AccountSwitchDependencies(
+            imageCache: spyImageCache,
+            accountStateStore: stateStore,
+            resetCoverCircuitBreaker: { log.record("resetCoverCircuitBreaker") },
+            networkExecutorProvider: { spyExecutor },
+            popToRootForAccountSwitch: { log.record("popToRoot") }
+        )
+
+        let defaults = Self.testUserDefaults() // currentAccountId starts nil
+        let manager = makeFreshAccountsManager(
+            defaults: defaults,
+            borrowReauthResetter: spyBorrow,
+            switchDependencies: deps
+        )
+        XCTAssertNil(manager.currentAccountId, "Setup: first selection requires a nil starting id")
+
+        manager.currentAccount = accountB
+
+        // Give any (erroneously scheduled) async cleanup a chance to run.
+        for _ in 0..<50 { await Task.yield() }
+
+        XCTAssertTrue(log.snapshot().isEmpty,
+                      "nil→B must drive NO cleanup seams (no prior content)")
+        XCTAssertFalse(manager.isAccountSwitching,
+                       "first selection must not enter the switching state")
+    }
+
     // MARK: - Helpers
 
     /// Register a synchronous (`queue: nil`) `.TPPCurrentAccountDidChange`
@@ -234,6 +369,44 @@ final class AccountsManagerCurrentAccountSwitchContractTests: PalaceWiringTestCa
         let publication = OPDS2Publication(links: [], metadata: metadata, images: nil)
         return Account(publication: publication, imageCache: MockImageCache())
     }
+}
+
+// MARK: - Spies for the Wave 3 S3 switch-cleanup contract
+
+/// Records `cancelNonEssentialTasks()` into a shared `CallLog`. Subclasses the real
+/// `TPPNetworkExecutor` (the only way to observe the concrete cancel seam); every
+/// other executor behavior is inherited but never exercised on the switch path.
+fileprivate final class SpyAccountSwitchNetworkExecutor: TPPNetworkExecutor, @unchecked Sendable {
+    let log: CallLog
+    init(log: CallLog) {
+        self.log = log
+        super.init(cachingStrategy: .ephemeral)
+    }
+    override func cancelNonEssentialTasks() {
+        log.record("cancelNonEssentialTasks")
+    }
+}
+
+/// Records `evictDecodedImages()`; all other `ImageCacheType` surface is inert (the
+/// switch setter only evicts). `@unchecked Sendable`: it holds only the thread-safe
+/// `CallLog`.
+fileprivate final class SpySwitchImageCache: ImageCacheType, @unchecked Sendable {
+    let log: CallLog
+    init(log: CallLog) { self.log = log }
+    func set(_ image: UIImage, for key: String, expiresIn: TimeInterval?) {}
+    func get(for key: String) -> UIImage? { nil }
+    func getAsync(for key: String) async -> UIImage? { nil }
+    func remove(for key: String) {}
+    func clear() {}
+    func warmMemoryCache(for keys: [String]) async {}
+    func evictDecodedImages() { log.record("evictDecodedImages") }
+}
+
+/// Records the account-switch borrow-reauth circuit-breaker clear (Wave 3 S1 seam).
+fileprivate final class SpySwitchBorrowReauthResetter: BorrowReauthResetting, @unchecked Sendable {
+    let log: CallLog
+    init(log: CallLog) { self.log = log }
+    func clearAllBorrowReauthState() { log.record("clearAllBorrowReauthState") }
 }
 
 /// Stable, associated-value-free `LoadState` label. Free function (nonisolated) so

--- a/PalaceTests/Mocks/MockImageCache.swift
+++ b/PalaceTests/Mocks/MockImageCache.swift
@@ -83,6 +83,8 @@ public nonisolated final class MockImageCache: ImageCacheType, @unchecked Sendab
         for key in keys { _ = get(for: key) }
     }
 
+    public func evictDecodedImages() {}
+
     public func resetHistory() {
         sync {
             setKeys.removeAll()

--- a/PalaceTests/Support/PalaceWiringTestCase.swift
+++ b/PalaceTests/Support/PalaceWiringTestCase.swift
@@ -262,6 +262,32 @@ class PalaceWiringTestCase: PalaceTestCase {
         return manager
     }
 
+    /// DI-aware overload that injects BOTH the account-switch borrow-reauth reset
+    /// seam and the account-switch cleanup collaborators (`AccountSwitchDependencies`,
+    /// Wave 3 S3). Lets the switch-cleanup contract test drive the setter with spies
+    /// for every cleanup side effect (image evict, cover reset, account-state store,
+    /// nav pop-to-root, network cancel) while keeping the same `loadCatalogs` opt-out
+    /// pin + tearDown drain — so it stays off the isolation-lint bare-construction ban.
+    @discardableResult
+    nonisolated func makeFreshAccountsManager(
+        defaults: UserDefaults,
+        borrowReauthResetter: any BorrowReauthResetting,
+        switchDependencies: AccountSwitchDependencies,
+        _ configure: (AccountsManager) -> Void = { _ in }
+    ) -> AccountsManager {
+        #if DEBUG
+        AccountsManager.deferInitialLoadCatalogsForTesting = true
+        #endif
+        let manager = AccountsManager(
+            defaults: defaults,
+            borrowReauthResetter: borrowReauthResetter,
+            switchDependencies: switchDependencies
+        )
+        configure(manager)
+        managersToCancelOnTearDown.append(manager)
+        return manager
+    }
+
     // MARK: - Disk-cache cleanup
 
     /// Remove every on-disk catalog/auth/crawl cache file in the test

--- a/scripts/godclass-appcontainer-locator-baseline.txt
+++ b/scripts/godclass-appcontainer-locator-baseline.txt
@@ -3,4 +3,10 @@
 # Single integer. Count may only go DOWN. Captured 2026-07-23.
 # Allowlist: scripts/godclass-appcontainer-locator-allowlist.txt.
 # See docs/architecture/god-class-decomposition-plan.md §3c gap 3.
-313
+# Wave 3 S3 (AccountsManager de-locatoring): the setter/cleanup's two bare
+# `AppContainer.production()` locators (networkExecutor + navigationCoordinatorHub)
+# were inverted behind the injected `AccountSwitchDependencies` seam; the production
+# resolution now lives at the composition root (`AppContainer.swift`, allowlisted).
+# Combined with pre-existing de-flake drift this ratchets 313 -> 305 (rebased onto
+# develop after S2 #1350 landed its download-seam resolutions; net still down from 313).
+305

--- a/scripts/godclass-loc-baseline.txt
+++ b/scripts/godclass-loc-baseline.txt
@@ -56,8 +56,12 @@
 #   must not also carry a decomposition move): `boundedCompletion` + `TPPOnceGuard` + both
 #   carriers are a self-contained, network-free, sign-in-agnostic primitive (~90 LOC) and
 #   should be EXTRACTED to its own file, which nets this hub back BELOW 1207.
+# Wave 3 S3 (AccountsManager de-locatoring): 2384 -> 2383. The account-switch cleanup
+#   seams were inverted behind the injected `AccountSwitchDependencies` bundle; the
+#   net is slightly NEGATIVE (the extracted nav-pop closure + deleted inline reaches
+#   outweigh the stored dependency + its docs). Re-baselined by the exact delta.
 3093 Palace/Audiobooks/AudiobookSessionManager.swift
-2384 Palace/Accounts/Library/AccountsManager.swift
+2383 Palace/Accounts/Library/AccountsManager.swift
 2180 Palace/MyBooks/MyBooksDownloadCenter.swift
 1378 Palace/Book/UI/BookDetail/BookDetailViewModel.swift
 1261 Palace/SignInLogic/TPPSignInBusinessLogic.swift

--- a/scripts/godclass-shared-read-baseline.txt
+++ b/scripts/godclass-shared-read-baseline.txt
@@ -9,4 +9,10 @@
 # book-model files that moved into Palace/Packages/PalaceBookModel/ took their
 # remaining `.shared` mentions out of the counted (non-package) tree. No new
 # `.shared` read was introduced app-side.
-224
+# Wave 3 S3 (AccountsManager de-locatoring): 224 -> 213. The account-switch cleanup
+# path's ambient reads (5 `ImageCache.shared`, 6 `AccountStateStore.shared`, 1
+# `TPPBookCoverRegistry.shared`) were inverted behind the injected
+# `AccountSwitchDependencies` bundle; the composition-root `.production` binding
+# re-introduces only `ImageCache.shared` + `TPPBookCoverRegistry.shared` (2), for a
+# net -11. (There was already a -1 drift to 223 from the de-flake before this change.)
+213


### PR DESCRIPTION
## Wave 3 S3 — de-locator the account-switch cleanup path

Inverts every ambient singleton/`AppContainer.production()` reach in `AccountsManager`'s `currentAccount` setter + `cleanupActiveContentBeforeAccountSwitch`, so the 3a `PalaceAccounts` package move is unblocked and the cleanup order is spy-testable (was NotificationCenter-only).

### Seams injected (frozen `AccountSwitchDependencies` bundle — `RegistryExternalDependencies` precedent)
- `imageCache: ImageCacheType` (evict + `Account(imageCache:)` construction)
- `accountStateStore: AccountStateStore` instance
- `resetCoverCircuitBreaker: @Sendable () -> Void`
- `networkExecutorProvider: @Sendable () -> TPPNetworkExecutor` (init-cycle deferral preserved)
- `popToRootForAccountSwitch: @MainActor @Sendable () async -> Void`

S1's injected `borrowReauthResetter` left untouched.

### Ratchets — all monotone-DOWN (baselines re-based to actuals; scripts pass)
| gate | before | after |
|---|---|---|
| `.shared` reads | 224 | 213 |
| AppContainer locators | 313 | 305 |
| AccountsManager LOC | 2384 | 2383 |

### Contract test
`AccountsManagerCurrentAccountSwitchContractTests` — spy-order pins `cancelNonEssential → clearAllBorrowReauthState → evictDecodedImages → resetCoverCircuitBreaker → state evict → nav pop → isAccountSwitching reset`, plus the `previousAccountId != nil` guard (nil→B drives no cleanup). Write-first: any reorder/removal flips red. Zero `__Snapshots__/` diffs (explicit ordered `CallLog` assertions).

**Scope:** AccountsManager switch/cleanup de-locatoring + new `AccountSwitchDependencies.swift` + AppContainer wiring + spy-order contract test.
**Not done:** full CI suite is the test gate (DRM PalaceTests host can't build in a worktree — `Palace-noDRM` BUILD SUCCEEDED locally); mutation pending. SoD review via forge-review next.
**Deferred:** `AccountStateStore` type moves into PalaceAccounts at the 3a package move (instance injected now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
