### PR TITLE
chore(ratchets): make god-class decomposition detectors comment-aware

### DIFF
--- a/scripts/check-appcontainer-locator-count.sh
+++ b/scripts/check-appcontainer-locator-count.sh
@@ -16,6 +16,11 @@
 #
 # What is counted: occurrences of `AppContainer.production()` in Palace/*.swift,
 # EXCLUDING:
+#   - matches inside COMMENTS — `//`/`///` line comments and block-comment lines.
+#     Naming `AppContainer.production()` in a doc comment (explaining why NOT to use it,
+#     say) is documentation, not a locator call; counting it produced false-positive
+#     freezes during the decomposition. (Residual: a same-line trailing `/* … */` block
+#     is still counted — rare.)
 #   - files whose repo-relative path matches an allowlist entry (composition roots:
 #     AppContainer.swift itself, the app/scene delegates — see the allowlist file),
 #   - lines that are an `@Environment` default (SwiftUI environment default value),
@@ -51,6 +56,15 @@ MODE="${1:-}"
 
 [ -d "$SCAN_ROOT" ] || { echo "[locator] ERROR: scan root not found: $SCAN_ROOT"; exit 2; }
 
+# Strip Swift comments so `AppContainer.production()` named in a comment isn't counted:
+# drop block-comment lines, then strip `//` line comments (only when `//` is at
+# line-start or preceded by whitespace, so `://` in a string URL survives). `//` is
+# unambiguously a comment in Swift, so this never removes a real call.
+strip_comments() {
+  awk '{ s=$0; sub(/^[[:space:]]+/,"",s); if (s ~ "^/?[*]") next; print }' \
+    | sed -E 's#(^|[[:space:]])//.*$#\1#'
+}
+
 path_allowlisted() {  # 0 (true) if $1 contains any allowlist entry
   local path="$1"
   [ -f "$ALLOWLIST" ] || return 1
@@ -69,9 +83,10 @@ count_locator() {
   local total=0 file
   while IFS= read -r file; do
     path_allowlisted "$file" && continue
-    # occurrences in this file that are NOT @Environment defaults
+    # occurrences in this file (comments stripped) that are NOT @Environment defaults
     local c
-    c="$(grep -nE 'AppContainer\.production\(\)' "$file" 2>/dev/null \
+    c="$(strip_comments < "$file" \
+          | grep -E 'AppContainer\.production\(\)' \
           | grep -vE '@Environment' \
           | grep -oE 'AppContainer\.production\(\)' | wc -l | tr -d ' ')"
     total=$((total + c))
@@ -84,7 +99,7 @@ list_locator() {
   local file c
   while IFS= read -r file; do
     path_allowlisted "$file" && continue
-    c="$(grep -nE 'AppContainer\.production\(\)' "$file" 2>/dev/null | grep -vE '@Environment' | grep -cE 'AppContainer\.production\(\)' || true)"
+    c="$(strip_comments < "$file" | grep -E 'AppContainer\.production\(\)' | grep -vE '@Environment' | grep -cE 'AppContainer\.production\(\)' || true)"
     [ "${c:-0}" -gt 0 ] && printf '%4d  %s\n' "$c" "$file"
   done < <(grep -rlE 'AppContainer\.production\(\)' "$SCAN_ROOT" --include='*.swift' --exclude-dir='Packages' 2>/dev/null) | sort -rn
 }

--- a/scripts/check-godclass-loc-freeze.sh
+++ b/scripts/check-godclass-loc-freeze.sh
@@ -14,10 +14,18 @@
 #                          ratchet the baseline down (this script never rewrites
 #                          the baseline — a ratchet only tightens by hand).
 #
-# Counts are read LIVE from the tree (wc -l), so no generated state to drift.
+# Counts are read LIVE from the tree, so no generated state to drift.
+#
+# LINE COUNTING: CODE lines only — blank lines and comment-only lines (`//`, `///`,
+# and block-comment bodies `/* … * … */`) are NOT counted. This is deliberate
+# (retires the "Wave 0 debt" noted in the baseline file): a doc-comment or blank-line
+# edit must not trip the freeze, because those are the opposite of the hub accretion
+# this ratchet exists to stop. Only executable/declaration lines move the number.
+# (Residual: a block-comment continuation line that starts with neither `*` nor
+# whitespace-then-`*` is counted as code — rare; Swift block comments align on `*`.)
 #
 # Baseline file (checked in): scripts/godclass-loc-baseline.txt
-#   Format, one file per line:   <loc><whitespace><repo-relative-path>
+#   Format, one file per line:   <code-loc><whitespace><repo-relative-path>
 #   '#' comments and blank lines ignored.
 #
 # Usage:
@@ -40,10 +48,20 @@ MODE="${1:-}"
 
 [ -f "$BASELINE" ] || { echo "[godclass-loc] ERROR: baseline not found: $BASELINE"; exit 2; }
 
-loc_of() {  # live line count of a file, 0 if missing
+loc_of() {  # live CODE-line count (non-blank, non-comment-only); -1 if missing
   local p="$1"
   [ -f "$p" ] || { echo "-1"; return; }
-  wc -l < "$p" | tr -d ' '
+  awk '
+    {
+      s = $0
+      sub(/^[[:space:]]+/, "", s)   # left-trim
+      if (s == "")            next  # blank
+      if (s ~ "^//")          next  # // or /// line comment
+      if (s ~ "^/?[*]")       next  # /* start, * body, */ end
+      n++
+    }
+    END { print n + 0 }
+  ' "$p"
 }
 
 FAIL=0

--- a/scripts/check-shared-read-count.sh
+++ b/scripts/check-shared-read-count.sh
@@ -14,6 +14,12 @@
 #
 # What is counted: occurrences of `<UpperCamelType>.shared` in Palace/*.swift,
 # EXCLUDING:
+#   - matches inside COMMENTS — `//`/`///` line comments (trailing or full-line) and
+#     block-comment lines (`/* … * … */`). A `.shared` mention in a doc comment is
+#     documentation, not a coupling edge; counting it penalizes accurate comments and
+#     produced repeated false-positive freezes during the decomposition. (Residual: a
+#     `.shared` on the SAME line after code but inside a trailing `/* … */` block, or a
+#     non-`*`-aligned block-comment continuation line, is still counted — rare.)
 #   - anything under Palace/Packages/ (SPM packages — already the target shape),
 #   - the platform/system singletons listed in SYS_EXCLUDE below (UIApplication,
 #     URLSession, URLCache, HTTPCookieStorage, FileManager, NotificationCenter,
@@ -47,12 +53,28 @@ SYS_EXCLUDE='^(UIApplication|URLSession|URLCache|HTTPCookieStorage|FileManager|N
 
 [ -d "$SCAN_ROOT" ] || { echo "[shared-read] ERROR: scan root not found: $SCAN_ROOT"; exit 2; }
 
+# Strip Swift comments so a `.shared` mention in a comment isn't counted as a read:
+#   1. drop block-comment lines (trimmed line starts with `*`, `*/`, or `/*`),
+#   2. strip trailing/full `//` line comments — only when `//` is at line-start or
+#      preceded by whitespace, so `://` inside a string URL is preserved.
+# `//` is unambiguously a comment in Swift (there is no `//` operator), so this never
+# strips real code. Line-oriented, so it is safe over cat-concatenated files.
+strip_comments() {
+  awk '{ s=$0; sub(/^[[:space:]]+/,"",s); if (s ~ "^/?[*]") next; print }' \
+    | sed -E 's#(^|[[:space:]])//.*$#\1#'
+}
+
+# Concatenate all non-Packages Swift files, strip comments, then count occurrences.
+shared_reads() {
+  find "$SCAN_ROOT" -type f -name '*.swift' -not -path '*/Packages/*' -print0 2>/dev/null \
+    | xargs -0 cat 2>/dev/null \
+    | strip_comments \
+    | grep -oE '[A-Z][A-Za-z0-9_]*\.shared' \
+    | grep -vE "$SYS_EXCLUDE"
+}
+
 count_shared() {
-  # One match per occurrence (grep -o); exclude Packages dir + system types.
-  grep -rhoE '[A-Z][A-Za-z0-9_]*\.shared' "$SCAN_ROOT" \
-      --include='*.swift' --exclude-dir='Packages' 2>/dev/null \
-    | grep -vE "$SYS_EXCLUDE" \
-    | wc -l | tr -d ' '
+  shared_reads | wc -l | tr -d ' '
 }
 
 CUR="$(count_shared)"
@@ -72,9 +94,8 @@ if [ "$CUR" -gt "$BASE" ]; then
   echo "[shared-read] FAIL: non-system \`.shared\` reads went UP: $BASE -> $CUR (+$((CUR - BASE)))."
   echo "  This ratchet is monotone-down. Inject the dependency via an AppContainer seam"
   echo "  instead of reaching for \`.shared\` (see decomposition plan §3c)."
-  echo "  New reads (sample):"
-  grep -rnE '[A-Z][A-Za-z0-9_]*\.shared' "$SCAN_ROOT" --include='*.swift' --exclude-dir='Packages' 2>/dev/null \
-    | grep -vE "$SYS_EXCLUDE" | grep -oE '[A-Z][A-Za-z0-9_]*\.shared' | sort | uniq -c | sort -rn | head -15
+  echo "  Reads by type (sample, comments excluded):"
+  shared_reads | sort | uniq -c | sort -rn | head -15
   exit 1
 fi
 

--- a/scripts/godclass-appcontainer-locator-baseline.txt
+++ b/scripts/godclass-appcontainer-locator-baseline.txt
@@ -15,4 +15,8 @@
 # Wave 3 / 3a-4 (AccountRegistryLoader extraction): 304 -> 302. Two `AppContainer.production()`
 # reaches left AccountsManager with the relocated load bodies (into the new, unfrozen
 # AccountRegistryLoader.swift), so the hub's out-of-allowlist count drops by 2.
-302
+# 2026-07-31: detector now strips comments before matching, so `AppContainer.production()`
+#   named in a doc/line comment (e.g. the S2b AccountScope rationale prose above) is no
+#   longer counted — it is documentation, not a locator call. Re-baselined 302 -> 256 by
+#   that recount alone: a pure measurement correction, not 46 removed call sites.
+256

--- a/scripts/godclass-loc-baseline.txt
+++ b/scripts/godclass-loc-baseline.txt
@@ -1,8 +1,18 @@
 # God-class LOC freeze baseline — Wave 0 ratchet.
 # Consumed by scripts/check-godclass-loc-freeze.sh.
-# Format: <loc> <repo-relative-path>. A file may NOT exceed its count.
+# Format: <code-loc> <repo-relative-path>. A file may NOT exceed its count.
 # When a file SHRINKS, the script prints the new number; ratchet this DOWN by hand.
-# Captured 2026-07-23 (live wc -l). See docs/architecture/god-class-decomposition-plan.md §3a.
+# Captured 2026-07-23. See docs/architecture/god-class-decomposition-plan.md §3a.
+#
+# ┌── 2026-07-31: COUNTING CHANGED to CODE LINES, all numbers recomputed ──────────┐
+# │ The detector now counts non-blank, non-comment-only lines (see the script      │
+# │ header), retiring the "Wave 0 debt" flagged in the Wave 1a note below. The      │
+# │ per-wave narrative in this file was written against the OLD physical `wc -l`    │
+# │ counts and is preserved as the campaign's decision ledger — but the six NUMBERS │
+# │ at the bottom are now CODE lines and are NOT comparable to the deltas below.    │
+# │ For the physical-line history, see this file's git log. The freeze still only   │
+# │ tightens by hand; a doc-comment or blank-line edit no longer moves the number.  │
+# └────────────────────────────────────────────────────────────────────────────────┘
 # Wave 1a (+1 on 4 files): each gained a single `import PalacePreferences` line when
 # TPPSettings moved to the leaf package — a decomposition import that REDUCES coupling,
 # not accretion. Re-baselined by exactly the import delta. (Follow-up: make the ratchet
@@ -113,9 +123,12 @@
 #   NEGATIVE at the 3a/3b package move, when the MBDC cluster leaves the hub for
 #   PalaceDownloads and the account-scope wiring goes with it. Re-baselined by the exact
 #   delta; the freeze still catches any further unrelated growth.
-3093 Palace/Audiobooks/AudiobookSessionManager.swift
-915 Palace/Accounts/Library/AccountsManager.swift
-2184 Palace/MyBooks/MyBooksDownloadCenter.swift
-1378 Palace/Book/UI/BookDetail/BookDetailViewModel.swift
-1261 Palace/SignInLogic/TPPSignInBusinessLogic.swift
-968 Palace/MyBooks/BorrowOperation.swift
+# Code-line counts (2026-07-31 recount). Physical `wc -l` at this same tree was:
+#   AudiobookSessionManager 3093, AccountsManager 915, MyBooksDownloadCenter 2184,
+#   BookDetailViewModel 1378, TPPSignInBusinessLogic 1261, BorrowOperation 968.
+1571 Palace/Audiobooks/AudiobookSessionManager.swift
+374 Palace/Accounts/Library/AccountsManager.swift
+1244 Palace/MyBooks/MyBooksDownloadCenter.swift
+966 Palace/Book/UI/BookDetail/BookDetailViewModel.swift
+638 Palace/SignInLogic/TPPSignInBusinessLogic.swift
+575 Palace/MyBooks/BorrowOperation.swift

--- a/scripts/godclass-shared-read-baseline.txt
+++ b/scripts/godclass-shared-read-baseline.txt
@@ -19,4 +19,8 @@
 # MBDC `.shared` read inverted via the account-scope seam is offset by a `.shared`
 # mention in the new MyBooksDownloadCenter+AccountScope.swift rationale (the detector
 # counts prose too — Wave-0 debt noted above). Baseline held at the measured 213.
-213
+# 2026-07-31: THAT WAVE-0 DEBT IS NOW RETIRED — the detector strips comments before
+#   matching, so a `.shared` named in a doc/line comment (like the S2b rationale prose
+#   above) is no longer counted as a read. Re-baselined 213 -> 164 by that recount alone:
+#   a pure measurement correction, not 49 removed reads.
+164

--- a/scripts/tests/test_check_appcontainer_locator_count.py
+++ b/scripts/tests/test_check_appcontainer_locator_count.py
@@ -128,6 +128,28 @@ def test_empty_allowlist_counts_the_root_file(tmp_path):
     assert r.stdout.strip() == "3", r.stdout
 
 
+def test_comment_mentions_not_counted(tmp_path):
+    """THE FIX: `AppContainer.production()` named in a `//`, `///`, or block comment is
+    documentation (often warning against its use), not a locator call — only the one
+    real call site counts."""
+    root = tmp_path / "Palace" / "Book"
+    root.mkdir(parents=True)
+    (root / "Doc.swift").write_text(
+        "let am = AppContainer.production().accountsManager\n"          # 1 real call
+        "// Do NOT reach for AppContainer.production() outside a root.\n"  # line comment
+        "let y = 1  // AppContainer.production() also mentioned here\n"    # trailing comment
+        "/// Inject instead of calling AppContainer.production().\n"       # doc comment
+        "/* AppContainer.production() named in a block comment */\n"       # block comment
+    )
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("1\n")
+    empty = tmp_path / "empty.txt"
+    empty.write_text("# none\n")
+    r = _run(tmp_path / "Palace", baseline, empty, mode="--count")
+    assert r.returncode == 0
+    assert r.stdout.strip() == "1", r.stdout
+
+
 def test_live_repo_baseline_passes():
     """Checked-in baseline + allowlist must PASS against today's Palace/ tree."""
     r = subprocess.run(["bash", str(_SCRIPT)], capture_output=True, text=True, timeout=60)

--- a/scripts/tests/test_check_godclass_loc_freeze.py
+++ b/scripts/tests/test_check_godclass_loc_freeze.py
@@ -37,8 +37,9 @@ def _run(root: Path, baseline: Path) -> subprocess.CompletedProcess:
 
 
 def _make_swift(path: Path, lines: int) -> None:
+    """Write `lines` CODE lines (the detector counts non-blank, non-comment lines)."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("\n".join(f"// line {i}" for i in range(lines)) + "\n")
+    path.write_text("\n".join(f"let v{i} = {i}" for i in range(lines)) + "\n")
 
 
 def test_script_passes_bash_syntax_check():
@@ -85,12 +86,51 @@ def test_missing_baselined_file_fails(tmp_path):
     assert "MISSING" in r.stdout
 
 
-def test_comments_and_blanks_ignored(tmp_path):
+def test_baseline_file_comments_and_blanks_ignored(tmp_path):
+    """`#` comments / blank lines in the BASELINE FILE are skipped when parsing it."""
     _make_swift(tmp_path / "Palace" / "God.swift", 100)
     baseline = tmp_path / "baseline.txt"
     baseline.write_text("# a comment\n\n100 Palace/God.swift\n")
     r = _run(tmp_path, baseline)
     assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_source_comments_and_blanks_do_not_count(tmp_path):
+    """THE FIX: a source file whose ONLY additions are doc comments and blank lines
+    keeps the same code-line count — a doc edit must not trip the freeze. Here 50 code
+    lines are interleaved with 100 comment/blank lines (150 physical) yet still count 50."""
+    path = tmp_path / "Palace" / "God.swift"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = []
+    for i in range(50):
+        body.append(f"let v{i} = {i}    // trailing doc for v{i}")
+        body.append(f"  /// full-line doc comment {i}")
+        body.append("")
+    path.write_text("\n".join(body) + "\n")
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("50 Palace/God.swift\n")
+    r = _run(tmp_path, baseline)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "PASS" in r.stdout
+
+
+def test_block_comment_body_lines_do_not_count(tmp_path):
+    """Block-comment bodies (`/* … * … */`) are not code lines."""
+    path = tmp_path / "Palace" / "God.swift"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "let a = 1\n"
+        "/*\n"
+        " * a long block comment\n"
+        " * spanning several lines\n"
+        " */\n"
+        "let b = 2\n"
+    )
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("2 Palace/God.swift\n")  # only `let a` + `let b`
+    r = _run(tmp_path, baseline)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "PASS" in r.stdout
 
 
 def test_live_repo_baseline_passes():

--- a/scripts/tests/test_check_shared_read_count.py
+++ b/scripts/tests/test_check_shared_read_count.py
@@ -111,6 +111,38 @@ def test_baseline_comments_ignored(tmp_path):
     assert r.returncode == 0, r.stdout + r.stderr
 
 
+# One real read; the rest are `.shared` mentions inside comments that must NOT count.
+_BODY_COMMENTS = """
+let real = AccountStateStore.shared
+// Prefer the injected seam over RemoteFeatureFlags.shared here.
+let x = 1  // legacy path used ImageCache.shared before the extraction
+/// doc: TPPBookCoverRegistry.shared is the old ambient reach
+/* AnotherStore.shared named in a block comment */
+"""
+
+
+def test_comment_mentions_not_counted(tmp_path):
+    """THE FIX: a `.shared` named in a `//`, `///`, or block comment is documentation,
+    not a read — only the one real `AccountStateStore.shared` counts."""
+    root = _scan_root(tmp_path, _BODY_COMMENTS)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("1\n")
+    r = _run(root, baseline, mode="--count")
+    assert r.returncode == 0
+    assert r.stdout.strip() == "1", r.stdout
+
+
+def test_url_double_slash_not_mistaken_for_comment(tmp_path):
+    """A `://` inside a string URL must not be treated as a comment start, so a real
+    read on the same line is still counted."""
+    body = 'let u = URL(string: "https://x.example/shared")!; let r = ImageCache.shared\n'
+    root = _scan_root(tmp_path, body)
+    baseline = tmp_path / "b.txt"
+    baseline.write_text("1\n")
+    r = _run(root, baseline, mode="--count")
+    assert r.stdout.strip() == "1", r.stdout
+
+
 def test_live_repo_baseline_passes():
     """Checked-in baseline must PASS against today's Palace/ tree."""
     r = subprocess.run(["bash", str(_SCRIPT)], capture_output=True, text=True, timeout=60)


### PR DESCRIPTION
## What & why

The three Wave-0 god-class decomposition ratchets counted **comments as code**, so editing documentation tripped them. This recurred repeatedly during the 3a `AccountsManager` campaign — a `.shared` or `AppContainer.production()` *named in a doc comment* reddened the gate — and the shared-read baseline note even held the count at 213 to absorb one prose mention. A detector that penalizes accurate comments trains you to write worse ones.

## Changes

- **check-godclass-loc-freeze.sh** — counts **code lines** (non-blank, non-comment-only) instead of raw `wc -l`. Retires the "Wave 0 debt" the baseline itself flagged. A doc-comment/blank-line edit no longer moves the number. Baselines recomputed to code lines (e.g. AccountsManager 915 physical → 374 code).
- **check-appcontainer-locator-count.sh** + **check-shared-read-count.sh** — strip Swift comments before matching (`//`/`///`, only when `//` is at line-start or after whitespace so `://` in URLs survives; plus block-comment lines). Baselines recomputed by that measurement correction alone: locator **302 → 256**, shared-read **213 → 164** — *not* removed call sites, the same tree counted correctly.

## Proof it bites

On a 5-line fixture (1 real read + 4 `.shared` comment mentions) the **old** grep counted **5**, the **new** logic counts **1**. New pytests pin the comment-mention exclusion + URL-`://` preservation for all three detectors; the god-class fixture now emits code lines, and a new test proves 50 code lines interleaved with 100 comment/blank lines still counts 50.

## Verification

- `pytest scripts/tests/test_check_*` → **26/26 pass** (includes the live-repo-baseline tests, so the recomputed baselines PASS against develop).
- CI runs these via `.github/workflows/tooling-checks.yml` (`pytest scripts/tests/`).
- Behaviour change is measurement-only; the monotone-down gate semantics are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>