### PR TITLE
chore(toolkit): bump to 9802581a — ships the PP-4955 crash fix

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1852,6 +1852,7 @@
 		EA0245CC67E44E6B98E0943D /* AudiobookLoadFailureSAMLReauthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363B8BAFC71462390D7DD31 /* AudiobookLoadFailureSAMLReauthTests.swift */; };
 		EA12FB34567890ABCDEF0002 /* EPUBToolbarToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA12FB34567890ABCDEF0001 /* EPUBToolbarToggleTests.swift */; };
 		EA4E793DB293880E4CFCADC7 /* AppContainerIsolationLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CEA3369458249AC6239C383 /* AppContainerIsolationLintTests.swift */; };
+		EA87B0AABCBF12E1F8B6D1FE /* ManifestFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436767C8EF996AEDAA2C422E /* ManifestFixture.swift */; };
 		EAA257DC34BE8DF11BDD43A7 /* MockSyncBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48995B25FD329E6962BC998 /* MockSyncBackend.swift */; };
 		EAD51505BBFD93F738787019 /* OfflineQueueServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FEEC427223FFDB026D6137 /* OfflineQueueServiceProtocol.swift */; };
 		EAF119E22F1A6B735238C6D4 /* TPPSignInBusinessLogicStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5F04553ABBB927952EB31B /* TPPSignInBusinessLogicStateMachineTests.swift */; };
@@ -2501,6 +2502,7 @@
 		426F162F6CFC705CE42A45B2 /* CarPlayAuthHelperReadinessTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarPlayAuthHelperReadinessTests.swift; sourceTree = "<group>"; };
 		42F178DBC9EBCF7C7FA70BEC /* FocusIndicationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FocusIndicationTests.swift; sourceTree = "<group>"; };
 		43040747774740399559510F /* UserRetryTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRetryTracker.swift; sourceTree = "<group>"; };
+		436767C8EF996AEDAA2C422E /* ManifestFixture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManifestFixture.swift; sourceTree = "<group>"; };
 		43D3F34D468B2BB51C86A5BA /* AudiobookPositionAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookPositionAdapter.swift; sourceTree = "<group>"; };
 		440B8B1CCFD6A6D539D6AB83 /* RatingFeedbackPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingFeedbackPresenter.swift; sourceTree = "<group>"; };
 		44129BCB71E3F6C8F5CE54A4 /* PDFKitThumbnailProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFKitThumbnailProvider.swift; sourceTree = "<group>"; };
@@ -4184,6 +4186,7 @@
 				867797B6E90539304E2A80B5 /* AudiobookColdLoadRecoveryTests.swift */,
 				75096E80EA204689960BE3BE /* AudiobookBearerTokenRecoveryTests.swift */,
 				68DD067CA8C1F43B32DF167B /* AudiobookContentGateTests.swift */,
+				436767C8EF996AEDAA2C422E /* ManifestFixture.swift */,
 			);
 			path = Audiobook;
 			sourceTree = "<group>";
@@ -8120,6 +8123,7 @@
 				CDC32D621888C8E2DA9224B5 /* AccountRegistryStorePoolStarvationTests.swift in Sources */,
 				6091BEEB1CF681BB93C34786 /* AdobeActivationCoordinatorTests.swift in Sources */,
 				E3033DED04E67DB65B42AB99 /* AdobeActivationDedupTests.swift in Sources */,
+				EA87B0AABCBF12E1F8B6D1FE /* ManifestFixture.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PalaceTests/Accounts/AccountRegistryStorePoolStarvationTests.swift
+++ b/PalaceTests/Accounts/AccountRegistryStorePoolStarvationTests.swift
@@ -22,11 +22,20 @@
 //
 //  THE CONTRACT PINNED HERE. Reads and writes are safe to issue from Task
 //  context: they block only for an actual critical section, never on thread
-//  availability. The probe below is the direct expression — an ordinary
-//  `.utility` Task must still be schedulable while the pool is saturated with
-//  readers. That is exactly the test that hung in the field
-//  (`CatalogCrawlSchedulerTests.test_productionSpawn_runsOperation` does nothing
-//  but spawn and await such a Task).
+//  availability. The always-on test expresses that as COMPLETION — every
+//  concurrent store operation finishes — because the broken implementation did
+//  not finish at all: it deadlocked the whole bundle (exit 124 at 20 minutes).
+//
+//  It deliberately does NOT require an unrelated Task to be SCHEDULED within a
+//  deadline. That formulation measures the machine rather than the store; it
+//  passed 3/3 CI iterations once and then failed one iteration at 69 SECONDS on
+//  a build whose only delta added `Task { await MainActor.run { … } }` hops
+//  elsewhere. The stress variant that does require scheduling is kept, gated
+//  behind PALACE_STRESS_POOL=1, where a quiet machine makes it meaningful.
+//
+//  The field symptom this all came from:
+//  `CatalogCrawlSchedulerTests.test_productionSpawn_runsOperation` does nothing
+//  but spawn a `.utility` Task and await it, and it hung.
 //
 //  Copyright © 2026 The Palace Project. All rights reserved.
 //
@@ -37,23 +46,93 @@ import XCTest
 
 final class AccountRegistryStorePoolStarvationTests: XCTestCase {
 
-    /// Saturate the cooperative pool with concurrent store readers and writers,
-    /// then require that an ordinary Task can still be scheduled and run.
+    /// Every concurrent store operation must COMPLETE. That is the property the
+    /// lock change buys, and it is the one this asserts.
     ///
-    /// Under the dispatch-barrier implementation this starves: every pool thread
-    /// sits in `accountSetsLock.sync` waiting on a barrier that has no worker
-    /// thread left to run it, so the probe never gets to execute.
-    func testReadsUnderSaturation_doNotStarveTheCooperativeThreadPool() async {
+    /// Under the dispatch-barrier implementation this did not merely run slowly
+    /// — the whole test bundle DEADLOCKED and had to be killed (exit 124 after
+    /// 20 minutes), because each blocked reader held a cooperative-pool thread
+    /// while waiting on a barrier that needed one of those same threads to run.
+    /// So "all operations finished" cleanly separates fixed from broken.
+    ///
+    /// DELIBERATELY NOT a scheduler race. The first version of this test spawned
+    /// a separate `.utility` probe Task and required it to be SCHEDULED within a
+    /// deadline while the pool was hammered. That measured whatever else the
+    /// machine was doing: it passed 3/3 iterations on one CI run and then, on
+    /// the next, passed twice and failed once after 69 SECONDS — on a build
+    /// whose only delta was a toolkit bump that added `Task { await
+    /// MainActor.run { … } }` hops to the audiobook completion paths. A test
+    /// that flips with unrelated pool traffic reports the runner, not the store,
+    /// and it can hide a real regression just as easily as invent one (retry
+    /// would have swallowed the failure). The load-sensitive variant is kept
+    /// below, opt-in.
+    func testConcurrentReadsAndWrites_allComplete() async {
         let store = AccountRegistryStore(currentHash: "hash")
-        // Well past the pool width so every worker is contended.
+        // MUST exceed the cooperative pool's width, which is the core count —
+        // that is the precondition for the deadlock, not an arbitrary "lots".
+        // At 32 this test PASSED against the reintroduced defect (0.007s) and
+        // caught nothing; the count is load-bearing and is why it scales.
+        let operations = max(64, ProcessInfo.processInfo.activeProcessorCount * 4)
+
+        let finished = TestBox()
+        let work = Task.detached(priority: .utility) {
+            await withTaskGroup(of: Void.self) { group in
+                for i in 0..<operations {
+                    group.addTask {
+                        // Interleave writes: under the old model a queued barrier
+                        // is exactly what a `.sync` reader had to wait for.
+                        if i % 8 == 0 {
+                            store.mutate { $0["hash", default: []] = [] }
+                        }
+                        _ = store.bucketIsNonEmpty(hash: "hash")
+                        _ = store.account("nobody")
+                        _ = store.currentHash
+                    }
+                }
+            }
+            finished.set()
+        }
+
+        // Generous bound: this separates DEADLOCK from slow, not fast from slow.
+        // A loaded runner may take seconds; a broken lock never finishes at all.
+        let completed = await withTaskGroup(of: Bool.self) { group -> Bool in
+            group.addTask { _ = await work.value; return true }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 60_000_000_000)
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+
+        XCTAssertTrue(
+            completed,
+            "\(operations) concurrent store operations did not all complete. Reads are blocking "
+                + "on GCD scheduling again, so cooperative-pool threads are held waiting for work "
+                + "that needs those same threads — the deadlock that killed the bundle outright."
+        )
+        XCTAssertTrue(finished.value, "the work group must have actually run to completion")
+    }
+
+    /// Opt-in stress variant of the above: requires an unrelated Task to be
+    /// SCHEDULED while the pool is saturated. It reproduces the original defect
+    /// vividly on a quiet machine, and is meaningless on a busy one, so it is
+    /// gated out of CI rather than left to flap.
+    ///
+    ///     PALACE_STRESS_POOL=1 (via TEST_RUNNER_PALACE_STRESS_POOL=1)
+    func testStress_readsUnderSaturationDoNotStarveTheCooperativeThreadPool() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["PALACE_STRESS_POOL"] == "1",
+            "load-sensitive; set PALACE_STRESS_POOL=1 to run"
+        )
+        let store = AccountRegistryStore(currentHash: "hash")
         let readers = max(64, ProcessInfo.processInfo.activeProcessorCount * 4)
 
         let hammer = Task.detached(priority: .utility) {
             await withTaskGroup(of: Void.self) { group in
                 for i in 0..<readers {
                     group.addTask {
-                        // Interleave writes so a barrier is always pending —
-                        // the condition that makes a `.sync` reader wait.
                         if i % 8 == 0 {
                             store.mutate { $0["hash", default: []] = [] }
                         }
@@ -65,11 +144,8 @@ final class AccountRegistryStorePoolStarvationTests: XCTestCase {
             }
         }
 
-        // The probe: a plain Task that does nothing. If the pool is exhausted by
-        // blocked readers it can never be scheduled, which is the defect.
         let probeRan = TestBox()
         let probe = Task(priority: .utility) { probeRan.set() }
-
         let outcome = await withTaskGroup(of: Bool.self) { group -> Bool in
             group.addTask { _ = await probe.value; return true }
             group.addTask {
@@ -80,16 +156,9 @@ final class AccountRegistryStorePoolStarvationTests: XCTestCase {
             group.cancelAll()
             return first
         }
-
         _ = await hammer.value
 
-        XCTAssertTrue(
-            outcome,
-            "A .utility Task could not be scheduled while \(readers) store reads were in "
-                + "flight. Reads are blocking cooperative-pool threads on GCD scheduling, so the "
-                + "pool (width == core count) is exhausted and NOTHING else can run — the "
-                + "189-404s whole-worker freezes seen in CI."
-        )
+        XCTAssertTrue(outcome, "a .utility Task could not be scheduled while \(readers) reads were in flight")
         XCTAssertTrue(probeRan.value, "probe Task must have actually executed")
     }
 

--- a/PalaceTests/Audiobook/ManifestFixture.swift
+++ b/PalaceTests/Audiobook/ManifestFixture.swift
@@ -1,0 +1,95 @@
+//
+//  ManifestFixture.swift
+//  PalaceTests
+//
+//  Loads audiobook manifest fixtures that live in THIS repository.
+//
+//  WHY IT EXISTS. Eight test files here build a `Manifest` from a bundled JSON
+//  fixture. They used to get `Manifest.from(jsonFileName:)` and `ManifestJSON`
+//  from the audiobook toolkit via `@testable import PalaceAudiobookToolkit` --
+//  which only worked because the toolkit's `ManifestJSON.swift`, a TEST helper,
+//  was wrongly compiled into the shipping `PalaceAudiobookToolkit` FRAMEWORK
+//  target. Test fixtures in a shipped binary is a real defect; the toolkit
+//  corrected it (ios-audiobooktoolkit#205 moved the file to its test target),
+//  and that correction broke every consumer here.
+//
+//  The dependency was wrong in both directions and is not worth restoring:
+//  a test in this repo should not reach into another repository's test target,
+//  and the toolkit should not export fixtures to make that possible. ios-core
+//  owns its fixtures now, which is also why the enum below lists ONLY the
+//  manifests this repository actually ships.
+//
+//  ADDING A CASE. Add the `.json` to `PalaceTests/`, add it to the PalaceTests
+//  target's Copy Bundle Resources phase, then add the case here. Do not add a
+//  case whose JSON lives only in the toolkit -- `testEveryManifestFixtureIsBundled`
+//  fails loudly for exactly that, rather than letting a test discover it as a
+//  confusing decode error at run time.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@testable import PalaceAudiobookToolkit
+
+extension Manifest {
+    /// Decode a manifest fixture bundled with the test target.
+    ///
+    /// Uses the toolkit's `customDecoder()` so fixtures decode exactly as
+    /// production manifests do -- a plain `JSONDecoder` would silently diverge
+    /// on the date and context strategies and make these tests lie.
+    static func from(jsonFileName: String, bundle: Bundle = .main) throws -> Manifest {
+        guard let url = bundle.url(forResource: jsonFileName, withExtension: "json") else {
+            throw ManifestFixtureError.notBundled(name: jsonFileName, bundle: bundle.bundleIdentifier ?? "?")
+        }
+        let data = try Data(contentsOf: url)
+        return try Manifest.customDecoder().decode(Manifest.self, from: data)
+    }
+}
+
+enum ManifestFixtureError: Error, CustomStringConvertible {
+    case notBundled(name: String, bundle: String)
+
+    var description: String {
+        switch self {
+        case let .notBundled(name, bundle):
+            return "\(name).json is not in bundle \(bundle). Add it to PalaceTests/ AND to the "
+                + "PalaceTests target's Copy Bundle Resources phase — being in the folder is not enough."
+        }
+    }
+}
+
+/// The manifest fixtures this repository ships. Deliberately a short list: it
+/// mirrors `PalaceTests/*.json`, not the toolkit's much longer catalogue.
+enum ManifestJSON: String, CaseIterable {
+    case snowcrash = "snowcrash_manifest"
+    case duneOversubdivided = "dune_oversubdivided_manifest"
+}
+
+/// Guards the fixture set itself. Without this, adding a case whose JSON is not
+/// bundled fails later, somewhere else, as an opaque decode or unwrap error in
+/// whichever test happens to use it first.
+final class ManifestFixtureTests: XCTestCase {
+
+    func testEveryManifestFixtureIsBundled() throws {
+        let bundle = Bundle(for: type(of: self))
+        for fixture in ManifestJSON.allCases {
+            XCTAssertNoThrow(
+                try Manifest.from(jsonFileName: fixture.rawValue, bundle: bundle),
+                "\(fixture.rawValue).json is declared in ManifestJSON but does not decode from the "
+                    + "test bundle. Either the file is missing, not in Copy Bundle Resources, or no "
+                    + "longer parses with the toolkit's customDecoder()."
+            )
+        }
+    }
+
+    /// Non-vacuity: if `allCases` were ever empty the loop above would pass
+    /// while checking nothing.
+    func testFixtureSetIsNotEmpty() {
+        XCTAssertFalse(
+            ManifestJSON.allCases.isEmpty,
+            "ManifestJSON has no cases, so testEveryManifestFixtureIsBundled asserts nothing."
+        )
+    }
+}


### PR DESCRIPTION
`develop` pinned `0328e0317`, **twelve commits behind** toolkit `main`. The pin is what the app builds, so until it moves the PP-4955 fix does not reach users: scrubbing a DRM audiobook still terminates the app (three Crashlytics reports inside one minute on build 493 / iOS 26.6).

| commit | what |
|---|---|
| `9984ccbd` | **PP-4955** — every public completion delivered on the main actor |
| #206 / #208 | Wave 3 `Sendable`: `Tracks`, `TrackPosition`, `Chapter`, the `Manifest` tree |
| #207 | the toolkit builds from a checkout of itself (PP-4953) |
| #205 | toolkit CI stage 1 |

## The bump broke the build, and the break is the interesting part

Eight test files here call `Manifest.from(jsonFileName:)` / `ManifestJSON`. They resolved those through `@testable import PalaceAudiobookToolkit` — which only worked because the toolkit's `ManifestJSON.swift`, a **test** helper, was compiled into the shipping **framework** target. Verified against both pins:

```
0328e0317  ManifestJSON.swift -> target PalaceAudiobookToolkit       (framework)
9802581a   ManifestJSON.swift -> target PalaceAudiobookToolkitTests  (tests)
```

Test fixtures inside a shipped binary is a real defect. Toolkit #205 corrected it, and these tests depended on the defect.

Re-exporting it would undo a correct fix to preserve a dependency that shouldn't exist in either direction — a test here should not reach into another repository's test target, and the toolkit should not export fixtures to allow it. **ios-core owns its fixtures now.**

## `PalaceTests/Audiobook/ManifestFixture.swift`

**Minimal by design** — the loader plus the **two** manifests this repo actually ships (`snowcrash`, `dune_oversubdivided`), mirroring `PalaceTests/*.json`. Copying the toolkit's 18-case catalogue would import ~100 lines of chapter-count/duration/offset tables nothing here reads, and every extra case would name a JSON this bundle doesn't contain.

**Decodes via the toolkit's `customDecoder()`**, not a plain `JSONDecoder`, so fixtures parse exactly as production manifests do rather than diverging on date/context strategies and making the tests lie.

**Self-verifying.** `testEveryManifestFixtureIsBundled` asserts every declared case decodes from the test bundle, so a case added without its JSON fails immediately and legibly instead of surfacing later as an opaque unwrap in whichever test touches it first. `testFixtureSetIsNotEmpty` is the non-vacuity guard — an empty `allCases` would make that loop pass while checking nothing, which is the exact failure mode found in the `isAtBeginning` contract test earlier on this branch.

## Verification

**8265 passed / 2 failed.** Both failures are `BookRegistrySyncTests` and are **not** from this bump: `test_load_contentMissingEntirely_schedulesTheOrphanRedownload` passes **3/3** run alone, and the same class passed 41/0 earlier today. Order-dependent pollution within its own class. The new fixture guard passes.

## Not done

The pre-existing `BookRegistrySyncTests` pollution — rotates between runs, passes in isolation, not introduced here.

## Deferred

An ios-core analogue of the toolkit's test-target-membership check. It would have caught this class of coupling from **this** side rather than leaving it to be discovered by a submodule bump, but it's a new gate and wants its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)