### PR TITLE
refactor(accounts): extract AuthDocumentLoader state-machine collaborator (Wave 3 / 3a-3)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 		364459D0B4CBC9DACC5C6C2F /* AccessibilityServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21803F06C0E1741DD2F7973E /* AccessibilityServiceProtocol.swift */; };
 		36650A19392D0CF505DA037D /* TPPMigrationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3391CCE50BC961BC7A5726 /* TPPMigrationManagerTests.swift */; };
 		366C7E46CBA55744BEE438CD /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153576DF8AE3801A58DE3F75 /* DateExtensionTests.swift */; };
+		36BD44B00F9DEB4FB6473B9E /* AuthDocumentLoaderSeamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3882A91BE56A431D3BAC9EB /* AuthDocumentLoaderSeamTests.swift */; };
 		36D5376F01972FB0278F2CB9 /* AudioSessionActivatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22962DCAAE51DD5C78AFB85B /* AudioSessionActivatorTests.swift */; };
 		36F5308F6729B23EA8F5180F /* TPPIndeterminateProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F8E5B987D7324D570F67D0 /* TPPIndeterminateProgressView.swift */; };
 		36FD0974914BA5944F65C95F /* ContractSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73668D395F71A962A961AB94 /* ContractSnapshot.swift */; };
@@ -497,6 +498,7 @@
 		54D213147B9B62D2A4616A7C /* EPUBPositionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FBCE9F366E7A29724332D4 /* EPUBPositionAdapter.swift */; };
 		54E99B7757E6F82038D5F0D6 /* PerformanceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61585F7AD2A0D6CDAF2EF098 /* PerformanceMonitor.swift */; };
 		55104FF85DE440C78F18B4E7 /* TPPLastReadPositionSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706130D4BA8B4FE88304EC9C /* TPPLastReadPositionSynchronizerTests.swift */; };
+		55259176804CBB1F48F10FB3 /* AuthDocumentLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D66F77DC2F6D47EEC5AC3A /* AuthDocumentLoader.swift */; };
 		554C23F2A78ABCFFF01826C9 /* TestTargetHermeticityRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE3B44EDE02103E6515DE7 /* TestTargetHermeticityRegressionTests.swift */; };
 		55630B356BB033C09FEAA9F9 /* TPPBookRegistryAsyncReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E795C64A644FD2C0F982CA69 /* TPPBookRegistryAsyncReadinessTests.swift */; };
 		55FB16FFA837DFA8E0B19E5E /* TPPOPDSFeed+Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4E0EAE6DA244AAE005691B /* TPPOPDSFeed+Networking.swift */; };
@@ -1198,6 +1200,7 @@
 		C3B4C5D6E7F8A9B0C1D2E3F4 /* DownloadStartCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B2C3D4E5F6A7B8C9D0E1F2 /* DownloadStartCoordinator.swift */; };
 		C3C7B0F9C4F9B13DD69CEA84 /* TPPReaderSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2ADD2980F56FC974B6DEBAC /* TPPReaderSettingsTests.swift */; };
 		C3C7B0F9C4F9B13DD69CEA85 /* EPUBSearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A2B3C4D5E6F7A8B9C0D1E2 /* EPUBSearchViewModelTests.swift */; };
+		C3FB1B86998C6337127728A9 /* AuthDocumentLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D66F77DC2F6D47EEC5AC3A /* AuthDocumentLoader.swift */; };
 		C40757CBD12CF84CFC242548 /* AccountsManagerFirstRunDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D221ADA98A856B50628D902 /* AccountsManagerFirstRunDecodeTests.swift */; };
 		C417B57160B14AD69C10AF87 /* DownloadErrorRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4E96DEEFAA4607B343D65D /* DownloadErrorRecoveryTests.swift */; };
 		C44E1D3CA3E045C6A5D43370 /* CarPlayImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639A868F3BDA4A7F97660BEA /* CarPlayImageProvider.swift */; };
@@ -2455,6 +2458,7 @@
 		38BB1056721E445D90C72FFF /* TPPLastReadPositionPosterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPLastReadPositionPosterTests.swift; sourceTree = "<group>"; };
 		38D1A95DE8674E6D83B5A8CA /* TPPNetworkExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPNetworkExecutorTests.swift; sourceTree = "<group>"; };
 		398C885262F88AA0254CD1C6 /* TPPNetworkResponderAuthCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPNetworkResponderAuthCoordinatorTests.swift; sourceTree = "<group>"; };
+		39D66F77DC2F6D47EEC5AC3A /* AuthDocumentLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthDocumentLoader.swift; sourceTree = "<group>"; };
 		39F833987DFE38DF4D313424 /* SideLoadingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideLoadingView.swift; sourceTree = "<group>"; };
 		39FED88A010E48C748A3410B /* SideloadImportContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadImportContractTests.swift; sourceTree = "<group>"; };
 		3A213D524079F39BA952025A /* StreamingReaderPresentationContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingReaderPresentationContractTests.swift; sourceTree = "<group>"; };
@@ -3203,6 +3207,7 @@
 		E2B6CEA300F1440914E64EE8 /* AppRatingServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppRatingServiceTests.swift; sourceTree = "<group>"; };
 		E3465465A1B2C3D4E5F60829 /* OverdriveDownloadHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverdriveDownloadHandler.swift; sourceTree = "<group>"; };
 		E358F2BF99213E34F1B052ED /* OPDS2BookBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OPDS2BookBridgeTests.swift; sourceTree = "<group>"; };
+		E3882A91BE56A431D3BAC9EB /* AuthDocumentLoaderSeamTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthDocumentLoaderSeamTests.swift; sourceTree = "<group>"; };
 		E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPReaderFootnoteAccessibility.swift; path = ../../Palace/Reader2/BusinessLogic/TPPReaderFootnoteAccessibility.swift; sourceTree = "<group>"; };
 		E3FF91DFB962417EA742080A /* RetryClassificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryClassificationTests.swift; sourceTree = "<group>"; };
 		E415908E010C0F85A1BB8FF2 /* BadgeUnlockPhaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BadgeUnlockPhaseTests.swift; sourceTree = "<group>"; };
@@ -4982,6 +4987,7 @@
 				5CDD5AA4C49CC5D388BA9F31 /* AccountNetworking.swift */,
 				EF3B037BFF273D82D2D88CE5 /* AccountRegistryCache.swift */,
 				C49DDACF93DCF459DC310653 /* AccountRegistryStore.swift */,
+				39D66F77DC2F6D47EEC5AC3A /* AuthDocumentLoader.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -6074,6 +6080,7 @@
 				9963A35F959660D52B46E3EC /* AccountNetworkingSeamTests.swift */,
 				7A2745714D1B395FCB45D9C3 /* AccountRegistryCacheSeamTests.swift */,
 				1D5D921DA42F7B66434E0D5F /* AccountRegistryStoreSeamTests.swift */,
+				E3882A91BE56A431D3BAC9EB /* AuthDocumentLoaderSeamTests.swift */,
 			);
 			name = Decomp;
 			path = Decomp;
@@ -8076,6 +8083,7 @@
 				DE253F8C8C4CC3BA89F45090 /* AccountNetworkingSeamTests.swift in Sources */,
 				181FDBB5DF170830CFDA55D2 /* AccountRegistryCacheSeamTests.swift in Sources */,
 				092C37A2AA45C900DCCD7A8E /* AccountRegistryStoreSeamTests.swift in Sources */,
+				36BD44B00F9DEB4FB6473B9E /* AuthDocumentLoaderSeamTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8646,6 +8654,7 @@
 				A7D4A0D17DACC00FB34F5289 /* TPPNetworkExecutor+AccountNetworking.swift in Sources */,
 				AEFABDFE2619088183740385 /* AccountRegistryCache.swift in Sources */,
 				0AE214B06AC5C39759675519 /* AccountRegistryStore.swift in Sources */,
+				C3FB1B86998C6337127728A9 /* AuthDocumentLoader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9219,6 +9228,7 @@
 				31E755A021BE24D982712F6B /* TPPNetworkExecutor+AccountNetworking.swift in Sources */,
 				D8AEB498F4BA7DC04FC5A30E /* AccountRegistryCache.swift in Sources */,
 				4731E519F95F0E4A6F77BFBF /* AccountRegistryStore.swift in Sources */,
+				55259176804CBB1F48F10FB3 /* AuthDocumentLoader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -92,7 +92,9 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
 ///     barrier-write model; the hub holds the store as an immutable `Sendable` `let`.
 ///   - `loadingCompletionHandlers`  → read via `loadingHandlersQueue.sync`,
 ///     written via `loadingHandlersQueue.async(flags:.barrier)`.
-///   - `inflightAuthDocFetches`  → read/written only under `inflightAuthDocLock`.
+///   - the auth-document fetch state (single-flight map + lock)  → moved to the
+///     injected `AuthDocumentLoader` (Wave 3 / 3a-3), which owns its own `NSLock`; the
+///     hub holds the loader as a `lazy var` and no longer names that state.
 ///   - `userAccounts`, `lastKnownCurrentUserAccount`  → read/written only under
 ///     `userAccountsLock`.
 ///   - `_trackedFirstRunTasks`  → read/written only under `_trackedCrawlTasksLock`.
@@ -116,7 +118,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
 ///   Immutable (`let`) state — inherently safe: `tppAccountUUID`, `ageCheck`,
 ///   `settings`, `defaults`, `registryStore` (internally synchronized),
 ///   `registryCache`, `catalogPreloader`, `loadingHandlersQueue`,
-///   `inflightAuthDocLock`, `userAccountsLock`, `_trackedCrawlTasksLock`.
+///   `userAccountsLock`, `_trackedCrawlTasksLock`.
 ///
 ///   `currentAccountId` is a computed property backed by the injected
 ///   `UserDefaults` (`defaults`), which is itself internally thread-safe — no
@@ -184,6 +186,25 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// we cannot resolve the executor during init. First accessed *after* AppContainer
     /// finishes constructing; resolved exactly once, then cached here.
     private lazy var networkExecutor: any AccountNetworking = switchDeps.networkExecutorProvider()
+    /// Per-account auth-document fetch + state-machine collaborator (Wave 3 / 3a-3).
+    /// A `lazy var` (not a `let` default arg like `registryStore`) because its provider
+    /// closures capture `self`, so it can't be resolved before `super.init()`; first
+    /// access is post-init (the earliest drive is the preload / background `loadCatalogs`),
+    /// exactly like `networkExecutor`. The `isTornDown` binding is `#if DEBUG` (reads the
+    /// DEBUG-only `_explicitCancelCalled`); release binds `{ false }` so the DRM build compiles.
+    private lazy var authDocLoader: AuthDocumentLoader = {
+        #if DEBUG
+        let torn: @Sendable () -> Bool = { [weak self] in self?._explicitCancelCalled ?? true }
+        #else
+        let torn: @Sendable () -> Bool = { false }
+        #endif
+        return AuthDocumentLoader(
+            accountStateStore: switchDeps.accountStateStore,
+            currentAccountProvider: { [weak self] in self?.currentAccount },
+            signedInStateProvider: { [weak self] in self?.currentUserAccount },
+            isTornDown: torn
+        )
+    }()
     /// Injectable background-crawl spawn seam (see `CatalogCrawlScheduler`).
     /// Immutable `Sendable` `let`; `.production` by default, recording under test.
     private let crawlScheduler: CrawlTaskScheduler
@@ -214,30 +235,13 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     private var loadingCompletionHandlers = [String: [(Bool) -> Void]]()
     private let loadingHandlersQueue = DispatchQueue(label: "com.tpp.loadingHandlers", attributes: .concurrent)
 
-    /// Per-UUID single-flight guard for `authentication_document` fetches,
-    /// keyed by UUID → the `Date` the fetch was started. Without single-flight,
-    /// two concurrent consumers calling `awaitReady()` on the same Account would
-    /// each cause `current.loadAuthenticationDocument` to fire a duplicate HTTP
-    /// request. The state machine's broadcast (`CurrentValueSubject`) handles
-    /// multi-consumer observation; this map just prevents the duplicate network
-    /// request. See ADR docs/architecture/account-state-machine.md Open Q #1.
-    ///
-    /// The start-time value (rather than a bare `Set`) exists so a wedged fetch
-    /// can be reclaimed: if a fetch's network completion is DROPPED, the UUID
-    /// would otherwise stay in-flight forever and every later
-    /// `driveCurrentAccountAuthDocIfNeeded` would early-return on the dead entry,
-    /// leaving the account stuck at `.detailsLoading` (HelpSpot #18414). When an
-    /// entry is older than `authDocInflightTimeout`, the next fetch reclaims the
-    /// slot and re-fires instead of deduping against the corpse.
-    private var inflightAuthDocFetches = [String: Date]()
-    private let inflightAuthDocLock = NSLock()
+    // The per-account auth-document fetch + state-machine wiring (the single-flight
+    // map + lock, the timeout, and the fetch/drive/terminal logic) moved to
+    // `AuthDocumentLoader.swift` (Wave 3 / 3a-3) — injected via `authDocLoader` below.
 
-    /// How long a single-flight `authentication_document` fetch may remain
-    /// in-flight before a subsequent fetch treats it as wedged (dropped
-    /// completion) and reclaims the slot. Sized above a healthy auth-doc
-    /// round-trip so a genuinely concurrent fetch is still deduped, while a
-    /// dropped-completion wedge self-heals on the next drive.
-    static let authDocInflightTimeout: TimeInterval = 30
+    /// Alias retained so `AccountsManager.authDocInflightTimeout` keeps resolving for
+    /// the wiring-suite tests; the value + the fetch machinery live on `AuthDocumentLoader`.
+    static let authDocInflightTimeout: TimeInterval = AuthDocumentLoader.authDocInflightTimeout
 
     #if DEBUG
     /// Test-only opt-out from the post-init background `loadCatalogs` spawn.
@@ -316,21 +320,14 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// surface conflating those two semantics.
     private var _explicitCancelCalled: Bool = false
 
-    /// Test-only: seed the single-flight `inflightAuthDocFetches` map with an
-    /// entry whose start time is `age` seconds in the past. Lets the stale-wedge
-    /// reclaim path in `fetchAuthDocumentWithStateMachine` be exercised
-    /// deterministically without burning `authDocInflightTimeout` wall-clock
-    /// seconds. NOT compiled into release builds.
+    /// Test-only: forwards to the loader's single-flight seed (Wave 3 / 3a-3).
     func _seedInflightAuthDocForTesting(uuid: String, age: TimeInterval) {
-        inflightAuthDocLock.lock()
-        inflightAuthDocFetches[uuid] = Date().addingTimeInterval(-age)
-        inflightAuthDocLock.unlock()
+        authDocLoader._seedInflightAuthDocForTesting(uuid: uuid, age: age)
     }
 
-    /// Test-only read of whether a UUID currently occupies the single-flight map.
+    /// Test-only read of whether a UUID currently occupies the loader's single-flight map.
     func _inflightAuthDocContainsForTesting(uuid: String) -> Bool {
-        inflightAuthDocLock.lock(); defer { inflightAuthDocLock.unlock() }
-        return inflightAuthDocFetches[uuid] != nil
+        authDocLoader._inflightAuthDocContainsForTesting(uuid: uuid)
     }
     #endif
 
@@ -1429,206 +1426,37 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
         return previousAccountId == newAccountId || previousAccountId == nil
     }
 
-    // MARK: – Auth Document fetch with state-machine wiring
+    // MARK: – Auth Document fetch with state-machine wiring (facades → AuthDocumentLoader)
+    //
+    // The single-flight guard, the `.detailsLoading → .detailsLoaded/.detailsFailed`
+    // transitions, and the `.detailsEvicted` disambiguation moved to
+    // `AuthDocumentLoader.swift` (Wave 3 / 3a-3). The hub keeps thin forwarders so every
+    // call site (the `currentAccount` setter, the warm path) and every test stays byte-
+    // identical.
 
-    /// Wraps `Account.loadAuthenticationDocument` with:
-    /// 1. Per-UUID single-flight guard — the second concurrent caller for
-    ///    the same UUID does NOT fire a duplicate HTTP request; the state
-    ///    stream's broadcast (`CurrentValueSubject`) ensures both callers
-    ///    observe the same eventual transition.
-    /// 2. State-machine transitions — `.detailsLoading` before the fetch;
-    ///    `.detailsLoaded(details)` on success; `.detailsFailed(...)` on
-    ///    failure. New code that reads `account.details` must go through
-    ///    `Account.awaitReady()`, which observes these transitions.
-    ///
-    /// Exposed `internal` so contract-snapshot tests can drive the wiring
-    /// path directly without going through the full `loadCatalogs` cycle.
-    /// Whether an auth-doc fetch completion may write its own terminal
-    /// (`.detailsLoaded`/`.detailsFailed`). Returns `false` when the account has
-    /// since been evicted by a library switch — the deliberate, newer
-    /// `.detailsEvicted` terminal supersedes the in-flight fetch this completion
-    /// belonged to, and awaiters rely on it to fail-fast + redrive on return.
-    /// Pure so the guard is unit-testable without a controllable async fetch.
-    /// CP-D1 (swarm_27c181b5).
+    /// Static forwarder — `AuthDocumentLoader.fetchCompletionMayWriteTerminal` holds the
+    /// pure guard; retained here because the wiring/snapshot tests call
+    /// `AccountsManager.fetchCompletionMayWriteTerminal`.
     static func fetchCompletionMayWriteTerminal(currentState: Account.LoadState) -> Bool {
-        if case .detailsEvicted = currentState { return false }
-        return true
+        AuthDocumentLoader.fetchCompletionMayWriteTerminal(currentState: currentState)
     }
 
+    /// Forwards to `authDocLoader` (Wave 3 / 3a-3). Exposed `internal` so contract-snapshot
+    /// tests can drive the wiring path directly without the full `loadCatalogs` cycle.
     internal func fetchAuthDocumentWithStateMachine(
         for account: Account,
         completion: @escaping (Bool) -> Void
     ) {
-        #if DEBUG
-        // Test-isolation (entry guard): once this manager was explicitly torn
-        // down (`cancelBackgroundWork()` in `AppContainer._resetForTesting()`),
-        // it must not drive any auth-doc state — neither the synchronous
-        // `.detailsLoading` below nor the async terminal write. Otherwise a
-        // late/deferred drive (`driveCurrentAccountAuthDocIfNeeded` dispatched
-        // via `DispatchQueue.main.async`) fires on a later runloop turn, after
-        // the next test's `AccountStateStore` reset, keyed by a fixture-shared
-        // library UUID, and pollutes whichever Accounts test runs next (the
-        // order-dependent flakes in AccountsManagerLaunchSnapshotTests /
-        // AccountsManagerStateMachineWiringTests). Production is UNAFFECTED:
-        // `_explicitCancelCalled` and `cancelBackgroundWork()` are `#if DEBUG`
-        // test-only (the latter is reachable only from `_resetForTesting()`).
-        if _explicitCancelCalled {
-            completion(false)
-            return
-        }
-        #endif
-
-        let now = Date()
-        inflightAuthDocLock.lock()
-        let existingStart = inflightAuthDocFetches[account.uuid]
-        let isStaleWedge: Bool
-        if let existingStart {
-            isStaleWedge = now.timeIntervalSince(existingStart) >= Self.authDocInflightTimeout
-        } else {
-            isStaleWedge = false
-        }
-        // Claim (or re-claim) the slot unless a genuinely-recent fetch owns it.
-        let deduping = existingStart != nil && !isStaleWedge
-        if !deduping {
-            inflightAuthDocFetches[account.uuid] = now
-        }
-        inflightAuthDocLock.unlock()
-
-        if deduping {
-            // A fresh fetch for this UUID is already in flight. Don't fire a
-            // duplicate HTTP request — the state stream's broadcast covers
-            // multi-consumer observation. Caller's completion gets `true`
-            // so the calling DispatchGroup (if any) balances.
-            completion(true)
-            return
-        }
-
-        if isStaleWedge {
-            // The prior in-flight fetch never reported back (its network
-            // completion was dropped) — the account is wedged at
-            // `.detailsLoading`. We reclaimed the slot above; re-fire the fetch
-            // so `awaitReady()` callers aren't stuck forever (HelpSpot #18414).
-            // Re-entering `.detailsLoading` below is the retryable reset: the
-            // stream re-broadcasts and the fresh fetch drives a real terminal.
-            Log.warn(#file, "Auth-doc fetch for \(account.uuid) was wedged in-flight beyond \(Self.authDocInflightTimeout)s — reclaiming and re-firing")
-        }
-
-        account._setState(.detailsLoading)
-        account.loadAuthenticationDocument(using: self.currentUserAccount) { [weak self] success in
-            guard let self = self else {
-                completion(success)
-                return
-            }
-            self.inflightAuthDocLock.lock()
-            self.inflightAuthDocFetches.removeValue(forKey: account.uuid)
-            self.inflightAuthDocLock.unlock()
-
-            #if DEBUG
-            // Test-isolation (completion guard): companion to the entry guard —
-            // an auth-doc fetch that was already IN FLIGHT when this manager was
-            // torn down must not land its terminal `_setState` after the test
-            // boundary. Suppress the write; still balance the caller's completion.
-            // (DEBUG-only — see entry guard; production is unaffected.)
-            if self._explicitCancelCalled {
-                completion(success)
-                return
-            }
-            #endif
-
-            // A fetch that was SUPERSEDED by a library switch must not overwrite
-            // the eviction marker the `currentAccount` setter wrote. Sequence
-            // (CP-D1, swarm_27c181b5): the setter cancels this account's in-flight
-            // fetch (`cancelNonEssentialTasks`) THEN writes
-            // `.detailsEvicted(.libraryDeselected)`; this cancellation completion
-            // then fires ASYNC with `success == false` (NSURLError -999). Without
-            // this guard it clobbers `.detailsEvicted` with
-            // `.detailsFailed(.authDocumentFetchFailed)`, and on switch-back
-            // `driveCurrentAccountAuthDocIfNeeded` reads `.detailsFailed` → the
-            // "genuine failure, don't redrive" arm → `awaitReady()` consumers
-            // (audiobook open, token refresh, bookmark sync, CarPlay auth) stay
-            // stuck (the regression class PR #1021 split the enum to prevent). A
-            // switch-cancellation is NOT a genuine auth failure — the deliberate,
-            // newer `.detailsEvicted` terminal must win. Applies to success too:
-            // a fetch that landed just before cancellation must not resurrect the
-            // now-non-current account.
-            if AccountsManager.fetchCompletionMayWriteTerminal(
-                currentState: switchDeps.accountStateStore.state(for: account.uuid)
-            ) {
-                if success, let details = account.details {
-                    account._setState(.detailsLoaded(details))
-                } else {
-                    account._setState(.detailsFailed(
-                        .authDocumentFetchFailed(underlyingDescription: "loadAuthenticationDocument returned false")
-                    ))
-                }
-            }
-            completion(success)
-        }
+        authDocLoader.fetchAuthDocumentWithStateMachine(for: account, completion: completion)
     }
 
-    /// Fires `fetchAuthDocumentWithStateMachine` for the current account
-    /// when its `LoadState` is non-terminal. Used by the `loadCatalogs`
-    /// warm-path to close the driver gap on cold-launch with a hot
-    /// in-memory accountSets cache — without this, `awaitReady()` callers
-    /// (audiobook open, token refresh, bookmark sync, CarPlay auth) hang
-    /// indefinitely waiting for `.detailsLoaded`/`.detailsFailed` because
-    /// nothing drives the transition. No-op when there is no current
-    /// account, or when state has already settled at a terminal value
-    /// (existing `awaitReady()` awaiters resolve via that terminal).
-    /// Single-flight guard inside `fetchAuthDocumentWithStateMachine`
-    /// dedupes against concurrent callers from `refreshInBackground` or
-    /// the library-switch path.
+    /// Forwards to `authDocLoader` (Wave 3 / 3a-3). Called synchronously from the
+    /// `currentAccount` setter, the slim-hydrate drive, and the `loadCatalogs` warm path
+    /// to close the readiness driver gap; no-op at a terminal state, redrive on a stale
+    /// `.detailsEvicted` marker. The `.detailsEvicted`-vs-`.detailsFailed` disambiguation
+    /// + the forward-compat exhaustiveness guard live in `AuthDocumentLoader`.
     internal func driveCurrentAccountAuthDocIfNeeded() {
-        guard let account = currentAccount else { return }
-        switch switchDeps.accountStateStore.state(for: account.uuid) {
-        case .detailsLoaded:
-            return // terminal — `awaitReady()` awaiters resolve via the loaded details
-        case .detailsEvicted(.libraryDeselected):
-            // `.detailsEvicted(.libraryDeselected)` is the eviction marker
-            // the `currentAccount` setter writes against the PRIOR uuid
-            // when the user switches libraries. If this account is back to
-            // being the current account, that marker is stale — re-drive
-            // the auth-doc fetch so awaitReady() callers (audiobook open,
-            // token refresh, bookmark sync, CarPlay auth) don't throw
-            // `.evicted` forever after a swap-away/swap-back.
-            //
-            // PR #1021 (Module A, swarm_51f248d5) split this case off from
-            // `.detailsFailed(.accountNotFound)` so the eviction marker
-            // stops sharing storage with the genuine HTTP-404 load failure
-            // below. Now a real `.accountNotFound` correctly hits the
-            // `.detailsFailed` arm and does NOT redrive.
-            //
-            // FORWARD-COMPAT (added by swarm_18b0d071 wave 3 Module B):
-            // This arm matches ONLY `.libraryDeselected` today because
-            // that is the only known `AccountEvictionReason`. When a NEW
-            // `AccountEvictionReason` case is added in the future, the
-            // implementer must decide between two semantics:
-            //   (a) "Re-drive on re-entry" — same semantics as
-            //       `.libraryDeselected`: the eviction was triggered by a
-            //       reversible UX action (library swap, sign-out-on-
-            //       current, etc.). Add `case .detailsEvicted(.<newReason>):`
-            //       to THIS arm (alongside `.libraryDeselected`) so
-            //       awaitReady() callers can resume after re-entry.
-            //   (b) "Do NOT re-drive" — the eviction was triggered by an
-            //       irreversible state (account deleted server-side,
-            //       policy expiry, etc.). Add a NEW
-            //       `case .detailsEvicted(.<newReason>):` arm that
-            //       `return`s (mirroring the `.detailsFailed` arm below at
-            //       line ~983) so awaitReady() correctly surfaces the
-            //       failure to consumers instead of looping fetches.
-            // The `default` case is deliberately NOT added to this switch
-            // — Swift's switch-exhaustiveness check will fail at compile
-            // time when a new `AccountEvictionReason` case is added,
-            // forcing the future implementer to make the (a)/(b) decision
-            // explicit here rather than silently inheriting the wrong
-            // behaviour from a default fall-through.
-            break
-        case .detailsFailed:
-            return // genuine load failure — caller must retry explicitly
-        case .notLoaded, .basicInfoLoaded, .detailsLoading:
-            break
-        }
-        fetchAuthDocumentWithStateMachine(for: account) { _ in }
+        authDocLoader.driveCurrentAccountAuthDocIfNeeded()
     }
 
     // MARK: – Parsing & notifying

--- a/Palace/Accounts/Library/AuthDocumentLoader.swift
+++ b/Palace/Accounts/Library/AuthDocumentLoader.swift
@@ -1,0 +1,245 @@
+//
+//  AuthDocumentLoader.swift
+//  Palace
+//
+//  god-class decomposition — Wave 3 / 3a-3 (the third in-target collaborator split
+//  out of `AccountsManager`).
+//
+//  The per-account authentication-document fetch + state-machine wiring: the
+//  single-flight guard, the `.detailsLoading → .detailsLoaded/.detailsFailed`
+//  transitions, and the `.detailsEvicted` disambiguation that keeps a library-switch
+//  cancellation from clobbering the eviction marker. This is the readiness driver
+//  that every `awaitReady()` consumer (audiobook open, token refresh, bookmark sync,
+//  CarPlay auth, sign-in) gates on, extracted behind an injected collaborator so the
+//  hub carries none of it and a packaged `AccountsManager` names none of the state.
+//
+//  A `final class @unchecked Sendable` (NOT an actor): `driveCurrentAccountAuthDocIfNeeded`
+//  is called SYNCHRONOUSLY from the `AccountsManager.currentAccount` property setter,
+//  which cannot `await` — the same class-not-actor rationale as `AccountRegistryStore`.
+//  `@unchecked Sendable` invariant: the only mutable state is `inflightAuthDocFetches`,
+//  read/written exclusively under `inflightAuthDocLock`.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import PalaceLogging
+
+/// Drives per-account auth-document fetches through the `Account.LoadState` machine
+/// with a per-UUID single-flight guard. See the file header for the class-not-actor
+/// and `@unchecked Sendable` rationale. Injected into `AccountsManager`; tests
+/// construct it directly with spy providers.
+final class AuthDocumentLoader: @unchecked Sendable {
+
+    /// How long a single-flight `authentication_document` fetch may remain in-flight
+    /// before a subsequent fetch treats it as wedged (dropped completion) and reclaims
+    /// the slot. Sized above a healthy auth-doc round-trip so a genuinely concurrent
+    /// fetch is still deduped, while a dropped-completion wedge self-heals on the next
+    /// drive.
+    static let authDocInflightTimeout: TimeInterval = 30
+
+    /// Per-UUID single-flight guard, keyed by UUID → the `Date` the fetch started.
+    /// The start-time value (rather than a bare `Set`) lets a wedged fetch be reclaimed
+    /// once older than `authDocInflightTimeout` (HelpSpot #18414). Read/written ONLY
+    /// under `inflightAuthDocLock`.
+    private var inflightAuthDocFetches = [String: Date]()
+    private let inflightAuthDocLock = NSLock()
+
+    /// Per-uuid load-state store. Read side of the state machine (the terminal WRITE
+    /// goes through `Account._setState`, which sinks to the shared account-state store; in
+    /// production this is the same instance — the read/write asymmetry is prod-identical
+    /// and out of scope, matching the note in `AccountsManagerAuthDocContractTests`).
+    private let accountStateStore: AccountStateStore
+
+    /// Resolves the current account to drive. Injected so the loader stays agnostic of
+    /// the defaults-backed `currentAccountId` → `registryStore.account(uuid)` lookup.
+    private let currentAccountProvider: () -> Account?
+
+    /// Resolves the signed-in credential state for `Account.loadAuthenticationDocument`.
+    /// `TPPSignedInStateProvider?` (the parameter's own type) — nil only if the owning
+    /// manager has been deallocated, which cannot happen while the loader (its `lazy var`)
+    /// is alive to call this.
+    private let signedInStateProvider: () -> TPPSignedInStateProvider?
+
+    /// Whether the owning manager has been torn down (a DEBUG test-boundary reset). When
+    /// true, the loader must not drive any state (neither the synchronous `.detailsLoading`
+    /// nor the async terminal), or a late drive pollutes the next test. Production binds
+    /// `{ false }`.
+    private let isTornDown: @Sendable () -> Bool
+
+    init(
+        accountStateStore: AccountStateStore,
+        currentAccountProvider: @escaping () -> Account?,
+        signedInStateProvider: @escaping () -> TPPSignedInStateProvider?,
+        isTornDown: @escaping @Sendable () -> Bool
+    ) {
+        self.accountStateStore = accountStateStore
+        self.currentAccountProvider = currentAccountProvider
+        self.signedInStateProvider = signedInStateProvider
+        self.isTornDown = isTornDown
+    }
+
+    /// Whether an auth-doc fetch completion may write its own terminal
+    /// (`.detailsLoaded`/`.detailsFailed`). Returns `false` when the account has since
+    /// been evicted by a library switch — the deliberate, newer `.detailsEvicted`
+    /// terminal supersedes the in-flight fetch this completion belonged to, and awaiters
+    /// rely on it to fail-fast + redrive on return. Pure so the guard is unit-testable
+    /// without a controllable async fetch. CP-D1 (swarm_27c181b5).
+    static func fetchCompletionMayWriteTerminal(currentState: Account.LoadState) -> Bool {
+        if case .detailsEvicted = currentState { return false }
+        return true
+    }
+
+    /// Wraps `Account.loadAuthenticationDocument` with a per-UUID single-flight guard and
+    /// the `.detailsLoading → .detailsLoaded/.detailsFailed` state-machine transitions.
+    /// The second concurrent caller for the same UUID does NOT fire a duplicate HTTP
+    /// request; the state stream's broadcast (`CurrentValueSubject`) covers multi-consumer
+    /// observation.
+    func fetchAuthDocumentWithStateMachine(
+        for account: Account,
+        completion: @escaping (Bool) -> Void
+    ) {
+        // Test-isolation (entry guard): once the owning manager was explicitly torn down
+        // (`cancelBackgroundWork()` in the composition root's test-boundary reset), it must not
+        // drive any auth-doc state. `isTornDown` is `{ false }` in production (see init).
+        if isTornDown() {
+            completion(false)
+            return
+        }
+
+        let now = Date()
+        inflightAuthDocLock.lock()
+        let existingStart = inflightAuthDocFetches[account.uuid]
+        let isStaleWedge: Bool
+        if let existingStart {
+            isStaleWedge = now.timeIntervalSince(existingStart) >= Self.authDocInflightTimeout
+        } else {
+            isStaleWedge = false
+        }
+        // Claim (or re-claim) the slot unless a genuinely-recent fetch owns it.
+        let deduping = existingStart != nil && !isStaleWedge
+        if !deduping {
+            inflightAuthDocFetches[account.uuid] = now
+        }
+        inflightAuthDocLock.unlock()
+
+        if deduping {
+            // A fresh fetch for this UUID is already in flight. Don't fire a duplicate
+            // HTTP request — the state stream's broadcast covers multi-consumer
+            // observation. Caller's completion gets `true` so the calling DispatchGroup
+            // (if any) balances.
+            completion(true)
+            return
+        }
+
+        if isStaleWedge {
+            // The prior in-flight fetch never reported back (its network completion was
+            // dropped) — the account is wedged at `.detailsLoading`. We reclaimed the
+            // slot above; re-fire so `awaitReady()` callers aren't stuck forever
+            // (HelpSpot #18414). Re-entering `.detailsLoading` below is the retryable
+            // reset: the stream re-broadcasts and the fresh fetch drives a real terminal.
+            Log.warn(#file, "Auth-doc fetch for \(account.uuid) was wedged in-flight beyond \(Self.authDocInflightTimeout)s — reclaiming and re-firing")
+        }
+
+        account._setState(.detailsLoading)
+        account.loadAuthenticationDocument(using: signedInStateProvider()) { [weak self] success in
+            guard let self = self else {
+                completion(success)
+                return
+            }
+            self.inflightAuthDocLock.lock()
+            self.inflightAuthDocFetches.removeValue(forKey: account.uuid)
+            self.inflightAuthDocLock.unlock()
+
+            // Test-isolation (completion guard): companion to the entry guard — an
+            // in-flight fetch that completes after the manager was torn down must not
+            // land its terminal `_setState` after the test boundary. `{ false }` in prod.
+            if self.isTornDown() {
+                completion(success)
+                return
+            }
+
+            // A fetch SUPERSEDED by a library switch must not overwrite the eviction
+            // marker the `currentAccount` setter wrote. Sequence (CP-D1, swarm_27c181b5):
+            // the setter cancels this account's in-flight fetch THEN writes
+            // `.detailsEvicted(.libraryDeselected)`; this cancellation completion then
+            // fires ASYNC with `success == false` (NSURLError -999). Without this guard
+            // it clobbers `.detailsEvicted` with `.detailsFailed(.authDocumentFetchFailed)`,
+            // and on switch-back `driveCurrentAccountAuthDocIfNeeded` reads `.detailsFailed`
+            // → the "genuine failure, don't redrive" arm → `awaitReady()` consumers stay
+            // stuck (the regression class PR #1021 split the enum to prevent). Applies to
+            // success too: a fetch that landed just before cancellation must not resurrect
+            // the now-non-current account.
+            if AuthDocumentLoader.fetchCompletionMayWriteTerminal(
+                currentState: self.accountStateStore.state(for: account.uuid)
+            ) {
+                if success, let details = account.details {
+                    account._setState(.detailsLoaded(details))
+                } else {
+                    account._setState(.detailsFailed(
+                        .authDocumentFetchFailed(underlyingDescription: "loadAuthenticationDocument returned false")
+                    ))
+                }
+            }
+            completion(success)
+        }
+    }
+
+    /// Fires `fetchAuthDocumentWithStateMachine` for the current account when its
+    /// `LoadState` is non-terminal. Used by the `loadCatalogs` warm-path + the
+    /// library-switch setter to close the driver gap — without it, `awaitReady()` callers
+    /// hang waiting for `.detailsLoaded`/`.detailsFailed`. No-op when there is no current
+    /// account, or when state has settled at a terminal value.
+    func driveCurrentAccountAuthDocIfNeeded() {
+        guard let account = currentAccountProvider() else { return }
+        switch accountStateStore.state(for: account.uuid) {
+        case .detailsLoaded:
+            return // terminal — `awaitReady()` awaiters resolve via the loaded details
+        case .detailsEvicted(.libraryDeselected):
+            // `.detailsEvicted(.libraryDeselected)` is the eviction marker the
+            // `currentAccount` setter writes against the PRIOR uuid on a library switch.
+            // If this account is back to being current, that marker is stale — re-drive
+            // so awaitReady() callers (audiobook open, token refresh, bookmark sync,
+            // CarPlay auth) don't throw `.evicted` forever after a swap-away/swap-back.
+            //
+            // PR #1021 (Module A, swarm_51f248d5) split this case off from
+            // `.detailsFailed(.accountNotFound)` so the eviction marker stops sharing
+            // storage with the genuine HTTP-404 load failure below. Now a real
+            // `.accountNotFound` correctly hits the `.detailsFailed` arm and does NOT
+            // redrive.
+            //
+            // FORWARD-COMPAT (swarm_18b0d071 wave 3 Module B): this arm matches ONLY
+            // `.libraryDeselected` today. When a NEW `AccountEvictionReason` case is
+            // added, the implementer must choose:
+            //   (a) "Re-drive on re-entry" (reversible UX action) — add
+            //       `case .detailsEvicted(.<newReason>):` to THIS arm.
+            //   (b) "Do NOT re-drive" (irreversible) — add a NEW arm that `return`s
+            //       (mirroring `.detailsFailed`).
+            // The `default` case is deliberately NOT added — Swift's exhaustiveness
+            // check fails at compile time when a new reason is added, forcing the
+            // future implementer to make the (a)/(b) decision explicit here rather than
+            // silently inheriting the wrong behaviour from a default fall-through.
+            break
+        case .detailsFailed:
+            return // genuine load failure — caller must retry explicitly
+        case .notLoaded, .basicInfoLoaded, .detailsLoading:
+            break
+        }
+        fetchAuthDocumentWithStateMachine(for: account) { _ in }
+    }
+
+    #if DEBUG
+    /// Test-only: seed the single-flight map so wedge/dedupe paths are exercised
+    /// deterministically without burning `authDocInflightTimeout` wall-clock.
+    func _seedInflightAuthDocForTesting(uuid: String, age: TimeInterval) {
+        inflightAuthDocLock.lock()
+        inflightAuthDocFetches[uuid] = Date().addingTimeInterval(-age)
+        inflightAuthDocLock.unlock()
+    }
+
+    func _inflightAuthDocContainsForTesting(uuid: String) -> Bool {
+        inflightAuthDocLock.lock(); defer { inflightAuthDocLock.unlock() }
+        return inflightAuthDocFetches[uuid] != nil
+    }
+    #endif
+}

--- a/PalaceTests/Decomp/AuthDocumentLoaderSeamTests.swift
+++ b/PalaceTests/Decomp/AuthDocumentLoaderSeamTests.swift
@@ -1,0 +1,173 @@
+//
+//  AuthDocumentLoaderSeamTests.swift
+//  PalaceTests
+//
+//  Pins the Wave 3 / 3a-3 `AuthDocumentLoader` seam: the auth-document fetch +
+//  state-machine wiring extracted from AccountsManager into an injected collaborator.
+//
+//  Constructs `AuthDocumentLoader` DIRECTLY with spy providers + an ISOLATED
+//  `AccountStateStore` (no manager ⇒ no wiring-suite isolation flake). Because
+//  `Account._setState` hard-codes `AccountStateStore.shared`, a *terminal* landed by a
+//  fired fetch is NOT observable through the injected store — so these tests never
+//  assert terminals (that stays with the retained `AccountsManagerAuthDocContractTests`
+//  wiring pin). Instead the injected-store-independent observable is: **was the network
+//  fetch fired?** — captured by whether `signedInStateProvider` is called, which the
+//  loader evaluates synchronously at the `loadAuthenticationDocument(using:)` call site
+//  and ONLY on the non-dedup path. Deterministic, no async race, no `.shared` assertion.
+//
+//  The fired fetches use link-less accounts (no auth-doc URL) so the real
+//  `loadAuthenticationDocument` returns false without network; any `.shared` terminal is
+//  reset in tearDown, and every uuid is unique per test.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+import PalaceBookModel
+@testable import Palace
+
+@MainActor
+final class AuthDocumentLoaderSeamTests: XCTestCase {
+
+    private var touchedUUIDs: [String] = []
+
+    override func tearDown() {
+        // A fired fetch writes a terminal to AccountStateStore.shared (Account._setState
+        // hard-codes .shared); reset so nothing bleeds into a later test.
+        for uuid in touchedUUIDs { AccountStateStore.shared.reset(for: uuid) }
+        touchedUUIDs.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - Pure guard
+
+    /// `fetchCompletionMayWriteTerminal` returns false ONLY for an evicted state (so a
+    /// switch-cancellation completion can't clobber the eviction marker), true otherwise.
+    /// Kill case: dropping the `.detailsEvicted` short-circuit ⇒ the evicted assertion flips.
+    func testFetchCompletionMayWriteTerminal_purity() {
+        XCTAssertFalse(
+            AuthDocumentLoader.fetchCompletionMayWriteTerminal(currentState: .detailsEvicted(.libraryDeselected(uuid: "x"))),
+            "an evicted account's in-flight completion must NOT write a terminal")
+        XCTAssertTrue(AuthDocumentLoader.fetchCompletionMayWriteTerminal(currentState: .notLoaded))
+        XCTAssertTrue(AuthDocumentLoader.fetchCompletionMayWriteTerminal(currentState: .basicInfoLoaded))
+        XCTAssertTrue(AuthDocumentLoader.fetchCompletionMayWriteTerminal(currentState: .detailsLoading))
+        XCTAssertTrue(AuthDocumentLoader.fetchCompletionMayWriteTerminal(currentState: .detailsFailed(.accountNotFound(uuid: "x"))))
+    }
+
+    // MARK: - Single-flight dedup / wedge reclaim (via the inflight map + fetch-fired spy)
+
+    /// A recent in-flight entry DEDUPES the next fetch: completion fires `true`
+    /// synchronously and NO network is fired (`signedInStateProvider` untouched).
+    ///
+    /// Kill case: dropping the dedup guard ⇒ the fetch fires the network (spy called).
+    func testFetch_dedupesAgainstRecentInflight() {
+        let (loader, account, spy) = makeLoader()
+        loader._seedInflightAuthDocForTesting(uuid: account.uuid, age: 1) // recent
+
+        var completedWith: Bool?
+        loader.fetchAuthDocumentWithStateMachine(for: account) { completedWith = $0 }
+
+        XCTAssertEqual(completedWith, true, "a deduped caller's completion balances with true")
+        XCTAssertFalse(spy.called, "dedup must NOT fire the network fetch")
+        XCTAssertTrue(loader._inflightAuthDocContainsForTesting(uuid: account.uuid), "the recent slot is untouched")
+    }
+
+    /// A STALE in-flight entry (older than the timeout) is reclaimed and the fetch
+    /// re-fires: `signedInStateProvider` IS called and the slot stays claimed.
+    ///
+    /// Kill case: treating a stale wedge as a live dedup ⇒ the fetch never re-fires
+    /// (spy untouched) and `awaitReady()` stays wedged (HelpSpot #18414).
+    func testFetch_reclaimsStaleWedge() {
+        let (loader, account, spy) = makeLoader()
+        loader._seedInflightAuthDocForTesting(uuid: account.uuid, age: AuthDocumentLoader.authDocInflightTimeout + 5)
+
+        loader.fetchAuthDocumentWithStateMachine(for: account) { _ in }
+
+        XCTAssertTrue(spy.called, "a stale wedge must be reclaimed and the fetch re-fired")
+        // The re-fired fetch reclaims the slot, then its network completion clears it.
+        // For a link-less account `loadAuthenticationDocument` calls back SYNCHRONOUSLY
+        // (no URL → completion(false)), and the loader's completion synchronously removes
+        // the slot before this line — so it is already gone (mirrors the wiring-suite
+        // wedge precedent `testWedgedInflightAuthDoc…`, which asserts the same clear).
+        XCTAssertFalse(loader._inflightAuthDocContainsForTesting(uuid: account.uuid), "the re-fired fetch's synchronous completion clears the reclaimed slot")
+    }
+
+    // MARK: - Drive routing (via the injected store + fetch-fired spy)
+
+    /// `drive` at a genuine terminal failure does NOT re-fetch (the "real failure, don't
+    /// redrive" arm). Kill case: routing `.detailsFailed` to a redrive ⇒ spy called.
+    func testDrive_atTerminalFailure_doesNotRefetch() {
+        let (loader, account, spy, store) = makeLoaderWithStore()
+        store.setState(.detailsFailed(.accountNotFound(uuid: account.uuid)), for: account.uuid)
+
+        loader.driveCurrentAccountAuthDocIfNeeded()
+
+        XCTAssertFalse(spy.called, "a genuine .detailsFailed terminal must NOT redrive")
+    }
+
+    /// `drive` on a STALE `.detailsEvicted(.libraryDeselected)` marker REDRIVES (swap-back).
+    /// Kill case: routing `.detailsEvicted` to `return` ⇒ awaitReady() stuck after swap-back.
+    func testDrive_atStaleEvictionMarker_redrives() {
+        let (loader, account, spy, store) = makeLoaderWithStore()
+        store.setState(.detailsEvicted(.libraryDeselected(uuid: account.uuid)), for: account.uuid)
+
+        loader.driveCurrentAccountAuthDocIfNeeded()
+
+        XCTAssertTrue(spy.called, "a stale .detailsEvicted marker for the current account must redrive")
+    }
+
+    /// `drive` at a non-terminal state fetches. Kill case: a mutant that early-returns
+    /// on `.notLoaded` ⇒ awaitReady() consumers never get a terminal.
+    func testDrive_atNonTerminal_fetches() {
+        let (loader, _, spy, _) = makeLoaderWithStore() // fresh store ⇒ .notLoaded
+
+        loader.driveCurrentAccountAuthDocIfNeeded()
+
+        XCTAssertTrue(spy.called, "a non-terminal (.notLoaded) current account must be driven")
+    }
+
+    // MARK: - Helpers
+
+    /// Loader with an isolated store, a spy `signedInStateProvider`, and a fixed current
+    /// account. `signedInStateProvider` returns nil (the param is optional; the no-URL
+    /// account fails fast) and records that the fetch reached the network call site.
+    private func makeLoaderWithStore() -> (AuthDocumentLoader, Account, ProviderSpy, AccountStateStore) {
+        let account = Self.makeAccount("authdoc-\(UUID().uuidString)")
+        touchedUUIDs.append(account.uuid)
+        let store = AccountStateStore()
+        let spy = ProviderSpy()
+        let loader = AuthDocumentLoader(
+            accountStateStore: store,
+            currentAccountProvider: { account },
+            signedInStateProvider: { spy.called = true; return nil },
+            isTornDown: { false }
+        )
+        return (loader, account, spy, store)
+    }
+
+    private func makeLoader() -> (AuthDocumentLoader, Account, ProviderSpy) {
+        let (loader, account, spy, _) = makeLoaderWithStore()
+        return (loader, account, spy)
+    }
+
+    /// Link-less account whose `metadata.id` is the uuid; no auth-doc URL ⇒ any fired
+    /// `loadAuthenticationDocument` fails fast without network.
+    private static func makeAccount(_ uuid: String) -> Account {
+        let metadata = OPDS2Publication.Metadata(
+            updated: Date(),
+            description: "auth-doc-loader seam",
+            id: uuid,
+            title: "AuthDoc \(uuid.suffix(6))"
+        )
+        return Account(publication: OPDS2Publication(links: [], metadata: metadata, images: nil),
+                       imageCache: MockImageCache())
+    }
+}
+
+/// Records whether the loader reached the `loadAuthenticationDocument(using:)` call site
+/// (i.e. actually fired the fetch, vs deduped/returned early). `@unchecked Sendable`: the
+/// loader evaluates the provider synchronously on the test thread.
+fileprivate final class ProviderSpy: @unchecked Sendable {
+    var called = false
+}

--- a/scripts/godclass-loc-baseline.txt
+++ b/scripts/godclass-loc-baseline.txt
@@ -60,6 +60,15 @@
 #   seams were inverted behind the injected `AccountSwitchDependencies` bundle; the
 #   net is slightly NEGATIVE (the extracted nav-pop closure + deleted inline reaches
 #   outweigh the stored dependency + its docs). Re-baselined by the exact delta.
+# Wave 3 / 3a-3 (-172 on AccountsManager, 2082 -> 1910): the per-account auth-document
+#   fetch + state-machine wiring (the single-flight `inflightAuthDocFetches` map + lock,
+#   `authDocInflightTimeout`, `fetchAuthDocumentWithStateMachine`, `fetchCompletionMayWriteTerminal`,
+#   `driveCurrentAccountAuthDocIfNeeded` with the `.detailsEvicted` disambiguation + the
+#   forward-compat exhaustiveness block, and the DEBUG single-flight seeds) EXTRACTED to the
+#   injected `AuthDocumentLoader` (a `final class`, not an actor — drive is called
+#   synchronously from the currentAccount setter). The hub keeps thin forwarders + a
+#   `static let authDocInflightTimeout` alias. Third of the 3a collaborator splits;
+#   strongly NEGATIVE. Re-baselined DOWN.
 # Wave 3 / 3a-2 (-91 on AccountsManager, 2173 -> 2082): the account-registry STATE +
 #   thread-safe access (the current-hash, `accountSets`, the lockstep `accountByUUID`
 #   index, the slim fallback, the concurrent `accountSetsLock` sync-read/barrier-write
@@ -89,7 +98,7 @@
 #   PalaceDownloads and the account-scope wiring goes with it. Re-baselined by the exact
 #   delta; the freeze still catches any further unrelated growth.
 3093 Palace/Audiobooks/AudiobookSessionManager.swift
-2082 Palace/Accounts/Library/AccountsManager.swift
+1910 Palace/Accounts/Library/AccountsManager.swift
 2184 Palace/MyBooks/MyBooksDownloadCenter.swift
 1378 Palace/Book/UI/BookDetail/BookDetailViewModel.swift
 1261 Palace/SignInLogic/TPPSignInBusinessLogic.swift


### PR DESCRIPTION
## What & why

Third — and most critical — of the **3a `PalaceAccounts` collaborator splits**. The per-account **authentication-document fetch + state-machine wiring** moves out of `AccountsManager` into an injected `AuthDocumentLoader`. This is the readiness driver every `awaitReady()` consumer — audiobook open, token refresh, bookmark sync, CarPlay auth, sign-in — gates on. **Behaviour-identical.**

Follows #1360 / #1361 (3a-1) / #1363 (3a-2), all merged. `AccountsManager` is now **2383 → 1910** across the four extractions.

## Design (architect-validated)

- **`final class`, not an `actor`** — `driveCurrentAccountAuthDocIfNeeded` is called *synchronously* from the `currentAccount` property setter (which can't `await`). Same rationale as `AccountRegistryStore`.
- Owns the single-flight `inflightAuthDocFetches` map + `NSLock` + `authDocInflightTimeout`. `@unchecked Sendable` (state read/written only under the lock).
- Moves `fetchAuthDocumentWithStateMachine`, `fetchCompletionMayWriteTerminal` (static), `driveCurrentAccountAuthDocIfNeeded` **verbatim** — including **both `.detailsEvicted` guards** and the **no-`default` forward-compat exhaustiveness block** (the PR #996/#1021 swap-back regression class: a library-switch cancellation must not clobber the eviction marker, and a real `.accountNotFound` must not redrive).
- Injected deps: `accountStateStore` (read side), `currentAccountProvider` / `signedInStateProvider` / `isTornDown` closures. The fetch goes through `Account.loadAuthenticationDocument`, not the hub network executor. Bound via a `lazy var` (closures capture `self`) with a **`#if DEBUG`-conditional `isTornDown`** (reads DEBUG-only `_explicitCancelCalled`; release binds `{ false }` so the DRM build compiles).
- Hub keeps thin forwarders (drive / fetch / `fetchCompletionMayWriteTerminal` static / DEBUG seeds) **+ a `static let authDocInflightTimeout` alias** so the wiring suite compiles unchanged → **zero test edits**.

## Tests

New `AuthDocumentLoaderSeamTests` constructs the loader directly with spy providers + an isolated store. The injected-store-independent, deterministic observable is **"did the fetch fire the network" = `signedInStateProvider` called** (evaluated synchronously at the call site, only on the non-dedup path): recent-inflight dedup (no fire), stale-wedge reclaim (fire), drive routing (terminal-failure no-fire / stale-`.detailsEvicted` fire / non-terminal fire), + `fetchCompletionMayWriteTerminal` purity. **Terminal-order** is left to the retained `AccountsManagerAuthDocContractTests` wiring pin — `Account._setState` writes `AccountStateStore.shared`, so a terminal isn't observable through an isolated store (asserting it there would be inert — architect Finding 2).

## Verification

| Gate | Result |
|---|---|
| God-class LOC freeze | re-baselined **DOWN 2082 → 1910 (−172)** |
| Palace-noDRM build (production compile) | BUILD SUCCEEDED |
| Locator / shared-read / snapshot drift | 304 / 213 / zero |
| Package-purity (loader names no AppContainer/MBDC/ImageCache.shared) | clean |
| **DRM `PalaceTests` (incl. the new seam tests)** | **run in CI** — worktree can't build the Adobe DRM test host (`dp_all.h`); verified by reading + noDRM compile. **CI must be green before merge.** |

## Review rigor

`/rigorous-fix`: fix-contract → architect pre-review **BLOCKED** (missing `authDocInflightTimeout` facade, `isTornDown` release-build compile, inert-against-isolated-store seam assertions) → fixed → **APPROVED** → implement → 3× SoD (`architect`, `qa_test`, `blast_radius`). Reviewers are session-spawned agents (the `[Self-Approval]` flag is the known false-positive), not an independent human review.

## Not in this PR

The per-account terminal-stamping loop in `loadAccountSetsAndAuthDoc` (future `RegistryLoader`); `Account._setState` write-side injection (future). Remaining 3a collaborators: `RegistryLoader`, `CredentialResolver`, `CurrentAccountStore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
