### PR TITLE
fix(triage-bot): remaining V1 launch fixes off the V2 doc stack (PP-4886 + redaction CI gate)

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -95,6 +95,13 @@ jobs:
       - name: Run PalaceTriageBot package tests
         run: swift test --package-path Palace/Packages/PalaceTriageBot
 
+      # The package suite above runs RedactionCorpusTests, but a deny-list guard
+      # is only worth its ability to fail. --self-test disables redaction to prove
+      # the guard goes red on an un-redacted corpus, catching a guard that has
+      # silently stopped guarding. Build products are warm from the step above.
+      - name: Verify TriageBot redaction leak gate
+        run: bash scripts/triage-corpus-check.sh --self-test
+
       - name: Checkout Certificates
         uses: actions/checkout@v7
         with:

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KBMatchActionPolicy.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KBMatchActionPolicy.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Pure visibility rules for the secondary actions on a KB match card.
+///
+/// Kept in TriageBotCore, alongside `HelpEntryPointPolicy`, so the rule is
+/// portable and testable without a SwiftUI host (which cannot build under
+/// macOS `swift test`).
+public enum KBMatchActionPolicy {
+
+    /// Whether the "Notify me" affordance should render on a KB match card.
+    ///
+    /// Currently always false. The affordance used to render whenever an entry
+    /// carried a `fixed_in_version`, and tapping it produced a synthetic local
+    /// receipt plus a reassuring message. Nothing was ever scheduled and no
+    /// mechanism existed to deliver a notification, so the card promised the
+    /// patron something the app could not do.
+    ///
+    /// `entryHasFixVersion` is the condition that gates the affordance once a
+    /// real delivery path exists; return it in place of `false` to restore.
+    /// The reducer still handles `.userTappedNotifyMeOnFix`, and its tests
+    /// still cover that path, so restoring is a one-line change here.
+    public static func showsNotifyMeOnFix(entryHasFixVersion: Bool) -> Bool {
+        false
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/KBMatchCard.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/KBMatchCard.swift
@@ -45,7 +45,9 @@ struct KBMatchCard: View {
             // Secondary actions row. Single line, tight chips. Only shown
             // when there ARE secondary actions to take.
             HStack(spacing: BotUI.Spacing.small) {
-                if entry.fixedInVersion != nil {
+                if KBMatchActionPolicy.showsNotifyMeOnFix(
+                    entryHasFixVersion: entry.fixedInVersion != nil
+                ) {
                     BotUI.SecondaryChip(title: "Notify me", systemImage: "bell.fill") {
                         onAction(.notifyMe)
                     }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/KBMatchActionPolicyTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/KBMatchActionPolicyTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import TriageBotCore
+
+/// Pins the suppression of the notify-me-on-fix affordance.
+///
+/// The affordance previously rendered whenever an entry carried a
+/// `fixed_in_version`, and tapping it produced a synthetic local receipt plus a
+/// reassuring message. No notification was ever scheduled and no mechanism
+/// existed to deliver one, so the card promised the patron something the app
+/// could not do. These tests fail if the affordance is re-enabled before a real
+/// delivery path exists.
+final class KBMatchActionPolicyTests: XCTestCase {
+
+    /// The case that used to show the chip. This is the one that matters: a
+    /// regression that restores the old `entry.fixedInVersion != nil` rule
+    /// fails here rather than shipping a false promise.
+    func testNotifyMeOnFix_whenEntryHasFixVersion_staysHidden() {
+        XCTAssertFalse(
+            KBMatchActionPolicy.showsNotifyMeOnFix(entryHasFixVersion: true),
+            "Notify-me must stay hidden while no notification can be delivered"
+        )
+    }
+
+    func testNotifyMeOnFix_whenEntryHasNoFixVersion_staysHidden() {
+        XCTAssertFalse(
+            KBMatchActionPolicy.showsNotifyMeOnFix(entryHasFixVersion: false)
+        )
+    }
+}

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -386,6 +386,37 @@ else
   fi
 fi
 
+# 2c. TriageBot redaction leak gate (self-testing)
+# The package suite above already runs RedactionCorpusTests, but a deny-list
+# guard is only worth as much as its ability to fail. This runs the guard AND
+# its --self-test, which disables redaction to prove the guard goes red on an
+# un-redacted corpus. A guard that silently stopped guarding is the failure
+# mode this catches; the suite alone cannot catch it. Build products are warm
+# from 2b, so this is seconds.
+echo "--- TriageBot Redaction Leak Gate ---"
+if [ "$MUTATION_ONLY" = "true" ]; then
+  record "triage_redaction_gate" "pass" "Skipped (--mutation-only)"
+elif [ ! -f "scripts/triage-corpus-check.sh" ]; then
+  record "triage_redaction_gate" "pass" "Gate script not present (skipped)"
+elif [ ! -d "Palace/Packages/PalaceTriageBot" ]; then
+  record "triage_redaction_gate" "pass" "Package not present (skipped)"
+else
+  # Capture rc from the command itself; `|| true` would mask it and $? would
+  # always read 0.
+  if GATE_OUTPUT=$(bash scripts/triage-corpus-check.sh --self-test 2>&1); then
+    GATE_RC=0
+  else
+    GATE_RC=$?
+  fi
+  if echo "$GATE_OUTPUT" | grep -q "SELF-TEST PASS"; then
+    record "triage_redaction_gate" "pass" "Deny-list guard clean; gate provably fails on a leak"
+  elif echo "$GATE_OUTPUT" | grep -q "SELF-TEST FAIL"; then
+    record "triage_redaction_gate" "fail" "Guard did NOT go red on an injected leak — the gate is broken"
+  else
+    record "triage_redaction_gate" "fail" "A credential shape survived redaction (rc=$GATE_RC)"
+  fi
+fi
+
 # 3. Test quality lint
 # Diff-scoped: only fail when *changed* test files carry blocking rules
 # (FLAKE-* / FLUFF-* / MISSING-* / TIMEOUT-*). SHALLOW-001 is advisory —


### PR DESCRIPTION
## What

Relocates the **remaining V1 iOS triage-bot fixes** that were stuck behind the **V2 documentation** PR #1355 (`docs/pp-4858-triage-bot-architecture`). The #1355 stack mixes V2 design docs (the Android/server shared-architecture proposal) with V1 code/CI fixes; those fixes need to ship in V1 iOS, which goes out soon, so they belong on `develop` now — not gated on a V2 doc review.

Companion to **#1364** (PP-4882 launch gates). Together they move every V1 code/CI fix off the V2 doc stack, leaving #1355 as docs-only.

- **PP-4886** — stop offering "Notify me when this is fixed" until delivery exists. The bot advertised a follow-up it can't fulfill; `KBMatchActionPolicy` (new, pure Core) decides which actions are offerable so the UI can't surface an undeliverable one. Pinned by `KBMatchActionPolicyTests`.
- **CI: triage redaction leak gate** — wires `scripts/triage-corpus-check.sh` (with its `--self-test`) into `unit-testing.yml` + `verify-pr.sh`, so the deny-list guard runs on every PR and is proven to go RED when redaction is disabled.

## Verification
- `swift test` (TriageBotCore): **285 passed, 0 failures** (includes the new `KBMatchActionPolicyTests`).
- `bash -n scripts/verify-pr.sh` clean; `unit-testing.yml` parses; `triage-corpus-check.sh --self-test` passes locally (guard correctly goes RED with redaction off).
- Cherry-picked from the reviewed #1355 stack (`0e53b6e98`, `935089a49`) onto `develop`; zero conflicts.

## Scope
V1 code/CI only. The V2 shared-architecture proposal + as-built reference docs stay with #1355 (which becomes docs-only). Non-code product/legal sign-offs (privacy review, telemetry destination) remain open on PP-4884/PP-4885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
