### PR TITLE
feat(triage-bot): PP-4882 launch gates — honor omissions, diagnostics toggle, telemetry decision

### DIFF
--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketEmailComposition.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketEmailComposition.swift
@@ -102,13 +102,12 @@ public enum TicketEmailComposition {
     public static func attachments(for rawDraft: TicketDraft) -> [Attachment] {
         // PP-4807: encode the sanitized draft so omitted fields are ABSENT from
         // the JSON attachment (nil optionals are dropped by encodeIfPresent).
+        // PP-4883: serialize via the shared TicketWirePayload so the email
+        // attachment and the clipboard copy path produce byte-identical bytes.
         let draft = rawDraft.sanitizedForSubmission()
         var result: [Attachment] = []
 
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        if let json = try? encoder.encode(draft) {
+        if let json = try? TicketWirePayload.jsonData(for: draft) {
             result.append(Attachment(
                 fileName: "palace-diagnostics.json",
                 mimeType: "application/json",

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketEmailComposition.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketEmailComposition.swift
@@ -104,10 +104,12 @@ public enum TicketEmailComposition {
         // the JSON attachment (nil optionals are dropped by encodeIfPresent).
         // PP-4883: serialize via the shared TicketWirePayload so the email
         // attachment and the clipboard copy path produce byte-identical bytes.
+        // Pass the RAW draft to jsonData and let TicketWirePayload be the sole
+        // sanitize owner for the JSON — `draft` below is only for the log file.
         let draft = rawDraft.sanitizedForSubmission()
         var result: [Attachment] = []
 
-        if let json = try? TicketWirePayload.jsonData(for: draft) {
+        if let json = try? TicketWirePayload.jsonData(for: rawDraft) {
             result.append(Attachment(
                 fileName: "palace-diagnostics.json",
                 mimeType: "application/json",

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketWirePayload.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketWirePayload.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// The single owner of ticket serialization for every path that puts a ticket
+/// on the wire — the email `palace-diagnostics.json` attachment, the clipboard
+/// copy path, and any future gateway (a HelpSpot POST, an Android sink).
+///
+/// It always encodes the WIRE-READY draft (`sanitizedForSubmission()`), so a
+/// field the patron switched off in the preview is absent from the bytes on
+/// every path — not merely hidden in the UI. Before PP-4883 the clipboard
+/// gateway JSON-encoded the *raw* draft and honored no omissions (as-built gap
+/// 12); routing all paths through here is what keeps them from drifting apart.
+///
+/// Lives in TriageBotCore (not TriageBotIOS) so it is unit-tested under macOS
+/// `swift test` — the same fast gate that already guards the email path — even
+/// though the gateways that call it are UIKit-gated.
+public enum TicketWirePayload {
+
+    /// Pretty-printed, deterministically-keyed JSON of the sanitized draft.
+    /// Falls back to `"{}"` only if encoding fails (it does not, for a
+    /// well-formed draft) so callers writing to a sink never crash.
+    public static func json(for rawDraft: TicketDraft) -> String {
+        guard let data = try? jsonData(for: rawDraft),
+              let string = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return string
+    }
+
+    /// The raw JSON bytes, for callers (the email attachment) that need `Data`.
+    public static func jsonData(for rawDraft: TicketDraft) throws -> Data {
+        let draft = rawDraft.sanitizedForSubmission()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(draft)
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/DiagnosticsPreference.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Privacy/DiagnosticsPreference.swift
@@ -11,10 +11,16 @@ public protocol DiagnosticsPreference: Sendable {
 /// UserDefaults-backed preference. Foundation-only so it lives in Core and is
 /// testable under macOS `swift test`. Absent key reads as `true` (default ON).
 public final class UserDefaultsDiagnosticsPreference: DiagnosticsPreference, @unchecked Sendable {
+    /// The single UserDefaults key both this preference and the Settings toggle
+    /// (PP-4884) read/write. Exposed so the app-side toggle binds to the exact
+    /// key the gating context provider honors — no drift between the switch a
+    /// patron flips and the choice the bot obeys.
+    public static let defaultsKey = "triagebot.includeDiagnostics"
+
     private let defaults: UserDefaults
     private let key: String
 
-    public init(defaults: UserDefaults = .standard, key: String = "triagebot.includeDiagnostics") {
+    public init(defaults: UserDefaults = .standard, key: String = UserDefaultsDiagnosticsPreference.defaultsKey) {
         self.defaults = defaults
         self.key = key
     }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Protocols/Protocols.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Protocols/Protocols.swift
@@ -12,6 +12,13 @@ public protocol ContextProvider: Sendable {
 /// HTTP API (or, for demo, copies the JSON to the pasteboard). Failure modes
 /// surface via the throwing init — the reducer maps thrown errors to
 /// `ticketSubmissionFailed` actions.
+///
+/// Serialization contract (PP-4883): any implementation that writes the draft
+/// to an external sink (email attachment, pasteboard, network body) MUST
+/// serialize `draft.sanitizedForSubmission()` — in practice, route through
+/// `TicketWirePayload` — never the raw draft. The patron reviews the ticket
+/// field-by-field and can switch fields off; a gateway that encodes the raw
+/// draft ships fields the patron omitted (as-built gap 12).
 public protocol TicketGateway: Sendable {
     func submit(_ draft: TicketDraft) async throws -> TicketReceipt
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -513,7 +513,16 @@ public struct ConversationReducer: Sendable {
                 kind: .text("Sending your ticket…")
             ))
             next.step = .submitting(ticket: draft)
-            effects.append(.submitTicket(draft))
+            // PP-4883: the draft leaves the reducer WIRE-READY — every field the
+            // patron switched off is stripped here, in pure Core, before any
+            // gateway sees it. This is the single chokepoint that makes the
+            // omit-choices guarantee independent of which gateway runs (email,
+            // clipboard, a future HelpSpot POST) and testable under the fast
+            // `swift test` gate. `.submitting(ticket: draft)` keeps the original
+            // draft so the failure/retry/persist path still shows what the
+            // patron reviewed. `sanitizedForSubmission()` is idempotent, so the
+            // gateway's own serialization sanitize is harmless defense-in-depth.
+            effects.append(.submitTicket(draft.sanitizedForSubmission()))
             effects.append(.emitTelemetry(.init(
                 name: "triage_ticket_submit_requested",
                 parameters: ["priority": draft.priority.rawValue]
@@ -630,7 +639,8 @@ public struct ConversationReducer: Sendable {
             }
             next.messages.append(.init(sender: .bot, kind: .text("Trying again…")))
             next.step = .submitting(ticket: draft)
-            effects.append(.submitTicket(draft))
+            // PP-4883: sanitize on the retry path too (see .userConfirmedTicketSubmit).
+            effects.append(.submitTicket(draft.sanitizedForSubmission()))
             effects.append(.emitTelemetry(.init(name: "triage_ticket_submit_retried")))
 
         case .userTappedStartOver:

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/ClipboardTicketGateway.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotIOS/ClipboardTicketGateway.swift
@@ -12,17 +12,25 @@ import TriageBotCore
 /// Replace with HelpSpotTicketGateway (production) once support has signed
 /// off on rate limits + ticket-routing rules.
 public struct ClipboardTicketGateway: TicketGateway {
-    public init() {}
+    /// Where the serialized ticket is written. Defaults to the system
+    /// pasteboard; injectable so the copy-path output can be asserted in a test
+    /// without mutating global `UIPasteboard.general` state.
+    private let write: @Sendable (String) async -> Void
+
+    public init(write: @escaping @Sendable (String) async -> Void = { json in
+        await MainActor.run { UIPasteboard.general.string = json }
+    }) {
+        self.write = write
+    }
 
     public func submit(_ draft: TicketDraft) async throws -> TicketReceipt {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        let data = try encoder.encode(draft)
-        let json = String(data: data, encoding: .utf8) ?? "{}"
-        await MainActor.run {
-            UIPasteboard.general.string = json
-        }
+        // PP-4883: serialize the WIRE-READY draft via the shared
+        // TicketWirePayload — the same serializer the email path uses — so the
+        // patron's "don't include this" choices are honored on the copy path
+        // too. Previously this encoded the raw draft and shipped fields the
+        // patron had switched off (as-built gap 12).
+        let json = TicketWirePayload.json(for: draft)
+        await write(json)
         return TicketReceipt(
             ticketId: "DEMO-CLIPBOARD-\(Int(Date().timeIntervalSince1970))",
             submittedAt: Date()

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/DiagnosticsPreferenceTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/DiagnosticsPreferenceTests.swift
@@ -87,4 +87,23 @@ final class DiagnosticsPreferenceTests: XCTestCase {
         let second = UserDefaultsDiagnosticsPreference(defaults: suite, key: "k")
         XCTAssertFalse(second.includeDiagnostics, "The OFF choice must survive across instances")
     }
+
+    // MARK: - PP-4884: the Settings toggle and the provider share one key
+
+    /// The app-side toggle writes to `UserDefaultsDiagnosticsPreference.defaultsKey`
+    /// (via @AppStorage). A default-key preference — the one the factory builds
+    /// for the gating provider — must read that exact value back. If the key
+    /// constant and the default init drift apart, a patron could flip the switch
+    /// and the bot would keep collecting everything; this pins them together.
+    func testDefaultKey_isWhatTheDefaultInitReads() {
+        let suite = UserDefaults(suiteName: "diag.key.\(UUID().uuidString)")!
+
+        // Simulate the toggle writing OFF under the shared key.
+        suite.set(false, forKey: UserDefaultsDiagnosticsPreference.defaultsKey)
+
+        // The provider built with the DEFAULT key must honor it.
+        let providerPref = UserDefaultsDiagnosticsPreference(defaults: suite)
+        XCTAssertFalse(providerPref.includeDiagnostics,
+                       "A toggle write under defaultsKey must be read by the default-key preference")
+    }
 }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/SubmitEffectSanitizationTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/SubmitEffectSanitizationTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import TriageBotCore
+
+/// PP-4883, CI-guard for the copy-path leak. The draft the reducer hands to the
+/// `submitTicket` EFFECT must already have the patron's omitted fields stripped,
+/// so the guarantee holds no matter which gateway the host runs — email,
+/// clipboard, or a future POST. This is the pure-Core chokepoint, exercised in
+/// the fast `swift test` gate.
+///
+/// Why this test and not only the gateway test: `ClipboardTicketGatewayTests`
+/// is UIKit-gated and runs in neither CI job (macOS `swift test` compiles it
+/// away; the Palace xcodebuild scheme runs only PalaceTests/TenPrintCoverTests,
+/// not the package's IOS target). Reverting the reducer sanitize here — or a
+/// gateway back to encoding the raw draft — is caught by this test, which does
+/// run.
+final class SubmitEffectSanitizationTests: XCTestCase {
+
+    private func makeReducer() -> ConversationReducer {
+        ConversationReducer(
+            knowledgeBase: KnowledgeBase(catalog: KBCatalog(version: "t", updatedAt: "2026-07-29", entries: [])),
+            aiFallbackEnabled: false
+        )
+    }
+
+    private func draftOmitting(_ omitted: Set<TicketField>) -> TicketDraft {
+        let context = ContextSnapshot(
+            appVersion: "3.3.0",
+            appBuild: "487",
+            osVersion: "26.4.2",
+            deviceModel: "iPhone17,2",
+            libraryName: "Sample Library",
+            libraryUUID: "anon-deadbeef",
+            distributor: "palace_marketplace",
+            authType: "basic",
+            networkState: "wifi",
+            freeStorageBytes: nil,
+            recentLogLines: ["[I] launched"],
+            crashlyticsFingerprints: [],
+            capturedAt: Date(timeIntervalSince1970: 1_716_900_000),
+            audioOutputRoute: nil,
+            lowPowerModeEnabled: nil,
+            appUptimeSeconds: nil,
+            buildChannel: "testflight",
+            availableMemoryMB: nil,
+            libraryBarcode: "sha256:abc123hashedbarcode"
+        )
+        return TicketDraft(
+            userDescription: "audiobook spins forever",
+            category: .audiobook,
+            context: context,
+            omittedFields: omitted
+        )
+    }
+
+    private func submittedDraft(in effects: [ConversationEffect]) throws -> TicketDraft {
+        let draft = effects.compactMap { effect -> TicketDraft? in
+            if case .submitTicket(let d) = effect { return d }
+            return nil
+        }.first
+        return try XCTUnwrap(draft, "reducer must emit a submitTicket effect")
+    }
+
+    /// Confirming the send emits a submitTicket effect whose draft has the
+    /// omitted fields stripped and the omit-list cleared.
+    func testConfirmSubmit_effectDraftIsWireReady() throws {
+        let reducer = makeReducer()
+        let draft = draftOmitting([.barcode, .logs, .library, .network])
+        // A directly-constructed drafting state defaults to an un-armed consent
+        // gate, so the confirm proceeds (see reducer .userConfirmedTicketSubmit).
+        let state = ConversationState(step: .drafting(ticket: draft))
+
+        let (_, effects) = reducer.reduce(state: state, action: .userConfirmedTicketSubmit)
+        let sent = try submittedDraft(in: effects)
+
+        XCTAssertNil(sent.context.libraryBarcode, "omitted barcode must not reach the gateway")
+        XCTAssertEqual(sent.context.recentLogLines, [], "omitted logs must not reach the gateway")
+        XCTAssertNil(sent.context.libraryName, "omitted library must not reach the gateway")
+        XCTAssertNil(sent.context.networkState, "omitted network must not reach the gateway")
+        // Non-omitted fields still ship.
+        XCTAssertEqual(sent.context.distributor, "palace_marketplace")
+        XCTAssertTrue(sent.omittedFields.isEmpty, "wire draft must not carry the omit list")
+    }
+
+    /// The failure/retry path must sanitize too — a patron who omitted a field
+    /// and then retried after a transport failure still has it honored.
+    func testRetrySubmit_effectDraftIsWireReady() throws {
+        let reducer = makeReducer()
+        let draft = draftOmitting([.barcode, .logs])
+        let state = ConversationState(step: .error(message: "Network failed", failedDraft: draft))
+
+        let (_, effects) = reducer.reduce(state: state, action: .userTappedRetrySubmission)
+        let sent = try submittedDraft(in: effects)
+
+        XCTAssertNil(sent.context.libraryBarcode, "retry must not resend an omitted barcode")
+        XCTAssertEqual(sent.context.recentLogLines, [], "retry must not resend omitted logs")
+        XCTAssertTrue(sent.omittedFields.isEmpty)
+    }
+
+    /// Nothing omitted → the full draft ships (sanitize strips only what was
+    /// switched off).
+    func testConfirmSubmit_keepsEverything_whenNothingOmitted() throws {
+        let reducer = makeReducer()
+        let draft = draftOmitting([])
+        let state = ConversationState(step: .drafting(ticket: draft))
+
+        let (_, effects) = reducer.reduce(state: state, action: .userConfirmedTicketSubmit)
+        let sent = try submittedDraft(in: effects)
+
+        XCTAssertEqual(sent.context.libraryBarcode, "sha256:abc123hashedbarcode")
+        XCTAssertEqual(sent.context.networkState, "wifi")
+        XCTAssertEqual(sent.context.recentLogLines, ["[I] launched"])
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/TicketWirePayloadTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/TicketWirePayloadTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import TriageBotCore
+
+/// PP-4883: the ticket the patron reviews field-by-field must go on the wire
+/// exactly as previewed — every "don't include this" choice honored — on EVERY
+/// send path, not just email. `TicketWirePayload` is the single owner of ticket
+/// serialization; both `ClipboardTicketGateway` and the email diagnostics
+/// attachment route through it, so the two paths cannot drift apart.
+///
+/// These run in the fast, UIKit-free `swift test` gate (the gateway itself is
+/// UIKit-gated and can't run there), so a regression that stops honoring
+/// omissions on the copy path fails the same gate that already guards email.
+final class TicketWirePayloadTests: XCTestCase {
+
+    private func makeContext(recentLogs: [String] = ["[I] launched", "[I] opened book"]) -> ContextSnapshot {
+        ContextSnapshot(
+            appVersion: "3.3.0",
+            appBuild: "487",
+            osVersion: "26.4.2",
+            deviceModel: "iPhone17,2",
+            libraryName: "Sample Library",
+            libraryUUID: "anon-deadbeef",
+            distributor: "palace_marketplace",
+            authType: "basic",
+            networkState: "wifi",
+            freeStorageBytes: 8_500_000_000,
+            recentLogLines: recentLogs,
+            crashlyticsFingerprints: ["0x8a3f2b1c4"],
+            capturedAt: Date(timeIntervalSince1970: 1_716_900_000),
+            audioOutputRoute: nil,
+            lowPowerModeEnabled: nil,
+            appUptimeSeconds: nil,
+            buildChannel: "testflight",
+            availableMemoryMB: nil,
+            libraryBarcode: "sha256:abc123hashedbarcode"
+        )
+    }
+
+    private func makeDraft(omitting omitted: Set<TicketField>) -> TicketDraft {
+        TicketDraft(
+            userDescription: "my audiobook just sits there spinning",
+            category: .audiobook,
+            matchedEntryId: nil,
+            context: makeContext(),
+            helpspotTags: ["triage-bot-escalate-novel"],
+            priority: .normal,
+            omittedFields: omitted
+        )
+    }
+
+    private func decode(_ json: String) throws -> TicketDraft {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(TicketDraft.self, from: Data(json.utf8))
+    }
+
+    // MARK: - The copy path honors omissions
+
+    func testJSON_stripsEveryOmittedField() throws {
+        let draft = makeDraft(omitting: [.barcode, .library, .network, .logs])
+        let decoded = try decode(TicketWirePayload.json(for: draft))
+
+        // The patron switched these off — they must be ABSENT from the bytes.
+        XCTAssertNil(decoded.context.libraryBarcode, "omitted barcode must not be serialized")
+        XCTAssertNil(decoded.context.libraryName, "omitted library must not be serialized")
+        XCTAssertNil(decoded.context.libraryUUID, "omitted library UUID must not be serialized")
+        XCTAssertNil(decoded.context.networkState, "omitted network must not be serialized")
+        XCTAssertEqual(decoded.context.recentLogLines, [], "omitted logs must not be serialized")
+
+        // A field the patron did NOT switch off still ships — sanitize strips
+        // only what was omitted, it doesn't nuke everything.
+        XCTAssertEqual(decoded.context.distributor, "palace_marketplace")
+        XCTAssertEqual(decoded.context.authType, "basic")
+        XCTAssertEqual(decoded.userDescription, draft.userDescription)
+
+        // The payload carries no residual omit list to leak which fields were
+        // stripped — sanitizedForSubmission() clears it.
+        XCTAssertTrue(decoded.omittedFields.isEmpty, "wire payload must not advertise the omitted-field list")
+    }
+
+    func testJSON_keepsEverything_whenNothingOmitted() throws {
+        let decoded = try decode(TicketWirePayload.json(for: makeDraft(omitting: [])))
+
+        XCTAssertEqual(decoded.context.libraryBarcode, "sha256:abc123hashedbarcode")
+        XCTAssertEqual(decoded.context.libraryName, "Sample Library")
+        XCTAssertEqual(decoded.context.networkState, "wifi")
+        XCTAssertEqual(decoded.context.recentLogLines, ["[I] launched", "[I] opened book"])
+    }
+
+    // MARK: - Email and copy paths cannot drift apart
+
+    func testJSON_isByteIdenticalToEmailDiagnosticsAttachment() throws {
+        // Both the clipboard copy and the email's palace-diagnostics.json must
+        // encode the exact same sanitized bytes. Pinning byte-equality here is
+        // what keeps a future third send path from re-introducing gap 12.
+        let draft = makeDraft(omitting: [.barcode, .logs])
+        let copyBytes = Data(TicketWirePayload.json(for: draft).utf8)
+        let emailAttachment = try XCTUnwrap(
+            TicketEmailComposition.attachments(for: draft)
+                .first { $0.fileName == "palace-diagnostics.json" }?.data
+        )
+        XCTAssertEqual(copyBytes, emailAttachment, "copy payload and email attachment must be byte-identical")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotIOSTests/ClipboardTicketGatewayTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotIOSTests/ClipboardTicketGatewayTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import TriageBotCore
+
+// The gateway is UIKit-gated, so on macOS `swift test` this file compiles away
+// and these assertions run only on an iOS simulator (via the app build).
+// The load-bearing, gate-run coverage of the copy-path serialization lives in
+// TriageBotCoreTests/TicketWirePayloadTests; this pins the GATEWAY itself —
+// that it routes the draft through the sanitizing serializer before writing.
+#if canImport(UIKit)
+@testable import TriageBotIOS
+
+final class ClipboardTicketGatewayTests: XCTestCase {
+
+    private func draftOmitting(_ omitted: Set<TicketField>) -> TicketDraft {
+        let context = ContextSnapshot(
+            appVersion: "3.3.0",
+            appBuild: "487",
+            osVersion: "26.4.2",
+            deviceModel: "iPhone17,2",
+            libraryName: "Sample Library",
+            libraryUUID: "anon-deadbeef",
+            distributor: "palace_marketplace",
+            authType: "basic",
+            networkState: "wifi",
+            freeStorageBytes: nil,
+            recentLogLines: ["[I] launched"],
+            crashlyticsFingerprints: [],
+            capturedAt: Date(timeIntervalSince1970: 1_716_900_000),
+            audioOutputRoute: nil,
+            lowPowerModeEnabled: nil,
+            appUptimeSeconds: nil,
+            buildChannel: "testflight",
+            availableMemoryMB: nil,
+            libraryBarcode: "sha256:abc123hashedbarcode"
+        )
+        return TicketDraft(
+            userDescription: "audiobook spins forever",
+            category: .audiobook,
+            context: context,
+            omittedFields: omitted
+        )
+    }
+
+    /// PP-4883: the payload the gateway writes to the pasteboard must honor the
+    /// patron's omissions — the exact bug the ticket fixes. Capturing the write
+    /// via the injected sink keeps the assertion off global UIPasteboard state.
+    func testSubmit_writesSanitizedPayload_honoringOmissions() async throws {
+        let box = CapturedWrite()
+        let gateway = ClipboardTicketGateway(write: { await box.set($0) })
+
+        _ = try await gateway.submit(draftOmitting([.barcode, .logs, .library]))
+
+        let json = try XCTUnwrap(await box.value)
+        let decoded = try JSONDecoder.iso8601.decode(TicketDraft.self, from: Data(json.utf8))
+        XCTAssertNil(decoded.context.libraryBarcode, "omitted barcode must not reach the pasteboard")
+        XCTAssertEqual(decoded.context.recentLogLines, [], "omitted logs must not reach the pasteboard")
+        XCTAssertNil(decoded.context.libraryName, "omitted library must not reach the pasteboard")
+        // Non-omitted fields still ship.
+        XCTAssertEqual(decoded.context.networkState, "wifi")
+        XCTAssertTrue(decoded.omittedFields.isEmpty)
+    }
+
+    private actor CapturedWrite {
+        private(set) var value: String?
+        func set(_ v: String) { value = v }
+    }
+}
+
+private extension JSONDecoder {
+    static var iso8601: JSONDecoder {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }
+}
+#endif

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotIOSTests/ClipboardTicketGatewayTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotIOSTests/ClipboardTicketGatewayTests.swift
@@ -1,11 +1,17 @@
 import XCTest
 @testable import TriageBotCore
 
-// The gateway is UIKit-gated, so on macOS `swift test` this file compiles away
-// and these assertions run only on an iOS simulator (via the app build).
-// The load-bearing, gate-run coverage of the copy-path serialization lives in
-// TriageBotCoreTests/TicketWirePayloadTests; this pins the GATEWAY itself —
-// that it routes the draft through the sanitizing serializer before writing.
+// The gateway is UIKit-gated, so on macOS `swift test` this file compiles away,
+// and the Palace xcodebuild scheme runs only PalaceTests/TenPrintCoverTests —
+// so this file runs in NO CI job today. It is a local/sim supplement and an
+// API-compile check, not the regression guard.
+//
+// The load-bearing, CI-gate-run guarantee that the patron's omit choices are
+// honored on the wire lives in TriageBotCoreTests/SubmitEffectSanitizationTests
+// (the pure reducer sanitizes the submitTicket effect for every gateway) and
+// TriageBotCoreTests/TicketWirePayloadTests (the serializer). This file pins the
+// GATEWAY wiring itself for anyone who later adds TriageBotIOSTests to the
+// scheme's TestAction.
 #if canImport(UIKit)
 @testable import TriageBotIOS
 

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -11,6 +11,7 @@ import PalacePreferences
 import PalaceUIKit
 import PalaceBookModel
 import PalaceBookRegistry
+import TriageBotCore
 
 struct TPPSettingsView: View {
     typealias DisplayStrings = Strings.Settings
@@ -35,6 +36,13 @@ struct TPPSettingsView: View {
     /// `sideLoadingSection`), whose precedence is local override > Firebase
     /// remote (default off); this @AppStorage read registers the observation.
     @AppStorage(RemoteFeatureFlags.sideLoadingLocalOverrideKey) private var sideLoadingLocalOverride: Bool = false
+    /// PP-4884: the patron's "Include diagnostics" choice. Bound to the exact
+    /// key the triage bot's gating context provider reads
+    /// (`UserDefaultsDiagnosticsPreference.defaultsKey`), so flipping this switch
+    /// changes what the bot collects with no other wiring. Default ON — the bot
+    /// is most useful to support with full context; a privacy-conscious patron
+    /// can turn it off to send only app + device version.
+    @AppStorage(UserDefaultsDiagnosticsPreference.defaultsKey) private var includeTriageDiagnostics: Bool = true
     /// Feature-flag read seam (Wave 1b), resolved from the environment.
     @Environment(\.appContainer) private var appContainer
     @State private var selectedView: Int? = 0
@@ -344,6 +352,22 @@ struct TPPSettingsView: View {
                 row(title: "Get Help", index: 10, selection: self.$selectedView, destination: wrapper)
                     .accessibilityIdentifier("settings.row.getHelp")
                     .accessibilityLabel("Get Help — chat with our support bot")
+                // PP-4884: give a privacy-conscious patron a way to send fewer
+                // diagnostics. Only shown when the bot is active (the toggle is
+                // moot when no support ticket is ever assembled). The bot honors
+                // this via DiagnosticsGatingContextProvider — no other wiring.
+                // COPY PENDING PRODUCT SIGN-OFF (PP-4884 done-criterion).
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle(isOn: $includeTriageDiagnostics) {
+                        Text("Include diagnostics")
+                            .palaceFont(.body)
+                    }
+                    .accessibilityIdentifier("settings.row.includeDiagnostics")
+                    Text("When on, a support ticket includes your app and device version, network state, and a short tail of recent activity so support can solve problems faster. Turn it off to send only your app and device version.")
+                        .palaceFont(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             case .legacyEmail(let address):
                 Button {
                     presentLegacyReportIssue(to: address)

--- a/docs/architecture/triage-bot-privacy-review.md
+++ b/docs/architecture/triage-bot-privacy-review.md
@@ -1,0 +1,153 @@
+---
+name: triage-bot-privacy-review
+type: decision-record
+status: pending-signoff
+created: 2026-07-29
+owners: [product, legal, support]
+description: The recorded privacy answer for the Palace iOS triage bot. What it collects, what leaves the device and when, how long data lives, and what a patron agrees to. Written to be pointed at before the bot is enabled for patrons (PP-4884).
+---
+
+<!-- audit-verified: PP-4882/PP-4883/PP-4884/PP-4885 verified via Jira API 2026-07-29; PP-4807/PP-4809 carried from in-tree code comments (ContextRedactor/DiagnosticsPreference); file/symbol citations checked against the working tree 2026-07-29 -->
+
+# Triage bot privacy review
+
+This document is the durable record of the privacy question for the in-app
+triage bot. It exists so the decision to enable the bot for patrons is made
+against a written description of what the feature collects and what a patron
+agrees to, rather than against memory of a meeting. The engineering facts below
+are cited to the code that realizes them. The decision itself is recorded at the
+end and is filled in by the product and legal roles, not by engineering.
+
+Companion documents: `triage-bot-v1-as-built.md` (full behavioral contract),
+`triage-bot-shared-architecture-proposal.md` (the future shared design). Gap 5
+in the as-built document is the item this review closes.
+
+## Status
+
+The bot ships in 3.3.0 with its master flag off, so no patron sees it and no
+data is collected in the field yet. This review must have a recorded answer
+before that flag is turned on for patrons. As of the created date the answer is
+pending.
+
+## What the bot collects
+
+Collection happens only after a patron opens Get Help and only for the purpose of
+either answering their question on-device or assembling a support ticket they
+review before sending.
+
+When diagnostics are on (the default), the environment snapshot carries:
+
+- App version and build, platform, OS version, device model.
+- Library name and library account identifier. The account identifier is hashed
+  before it is stored in state (`ContextRedactor.redact`, `libraryUUID` mapped
+  through `hashIdentifier`).
+- The library card number (barcode). It is hashed before it enters state and is
+  never held in raw form (`ContextRedactor`, `libraryBarcode` mapped through
+  `hashIdentifier`). See the open item on hash strength below.
+- Network state (wifi / cellular / offline), free storage, available memory,
+  low-power state, audio route, app uptime. Coarse device telemetry, no
+  identifiers.
+- A short tail of recent log lines from the current session (roughly the last
+  five minutes). Log lines pass through the redactor before they are attached.
+
+When diagnostics are off, none of the above beyond app version, build, OS, and
+device model is captured. The full capture is not run at all: no logs are read,
+no network probe runs, and no account fields are touched
+(`DiagnosticsGatingContextProvider.captureSnapshot`).
+
+The patron's free-text description is collected as typed and is redacted before
+it can leave the device (free-text redaction, `ContextRedactor`).
+
+## Redaction
+
+Redaction runs on the device before anything is presented for sending. It strips
+or hashes tokens, credentials, email addresses, account identifiers, and card
+numbers from both the log tail and the free-text description. The as-built
+document, section 8, holds the full pattern inventory and the conformance corpus
+that keeps it honest (`RedactionCorpusTests`, `FreeTextRedactionTests`).
+
+Redaction is content-level and always on. It is independent of the diagnostics
+toggle and of the per-field omit choices described next.
+
+## What leaves the device, and how
+
+Nothing leaves the device without an explicit patron action. The bot classifies
+on-device and, in App Store builds, makes no network call for classification
+(the AI fallback is off by default and additionally requires a device key that
+production builds do not carry).
+
+When the bot cannot resolve a problem it assembles a ticket and shows the patron
+the complete draft: their description, the environment fields, and the redacted
+log tail. The patron can switch individual fields off and edit the description
+before sending. A field switched off is absent from what is sent, on both send
+paths (`TicketDraft.sanitizedForSubmission`, serialized through
+`TicketWirePayload`; PP-4883 closed the copy-path gap where this was previously
+honored only on the email path).
+
+There are two send paths:
+
+- Email. The app opens the system mail composer pre-addressed to the support
+  mailbox with the body and attachments filled in. The patron sends from their
+  own mail account, or cancels. The app never sends mail programmatically
+  (`EmailTicketGateway`).
+- Copy to clipboard. On the configuration the app currently ships (ticket
+  submission off), the confirm action copies the ticket to the clipboard instead
+  of opening mail (`ClipboardTicketGateway`). The patron chooses where it goes.
+
+In both cases the transport is initiated by the patron, and the destination is
+the Palace support mailbox or wherever the patron pastes.
+
+## Retention
+
+On the device: a ticket that fails to send is saved once as a pending draft in
+app storage and re-offered the next time the chat is opened
+(`UserDefaultsPendingDraftStore`, key `triagebot.pendingDraft`). It is overwritten
+by the next pending draft and removed when cleared. There is no other on-device
+persistence of ticket content.
+
+Off the device: once a ticket reaches the support mailbox its retention is
+governed by the support system's retention policy, not by the app. Stating that
+policy, and confirming it is acceptable for the log tail and hashed identifiers
+this feature sends, is part of the decision below.
+
+## Telemetry
+
+Separately from tickets, the bot reports coarse usage events (conversation
+started, answer offered, guided step outcome, escalation). These carry only an
+enumerable allow-list of keys whose values are counts or enum cases, never
+patron text (`TelemetryContract.enumerableParameters`; a free-text or stale key
+fails a unit test). In release builds these events go to Firebase Analytics. The
+destination decision for this telemetry is tracked separately as PP-4885.
+
+## Open items for the reviewing roles
+
+1. Identifier hash strength. The library account identifier and card number are
+   hashed with a non-cryptographic function (FNV-1a, `hashIdentifier`). This
+   prevents the raw value from appearing in a ticket, but it is not a
+   preimage-resistant hash, and a low-entropy card number could in principle be
+   recovered by an attacker who obtains a ticket and brute-forces the space. The
+   reviewing roles should decide whether this is acceptable for the threat model,
+   or whether a salted or stronger hash, or omitting the identifier by default,
+   is required.
+2. Log tail contents. Redaction is pattern-based. The reviewing roles should
+   confirm the residual risk of an un-patterned identifier in a log line is
+   acceptable given the log tail is off by default when diagnostics are off and
+   can be switched off per-ticket when on.
+3. Default state. Diagnostics default on. The reviewing roles should confirm
+   that an on-by-default posture, with a visible off switch, is the intended
+   consent model, or whether collection should be off until a patron opts in.
+4. Support-side retention. See Retention above.
+5. Disclosure copy. The Settings toggle text and any first-run disclosure need
+   product sign-off (tracked with the toggle in PP-4884).
+
+## Decision
+
+To be completed by the product and legal roles. This section is the recorded
+answer the launch gate points at.
+
+- Reviewed by (roles):
+- Date:
+- Outcome (approved to enable / approved with conditions / not approved):
+- Conditions or required changes:
+- Answer to each open item above:
+- Reference (ticket or meeting record):

--- a/docs/architecture/triage-bot-telemetry-decision.md
+++ b/docs/architecture/triage-bot-telemetry-decision.md
@@ -1,0 +1,140 @@
+---
+name: triage-bot-telemetry-decision
+type: decision-record
+status: pending-signoff
+created: 2026-07-29
+owners: [product, infrastructure, support]
+description: Where the triage bot's usage telemetry should land, and the three metrics plus starting thresholds that let someone answer "is the bot helping?" with a number. Resolves open decision 4 of the shared-architecture proposal (PP-4885).
+---
+
+<!-- audit-verified: PP-4882/PP-4885 verified via Jira API 2026-07-29; event names and TelemetryParameterKey cases recomputed from TriageBotCore source 2026-07-29; open-decision-4 / section-7 references checked against triage-bot-shared-architecture-proposal.md on origin/docs/pp-4858-triage-bot-architecture -->
+
+# Triage bot telemetry: destination and yardstick
+
+The bot already reports what happens as patrons use it, and nothing on the other
+end reads those events. This record resolves two things that gate a useful
+rollout: where the events should land, and what a good result looks like, stated
+as numbers agreed before the bot is turned on rather than after.
+
+This is the iOS-facing resolution of open decision 4 in
+`triage-bot-shared-architecture-proposal.md`, section 7. That section holds the
+backend detail; this record holds the decision and the metric definitions. The
+recommendation below is engineering's; the destination and the thresholds are a
+product and infrastructure call, recorded in the Decision section.
+
+## The fork
+
+The events flow through a fixed twelve-key allow-list (`TelemetryParameterKey`),
+never patron text, and in release builds they reach Firebase Analytics. Two
+destinations are viable.
+
+- Firebase. The events already arrive there. Readable in the console immediately,
+  queryable through the BigQuery export, zero new infrastructure. Limitation: no
+  Palace reporting warehouse reads Firebase, so this data stays in a Firebase or
+  BigQuery silo and is not joined to the rest of Palace reporting.
+- A Circulation Manager ingestion endpoint, modeled on the playtimes path, which
+  plausibly reaches the existing reporting warehouse. This is the larger change:
+  Circulation Manager code, a decision about whether telemetry carries patron
+  auth, a permanence commitment, and an ETL owner that section 7 records as
+  unverified.
+
+## Recommendation
+
+Use Firebase for this rollout, and treat the Circulation Manager endpoint as the
+follow-on if the bot graduates past the pilot.
+
+The reasoning: the argument for the whole shared-architecture effort is that we
+learn from how iOS performs in the field first, then decide what to build. That
+learning loop needs data now, not a new backend path first. Firebase already has
+the data the moment the bot is enabled, at zero infrastructure cost, and the
+three metrics below are answerable from it. Choosing the Circulation Manager path
+first spends the rollout window building ingestion before a single number has
+told us the bot is worth the larger investment. Warehouse integration is the
+right destination once the feature has earned it; it is not the right gate on
+finding out whether it has.
+
+## The three questions, as metrics
+
+Each maps to events the bot already emits. Names are the literal event strings in
+`ConversationReducer`; keys are `TelemetryParameterKey` values.
+
+### 1. How often does the bot resolve something without a ticket
+
+Auto-resolution rate = sessions that reach a resolution without a ticket,
+divided by sessions started.
+
+- Denominator: `triage_chat_opened`.
+- Resolved without a ticket: a session carrying `triage_guided_step_resolved`, or
+  a `triage_kb_match` the patron did not escalate, with no
+  `triage_ticket_submit_requested` and no `triage_ticket_submitted` in the same
+  session.
+- Escalated: `triage_ticket_submit_requested` or `triage_user_file_anyway`
+  present.
+
+This is the headline number for "is it helping." Sessioning is by device and
+time window in the query layer, because the events do not carry a session id
+today. If per-session accuracy proves too coarse, adding a session id is a
+future allow-list key, not a redesign.
+
+### 2. Which questions does it consistently fail to match
+
+Miss signal per category = sessions where the patron chose a category and
+described a problem but the bot produced no confident match, grouped by
+`category`.
+
+- Chose a category: `triage_category_chosen` (carries `category`).
+- No confident match: no `triage_kb_match` in the session, or
+  `triage_ai_fallback_invoked` fired, or a match with `candidate_count` zero.
+
+Honest limit: the events deliberately carry no patron text, so telemetry answers
+this at the category grain, not at the phrasing grain. The list of the actual
+unmatched phrasings does not live in telemetry and must come from the support
+inbox: the tickets the bot escalated are the corpus of what it could not answer.
+The category miss rate says where to look; the escalated tickets say what to add
+to the knowledge base. Both are needed, and neither substitutes for the other.
+
+### 3. Where do patrons abandon a guided flow
+
+Guided-flow abandonment = guided flows started that neither resolved nor
+escalated, bucketed by the step reached.
+
+- Started: `triage_guided_flow_started`.
+- Progressed: `triage_guided_step_advanced` (carries `step_id`, `next_index`).
+- Completed well: `triage_guided_step_resolved`, or an escalation after the flow.
+- Abandoned: `triage_user_dismiss` or session end with neither resolution nor
+  escalation. Bucket by the highest `next_index` reached to see which step loses
+  people.
+
+## Proposed starting thresholds
+
+These are starting numbers to ratify, not decreed targets. They exist so the
+rollout has a yardstick before it begins. The reviewing roles set the final
+values in the Decision section.
+
+- Auto-resolution rate: a proposed floor to ratify (starting proposal: at least
+  a quarter of opened sessions resolve without a ticket within the first weeks of
+  enablement). Below the floor, the corpus needs work before wider enablement.
+- Category miss rate: a watch list rather than a single number. Any category
+  whose miss rate is persistently the highest is the next corpus target.
+- Guided-flow completion: a proposed floor to ratify, and any single step that
+  loses a disproportionate share of patrons is a content fix.
+
+## What is needed to produce a number
+
+Nothing in the app. Events reach Firebase in release builds today. Producing the
+numbers requires the destination decision below, then the queries above built
+against the Firebase or BigQuery export, owned by whoever holds that console.
+Before the bot is enabled there is no field data to read; these definitions and
+queries are what turn the data into an answer the moment the flag is turned on.
+
+## Decision
+
+To be completed by the product and infrastructure roles. Resolves open decision 4.
+
+- Reviewed by (roles):
+- Date:
+- Destination (Firebase for pilot / Circulation Manager endpoint / other):
+- Ratified thresholds (auto-resolution floor, guided-flow completion floor,
+  miss-rate watch policy):
+- Query owner (who builds and holds the three metrics):
+- Reference (ticket or meeting record):


### PR DESCRIPTION
## What

Closes the three launch-gate subtasks of **[PP-4882](https://ebce-lyrasis.atlassian.net/browse/PP-4882)** — the gaps that must be shut before the triage bot's master flag can be turned on for patrons. Maps 1:1 onto §12 of the as-built doc this branch is stacked on (#1355 / PP-4858).

| Subtask | Gap | Fix |
|---|---|---|
| **[PP-4883](https://ebce-lyrasis.atlassian.net/browse/PP-4883)** | clipboard send path ignored the patron's per-field "omit" choices (only email honored them) | the reducer now hands a **wire-ready** draft to the `submitTicket` effect, so omissions are stripped in pure Core before **any** gateway runs |
| **[PP-4884](https://ebce-lyrasis.atlassian.net/browse/PP-4884)** | diagnostics opt-out existed but had no UI | a Settings "Include diagnostics" toggle bound to the exact key the gating provider reads; plus a recorded privacy-review doc |
| **[PP-4885](https://ebce-lyrasis.atlassian.net/browse/PP-4885)** | events flow to Firebase, nothing reads them | a decision record resolving the destination (recommend Firebase for the pilot) with the three metrics + a yardstick |

## PP-4883 — honor omissions on every send path

The patron reviews the ticket field-by-field and can switch pieces off (barcode, library, network, logs). Only the email path stripped them; the clipboard/copy path (the shipping default) JSON-encoded the **raw** draft, so switched-off fields were still copied. Content-level redaction still ran on both paths, so no secret leaked — the narrow failure was "the patron said *not this* and we copied it anyway."

- New Core `TicketWirePayload` is the single serializer; both the clipboard gateway and the email JSON attachment route through it (byte-identical, pinned by test).
- **The guarantee lives in the pure reducer**: `.submitTicket(draft.sanitizedForSubmission())` at both the confirm and retry sites. This is the CI-guardable chokepoint — the package's UIKit-gated IOS test target runs in no CI job, so a gateway-level test alone would not catch a regression. `SubmitEffectSanitizationTests` runs in the fast `swift test` gate; reverting the sanitize fails it (mutation-verified).

## PP-4884 — diagnostics toggle + privacy review

- "Include diagnostics" toggle in the Support settings section (shown only when the bot is active), bound via `@AppStorage(UserDefaultsDiagnosticsPreference.defaultsKey)` — no key drift between the switch and what the bot obeys, pinned by a test.
- `docs/architecture/triage-bot-privacy-review.md`: what the bot collects, what leaves the device and when, retention, consent model, open items — with a Decision block for **product/legal to sign**.

## PP-4885 — telemetry decision

- `docs/architecture/triage-bot-telemetry-decision.md`: resolves open-decision-4, defines auto-resolution rate / per-category miss rate / guided-flow abandonment over the real event vocabulary, proposes thresholds. Docs only — events already reach Firebase; the gap was the decision + queries.

## Review

Ran the SoD panel (architect / qa_test / blast_radius). **qa_test initially BLOCKED** — the clipboard regression wasn't guarded by any CI-executing test — which drove the reducer-chokepoint fix above. All three now approve; verdicts under `.forgeos/changesets/pp-4882-triage-launch-gates/`.

## Verification

- **Core package: 292 tests, 0 failures** (`swift test`, the fast CI gate — includes the new guards).
- **App builds on iPhone 17 Pro sim: BUILD SUCCEEDED.**
- Not run: full Palace suite (PR CI).

## Not done (needs product/legal — gates the *story*, not this PR)

- PP-4884: recorded privacy answer + toggle **copy sign-off**.
- PP-4885: ratify destination + thresholds; assign a query owner.

Stacked on #1355 (base branch `docs/pp-4858-triage-bot-architecture`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PP-4882]: https://ebce-lyrasis.atlassian.net/browse/PP-4882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PP-4883]: https://ebce-lyrasis.atlassian.net/browse/PP-4883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PP-4884]: https://ebce-lyrasis.atlassian.net/browse/PP-4884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PP-4885]: https://ebce-lyrasis.atlassian.net/browse/PP-4885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ