### PR TITLE
refactor(accounts): extract AccountRegistryLoader load-orchestration collaborator (Wave 3 / 3a-4)

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -955,6 +955,7 @@
 		99ACB0B5B92C44F4AA5845B3 /* BookRegistryEngineTestInits.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC2DF4183065FB1AA9905C0 /* BookRegistryEngineTestInits.swift */; };
 		99D20F898EFFA152025AF8EF /* LCPPDFAcquisitionPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A69DBB718593D67B0150D7 /* LCPPDFAcquisitionPredicateTests.swift */; };
 		99DE76185D4D238A94C9AD9A /* StreamingReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1F0281468BF6D1F7112951 /* StreamingReaderViewModelTests.swift */; };
+		9A060754EB6CCAF39D8F7860 /* AccountRegistryLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D9267074DA0CF6A7A3834 /* AccountRegistryLoader.swift */; };
 		9A0C46503A244883B9CF4005 /* DownloadErrorInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A22586E379F04E1E9348FAAB /* DownloadErrorInfoTests.swift */; };
 		9A936EC0707DA7E918AF9419 /* AccountsManager+TPPCurrentLibraryAccountProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8673802153960A8CA7EAE753 /* AccountsManager+TPPCurrentLibraryAccountProviding.swift */; };
 		9AADE85EC7784278CCF12FA8 /* StatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B365956298AA1A7256D63D8E /* StatsViewModel.swift */; };
@@ -1136,6 +1137,7 @@
 		B82E5D8A62F1988332D1F9BE /* AudiobookSkipIntervalSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A379F8B76503AB9D2BB9DB48 /* AudiobookSkipIntervalSettings.swift */; };
 		B86221BBA29B2EC99494DB3C /* HostFailureTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535929C8F559713321004F38 /* HostFailureTrackerTests.swift */; };
 		B865C34CA9799A7AA0042BBF /* BorrowReauthResetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC47AED382982103F213534 /* BorrowReauthResetting.swift */; };
+		B86ABC14203789D64ABC9A16 /* AccountRegistryLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D9267074DA0CF6A7A3834 /* AccountRegistryLoader.swift */; };
 		B889ECCF0F07418C40A3AEFE /* AccountsManagerStateMachineWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40B096C4C124B0219339E8E /* AccountsManagerStateMachineWiringTests.swift */; };
 		B8D7C87702A528FA7C2D47AF /* BookRegistrySyncReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED5DCD8E5494F99E3E01D1D /* BookRegistrySyncReadinessTests.swift */; };
 		B8DB7D16CE8EDE10BAD7E6E2 /* CallLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E45ABDAD5DEC345C87749C2 /* CallLog.swift */; };
@@ -1318,6 +1320,7 @@
 		D5E6F7A8B9C0D1E2F3A4B5C6 /* DownloadCompletionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C9D0E1F2A3B4C5 /* DownloadCompletionParserTests.swift */; };
 		D62CE75C27E4108F51A097C1 /* BookRegistrySyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050A1EBA3EB1555A8C0E667C /* BookRegistrySyncTests.swift */; };
 		D63BDE36DA0FF88C854C73AB /* NowPlayingCoordinatorBackgroundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE63FC2CA5B2184E8BD6A4F /* NowPlayingCoordinatorBackgroundTests.swift */; };
+		D669BCA946AA705EA8922727 /* AccountRegistryLoaderSeamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C795CD960351D3714E97A895 /* AccountRegistryLoaderSeamTests.swift */; };
 		D674DAC00606CD56F2D1CF11 /* UIFont+TPPSystemFontOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CD20B0A844EE53B3370192 /* UIFont+TPPSystemFontOverride.swift */; };
 		D6E301B17A5D47A7887F5A7F /* EULAView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAA704224204121A301A289 /* EULAView.swift */; };
 		D6E301B27A5D47A7887F5A80 /* EULAView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAA704224204121A301A289 /* EULAView.swift */; };
@@ -2382,6 +2385,7 @@
 		21F238C724991A2A004DC0B1 /* AdobeDRMLibraryService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdobeDRMLibraryService.swift; sourceTree = "<group>"; };
 		21F4BF3926BC62D4000CF592 /* AdobeCertificate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeCertificate.swift; sourceTree = "<group>"; };
 		21F634E426D828CF00C8BE87 /* ReadiumLCP.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ReadiumLCP.xcframework; path = Carthage/Build/ReadiumLCP.xcframework; sourceTree = "<group>"; };
+		221D9267074DA0CF6A7A3834 /* AccountRegistryLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountRegistryLoader.swift; sourceTree = "<group>"; };
 		22962DCAAE51DD5C78AFB85B /* AudioSessionActivatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioSessionActivatorTests.swift; sourceTree = "<group>"; };
 		22C9565C8C9D4F8F6DA585CE /* LCPBotanCRLGuardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPBotanCRLGuardTests.swift; sourceTree = "<group>"; };
 		22D5C28E71B1D177EAF1E5F9 /* TPPReauthenticatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPReauthenticatorTests.swift; sourceTree = "<group>"; };
@@ -3084,6 +3088,7 @@
 		C61A8F5FC897F582128D45B7 /* NetworkClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClientTests.swift; sourceTree = "<group>"; };
 		C71662BC50D2A8BFAFD5C37A /* AudiobookTimeEntryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookTimeEntryTests.swift; sourceTree = "<group>"; };
 		C72E88998C74489891046AA2 /* TPPBookmarkDeletionLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TPPBookmarkDeletionLogTests.swift; path = Bookmarks/TPPBookmarkDeletionLogTests.swift; sourceTree = "<group>"; };
+		C795CD960351D3714E97A895 /* AccountRegistryLoaderSeamTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountRegistryLoaderSeamTests.swift; sourceTree = "<group>"; };
 		C7A10001AAAA000000000001 /* PreviewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewControllerFactory.swift; sourceTree = "<group>"; };
 		C7A10002AAAA000000000001 /* BookAvailabilityFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookAvailabilityFormatter.swift; sourceTree = "<group>"; };
 		C814ACEF8225153039002C2F /* FirebaseTriageTelemetrySink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirebaseTriageTelemetrySink.swift; sourceTree = "<group>"; };
@@ -4988,6 +4993,7 @@
 				EF3B037BFF273D82D2D88CE5 /* AccountRegistryCache.swift */,
 				C49DDACF93DCF459DC310653 /* AccountRegistryStore.swift */,
 				39D66F77DC2F6D47EEC5AC3A /* AuthDocumentLoader.swift */,
+				221D9267074DA0CF6A7A3834 /* AccountRegistryLoader.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -6081,6 +6087,7 @@
 				7A2745714D1B395FCB45D9C3 /* AccountRegistryCacheSeamTests.swift */,
 				1D5D921DA42F7B66434E0D5F /* AccountRegistryStoreSeamTests.swift */,
 				E3882A91BE56A431D3BAC9EB /* AuthDocumentLoaderSeamTests.swift */,
+				C795CD960351D3714E97A895 /* AccountRegistryLoaderSeamTests.swift */,
 			);
 			name = Decomp;
 			path = Decomp;
@@ -8084,6 +8091,7 @@
 				181FDBB5DF170830CFDA55D2 /* AccountRegistryCacheSeamTests.swift in Sources */,
 				092C37A2AA45C900DCCD7A8E /* AccountRegistryStoreSeamTests.swift in Sources */,
 				36BD44B00F9DEB4FB6473B9E /* AuthDocumentLoaderSeamTests.swift in Sources */,
+				D669BCA946AA705EA8922727 /* AccountRegistryLoaderSeamTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8655,6 +8663,7 @@
 				AEFABDFE2619088183740385 /* AccountRegistryCache.swift in Sources */,
 				0AE214B06AC5C39759675519 /* AccountRegistryStore.swift in Sources */,
 				C3FB1B86998C6337127728A9 /* AuthDocumentLoader.swift in Sources */,
+				9A060754EB6CCAF39D8F7860 /* AccountRegistryLoader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9229,6 +9238,7 @@
 				D8AEB498F4BA7DC04FC5A30E /* AccountRegistryCache.swift in Sources */,
 				4731E519F95F0E4A6F77BFBF /* AccountRegistryStore.swift in Sources */,
 				55259176804CBB1F48F10FB3 /* AuthDocumentLoader.swift in Sources */,
+				B86ABC14203789D64ABC9A16 /* AccountRegistryLoader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountRegistryLoader.swift
+++ b/Palace/Accounts/Library/AccountRegistryLoader.swift
@@ -1,0 +1,875 @@
+//
+//  AccountRegistryLoader.swift
+//  Palace
+//
+//  god-class decomposition — Wave 3 / 3a-4 (the fourth, largest, in-target
+//  collaborator split out of `AccountsManager`).
+//
+//  The catalog LOAD orchestration: `loadCatalogs`' stale-while-revalidate pipeline,
+//  the first-page-then-paginate network crawl + its direct-GET fallbacks, the CP-D1
+//  launch preload + slim-snapshot hydration, the owned background-crawl task registry
+//  + its test-boundary drain choreography, and the per-catalog loading-completion
+//  handler dedupe. It ORCHESTRATES the already-extracted collaborators — the disk
+//  cache (`AccountRegistryCaching`, 3a-1), the registry state store
+//  (`AccountRegistryStore`, 3a-2), and the auth-doc state machine (`AuthDocumentLoader`,
+//  3a-3, reached through the injected drive/fetch closures) — so the hub carries none
+//  of the load pipeline.
+//
+//  A `final class @unchecked Sendable` (NOT an actor): `loadCatalogs` and the drain are
+//  called synchronously from init / the currentAccount setter / the test-boundary reset
+//  (which cannot `await`), and the drain depends on a synchronous `registryStore` barrier
+//  read blocking — same class-not-actor rationale as `AccountRegistryStore` /
+//  `AuthDocumentLoader`.
+//
+//  `@unchecked Sendable` invariant: `loadingCompletionHandlers` is read via
+//  `loadingHandlersQueue.sync` / written via `.async(flags:.barrier)`; `ownedCrawlTasks`
+//  is an internally-synchronized `OwnedCrawlTaskRegistry`; `_trackedFirstRunTasks` is
+//  guarded by `_trackedCrawlTasksLock`; `_fetchFromNetworkCount` by its own lock;
+//  `crawlScheduler`/`catalogPreloader`/the injected values are immutable; the DEBUG-only
+//  `backgroundFetchTask` handle is driven only from the test-boundary seams. Every
+//  background crawl `Task { [weak self] … }` captures the loader, whose mutable state is
+//  all so-synchronized.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import PalacePreferences
+import PalaceLogging
+import PalaceCatalog
+import PalaceBookRegistry
+import PalaceBookModel
+import UIKit
+
+/// Documented carrier for a non-Sendable `(Bool) -> Void` load-completion handler
+/// stored into the `loadingHandlersQueue` barrier in `addLoadingHandler` (and reused
+/// for the `group.notify` completion box in `loadAccountSetsAndAuthDoc`). `@unchecked
+/// Sendable` invariant: the wrapped closure is only appended to / read from
+/// `loadingCompletionHandlers[hash]` under the serial `.barrier` of the concurrent
+/// `loadingHandlersQueue`, and invoked later on the caller's queue — never concurrently
+/// with its own storage mutation. Thread-affinity is the caller's contract (unchanged).
+private struct LoadCompletionBox: @unchecked Sendable {
+    let handler: (Bool) -> Void
+}
+
+/// Documented carrier for the non-Sendable `LibraryRegistryCrawler` handed from the
+/// first-page crawl Task into its nested background pagination Task in `fetchFromNetwork`.
+/// `@unchecked Sendable` invariant: the crawler is used strictly sequentially — the outer
+/// Task finishes `crawlFirstPage` BEFORE the pagination Task is spawned, and only the
+/// pagination Task touches it thereafter, so the two never touch it concurrently.
+private struct CrawlerHandoffBox: @unchecked Sendable {
+    let crawler: LibraryRegistryCrawler
+}
+
+/// Catalog load orchestration + owned background-crawl + drain. See the file header for
+/// the class-not-actor and `@unchecked Sendable` rationale. Injected into `AccountsManager`
+/// as a `lazy var`; tests construct it directly with spy providers.
+final class AccountRegistryLoader: @unchecked Sendable {
+
+    // MARK: - Injected collaborators (values)
+
+    private let registryCache: any AccountRegistryCaching
+    private let registryStore: AccountRegistryStore
+    private let crawlScheduler: CrawlTaskScheduler
+    private let settings: TPPSettings
+    private let imageCache: ImageCacheType
+    private let accountStateStore: AccountStateStore
+    private let ageCheck: TPPAgeCheckVerifying
+
+    private let catalogPreloader = CatalogPreloader()
+
+    // MARK: - Injected provider closures (the self-referential drive surface — 9)
+
+    private let networkExecutorProvider: () -> any AccountNetworking
+    private let currentAccountProvider: () -> Account?
+    private let currentAccountIdProvider: () -> String?
+    private let accountsForKeyProvider: (String) -> [Account]
+    private let accountProvider: (String) -> Account?
+    private let currentUserAccountProvider: () -> TPPUserAccount?
+    private let driveCurrentAccountAuthDoc: () -> Void
+    private let fetchAuthDocumentWithStateMachineImpl: (Account, @escaping (Bool) -> Void) -> Void
+    /// COPPA age-check needs the owning manager as a `TPPCurrentLibraryAccountProvider`
+    /// (the loader is not that type — architect finding 3).
+    private let currentLibraryAccountProvider: () -> TPPCurrentLibraryAccountProvider?
+
+    /// Resolves the build-time bundled registry snapshot resource. Production binds
+    /// `Bundle.main`; tests inject a stub to observe the first-launch bundled decode's
+    /// thread + invocation count without a `#if DEBUG` seam.
+    var snapshotResourceResolver: BundleResourceResolving = Bundle.main
+
+    // MARK: - Owned load state
+
+    // Per-catalog in-flight tracking:
+    private var loadingCompletionHandlers = [String: [(Bool) -> Void]]()
+    private let loadingHandlersQueue = DispatchQueue(label: "com.tpp.loadingHandlers", attributes: .concurrent)
+
+    /// Owns every background catalog-crawl Task (PP-4754) so the reset choreography can
+    /// cancel + await them. Self-pruning + internally synchronized.
+    private let ownedCrawlTasks = OwnedCrawlTaskRegistry()
+
+    /// Loader-local copy of the XCTest env gate (the hub's `_isRunningUnderXCTest`).
+    private static let _isRunningUnderXCTest =
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+
+    /// Guards `_trackedFirstRunTasks`.
+    private let _trackedCrawlTasksLock = NSLock()
+    /// Subset of owned tasks that are `loadCatalogs` FIRST-RUN tasks (populated only
+    /// under XCTest). The narrow join seam awaits only these; the broad one awaits all.
+    private var _trackedFirstRunTasks: [Task<Void, Never>] = []
+
+    /// Test-observability: count of `fetchFromNetwork` entries (bumped only under XCTest).
+    private let _fetchFromNetworkCountLock = NSLock()
+    private var _fetchFromNetworkCount = 0
+    var fetchFromNetworkCountForTesting: Int {
+        _fetchFromNetworkCountLock.lock()
+        defer { _fetchFromNetworkCountLock.unlock() }
+        return _fetchFromNetworkCount
+    }
+
+    #if DEBUG
+    /// Test-only handle to the post-init background `loadCatalogs` task (see the hub's
+    /// cancel/inject seams). Only non-nil under DEBUG.
+    var backgroundFetchTask: Task<Void, Never>?
+    #endif
+
+    init(
+        registryCache: any AccountRegistryCaching,
+        registryStore: AccountRegistryStore,
+        crawlScheduler: CrawlTaskScheduler,
+        settings: TPPSettings,
+        imageCache: ImageCacheType,
+        accountStateStore: AccountStateStore,
+        ageCheck: TPPAgeCheckVerifying,
+        networkExecutorProvider: @escaping () -> any AccountNetworking,
+        currentAccountProvider: @escaping () -> Account?,
+        currentAccountIdProvider: @escaping () -> String?,
+        accountsForKeyProvider: @escaping (String) -> [Account],
+        accountProvider: @escaping (String) -> Account?,
+        currentUserAccountProvider: @escaping () -> TPPUserAccount?,
+        driveCurrentAccountAuthDoc: @escaping () -> Void,
+        fetchAuthDocumentWithStateMachine: @escaping (Account, @escaping (Bool) -> Void) -> Void,
+        currentLibraryAccountProvider: @escaping () -> TPPCurrentLibraryAccountProvider?
+    ) {
+        self.registryCache = registryCache
+        self.registryStore = registryStore
+        self.crawlScheduler = crawlScheduler
+        self.settings = settings
+        self.imageCache = imageCache
+        self.accountStateStore = accountStateStore
+        self.ageCheck = ageCheck
+        self.networkExecutorProvider = networkExecutorProvider
+        self.currentAccountProvider = currentAccountProvider
+        self.currentAccountIdProvider = currentAccountIdProvider
+        self.accountsForKeyProvider = accountsForKeyProvider
+        self.accountProvider = accountProvider
+        self.currentUserAccountProvider = currentUserAccountProvider
+        self.driveCurrentAccountAuthDoc = driveCurrentAccountAuthDoc
+        self.fetchAuthDocumentWithStateMachineImpl = fetchAuthDocumentWithStateMachine
+        self.currentLibraryAccountProvider = currentLibraryAccountProvider
+    }
+
+    // MARK: - Owned-task spawning + join seams
+
+    /// Spawn a background crawl `Task` through `crawlScheduler` and register it in
+    /// `ownedCrawlTasks` so the reset choreography can cancel + await it. A `defer`
+    /// self-prunes the token as the task unwinds, bounding the live set.
+    @discardableResult
+    func spawnOwnedCrawlTask(
+        priority: TaskPriority,
+        detached: Bool,
+        firstRun: Bool = false,
+        _ operation: @escaping @Sendable () async -> Void
+    ) -> Task<Void, Never> {
+        let token = UUID()
+        let registry = ownedCrawlTasks
+        let owned: @Sendable () async -> Void = {
+            defer { registry.complete(token) }
+            await operation()
+        }
+        let task = detached
+            ? crawlScheduler.spawnDetached(priority, owned)
+            : crawlScheduler.spawn(priority, owned)
+        ownedCrawlTasks.register(token, task)
+        if firstRun { _trackFirstRunTask(task) }
+        return task
+    }
+
+    /// Record a `loadCatalogs` FIRST-RUN task in the narrow-join subset. No-op outside XCTest.
+    private func _trackFirstRunTask(_ task: Task<Void, Never>) {
+        guard Self._isRunningUnderXCTest else { return }
+        _trackedCrawlTasksLock.lock()
+        _trackedFirstRunTasks.append(task)
+        _trackedCrawlTasksLock.unlock()
+    }
+
+    /// Test-only whole-quiescence JOIN seam (PP-4754). Grows-until-stable; NO wall-clock.
+    func _awaitCatalogLoadForTesting(maxRounds: Int = 8) async {
+        guard Self._isRunningUnderXCTest else { return }
+        var awaited = Set<UUID>()
+        for _ in 0..<maxRounds {
+            let fresh = ownedCrawlTasks.snapshot().filter { !awaited.contains($0.0) }
+            if fresh.isEmpty { return }
+            for (token, task) in fresh {
+                _ = await task.value
+                awaited.insert(token)
+            }
+        }
+    }
+
+    /// Test-only quiescence assertion helper: number of live owned crawl tasks.
+    var _ownedCrawlTaskCountForTesting: Int { ownedCrawlTasks.count }
+
+    /// Snapshot-then-await-without-a-lock (Swift 6 bans `NSLock.lock()` across an await).
+    private func _snapshotFirstRunTasksForTesting() -> [Task<Void, Never>] {
+        _trackedCrawlTasksLock.lock()
+        defer { _trackedCrawlTasksLock.unlock() }
+        return _trackedFirstRunTasks
+    }
+
+    /// Test-only NARROW deterministic JOIN seam. Awaits every tracked FIRST-RUN task.
+    func _awaitAllCrawlTasksForTesting() async {
+        for task in _snapshotFirstRunTasksForTesting() {
+            _ = await task.value
+        }
+    }
+
+    // MARK: - Preload + CP-D1 slim hydration
+
+    /// Hydrate the registry from the on-disk OPDS2 catalog cache without dispatching to a
+    /// background queue. Safe from `init()` (local I/O, single-digit ms). CP-D1.
+    func preloadAccountsFromDiskCacheSync() {
+        let hash = registryStore.currentHash
+        // Fast path (CP-D1 LaunchHydration): when a slim snapshot exists, decode ONLY the
+        // current + settings accounts synchronously so `currentAccount` resolves and its
+        // auth-doc drive fires within a few ms of launch. The full decode+map moves OFF
+        // the launch main thread — it materializes via the background `loadCatalogs` that
+        // `init()` dispatches immediately after. Consumers block on the EXISTING
+        // `Account.awaitReady()` gate, which survives the slim→full instance swap.
+        //
+        // Gated on `registryCache.hasFreshCatalogData`: the slim snapshot carries no
+        // separate metadata, so a truly-expired cache still falls through to the no-op.
+        if registryCache.hasFreshCatalogData(hash: hash), hydrateSlimLaunchSnapshot(hash: hash) {
+            refreshSlimLaunchSnapshotOffMain(hash: hash)
+            return
+        }
+        // Slow path: no slim snapshot yet. Hydrate the full set synchronously exactly as
+        // before, then seed a slim snapshot off-main so the NEXT launch takes the fast path.
+        guard registryCache.hasFreshCatalogData(hash: hash),
+              let cachedData = registryCache.readCatalogData(hash: hash) else {
+            return
+        }
+        hydrateFullAccountSets(fromCatalogData: cachedData, hash: hash)
+        refreshSlimLaunchSnapshotOffMain(hash: hash)
+    }
+
+    /// Decode the small slim snapshot, hydrate the current + settings accounts, drive them
+    /// to `.basicInfoLoaded` (only if still `.notLoaded`), and fire the current account's
+    /// auth-doc drive. Returns false to fall through to the full sync path. CP-D1.
+    private func hydrateSlimLaunchSnapshot(hash: String) -> Bool {
+        guard let url = registryCache.slimSnapshotURL(hash: hash),
+              FileManager.default.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url) else {
+            return false
+        }
+        do {
+            let feed = try OPDS2CatalogsFeed.fromData(data)
+            let accounts = feed.catalogs.map {
+                Account(publication: $0, imageCache: imageCache)
+            }
+            guard !accounts.isEmpty else { return false }
+            // CP-D1 (Finding 5): a stale slim file can LACK the now-current account
+            // (currentAccountId ≠ slim set after a mid-session switch). If the current
+            // account is absent, fall through to the full sync hydrate rather than take
+            // the fast path with a slim set that can't resolve `currentAccount` —
+            // otherwise a transient nil-currentAccount launch window (spurious sign-in
+            // modals / empty library UI) that did not exist pre-D1.
+            if let currentId = currentAccountIdProvider(),
+               !accounts.contains(where: { $0.uuid == currentId }) {
+                return false
+            }
+            registryStore.storeSlim(accounts)
+            for account in accounts {
+                if case .notLoaded = accountStateStore.state(for: account.uuid) {
+                    account._setState(.basicInfoLoaded)
+                }
+            }
+            // Drive the current account's auth-doc so `awaitReady()` consumers resolve
+            // without waiting on the full off-main materialization. `currentAccount`
+            // resolves via `account(_:)`'s slim fallback.
+            //
+            // DEFERRED off this synchronous stack (was a direct call). On cold launch the
+            // manager is constructed INSIDE `_buildCachedAppContainer()` under
+            // `_cachedLock.withLock`; the drive transitively re-enters the composition root
+            // (auth-doc → network executor), and re-entering the non-recursive lock on the
+            // same thread traps — it crashed launch for every signed-in user. Hopping to the
+            // next main-runloop turn lets the container finish building + release the lock
+            // first. The drive is an async fire-and-forget fetch, so a one-turn defer is
+            // behaviorally inert for `awaitReady()` consumers (all run well after launch).
+            DispatchQueue.main.async { [weak self] in
+                self?.driveCurrentAccountAuthDoc()
+            }
+            Log.info(#file, "CP-D1: slim launch snapshot hydrated \(accounts.count) accounts (hash=\(hash))")
+            return true
+        } catch {
+            Log.warn(#file, "CP-D1: slim launch snapshot decode failed: \(error). Falling back to full sync hydrate.")
+            return false
+        }
+    }
+
+    /// The original synchronous full-hydrate path. Only advances still-`.notLoaded` uuids.
+    private func hydrateFullAccountSets(fromCatalogData cachedData: Data, hash: String) {
+        do {
+            let feed = try OPDS2CatalogsFeed.fromData(cachedData)
+            let accounts = feed.catalogs.map {
+                Account(publication: $0, imageCache: imageCache)
+            }
+            registryStore.mutate { $0[hash] = accounts }
+            for account in accounts {
+                if case .notLoaded = accountStateStore.state(for: account.uuid) {
+                    account._setState(.basicInfoLoaded)
+                }
+            }
+            Log.info(#file, "Pre-loaded \(accounts.count) accounts from disk cache (sync, hash=\(hash))")
+        } catch {
+            Log.warn(#file, "Sync disk-cache pre-load failed: \(error). Will refresh from network async.")
+        }
+    }
+
+    /// Rebuild the slim launch snapshot from the full on-disk cache, OFF the main thread.
+    /// XCTest-gated (a detached best-effort write outlives the test and pollutes siblings).
+    func refreshSlimLaunchSnapshotOffMain(hash: String) {
+        guard !Self._isRunningUnderXCTest else { return }
+        spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
+            guard let self, !Task.isCancelled else { return }
+            guard let data = self.registryCache.readCatalogData(hash: hash) else { return }
+            guard !Task.isCancelled else { return }
+            self.writeSlimSnapshot(fromFullCatalogData: data, hash: hash)
+        }
+    }
+
+    /// Carve the current + settings accounts out of the full blob and persist them as a
+    /// small OPDS2 feed. Runs on a background queue. CP-D1.
+    private func writeSlimSnapshot(fromFullCatalogData data: Data, hash: String) {
+        let keepUUIDs = slimSnapshotUUIDs()
+        guard !keepUUIDs.isEmpty, let url = registryCache.slimSnapshotURL(hash: hash) else { return }
+        guard let carved = Self.carveSlimFeed(fromFullCatalogData: data, keepUUIDs: keepUUIDs) else {
+            Log.warn(#file, "CP-D1: slim snapshot carve produced no data (hash=\(hash))")
+            return
+        }
+        do {
+            try carved.write(to: url)
+            Log.info(#file, "CP-D1: slim launch snapshot written (\(keepUUIDs.count) uuids, \(carved.count) bytes, hash=\(hash))")
+        } catch {
+            Log.warn(#file, "CP-D1: slim snapshot write failed: \(error)")
+        }
+    }
+
+    /// The uuids the slim launch snapshot must carry: the current account plus
+    /// `settingsAccountIdsList`. CP-D1.
+    private func slimSnapshotUUIDs() -> Set<String> {
+        var uuids = Set<String>()
+        if let current = currentAccountIdProvider() {
+            uuids.insert(current)
+        }
+        for uuid in settings.settingsAccountIdsList {
+            uuids.insert(uuid)
+        }
+        return uuids
+    }
+
+    /// Pure raw-JSON carve: keep only the `catalogs` entries whose `metadata.id` is in
+    /// `keepUUIDs`, re-serialize the otherwise-unchanged root (preserves the exact
+    /// date-string format the reader expects). Static + pure. CP-D1.
+    static func carveSlimFeed(fromFullCatalogData data: Data, keepUUIDs: Set<String>) -> Data? {
+        guard let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let catalogs = root["catalogs"] as? [[String: Any]] else {
+            return nil
+        }
+        let kept = catalogs.filter { entry in
+            guard let metadata = entry["metadata"] as? [String: Any],
+                  let id = metadata["id"] as? String else { return false }
+            return keepUUIDs.contains(id)
+        }
+        guard !kept.isEmpty else { return nil }
+        var slimRoot = root
+        slimRoot["catalogs"] = kept
+        return try? JSONSerialization.data(withJSONObject: slimRoot)
+    }
+
+    // MARK: - Loading-completion handler dedupe
+
+    /// Adds a completion handler for the given catalog hash, returns true if a load is
+    /// already underway.
+    private func addLoadingHandler(for hash: String, _ handler: ((Bool) -> Void)?) -> Bool {
+        var alreadyLoading = false
+        loadingHandlersQueue.sync {
+            alreadyLoading = loadingCompletionHandlers[hash] != nil
+        }
+
+        guard !alreadyLoading else {
+            if let h = handler {
+                let box = LoadCompletionBox(handler: h)
+                loadingHandlersQueue.async(flags: .barrier) { [weak self] in
+                    self?.loadingCompletionHandlers[hash]?.append(box.handler)
+                }
+            }
+            return true
+        }
+
+        let box = handler.map { LoadCompletionBox(handler: $0) }
+        loadingHandlersQueue.async(flags: .barrier) {
+            self.loadingCompletionHandlers[hash] = box.map { [$0.handler] } ?? []
+        }
+        return false
+    }
+
+    /// Calls & clears all handlers for the given hash.
+    private func callAndClearLoadingHandlers(for hash: String, _ success: Bool) {
+        var handlers: [(Bool) -> Void] = []
+        loadingHandlersQueue.sync {
+            handlers = loadingCompletionHandlers[hash] ?? []
+        }
+        loadingHandlersQueue.async(flags: .barrier) {
+            self.loadingCompletionHandlers[hash] = nil
+        }
+        handlers.forEach { $0(success) }
+    }
+
+    // MARK: - Load orchestration
+
+    /// Spawn the post-init background `loadCatalogs` crawl (owned + drainable), storing
+    /// the handle for the DEBUG cancel/inject seams. Called from `AccountsManager.init`.
+    func spawnInitialBackgroundLoad() {
+        let task = spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
+            self?.loadCatalogs(completion: nil)
+        }
+        #if DEBUG
+        backgroundFetchTask = task
+        #else
+        _ = task
+        #endif
+    }
+
+    /// Public entrypoint — stale-while-revalidate: memory hit → immediate (refresh if
+    /// stale); disk hit → immediate + background refresh; miss → bundled fast-path + network.
+    func loadCatalogs(completion: ((Bool) -> Void)?) {
+        let targetUrl = TPPConfiguration.customUrl()
+            ?? (settings.useBetaLibraries
+                    ? TPPConfiguration.betaUrl
+                    : TPPConfiguration.prodUrl)
+        let hash = targetUrl.absoluteString
+            .md5()
+            .base64EncodedStringUrlSafe()
+            .trimmingCharacters(in: ["="])
+
+        // 1. Already loaded in memory → return immediately (still drive the current
+        // account's auth-doc so `awaitReady()` callers resolve on cold-launch warm path).
+        if registryStore.bucketIsNonEmpty(hash: hash) {
+            driveCurrentAccountAuthDoc()
+            completion?(true)
+            if registryCache.isCatalogStale(hash: hash) {
+                refreshInBackground(targetUrl: targetUrl, hash: hash)
+            }
+            return
+        }
+
+        // 2. Disk cache (stale-while-revalidate).
+        if registryCache.hasFreshCatalogData(hash: hash),
+           let cachedData = registryCache.readCatalogData(hash: hash) {
+            Log.info(#file, "Loading catalogs from cache (stale-while-revalidate), hash=\(hash), dataSize=\(cachedData.count)")
+
+            if addLoadingHandler(for: hash, completion) { return }
+
+            loadAccountSetsAndAuthDoc(fromCatalogData: cachedData, key: hash) { [weak self] success in
+                NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                self?.callAndClearLoadingHandlers(for: hash, success)
+            }
+
+            refreshInBackground(targetUrl: targetUrl, hash: hash)
+            return
+        }
+
+        // 2.5 + 3. No disk cache: build-time bundled snapshot fast-path THEN the network
+        // fetch that supersedes it. SINGLE dedupe guard above the bundled branch (a
+        // concurrent second caller short-circuits HERE, before the ~2.4 MB bundled decode)
+        // and deliberately NOT re-checked before `fetchFromNetwork`.
+        if addLoadingHandler(for: hash, completion) { return }
+
+        // Hop the bundled decode + network kickoff OFF the calling thread (cold first
+        // launch reaches here from @MainActor). `.utility` matches the init crawl arms;
+        // tracked so `cancelBackgroundWork()` cancels it.
+        spawnOwnedCrawlTask(priority: .utility, detached: true, firstRun: true) { [weak self] in
+            guard let self = self else { return }
+
+            if let bundledData = BundledRegistrySnapshot.load(resolver: self.snapshotResourceResolver),
+               !Task.isCancelled {
+                Log.info(#file, "First launch — loading bundled registry snapshot for hash \(hash), dataSize=\(bundledData.count)")
+                self.registryCache.writeCatalogData(bundledData, hash: hash, isBundled: true)
+                self.loadAccountSetsAndAuthDoc(fromCatalogData: bundledData, key: hash) { _ in
+                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                }
+            }
+
+            if Task.isCancelled { return }
+            Log.debug(#file, "Loading catalogs from network for hash \(hash)…")
+            self.fetchFromNetwork(targetUrl: targetUrl, hash: hash)
+        }
+    }
+
+    /// First-page fast path: fetch first page → display; paginate remaining in background.
+    /// Falls back to a direct GET if even the first page fails.
+    private func fetchFromNetwork(targetUrl: URL, hash: String) {
+        if Self._isRunningUnderXCTest {
+            _fetchFromNetworkCountLock.lock()
+            _fetchFromNetworkCount += 1
+            _fetchFromNetworkCountLock.unlock()
+        }
+
+        if TPPConfiguration.customRegistryIsExplicitURL() {
+            fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
+            return
+        }
+        spawnOwnedCrawlTask(priority: .userInitiated, detached: false) { [weak self] in
+            guard let self = self else { return }
+            Log.debug(#file, "Fetching catalogs via first-page fast path for hash \(hash)")
+
+            let crawler = LibraryRegistryCrawler(fetcher: URLSessionCrawlerFetcher(), hash: hash)
+
+            let firstPageResult = await crawler.crawlFirstPage(baseURL: targetUrl)
+            if Task.isCancelled { return }
+
+            switch firstPageResult {
+            case .success(let firstPageData, let firstPage):
+                self.registryCache.writeCatalogData(firstPageData, hash: hash)
+                self.loadAccountSetsAndAuthDoc(fromCatalogData: firstPageData, key: hash) { success in
+                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                    self.callAndClearLoadingHandlers(for: hash, success)
+                }
+
+                guard firstPage.nextPageURL != nil else {
+                    Log.info(#file, "Single-page registry response (\(firstPage.catalogs.count) libraries) — no pagination needed")
+                    self.triggerCatalogPreload()
+                    break
+                }
+
+                Log.info(#file, "Registry has more pages (first page: \(firstPage.catalogs.count) of \(firstPage.metadata.numberOfItems ?? -1)) — paginating in background")
+                let crawlerBox = CrawlerHandoffBox(crawler: crawler)
+                self.spawnOwnedCrawlTask(priority: .utility, detached: false) { [weak self] in
+                    guard let self = self else { return }
+
+                    let remainingResult = await crawlerBox.crawler.crawlRemainingPages(
+                        firstPage: firstPage,
+                        baseURL: targetUrl,
+                        existingPublications: firstPage.catalogs,
+                        feedMetadata: firstPage.metadata
+                    )
+
+                    if case .success(let fullData) = remainingResult {
+                        let fullCount = (try? OPDS2CatalogsFeed.fromData(fullData))?.catalogs.count ?? -1
+                        Log.info(#file, "Background pagination complete: \(fullCount) total libraries cached")
+                        self.registryCache.writeCatalogData(fullData, hash: hash)
+                        self.loadAccountSetsAndAuthDoc(fromCatalogData: fullData, key: hash) { _ in
+                            NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                        }
+                    }
+                    self.triggerCatalogPreload()
+                }
+
+            case .noChanges:
+                self.callAndClearLoadingHandlers(for: hash, true)
+
+            case .failure(let error):
+                Log.info(#file, "First page crawl failed: \(error), falling back to direct GET to \(targetUrl)")
+                self.fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
+            }
+        }
+    }
+
+    /// Fallback direct GET when the crawler fails on first launch (owned + drainable).
+    private func fallbackFetchFromNetwork(targetUrl: URL, hash: String) {
+        spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
+            guard let self = self else { return }
+            do {
+                let (data, _) = try await self.networkExecutorProvider().GET(targetUrl, useTokenIfAvailable: false)
+                if Task.isCancelled { return }
+                self.registryCache.writeCatalogData(data, hash: hash)
+                self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { success in
+                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                    self.callAndClearLoadingHandlers(for: hash, success)
+                }
+            } catch {
+                if Task.isCancelled { return }
+                Log.error(#file, "Failed to load catalogs from network: \(error.localizedDescription)")
+                if let data = self.registryCache.readCatalogData(hash: hash) {
+                    Log.info(#file, "Using cached catalog data as fallback after network failure")
+                    self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { success in
+                        NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                        self.callAndClearLoadingHandlers(for: hash, success)
+                    }
+                } else {
+                    Log.error(#file, "No cached catalog data available, catalog load failed completely")
+                    self.callAndClearLoadingHandlers(for: hash, false)
+                }
+            }
+        }
+    }
+
+    /// Background refresh via the incremental crawler; direct-GET fallback.
+    private func refreshInBackground(targetUrl: URL, hash: String) {
+        if TPPConfiguration.customRegistryIsExplicitURL() {
+            fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
+            return
+        }
+        spawnOwnedCrawlTask(priority: .utility, detached: false) { [weak self] in
+            guard let self = self else { return }
+            Log.debug(#file, "Starting background refresh (crawl) for catalog hash \(hash)")
+
+            let existingPubs: [OPDS2Publication]
+            let existingMetadata: OPDS2CatalogsFeed.Metadata?
+            if let cachedData = self.registryCache.readCatalogData(hash: hash),
+               let feed = try? OPDS2CatalogsFeed.fromData(cachedData) {
+                existingPubs = feed.catalogs
+                existingMetadata = feed.metadata
+            } else {
+                existingPubs = []
+                existingMetadata = nil
+            }
+
+            let crawler = LibraryRegistryCrawler(fetcher: URLSessionCrawlerFetcher(), hash: hash)
+            let result = await crawler.crawl(
+                baseURL: targetUrl,
+                existingPublications: existingPubs,
+                feedMetadata: existingMetadata
+            )
+
+            switch result {
+            case .success(let data):
+                let pubCount = (try? OPDS2CatalogsFeed.fromData(data))?.catalogs.count ?? -1
+                Log.info(#file, "Background crawl successful for hash \(hash), \(pubCount) libraries in result, dataSize=\(data.count)")
+                self.registryCache.writeCatalogData(data, hash: hash)
+                self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { [weak self] _ in
+                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                    self?.triggerCatalogPreload()
+                }
+
+            case .noChanges:
+                Log.debug(#file, "Background crawl found no changes for hash \(hash)")
+                self.triggerCatalogPreload()
+
+            case .failure(let error):
+                Log.debug(#file, "Background crawl failed for hash \(hash): \(error.localizedDescription)")
+                self.fallbackDirectRefresh(targetUrl: targetUrl, hash: hash)
+            }
+        }
+    }
+
+    /// Fallback direct GET when the crawlable refresh endpoint fails (owned + drainable).
+    private func fallbackDirectRefresh(targetUrl: URL, hash: String) {
+        spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
+            guard let self = self else { return }
+            do {
+                let (data, _) = try await self.networkExecutorProvider().GET(targetUrl, useTokenIfAvailable: false)
+                if Task.isCancelled { return }
+                Log.info(#file, "Fallback direct refresh successful for hash \(hash)")
+                self.registryCache.writeCatalogData(data, hash: hash)
+                self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { _ in
+                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
+                }
+            } catch {
+                Log.debug(#file, "Fallback direct refresh also failed for hash \(hash): \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Triggers catalog feed preloading for active accounts.
+    private func triggerCatalogPreload() {
+        spawnOwnedCrawlTask(priority: .utility, detached: false) { [weak self] in
+            guard let self = self else { return }
+            await self.catalogPreloader.preloadCatalogs(
+                currentAccount: self.currentAccountProvider(),
+                recentAccountUUIDs: self.settings.settingsAccountIdsList,
+                accountProvider: { self.accountProvider($0) }
+            )
+        }
+    }
+
+    // MARK: - Parsing & notifying
+
+    func loadAccountSetsAndAuthDoc(
+        fromCatalogData data: Data,
+        key hash: String,
+        completion: @escaping (Bool) -> Void
+    ) {
+        let completionBox = LoadCompletionBox(handler: completion)
+        do {
+            let feed = try OPDS2CatalogsFeed.fromData(data)
+            let hadAccount = currentAccountProvider() != nil
+            let oldAccounts = accountsForKeyProvider(hash)
+            let oldAccountsByUUID = Dictionary(
+                oldAccounts.map { ($0.uuid, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            let newAccounts = feed.catalogs.map { publication -> Account in
+                // CP-D1 (Finding 4): on the slim→full LAUNCH materialization REUSE the
+                // existing slim instance so an in-flight slim auth-doc fetch lands on the
+                // current instance (one Account per uuid). Bounded to launch: once
+                // populated (warm / network-refresh), the carry-over loop wins.
+                if oldAccountsByUUID[publication.metadata.id] == nil,
+                   let slim = registryStore.slimAccount(publication.metadata.id) {
+                    return slim
+                }
+                return Account(publication: publication, imageCache: imageCache)
+            }
+
+            for newAccount in newAccounts {
+                if let old = oldAccountsByUUID[newAccount.uuid] {
+                    if let authDoc = old.authenticationDocument {
+                        newAccount.authenticationDocument = authDoc
+                    }
+                    if old.logoUrl != newAccount.logoUrl {
+                        imageCache.remove(for: newAccount.uuid)
+                    }
+                }
+            }
+
+            registryStore.mutate { $0[hash] = newAccounts }
+
+            for newAccount in newAccounts {
+                if newAccount.authenticationDocument != nil,
+                   let details = newAccount.details {
+                    newAccount._setState(.detailsLoaded(details))
+                } else if case .notLoaded = accountStateStore.state(for: newAccount.uuid) {
+                    newAccount._setState(.basicInfoLoaded)
+                }
+            }
+
+            let group = DispatchGroup()
+
+            let accountExistenceChanged = hadAccount != (currentAccountProvider() != nil)
+            let currentAccountMissingDetails = currentAccountProvider() != nil && currentAccountProvider()?.details == nil
+
+            if accountExistenceChanged || currentAccountMissingDetails, let current = currentAccountProvider() {
+                group.enter()
+                current.loadLogo()
+                fetchAuthDocumentWithStateMachineImpl(current) { [self] _ in
+                    if current.details?.needsAgeCheck ?? false,
+                       let libraryProvider = currentLibraryAccountProvider(),
+                       let userAccount = currentUserAccountProvider() {
+                        group.enter()
+                        ageCheck.verifyCurrentAccountAgeRequirement(
+                            userAccountProvider: userAccount,
+                            currentLibraryAccountProvider: libraryProvider
+                        ) { _ in group.leave() }
+                    }
+                    group.leave()
+                }
+            }
+
+            group.notify(queue: .main) { [self] in
+                var mainFeed = URL(string: currentAccountProvider()?.catalogUrl ?? "")
+                if let cur = currentAccountProvider(), cur.details?.needsAgeCheck ?? false {
+                    mainFeed = cur.details?.defaultAuth?.coppaURL(isOfAge: true)
+                }
+                if let mainFeed {
+                    settings.accountMainFeedURL = mainFeed
+                } else if settings.accountMainFeedURL == nil {
+                    Log.warn(#file, "accountMainFeedURL is nil and no cached value — catalog will not load until auth doc completes")
+                }
+                MainActor.assumeIsolated {
+                    UIApplication.shared.delegate?.window??.tintColor = TPPConfiguration.mainColor()
+                }
+                NotificationCenter.default.post(name: .TPPCurrentAccountDidChange, object: nil)
+                completionBox.handler(true)
+            }
+
+        } catch {
+            TPPErrorLogger.logError(error, summary: "Error parsing catalog feed")
+            completion(false)
+        }
+    }
+
+    // MARK: - Test-boundary drain (DEBUG)
+
+    #if DEBUG
+    /// Cancel the in-flight background `loadCatalogs` Task + owned crawl tasks + the
+    /// network executor's non-essential tasks. Cooperative — returns immediately.
+    ///
+    /// NOTE (Wave 3 / 3a-4): the `_explicitCancelCalled` flag stays on `AccountsManager`
+    /// (the `AuthDocumentLoader.isTornDown` binding reads it) and is set by the HUB facade
+    /// BEFORE this delegates — this body must NOT set it (it can't reach the hub flag) and
+    /// must NOT call a flag-setting cancel, or the torn-down semantics never engage and a
+    /// leaked auth-doc main-hop pollutes the next test.
+    func cancelBackgroundWork() {
+        backgroundFetchTask?.cancel()
+        backgroundFetchTask = nil
+        ownedCrawlTasks.cancelAll()
+        _trackedCrawlTasksLock.lock()
+        _trackedFirstRunTasks.removeAll()
+        _trackedCrawlTasksLock.unlock()
+        networkExecutorProvider().cancelNonEssentialTasks()
+    }
+
+    /// Cancel the in-flight crawl AND synchronously DRAIN it (pumping the run loop) before
+    /// returning, so no orphan crawl outlives the test boundary holding the store barrier.
+    func cancelAndDrainBackgroundWork(timeout: TimeInterval = 3.0) {
+        let ownedTasks = ownedCrawlTasks.snapshot().map { $0.1 }
+        let fetchTask = backgroundFetchTask
+        let tasksToDrain = ownedTasks + [fetchTask].compactMap { $0 }
+
+        cancelBackgroundWork() // requests cancellation, nils the handle (does NOT set the hub flag)
+
+        if tasksToDrain.isEmpty {
+            // No tracked Tasks, but init may have enqueued a DispatchQueue.main.async
+            // auth-doc drive (see `hydrateSlimLaunchSnapshot`'s deferred hop) that is NOT
+            // a Task and CANNOT be cancelled. Pump the main run loop briefly so any pending
+            // hop fires NOW, inside the boundary — never BLOCK main (the crawl-drain
+            // deadlock reason applies). Enqueue a sentinel AFTER any pending hop (FIFO) and
+            // spin until it drains, bounded by 50ms.
+            let sentinel = DispatchGroup()
+            sentinel.enter()
+            DispatchQueue.main.async { sentinel.leave() }
+            let pumpDeadline = Date().addingTimeInterval(0.05)
+            while sentinel.wait(timeout: .now()) == .timedOut && Date() < pumpDeadline {
+                RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+            }
+            return
+        }
+
+        let started = Date()
+        let group = DispatchGroup()
+        for task in tasksToDrain {
+            group.enter()
+            Task { _ = await task.value; group.leave() }
+        }
+        let deadline = started.addingTimeInterval(timeout)
+        while group.wait(timeout: .now()) == .timedOut && Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        let elapsedMs = Int(Date().timeIntervalSince(started) * 1000)
+        if group.wait(timeout: .now()) == .timedOut {
+            NSLog("[WS0-DRAIN] cancelAndDrainBackgroundWork TIMED OUT after %dms draining %d task(s) — crawl did not observe cancellation; investigate.", elapsedMs, tasksToDrain.count)
+        } else if elapsedMs >= 50 {
+            NSLog("[WS0-DRAIN] cancelAndDrainBackgroundWork drained %d task(s) in %dms.", tasksToDrain.count, elapsedMs)
+        }
+    }
+
+    /// Test-only setter that swaps a caller-provided Task into `backgroundFetchTask`.
+    @discardableResult
+    func _injectBackgroundFetchTaskForTesting(_ task: Task<Void, Never>?) -> Task<Void, Never>? {
+        let prior = backgroundFetchTask
+        backgroundFetchTask = task
+        return prior
+    }
+
+    /// Test-only: `true` iff `backgroundFetchTask` is currently nil.
+    var _backgroundFetchTaskHandleIsNil: Bool {
+        return backgroundFetchTask == nil
+    }
+
+    /// Test-only: `true` if the task is cancelled OR the handle was nilled.
+    var _backgroundFetchTaskIsCancelledOrCleared: Bool {
+        guard let task = backgroundFetchTask else { return true }
+        return task.isCancelled
+    }
+    #endif
+}

--- a/Palace/Accounts/Library/AccountsManager.swift
+++ b/Palace/Accounts/Library/AccountsManager.swift
@@ -43,31 +43,8 @@ private final class AccountsManagerBoolFlag: @unchecked Sendable {
     }
 }
 
-/// Documented carrier for a non-Sendable `(Bool) -> Void` load-completion
-/// handler stored into the `loadingHandlersQueue` barrier in
-/// `AccountsManager.addLoadingHandler`. `@unchecked Sendable` invariant: the
-/// wrapped closure is only ever appended to / read from
-/// `loadingCompletionHandlers[hash]` under the serial `.barrier` of the
-/// concurrent `loadingHandlersQueue`, and invoked later on whatever queue the
-/// caller of `callAndClearLoadingHandlers` runs on — never concurrently with
-/// its own storage mutation. The handler's own thread-affinity is the caller's
-/// contract (unchanged); this box only satisfies the `@Sendable` boundary of
-/// the dispatch barrier.
-private struct LoadCompletionBox: @unchecked Sendable {
-    let handler: (Bool) -> Void
-}
-
-/// Documented carrier for the non-Sendable `LibraryRegistryCrawler` handed
-/// from the first-page crawl Task into its nested background pagination Task
-/// in `AccountsManager.fetchFromNetwork`. `@unchecked Sendable` invariant: the
-/// crawler is used strictly sequentially — the outer Task finishes its
-/// `crawlFirstPage` await BEFORE the pagination Task is spawned, and only the
-/// pagination Task touches the crawler thereafter (`crawlRemainingPages`), so
-/// the two never touch it concurrently. Mirrors `LibraryRegistryCrawler`'s own
-/// `CrawlerFetcherBox`.
-private struct CrawlerHandoffBox: @unchecked Sendable {
-    let crawler: LibraryRegistryCrawler
-}
+/// The load-completion + crawler-handoff `@unchecked Sendable` carrier boxes moved to
+/// `AccountRegistryLoader.swift` (Wave 3 / 3a-4) with the load pipeline.
 
 /// Manages library accounts asynchronously with authentication & image loading
 ///
@@ -90,16 +67,16 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
 ///     index, and the slim fallback)  → moved to the injected `AccountRegistryStore`
 ///     (Wave 3 / 3a-2), which owns their concurrent `accountSetsLock` sync-read /
 ///     barrier-write model; the hub holds the store as an immutable `Sendable` `let`.
-///   - `loadingCompletionHandlers`  → read via `loadingHandlersQueue.sync`,
-///     written via `loadingHandlersQueue.async(flags:.barrier)`.
+///   - the catalog LOAD state (loading-handler map, owned-crawl registry, first-run
+///     subset, `backgroundFetchTask`)  → moved to the injected `AccountRegistryLoader`
+///     (Wave 3 / 3a-4), which owns its own queues/locks; the hub holds it as a `lazy var`.
 ///   - the auth-document fetch state (single-flight map + lock)  → moved to the
 ///     injected `AuthDocumentLoader` (Wave 3 / 3a-3), which owns its own `NSLock`; the
 ///     hub holds the loader as a `lazy var` and no longer names that state.
 ///   - `userAccounts`, `lastKnownCurrentUserAccount`  → read/written only under
 ///     `userAccountsLock`.
-///   - `_trackedFirstRunTasks`  → read/written only under `_trackedCrawlTasksLock`.
-///   - `ownedCrawlTasks`  → an `OwnedCrawlTaskRegistry`, internally synchronized;
-///     `crawlScheduler`  → immutable `Sendable` `let` bound once from `init`.
+///   - `crawlScheduler`  → immutable `Sendable` `let` bound once from `init`, passed
+///     into the load collaborator.
 ///   - `isAccountSwitching`  → storage moved into the lock-backed
 ///     `AccountsManagerBoolFlag` holder (`_isAccountSwitching`), so its `Bool`
 ///     set/get is serialized by the holder's own `NSLock`; the public
@@ -111,14 +88,13 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
 ///     `networkExecutor` is inside the background load path after `AppContainer`
 ///     finishes constructing, and for `noAccountPlaceholder` only on the fresh-
 ///     install `currentUserAccount` path. Effectively write-once.
-///   - `backgroundFetchTask`, `_explicitCancelCalled`  → `#if DEBUG` test-only;
-///     compiled out of release. Driven only from the test-boundary
-///     `cancelBackgroundWork()` / `_injectBackgroundFetchTaskForTesting` seams.
+///   - `_explicitCancelCalled`  → `#if DEBUG` test-only; compiled out of release. Set by
+///     the hub cancel/drain facades BEFORE delegating to the load collaborator (so the
+///     3a-3 `AuthDocumentLoader.isTornDown` binding stays byte-identical).
 ///
 ///   Immutable (`let`) state — inherently safe: `tppAccountUUID`, `ageCheck`,
 ///   `settings`, `defaults`, `registryStore` (internally synchronized),
-///   `registryCache`, `catalogPreloader`, `loadingHandlersQueue`,
-///   `userAccountsLock`, `_trackedCrawlTasksLock`.
+///   `registryCache`, `crawlScheduler`, `userAccountsLock`.
 ///
 ///   `currentAccountId` is a computed property backed by the injected
 ///   `UserDefaults` (`defaults`), which is itself internally thread-safe — no
@@ -208,17 +184,38 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// Injectable background-crawl spawn seam (see `CatalogCrawlScheduler`).
     /// Immutable `Sendable` `let`; `.production` by default, recording under test.
     private let crawlScheduler: CrawlTaskScheduler
+    /// Catalog LOAD orchestration + owned background-crawl + drain collaborator
+    /// (Wave 3 / 3a-4). A `lazy var` (not a `let` default arg) because its provider
+    /// closures capture `self`; first access is post-init (the preload / background
+    /// `loadCatalogs`), exactly like `authDocLoader`. Orchestrates registryCache /
+    /// registryStore / authDocLoader (via the injected drive/fetch closures).
+    private lazy var registryLoader: AccountRegistryLoader = AccountRegistryLoader(
+        registryCache: registryCache,
+        registryStore: registryStore,
+        crawlScheduler: crawlScheduler,
+        settings: settings,
+        imageCache: switchDeps.imageCache,
+        accountStateStore: switchDeps.accountStateStore,
+        ageCheck: ageCheck,
+        networkExecutorProvider: switchDeps.networkExecutorProvider,
+        currentAccountProvider: { [weak self] in self?.currentAccount },
+        currentAccountIdProvider: { [weak self] in self?.currentAccountId },
+        accountsForKeyProvider: { [weak self] in self?.accounts($0) ?? [] },
+        accountProvider: { [weak self] in self?.account($0) },
+        currentUserAccountProvider: { [weak self] in self?.currentUserAccount },
+        driveCurrentAccountAuthDoc: { [weak self] in self?.driveCurrentAccountAuthDocIfNeeded() },
+        fetchAuthDocumentWithStateMachine: { [weak self] account, completion in
+            guard let self else { completion(false); return }
+            self.fetchAuthDocumentWithStateMachine(for: account, completion: completion)
+        },
+        currentLibraryAccountProvider: { [weak self] in self }
+    )
     /// On-disk catalog cache collaborator (Wave 3 / 3a-1). Immutable `Sendable`
     /// `let`; the stateless `DiskAccountRegistryCache` by default, a recording
     /// double under test. All catalog read/write/staleness/clear disk I/O routes
     /// here, so the hub carries none of it and a packaged manager names no
     /// FileManager cache body.
     private let registryCache: any AccountRegistryCaching
-    /// Owns every background catalog-crawl Task — production included (PP-4754):
-    /// the previously fire-and-forget crawl now has an owner the reset
-    /// choreography cancels + awaits, so no un-drainable write channel survives a
-    /// test boundary. Self-pruning + internally synchronized.
-    private let ownedCrawlTasks = OwnedCrawlTaskRegistry()
     /// Account-registry state + all thread-safe access (Wave 3 / 3a-2): the current
     /// catalog hash, the `[hash → [Account]]` sets, the O(1) `uuid → Account` index
     /// rebuilt in-barrier-lockstep with them, and the separate slim launch-hydration
@@ -229,11 +226,9 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// `@unchecked Sendable` invariant and the class-not-actor rationale.
     private let registryStore: AccountRegistryStore
 
-    private let catalogPreloader = CatalogPreloader()
-
-    // Per‐catalog in‐flight tracking:
-    private var loadingCompletionHandlers = [String: [(Bool) -> Void]]()
-    private let loadingHandlersQueue = DispatchQueue(label: "com.tpp.loadingHandlers", attributes: .concurrent)
+    // The catalog load orchestration + owned-crawl + drain (the loading-completion
+    // handler map, the owned-task registry, the catalog preloader, the load bodies)
+    // moved to `AccountRegistryLoader.swift` (Wave 3 / 3a-4) — injected via `registryLoader`.
 
     // The per-account auth-document fetch + state-machine wiring (the single-flight
     // map + lock, the timeout, and the fetch/drive/terminal logic) moved to
@@ -301,16 +296,9 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
         set { _deferDiskCachePreloadForTesting.value = newValue }
     }
 
-    /// Test-only handle to the post-init background `loadCatalogs` task so
-    /// `cancelBackgroundWork()` can issue cooperative cancellation. Only ever
-    /// non-nil under DEBUG builds AND when `deferInitialLoadCatalogsForTesting`
-    /// was `false` at init time. Production reads this field implicitly via
-    /// `cancelBackgroundWork()` (called by `AppContainer._resetForTesting()`);
-    /// production does NOT pay the storage cost in release builds because the
-    /// whole field is `#if DEBUG`-gated.
-    ///
-    /// swarm_4b64e4e0 Fix 2 — closes the H1 finding from swarm_f88ae9e3 A.
-    private var backgroundFetchTask: Task<Void, Never>?
+    /// (The `backgroundFetchTask` handle moved to `AccountRegistryLoader` with the
+    /// crawl/drain machinery — Wave 3 / 3a-4; the hub sets `_explicitCancelCalled` in the
+    /// cancel/drain facades before delegating.)
 
     /// Test-only flag flipped to `true` inside `cancelBackgroundWork()` BEFORE
     /// the `.cancel()` is issued on `backgroundFetchTask`. Used by
@@ -331,122 +319,32 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     }
     #endif
 
-    /// PP-4754: every background catalog-crawl `Task` (init load, first-run,
-    /// crawl, pagination, refresh, the wrapped fallback GETs, preload) is spawned
-    /// through `spawnOwnedCrawlTask` into `ownedCrawlTasks` — production included,
-    /// no XCTest/`#if DEBUG` bookkeeping on the spawn path — so the reset
-    /// choreography cancels + awaits every one, closing the last un-drainable
-    /// write channel that leaked a live crawl into the next test.
-    private static let _isRunningUnderXCTest =
-        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-    /// Guards `_trackedFirstRunTasks`.
-    private let _trackedCrawlTasksLock = NSLock()
-    /// Subset of owned tasks that are `loadCatalogs` FIRST-RUN tasks. Populated
-    /// only under XCTest (byte-identical to the prior `_trackFirstRunTask` gate).
-    /// The narrow `_awaitAllCrawlTasksForTesting()` seam joins ONLY these (see it
-    /// for why); the broad `_awaitCatalogLoadForTesting()` joins the whole set.
-    private var _trackedFirstRunTasks: [Task<Void, Never>] = []
+    // The owned-crawl-task registry, its spawn/first-run-tracking, the XCTest join
+    // seams, and the `_fetchFromNetworkCount` observability moved to
+    // `AccountRegistryLoader.swift` (Wave 3 / 3a-4). The hub keeps the forwarders below
+    // so AppContainer + every test call site stays byte-identical.
 
-    /// Resolves the build-time bundled registry snapshot resource. Production
-    /// binds `Bundle.main`; tests inject a stub (`BundleResourceResolving`) to
-    /// observe the first-launch bundled decode's thread + invocation count
-    /// WITHOUT a `#if DEBUG` seam (mirrors `BundledRegistrySnapshot.load(resolver:)`,
-    /// which was designed for exactly this injection). Read on the first-run
-    /// decode task; never mutated in production.
-    var snapshotResourceResolver: BundleResourceResolving = Bundle.main
-
-    /// Test-observability: count of `fetchFromNetwork` entries. Incremented
-    /// only under XCTest (same env-var gate as `_trackCrawlTask` — no
-    /// `#if DEBUG`, so blast-radius BR-2 stays clean). Lets the first-run-decode
-    /// tests assert the network fetch STILL fires after the bundled snapshot
-    /// decode (the Phase 1a regression the naive dedupe would swallow) without
-    /// waiting on a live network round-trip.
-    private let _fetchFromNetworkCountLock = NSLock()
-    private var _fetchFromNetworkCount = 0
-    var fetchFromNetworkCountForTesting: Int {
-        _fetchFromNetworkCountLock.lock()
-        defer { _fetchFromNetworkCountLock.unlock() }
-        return _fetchFromNetworkCount
+    /// Resolves the build-time bundled registry snapshot resource (forwards to the loader,
+    /// where the first-run decode reads it). Settable so tests inject a stub.
+    var snapshotResourceResolver: BundleResourceResolving {
+        get { registryLoader.snapshotResourceResolver }
+        set { registryLoader.snapshotResourceResolver = newValue }
     }
 
-    /// Spawn a background crawl `Task` through `crawlScheduler` and register it in
-    /// `ownedCrawlTasks` so the reset choreography can cancel + await it.
-    /// `detached`/`priority` preserve each call site's exact semantics + QoS;
-    /// `firstRun` also records it in the narrow-join subset (XCTest only). A
-    /// `defer` self-prunes the token as the task unwinds, bounding the live set.
-    @discardableResult
-    private func spawnOwnedCrawlTask(
-        priority: TaskPriority,
-        detached: Bool,
-        firstRun: Bool = false,
-        _ operation: @escaping @Sendable () async -> Void
-    ) -> Task<Void, Never> {
-        let token = UUID()
-        let registry = ownedCrawlTasks
-        let owned: @Sendable () async -> Void = {
-            defer { registry.complete(token) }
-            await operation()
-        }
-        let task = detached
-            ? crawlScheduler.spawnDetached(priority, owned)
-            : crawlScheduler.spawn(priority, owned)
-        ownedCrawlTasks.register(token, task)
-        if firstRun { _trackFirstRunTask(task) }
-        return task
+    /// Test-observability forwarder: count of `fetchFromNetwork` entries.
+    var fetchFromNetworkCountForTesting: Int { registryLoader.fetchFromNetworkCountForTesting }
+
+    /// Test-only whole-quiescence JOIN seam forwarder (PP-4754).
+    func _awaitCatalogLoadForTesting(maxRounds: Int = 8) async {
+        await registryLoader._awaitCatalogLoadForTesting(maxRounds: maxRounds)
     }
 
-    /// Record a `loadCatalogs` FIRST-RUN task in the narrow-join subset. No-op
-    /// outside XCTest (the whole-set drain uses `ownedCrawlTasks`, not this).
-    private func _trackFirstRunTask(_ task: Task<Void, Never>) {
-        guard Self._isRunningUnderXCTest else { return }
-        _trackedCrawlTasksLock.lock()
-        _trackedFirstRunTasks.append(task)
-        _trackedCrawlTasksLock.unlock()
-    }
+    /// Test-only quiescence assertion helper forwarder.
+    var _ownedCrawlTaskCountForTesting: Int { registryLoader._ownedCrawlTaskCountForTesting }
 
-    /// Test-only whole-quiescence JOIN seam (PP-4754). Grows-until-stable: awaits
-    /// every owned crawl `Task`, re-snapshotting to catch tasks the wave spawned
-    /// (crawl → pagination/fallback → preload is a finite chain) until none is
-    /// new or `maxRounds` is hit. NO wall-clock — pure Task-join, so it never
-    /// starves under parallel CI clones (STARVE-001-clean) and never blocks main
-    /// (it suspends). No-op outside XCTest.
-    nonisolated func _awaitCatalogLoadForTesting(maxRounds: Int = 8) async {
-        guard Self._isRunningUnderXCTest else { return }
-        var awaited = Set<UUID>()
-        for _ in 0..<maxRounds {
-            let fresh = ownedCrawlTasks.snapshot().filter { !awaited.contains($0.0) }
-            if fresh.isEmpty { return }
-            for (token, task) in fresh {
-                _ = await task.value
-                awaited.insert(token)
-            }
-        }
-    }
-
-    /// Test-only quiescence assertion helper: number of live owned crawl tasks.
-    var _ownedCrawlTaskCountForTesting: Int { ownedCrawlTasks.count }
-
-    /// Test-only NARROW deterministic JOIN seam. Awaits every tracked FIRST-RUN
-    /// task (bundled decode → synchronous `fetchFromNetwork` kickoff) instead of
-    /// polling a wall-clock deadline that starves under parallel CI clones. It
-    /// deliberately does NOT await the downstream live crawl `fetchFromNetwork`
-    /// spawns — the first-run task's synchronous `fetchFromNetwork` call has
-    /// already returned (bumping `_fetchFromNetworkCount`) by the time its
-    /// `.value` resolves, so joining the first-run task alone suffices for the
-    /// decode + fetch-fired observations. (For whole-quiescence use
-    /// `_awaitCatalogLoadForTesting`.) No-op in RELEASE — the array only
-    /// populates under XCTest. Snapshot-then-await-without-a-lock (Swift 6 bans
-    /// `NSLock.lock()` across an await).
-    nonisolated private func _snapshotFirstRunTasksForTesting() -> [Task<Void, Never>] {
-        _trackedCrawlTasksLock.lock()
-        defer { _trackedCrawlTasksLock.unlock() }
-        return _trackedFirstRunTasks
-    }
-
-    nonisolated func _awaitAllCrawlTasksForTesting() async {
-        for task in _snapshotFirstRunTasksForTesting() {
-            _ = await task.value
-        }
+    /// Test-only NARROW deterministic JOIN seam forwarder.
+    func _awaitAllCrawlTasksForTesting() async {
+        await registryLoader._awaitAllCrawlTasksForTesting()
     }
 
     /// Initializer is `internal` rather than `private` so `AppContainer` can
@@ -520,10 +418,10 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
         // Test-only skip (see `deferDiskCachePreloadForTesting`): a test that
         // never reads `accountSets` can opt out of the >5s cached-account load.
         if !Self.deferDiskCachePreloadForTesting {
-            preloadAccountsFromDiskCacheSync()
+            registryLoader.preloadAccountsFromDiskCacheSync()
         }
         #else
-        preloadAccountsFromDiskCacheSync()
+        registryLoader.preloadAccountsFromDiskCacheSync()
         #endif
 
         #if DEBUG
@@ -537,244 +435,17 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             return
         }
         #endif
-        // Unified background-load arm (both configs) — PP-4754. Routed through
-        // `spawnOwnedCrawlTask` so the crawl is OWNED (cancellable + drainable at
-        // a test boundary). RELEASE previously used a bare
-        // `DispatchQueue.global(qos: .utility).async` (untracked); it now spawns
-        // the SAME detached `.utility` work DEBUG has exercised for months. This
-        // ownership unification is the single deliberate production-visible
-        // delta; the crawl work (`loadCatalogs`) is unchanged. DEBUG keeps a
-        // separate `backgroundFetchTask` handle for the injection + cancellation
-        // observation seams; RELEASE lets the registry own it.
-        let initialLoadTask = spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
-            self?.loadCatalogs(completion: nil)
-        }
-        #if DEBUG
-        backgroundFetchTask = initialLoadTask
-        #else
-        _ = initialLoadTask
-        #endif
+        // Unified background-load arm — PP-4754, owned + drainable. The spawn + the
+        // DEBUG `backgroundFetchTask` handle live on the loader now (Wave 3 / 3a-4).
+        registryLoader.spawnInitialBackgroundLoad()
     }
 
-    /// Hydrate `accountSets[accountSet]` from the on-disk OPDS2 catalog cache
-    /// without dispatching to a background queue. Safe to call from `init()`
-    /// because the cache read is local I/O measured in single-digit ms.
-    ///
-    /// Exposed `internal` so contract-snapshot tests can drive the preload
-    /// path directly after seeding the on-disk cache.
+    /// Forwards the CP-D1 launch preload to `registryLoader` (Wave 3 / 3a-4). Exposed
+    /// `internal` so contract-snapshot tests can drive the preload path after seeding the
+    /// on-disk cache. The slim-hydration + full-hydrate + slim-snapshot carve/write bodies
+    /// live on the loader.
     internal func preloadAccountsFromDiskCacheSync() {
-        let hash = registryStore.currentHash
-        // Fast path (CP-D1 LaunchHydration): when a slim snapshot exists, decode
-        // ONLY the current + settings accounts (a few KB) synchronously so
-        // `currentAccount` resolves and its auth-doc drive fires within a few ms
-        // of launch. The full 1142-account decode+map moves OFF the launch main
-        // thread — it materializes into `accountSets` via the background
-        // `loadCatalogs` that `init()` dispatches immediately after this call
-        // (its disk-cache branch decodes the full blob off-main and posts
-        // `.TPPCatalogDidLoad`). Consumers block on the EXISTING
-        // `Account.awaitReady()` gate, which reads `AccountStateStore` keyed by
-        // uuid and so survives the slim→full Account-instance swap.
-        //
-        // Gated on `registryCache.hasFreshCatalogData` (full-cache freshness): the slim
-        // snapshot carries no separate metadata, so a truly-expired cache still
-        // falls through to the no-op below rather than hydrating stale data.
-        if registryCache.hasFreshCatalogData(hash: hash), hydrateSlimLaunchSnapshot(hash: hash) {
-            refreshSlimLaunchSnapshotOffMain(hash: hash)
-            return
-        }
-        // Slow path: no slim snapshot yet (first launch after this ships, or a
-        // fresh install whose catalog cache was just written). Hydrate the full
-        // set synchronously exactly as before so behaviour is unchanged on that
-        // one launch, then seed a slim snapshot off-main so the NEXT launch takes
-        // the fast path above.
-        guard registryCache.hasFreshCatalogData(hash: hash),
-              let cachedData = registryCache.readCatalogData(hash: hash) else {
-            return
-        }
-        hydrateFullAccountSets(fromCatalogData: cachedData, hash: hash)
-        refreshSlimLaunchSnapshotOffMain(hash: hash)
-    }
-
-    /// Decode the small `accounts_catalog_slim_<hash>.json` snapshot and hydrate
-    /// the current + settings accounts into `slimAccountsByUUID` (NOT
-    /// `accountSets` — see that property's doc for why). Drives each slim account
-    /// to `.basicInfoLoaded` (only if still `.notLoaded`, so a state already
-    /// advanced by a concurrent path is never knocked back) and fires the current
-    /// account's auth-doc drive. Returns `false` when there is no slim snapshot,
-    /// it is empty, or it fails to decode — the caller then takes the full sync
-    /// path. CP-D1.
-    private func hydrateSlimLaunchSnapshot(hash: String) -> Bool {
-        guard let url = registryCache.slimSnapshotURL(hash: hash),
-              FileManager.default.fileExists(atPath: url.path),
-              let data = try? Data(contentsOf: url) else {
-            return false
-        }
-        do {
-            let feed = try OPDS2CatalogsFeed.fromData(data)
-            let accounts = feed.catalogs.map {
-                Account(publication: $0, imageCache: switchDeps.imageCache)
-            }
-            guard !accounts.isEmpty else { return false }
-            // CP-D1 (Finding 5): the slim snapshot is written from the
-            // then-current account at launch; a mid-session library switch does
-            // NOT rewrite it, so a stale slim file can LACK the now-current
-            // account (currentAccountId persisted in UserDefaults ≠ slim set).
-            // If the current account is absent from the decoded slim set, fall
-            // through to the full sync hydrate (return false) rather than taking
-            // the fast path with a slim set that can't resolve `currentAccount`
-            // — otherwise there'd be a transient nil-currentAccount window at
-            // launch (spurious sign-in modals / empty library UI) that did not
-            // exist pre-D1. Belt-and-suspenders alongside the setter refresh.
-            if let currentId = currentAccountId,
-               !accounts.contains(where: { $0.uuid == currentId }) {
-                return false
-            }
-            registryStore.storeSlim(accounts)
-            for account in accounts {
-                if case .notLoaded = switchDeps.accountStateStore.state(for: account.uuid) {
-                    account._setState(.basicInfoLoaded)
-                }
-            }
-            // Drive the current account's auth-doc so `awaitReady()` consumers
-            // (audiobook open, token refresh, bookmark sync, CarPlay auth)
-            // resolve without waiting on the full off-main materialization.
-            // `currentAccount` resolves via `account(_:)`'s slim fallback.
-            //
-            // DEFERRED off this synchronous stack (was a direct call). This path
-            // is reached from `AccountsManager.init` → `preloadAccountsFromDiskCacheSync`,
-            // and on cold launch `AccountsManager()` is constructed INSIDE
-            // `AppContainer._buildCachedAppContainer()`, which runs under
-            // `AppContainer._cachedLock.withLock`. The drive transitively calls
-            // `AppContainer.production()` again (`Account.fetchAuthenticationDocument`
-            // → `.networkExecutor`), and re-entering the non-recursive
-            // `OSAllocatedUnfairLock` on the same thread traps (`EXC_BREAKPOINT`)
-            // — it crashed launch for every signed-in user (a logged-out sim has
-            // no current account to drive, which is why it didn't reproduce there).
-            // Hopping to the next main-runloop turn lets the container finish
-            // building and release the lock first, so the re-entrant
-            // `production()` returns the now-cached graph. The drive is an async
-            // fire-and-forget network fetch, so a one-turn defer is behaviorally
-            // inert for `awaitReady()` consumers (all of which run well after launch).
-            DispatchQueue.main.async { [weak self] in
-                self?.driveCurrentAccountAuthDocIfNeeded()
-            }
-            Log.info(#file, "CP-D1: slim launch snapshot hydrated \(accounts.count) accounts (hash=\(hash))")
-            return true
-        } catch {
-            Log.warn(#file, "CP-D1: slim launch snapshot decode failed: \(error). Falling back to full sync hydrate.")
-            return false
-        }
-    }
-
-    /// The original synchronous full-hydrate path, factored out of
-    /// `preloadAccountsFromDiskCacheSync` so the slow (no-slim-snapshot) launch
-    /// keeps behaving exactly as before. Only advances still-`.notLoaded` uuids
-    /// so a concurrently-advanced current account is never downgraded. CP-D1.
-    private func hydrateFullAccountSets(fromCatalogData cachedData: Data, hash: String) {
-        do {
-            let feed = try OPDS2CatalogsFeed.fromData(cachedData)
-            let accounts = feed.catalogs.map {
-                Account(publication: $0, imageCache: switchDeps.imageCache)
-            }
-            registryStore.mutate { $0[hash] = accounts }
-            // Account state-machine wiring (3.2.0): Phase 1 — drive every
-            // preloaded account into `.basicInfoLoaded`. Display-only
-            // consumers (Settings/Libraries) can render the row immediately;
-            // critical-path readers `awaitReady()` continue blocking until
-            // the auth-doc transition completes.
-            for account in accounts {
-                if case .notLoaded = switchDeps.accountStateStore.state(for: account.uuid) {
-                    account._setState(.basicInfoLoaded)
-                }
-            }
-            Log.info(#file, "Pre-loaded \(accounts.count) accounts from disk cache (sync, hash=\(hash))")
-        } catch {
-            // Best-effort. If the cached blob is corrupt or schema-shifted,
-            // we silently fall through to the async network refresh.
-            Log.warn(#file, "Sync disk-cache pre-load failed: \(error). Will refresh from network async.")
-        }
-    }
-
-    /// Rebuild the slim launch snapshot from the authoritative full on-disk
-    /// catalog cache, OFF the main thread. Best-effort: keeps the slim file in
-    /// sync with the latest current + settings selection so the NEXT cold
-    /// launch's synchronous hydrate reflects it. Reads the full blob and
-    /// serializes off-main so no launch main-thread time is spent here. CP-D1.
-    private func refreshSlimLaunchSnapshotOffMain(hash: String) {
-        // Skip the background slim-snapshot write under XCTest. A detached
-        // best-effort file write outlives the test (cooperative cancel can't
-        // stop an in-progress `Data.write`), leaking an
-        // `accounts_catalog_slim_<hash>.json` — whose slim uuids are the writer
-        // test's, not the reader's — into a sibling test's launch, flipping it
-        // onto the slim fast path with a non-matching current account. Same
-        // cross-test-pollution rationale + mechanism as `_trackCrawlTask`'s
-        // XCTest gate (BR-2: runtime env gate, not `#if DEBUG`, so no
-        // conditional compilation on the production path). Production always
-        // refreshes; tests seed slim snapshots explicitly.
-        guard !Self._isRunningUnderXCTest else { return }
-        spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
-            guard let self, !Task.isCancelled else { return }
-            guard let data = self.registryCache.readCatalogData(hash: hash) else { return }
-            guard !Task.isCancelled else { return }
-            self.writeSlimSnapshot(fromFullCatalogData: data, hash: hash)
-        }
-    }
-
-    /// Carve the current + settings accounts out of the full catalog blob and
-    /// persist them as a small OPDS2 feed at `accounts_catalog_slim_<hash>.json`.
-    /// Runs on a background queue (never the launch main thread). CP-D1.
-    private func writeSlimSnapshot(fromFullCatalogData data: Data, hash: String) {
-        let keepUUIDs = slimSnapshotUUIDs()
-        guard !keepUUIDs.isEmpty, let url = registryCache.slimSnapshotURL(hash: hash) else { return }
-        guard let carved = Self.carveSlimFeed(fromFullCatalogData: data, keepUUIDs: keepUUIDs) else {
-            Log.warn(#file, "CP-D1: slim snapshot carve produced no data (hash=\(hash))")
-            return
-        }
-        do {
-            try carved.write(to: url)
-            Log.info(#file, "CP-D1: slim launch snapshot written (\(keepUUIDs.count) uuids, \(carved.count) bytes, hash=\(hash))")
-        } catch {
-            Log.warn(#file, "CP-D1: slim snapshot write failed: \(error)")
-        }
-    }
-
-    /// The uuids the slim launch snapshot must carry: the current account plus
-    /// `settingsAccountIdsList` (which itself always includes the current
-    /// account + the SimplyE instant-classics default per `TPPSettings+SE`). CP-D1.
-    private func slimSnapshotUUIDs() -> Set<String> {
-        var uuids = Set<String>()
-        if let current = currentAccountId {
-            uuids.insert(current)
-        }
-        for uuid in settings.settingsAccountIdsList {
-            uuids.insert(uuid)
-        }
-        return uuids
-    }
-
-    /// Pure raw-JSON carve: parse the full OPDS2 catalog blob with
-    /// `JSONSerialization`, keep only the `catalogs` entries whose
-    /// `metadata.id` is in `keepUUIDs`, and re-serialize the (otherwise
-    /// unchanged) root. Carving the raw JSON rather than re-encoding decoded
-    /// models preserves the exact date-string format `OPDS2CatalogsFeed.fromData`'s
-    /// custom date decoder expects, so the slim snapshot round-trips through the
-    /// same reader with no encoder date-strategy hazard. Returns nil if the blob
-    /// isn't the expected shape or no entries match. Static + pure so it is
-    /// unit-testable without a manager or disk. CP-D1.
-    static func carveSlimFeed(fromFullCatalogData data: Data, keepUUIDs: Set<String>) -> Data? {
-        guard let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
-              let catalogs = root["catalogs"] as? [[String: Any]] else {
-            return nil
-        }
-        let kept = catalogs.filter { entry in
-            guard let metadata = entry["metadata"] as? [String: Any],
-                  let id = metadata["id"] as? String else { return false }
-            return keepUUIDs.contains(id)
-        }
-        guard !kept.isEmpty else { return nil }
-        var slimRoot = root
-        slimRoot["catalogs"] = kept
-        return try? JSONSerialization.data(withJSONObject: slimRoot)
+        registryLoader.preloadAccountsFromDiskCacheSync()
     }
 
     // MARK: – Account index (static shim)
@@ -785,6 +456,12 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
     /// for `AccountsManagerAccountIndexTests`.
     static func buildAccountIndex(_ sets: [String: [Account]]) -> [String: Account] {
         AccountRegistryStore.buildAccountIndex(sets)
+    }
+
+    /// Static shim retained for `AccountsManagerLaunchSnapshotTests` — the pure raw-JSON
+    /// slim carve moved to `AccountRegistryLoader` (Wave 3 / 3a-4).
+    static func carveSlimFeed(fromFullCatalogData data: Data, keepUUIDs: Set<String>) -> Data? {
+        AccountRegistryLoader.carveSlimFeed(fromFullCatalogData: data, keepUUIDs: keepUUIDs)
     }
 
     // MARK: - Account Retrieval
@@ -878,7 +555,7 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
             // Off-main + best-effort + XCTest-gated (see the method); no launch
             // main-thread cost. The `hydrateSlimLaunchSnapshot` current-account
             // presence check is the belt-and-suspenders if this ever lags.
-            refreshSlimLaunchSnapshotOffMain(hash: registryStore.currentHash)
+            registryLoader.refreshSlimLaunchSnapshotOffMain(hash: registryStore.currentHash)
             NotificationCenter.default.post(name: .TPPCurrentAccountDidChange, object: nil)
         }
     }
@@ -1031,375 +708,14 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
         return last ?? noAccountPlaceholder
     }
 
-    // MARK: – Load logic
+    // MARK: – Load logic (facade → AccountRegistryLoader)
 
-    /// Adds a completion handler for the given catalog hash,
-    /// returns true if a load is already underway.
-    private func addLoadingHandler(for hash: String, _ handler: ((Bool) -> Void)?) -> Bool {
-        var alreadyLoading = false
-        loadingHandlersQueue.sync {
-            alreadyLoading = loadingCompletionHandlers[hash] != nil
-        }
-
-        guard !alreadyLoading else {
-            if let h = handler {
-                // Box the non-Sendable handler across the `@Sendable` barrier.
-                let box = LoadCompletionBox(handler: h)
-                loadingHandlersQueue.async(flags: .barrier) { [weak self] in
-                    self?.loadingCompletionHandlers[hash]?.append(box.handler)
-                }
-            }
-            return true
-        }
-
-        // first request for this hash
-        let box = handler.map { LoadCompletionBox(handler: $0) }
-        loadingHandlersQueue.async(flags: .barrier) {
-            self.loadingCompletionHandlers[hash] = box.map { [$0.handler] } ?? []
-        }
-        return false
-    }
-
-    /// Calls & clears all handlers for the given hash
-    private func callAndClearLoadingHandlers(for hash: String, _ success: Bool) {
-        var handlers: [(Bool) -> Void] = []
-        loadingHandlersQueue.sync {
-            handlers = loadingCompletionHandlers[hash] ?? []
-        }
-        loadingHandlersQueue.async(flags: .barrier) {
-            self.loadingCompletionHandlers[hash] = nil
-        }
-        handlers.forEach { $0(success) }
-    }
-
-    /// Public entrypoint - implements stale-while-revalidate pattern
-    /// 1. If data is in memory, return immediately (refresh in background if stale)
-    /// 2. If data is on disk and not expired, load it immediately and refresh in background
-    /// 3. If no cache or expired, fetch from network
+    /// Public catalog-load entrypoint. The stale-while-revalidate pipeline (memory/disk/
+    /// network fast paths, the owned background crawl, the loading-handler dedupe) lives on
+    /// `registryLoader` (Wave 3 / 3a-4); this thin facade keeps every call site + test
+    /// (AppContainer, updateAccountSet, the wiring/first-run/cache suites) byte-identical.
     func loadCatalogs(completion: ((Bool) -> Void)?) {
-        let targetUrl = TPPConfiguration.customUrl()
-            ?? (settings.useBetaLibraries
-                    ? TPPConfiguration.betaUrl
-                    : TPPConfiguration.prodUrl)
-        let hash = targetUrl.absoluteString
-            .md5()
-            .base64EncodedStringUrlSafe()
-            .trimmingCharacters(in: ["="])
-
-        // 1. If already loaded in memory, return immediately
-        if registryStore.bucketIsNonEmpty(hash: hash) {
-            // State-machine wiring (3.2.0): the cold path drives the
-            // current account's LoadState past `.basicInfoLoaded` via
-            // `loadAccountSetsAndAuthDoc → fetchAuthDocumentWithStateMachine`.
-            // The warm path historically returned here without firing the
-            // auth-doc transition, leaving every `awaitReady()` caller
-            // (audiobook open, token refresh, bookmark sync, CarPlay auth)
-            // blocked forever on cold-launch for already-signed-in users
-            // whose accounts were populated by `preloadAccountsFromDiskCacheSync`.
-            // Restore the invariant: any account in `accountSets[hash]`
-            // must reach a terminal LoadState. The single-flight guard
-            // inside `fetchAuthDocumentWithStateMachine` dedupes against
-            // any concurrent invocation from refreshInBackground or a
-            // library switch.
-            driveCurrentAccountAuthDocIfNeeded()
-            completion?(true)
-            // Still refresh in background if stale
-            if registryCache.isCatalogStale(hash: hash) {
-                refreshInBackground(targetUrl: targetUrl, hash: hash)
-            }
-            return
-        }
-
-        // 2. Try disk cache first (stale-while-revalidate)
-        if registryCache.hasFreshCatalogData(hash: hash),
-           let cachedData = registryCache.readCatalogData(hash: hash) {
-            Log.info(#file, "Loading catalogs from cache (stale-while-revalidate), hash=\(hash), dataSize=\(cachedData.count)")
-
-            // dedupe concurrent loads for initial cache load
-            if addLoadingHandler(for: hash, completion) { return }
-
-            loadAccountSetsAndAuthDoc(fromCatalogData: cachedData, key: hash) { [weak self] success in
-                NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
-                self?.callAndClearLoadingHandlers(for: hash, success)
-            }
-
-            // Always refresh in background when loading from cache
-            refreshInBackground(targetUrl: targetUrl, hash: hash)
-            return
-        }
-
-        // 2.5 + 3. No disk cache: the build-time bundled snapshot fast-path
-        // (PP-4258) for immediate library-picker display, THEN the network
-        // fetch that supersedes it.
-        //
-        // SINGLE dedupe guard covering BOTH the bundled decode and the network
-        // fetch. It is placed ABOVE the bundled branch (so a concurrent second
-        // caller short-circuits HERE, before paying the ~2.4 MB bundled decode
-        // — the double-decode bug) and is deliberately NOT re-checked before
-        // `fetchFromNetwork` below. Re-checking there is the Phase 1a
-        // regression: the first caller would observe its OWN registration and
-        // `return` before the network ever fires, stranding the picker on
-        // stale bundled data until the next launch. The previous redundant
-        // guard immediately before `fetchFromNetwork` has been removed.
-        if addLoadingHandler(for: hash, completion) { return }
-
-        // Hop the bundled decode + network kickoff OFF the calling thread. On
-        // cold first launch `loadCatalogs` is reachable from
-        // `TPPAppDelegate.presentFirstRunFlowIfNeeded` (@MainActor); decoding
-        // the ~2.4 MB snapshot there would block the main thread. Runs at
-        // `.utility` (matching the init crawl arms) and is tracked via
-        // `_trackCrawlTask` so `cancelBackgroundWork()` cancels it — which
-        // keeps the `Task.isCancelled` guard below meaningful (mirrors the
-        // crawl tasks spawned inside `fetchFromNetwork`).
-        spawnOwnedCrawlTask(priority: .utility, detached: true, firstRun: true) { [weak self] in
-            guard let self = self else { return }
-
-            // 2.5. Bundled snapshot fast-path. The `Task.isCancelled` guard
-            // mirrors `fetchFromNetwork`'s post-await branch: a cancelled
-            // first-run task must not write the bundled bytes over a
-            // fixture-seeded test's on-disk cache.
-            if let bundledData = BundledRegistrySnapshot.load(resolver: self.snapshotResourceResolver),
-               !Task.isCancelled {
-                Log.info(#file, "First launch — loading bundled registry snapshot for hash \(hash), dataSize=\(bundledData.count)")
-                // isBundled=true keeps the cache flagged as non-authoritative so
-                // every subsequent loadCatalogs call still triggers refresh until
-                // a real network response overwrites the metadata.
-                self.registryCache.writeCatalogData(bundledData, hash: hash, isBundled: true)
-                self.loadAccountSetsAndAuthDoc(fromCatalogData: bundledData, key: hash) { _ in
-                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
-                }
-            }
-
-            // 3. Network fetch — ALWAYS fires (the bundled snapshot is a
-            // fast-path, not a replacement). The caller's completion is cleared
-            // on network completion via `callAndClearLoadingHandlers` inside
-            // `fetchFromNetwork`, NOT on the bundled load (whose completion
-            // above is `_ in`).
-            if Task.isCancelled { return }
-            Log.debug(#file, "Loading catalogs from network for hash \(hash)…")
-            self.fetchFromNetwork(targetUrl: targetUrl, hash: hash)
-        }
-    }
-
-    /// Fetches catalog data using the first-page fast path:
-    /// 1. Fetch first page (~35KB, ~260ms) → display immediately
-    /// 2. Paginate remaining pages in background → update cache when done
-    /// Falls back to a direct GET if even the first page fails.
-    private func fetchFromNetwork(targetUrl: URL, hash: String) {
-        // Test-observability (env-gated, no-op outside XCTest — see
-        // `_fetchFromNetworkCount`): record that the network fetch fired so the
-        // first-run-decode tests can prove the bundled-snapshot dedupe did not
-        // swallow it (Phase 1a regression guard).
-        if Self._isRunningUnderXCTest {
-            _fetchFromNetworkCountLock.lock()
-            _fetchFromNetworkCount += 1
-            _fetchFromNetworkCountLock.unlock()
-        }
-
-        // A developer-configured explicit registry URL is fetched verbatim via a
-        // direct GET — no crawlable rewrite — so the exact endpoint (e.g. a bare
-        // /libraries feed) is exercised. Gated behind a custom registry being set;
-        // production registry loading still uses the crawler below.
-        if TPPConfiguration.customRegistryIsExplicitURL() {
-            fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
-            return
-        }
-        spawnOwnedCrawlTask(priority: .userInitiated, detached: false) { [weak self] in
-            guard let self = self else { return }
-            Log.debug(#file, "Fetching catalogs via first-page fast path for hash \(hash)")
-
-            let crawler = LibraryRegistryCrawler(fetcher: URLSessionCrawlerFetcher(), hash: hash)
-
-            // Step 1: Fetch first page for immediate display
-            let firstPageResult = await crawler.crawlFirstPage(baseURL: targetUrl)
-            // Cooperative cancellation observation (swarm_4b64e4e0 Fix 2):
-            // if `cancelBackgroundWork()` was called while we were awaiting
-            // `crawlFirstPage`, drop the result on the floor instead of
-            // writing through to `accountSets` / `registryCache.writeCatalogData`.
-            // Without this, a test that `_resetForTesting()`s the AppContainer
-            // mid-fetch still sees the prior `AccountsManager`'s response
-            // land in its caches a few ms later.
-            if Task.isCancelled { return }
-
-            switch firstPageResult {
-            case .success(let firstPageData, let firstPage):
-                // Display first page immediately
-                self.registryCache.writeCatalogData(firstPageData, hash: hash)
-                self.loadAccountSetsAndAuthDoc(fromCatalogData: firstPageData, key: hash) { success in
-                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
-                    self.callAndClearLoadingHandlers(for: hash, success)
-                }
-
-                // Step 2: Paginate remaining pages in background
-                // Use the parsed firstPage (not re-parsed data) to check nextPageURL,
-                // because serializeAsCatalogsFeed drops pagination links.
-                guard firstPage.nextPageURL != nil else {
-                    Log.info(#file, "Single-page registry response (\(firstPage.catalogs.count) libraries) — no pagination needed")
-                    self.triggerCatalogPreload()
-                    break
-                }
-
-                Log.info(#file, "Registry has more pages (first page: \(firstPage.catalogs.count) of \(firstPage.metadata.numberOfItems ?? -1)) — paginating in background")
-                // Carry the non-Sendable crawler into the nested pagination Task
-                // via a documented box (used strictly sequentially — see
-                // `CrawlerHandoffBox`). `firstPage`/`targetUrl` are Sendable.
-                let crawlerBox = CrawlerHandoffBox(crawler: crawler)
-                self.spawnOwnedCrawlTask(priority: .utility, detached: false) { [weak self] in
-                    guard let self = self else { return }
-
-                    let remainingResult = await crawlerBox.crawler.crawlRemainingPages(
-                        firstPage: firstPage,
-                        baseURL: targetUrl,
-                        existingPublications: firstPage.catalogs,
-                        feedMetadata: firstPage.metadata
-                    )
-
-                    if case .success(let fullData) = remainingResult {
-                        let fullCount = (try? OPDS2CatalogsFeed.fromData(fullData))?.catalogs.count ?? -1
-                        Log.info(#file, "Background pagination complete: \(fullCount) total libraries cached")
-                        self.registryCache.writeCatalogData(fullData, hash: hash)
-                        self.loadAccountSetsAndAuthDoc(fromCatalogData: fullData, key: hash) { _ in
-                            NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
-                        }
-                    }
-                    self.triggerCatalogPreload()
-                }
-
-            case .noChanges:
-                self.callAndClearLoadingHandlers(for: hash, true)
-
-            case .failure(let error):
-                Log.info(#file, "First page crawl failed: \(error), falling back to direct GET to \(targetUrl)")
-                self.fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
-            }
-        }
-    }
-
-    /// Fallback direct GET when crawler fails on first launch.
-    ///
-    /// PP-4754: the GET completion used to be a fire-and-forget closure the
-    /// test-boundary drain could not await (the last un-drainable write channel).
-    /// It now runs inside an OWNED `spawnOwnedCrawlTask` bridging the callback GET
-    /// via the existing `ContinuationGuard`-protected `async throws` `GET` (so
-    /// the continuation resumes exactly once even on a -999 cancel). The
-    /// post-await `Task.isCancelled` guard drops a late response instead of
-    /// late-writing `AccountStateStore.shared` into the next test — now that the
-    /// task is owned+cancelled, this fully supersedes the prior DEBUG
-    /// `_explicitCancelCalled` completion guard.
-    private func fallbackFetchFromNetwork(targetUrl: URL, hash: String) {
-        spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
-            guard let self = self else { return }
-            do {
-                let (data, _) = try await self.networkExecutor.GET(targetUrl, useTokenIfAvailable: false)
-                if Task.isCancelled { return }
-                self.registryCache.writeCatalogData(data, hash: hash)
-                self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { success in
-                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
-                    self.callAndClearLoadingHandlers(for: hash, success)
-                }
-            } catch {
-                if Task.isCancelled { return }
-                Log.error(#file, "Failed to load catalogs from network: \(error.localizedDescription)")
-                if let data = self.registryCache.readCatalogData(hash: hash) {
-                    Log.info(#file, "Using cached catalog data as fallback after network failure")
-                    self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { success in
-                        NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
-                        self.callAndClearLoadingHandlers(for: hash, success)
-                    }
-                } else {
-                    Log.error(#file, "No cached catalog data available, catalog load failed completely")
-                    self.callAndClearLoadingHandlers(for: hash, false)
-                }
-            }
-        }
-    }
-
-    /// Refreshes catalog data in background using the incremental crawler.
-    /// Falls back to a direct GET if the crawlable endpoint fails.
-    private func refreshInBackground(targetUrl: URL, hash: String) {
-        // Explicit dev registry URLs bypass the incremental crawler and refresh
-        // via a verbatim direct GET, mirroring fetchFromNetwork.
-        if TPPConfiguration.customRegistryIsExplicitURL() {
-            fallbackFetchFromNetwork(targetUrl: targetUrl, hash: hash)
-            return
-        }
-        spawnOwnedCrawlTask(priority: .utility, detached: false) { [weak self] in
-            guard let self = self else { return }
-            Log.debug(#file, "Starting background refresh (crawl) for catalog hash \(hash)")
-
-            // Parse existing cached publications for merge
-            let existingPubs: [OPDS2Publication]
-            let existingMetadata: OPDS2CatalogsFeed.Metadata?
-            if let cachedData = self.registryCache.readCatalogData(hash: hash),
-               let feed = try? OPDS2CatalogsFeed.fromData(cachedData) {
-                existingPubs = feed.catalogs
-                existingMetadata = feed.metadata
-            } else {
-                existingPubs = []
-                existingMetadata = nil
-            }
-
-            let crawler = LibraryRegistryCrawler(fetcher: URLSessionCrawlerFetcher(), hash: hash)
-            let result = await crawler.crawl(
-                baseURL: targetUrl,
-                existingPublications: existingPubs,
-                feedMetadata: existingMetadata
-            )
-
-            switch result {
-            case .success(let data):
-                let pubCount = (try? OPDS2CatalogsFeed.fromData(data))?.catalogs.count ?? -1
-                Log.info(#file, "Background crawl successful for hash \(hash), \(pubCount) libraries in result, dataSize=\(data.count)")
-                self.registryCache.writeCatalogData(data, hash: hash)
-                self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { [weak self] _ in
-                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
-                    // Preload catalogs for active accounts
-                    self?.triggerCatalogPreload()
-                }
-
-            case .noChanges:
-                Log.debug(#file, "Background crawl found no changes for hash \(hash)")
-                // Still preload catalogs — they may not be cached yet
-                self.triggerCatalogPreload()
-
-            case .failure(let error):
-                Log.debug(#file, "Background crawl failed for hash \(hash): \(error.localizedDescription)")
-                // Fallback: try direct GET (old behavior)
-                self.fallbackDirectRefresh(targetUrl: targetUrl, hash: hash)
-            }
-        }
-    }
-
-    /// Fallback to direct GET when crawlable endpoint fails. PP-4754: owned +
-    /// drainable, bridging the callback GET via the `ContinuationGuard`-protected
-    /// `async throws` `GET` — see `fallbackFetchFromNetwork` for the rationale.
-    private func fallbackDirectRefresh(targetUrl: URL, hash: String) {
-        spawnOwnedCrawlTask(priority: .utility, detached: true) { [weak self] in
-            guard let self = self else { return }
-            do {
-                let (data, _) = try await self.networkExecutor.GET(targetUrl, useTokenIfAvailable: false)
-                if Task.isCancelled { return }
-                Log.info(#file, "Fallback direct refresh successful for hash \(hash)")
-                self.registryCache.writeCatalogData(data, hash: hash)
-                self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { _ in
-                    NotificationCenter.default.post(name: .TPPCatalogDidLoad, object: nil)
-                }
-            } catch {
-                Log.debug(#file, "Fallback direct refresh also failed for hash \(hash): \(error.localizedDescription)")
-            }
-        }
-    }
-
-    /// Triggers catalog feed preloading for active accounts.
-    private func triggerCatalogPreload() {
-        spawnOwnedCrawlTask(priority: .utility, detached: false) { [weak self] in
-            guard let self = self else { return }
-            await self.catalogPreloader.preloadCatalogs(
-                currentAccount: self.currentAccount,
-                recentAccountUUIDs: self.settings.settingsAccountIdsList,
-                accountProvider: { self.account($0) }
-            )
-        }
+        registryLoader.loadCatalogs(completion: completion)
     }
 
     // MARK: – Account-switch pure helpers
@@ -1461,150 +777,15 @@ private struct CrawlerHandoffBox: @unchecked Sendable {
 
     // MARK: – Parsing & notifying
 
+    /// Facade → `registryLoader.loadAccountSetsAndAuthDoc` (Wave 3 / 3a-4). Exposed
+    /// `internal` so the cache-read + launch-snapshot contract tests can drive registry
+    /// materialization directly; the parse + carry-over + auth-doc-drive body lives on the loader.
     internal func loadAccountSetsAndAuthDoc(
         fromCatalogData data: Data,
         key hash: String,
         completion: @escaping (Bool) -> Void
     ) {
-        // Box the non-Sendable `completion` so it can be invoked from the
-        // `@Sendable` `group.notify(queue: .main)` block below. The handler is
-        // still only called once, on `.main`; its thread-affinity contract is
-        // unchanged — the box only satisfies the `@Sendable` boundary.
-        let completionBox = LoadCompletionBox(handler: completion)
-        do {
-            let feed = try OPDS2CatalogsFeed.fromData(data)
-            let hadAccount = self.currentAccount != nil
-            let oldAccounts = self.accounts(hash)
-            // Index old accounts by uuid ONCE so the carry-over loop below is a
-            // dict lookup per new account instead of an O(n²) linear scan over
-            // the ~1142-account registry snapshot (precedent: `accountByUUID`).
-            // First-write-wins mirrors the prior `oldAccounts.first(where:)`
-            // semantics exactly for the (rare) duplicate-uuid case.
-            let oldAccountsByUUID = Dictionary(
-                oldAccounts.map { ($0.uuid, $0) },
-                uniquingKeysWith: { first, _ in first }
-            )
-            let newAccounts = feed.catalogs.map { publication -> Account in
-                // CP-D1 (Finding 4): on the slim→full LAUNCH materialization
-                // (accountSets/`oldAccounts` empty for this uuid), REUSE the
-                // existing slim instance instead of constructing a fresh one.
-                // `details`/`authenticationDocument` are per-INSTANCE stored
-                // properties, and the slim current-account drive fetches the
-                // auth-doc onto the SLIM instance. If we swapped in a fresh
-                // instance here, an in-flight slim fetch would land on the
-                // discarded instance — leaving `currentAccount.details == nil`
-                // while state reads `.detailsLoaded` (split-brain: legacy direct
-                // readers `.details`/`.needsAuth`/`.loansUrl`/`.authSurfaceHosts`
-                // see nil). Reusing keeps ONE Account per uuid so the fetch
-                // completion lands on the current instance. BOUNDED to launch:
-                // once `accountSets` is populated (warm / network-refresh path),
-                // `oldAccountsByUUID` carries the auth-doc forward via the loop
-                // below and fresh network data must win, so we do NOT reuse then.
-                if oldAccountsByUUID[publication.metadata.id] == nil,
-                   let slim = registryStore.slimAccount(publication.metadata.id) {
-                    return slim
-                }
-                return Account(publication: publication, imageCache: switchDeps.imageCache)
-            }
-
-            // Carry over authenticationDocument (and thus details) from old
-            // accounts so a background refresh doesn't nil-out details while
-            // the user is actively using the app. Also invalidate logo cache
-            // entries when the thumbnail URL has changed.
-            for newAccount in newAccounts {
-                if let old = oldAccountsByUUID[newAccount.uuid] {
-                    if let authDoc = old.authenticationDocument {
-                        newAccount.authenticationDocument = authDoc
-                    }
-                    // Evict cached logo if the thumbnail URL changed
-                    if old.logoUrl != newAccount.logoUrl {
-                        switchDeps.imageCache.remove(for: newAccount.uuid)
-                    }
-                }
-            }
-
-            self.registryStore.mutate { $0[hash] = newAccounts }
-
-            // Account state-machine wiring (3.2.0): Phase 1 — drive every
-            // freshly-constructed account into its post-load terminal state.
-            // The `authentication_document` carry-over path above means an
-            // account that previously held `.detailsLoaded` continues to
-            // observe loaded details (under the new instance). Accounts
-            // without a carry-over auth doc fall back to `.basicInfoLoaded`
-            // until the current-account fetch below drives them through
-            // `.detailsLoading` → `.detailsLoaded` / `.detailsFailed`.
-            for newAccount in newAccounts {
-                if newAccount.authenticationDocument != nil,
-                   let details = newAccount.details {
-                    // Belt-and-suspenders `guard let`: `authenticationDocument`
-                    // didSet populates `details` synchronously, but a
-                    // mock-data publication could in principle land here
-                    // with an authDoc that fails to construct details.
-                    newAccount._setState(.detailsLoaded(details))
-                } else if case .notLoaded = switchDeps.accountStateStore.state(for: newAccount.uuid) {
-                    // CP-D1: preserve any state the slim launch snapshot already
-                    // advanced this uuid to. The slim current-account drive can
-                    // reach `.detailsLoading`/`.detailsLoaded` BEFORE this async
-                    // full-list materialization runs; only stamp `.basicInfoLoaded`
-                    // on a still-fresh uuid so the off-main full load can't knock a
-                    // mid-flight current account back down and force a redundant
-                    // re-drive. (No-op change for the cold-launch case where the
-                    // store is fresh `.notLoaded` — this else-branch only fires for
-                    // accounts without a carry-over auth doc, which were previously
-                    // `.notLoaded`/`.basicInfoLoaded` anyway.)
-                    newAccount._setState(.basicInfoLoaded)
-                }
-            }
-
-            let group = DispatchGroup()
-
-            let accountExistenceChanged = hadAccount != (self.currentAccount != nil)
-            let currentAccountMissingDetails = self.currentAccount != nil && self.currentAccount?.details == nil
-
-            if accountExistenceChanged || currentAccountMissingDetails, let current = self.currentAccount {
-                group.enter()
-                current.loadLogo()
-                fetchAuthDocumentWithStateMachine(for: current) { _ in
-                    if current.details?.needsAgeCheck ?? false {
-                        group.enter()
-                        self.ageCheck.verifyCurrentAccountAgeRequirement(
-                            userAccountProvider: self.currentUserAccount,
-                            currentLibraryAccountProvider: self
-                        ) { _ in group.leave() }
-                    }
-                    group.leave()
-                }
-            }
-
-            group.notify(queue: .main) {
-                var mainFeed = URL(string: self.currentAccount?.catalogUrl ?? "")
-                if let cur = self.currentAccount, cur.details?.needsAgeCheck ?? false {
-                    mainFeed = cur.details?.defaultAuth?.coppaURL(isOfAge: true)
-                }
-                // Don't overwrite a valid accountMainFeedURL with nil.
-                // On cache loads the current account may not have its catalogUrl
-                // populated yet (auth doc hasn't loaded), but the URL from the
-                // previous session is still valid in UserDefaults.
-                if let mainFeed {
-                    self.settings.accountMainFeedURL = mainFeed
-                } else if self.settings.accountMainFeedURL == nil {
-                    Log.warn(#file, "accountMainFeedURL is nil and no cached value — catalog will not load until auth doc completes")
-                }
-                // This `group.notify(queue: .main)` block runs on the main
-                // queue but is a nonisolated closure; hop the main-actor
-                // `UIApplication` access through `assumeIsolated` (safe — we
-                // are provably on `.main`). Behavior unchanged.
-                MainActor.assumeIsolated {
-                    UIApplication.shared.delegate?.window??.tintColor = TPPConfiguration.mainColor()
-                }
-                NotificationCenter.default.post(name: .TPPCurrentAccountDidChange, object: nil)
-                completionBox.handler(true)
-            }
-
-        } catch {
-            TPPErrorLogger.logError(error, summary: "Error parsing catalog feed")
-            completion(false)
-        }
+        registryLoader.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash, completion: completion)
     }
 
     @objc private func updateAccountSetFromNotification(_ notif: Notification) {
@@ -1729,182 +910,46 @@ extension AccountsManager {
     /// the prior `accountsManager` (vanishingly few in tests; none in
     /// production). Acceptable per swarm_4b64e4e0 outcome.md.
     func cancelBackgroundWork() {
-        // Order matters: flip the explicit-cancel flag BEFORE issuing the
-        // .cancel() so the observation surface
-        // `_backgroundFetchTaskWasExplicitlyCancelled` distinguishes "we
-        // called cancel" from "the handle was nilled by some other path."
-        // swarm_4b64e4e0 qa-fixup Fix 3.
+        // Flip the hub-owned explicit-cancel flag BEFORE delegating so the observation
+        // surface `_backgroundFetchTaskWasExplicitlyCancelled` (which reads this flag)
+        // distinguishes "we called cancel" from "handle nilled by another path." The task/
+        // registry cancel + network cancel live on the loader now (Wave 3 / 3a-4); the loader
+        // body must NOT touch this flag (it can't reach it).
         _explicitCancelCalled = true
-        backgroundFetchTask?.cancel()
-        backgroundFetchTask = nil
-        // Cancel every OWNED crawl / pagination / refresh / fallback-GET /
-        // preload task spawned by loadCatalogs — without this they leak a live
-        // crawl past the test boundary and pollute the next test. Each task
-        // self-prunes its token as it unwinds, so cancelAll() does not clear the
-        // map — the drain then awaits whatever is still live.
-        ownedCrawlTasks.cancelAll()
-        // Drop the first-run subset so the narrow join seam does not re-await an
-        // already-cancelled task.
-        _trackedCrawlTasksLock.lock()
-        _trackedFirstRunTasks.removeAll()
-        _trackedCrawlTasksLock.unlock()
-        networkExecutor.cancelNonEssentialTasks()
+        registryLoader.cancelBackgroundWork()
     }
 
-    /// Test-only: cancel the in-flight background `loadCatalogs` crawl AND
-    /// synchronously DRAIN it before returning, so no orphan crawl outlives the
-    /// test boundary holding the `accountSetsLock` barrier.
-    ///
-    /// Why this exists (WS-0 follow-up — closes the residual race documented on
-    /// `cancelBackgroundWork()` above): the cooperative `cancelBackgroundWork()`
-    /// returns immediately, so a just-cancelled crawl can still be mid-flight —
-    /// holding the `.barrier` on the registry store's `accountSetsLock` (via
-    /// `registryStore.mutate`) — when the NEXT test's `@MainActor` reauth path does a
-    /// synchronous `currentUserAccount` / store `.sync` read. That read blocks
-    /// behind the barrier; because the crawl hops to the main actor to complete,
-    /// and main is now blocked on the read, the two deadlock → the victim test's
-    /// 5s `waitForExpectations` timer never fires → 120s main-thread jam. This
-    /// is the "auth-state-bleed" board-red whose ROOT is a leaked
-    /// `deferInitialLoadCatalogsForTesting = false` crawl (flag-value-restored ≠
-    /// crawl-drained — the gap the flag-value defer gate could not see).
-    ///
-    /// The drain MUST pump the run loop while waiting: the crawl needs the main
-    /// actor to finish, so blocking main outright would re-create the deadlock.
-    /// Pumping lets the cancelled crawl's main-hops + barrier writes complete,
-    /// then it observes cancellation and exits — bounded by `timeout`.
-    ///
-    /// Production-safe — `#if DEBUG`, called only from
-    /// `AppContainer._resetForTesting()` (every test boundary) so the fix is
-    /// global across ALL flag-false crawl spawners, not a per-test patch.
+    /// Test-only: cancel + synchronously DRAIN the in-flight background crawl (pumping the
+    /// run loop) before returning, so no orphan crawl outlives the test boundary. The drain
+    /// body lives on the loader; the hub sets `_explicitCancelCalled` FIRST so the torn-down
+    /// semantics engage for the pending auth-doc main-hop (Wave 3 / 3a-4 — the critical seam).
     func cancelAndDrainBackgroundWork(timeout: TimeInterval = 3.0) {
-        // Capture the FULL owned set BEFORE cancelBackgroundWork() cancels it —
-        // including the newly-wrapped fallback GET tasks, so the last
-        // un-drainable write channel is now awaited, not missed.
-        // `backgroundFetchTask` is also awaited to cover a test-INJECTED task
-        // not in the registry (an owned task awaited twice returns immediately).
-        let ownedTasks = ownedCrawlTasks.snapshot().map { $0.1 }
-        let fetchTask = backgroundFetchTask
-        let tasksToDrain = ownedTasks + [fetchTask].compactMap { $0 }
-
-        cancelBackgroundWork() // requests cancellation, nils the handle
-
-        if tasksToDrain.isEmpty {
-            // No tracked Tasks, but init may have enqueued a DispatchQueue.main.async
-            // auth-doc drive (see `preloadAccountsFromDiskCacheSync`'s deferred
-            // `driveCurrentAccountAuthDocIfNeeded()` hop) that is NOT a Task and
-            // therefore CANNOT be cancelled by `cancelBackgroundWork()`. If it
-            // escapes this boundary it fires on a LATER runloop turn — after the
-            // next test's `_resetForTesting()` store reset — and writes a
-            // fixture-shared library UUID's `.detailsLoading`/`.detailsFailed`
-            // into the next test (the order-dependent Accounts-suite flakes).
-            // Pump the main run loop briefly so any such pending main-hop fires
-            // NOW, inside the boundary: for THIS torn-down manager the
-            // `_explicitCancelCalled` entry guard in
-            // `fetchAuthDocumentWithStateMachine` makes its own drive inert; for a
-            // foreign, never-torn-down manager's pending hop (e.g. an
-            // `AppContainer.production()` manager built by a Catalog test) the
-            // write lands here and is then wiped by the boundary's own store
-            // reset — either way nothing leaks past `_resetForTesting()`.
-            //
-            // CRITICAL invariant (see the drain-must-pump note above): PUMP the
-            // run loop, never BLOCK main — the crawl-drain deadlock reason applies
-            // equally here. A single `RunLoop.run(mode:before:)` can return BEFORE
-            // libdispatch services a lone pending main-queue block (it exits early
-            // when no traditional run-loop source is ready), so — exactly like the
-            // Task-drain loop below — we pump in a BOUNDED loop. We enqueue a
-            // sentinel AFTER any pending hop (the main queue is FIFO) and spin
-            // until it drains: once the sentinel runs, every earlier main-hop has
-            // already fired. Bounded by a 50ms ceiling so a wedged main queue can
-            // never hang the boundary; the common case exits in well under 1ms.
-            let sentinel = DispatchGroup()
-            sentinel.enter()
-            DispatchQueue.main.async { sentinel.leave() }
-            let pumpDeadline = Date().addingTimeInterval(0.05)
-            while sentinel.wait(timeout: .now()) == .timedOut && Date() < pumpDeadline {
-                RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
-            }
-            return
-        }
-
-        // Await all (now-cancelled) tasks while pumping the run loop, so any
-        // barrier the crawl holds is released and its main-actor hops complete
-        // before we return. Bounded by `timeout` so a stuck task can't hang the
-        // boundary.
-        let started = Date()
-        let group = DispatchGroup()
-        for task in tasksToDrain {
-            group.enter()
-            Task { _ = await task.value; group.leave() }
-        }
-        let deadline = started.addingTimeInterval(timeout)
-        while group.wait(timeout: .now()) == .timedOut && Date() < deadline {
-            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
-        }
-        // Telemetry: a fast drain (cancelled crawl + pumped main unwinds in
-        // single-digit ms) is the expected case. Hitting the `timeout` ceiling
-        // means the cancel did NOT actually stop the crawl — surface it loudly
-        // (a stuck crawl is a real bug) but never hang the boundary.
-        let elapsedMs = Int(Date().timeIntervalSince(started) * 1000)
-        if group.wait(timeout: .now()) == .timedOut {
-            NSLog("[WS0-DRAIN] cancelAndDrainBackgroundWork TIMED OUT after %dms draining %d task(s) — crawl did not observe cancellation; investigate.", elapsedMs, tasksToDrain.count)
-        } else if elapsedMs >= 50 {
-            NSLog("[WS0-DRAIN] cancelAndDrainBackgroundWork drained %d task(s) in %dms.", tasksToDrain.count, elapsedMs)
-        }
+        _explicitCancelCalled = true
+        registryLoader.cancelAndDrainBackgroundWork(timeout: timeout)
     }
 
-    /// Test-only setter that swaps a caller-provided Task into
-    /// `backgroundFetchTask`. Used by the race-guard test in
-    /// `AccountsManagerCancellationTests` to install a Task it controls (via
-    /// a CheckedContinuation) so it can drive cancel-mid-await semantics
-    /// without going through a live network round-trip. Returns the prior
-    /// task so the caller can restore it or cancel it as needed.
-    ///
-    /// swarm_4b64e4e0 qa-fixup Fix 2 — addresses qa_test concern that the
-    /// cooperative-cancel guard at line 651 of `fetchFromNetwork` has no
-    /// behavioral test covering the post-resume branch.
+    /// Test-only setter forwarder for the loader's `backgroundFetchTask`.
     @discardableResult
     func _injectBackgroundFetchTaskForTesting(_ task: Task<Void, Never>?) -> Task<Void, Never>? {
-        let prior = backgroundFetchTask
-        backgroundFetchTask = task
-        return prior
+        return registryLoader._injectBackgroundFetchTaskForTesting(task)
     }
 
-    /// Test-only observation surface. Returns `true` iff `cancelBackgroundWork()`
-    /// was called on this instance (the flag is flipped BEFORE the underlying
-    /// `.cancel()` call so a partial cancel-then-throw cannot leave this
-    /// false). Pin this in tests when you want to prove the explicit
-    /// production seam was invoked, distinct from the task handle being nil.
-    ///
-    /// swarm_4b64e4e0 qa-fixup Fix 3.
+    /// Test-only observation surface: `true` iff `cancelBackgroundWork()` was called on this
+    /// instance. Reads the hub-owned `_explicitCancelCalled` flag (stays here so the 3a-3
+    /// `AuthDocumentLoader.isTornDown` binding is byte-identical). swarm_4b64e4e0 qa-fixup Fix 3.
     var _backgroundFetchTaskWasExplicitlyCancelled: Bool {
         return _explicitCancelCalled
     }
 
-    /// Test-only observation surface. Returns `true` iff `backgroundFetchTask`
-    /// is currently `nil` (post-cancel cleanup OR pre-init OR opt-out
-    /// construction). Pin this in tests when you want to prove the handle
-    /// was nilled out.
-    ///
-    /// swarm_4b64e4e0 qa-fixup Fix 3.
+    /// Test-only observation-surface forwarder: `true` iff the loader's `backgroundFetchTask` is nil.
     var _backgroundFetchTaskHandleIsNil: Bool {
-        return backgroundFetchTask == nil
+        return registryLoader._backgroundFetchTaskHandleIsNil
     }
 
-    /// Test-only observation surface for `backgroundFetchTask`. Returns
-    /// `true` if the task is currently in a cancelled state OR if the task
-    /// handle has been nilled out by `cancelBackgroundWork()`. Used by
-    /// `AccountsManagerCancellationTests` to verify the cooperative-cancel
-    /// invariant without poking at the private storage directly.
-    ///
-    /// - DEPRECATED in qa-fixup: this property conflates "explicit cancel
-    ///   was called" with "task handle was nilled." Prefer
-    ///   `_backgroundFetchTaskWasExplicitlyCancelled` AND
-    ///   `_backgroundFetchTaskHandleIsNil` together so a mutation that
-    ///   removes only ONE of the two effects fails its dedicated test.
+    /// Test-only observation-surface forwarder.
     @available(*, deprecated, message: "Use _backgroundFetchTaskWasExplicitlyCancelled + _backgroundFetchTaskHandleIsNil so cancel-vs-nil mutations are independently observable. See swarm_4b64e4e0 qa-fixup Fix 3.")
     var _backgroundFetchTaskIsCancelledOrCleared: Bool {
-        guard let task = backgroundFetchTask else { return true }
-        return task.isCancelled
+        return registryLoader._backgroundFetchTaskIsCancelledOrCleared
     }
 }
 #endif

--- a/PalaceTests/Decomp/AccountRegistryLoaderSeamTests.swift
+++ b/PalaceTests/Decomp/AccountRegistryLoaderSeamTests.swift
@@ -1,0 +1,140 @@
+//
+//  AccountRegistryLoaderSeamTests.swift
+//  PalaceTests
+//
+//  Pins the Wave 3 / 3a-4 `AccountRegistryLoader` seam: the catalog load orchestration +
+//  owned background-crawl + drain extracted from AccountsManager. Constructs the loader
+//  DIRECTLY with spy providers + a recording `CrawlTaskScheduler` + a stub cache/network,
+//  so the deterministic contracts pin WITHOUT racing a live network:
+//   - the initial-background-load SCHEDULING contract (one detached `.utility` spawn),
+//   - the drain's empty-set path returns promptly (no wall-clock hang),
+//   - `carveSlimFeed` purity (also reached via the retained `AccountsManager` shim).
+//  The broad load-pipeline behaviour + the drain-under-live-crawl are pinned by the
+//  retained (byte-unchanged) AccountsManager suites (cancellation / first-run-decode /
+//  cache-read / wiring), which run through the hub facades in CI.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+import PalaceCatalog
+import PalaceBookModel
+import PalacePreferences
+@testable import Palace
+
+@MainActor
+final class AccountRegistryLoaderSeamTests: XCTestCase {
+
+    /// `spawnInitialBackgroundLoad()` schedules exactly one DETACHED `.utility` crawl task
+    /// (the init background-load arm). Kill case: a mutant that changes detachedness/QoS or
+    /// spawns zero/many tasks flips the recorded spawn list.
+    func testSpawnInitialBackgroundLoad_schedulesOneDetachedUtilityTask() {
+        let recorder = SchedulerRecorder()
+        let loader = makeLoader(scheduler: recorder.scheduler)
+
+        loader.spawnInitialBackgroundLoad()
+
+        XCTAssertEqual(recorder.spawns.count, 1, "exactly one initial background-load task")
+        XCTAssertEqual(recorder.spawns.first?.detached, true, "the init load arm is detached")
+        XCTAssertEqual(recorder.spawns.first?.priority, .utility, "the init load arm runs at .utility")
+    }
+
+    /// `cancelAndDrainBackgroundWork` with no owned tasks pumps the main run loop briefly
+    /// then RETURNS — it must never hang the test boundary (bounded pump). Kill case: a
+    /// mutant that blocks main / drops the bound would time out.
+    func testCancelAndDrain_withNoTasks_returnsPromptly() {
+        let recorder = SchedulerRecorder()
+        let loader = makeLoader(scheduler: recorder.scheduler)
+
+        let start = Date()
+        loader.cancelAndDrainBackgroundWork(timeout: 0.2)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 1.0,
+                          "empty-set drain must return well within the bound, never hang")
+    }
+
+    /// `carveSlimFeed` keeps only the `catalogs` entries whose `metadata.id` is in
+    /// `keepUUIDs`, and returns nil when none match. Kill case: dropping the filter or the
+    /// empty-guard.
+    func testCarveSlimFeed_keepsOnlyMatchingUUIDs() throws {
+        let full = """
+        {"catalogs":[
+          {"metadata":{"id":"A","title":"a"}},
+          {"metadata":{"id":"B","title":"b"}}
+        ]}
+        """.data(using: .utf8)!
+
+        let carved = try XCTUnwrap(AccountRegistryLoader.carveSlimFeed(fromFullCatalogData: full, keepUUIDs: ["A"]))
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: carved) as? [String: Any])
+        let catalogs = try XCTUnwrap(root["catalogs"] as? [[String: Any]])
+        XCTAssertEqual(catalogs.count, 1)
+        XCTAssertEqual((catalogs.first?["metadata"] as? [String: Any])?["id"] as? String, "A")
+
+        XCTAssertNil(AccountRegistryLoader.carveSlimFeed(fromFullCatalogData: full, keepUUIDs: ["Z"]),
+                     "no matching uuid → nil")
+        XCTAssertNil(AccountRegistryLoader.carveSlimFeed(fromFullCatalogData: full, keepUUIDs: []),
+                     "empty keep set → nil")
+    }
+
+    // MARK: - Helper
+
+    private func makeLoader(scheduler: CrawlTaskScheduler) -> AccountRegistryLoader {
+        AccountRegistryLoader(
+            registryCache: StubRegistryCache(),
+            registryStore: AccountRegistryStore(),
+            crawlScheduler: scheduler,
+            settings: TPPSettings(),
+            imageCache: MockImageCache(),
+            accountStateStore: AccountStateStore(),
+            ageCheck: TPPAgeCheck(ageCheckChoiceStorage: TPPSettings()),
+            networkExecutorProvider: { StubNetworking() },
+            currentAccountProvider: { nil },
+            currentAccountIdProvider: { nil },
+            accountsForKeyProvider: { _ in [] },
+            accountProvider: { _ in nil },
+            currentUserAccountProvider: { nil },
+            driveCurrentAccountAuthDoc: {},
+            fetchAuthDocumentWithStateMachine: { _, completion in completion(true) },
+            currentLibraryAccountProvider: { nil }
+        )
+    }
+}
+
+// MARK: - Test doubles
+
+/// Records each crawl-task spawn (detachedness + priority) and returns a trivial completed
+/// Task WITHOUT running the operation — so `spawnInitialBackgroundLoad`'s scheduling is
+/// observable with no live network / crawl firing.
+fileprivate final class SchedulerRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _spawns: [(detached: Bool, priority: TaskPriority)] = []
+    var spawns: [(detached: Bool, priority: TaskPriority)] {
+        lock.lock(); defer { lock.unlock() }; return _spawns
+    }
+    private func record(_ detached: Bool, _ priority: TaskPriority) {
+        lock.lock(); _spawns.append((detached, priority)); lock.unlock()
+    }
+    lazy var scheduler = CrawlTaskScheduler(
+        spawn: { [self] priority, _ in record(false, priority); return Task {} },
+        spawnDetached: { [self] priority, _ in record(true, priority); return Task {} }
+    )
+}
+
+/// Inert `AccountRegistryCaching` — the loader construction/scheduling/drain tests never
+/// exercise the disk path. `@unchecked Sendable`: no mutable state.
+fileprivate final class StubRegistryCache: AccountRegistryCaching, @unchecked Sendable {
+    func writeCatalogData(_ data: Data, hash: String, isBundled: Bool) {}
+    func readCatalogData(hash: String) -> Data? { nil }
+    func hasFreshCatalogData(hash: String) -> Bool { false }
+    func isCatalogStale(hash: String) -> Bool { false }
+    func slimSnapshotURL(hash: String) -> URL? { nil }
+    func clearFileCaches() {}
+}
+
+/// Inert `AccountNetworking` — the drain's `cancelNonEssentialTasks` is a no-op here.
+fileprivate final class StubNetworking: AccountNetworking, @unchecked Sendable {
+    func cancelNonEssentialTasks() {}
+    func clearCache() {}
+    func GET(_ reqURL: URL, useTokenIfAvailable: Bool) async throws -> (Data, URLResponse?) {
+        (Data(), nil)
+    }
+}

--- a/scripts/godclass-appcontainer-locator-baseline.txt
+++ b/scripts/godclass-appcontainer-locator-baseline.txt
@@ -12,4 +12,7 @@
 # Wave 3 S2b: MBDC's B6 `authSurfaceHosts` locators route through the S2
 # `DownloadAccountScopeProviding` seam instead → 305 -> 304 (net -1 after rebase; one
 # `AppContainer.production()` prose mention remains in the new AccountScope rationale).
-304
+# Wave 3 / 3a-4 (AccountRegistryLoader extraction): 304 -> 302. Two `AppContainer.production()`
+# reaches left AccountsManager with the relocated load bodies (into the new, unfrozen
+# AccountRegistryLoader.swift), so the hub's out-of-allowlist count drops by 2.
+302

--- a/scripts/godclass-loc-baseline.txt
+++ b/scripts/godclass-loc-baseline.txt
@@ -60,6 +60,16 @@
 #   seams were inverted behind the injected `AccountSwitchDependencies` bundle; the
 #   net is slightly NEGATIVE (the extracted nav-pop closure + deleted inline reaches
 #   outweigh the stored dependency + its docs). Re-baselined by the exact delta.
+# Wave 3 / 3a-4 (-954 on AccountsManager, 1910 -> 956): the catalog LOAD orchestration
+#   (loadCatalogs stale-while-revalidate pipeline, the first-page/paginate network crawl +
+#   direct-GET fallbacks, CP-D1 preload + slim-snapshot hydrate/carve/write, the owned
+#   background-crawl task registry + its test-boundary drain choreography, and the
+#   loading-completion handler dedupe) EXTRACTED to the injected `AccountRegistryLoader`
+#   (a `final class`, not an actor). The hub keeps thin facades (loadCatalogs,
+#   loadAccountSetsAndAuthDoc, preloadAccountsFromDiskCacheSync, the drain/join seams) +
+#   static shims (carveSlimFeed). `_explicitCancelCalled` + the live-instance registry STAY
+#   on the hub; the hub cancel/drain facades set the flag before delegating. Largest of the
+#   3a splits (~950 LOC). Re-baselined DOWN.
 # Wave 3 / 3a-3 (-172 on AccountsManager, 2082 -> 1910): the per-account auth-document
 #   fetch + state-machine wiring (the single-flight `inflightAuthDocFetches` map + lock,
 #   `authDocInflightTimeout`, `fetchAuthDocumentWithStateMachine`, `fetchCompletionMayWriteTerminal`,
@@ -98,7 +108,7 @@
 #   PalaceDownloads and the account-scope wiring goes with it. Re-baselined by the exact
 #   delta; the freeze still catches any further unrelated growth.
 3093 Palace/Audiobooks/AudiobookSessionManager.swift
-1910 Palace/Accounts/Library/AccountsManager.swift
+955 Palace/Accounts/Library/AccountsManager.swift
 2184 Palace/MyBooks/MyBooksDownloadCenter.swift
 1378 Palace/Book/UI/BookDetail/BookDetailViewModel.swift
 1261 Palace/SignInLogic/TPPSignInBusinessLogic.swift


### PR DESCRIPTION
## What & why

Fourth and **largest** of the 3a `PalaceAccounts` collaborator splits. The catalog **LOAD orchestration** — the `loadCatalogs` stale-while-revalidate pipeline, the first-page/paginate network crawl + direct-GET fallbacks, CP-D1 preload + slim-snapshot hydrate/carve/write, the owned background-crawl task registry + its **test-boundary drain choreography**, and the loading-completion handler dedupe — moves out of `AccountsManager` into an injected `AccountRegistryLoader`. It orchestrates the already-extracted `registryCache` (3a-1) / `registryStore` (3a-2) / `authDocLoader` (3a-3). **Behaviour-identical.** Follows #1360/#1361/#1363/#1366 (all merged).

## The number

**`AccountsManager` 1910 → 955 LOC (−955).** New `AccountRegistryLoader.swift` (873 LOC). Across the four extractions this session the hub is **2383 → 955** (−60%).

## Design (architect-validated, single-module `/rigorous-fix`)

- **`final class`, not an actor** — `loadCatalogs`/`cancelAndDrainBackgroundWork` are called synchronously; the drain depends on a synchronous `registryStore` barrier read. Same rationale as the prior three collaborators.
- **Zero external edits** — the hub keeps thin facades (`loadCatalogs`, `loadAccountSetsAndAuthDoc`, `preloadAccountsFromDiskCacheSync`, a settable `snapshotResourceResolver` forwarding property, all the drain/join `_*ForTesting` seams) + static shims (`carveSlimFeed`, `buildAccountIndex`), so `AppContainer` / `CatalogCrawlScheduler` / `PalaceTestSetup` / **every existing test** are byte-identical. `git status` = 6 files only. That zero-edit surface *is* the single-module proof.
- **Drain-flag set-point (the anti-pollution seam):** the hub `cancelBackgroundWork()` / `cancelAndDrainBackgroundWork(timeout:)` facades set `_explicitCancelCalled = true` **first**, then delegate; the loader's cancel/drain bodies do **not** set the flag. `_explicitCancelCalled` + the live-instance registry stay on the hub, preserving the byte-identical 3a-3 `AuthDocumentLoader.isTornDown` binding. A verbatim relocation here would have *reintroduced* the exact test-pollution regression this wave exists to prevent (caught at contract review).
- **9 injected `[weak self]` provider closures** incl. `currentLibraryAccountProvider` for the COPPA age-check. `lazy var` (closures capture self — the `authDocLoader` precedent).

## Verification

| Gate | Result |
|---|---|
| God-class LOC freeze | re-baselined **DOWN 1910 → 955** |
| Palace-noDRM build (production compile) | BUILD SUCCEEDED |
| Locator / shared-read | 304→302 / 213 |
| Zero external edits (AppContainer/CrawlScheduler/PalaceTestSetup/tests) | confirmed (6-file diff) |
| **DRM PalaceTests + the FULL pollution-sensitive suite** (Cancellation/FirstRunDecode/CacheRead/LaunchSnapshot/StateMachineWiring) + mutation gate | **run in CI** — worktree can't build the Adobe host. **CI must be green before merge.** |

## Review rigor

`/rigorous-fix`: fix-contract → architect pre-review **BLOCKED** (missing preload/snapshotResolver facades = ~21 broken sites; the drain-flag verbatim-relocation trap; a missing COPPA-age-check closure) → corrected → **APPROVED** → implement → 3× SoD (`architect`, `qa_test`, `blast_radius`). Session-spawned agent reviewers (the `[Self-Approval]` flag is the known false-positive), not an independent human review.

## Flagged for review

`currentUserAccountProvider`'s **unreachable** `[weak self]==nil` fallback uses `TPPUserAccount.sharedAccount()` (the checklist discourages `sharedAccount()` in new code). It is never hit at runtime — the hub-owned loader is always alive when it calls the provider — and no non-hub `TPPUserAccount` exists (a strong capture would retain-cycle). Surfaced for the reviewers to rule on.

## Not in this PR

The last two 3a collaborators: `AccountCredentialResolver`, `CurrentAccountStore`. `Account._setState` write-side injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
