### PR TITLE
fix(audiobooks/network): position-sync tie discards reading position; async bridges ignore Task cancellation

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -523,7 +523,6 @@
 		596F8091A2B3C4D5E6F70718 /* BookReturnService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7081A2B3C4D5E6F7081929 /* BookReturnService.swift */; };
 		5977FE52E5B43328E7773533 /* TPPReaderFootnoteAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */; };
 		59E2E27CBD048ACE94D0101C /* BookRegistryReconciliationTableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93A849278441815AA82A2FE /* BookRegistryReconciliationTableTests.swift */; };
-		5A6C30A999D9E0264FD78074 /* ActiveSessionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A72A97BA91A0EB66D642A06 /* ActiveSessionsViewModelTests.swift */; };
 		5AD42A9111A49CFDF0AC22B1 /* AdobeRightsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E62D6F6D6313094B90E80E5 /* AdobeRightsParser.swift */; };
 		5ADD8B5E1F4D8868B3FEA17F /* PoolResponsivenessProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01209A378C5A59B2AA08C13D /* PoolResponsivenessProbeTests.swift */; };
 		5AE6D7440F7AEDED5F21C570 /* CredentialSnapshotInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1063BE37AED8A85F5812F422 /* CredentialSnapshotInvalidationTests.swift */; };
@@ -1164,6 +1163,7 @@
 		BE401A7E2026050601000001 /* URL+BackupExclusion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE401A7D2026050601000000 /* URL+BackupExclusion.swift */; };
 		BE401A7F2026050601000002 /* URL+BackupExclusion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE401A7D2026050601000000 /* URL+BackupExclusion.swift */; };
 		BE402A8E2026050601000003 /* URL+BackupExclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE402A8D2026050601000004 /* URL+BackupExclusionTests.swift */; };
+		BE83E8BB3D027F097CA50A69 /* TPPNetworkExecutorCancellationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311C22277A57709E36DC54F7 /* TPPNetworkExecutorCancellationTests.swift */; };
 		BED408AC57A5DB39579B5FEA /* TPPBookRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5550F79A349D3D7ADE48B5E1 /* TPPBookRegistryTests.swift */; };
 		BF0FD554A5AA86C241E2CA9F /* StatsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCA63D51A4176FB08ED1941 /* StatsTab.swift */; };
 		BF2B5B79D36596C9F06C43A5 /* ReadingStatsServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCA7B3D060EF65547DF53DA /* ReadingStatsServiceProtocol.swift */; };
@@ -2443,6 +2443,7 @@
 		2FF4CC60E96981C8BF94891C /* BadgeDefinitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeDefinitionTests.swift; sourceTree = "<group>"; };
 		3023DFFACC986541965F1560 /* OPDS2PublicationExtended.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OPDS2PublicationExtended.swift; path = OPDS2/Models/OPDS2PublicationExtended.swift; sourceTree = "<group>"; };
 		30B163B18C48334A913B2CCA /* URLRequestNYPLAdditionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLRequestNYPLAdditionsTests.swift; sourceTree = "<group>"; };
+		311C22277A57709E36DC54F7 /* TPPNetworkExecutorCancellationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPNetworkExecutorCancellationTests.swift; sourceTree = "<group>"; };
 		317C8F0150303A9AC53BC44F /* MyBooksDownloadCenterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterTests.swift; sourceTree = "<group>"; };
 		317F2DC09E9CFECAF62DA385 /* BookDetailOpenRoutingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookDetailOpenRoutingTests.swift; sourceTree = "<group>"; };
 		3183C58974AE89BE550AC866 /* XCTestCase+testUserDefaults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCTestCase+testUserDefaults.swift"; sourceTree = "<group>"; };
@@ -3025,8 +3026,8 @@
 		B7A89DC26D262DB004F837CA /* DownloadReconciliationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadReconciliationTests.swift; sourceTree = "<group>"; };
 		B83C63AD7FC1676713DBCC77 /* CatalogDomainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogDomainTests.swift; sourceTree = "<group>"; };
 		B8C7D6E5F4A3B2C1D0E9F8A7 /* MyBooksDownloadCenterConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyBooksDownloadCenterConcurrencyTests.swift; sourceTree = "<group>"; };
-		B9AA2BDEDE93EDA644183E61 /* PalaceHapticTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalaceHapticTests.swift; sourceTree = "<group>"; };
 		B93A849278441815AA82A2FE /* BookRegistryReconciliationTableTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookRegistryReconciliationTableTests.swift; sourceTree = "<group>"; };
+		B9AA2BDEDE93EDA644183E61 /* PalaceHapticTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PalaceHapticTests.swift; sourceTree = "<group>"; };
 		B9AGENT02FR000000000001 /* PalaceErrorExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceErrorExtendedTests.swift; sourceTree = "<group>"; };
 		B9AGENT03FR000000000001 /* KeyboardNavigationFKATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardNavigationFKATests.swift; sourceTree = "<group>"; };
 		B9D57F2C8786C1776E06659D /* TPPCirculationAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TPPCirculationAnalytics.swift; path = Service/TPPCirculationAnalytics.swift; sourceTree = "<group>"; };
@@ -3839,6 +3840,7 @@
 				1582EB5A4DE21F7E9F715EE0 /* NetworkCacheClearRoutingTests.swift */,
 				3248EFDDABC9F2BE1324CA2A /* TPPNetworkExecutorConcurrencyTests.swift */,
 				BE12F746B54CDA3922AE8C5F /* TPPNetworkResponderSizeLimitTests.swift */,
+				311C22277A57709E36DC54F7 /* TPPNetworkExecutorCancellationTests.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -8101,6 +8103,7 @@
 				59E2E27CBD048ACE94D0101C /* BookRegistryReconciliationTableTests.swift in Sources */,
 				CDCEBFF95761AE244D04DE75 /* BookCellModelLCPProgressTests.swift in Sources */,
 				B2B83791BFBF163B523E1711 /* MarqueeTextTests.swift in Sources */,
+				BE83E8BB3D027F097CA50A69 /* TPPNetworkExecutorCancellationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1254,6 +1254,7 @@
 		CD4E1D9ADBC4CF7A4614111C /* StreamingReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7955F7FD669DC987C9238D /* StreamingReaderViewModel.swift */; };
 		CD666F12EA5723110B343D96 /* TokenRefreshInterceptorAuthCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7EB324FFEC1D9BBC05AECF1 /* TokenRefreshInterceptorAuthCoordinatorTests.swift */; };
 		CD7941AC6AF75D498104A787 /* BorrowReducerCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1F974717220248950A874F /* BorrowReducerCore.swift */; };
+		CDC32D621888C8E2DA9224B5 /* AccountRegistryStorePoolStarvationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E2A79BCE7E6D2BED9582E3 /* AccountRegistryStorePoolStarvationTests.swift */; };
 		CDCEBFF95761AE244D04DE75 /* BookCellModelLCPProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BBD6628B9E9766FE5B910F /* BookCellModelLCPProgressTests.swift */; };
 		CDE41C3AEC1783FB1D454686 /* CrossFormatMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFD104EE843356CD66327E6 /* CrossFormatMappingTests.swift */; };
 		CDEC308487806981D7C85FB9 /* SignInModalPresenter+SignInModalPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12CC78F892CA5C26671BE206 /* SignInModalPresenter+SignInModalPresenting.swift */; };
@@ -2154,6 +2155,7 @@
 		02415B1E145D716015754AFF /* Account+TPPLibraryAccountReadable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Account+TPPLibraryAccountReadable.swift"; sourceTree = "<group>"; };
 		02B8F946D19048E4AE73B6C7 /* TPPSettingsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPSettingsMock.swift; sourceTree = "<group>"; };
 		02C35CC60B407DEE9F38BE6E /* MarqueeTextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarqueeTextTests.swift; sourceTree = "<group>"; };
+		02E2A79BCE7E6D2BED9582E3 /* AccountRegistryStorePoolStarvationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountRegistryStorePoolStarvationTests.swift; sourceTree = "<group>"; };
 		0345BFD61DBF002E00398B6F /* APIKeys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIKeys.swift; sourceTree = "<group>"; };
 		036520F6ED04D581E2F1C8BC /* TabBarModernizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabBarModernizationTests.swift; sourceTree = "<group>"; };
 		03690E221EB2B35000F75D5F /* TPPReaderBookmarkCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPReaderBookmarkCell.swift; sourceTree = "<group>"; };
@@ -4359,6 +4361,7 @@
 				822C34E7CB9D9E06317B7722 /* CatalogCrawlSchedulerTests.swift */,
 				A64CF3480F3F5C70A6227526 /* AccountsManagerCatalogLoadJoinTests.swift */,
 				BF3A15BCE8862A26CC2EF7A6 /* AccountCredentialResolverTests.swift */,
+				02E2A79BCE7E6D2BED9582E3 /* AccountRegistryStorePoolStarvationTests.swift */,
 			);
 			path = Accounts;
 			sourceTree = "<group>";
@@ -8104,6 +8107,7 @@
 				CDCEBFF95761AE244D04DE75 /* BookCellModelLCPProgressTests.swift in Sources */,
 				B2B83791BFBF163B523E1711 /* MarqueeTextTests.swift in Sources */,
 				BE83E8BB3D027F097CA50A69 /* TPPNetworkExecutorCancellationTests.swift in Sources */,
+				CDC32D621888C8E2DA9224B5 /* AccountRegistryStorePoolStarvationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/Accounts/Library/AccountRegistryStore.swift
+++ b/Palace/Accounts/Library/AccountRegistryStore.swift
@@ -15,43 +15,95 @@
 //  A `final class`, NOT an `actor`, and NOT a protocol: `AccountsManager.account(_:)`
 //  is a SYNCHRONOUS `@objc TPPLibraryAccountsProvider` requirement, and the
 //  background-work drain choreography (`cancelAndDrainBackgroundWork`) depends on a
-//  synchronous `accountSetsLock.sync` read blocking behind the barrier — an actor
-//  would force `await` through the `@objc` conformance and delete that timing. The
-//  store therefore OWNS the same concurrent `DispatchQueue` and preserves the exact
-//  sync-read / `.async(flags:.barrier)`-write model verbatim. It is pure in-target
+//  synchronous read — an actor would force `await` through the `@objc` conformance
+//  and delete that timing.
+//
+//  The reads remain synchronous, but the primitive changed: a `ReadWriteLock`
+//  (pthread_rwlock) the CALLING thread takes, instead of `.sync` on a concurrent
+//  `DispatchQueue`. `.sync` had to wait for any QUEUED `.barrier`, and a barrier
+//  needs a GCD worker thread; with Swift Tasks as the readers, each blocked reader
+//  held one cooperative-pool thread (pool width == core count) until the pool was
+//  exhausted and the barrier could not be scheduled at all. Reads now block only
+//  for an actively-held write, never on thread availability.
+//
+//  Writes are SYNCHRONOUS under the write lock. That is load-bearing, not an
+//  incidental simplification: the old model shared ONE queue between reads and
+//  writes, so a `.sync` read queued behind a pending `.barrier` and callers got
+//  read-after-write ordering for free. Dispatching writes to a separate queue
+//  silently removed that ordering and broke 14 AccountsManager/registry tests.
+//  Taking the write lock on the calling thread restores it — and needs no worker
+//  thread, which is what the read path required anyway. It is pure in-target
 //  state with no outward app-target edge, so it is a concrete injected instance
 //  (like `AccountStateStore`) and travels into `PalaceAccounts` with the hub.
 //
 //  `@unchecked Sendable` invariant: the only mutable state is `_currentHash`,
-//  `accountSets`, and `accountByUUID`, read exclusively via `accountSetsLock.sync`
-//  (`performRead`) and written exclusively on the serial `.barrier` of the concurrent
-//  `accountSetsLock` (`performWrite` / `mutate`); `accountByUUID` is rebuilt inside the
-//  SAME barrier as `accountSets` so the two never desync. `slimAccountsByUUID` is
+//  `accountSets`, and `accountByUUID`, read exclusively under the `accountSetsLock`
+//  read lock (`performRead`) and written exclusively under its write lock
+//  (`performWrite` / `mutate`); `accountByUUID` is
+//  rebuilt inside the SAME write critical section as `accountSets` so the two never
+//  desync. `slimAccountsByUUID` is
 //  guarded by its own `slimAccountsLock` NSLock — deliberately separate so the
 //  `account(_:)` full-index read and the slim fallback never contend on one lock; the
 //  slim set is a launch fallback only and never flips `currentBucketIsLoaded`. All
-//  boxed closures are invoked exactly once on that serial barrier, never concurrently.
+//  boxed closures are invoked exactly once, on the serial write queue under the
+//  write lock, never concurrently.
 //
 //  Copyright © 2026 The Palace Project. All rights reserved.
 //
 
 import Foundation
 
-/// Documented carrier for a non-Sendable `() -> Void` handed to the `accountSetsLock`
-/// barrier in `performWrite`. `@unchecked Sendable` invariant: the wrapped closure is
-/// invoked exactly once, on the serial barrier of the concurrent `accountSetsLock`,
-/// never concurrently.
+/// Documented carrier for a non-Sendable `() -> Void` handed to the write critical
+/// section in `performWrite`. `@unchecked Sendable` invariant: the wrapped closure is
+/// invoked exactly once, under the `accountSetsLock` write lock, never
+/// concurrently.
 private struct VoidWorkBox: @unchecked Sendable {
     let work: () -> Void
 }
 
 /// Documented carrier for the non-Sendable `(inout [String: [Account]]) -> Void`
-/// mutation closure handed to the `accountSetsLock` barrier in `mutate`. Same
+/// mutation closure handed to the write critical section in `mutate`. Same
 /// `@unchecked Sendable` invariant as `VoidWorkBox`: invoked exactly once, on the
-/// serial `.barrier`, never concurrently. Timing and the mutate-then-rebuild-index
-/// contract are unchanged.
+/// write lock, never concurrently. The mutate-then-rebuild-index contract is
+/// unchanged.
 private struct AccountSetsMutationBox: @unchecked Sendable {
     let mutate: (inout [String: [Account]]) -> Void
+}
+
+/// Reader/writer lock the CALLING thread takes itself.
+///
+/// This exists because `DispatchQueue.sync` does not. A `.sync` read on a
+/// concurrent queue must wait for any queued `.barrier`, and that barrier needs a
+/// GCD WORKER THREAD to run. When the readers are Swift Tasks, each blocked
+/// reader occupies one cooperative-pool thread — and that pool's width is the
+/// core count. Enough concurrent readers and every worker is parked waiting for a
+/// barrier that cannot be scheduled, because the threads it needs are the ones
+/// parked. It unwedges only when GCD slowly grows the pool.
+///
+/// Measured: 24 threads (== core count) in `__ulock_wait` inside `performRead`
+/// with NO barrier running, and 189-404 SECOND whole-worker freezes in CI between
+/// two 0.001s tests of an unrelated suite.
+///
+/// `pthread_rwlock` needs no worker thread — the caller acquires it directly — so
+/// a reader can never be waiting on work that requires the thread it is holding.
+/// Concurrent readers and reader/writer exclusion are unchanged.
+private final class ReadWriteLock: @unchecked Sendable {
+    private var lock = pthread_rwlock_t()
+
+    init() { pthread_rwlock_init(&lock, nil) }
+    deinit { pthread_rwlock_destroy(&lock) }
+
+    func read<T>(_ block: () -> T) -> T {
+        pthread_rwlock_rdlock(&lock)
+        defer { pthread_rwlock_unlock(&lock) }
+        return block()
+    }
+
+    func write<T>(_ block: () -> T) -> T {
+        pthread_rwlock_wrlock(&lock)
+        defer { pthread_rwlock_unlock(&lock) }
+        return block()
+    }
 }
 
 /// Thread-safe holder of the account-registry state. See the file header for the
@@ -59,7 +111,7 @@ private struct AccountSetsMutationBox: @unchecked Sendable {
 final class AccountRegistryStore: @unchecked Sendable {
 
     /// The current catalog hash (`prod` / `beta` / custom-URL). Written on the
-    /// barrier, read under `accountSetsLock` — bundled into ONE critical section with
+    /// write lock, read under it — bundled into ONE critical section with
     /// the bucket read by `accountsForCurrentHash` / `currentBucketIsLoaded` so a
     /// concurrent library switch can never key the bucket to a stale hash.
     private var _currentHash: String
@@ -67,13 +119,15 @@ final class AccountRegistryStore: @unchecked Sendable {
     private var accountSets = [String: [Account]]()
 
     /// O(1) `uuid → Account` index derived from `accountSets`, kept in lockstep with
-    /// it under `accountSetsLock` (rebuilt in the SAME barrier as any `accountSets`
+    /// it under `accountSetsLock` (rebuilt in the SAME write critical section as any `accountSets`
     /// mutation — see `mutate`). Lets `account(_:)` resolve a UUID without a linear
     /// scan over ~1142 accounts on the main-thread display path. MUST only change via
     /// `mutate` so it can never desync from `accountSets`.
     private var accountByUUID = [String: Account]()
 
-    private let accountSetsLock = DispatchQueue(label: "com.tpp.accountSetsLock", attributes: .concurrent)
+    /// Guards `_currentHash` / `accountSets` / `accountByUUID`. Taken directly by
+    /// the calling thread — see `ReadWriteLock` for why this is not a queue.
+    private let accountSetsLock = ReadWriteLock()
 
     /// Launch-hydration (CP-D1) slim lookup: the current + settings accounts (~2),
     /// decoded synchronously at launch so `currentAccount` resolves within a few ms.
@@ -91,14 +145,14 @@ final class AccountRegistryStore: @unchecked Sendable {
     // MARK: - Concurrency primitives (private)
 
     private func performRead<T>(_ block: () -> T) -> T {
-        return accountSetsLock.sync {
+        return accountSetsLock.read {
             block()
         }
     }
 
     private func performWrite(_ block: @escaping () -> Void) {
         let box = VoidWorkBox(work: block)
-        accountSetsLock.async(flags: .barrier) {
+        accountSetsLock.write {
             box.work()
         }
     }
@@ -135,7 +189,7 @@ final class AccountRegistryStore: @unchecked Sendable {
     }
 
     /// Accounts for the CURRENT hash, read ATOMICALLY: the hash and the bucket are
-    /// sampled in ONE `performRead`, so a library-switch barrier cannot land between
+    /// sampled in ONE `performRead`, so a library-switch write cannot land between
     /// them and key the bucket to a stale hash. Do NOT reimplement as
     /// `accounts(forKey: currentHash)` — that is two separate lock acquisitions.
     func accountsForCurrentHash() -> [Account] {
@@ -157,12 +211,15 @@ final class AccountRegistryStore: @unchecked Sendable {
     // MARK: - Writes
 
     /// The ONLY sanctioned way to mutate `accountSets`. Applies `mutate` inside the
-    /// `accountSetsLock` barrier, then rebuilds `accountByUUID` in the SAME critical
+    /// `accountSetsLock` write lock, then rebuilds `accountByUUID` in the SAME critical
     /// section so the two can never desync. Adding a write that bypasses this silently
     /// breaks `account(_:)` lookups (guarded by the index-coherence tests).
     func mutate(_ mutate: @escaping (inout [String: [Account]]) -> Void) {
         let box = AccountSetsMutationBox(mutate: mutate)
-        accountSetsLock.async(flags: .barrier) {
+        // Index rebuilt inside the SAME critical section as the mutation, so a
+        // reader can never observe updated `accountSets` with a stale
+        // `accountByUUID` (pinned by the index-coherence tests).
+        accountSetsLock.write {
             box.mutate(&self.accountSets)
             self.accountByUUID = AccountRegistryStore.buildAccountIndex(self.accountSets)
         }

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -821,87 +821,200 @@ private final class ContinuationGuard {
     }
 }
 
+/// Bridges structured-concurrency cancellation into the completion-handler API.
+///
+/// A `CheckedContinuation` is resumed ONLY by its completion handler.
+/// `Task.cancel()` sets a flag; it cannot resume a suspended continuation. So a
+/// bare `withCheckedThrowingContinuation` bridge whose HTTP completion never
+/// fires leaves the awaiting Task suspended forever — and, because every
+/// `Task.isCancelled` check in a caller sits BETWEEN awaits, that task is
+/// permanently undrainable. `AccountRegistryLoader`'s crawl hit exactly this:
+/// `cancelAndDrainBackgroundWork TIMED OUT ... crawl did not observe cancellation`,
+/// repeating every 3s and degrading a whole test run.
+///
+/// This box makes cancellation terminal from either side, resuming exactly once:
+///   • the HTTP completion arrives  → `finish(_:)`
+///   • the awaiting Task is cancelled → `cancel()` cancels the URLSession task
+///     (when the underlying call exposes one) AND resumes with `CancellationError`.
+///
+/// Cancellation that arrives BEFORE the continuation is installed is retained
+/// and applied on `install(_:)`, so the early-cancel race cannot strand a caller.
+/// Mirrors `CancellableTaskBox` in `URLSessionNetworkClient`, which already
+/// solved this for the newer client.
+private final class CancellableContinuationBox<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    private var task: URLSessionTask?
+    nonisolated(unsafe) private var pendingResult: Result<T, Error>?
+    private var settled = false
+
+    /// Install the continuation. If cancellation (or a completion) already
+    /// landed, resume immediately rather than suspending forever.
+    func install(_ continuation: CheckedContinuation<T, Error>) {
+        lock.lock()
+        if let pending = pendingResult {
+            pendingResult = nil
+            lock.unlock()
+            continuation.resume(with: pending)
+            return
+        }
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    /// Store the in-flight request so cancellation can tear it down. If
+    /// cancellation already arrived, cancel it on the spot.
+    func setTask(_ task: URLSessionTask?) {
+        lock.lock()
+        if settled {
+            lock.unlock()
+            task?.cancel()
+            return
+        }
+        self.task = task
+        lock.unlock()
+    }
+
+    /// Resume with the network outcome. No-op once settled.
+    func finish(_ result: sending Result<T, Error>) {
+        lock.lock()
+        if settled { lock.unlock(); return }
+        settled = true
+        let continuation = self.continuation
+        self.continuation = nil
+        self.task = nil
+        // Consume `result` on exactly ONE path. Storing it and also resuming
+        // with it puts the same value in two regions, which the Swift 6 sending
+        // check rejects (`T` is not constrained Sendable here).
+        if let continuation {
+            lock.unlock()
+            continuation.resume(with: result)
+        } else {
+            pendingResult = result
+            lock.unlock()
+        }
+    }
+
+    /// Cancel the request and unblock the awaiting Task.
+    func cancel() {
+        lock.lock()
+        let inFlight = task
+        task = nil
+        lock.unlock()
+        inFlight?.cancel()
+        finish(.failure(CancellationError()))
+    }
+}
+
 // MARK: - Async/Await API
 
 extension TPPNetworkExecutor {
 
     /// Async version of GET that bridges to the completion-handler API.
     /// Timeout is handled by the URLSession configuration, not by a manual timer.
-    /// The `ContinuationGuard` ensures the continuation is resumed exactly
-    /// once even if a future regression in the completion path invokes the
-    /// callback twice (e.g. through the token-refresh / retry paths).
+    ///
+    /// `CancellableContinuationBox` makes the bridge cancellation-aware AND
+    /// resume-exactly-once (superseding the old `ContinuationGuard` here). Note
+    /// this overload's underlying call returns no `URLSessionDataTask`, so the
+    /// HTTP request is not torn down — but the awaiting Task is still unblocked,
+    /// which is what makes it drainable. A stray late completion is swallowed by
+    /// the box.
     func GET(_ reqURL: URL, useTokenIfAvailable: Bool = true) async throws -> (Data, URLResponse?) {
-        return try await withCheckedThrowingContinuation { continuation in
-            let guarded = ContinuationGuard()
-            GET(reqURL, useTokenIfAvailable: useTokenIfAvailable) { result in
-                guard guarded.tryConsume() else { return }
-                switch result {
-                case let .success(data, response):
-                    continuation.resume(returning: (data, response))
-                case let .failure(error, _):
-                    continuation.resume(throwing: error)
+        let box = CancellableContinuationBox<(Data, URLResponse?)>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                box.install(continuation)
+                GET(reqURL, useTokenIfAvailable: useTokenIfAvailable) { result in
+                    switch result {
+                    case let .success(data, response):
+                        box.finish(.success((data, response)))
+                    case let .failure(error, _):
+                        box.finish(.failure(error))
+                    }
                 }
             }
+        } onCancel: {
+            box.cancel()
         }
     }
 
     /// Async version of GET with full request control.
     func GET(request: URLRequest, cachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy, useTokenIfAvailable: Bool) async throws -> (Data, URLResponse?) {
-        return try await withCheckedThrowingContinuation { continuation in
-            let guarded = ContinuationGuard()
-            GET(request: request, cachePolicy: cachePolicy, useTokenIfAvailable: useTokenIfAvailable) { data, response, error in
-                guard guarded.tryConsume() else { return }
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: (data ?? Data(), response))
+        let box = CancellableContinuationBox<(Data, URLResponse?)>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                box.install(continuation)
+                let task = GET(request: request, cachePolicy: cachePolicy, useTokenIfAvailable: useTokenIfAvailable) { data, response, error in
+                    if let error = error {
+                        box.finish(.failure(error))
+                    } else {
+                        box.finish(.success((data ?? Data(), response)))
+                    }
                 }
+                box.setTask(task)
             }
+        } onCancel: {
+            box.cancel()
         }
     }
 
     /// Async version of PUT.
     func PUT(_ reqURL: URL, useTokenIfAvailable: Bool) async throws -> (Data, URLResponse?) {
-        return try await withCheckedThrowingContinuation { continuation in
-            let guarded = ContinuationGuard()
-            PUT(reqURL, useTokenIfAvailable: useTokenIfAvailable) { data, response, error in
-                guard guarded.tryConsume() else { return }
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: (data ?? Data(), response))
+        let box = CancellableContinuationBox<(Data, URLResponse?)>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                box.install(continuation)
+                let task = PUT(reqURL, useTokenIfAvailable: useTokenIfAvailable) { data, response, error in
+                    if let error = error {
+                        box.finish(.failure(error))
+                    } else {
+                        box.finish(.success((data ?? Data(), response)))
+                    }
                 }
+                box.setTask(task)
             }
+        } onCancel: {
+            box.cancel()
         }
     }
 
     /// Async version of POST.
     func POST(_ request: URLRequest, useTokenIfAvailable: Bool) async throws -> (Data, URLResponse?) {
-        return try await withCheckedThrowingContinuation { continuation in
-            let guarded = ContinuationGuard()
-            POST(request, useTokenIfAvailable: useTokenIfAvailable) { data, response, error in
-                guard guarded.tryConsume() else { return }
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: (data ?? Data(), response))
+        let box = CancellableContinuationBox<(Data, URLResponse?)>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                box.install(continuation)
+                let task = POST(request, useTokenIfAvailable: useTokenIfAvailable) { data, response, error in
+                    if let error = error {
+                        box.finish(.failure(error))
+                    } else {
+                        box.finish(.success((data ?? Data(), response)))
+                    }
                 }
+                box.setTask(task)
             }
+        } onCancel: {
+            box.cancel()
         }
     }
 
     /// Async version of DELETE.
     func DELETE(_ request: URLRequest, useTokenIfAvailable: Bool) async throws -> (Data, URLResponse?) {
-        return try await withCheckedThrowingContinuation { continuation in
-            let guarded = ContinuationGuard()
-            DELETE(request, useTokenIfAvailable: useTokenIfAvailable) { data, response, error in
-                guard guarded.tryConsume() else { return }
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: (data ?? Data(), response))
+        let box = CancellableContinuationBox<(Data, URLResponse?)>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                box.install(continuation)
+                let task = DELETE(request, useTokenIfAvailable: useTokenIfAvailable) { data, response, error in
+                    if let error = error {
+                        box.finish(.failure(error))
+                    } else {
+                        box.finish(.success((data ?? Data(), response)))
+                    }
                 }
+                box.setTask(task)
             }
+        } onCancel: {
+            box.cancel()
         }
     }
 }

--- a/Palace/Reader2/Bookmarks/AudiobookBookmarkBusinessLogic.swift
+++ b/Palace/Reader2/Bookmarks/AudiobookBookmarkBusinessLogic.swift
@@ -170,10 +170,27 @@ import PalaceBookModel
                 }
 
                 // Conflict resolution against the current local state.
-                // Preserved verbatim from swarm_f3b9b087 P0 #4/#5: the
-                // timestamp-newer race check (5s window) and the strict-
-                // zero isAtBeginning guard protect a valid local position
-                // from being overwritten by a stale upload result.
+                // Preserved from swarm_f3b9b087 P0 #4/#5: the timestamp-newer
+                // race check and the strict-zero isAtBeginning guard protect a
+                // valid local position from being overwritten by a STALE upload
+                // result — stale meaning older.
+                //
+                // The tolerance is 0, and that is load-bearing. `isDate` computes
+                // `d1 + delay > d2`, so any positive delay makes an EQUAL pair
+                // report "local is newer" unconditionally, and makes a local up to
+                // `delay` staler win as well. `lastSavedTimeStamp` is ISO8601 at
+                // second granularity and a save round-trips in far less than a
+                // second, so with a 1.0 window every real resolution tied and took
+                // this branch: a 37-minute locked-screen run on device produced 10
+                // resolutions, all 10 ties, all 10 discarding the just-saved
+                // position in favour of a local `track=0` — including one 331s into
+                // track 003. Zero gives the strict `d1 > d2` this guard is
+                // documented to want.
+                //
+                // Do NOT "fix" this by changing `isDate` itself. Its two other
+                // callers (BookAvailabilityFormatter:31, BookDetailViewModel:1328)
+                // use the delay deliberately, as a grace window that favours a
+                // lagging server timestamp, and ~60 assertions pin that meaning.
                 if let currentLocal = self.registry.location(forIdentifier: self.book.identifier),
                    let currentDict = currentLocal.locationStringDictionary(),
                    let currentBookmark = AudioBookmark.create(locatorData: currentDict) {
@@ -181,7 +198,7 @@ import PalaceBookModel
                     let currentLocalTimestamp = currentBookmark.lastSavedTimeStamp ?? ""
 
                     if !currentLocalTimestamp.isEmpty && !sentTimestamp.isEmpty,
-                       String.isDate(currentLocalTimestamp, moreRecentThan: sentTimestamp, with: 1.0) {
+                       String.isDate(currentLocalTimestamp, moreRecentThan: sentTimestamp, with: 0) {
                         Log.warn(#file, "⚠️ Race condition detected: Local position is newer. Keeping local.")
                         Log.warn(#file, "  Sent: track=\(sentTrackKey), time=\(sentPlaybackTime), timestamp=\(sentTimestamp)")
                         Log.warn(#file, "  Current local: track=\(currentBookmark.chapter ?? "?"), timestamp=\(currentLocalTimestamp)")

--- a/PalaceTests/Accounts/AccountRegistryStorePoolStarvationTests.swift
+++ b/PalaceTests/Accounts/AccountRegistryStorePoolStarvationTests.swift
@@ -1,0 +1,125 @@
+//
+//  AccountRegistryStorePoolStarvationTests.swift
+//  PalaceTests
+//
+//  `AccountRegistryStore` reads must not consume cooperative-pool threads while
+//  waiting on GCD to schedule work.
+//
+//  THE DEFECT. `performRead` was `accountSetsLock.sync { }` on a concurrent
+//  queue, and writes were `.async(flags: .barrier)`. A `.sync` read must wait
+//  for any queued barrier — and that barrier needs a GCD WORKER THREAD to run.
+//  When the readers are Swift Tasks, each blocked reader occupies one
+//  cooperative-pool thread, and that pool's width is the core count. Enough
+//  concurrent readers and every worker is blocked waiting for a barrier that
+//  cannot be scheduled because the threads it needs are the ones blocked. It
+//  resolves only when GCD's thread-explosion heuristic slowly adds threads.
+//
+//  Measured on device/CI: 24 threads (== core count) parked in `__ulock_wait`
+//  inside `performRead`, with NO barrier writer running. Whole-worker freezes of
+//  189-404 SECONDS between two 0.001s tests in an unrelated suite — the CI job
+//  spends 1600-2500s of its 3600s budget stalled, which is what pushes it over
+//  the 60-minute ceiling.
+//
+//  THE CONTRACT PINNED HERE. Reads and writes are safe to issue from Task
+//  context: they block only for an actual critical section, never on thread
+//  availability. The probe below is the direct expression — an ordinary
+//  `.utility` Task must still be schedulable while the pool is saturated with
+//  readers. That is exactly the test that hung in the field
+//  (`CatalogCrawlSchedulerTests.test_productionSpawn_runsOperation` does nothing
+//  but spawn and await such a Task).
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+
+@testable import Palace
+
+final class AccountRegistryStorePoolStarvationTests: XCTestCase {
+
+    /// Saturate the cooperative pool with concurrent store readers and writers,
+    /// then require that an ordinary Task can still be scheduled and run.
+    ///
+    /// Under the dispatch-barrier implementation this starves: every pool thread
+    /// sits in `accountSetsLock.sync` waiting on a barrier that has no worker
+    /// thread left to run it, so the probe never gets to execute.
+    func testReadsUnderSaturation_doNotStarveTheCooperativeThreadPool() async {
+        let store = AccountRegistryStore(currentHash: "hash")
+        // Well past the pool width so every worker is contended.
+        let readers = max(64, ProcessInfo.processInfo.activeProcessorCount * 4)
+
+        let hammer = Task.detached(priority: .utility) {
+            await withTaskGroup(of: Void.self) { group in
+                for i in 0..<readers {
+                    group.addTask {
+                        // Interleave writes so a barrier is always pending —
+                        // the condition that makes a `.sync` reader wait.
+                        if i % 8 == 0 {
+                            store.mutate { $0["hash", default: []] = [] }
+                        }
+                        _ = store.bucketIsNonEmpty(hash: "hash")
+                        _ = store.account("nobody")
+                        _ = store.currentHash
+                    }
+                }
+            }
+        }
+
+        // The probe: a plain Task that does nothing. If the pool is exhausted by
+        // blocked readers it can never be scheduled, which is the defect.
+        let probeRan = TestBox()
+        let probe = Task(priority: .utility) { probeRan.set() }
+
+        let outcome = await withTaskGroup(of: Bool.self) { group -> Bool in
+            group.addTask { _ = await probe.value; return true }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 20_000_000_000)
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+
+        _ = await hammer.value
+
+        XCTAssertTrue(
+            outcome,
+            "A .utility Task could not be scheduled while \(readers) store reads were in "
+                + "flight. Reads are blocking cooperative-pool threads on GCD scheduling, so the "
+                + "pool (width == core count) is exhausted and NOTHING else can run — the "
+                + "189-404s whole-worker freezes seen in CI."
+        )
+        XCTAssertTrue(probeRan.value, "probe Task must have actually executed")
+    }
+
+    /// The lock change must not weaken the index-coherence invariant: a reader
+    /// must never observe updated `accountSets` with a stale `accountByUUID`.
+    func testConcurrentMutation_keepsAccountIndexCoherent() async {
+        let store = AccountRegistryStore(currentHash: "hash")
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<64 {
+                group.addTask {
+                    if i % 2 == 0 {
+                        store.mutate { $0["hash", default: []] = [] }
+                    } else {
+                        XCTAssertTrue(
+                            store._coherentSnapshot(),
+                            "accountByUUID desynced from accountSets — the index must be "
+                                + "rebuilt inside the SAME critical section as the mutation."
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Minimal thread-safe flag; the test target's shared helpers are not visible
+/// from every file and this needs to be `Sendable` for the Task capture.
+private final class TestBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flag = false
+    func set() { lock.lock(); flag = true; lock.unlock() }
+    var value: Bool { lock.lock(); defer { lock.unlock() }; return flag }
+}

--- a/PalaceTests/Audiobook/AudiobookBookmarkBusinessLogicPositionWriteTests.swift
+++ b/PalaceTests/Audiobook/AudiobookBookmarkBusinessLogicPositionWriteTests.swift
@@ -398,11 +398,14 @@ final class AudiobookBookmarkBusinessLogicPositionWriteTests: XCTestCase {
     // MARK: - 6. Timestamp-newer race-check preserved (swarm_f3b9b087 #4)
 
     /// Pin the swarm_f3b9b087 P0 #4 race-check predicate: when a save's
-    /// timestamp is older than the current local timestamp by more than
-    /// the 1.0-second window (the implementation passes `with: 1.0` to
-    /// `String.isDate(_:moreRecentThan:with:)`), the post-save commit MUST
-    /// be suppressed so a stale upload result cannot overwrite a fresh
-    /// local position.
+    /// timestamp is genuinely OLDER than the current local timestamp, the
+    /// post-save commit MUST be suppressed so a stale upload result cannot
+    /// overwrite a fresh local position.
+    ///
+    /// Note this seeds local at +1 hour — "well outside any grace window" —
+    /// so it passes under any tolerance and never exercises the boundary.
+    /// `testTimestampTie_sameSecondStamp_commitsTheSavedPosition` covers the
+    /// boundary, which is the case that actually occurs in the field.
     func testTimestampNewerRace_preservedAfterMigration_keepsLocal() async throws {
         // The sentTimestamp the SUT sets is `Date().iso8601` at the moment
         // of the save call. To make the post-save guard fire, the
@@ -484,5 +487,87 @@ final class AudiobookBookmarkBusinessLogicPositionWriteTests: XCTestCase {
                        "Fresh-local annotationId MUST survive a stale upload result")
         XCTAssertEqual(finalBookmark.chapter, "chapter-2",
                        "Fresh-local chapter MUST survive a stale upload result")
+    }
+
+    // MARK: - 7. Timestamp TIE — the case that actually happens in production
+
+    /// The race check above seeds local at +1 hour, "well outside any grace
+    /// window", so it passes whatever tolerance the call site uses and never
+    /// touches the boundary. This test pins the boundary, and the boundary is
+    /// not an edge case here — it is the ONLY case observed in the field.
+    ///
+    /// `lastSavedTimeStamp` is ISO8601 at SECOND granularity ("2026-08-13T15:30:52Z",
+    /// no fractional part). A save round-trips in well under a second, so the
+    /// local and sent stamps land in the same second and compare EQUAL. A
+    /// 37-minute locked-screen run on device produced 10 post-save resolutions
+    /// and all 10 were equal-timestamp ties.
+    ///
+    /// The call site's intent, per its own comment, is to protect local "from
+    /// being overwritten by a STALE upload result" — stale meaning older. A tie
+    /// is not stale, so the position we just successfully saved must be
+    /// committed. Passing a 1.0s grace window inverted that: `d1 + 1.0 > d2` is
+    /// unconditionally true when `d1 == d2`, so every tie took the "local is
+    /// newer" branch and discarded the save.
+    func testTimestampTie_sameSecondStamp_commitsTheSavedPosition() async throws {
+        // Local carries a stamp from the SAME SECOND as the one the SUT will
+        // send — which is what production always produces.
+        let tieTimestamp = ISO8601DateFormatter().string(from: Date())
+        let tieLocal = AudioBookmark(
+            type: .locatorAudioBookTime,
+            version: 1,
+            timeStamp: tieTimestamp,
+            annotationId: "ann-tie-local",
+            readingOrderItem: "track-2",
+            readingOrderItemOffsetMilliseconds: 30_000,
+            chapter: "chapter-2",
+            title: "Chapter 2",
+            part: nil,
+            time: 30
+        )
+        guard let tieLocation = tieLocal.toTPPBookLocation() else {
+            XCTFail("Failed to build tie-local TPPBookLocation")
+            return
+        }
+
+        final class TieWriter: PositionWriter, @unchecked Sendable {
+            let onSave: () -> Void
+            init(onSave: @escaping () -> Void) { self.onSave = onSave }
+            func save(_ snapshot: PositionSnapshot) async throws -> ServerPositionID? {
+                onSave()
+                return "server-tie-id"
+            }
+            func load(for bookID: String) async throws -> PositionSnapshot? { nil }
+            func cancel(for bookID: String) async {}
+        }
+        let tieWriter = TieWriter { [weak self] in
+            self?.mockRegistry.setLocation(tieLocation,
+                                           forIdentifier: self?.bookIdentifier ?? "")
+        }
+        sut = AudiobookBookmarkBusinessLogic(
+            book: fakeBook,
+            registry: mockRegistry,
+            annotationsManager: mockAnnotations,
+            positionWriter: tieWriter
+        )
+
+        // trackIndex 0 with a non-zero time is deliberately NOT "at beginning"
+        // (BeginningPositionPolicy is strict-zero), so the later guard cannot be
+        // what answers this test.
+        let returned = await saveAndWait(position: position(trackIndex: 0, time: 5.0))
+
+        XCTAssertEqual(returned, "server-tie-id",
+                       "Completion should still receive the server ID")
+        guard let finalLocation = mockRegistry.location(forIdentifier: bookIdentifier),
+              let dict = finalLocation.locationStringDictionary(),
+              let finalBookmark = AudioBookmark.create(locatorData: dict) else {
+            XCTFail("Final registry state missing or malformed")
+            return
+        }
+        XCTAssertEqual(
+            finalBookmark.annotationId, "server-tie-id",
+            "An EQUAL timestamp is not a stale upload. The position that was just saved "
+                + "must be committed; keeping local here is how a real reading position "
+                + "(observed: 331s into track 003) was discarded in favour of track=0."
+        )
     }
 }

--- a/PalaceTests/Contract/AudiobookPositionAdapterContractTests.swift
+++ b/PalaceTests/Contract/AudiobookPositionAdapterContractTests.swift
@@ -315,11 +315,20 @@ final class AudiobookPositionAdapterContractTests: XCTestCase {
     // MARK: - 2. isAtBeginning guard — second registry write is suppressed
 
     /// Pins the swarm_f3b9b087 P0 #4 guard predicate:
-    ///   When (incoming trackIndex == 0 AND playbackTime < 30.0) AND the
+    ///   When (incoming trackIndex == 0 AND playbackTime == 0) AND the
     ///   current local bookmark is in a LATER track, the post-save commit
     ///   MUST be suppressed — the snapshot shows ONE `registry.setLocation`
     ///   (the initial local save) and ONE `writer.save`, with NO follow-up
     ///   `registry.setLocation`.
+    ///
+    /// The predicate is STRICT ZERO (`BeginningPositionPolicy.isAtBeginning`
+    /// returns true iff `trackIndex == 0 && playbackTime == 0`); the 30s grace
+    /// was removed because it discarded real 0:25-of-chapter-1 pauses. This
+    /// test used to drive `time: 5.0`, which under strict zero does NOT reach
+    /// the guard at all — it passed only because a separate defect (the
+    /// timestamp-tie in `AudiobookBookmarkBusinessLogic`, since fixed) happened
+    /// to suppress the same commit. It was green for the wrong reason and would
+    /// not have caught the inversion it claims to catch.
     ///
     /// Regression caught: if the predicate inverts (e.g. `trackIndex == 0`
     /// → `trackIndex != 0`) the snapshot grows a second
@@ -341,13 +350,21 @@ final class AudiobookPositionAdapterContractTests: XCTestCase {
             time: 60
         )
         let laterLoc = try XCTUnwrap(later.toTPPBookLocation())
-        // Pre-seed via the INNER mock so the pre-state setLocation isn't
-        // captured by the CallLog (we want the snapshot to start at the
-        // SUT's first call, not at test setup).
-        innerRegistry.setLocation(laterLoc, forIdentifier: bookIdentifier)
 
+        // Seed the later position DURING the save, not before it. Seeding
+        // beforehand cannot reach the guard: `saveListeningPosition` writes the
+        // INCOMING position to the registry first (the crash-safety net), so by
+        // the time the post-save guard reads `currentLocal` it would see track 0
+        // — its own write — and `currentTrackIndex > 0` could never hold. The
+        // guard is only reachable when a DIFFERENT writer moves the position
+        // mid-flight, which is exactly what this hook simulates (and what the
+        // timestamp-race test above does for its own predicate).
         writer.outcome = .success("server-beginning-id")
-        let p = position(trackIndex: 0, time: 5.0)  // < 30.0 → guard fires
+        writer.setOnSave { [weak self] in
+            guard let self else { return }
+            self.innerRegistry.setLocation(laterLoc, forIdentifier: self.bookIdentifier)
+        }
+        let p = position(trackIndex: 0, time: 0)  // strict zero → guard fires
         saveAndWait(position: p)
 
         ContractSnapshot.assert(log, named: "audiobookSave_preservesIsAtBeginningGuard")

--- a/PalaceTests/Contract/__Snapshots__/AudiobookPositionAdapterContractTests/audiobookSave_localFirstThenWriter.json
+++ b/PalaceTests/Contract/__Snapshots__/AudiobookPositionAdapterContractTests/audiobookSave_localFirstThenWriter.json
@@ -14,5 +14,13 @@
       "payloadIsEmpty" : "false"
     },
     "method" : "writer.save"
+  },
+  {
+    "args" : {
+      "bookID" : "contract-audiobook-1",
+      "hasLocation" : "true",
+      "renderer" : "PalaceAudiobookToolkit"
+    },
+    "method" : "registry.setLocation"
   }
 ]

--- a/PalaceTests/Network/TPPNetworkExecutorCancellationTests.swift
+++ b/PalaceTests/Network/TPPNetworkExecutorCancellationTests.swift
@@ -1,0 +1,267 @@
+//
+//  TPPNetworkExecutorCancellationTests.swift
+//  PalaceTests
+//
+//  `TPPNetworkExecutor`'s async bridges must honour Task cancellation.
+//
+//  WHY THIS EXISTS. The five async bridges (`GET`, `GET(request:)`, `PUT`,
+//  `POST`, `DELETE`) suspend in `withCheckedThrowingContinuation`. A
+//  `CheckedContinuation` is resumed only by its completion handler —
+//  `Task.cancel()` sets a flag and cannot resume it. So a task suspended in one
+//  of these bridges whose HTTP completion never fires is PERMANENTLY
+//  uncancellable.
+//
+//  That is not hypothetical. `AccountRegistryLoader` guards its crawl with
+//  eight `Task.isCancelled` checks, but every one of them sits BETWEEN awaits,
+//  so a task parked inside the bridge never reaches any of them. The test
+//  boundary drain then fails forever, once per test:
+//
+//      [WS0-DRAIN] cancelAndDrainBackgroundWork TIMED OUT after 3006ms
+//                  draining 2 task(s) — crawl did not observe cancellation
+//
+//  Observed repeating every 3 seconds for 23 minutes in a full-suite run: two
+//  leaked crawl tasks made EVERY subsequent test boundary pay a 3s timeout,
+//  degrading the suite until it was killed. It presents as a moving "hang"
+//  because the cost is cumulative, not located in any one test.
+//
+//  `URLSessionNetworkClient` already gets this right (`withTaskCancellationHandler`
+//  + `CancellableTaskBox`); these bridges never adopted it.
+//
+//  HOW IT IS TESTED. `TPPNetworkExecutor` builds its own `URLSession` and takes
+//  no session injection, so `HTTPStubURLProtocol` cannot reach it. Instead we
+//  point it at a real local listener that accepts the connection and never
+//  answers — the production failure exactly. The assertions race the awaiting
+//  task against a short sleep so a REGRESSION FAILS FAST instead of wedging the
+//  bundle, which is the very pathology under test.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Network
+import XCTest
+
+@testable import Palace
+
+/// Accepts TCP connections and never writes a byte, so any HTTP request sent to
+/// it stays in flight until the client gives up or is cancelled.
+private final class NeverRespondingServer: @unchecked Sendable {
+
+    /// Holds accepted connections so the peer stays open — a torn-down peer
+    /// would fail the request fast and the test would pass for the wrong reason.
+    private final class ConnectionStore: @unchecked Sendable {
+        private let lock = NSLock()
+        private var connections: [NWConnection] = []
+        func keep(_ c: NWConnection) {
+            lock.lock(); defer { lock.unlock() }
+            connections.append(c)
+        }
+        func closeAll() {
+            lock.lock(); defer { lock.unlock() }
+            connections.forEach { $0.cancel() }
+            connections.removeAll()
+        }
+    }
+
+    private let listener: NWListener
+    private let store: ConnectionStore
+    private let firstConnection: DispatchSemaphore
+
+    let port: UInt16
+
+    /// Resolves when a request actually reaches the socket. Deterministic —
+    /// replaces a fixed sleep, which STARVE-001 correctly rejects: an arbitrary
+    /// deadline starves under parallel sim clones, and "the connection arrived"
+    /// is the real event we were approximating.
+    func awaitFirstConnection() async {
+        let sem = firstConnection
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                // Bounded: if the connection never lands, resume anyway so the
+                // test fails on its assertion rather than wedging the bundle —
+                // wedging is the very pathology under test.
+                _ = sem.wait(timeout: .now() + 10)
+                c.resume()
+            }
+        }
+    }
+
+    init() throws {
+        let params = NWParameters.tcp
+        params.allowLocalEndpointReuse = true
+        let listener = try NWListener(using: params, on: .any)
+        let store = ConnectionStore()
+
+        let ready = DispatchSemaphore(value: 0)
+        let firstConnection = DispatchSemaphore(value: 0)
+        listener.newConnectionHandler = { conn in
+            conn.start(queue: .global())
+            store.keep(conn)
+            firstConnection.signal()
+        }
+        listener.stateUpdateHandler = { state in
+            if case .ready = state { ready.signal() }
+        }
+        listener.start(queue: .global())
+
+        guard ready.wait(timeout: .now() + 5) == .success,
+              let bound = listener.port?.rawValue, bound != 0 else {
+            listener.cancel()
+            throw NSError(domain: "NeverRespondingServer", code: 1)
+        }
+
+        self.listener = listener
+        self.store = store
+        self.firstConnection = firstConnection
+        self.port = bound
+    }
+
+    func shutdown() {
+        store.closeAll()
+        listener.cancel()
+    }
+}
+
+final class TPPNetworkExecutorCancellationTests: XCTestCase {
+
+    private var server: NeverRespondingServer!
+    private var executor: TPPNetworkExecutor!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        server = try NeverRespondingServer()
+        executor = TPPNetworkExecutor(credentialsProvider: nil, cachingStrategy: .fallback)
+    }
+
+    override func tearDown() {
+        server?.shutdown()
+        server = nil
+        executor = nil
+        super.tearDown()
+    }
+
+    private var hangingURL: URL {
+        URL(string: "http://127.0.0.1:\(server.port)/never-answers")!
+    }
+
+    private enum Outcome: Equatable {
+        case cancelled
+        case returned
+        case failed(String)
+        /// The awaiting task did NOT unblock — the defect.
+        case stillRunning
+    }
+
+    /// Cancels an in-flight bridge call and reports what the awaiting task did,
+    /// bounded so a regression fails in seconds rather than hanging the bundle.
+    private func outcomeAfterCancelling(
+        _ call: @escaping @Sendable (TPPNetworkExecutor) async throws -> Void
+    ) async -> Outcome {
+        let executor = self.executor!
+        let server = self.server!
+
+        let task = Task<Outcome, Never> {
+            do {
+                try await call(executor)
+                return .returned
+            } catch is CancellationError {
+                return .cancelled
+            } catch {
+                // A cancelled URLSession task surfaces as NSURLErrorCancelled;
+                // that is an honest cancellation too.
+                let ns = error as NSError
+                if ns.domain == NSURLErrorDomain && ns.code == NSURLErrorCancelled {
+                    return .cancelled
+                }
+                return .failed("\(ns.domain):\(ns.code)")
+            }
+        }
+
+        // Wait for the REQUEST TO REACH THE SOCKET — an actual event, not a
+        // guessed interval. Cancelling before the request is in flight would
+        // test the trivial already-cancelled path instead of the defect.
+        await server.awaitFirstConnection()
+        task.cancel()
+
+        // Race the task against a bound so the RED case is fast and legible.
+        return await withTaskGroup(of: Outcome?.self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 3_000_000_000)
+                return Outcome.stillRunning
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first ?? .stillRunning
+        }
+    }
+
+    func testGET_url_honoursTaskCancellation() async throws {
+        let url = hangingURL
+        let outcome = await outcomeAfterCancelling { try await _ = $0.GET(url) }
+        XCTAssertEqual(
+            outcome, .cancelled,
+            "GET(_:) must unblock its awaiting Task on cancellation. Suspended in a bare "
+                + "withCheckedThrowingContinuation it never will, and the task becomes "
+                + "permanently undrainable — the crawl-did-not-observe-cancellation defect."
+        )
+    }
+
+    func testGETRequest_honoursTaskCancellation() async throws {
+        let request = URLRequest(url: hangingURL)
+        let outcome = await outcomeAfterCancelling {
+            try await _ = $0.GET(request: request, useTokenIfAvailable: false)
+        }
+        XCTAssertEqual(outcome, .cancelled, "GET(request:) must unblock on cancellation.")
+    }
+
+    func testPUT_honoursTaskCancellation() async throws {
+        let url = hangingURL
+        let outcome = await outcomeAfterCancelling {
+            try await _ = $0.PUT(url, useTokenIfAvailable: false)
+        }
+        XCTAssertEqual(outcome, .cancelled, "PUT must unblock on cancellation.")
+    }
+
+    func testPOST_honoursTaskCancellation() async throws {
+        let request: URLRequest = {
+            var r = URLRequest(url: hangingURL)
+            r.httpMethod = "POST"
+            return r
+        }()
+        let outcome = await outcomeAfterCancelling {
+            try await _ = $0.POST(request, useTokenIfAvailable: false)
+        }
+        XCTAssertEqual(outcome, .cancelled, "POST must unblock on cancellation.")
+    }
+
+    func testDELETE_honoursTaskCancellation() async throws {
+        let request: URLRequest = {
+            var r = URLRequest(url: hangingURL)
+            r.httpMethod = "DELETE"
+            return r
+        }()
+        let outcome = await outcomeAfterCancelling {
+            try await _ = $0.DELETE(request, useTokenIfAvailable: false)
+        }
+        XCTAssertEqual(outcome, .cancelled, "DELETE must unblock on cancellation.")
+    }
+
+    /// Guards the fixture itself. If the local server ever answered, every test
+    /// above would pass for the wrong reason — the call would simply complete
+    /// before cancellation mattered.
+    func testFixture_serverNeverAnswers() async throws {
+        let url = hangingURL
+        let executor = self.executor!
+        let finished = expectation(description: "request settled")
+        finished.isInverted = true
+        let probe = Task { @Sendable in
+            _ = try? await executor.GET(url)
+            finished.fulfill()
+        }
+        // Inverted expectation: the timeout ELAPSING is the assertion (the
+        // request must NOT settle). There is no async work to join here; a
+        // Task-join seam would invert the meaning of the test.
+        await fulfillment(of: [finished], timeout: 2.0)  // STARVE-001-OK: inverted expectation — elapsing IS the assertion; nothing to join
+        probe.cancel()
+    }
+}

--- a/scripts/check-completion-isolation.py
+++ b/scripts/check-completion-isolation.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Fail if a completion handler is invoked from a Task that does not run on the main actor.
+
+THE DEFECT (PP-4955). `DefaultAudiobookManager.seekWithSlider` in the audiobook
+toolkit did its work inside a bare `Task { … }` and called the caller's
+completion closure from that Task. The app's `AudiobookSessionManager` is
+`@MainActor`, so the closure it passed in was main-actor-isolated. Swift does not
+warn about this. At runtime it does not throw either — it kills the process:
+
+    dispatch_assert_queue_fail
+    swift_task_checkIsolatedSwift
+    closure #1 in AudiobookSessionManager.seek(to:)
+    closure #2 in DefaultAudiobookManager.seekWithSlider(value:completion:)
+
+Scrubbing a DRM audiobook terminated the app, with no error and no chance to save
+the patron's position. Three crash reports in one minute on a shipping build.
+
+THE RULE, which is the entire subtlety. `Task { }` INHERITS the enclosing actor
+isolation. So a bare `Task { }` inside a `@MainActor` type already runs on main
+and its completion call is safe — `CarPlayAudiobookBridge.playAudiobook` and
+`LibraryService.openPublication` both look exactly like the crash and are both
+fine for this reason. `DefaultAudiobookManager` is a plain class, so ITS `Task { }`
+inherited nothing and landed on the cooperative executor. The difference between
+a crash and correct code is the isolation of the enclosing declaration, not the
+shape of the call. That is why this check reads context rather than grepping for
+`Task`. `Task.detached` inherits nothing regardless and is always flagged.
+
+WHY NOT A RUNTIME ASSERTION. An explicit `MainActor.assertIsolated()` inside a
+closure created by a `@MainActor` type is unreachable: Swift's own isolation
+check runs on entry and traps first. In this app every audiobook call site is
+inside a `@MainActor` type, so such an assertion would be dead code that looks
+like safety. The check that earns its place is this one — static, over the sites
+where isolation is genuinely absent.
+
+WHAT IT DELIBERATELY DOES NOT FLAG. Completions documented as off-main whose
+callers handle it — `TPPBookRegistry.syncLocation` is the live example: the
+registry is `@unchecked Sendable`, not `@MainActor`, and its one caller hops
+explicitly. Add such a site to EXEMPT with the reason, not a blanket suppression.
+
+    python3 scripts/check-completion-isolation.py [file ...]
+
+With no arguments it scans every tracked Swift file under Palace/.
+Exit 0 when clean, 1 on a finding, 2 on a usage error.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# "path:symbol" -> reason. Every entry was triaged by reading the CALLERS and
+# establishing that no caller passes a @MainActor-isolated closure. That is the
+# only question that matters: off-main delivery is not itself a defect, it is a
+# defect when the closure on the other side is actor-isolated.
+EXEMPT: dict[str, str] = {
+    "Palace/Book/Models/TPPBookRegistry+Extensions.swift:syncLocation":
+        "TPPBookRegistry is @unchecked Sendable, not @MainActor, and this completion is "
+        "documented as firing off-main. Its sole caller "
+        "(AudiobookSessionManager.swift:1746) hops deliberately and says so.",
+
+    "Palace/Accounts/AgeCheck/TPPAgeCheck.swift:verifyCurrentAccountAgeRequirement":
+        "delivery is explicitly onto a private serialQueue — an intentional off-main "
+        "contract, not an omitted hop.",
+
+    # URLSession hands these completions to the delegate itself. There is no
+    # caller-supplied closure and therefore no isolation to violate; URLSession
+    # requires only that the handler be invoked, not on which queue.
+    "Palace/MyBooks/MyBooksDownloadCenter.swift:urlSession":
+        "completionHandler is a URLSessionDelegate parameter supplied by URLSession, "
+        "not a caller's isolated closure.",
+    "Palace/Reader2/ReaderStackConfiguration/LCP/LicensesService.swift:urlSession":
+        "completionHandler is a URLSessionDownloadDelegate parameter supplied by "
+        "URLSession, not a caller's isolated closure.",
+
+    # Documented off-main contract. Worth knowing: NOT hopping here is exactly what
+    # crashed Sign In in 3.3.0 (Crashlytics, 2/2 repro) — the caller comment at
+    # TPPSignInBusinessLogic.swift:583 records it. The call site now hops with
+    # `Task { @MainActor in }`, so the contract is honoured rather than absent.
+    # This is the strongest evidence that this defect class is live in this app.
+    "Palace/Network/TPPNetworkExecutor.swift:executeTokenRefresh":
+        "documented as completing on a background queue; both callers "
+        "(TPPSignInBusinessLogic:579 hops to @MainActor; TPPNetworkExecutor:675 is "
+        "itself non-isolated) handle it.",
+    "Palace/Packages/PalaceAuth/Sources/PalaceAuth/TokenRequest.swift:execute":
+        "PalaceAuth is a transport package with no main-actor callers; the completion "
+        "is consumed by TPPNetworkExecutor, which is not main-actor isolated.",
+
+    # ReaderModule is `@unchecked Sendable`, NOT @MainActor, so the closure it
+    # passes to `sync` is not isolated. `finalizePresentation` does touch UIKit,
+    # and marshals onto the main actor itself via MainActor.run — see its comment.
+    "Palace/Reader2/BusinessLogic/TPPLastReadPositionSynchronizer.swift:sync":
+        "sole completion-taking caller is ReaderModule (not @MainActor); its closure "
+        "calls finalizePresentation, which marshals its own UIKit work onto main.",
+    "Palace/Reader2/BusinessLogic/TPPLastReadPositionSynchronizer.swift:presentNavigationAlert":
+        "the async twin it awaits already wraps its UI in DispatchQueue.main.async; the "
+        "completion afterwards carries no main-actor closure.",
+}
+
+DECL = re.compile(
+    r"^\s*(?:@\w+(?:\([^)]*\))?\s+)*"
+    r"(?:public\s+|internal\s+|private\s+|fileprivate\s+|open\s+)?"
+    r"(?:final\s+)?(class|struct|actor|enum|extension)\s+([A-Za-z_]\w*)"
+)
+FUNC = re.compile(
+    r"^\s*(?:@\w+(?:\([^)]*\))?\s+)*"
+    r"(?:public\s+|internal\s+|private\s+|fileprivate\s+|open\s+)?"
+    r"(?:static\s+|class\s+|final\s+|override\s+|nonisolated\s+)*func\s+([A-Za-z_]\w*)"
+)
+TASK = re.compile(r"^\s*(?:\w+\s*=\s*)?Task(\.detached)?\s*(?:\([^)]*\))?\s*\{")
+COMPLETION_CALL = re.compile(
+    r"\b(?:completion|callback|completionHandler)\s*\??\s*\(|\bcompletionBox\.call\s*\??\s*\("
+)
+MAIN = re.compile(r"@MainActor|MainActor\.run|MainActor\.assumeIsolated|DispatchQueue\.main")
+
+
+def die(msg: str) -> "NoReturn":  # type: ignore[valid-type]
+    print(f"error: {msg}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _annotation_block(lines: list[str], idx: int) -> str:
+    """The attribute lines immediately above `idx`, which is where @MainActor lives."""
+    out = []
+    j = idx - 1
+    while j >= 0 and lines[j].strip().startswith("@"):
+        out.append(lines[j])
+        j -= 1
+    return "\n".join(out)
+
+
+def check_file(path: str, rel: str) -> list[str]:
+    try:
+        lines = open(path, encoding="utf-8", errors="replace").read().splitlines()
+    except OSError as exc:
+        return [f"{rel}: could not read ({exc})"]
+
+    problems: list[str] = []
+    type_is_main = False       # enclosing type / extension is @MainActor
+    func_is_main = False       # this func is itself @MainActor
+    current_func: str | None = None
+    task_line: int | None = None
+    task_detached = False
+    task_indent = 0
+
+    for i, raw in enumerate(lines):
+        line = raw.rstrip()
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+
+        d = DECL.match(line)
+        if d and indent == 0:
+            head = line + "\n" + _annotation_block(lines, i)
+            type_is_main = "@MainActor" in head
+            current_func, task_line = None, None
+
+        f = FUNC.match(line)
+        if f:
+            current_func = f.group(1)
+            head = line + "\n" + _annotation_block(lines, i)
+            func_is_main = "@MainActor" in head
+            task_line = None
+
+        if TASK.match(line):
+            task_detached = bool(TASK.match(line).group(1))
+            # A Task pinned to the main actor at the declaration is fine.
+            task_line = None if MAIN.search(line) else i
+            task_indent = indent
+            continue
+
+        if task_line is not None and stripped.startswith("}") and indent <= task_indent:
+            task_line = None
+            continue
+
+        if task_line is None or current_func is None:
+            continue
+
+        # A plain `Task { }` inherits the enclosing isolation. If that isolation is
+        # the main actor, the completion is already delivered on main. `Task.detached`
+        # inherits nothing, so it is unsafe no matter where it appears.
+        inherits_main = (type_is_main or func_is_main) and not task_detached
+        if inherits_main:
+            continue
+
+        if COMPLETION_CALL.search(line) and not MAIN.search(line):
+            if f"{rel}:{current_func}" in EXEMPT:
+                continue
+            body = "\n".join(lines[task_line:i + 1])
+            if MAIN.search(body):
+                continue
+            kind = "Task.detached" if task_detached else "Task"
+            problems.append(
+                f"{rel}:{i + 1}: `{stripped[:52]}` runs in a {kind} inside "
+                f"`{current_func}`, which is not main-actor isolated, so the completion "
+                f"is delivered off the main actor. If any caller is @MainActor its "
+                f"closure TRAPS the process here (PP-4955). Either annotate the "
+                f"declaration @MainActor or wrap the call: `await MainActor.run {{ … }}`."
+            )
+    return problems
+
+
+def swift_files(paths: list[str]) -> list[str]:
+    if paths:
+        return paths
+    try:
+        out = subprocess.run(
+            ["git", "-C", REPO, "ls-files", "-z", "Palace/*.swift"],
+            capture_output=True, check=True,
+        ).stdout.decode("utf-8", "replace")
+        return sorted(os.path.join(REPO, p) for p in out.split("\0") if p)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        die(f"could not list tracked files via git ({exc})")
+
+
+def main(argv: list[str]) -> int:
+    for arg in argv[1:]:
+        if arg.startswith("-"):
+            die(f"unknown option {arg!r}; this check takes file paths or nothing")
+
+    files = swift_files(argv[1:])
+    if not files:
+        die("no Swift files to check; expected tracked files under Palace/")
+
+    problems: list[str] = []
+    for path in files:
+        problems.extend(check_file(path, os.path.relpath(path, REPO)))
+
+    if problems:
+        print(f"{len(problems)} completion(s) delivered off the main actor:\n")
+        for p in problems:
+            print(f"  {p}")
+        print(
+            "\nSwift does not warn about this. At runtime a @MainActor caller's closure "
+            "invoked off the main actor fails an isolation assertion and the process is "
+            "killed outright — no error, no unwinding, no saved reading position."
+        )
+        return 1
+
+    print(f"ok: {len(files)} file(s); no completion is delivered off the main actor")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Two independent defects found while investigating a full-suite hang, plus a static detector for a third class. Each is proven by **reintroducing** the defect, not by a passing run.

## 1. A saved reading position was discarded whenever its timestamp tied the local one

`AudiobookBookmarkBusinessLogic` resolves a successful upload against the current local position and keeps local when local is newer. It asked with a 1.0s grace window:

```swift
String.isDate(currentLocalTimestamp, moreRecentThan: sentTimestamp, with: 1.0)
```

`isDate` computes `d1 + delay > d2`, so a positive delay reports "local is newer" for an **equal** pair unconditionally — and for a local up to a second *staler*. `lastSavedTimeStamp` is ISO8601 at second granularity and a save round-trips in far less than a second, so real resolutions tie.

**Measured on device.** A 37-minute locked-screen Findaway session produced 10 post-save resolutions. All 10 tied, all 10 took the "local is newer" branch, and all 10 kept a local `track=0` over the position just saved — including one 331 seconds into `003_CrashHAG.mp3`.

The helper is deliberately **not** changed: its other two callers (`BookAvailabilityFormatter:31`, `BookDetailViewModel:1328`) use the delay as a grace window favouring a lagging server timestamp, and ~60 assertions pin that meaning. Changing `isDate` would have broken both.

**Why no test caught it:** the existing race test seeds local at +1 hour, "well outside any grace window", so it passes under any tolerance and never touches the boundary — the only case that occurs in the field.

| | `with:` | result |
|---|---|---|
| before | `1.0` | **FAILED** — `("ann-tie-local")` is not equal to `("server-tie-id")` |
| after | `0` | passed (0.038s) |

## 2. The async executor bridges could not be cancelled

`TPPNetworkExecutor`'s five async bridges suspended in a bare `withCheckedThrowingContinuation`. A `CheckedContinuation` is resumed only by its completion handler — `Task.cancel()` sets a flag and cannot resume it. A task suspended there whose HTTP completion never fired was **permanently uncancellable**.

`AccountRegistryLoader` guards its crawl with eight `Task.isCancelled` checks, but all sit *between* awaits, so a parked task reached none of them. The per-test boundary drain then failed forever:

```
[WS0-DRAIN] cancelAndDrainBackgroundWork TIMED OUT after 3006ms
            draining 2 task(s) — crawl did not observe cancellation
```

That repeated **every 3 seconds for 23 minutes**: two leaked tasks made every later test boundary pay a 3s timeout, degrading the suite until it was killed. It presented as a "hang" that moved between runs because the cost was cumulative.

`URLSessionNetworkClient` already solved this (`withTaskCancellationHandler` + `CancellableTaskBox`); these bridges never adopted it. `CancellableContinuationBox` resumes exactly once from either side, cancels the underlying `URLSessionTask` where one is exposed, and retains a cancellation that arrives *before* the continuation is installed — that race would otherwise re-create the same bug in a narrower window.

Tested against a real local listener that accepts and never answers (the executor builds its own session, so `HTTPStubURLProtocol` cannot reach it); `testFixture_serverNeverAnswers` guards the fixture.

| | before | after |
|---|---|---|
| `GET(_:)` | `stillRunning` @ 30.8s | cancelled @ 0.311s |
| `GET(request:)` | `stillRunning` @ 30.1s | cancelled @ 0.307s |
| `PUT` | `stillRunning` @ 30.1s | cancelled @ 0.303s |
| `POST` | `stillRunning` @ 30.1s | cancelled @ 0.338s |
| `DELETE` | `stillRunning` @ 30.1s | cancelled @ 0.311s |

System-level: full-suite `[WS0-DRAIN] ... TIMED OUT` count went to **zero**, and the run reached 4828 passes / 0 failures (was 4310 before wedging).

## 3. `scripts/check-completion-isolation.py`

Static check for the PP-4955 class — a completion delivered off the main actor to a `@MainActor` caller, which *traps the process* rather than warning. It encodes the rule that separates crash from correct: `Task { }` **inherits** enclosing actor isolation, so the identical shape is fatal in a plain class and fine in a `@MainActor` one. All 11 sites it finds in `Palace/` were triaged by reading their callers and are exempted with that evidence — none is a live defect. Proven to bite by reintroducing PP-4955's shape.

## Not done

The full suite is **not** green. It now wedges later, at `CatalogCrawlSchedulerTests test_productionSpawn_runsOperation`, for a different reason: 24 cooperative-pool threads (== core count) blocked in `AccountRegistryStore.performRead`'s `accountSetsLock.sync`, entered from Task context. Blocking dispatch calls on cooperative threads exhaust the fixed-width pool, so even a trivial `.utility` task cannot be scheduled. Sampled and confirmed; no barrier writer present.

That fix is architectural (actor conversion, or removing blocking `.sync` from Task context) and the file header records that an actor was previously considered and rejected — so it needs a decision, not a quiet patch. Also still open: the single-flight guard producing 2 `.detailsLoading` transitions where it must produce 1 (passes in isolation, fails when combined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)