### PR TITLE
fix(triage-bot): answer the patron instead of filing a blank ticket (PP-4865)

### DIFF
--- a/.forgeos/intent/pp-4865-triage-bot-keyword-strength-tiers.md
+++ b/.forgeos/intent/pp-4865-triage-bot-keyword-strength-tiers.md
@@ -1,5 +1,5 @@
 ---
-name: triage-bot-keyword-strength-tiers
+name: pp-4865-triage-bot-keyword-strength-tiers
 created: 2026-08-13
 author: claude-opus-5
 ---

--- a/.forgeos/intent/triage-bot-keyword-strength-tiers.md
+++ b/.forgeos/intent/triage-bot-keyword-strength-tiers.md
@@ -73,3 +73,49 @@ known-issue entries by making keyword strength explicit rather than implicit.
 
 - `swift test` on the PalaceTriageBot package (macOS) — the whole existing suite, not a filtered subset, since `LocalClassifier` behavior is asserted across several existing test classes
 - capture / misroute rates reported per provenance slice before and after, so the trade is stated as a number rather than a claim
+
+## Scope amendment (2026-08-13, during implementation)
+
+The original Claims/Anti-claims describe only the evidence model. The work grew
+in response to a QA question and an adversarial architecture review, and the
+following are now in scope. Recording them here rather than leaving the intent
+describing a smaller change than the diff — the reconciliation gate exists to
+catch exactly that drift, and it caught it.
+
+Added beyond the original claims:
+
+- `ConversationReducer` and `KBEscalationFollowUp` ARE modified, contradicting
+  the original anti-claim "does NOT change the reducer". Escalation now splits
+  ticket SCOPING (on any recognition) from the targeted follow-up QUESTION (only
+  on strong evidence, or when a prompt declares `presumes_issue: false`). The
+  anti-claim was written before the finding that every catalog prompt presumes
+  its own bug, which made weak-evidence questioning actively misleading.
+- Matching moved from substring to TOKEN comparison (`TextTokenizer`). Not
+  foreseen; forced by the discovery that `stalled` matches inside `reinstalled`,
+  a defect the old ≥2 floor had been masking.
+- Ranking and the margin guard now read strong evidence first. Prerequisite for
+  adding any corroborating keyword: without it a weak-many entry outranks a
+  strong-one entry and suppresses the better match.
+- Keyword changes the original anti-claims forbade ("does NOT add new keywords",
+  "does NOT add/remove/reword any KB entry"). Retracted deliberately: the
+  near-miss corpus produced evidence that `never works` and `add a library` were
+  misrouting real patrons, and `trying to download` was added to recover recall
+  the demotions cost. Each change is justified by a cited ticket, not by feel.
+- Nine `how_to` entries gained `escalation_follow_up` prompts and corroborating
+  keywords, so an unmatched FAQ question reaches support scoped rather than
+  blank. These prompts are NEW PATRON-FACING COPY and have not had product
+  sign-off.
+- Suggestions resting on a single matched concept are now phrased as a question
+  rather than asserted.
+
+Claims from the original document that did NOT hold as written:
+
+- "moves the generic single-word keywords … `stalled` …" — `stalled` was NOT
+  moved in the first commit. Caught by review; fixed here.
+
+## Verification amendment
+
+- `keyword_strength.py` (scratch, not committed) implements the measured-strength
+  approach. It does NOT work at this corpus size: only 5 of 187 strong keywords
+  occur ≥3 times across 318 tickets. Recorded as a negative result rather than
+  shipped as a 3%-coverage gate.

--- a/.forgeos/intent/triage-bot-keyword-strength-tiers.md
+++ b/.forgeos/intent/triage-bot-keyword-strength-tiers.md
@@ -1,0 +1,75 @@
+---
+name: triage-bot-keyword-strength-tiers
+created: 2026-08-13
+author: claude-opus-5
+---
+
+**ADR refs:** none — no prior decision covers triage-bot matcher evidence
+weighting. `docs/architecture/` has no triage-bot entry; the classifier's design
+rationale lives in source comments (`LocalClassifier.swift`) and in the PP-4825 /
+PP-4832 PR history (#1307, #1308). ForgeOS ADR API not queried — governance is OFF
+in this environment per `CLAUDE.local.md`.
+
+## Context
+
+QA reported on PP-4865 that the triage bot answers nearly every input with
+"I haven't seen exactly that before — let me file a ticket", never surfacing
+troubleshooting steps. Measured against the shipped catalog, 17 of 21 realistic
+patron phrasings escalate.
+
+The cause is the classifier's evidence model, not catalog size alone. Guided
+troubleshooting steps exist **only** on `known_issue` entries, and those entries
+require **≥2 distinct match regions** to suggest (`LocalClassifier.swift:120`,
+the F-002 precision guard). A patron writes one short sentence naming one
+symptom, so nearly every real input lands at exactly 1 region and escalates.
+
+Lowering that floor to 1 is not a fix: measured over the shipped catalog it
+recovers 9/11 genuine complaints but newly misroutes 6/7 generic ones — e.g.
+"the app crashes when I open it" → the CarPlay SIGABRT workaround, for a patron
+who has never opened CarPlay. That is the F-002 defect class returning.
+
+Both numbers are high for the same reason: `symptom_keywords` mixes evidence of
+very different strength in one flat list, and the classifier can only count
+entries in it, not weigh them. KI-008 lists both `"won't download"` (specific,
+decisive) and `"download"` (generic, near-meaningless alone) and treats them as
+equal. The ≥2 floor is a blunt proxy for "don't trust weak evidence alone" — it
+suppresses weak keywords at the cost of suppressing strong ones too.
+
+The `how_to` lane is the existence proof for the alternative: it already runs at
+floor 1 without misrouting, because `CatalogSchemaLintTests` forces its keywords
+to be multi-word intent phrases. This change generalizes that discipline to
+known-issue entries by making keyword strength explicit rather than implicit.
+
+## Claims
+
+- adds an optional `corroborating_keywords` array to the `KBEntry` schema, decoded in `KBEntry.swift`, defaulting to empty so existing catalogs (and the Android/KMP reader of the same JSON) stay valid
+- redefines `symptom_keywords` as STRONG evidence (sufficient alone to suggest) and `corroborating_keywords` as WEAK evidence (raises confidence, never sufficient alone)
+- changes `LocalClassifier` to require ≥1 strong match region to suggest, replacing the `known_issue` ≥2-total-region floor
+- changes `LocalClassifier` scoring to weight a strong region at 1.0 and a corroborating region at 0.5, still saturating at 3.0
+- moves the generic single-word keywords already in the shipped catalog (`stuck`, `crashes`, `crashed`, `hangs`, `spinning`, `spinner`, `blinks`, `download`, `stalled`, `bookshelf`, `boxes`, `placeholder`, `reinstall`) from `symptom_keywords` to `corroborating_keywords`
+- adds a lint test asserting no `symptom_keywords` entry is a known generic symptom word, so a future weak keyword cannot silently regain sufficient-alone status
+- adds a scored corpus fixture (`Fixtures/MatchCorpus.json`) of real patron phrasings drawn from HelpSpot, PII-stripped, labelled with provenance (`mined` = tickets the catalog was authored from; `held_out` = August 2026 tickets postdating the catalog's 2026-07-20 review; `trap` = generic inputs that must escalate)
+- adds `MatchCorpusTests` reporting capture rate and misroute rate per provenance slice, asserting zero misroutes on the trap slice
+
+## Anti-claims
+
+- does NOT enable or change the AI fallback wiring (`TriageBotAIWiring`, `ClaudeFallbackClassifier`, the Firebase flag, or the release-build key gap) — that is a separate, still-open gap
+- does NOT add, remove, or reword any KB entry, workaround text, or guided step; only the strength partition of existing keywords changes
+- does NOT add new keywords to any entry — growing coverage is deliberately left out so the measured delta is attributable to the evidence model alone
+- does NOT change the reducer, the conversation state machine, or any UI; the multi-turn follow-up gap QA also reported is untouched
+- does NOT change `distinctMatchRegionCount`, the runner-up/ambiguity guards, the per-entry `confidence_threshold`, the version gate, or the context filters
+- does NOT change `how_to` behavior — those entries have no corroborating keywords, so their floor-1 path is bit-identical
+
+## Files in scope
+
+- Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
+- Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
+- Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+- Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogSchemaLintTests.swift
+- Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/MatchCorpusTests.swift
+- Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/MatchCorpus.json
+
+## Verification
+
+- `swift test` on the PalaceTriageBot package (macOS) — the whole existing suite, not a filtered subset, since `LocalClassifier` behavior is asserted across several existing test classes
+- capture / misroute rates reported per provenance slice before and after, so the trade is stated as a number rather than a claim

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
@@ -209,7 +209,8 @@ public struct LocalClassifier: Sendable {
                 decision: .suggest(entryId: top.entry.id),
                 confidence: top.score,
                 matchedKeywords: top.matched,
-                consideredEntryIds: consideredIds
+                consideredEntryIds: consideredIds,
+                strongRegionCount: top.strongCount
             )
         }
 
@@ -244,7 +245,8 @@ public struct LocalClassifier: Sendable {
             matchedKeywords: top.matched,
             consideredEntryIds: consideredIds,
             recognizedEntryId: top.entry.id,
-            recognitionIsStrong: top.strongCount >= 1
+            recognitionIsStrong: top.strongCount >= 1,
+            strongRegionCount: top.strongCount
         )
     }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
@@ -51,28 +51,43 @@ public struct LocalClassifier: Sendable {
             )
         }
 
-        let scored = candidates.map { entry -> (entry: KBEntry, score: Double, matched: [String], distinctCount: Int) in
-            let matched = entry.symptomKeywords.filter { keyword in
+        let scored = candidates.map { entry -> (entry: KBEntry, score: Double, matched: [String], distinctCount: Int, strongCount: Int) in
+            let strongMatched = entry.symptomKeywords.filter { keyword in
                 normalized.contains(TextNormalizer.normalize(keyword))
             }
-            // Score on the count of DISTINCT non-overlapping regions of the
-            // patron's text that matched — not the raw count of keyword-list
-            // hits. A single word ("hangs") substring-matches every nested
-            // variant an entry lists ("hang", "hangs"), which inflated the raw
-            // count and let one word clear the ≥2 confidence guard. Counting
-            // merged match regions collapses those synonyms to the one concept
-            // the patron actually mentioned.
+            let weakMatched = (entry.corroboratingKeywords ?? []).filter { keyword in
+                normalized.contains(TextNormalizer.normalize(keyword))
+            }
+            let matched = strongMatched + weakMatched
+
+            // Count DISTINCT non-overlapping regions of the patron's text — not
+            // raw keyword-list hits. A single word ("hangs") substring-matches
+            // every nested variant an entry lists ("hang", "hangs"), which
+            // inflated the raw count. Counting merged match regions collapses
+            // those synonyms to the one concept the patron actually mentioned.
             //
-            // Each region is worth at most 1/3, saturating at 3+ → 1.0. The cap
-            // means a confident 3-concept hit reads as "very likely" regardless
-            // of how exhaustive the entry's synonym list is.
-            let distinctCount = Self.distinctMatchRegionCount(
+            // Strong and weak regions are counted SEPARATELY, because they answer
+            // different questions: strong regions decide whether we may suggest at
+            // all, weak regions only shade how confident the suggestion reads.
+            let strongCount = Self.distinctMatchRegionCount(
+                of: strongMatched.map { TextNormalizer.normalize($0) },
+                in: normalized
+            )
+            let totalCount = Self.distinctMatchRegionCount(
                 of: matched.map { TextNormalizer.normalize($0) },
                 in: normalized
             )
-            let kSaturation = 3
-            let normalizedScore = min(Double(distinctCount) / Double(kSaturation), 1.0)
-            return (entry, normalizedScore, matched, distinctCount)
+            let weakCount = max(totalCount - strongCount, 0)
+
+            // A strong region is worth a full unit, a weak one half — a generic
+            // "stuck" alongside "won't play" should sharpen the match, not count
+            // as much as a second decisive phrase. Saturates at 3.0 → 1.0, so a
+            // confident hit reads as "very likely" regardless of how exhaustive
+            // the entry's synonym list is.
+            let kSaturation = 3.0
+            let weightedEvidence = Double(strongCount) + 0.5 * Double(weakCount)
+            let normalizedScore = min(weightedEvidence / kSaturation, 1.0)
+            return (entry, normalizedScore, matched, totalCount, strongCount)
         }
 
         let consideredIds = scored.map { $0.entry.id }
@@ -93,31 +108,33 @@ public struct LocalClassifier: Sendable {
         //   2. runner-up score < 0.8 — when BOTH entries are at/near saturation
         //      (e.g. user stuffed keywords from multiple entries), we have
         //      genuine ambiguity and should disambiguate, not confidently pick.
-        //   3. top.distinctCount ≥ 2 — chaos-qa F-002 (2026-05-29) showed
-        //      that a single keyword match like "my library" in KI-004
-        //      could route a generic auth-loop complaint to the wrong
-        //      workaround. Requiring ≥2 DISTINCT match regions for confident
-        //      LOCAL suggest means single-match-only inputs escalate
-        //      instead, which routes them to the AI fallback (Claude)
-        //      that has semantic understanding to either confirm or
-        //      reject the match. Cost: ~1 extra Claude call per
-        //      single-keyword-overlap input. Worth it — false positives
-        //      misdirect users; the AI fallback's whole purpose is to
-        //      catch them.
+        //   3. top.strongCount ≥ 1 — the precision guard. See below.
         let secondScore = ranked.count > 1 ? ranked[1].score : 0
         let secondMatchCount = ranked.count > 1 ? ranked[1].distinctCount : 0
         let matchCountMargin = top.distinctCount - secondMatchCount
 
-        // Per-kind suggest floor. known_issue entries require ≥2 distinct match
-        // regions (the F-002 precision guard: a symptom word like "stuck" is too
-        // weak alone to route to a specific bug workaround). how_to entries carry
-        // specific multi-word intent phrases ("switch library", "return early")
-        // that are disjoint from symptom language, so a single strong intent
-        // match is a confident signal — requiring two would make most FAQ
-        // phrasings escalate. (The multi-word requirement is enforced by
-        // CatalogSchemaLintTests so a bare word like "renew" can't sneak in and
-        // fire on "renewed my card".)
-        let minDistinctRegions = top.entry.resolvedKind == .howTo ? 1 : 2
+        // The precision guard: at least one STRONG match region, for every kind.
+        //
+        // This replaces a per-kind COUNT floor (known_issue needed ≥2 regions of
+        // any kind, how_to needed 1). That floor was a proxy for evidence quality
+        // — chaos-qa F-002 (2026-05-29) showed a lone weak match could route a
+        // generic auth-loop complaint to the wrong-library workaround, and
+        // requiring two matches made that unlikely. But it was a bad proxy: it
+        // also suppressed the single DECISIVE phrase. Measured on the shipped
+        // catalog, 17 of 21 realistic patron phrasings escalated, including ones
+        // where the classifier had already identified the right entry — a patron
+        // typing "my book won't download" was told "I haven't seen exactly that
+        // before" (PP-4865).
+        //
+        // Gating on strength instead of count keeps F-002 closed — a weak word
+        // alone still cannot suggest, which is what that defect actually was —
+        // while letting one decisive phrase through, which is how patrons write.
+        // how_to entries are unaffected: they carry no corroborating keywords, so
+        // every match they can make is strong and their floor stays effectively 1.
+        //
+        // The partition is enforced by CatalogSchemaLintTests, so a generic word
+        // cannot drift back into `symptom_keywords` and quietly become sufficient.
+        let hasStrongEvidence = top.strongCount >= 1
 
         // confidenceThreshold lets an individual entry DEMAND more evidence than
         // its kind floor. Scores are quantized to {1/3, 2/3, 1.0} (1, 2, 3+
@@ -131,7 +148,7 @@ public struct LocalClassifier: Sendable {
         // which already implies matchCountMargin ≥ 1. It was provably dead.
         let runnerUpAlsoSaturated = secondScore >= 0.8
         if top.score >= top.entry.confidenceThreshold &&
-           top.distinctCount >= minDistinctRegions &&
+           hasStrongEvidence &&
            matchCountMargin >= 1 &&
            !runnerUpAlsoSaturated {
             // escalate_anyway: recognized AND confident, but this class of problem

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
@@ -32,6 +32,12 @@ public struct LocalClassifier: Sendable {
         } else {
             rawCandidates = kb.entries(matching: context)
         }
+        // Generic ladders are remedies, not diagnoses — they never compete for a
+        // match. Excluded here rather than by relying on an empty keyword list,
+        // because an empty-keyword entry still enters the candidate set and would
+        // surface in consideredEntryIds (and would compete outright the moment
+        // someone gave a ladder a keyword).
+        let matchable = rawCandidates.filter { $0.resolvedKind != .genericFlow }
 
         // Version-aware filter — don't surface a `fixed_in` entry to a user
         // who's already on / past the fix version. They have the fix; if
@@ -40,7 +46,7 @@ public struct LocalClassifier: Sendable {
         // implicitly accepted. Entries without `fixed_in_version`, entries
         // with `status: open`, or contexts without an app version all pass
         // through unfiltered.
-        let candidates = rawCandidates.filter { entry in
+        let candidates = matchable.filter { entry in
             // Only known-issue `fixed_in` entries are version-gated. how_to
             // (general-help) entries have no fix version and must always
             // surface — a "how do I renew?" answer never expires against a

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
@@ -91,7 +91,15 @@ public struct LocalClassifier: Sendable {
         }
 
         let consideredIds = scored.map { $0.entry.id }
-        let ranked = scored.sorted { $0.score > $1.score }
+        // Rank on STRENGTH first, score second. Weak regions are worth half a
+        // strong one, so two vague matches tie one decisive phrase on raw score —
+        // and a score-only sort let the vague entry take the top slot, where its
+        // lack of strong evidence then blocked the suggest outright. The decisive
+        // match lost to a competitor that could not itself answer. Strength-first
+        // ordering is what makes corroborating keywords safe to add at all.
+        let ranked = scored.sorted {
+            $0.strongCount != $1.strongCount ? $0.strongCount > $1.strongCount : $0.score > $1.score
+        }
 
         guard let top = ranked.first, top.score > 0 else {
             return ClassificationResult(
@@ -111,7 +119,16 @@ public struct LocalClassifier: Sendable {
         //   3. top.strongCount ≥ 1 — the precision guard. See below.
         let secondScore = ranked.count > 1 ? ranked[1].score : 0
         let secondMatchCount = ranked.count > 1 ? ranked[1].distinctCount : 0
-        let matchCountMargin = top.distinctCount - secondMatchCount
+        let secondStrongCount = ranked.count > 1 ? ranked[1].strongCount : 0
+
+        // Measure the lead on the same axis the ranking used, or the guard fights
+        // the sort: a 1-strong-region winner trails a 2-weak-region runner-up on
+        // total regions and would fail a region-only margin despite being the
+        // better match. Strong evidence decides when it differs; total regions
+        // break ties between entries with equal strong evidence.
+        let strongMargin = top.strongCount - secondStrongCount
+        let regionMargin = top.distinctCount - secondMatchCount
+        let matchCountMargin = strongMargin >= 1 ? strongMargin : regionMargin
 
         // The precision guard: at least one STRONG match region, for every kind.
         //
@@ -177,9 +194,15 @@ public struct LocalClassifier: Sendable {
             )
         }
 
-        // Multiple plausible matches → disambiguate by asking a follow-up
+        // Multiple plausible matches → disambiguate by asking a follow-up.
+        //
+        // Only when at least one candidate is backed by a decisive phrase. Offering
+        // a choice asserts we have two good guesses; if every candidate rests on
+        // vague words we have none, and the patron gets a menu of topics we merely
+        // brushed against. Weak-only competition falls through to the escalation
+        // below, which is honest about not knowing and still scopes the ticket.
         let plausible = ranked.prefix(3).filter { $0.score > 0 }.map { $0.entry.id }
-        if plausible.count >= 2 {
+        if plausible.count >= 2 && top.strongCount >= 1 {
             return ClassificationResult(
                 decision: .disambiguate(candidates: Array(plausible)),
                 confidence: top.score,

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
@@ -3,11 +3,18 @@ import Foundation
 /// Pure-function classifier — given user text + (optional) context + a KB,
 /// returns what the bot should do next. No I/O, no side effects, deterministic.
 ///
-/// Scoring is simple keyword overlap normalized to [0, 1]: count of matched
-/// keywords ÷ total keywords on the entry. Confidence threshold per entry
-/// gates suggest-vs-disambiguate. Below the lowest entry threshold the
-/// classifier returns .escalate — we'd rather waste a triager's time on a
-/// known issue than tell the user something wrong about a novel bug.
+/// Matching is token-based: both the patron's text and each keyword are split
+/// into word tokens, and a keyword hits when its tokens appear as a contiguous
+/// run. Evidence is then counted as DISTINCT match regions — overlapping hits
+/// merge, so an entry listing a phrase and its head noun scores the concept
+/// once.
+///
+/// Regions are weighted by keyword STRENGTH: a `symptom_keywords` hit is worth a
+/// full unit and can carry a suggestion alone; a `corroborating_keywords` hit is
+/// worth half and never can. Score = (strong + 0.5·weak) / 3, capped at 1.0.
+/// A suggestion additionally requires clearing the entry's threshold and leading
+/// the runner-up. Otherwise the classifier escalates — we would rather waste a
+/// triager's time on a known issue than tell a patron something wrong.
 public struct LocalClassifier: Sendable {
     public init() {}
 
@@ -51,13 +58,18 @@ public struct LocalClassifier: Sendable {
             )
         }
 
+        // Tokenize ONCE per classify() call, not per entry per keyword.
+        let textTokens = TextTokenizer.tokens(normalized)
+
         let scored = candidates.map { entry -> (entry: KBEntry, score: Double, matched: [String], distinctCount: Int, strongCount: Int) in
-            let strongMatched = entry.symptomKeywords.filter { keyword in
-                normalized.contains(TextNormalizer.normalize(keyword))
+            func hits(_ keyword: String) -> Bool {
+                !TextTokenizer.matchRanges(
+                    of: TextTokenizer.tokens(TextNormalizer.normalize(keyword)),
+                    in: textTokens
+                ).isEmpty
             }
-            let weakMatched = (entry.corroboratingKeywords ?? []).filter { keyword in
-                normalized.contains(TextNormalizer.normalize(keyword))
-            }
+            let strongMatched = entry.symptomKeywords.filter(hits)
+            let weakMatched = (entry.corroboratingKeywords ?? []).filter(hits)
             let matched = strongMatched + weakMatched
 
             // Count DISTINCT non-overlapping regions of the patron's text — not
@@ -77,6 +89,7 @@ public struct LocalClassifier: Sendable {
                 of: matched.map { TextNormalizer.normalize($0) },
                 in: normalized
             )
+            _ = textTokens  // tokens are consumed by `hits` above
             let weakCount = max(totalCount - strongCount, 0)
 
             // A strong region is worth a full unit, a weak one half — a generic
@@ -153,16 +166,22 @@ public struct LocalClassifier: Sendable {
         // cannot drift back into `symptom_keywords` and quietly become sufficient.
         let hasStrongEvidence = top.strongCount >= 1
 
-        // confidenceThreshold lets an individual entry DEMAND more evidence than
-        // its kind floor. Scores are quantized to {1/3, 2/3, 1.0} (1, 2, 3+
-        // regions), so a threshold in (1/3, 2/3] means "require ≥2 regions" and
-        // (2/3, 1.0] means "require ≥3". A threshold ≤ 1/3 is a no-op beyond the
-        // kind floor. Shipped catalog entries sit at the floor; the knob exists
-        // for a future entry so broad it needs 3 regions to be safe.
+        // confidenceThreshold lets an entry DEMAND more evidence than the floor.
         //
-        // NOTE: the old `scoreMargin >= 0.1` disjunct was removed — with quantized
-        // scores, scoreMargin ≥ 0.1 can only happen when the region counts differ,
-        // which already implies matchCountMargin ≥ 1. It was provably dead.
+        // CALIBRATION WARNING: the scale it is read against has changed twice and
+        // the shipped values have not been re-derived. Scores were once quantized
+        // to {1/3, 2/3, 1.0}, which is what made "a threshold in (1/3, 2/3] means
+        // require two regions" true. Weighting corroborating regions at 0.5 put
+        // halves on the scale, so a 0.5 threshold is now satisfiable by one strong
+        // plus one weak — the knob no longer means "region count".
+        //
+        // Every threshold in the shipped catalog is 0.08-0.1, and the weakest
+        // possible non-zero score is one corroborating region at 1/6 = 0.167, so
+        // ALL of them currently pass unconditionally: the suggest gate is carried
+        // entirely by hasStrongEvidence and the margin guards. The knob is inert,
+        // not protective - do not read a shipped threshold as a safety property.
+        // Either re-derive these against the strong-count axis the classifier
+        // actually ranks on, or delete the field.
         let runnerUpAlsoSaturated = secondScore >= 0.8
         if top.score >= top.entry.confidenceThreshold &&
            hasStrongEvidence &&
@@ -237,10 +256,15 @@ public struct LocalClassifier: Sendable {
     /// Uses each keyword's first occurrence; merges overlapping/touching
     /// ranges and returns the cluster count.
     static func distinctMatchRegionCount(of keywords: [String], in text: String) -> Int {
-        var ranges: [Range<String.Index>] = []
-        for keyword in keywords where !keyword.isEmpty {
-            if let range = text.range(of: keyword) {
-                ranges.append(range)
+        let textTokens = TextTokenizer.tokens(text)
+        var ranges: [Range<Int>] = []
+        for keyword in keywords {
+            let kw = TextTokenizer.tokens(keyword)
+            // First occurrence only: a concept the patron mentioned once counts
+            // once, and a phrase repeated across a long complaint is still one
+            // concept.
+            if let first = TextTokenizer.matchRanges(of: kw, in: textTokens).first {
+                ranges.append(first)
             }
         }
         guard !ranges.isEmpty else { return 0 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/LocalClassifier.swift
@@ -162,7 +162,11 @@ public struct LocalClassifier: Sendable {
                     confidence: top.score,
                     matchedKeywords: top.matched,
                     consideredEntryIds: consideredIds,
-                    recognizedEntryId: top.entry.id
+                    recognizedEntryId: top.entry.id,
+                    // Reached only inside the strong-evidence branch, so this
+                    // recognition is strong by construction — the entry's
+                    // targeted follow-up is warranted.
+                    recognitionIsStrong: true
                 )
             }
             return ClassificationResult(
@@ -184,16 +188,21 @@ public struct LocalClassifier: Sendable {
             )
         }
 
-        // Single low-confidence match — escalate rather than over-promise. We DID
+        // Low-confidence match — escalate rather than over-promise. We DID
         // recognize a topic (top.entry), just not confidently enough to suggest;
-        // carry it so the escalation can ask that entry's targeted follow-up and
-        // hand support a scoped ticket instead of a blank hand-off.
+        // carry it so the ticket reaches support scoped rather than blank.
+        //
+        // Whether that recognition also earns the entry's targeted follow-up
+        // QUESTION depends on its strength: a decisive phrase that merely lost on
+        // the margin justifies asking; a lone generic word does not, because every
+        // such prompt presumes its bug and would read as the bot inventing one.
         return ClassificationResult(
             decision: .escalate,
             confidence: top.score,
             matchedKeywords: top.matched,
             consideredEntryIds: consideredIds,
-            recognizedEntryId: top.entry.id
+            recognizedEntryId: top.entry.id,
+            recognitionIsStrong: top.strongCount >= 1
         )
     }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
@@ -21,6 +21,15 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
     case otherDevice
     case pullToRefresh
     case switchLibrary
+    /// Check the same account in the library's web catalog.
+    ///
+    /// Not a repair — it is the one action that splits an app-side problem from
+    /// an account-side one (expired card, ILS outage, a title the library does
+    /// not license), which is roughly a quarter of real tickets and the class no
+    /// app-side remedy can ever fix. Corpus-invisible for a precise reason:
+    /// support performs this check itself, server-side, so it is prescribed
+    /// almost never and performed almost always.
+    case verifyOnWeb
 
     /// What the remedy costs the patron if it does NOT work.
     ///
@@ -45,8 +54,15 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
 
     public var costTier: CostTier {
         switch self {
-        case .pullToRefresh, .reopenTitle, .updateApp: return .free
-        case .restartDevice, .toggleNetwork, .otherDevice, .switchLibrary: return .disruptive
+        case .pullToRefresh, .reopenTitle, .verifyOnWeb: return .free
+        // Not free: minutes, possibly hundreds of megabytes on metered data, an
+        // Apple ID prompt and a relaunch. The version gate reduces how often it
+        // is WASTED, not what it costs when offered.
+        case .updateApp: return .disruptive
+        case .restartDevice, .toggleNetwork, .otherDevice: return .disruptive
+        // Changing which library is selected is two taps and reversible; it
+        // destroys nothing, and the rung that uses it is an observation.
+        case .switchLibrary: return .free
         case .signOutIn, .reinstall: return .destructive
         }
     }
@@ -63,6 +79,7 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
         case .otherDevice:   return "trying another device"
         case .pullToRefresh: return "pulling down to refresh"
         case .switchLibrary: return "switching libraries"
+        case .verifyOnWeb:   return "checking the web catalog"
         }
     }
 }
@@ -87,36 +104,71 @@ public struct RemedyDetector: Sendable {
         .reinstall: [
             "reinstalled", "re installed", "uninstalled and", "deleted the app",
             "deleted and reinstalled", "removed the app and", "redownloaded the app",
-            "delete and reinstall it", "uninstalled it",
+            "delete and reinstall it", "uninstalled it", "deleted palace",
+            "fresh install", "took the app off",
         ],
         .restartDevice: [
-            "rebooted", "restarted my phone", "restarted the phone", "restarted my ipad",
-            "turned my phone off", "power cycled", "restarted my device",
+            // Not bare "rebooted": "my phone rebooted itself while playing" is a
+            // symptom (a spontaneous restart), not a remedy the patron applied.
+            // Third-person forms are NOT optional — a large share of this corpus
+            // is librarians writing on a patron's behalf ("they've reinstalled
+            // the app, rebooted their phone"), so a first-person-only list drops
+            // them.
+            "i rebooted", "rebooted my", "rebooted the", "rebooted their",
+            "rebooted her", "rebooted his", "they rebooted",
+            "restarted my phone", "restarted the phone", "restarted my ipad",
+            "restarted my iphone", "restarted my device", "restarted the app",
+            "restarted their phone", "restarted her phone", "restarted his phone",
+            "turned my phone off", "turned my ipad off", "power cycled",
+            "turned it off and on", "powered it off",
         ],
         .signOutIn: [
+            // Phrases match CONTIGUOUS token runs, so "signed out and back" never
+            // matched "signed out and SIGNED back in" — the way most people write
+            // it. The short trailing forms carry the claim on their own.
+            "signed back in", "logged back in", "sign back in",
             "signed out and back", "signed out and in", "logged out and back",
             "logged out and in", "signed out then", "logged out then",
         ],
         .toggleNetwork: [
             "on and off wifi", "off and on wifi", "toggled wifi", "turned wifi off",
-            "switched to cellular", "tried cellular", "different wifi",
+            "turned off wifi", "switched to cellular", "tried cellular",
+            "different wifi", "different network", "another network",
+            "airplane mode on and off", "turned airplane mode on",
+            "toggled airplane mode", "restarted my router",
         ],
         .reopenTitle: [
             "closed and reopened", "reopened the book", "reopened it", "opened it again",
             "backed out and tried again",
         ],
         .updateApp: [
-            "updated the app", "installed the update", "already updated", "on the latest version",
-            "running the latest", "up to date",
+            // Not bare "up to date": patrons say it of their library CARD and of
+            // iOS. Only claims naming the app or an update count.
+            "updated the app", "updated palace", "installed the update",
+            "already updated", "on the latest version", "running the latest",
+            "app is up to date", "palace is up to date", "installed it again",
         ],
         .pullToRefresh: [
-            "pulled down to refresh", "pulled to refresh", "pull to refresh",
+            // Not "pull to refresh" — imperative, so it matches a patron ASKING
+            // how, and skips the safest rung in the library ladder.
+            "pulled down to refresh", "pulled to refresh",
             "swiped down to refresh", "refreshed the list", "refreshed my holds",
+            "i refreshed",
         ],
         .switchLibrary: [
-            "switched to my other", "switched libraries", "switched library",
-            "changed to my other library", "tried my other library",
-            "switched to my other library",
+            // NOT "switched libraries" / "switched library" / "changed library":
+            // those are KI-2026-002's symptom keywords verbatim. A patron writing
+            // "I switched libraries and now my books are gone" is naming their
+            // trigger, and treating it as a remedy skipped the library ladder's
+            // first rung — the one telling them to check which library is
+            // selected, which is the likeliest fix for that exact complaint.
+            // Only deliberate-attempt phrasings remain.
+            "switched to my other", "tried my other library",
+            "changed to my other library", "tried a different library",
+        ],
+        .verifyOnWeb: [
+            "tried the web", "on the website", "in the browser", "web catalog",
+            "works on the computer", "on my computer", "logged in online",
         ],
         .otherDevice: [
             "tried on my ipad", "tried on my phone", "tried a different device",
@@ -130,7 +182,8 @@ public struct RemedyDetector: Sendable {
     /// strand the patron with no path at all.
     private static let blanketPhrases = [
         "tried everything", "done everything", "tried it all", "nothing works",
-        "nothing has worked",
+        "nothing has worked", "tried all your suggestions", "no luck with anything",
+        "exhausted every", "at my wits end",
     ]
 
     /// Remedies the text says were already attempted.

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
@@ -19,6 +19,37 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
     case reopenTitle
     case updateApp
     case otherDevice
+    case pullToRefresh
+    case switchLibrary
+
+    /// What the remedy costs the patron if it does NOT work.
+    ///
+    /// The claim that a generic remedy is "never wrong, only unhelpful" is false
+    /// in this app, and the distinction is what lets a ladder order itself safely:
+    ///
+    ///  - `free` — costs seconds and nothing else. Safe to offer early, anywhere.
+    ///  - `disruptive` — interrupts something or may cost money (metered data,
+    ///    a lost playback position).
+    ///  - `destructive` — DESTROYS content. Signing out removes that library's
+    ///    downloaded books, and a patron who then cannot sign back in (expired
+    ///    card, ILS outage — a quarter of real tickets) has gone from "app
+    ///    misbehaving, books still readable" to "locked out, books gone".
+    ///    Reinstalling deletes every download across every library, and with the
+    ///    Adobe activation history (PP-4951) re-fulfilment afterwards is not
+    ///    guaranteed. These go last or never, and always skippable.
+    public enum CostTier: String, Codable, Sendable {
+        case free
+        case disruptive
+        case destructive
+    }
+
+    public var costTier: CostTier {
+        switch self {
+        case .pullToRefresh, .reopenTitle, .updateApp: return .free
+        case .restartDevice, .toggleNetwork, .otherDevice, .switchLibrary: return .disruptive
+        case .signOutIn, .reinstall: return .destructive
+        }
+    }
 
     /// Patron-facing name, for acknowledging what they have already done.
     public var displayName: String {
@@ -30,6 +61,8 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
         case .reopenTitle:   return "reopening the title"
         case .updateApp:     return "updating the app"
         case .otherDevice:   return "trying another device"
+        case .pullToRefresh: return "pulling down to refresh"
+        case .switchLibrary: return "switching libraries"
         }
     }
 }
@@ -75,6 +108,15 @@ public struct RemedyDetector: Sendable {
         .updateApp: [
             "updated the app", "installed the update", "already updated", "on the latest version",
             "running the latest", "up to date",
+        ],
+        .pullToRefresh: [
+            "pulled down to refresh", "pulled to refresh", "pull to refresh",
+            "swiped down to refresh", "refreshed the list", "refreshed my holds",
+        ],
+        .switchLibrary: [
+            "switched to my other", "switched libraries", "switched library",
+            "changed to my other library", "tried my other library",
+            "switched to my other library",
         ],
         .otherDevice: [
             "tried on my ipad", "tried on my phone", "tried a different device",

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
@@ -48,7 +48,8 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
     ///
     /// Not a repair, and the only entry here that resolves nothing today. It
     /// earns its place because it is the largest single resolution class in the
-    /// corpus — 44 of 212 resolved tickets, more than any actual remedy. Support's
+    /// corpus — 29 of 135 resolved tickets (21%), more than any actual remedy.
+    /// Concentrated in audiobook, where it is 26 of 36. Support's
     /// answer to one patron in five is "we know, it ships in the next release."
     /// Walking that patron through refreshes instead is worse than telling them
     /// the truth. May only be said about an entry that documents a real defect;

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
@@ -11,6 +11,12 @@ import Foundation
 /// That is worse than unhelpful. A patron who has spent twenty minutes
 /// reinstalling and is then told to reinstall concludes the thing is not
 /// listening, and they are right.
+///
+// PUBLIC_INTENT: `KBStep.remedy` is public and decoded from the catalog, so this
+// type has to be at least as accessible as the step that carries it. It is also
+// the tag a server-supplied catalog writes, which makes it contracted schema
+// rather than an implementation detail. Its `costTier` is deliberately NOT
+// public — that one is a local authoring rule, enforced inside this module.
 public enum Remedy: String, Codable, Sendable, CaseIterable {
     case reinstall
     case restartDevice
@@ -84,13 +90,13 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
     ///    Reinstalling deletes every download across every library, and with the
     ///    Adobe activation history (PP-4951) re-fulfilment afterwards is not
     ///    guaranteed. These go last or never, and always skippable.
-    public enum CostTier: String, Codable, Sendable {
+    enum CostTier: String, Codable, Sendable {
         case free
         case disruptive
         case destructive
     }
 
-    public var costTier: CostTier {
+    var costTier: CostTier {
         switch self {
         case .pullToRefresh, .reopenTitle, .verifyOnWeb, .waitForFix: return .free
         // Costs a catalog refetch and nothing the patron owns — no books, no

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
@@ -30,6 +30,44 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
     /// support performs this check itself, server-side, so it is prescribed
     /// almost never and performed almost always.
     case verifyOnWeb
+    /// Return the title and borrow it again.
+    ///
+    /// Addresses a failure mode nothing else in this set touches: one bad loan or
+    /// fulfilment rather than a bad app state. Support reached for it when they
+    /// could play a title themselves that the patron could not — the loan, not
+    /// the app, was broken.
+    case returnAndReborrow
+    /// Tell the patron a fix is already coming, and that there is nothing for
+    /// them to do.
+    ///
+    /// Not a repair, and the only entry here that resolves nothing today. It
+    /// earns its place because it is the largest single resolution class in the
+    /// corpus — 44 of 212 resolved tickets, more than any actual remedy. Support's
+    /// answer to one patron in five is "we know, it ships in the next release."
+    /// Walking that patron through refreshes instead is worse than telling them
+    /// the truth. May only be said about an entry that documents a real defect;
+    /// promising a fix for a problem we did not identify would be an invention,
+    /// and the validator enforces that.
+    case waitForFix
+    /// Settings → Advanced → Clear Cached Data.
+    ///
+    /// Clears the network cache and the on-disk catalog, metadata and registry
+    /// caches. Downloaded books, loans and sign-in all survive. This is the
+    /// surgical step the set was missing between reopening a title, which fixes
+    /// nothing persistent, and reinstalling, which destroys everything — and its
+    /// absence is a plausible reason support reaches for reinstall in a third of
+    /// resolved download tickets.
+    ///
+    /// The screen was deliberately made always-visible (PP-4788) so support could
+    /// direct patrons to it, which means support has been prescribing an action
+    /// the bot could not name.
+    case clearCache
+    /// Settings → Advanced → Reset This Library.
+    ///
+    /// Scoped destruction: one library's local content and state, leaving other
+    /// libraries intact. Strictly better than a reinstall when the problem is
+    /// isolated to one library, and still destructive.
+    case resetLibrary
 
     /// What the remedy costs the patron if it does NOT work.
     ///
@@ -54,7 +92,10 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
 
     public var costTier: CostTier {
         switch self {
-        case .pullToRefresh, .reopenTitle, .verifyOnWeb: return .free
+        case .pullToRefresh, .reopenTitle, .verifyOnWeb, .waitForFix: return .free
+        // Costs a catalog refetch and nothing the patron owns — no books, no
+        // loans, no sign-in.
+        case .clearCache: return .free
         // Not free: minutes, possibly hundreds of megabytes on metered data, an
         // Apple ID prompt and a relaunch. The version gate reduces how often it
         // is WASTED, not what it costs when offered.
@@ -63,7 +104,10 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
         // Changing which library is selected is two taps and reversible; it
         // destroys nothing, and the rung that uses it is an observation.
         case .switchLibrary: return .free
-        case .signOutIn, .reinstall: return .destructive
+        // Returning a loan to fix it can cost the patron their place in a hold
+        // queue, which they cannot undo. A smaller blast radius than reinstalling,
+        // the same kind of loss.
+        case .signOutIn, .reinstall, .returnAndReborrow, .resetLibrary: return .destructive
         }
     }
 
@@ -80,6 +124,10 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
         case .pullToRefresh: return "pulling down to refresh"
         case .switchLibrary: return "switching libraries"
         case .verifyOnWeb:   return "checking the web catalog"
+        case .returnAndReborrow: return "returning and borrowing it again"
+        case .waitForFix:    return "waiting for the fix"
+        case .clearCache:    return "clearing cached data"
+        case .resetLibrary:  return "resetting that library"
         }
     }
 }
@@ -165,6 +213,23 @@ public struct RemedyDetector: Sendable {
             // Only deliberate-attempt phrasings remain.
             "switched to my other", "tried my other library",
             "changed to my other library", "tried a different library",
+        ],
+        .clearCache: [
+            "cleared the cache", "cleared cache", "clear cached data",
+            "cleared cached data", "cleared my cache", "clearing the cache",
+        ],
+        .resetLibrary: [
+            "reset this library", "reset the library", "reset my library",
+        ],
+        .returnAndReborrow: [
+            "returned it and checked it back out", "returned and re-borrowed",
+            "returned and reborrowed", "checked it back out", "borrowed it again",
+            "gave the book back and borrowed", "returned it and borrowed",
+            "turned it in and checked it back out",
+        ],
+        .waitForFix: [
+            "waiting for the fix", "told this is fixed in", "waiting for the update",
+            "waiting on a fix", "know it is fixed in", "supposed to be fixed in",
         ],
         .verifyOnWeb: [
             "tried the web", "on the website", "in the browser", "web catalog",

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
@@ -118,7 +118,7 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
     }
 
     /// Patron-facing name, for acknowledging what they have already done.
-    public var displayName: String {
+    var displayName: String {
         switch self {
         case .reinstall:     return "reinstalling the app"
         case .restartDevice: return "restarting your device"
@@ -148,9 +148,9 @@ public enum Remedy: String, Codable, Sendable, CaseIterable {
 /// repeats advice, which is the status quo. So the phrases are all explicit
 /// past-tense statements of having done the thing, not mentions of the concept —
 /// "I reinstalled" counts, "should I reinstall?" does not.
-public struct RemedyDetector: Sendable {
+struct RemedyDetector: Sendable {
 
-    public init() {}
+    init() {}
 
     /// Past-tense phrasings only. Every entry was taken from wording that appears
     /// in the mined ticket corpus.
@@ -258,7 +258,7 @@ public struct RemedyDetector: Sendable {
     ]
 
     /// Remedies the text says were already attempted.
-    public func alreadyTried(in text: String) -> Set<Remedy> {
+    func alreadyTried(in text: String) -> Set<Remedy> {
         let tokens = TextTokenizer.tokens(TextNormalizer.normalize(text))
         var found: Set<Remedy> = []
         for (remedy, phrases) in Self.phrases {
@@ -275,7 +275,7 @@ public struct RemedyDetector: Sendable {
 
     /// Whether the patron claims broad unsuccessful effort without naming steps.
     /// Worth telling support even though it cannot skip anything.
-    public func claimsExhaustedEffort(in text: String) -> Bool {
+    func claimsExhaustedEffort(in text: String) -> Bool {
         let tokens = TextTokenizer.tokens(TextNormalizer.normalize(text))
         return Self.blanketPhrases.contains { phrase in
             !TextTokenizer.matchRanges(

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/RemedyDetector.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// A remedy a patron may already have tried before contacting support.
+///
+/// Measured on 318 real tickets, 10% say up front what they have already done —
+/// "They've reinstalled the app, rebooted their phone", "I have uninstalled and
+/// redownloaded several times", "tried everything". The bot reads none of it and
+/// will cheerfully open a guided flow whose first step is the thing they just
+/// told us they did twice.
+///
+/// That is worse than unhelpful. A patron who has spent twenty minutes
+/// reinstalling and is then told to reinstall concludes the thing is not
+/// listening, and they are right.
+public enum Remedy: String, Codable, Sendable, CaseIterable {
+    case reinstall
+    case restartDevice
+    case signOutIn
+    case toggleNetwork
+    case reopenTitle
+    case updateApp
+    case otherDevice
+
+    /// Patron-facing name, for acknowledging what they have already done.
+    public var displayName: String {
+        switch self {
+        case .reinstall:     return "reinstalling the app"
+        case .restartDevice: return "restarting your device"
+        case .signOutIn:     return "signing out and back in"
+        case .toggleNetwork: return "switching between WiFi and cellular"
+        case .reopenTitle:   return "reopening the title"
+        case .updateApp:     return "updating the app"
+        case .otherDevice:   return "trying another device"
+        }
+    }
+}
+
+/// Finds remedies the patron says they have ALREADY tried.
+///
+/// Pure and KMP-portable: token matching against phrase lists, the same
+/// mechanism the classifier uses, so a Kotlin port behaves identically.
+///
+/// Deliberately conservative. A false positive here SKIPS a step the patron
+/// might not have taken, which costs them the fix; a false negative merely
+/// repeats advice, which is the status quo. So the phrases are all explicit
+/// past-tense statements of having done the thing, not mentions of the concept —
+/// "I reinstalled" counts, "should I reinstall?" does not.
+public struct RemedyDetector: Sendable {
+
+    public init() {}
+
+    /// Past-tense phrasings only. Every entry was taken from wording that appears
+    /// in the mined ticket corpus.
+    private static let phrases: [Remedy: [String]] = [
+        .reinstall: [
+            "reinstalled", "re installed", "uninstalled and", "deleted the app",
+            "deleted and reinstalled", "removed the app and", "redownloaded the app",
+            "delete and reinstall it", "uninstalled it",
+        ],
+        .restartDevice: [
+            "rebooted", "restarted my phone", "restarted the phone", "restarted my ipad",
+            "turned my phone off", "power cycled", "restarted my device",
+        ],
+        .signOutIn: [
+            "signed out and back", "signed out and in", "logged out and back",
+            "logged out and in", "signed out then", "logged out then",
+        ],
+        .toggleNetwork: [
+            "on and off wifi", "off and on wifi", "toggled wifi", "turned wifi off",
+            "switched to cellular", "tried cellular", "different wifi",
+        ],
+        .reopenTitle: [
+            "closed and reopened", "reopened the book", "reopened it", "opened it again",
+            "backed out and tried again",
+        ],
+        .updateApp: [
+            "updated the app", "installed the update", "already updated", "on the latest version",
+            "running the latest", "up to date",
+        ],
+        .otherDevice: [
+            "tried on my ipad", "tried on my phone", "tried a different device",
+            "on different devices", "on another device", "works on my iphone",
+            "works on my ipad",
+        ],
+    ]
+
+    /// A blanket "I tried everything" claim. Treated as evidence of effort but NOT
+    /// mapped to specific remedies — skipping every step on a vague claim would
+    /// strand the patron with no path at all.
+    private static let blanketPhrases = [
+        "tried everything", "done everything", "tried it all", "nothing works",
+        "nothing has worked",
+    ]
+
+    /// Remedies the text says were already attempted.
+    public func alreadyTried(in text: String) -> Set<Remedy> {
+        let tokens = TextTokenizer.tokens(TextNormalizer.normalize(text))
+        var found: Set<Remedy> = []
+        for (remedy, phrases) in Self.phrases {
+            for phrase in phrases {
+                let needle = TextTokenizer.tokens(TextNormalizer.normalize(phrase))
+                if !TextTokenizer.matchRanges(of: needle, in: tokens).isEmpty {
+                    found.insert(remedy)
+                    break
+                }
+            }
+        }
+        return found
+    }
+
+    /// Whether the patron claims broad unsuccessful effort without naming steps.
+    /// Worth telling support even though it cannot skip anything.
+    public func claimsExhaustedEffort(in text: String) -> Bool {
+        let tokens = TextTokenizer.tokens(TextNormalizer.normalize(text))
+        return Self.blanketPhrases.contains { phrase in
+            !TextTokenizer.matchRanges(
+                of: TextTokenizer.tokens(TextNormalizer.normalize(phrase)), in: tokens
+            ).isEmpty
+        }
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/TextTokenizer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/TextTokenizer.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Splits patron text and KB keywords into comparable word tokens.
+///
+/// Matching used to be `text.contains(keyword)`, which has no notion of a word
+/// boundary. That was survivable while a known-issue entry needed two matches to
+/// suggest — one accidental substring could not carry a decision on its own.
+/// Once a single decisive phrase became sufficient, every accidental substring
+/// became a full workaround card, and the catalog contains keywords that are
+/// substrings of ordinary words:
+///
+///     "stalled"  ⊂  "I reinstalled the app"      → download-no-network advice
+///     "add"      ⊂  "additional"
+///     "card"     ⊂  "discard"
+///
+/// The first is not hypothetical — "reinstalled the app" is one of the most
+/// common sentences in the support corpus, and it was matching KI-008's
+/// `stalled` and suggesting a network fix for a launch crash.
+///
+/// Tokenizing both sides fixes the whole class at once. Pure Swift with no
+/// Foundation-locale or NaturalLanguage dependency, so `TriageBotCore` stays
+/// KMP-portable: the Kotlin port splits on the same rule and gets the same
+/// tokens.
+public enum TextTokenizer {
+
+    /// Lowercased alphanumeric runs. Everything else — spaces, apostrophes,
+    /// hyphens, punctuation — separates.
+    ///
+    /// Apostrophes SEPARATE rather than bind, so "won't" becomes ["won", "t"].
+    /// That looks lossy in isolation and is not, because the same rule is applied
+    /// to the keyword: `won't download` and `wont download` both tokenize to
+    /// ["won", "t", "download"] and ["wont", "download"] respectively, and the
+    /// patron's text tokenizes the same way it was written. Consistency across
+    /// both sides is what matters, not linguistic fidelity.
+    public static func tokens(_ text: String) -> [String] {
+        var out: [String] = []
+        var current = ""
+        for ch in text.lowercased() {
+            if ch.isLetter || ch.isNumber {
+                current.append(ch)
+            } else if !current.isEmpty {
+                out.append(current)
+                current = ""
+            }
+        }
+        if !current.isEmpty { out.append(current) }
+        return out
+    }
+
+    /// Token-index ranges where `keyword` occurs as a contiguous run inside
+    /// `text`. Empty when the keyword does not occur, or is empty.
+    ///
+    /// Returns EVERY occurrence, not just the first: a phrase repeated in a long
+    /// complaint is still one concept, and leaving the merge to the caller keeps
+    /// that decision in one place.
+    public static func matchRanges(of keyword: [String], in text: [String]) -> [Range<Int>] {
+        guard !keyword.isEmpty, keyword.count <= text.count else { return [] }
+        var ranges: [Range<Int>] = []
+        for start in 0...(text.count - keyword.count) {
+            if Array(text[start..<(start + keyword.count)]) == keyword {
+                ranges.append(start..<(start + keyword.count))
+            }
+        }
+        return ranges
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/TextTokenizer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Classifier/TextTokenizer.swift
@@ -21,7 +21,7 @@ import Foundation
 /// Foundation-locale or NaturalLanguage dependency, so `TriageBotCore` stays
 /// KMP-portable: the Kotlin port splits on the same rule and gets the same
 /// tokens.
-public enum TextTokenizer {
+enum TextTokenizer {
 
     /// Lowercased alphanumeric runs. Everything else — spaces, apostrophes,
     /// hyphens, punctuation — separates.
@@ -32,7 +32,7 @@ public enum TextTokenizer {
     /// ["won", "t", "download"] and ["wont", "download"] respectively, and the
     /// patron's text tokenizes the same way it was written. Consistency across
     /// both sides is what matters, not linguistic fidelity.
-    public static func tokens(_ text: String) -> [String] {
+    static func tokens(_ text: String) -> [String] {
         var out: [String] = []
         var current = ""
         for ch in text.lowercased() {
@@ -53,7 +53,7 @@ public enum TextTokenizer {
     /// Returns EVERY occurrence, not just the first: a phrase repeated in a long
     /// complaint is still one concept, and leaving the merge to the caller keeps
     /// that decision in one place.
-    public static func matchRanges(of keyword: [String], in text: [String]) -> [Range<Int>] {
+    static func matchRanges(of keyword: [String], in text: [String]) -> [Range<Int>] {
         guard !keyword.isEmpty, keyword.count <= text.count else { return [] }
         var ranges: [Range<Int>] = []
         for start in 0...(text.count - keyword.count) {

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/CatalogValidator.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/CatalogValidator.swift
@@ -86,6 +86,14 @@ public enum CatalogValidator {
             for step in steps {
                 guard let remedy = step.remedy else { continue }
 
+                // A ladder fires when nothing matched. Telling that patron a fix
+                // is coming would be an invention: we do not know what their
+                // problem is, so we cannot know a fix exists for it.
+                if remedy == .waitForFix && isLadder {
+                    problems.append(
+                        "\(entry.id)/\(step.id): waitForFix promises a fix for a problem this flow did not identify")
+                }
+
                 // Trying another device diagnoses; it repairs nothing. Keep it as
                 // detection vocabulary and out of the instruction set.
                 if remedy == .otherDevice {

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/CatalogValidator.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/CatalogValidator.swift
@@ -60,22 +60,38 @@ public enum CatalogValidator {
     public static func violations(in catalog: KBCatalog) -> [String] {
         var problems: [String] = []
 
-        for entry in catalog.entries where entry.resolvedKind == .genericFlow {
+        for entry in catalog.entries {
             let steps = entry.userFacingSteps ?? []
+            let isLadder = entry.resolvedKind == .genericFlow
 
-            if steps.isEmpty {
-                problems.append("\(entry.id): a ladder with no rungs offers nothing")
-            }
-            if steps.count > maxRungs {
-                problems.append("\(entry.id): \(steps.count) rungs exceeds the limit of \(maxRungs)")
-            }
-            if !entry.symptomKeywords.isEmpty {
-                problems.append("\(entry.id): a ladder must not claim symptoms — it is offered when nothing matched")
+            // Shape rules that only make sense for a ladder.
+            if isLadder {
+                if steps.isEmpty {
+                    problems.append("\(entry.id): a ladder with no rungs offers nothing")
+                }
+                if steps.count > maxRungs {
+                    problems.append("\(entry.id): \(steps.count) rungs exceeds the limit of \(maxRungs)")
+                }
+                if !entry.symptomKeywords.isEmpty {
+                    problems.append("\(entry.id): a ladder must not claim symptoms — it is offered when nothing matched")
+                }
             }
 
+            // SAFETY rules apply to every entry kind, not only ladders. Scoping
+            // them to ladders contradicted this file's own charter: a hot-pushed
+            // known_issue entry in the signin category with a sign-out step told
+            // exactly the patron we suppress it for to do the thing we suppress,
+            // and validated clean.
             let banned = suppressed[entry.category] ?? []
             for step in steps {
                 guard let remedy = step.remedy else { continue }
+
+                // Trying another device diagnoses; it repairs nothing. Keep it as
+                // detection vocabulary and out of the instruction set.
+                if remedy == .otherDevice {
+                    problems.append(
+                        "\(entry.id)/\(step.id): otherDevice is a diagnostic, not a remedy — it belongs in an escalation question, not a step")
+                }
 
                 if banned.contains(remedy) {
                     problems.append(

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/CatalogValidator.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/CatalogValidator.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Structural rules a catalog must satisfy before the bot will speak from it.
+///
+/// This runs at LOAD, not only in tests, because the catalog is designed to be
+/// server-supplied for hot updates. A rule enforced only by the test suite is a
+/// rule the shipped app does not have: a hot-pushed catalog could tell every
+/// sign-in patron to sign out, and nothing on the device would object.
+///
+/// Scope is deliberately narrow — these are safety invariants about REMEDY
+/// LADDERS, where being wrong costs the patron something concrete. Schema shape,
+/// keyword strength and copy quality stay in `CatalogSchemaLintTests`, which runs
+/// against the bundled file at build time and can afford to be stricter than
+/// anything we would enforce against a live catalog.
+public enum CatalogValidator {
+
+    /// Per-category remedies that evidence says must never be offered.
+    ///
+    /// Derived from 204 authoring tickets, using a pre-registered threshold
+    /// rather than per-cell judgement: suppress only where the category has at
+    /// least 15 resolved tickets AND the remedy was prescribed in at most 3% of
+    /// them. Categories below that count (reader, n=4) are UNKNOWN, not zero, and
+    /// are governed by the default order instead.
+    ///
+    ///   sign-in, n=41 — update-the-app prescribed 0 times, sign-out once.
+    ///   The two cheapest remedies are the two least applicable in the largest
+    ///   category, which is precisely the ordering a cost-only ladder would have
+    ///   produced. That is why this table exists.
+    static let suppressed: [KBCategory: Set<Remedy>] = [
+        .signin: [.updateApp, .signOutIn],
+        .audiobook: [.switchLibrary],
+        .download: [.switchLibrary],
+        .other: [.switchLibrary],
+    ]
+
+    /// At most this many rungs in a ladder. The quarter of patrons whose problem
+    /// only staff or their library can resolve pay the entire ladder as delay
+    /// before reaching a human; three cheap steps is a defensible tax, six is not.
+    static let maxRungs = 3
+
+    public static func violations(in catalog: KBCatalog) -> [String] {
+        var problems: [String] = []
+
+        for entry in catalog.entries where entry.resolvedKind == .genericFlow {
+            let steps = entry.userFacingSteps ?? []
+
+            if steps.isEmpty {
+                problems.append("\(entry.id): a ladder with no rungs offers nothing")
+            }
+            if steps.count > maxRungs {
+                problems.append("\(entry.id): \(steps.count) rungs exceeds the limit of \(maxRungs)")
+            }
+            if !entry.symptomKeywords.isEmpty {
+                problems.append("\(entry.id): a ladder must not claim symptoms — it is offered when nothing matched")
+            }
+
+            let banned = suppressed[entry.category] ?? []
+            for step in steps {
+                guard let remedy = step.remedy else { continue }
+
+                if banned.contains(remedy) {
+                    problems.append(
+                        "\(entry.id)/\(step.id): \(remedy.rawValue) is suppressed for \(entry.category.rawValue) — support prescribed it for this category in ≤3% of resolved tickets")
+                }
+
+                if remedy.costTier == .destructive {
+                    // Never first: a ladder must not open by destroying content.
+                    if step.id == steps.first?.id {
+                        problems.append(
+                            "\(entry.id)/\(step.id): \(remedy.rawValue) destroys downloaded content and must not be the first rung")
+                    }
+                    // Always refusable. `responses` nil means the UI renders the
+                    // legacy yes/no pair, where "no" advances — which is a way
+                    // out — so only an explicit response set that offers no
+                    // advance/escalate route is a trap.
+                    if let responses = step.responses,
+                       !responses.contains(where: { $0.outcome == .advance || $0.outcome == .escalate }) {
+                        problems.append(
+                            "\(entry.id)/\(step.id): \(remedy.rawValue) is destructive and must remain refusable — no response advances or escalates")
+                    }
+                }
+            }
+        }
+        return problems
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/CatalogValidator.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/CatalogValidator.swift
@@ -22,10 +22,29 @@ public enum CatalogValidator {
     /// them. Categories below that count (reader, n=4) are UNKNOWN, not zero, and
     /// are governed by the default order instead.
     ///
-    ///   sign-in, n=41 — update-the-app prescribed 0 times, sign-out once.
+    ///   sign-in, n=44 — update-the-app prescribed 0 times, sign-out 0 times.
     ///   The two cheapest remedies are the two least applicable in the largest
     ///   category, which is precisely the ordering a cost-only ladder would have
     ///   produced. That is why this table exists.
+    ///
+    /// TWO TRAPS FOR WHOEVER RE-DERIVES THIS. Both were hit on the first
+    /// re-derivation against a freshly mined corpus, and both would have loosened
+    /// a correct rule.
+    ///
+    /// 1. A keyword scan over resolution text counts MENTIONS, not
+    ///    PRESCRIPTIONS. Re-deriving naively put sign-out at 7% for sign-in and
+    ///    appeared to contradict this table. Reading the three tickets showed
+    ///    none of them prescribed it: one patron was already signed out and was
+    ///    walked TO the login screen, one resolution merely explained that
+    ///    credentials persist "until you sign out", and one described replacing a
+    ///    library card. Zero were a remedy for a failing sign-in. Read the cited
+    ///    tickets before moving any cell.
+    /// 2. Absence is only evidence for remedies support would WRITE DOWN.
+    ///    Pull-to-refresh appears in 3 of 135 resolutions total, so it reads 0%
+    ///    in every category — not because it never helps but because it is too
+    ///    small to record. Suppressing on that would remove the safest remedy we
+    ///    have. The <=3% rule applies only to substantive, mentionable remedies:
+    ///    update, reinstall, sign-out, switch-library.
     static let suppressed: [KBCategory: Set<Remedy>] = [
         .signin: [.updateApp, .signOutIn],
         .audiobook: [.switchLibrary],

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/CatalogValidator.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/CatalogValidator.swift
@@ -12,7 +12,7 @@ import Foundation
 /// keyword strength and copy quality stay in `CatalogSchemaLintTests`, which runs
 /// against the bundled file at build time and can afford to be stricter than
 /// anything we would enforce against a live catalog.
-public enum CatalogValidator {
+enum CatalogValidator {
 
     /// Per-category remedies that evidence says must never be offered.
     ///
@@ -57,7 +57,7 @@ public enum CatalogValidator {
     /// before reaching a human; three cheap steps is a defensible tax, six is not.
     static let maxRungs = 3
 
-    public static func violations(in catalog: KBCatalog) -> [String] {
+    static func violations(in catalog: KBCatalog) -> [String] {
         var problems: [String] = []
 
         for entry in catalog.entries {

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/KnowledgeBase.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/KnowledgeBase.swift
@@ -31,7 +31,8 @@ public struct KnowledgeBase: Sendable {
                 version: catalog.version,
                 updatedAt: catalog.updatedAt,
                 entries: catalog.entries.filter { !offending.contains($0.id) },
-                categoryFollowUps: catalog.categoryFollowUps
+                categoryFollowUps: catalog.categoryFollowUps,
+                latestKnownAppVersion: catalog.latestKnownAppVersion
             )
         }
     }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/KnowledgeBase.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/KnowledgeBase.swift
@@ -16,6 +16,15 @@ public struct KnowledgeBase: Sendable {
         return catalog.categoryFollowUps?[category.rawValue]
     }
 
+    /// The remedy ladder for a category, if the catalog defines one.
+    public func genericFlow(for category: KBCategory?) -> KBEntry? {
+        guard let category else { return nil }
+        return catalog.entries.first {
+            $0.resolvedKind == .genericFlow && $0.category == category
+                && !($0.userFacingSteps ?? []).isEmpty
+        }
+    }
+
     public func entry(id: String) -> KBEntry? {
         catalog.entries.first { $0.id == id }
     }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/KnowledgeBase.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/KnowledgeBase.swift
@@ -5,9 +5,35 @@ import Foundation
 /// reducer asks it for a single entry by id.
 public struct KnowledgeBase: Sendable {
     public let catalog: KBCatalog
+    /// Ladder rules the loaded catalog broke. Non-empty means the offending
+    /// ladders were dropped rather than spoken from — see `init`.
+    public let validationViolations: [String]
 
     public init(catalog: KBCatalog) {
-        self.catalog = catalog
+        // Validate at LOAD, and degrade rather than refuse. A catalog that
+        // violates a ladder rule is not wholly untrustworthy — its entries and
+        // answers are still good — so the safe response is to drop the offending
+        // LADDERS and keep everything else. The bot then behaves as it did before
+        // ladders existed for those categories, which is a known-good state.
+        //
+        // Enforced here rather than only in tests because this schema is designed
+        // to be server-supplied later: a rule that lives only in the test suite is
+        // a rule the shipped app does not have.
+        let violations = CatalogValidator.violations(in: catalog)
+        self.validationViolations = violations
+
+        if violations.isEmpty {
+            self.catalog = catalog
+        } else {
+            let offending = Set(violations.compactMap { $0.split(separator: ":").first.map(String.init) }
+                                          .map { $0.split(separator: "/").first.map(String.init) ?? $0 })
+            self.catalog = KBCatalog(
+                version: catalog.version,
+                updatedAt: catalog.updatedAt,
+                entries: catalog.entries.filter { !offending.contains($0.id) },
+                categoryFollowUps: catalog.categoryFollowUps
+            )
+        }
     }
 
     /// The catch-all question for a category, used when no entry was recognized.

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/KnowledgeBase.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/KnowledgeBase.swift
@@ -7,7 +7,7 @@ public struct KnowledgeBase: Sendable {
     public let catalog: KBCatalog
     /// Ladder rules the loaded catalog broke. Non-empty means the offending
     /// ladders were dropped rather than spoken from — see `init`.
-    public let validationViolations: [String]
+    let validationViolations: [String]
 
     public init(catalog: KBCatalog) {
         // Validate at LOAD, and degrade rather than refuse. A catalog that
@@ -38,13 +38,13 @@ public struct KnowledgeBase: Sendable {
     }
 
     /// The catch-all question for a category, used when no entry was recognized.
-    public func categoryFollowUp(for category: KBCategory?) -> KBEscalationFollowUp? {
+    func categoryFollowUp(for category: KBCategory?) -> KBEscalationFollowUp? {
         guard let category else { return nil }
         return catalog.categoryFollowUps?[category.rawValue]
     }
 
     /// The remedy ladder for a category, if the catalog defines one.
-    public func genericFlow(for category: KBCategory?) -> KBEntry? {
+    func genericFlow(for category: KBCategory?) -> KBEntry? {
         guard let category else { return nil }
         return catalog.entries.first {
             $0.resolvedKind == .genericFlow && $0.category == category

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/KnowledgeBase.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/KB/KnowledgeBase.swift
@@ -10,6 +10,12 @@ public struct KnowledgeBase: Sendable {
         self.catalog = catalog
     }
 
+    /// The catch-all question for a category, used when no entry was recognized.
+    public func categoryFollowUp(for category: KBCategory?) -> KBEscalationFollowUp? {
+        guard let category else { return nil }
+        return catalog.categoryFollowUps?[category.rawValue]
+    }
+
     public func entry(id: String) -> KBEntry? {
         catalog.entries.first { $0.id == id }
     }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ClassificationResult.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ClassificationResult.swift
@@ -44,13 +44,13 @@ public struct ClassificationResult: Equatable, Sendable {
     ///
     /// False for a genuine no-match, and irrelevant on `.suggest` (which already
     /// requires strong evidence by construction).
-    public let recognitionIsStrong: Bool
+    let recognitionIsStrong: Bool
     /// How many DISTINCT strong concepts the patron's text matched on the winning
     /// entry. One is enough to suggest — that is the fix for QA's complaint — but
     /// one is also the thinnest evidence that can produce a suggestion, so the UI
     /// hedges there rather than asserting. Two or more distinct concepts is a
     /// coincidence worth stating plainly.
-    public let strongRegionCount: Int
+    let strongRegionCount: Int
 
     public init(
         decision: Decision,

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ClassificationResult.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ClassificationResult.swift
@@ -45,6 +45,12 @@ public struct ClassificationResult: Equatable, Sendable {
     /// False for a genuine no-match, and irrelevant on `.suggest` (which already
     /// requires strong evidence by construction).
     public let recognitionIsStrong: Bool
+    /// How many DISTINCT strong concepts the patron's text matched on the winning
+    /// entry. One is enough to suggest — that is the fix for QA's complaint — but
+    /// one is also the thinnest evidence that can produce a suggestion, so the UI
+    /// hedges there rather than asserting. Two or more distinct concepts is a
+    /// coincidence worth stating plainly.
+    public let strongRegionCount: Int
 
     public init(
         decision: Decision,
@@ -52,7 +58,8 @@ public struct ClassificationResult: Equatable, Sendable {
         matchedKeywords: [String] = [],
         consideredEntryIds: [String] = [],
         recognizedEntryId: String? = nil,
-        recognitionIsStrong: Bool = false
+        recognitionIsStrong: Bool = false,
+        strongRegionCount: Int = 0
     ) {
         self.decision = decision
         self.confidence = confidence
@@ -60,5 +67,6 @@ public struct ClassificationResult: Equatable, Sendable {
         self.consideredEntryIds = consideredEntryIds
         self.recognizedEntryId = recognizedEntryId
         self.recognitionIsStrong = recognitionIsStrong
+        self.strongRegionCount = strongRegionCount
     }
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ClassificationResult.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ClassificationResult.swift
@@ -29,18 +29,36 @@ public struct ClassificationResult: Equatable, Sendable {
     /// Nil for a genuine no-match. On `.suggest` the id is in the decision, so
     /// this stays nil there.
     public let recognizedEntryId: String?
+    /// Whether `recognizedEntryId` rests on STRONG evidence (a decisive phrase)
+    /// or only on corroborating words.
+    ///
+    /// The two uses of a recognized entry have very different tolerances:
+    ///
+    ///  - Tagging the outgoing ticket is support-facing metadata the patron never
+    ///    sees. A wrong hint costs a triager a moment; a missing one costs them
+    ///    the whole diagnosis. Do this on ANY recognition.
+    ///  - Asking the entry's targeted follow-up is patron-facing, and every such
+    ///    prompt in the catalog presumes its bug ("is it wired CarPlay or
+    ///    wireless?"). Asked off a lone generic word it is baffling and reads as
+    ///    the bot inventing a problem. Do this only when this flag is true.
+    ///
+    /// False for a genuine no-match, and irrelevant on `.suggest` (which already
+    /// requires strong evidence by construction).
+    public let recognitionIsStrong: Bool
 
     public init(
         decision: Decision,
         confidence: Double,
         matchedKeywords: [String] = [],
         consideredEntryIds: [String] = [],
-        recognizedEntryId: String? = nil
+        recognizedEntryId: String? = nil,
+        recognitionIsStrong: Bool = false
     ) {
         self.decision = decision
         self.confidence = confidence
         self.matchedKeywords = matchedKeywords
         self.consideredEntryIds = consideredEntryIds
         self.recognizedEntryId = recognizedEntryId
+        self.recognitionIsStrong = recognitionIsStrong
     }
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
@@ -97,12 +97,12 @@ public struct ConversationState: Equatable, Sendable {
     /// tried. Guided flows skip these rather than asking someone who has
     /// reinstalled three times to reinstall again — 10% of real tickets open by
     /// listing what they have already done.
-    public var alreadyTriedRemedies: Set<Remedy>
+    var alreadyTriedRemedies: Set<Remedy>
     /// The patron said they had tried everything, without naming steps. Cannot
     /// skip any specific rung, but must suppress the remedy ladder entirely —
     /// walking someone through remedies after they told us they had exhausted
     /// them is the not-listening defect in its purest form.
-    public var claimsExhaustedEffort: Bool
+    var claimsExhaustedEffort: Bool
 
     public init(
         step: Step = .welcome,

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
@@ -93,6 +93,11 @@ public struct ConversationState: Equatable, Sendable {
     /// every pre-PP-4843 flow) sends normally — only reducer-driven fresh
     /// previews arm the gate.
     public var pendingSendConsent: Bool
+    /// Remedies the patron said, in their own description, that they already
+    /// tried. Guided flows skip these rather than asking someone who has
+    /// reinstalled three times to reinstall again — 10% of real tickets open by
+    /// listing what they have already done.
+    public var alreadyTriedRemedies: Set<Remedy>
 
     public init(
         step: Step = .welcome,
@@ -100,7 +105,8 @@ public struct ConversationState: Equatable, Sendable {
         context: ContextSnapshot? = nil,
         lastClassification: ClassificationResult? = nil,
         inputText: String = "",
-        pendingSendConsent: Bool = false
+        pendingSendConsent: Bool = false,
+        alreadyTriedRemedies: Set<Remedy> = []
     ) {
         self.step = step
         self.messages = messages
@@ -108,6 +114,7 @@ public struct ConversationState: Equatable, Sendable {
         self.lastClassification = lastClassification
         self.inputText = inputText
         self.pendingSendConsent = pendingSendConsent
+        self.alreadyTriedRemedies = alreadyTriedRemedies
     }
 }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/ConversationState.swift
@@ -98,6 +98,11 @@ public struct ConversationState: Equatable, Sendable {
     /// reinstalled three times to reinstall again — 10% of real tickets open by
     /// listing what they have already done.
     public var alreadyTriedRemedies: Set<Remedy>
+    /// The patron said they had tried everything, without naming steps. Cannot
+    /// skip any specific rung, but must suppress the remedy ladder entirely —
+    /// walking someone through remedies after they told us they had exhausted
+    /// them is the not-listening defect in its purest form.
+    public var claimsExhaustedEffort: Bool
 
     public init(
         step: Step = .welcome,
@@ -106,7 +111,8 @@ public struct ConversationState: Equatable, Sendable {
         lastClassification: ClassificationResult? = nil,
         inputText: String = "",
         pendingSendConsent: Bool = false,
-        alreadyTriedRemedies: Set<Remedy> = []
+        alreadyTriedRemedies: Set<Remedy> = [],
+        claimsExhaustedEffort: Bool = false
     ) {
         self.step = step
         self.messages = messages
@@ -115,6 +121,7 @@ public struct ConversationState: Equatable, Sendable {
         self.inputText = inputText
         self.pendingSendConsent = pendingSendConsent
         self.alreadyTriedRemedies = alreadyTriedRemedies
+        self.claimsExhaustedEffort = claimsExhaustedEffort
     }
 }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
@@ -62,6 +62,14 @@ public enum KBCategory: String, Codable, Sendable, CaseIterable {
 public enum KBKind: String, Codable, Sendable {
     case knownIssue = "known_issue"
     case howTo = "how_to"
+    /// A per-category remedy ladder, not a diagnosis.
+    ///
+    /// Carries `user_facing_steps` like a known_issue, but claims nothing about
+    /// what is wrong — it is the short, safe sequence offered when no entry
+    /// matched, which is most of the time. Deliberately excluded from
+    /// classification: a ladder must never win a match, scope a ticket, or appear
+    /// as a considered candidate, because it has no diagnostic content to offer.
+    case genericFlow = "generic_flow"
 }
 
 public struct KBInternalReference: Codable, Equatable, Sendable {

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
@@ -115,7 +115,7 @@ public struct KBEntry: Codable, Equatable, Identifiable, Sendable {
     /// Optional in JSON so existing catalogs — and the Kotlin reader of the same
     /// schema — decode unchanged; absent means "this entry has no weak keywords",
     /// which is the correct reading for every `how_to` entry.
-    public let corroboratingKeywords: [String]?
+    let corroboratingKeywords: [String]?
     public let distributorFilter: [String]?
     public let authTypeFilter: [String]?
     public let iosVersionFilter: [String]?
@@ -243,7 +243,7 @@ public struct KBCatalog: Codable, Equatable, Sendable {
     ///
     /// Keyed by `KBCategory.rawValue`. Optional so existing catalogs decode
     /// unchanged; a missing category simply asks nothing, as today.
-    public let categoryFollowUps: [String: KBEscalationFollowUp]?
+    let categoryFollowUps: [String: KBEscalationFollowUp]?
     /// The newest app version this catalog knows about.
     ///
     /// Lets a ladder skip its "check for an update" rung for anyone already at or
@@ -253,7 +253,7 @@ public struct KBCatalog: Codable, Equatable, Sendable {
     /// rung. Going stale costs one cohort a wasted rung — the same cost as having
     /// no gate at all — so staleness degrades to today's behaviour rather than to
     /// a withheld fix.
-    public let latestKnownAppVersion: String?
+    let latestKnownAppVersion: String?
 
     enum CodingKeys: String, CodingKey {
         case version
@@ -263,7 +263,7 @@ public struct KBCatalog: Codable, Equatable, Sendable {
         case latestKnownAppVersion = "latest_known_app_version"
     }
 
-    public init(version: String, updatedAt: String, entries: [KBEntry],
+    init(version: String, updatedAt: String, entries: [KBEntry],
                 categoryFollowUps: [String: KBEscalationFollowUp]? = nil,
                 latestKnownAppVersion: String? = nil) {
         self.version = version

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
@@ -219,10 +219,36 @@ public struct KBCatalog: Codable, Equatable, Sendable {
     public let version: String
     public let updatedAt: String
     public let entries: [KBEntry]
+    /// One question per category, asked when we recognized NOTHING.
+    ///
+    /// Measured on 318 real tickets, 69% of escalations carry no recognized entry
+    /// and therefore ask nothing — support receives "a patron reports a problem"
+    /// plus diagnostics. Matching cannot close that: 8% of complaints are under a
+    /// dozen words ("Cant sign in"), and the catalog covers a fraction of the
+    /// causes behind the rest.
+    ///
+    /// A per-category question does not need to know the cause. It only needs to
+    /// ask the thing that most often splits that category's clusters — for
+    /// sign-in, whether the card came from the library or was created in the app,
+    /// which separates the two largest groups in one answer. That turns a blank
+    /// ticket into a scoped one without any claim about what is wrong.
+    ///
+    /// Keyed by `KBCategory.rawValue`. Optional so existing catalogs decode
+    /// unchanged; a missing category simply asks nothing, as today.
+    public let categoryFollowUps: [String: KBEscalationFollowUp]?
 
     enum CodingKeys: String, CodingKey {
         case version
         case updatedAt = "updated_at"
         case entries
+        case categoryFollowUps = "category_follow_ups"
+    }
+
+    public init(version: String, updatedAt: String, entries: [KBEntry],
+                categoryFollowUps: [String: KBEscalationFollowUp]? = nil) {
+        self.version = version
+        self.updatedAt = updatedAt
+        self.entries = entries
+        self.categoryFollowUps = categoryFollowUps
     }
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
@@ -244,19 +244,32 @@ public struct KBCatalog: Codable, Equatable, Sendable {
     /// Keyed by `KBCategory.rawValue`. Optional so existing catalogs decode
     /// unchanged; a missing category simply asks nothing, as today.
     public let categoryFollowUps: [String: KBEscalationFollowUp]?
+    /// The newest app version this catalog knows about.
+    ///
+    /// Lets a ladder skip its "check for an update" rung for anyone already at or
+    /// past it. The bot cannot see the App Store, so this is the only way it can
+    /// avoid sending a patron on the newest build to look for an update that is
+    /// not there. Optional and conservatively handled: absent means offer the
+    /// rung. Going stale costs one cohort a wasted rung — the same cost as having
+    /// no gate at all — so staleness degrades to today's behaviour rather than to
+    /// a withheld fix.
+    public let latestKnownAppVersion: String?
 
     enum CodingKeys: String, CodingKey {
         case version
         case updatedAt = "updated_at"
         case entries
         case categoryFollowUps = "category_follow_ups"
+        case latestKnownAppVersion = "latest_known_app_version"
     }
 
     public init(version: String, updatedAt: String, entries: [KBEntry],
-                categoryFollowUps: [String: KBEscalationFollowUp]? = nil) {
+                categoryFollowUps: [String: KBEscalationFollowUp]? = nil,
+                latestKnownAppVersion: String? = nil) {
         self.version = version
         self.updatedAt = updatedAt
         self.entries = entries
         self.categoryFollowUps = categoryFollowUps
+        self.latestKnownAppVersion = latestKnownAppVersion
     }
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEntry.swift
@@ -88,7 +88,26 @@ public struct KBEntry: Codable, Equatable, Identifiable, Sendable {
     /// status). Present for `.knownIssue` entries.
     public let status: KBStatus?
     public let fixedInVersion: String?
+    /// STRONG evidence — phrases specific enough that one of them, alone, is
+    /// grounds to offer this entry. "won't download", "hold is ready",
+    /// "grayed out". A patron who writes one of these has named this problem.
     public let symptomKeywords: [String]
+    /// WEAK evidence — generic symptom words that are consistent with this entry
+    /// but describe half the app: "stuck", "crashes", "download", "bookshelf".
+    /// They raise confidence when they accompany a strong match and are NEVER
+    /// sufficient on their own.
+    ///
+    /// The distinction exists because these two populations were previously one
+    /// flat `symptom_keywords` list, which forced the classifier to gate on
+    /// COUNT ("require ≥2 matches") as a proxy for quality. That proxy suppressed
+    /// the strong keywords along with the weak ones: a patron writing the single
+    /// decisive phrase "my book won't download" scored 1 and escalated, while the
+    /// bot's guided steps sat unreachable behind the ≥2 floor (PP-4865).
+    ///
+    /// Optional in JSON so existing catalogs — and the Kotlin reader of the same
+    /// schema — decode unchanged; absent means "this entry has no weak keywords",
+    /// which is the correct reading for every `how_to` entry.
+    public let corroboratingKeywords: [String]?
     public let distributorFilter: [String]?
     public let authTypeFilter: [String]?
     public let iosVersionFilter: [String]?
@@ -129,6 +148,7 @@ public struct KBEntry: Codable, Equatable, Identifiable, Sendable {
         case status
         case fixedInVersion = "fixed_in_version"
         case symptomKeywords = "symptom_keywords"
+        case corroboratingKeywords = "corroborating_keywords"
         case distributorFilter = "distributor_filter"
         case authTypeFilter = "auth_type_filter"
         case iosVersionFilter = "ios_version_filter"
@@ -152,6 +172,7 @@ public struct KBEntry: Codable, Equatable, Identifiable, Sendable {
         status: KBStatus? = nil,
         fixedInVersion: String? = nil,
         symptomKeywords: [String],
+        corroboratingKeywords: [String]? = nil,
         distributorFilter: [String]? = nil,
         authTypeFilter: [String]? = nil,
         iosVersionFilter: [String]? = nil,
@@ -173,6 +194,7 @@ public struct KBEntry: Codable, Equatable, Identifiable, Sendable {
         self.status = status
         self.fixedInVersion = fixedInVersion
         self.symptomKeywords = symptomKeywords
+        self.corroboratingKeywords = corroboratingKeywords
         self.distributorFilter = distributorFilter
         self.authTypeFilter = authTypeFilter
         self.iosVersionFilter = iosVersionFilter

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEscalationFollowUp.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEscalationFollowUp.swift
@@ -34,7 +34,7 @@ public struct KBEscalationFollowUp: Codable, Equatable, Sendable {
     ///
     /// This is a property of the PROMPT's wording, not of the entry: it says "this
     /// sentence is safe to say to someone whose problem we may have misread."
-    public let presumesIssue: Bool
+    let presumesIssue: Bool
 
     enum CodingKeys: String, CodingKey {
         case prompt
@@ -43,7 +43,7 @@ public struct KBEscalationFollowUp: Codable, Equatable, Sendable {
         case presumesIssue = "presumes_issue"
     }
 
-    public init(
+    init(
         prompt: String,
         placeholder: String? = nil,
         diagnostic: String? = nil,

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEscalationFollowUp.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEscalationFollowUp.swift
@@ -22,11 +22,48 @@ public struct KBEscalationFollowUp: Codable, Equatable, Sendable {
     /// so support can see which follow-ups patrons actually answer vs
     /// skip past.
     public let diagnostic: String?
+    /// Whether this question only makes sense if we correctly identified the
+    /// issue. Defaults TRUE, because most prompts do: "is it wired CarPlay or
+    /// wireless?" is excellent triage off a confident match and baffling off a
+    /// lone match on the word "crashes".
+    ///
+    /// Set FALSE for questions that are useful no matter what the patron is
+    /// actually reporting — asking which library they use, or which title is
+    /// involved. Those may be asked even when recognition is weak, which is how a
+    /// hand-off we could not answer still reaches support with something in it.
+    ///
+    /// This is a property of the PROMPT's wording, not of the entry: it says "this
+    /// sentence is safe to say to someone whose problem we may have misread."
+    public let presumesIssue: Bool
 
-    public init(prompt: String, placeholder: String? = nil, diagnostic: String? = nil) {
+    enum CodingKeys: String, CodingKey {
+        case prompt
+        case placeholder
+        case diagnostic
+        case presumesIssue = "presumes_issue"
+    }
+
+    public init(
+        prompt: String,
+        placeholder: String? = nil,
+        diagnostic: String? = nil,
+        presumesIssue: Bool = true
+    ) {
         self.prompt = prompt
         self.placeholder = placeholder
         self.diagnostic = diagnostic
+        self.presumesIssue = presumesIssue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        prompt = try c.decode(String.self, forKey: .prompt)
+        placeholder = try c.decodeIfPresent(String.self, forKey: .placeholder)
+        diagnostic = try c.decodeIfPresent(String.self, forKey: .diagnostic)
+        // Absent in JSON means "presumes the issue" — the conservative reading,
+        // so an existing catalog cannot start asking its prompts off weak matches
+        // just because a field was added.
+        presumesIssue = try c.decodeIfPresent(Bool.self, forKey: .presumesIssue) ?? true
     }
 }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEscalationFollowUp.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBEscalationFollowUp.swift
@@ -55,6 +55,12 @@ public struct KBEscalationFollowUp: Codable, Equatable, Sendable {
         self.presumesIssue = presumesIssue
     }
 
+    // PUBLIC_INTENT: not a choice — Swift requires the witness for a public
+    // protocol requirement to be public, and `KBEscalationFollowUp` is a public
+    // `Decodable` type. Established by flipping it to `internal`, which fails the
+    // build with "must be declared public because it matches a requirement in
+    // public protocol 'Decodable'". The other 26 declarations flagged alongside
+    // it built clean as `internal` and were narrowed instead.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         prompt = try c.decode(String.self, forKey: .prompt)

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBStep.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBStep.swift
@@ -42,7 +42,7 @@ public struct KBStep: Codable, Equatable, Sendable, Identifiable {
     /// skip a step the patron has already told us they did, rather than asking
     /// them to reinstall for the third time. Nil for steps that are not a
     /// standard remedy (e.g. "tap the field anyway, it IS active").
-    public let remedy: Remedy?
+    let remedy: Remedy?
 
     enum CodingKeys: String, CodingKey {
         case id, instruction, check, responses, diagnostic, remedy

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBStep.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/KBStep.swift
@@ -37,19 +37,31 @@ public struct KBStep: Codable, Equatable, Sendable, Identifiable {
     /// so support can see per-step success rates without naming-convention
     /// guessing later.
     public let diagnostic: String?
+    /// Which remedy this step asks the patron to perform, if it is one of the
+    /// common ones they often try before contacting support. Lets the reducer
+    /// skip a step the patron has already told us they did, rather than asking
+    /// them to reinstall for the third time. Nil for steps that are not a
+    /// standard remedy (e.g. "tap the field anyway, it IS active").
+    public let remedy: Remedy?
+
+    enum CodingKeys: String, CodingKey {
+        case id, instruction, check, responses, diagnostic, remedy
+    }
 
     public init(
         id: String,
         instruction: String,
         check: String,
         responses: [KBStepResponse]? = nil,
-        diagnostic: String? = nil
+        diagnostic: String? = nil,
+        remedy: Remedy? = nil
     ) {
         self.id = id
         self.instruction = instruction
         self.check = check
         self.responses = responses
         self.diagnostic = diagnostic
+        self.remedy = remedy
     }
 }
 

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketDraft.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketDraft.swift
@@ -40,6 +40,16 @@ public struct TicketDraft: Codable, Equatable, Sendable {
     /// field is dropped from the email body AND absent from the JSON
     /// attachment, not merely hidden in the card.
     public let omittedFields: Set<TicketField>
+    /// Remedies the patron stated, in their own words, that they had already
+    /// tried. Parsed from the description to skip redundant guided steps, and
+    /// carried here so support does not have to re-read the free text to learn
+    /// something the bot already extracted.
+    public let alreadyTried: Set<Remedy>
+    /// The patron claimed broad unsuccessful effort ("I've tried everything")
+    /// without naming steps. It cannot skip a specific remedy, but it tells a
+    /// triager the patron has already spent time, which changes how the reply
+    /// should open.
+    public let claimsExhaustedEffort: Bool
 
     public enum Priority: String, Codable, Sendable {
         case low      // user accepted bot's match, filing for impact tracking only
@@ -50,6 +60,8 @@ public struct TicketDraft: Codable, Equatable, Sendable {
     public init(
         userDescription: String,
         category: KBCategory,
+        alreadyTried: Set<Remedy> = [],
+        claimsExhaustedEffort: Bool = false,
         matchedEntryId: String? = nil,
         context: ContextSnapshot,
         helpspotTags: [String] = [],
@@ -60,6 +72,8 @@ public struct TicketDraft: Codable, Equatable, Sendable {
     ) {
         self.userDescription = userDescription
         self.category = category
+        self.alreadyTried = alreadyTried
+        self.claimsExhaustedEffort = claimsExhaustedEffort
         self.matchedEntryId = matchedEntryId
         self.context = context
         self.helpspotTags = helpspotTags
@@ -72,6 +86,7 @@ public struct TicketDraft: Codable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case userDescription, category, matchedEntryId, context, helpspotTags
         case priority, resolutionTrace, escalationFollowUp, omittedFields
+        case alreadyTried, claimsExhaustedEffort
     }
 
     // Decode-tolerant: a draft persisted by an older build (or the sanitized
@@ -81,6 +96,9 @@ public struct TicketDraft: Codable, Equatable, Sendable {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         userDescription = try c.decode(String.self, forKey: .userDescription)
         category = try c.decode(KBCategory.self, forKey: .category)
+        // Absent in drafts persisted before these fields existed.
+        alreadyTried = try c.decodeIfPresent(Set<Remedy>.self, forKey: .alreadyTried) ?? []
+        claimsExhaustedEffort = try c.decodeIfPresent(Bool.self, forKey: .claimsExhaustedEffort) ?? false
         matchedEntryId = try c.decodeIfPresent(String.self, forKey: .matchedEntryId)
         context = try c.decode(ContextSnapshot.self, forKey: .context)
         helpspotTags = try c.decodeIfPresent([String].self, forKey: .helpspotTags) ?? []

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketDraft.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Models/TicketDraft.swift
@@ -44,12 +44,12 @@ public struct TicketDraft: Codable, Equatable, Sendable {
     /// tried. Parsed from the description to skip redundant guided steps, and
     /// carried here so support does not have to re-read the free text to learn
     /// something the bot already extracted.
-    public let alreadyTried: Set<Remedy>
+    let alreadyTried: Set<Remedy>
     /// The patron claimed broad unsuccessful effort ("I've tried everything")
     /// without naming steps. It cannot skip a specific remedy, but it tells a
     /// triager the patron has already spent time, which changes how the reply
     /// should open.
-    public let claimsExhaustedEffort: Bool
+    let claimsExhaustedEffort: Bool
 
     public enum Priority: String, Codable, Sendable {
         case low      // user accepted bot's match, filing for impact tracking only

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -118,6 +118,7 @@ public struct ConversationReducer: Sendable {
             next.inputText = ""
             // Read what they have already done BEFORE deciding what to suggest.
             next.alreadyTriedRemedies = remedyDetector.alreadyTried(in: userText)
+            next.claimsExhaustedEffort = remedyDetector.claimsExhaustedEffort(in: userText)
 
             let result = classifier.classify(
                 userText: userText,
@@ -202,6 +203,35 @@ public struct ConversationReducer: Sendable {
                     // handing support a blank "couldn't help." nil = a genuine
                     // no-match (novel issue).
                     let recognized = result.recognizedEntryId
+
+                    // Nothing matched, or matched only weakly — this is ~88% of
+                    // real complaints. Offer the category's remedy ladder before
+                    // filing, rather than only asking a question.
+                    //
+                    // Not offered when the patron said they had tried everything,
+                    // and never for escalate_anyway entries (handled in the
+                    // classifier — those never reach this arm with a suggestion).
+                    // `escalate_anyway` means the entry was recognized WITH
+                    // confidence and has no safe self-serve fix — the account-side
+                    // and library-side class that is a quarter of real tickets.
+                    // Offering remedies there is delay dressed as help, and it
+                    // contradicts the entry's own declaration.
+                    let staffOnly = recognized
+                        .flatMap { knowledgeBase.entry(id: $0) }?
+                        .escalateAnyway ?? false
+
+                    if !next.claimsExhaustedEffort, !staffOnly,
+                       let flow = knowledgeBase.genericFlow(for: category) {
+                        next.step = .matched(entryId: flow.id)
+                        next.messages.append(.init(
+                            sender: .bot, kind: .kbMatch(entryId: flow.id)))
+                        effects.append(.emitTelemetry(.init(
+                            name: "triage_generic_ladder_offered",
+                            parameters: ["category": category?.rawValue ?? "(none)"]
+                        )))
+                        return (next, effects)
+                    }
+
                     transitionToDrafting(
                         state: &next,
                         effects: &effects,
@@ -1027,8 +1057,13 @@ public struct ConversationReducer: Sendable {
         // an escalationFollowUp, ask it first; otherwise go straight to
         // the ticket preview. Acknowledgment text leads either way so the
         // chat reads naturally.
-        if let entry = knowledgeBase.entry(id: matchedEntryId),
-           let followUp = entry.escalationFollowUp {
+        // Same fallback as askEscalationFollowUpOrDraft: prefer the entry's own
+        // question, else the category's catch-all. Without this, an entry with
+        // steps but no follow-up walked the patron through a whole flow and then
+        // filed with nothing asked — the blank-ticket class, surviving on the one
+        // path where the patron had invested the most effort.
+        let entryFollowUp = knowledgeBase.entry(id: matchedEntryId)?.escalationFollowUp
+        if let followUp = entryFollowUp ?? knowledgeBase.categoryFollowUp(for: draft.category) {
             next.step = .awaitingEscalationFollowUp(prompt: followUp.prompt, pendingDraft: draft)
             // "That didn't resolve it" is only true if they tried something. When
             // every step was skipped because the patron had already done it, the
@@ -1046,7 +1081,7 @@ public struct ConversationReducer: Sendable {
             ))
             effects.append(.emitTelemetry(.init(
                 name: "triage_escalation_followup_asked",
-                parameters: ["entry_id": matchedEntryId]
+                parameters: ["entry_id": entryFollowUp != nil ? matchedEntryId : "(category)"]
             )))
         } else {
             next.step = .drafting(ticket: draft)

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -891,10 +891,21 @@ public struct ConversationReducer: Sendable {
         // patron's situation rather than about a bug we may have misread.
         recognitionIsStrong: Bool = true
     ) {
-        if let entryId,
-           let entry = knowledgeBase.entry(id: entryId),
-           let followUp = entry.escalationFollowUp,
-           recognitionIsStrong || !followUp.presumesIssue {
+        // Prefer the recognized entry's own question; fall back to the category's.
+        //
+        // A blank ticket is the worst thing this bot can produce, and 69% of
+        // escalations were producing one. The category question does not claim to
+        // know the cause — it asks the thing that most often separates that
+        // category's clusters — so it is safe precisely when we know least.
+        let entryFollowUp: KBEscalationFollowUp? = {
+            guard let entryId, let entry = knowledgeBase.entry(id: entryId),
+                  let followUp = entry.escalationFollowUp,
+                  recognitionIsStrong || !followUp.presumesIssue else { return nil }
+            return followUp
+        }()
+        let followUp = entryFollowUp ?? knowledgeBase.categoryFollowUp(for: draft.category)
+
+        if let followUp {
             next.step = .awaitingEscalationFollowUp(prompt: followUp.prompt, pendingDraft: draft)
             next.messages.append(.init(
                 sender: .bot,
@@ -902,7 +913,9 @@ public struct ConversationReducer: Sendable {
             ))
             effects.append(.emitTelemetry(.init(
                 name: "triage_escalation_followup_asked",
-                parameters: ["entry_id": entryId]
+                // "(category)" distinguishes a catch-all question from an entry's
+                // own, so the two can be compared for answer rate later.
+                parameters: ["entry_id": entryFollowUp != nil ? (entryId ?? "(none)") : "(category)"]
             )))
         } else {
             next.step = .drafting(ticket: draft)

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -127,13 +127,30 @@ public struct ConversationReducer: Sendable {
             switch result.decision {
             case .suggest(let entryId):
                 next.step = .matched(entryId: entryId)
-                // Trust level shapes how we speak the match. An `authoritative`
-                // entry is stated directly; a lower-confidence `signal` / `context`
-                // entry is hedged so the bot doesn't assert a maybe as a fact.
-                if let entry = knowledgeBase.entry(id: entryId), entry.trustLevel != .authoritative {
+                // How confidently we SPEAK the match is separate from whether we
+                // make it. Two things force a hedge:
+                //
+                //  - a non-`authoritative` entry, which is a maybe by definition;
+                //  - evidence resting on ONE matched concept. A single decisive
+                //    phrase is enough to offer the entry — that is the fix for the
+                //    "I haven't seen exactly that before" complaint — but it is
+                //    also the thinnest evidence that can produce a suggestion, and
+                //    the near-miss corpus shows single-concept matches are where
+                //    real misroutes live. Stating a one-concept guess as fact is
+                //    what turns a wrong guess into wrong instructions; asking
+                //    turns it into a tap. Two of the entries reachable this way
+                //    advise signing out and back in, which given the DRM
+                //    data-loss history (PP-4951) is not free advice to hand the
+                //    wrong patron.
+                let entry = knowledgeBase.entry(id: entryId)
+                let thinEvidence = result.strongRegionCount <= 1
+                let untrusted = entry?.trustLevel != .authoritative
+                if untrusted || thinEvidence {
                     next.messages.append(.init(
                         sender: .bot,
-                        kind: .text("This might be what's going on — take a look:")
+                        kind: .text(thinEvidence && !untrusted
+                            ? "This sounds like it might be the problem below — does that match what you're seeing?"
+                            : "This might be what's going on — take a look:")
                     ))
                 }
                 next.messages.append(.init(sender: .bot, kind: .kbMatch(entryId: entryId)))

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -1030,9 +1030,19 @@ public struct ConversationReducer: Sendable {
         if let entry = knowledgeBase.entry(id: matchedEntryId),
            let followUp = entry.escalationFollowUp {
             next.step = .awaitingEscalationFollowUp(prompt: followUp.prompt, pendingDraft: draft)
+            // "That didn't resolve it" is only true if they tried something. When
+            // every step was skipped because the patron had already done it, the
+            // trace is empty and asserting a failed attempt reads as the bot not
+            // following its own conversation — one line after it demonstrated
+            // that it was. Found by driving the app; the reducer tests assert
+            // state, not prose, so it was invisible to them.
+            let attemptedSomething = !trace.attempts.isEmpty
+            let preamble = attemptedSomething
+                ? "That didn't resolve it. Before I file the ticket — "
+                : "Before I file the ticket — "
             next.messages.append(.init(
                 sender: .bot,
-                kind: .text("That didn't resolve it. Before I file the ticket — \(followUp.prompt) (Tap Skip if you'd rather not say.)")
+                kind: .text("\(preamble)\(followUp.prompt) (Tap Skip if you'd rather not say.)")
             ))
             effects.append(.emitTelemetry(.init(
                 name: "triage_escalation_followup_asked",

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -442,7 +442,7 @@ public struct ConversationReducer: Sendable {
             )))
             // Phase 2: persist trace to a local backfill log so a server-
             // backed catalog source can ingest per-step success rates.
-            _ = trace
+            effects.append(.persistResolutionTrace(trace))
 
         case .userConfirmedStepDidNotResolve(let stepId):
             guard case .guidedStep(let entryId, let stepIndex, let startedAt, var attempts) = next.step,
@@ -1042,6 +1042,9 @@ public struct ConversationReducer: Sendable {
         helpspotTag: String,
         tagSuffix: String
     ) {
+        // Every terminal outcome records what was tried, not just the ones that
+        // produce a ticket.
+        effects.append(.persistResolutionTrace(trace))
         let draft = TicketDraft(
             // PP-4805: redact patron-typed free text at draft assembly.
             userDescription: redactor.redactLine(userText),
@@ -1132,4 +1135,22 @@ public enum ConversationEffect: Equatable, Sendable {
     /// userText is the pre-sanitized version — sanitization happens inside
     /// the classifier per the contract on `FallbackClassifier`.
     case runAIFallback(userText: String, category: KBCategory?, context: ContextSnapshot?)
+    /// Record how a guided flow ended — which steps were tried, in order, and
+    /// whether one of them worked.
+    ///
+    /// Emitted on all three terminal outcomes, including RESOLVED, which is the
+    /// one the reducer used to discard. That was the asymmetry worth fixing:
+    /// exhausted and abandoned flows carried their trace out on the ticket, but a
+    /// flow that succeeded produced no ticket and therefore no record — so the
+    /// only outcome that says "this remedy works" was the only one never kept.
+    ///
+    /// Nothing reads this yet, deliberately. It is the precondition for ever
+    /// replacing the current per-category ordering, which was derived from 204
+    /// tickets and is known to be era-bound, with measured rates. The rule for
+    /// doing so is pre-registered rather than left to future judgement: re-rank
+    /// only at catalog-review cadence, only for rungs with at least 50 recorded
+    /// attempts, ranking on the Wilson lower bound of their resolution rate. No
+    /// in-app adaptive ordering — it would make the bot's answers irreproducible,
+    /// and reproducibility is half of what "consistent" means here.
+    case persistResolutionTrace(ResolutionTrace)
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -188,7 +188,11 @@ public struct ConversationReducer: Sendable {
                         userText: userText,
                         category: category,
                         matchedEntryId: recognized,
-                        tagSuffix: recognized != nil ? "escalate-recognized" : "escalate-novel"
+                        tagSuffix: recognized != nil ? "escalate-recognized" : "escalate-novel",
+                        // Weak-only recognition still scopes the ticket, but must
+                        // not interrogate the patron about a bug we have not
+                        // actually identified.
+                        mayAskTargetedFollowUp: result.recognitionIsStrong
                     )
                 }
             }
@@ -826,7 +830,13 @@ public struct ConversationReducer: Sendable {
         userText: String,
         category: KBCategory?,
         matchedEntryId: String?,
-        tagSuffix: String
+        tagSuffix: String,
+        // Whether the recognition is strong enough to justify the entry's
+        // bug-presuming follow-up question. The ticket is scoped either way;
+        // only the patron-facing question is gated. Defaults true — callers
+        // that got here from a guided flow have watched the patron walk the
+        // entry's own steps, which is the strongest recognition there is.
+        mayAskTargetedFollowUp: Bool = true
     ) {
         let draft = TicketDraft(
             // PP-4805: redact patron-typed free text at draft assembly.
@@ -841,7 +851,7 @@ public struct ConversationReducer: Sendable {
         askEscalationFollowUpOrDraft(
             state: &next,
             effects: &effects,
-            entryId: matchedEntryId,
+            entryId: mayAskTargetedFollowUp ? matchedEntryId : nil,
             draft: draft,
             tagSuffix: tagSuffix
         )

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -851,9 +851,10 @@ public struct ConversationReducer: Sendable {
         askEscalationFollowUpOrDraft(
             state: &next,
             effects: &effects,
-            entryId: mayAskTargetedFollowUp ? matchedEntryId : nil,
+            entryId: matchedEntryId,
             draft: draft,
-            tagSuffix: tagSuffix
+            tagSuffix: tagSuffix,
+            recognitionIsStrong: mayAskTargetedFollowUp
         )
     }
 
@@ -866,11 +867,17 @@ public struct ConversationReducer: Sendable {
         effects: inout [ConversationEffect],
         entryId: String?,
         draft: TicketDraft,
-        tagSuffix: String
+        tagSuffix: String,
+        // True when the recognition rests on a decisive phrase. A prompt that
+        // presumes the issue is only asked then; a prompt marked
+        // `presumes_issue: false` is safe either way, because it asks about the
+        // patron's situation rather than about a bug we may have misread.
+        recognitionIsStrong: Bool = true
     ) {
         if let entryId,
            let entry = knowledgeBase.entry(id: entryId),
-           let followUp = entry.escalationFollowUp {
+           let followUp = entry.escalationFollowUp,
+           recognitionIsStrong || !followUp.presumesIssue {
             next.step = .awaitingEscalationFollowUp(prompt: followUp.prompt, pendingDraft: draft)
             next.messages.append(.init(
                 sender: .bot,

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -10,6 +10,7 @@ import Foundation
 /// a synthetic KB without mocking.
 public struct ConversationReducer: Sendable {
     public let classifier: LocalClassifier
+    private let remedyDetector = RemedyDetector()
     public let redactor: ContextRedactor
     public let knowledgeBase: KnowledgeBase
     /// When true, local-classifier escalations route through
@@ -115,6 +116,8 @@ public struct ConversationReducer: Sendable {
 
             next.messages.append(.init(sender: .user, kind: .text(userText)))
             next.inputText = ""
+            // Read what they have already done BEFORE deciding what to suggest.
+            next.alreadyTriedRemedies = remedyDetector.alreadyTried(in: userText)
 
             let result = classifier.classify(
                 userText: userText,
@@ -326,19 +329,53 @@ public struct ConversationReducer: Sendable {
                 return (next, effects)
             }
             let startedAt = Date()
+            // Skip anything they already told us they did. If that is every step,
+            // there is nothing left to walk through and the honest move is to
+            // escalate with the trace rather than open an empty flow.
+            let skipped = Set(steps.compactMap(\.remedy)).intersection(next.alreadyTriedRemedies)
+            guard let firstIndex = nextUntriedStepIndex(
+                from: 0, steps: steps, alreadyTried: next.alreadyTriedRemedies
+            ) else {
+                if let ack = acknowledgement(for: skipped) {
+                    next.messages.append(.init(sender: .bot, kind: .text(ack)))
+                }
+                effects.append(.emitTelemetry(.init(
+                    name: "triage_guided_flow_all_steps_already_tried",
+                    parameters: ["entry_id": entryId]
+                )))
+                escalateWithTrace(
+                    state: &next, effects: &effects,
+                    userText: next.messages.compactMap {
+                        if case .text(let t) = $0.kind, $0.sender == .user { return t }
+                        return nil
+                    }.last ?? "",
+                    category: entry.category,
+                    matchedEntryId: entryId,
+                    trace: ResolutionTrace(entryId: entryId, attempts: [],
+                                           startedAt: startedAt, endedAt: Date(),
+                                           outcome: .escalatedAfterStepsExhausted),
+                    helpspotTag: entry.helpspotTag ?? entryId,
+                    tagSuffix: "escalate-all-steps-already-tried"
+                )
+                return (next, effects)
+            }
             next.step = .guidedStep(
                 entryId: entryId,
-                stepIndex: 0,
+                stepIndex: firstIndex,
                 startedAt: startedAt,
                 attempts: []
             )
+            if let ack = acknowledgement(for: skipped) {
+                next.messages.append(.init(sender: .bot, kind: .text(ack)))
+            }
+            let remaining = steps.count - skipped.count
             next.messages.append(.init(
                 sender: .bot,
-                kind: .text("Let's walk through this together. \(steps.count) thing\(steps.count == 1 ? "" : "s") to try.")
+                kind: .text("Let's walk through this together. \(remaining) thing\(remaining == 1 ? "" : "s") to try.")
             ))
             next.messages.append(.init(
                 sender: .bot,
-                kind: .guidedStep(entryId: entryId, stepIndex: 0)
+                kind: .guidedStep(entryId: entryId, stepIndex: firstIndex)
             ))
             effects.append(.emitTelemetry(.init(
                 name: "triage_guided_flow_started",
@@ -385,7 +422,9 @@ public struct ConversationReducer: Sendable {
             }
             attempts.append(StepAttempt(stepId: stepId, outcome: .didNotResolve, timestamp: Date()))
 
-            let nextIndex = stepIndex + 1
+            let nextIndex = nextUntriedStepIndex(
+                from: stepIndex + 1, steps: steps, alreadyTried: next.alreadyTriedRemedies
+            ) ?? steps.count
             if nextIndex < steps.count {
                 next.step = .guidedStep(
                     entryId: entryId,
@@ -830,6 +869,33 @@ public struct ConversationReducer: Sendable {
             }
         }
         return nil
+    }
+
+    /// First step at or after `from` that the patron has NOT already tried.
+    /// Returns nil when every remaining step is one they have done.
+    private func nextUntriedStepIndex(
+        from index: Int, steps: [KBStep], alreadyTried: Set<Remedy>
+    ) -> Int? {
+        var i = index
+        while i < steps.count {
+            if let remedy = steps[i].remedy, alreadyTried.contains(remedy) { i += 1; continue }
+            return i
+        }
+        return nil
+    }
+
+    /// "You have already tried X and Y" — said once, so skipping does not look
+    /// like steps silently going missing.
+    private func acknowledgement(for remedies: Set<Remedy>) -> String? {
+        guard !remedies.isEmpty else { return nil }
+        let names = remedies.map(\.displayName).sorted()
+        let list: String
+        switch names.count {
+        case 1: list = names[0]
+        case 2: list = "\(names[0]) and \(names[1])"
+        default: list = names.dropLast().joined(separator: ", ") + ", and " + names[names.count - 1]
+        }
+        return "You have already tried \(list), so I will skip that."
     }
 
     /// Shared escalation transition — used by both the local-only escalate

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -364,7 +364,8 @@ public struct ConversationReducer: Sendable {
             // escalate with the trace rather than open an empty flow.
             let skipped = Set(steps.compactMap(\.remedy)).intersection(next.alreadyTriedRemedies)
             guard let firstIndex = nextUntriedStepIndex(
-                from: 0, steps: steps, alreadyTried: next.alreadyTriedRemedies
+                from: 0, steps: steps, alreadyTried: next.alreadyTriedRemedies,
+                context: next.context
             ) else {
                 if let ack = acknowledgement(for: skipped) {
                     next.messages.append(.init(sender: .bot, kind: .text(ack)))
@@ -453,7 +454,8 @@ public struct ConversationReducer: Sendable {
             attempts.append(StepAttempt(stepId: stepId, outcome: .didNotResolve, timestamp: Date()))
 
             let nextIndex = nextUntriedStepIndex(
-                from: stepIndex + 1, steps: steps, alreadyTried: next.alreadyTriedRemedies
+                from: stepIndex + 1, steps: steps, alreadyTried: next.alreadyTriedRemedies,
+                context: next.context
             ) ?? steps.count
             if nextIndex < steps.count {
                 next.step = .guidedStep(
@@ -492,7 +494,7 @@ public struct ConversationReducer: Sendable {
                     effects: &effects,
                     userText: lastUserText(next.messages) ?? "(no description)",
                     category: entry.category,
-                    matchedEntryId: entryId,
+                    matchedEntryId: ticketScope(for: entryId, state: next),
                     trace: trace,
                     helpspotTag: entry.helpspotTag ?? "triage-bot-known-issue",
                     tagSuffix: "escalate-after-guided-flow-exhausted"
@@ -559,7 +561,7 @@ public struct ConversationReducer: Sendable {
                 effects: &effects,
                 userText: lastUserText(next.messages) ?? "(no description)",
                 category: entry.category,
-                matchedEntryId: entryId,
+                matchedEntryId: ticketScope(for: entryId, state: next),
                 trace: trace,
                 helpspotTag: entry.helpspotTag ?? "triage-bot-known-issue",
                 tagSuffix: "escalate-after-guided-flow-abandoned"
@@ -901,17 +903,45 @@ public struct ConversationReducer: Sendable {
         return nil
     }
 
+    /// Which entry a ticket should be scoped to when a flow ends.
+    ///
+    /// For a real entry, itself. For a generic ladder, whatever the classifier
+    /// weakly recognised — the ladder's own id tells a triager only that the bot
+    /// had no idea, which the absence of an answer already tells them. The hint
+    /// survives in `lastClassification` because the ladder does not clear it.
+    private func ticketScope(for entryId: String, state: ConversationState) -> String {
+        guard knowledgeBase.entry(id: entryId)?.resolvedKind == .genericFlow else { return entryId }
+        return state.lastClassification?.recognizedEntryId ?? entryId
+    }
+
     /// First step at or after `from` that the patron has NOT already tried.
     /// Returns nil when every remaining step is one they have done.
     private func nextUntriedStepIndex(
-        from index: Int, steps: [KBStep], alreadyTried: Set<Remedy>
+        from index: Int, steps: [KBStep], alreadyTried: Set<Remedy>,
+        context: ContextSnapshot? = nil
     ) -> Int? {
         var i = index
         while i < steps.count {
-            if let remedy = steps[i].remedy, alreadyTried.contains(remedy) { i += 1; continue }
+            if let remedy = steps[i].remedy {
+                if alreadyTried.contains(remedy) { i += 1; continue }
+                // Nothing to find in the App Store if they are already current.
+                if remedy == .updateApp, isAlreadyOnNewestKnownVersion(context) { i += 1; continue }
+            }
             return i
         }
         return nil
+    }
+
+    /// True only when BOTH the catalog's newest-known version and the patron's
+    /// app version are known, and the patron is at or past it. Either unknown
+    /// returns false — offer the rung — because a wasted rung costs seconds and a
+    /// suppressed one may cost the fix.
+    private func isAlreadyOnNewestKnownVersion(_ context: ContextSnapshot?) -> Bool {
+        guard let latest = knowledgeBase.catalog.latestKnownAppVersion,
+              let latestVersion = SemanticVersion(latest),
+              let current = context?.appVersion,
+              let currentVersion = SemanticVersion(current) else { return false }
+        return currentVersion >= latestVersion
     }
 
     /// "You have already tried X and Y" — said once, so skipping does not look

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Reducer/ConversationReducer.swift
@@ -321,9 +321,21 @@ public struct ConversationReducer: Sendable {
                 // through the redactor before it can land in a ticket.
                 userDescription: redactor.redactLine(lastUserText(next.messages) ?? "(no description)"),
                 category: entry.category,
-                matchedEntryId: entryId,
+                alreadyTried: next.alreadyTriedRemedies,
+                claimsExhaustedEffort: next.claimsExhaustedEffort,
+                // Declining a ladder is its THIRD exit, and the only one that was
+                // not scoping the ticket. A patron who taps "just file a ticket"
+                // was handed the ladder's own id, which tells a triager the bot
+                // had no idea — something the absence of an answer already says —
+                // while the weak recognition sat unused in lastClassification.
+                matchedEntryId: ticketScope(for: entryId, state: next),
                 context: next.context ?? emptyContext(),
-                helpspotTags: [entry.helpspotTag ?? "triage-bot-known-issue", "user-requested-followup"],
+                helpspotTags: [
+                    entry.resolvedKind == .genericFlow
+                        ? "triage-bot-generic-ladder"
+                        : (entry.helpspotTag ?? "triage-bot-known-issue"),
+                    "user-requested-followup"
+                ],
                 priority: .low,
                 omittedFields: initialOmittedFields(next.context)
             )
@@ -985,6 +997,8 @@ public struct ConversationReducer: Sendable {
             // PP-4805: redact patron-typed free text at draft assembly.
             userDescription: redactor.redactLine(userText),
             category: category ?? .other,
+            alreadyTried: next.alreadyTriedRemedies,
+            claimsExhaustedEffort: next.claimsExhaustedEffort,
             matchedEntryId: matchedEntryId,
             context: next.context ?? emptyContext(),
             helpspotTags: ["triage-bot-\(tagSuffix)"],
@@ -1079,6 +1093,8 @@ public struct ConversationReducer: Sendable {
             // PP-4805: redact patron-typed free text at draft assembly.
             userDescription: redactor.redactLine(userText),
             category: category,
+            alreadyTried: next.alreadyTriedRemedies,
+            claimsExhaustedEffort: next.claimsExhaustedEffort,
             matchedEntryId: matchedEntryId,
             context: next.context ?? emptyContext(),
             helpspotTags: [helpspotTag, "guided-flow-\(trace.outcome.rawValue)"],

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -717,6 +717,25 @@
           "diagnostic": "addlibrary.pull_to_refresh"
         },
         {
+          "id": "ki009-step2-clear-cache",
+          "instruction": "Go to Settings, tap Advanced, then tap Clear Cached Data. Your books and sign-in stay put — this only clears the saved copy of the library list. Then try Add Library again.",
+          "remedy": "clearCache",
+          "check": "Is your library there now?",
+          "responses": [
+            {
+              "label": "Found it",
+              "outcome": "resolved",
+              "diagnostic": "library.registry.cleared_cache_resolved"
+            },
+            {
+              "label": "Still missing",
+              "outcome": "advance",
+              "diagnostic": "library.registry.cleared_cache_no_change"
+            }
+          ],
+          "diagnostic": "library.registry.clear_cache"
+        },
+        {
           "id": "ki009-step2-check-registry",
           "instruction": "If it is still missing, check whether your library is listed at the Palace web catalog on a computer or browser. If it is not there either, the library may not be participating yet, and support can confirm.",
           "remedy": "verifyOnWeb",

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -759,7 +759,19 @@
         "keep it longer",
         "borrow it again"
       ],
+      "corroborating_keywords": [
+        "renew",
+        "renewal",
+        "renewed",
+        "extend"
+      ],
       "user_facing_workaround": "Palace doesn't renew loans inside the app — when your lending period ends, the book returns itself automatically. To keep reading, just borrow the title again from the catalog. If someone else has it on hold, place a hold to get back in line.",
+      "escalation_follow_up": {
+        "prompt": "Which library issued the card you're using? Loan and renewal rules are set by each library, so support can check yours.",
+        "placeholder": "City, county, or system name",
+        "diagnostic": "howto.renewals",
+        "presumes_issue": false
+      },
       "internal_reference": {
         "helpspot": [
           18028,
@@ -791,7 +803,18 @@
         "give it back early",
         "send it back"
       ],
+      "corroborating_keywords": [
+        "return",
+        "returning",
+        "give back"
+      ],
       "user_facing_workaround": "To return a book before it's due, go to My Books, swipe left on the title, and tap Return (or open the book's menu and choose Return). It goes straight back to the library so the next reader can borrow it.",
+      "escalation_follow_up": {
+        "prompt": "Which library are you using, and is this an ebook or an audiobook?",
+        "placeholder": "City or library name",
+        "diagnostic": "howto.early",
+        "presumes_issue": false
+      },
       "internal_reference": {
         "helpspot": [
           17901
@@ -820,7 +843,17 @@
         "go back to my other library",
         "toggle between libraries"
       ],
+      "corroborating_keywords": [
+        "switch",
+        "different library"
+      ],
       "user_facing_workaround": "You can keep more than one library in Palace and switch between them anytime. Go to Settings → Libraries to see your libraries, then tap the one you want to switch to it. To add another, tap Add Library there and search for it by name.",
+      "escalation_follow_up": {
+        "prompt": "Which library are you trying to use? (City, county, or system name is fine.)",
+        "placeholder": "City or library name",
+        "diagnostic": "howto.library",
+        "presumes_issue": false
+      },
       "internal_reference": {
         "helpspot": [
           17930
@@ -849,7 +882,20 @@
         "enable notifications",
         "when my book is due"
       ],
+      "corroborating_keywords": [
+        "notification",
+        "notified",
+        "reminder",
+        "reminders",
+        "alert"
+      ],
       "user_facing_workaround": "Turn on notifications and Palace will alert you when a hold you placed is ready to borrow, and again when a loan is about to expire. You can enable them when you first install the app, or later in your phone's Settings under Palace.",
+      "escalation_follow_up": {
+        "prompt": "Which library are you using, and which notifications were you expecting to get?",
+        "placeholder": "City or library name",
+        "diagnostic": "howto.notifications",
+        "presumes_issue": false
+      },
       "internal_reference": {
         "helpspot": [
           18103
@@ -878,7 +924,19 @@
         "hold pickup deadline",
         "how long to get my hold"
       ],
+      "corroborating_keywords": [
+        "hold",
+        "holds",
+        "pick up",
+        "expires"
+      ],
       "user_facing_workaround": "How long you have to pick up a ready hold varies by library and distributor. When your hold is ready, Palace shows the exact \"pick up by\" date right on it — open the title from your holds to see the deadline.",
+      "escalation_follow_up": {
+        "prompt": "Which library are you using? Hold pickup windows are set by each library.",
+        "placeholder": "City, county, or system name",
+        "diagnostic": "howto.window",
+        "presumes_issue": false
+      },
       "internal_reference": {
         "jira": "PP-4831"
       },
@@ -904,7 +962,17 @@
         "how many at once",
         "how many titles at once"
       ],
+      "corroborating_keywords": [
+        "limit",
+        "how many"
+      ],
       "user_facing_workaround": "The number of titles you can borrow at once is set by your library, so it varies. If you've reached the limit, returning a title you've finished frees up a slot — or check with your library for its exact borrowing limit.",
+      "escalation_follow_up": {
+        "prompt": "Which library are you using? Borrowing limits are set by each library.",
+        "placeholder": "City, county, or system name",
+        "diagnostic": "howto.limit",
+        "presumes_issue": false
+      },
       "internal_reference": {
         "jira": "PP-4831"
       },
@@ -930,7 +998,17 @@
         "lending period",
         "loan period"
       ],
+      "corroborating_keywords": [
+        "how long",
+        "due date"
+      ],
       "user_facing_workaround": "Loan length is set by your library, so it varies — you'll see the due date on each title when you borrow it. Palace can't extend or renew a loan in the app: when the lending period ends the book returns automatically, and to keep reading you simply borrow it again (or place a hold if there's a waitlist).",
+      "escalation_follow_up": {
+        "prompt": "Which library are you using? Loan lengths are set by each library.",
+        "placeholder": "City, county, or system name",
+        "diagnostic": "howto.length",
+        "presumes_issue": false
+      },
       "internal_reference": {
         "jira": "PP-4831"
       },
@@ -957,7 +1035,18 @@
         "put in my library card",
         "register my card"
       ],
+      "corroborating_keywords": [
+        "card",
+        "library card",
+        "add"
+      ],
       "user_facing_workaround": "To add your library card, open Settings → Libraries. If your library isn't listed yet, add it there first, then tap it and sign in with your library card number (barcode) and PIN. Once you're signed in, your loans and holds show up in Palace.",
+      "escalation_follow_up": {
+        "prompt": "Which library are you trying to add? (City, county, or system name is fine.)",
+        "placeholder": "City or library name",
+        "diagnostic": "howto.card",
+        "presumes_issue": false
+      },
       "internal_reference": {
         "jira": "PP-4831"
       },
@@ -982,7 +1071,18 @@
         "reading format",
         "send to my ereader"
       ],
+      "corroborating_keywords": [
+        "kindle",
+        "format",
+        "e-reader"
+      ],
       "user_facing_workaround": "Palace isn't connected to Kindle — there's no \"send to Kindle\" step. You read your borrowed books right in the Palace app: ebooks open in the built-in reader and audiobooks play in the built-in player, and everything stays in Palace for the length of your loan.",
+      "escalation_follow_up": {
+        "prompt": "Which library are you using, and which device were you hoping to read on?",
+        "placeholder": "City or library name",
+        "diagnostic": "howto.kindle",
+        "presumes_issue": false
+      },
       "internal_reference": {
         "jira": "PP-4831"
       },

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -575,17 +575,18 @@
       "symptom_keywords": [
         "won't download",
         "wont download",
-        "never works",
         "download stuck",
         "download failed",
         "no progress",
         "hasn't moved",
         "hasnt moved",
-        "stalled",
-        "stuck downloading"
+        "stuck downloading",
+        "trying to download"
       ],
       "corroborating_keywords": [
-        "download"
+        "download",
+        "stalled",
+        "never works"
       ],
       "user_facing_workaround": "If a download stalls, check that you're connected to WiFi or cellular data, then pull down to refresh your bookshelf. If it still fails, sign out and back in.",
       "user_facing_steps": [
@@ -667,8 +668,6 @@
       "symptom_keywords": [
         "second library",
         "another library",
-        "add a library",
-        "add library",
         "add a card",
         "second card",
         "additional libraries",
@@ -683,7 +682,9 @@
         "cant add"
       ],
       "corroborating_keywords": [
-        "not showing"
+        "not showing",
+        "add a library",
+        "add library"
       ],
       "user_facing_workaround": "The Add Library list can go stale and stop showing newly-added libraries. On the Add Library screen, pull down and hold for a second to force a refresh — your library should then appear so you can add it.",
       "user_facing_steps": [

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -1095,5 +1095,43 @@
       "ui_surface": "my-books",
       "reviewed_at": "2026-07-22"
     }
-  ]
+  ],
+  "category_follow_ups": {
+    "signin": {
+      "prompt": "Is the card you're using one your library gave you, or one you created inside the Palace app?",
+      "placeholder": "Library-issued or created in the app",
+      "diagnostic": "category.signin",
+      "presumes_issue": false
+    },
+    "audiobook": {
+      "prompt": "Does the audiobook fail right when you open it, or does it start and then stop partway through?",
+      "placeholder": "At the start, or partway through",
+      "diagnostic": "category.audiobook",
+      "presumes_issue": false
+    },
+    "download": {
+      "prompt": "Did the download never start, or did it begin and then stop before finishing?",
+      "placeholder": "Never started, or stopped partway",
+      "diagnostic": "category.download",
+      "presumes_issue": false
+    },
+    "library": {
+      "prompt": "Which library are you trying to use, and is it missing from the list or showing the wrong books?",
+      "placeholder": "City or library name",
+      "diagnostic": "category.library",
+      "presumes_issue": false
+    },
+    "reader": {
+      "prompt": "Is this an ebook or a PDF, and does it fail to open at all or fail partway through?",
+      "placeholder": "Ebook or PDF",
+      "diagnostic": "category.reader",
+      "presumes_issue": false
+    },
+    "other": {
+      "prompt": "What were you doing in the app just before this happened?",
+      "placeholder": "e.g. borrowing a book, opening my shelf",
+      "diagnostic": "category.other",
+      "presumes_issue": false
+    }
+  }
 }

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -13,25 +13,27 @@
         "wont load",
         "will not play",
         "will not load",
-        "spinning",
-        "spinner",
-        "first time",
-        "hangs",
-        "stuck",
         "sits there",
-        "nothing happens",
         "tap play",
         "tapped play",
         "play button",
-        "blinks",
         "no sound",
         "stops playing",
         "just loads",
         "doesn't start",
         "doesnt start",
         "play and nothing",
+        "loan disappear"
+      ],
+      "corroborating_keywords": [
+        "spinning",
+        "spinner",
+        "first time",
+        "hangs",
+        "stuck",
+        "nothing happens",
+        "blinks",
         "opens but",
-        "loan disappear",
         "reinstall"
       ],
       "distributor_filter": [
@@ -126,8 +128,10 @@
         "switched libraries",
         "changed library",
         "playback crash",
-        "crashed",
         "crash while playing"
+      ],
+      "corroborating_keywords": [
+        "crashed"
       ],
       "distributor_filter": [
         "palace_marketplace"
@@ -199,10 +203,12 @@
         "fields look disabled",
         "where to type",
         "where do i type",
-        "placeholder",
-        "boxes",
         "never prompted",
         "looks disabled"
+      ],
+      "corroborating_keywords": [
+        "placeholder",
+        "boxes"
       ],
       "user_facing_workaround": "The field looks grayed out, but it's actually active — tap it and start typing. This is a contrast issue we've already fixed; the next App Store update will look correct.",
       "user_facing_steps": [
@@ -248,17 +254,19 @@
         "not my library",
         "where is my library",
         "where's my library",
-        "can't find",
-        "cant find",
         "missing titles",
         "missing books",
         "demo books",
         "demo collection",
+        "doesn't appear",
+        "doesnt appear"
+      ],
+      "corroborating_keywords": [
+        "can't find",
+        "cant find",
         "bookshelf",
         "these aren't",
         "these arent",
-        "doesn't appear",
-        "doesnt appear",
         "on my ipad",
         "on my phone"
       ],
@@ -349,7 +357,9 @@
         "connecting to car",
         "in the car",
         "in my car",
-        "crash in car",
+        "crash in car"
+      ],
+      "corroborating_keywords": [
         "crashes"
       ],
       "user_facing_workaround": "This CarPlay crash is fixed in the next release. As a workaround, start playback before connecting to your car.",
@@ -416,7 +426,6 @@
         "holds disappeared",
         "holds list",
         "still on hold",
-        "still shows",
         "shows as reserved",
         "next in line",
         "got a notification",
@@ -427,6 +436,9 @@
         "list disagrees",
         "not in my holds",
         "hold list"
+      ],
+      "corroborating_keywords": [
+        "still shows"
       ],
       "user_facing_workaround": "Pull down on the Holds list to refresh. If the hold is still missing, sign out and back in — your account will sync from the server.",
       "user_facing_steps": [
@@ -563,7 +575,6 @@
       "symptom_keywords": [
         "won't download",
         "wont download",
-        "download",
         "never works",
         "download stuck",
         "download failed",
@@ -572,6 +583,9 @@
         "hasnt moved",
         "stalled",
         "stuck downloading"
+      ],
+      "corroborating_keywords": [
+        "download"
       ],
       "user_facing_workaround": "If a download stalls, check that you're connected to WiFi or cellular data, then pull down to refresh your bookshelf. If it still fails, sign out and back in.",
       "user_facing_steps": [
@@ -661,13 +675,15 @@
         "does not show",
         "doesn't show",
         "doesnt show",
-        "not showing",
         "no additional",
         "won't let me add",
         "wont let me add",
         "unable to add",
         "can't add",
         "cant add"
+      ],
+      "corroborating_keywords": [
+        "not showing"
       ],
       "user_facing_workaround": "The Add Library list can go stale and stop showing newly-added libraries. On the Add Library screen, pull down and hold for a second to force a refresh — your library should then appear so you can add it.",
       "user_facing_steps": [

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -742,6 +742,89 @@
       "visibility": "user_facing"
     },
     {
+      "id": "KI-2026-010-audiobook-fulfillment-3-2-x",
+      "category": "audiobook",
+      "status": "fixed_in",
+      "fixed_in_version": "3.2.3",
+      "symptom_keywords": [
+        "audio book unavailable",
+        "no longer available",
+        "listen button",
+        "hit listen",
+        "press the listen",
+        "spins in circles",
+        "spinning wheel",
+        "since the update"
+      ],
+      "corroborating_keywords": [
+        "audiobook unavailable",
+        "temporarily unavailable",
+        "times out",
+        "keeps spinning",
+        "just spins",
+        "contact your library"
+      ],
+      "user_facing_workaround": "This was a bug in Palace 3.2.0-3.2.2 that stopped some audiobooks from opening, and it is fixed in Palace 3.2.3. Update Palace from the App Store, then open the title again from My Books. If you are already on 3.2.3 or later and it still will not play, we should take a look.",
+      "user_facing_steps": [
+        {
+          "id": "ki010-step1-update",
+          "instruction": "Open the App Store, search for Palace, and install any available update. The fix for this shipped in version 3.2.3.",
+          "check": "Did the App Store offer you an update?",
+          "responses": [
+            {
+              "label": "Updated it",
+              "outcome": "advance",
+              "diagnostic": "audiobook.3_2_x.updated"
+            },
+            {
+              "label": "Already up to date",
+              "outcome": "escalate",
+              "diagnostic": "audiobook.3_2_x.already_current"
+            }
+          ],
+          "diagnostic": "audiobook.3_2_x.update_offered"
+        },
+        {
+          "id": "ki010-step2-reopen",
+          "instruction": "Go back to My Books and tap Listen on the title again.",
+          "check": "Does it play now?",
+          "responses": [
+            {
+              "label": "Yes, playing",
+              "outcome": "resolved",
+              "diagnostic": "audiobook.3_2_x.resolved_after_update"
+            },
+            {
+              "label": "Still not playing",
+              "outcome": "escalate",
+              "diagnostic": "audiobook.3_2_x.persists_after_update"
+            }
+          ],
+          "diagnostic": "audiobook.3_2_x.reopen_after_update"
+        }
+      ],
+      "escalation_follow_up": {
+        "prompt": "Which version of Palace does the App Store show you have, and which audiobook is doing this?",
+        "placeholder": "e.g. 3.2.3, and the title",
+        "diagnostic": "audiobook.3_2_x.version_and_title",
+        "presumes_issue": false
+      },
+      "internal_reference": {
+        "helpspot": [
+          18449,
+          18464,
+          18475,
+          18486,
+          18571
+        ]
+      },
+      "confidence_threshold": 0.1,
+      "escalate_anyway": false,
+      "helpspot_tag": "audiobook-fulfillment-3-2-x",
+      "trust_level": "authoritative",
+      "visibility": "user_facing"
+    },
+    {
       "id": "HT-2026-001-renewals",
       "category": "other",
       "kind": "how_to",

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -717,23 +717,23 @@
           "diagnostic": "addlibrary.pull_to_refresh"
         },
         {
-          "id": "ki009-step2-signout-reinstall",
-          "instruction": "If it's still missing, sign out of your current library, then delete and reinstall Palace. Open it and try Add Library again.",
-          "remedy": "reinstall",
-          "check": "Can you add the second library now?",
+          "id": "ki009-step2-check-registry",
+          "instruction": "If it is still missing, check whether your library is listed at the Palace web catalog on a computer or browser. If it is not there either, the library may not be participating yet, and support can confirm.",
+          "remedy": "verifyOnWeb",
+          "check": "Did you find your library there?",
           "responses": [
             {
-              "label": "Still can't",
+              "label": "Yes, it's listed",
               "outcome": "escalate",
-              "diagnostic": "addlibrary.reinstall_did_not_resolve"
+              "diagnostic": "library.registry.listed_on_web"
             },
             {
-              "label": "Yes, added",
-              "outcome": "resolved",
-              "diagnostic": "addlibrary.reinstall_resolved"
+              "label": "No, not listed",
+              "outcome": "escalate",
+              "diagnostic": "library.registry.absent_on_web"
             }
           ],
-          "diagnostic": "addlibrary.signout_reinstall"
+          "diagnostic": "library.registry.web_check"
         }
       ],
       "internal_reference": {

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -44,6 +44,7 @@
         {
           "id": "ki001-step1-tap-back-tap-again",
           "instruction": "Tap back to your library list, then tap the audiobook title again. This usually clears the hang on the second open.",
+          "remedy": "reopenTitle",
           "check": "Did it start playing this time?",
           "responses": [
             {
@@ -62,6 +63,7 @@
         {
           "id": "ki001-step2-force-quit",
           "instruction": "Force-quit Palace: swipe up from the bottom of the screen and pause, then swipe up on Palace's preview to close it. Reopen Palace and tap the audiobook again.",
+          "remedy": "reopenTitle",
           "check": "Plays now?",
           "responses": [
             {
@@ -80,6 +82,7 @@
         {
           "id": "ki001-step3-sign-out-in",
           "instruction": "In Settings → Libraries, tap your library, scroll down and tap Sign Out. Sign back in and try the audiobook.",
+          "remedy": "signOutIn",
           "check": "Plays after sign-in?",
           "responses": [
             {
@@ -141,6 +144,7 @@
         {
           "id": "ki002-step1-update",
           "instruction": "Check the App Store for a Palace update — this crash is fixed in version 3.2.0 or later. Update if available, then try again.",
+          "remedy": "updateApp",
           "check": "Are you now on 3.2.0 or later, and the crash gone?",
           "responses": [
             {
@@ -367,6 +371,7 @@
         {
           "id": "ki005-step1-update",
           "instruction": "Check the App Store — this CarPlay crash is fixed in version 3.1.0 or later. Update if available.",
+          "remedy": "updateApp",
           "check": "Are you now on 3.1.0+, and the crash gone when you connect to CarPlay?",
           "responses": [
             {
@@ -463,6 +468,7 @@
         {
           "id": "ki006-step2-sign-out-in",
           "instruction": "Go to Settings → Libraries → tap your library → Sign Out. Sign back in. Then check the Holds tab again.",
+          "remedy": "signOutIn",
           "check": "Is the ready hold visible after sign-in?",
           "responses": [
             {
@@ -520,6 +526,7 @@
         {
           "id": "ki007-step1-pull-refresh-and-reopen",
           "instruction": "Go to My Books, pull down to refresh, then tap the PDF title to reopen it.",
+          "remedy": "reopenTitle",
           "check": "Did the PDF render this time?",
           "responses": [
             {
@@ -593,6 +600,7 @@
         {
           "id": "ki008-step1-check-connection",
           "instruction": "Check the top-right of your screen — do you see WiFi or cellular signal? If you're in airplane mode or your WiFi dropped, toggle it back on.",
+          "remedy": "toggleNetwork",
           "check": "Is your connection up, and the download resuming?",
           "responses": [
             {
@@ -629,6 +637,7 @@
         {
           "id": "ki008-step3-sign-out-in",
           "instruction": "Go to Settings → Libraries → your library → Sign Out. Sign back in. Then re-attempt the download from My Books or the Catalog.",
+          "remedy": "signOutIn",
           "check": "Does the download complete after sign-in?",
           "responses": [
             {
@@ -709,6 +718,7 @@
         {
           "id": "ki009-step2-signout-reinstall",
           "instruction": "If it's still missing, sign out of your current library, then delete and reinstall Palace. Open it and try Add Library again.",
+          "remedy": "reinstall",
           "check": "Can you add the second library now?",
           "responses": [
             {
@@ -769,6 +779,7 @@
         {
           "id": "ki010-step1-update",
           "instruction": "Open the App Store, search for Palace, and install any available update. The fix for this shipped in version 3.2.3.",
+          "remedy": "updateApp",
           "check": "Did the App Store offer you an update?",
           "responses": [
             {
@@ -787,6 +798,7 @@
         {
           "id": "ki010-step2-reopen",
           "instruction": "Go back to My Books and tap Listen on the title again.",
+          "remedy": "reopenTitle",
           "check": "Does it play now?",
           "responses": [
             {

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -1195,13 +1195,13 @@
       "category": "audiobook",
       "kind": "generic_flow",
       "symptom_keywords": [],
-      "user_facing_workaround": "A few things worth trying before we send this to support.",
+      "user_facing_workaround": "A couple of things worth trying before we send this to support.",
       "user_facing_steps": [
         {
           "id": "gf-audio-1",
           "instruction": "Open the App Store and check for a Palace update. Several audiobook problems were fixed in recent releases.",
           "remedy": "updateApp",
-          "check": "Did an update install?",
+          "check": "Does it play now?",
           "responses": [
             {
               "label": "It plays now",
@@ -1248,13 +1248,13 @@
       "category": "download",
       "kind": "generic_flow",
       "symptom_keywords": [],
-      "user_facing_workaround": "Let's try a couple of things before we file this.",
+      "user_facing_workaround": "A couple of things worth trying before we send this to support.",
       "user_facing_steps": [
         {
           "id": "gf-dl-1",
-          "instruction": "Check the top of your screen for WiFi or cellular signal. If you're on WiFi, try switching to cellular, or the other way round.",
+          "instruction": "Check the top of your screen for WiFi or cellular signal. If you're on WiFi, try switching to cellular — or if you're on cellular, try WiFi.",
           "remedy": "toggleNetwork",
-          "check": "Does the download move now?",
+          "check": "Is the download moving now?",
           "responses": [
             {
               "label": "It's downloading",
@@ -1273,7 +1273,7 @@
           "id": "gf-dl-2",
           "instruction": "Open the App Store and check for a Palace update.",
           "remedy": "updateApp",
-          "check": "Did that help?",
+          "check": "Is it downloading now?",
           "responses": [
             {
               "label": "It's downloading",
@@ -1301,7 +1301,7 @@
       "category": "library",
       "kind": "generic_flow",
       "symptom_keywords": [],
-      "user_facing_workaround": "Two things to check before we send this on.",
+      "user_facing_workaround": "Two things worth checking before we send this to support.",
       "user_facing_steps": [
         {
           "id": "gf-lib-1",
@@ -1324,12 +1324,12 @@
         },
         {
           "id": "gf-lib-2",
-          "instruction": "On the library list, pull down and hold for a second to refresh it from the server.",
+          "instruction": "Go back to My Books, pull down from the top of the list, and hold for a second to reload your books.",
           "remedy": "pullToRefresh",
-          "check": "Any change?",
+          "check": "Are your books there now?",
           "responses": [
             {
-              "label": "That fixed it",
+              "label": "Found them",
               "outcome": "resolved",
               "diagnostic": "ladder.gf-lib-2.resolved"
             },
@@ -1350,45 +1350,11 @@
       "reviewed_at": "2026-08-13"
     },
     {
-      "id": "GF-signin",
-      "category": "signin",
-      "kind": "generic_flow",
-      "symptom_keywords": [],
-      "user_facing_workaround": "One thing worth checking before we send this to support.",
-      "user_facing_steps": [
-        {
-          "id": "gf-signin-1",
-          "instruction": "On the sign-in screen, close it and reopen it from Settings → Libraries. Sometimes the sign-in form loads before your library's settings do.",
-          "remedy": "pullToRefresh",
-          "check": "Can you sign in now?",
-          "responses": [
-            {
-              "label": "I'm signed in",
-              "outcome": "resolved",
-              "diagnostic": "ladder.gf-signin-1.resolved"
-            },
-            {
-              "label": "No change",
-              "outcome": "advance",
-              "diagnostic": "ladder.gf-signin-1.no_change"
-            }
-          ],
-          "diagnostic": "ladder.gf-signin-1"
-        }
-      ],
-      "confidence_threshold": 0.1,
-      "escalate_anyway": false,
-      "helpspot_tag": "generic-ladder-signin",
-      "trust_level": "authoritative",
-      "visibility": "user_facing",
-      "reviewed_at": "2026-08-13"
-    },
-    {
       "id": "GF-reader",
       "category": "reader",
       "kind": "generic_flow",
       "symptom_keywords": [],
-      "user_facing_workaround": "A couple of things to try before we file this.",
+      "user_facing_workaround": "A couple of things worth trying before we send this to support.",
       "user_facing_steps": [
         {
           "id": "gf-read-1",
@@ -1413,7 +1379,7 @@
           "id": "gf-read-2",
           "instruction": "Open the App Store and check for a Palace update.",
           "remedy": "updateApp",
-          "check": "Did that help?",
+          "check": "Does it open now?",
           "responses": [
             {
               "label": "It opens now",
@@ -1441,13 +1407,13 @@
       "category": "other",
       "kind": "generic_flow",
       "symptom_keywords": [],
-      "user_facing_workaround": "Let's try one thing before we send this on.",
+      "user_facing_workaround": "One thing worth trying before we send this to support.",
       "user_facing_steps": [
         {
           "id": "gf-other-1",
           "instruction": "Open the App Store and check for a Palace update — it's the quickest thing to rule out.",
           "remedy": "updateApp",
-          "check": "Did an update install?",
+          "check": "Did that fix it?",
           "responses": [
             {
               "label": "That fixed it",

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -1189,6 +1189,286 @@
       "visibility": "user_facing",
       "ui_surface": "my-books",
       "reviewed_at": "2026-07-22"
+    },
+    {
+      "id": "GF-audiobook",
+      "category": "audiobook",
+      "kind": "generic_flow",
+      "symptom_keywords": [],
+      "user_facing_workaround": "A few things worth trying before we send this to support.",
+      "user_facing_steps": [
+        {
+          "id": "gf-audio-1",
+          "instruction": "Open the App Store and check for a Palace update. Several audiobook problems were fixed in recent releases.",
+          "remedy": "updateApp",
+          "check": "Did an update install?",
+          "responses": [
+            {
+              "label": "It plays now",
+              "outcome": "resolved",
+              "diagnostic": "ladder.gf-audio-1.resolved"
+            },
+            {
+              "label": "No change",
+              "outcome": "advance",
+              "diagnostic": "ladder.gf-audio-1.no_change"
+            }
+          ],
+          "diagnostic": "ladder.gf-audio-1"
+        },
+        {
+          "id": "gf-audio-2",
+          "instruction": "Go back to My Books and tap the title again. The second open often works when the first one stalls.",
+          "remedy": "reopenTitle",
+          "check": "Does it play now?",
+          "responses": [
+            {
+              "label": "It plays now",
+              "outcome": "resolved",
+              "diagnostic": "ladder.gf-audio-2.resolved"
+            },
+            {
+              "label": "No change",
+              "outcome": "advance",
+              "diagnostic": "ladder.gf-audio-2.no_change"
+            }
+          ],
+          "diagnostic": "ladder.gf-audio-2"
+        }
+      ],
+      "confidence_threshold": 0.1,
+      "escalate_anyway": false,
+      "helpspot_tag": "generic-ladder-audiobook",
+      "trust_level": "authoritative",
+      "visibility": "user_facing",
+      "reviewed_at": "2026-08-13"
+    },
+    {
+      "id": "GF-download",
+      "category": "download",
+      "kind": "generic_flow",
+      "symptom_keywords": [],
+      "user_facing_workaround": "Let's try a couple of things before we file this.",
+      "user_facing_steps": [
+        {
+          "id": "gf-dl-1",
+          "instruction": "Check the top of your screen for WiFi or cellular signal. If you're on WiFi, try switching to cellular, or the other way round.",
+          "remedy": "toggleNetwork",
+          "check": "Does the download move now?",
+          "responses": [
+            {
+              "label": "It's downloading",
+              "outcome": "resolved",
+              "diagnostic": "ladder.gf-dl-1.resolved"
+            },
+            {
+              "label": "No change",
+              "outcome": "advance",
+              "diagnostic": "ladder.gf-dl-1.no_change"
+            }
+          ],
+          "diagnostic": "ladder.gf-dl-1"
+        },
+        {
+          "id": "gf-dl-2",
+          "instruction": "Open the App Store and check for a Palace update.",
+          "remedy": "updateApp",
+          "check": "Did that help?",
+          "responses": [
+            {
+              "label": "It's downloading",
+              "outcome": "resolved",
+              "diagnostic": "ladder.gf-dl-2.resolved"
+            },
+            {
+              "label": "No change",
+              "outcome": "advance",
+              "diagnostic": "ladder.gf-dl-2.no_change"
+            }
+          ],
+          "diagnostic": "ladder.gf-dl-2"
+        }
+      ],
+      "confidence_threshold": 0.1,
+      "escalate_anyway": false,
+      "helpspot_tag": "generic-ladder-download",
+      "trust_level": "authoritative",
+      "visibility": "user_facing",
+      "reviewed_at": "2026-08-13"
+    },
+    {
+      "id": "GF-library",
+      "category": "library",
+      "kind": "generic_flow",
+      "symptom_keywords": [],
+      "user_facing_workaround": "Two things to check before we send this on.",
+      "user_facing_steps": [
+        {
+          "id": "gf-lib-1",
+          "instruction": "Open Settings, then Libraries, and check which library is selected. If you have more than one card, the books you're looking for may be under a different library.",
+          "remedy": "switchLibrary",
+          "check": "Are your books there?",
+          "responses": [
+            {
+              "label": "Found them",
+              "outcome": "resolved",
+              "diagnostic": "ladder.gf-lib-1.resolved"
+            },
+            {
+              "label": "No change",
+              "outcome": "advance",
+              "diagnostic": "ladder.gf-lib-1.no_change"
+            }
+          ],
+          "diagnostic": "ladder.gf-lib-1"
+        },
+        {
+          "id": "gf-lib-2",
+          "instruction": "On the library list, pull down and hold for a second to refresh it from the server.",
+          "remedy": "pullToRefresh",
+          "check": "Any change?",
+          "responses": [
+            {
+              "label": "That fixed it",
+              "outcome": "resolved",
+              "diagnostic": "ladder.gf-lib-2.resolved"
+            },
+            {
+              "label": "No change",
+              "outcome": "advance",
+              "diagnostic": "ladder.gf-lib-2.no_change"
+            }
+          ],
+          "diagnostic": "ladder.gf-lib-2"
+        }
+      ],
+      "confidence_threshold": 0.1,
+      "escalate_anyway": false,
+      "helpspot_tag": "generic-ladder-library",
+      "trust_level": "authoritative",
+      "visibility": "user_facing",
+      "reviewed_at": "2026-08-13"
+    },
+    {
+      "id": "GF-signin",
+      "category": "signin",
+      "kind": "generic_flow",
+      "symptom_keywords": [],
+      "user_facing_workaround": "One thing worth checking before we send this to support.",
+      "user_facing_steps": [
+        {
+          "id": "gf-signin-1",
+          "instruction": "On the sign-in screen, close it and reopen it from Settings → Libraries. Sometimes the sign-in form loads before your library's settings do.",
+          "remedy": "pullToRefresh",
+          "check": "Can you sign in now?",
+          "responses": [
+            {
+              "label": "I'm signed in",
+              "outcome": "resolved",
+              "diagnostic": "ladder.gf-signin-1.resolved"
+            },
+            {
+              "label": "No change",
+              "outcome": "advance",
+              "diagnostic": "ladder.gf-signin-1.no_change"
+            }
+          ],
+          "diagnostic": "ladder.gf-signin-1"
+        }
+      ],
+      "confidence_threshold": 0.1,
+      "escalate_anyway": false,
+      "helpspot_tag": "generic-ladder-signin",
+      "trust_level": "authoritative",
+      "visibility": "user_facing",
+      "reviewed_at": "2026-08-13"
+    },
+    {
+      "id": "GF-reader",
+      "category": "reader",
+      "kind": "generic_flow",
+      "symptom_keywords": [],
+      "user_facing_workaround": "A couple of things to try before we file this.",
+      "user_facing_steps": [
+        {
+          "id": "gf-read-1",
+          "instruction": "Go back to My Books and tap the title again.",
+          "remedy": "reopenTitle",
+          "check": "Does it open now?",
+          "responses": [
+            {
+              "label": "It opens now",
+              "outcome": "resolved",
+              "diagnostic": "ladder.gf-read-1.resolved"
+            },
+            {
+              "label": "No change",
+              "outcome": "advance",
+              "diagnostic": "ladder.gf-read-1.no_change"
+            }
+          ],
+          "diagnostic": "ladder.gf-read-1"
+        },
+        {
+          "id": "gf-read-2",
+          "instruction": "Open the App Store and check for a Palace update.",
+          "remedy": "updateApp",
+          "check": "Did that help?",
+          "responses": [
+            {
+              "label": "It opens now",
+              "outcome": "resolved",
+              "diagnostic": "ladder.gf-read-2.resolved"
+            },
+            {
+              "label": "No change",
+              "outcome": "advance",
+              "diagnostic": "ladder.gf-read-2.no_change"
+            }
+          ],
+          "diagnostic": "ladder.gf-read-2"
+        }
+      ],
+      "confidence_threshold": 0.1,
+      "escalate_anyway": false,
+      "helpspot_tag": "generic-ladder-reader",
+      "trust_level": "authoritative",
+      "visibility": "user_facing",
+      "reviewed_at": "2026-08-13"
+    },
+    {
+      "id": "GF-other",
+      "category": "other",
+      "kind": "generic_flow",
+      "symptom_keywords": [],
+      "user_facing_workaround": "Let's try one thing before we send this on.",
+      "user_facing_steps": [
+        {
+          "id": "gf-other-1",
+          "instruction": "Open the App Store and check for a Palace update — it's the quickest thing to rule out.",
+          "remedy": "updateApp",
+          "check": "Did an update install?",
+          "responses": [
+            {
+              "label": "That fixed it",
+              "outcome": "resolved",
+              "diagnostic": "ladder.gf-other-1.resolved"
+            },
+            {
+              "label": "No change",
+              "outcome": "advance",
+              "diagnostic": "ladder.gf-other-1.no_change"
+            }
+          ],
+          "diagnostic": "ladder.gf-other-1"
+        }
+      ],
+      "confidence_threshold": 0.1,
+      "escalate_anyway": false,
+      "helpspot_tag": "generic-ladder-other",
+      "trust_level": "authoritative",
+      "visibility": "user_facing",
+      "reviewed_at": "2026-08-13"
     }
   ],
   "category_follow_ups": {

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotCore/Resources/catalog.json
@@ -1,6 +1,7 @@
 {
   "version": "v1.2-2026-07-20",
   "updated_at": "2026-07-20",
+  "latest_known_app_version": "3.2.3",
   "entries": [
     {
       "id": "KI-2026-001-audiobook-first-open-hang",

--- a/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TriageBotViewModel.swift
+++ b/Palace/Packages/PalaceTriageBot/Sources/TriageBotUI/TriageBotViewModel.swift
@@ -82,6 +82,27 @@ public final class TriageBotViewModel: ObservableObject {
             }
         case .emitTelemetry(let event):
             telemetry.emit(event)
+        case .persistResolutionTrace(let trace):
+            // Route the trace through telemetry rather than a new store. What it
+            // answers — which remedy actually resolved which class of problem —
+            // is only useful in aggregate across the fleet, and telemetry is
+            // already the aggregating channel. A local log would sit on one
+            // device and be read by nobody.
+            //
+            // Parameters stay enumerable (ids, an outcome, a count) so
+            // TelemetryContract's no-free-text rule holds: nothing a patron typed
+            // can ride along.
+            telemetry.emit(.init(
+                name: "triage_resolution_trace",
+                parameters: [
+                    "entry_id": trace.entryId,
+                    "outcome": trace.outcome.rawValue,
+                    "attempts": String(trace.attempts.count),
+                    // Which step ended it — the field the pre-registered re-rank
+                    // rule needs, and the reason this effect exists.
+                    "final_step_id": trace.attempts.last?.stepId ?? "(none)",
+                ]
+            ))
         case .runAIFallback(let userText, let category, let context):
             Task { [fallbackClassifier, knowledgeBase] in
                 guard let fallback = fallbackClassifier else {

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AdversarialChaosTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AdversarialChaosTests.swift
@@ -72,33 +72,58 @@ final class AdversarialChaosTests: XCTestCase {
 
     // MARK: - LocalClassifier degenerate cases
 
-    /// Chaos-qa F-002 (2026-05-29) regression: when a user's text overlaps
-    /// exactly ONE keyword with a KI, the local classifier must NOT
-    /// confidently suggest — single keyword overlap is not enough signal.
-    /// Escalating routes the case to the AI fallback (Claude) which has
-    /// semantic context to either confirm or reject. Before this rule,
-    /// "my library account keeps asking me to log in" matched KI-004
-    /// wrong-library at confidence 0.33 via the single token "my library",
-    /// misdirecting an auth complaint to demo-collection guidance.
-    func testClassifier_singleKeywordMatch_escalates_F002_regression() {
-        let kb = KnowledgeBase(catalog: KBCatalog(version: "test", updatedAt: "x", entries: [
+    /// Chaos-qa F-002 (2026-05-29) regression: an auth complaint whose ONLY
+    /// overlap with the wrong-library entry is the weak token "my library" must
+    /// not be handed demo-collection guidance. The original defect was
+    /// "my library account keeps asking me to log in" matching KI-004 at
+    /// confidence 0.33 on that one token.
+    ///
+    /// The guard is that weak evidence cannot carry a suggestion by itself —
+    /// "my library" lives in `corroborating_keywords`, so it sharpens a real
+    /// match but can never be one. (This previously asserted the same property
+    /// via a COUNT floor of two matches. The fixture had drifted to the input
+    /// "I think I'm using the wrong library", which matches the decisive phrase
+    /// "wrong library" — a case where suggesting is the RIGHT answer, so it no
+    /// longer described F-002. Restored to the defect's actual shape.)
+    func testClassifier_weakKeywordMatchAlone_escalates_F002_regression() {
+        let result = LocalClassifier().classify(
+            userText: "my library account keeps asking me to log in",
+            category: .library,
+            knowledgeBase: Self.wrongLibraryKB
+        )
+        XCTAssertEqual(result.decision, .escalate,
+            "A lone weak-keyword match must escalate, not confidently misroute an auth complaint")
+    }
+
+    /// The other half of the same contract, and the reason the count floor had to
+    /// go: a patron who writes the one decisive phrase gets the workaround. Under
+    /// the old ≥2-match rule this escalated, which is what left QA unable to reach
+    /// any troubleshooting steps (PP-4865).
+    func testClassifier_singleStrongKeywordMatch_suggests() {
+        let result = LocalClassifier().classify(
+            userText: "I think I'm using the wrong library",
+            category: .library,
+            knowledgeBase: Self.wrongLibraryKB
+        )
+        XCTAssertEqual(result.decision, .suggest(entryId: "KI-WRONG-LIB"),
+            "One decisive phrase is sufficient evidence — this is how patrons actually write")
+    }
+
+    /// Shared so both halves are scored against the identical entry; the only
+    /// variable between them is the strength of the keyword the patron hit.
+    private static let wrongLibraryKB = KnowledgeBase(
+        catalog: KBCatalog(version: "test", updatedAt: "x", entries: [
             KBEntry(
                 id: "KI-WRONG-LIB",
                 category: .library,
                 status: .userError,
-                symptomKeywords: ["wrong library", "demo books", "bookshelf"],
+                symptomKeywords: ["wrong library", "demo books"],
+                corroboratingKeywords: ["my library", "bookshelf"],
                 userFacingWorkaround: "...",
                 confidenceThreshold: 0.1
             )
-        ]))
-        let result = LocalClassifier().classify(
-            userText: "I think I'm using the wrong library",
-            category: .library,
-            knowledgeBase: kb
-        )
-        XCTAssertEqual(result.decision, .escalate,
-            "Single keyword match must escalate — surfaces to AI fallback, not a confident wrong suggestion")
-    }
+        ])
+    )
 
     func testClassifier_emptyKB_returnsEscalate() {
         let kb = KnowledgeBase(catalog: KBCatalog(version: "empty", updatedAt: "2026-05-28", entries: []))

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AlreadyTriedTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AlreadyTriedTests.swift
@@ -17,8 +17,10 @@ final class AlreadyTriedTests: XCTestCase {
                        [.reinstall, .restartDevice])
         XCTAssertEqual(detector.alreadyTried(in: "I have gone on and off wifi, I have logged out of the app"),
                        [.toggleNetwork])
+        // "turned it in and checked it back out" is a return-and-reborrow, which
+        // was invisible until that remedy existed.
         XCTAssertEqual(detector.alreadyTried(in: "I've tried on different devices. I've turned it in and checked it back out."),
-                       [.otherDevice])
+                       [.otherDevice, .returnAndReborrow])
     }
 
     /// Conservative by design: a false positive SKIPS a step the patron may need,

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AlreadyTriedTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AlreadyTriedTests.swift
@@ -30,6 +30,27 @@ final class AlreadyTriedTests: XCTestCase {
         XCTAssertTrue(detector.alreadyTried(in: "my audiobook won't play").isEmpty)
     }
 
+    /// The two remedies a generic ladder would offer that the detector could not
+    /// see. Without these, a patron who wrote "I pulled down to refresh and
+    /// nothing happened" would be told to pull down to refresh — the exact
+    /// not-listening defect this work exists to remove, reintroduced on the new
+    /// surface.
+    func testDetectsTheRemediesAGenericLadderWouldOffer() {
+        XCTAssertTrue(detector.alreadyTried(in: "I pulled down to refresh and nothing changed").contains(.pullToRefresh))
+        XCTAssertTrue(detector.alreadyTried(in: "I switched to my other library and it is the same").contains(.switchLibrary))
+    }
+
+    /// Cost tiers are what let the ladder put destructive remedies last. Asserted
+    /// through behaviour that depends on them, not as a constant echo: the two
+    /// remedies that destroy downloaded content must not sit in the free tier.
+    func testDestructiveRemediesAreNotClassifiedAsFree() {
+        XCTAssertEqual(Remedy.reinstall.costTier, .destructive,
+                       "reinstall deletes every downloaded book")
+        XCTAssertEqual(Remedy.signOutIn.costTier, .destructive,
+                       "signing out removes that library's downloaded content, and a patron who cannot sign back in is stranded")
+        XCTAssertEqual(Remedy.pullToRefresh.costTier, .free)
+    }
+
     /// A blanket claim is real information for support but cannot skip anything —
     /// skipping every step on "tried everything" strands the patron.
     func testBlanketClaimIsReportedButSkipsNothing() {

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AlreadyTriedTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AlreadyTriedTests.swift
@@ -80,6 +80,35 @@ final class AlreadyTriedTests: XCTestCase {
         XCTAssertEqual(index, 0)
     }
 
+    /// Found by dogfooding: when every step is skipped the patron attempted
+    /// nothing, so the escalation must not open by telling them their attempt
+    /// failed. The reducer tests assert state rather than prose, which is exactly
+    /// why this survived them.
+    func testAllStepsSkipped_doesNotClaimAnAttemptFailed() {
+        let entry = KBEntry(
+            id: "K", category: .audiobook, status: .open,
+            symptomKeywords: ["alpha thing"],
+            userFacingWorkaround: "Fix it.",
+            userFacingSteps: [
+                KBStep(id: "s1", instruction: "Delete and reinstall Palace.", check: "Better?", remedy: .reinstall),
+            ],
+            escalationFollowUp: KBEscalationFollowUp(prompt: "Which title is doing this?"),
+            confidenceThreshold: 0.1)
+        let r = ConversationReducer(knowledgeBase: KnowledgeBase(
+            catalog: KBCatalog(version: "t", updatedAt: "x", entries: [entry])))
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(.audiobook))
+        (s, _) = r.reduce(state: s, action: .inputChanged("the alpha thing is broken, I already reinstalled the app"))
+        (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
+        (s, _) = r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "K"))
+
+        let said = s.messages.compactMap { if case .text(let t) = $0.kind { return t }; return nil }
+        XCTAssertFalse(said.contains { $0.contains("That didn't resolve it") },
+                       "nothing was attempted — do not assert a failed attempt: \(said)")
+        XCTAssertTrue(said.contains { $0.contains("Which title is doing this?") },
+                      "the entry's question should still be asked: \(said)")
+    }
+
     /// Skipping must apply while ADVANCING too, not only when the flow opens.
     /// A mutant that ignored already-tried on advance survived the first version
     /// of this suite — every step boundary is a place to re-check, not just the

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AlreadyTriedTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AlreadyTriedTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import TriageBotCore
+
+/// 10% of real tickets open by listing what the patron already did — "They've
+/// reinstalled the app, rebooted their phone", "I have uninstalled and
+/// redownloaded several times". Walking that patron into a flow whose first step
+/// is "reinstall the app" is how the bot loses their trust in one move.
+final class AlreadyTriedTests: XCTestCase {
+
+    private let detector = RemedyDetector()
+
+    // MARK: - Detection
+
+    func testDetectsRemediesFromRealTicketWording() {
+        // Verbatim shapes from the mined corpus.
+        XCTAssertEqual(detector.alreadyTried(in: "They've reinstalled the app, rebooted their phone, and it's not working."),
+                       [.reinstall, .restartDevice])
+        XCTAssertEqual(detector.alreadyTried(in: "I have gone on and off wifi, I have logged out of the app"),
+                       [.toggleNetwork])
+        XCTAssertEqual(detector.alreadyTried(in: "I've tried on different devices. I've turned it in and checked it back out."),
+                       [.otherDevice])
+    }
+
+    /// Conservative by design: a false positive SKIPS a step the patron may need,
+    /// which costs them the fix. Mentioning a remedy is not claiming to have done
+    /// it.
+    func testMentioningARemedyIsNotHavingTriedIt() {
+        XCTAssertTrue(detector.alreadyTried(in: "should I reinstall the app?").isEmpty)
+        XCTAssertTrue(detector.alreadyTried(in: "do I need to sign out and back in").isEmpty)
+        XCTAssertTrue(detector.alreadyTried(in: "my audiobook won't play").isEmpty)
+    }
+
+    /// A blanket claim is real information for support but cannot skip anything —
+    /// skipping every step on "tried everything" strands the patron.
+    func testBlanketClaimIsReportedButSkipsNothing() {
+        XCTAssertTrue(detector.claimsExhaustedEffort(in: "I have done everything I can to get these books to play"))
+        XCTAssertTrue(detector.alreadyTried(in: "I have done everything I can to get these books to play").isEmpty)
+    }
+
+    // MARK: - Guided flow
+
+    private func drive(_ text: String) -> ConversationState {
+        let entry = KBEntry(
+            id: "K", category: .audiobook, status: .open,
+            symptomKeywords: ["alpha thing"],
+            userFacingWorkaround: "Fix it.",
+            userFacingSteps: [
+                KBStep(id: "s1", instruction: "Delete and reinstall Palace.", check: "Better?", remedy: .reinstall),
+                KBStep(id: "s2", instruction: "Tap the title again.", check: "Better?", remedy: .reopenTitle),
+            ],
+            confidenceThreshold: 0.1)
+        let r = ConversationReducer(knowledgeBase: KnowledgeBase(
+            catalog: KBCatalog(version: "t", updatedAt: "x", entries: [entry])))
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(.audiobook))
+        (s, _) = r.reduce(state: s, action: .inputChanged(text))
+        (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
+        return r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "K")).0
+    }
+
+    private func texts(_ s: ConversationState) -> [String] {
+        s.messages.compactMap { if case .text(let t) = $0.kind { return t }; return nil }
+    }
+
+    func testGuidedFlow_startsAfterTheStepTheyAlreadyDid() {
+        let state = drive("the alpha thing is broken, I already reinstalled the app twice")
+        guard case .guidedStep(_, let index, _, _) = state.step else {
+            return XCTFail("expected a guided step; got \(state.step)")
+        }
+        XCTAssertEqual(index, 1, "must start at the step they have NOT tried")
+        XCTAssertTrue(texts(state).contains { $0.contains("already tried reinstalling the app") },
+                      "skipping silently looks like steps going missing: \(texts(state))")
+    }
+
+    func testGuidedFlow_withoutThatClaim_startsAtTheBeginning() {
+        let state = drive("the alpha thing is broken")
+        guard case .guidedStep(_, let index, _, _) = state.step else {
+            return XCTFail("expected a guided step; got \(state.step)")
+        }
+        XCTAssertEqual(index, 0)
+    }
+
+    /// Skipping must apply while ADVANCING too, not only when the flow opens.
+    /// A mutant that ignored already-tried on advance survived the first version
+    /// of this suite — every step boundary is a place to re-check, not just the
+    /// first.
+    func testGuidedFlow_skipsAnAlreadyTriedStepMidFlow() {
+        let entry = KBEntry(
+            id: "K", category: .audiobook, status: .open,
+            symptomKeywords: ["alpha thing"],
+            userFacingWorkaround: "Fix it.",
+            userFacingSteps: [
+                KBStep(id: "s1", instruction: "Tap the title again.", check: "Better?", remedy: .reopenTitle),
+                KBStep(id: "s2", instruction: "Delete and reinstall Palace.", check: "Better?", remedy: .reinstall),
+                KBStep(id: "s3", instruction: "Sign out and back in.", check: "Better?", remedy: .signOutIn),
+            ],
+            confidenceThreshold: 0.1)
+        let r = ConversationReducer(knowledgeBase: KnowledgeBase(
+            catalog: KBCatalog(version: "t", updatedAt: "x", entries: [entry])))
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(.audiobook))
+        (s, _) = r.reduce(state: s, action: .inputChanged("the alpha thing is broken, I already reinstalled the app"))
+        (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
+        (s, _) = r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "K"))
+        guard case .guidedStep(_, let first, _, _) = s.step, first == 0 else {
+            return XCTFail("expected to open at step 0; got \(s.step)")
+        }
+        (s, _) = r.reduce(state: s, action: .userConfirmedStepDidNotResolve(stepId: "s1"))
+        guard case .guidedStep(_, let next, _, _) = s.step else {
+            return XCTFail("expected another step; got \(s.step)")
+        }
+        XCTAssertEqual(next, 2, "must jump over the reinstall step they already did")
+    }
+
+    /// If they have done everything the entry would suggest, opening an empty
+    /// flow wastes their time — escalate with the trace instead.
+    func testGuidedFlow_whenEveryStepIsAlreadyTried_escalatesInstead() {
+        let state = drive("the alpha thing is broken. I reinstalled the app and I closed and reopened it.")
+        if case .guidedStep = state.step {
+            XCTFail("opened a flow with nothing left to try")
+        }
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AlreadyTriedTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/AlreadyTriedTests.swift
@@ -65,9 +65,12 @@ final class AlreadyTriedTests: XCTestCase {
             id: "K", category: .audiobook, status: .open,
             symptomKeywords: ["alpha thing"],
             userFacingWorkaround: "Fix it.",
+            // Destructive rungs may not come first, in any entry kind — so the
+            // free step leads and the reinstall follows. The test still turns on
+            // whether an already-tried rung is skipped.
             userFacingSteps: [
-                KBStep(id: "s1", instruction: "Delete and reinstall Palace.", check: "Better?", remedy: .reinstall),
-                KBStep(id: "s2", instruction: "Tap the title again.", check: "Better?", remedy: .reopenTitle),
+                KBStep(id: "s1", instruction: "Tap the title again.", check: "Better?", remedy: .reopenTitle),
+                KBStep(id: "s2", instruction: "Delete and reinstall Palace.", check: "Better?", remedy: .reinstall),
             ],
             confidenceThreshold: 0.1)
         let r = ConversationReducer(knowledgeBase: KnowledgeBase(
@@ -84,12 +87,12 @@ final class AlreadyTriedTests: XCTestCase {
     }
 
     func testGuidedFlow_startsAfterTheStepTheyAlreadyDid() {
-        let state = drive("the alpha thing is broken, I already reinstalled the app twice")
+        let state = drive("the alpha thing is broken, I already closed and reopened it")
         guard case .guidedStep(_, let index, _, _) = state.step else {
             return XCTFail("expected a guided step; got \(state.step)")
         }
         XCTAssertEqual(index, 1, "must start at the step they have NOT tried")
-        XCTAssertTrue(texts(state).contains { $0.contains("already tried reinstalling the app") },
+        XCTAssertTrue(texts(state).contains { $0.contains("already tried reopening the title") },
                       "skipping silently looks like steps going missing: \(texts(state))")
     }
 
@@ -111,7 +114,7 @@ final class AlreadyTriedTests: XCTestCase {
             symptomKeywords: ["alpha thing"],
             userFacingWorkaround: "Fix it.",
             userFacingSteps: [
-                KBStep(id: "s1", instruction: "Delete and reinstall Palace.", check: "Better?", remedy: .reinstall),
+                KBStep(id: "s1", instruction: "Tap the title again.", check: "Better?", remedy: .reopenTitle),
             ],
             escalationFollowUp: KBEscalationFollowUp(prompt: "Which title is doing this?"),
             confidenceThreshold: 0.1)
@@ -119,7 +122,7 @@ final class AlreadyTriedTests: XCTestCase {
             catalog: KBCatalog(version: "t", updatedAt: "x", entries: [entry])))
         var (s, _) = r.reduce(state: ConversationState(), action: .start)
         (s, _) = r.reduce(state: s, action: .userTappedCategory(.audiobook))
-        (s, _) = r.reduce(state: s, action: .inputChanged("the alpha thing is broken, I already reinstalled the app"))
+        (s, _) = r.reduce(state: s, action: .inputChanged("the alpha thing is broken, I already closed and reopened it"))
         (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
         (s, _) = r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "K"))
 
@@ -149,6 +152,7 @@ final class AlreadyTriedTests: XCTestCase {
             catalog: KBCatalog(version: "t", updatedAt: "x", entries: [entry])))
         var (s, _) = r.reduce(state: ConversationState(), action: .start)
         (s, _) = r.reduce(state: s, action: .userTappedCategory(.audiobook))
+        // Claims the MIDDLE rung, so the flow opens at 0 and must jump over 1.
         (s, _) = r.reduce(state: s, action: .inputChanged("the alpha thing is broken, I already reinstalled the app"))
         (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
         (s, _) = r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "K"))
@@ -165,7 +169,7 @@ final class AlreadyTriedTests: XCTestCase {
     /// If they have done everything the entry would suggest, opening an empty
     /// flow wastes their time — escalate with the trace instead.
     func testGuidedFlow_whenEveryStepIsAlreadyTried_escalatesInstead() {
-        let state = drive("the alpha thing is broken. I reinstalled the app and I closed and reopened it.")
+        let state = drive("the alpha thing is broken. I closed and reopened it and I reinstalled the app.")
         if case .guidedStep = state.step {
             XCTFail("opened a flow with nothing left to try")
         }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogContractCompletenessTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogContractCompletenessTests.swift
@@ -15,7 +15,7 @@ final class CatalogContractCompletenessTests: XCTestCase {
     // MARK: - Guided-step flow is well-formed and terminating
 
     func testGuidedSteps_areWellFormedAndCanTerminate() throws {
-        for entry in try loadEntries() {
+        for entry in try loadEntries() where entry.resolvedKind != .genericFlow {
             guard let steps = entry.userFacingSteps, !steps.isEmpty else { continue }
 
             // Unique step ids within the entry (routing + telemetry rely on it).
@@ -61,7 +61,7 @@ final class CatalogContractCompletenessTests: XCTestCase {
     // MARK: - Telemetry diagnostics are unique within an entry
 
     func testDiagnostics_areUniqueWithinEntry() throws {
-        for entry in try loadEntries() {
+        for entry in try loadEntries() where entry.resolvedKind != .genericFlow {
             guard let steps = entry.userFacingSteps else { continue }
             var diagnostics: [String] = []
             for step in steps {
@@ -76,7 +76,7 @@ final class CatalogContractCompletenessTests: XCTestCase {
     // MARK: - Escalation follow-up prompt is real when present
 
     func testEscalationFollowUp_hasNonEmptyPrompt() throws {
-        for entry in try loadEntries() {
+        for entry in try loadEntries() where entry.resolvedKind != .genericFlow {
             guard let followUp = entry.escalationFollowUp else { continue }
             XCTAssertFalse(followUp.prompt.trimmingCharacters(in: .whitespaces).isEmpty,
                            "\(entry.id): escalation follow-up present but prompt is empty")
@@ -85,8 +85,12 @@ final class CatalogContractCompletenessTests: XCTestCase {
 
     // MARK: - Every entry is REACHABLE (its own keywords can surface it)
 
+    /// Every entry a patron can be MATCHED to must be reachable from its own
+    /// keywords. `generic_flow` ladders are exempt by design: they carry no
+    /// keywords and are offered when nothing matched, so "unreachable by
+    /// keywords" is their defining property rather than a defect.
     func testEveryEntry_isSuggestableByItsOwnKeywords() throws {
-        let entries = try loadEntries()
+        let entries = try loadEntries().filter { $0.resolvedKind != .genericFlow }
         let kb = KnowledgeBase(catalog: KBCatalog(version: "reach", updatedAt: "2026-07-20", entries: entries))
         let classifier = LocalClassifier()
 

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogSchemaLintTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogSchemaLintTests.swift
@@ -96,6 +96,35 @@ final class CatalogSchemaLintTests: XCTestCase {
         }
     }
 
+    /// `confidence_threshold` must not read as a safety knob it is not.
+    ///
+    /// Scores are (strong + 0.5·weak) / 3. The weakest non-zero score any input
+    /// can produce is a single corroborating region: 1/6 ≈ 0.167. Every threshold
+    /// in the shipped catalog is 0.08–0.1, so every one of them passes
+    /// unconditionally — the suggest gate is carried entirely by the
+    /// strong-evidence requirement and the margin guards.
+    ///
+    /// That is fine as long as it is DELIBERATE. This test pins the two states
+    /// apart: a threshold below the floor is an explicit no-op, and anything at or
+    /// above it is a real constraint that must be chosen against the current
+    /// scale, not inherited from the old quantized one where 0.5 meant "two
+    /// regions". Raising a value without reading this is how a knob that never
+    /// fired starts silently suppressing matches.
+    func testConfidenceThresholdsAreDeliberate() throws {
+        let weakestPossibleScore = 0.5 / 3.0   // one corroborating region
+        var active: [String] = []
+        for entry in try loadEntries() where entry.confidenceThreshold >= weakestPossibleScore {
+            let impliedStrongRegions = Int((entry.confidenceThreshold * 3.0).rounded(.up))
+            active.append("\(entry.id): \(entry.confidenceThreshold) demands ~\(impliedStrongRegions) strong region(s)")
+        }
+        XCTAssertTrue(
+            active.isEmpty,
+            """
+            these thresholds now constrain matching on the CURRENT score scale.             Confirm each was chosen against (strong + 0.5·weak)/3 rather than the             retired {1/3, 2/3, 1} quantization, then add it to this test's             allowance: \(active)
+            """
+        )
+    }
+
     /// Duplicate entry ids silently break `entry(id:)` lookups and telemetry.
     func testEntryIdsAreUnique() throws {
         let ids = try loadEntries().map { $0.id }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogSchemaLintTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogSchemaLintTests.swift
@@ -141,6 +141,15 @@ final class CatalogSchemaLintTests: XCTestCase {
                 XCTAssertNil(entry.fixedInVersion, "\(entry.id): how_to entry must not carry a fix version")
             case .knownIssue:
                 XCTAssertNotNil(entry.status, "\(entry.id): known_issue entry must declare a status")
+            case .genericFlow:
+                // A ladder is not a diagnosis: no known-issue status, no version
+                // gate, and it must carry rungs or it has nothing to offer.
+                XCTAssertNil(entry.status, "\(entry.id): generic_flow must not carry a known-issue status")
+                XCTAssertNil(entry.fixedInVersion, "\(entry.id): generic_flow must not carry a fix version")
+                XCTAssertFalse((entry.userFacingSteps ?? []).isEmpty,
+                               "\(entry.id): generic_flow with no steps offers nothing")
+                XCTAssertTrue(entry.symptomKeywords.isEmpty,
+                              "\(entry.id): a ladder must not claim symptoms — it is offered when nothing matched")
             }
         }
     }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogSchemaLintTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogSchemaLintTests.swift
@@ -39,6 +39,63 @@ final class CatalogSchemaLintTests: XCTestCase {
                       "how_to keywords must be multi-word intent phrases, not single words: \(offenders)")
     }
 
+    /// Generic symptom words are corroborating evidence, never strong evidence.
+    ///
+    /// `symptom_keywords` is the sufficient-alone list: one match there is grounds
+    /// to offer the entry's workaround. A word like "stuck" or "crashes" describes
+    /// half the app, so if it sits in that list the bot will hand a patron a
+    /// specific bug's fix on the strength of one generic word — the chaos-qa F-002
+    /// defect. Such words belong in `corroborating_keywords`, where they sharpen a
+    /// real match without ever being one.
+    ///
+    /// This is the guard that lets the classifier gate on evidence STRENGTH rather
+    /// than evidence COUNT. Without it, the partition would drift the first time
+    /// someone adds a keyword to fix a missed ticket, and the ≥1-strong-region
+    /// floor would quietly become as unsafe as the ≥2-of-anything floor it
+    /// replaced.
+    func testGenericSymptomWordsAreNotStrongEvidence() throws {
+        // Bare words that describe a symptom without identifying a cause. Each one
+        // appears verbatim in the shipped catalog, on entries whose actual bug is
+        // far narrower than the word.
+        let generic: Set<String> = [
+            "stuck", "crashes", "crashed", "crash", "hangs", "hang", "hanging",
+            "spinning", "spinner", "blinks", "blinking", "frozen", "freezes",
+            "download", "downloads", "downloading", "bookshelf", "boxes",
+            "placeholder", "reinstall", "broken", "error", "failed", "failing",
+            "slow", "buggy", "glitch", "weird", "wrong"
+        ]
+
+        var offenders: [String] = []
+        for entry in try loadEntries() {
+            for keyword in entry.symptomKeywords
+            where generic.contains(keyword.lowercased().trimmingCharacters(in: .whitespaces)) {
+                offenders.append("\(entry.id): '\(keyword)'")
+            }
+        }
+        XCTAssertTrue(
+            offenders.isEmpty,
+            """
+            generic symptom words found in symptom_keywords (the sufficient-alone list). \
+            Move them to corroborating_keywords — as strong evidence they let one \
+            vague word route a patron to a specific bug's workaround: \(offenders)
+            """
+        )
+    }
+
+    /// A word cannot be both sufficient-alone and corroborating. Overlap would make
+    /// the strength partition meaningless — the strong list would win and the weak
+    /// listing would read as a guard that isn't there.
+    func testStrengthTiersDoNotOverlap() throws {
+        for entry in try loadEntries() {
+            let strong = Set(entry.symptomKeywords.map { $0.lowercased() })
+            let weak = Set((entry.corroboratingKeywords ?? []).map { $0.lowercased() })
+            XCTAssertTrue(
+                strong.isDisjoint(with: weak),
+                "\(entry.id): keywords in both tiers: \(strong.intersection(weak).sorted())"
+            )
+        }
+    }
+
     /// Duplicate entry ids silently break `entry(id:)` lookups and telemetry.
     func testEntryIdsAreUnique() throws {
         let ids = try loadEntries().map { $0.id }
@@ -75,20 +132,20 @@ final class CatalogSchemaLintTests: XCTestCase {
                 }
             }
         }
-        // The known, intentional set is exactly the 5 bare-"download" pairs in
-        // KI-008: "download" is load-bearing for recall on inputs like "trying to
-        // download an ebook and it never works" (it forms the second distinct
-        // region alongside "never works"), so it stays despite being a substring
-        // of the specific "won't download" etc. Every other entry was pruned to
-        // distinct concepts. Asserting the exact SET (not a count ≤ N) means a
-        // swap — one nesting fixed, a new one introduced — still fails.
-        let allowed: Set<String> = [
-            "KI-2026-008-download-no-network: 'download' is nested inside 'won't download'",
-            "KI-2026-008-download-no-network: 'download' is nested inside 'wont download'",
-            "KI-2026-008-download-no-network: 'download' is nested inside 'download stuck'",
-            "KI-2026-008-download-no-network: 'download' is nested inside 'download failed'",
-            "KI-2026-008-download-no-network: 'download' is nested inside 'stuck downloading'",
-        ]
+        // Empty, and deliberately so. This set used to grandfather 5 bare-"download"
+        // nestings in KI-008: under the old count-based floor a known-issue entry
+        // needed TWO distinct regions to suggest, so bare "download" was kept as
+        // load-bearing padding — it supplied the second region alongside "never
+        // works" on inputs like "trying to download an ebook and it never works".
+        //
+        // Keyword strength tiers removed the need for that padding: "never works"
+        // is strong evidence and now suffices alone, so "download" moved to
+        // `corroborating_keywords` where a bare category noun belongs. The
+        // exception retired with the floor that forced it.
+        //
+        // Asserting the exact SET (not a count ≤ N) means a swap — one nesting
+        // fixed, a new one introduced — still fails.
+        let allowed: Set<String> = []
         if Set(offenders) != allowed {
             for o in offenders where !allowed.contains(o) { print("  UNEXPECTED NESTED-KEYWORD: \(o)") }
         }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogValidationTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogValidationTests.swift
@@ -77,6 +77,46 @@ final class CatalogValidationTests: XCTestCase {
         ]).isEmpty)
     }
 
+    /// The validator's stated reason for existing is that a hot-pushed catalog
+    /// "could tell every sign-in patron to sign out, and nothing on the device
+    /// would object". It only ever checked `generic_flow` entries — so a pushed
+    /// KNOWN_ISSUE entry in the signin category with a sign-out step did exactly
+    /// that and validated clean. The shipped entries happen to comply, but that
+    /// is luck rather than enforcement.
+    func testSuppressionApplies_toAnyEntryKindNotJustLadders() {
+        let sneaky = KBEntry(
+            id: "KI-SNEAK", category: .signin, status: .open,
+            symptomKeywords: ["cannot sign in"],
+            userFacingWorkaround: "Sign out and back in.",
+            userFacingSteps: [rung("s1", .signOutIn)])
+        XCTAssertFalse(validate([sneaky]).isEmpty,
+            "a suppressed remedy must be rejected in ANY entry kind, not only in ladders")
+    }
+
+    /// Destructive-first and refusability are safety rules about what we ask a
+    /// patron to do. They cannot be scoped to one entry kind either.
+    func testDestructiveRulesApply_toAnyEntryKind() {
+        let firstDestructive = KBEntry(
+            id: "KI-FIRST", category: .audiobook, status: .open,
+            symptomKeywords: ["will not play"],
+            userFacingWorkaround: "Reinstall.",
+            userFacingSteps: [rung("s1", .reinstall), rung("s2", .pullToRefresh)])
+        XCTAssertFalse(validate([firstDestructive]).isEmpty,
+            "no entry of any kind may open by destroying the patron's downloads")
+    }
+
+    /// `otherDevice` is a diagnostic, not a fix — trying another device tells us
+    /// something and repairs nothing. It appears in no ladder and no entry step
+    /// today; this stops a future author reading the enum as a menu.
+    func testOtherDeviceIsNeverARung() {
+        let diagnostic = KBEntry(
+            id: "GF-diag", category: .audiobook, kind: .genericFlow,
+            symptomKeywords: [], userFacingWorkaround: "Try things.",
+            userFacingSteps: [rung("s1", .otherDevice)])
+        XCTAssertFalse(validate([diagnostic]).isEmpty,
+            "trying another device is a diagnostic; it belongs in a question, not a rung")
+    }
+
     /// The shipped catalog must satisfy the same rules it will be held to in
     /// production — the producer check, not just the fixture check.
     func testShippedCatalogIsValid() throws {

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogValidationTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CatalogValidationTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import TriageBotCore
+
+/// Invariants a remedy ladder must satisfy, enforced when the catalog LOADS.
+///
+/// Deliberately not test-only lint. The catalog is designed to be server-supplied
+/// later for hot updates, so a rule that lives only in the test suite is a rule
+/// the shipped app does not have — a hot-pushed catalog could tell every sign-in
+/// patron to sign out. Validate the producer, not just the fixture.
+///
+/// The evidenced rules, from 204 authoring tickets:
+///  - sign-in ladders must not contain sign-out or update-the-app. Support
+///    prescribed sign-out for sign-in complaints once in 41, and update zero
+///    times in 41 — the two cheapest remedies are the two least applicable in
+///    the largest category, which is the opposite of what cost-ordering alone
+///    would produce.
+///  - destructive rungs (sign-out, reinstall) never come first and must always
+///    be skippable, because being wrong about them costs the patron their
+///    downloaded books.
+///  - a ladder is at most three rungs. The quarter of patrons whose problem only
+///    staff can fix pay the whole ladder as delay; three cheap rungs is a
+///    defensible tax, six is not.
+final class CatalogValidationTests: XCTestCase {
+
+    private func rung(_ id: String, _ remedy: Remedy, skippable: Bool = true) -> KBStep {
+        KBStep(id: id, instruction: "Do \(remedy.rawValue).", check: "Any change?",
+               responses: skippable
+                   ? [KBStepResponse(label: "Didn't help", outcome: .advance),
+                      KBStepResponse(label: "Fixed it", outcome: .resolved)]
+                   : [KBStepResponse(label: "Fixed it", outcome: .resolved)],
+               remedy: remedy)
+    }
+
+    private func ladder(_ category: KBCategory, _ steps: [KBStep]) -> KBEntry {
+        KBEntry(id: "GF-\(category.rawValue)", category: category, kind: .genericFlow,
+                symptomKeywords: [], userFacingWorkaround: "A few things to try.",
+                userFacingSteps: steps)
+    }
+
+    private func validate(_ entries: [KBEntry]) -> [String] {
+        CatalogValidator.violations(in: KBCatalog(version: "t", updatedAt: "x", entries: entries))
+    }
+
+    func testSigninLadderContainingSignOut_isRejected() {
+        let v = validate([ladder(.signin, [rung("a", .pullToRefresh), rung("b", .signOutIn)])])
+        XCTAssertFalse(v.isEmpty,
+            "sign-out must not be offered to someone whose complaint is that sign-in fails")
+    }
+
+    func testSigninLadderContainingUpdateApp_isRejected() {
+        XCTAssertFalse(validate([ladder(.signin, [rung("a", .updateApp)])]).isEmpty)
+    }
+
+    func testDestructiveRungFirst_isRejected() {
+        let v = validate([ladder(.audiobook, [rung("a", .reinstall), rung("b", .pullToRefresh)])])
+        XCTAssertFalse(v.isEmpty, "a ladder must not open by deleting the patron's books")
+    }
+
+    func testDestructiveRungWithoutASkip_isRejected() {
+        let v = validate([ladder(.audiobook, [rung("a", .pullToRefresh),
+                                              rung("b", .reinstall, skippable: false)])])
+        XCTAssertFalse(v.isEmpty, "a destructive rung must always be refusable")
+    }
+
+    func testLadderLongerThanThreeRungs_isRejected() {
+        let v = validate([ladder(.audiobook, [rung("a", .pullToRefresh), rung("b", .updateApp),
+                                              rung("c", .reopenTitle), rung("d", .toggleNetwork)])])
+        XCTAssertFalse(v.isEmpty, "the staff-only quarter pays the whole ladder as delay")
+    }
+
+    /// A ladder obeying every rule must pass — a validator that rejects
+    /// everything is as useless as one that rejects nothing.
+    func testWellFormedLadder_passes() {
+        XCTAssertTrue(validate([
+            ladder(.audiobook, [rung("a", .updateApp), rung("b", .reopenTitle), rung("c", .reinstall)]),
+            ladder(.signin, [rung("d", .pullToRefresh)]),
+        ]).isEmpty)
+    }
+
+    /// The shipped catalog must satisfy the same rules it will be held to in
+    /// production — the producer check, not just the fixture check.
+    func testShippedCatalogIsValid() throws {
+        XCTAssertEqual(CatalogValidator.violations(in: try BundledCatalogSource.loadCatalogSync()), [])
+    }
+}
+
+extension CatalogValidationTests {
+
+    /// The rules must bite at LOAD, not only when a test calls the validator.
+    /// A violating ladder is dropped and the rest of the catalog survives — the
+    /// bot falls back to its pre-ladder behaviour for that category rather than
+    /// losing every entry over one bad rung.
+    func testViolatingLadderIsDroppedAtLoad_andTheRestOfTheCatalogSurvives() {
+        let bad = ladder(.signin, [rung("x", .signOutIn)])
+        let good = KBEntry(id: "KI-KEEP", category: .signin, status: .open,
+                           symptomKeywords: ["grayed out"],
+                           userFacingWorkaround: "Tap the field anyway.")
+        let kb = KnowledgeBase(catalog: KBCatalog(version: "t", updatedAt: "x", entries: [bad, good]))
+
+        XCTAssertNil(kb.genericFlow(for: .signin),
+                     "a ladder that breaks a safety rule must not be offered to anyone")
+        XCTAssertNotNil(kb.entry(id: "KI-KEEP"),
+                        "one bad ladder must not cost the catalog its working entries")
+        XCTAssertFalse(kb.validationViolations.isEmpty, "the reason must be reportable, not silent")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CategoryFollowUpTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CategoryFollowUpTests.swift
@@ -29,11 +29,33 @@ final class CategoryFollowUpTests: XCTestCase {
     }
 
     /// The exact input class that no keyword can ever reach.
-    func testUnrecognizableComplaint_isStillAskedSomethingUseful() throws {
-        let state = drive(try shipped(), .signin, "Cant sign in")
+    ///
+    /// The shape changed when remedy ladders shipped: such a complaint is now
+    /// offered the category's ladder FIRST, and the catch-all question arrives
+    /// when the ladder is exhausted. The invariant that matters is unchanged —
+    /// this patron is never filed blind — so the test walks the whole path
+    /// rather than asserting the first screen.
+    func testUnrecognizableComplaint_isOfferedRemediesThenStillAsked() throws {
+        let r = try shipped()
+        var state = drive(r, .signin, "Cant sign in")
+
+        guard case .matched(let offered) = state.step, offered.hasPrefix("GF-") else {
+            return XCTFail("expected the sign-in remedy ladder; got \(state.step)")
+        }
+        state = r.reduce(state: state, action: .userTappedStartGuidedFlow(entryId: offered)).0
+        guard case .guidedStep(_, _, _, _) = state.step else {
+            return XCTFail("expected a rung; got \(state.step)")
+        }
+        // Exhaust every rung.
+        var guard_ = 0
+        while case .guidedStep(let e, let i, _, _) = state.step, guard_ < 5 {
+            let stepId = r.knowledgeBase.entry(id: e)?.userFacingSteps?[i].id ?? ""
+            state = r.reduce(state: state, action: .userConfirmedStepDidNotResolve(stepId: stepId)).0
+            guard_ += 1
+        }
         let asked = try XCTUnwrap(prompt(state), "a blank ticket is the worst outcome this bot can produce")
         XCTAssertTrue(asked.contains("library gave you") || asked.contains("created inside"),
-                      "sign-in's catch-all must split library-issued from app-created cards: \(asked)")
+                      "sign-in's catch-all must still split library-issued from app-created cards: \(asked)")
     }
 
     /// Every category has one, so no route to a ticket is blind.
@@ -62,11 +84,17 @@ final class CategoryFollowUpTests: XCTestCase {
     /// The catch-all must NOT override the deliberate silence on weak recognition:
     /// a bug-presuming entry question is withheld there, and the category question
     /// — which presumes nothing — is the right thing to ask instead.
-    func testWeakRecognition_fallsBackToTheNonPresumingCategoryQuestion() throws {
+    /// Weak recognition is now also offered the ladder before any question. What
+    /// must never happen is unchanged: the entry's bug-presuming question must
+    /// not be asked off a lone generic word.
+    func testWeakRecognition_isOfferedTheLadder_andNeverThePresumingQuestion() throws {
         let state = drive(try shipped(), .audiobook, "the app crashes when I open it")
-        let asked = try XCTUnwrap(prompt(state))
-        XCTAssertFalse(asked.contains("car"), "must not ask the CarPlay question off a weak match: \(asked)")
-        XCTAssertTrue(asked.contains("open it") || asked.contains("partway"),
-                      "should ask the category's non-presuming question: \(asked)")
+        if case .matched(let id) = state.step {
+            XCTAssertTrue(id.hasPrefix("GF-"), "weak recognition must not present a diagnosis: \(id)")
+        }
+        if let asked = prompt(state) {
+            XCTAssertFalse(asked.lowercased().contains("car "),
+                           "must not ask the CarPlay question off a weak match: \(asked)")
+        }
     }
 }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CategoryFollowUpTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CategoryFollowUpTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import TriageBotCore
+
+/// No ticket should be filed blind.
+///
+/// Measured on 318 real tickets, 69% of escalations recognized nothing and so
+/// asked nothing — support received "a patron reports a problem" plus
+/// diagnostics. Matching cannot close that gap: 8% of complaints are under a
+/// dozen words, and the catalog covers a fraction of the causes behind the rest.
+/// A per-category question makes no claim about the cause; it asks the thing that
+/// most often splits that category's clusters, which is safe precisely when we
+/// know least.
+final class CategoryFollowUpTests: XCTestCase {
+
+    private func drive(_ r: ConversationReducer, _ cat: KBCategory, _ text: String) -> ConversationState {
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(cat))
+        (s, _) = r.reduce(state: s, action: .inputChanged(text))
+        return r.reduce(state: s, action: .userSubmittedDescription).0
+    }
+
+    private func shipped() throws -> ConversationReducer {
+        ConversationReducer(knowledgeBase: KnowledgeBase(catalog: try BundledCatalogSource.loadCatalogSync()))
+    }
+
+    private func prompt(_ s: ConversationState) -> String? {
+        if case .awaitingEscalationFollowUp(let p, _) = s.step { return p }
+        return nil
+    }
+
+    /// The exact input class that no keyword can ever reach.
+    func testUnrecognizableComplaint_isStillAskedSomethingUseful() throws {
+        let state = drive(try shipped(), .signin, "Cant sign in")
+        let asked = try XCTUnwrap(prompt(state), "a blank ticket is the worst outcome this bot can produce")
+        XCTAssertTrue(asked.contains("library gave you") || asked.contains("created inside"),
+                      "sign-in's catch-all must split library-issued from app-created cards: \(asked)")
+    }
+
+    /// Every category has one, so no route to a ticket is blind.
+    func testEveryCategoryHasACatchAllQuestion() throws {
+        let kb = KnowledgeBase(catalog: try BundledCatalogSource.loadCatalogSync())
+        for category in KBCategory.allCases {
+            XCTAssertNotNil(kb.categoryFollowUp(for: category),
+                            "\(category.rawValue) can still file a ticket with no question asked")
+        }
+    }
+
+    /// A recognized entry's own question is more specific and must win.
+    func testRecognizedEntry_prefersItsOwnQuestionOverTheCatchAll() {
+        let entry = KBEntry(id: "K", category: .audiobook, status: .open,
+                            symptomKeywords: ["alpha thing"],
+                            userFacingWorkaround: "Fix it.",
+                            escalationFollowUp: KBEscalationFollowUp(prompt: "Which title is doing this?"),
+                            confidenceThreshold: 0.1, escalateAnyway: true)
+        let kb = KBCatalog(version: "t", updatedAt: "x", entries: [entry],
+                           categoryFollowUps: ["audiobook": KBEscalationFollowUp(prompt: "Generic question?")])
+        let state = drive(ConversationReducer(knowledgeBase: KnowledgeBase(catalog: kb)),
+                          .audiobook, "the alpha thing is broken")
+        XCTAssertEqual(prompt(state), "Which title is doing this?")
+    }
+
+    /// The catch-all must NOT override the deliberate silence on weak recognition:
+    /// a bug-presuming entry question is withheld there, and the category question
+    /// — which presumes nothing — is the right thing to ask instead.
+    func testWeakRecognition_fallsBackToTheNonPresumingCategoryQuestion() throws {
+        let state = drive(try shipped(), .audiobook, "the app crashes when I open it")
+        let asked = try XCTUnwrap(prompt(state))
+        XCTAssertFalse(asked.contains("car"), "must not ask the CarPlay question off a weak match: \(asked)")
+        XCTAssertTrue(asked.contains("open it") || asked.contains("partway"),
+                      "should ask the category's non-presuming question: \(asked)")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CategoryFollowUpTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/CategoryFollowUpTests.swift
@@ -30,32 +30,19 @@ final class CategoryFollowUpTests: XCTestCase {
 
     /// The exact input class that no keyword can ever reach.
     ///
-    /// The shape changed when remedy ladders shipped: such a complaint is now
-    /// offered the category's ladder FIRST, and the catch-all question arrives
-    /// when the ladder is exhausted. The invariant that matters is unchanged —
-    /// this patron is never filed blind — so the test walks the whole path
-    /// rather than asserting the first screen.
-    func testUnrecognizableComplaint_isOfferedRemediesThenStillAsked() throws {
-        let r = try shipped()
-        var state = drive(r, .signin, "Cant sign in")
-
-        guard case .matched(let offered) = state.step, offered.hasPrefix("GF-") else {
-            return XCTFail("expected the sign-in remedy ladder; got \(state.step)")
-        }
-        state = r.reduce(state: state, action: .userTappedStartGuidedFlow(entryId: offered)).0
-        guard case .guidedStep(_, _, _, _) = state.step else {
-            return XCTFail("expected a rung; got \(state.step)")
-        }
-        // Exhaust every rung.
-        var guard_ = 0
-        while case .guidedStep(let e, let i, _, _) = state.step, guard_ < 5 {
-            let stepId = r.knowledgeBase.entry(id: e)?.userFacingSteps?[i].id ?? ""
-            state = r.reduce(state: state, action: .userConfirmedStepDidNotResolve(stepId: stepId)).0
-            guard_ += 1
-        }
+    /// Sign-in deliberately has NO remedy ladder, so this complaint goes straight
+    /// to the question. Both cheap remedies were suppressed for the category by
+    /// evidence — support prescribed update-the-app 0 times in 41 sign-in tickets
+    /// and sign-out once — and the only rung left was a mechanism nobody had
+    /// measured. Copy review rejected it rather than ship filler to the least
+    /// tolerant audience in the app. Zero rungs is the honest ladder here, and
+    /// this test is what keeps it that way: if a sign-in ladder is ever added,
+    /// this fails and someone has to justify it.
+    func testUnrecognizableComplaint_isStillAskedSomethingUseful() throws {
+        let state = drive(try shipped(), .signin, "Cant sign in")
         let asked = try XCTUnwrap(prompt(state), "a blank ticket is the worst outcome this bot can produce")
         XCTAssertTrue(asked.contains("library gave you") || asked.contains("created inside"),
-                      "sign-in's catch-all must still split library-issued from app-created cards: \(asked)")
+                      "sign-in's catch-all must split library-issued from app-created cards: \(asked)")
     }
 
     /// Every category has one, so no route to a ticket is blind.

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ClassifierInternalsTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ClassifierInternalsTests.swift
@@ -27,10 +27,29 @@ final class ClassifierInternalsTests: XCTestCase {
 
     // MARK: - distinctMatchRegionCount (kills M2 merge-boundary, pins M8 init)
 
-    func testRegionCount_touchingRangesAreTwoRegions() {
-        // "sign"[0..4) touches "in"[4..6): lowerBound(4) >= currentUpper(4) → new
-        // cluster. If the boundary were `>` they would merge into one.
-        XCTAssertEqual(LocalClassifier.distinctMatchRegionCount(of: ["sign", "in"], in: "signin"), 2)
+    /// Keywords match whole words, not substrings. This test previously asserted
+    /// that "sign" + "in" found two regions inside the single word "signin" —
+    /// pinning the substring behavior that let "stalled" match "rein**stalled**"
+    /// and hand a launch-crash report the download-no-network workaround.
+    func testRegionCount_keywordsDoNotMatchInsideAWord() {
+        XCTAssertEqual(LocalClassifier.distinctMatchRegionCount(of: ["sign", "in"], in: "signin"), 0)
+        XCTAssertEqual(LocalClassifier.distinctMatchRegionCount(of: ["stalled"], in: "I reinstalled the app"), 0)
+        XCTAssertEqual(LocalClassifier.distinctMatchRegionCount(of: ["add"], in: "additional libraries"), 0)
+    }
+
+    /// Adjacent whole-word matches are still two regions — the boundary rule that
+    /// keeps two distinct concepts from merging survives the move to tokens.
+    func testRegionCount_adjacentWordsAreTwoRegions() {
+        XCTAssertEqual(LocalClassifier.distinctMatchRegionCount(of: ["sign", "in"], in: "sign in"), 2)
+    }
+
+    /// The cost of the above, stated rather than hidden: a patron who writes the
+    /// phrase as one word is no longer matched by the two-word keyword. The fix
+    /// is a keyword spelling ("signin"), not a return to substring matching —
+    /// recall gaps are additive and cheap, false workarounds are not.
+    func testRegionCount_closedUpSpellingIsMissed_knownTradeoff() {
+        XCTAssertEqual(LocalClassifier.distinctMatchRegionCount(of: ["sign in"], in: "cant signin"), 0)
+        XCTAssertEqual(LocalClassifier.distinctMatchRegionCount(of: ["signin"], in: "cant signin"), 1)
     }
 
     func testRegionCount_nestedRangesAreOneRegion() {

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ClassifierInternalsTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ClassifierInternalsTests.swift
@@ -132,6 +132,71 @@ final class ClassifierInternalsTests: XCTestCase {
                        "strong alone scores 0.333 and must not clear a 0.4 threshold")
     }
 
+    /// Ranking is strength-first: an entry the patron named decisively must not be
+    /// outranked by one they merely brushed with vague words.
+    ///
+    /// Weak regions are worth 0.5 each, so two of them tie one strong region on
+    /// raw score. Sorting on score alone let the weak entry take the top slot,
+    /// where its lack of strong evidence then blocked the suggest entirely — the
+    /// decisive match was suppressed by a vaguer competitor. Ranking on
+    /// (strongCount, score) is what makes it safe to give entries corroborating
+    /// keywords at all.
+    func testRanking_oneStrongRegionOutranksTwoWeakRegions() {
+        let weakMany = knownIssue("W", ["nothing here"], corroborating: ["alpha", "beta"], threshold: 0.1)
+        let strongOne = knownIssue("S", ["gamma"], threshold: 0.1)
+        let kb = makeKB([weakMany, strongOne])
+
+        XCTAssertEqual(classifier.classify(userText: "alpha beta gamma", knowledgeBase: kb).decision,
+                       .suggest(entryId: "S"),
+                       "a decisive phrase must beat two vague ones, not be suppressed by them")
+    }
+
+    /// The margin guard must compare on the same axis the ranking uses. If it
+    /// still compared total regions, the winner above (1 region) would trail the
+    /// loser (2 regions) and fail the margin — suggesting nothing.
+    func testRanking_marginIsMeasuredOnStrongEvidenceFirst() {
+        let weakMany = knownIssue("W", ["nothing here"],
+                                  corroborating: ["alpha", "beta", "delta"], threshold: 0.1)
+        let strongOne = knownIssue("S", ["gamma"], threshold: 0.1)
+        let kb = makeKB([weakMany, strongOne])
+
+        // W has THREE weak regions (score 0.5) vs S's one strong (0.333). Strength
+        // still wins the sort, and the margin must be read the same way.
+        XCTAssertEqual(classifier.classify(userText: "alpha beta delta gamma", knowledgeBase: kb).decision,
+                       .suggest(entryId: "S"))
+    }
+
+    /// Equal strong evidence on both sides is genuine ambiguity and must still
+    /// disambiguate — the strength-first ordering must not collapse that into a
+    /// confident pick.
+    func testRanking_equalStrongEvidence_stillDisambiguates() {
+        let a = knownIssue("A", ["gamma"], threshold: 0.1)
+        let b = knownIssue("B", ["gamma"], threshold: 0.1)
+        guard case .disambiguate = classifier.classify(userText: "gamma", knowledgeBase: makeKB([a, b])).decision else {
+            return XCTFail("two entries with identical strong evidence must disambiguate")
+        }
+    }
+
+    /// Disambiguation is a claim that we have two GOOD candidates and need the
+    /// patron to pick. When every candidate rests on vague words we have none, and
+    /// the reducer's disambiguation prompt ("is this happening right now, or did it
+    /// happen earlier today?") does not separate topics anyway — so a renewals
+    /// question would be answered with a timing question, and no ticket scoped.
+    ///
+    /// Escalating with the top candidate attached is the honest outcome: it says
+    /// "I am not sure", asks the entry's non-presuming question, and still hands
+    /// support a lead.
+    func testDisambiguate_requiresAtLeastOneStrongCandidate() {
+        let a = knownIssue("A", ["nothing here"], corroborating: ["alpha"], threshold: 0.1)
+        let b = knownIssue("B", ["nor here"], corroborating: ["beta"], threshold: 0.1)
+        let result = classifier.classify(userText: "alpha beta", knowledgeBase: makeKB([a, b]))
+
+        XCTAssertEqual(result.decision, .escalate,
+                       "weak-only candidates must not be presented as a choice between two guesses")
+        XCTAssertNotNil(result.recognizedEntryId, "…but the ticket must still carry a lead")
+        XCTAssertFalse(result.recognitionIsStrong)
+    }
+
     func testGuard_tiedRegionCounts_disambiguates() {
         // Two entries, 2 regions each → matchCountMargin 0 → no clear leader.
         let kb = makeKB([knownIssue("A", ["alpha", "beta"]), knownIssue("B", ["alpha", "beta"])])

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ClassifierInternalsTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ClassifierInternalsTests.swift
@@ -13,9 +13,15 @@ final class ClassifierInternalsTests: XCTestCase {
         KnowledgeBase(catalog: KBCatalog(version: "test", updatedAt: "2026-07-20", entries: entries))
     }
 
-    private func knownIssue(_ id: String, _ keywords: [String], threshold: Double = 0.0) -> KBEntry {
+    private func knownIssue(
+        _ id: String,
+        _ keywords: [String],
+        corroborating: [String]? = nil,
+        threshold: Double = 0.0
+    ) -> KBEntry {
         KBEntry(id: id, category: .other, status: .open,
-                symptomKeywords: keywords, userFacingWorkaround: "Do the thing to fix it.",
+                symptomKeywords: keywords, corroboratingKeywords: corroborating,
+                userFacingWorkaround: "Do the thing to fix it.",
                 confidenceThreshold: threshold)
     }
 
@@ -95,9 +101,35 @@ final class ClassifierInternalsTests: XCTestCase {
                        .suggest(entryId: "K"))
     }
 
-    func testGuard_knownIssueSingleRegion_escalates() {
+    /// One STRONG region is sufficient. This is the behavior change that made the
+    /// bot usable: a patron naming the problem once gets the answer.
+    func testGuard_knownIssueSingleStrongRegion_suggests() {
         let kb = makeKB([knownIssue("K", ["alpha", "beta"])])
-        XCTAssertEqual(classifier.classify(userText: "alpha only", knowledgeBase: kb).decision, .escalate)
+        XCTAssertEqual(classifier.classify(userText: "alpha only", knowledgeBase: kb).decision,
+                       .suggest(entryId: "K"))
+    }
+
+    /// One WEAK region is not, however many of them there are. Corroborating
+    /// keywords shade confidence; they never carry a suggestion alone. Kills the
+    /// mutant that drops the strong-evidence conjunct from the suggest guard.
+    func testGuard_knownIssueWeakRegionsOnly_escalates() {
+        let kb = makeKB([knownIssue("K", ["alpha"], corroborating: ["beta", "gamma"])])
+        XCTAssertEqual(classifier.classify(userText: "beta and gamma", knowledgeBase: kb).decision,
+                       .escalate,
+                       "two weak matches are still weak — only strong evidence may carry a suggestion")
+    }
+
+    /// Weak evidence still counts toward the score once a strong match exists —
+    /// that is the whole point of keeping it rather than deleting it. Strong(1) +
+    /// weak(1) = 1.5/3 = 0.5, which clears a 0.4 threshold that strong alone
+    /// (1/3 = 0.333) would not.
+    func testScoring_corroboratingEvidenceRaisesConfidenceOnceStrongMatchExists() {
+        let kb = makeKB([knownIssue("K", ["alpha"], corroborating: ["beta"], threshold: 0.4)])
+        XCTAssertEqual(classifier.classify(userText: "alpha beta", knowledgeBase: kb).decision,
+                       .suggest(entryId: "K"))
+        XCTAssertEqual(classifier.classify(userText: "alpha only", knowledgeBase: kb).decision,
+                       .escalate,
+                       "strong alone scores 0.333 and must not clear a 0.4 threshold")
     }
 
     func testGuard_tiedRegionCounts_disambiguates() {
@@ -133,18 +165,35 @@ final class ClassifierInternalsTests: XCTestCase {
                        .suggest(entryId: "H"))
     }
 
-    func testKnownIssueVsHowTo_sameSingleRegionInput_divergeByKind() {
-        // Identical 1-region match: how_to suggests, known_issue escalates.
-        // Kills M5 (both→2: how_to would escalate) AND M6 (both→1: known_issue
-        // would suggest) from one paired assertion.
+    /// The suggest floor diverges on keyword STRENGTH, not on entry KIND.
+    ///
+    /// This replaces a paired assertion that a 1-region input suggested for
+    /// how_to and escalated for known_issue. That divergence was an artifact of
+    /// the per-kind count floor: `how_to` was allowed one region because its
+    /// keywords are lint-forced to be specific multi-word phrases, while
+    /// `known_issue` needed two because its keyword list mixed specific phrases
+    /// with generic words. Making strength explicit removes the need to
+    /// approximate it by kind — so an identical strong match now behaves
+    /// identically for both, and the axis that actually decides is which list the
+    /// keyword came from.
+    func testSuggestFloor_divergesByKeywordStrength_notByEntryKind() {
         let howTo = KBEntry(id: "H", category: .other, kind: .howTo,
                             symptomKeywords: ["magicphrase"],
                             userFacingWorkaround: "Here is how you do the thing.",
                             confidenceThreshold: 0.1)
-        let known = knownIssue("K", ["magicphrase"])
+        let known = knownIssue("K", ["magicphrase"], threshold: 0.1)
+
+        // Same input, same strength, both kinds → same decision. Kills the mutant
+        // that reintroduces a kind-specific floor.
         XCTAssertEqual(classifier.classify(userText: "magicphrase", knowledgeBase: makeKB([howTo])).decision,
                        .suggest(entryId: "H"))
         XCTAssertEqual(classifier.classify(userText: "magicphrase", knowledgeBase: makeKB([known])).decision,
+                       .suggest(entryId: "K"))
+
+        // Same input, same kind, weak instead of strong → escalates. Strength is
+        // the live axis.
+        let weakKnown = knownIssue("W", ["unrelated"], corroborating: ["magicphrase"], threshold: 0.1)
+        XCTAssertEqual(classifier.classify(userText: "magicphrase", knowledgeBase: makeKB([weakKnown])).decision,
                        .escalate)
     }
 

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ClearCacheRemedyTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ClearCacheRemedyTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import TriageBotCore
+
+/// The app already ships the remedy that was missing from the middle of the set.
+///
+/// Settings → Advanced → "Clear Cached Data" clears the network cache and the
+/// on-disk catalog/metadata/registry caches. It does NOT touch downloaded books.
+/// That screen was deliberately made always-visible (PP-4788) "so support can
+/// direct patrons to Send Error Logs / Data & Reset without the hidden version
+/// long-press" — so support is already sending patrons there, and the bot could
+/// not name the action.
+///
+/// This is the surgical step between reopening a title (fixes nothing
+/// persistent) and reinstalling the app (destroys every download). Its absence is
+/// a plausible reason support reaches for reinstall in a third of resolved
+/// download tickets.
+final class ClearCacheRemedyTests: XCTestCase {
+
+    private let detector = RemedyDetector()
+
+    /// Nothing the patron owns is lost: books stay, sign-in stays, only cached
+    /// catalog data is refetched.
+    func testClearingCacheIsFree() {
+        XCTAssertEqual(Remedy.clearCache.costTier, .free)
+    }
+
+    /// Resetting a single library is scoped destruction — that library's content
+    /// goes. Better than a full reinstall, still not free.
+    func testResettingOneLibraryIsDestructive() {
+        XCTAssertEqual(Remedy.resetLibrary.costTier, .destructive)
+    }
+
+    func testDetectsAPatronWhoAlreadyClearedTheCache() {
+        for text in ["I cleared the cache already", "I used clear cached data in settings",
+                     "cleared cached data and it did not help"] {
+            XCTAssertTrue(detector.alreadyTried(in: text).contains(.clearCache),
+                          "missed a clear-cache claim in: \(text)")
+        }
+    }
+
+    /// The stale-registry bug is precisely what clearing cached data repairs, and
+    /// the shipped entry never named it.
+    func testTheStaleLibraryListEntryOffersClearingTheCache() throws {
+        let kb = KnowledgeBase(catalog: try BundledCatalogSource.loadCatalogSync())
+        let entry = try XCTUnwrap(kb.entry(id: "KI-2026-009-add-library-stale-registry"))
+        let remedies = (entry.userFacingSteps ?? []).compactMap(\.remedy)
+        XCTAssertTrue(remedies.contains(.clearCache),
+                      "a stale cached library list is what clearing cached data fixes: \(remedies)")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/EscalationFollowUpFallbackTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/EscalationFollowUpFallbackTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import TriageBotCore
+
+/// A guided flow that runs out of steps must still ask something before filing.
+///
+/// `askEscalationFollowUpOrDraft` falls back to the category's catch-all question
+/// when the entry has none, but `escalateWithTrace` — the path taken when a
+/// guided flow is exhausted or abandoned — only ever consulted the entry's own.
+/// An entry with steps and no `escalationFollowUp` therefore walked the patron
+/// through a troubleshooting flow and then filed a ticket with no question asked:
+/// the blank-ticket class this branch exists to eliminate, surviving on the one
+/// path that had the most patron effort invested in it.
+final class EscalationFollowUpFallbackTests: XCTestCase {
+
+    private func kb() -> KnowledgeBase {
+        // Steps, but deliberately NO escalationFollowUp of its own.
+        let entry = KBEntry(
+            id: "K", category: .audiobook, status: .open,
+            symptomKeywords: ["alpha thing"],
+            userFacingWorkaround: "Try the fix.",
+            userFacingSteps: [KBStep(id: "s1", instruction: "Do the thing.", check: "Better?")],
+            confidenceThreshold: 0.1)
+        return KnowledgeBase(catalog: KBCatalog(
+            version: "t", updatedAt: "x", entries: [entry],
+            categoryFollowUps: ["audiobook": KBEscalationFollowUp(
+                prompt: "Does it fail at the start, or partway through?",
+                presumesIssue: false)]))
+    }
+
+    private func walkToExhaustion() -> ConversationState {
+        let r = ConversationReducer(knowledgeBase: kb())
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(.audiobook))
+        (s, _) = r.reduce(state: s, action: .inputChanged("the alpha thing is broken"))
+        (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
+        (s, _) = r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "K"))
+        return r.reduce(state: s, action: .userConfirmedStepDidNotResolve(stepId: "s1")).0
+    }
+
+    func testGuidedFlowExhausted_entryWithoutOwnFollowUp_asksTheCategoryQuestion() {
+        let state = walkToExhaustion()
+        guard case .awaitingEscalationFollowUp(let prompt, _) = state.step else {
+            return XCTFail("""
+                exhausted a guided flow and filed without asking anything — \
+                got \(state.step)
+                """)
+        }
+        XCTAssertTrue(prompt.contains("at the start, or partway through"),
+                      "should fall back to the category's catch-all: \(prompt)")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/EscalationPreambleTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/EscalationPreambleTests.swift
@@ -34,17 +34,16 @@ final class EscalationPreambleTests: XCTestCase {
     /// The reducer renders exactly one preamble, sitting directly in front of the
     /// bare-question prompt.
     func testReducer_followUpMessage_hasExactlyOnePreamble() {
-        // The keyword is CORROBORATING so the classifier recognizes the entry but
-        // escalates on it — which is the state that renders the follow-up prompt.
-        // (It was a `symptom_keywords` entry when known-issue suggest required two
-        // matches; a single strong match now suggests, and a suggestion never asks
-        // an escalation follow-up.)
         let entries = [KBEntry(id: "KI-FU", category: .other, status: .open,
-                               symptomKeywords: ["some unrelated phrase"],
-                               corroboratingKeywords: ["frobnicate widget"],
+                               symptomKeywords: ["frobnicate widget"],
                                userFacingWorkaround: "Try turning it off and on again please.",
                                escalationFollowUp: KBEscalationFollowUp(prompt: "Which widget model is it?"),
-                               confidenceThreshold: 0.1)]
+                               confidenceThreshold: 0.1,
+                               // escalate_anyway = recognized confidently, but no
+                               // safe self-serve fix. The strong-recognition
+                               // escalation, which is exactly when the targeted
+                               // question is warranted.
+                               escalateAnyway: true)]
         let r = ConversationReducer(knowledgeBase: KnowledgeBase(
             catalog: KBCatalog(version: "test", updatedAt: "2026-07-20", entries: entries)))
         let state = drive(r, category: .other, text: "my frobnicate widget is broken")

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/EscalationPreambleTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/EscalationPreambleTests.swift
@@ -34,8 +34,14 @@ final class EscalationPreambleTests: XCTestCase {
     /// The reducer renders exactly one preamble, sitting directly in front of the
     /// bare-question prompt.
     func testReducer_followUpMessage_hasExactlyOnePreamble() {
+        // The keyword is CORROBORATING so the classifier recognizes the entry but
+        // escalates on it — which is the state that renders the follow-up prompt.
+        // (It was a `symptom_keywords` entry when known-issue suggest required two
+        // matches; a single strong match now suggests, and a suggestion never asks
+        // an escalation follow-up.)
         let entries = [KBEntry(id: "KI-FU", category: .other, status: .open,
-                               symptomKeywords: ["frobnicate widget"],
+                               symptomKeywords: ["some unrelated phrase"],
+                               corroboratingKeywords: ["frobnicate widget"],
                                userFacingWorkaround: "Try turning it off and on again please.",
                                escalationFollowUp: KBEscalationFollowUp(prompt: "Which widget model is it?"),
                                confidenceThreshold: 0.1)]

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/MatchCorpus.json
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/MatchCorpus.json
@@ -21,6 +21,7 @@
     "`expected` is a KB entry id, or \"escalate\". `also_acceptable` lists entry ids",
     "that would not count as a misroute if returned instead.",
     "",
+    "  near_miss — real tickets that CONTAIN a strong keyword but that support resolved to a different cause. The trap slice above only samples inputs whose overlap is a WEAK word, which makes its zero-misroute result circular: the partition decides what is weak, so a mis-partitioned STRONG keyword can never appear there. These are drawn from the strong side and are the real precision test. Expected escalate in every case: the entry that would fire cannot help this patron.",
     "Patron text is verbatim apart from PII stripping (names, emails, card and",
     "patron-ID numbers, phone numbers, signatures and mail-client boilerplate",
     "removed) and trimming to the substantive complaint. Book titles are dropped —",
@@ -107,7 +108,10 @@
       "category": "library",
       "text": "I have two libraries in my area and both use the palace project app. I currently have one as my library in the app and would like to add the other as well but am unable. When I click add library it only lets me search the palace shelf.",
       "expected": "KI-2026-009-add-library-stale-registry",
-      "also_acceptable": ["HT-2026-008-add-library-card", "HT-2026-003-switch-library"]
+      "also_acceptable": [
+        "HT-2026-008-add-library-card",
+        "HT-2026-003-switch-library"
+      ]
     },
     {
       "id": "hs-18028",
@@ -141,7 +145,6 @@
       "text": "Does Palace Project send reminders to the borrower when items are coming due?",
       "expected": "HT-2026-004-notifications"
     },
-
     {
       "id": "hs-18659",
       "source": "helpspot:18659",
@@ -175,7 +178,9 @@
       "category": "library",
       "text": "Couldn't access my library content this morning. When I went to the Libraries page, I noticed that the only libraries listed are school libraries in another state. I'm guessing this is a bug with the app rather than an issue with my local library dropping palace.",
       "expected": "escalate",
-      "also_acceptable": ["KI-2026-009-add-library-stale-registry"],
+      "also_acceptable": [
+        "KI-2026-009-add-library-stale-registry"
+      ],
       "note": "A stale registry list is a plausible cause, so KI-009 is allowed, but the patron is not on the Add Library screen and its pull-to-refresh instruction may not apply. Escalating is the safe outcome."
     },
     {
@@ -185,7 +190,9 @@
       "category": "library",
       "text": "My screen is not showing any books",
       "expected": "escalate",
-      "also_acceptable": ["KI-2026-004-wrong-library-palace-bookshelf"],
+      "also_acceptable": [
+        "KI-2026-004-wrong-library-palace-bookshelf"
+      ],
       "note": "Genuinely underspecified. Either escalating or offering the wrong-library check is defensible; misrouting to an unrelated entry is not."
     },
     {
@@ -228,7 +235,6 @@
       "text": "Please add the ability to like or favorite a book.",
       "expected": "escalate"
     },
-
     {
       "id": "trap-generic-crash-audiobook",
       "provenance": "trap",
@@ -286,6 +292,51 @@
       "text": "I keep getting kicked out and have to sign in to my library again",
       "expected": "escalate",
       "note": "The original chaos-qa F-002 input: a generic auth loop that must not route to the wrong-library workaround."
+    },
+    {
+      "id": "nm-18181",
+      "source": "helpspot:18181",
+      "provenance": "near_miss",
+      "category": "other",
+      "text": "There is an e-book not checking out for a member. The page just loads without fully confirming.",
+      "expected": "escalate",
+      "note": "Contains KI-001's strong phrase \"just loads\". Support's cause was location services never being granted — the first-open-hang workaround does nothing."
+    },
+    {
+      "id": "nm-18353",
+      "source": "helpspot:18353",
+      "provenance": "near_miss",
+      "category": "library",
+      "text": "I have not been able to log in to Boston Public Library as a library. I tried looking for how to add a library and could not find it.",
+      "expected": "escalate",
+      "note": "Contains KI-009's strong phrase \"add a library\". Support's cause: a new library must be added before an old one can be deleted — not a stale registry needing pull-to-refresh."
+    },
+    {
+      "id": "nm-18571",
+      "source": "helpspot:18571",
+      "provenance": "near_miss",
+      "category": "download",
+      "text": "The app almost never works. It is so hit or miss on if my audiobook plays or not.",
+      "expected": "escalate",
+      "note": "Contains KI-008's strong phrase \"never works\". Support's cause was the 3.2.x audiobook playback bug fixed in 3.2.3 — telling this patron to check WiFi is wrong."
+    },
+    {
+      "id": "nm-18449",
+      "source": "helpspot:18449",
+      "provenance": "near_miss",
+      "category": "download",
+      "text": "It won't let me download the book. I have a returned date but I can't listen to it.",
+      "expected": "escalate",
+      "note": "Contains KI-008's strong phrase \"won't download\". Support's cause was the same 3.2.3 audiobook defect, not a network failure."
+    },
+    {
+      "id": "nm-17978",
+      "source": "helpspot:17978",
+      "provenance": "near_miss",
+      "category": "other",
+      "text": "I got a notification a book was ready to borrow. When I opened the app, none of the books in my holds were available.",
+      "expected": "escalate",
+      "note": "Contains KI-006's strong phrases \"got a notification\"/\"notification that\". Support reached no diagnosis and escalated to the library — the hold-desync refresh advice is a guess."
     }
   ]
 }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/MatchCorpus.json
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/Fixtures/MatchCorpus.json
@@ -1,0 +1,291 @@
+{
+  "_readme": [
+    "Scored corpus for the triage-bot local matcher. Each case is a patron-voice",
+    "input plus the outcome the bot SHOULD produce, so capture rate and misroute",
+    "rate are numbers we can regress against instead of impressions.",
+    "",
+    "PROVENANCE — the slice a case belongs to determines what it proves:",
+    "  mined    — drawn from the HelpSpot tickets the catalog entry itself cites in",
+    "             `internal_reference.helpspot`. The catalog was AUTHORED from these,",
+    "             so a high score here is memorization, not generalization. Treat it",
+    "             as an upper bound only. Expected label = the entry that cites the",
+    "             ticket (support's own resolution), NOT a fixture author's judgment.",
+    "  held_out — HelpSpot tickets from August 2026, postdating every catalog entry's",
+    "             `reviewed_at` (2026-07-20). No keyword was written with these in",
+    "             view. This slice is the honest generalization measure.",
+    "  trap     — generic complaints whose only overlap with an entry is a weak,",
+    "             non-diagnostic word. These MUST escalate. A suggestion here is a",
+    "             misroute: the patron is handed a workaround for a bug they don't",
+    "             have (the chaos-qa F-002 defect class).",
+    "",
+    "`expected` is a KB entry id, or \"escalate\". `also_acceptable` lists entry ids",
+    "that would not count as a misroute if returned instead.",
+    "",
+    "Patron text is verbatim apart from PII stripping (names, emails, card and",
+    "patron-ID numbers, phone numbers, signatures and mail-client boilerplate",
+    "removed) and trimming to the substantive complaint. Book titles are dropped —",
+    "they carry no signal for a keyword matcher and are needless detail to retain."
+  ],
+  "cases": [
+    {
+      "id": "hs-17964",
+      "source": "helpspot:17964",
+      "provenance": "mined",
+      "category": "audiobook",
+      "text": "Can you help me load books? It is hit or miss. Sometimes they load and sometimes they don't. I have been on hold for it 3 times. All three times it comes available to me, but will not load. Then it eventually goes away.",
+      "expected": "KI-2026-001-audiobook-first-open-hang"
+    },
+    {
+      "id": "hs-17929",
+      "source": "helpspot:17929",
+      "provenance": "mined",
+      "category": "audiobook",
+      "text": "We've been contacted by a patron that the audiobook they've checked out won't play. They've reinstalled the app, rebooted their phone, and it's not working.",
+      "expected": "KI-2026-001-audiobook-first-open-hang"
+    },
+    {
+      "id": "hs-17989",
+      "source": "helpspot:17989",
+      "provenance": "mined",
+      "category": "audiobook",
+      "text": "I have tried to get the audiobook to work and can't seem to get it to play. I've tried on different devices. I've turned it in and checked it back out. I have left it open to download. I push the play button and it just blinks.",
+      "expected": "KI-2026-001-audiobook-first-open-hang"
+    },
+    {
+      "id": "hs-17959",
+      "source": "helpspot:17959",
+      "provenance": "mined",
+      "category": "audiobook",
+      "text": "The app is still not working properly, even after deleting the app on my phone and redownloading. It stops playing and will not load. The audiobook will not load properly.",
+      "expected": "KI-2026-001-audiobook-first-open-hang"
+    },
+    {
+      "id": "hs-17923",
+      "source": "helpspot:17923",
+      "provenance": "mined",
+      "category": "signin",
+      "text": "I am attempting to set up the Palace app, but am not able to login. Instead, I see the following grayed out options at the sign in page, and am never prompted at first use after download to sign in. I have uninstalled, restarted the phone, and reinstalled to no effect.",
+      "expected": "KI-2026-003-signin-placeholder-contrast"
+    },
+    {
+      "id": "hs-17957",
+      "source": "helpspot:17957",
+      "provenance": "mined",
+      "category": "library",
+      "text": "I have a book on my phone that I downloaded that does not appear on my iPad",
+      "expected": "KI-2026-004-wrong-library-palace-bookshelf"
+    },
+    {
+      "id": "hs-17917",
+      "source": "helpspot:17917",
+      "provenance": "mined",
+      "category": "signin",
+      "text": "I have tried to use the app but I keep getting this error when trying to log in. I have confirmed my credentials are correct.",
+      "expected": "KI-2026-004-wrong-library-palace-bookshelf",
+      "note": "Label follows support's citation (KI-004 cites this ticket) rather than the fixture author's reading of the text, which alone would suggest a generic sign-in failure. Kept deliberately: it is a case the text does not support, and it should read as a miss rather than be quietly relabelled."
+    },
+    {
+      "id": "hs-17960",
+      "source": "helpspot:17960",
+      "provenance": "mined",
+      "category": "library",
+      "text": "I love the app, but constantly get messages that my hold is ready but when I go to the list of holds, the book is not ready. Is there a fix?",
+      "expected": "KI-2026-006-hold-ready-desync"
+    },
+    {
+      "id": "hs-17976",
+      "source": "helpspot:17976",
+      "provenance": "mined",
+      "category": "download",
+      "text": "I'm trying to download the book and it never works. I have gone on and off wifi, I have logged out of the app and I have tried uninstalling and reinstalling the app.",
+      "expected": "KI-2026-008-download-no-network"
+    },
+    {
+      "id": "hs-17930",
+      "source": "helpspot:17930",
+      "provenance": "mined",
+      "category": "library",
+      "text": "I have two libraries in my area and both use the palace project app. I currently have one as my library in the app and would like to add the other as well but am unable. When I click add library it only lets me search the palace shelf.",
+      "expected": "KI-2026-009-add-library-stale-registry",
+      "also_acceptable": ["HT-2026-008-add-library-card", "HT-2026-003-switch-library"]
+    },
+    {
+      "id": "hs-18028",
+      "source": "helpspot:18028",
+      "provenance": "mined",
+      "category": "other",
+      "text": "Could you please tell me how many times a ebook or eaudiobook can be renewed if there are no holds on the item?",
+      "expected": "HT-2026-001-renewals"
+    },
+    {
+      "id": "hs-17901",
+      "source": "helpspot:17901",
+      "provenance": "mined",
+      "category": "other",
+      "text": "I have a patron. She has 2 books that she has not been able to return.",
+      "expected": "HT-2026-002-return-early"
+    },
+    {
+      "id": "hs-18103-a",
+      "source": "helpspot:18103",
+      "provenance": "mined",
+      "category": "other",
+      "text": "When a held item becomes available for the patron to borrow, how long do they have to borrow the hold before it goes to the next person in the queue?",
+      "expected": "HT-2026-005-hold-pickup-window"
+    },
+    {
+      "id": "hs-18103-b",
+      "source": "helpspot:18103",
+      "provenance": "mined",
+      "category": "other",
+      "text": "Does Palace Project send reminders to the borrower when items are coming due?",
+      "expected": "HT-2026-004-notifications"
+    },
+
+    {
+      "id": "hs-18659",
+      "source": "helpspot:18659",
+      "provenance": "held_out",
+      "category": "audiobook",
+      "text": "I was listening and just finished chapter 46. It says I have 3 hours left, but the book won't continue playing. Any ideas on how I can listen to the last 3 hours of the book?",
+      "expected": "escalate",
+      "note": "KI-002 is switching libraries mid-playback, which this is not. No catalog entry covers a mid-book stall, so escalating is correct."
+    },
+    {
+      "id": "hs-18635",
+      "source": "helpspot:18635",
+      "provenance": "held_out",
+      "category": "audiobook",
+      "text": "I want to report that every time I try to listen to an audio book from this platform I am not able to. I called my library that I have my card with and they said there are no problems with my account. I've been trying to listen to this one book for months.",
+      "expected": "KI-2026-001-audiobook-first-open-hang"
+    },
+    {
+      "id": "hs-18657",
+      "source": "helpspot:18657",
+      "provenance": "held_out",
+      "category": "audiobook",
+      "text": "We're having an issue where a patron is unable to open an audiobook if they do not have a data connection. If they do not have cell service or are in airplane mode, the app asks them to authenticate, which they cannot do if no data connection is available.",
+      "expected": "escalate",
+      "note": "Offline re-authentication has no catalog entry. KI-008 is a download failure with no network, which is adjacent but a different symptom and a different fix."
+    },
+    {
+      "id": "hs-18620",
+      "source": "helpspot:18620",
+      "provenance": "held_out",
+      "category": "library",
+      "text": "Couldn't access my library content this morning. When I went to the Libraries page, I noticed that the only libraries listed are school libraries in another state. I'm guessing this is a bug with the app rather than an issue with my local library dropping palace.",
+      "expected": "escalate",
+      "also_acceptable": ["KI-2026-009-add-library-stale-registry"],
+      "note": "A stale registry list is a plausible cause, so KI-009 is allowed, but the patron is not on the Add Library screen and its pull-to-refresh instruction may not apply. Escalating is the safe outcome."
+    },
+    {
+      "id": "hs-18619",
+      "source": "helpspot:18619",
+      "provenance": "held_out",
+      "category": "library",
+      "text": "My screen is not showing any books",
+      "expected": "escalate",
+      "also_acceptable": ["KI-2026-004-wrong-library-palace-bookshelf"],
+      "note": "Genuinely underspecified. Either escalating or offering the wrong-library check is defensible; misrouting to an unrelated entry is not."
+    },
+    {
+      "id": "hs-18651",
+      "source": "helpspot:18651",
+      "provenance": "held_out",
+      "category": "signin",
+      "text": "When trying to log in on a new device it is telling me the card is invalid",
+      "expected": "escalate"
+    },
+    {
+      "id": "hs-18644",
+      "source": "helpspot:18644",
+      "provenance": "held_out",
+      "category": "other",
+      "text": "It doesn't let me borrow ebooks. It just loads for a long time. Then eventually it goes back.",
+      "expected": "escalate"
+    },
+    {
+      "id": "hs-18616",
+      "source": "helpspot:18616",
+      "provenance": "held_out",
+      "category": "other",
+      "text": "It looks like ebooks from our overdrive collection can't currently be borrowed on the Palace app. I attempted to borrow a title I had previously read on my iPad using another app.",
+      "expected": "escalate"
+    },
+    {
+      "id": "hs-18624",
+      "source": "helpspot:18624",
+      "provenance": "held_out",
+      "category": "download",
+      "text": "When downloading a book to either my iPhone or iPad, shouldn't it also sync to the other device and download it there as well? I find I have to download it on both devices. I downloaded a book today to my iPhone and when I try to download it on my iPad, the app never finished searching.",
+      "expected": "escalate"
+    },
+    {
+      "id": "hs-18617",
+      "source": "helpspot:18617",
+      "provenance": "held_out",
+      "category": "other",
+      "text": "Please add the ability to like or favorite a book.",
+      "expected": "escalate"
+    },
+
+    {
+      "id": "trap-generic-crash-audiobook",
+      "provenance": "trap",
+      "category": "audiobook",
+      "text": "the app crashes when I open it",
+      "expected": "escalate",
+      "note": "Overlaps KI-005 only on the weak word 'crashes'. Suggesting the CarPlay workaround to a patron who has never opened CarPlay is the F-002 defect."
+    },
+    {
+      "id": "trap-generic-stuck",
+      "provenance": "trap",
+      "category": "audiobook",
+      "text": "everything is stuck",
+      "expected": "escalate"
+    },
+    {
+      "id": "trap-generic-hang-launch",
+      "provenance": "trap",
+      "category": "audiobook",
+      "text": "the whole app hangs on launch",
+      "expected": "escalate"
+    },
+    {
+      "id": "trap-generic-download",
+      "provenance": "trap",
+      "category": "download",
+      "text": "I can't download anything since the update",
+      "expected": "escalate"
+    },
+    {
+      "id": "trap-generic-bookshelf",
+      "provenance": "trap",
+      "category": "library",
+      "text": "my bookshelf looks empty",
+      "expected": "escalate"
+    },
+    {
+      "id": "trap-generic-boxes",
+      "provenance": "trap",
+      "category": "signin",
+      "text": "the boxes are weird",
+      "expected": "escalate"
+    },
+    {
+      "id": "trap-generic-crashed-reader",
+      "provenance": "trap",
+      "category": "reader",
+      "text": "it crashed",
+      "expected": "escalate"
+    },
+    {
+      "id": "trap-auth-loop-f002",
+      "provenance": "trap",
+      "category": "library",
+      "text": "I keep getting kicked out and have to sign in to my library again",
+      "expected": "escalate",
+      "note": "The original chaos-qa F-002 input: a generic auth loop that must not route to the wrong-library workaround."
+    }
+  ]
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/GenericLadderTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/GenericLadderTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import TriageBotCore
+
+/// A remedy ladder for the 88% of complaints that match no entry.
+///
+/// Measured on 114 sealed tickets, 13 reach guided steps and 100 escalate with no
+/// remedy offered at all, against a ceiling of 42% — the share of real
+/// resolutions naming something a patron could have done themselves. The gap is
+/// not exotic; it is a handful of remedies that exist in the catalog but are
+/// reachable only through an entry match that usually does not happen.
+///
+/// The ladder is NOT a classifier. Grouping 204 tickets by the remedy support
+/// prescribed and mining for distinguishing patron language produced noise
+/// ("to it", "so it", "it it") — there is no signal for picking the right remedy
+/// from a complaint. So the ladder does not pick: it offers a short, safe,
+/// per-category sequence and lets the patron eliminate. Elimination beats
+/// classification precisely when classification has nothing to go on.
+///
+/// It is also not new machinery. A ladder is a catalog entry of kind
+/// `generic_flow` whose steps carry remedy tags, executed by the guided-step
+/// engine that already exists — so already-tried skipping, step advance,
+/// exhaustion, abandonment and per-step telemetry all apply unchanged.
+final class GenericLadderTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func ladder(
+        category: KBCategory = .audiobook,
+        steps: [KBStep] = [
+            KBStep(id: "g1", instruction: "Pull down on the list to refresh.", check: "Any change?", remedy: .pullToRefresh),
+            KBStep(id: "g2", instruction: "Open the App Store and install any Palace update.", check: "Any change?", remedy: .updateApp),
+        ]
+    ) -> KBEntry {
+        KBEntry(id: "GF-\(category.rawValue)", category: category, kind: .genericFlow,
+                symptomKeywords: [], userFacingWorkaround: "A few things worth trying.",
+                userFacingSteps: steps, confidenceThreshold: 0.1)
+    }
+
+    private func reducer(_ entries: [KBEntry],
+                         categoryFollowUps: [String: KBEscalationFollowUp]? = nil) -> ConversationReducer {
+        ConversationReducer(knowledgeBase: KnowledgeBase(catalog: KBCatalog(
+            version: "t", updatedAt: "x", entries: entries, categoryFollowUps: categoryFollowUps)))
+    }
+
+    private func drive(_ r: ConversationReducer, _ cat: KBCategory, _ text: String) -> ConversationState {
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(cat))
+        (s, _) = r.reduce(state: s, action: .inputChanged(text))
+        return r.reduce(state: s, action: .userSubmittedDescription).0
+    }
+
+    // MARK: - Step 1: invisible to the classifier
+
+    /// A ladder must never win a match. Its keyword list is empty, but an entry
+    /// with no keywords still enters the candidate set today, which would let it
+    /// pollute `consideredEntryIds` and — if it ever gained a keyword — compete
+    /// for a suggestion against real entries.
+    func testGenericFlowEntries_neverCompeteForMatches() {
+        let trap = KBEntry(id: "GF-trap", category: .audiobook, kind: .genericFlow,
+                           symptomKeywords: ["my audiobook wont play"],
+                           userFacingWorkaround: "…", confidenceThreshold: 0.1)
+        let result = LocalClassifier().classify(
+            userText: "my audiobook wont play", category: .audiobook, context: nil,
+            knowledgeBase: KnowledgeBase(catalog: KBCatalog(version: "t", updatedAt: "x", entries: [trap])))
+
+        XCTAssertEqual(result.decision, .escalate, "a generic flow must never be suggested as a diagnosis")
+        XCTAssertNil(result.recognizedEntryId, "…nor scope a ticket as though it were one")
+        XCTAssertFalse(result.consideredEntryIds.contains("GF-trap"), "…nor appear as a considered candidate")
+    }
+
+    // MARK: - Step 2: the one changed cell
+
+    func testUnmatchedComplaint_isOfferedTheLadder() {
+        let state = drive(reducer([ladder()]), .audiobook, "something is wrong with this thing")
+        XCTAssertEqual(state.step, .matched(entryId: "GF-audiobook"),
+                       "an unmatched complaint should be offered remedies, not just a ticket")
+    }
+
+    /// Back-compat: a catalog with no ladder for the category must behave exactly
+    /// as it does today.
+    func testUnmatchedComplaint_withNoLadderForThatCategory_behavesAsBefore() {
+        let r = reducer([ladder(category: .library)],
+                        categoryFollowUps: ["audiobook": KBEscalationFollowUp(prompt: "Start or partway?", presumesIssue: false)])
+        let state = drive(r, .audiobook, "something is wrong with this thing")
+        guard case .awaitingEscalationFollowUp = state.step else {
+            return XCTFail("expected today's category-question behaviour; got \(state.step)")
+        }
+    }
+
+    // MARK: - Step 3: cells that must NOT get the ladder
+
+    /// `escalate_anyway` encodes "no safe self-serve fix exists" — the quarter of
+    /// real tickets only staff or the library can resolve. Offering remedies there
+    /// is delay dressed as help.
+    func testEscalateAnywayEntry_isNeverOfferedTheLadder() {
+        let staffOnly = KBEntry(id: "KI-STAFF", category: .audiobook, status: .open,
+                                symptomKeywords: ["card is expired"],
+                                userFacingWorkaround: "Your library needs to renew the card.",
+                                escalationFollowUp: KBEscalationFollowUp(prompt: "Which library issued it?"),
+                                confidenceThreshold: 0.1, escalateAnyway: true)
+        let state = drive(reducer([staffOnly, ladder()]), .audiobook, "my card is expired")
+        if case .matched(let id) = state.step, id.hasPrefix("GF-") {
+            XCTFail("offered self-serve remedies for a problem only staff can fix")
+        }
+    }
+
+    func testMatchedEntry_overridesTheLadderEntirely() {
+        let real = KBEntry(id: "KI-REAL", category: .audiobook, status: .open,
+                           symptomKeywords: ["wont play"],
+                           userFacingWorkaround: "Do the specific thing.",
+                           confidenceThreshold: 0.1)
+        let state = drive(reducer([real, ladder()]), .audiobook, "it wont play")
+        XCTAssertEqual(state.step, .matched(entryId: "KI-REAL"),
+                       "a real diagnosis always beats a generic ladder")
+    }
+
+    /// "I've tried everything" is a claim of exhausted effort. Walking that patron
+    /// through rungs is the not-listening defect in its purest form.
+    func testBlanketExhaustedEffort_bypassesTheLadder() {
+        let r = reducer([ladder()],
+                        categoryFollowUps: ["audiobook": KBEscalationFollowUp(prompt: "Start or partway?", presumesIssue: false)])
+        let state = drive(r, .audiobook, "I have tried everything and nothing works")
+        if case .matched(let id) = state.step, id.hasPrefix("GF-") {
+            XCTFail("offered a remedy ladder to someone who said they had tried everything")
+        }
+    }
+
+    // MARK: - Step 4: the existing engine does the work
+
+    func testLadder_skipsRungsThePatronAlreadyTried() {
+        let r = reducer([ladder()])
+        var s = drive(r, .audiobook, "something is broken, I already pulled down to refresh")
+        s = r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "GF-audiobook")).0
+        guard case .guidedStep(_, let index, _, _) = s.step else {
+            return XCTFail("expected a rung; got \(s.step)")
+        }
+        XCTAssertEqual(index, 1, "must start at the first rung they have not already tried")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/HoldoutGeneralizationTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/HoldoutGeneralizationTests.swift
@@ -45,7 +45,16 @@ final class HoldoutGeneralizationTests: XCTestCase {
              source: "HelpSpot 17834 — patron stuck on Palace Bookshelf demo; resolution was switch to real library (KI-004)."),
         Case(userText: "when a hold becomes available how long do I have to borrow it before it goes to the next person, and does Palace send reminders when items are coming due",
              expect: .shouldEscalate,
-             source: "HelpSpot 18103 — hold-window + due-date-reminder FAQ; no how_to entry exists for these yet (PP-4831)."),
+             // RE-ADJUDICATED: the original note said no how_to entry existed for
+             // these. HT-2026-005 (hold pickup window) and HT-2026-004
+             // (notifications) both exist now, so that justification is stale.
+             // The expectation still stands, for a different and better reason:
+             // this is ONE message asking TWO questions, and the matcher answers
+             // with a single entry. Suggesting either one would answer half the
+             // patron's message while implying it answered all of it. Escalating
+             // is correct until multi-issue input is handled — which is the real
+             // open gap this case documents.
+             source: "HelpSpot 18103 — a single message asking two distinct FAQ questions (hold window AND due-date reminders). Both entries now exist; the matcher cannot split a multi-issue message, so answering with one would be a partial answer presented as a whole."),
     ]
 
     // Tracked KNOWN limitations, keyed by userText. A case here is one the blind

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/LadderScopingTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/LadderScopingTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import TriageBotCore
+
+/// A ticket filed after a remedy ladder must still carry whatever the classifier
+/// recognised, not the ladder's own id.
+///
+/// Weak recognition is what scopes a ticket for support: the patron's words
+/// brushed an entry without earning a suggestion, and that hint is worth more to
+/// a triager than nothing. Routing those patrons through a generic ladder must
+/// not overwrite the hint — "generic-ladder-audiobook" tells support only that
+/// the bot had no idea, which they can already see from the absence of an answer.
+final class LadderScopingTests: XCTestCase {
+
+    private func kb() -> KnowledgeBase {
+        // Weak-only keyword: matches, cannot suggest, carries a recognition.
+        let weak = KBEntry(
+            id: "KI-WEAK", category: .audiobook, status: .open,
+            symptomKeywords: ["a phrase nobody types"],
+            corroboratingKeywords: ["crashes"],
+            userFacingWorkaround: "The CarPlay workaround.",
+            confidenceThreshold: 0.1)
+        let ladder = KBEntry(
+            id: "GF-audiobook", category: .audiobook, kind: .genericFlow,
+            symptomKeywords: [],
+            userFacingWorkaround: "A few things to try.",
+            userFacingSteps: [KBStep(id: "g1", instruction: "Try the thing.", check: "Any change?",
+                                     remedy: .pullToRefresh)])
+        return KnowledgeBase(catalog: KBCatalog(
+            version: "t", updatedAt: "x", entries: [weak, ladder],
+            categoryFollowUps: ["audiobook": KBEscalationFollowUp(prompt: "Start or partway?",
+                                                                 presumesIssue: false)]))
+    }
+
+    func testTicketAfterLadder_isScopedToTheWeaklyRecognizedEntry() {
+        let r = ConversationReducer(knowledgeBase: kb())
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(.audiobook))
+        (s, _) = r.reduce(state: s, action: .inputChanged("the app crashes when I open it"))
+        (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
+
+        guard case .matched(let offered) = s.step, offered == "GF-audiobook" else {
+            return XCTFail("expected the ladder to be offered; got \(s.step)")
+        }
+        (s, _) = r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "GF-audiobook"))
+        (s, _) = r.reduce(state: s, action: .userConfirmedStepDidNotResolve(stepId: "g1"))
+
+        // Walk past any follow-up to the draft.
+        if case .awaitingEscalationFollowUp = s.step {
+            (s, _) = r.reduce(state: s, action: .userAnsweredEscalationFollowUp(answer: nil))
+        }
+        guard case .drafting(let ticket) = s.step else {
+            return XCTFail("expected a ticket preview; got \(s.step)")
+        }
+        XCTAssertEqual(ticket.matchedEntryId, "KI-WEAK",
+                       "the ticket must carry the recognised entry, not the ladder id")
+    }
+
+    /// Abandoning a ladder mid-way must scope the ticket the same way — the
+    /// patron gave up on the remedies, not on the hint about what they reported.
+    func testTicketAfterAbandonedLadder_isAlsoScopedToTheRecognizedEntry() {
+        let r = ConversationReducer(knowledgeBase: kb())
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(.audiobook))
+        (s, _) = r.reduce(state: s, action: .inputChanged("the app crashes when I open it"))
+        (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
+        (s, _) = r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "GF-audiobook"))
+        (s, _) = r.reduce(state: s, action: .userTappedAbandonGuidedFlow)
+
+        if case .awaitingEscalationFollowUp = s.step {
+            (s, _) = r.reduce(state: s, action: .userAnsweredEscalationFollowUp(answer: nil))
+        }
+        guard case .drafting(let ticket) = s.step else {
+            return XCTFail("expected a ticket preview; got \(s.step)")
+        }
+        XCTAssertEqual(ticket.matchedEntryId, "KI-WEAK")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/LocalClassifierTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/LocalClassifierTests.swift
@@ -239,16 +239,24 @@ final class LocalClassifierTests: XCTestCase {
     // MARK: - Distinct-region match counting (nested-variant guard)
 
     func testNestedKeywordVariants_singleWord_doesNotOverPromise() {
-        // "hangs" substring-matches BOTH "hang" and "hangs". Counting raw
-        // keyword hits gave 2 → cleared the >=2 confidence guard → a confident
+        // "hangs" substring-matches BOTH "hang" and "hangs". Counting raw keyword
+        // hits gave 2 → cleared the old >=2 confidence guard → a confident
         // suggestion off ONE word. Distinct-region counting collapses the nested
-        // variants to a single region, so one word escalates instead.
+        // variants to a single region.
+        //
+        // Region merging alone no longer decides this, since one region can now
+        // suggest — what stops it is that "hang"/"hangs"/"stuck" are generic and
+        // therefore CORROBORATING, mirroring how they sit in the shipped catalog.
+        // Both mechanisms are load-bearing: merging stops one word from posing as
+        // several, and the strength tier stops a vague word from carrying a
+        // suggestion at all.
         let kb = makeKB([
             KBEntry(
                 id: "KI-001",
                 category: .audiobook,
                 status: .open,
-                symptomKeywords: ["hang", "hangs", "stuck", "won't play"],
+                symptomKeywords: ["won't play"],
+                corroboratingKeywords: ["hang", "hangs", "stuck"],
                 userFacingWorkaround: "Tap back, tap again.",
                 confidenceThreshold: 0.1
             )

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/MatchCorpusTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/MatchCorpusTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+@testable import TriageBotCore
+
+/// Scores the local matcher against a corpus of real patron phrasings
+/// (`Fixtures/MatchCorpus.json`) so recall and misrouting are numbers we can
+/// regress against rather than impressions.
+///
+/// Two rates, and they trade against each other — a change that only moves one
+/// has not been evaluated:
+///
+///  - **capture** — of the cases where the catalog genuinely has the answer, how
+///    many did the bot surface? Every uncaptured case is a patron who gets
+///    "I haven't seen exactly that before" for an issue we have a documented fix
+///    for, and who never reaches the guided troubleshooting steps (those live
+///    only on `known_issue` entries).
+///  - **misroute** — how many cases were handed the WRONG entry's workaround?
+///    This is worse than escalating: it tells a patron to fix a bug they don't
+///    have. The `trap` slice exists to hold this at zero.
+///
+/// Read the `held_out` slice as the honest generalization number; see the
+/// fixture's `_readme` for why `mined` is an upper bound.
+///
+/// Complements `HoldoutGeneralizationTests` rather than replacing it. That suite
+/// classifies with NO category, so every entry in the catalog competes — the
+/// harshest precision test available, and it pins its exact miss / false-suggest
+/// sets. This one classifies WITH the category the patron tapped, which is the
+/// path the UI actually drives, and adds the `trap` slice plus per-slice capture
+/// reporting. Keep both: the no-category suite guards precision under maximum
+/// competition, this one measures what a real session does. A change that moves
+/// either number should be explained against both.
+final class MatchCorpusTests: XCTestCase {
+
+    // MARK: - Fixture
+
+    private struct Corpus: Decodable {
+        struct Case: Decodable {
+            let id: String
+            let provenance: String
+            let category: String
+            let text: String
+            let expected: String
+            let alsoAcceptable: [String]?
+
+            enum CodingKeys: String, CodingKey {
+                case id, provenance, category, text, expected
+                case alsoAcceptable = "also_acceptable"
+            }
+
+            var expectsEscalation: Bool { expected == "escalate" }
+
+            /// Entry ids that count as a correct suggestion for this case.
+            var acceptableEntryIds: Set<String> {
+                var ids = Set(alsoAcceptable ?? [])
+                if !expectsEscalation { ids.insert(expected) }
+                return ids
+            }
+        }
+        let cases: [Case]
+    }
+
+    private enum Outcome {
+        case captured(String)       // suggested an acceptable entry
+        case misrouted(String)      // suggested an entry that is not acceptable
+        case escalated
+        case disambiguated
+    }
+
+    private struct Tally {
+        var capturable = 0          // cases where an entry is the right answer
+        var captured = 0
+        var misrouted = 0
+        var total = 0
+    }
+
+    private func loadCorpus() throws -> Corpus {
+        let url = try XCTUnwrap(
+            Bundle.module.url(forResource: "Fixtures/MatchCorpus", withExtension: "json")
+                ?? Bundle.module.url(forResource: "MatchCorpus", withExtension: "json"),
+            "MatchCorpus.json missing from the test bundle"
+        )
+        return try JSONDecoder().decode(Corpus.self, from: Data(contentsOf: url))
+    }
+
+    private func outcome(for testCase: Corpus.Case, kb: KnowledgeBase) throws -> Outcome {
+        let category = try XCTUnwrap(
+            KBCategory(rawValue: testCase.category),
+            "unknown category '\(testCase.category)' in case \(testCase.id)"
+        )
+        let result = LocalClassifier().classify(
+            userText: testCase.text,
+            category: category,
+            context: nil,
+            knowledgeBase: kb
+        )
+        switch result.decision {
+        case .suggest(let entryId):
+            return testCase.acceptableEntryIds.contains(entryId)
+                ? .captured(entryId)
+                : .misrouted(entryId)
+        case .escalate:
+            return .escalated
+        case .disambiguate:
+            return .disambiguated
+        }
+    }
+
+    // MARK: - The scored run
+
+    func testCorpus_captureAndMisrouteRates() throws {
+        let kb = KnowledgeBase(catalog: try BundledCatalogSource.loadCatalogSync())
+        let corpus = try loadCorpus()
+
+        var bySlice: [String: Tally] = [:]
+        var report: [String] = []
+
+        for testCase in corpus.cases {
+            let result = try outcome(for: testCase, kb: kb)
+            var tally = bySlice[testCase.provenance] ?? Tally()
+            tally.total += 1
+            if !testCase.expectsEscalation { tally.capturable += 1 }
+
+            let line: String
+            switch result {
+            case .captured(let id):
+                tally.captured += 1
+                line = "  ✓ captured    \(testCase.id) -> \(id)"
+            case .misrouted(let id):
+                tally.misrouted += 1
+                line = "  ✗ MISROUTED   \(testCase.id) -> \(id) (expected \(testCase.expected))"
+            case .escalated:
+                line = testCase.expectsEscalation
+                    ? "  ✓ escalated   \(testCase.id)"
+                    : "  – missed      \(testCase.id) (expected \(testCase.expected))"
+            case .disambiguated:
+                line = "  ? ambiguous   \(testCase.id) (expected \(testCase.expected))"
+            }
+            report.append(line)
+            bySlice[testCase.provenance] = tally
+        }
+
+        // Emit the full picture before asserting, so a failing run explains itself.
+        print("=== MATCH CORPUS ===")
+        for slice in ["mined", "held_out", "trap"] {
+            guard let tally = bySlice[slice] else { continue }
+            let pct = tally.capturable == 0 ? "n/a"
+                : String(format: "%.0f%%", 100.0 * Double(tally.captured) / Double(tally.capturable))
+            print("\n[\(slice)] cases=\(tally.total) capturable=\(tally.capturable) "
+                  + "captured=\(tally.captured) (\(pct)) misrouted=\(tally.misrouted)")
+        }
+        print("\n--- per case ---")
+        report.forEach { print($0) }
+
+        // A misroute hands a patron the wrong bug's workaround. The trap slice is
+        // built entirely from inputs whose only overlap with an entry is a weak,
+        // non-diagnostic word, so any suggestion here is a defect — this is the
+        // guard that stops "improve recall" from silently reintroducing F-002.
+        let trap = bySlice["trap"] ?? Tally()
+        XCTAssertEqual(
+            trap.misrouted, 0,
+            "generic complaints were handed a specific entry's workaround — see MISROUTED lines above"
+        )
+
+        // Held-out capture is REPORTED, not asserted, and that is deliberate.
+        //
+        // The slice currently holds exactly one capturable case, which is far too
+        // thin to gate on. Worse, gating it would create pressure to close the gap
+        // the only way available — adding the missing phrasing to the catalog —
+        // and the moment a keyword is written with a held-out ticket in view, that
+        // ticket stops being held out. The slice's whole value is that nothing in
+        // the catalog was authored against it; an assertion would quietly spend
+        // that value to turn a light green.
+        //
+        // So: watch this number, grow the slice from new tickets, and let capture
+        // rise as a side effect of catalog work aimed at patrons rather than at
+        // the metric. Promote it to an assertion once the slice is large enough
+        // that tuning to it is no longer the path of least resistance.
+        let heldOut = bySlice["held_out"] ?? Tally()
+        print("\nheld-out capture (reported, not gated): \(heldOut.captured)/\(heldOut.capturable)")
+    }
+
+    /// The mined slice is where the catalog's own source tickets live. If the
+    /// matcher cannot recall the very tickets its keywords were written from,
+    /// nothing downstream is worth tuning.
+    func testCorpus_minedSliceRecallsItsOwnSourceTickets() throws {
+        let kb = KnowledgeBase(catalog: try BundledCatalogSource.loadCatalogSync())
+        let corpus = try loadCorpus()
+
+        let mined = corpus.cases.filter { $0.provenance == "mined" && !$0.expectsEscalation }
+        var captured = 0
+        var missed: [String] = []
+        for testCase in mined {
+            if case .captured = try outcome(for: testCase, kb: kb) {
+                captured += 1
+            } else {
+                missed.append(testCase.id)
+            }
+        }
+
+        // Majority of the catalog's own source tickets must come back. Anything
+        // less means the keyword lists do not describe the tickets they were
+        // mined from.
+        XCTAssertGreaterThan(
+            captured * 2, mined.count,
+            "mined-slice recall is \(captured)/\(mined.count); missed: \(missed.joined(separator: ", "))"
+        )
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/MatchCorpusTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/MatchCorpusTests.swift
@@ -160,7 +160,7 @@ final class MatchCorpusTests: XCTestCase {
 
         // Emit the full picture before asserting, so a failing run explains itself.
         print("=== MATCH CORPUS ===")
-        for slice in ["mined", "held_out", "trap"] {
+        for slice in ["mined", "held_out", "trap", "near_miss"] {
             guard let tally = bySlice[slice] else { continue }
             let pct = tally.capturable == 0 ? "n/a"
                 : String(format: "%.0f%%", 100.0 * Double(tally.captured) / Double(tally.capturable))
@@ -182,6 +182,16 @@ final class MatchCorpusTests: XCTestCase {
         // built entirely from inputs whose only overlap with an entry is a weak,
         // non-diagnostic word, so any suggestion here is a defect — this is the
         // guard that stops "improve recall" from silently reintroducing F-002.
+        // near_miss is the slice that can actually fail: real tickets carrying a
+        // strong keyword whose true cause is elsewhere. The trap slice cannot
+        // catch a mis-partitioned strong keyword, because it is sampled from the
+        // weak side by construction.
+        let nearMiss = bySlice["near_miss"] ?? Tally()
+        XCTAssertEqual(
+            nearMiss.misrouted, 0,
+            "a real patron would be shown a workaround for a bug they do not have — see MISROUTED lines"
+        )
+
         let trap = bySlice["trap"] ?? Tally()
         XCTAssertEqual(
             trap.misrouted, 0,
@@ -224,12 +234,23 @@ final class MatchCorpusTests: XCTestCase {
             }
         }
 
-        // Majority of the catalog's own source tickets must come back. Anything
-        // less means the keyword lists do not describe the tickets they were
-        // mined from.
-        XCTAssertGreaterThan(
-            captured * 2, mined.count,
-            "mined-slice recall is \(captured)/\(mined.count); missed: \(missed.joined(separator: ", "))"
+        // A RATCHET, not a target. This was a majority rule until the near-miss
+        // slice showed the keywords carrying that majority were also misrouting
+        // real patrons: "never works" captured hs-17976 (a genuine download
+        // failure) and simultaneously fired KI-008's network advice at hs-18571,
+        // whose audiobook simply would not play. Demoting it cost recall and
+        // bought precision, which is the right direction — a missed ticket
+        // escalates safely, a misrouted one hands out a wrong fix.
+        //
+        // The remaining misses are COVERAGE, not matching: hs-18028/18103 are
+        // FAQ phrasings no how_to keyword covers, hs-17957 needs a "does not
+        // appear" variant, hs-17917's own text does not support its label, and
+        // hs-17930 would need a keyword overfitted to one ticket. Raise this
+        // floor by adding entries and phrasings; never by re-promoting an
+        // ambiguous phrase.
+        XCTAssertGreaterThanOrEqual(
+            captured, 7,
+            "mined-slice recall regressed below the ratchet: \(captured)/\(mined.count); missed: \(missed.joined(separator: ", "))"
         )
     }
 }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/MatchCorpusTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/MatchCorpusTests.swift
@@ -216,6 +216,78 @@ final class MatchCorpusTests: XCTestCase {
         print("\nheld-out capture (reported, not gated): \(heldOut.captured)/\(heldOut.capturable)")
     }
 
+    /// The floor the whole feature rests on: a patron who reaches the end of a
+    /// conversation is never filed as "someone reported a problem".
+    ///
+    /// A ticket is better-identified than the email the patron would have sent
+    /// unaided when it carries something that email would not have: the entry we
+    /// recognised, an answer or explicit skip to a question we asked, or the
+    /// remedies they told us they had already tried.
+    ///
+    /// The conversation is driven ALL THE WAY to a filed ticket — declining any
+    /// ladder and skipping any question — because nothing reaches `.drafting` in
+    /// one step any more. The first version of this test asserted on the state
+    /// immediately after submitting the description, where every case is either
+    /// `.matched` or `.awaitingEscalationFollowUp`, so it ran over an empty set
+    /// and passed unconditionally. A mutation that stripped identification from
+    /// every draft did not fail it; that is how the vacuum was found.
+    func testEveryCase_WalkedToATicket_FilesAnIdentifiedTicket() throws {
+        let kb = KnowledgeBase(catalog: try BundledCatalogSource.loadCatalogSync())
+        let corpus = try loadCorpus()
+        var blanks: [String] = []
+        var filed = 0
+        var beyondTheQuestion = 0
+
+        for testCase in corpus.cases {
+            guard let category = KBCategory(rawValue: testCase.category) else { continue }
+            let reducer = ConversationReducer(knowledgeBase: kb)
+            var (state, _) = reducer.reduce(state: ConversationState(), action: .start)
+            (state, _) = reducer.reduce(state: state, action: .userTappedCategory(category))
+            (state, _) = reducer.reduce(state: state, action: .inputChanged(testCase.text))
+            (state, _) = reducer.reduce(state: state, action: .userSubmittedDescription)
+
+            // A patron who wants a human: decline whatever is offered, skip
+            // whatever is asked, and file. Bounded so a routing bug cannot spin.
+            var hops = 0
+            loop: while hops < 6 {
+                hops += 1
+                switch state.step {
+                case .matched(let id):
+                    (state, _) = reducer.reduce(state: state, action: .userTappedFileTicketAnyway)
+                    _ = id
+                case .awaitingEscalationFollowUp:
+                    (state, _) = reducer.reduce(state: state, action: .userAnsweredEscalationFollowUp(answer: nil))
+                default:
+                    break loop
+                }
+            }
+
+            guard case .drafting(let draft) = state.step else { continue }
+            filed += 1
+            let identified = draft.matchedEntryId != nil
+                || draft.escalationFollowUp != nil
+                || !draft.alreadyTried.isEmpty
+                || draft.claimsExhaustedEffort
+            if !identified { blanks.append(testCase.id) }
+            if draft.matchedEntryId != nil || !draft.alreadyTried.isEmpty || draft.claimsExhaustedEffort {
+                beyondTheQuestion += 1
+            }
+        }
+
+        XCTAssertGreaterThan(filed, 20,
+            "the walk reached only \(filed) tickets — if this collapses the assertions below are vacuous")
+        XCTAssertTrue(blanks.isEmpty,
+            "these filed with nothing support could not have read off the raw email: \(blanks)")
+
+        // The assertion above is satisfied by the follow-up alone, which every
+        // category has, so it cannot fail while catch-alls exist. This one can:
+        // it requires that identification beyond the universal component actually
+        // reaches the ticket. Stripping scoping or already-tried from the drafts
+        // fails here and nowhere else in this suite.
+        XCTAssertGreaterThan(beyondTheQuestion, 5,
+            "no ticket carried anything beyond the question we ask everyone — scoping and already-tried are not reaching drafts")
+    }
+
     /// The mined slice is where the catalog's own source tickets live. If the
     /// matcher cannot recall the very tickets its keywords were written from,
     /// nothing downstream is worth tuning.

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/MatchCorpusTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/MatchCorpusTests.swift
@@ -58,10 +58,20 @@ final class MatchCorpusTests: XCTestCase {
         let cases: [Case]
     }
 
+    /// Three outcomes, not two — because with the AI fallback off, "we could not
+    /// self-serve this" is not the end of the bot's usefulness. An escalation that
+    /// carries `recognizedEntryId` hands support a SCOPED ticket and asks the
+    /// entry's targeted follow-up ("which title?", "which library?") before filing.
+    /// A blind escalation hands them "patron reports a problem".
+    ///
+    /// So the goal is layered: capture what we can, and for everything we cannot,
+    /// prefer a triaged escalation over a blind one. Misrouting stays the only
+    /// truly bad outcome — it is the one where the patron acts on wrong advice.
     private enum Outcome {
-        case captured(String)       // suggested an acceptable entry
+        case captured(String)       // suggested an acceptable entry — patron self-serves
         case misrouted(String)      // suggested an entry that is not acceptable
-        case escalated
+        case triaged(String)        // escalated, but recognized the topic → scoped ticket
+        case blindEscalated         // escalated with no recognition → generic ticket
         case disambiguated
     }
 
@@ -69,6 +79,8 @@ final class MatchCorpusTests: XCTestCase {
         var capturable = 0          // cases where an entry is the right answer
         var captured = 0
         var misrouted = 0
+        var triaged = 0
+        var blind = 0
         var total = 0
     }
 
@@ -98,7 +110,9 @@ final class MatchCorpusTests: XCTestCase {
                 ? .captured(entryId)
                 : .misrouted(entryId)
         case .escalate:
-            return .escalated
+            // recognizedEntryId is what turns a dead-end into a scoped hand-off.
+            if let recognized = result.recognizedEntryId { return .triaged(recognized) }
+            return .blindEscalated
         case .disambiguate:
             return .disambiguated
         }
@@ -127,10 +141,16 @@ final class MatchCorpusTests: XCTestCase {
             case .misrouted(let id):
                 tally.misrouted += 1
                 line = "  ✗ MISROUTED   \(testCase.id) -> \(id) (expected \(testCase.expected))"
-            case .escalated:
+            case .triaged(let id):
+                tally.triaged += 1
+                line = testCase.expectsEscalation
+                    ? "  ✓ triaged     \(testCase.id) (scoped to \(id))"
+                    : "  ~ triaged     \(testCase.id) (no answer shown, but ticket scoped to \(id))"
+            case .blindEscalated:
+                tally.blind += 1
                 line = testCase.expectsEscalation
                     ? "  ✓ escalated   \(testCase.id)"
-                    : "  – missed      \(testCase.id) (expected \(testCase.expected))"
+                    : "  – MISSED      \(testCase.id) (expected \(testCase.expected); ticket unscoped)"
             case .disambiguated:
                 line = "  ? ambiguous   \(testCase.id) (expected \(testCase.expected))"
             }
@@ -144,8 +164,16 @@ final class MatchCorpusTests: XCTestCase {
             guard let tally = bySlice[slice] else { continue }
             let pct = tally.capturable == 0 ? "n/a"
                 : String(format: "%.0f%%", 100.0 * Double(tally.captured) / Double(tally.capturable))
+            // "handled" = the patron got either an answer or a scoped hand-off.
+            // With the AI fallback off this is the number that describes what the
+            // bot is actually worth today; capture alone undersells it.
+            let handled = tally.captured + tally.triaged
+            let handledPct = tally.total == 0 ? "n/a"
+                : String(format: "%.0f%%", 100.0 * Double(handled) / Double(tally.total))
             print("\n[\(slice)] cases=\(tally.total) capturable=\(tally.capturable) "
                   + "captured=\(tally.captured) (\(pct)) misrouted=\(tally.misrouted)")
+            print("         triaged=\(tally.triaged) blind=\(tally.blind) "
+                  + "→ handled (answered or scoped) = \(handled)/\(tally.total) (\(handledPct))")
         }
         print("\n--- per case ---")
         report.forEach { print($0) }

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/RemedyDetectionAccuracyTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/RemedyDetectionAccuracyTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import TriageBotCore
+
+/// Detection decides which remedies the bot SKIPS. A false positive silently
+/// removes a step the patron never took — and the step removed is often the one
+/// most likely to help them, because the phrase that triggered it was them
+/// describing their problem rather than their attempts.
+///
+/// The rule the file states for itself is past-tense statements of having done
+/// the thing. These pin it.
+final class RemedyDetectionAccuracyTests: XCTestCase {
+
+    private let detector = RemedyDetector()
+
+    /// The worst live false positive: "switched libraries" is KI-2026-002's
+    /// SYMPTOM keyword, verbatim. A patron reporting that switching libraries
+    /// broke something had `switchLibrary` marked as already-tried, which skips
+    /// the library ladder's first rung — the rung telling them to check which
+    /// library is selected, which is the likeliest fix for that exact complaint.
+    func testDescribingALibrarySwitchAsTheCause_isNotAnAttemptedRemedy() {
+        XCTAssertFalse(
+            detector.alreadyTried(in: "I switched libraries and now my books are gone").contains(.switchLibrary),
+            "the patron named their trigger, not a remedy they tried")
+        XCTAssertFalse(
+            detector.alreadyTried(in: "it crashed after I changed library").contains(.switchLibrary))
+        // A deliberate attempt still counts.
+        XCTAssertTrue(
+            detector.alreadyTried(in: "I tried my other library and it does the same thing").contains(.switchLibrary))
+    }
+
+    /// "pull to refresh" is imperative, not past tense — it matches a patron
+    /// ASKING how to do it, and skips the safest rung we have.
+    func testAskingHowToRefresh_isNotHavingRefreshed() {
+        XCTAssertFalse(detector.alreadyTried(in: "how do I pull to refresh?").contains(.pullToRefresh))
+        XCTAssertFalse(detector.alreadyTried(in: "should I pull to refresh").contains(.pullToRefresh))
+        XCTAssertTrue(detector.alreadyTried(in: "I pulled down to refresh and nothing changed").contains(.pullToRefresh))
+    }
+
+    /// A phone that restarts itself is a symptom. A phone the patron restarted
+    /// is a remedy. Bare "rebooted" cannot tell them apart.
+    func testASpontaneousRestart_isNotARemedyTheyTried() {
+        XCTAssertFalse(detector.alreadyTried(in: "my phone rebooted itself while the audiobook was playing").contains(.restartDevice))
+        XCTAssertTrue(detector.alreadyTried(in: "I rebooted my phone and tried again").contains(.restartDevice))
+    }
+
+    /// "up to date" about a card or about iOS is not a claim about Palace.
+    func testUpToDateAboutSomethingElse_isNotAnAppUpdate() {
+        XCTAssertFalse(detector.alreadyTried(in: "my library card is up to date").contains(.updateApp))
+        XCTAssertFalse(detector.alreadyTried(in: "I keep my iphone up to date").contains(.updateApp))
+        XCTAssertTrue(detector.alreadyTried(in: "I updated the app and it still fails").contains(.updateApp))
+    }
+
+    /// The phrase lists match contiguous token runs, so a natural repetition
+    /// breaks them: "signed out and back" does not occur in "signed out and
+    /// SIGNED back in", which is how most people write it.
+    func testTheMostNaturalSignOutPhrasing_isDetected() {
+        for text in ["I signed out and signed back in",
+                     "logged out and logged back in again",
+                     "I signed out then signed back in and it still asks me to log in"] {
+            XCTAssertTrue(detector.alreadyTried(in: text).contains(.signOutIn),
+                          "missed a sign-out claim in: \(text)")
+        }
+    }
+
+    /// "iPhone" is the word patrons actually use, and it was the one device noun
+    /// missing from the restart list.
+    func testCommonRestartAndNetworkPhrasings_areDetected() {
+        XCTAssertTrue(detector.alreadyTried(in: "I restarted my iphone twice").contains(.restartDevice))
+        XCTAssertTrue(detector.alreadyTried(in: "turned it off and on again").contains(.restartDevice))
+        XCTAssertTrue(detector.alreadyTried(in: "I turned airplane mode on and off").contains(.toggleNetwork))
+        XCTAssertTrue(detector.alreadyTried(in: "tried a different network, no luck").contains(.toggleNetwork))
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResolutionTracePersistenceTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResolutionTracePersistenceTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import TriageBotCore
+
+/// Every guided flow must leave a record of what was tried and how it ended.
+///
+/// The reducer builds a full `ResolutionTrace` on the resolved path and then
+/// throws it away (`_ = trace`), so the one outcome worth learning from — the
+/// remedy that WORKED — was the only one never recorded. Exhausted and abandoned
+/// flows carried their trace out on the ticket; resolved flows carried it
+/// nowhere, because there is no ticket.
+///
+/// That asymmetry makes the per-step diagnostics unusable for their stated
+/// purpose ("support sees step 2 resolves 73% of KI-001 cases"), and it means
+/// any future re-ordering of remedies would rest on the same 204-ticket priors
+/// forever. The priors are already known to be era-bound — audiobook's
+/// update-the-app rate reflects a specific broken release. Without this, there
+/// is no path from those priors to measured ones.
+final class ResolutionTracePersistenceTests: XCTestCase {
+
+    private func flow() -> ConversationReducer {
+        let entry = KBEntry(
+            id: "K", category: .audiobook, status: .open,
+            symptomKeywords: ["alpha thing"],
+            userFacingWorkaround: "Try it.",
+            userFacingSteps: [
+                KBStep(id: "s1", instruction: "First thing.", check: "Better?", remedy: .pullToRefresh),
+                KBStep(id: "s2", instruction: "Second thing.", check: "Better?", remedy: .updateApp),
+            ],
+            confidenceThreshold: 0.1)
+        return ConversationReducer(knowledgeBase: KnowledgeBase(
+            catalog: KBCatalog(version: "t", updatedAt: "x", entries: [entry])))
+    }
+
+    private func intoFlow(_ r: ConversationReducer) -> ConversationState {
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(.audiobook))
+        (s, _) = r.reduce(state: s, action: .inputChanged("the alpha thing is broken"))
+        (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
+        return r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "K")).0
+    }
+
+    private func persisted(_ effects: [ConversationEffect]) -> ResolutionTrace? {
+        for e in effects { if case .persistResolutionTrace(let t) = e { return t } }
+        return nil
+    }
+
+    /// The important one: a remedy that worked is the only evidence that can ever
+    /// re-rank the ladder, and it was the one being discarded.
+    func testResolvedFlow_persistsTheTraceWithTheWinningStep() {
+        let r = flow()
+        let state = intoFlow(r)
+        let (_, effects) = r.reduce(state: state, action: .userConfirmedStepResolved(stepId: "s1"))
+
+        let trace = persisted(effects)
+        XCTAssertNotNil(trace, "the resolved outcome — the only one worth learning from — was discarded")
+        XCTAssertEqual(trace?.outcome, .resolved)
+        XCTAssertEqual(trace?.attempts.map(\.stepId), ["s1"], "must record WHICH step resolved it")
+    }
+
+    func testExhaustedFlow_persistsTheTrace() {
+        let r = flow()
+        var s = intoFlow(r)
+        (s, _) = r.reduce(state: s, action: .userConfirmedStepDidNotResolve(stepId: "s1"))
+        let (_, effects) = r.reduce(state: s, action: .userConfirmedStepDidNotResolve(stepId: "s2"))
+
+        let trace = persisted(effects)
+        XCTAssertEqual(trace?.outcome, .escalatedAfterStepsExhausted)
+        XCTAssertEqual(trace?.attempts.count, 2, "both failed attempts must be recorded, in order")
+    }
+
+    func testAbandonedFlow_persistsTheTrace() {
+        let r = flow()
+        let s = intoFlow(r)
+        let (_, effects) = r.reduce(state: s, action: .userTappedAbandonGuidedFlow)
+        XCTAssertEqual(persisted(effects)?.outcome, .abandoned,
+                       "abandonment is a signal about the rung, not an absence of one")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResponseQualityTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResponseQualityTests.swift
@@ -89,6 +89,17 @@ final class ResponseQualityTests: XCTestCase {
         distributor: "palace_marketplace"
     )
 
+    /// A patron still on an affected build. The 3.2.x fulfillment entry is
+    /// `fixed_in 3.2.3`, so the version gate hides it from anyone past the fix —
+    /// meaning the benchmark must pin an affected version or it would test
+    /// nothing.
+    private static let affectedBy32xContext = ContextSnapshot(
+        appVersion: "3.2.1",
+        appBuild: "489",
+        osVersion: "26.5.2",
+        deviceModel: "iPhone17,2"
+    )
+
     private static let openAccessContext = ContextSnapshot(
         appVersion: "3.0.3",
         appBuild: "478",
@@ -339,6 +350,14 @@ final class ResponseQualityTests: XCTestCase {
              category: .audiobook, context: marketplaceContext,
              expect: .shouldEscalate,
              source: "HelpSpot 17981 — KB GAP: post-recheckout permanent failure, distinct from KI-001 first-open hang. Needs new KI"),
+
+        // Verbatim shape from HelpSpot 18571-class tickets, all resolved as the
+        // 3.2.x fulfillment defect. Every keyword it hits appears only in tickets
+        // support resolved that way.
+        Case(userText: "Since the update, my checked out audiobook won't play. I hit listen and it just spins in circles like it's loading",
+             category: .audiobook, context: affectedBy32xContext,
+             expect: .shouldMatch(entryId: "KI-2026-010-audiobook-fulfillment-3-2-x"),
+             source: "HelpSpot 18449/18464/18475/18486/18571 — the 3.2.0-3.2.2 audiobook fulfillment defect; support's answer was uniformly 'fixed in 3.2.3'"),
 
         Case(userText: "trying to download an ebook and it never works after I toggled wifi and reinstalled the app",
              category: .download, context: nil,

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResponseQualityTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ResponseQualityTests.swift
@@ -779,7 +779,11 @@ final class ResponseQualityTests: XCTestCase {
 
     func testEveryCatalogEntry_hasABenchmarkCase() throws {
         let kb = try Self.loadCatalog()
-        let entryIds = Set(kb.catalog.entries.map { $0.id })
+        // Ladders cannot have a shouldMatch case — they are never matched. Their
+        // coverage lives in GenericLadderTests and CatalogValidationTests.
+        let entryIds = Set(kb.catalog.entries
+            .filter { $0.resolvedKind != .genericFlow }
+            .map { $0.id })
         let covered = Set(Self.corpus.compactMap { c -> String? in
             if case .shouldMatch(let id) = c.expect { return id }; return nil
         })
@@ -823,7 +827,9 @@ final class ResponseQualityTests: XCTestCase {
         let kb = try Self.loadCatalog()
         var failures: [String] = []
 
-        for entry in kb.catalog.entries {
+        // Ladders are offered, not matched, so they have no benchmark input —
+        // they are covered by GenericLadderTests instead.
+        for entry in kb.catalog.entries where entry.resolvedKind != .genericFlow {
             let text = entry.userFacingWorkaround
 
             // Length: too short usually means generic, too long means we

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/StructuredEscalationTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/StructuredEscalationTests.swift
@@ -72,11 +72,15 @@ final class StructuredEscalationTests: XCTestCase {
 
     func testEscalate_recognizedTopic_asksItsTargetedFollowUp() {
         let entries = [KBEntry(id: "KI-FU", category: .other, status: .open,
-                               symptomKeywords: ["some unrelated phrase"],
-                               corroboratingKeywords: ["frobnicate widget"],
+                               symptomKeywords: ["frobnicate widget"],
                                userFacingWorkaround: "Try turning it off and on again please.",
                                escalationFollowUp: KBEscalationFollowUp(prompt: "Which widget model is it?"),
-                               confidenceThreshold: 0.1)]
+                               confidenceThreshold: 0.1,
+                               // escalate_anyway = recognized confidently, but no
+                               // safe self-serve fix. The strong-recognition
+                               // escalation, which is exactly when the targeted
+                               // question is warranted.
+                               escalateAnyway: true)]
         let state = drive(reducer(entries), category: .other, text: "my frobnicate widget is broken")
 
         guard case .awaitingEscalationFollowUp(let prompt, _) = state.step else {

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/StructuredEscalationTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/StructuredEscalationTests.swift
@@ -17,10 +17,11 @@ final class StructuredEscalationTests: XCTestCase {
     // MARK: - Classifier: recognizedEntryId
 
     func testLowConfidenceEscalate_carriesRecognizedEntryId() {
-        // One region hit → below the known_issue floor → escalate. But we DID
-        // recognize the topic, so the id rides along for the hand-off.
+        // A weak-evidence-only hit → cannot carry a suggestion → escalate. But we
+        // DID recognize the topic, so the id rides along for the hand-off.
         let entries = [KBEntry(id: "KI-FU", category: .other, status: .open,
-                               symptomKeywords: ["frobnicate widget"],
+                               symptomKeywords: ["some unrelated phrase"],
+                               corroboratingKeywords: ["frobnicate widget"],
                                userFacingWorkaround: "Try turning it off and on again please.",
                                confidenceThreshold: 0.1)]
         let result = classifier.classify(userText: "my frobnicate widget is broken", knowledgeBase: kb(entries))
@@ -71,7 +72,8 @@ final class StructuredEscalationTests: XCTestCase {
 
     func testEscalate_recognizedTopic_asksItsTargetedFollowUp() {
         let entries = [KBEntry(id: "KI-FU", category: .other, status: .open,
-                               symptomKeywords: ["frobnicate widget"],
+                               symptomKeywords: ["some unrelated phrase"],
+                               corroboratingKeywords: ["frobnicate widget"],
                                userFacingWorkaround: "Try turning it off and on again please.",
                                escalationFollowUp: KBEscalationFollowUp(prompt: "Which widget model is it?"),
                                confidenceThreshold: 0.1)]

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/StuckSendReproTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/StuckSendReproTests.swift
@@ -17,8 +17,12 @@ final class StuckSendReproTests: XCTestCase {
     private func reducer() -> ConversationReducer {
         // An entry with NO escalationFollowUp → an escalating match drafts a
         // ticket directly (reaching the .drafting/preview step we then Discard).
+        // The keyword is corroborating so the match escalates rather than
+        // suggests; a suggestion would land on .matched and never reach the
+        // preview this flow is about.
         let entry = KBEntry(id: "KI-DRAFT", category: .audiobook, status: .open,
-                            symptomKeywords: ["glitchy audio"],
+                            symptomKeywords: ["some unrelated phrase"],
+                            corroboratingKeywords: ["glitchy audio"],
                             userFacingWorkaround: "Please try re-downloading the title.",
                             confidenceThreshold: 0.1)
         return ConversationReducer(knowledgeBase: KnowledgeBase(

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ThinEvidenceHedgeTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/ThinEvidenceHedgeTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import TriageBotCore
+
+/// A suggestion built on ONE matched concept is offered as a question; one built
+/// on two or more is stated. The near-miss corpus shows single-concept matches
+/// are where real misroutes live, so the cost of being wrong there should be a
+/// tap, not a patron following instructions for a bug they do not have.
+final class ThinEvidenceHedgeTests: XCTestCase {
+
+    private func drive(_ r: ConversationReducer, _ cat: KBCategory, _ text: String) -> ConversationState {
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(cat))
+        (s, _) = r.reduce(state: s, action: .inputChanged(text))
+        return r.reduce(state: s, action: .userSubmittedDescription).0
+    }
+
+    private func reducer(_ entries: [KBEntry]) -> ConversationReducer {
+        ConversationReducer(knowledgeBase: KnowledgeBase(
+            catalog: KBCatalog(version: "t", updatedAt: "2026-07-20", entries: entries)))
+    }
+
+    private var entry: KBEntry {
+        KBEntry(id: "K", category: .other, status: .open,
+                symptomKeywords: ["alpha thing", "beta thing"],
+                userFacingWorkaround: "Do the fix.", confidenceThreshold: 0.1)
+    }
+
+    private func hedgeText(_ state: ConversationState) -> String? {
+        state.messages.compactMap { m -> String? in
+            if case .text(let t) = m.kind, t.contains("does that match what you're seeing?") { return t }
+            return nil
+        }.first
+    }
+
+    func testOneMatchedConcept_isOfferedAsAQuestion() {
+        let state = drive(reducer([entry]), .other, "I have the alpha thing")
+        XCTAssertEqual(state.step, .matched(entryId: "K"), "one strong concept still suggests")
+        XCTAssertNotNil(hedgeText(state), "a one-concept match must be hedged, not asserted")
+    }
+
+    func testTwoMatchedConcepts_areStatedPlainly() {
+        let state = drive(reducer([entry]), .other, "I have the alpha thing and also the beta thing")
+        XCTAssertEqual(state.step, .matched(entryId: "K"))
+        XCTAssertNil(hedgeText(state), "two distinct concepts is not a guess — do not hedge")
+    }
+
+    /// The hedge must not silently replace the workaround: the patron still gets
+    /// the KB card, just introduced as a question.
+    func testHedgedMatch_stillShowsTheWorkaroundCard() {
+        let state = drive(reducer([entry]), .other, "I have the alpha thing")
+        let hasCard = state.messages.contains { if case .kbMatch(let id) = $0.kind { return id == "K" }; return false }
+        XCTAssertTrue(hasCard, "hedging changes the framing, not whether help is offered")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/TicketIdentificationTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/TicketIdentificationTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import TriageBotCore
+
+/// What a filed ticket tells support.
+///
+/// The bot's job is to resolve the problem OR hand support a better-identified
+/// one than the patron would have emailed unaided. The second half is measurable:
+/// a ticket is better identified when it carries something the raw email would
+/// not have — the entry we recognised, the question we asked, or the remedies the
+/// patron had already tried.
+///
+/// Two of those were being computed and then dropped on the floor.
+final class TicketIdentificationTests: XCTestCase {
+
+    private func kb() -> KnowledgeBase {
+        let weak = KBEntry(
+            id: "KI-WEAK", category: .download, status: .open,
+            symptomKeywords: ["a phrase nobody types"],
+            corroboratingKeywords: ["download"],
+            userFacingWorkaround: "Check your connection.",
+            confidenceThreshold: 0.1)
+        let ladder = KBEntry(
+            id: "GF-download", category: .download, kind: .genericFlow,
+            symptomKeywords: [],
+            userFacingWorkaround: "A few things to try.",
+            userFacingSteps: [KBStep(id: "g1", instruction: "Try it.", check: "Any change?",
+                                     remedy: .pullToRefresh)])
+        return KnowledgeBase(catalog: KBCatalog(version: "t", updatedAt: "x", entries: [weak, ladder]))
+    }
+
+    private func drive(_ text: String, then action: ConversationAction?) -> ConversationState {
+        let r = ConversationReducer(knowledgeBase: kb())
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(.download))
+        (s, _) = r.reduce(state: s, action: .inputChanged(text))
+        (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
+        if let action { (s, _) = r.reduce(state: s, action: action) }
+        return s
+    }
+
+    private func draft(_ s: ConversationState) -> TicketDraft? {
+        switch s.step {
+        case .drafting(let d): return d
+        case .awaitingEscalationFollowUp(_, let d): return d
+        default: return nil
+        }
+    }
+
+    /// Declining the ladder is the third exit from it, and the only one that was
+    /// not scoping the ticket. A patron who taps "just file a ticket" got
+    /// `GF-download` — which tells a triager the bot had no idea, something the
+    /// absence of an answer already tells them — while the weak recognition sat
+    /// unused in `lastClassification`.
+    func testFileAnywayFromLadder_scopesToTheRecognizedEntry() throws {
+        let state = drive("my download is stuck", then: .userTappedFileTicketAnyway)
+        let d = try XCTUnwrap(draft(state), "expected a draft; got \(state.step)")
+        XCTAssertEqual(d.matchedEntryId, "KI-WEAK",
+                       "the recognised entry must survive all three ladder exits, not two")
+        XCTAssertFalse(d.helpspotTags.contains("triage-bot-known-issue"),
+                       "a generic ladder is not a known issue and must not be tagged as one")
+    }
+
+    /// The detector reads "I already reinstalled" to skip a step, and then the
+    /// fact is discarded. Support re-reads the free text to learn something the
+    /// bot had already parsed.
+    func testTicketCarriesTheRemediesThePatronSaidTheyTried() throws {
+        let state = drive("my download is stuck, I deleted the app and reinstalled it twice",
+                          then: .userTappedFileTicketAnyway)
+        let d = try XCTUnwrap(draft(state))
+        XCTAssertTrue(d.alreadyTried.contains(.reinstall),
+                      "support should not have to re-read what the bot already parsed")
+    }
+
+    /// A blanket "tried everything" suppresses the ladder. That decision is worth
+    /// telling support, because it says the patron has already spent effort.
+    func testTicketRecordsABlanketExhaustedEffortClaim() throws {
+        let state = drive("my download is stuck and I have tried everything, nothing works",
+                          then: .userTappedFileTicketAnyway)
+        let d = try XCTUnwrap(draft(state))
+        XCTAssertTrue(d.claimsExhaustedEffort)
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/UpdateRungVersionGateTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/UpdateRungVersionGateTests.swift
@@ -66,3 +66,18 @@ final class UpdateRungVersionGateTests: XCTestCase {
         XCTAssertEqual(firstRung(latestKnown: "3.2.3", appVersion: nil), 0)
     }
 }
+
+extension UpdateRungVersionGateTests {
+
+    /// The gate is only real if the SHIPPED catalog arms it. It was built, tested
+    /// against fixture catalogs, and shipped inert — `latest_known_app_version`
+    /// was never authored, so every ladder offered "check for an update" to
+    /// patrons already on the newest build. Tested machinery with unauthored data
+    /// is indistinguishable from no machinery.
+    func testShippedCatalog_ArmsTheVersionGate() throws {
+        let catalog = try BundledCatalogSource.loadCatalogSync()
+        let declared = try XCTUnwrap(catalog.latestKnownAppVersion,
+            "the shipped catalog declares no newest-known version, so the update rung never skips")
+        XCTAssertNotNil(SemanticVersion(declared), "must parse as a version: \(declared)")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/UpdateRungVersionGateTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/UpdateRungVersionGateTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import TriageBotCore
+
+/// "Update the app" is the most-prescribed remedy in the corpus (20% of
+/// resolutions) and the first rung of several ladders. It is also the one rung
+/// the bot can be demonstrably wrong about: a patron already on the newest build
+/// is sent to the App Store to find nothing, which reads as the bot not knowing
+/// the state of their own device.
+///
+/// The catalog can carry the newest version it knows of, and the ladder skips
+/// the rung for anyone already at or past it. Deliberately conservative in both
+/// unknown cases — no context, or no declared version — because a wasted rung
+/// costs seconds while a suppressed one may cost the fix. Worst case the field
+/// goes stale and one cohort sees a rung they do not need, which is the same
+/// cost as not having the gate at all.
+final class UpdateRungVersionGateTests: XCTestCase {
+
+    private func kb(latestKnown: String?) -> KnowledgeBase {
+        let ladder = KBEntry(
+            id: "GF-audiobook", category: .audiobook, kind: .genericFlow,
+            symptomKeywords: [],
+            userFacingWorkaround: "A few things to try.",
+            userFacingSteps: [
+                KBStep(id: "g1", instruction: "Check the App Store.", check: "Updated?", remedy: .updateApp),
+                KBStep(id: "g2", instruction: "Tap the title again.", check: "Playing?", remedy: .reopenTitle),
+            ])
+        return KnowledgeBase(catalog: KBCatalog(
+            version: "t", updatedAt: "x", entries: [ladder], latestKnownAppVersion: latestKnown))
+    }
+
+    private func firstRung(latestKnown: String?, appVersion: String?) -> Int? {
+        let r = ConversationReducer(knowledgeBase: kb(latestKnown: latestKnown))
+        var (s, _) = r.reduce(state: ConversationState(), action: .start)
+        if let appVersion {
+            (s, _) = r.reduce(state: s, action: .contextLoaded(
+                ContextSnapshot(appVersion: appVersion, appBuild: "1", osVersion: "26.0", deviceModel: "iPhone")))
+        }
+        (s, _) = r.reduce(state: s, action: .userTappedCategory(.audiobook))
+        (s, _) = r.reduce(state: s, action: .inputChanged("something is wrong"))
+        (s, _) = r.reduce(state: s, action: .userSubmittedDescription)
+        (s, _) = r.reduce(state: s, action: .userTappedStartGuidedFlow(entryId: "GF-audiobook"))
+        if case .guidedStep(_, let index, _, _) = s.step { return index }
+        return nil
+    }
+
+    func testUpdateRung_isSkippedWhenAlreadyOnTheNewestKnownVersion() {
+        XCTAssertEqual(firstRung(latestKnown: "3.2.3", appVersion: "3.2.3"), 1,
+                       "sending someone already current to the App Store finds nothing")
+    }
+
+    func testUpdateRung_isSkippedWhenAheadOfTheNewestKnownVersion() {
+        XCTAssertEqual(firstRung(latestKnown: "3.2.3", appVersion: "3.3.0"), 1,
+                       "a stale catalog must not re-offer an update to a newer build")
+    }
+
+    func testUpdateRung_isOfferedWhenBehind() {
+        XCTAssertEqual(firstRung(latestKnown: "3.2.3", appVersion: "3.2.1"), 0)
+    }
+
+    func testUpdateRung_isOfferedWhenTheCatalogDeclaresNoLatestVersion() {
+        XCTAssertEqual(firstRung(latestKnown: nil, appVersion: "3.2.3"), 0,
+                       "unknown must not suppress — a wasted rung beats a withheld fix")
+    }
+
+    func testUpdateRung_isOfferedWhenTheAppVersionIsUnknown() {
+        XCTAssertEqual(firstRung(latestKnown: "3.2.3", appVersion: nil), 0)
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/WaitAndReborrowRemedyTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/WaitAndReborrowRemedyTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import TriageBotCore
+
+/// Two remedies the corpus argued for.
+///
+/// `waitForFix` is the largest single resolution class in 212 resolved tickets —
+/// 44 of them, more than any actual repair. Support's answer to one patron in
+/// five is "we know, it is fixed in a release that is coming." The bot could not
+/// say that at all, so it walked those patrons through refreshes instead, which
+/// is worse than saying nothing.
+///
+/// `returnAndReborrow` is rare in the corpus (2 of 212) but addresses a failure
+/// mode nothing else touches: one bad loan or fulfilment rather than a bad app
+/// state. Support reached for it when they could play a title themselves that
+/// the patron could not.
+final class WaitAndReborrowRemedyTests: XCTestCase {
+
+    private let detector = RemedyDetector()
+
+    // MARK: - Cost
+
+    /// Returning a title to fix it is not free and not merely disruptive. If a
+    /// hold queue has formed, giving the loan back can cost the patron their
+    /// place in line, which they cannot undo — a smaller blast radius than
+    /// reinstalling, but the same kind of loss.
+    func testReturnAndReborrowIsDestructive() {
+        XCTAssertEqual(Remedy.returnAndReborrow.costTier, .destructive)
+    }
+
+    /// Being told a fix is coming costs nothing.
+    func testWaitForFixIsFree() {
+        XCTAssertEqual(Remedy.waitForFix.costTier, .free)
+    }
+
+    // MARK: - Detection
+
+    func testDetectsAPatronWhoAlreadyReturnedAndReborrowed() {
+        for text in ["I returned it and checked it back out",
+                     "I gave the book back and borrowed it again",
+                     "returned and re-borrowed the audiobook, same thing"] {
+            XCTAssertTrue(detector.alreadyTried(in: text).contains(.returnAndReborrow),
+                          "missed a return-and-reborrow claim in: \(text)")
+        }
+    }
+
+    /// "I am waiting for the fix" is a patron telling us they already know. It
+    /// should not be re-offered as news.
+    func testDetectsAPatronAlreadyWaitingOnAFix() {
+        XCTAssertTrue(detector.alreadyTried(in: "I was told this is fixed in the next update, still waiting")
+                        .contains(.waitForFix))
+    }
+
+    /// Borrowing something for the first time is not returning it.
+    func testBorrowingIsNotReturning() {
+        XCTAssertFalse(detector.alreadyTried(in: "I borrowed a book yesterday and it will not open")
+                        .contains(.returnAndReborrow))
+    }
+
+    // MARK: - Where it may be said
+
+    /// A generic ladder fires when NOTHING matched. Telling that patron a fix is
+    /// coming would be an invention — we do not know what their problem is, so we
+    /// cannot know a fix exists for it. It may only appear on an entry that
+    /// documents a real defect.
+    func testWaitForFixIsRejectedInAGenericLadder() {
+        let ladder = KBEntry(
+            id: "GF-audiobook", category: .audiobook, kind: .genericFlow,
+            symptomKeywords: [], userFacingWorkaround: "Try things.",
+            userFacingSteps: [KBStep(id: "g1", instruction: "Sit tight.", check: "OK?", remedy: .waitForFix)])
+        XCTAssertFalse(
+            CatalogValidator.violations(in: KBCatalog(version: "t", updatedAt: "x", entries: [ladder])).isEmpty,
+            "we cannot promise a fix for a problem we did not identify")
+    }
+
+    /// On a known issue it is exactly the right thing to say.
+    func testWaitForFixIsAllowedOnAKnownIssue() {
+        let known = KBEntry(
+            id: "KI-REAL", category: .audiobook, status: .open,
+            symptomKeywords: ["will not play"],
+            userFacingWorkaround: "A fix is on the way.",
+            userFacingSteps: [KBStep(id: "s1", instruction: "A fix is in the next release.",
+                                     check: "Would you like support to follow up?", remedy: .waitForFix)])
+        XCTAssertEqual(
+            CatalogValidator.violations(in: KBCatalog(version: "t", updatedAt: "x", entries: [known])), [])
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/WeakRecognitionFollowUpTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/WeakRecognitionFollowUpTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import TriageBotCore
+
+/// Escalation asks the recognized entry's targeted follow-up before filing. That
+/// question is only a good question when we actually recognized the problem.
+///
+/// Every targeted follow-up in the catalog PRESUMES its entry's bug — "What car
+/// model + year are you using, and is it wired CarPlay or wireless?", "Which
+/// library are you trying to add?". Asked off a strong match those are excellent
+/// triage. Asked off a lone generic word they are baffling: a patron who wrote
+/// "the app crashes when I open it" and has never opened CarPlay gets interrogated
+/// about their car.
+///
+/// So recognition is split by strength:
+///   - ticket SCOPING happens on any recognition, strong or weak. It is support-
+///     facing metadata the patron never sees, and a hint costs a triager nothing.
+///   - the targeted QUESTION is asked only on strong recognition. On weak-only
+///     evidence the bot files the scoped ticket without pretending to know which
+///     bug this is.
+final class WeakRecognitionFollowUpTests: XCTestCase {
+
+    private func drive(_ r: ConversationReducer, category: KBCategory, text: String) -> ConversationState {
+        var (state, _) = r.reduce(state: ConversationState(), action: .start)
+        (state, _) = r.reduce(state: state, action: .userTappedCategory(category))
+        (state, _) = r.reduce(state: state, action: .inputChanged(text))
+        return r.reduce(state: state, action: .userSubmittedDescription).0
+    }
+
+    private func shippedReducer() throws -> ConversationReducer {
+        ConversationReducer(knowledgeBase: KnowledgeBase(catalog: try BundledCatalogSource.loadCatalogSync()))
+    }
+
+    /// The defect, against the real shipped catalog: a generic crash report must
+    /// not be asked a CarPlay-specific question.
+    func testGenericCrash_isNotAskedTheCarPlayQuestion() throws {
+        let state = drive(try shippedReducer(), category: .audiobook, text: "the app crashes when I open it")
+
+        if case .awaitingEscalationFollowUp(let prompt, _) = state.step {
+            XCTFail("""
+                a lone weak-keyword match must not ask a bug-specific question; \
+                patron said "the app crashes when I open it" and was asked: "\(prompt)"
+                """)
+        }
+    }
+
+    /// Same shape, different entry: "my bookshelf looks empty" overlaps KI-004
+    /// only on the weak word "bookshelf" and must not be asked which library the
+    /// patron is trying to add — they never said they were adding one.
+    func testGenericEmptyShelf_isNotAskedWhichLibraryToAdd() throws {
+        let state = drive(try shippedReducer(), category: .library, text: "my bookshelf looks empty")
+
+        if case .awaitingEscalationFollowUp(let prompt, _) = state.step {
+            XCTFail("""
+                a lone weak-keyword match must not ask a bug-specific question; \
+                patron said "my bookshelf looks empty" and was asked: "\(prompt)"
+                """)
+        }
+    }
+
+    /// The other side of the contract — this must NOT regress into silence. A
+    /// STRONG match that still escalates (an `escalate_anyway` entry, or a
+    /// low-confidence-but-strong hit) is exactly when the targeted question earns
+    /// its place, so it must still be asked.
+    func testStrongRecognition_stillAsksItsTargetedFollowUp() {
+        let entry = KBEntry(
+            id: "KI-STRONG", category: .other, status: .open,
+            symptomKeywords: ["frobnicate widget"],
+            userFacingWorkaround: "Try turning it off and on again please.",
+            escalationFollowUp: KBEscalationFollowUp(prompt: "Which widget model is it?"),
+            confidenceThreshold: 0.1,
+            // escalate_anyway: recognized AND confident, but no safe self-serve fix.
+            // The canonical strong-recognition escalation.
+            escalateAnyway: true
+        )
+        let reducer = ConversationReducer(knowledgeBase: KnowledgeBase(
+            catalog: KBCatalog(version: "test", updatedAt: "2026-07-20", entries: [entry])))
+
+        let state = drive(reducer, category: .other, text: "my frobnicate widget is broken")
+
+        guard case .awaitingEscalationFollowUp(let prompt, _) = state.step else {
+            return XCTFail("a strong recognition must still ask its targeted follow-up; got \(state.step)")
+        }
+        XCTAssertTrue(prompt.contains("Which widget model is it?"), "got: \(prompt)")
+    }
+
+    /// Weak recognition still SCOPES the ticket even though it asks nothing —
+    /// that is the "triage whenever possible" half. Support gets a hint; the
+    /// patron gets no baffling question.
+    func testWeakRecognition_stillScopesTheTicketForSupport() throws {
+        let result = LocalClassifier().classify(
+            userText: "the app crashes when I open it",
+            category: .audiobook,
+            context: nil,
+            knowledgeBase: KnowledgeBase(catalog: try BundledCatalogSource.loadCatalogSync())
+        )
+        XCTAssertEqual(result.decision, .escalate)
+        XCTAssertEqual(result.recognizedEntryId, "KI-2026-005-carplay-sigabrt",
+                       "weak evidence must still tag the ticket so support gets the hint")
+        XCTAssertFalse(result.recognitionIsStrong,
+                       "…but it must be marked weak so the reducer withholds the targeted question")
+    }
+}

--- a/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/WeakRecognitionFollowUpTests.swift
+++ b/Palace/Packages/PalaceTriageBot/Tests/TriageBotCoreTests/WeakRecognitionFollowUpTests.swift
@@ -15,8 +15,10 @@ import XCTest
 ///   - ticket SCOPING happens on any recognition, strong or weak. It is support-
 ///     facing metadata the patron never sees, and a hint costs a triager nothing.
 ///   - the targeted QUESTION is asked only on strong recognition. On weak-only
-///     evidence the bot files the scoped ticket without pretending to know which
-///     bug this is.
+///     evidence the bot asks its CATEGORY's catch-all instead — a question that
+///     presumes nothing — so the ticket is still scoped and the patron is still
+///     asked something useful, without the bot pretending to know which bug this
+///     is.
 final class WeakRecognitionFollowUpTests: XCTestCase {
 
     private func drive(_ r: ConversationReducer, category: KBCategory, text: String) -> ConversationState {
@@ -35,8 +37,11 @@ final class WeakRecognitionFollowUpTests: XCTestCase {
     func testGenericCrash_isNotAskedTheCarPlayQuestion() throws {
         let state = drive(try shippedReducer(), category: .audiobook, text: "the app crashes when I open it")
 
+        // A question IS asked now — the category catch-all, which presumes
+        // nothing. What must never appear is the entry's bug-specific one.
         if case .awaitingEscalationFollowUp(let prompt, _) = state.step {
-            XCTFail("""
+            XCTAssertFalse(prompt.lowercased().contains("carplay") || prompt.lowercased().contains("car model"),
+                """
                 a lone weak-keyword match must not ask a bug-specific question; \
                 patron said "the app crashes when I open it" and was asked: "\(prompt)"
                 """)
@@ -50,7 +55,8 @@ final class WeakRecognitionFollowUpTests: XCTestCase {
         let state = drive(try shippedReducer(), category: .library, text: "my bookshelf looks empty")
 
         if case .awaitingEscalationFollowUp(let prompt, _) = state.step {
-            XCTFail("""
+            XCTAssertFalse(prompt.lowercased().contains("trying to add"),
+                """
                 a lone weak-keyword match must not ask a bug-specific question; \
                 patron said "my bookshelf looks empty" and was asked: "\(prompt)"
                 """)

--- a/Palace/Packages/PalaceTriageBot/corpus/README.md
+++ b/Palace/Packages/PalaceTriageBot/corpus/README.md
@@ -1,0 +1,60 @@
+# Triage-bot ticket corpus
+
+The measurements that justify the classifier's thresholds, the per-category
+remedy priors, and the ladder ordering all come from real HelpSpot tickets. This
+directory holds the pipeline. It does not hold the corpus.
+
+## Where the corpus lives, and why not here
+
+`~/harness/corpora/palace-triage/` on a maintainer machine.
+
+The tickets are real patron support messages. They are PII-stripped — names,
+addresses, phone numbers, card and patron numbers, and book titles are removed
+rather than substituted, and each mining pass runs a regex sweep over its own
+output to confirm it. Even so, several hundred verbatim patron messages are not
+something to publish in an open repository without an explicit decision by the
+project, and that decision has not been made. The curated subset that the test
+suite actually needs is committed, at
+`Tests/TriageBotCoreTests/Fixtures/MatchCorpus.json`.
+
+Mining requires HelpSpot access, so an outside contributor could not reproduce it
+regardless of where the data sat. Nothing in the build or the test suite depends
+on this directory.
+
+## Rebuilding it
+
+1. Mine each id range through the `helpspot_multi_get` MCP tool into
+   `mined-<from>-<to>.json`, keeping only patron-facing iOS reports and recording
+   for each: the patron's verbatim words, support's actual diagnosis, a category,
+   and the device block. A rate limit is a stop-and-report signal. Do not seek
+   credentials by any other route — an earlier run did, and it was a security
+   incident.
+2. `python3 consolidate.py` — deduplicates, then splits deterministically.
+
+## The split is the point
+
+`id % 3 == 0` goes to a sealed holdout. The rule is mechanical so it cannot drift
+toward whichever tickets would flatter a score, and stable so a lost corpus
+rebuilds identically from the same id ranges — which is exactly what happened
+once already.
+
+Only `authoring.json` may be read while writing keywords, copy, or priors.
+`holdout.json` stays sealed until that work is frozen and is then read once.
+
+## Two traps when re-deriving the priors
+
+Both were hit on the first re-derivation and both would have loosened a correct
+rule. They are also recorded next to the table in `CatalogValidator.swift`.
+
+**A keyword scan counts mentions, not prescriptions.** Re-deriving naively put
+"sign out and back in" at 7% for sign-in, appearing to contradict a shipped
+suppression. Reading the three tickets showed none of them prescribed it: one
+patron was already signed out and was walked to the login screen, one resolution
+merely explained that credentials persist until you sign out, and one described
+replacing a library card. Read the tickets before moving a cell.
+
+**Absence is only evidence for remedies support would write down.**
+Pull-to-refresh appears in 3 of 135 resolutions, so it reads 0% everywhere — not
+because it never helps but because it is too small to record. The <=3%
+suppression rule applies only to substantive remedies: update, reinstall,
+sign-out, switch-library.

--- a/Palace/Packages/PalaceTriageBot/corpus/consolidate.py
+++ b/Palace/Packages/PalaceTriageBot/corpus/consolidate.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Consolidate mined HelpSpot batches into an authoring set and a sealed holdout.
+
+Run from anywhere; reads and writes alongside this file.
+
+WHY THE SPLIT IS MECHANICAL. Once a ticket has been read while writing keywords
+or copy, it can no longer measure whether that work generalises — it measures
+whether we remembered it. So the split happens before anyone reads anything, by a
+rule nobody can nudge: `id % 3 == 0` goes to the holdout. It is stable across
+re-runs, verifiable by inspection, and independent of content, so it cannot drift
+toward whichever tickets would flatter a score.
+
+That stability also means a lost corpus can be reconstructed: re-mining the same
+id ranges puts the same tickets in the same halves.
+
+Only `authoring.json` may be opened while authoring catalog entries, keywords,
+copy, or the per-category remedy priors. `holdout.json` stays sealed until that
+work is frozen, and is then read ONCE. A second look starts spending the seal.
+"""
+import json, glob, os, re, collections
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+def norm(t):
+    """Collapse whitespace so near-identical filings compare equal."""
+    return re.sub(r"\s+", " ", (t or "")).strip().lower()
+
+def main():
+    records, seen_ids = [], set()
+    batches = sorted(glob.glob(os.path.join(HERE, "mined-*.json")))
+    for path in batches:
+        data = json.load(open(path))
+        for r in data.get("kept", []):
+            if r["id"] in seen_ids:      # same ticket returned by overlapping ranges
+                continue
+            seen_ids.add(r["id"])
+            records.append(r)
+
+    # One patron filing the same complaint twice (contact form AND direct email)
+    # appears as two ids with identical text. Keeping both would double-weight one
+    # voice in every rate computed from this corpus.
+    by_text, dupes = {}, 0
+    for r in sorted(records, key=lambda r: r["id"]):
+        key = norm(r["text"])
+        if not key:
+            continue
+        if key in by_text:
+            dupes += 1
+            continue
+        by_text[key] = r
+    records = list(by_text.values())
+
+    authoring = [r for r in records if r["id"] % 3 != 0]
+    holdout   = [r for r in records if r["id"] % 3 == 0]
+
+    for name, rows in (("authoring", authoring), ("holdout", holdout)):
+        json.dump(
+            {"split": name,
+             "rule": "id % 3 == 0 -> holdout",
+             "count": len(rows),
+             "records": rows},
+            open(os.path.join(HERE, f"{name}.json"), "w"),
+            indent=2, ensure_ascii=False,
+        )
+
+    cats  = collections.Counter(r["category"] for r in records)
+    acats = collections.Counter(r["category"] for r in authoring)
+    hcats = collections.Counter(r["category"] for r in holdout)
+    resolved = sum(1 for r in records if r.get("resolution"))
+
+    print(f"batches: {len(batches)}")
+    print(f"unique tickets: {len(records)}  (dropped {dupes} duplicate filings)")
+    print(f"  authoring: {len(authoring)}   holdout (SEALED): {len(holdout)}")
+    print(f"  with a recorded resolution: {resolved}/{len(records)}")
+    print("\ncategory        all  auth  hold")
+    for c, n in cats.most_common():
+        print(f"  {c:<12} {n:4}  {acats[c]:4}  {hcats[c]:4}")
+
+    # A category with too few resolved authoring tickets cannot support a
+    # per-category prior; the suppression rule needs >= 15. Say which ones are
+    # under it rather than letting a thin cell look measured.
+    print("\nresolved AUTHORING tickets per category (>=15 needed for a prior):")
+    for c in cats:
+        n = sum(1 for r in authoring if r["category"] == c and r.get("resolution"))
+        print(f"  {c:<12} {n:4}  {'ok' if n >= 15 else 'TOO THIN — treat as unknown, not zero'}")
+
+if __name__ == "__main__":
+    main()

--- a/docs/architecture/reviews/2026-08-remedy-ladder-review.md
+++ b/docs/architecture/reviews/2026-08-remedy-ladder-review.md
@@ -1,0 +1,198 @@
+# Architecture review: remedy delivery for the triage bot
+
+Recovered verbatim from the reviewing agent's transcript on 2026-08-14 and
+committed so it cannot be lost again. This is the review that produced the
+12-step implementation path for PP-4865's remedy ladders. It is preserved as
+written, including the objections that were later acted on, because the reasoning
+behind a decision is worth more than the decision.
+
+Reviewer role: independent architect (adversarial). Verdict:
+sound-with-reservations. Subject: the proposal to decouple remedy delivery from
+entry matching.
+
+Implementation status as of the commit that adds this file:
+
+| Step | Subject | State |
+|---|---|---|
+| 0 | Remedy cost tiers, pullToRefresh + switchLibrary cases | done |
+| 1 | generic_flow excluded from classification | done |
+| 2 | Unrecognised escalate offers the ladder | done |
+| 3 | Cells that must not get the ladder | done |
+| 4 | Existing guided-step engine reused | done |
+| 5 | Load-time CatalogValidator + suppressions | done; the full 42-cell explicit fixture is NOT built |
+| 6 | updateApp version gate | done |
+| 7 | Weak-recognition ticket scoping | done |
+| 8 | escalateWithTrace category-question fallback | done |
+| 9 | ResolutionTrace persistence | done |
+| 10 | Corpus non-regression report | not done; corpus was lost and is being re-mined |
+| 11 | Catalog ladders and copy | done; the sign-in ladder was rejected at copy review and deleted |
+
+Two of the review's objections turned out to describe live defects rather than
+risks: `claimsExhaustedEffort` was computed and never called, and
+`escalateWithTrace` never fell back to the category question, so a stepped entry
+without its own follow-up filed a ticket with nothing asked.
+
+The current-state description of the resulting system is in
+[triage-bot-remedy-delivery.md](./triage-bot-remedy-delivery.md).
+
+---
+
+All three findings are folded in below. I read the full branch (10 commits), the intent file, the classifier/reducer/models/catalog, the corpus splits (204/114 confirmed, sign-in is the largest category in both halves), and the test suites.
+
+# VERDICT: sound-with-reservations
+
+The inversion itself — remedy delivery decoupled from entry matching — is right, and Finding 1 makes it *more* right: elimination over a small safe set is exactly what you do when classification has no signal. But three specifics of the proposal as written are flawed and must change: (1) the safety claim is false — two of the six proposed rungs are destructive in this app; (2) the cost-weighted global order is contradicted by your own data (the signin row); (3) the ladder must not be new machinery or a new state — it should be catalog data executed by the existing guided-step engine. Amended that way, build it.
+
+---
+
+## (A) Objections, ranked
+
+### 1. The safety claim is false. Two rungs are destructive, and one can strand a patron. (attacks Q3)
+
+"A generic remedy is never WRONG advice, only sometimes unhelpful" fails on inspection of this app:
+
+- **signOutIn is destructive.** Signing out of a library in Palace removes that library's downloaded content. A patron who signs out and then *cannot sign back in* (expired card, ILS outage — the 26% staff-only class) has been converted from "app misbehaving, books still readable" to "signed out, books gone, locked out." Offering it to a **signin**-category complaint is the degenerate case: their stated problem is that sign-in doesn't work, and Finding 2 confirms support prescribes it there ~once in 55 tickets. The catalog already hands this advice out as prose with no warning (`KI-2026-001` step 3, `KI-2026-006` step 2, `KI-2026-008` step 3 in `Sources/TriageBotCore/Resources/catalog.json`) — the ladder work should retrofit the cost class onto those too, which the shared-remedy design below gives you for free.
+- **reinstall is worse.** Deletes every downloaded book across all libraries, and with the live Adobe activation history (PP-4951 — this very worktree's sibling branch is the activation single-flight fix) re-fulfillment after reinstall is not guaranteed. A patron told to reinstall the night before a flight loses the trip's reading. The reducer's own comment already knows this (`ConversationReducer.swift:144-147`).
+- **updateApp can be wrong**, not just unhelpful, when the patron is already on latest — and the bot *cannot know* the latest released version offline. `RemedyDetector` only catches patrons who volunteer "up to date." Mitigation exists and is cheap: the catalog is designed for hot update (`README.md:82-83`), so it can carry a `latest_known_version` field; compare with `context.appVersion` via the existing `SemanticVersion`/`FixVersionGate` machinery. Worst case staleness = one release behind = one wasted rung.
+- **reopenTitle mid-audiobook** risks playback position (the #18414 position-loss class); **toggleNetwork** ("switch to cellular") can bill a metered patron for a multi-hundred-MB audiobook.
+
+Consequence for the design: replace the safety *claim* with a safety *mechanism* — every `Remedy` carries a declared cost tier (`free` / `disruptive` / `destructive`), destructive rungs are last-or-never per category, always skippable, and carry a data-loss warning (copy-gated). The claim "categorically different risk profile from entry workarounds" survives only for the `free` tier.
+
+### 2. Cost-ordering is refuted by the data; order and membership must be per-category. (attacks Q4, folds Finding 2 + 3)
+
+The proposal's cost order would lead sign-in patrons with pull-to-refresh → update → reopen → **sign out/in** — and Finding 3 shows updateApp is 0% and signOutIn 2% for signin. The two cheapest rungs are the two least applicable in the largest category. Cost-weighting is the right *tiebreak within* a category's applicable set; it is wrong as the *selection* mechanism.
+
+**Is the per-category table the right shape, or overfitting 204 tickets?** The *shape* is right — 6 categories × 7 remedies = 42 enumerable cells, and per CLAUDE.md's own transition-table rule, an enumerated fixture where every cell is explicitly `allowed(rank)` / `suppressed` / `unknown→default` is exactly how this should ship. The *contents* are only trustworthy at the extremes. Use a pre-registered rule, not judgment per cell: deviate from a conservative global default only where the category has ≥15 resolved tickets AND the remedy is ≥20% (promote to front) or ≤3% (suppress). That yields: audiobook leads updateApp; library leads switchLibrary; download promotes reinstall (with its destructive gate — 26% prescription rate does not waive data loss); signin suppresses updateApp+signOutIn; reader inherits the default (n=4 is unknown, not zero). Middle cells (5–15%) inherit the default order — treating them as measured *would* be overfitting. Check the resulting table against the holdout **once**, as validation, and do not iterate against it — a second look starts spending the seal.
+
+One caveat you must record next to the table: **audiobook-updateApp at 55% is era-bound.** The corpus was mined while 3.2.x's broken fulfillment (`KI-2026-010`, `fixed_in`) was driving audiobook tickets; "update the app" was the prescription because a specific release was broken. That prior decays. This is another argument for the table being catalog *data* revisable at review cadence, for the `latest_known_version` gate (which naturally retires the rung as the fleet updates), and for objection 6 (you cannot re-derive the table without closing the telemetry loop).
+
+### 3. The ladder must not be a new state. It should be catalog data run by the existing guided-step engine. (answers Q1 + Q2)
+
+The proposal is silent on mechanism, and the failure mode from the earlier phase — adding state dimensions faster than review samples them — is live here. The right answer is **zero new `ConversationState.Step` cases**:
+
+Model each per-category flow as a catalog entry with `kind: "generic_flow"`, `symptom_keywords: []`, and `user_facing_steps` whose steps carry `remedy:` tags. Then the *entire* existing guided-flow machinery applies verbatim: already-tried skipping (`ConversationReducer.swift:335-361`), step advance/exhaust (`:417-470`), abandon-with-trace (`:509-536`), outcome-driven responses (`:472-507`), per-step diagnostics. The offer itself reuses `.matched(entryId:)` and the existing KB-card affordances (walk-me-through / file-anyway / dismiss).
+
+**What this does to every existing cell**, stated per the standing rule:
+
+| Cell | Effect |
+|---|---|
+| `.escalate`, no recognition (`escalate-novel`, `ConversationReducer.swift:197-217`) | **The one changed cell.** Destination becomes "offer generic flow" instead of `transitionToDrafting`; a catalog without a generic flow for the category preserves today's behavior exactly (back-compat cell, tested). |
+| `.escalate`, weak recognition | Also offers the flow, but the eventual ticket must stay scoped to the weak-recognized entry. No new state payload needed: `state.lastClassification.recognizedEntryId` already persists — the exhaustion path reads it for tags. This is a wiring requirement with its own test, not a new dimension. |
+| `.escalate` via `escalate_anyway` (`LocalClassifier.swift:195-207`) | **Unchanged — deliberately.** These entries encode "no safe self-serve fix exists"; that is the 26% staff-only class codified. Ladder never offered. |
+| `.suggest` / `.disambiguate` / how_to | Unchanged; matched entry always overrides — there are no merge semantics between entry steps and the ladder, the entry wins wholesale (answers Q1's "what if they disagree about order": they never co-execute). |
+| AI-fallback arms (`aiFallbackResolved`/`Unavailable`) | Same insertion point (they call `transitionToDrafting`); one shared branch. |
+| All `guidedStep` cells | Structurally identical; exercised by a second entry population, no code change. |
+| `awaitingEscalationFollowUp`, drafting, submitting, sent, error | Untouched; reached after exhaustion exactly as after an entry flow. |
+
+Should entries' steps BE remedy references rather than prose? **No.** Half the shipped steps are entry-specific and better than any generic rung ("check the top-right of your screen for airplane mode"). Keep `KBStep.remedy` as the optional annotation it already is — that annotation is the whole coupling the skip logic and telemetry need.
+
+One classifier change is required to keep this safe: `generic_flow` entries must be excluded from classification candidates so they can never win a suggest or pollute the trap slice (a one-line kind filter, tested — objection to *not* doing it: an empty-keyword entry currently still enters `candidates` and `consideredEntryIds`).
+
+### 4. The remedy concept is fragmenting into three representations, and two ladder rungs can't be skip-detected at all.
+
+`Remedy` exists in the detector, in `KBStep.remedy`, and now in the proposed ladder. If the ladder ships its own remedy list, wording and semantics drift across three surfaces. Unify on the `Remedy` enum as the single vocabulary (the design above does this automatically since rungs are `KBStep`s).
+
+Sharper version of the same objection: the proposed rungs **pull-to-refresh** and **switch/check library** have no `Remedy` case, so `alreadyTriedRemedies` cannot skip them. A patron who writes "I pulled down to refresh and nothing happened" would be told to pull-to-refresh — the exact "bot isn't listening" defect PP-4865 just fixed, reintroduced on the new surface on day one. Adding the enum cases + past-tense phrase lists is a prerequisite step, not polish. (Note for KMP parity: new raw-value cases change the shared JSON vocabulary — Android reader must tolerate unknown remedy strings.)
+
+### 5. The measurement loop the ordering story depends on does not exist. (answers Q5)
+
+"Accurate and consistent" must mean, testably:
+
+- **Consistency** = determinism: identical (text, category, context, catalog) → identical action sequence, including rung order. Already partially pinned by `ResponseDeterminismTests`; extend to ladder flows. This is also the argument against any in-app adaptive reordering — it destroys reproducibility of support conversations.
+- **Accuracy for the matcher** = the existing capture/misroute/trap numbers on the sealed slice. Unchanged by this work, and the TDD path must prove that (the classifier diff is one kind filter).
+- **Accuracy for the ladder** = per Finding 1, *not* "the right remedy was chosen" — that is unknowable from this corpus. The testable properties are: never offer a rung the patron already tried; never offer a suppressed cell; destructive rungs gated and last; termination within a bounded rung count with escalation always reachable; trace fidelity (the ticket records exactly what was tried, in order).
+- **What best-in-class measures that this design cannot:** resolution and re-contact. Intercom/Zendesk close the loop — did the issue end, did the patron come back within 7 days? This design emits per-step resolved events and then **discards the trace**: `ConversationReducer.swift:415` is literally `_ = trace` on the resolved path, and the prompt confirms the `KBStep.diagnostic` telemetry is "collected and unused." Until a `.persistResolutionTrace` effect exists and lands somewhere aggregable, every future claim about rung ordering — including re-deriving Finding 3's table as the 3.2.x era decays — is unfounded. This is the single highest-leverage small change in the plan, and it must precede any "learn from data" ambition. Re-contact linkage (ticket id ↔ later ticket) is genuinely out of reach client-side; say so in the docs rather than implying the telemetry covers it.
+
+The smallest honest learning mechanism (Q4's last part): none in-app. Static per-category order in catalog data; re-rank *manually* at catalog review cadence by Wilson lower bound on per-rung resolution once a rung has ≥50 attempts; pre-register that rule now. No bandits, no online weights — 318 tickets sliced 6 ways cannot support them.
+
+### 6. Patrons who should never enter the ladder, and one wiring gap that would blank their tickets.
+
+- `RemedyDetector.claimsExhaustedEffort` is **computed but never called by the reducer** (verified: its only reference outside the detector is its own unit test, `AlreadyTriedTests.swift:36`). "I've tried everything, nothing works" must bypass the ladder to a scoped ticket, or the bot walks an exhausted patron through rungs it was just told were futile.
+- Ladder length must be bounded (≤3 rungs per category flow, enforced by the validator) and the existing abandon escape (`userTappedAbandonGuidedFlow`) must be visible on every rung — the 26% staff-only patrons pay the ladder as pure delay; three cheap rungs is a defensible tax, six is not.
+- **Wiring gap:** `escalateWithTrace` consults only `entry.escalationFollowUp` (`ConversationReducer.swift:1030-1051`) — it never falls back to `categoryFollowUp` the way `askEscalationFollowUpOrDraft` does (`:966-972`). A generic-flow entry with no follow-up of its own would exhaust its rungs and file **without asking the category question** — recreating the blank-ticket class this branch just eliminated, on the new path. Fix and test regardless of the ladder; it's a latent gap for any stepped entry without its own follow-up.
+
+### 7. Housekeeping this phase should carry, not create
+
+`confidenceThreshold` is documented in-source as inert (`LocalClassifier.swift:169-184`) — delete it or re-derive it before adding another knob next to it. The `.disambiguate` arm asks a question with no answer path (`userAnsweredFollowUp` is a no-op, `ConversationReducer.swift:732-736`) — out of scope here, but do not route anything new through it.
+
+---
+
+## Responses to the three findings, explicitly
+
+1. **Agreed, and it reshapes the tests.** No component may be, or resemble, a complaint→remedy classifier. Test names below assert ordering/suppression/elimination/termination — none asserts "the right remedy was chosen."
+2. **Suppression mechanism: allowlist, not blocklist; data for composition, Core code for invariants.** Each category's flow *is* the allowlist (a remedy absent from a category's `generic_flow` is suppressed by default — a new remedy appears nowhere until a category explicitly includes it). The *evidenced invariants* (signin must not contain signOutIn or updateApp; destructive-never-first; length ≤3; every destructive rung skippable) live in a Core **load-time validator**, not only in test-time lint — because the catalog is designed to be server-supplied later, and a validator only in tests would let a hot-pushed catalog violate every rule ("test the producer, not the helper"). The shipped catalog additionally gets a `CatalogSchemaLintTests` pass, and the full 42-cell table is a committed fixture so adding a remedy or category fails a test until every new cell is explicitly decided.
+3. **Table shape right; contents thresholded as in objection 2; audiobook-updateApp flagged era-bound; reader = default; one-shot holdout validation.**
+
+---
+
+## (B) TDD path
+
+Ordered. Every step is pure `swift test` in the package — the reducer takes `KnowledgeBase` by injection (`ConversationReducer.swift:33-43`), so every test runs on a **synthetic fixture catalog** and is not blocked on copy sign-off. No UIKit seams are needed; the only new seam is the catalog validator, itself a pure function. Copy-gated steps are marked and sequenced last.
+
+**Step 0 — vocabulary: `Remedy.costTier` + two new cases.**
+- Failing test: `AlreadyTriedTests.testDetectsPullToRefresh_pastTense` — `alreadyTried(in: "I pulled down to refresh and nothing changed")` contains `.pullToRefresh`; sibling for `.switchLibrary` ("I switched to my other library card"). Also `RemedyCostTests.testEveryRemedyDeclaresACostTier` is *not* written (constant-assertion fluff); the tier is exercised by the validator tests in step 5 instead.
+- Min change: add `.pullToRefresh`, `.switchLibrary` cases + past-tense phrase lists mined from the authoring half; add `costTier` property (`free`/`disruptive`/`destructive`).
+- Guard-proof: delete the `.pullToRefresh` phrase list → test fails. (KMP note: document that the Kotlin reader must tolerate unknown remedy raw values.)
+
+**Step 1 — `generic_flow` entries are invisible to the classifier.**
+- Failing test: `LocalClassifierTests.testGenericFlowEntries_neverCompeteForMatches` — synthetic KB where a `generic_flow` entry's keywords are the patron's exact words; assert decision is `.escalate`, `recognizedEntryId == nil`, and the generic id is absent from `consideredEntryIds`.
+- Min change: add `KBKind.genericFlow`; filter it out of `candidates` in `LocalClassifier.classify` (`LocalClassifier.swift:28-34`).
+- Guard-proof: remove the kind filter → the generic entry wins a suggest → test fails. This is also what keeps the trap slice's zero-misroute guarantee intact.
+
+**Step 2 — the changed cell: unrecognized escalate offers the flow; absent flow preserves today.**
+- Failing tests: `GenericLadderTests.testEscalateNovel_withCategoryGenericFlow_offersFlowNotImmediateDraft` — after `userSubmittedDescription` with no-match text, `next.step == .matched(entryId: "GF-…")`, a `.kbMatch` message is appended, and **no** `.ticketPreview` exists; and `testEscalateNovel_withoutGenericFlow_draftsExactlyAsToday` — fixture without a generic flow reproduces the current `awaitingEscalationFollowUp`/drafting outcome byte-for-byte.
+- Min change: in the escalate arm (`ConversationReducer.swift:197-217`) and the two AI-fallback arms, branch to the generic entry when the category has one.
+- Guard-proof: hard-code `transitionToDrafting` back → first test fails; delete the no-flow fallback → second fails.
+
+**Step 3 — cells that must NOT get the ladder.**
+- Failing tests: `GenericLadderTests.testEscalateAnywayEntry_neverOffersLadder` (strong match on an `escalate_anyway` fixture entry → targeted follow-up, no generic offer); `testMatchedEntry_overridesLadderEntirely` (a `.suggest` never routes near the generic flow); `testBlanketTriedEverything_bypassesLadder_ticketTaggedExhaustedEffort` — "I've tried everything, nothing works" → no offer, straight to the category follow-up, draft carries an `exhausted-effort` tag.
+- Min change: consult `remedyDetector.claimsExhaustedEffort` at `ConversationReducer.swift:120` (store alongside `alreadyTriedRemedies`), branch in the escalate arm.
+- Guard-proof: make the ladder offer unconditional on escalate → first and third tests fail. This step wires the currently-dead `claimsExhaustedEffort` (objection 6).
+
+**Step 4 — machinery reuse proven, not assumed.**
+- Test: `GenericLadderTests.testLadderFlow_skipsAlreadyTriedRungs_andAcknowledges` — description states a past reinstall; category flow contains a reinstall rung; assert the flow starts at the first untried rung and the acknowledgement message is present. `testLadderFlow_allRungsAlreadyTried_escalatesWithEmptyTraceAndNoFalseFailureClaim` — reuses the PP-4865 c8c9ee3e8 behavior on the new entry population.
+- Min change: none expected (that's the point of the design). If these pass first-run, prove they bite by mutation: comment out the `intersection` at `ConversationReducer.swift:335` → both fail. If they *don't* bite, the design claim "zero new machinery" was wrong and the step catches it.
+
+**Step 5 — the 42-cell table + load-time validator (the suppression mechanism, Finding 2/3).**
+- Failing tests: `CatalogValidationTests.testSigninFlowContainingSignOutIn_isRejectedAtLoad`; `testDestructiveRungBeforeNondestructive_isRejected`; `testFlowLongerThanThreeRungs_isRejected`; `testDestructiveRungWithoutSkippableResponse_isRejected`; and `RemedyCategoryTableTests.testEveryCategoryRemedyCellIsExplicitlyDecided` — loads the committed 42-cell fixture (`Fixtures/RemedyCategoryTable.json`, cells = `allowed(rank)` / `suppressed(evidence:)` / `default`), asserts the fixture is total over `KBCategory.allCases × Remedy.allCases` and that every shipped generic flow is consistent with it. Adding a remedy or category makes the totality assertion fail until each new cell is decided.
+- Min change: `CatalogValidator` (pure func) invoked from `KnowledgeBase.init`/catalog load — **not** only from tests, per objection re: future server catalogs; validator failure falls back to last-known-good/bundled catalog.
+- Guard-proof: hand the validator a signin flow containing `signOutIn` → must reject; disable the load-time call (leaving only lint) → a runtime-load test with a violating in-memory catalog fails.
+
+**Step 6 — updateApp version gate.**
+- Failing tests: `GenericLadderTests.testUpdateAppRung_skippedWhenAppVersionAtOrPastLatestKnown`; `…offeredWhenBehindLatestKnown`; `…offeredWhenVersionUnknown` (conservative: unknown → offer; a wasted rung beats a suppressed fix).
+- Min change: optional `latest_known_version` on `KBCatalog`; skip predicate reusing `SemanticVersion` comparison, applied in `nextUntriedStepIndex` alongside the already-tried skip.
+- Guard-proof: flip the comparison → the behind-version test fails.
+
+**Step 7 — weak-recognition scoping survives the ladder.**
+- Failing test: `GenericLadderTests.testWeakRecognition_ladderExhausted_ticketStillScopedToRecognizedEntry` — weak-only match → ladder offered → all rungs fail → assert draft tags/`matchedEntryId` reference the weak-recognized entry (read from `state.lastClassification`), not the generic flow id, and the trace still shows the generic rungs tried.
+- Min change: exhaustion path reads `lastClassification?.recognizedEntryId` when the flowing entry is `generic_flow`.
+- Guard-proof: tag with the generic id instead → fails.
+
+**Step 8 — escalateWithTrace category-follow-up fallback (pre-existing gap, objection 6).**
+- Failing test *against current code*: `EscalationFollowUpTests.testGuidedFlowExhausted_entryWithoutOwnFollowUp_asksCategoryQuestion` — fixture entry with steps but no `escalationFollowUp`, catalog with a category follow-up; walk to exhaustion; assert `.awaitingEscalationFollowUp` with the category prompt. Fails today at `ConversationReducer.swift:1030-1051`.
+- Min change: route `escalateWithTrace` through the same fallback as `askEscalationFollowUpOrDraft:966-972`.
+- Guard-proof: revert to entry-only lookup → fails. Without this, ladder-exhausted tickets are blank — the regression this branch exists to prevent.
+
+**Step 9 — stop discarding the resolution trace.**
+- Failing test: `TelemetryContractTests.testResolvedGuidedFlow_emitsPersistResolutionTraceEffect` — assert a `.persistResolutionTrace(trace)` effect on the resolved path (`ConversationReducer.swift:385-415`), and on exhausted + abandoned paths, with outcome and per-step diagnostics intact.
+- Min change: new `ConversationEffect` case replacing `_ = trace` at `:415`; `TriageBotIOS` host appends to a local log (existing persistence seam pattern, `PendingDraftStore`).
+- Guard-proof: delete the effect append → fails. **This step is what makes any future data-driven reordering honest; it must land in this phase even though nothing reads the log yet — pre-register the reorder rule (≥50 attempts/rung, Wilson lower bound, manual at catalog review) in the entry's doc comment now.**
+
+**Step 10 — corpus-level non-regression.**
+- Tests: extend `MatchCorpusTests` reporting with an `offered_ladder` column for blind-escalated cases (reported, like held-out capture — not gated, same rationale as `MatchCorpusTests.swift:201-214`); assert `testLadder_neverPreemptsACapturableCase` — every previously-captured corpus case still reaches its entry. Existing trap/near-miss zero-misroute assertions and the mined ratchet (≥7) must pass untouched — proving the classifier diff was only the kind filter.
+- Guard-proof: make the offer branch fire on `.suggest` → preemption test fails.
+
+**Step 11 — copy + shipped catalog (GATED: product sign-off; last, behind a flag).**
+- Author the per-category `generic_flow` entries in `catalog.json` per the thresholded Finding-3 table (audiobook: updateApp→reopenTitle→…; library: switchLibrary→…; signin: pullToRefresh/restart-tier only, **no** signOutIn/updateApp; reader: global default; destructive rungs last with warning copy), plus the offer-card copy and destructive-rung warnings. Gate behind a remote-config flag defaulting off (`triage_bot_generic_ladder_enabled`), same pattern as the existing flags (`README.md:19-37`). Batch into the same product-sign-off review as the nine `how_to` escalation prompts the intent file records as still unsigned (`.forgeos/intent/triage-bot-keyword-strength-tiers.md:104-107`) — that debt predates this phase; don't add to the pile twice.
+- Everything in steps 0–10 ships green with fixture catalogs regardless of when sign-off lands.
+
+### Do NOT build
+
+- Any complaint→remedy classifier or per-complaint remedy ranking (Finding 1: four independent methods found no signal).
+- In-app adaptive/bandit reordering of rungs (overfits 204 tickets; breaks determinism, which is the "consistency" half of the bar).
+- A new `ConversationState.Step` case, a parallel step-walker, or merge semantics between entry steps and ladder rungs (entry wins wholesale).
+- A blocklist-style suppression rule engine (the per-category allowlist plus the load-time validator covers it with less surface).
+- restartDevice/otherDevice rungs just because the enum has them — no category earns them under the ≥20% promote rule; `otherDevice` isn't even a fix, it's a diagnostic, and belongs (if anywhere) in escalation follow-ups.
+- New matcher/keyword coverage work inside this phase — it is orthogonal, and coupling it would make the ladder's measured delta unattributable (the same discipline the intent file applied to the strength-tier change).
+
+The 42-cell table fixture, the load-time validator, and the trace-persistence effect are the three pieces I would refuse to let ship without — they are respectively the enumerated-cells answer, the producer-side guard, and the only path to ever replacing today's priors with measured ones.

--- a/docs/architecture/triage-bot-remedy-delivery.md
+++ b/docs/architecture/triage-bot-remedy-delivery.md
@@ -62,7 +62,10 @@ escalation is where most patrons land.
 Escalation is not a dead end. Three things happen there, in order of preference:
 
 1. If an entry was recognised, the ticket carries its identity so support sees a
-   scoped report rather than "a patron reports a problem".
+   scoped report rather than "a patron reports a problem". This holds on all
+   three exits from a ladder: exhausting it, abandoning it, and declining it.
+   The third was added late, after review found that declining a ladder filed the
+   ladder's own id and dropped the recognition.
 2. The patron is offered the category's remedy ladder, if one exists.
 3. When the ladder is exhausted or the patron declines it, a question is asked
    before the ticket is filed. The entry's own question is used when recognition
@@ -78,9 +81,13 @@ has no signal to work with.
 Ladders reuse the existing guided-step engine rather than introducing new
 machinery. Already-tried skipping, step advance, exhaustion, abandonment and
 per-step telemetry all apply without modification, and no new conversation state
-was added. Exactly one existing transition changed: an unrecognised escalation now
-offers the ladder before drafting a ticket. A catalog with no ladder for a
-category behaves exactly as it did before.
+was added. Exactly one existing transition changed: an escalation that produced
+no suggestion now offers the ladder before drafting a ticket. That includes
+weakly-recognised escalations, not only wholly unrecognised ones — a weak match
+scopes the ticket but does not answer the patron, so the ladder is still the
+better thing to offer. It excludes `escalate_anyway` entries and patrons who said
+they had tried everything. A catalog with no ladder for a category behaves
+exactly as it did before.
 
 ### Rules a ladder must satisfy
 
@@ -179,7 +186,10 @@ attempts, ranking on the Wilson lower bound of their resolution rate.
   catalog reaches those; they are the permanent argument for asking one good
   question rather than guessing.
 - The category chip is a hard filter. A decisive match in another category is
-  discarded unseen.
+  discarded unseen, and because the filter runs before scoring, the conflict is
+  not merely unresolved but undetectable. When no chip is tapped at all the
+  classifier already scans the whole catalog, which is token-driven area
+  identification and is the cheapest place to start improving this.
 - A message asking two questions is answered with one entry or none.
 - The per-category priors are era-bound. Audiobook's update-the-app rate reflects
   one broken release and will decay, which is why they live in catalog data and

--- a/docs/architecture/triage-bot-remedy-delivery.md
+++ b/docs/architecture/triage-bot-remedy-delivery.md
@@ -1,0 +1,189 @@
+# Triage bot: how remedies reach patrons
+
+Status: implemented on `spike/triage-bot-keyword-strength-tiers`, pending review.
+Supersedes nothing. Companion to the classifier comments in `LocalClassifier.swift`.
+
+## The problem this solves
+
+QA reported that the in-app triage bot answered nearly every message with "I
+haven't seen exactly that before, let me file a ticket", and never showed
+troubleshooting steps. That was accurate, and the cause was not the one it
+looked like.
+
+Guided troubleshooting steps exist only on `known_issue` entries, and those
+entries required two distinct keyword match regions before the bot would offer
+them. A patron writes one short sentence naming one symptom, so real messages
+scored one region and escalated. The bot was frequently identifying the correct
+entry and then discarding it.
+
+Measured against 114 support tickets that postdate every catalog entry, the
+shipped bot answered 13 and escalated 100 with no remedy offered at all. Against
+that, 42 percent of real resolutions name an action the patron could have taken
+themselves. The gap was not exotic. It was a handful of remedies that existed in
+the catalog but were reachable only through an entry match that usually did not
+happen.
+
+## Three findings that shaped the design
+
+**Keyword strength is the axis, not keyword count.** `symptom_keywords` mixed
+evidence of very different quality in one flat list. KI-008 listed both "won't
+download" (decisive) and "download" (meaningless alone) and the classifier could
+only count them. The two-region floor was a blunt proxy for "do not trust weak
+evidence", and it suppressed the decisive phrases along with the vague ones.
+Splitting the list into strong evidence (sufficient alone) and corroborating
+evidence (never sufficient) lets the gate ask the right question.
+
+**Patron wording does not predict which remedy applies.** Grouping tickets by the
+remedy support prescribed and mining for distinguishing patron language returns
+noise. Four independent methods came up short on the same corpus: measured
+keyword strength, extractive answer copy, discriminating phrase mining, and
+on-device sentence embeddings. This is a property of the data, not a gap in
+effort, and it is the single most important constraint on the design. Nothing in
+this system may be, or resemble, a complaint-to-remedy classifier.
+
+**Per-category priors do carry signal.** While individual complaints do not
+predict a remedy, categories do. Support prescribed "update the app" for 55
+percent of resolved audiobook tickets and 0 percent of resolved sign-in tickets.
+That is what orders and filters the remedy ladders.
+
+## How a message becomes a response
+
+A patron taps a category chip, which narrows scoring to that category, then
+describes the problem. The classifier tokenises both the message and each
+candidate entry's keywords, matches whole words only, and merges overlapping hits
+into distinct regions so that an entry listing a phrase and its head noun scores
+the concept once. Strong regions are worth a full unit and corroborating regions
+half, saturating at three.
+
+An entry is suggested only when it has at least one strong region, clears its own
+threshold, and leads the runner-up. Otherwise the message escalates, and
+escalation is where most patrons land.
+
+Escalation is not a dead end. Three things happen there, in order of preference:
+
+1. If an entry was recognised, the ticket carries its identity so support sees a
+   scoped report rather than "a patron reports a problem".
+2. The patron is offered the category's remedy ladder, if one exists.
+3. When the ladder is exhausted or the patron declines it, a question is asked
+   before the ticket is filed. The entry's own question is used when recognition
+   was strong; otherwise the category's catch-all, which presumes nothing.
+
+## Remedy ladders
+
+A ladder is a catalog entry of kind `generic_flow` whose steps carry remedy tags.
+It claims nothing about what is wrong. It offers a short sequence of safe actions
+and lets the patron eliminate them, which is the correct shape when classification
+has no signal to work with.
+
+Ladders reuse the existing guided-step engine rather than introducing new
+machinery. Already-tried skipping, step advance, exhaustion, abandonment and
+per-step telemetry all apply without modification, and no new conversation state
+was added. Exactly one existing transition changed: an unrecognised escalation now
+offers the ladder before drafting a ticket. A catalog with no ladder for a
+category behaves exactly as it did before.
+
+### Rules a ladder must satisfy
+
+Enforced by `CatalogValidator` at catalog load, not only in tests, because the
+schema is designed to be server-supplied later. A rule that lives only in the test
+suite is a rule the shipped app does not have. A ladder that breaks a rule is
+dropped and the rest of the catalog survives.
+
+- **Suppressed remedies per category.** Derived from resolution data using a
+  pre-registered threshold rather than per-cell judgement: suppress only where a
+  category has at least 15 resolved tickets and the remedy was prescribed in at
+  most 3 percent of them. Categories below that count are unknown, not zero.
+- **Destructive remedies never go first, and are always refusable.**
+- **At most three rungs.** The quarter of patrons whose problem only staff can
+  resolve pay the whole ladder as delay before reaching a human.
+
+### Remedy cost tiers
+
+The claim that a generic remedy is never wrong, only unhelpful, is false in this
+app, and the design does not rely on it.
+
+Signing out removes that library's downloaded content, and a patron who then
+cannot sign back in, which describes a quarter of real tickets, has gone from an
+app that misbehaves to books they cannot open. Reinstalling deletes every
+download across every library, and given the Adobe activation history in PP-4951,
+re-fulfilment afterwards is not guaranteed. Both are classified `destructive`.
+
+Recommending an update is `free` but can still be wrong when the patron is
+already current, so the catalog may declare `latest_known_app_version` and the
+ladder skips that rung for anyone at or past it. Unknown values offer the rung: a
+wasted step costs seconds, a withheld one may cost the fix.
+
+## What the bot will not do
+
+- Ask a patron to do something they already said they did. Messages are scanned
+  for past-tense statements of having tried a remedy, and those steps are skipped
+  with an acknowledgement so the omission does not read as steps going missing.
+- Walk a patron through remedies after they said they had tried everything.
+- Offer a ladder for an `escalate_anyway` entry, which encodes that no safe
+  self-serve fix exists.
+- Ask an entry's bug-specific question off weak evidence. Every such question in
+  the catalog presumes its own bug, and asked off a lone generic word it reads as
+  the bot inventing a problem.
+- Adapt rung ordering in-app. Reproducibility is half of what consistency means
+  for a support tool, and 204 tickets sliced six ways cannot support online
+  learning.
+
+## Sign-in has no ladder, deliberately
+
+Both cheap remedies were suppressed for sign-in by evidence: support prescribed
+"update the app" zero times in 41 resolved sign-in tickets, and "sign out and back
+in" once. The remaining candidate rung asserted a mechanism nobody had measured,
+and was tagged with a remedy it did not actually perform, which would have
+polluted its own telemetry from the first day.
+
+Copy review rejected it. Sign-in goes directly to the question that separates its
+two largest real clusters: whether the card came from the library or was created
+in the app. A test pins this, so a future sign-in ladder has to be argued for.
+
+## Measuring this
+
+Two rates, and they trade against each other. A change that moves only one has not
+been evaluated.
+
+**Capture** is how many messages with a real answer in the catalog receive it.
+**Misroute** is how many receive the wrong entry's workaround, which is worse than
+escalating because the patron acts on it.
+
+The scored corpus in `Fixtures/MatchCorpus.json` slices cases by provenance, and
+the slice determines what a score means:
+
+- `mined` tickets are the ones the catalog was authored from. A high score here
+  is memorisation and is an upper bound only.
+- `held_out` tickets postdate the catalog. This is the honest generalisation
+  measure, and it is reported rather than asserted, because gating it would create
+  pressure to close gaps by writing keywords against it, spending the only
+  unbiased signal available.
+- `trap` cases are generic complaints that must escalate.
+- `near_miss` cases contain a strong keyword but were resolved to a different
+  cause. This slice exists because the trap slice cannot fail: it samples only
+  inputs whose overlap is a weak word, and the partition decides what is weak, so
+  a mis-partitioned strong keyword can never appear there. The near-miss slice
+  found two real misroutes on its first run.
+
+Resolution traces are persisted on all three terminal outcomes, including
+resolved, which previously produced no record because success files no ticket.
+Nothing reads that log yet. It is the precondition for replacing today's
+per-category priors with measured rates, and the rule for doing so is
+pre-registered so it cannot later be set by whoever wants a number to move:
+re-rank at catalog review cadence only, only for rungs with at least 50 recorded
+attempts, ranking on the Wilson lower bound of their resolution rate.
+
+## Known limits
+
+- Roughly 8 percent of real messages are under a dozen words. No keyword and no
+  catalog reaches those; they are the permanent argument for asking one good
+  question rather than guessing.
+- The category chip is a hard filter. A decisive match in another category is
+  discarded unseen.
+- A message asking two questions is answered with one entry or none.
+- The per-category priors are era-bound. Audiobook's update-the-app rate reflects
+  one broken release and will decay, which is why they live in catalog data and
+  why trace persistence matters.
+- On-device sentence embeddings were measured against keywords and performed
+  worse, with no usable confidence threshold. Lemmatisation remains worth taking:
+  it would let the catalog carry one spelling instead of hand-listing variants.

--- a/docs/architecture/triage-bot-remedy-delivery.md
+++ b/docs/architecture/triage-bot-remedy-delivery.md
@@ -42,9 +42,18 @@ effort, and it is the single most important constraint on the design. Nothing in
 this system may be, or resemble, a complaint-to-remedy classifier.
 
 **Per-category priors do carry signal.** While individual complaints do not
-predict a remedy, categories do. Support prescribed "update the app" for 55
-percent of resolved audiobook tickets and 0 percent of resolved sign-in tickets.
-That is what orders and filters the remedy ladders.
+predict a remedy, categories do. The clearest split is the class of tickets whose
+resolution was "a fix exists or is coming", which the patron can act on only by
+getting the build: 26 of 36 resolved audiobook tickets, and 0 of 44 resolved
+sign-in tickets. That is what orders and filters the remedy ladders.
+
+Counting that class needs care, and an earlier draft of this document had the
+audiobook figure wrong. Its dominant phrasing is "known issue with certain
+audiobooks; fixed in Palace v3.2.3" — which contains no form of the words
+"update" or "wait", so a scan built from remedy names misses almost all of it
+while a scan for "fix" sweeps in unrelated prose. The rate is only reproducible
+by matching the resolution's shape, not its vocabulary, which is the same trap
+as counting mentions instead of prescriptions.
 
 ## How a message becomes a response
 


### PR DESCRIPTION
## Summary

QA reported (PP-4865) that the in-app triage bot answers almost everything with "I haven't seen exactly that before — let me file a ticket," and never shows troubleshooting steps. That was accurate. This PR makes the bot answer what it recognises, offer a short safe remedy sequence when it does not, and always ask one scoped question before filing — so support stops receiving tickets that say only "a patron reports a problem."

## Root cause

Guided troubleshooting steps exist only on `known_issue` entries, and those entries required **two distinct keyword match regions** before the bot would offer them (`LocalClassifier`, the F-002 precision guard). A patron writes one short sentence naming one symptom, so real messages scored exactly one region and escalated.

The bot was frequently identifying the correct entry and then discarding it. Lowering the floor to 1 is not the fix: measured over the shipped catalog it recovers 9/11 genuine complaints but newly misroutes 6/7 generic ones — "the app crashes when I open it" would have returned the CarPlay SIGABRT workaround to a patron who has never opened CarPlay.

The real defect is that `symptom_keywords` mixed evidence of very different quality in one flat list. KI-008 listed both "won't download" (decisive) and "download" (meaningless alone), and the classifier could only count them. The two-region floor was a blunt proxy for "do not trust weak evidence," and it suppressed the decisive phrases along with the vague ones.

## Solution

**Keyword strength replaces keyword count.** `symptom_keywords` now means strong evidence — one is grounds to suggest. `corroborating_keywords` is weak evidence that raises confidence but is never sufficient alone. Suggestion requires ≥1 strong region rather than ≥2 regions of any quality.

**Matching is tokenised.** Substring matching had `stalled` firing inside `reinstalled`, which sent a launch-crash report download-and-network advice.

**Remedy ladders** (`kind: "generic_flow"`) handle the majority case where nothing matches. A ladder claims nothing about what is wrong; it offers a short sequence of safe actions and lets the patron eliminate them. It reuses the existing guided-step engine — no new `ConversationState` cases — so already-tried skipping, advance, exhaustion and per-step telemetry all apply unchanged.

**Remedies carry a cost tier.** The claim that a generic remedy is "never wrong, only unhelpful" is false here: signing out removes that library's downloaded content, and a patron who then cannot sign back in has gone from an app that misbehaves to books they cannot open. Reinstalling deletes every download across every library, and with the Adobe activation history (PP-4951) re-fulfilment afterwards is not guaranteed. Destructive rungs never go first and are always refusable.

**The bot stops asking patrons to do what they already did.** 10% of real tickets open by listing prior attempts; those steps are now skipped with an acknowledgement, so the omission does not read as steps going missing.

**Nothing files blank.** Every category has a catch-all question that presumes no cause — for sign-in, whether the card came from the library or was created in the app, which splits its two largest real clusters in one answer.

**`CatalogValidator` runs at catalog load**, not test-only, because the schema is designed to be server-supplied later. A rule that lives only in the test suite is a rule the shipped app does not have.

## Evidence

- `scripts/verify-pr.sh --quick --diff-baseline` → **30/31**; the only red is `unit_tests`, triaged below. An earlier run on the pre-rebase tree was **31/31 `CLEAR`**. Self-attested (local, sim `iPhone 17 Pro`).
- `unit_tests` red is **contention, not regression** — and the triage is worth reading because the gate could not do it itself. The run reported "1 failures"; its xcresult had **5**, three of them `Test crashed with signal kill` rather than assertion failures. A second session was running the full `Palace` suite concurrently from another worktree (load 6.81). All five classes — `SamplePlayerErrorTests`, `TPPBookRegistryLargeCorpusTests`, `InflightFeedFetchesTimeoutTests`, `BookRegistrySyncTests`, `TPPBookRegistryLoadReentrancyTests` — pass in isolation: **57 tests, 0 failures**, each suite confirmed to have actually executed. None is in the triage bot. `--diff-baseline` could not auto-triage because it failed to extract class names from the xcresult.
- TriageBotCore `swift test` → **378 tests, 0 failures**, top-level `All tests` rollup → **CI-reproduced** by `.github/workflows/unit-testing.yml` ("Run PalaceTriageBot package tests"). Note that step is Core-only; `TriageBotIOS`/`TriageBotUI` have no CI tests and are covered only by the app build.
- Full `Palace` app build for iOS Simulator → `BUILD SUCCEEDED`, 233 Swift compile tasks, with all four app files that `import TriageBotCore` recompiled — self-attested. This mattered: `TriageBotUI` sits behind `canImport(UIKit)`, so macOS `swift test` compiles it out entirely, and a missing `persistResolutionTrace` case broke the iOS build while macOS stayed 378/0.
- No-blank-ticket floor → `MatchCorpusTests` walks each corpus case to `.drafting` and asserts every draft carries identification, guarded by `XCTAssertGreaterThan(filed, 20)` so the assertion cannot pass vacuously over an empty set.
- Public-surface audit → all 27 declarations flagged by `check-blast-radius.py` were flipped to `internal` and rebuilt. Exactly one fails to compile (`KBEscalationFollowUp.init(from:)`, required to witness `Decodable`); the other 26 had no consumer and stayed narrowed. Determined by the compiler, not by inspection.

**Measured on the sealed holdout** (115 tickets postdating every catalog entry, split by `id % 3 == 0` before any were read): 10% receive a specific answer, 57% are offered a ladder, 33% receive a question only, **0% file blank**. The 33% is exactly the sign-in cohort, which has no ladder by design.

**Corpus figures were re-derived for this PR and two were wrong** — corrected in `b77ef5d6c`. `waitForFix` was documented as "44 of 212 resolved tickets"; 212 is the corpus total, and the class is 29 of the 135 that have a recorded resolution (21%, still the largest single class, 26 of 36 within audiobook). The design doc's "55 percent of resolved audiobook tickets" was likewise replaced with the measured 26 of 36. The priors the code actually depends on survive — sign-in is 0 of 44, which is what the sign-in suppression rests on. The cause is recorded next to the number, because it nearly produced a third error: the dominant phrasing is "known issue with certain audiobooks; fixed in Palace v3.2.3", which contains no form of "update" or "wait", so a scan built from remedy vocabulary reads 6% and a scan for "fix" reads 26%.

## Repro

- Scenario: patron opens support, taps a category, describes one symptom in one sentence. Jira: **PP-4865**
- Replay / fixture: `Tests/TriageBotCoreTests/Fixtures/MatchCorpus.json` (provenance-sliced: `mined` / `held_out` / `trap` / `near_miss`), driven by `MatchCorpusTests` and `HoldoutGeneralizationTests`.

QA's three scenarios from build 490, re-run against this branch at the same 3.2.3 context:

| QA input | build 490 | this branch |
|---|---|---|
| `audiobook download failed` | "I haven't seen exactly that before" | offers the download entry, hedged |
| `Invalid credentials error` | "I haven't seen exactly that before" | asks the library-card-origin question |
| `ebook lost last read position` | "I haven't seen exactly that before" | offers the Reading remedy ladder |

## Class

- Recurrence-of: `none` — new class: **`precision-guard-suppresses-signal`** (a guard that gates on a proxy for evidence quality — here match *count* — and suppresses the strong evidence along with the weak).

## Obligations

- [ ] `waitForFix` is implemented and cost-tiered but **no catalog entry references it**, so the bot still cannot tell a patron a fix is coming — despite that being the largest single resolution class in the corpus (29 of 135 resolved tickets, 21%; 26 of 36 within audiobook). Needs per-entry copy on the four `open` entries, and "a fix is coming" is a product commitment. — owner: product + @maurice
- [ ] `redownloadTitle` is not a tagged remedy; KI-2026-007 walks patrons through it untagged, so it is unskippable and invisible to telemetry. — owner: @maurice
- [ ] Ladder `updateApp` rungs have no "already up to date" response, so resolution traces will record no-op attempts as failures. KI-2026-010 has the correct shape to copy. — owner: @maurice
- [ ] `verify-pr.sh` under-reports, repeatedly and in more than one way. It prints only the **first 3** blast-radius findings, so a partial fix reads as complete (24 stayed hidden). Its unit-test tally disagreed with the xcresult on every run — `2815/1` vs `8246/7`, then `4786/1` vs `8250/5` — and it once recorded `[PASS]` for a run whose xcresult had 3 failures. `--diff-baseline`'s class-name extraction fails on these xcresults, so the auto-triage it exists for does not fire. Separately, `-only-testing` silently ignores unknown class names and still prints `TEST SUCCEEDED`, which makes hand-triage quietly wrong unless suite execution is asserted. A gate that under-reports is the exact failure mode the green-board contract exists to prevent. — owner: @maurice
- [ ] Nothing consumes `persistResolutionTrace` yet beyond a Firebase event. It is the precondition for replacing today's per-category priors with measured rates; the re-ranking rule is pre-registered in the design doc so it cannot be set later by whoever wants a number to move. — owner: @maurice

## Scope

Touches the `PalaceTriageBot` package (classifier, reducer, catalog, validator) plus its docs and corpus pipeline. No app-target behaviour outside the support sheet. Catalog grows 18 → 24 entries.

Deliberately **not** touched: the category chip remains a hard filter, so a decisive match in another category is still discarded unseen. Nothing here is, or resembles, a complaint-to-remedy classifier — four independent methods (measured keyword strength, extractive copy, discriminating n-grams, on-device sentence embeddings) each failed to find signal for that, and a pre-registered area-ID gate failed its own thresholds and was refused rather than shipped.

## Not done / Deferred

**Not done:** `waitForFix` ships detection-only (see Obligations). The bot recognises a patron saying they will wait, but cannot say it.

**Scope:** classifier evidence model, remedy delivery, catalog content, and the validator. Access-level narrowing of 26 package declarations rides along because the public-surface gate surfaced them.

**Deferred:** `redownloadTitle`; "already up to date" ladder responses; storage / date-time / VPN checks, which need a `DeviceSignals` seam in `TriageBotIOS`; copy sign-off for the nine pre-existing `how_to` prompts.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
