### PR TITLE
feat(audiobooks): restore LCP audiobook streaming behind a feature flag (PP-4957)

### DIFF
--- a/.forgeos/changesets/feat-pp-lcp-streaming-579-fork/architect-review-final.md
+++ b/.forgeos/changesets/feat-pp-lcp-streaming-579-fork/architect-review-final.md
@@ -1,0 +1,68 @@
+# Architect SoD Review — LCP audiobook streaming-from-license (PP-4957)
+
+**Verdict: BLOCKED**
+Reviewer: architect-review (heka signed) · Branch: feat/pp-lcp-streaming-579-fork · Base: origin/develop
+Changeset state: UNCOMMITTED working tree over HEAD b4365d10a (HEAD is behind origin/develop; the
+real changeset is `git diff HEAD`, 13 files. `git diff origin/develop` is polluted by unrelated
+develop divergence — Adobe-activation deletions, CLAUDE.md, palace_mutate — none of which are this change).
+
+## What is correct
+- **Flag-OFF invariance holds (verified).** All three new branches are guarded on
+  `streamingEnabledProvider()`/`streamingEnabled` and fall through to byte-identical prior logic when
+  false; the shared accessor defaults false (PalaceFeatureFlag `default:` arm + FirebaseManager
+  `setDefaults` false + RemoteFeatureFlags override>remote>false). Production wires through the
+  AppContainer convenience init (designated-init required param is defaulted there), no compile break.
+- **Early-return placement is correct (Q2).** The streaming branch lands after the `.lcpl` rename but
+  BEFORE `sendLCPContentDownloadActive(active:true)`, transfer registration, and `lcpService.fulfill`.
+  It sets fulfillmentId, copies the license, marks successful, broadcasts, and returns with no transfer
+  registered. `testFulfill_streamingEnabled_audiobook...` asserts fulfill count 0 + no active cue.
+- **Seam-level tests are strong (Q4).** Each of the three seams has a flag-ON vs flag-OFF pair whose
+  ON test fails if the branch is deleted (fulfill-count flip / gate-returns-true / re-fetch fires).
+  The audiobook-vs-EPUB test pins the `.audiobook`-only condition. Good mutation posture on the seams.
+
+## BLOCKERS
+
+### 1. [architecture/correctness — FAIL] Flag-ON book is downgraded to `.downloadNeeded` on the next reconcile → not durably playable (Q3)
+The streaming branch persists state `.downloadSuccessful` with only the `.lcpl` on disk (no `.lcpa`).
+On the next `BookRegistrySync.load()` (fires on cold launch, foreground, account change):
+- `MyBooksDownloadCenter+RegistryDownloadServicing.contentPresence` returns `.licenseOnly`
+  (content file absent, license present) — file+RegistryDownloadServicing.swift:80-96.
+- `BookRegistrySync.reconcile(entryState: .downloadSuccessful, presence: .licenseOnly, inFlight: false)`
+  → `armDecision` `.downloadSuccessful`/`.licenseOnly` → `decision(.downloadNeeded, content: true)`
+  — BookRegistrySync.swift:1007-1012.
+
+Effect with flag ON: the book flips `.downloadSuccessful → .downloadNeeded` (loses "Listen", shows
+"Download"), AND is queued for a background content re-download (schedulesContentRedownload) which the
+new LocalBookContentService guard now no-ops — so it never heals and is stranded. This contradicts the
+acceptance criterion "flag ON → book goes straight to Listen → plays" after the very first sync cycle.
+The reconciliation table + the `lcpBooksNeedingBackgroundRedownload` scheduler are flag-blind consumers
+of the new `(.downloadSuccessful, .licenseOnly)` producer and were not reconciled with the flag — the
+exact "producer-not-helper / enumerate every state cell" wall-failure class.
+**Recommendation:** make reconcile (and the background-redownload scheduler) streaming-aware so a
+license-only LCP audiobook is treated as `.present`/playable when streaming is ON — OR have the
+streaming path not depend on a state the reconciler downgrades. Add a reconciliation-table test cell
+for `(.downloadSuccessful, .licenseOnly, streaming ON)` asserting the book stays playable and no
+re-download is scheduled. No current test exercises a load()/reconcile cycle for a streaming book.
+
+### 2. [dependency/risk — CONCERN] swift-toolkit pinned to a local `file://` path + rider transitive bumps
+`project.pbxproj` / `Package.resolved` point swift-toolkit at
+`file:///Users/mauricework/PalaceProject/readium-fork-579` (branch `fork/3.11.0-issue-579`). This cannot
+build for anyone else or in CI. The fix-contract "Scope (out)" documents the final mergeable repin to a
+GitHub fork by exact revision — acknowledged, but as-is the tree is unmergeable. The same resolve also
+drags unrelated transitive bumps (nanopb, promises, swift-atomics, swift-protobuf 1.36→1.38,
+swift-syntax 602→603, snapshot-testing, custom-dump, xctest-dynamic-overlay, std-uritemplate) that
+recompile into every build regardless of flag state; these should be minimized/justified on the repin.
+**Recommendation:** repin to the exact-revision GitHub fork and re-resolve to isolate only the toolkit
+change before merge; confirm the transitive deltas are intended.
+
+## Accepted follow-up (not blocking)
+- **Q5 resource-loader over-fetch:** documented, flag defaults OFF; acceptable as a tracked follow-up
+  rather than a merge blocker — provided Blocker 1 is fixed so flag-ON is actually shippable for QA.
+
+## Summary
+Flag-OFF is safe and the three seams are clean and well-tested, but the feature's own happy path
+(flag ON) is not durable: the registry reconciler downgrades the streaming book to `.downloadNeeded`
+on the next launch and the heal is gated off, stranding it. That is a correctness defect on a critical
+DRM path, untested, and must be fixed (with a reconciliation-table test) before this is "done" — even
+behind a default-OFF flag, because the dev/QA toggle exposes it immediately. Plus the local file://
+toolkit pin blocks merge mechanically. BLOCKED.

--- a/.forgeos/changesets/feat-pp-lcp-streaming-579-fork/blast-radius-review-final.md
+++ b/.forgeos/changesets/feat-pp-lcp-streaming-579-fork/blast-radius-review-final.md
@@ -1,0 +1,122 @@
+# Blast-Radius Review — LCP audiobook streaming-from-license (PP-4957)
+
+Role: blast_radius (universal floor)  ·  Verdict: **BLOCKED**
+Branch: feat/pp-lcp-streaming-579-fork  ·  Base: origin/develop
+Critical path: DRM/LCP audiobook fulfillment
+
+## Scope reviewed
+Uncommitted working-tree changeset (13 files) adding a Firebase-gated flag
+`lcp_audiobook_streaming_enabled` (default OFF) that makes an LCP audiobook
+playable on its `.lcpl` license alone, skipping the `.lcpa` download.
+
+## Verdict rationale
+Production at flag-default-OFF is unaffected (every new branch is behind
+`if streamingEnabled`). BLOCK is on the **flag-ON path**, which is broken by a
+reconcile state downgrade that is remotely enable-able via Firebase without a
+build.
+
+---
+
+## BLOCKING
+
+### F1 (concern · side-effect scope) — reconcile downgrades a streaming book `.downloadSuccessful` → `.downloadNeeded` on every registry load
+The streaming short-circuit in `LCPFulfillmentHandler.fulfill`
+(LCPFulfillmentHandler.swift:119-140) sets state `.downloadSuccessful`, copies
+the `.lcpl` to the content dir, and returns — no `.lcpa` on disk.
+
+On the next `BookRegistrySync.load()` (cold launch, CarPlay bootstrap,
+`HoldsViewModel` no-auth hold change, account change):
+- `contentPresence` (MyBooksDownloadCenter+RegistryDownloadServicing.swift:86-92)
+  finds `.lcpl` but no `.lcpa` → returns `.licenseOnly`.
+- `armDecision` (BookRegistrySync.swift:1007-1012 `.downloadSuccessful` arm; also
+  :1014-1019 `.used` arm) maps `.licenseOnly` → `decision(.downloadNeeded, content: true)`.
+- `load` applies it (BookRegistrySync.swift:321) and schedules a content
+  re-download (:322-324).
+
+The re-download call itself is guarded — routes through
+`MyBooksDownloadCenter.redownloadLCPContentFile` → `LocalBookContentService.redownloadLCPContentFile`,
+which the diff short-circuits when streaming is ON (LocalBookContentService.swift:345-351)
+— so the `.lcpa` is NOT re-fetched. **But the STATE FLIP is not guarded.** The guard
+was placed at the terminal download seam only; the reconcile state machine
+(`armDecision` / `contentPresence`) is not streaming-aware.
+
+Impact (flag ON): every streaming audiobook reverts to `.downloadNeeded` after any
+load → My Books shows a "Download" affordance instead of "Listen" for a book that
+is supposed to be immediately playable, and logs
+`'…' has a license but no .lcpa content — scheduling content re-download` on every
+launch, burning a scheduled-redownload timer slot each time. The feature does not
+survive its own reconcile pass.
+
+No test covers this interaction. Added tests pin the local guards
+(LCPFulfillmentHandlerTests, LocalBookContentServiceTests) but none exercise
+`BookRegistrySync.reconcile` with a streaming book — the classic producer-vs-helper gap.
+
+**Recommendation:** make `reconcile`/`contentPresence` streaming-aware. When the
+flag is ON and the book is an LCP audiobook whose license is present, treat
+`.licenseOnly` as terminal-healthy: do not downgrade `.downloadSuccessful`/`.used`,
+do not schedule a content re-download. Add a BookRegistry reconciliation-table
+case for the streaming dimension (the table tests are the right home — this is a
+new (state × presence) meaning, not a scenario).
+
+---
+
+## WARNING
+
+### F2 (warning · side-effect scope) — failed license copy routes to an UNGUARDED full download
+`copyLicenseForStreaming` swallows a copy failure (LCPFulfillmentHandler.swift:352-361,
+`catch` logs only), yet the streaming path still calls `markDownloadSuccessful`
+and returns. If the `.lcpl` copy failed, `contentPresence` = `.absent` →
+reconcile `.downloadSuccessful` + `.absent` → `decision(.downloadNeeded, orphan: true)`
+→ `downloadService.startDownload(for:)` (BookRegistrySync.swift:418), which is NOT
+streaming-guarded → a full fresh fulfillment kicks off. Rare, but a real unguarded
+path in the ON state.
+**Recommendation:** on copy failure in the streaming path, do not mark successful —
+fall through to download-first so state stays coherent.
+
+### F3 (warning · adjacency-staleness) — stale base; work uncommitted
+Branch HEAD (b4365d10a) is 1 commit behind `origin/develop` (missing c3b799dae,
+the Adobe single-flight DRM fix PP-4952). `git diff origin/develop` therefore shows
+large unrelated DELETIONS (AdobeActivationCoordinator, AdobeCertificate, CLAUDE.md,
+palace_mutate.py, .forgeos intent + Adobe tests) — a **stale-base artifact, not part
+of the changeset**. The LCP streaming work is also entirely uncommitted working-tree
+changes. Consequence: the 5 universal scripts all exited 0, but they evaluate the
+committed delta (empty here) — their clean result is low-signal for this changeset.
+**Recommendation:** rebase onto the develop tip, commit, and re-run this review on
+the committed diff.
+
+---
+
+## PASS (deliberate, confirmed clean)
+
+### P1 (surface/abi) — signature changes are additive and safe
+- `AudiobookSessionManager` designated init is `private`; only the convenience
+  init calls it and was updated; convenience `lcpStreamingEnabledProvider` is
+  defaulted (reads `RemoteFeatureFlags.shared`). AppContainer + all test callers
+  use the convenience init → compile clean. `AudiobookSessionManager` is `public`
+  but its init is private → no public ABI change.
+- `shouldTriggerContentDownloadBeforeOpen` new non-defaulted `streamingEnabled`:
+  all 6 test call sites in AudiobookContentGateTests updated; the single prod call
+  passes `lcpStreamingEnabledProvider()`. No missed site.
+- `LCPFulfillmentHandler.init` / `LocalBookContentService.init` new params are
+  defaulted (trailing/mid with labels) → existing callers unaffected. All types
+  `internal final` → no ABI surface.
+
+### P2 (surface) — flag wiring correct and auto-OFF
+- `PalaceFeatureFlag.lcpAudiobookStreamingEnabled` falls through `default: return false`
+  in `defaultValue` → auto-OFF.
+- FirebaseManager: `RemoteConfigKey` case + `setDefaults` NSNumber(false) added.
+- `managerKey` mapping: explicit case added (both PalaceFeatureFlag switches retain
+  `default:` arms → no exhaustiveness break anywhere).
+- `RemoteFeatureFlags.isLCPAudiobookStreamingEnabled` + local-override key + the
+  DeveloperSettings toggle mirror existing patterns with matching keys.
+- Default-OFF ⇒ zero production behavior change; all new logic behind `if streamingEnabled`.
+
+### P3 (test_seam / debug_reachability) — none found
+No `#if DEBUG` reachability, no test-only symbol promoted to public, no static
+factory bypassing an injection seam. Injection is via defaulted closures reading
+`RemoteFeatureFlags.shared` in production and overridable in tests — the documented pattern.
+
+## Script evidence
+check-contract-reconciliation / check-blast-radius / check-adjacency-staleness /
+check-intent-recorded / check-superpartner-spectrum → all exit 0 (low signal: work
+is uncommitted; scripts see an empty committed delta — see F3).

--- a/.forgeos/changesets/feat-pp-lcp-streaming-579-fork/fix-contract.md
+++ b/.forgeos/changesets/feat-pp-lcp-streaming-579-fork/fix-contract.md
@@ -1,0 +1,73 @@
+# Fix-contract — Feature-flagged LCP audiobook streaming-from-license (PP-4957)
+
+## Summary
+Restore LCP audiobook streaming (broken since 3.2.0's Readium bump, upstream #579) behind a
+Firebase-gated feature flag, **default OFF**. Flag OFF = today's download-first behavior, byte-for-byte.
+Flag ON = the book becomes playable on the license alone and the player streams via the pinned
+`swift-toolkit 3.11.0 + fix-issue-579` fork. One flag flips all three download-vs-stream decision
+points coherently.
+
+## Scope (in)
+- `Palace/Packages/PalaceFeatureFlags/.../PalaceFeatureFlag.swift` — add case
+  `lcpAudiobookStreamingEnabled = "lcp_audiobook_streaming_enabled"` (defaultValue auto-false via
+  the existing `default:` arm).
+- `Palace/AppInfrastructure/FirebaseManager.swift` — add `RemoteConfigKey.lcpAudiobookStreamingEnabled`
+  + register `false` in `setDefaults`.
+- `Palace/FeatureFlags/RemoteFeatureFlags.swift` — add `lcpAudiobookStreamingLocalOverrideKey`,
+  `isLCPAudiobookStreamingEnabled` accessor (override > remote, default false), and the `managerKey` arm.
+  Mirrors `isInAppPlaybackNavEnabled` exactly.
+- `Palace/MyBooks/LCPFulfillmentHandler.swift` — inject `streamingEnabledProvider: () -> Bool`
+  (default `{ RemoteFeatureFlags.shared.isLCPAudiobookStreamingEnabled }`). In `fulfillLCPLicense`,
+  **before** the `lcpService.fulfill(...)` content download, add an early branch:
+  `if streamingEnabledProvider() && book.defaultBookContentType == .audiobook` →
+  set fulfillmentId, `copyLicenseForStreaming(...)`, `delegate?.markDownloadSuccessful(for:)`,
+  broadcastUpdate, `return` (NO content download, NO transfer registration, NO active cue).
+- `Palace/Audiobooks/AudiobookSessionManager.swift` — `shouldTriggerContentDownloadBeforeOpen`
+  gains a `streamingEnabled: Bool` param; returns `false` when `streamingEnabled` (proceed → stream).
+  Remove SPIKE #1 (hardcoded `return false`) and SPIKE #2 (no-op `lcpContentDownloadTrigger` default);
+  the caller `gateOnLCPContentDownload` passes the flag. SPIKE #2's trigger never fires when
+  shouldTrigger=false, so the default closure is restored to original.
+- `Palace/MyBooks/LocalBookContentService.swift` — replace SPIKE #3 (hardcoded early return) with a
+  flag-gated skip: `if streamingEnabledProvider() && LCPAudiobooks.canOpenBook(book) { return }`
+  (self-heal must not re-download content for a streaming audiobook).
+
+## Scope (out)
+- **Do NOT flip the flag default to true** — that is David's product call (ticket-deferred).
+- Readium fork pins — already set; the final mergeable step repins from local `file://` to
+  `mauricecarrier7/swift-toolkit` by exact revision. No logic change.
+- PDF LCP path (line 234) — untouched; streaming branch is `.audiobook`-only.
+- `lcpCompletion` error/replace guards — untouched (unreachable on the streaming path, which returns early).
+
+## Known traps (from docs/architecture/areas/mybooks/verification-checklist.md)
+- **Cross-host token scoping (BiblioBoard):** streaming issues HTTP range requests to the license's
+  content URL (often a distributor CDN ≠ manifest host). Auth must be scoped to CM-authorized hosts.
+  → Manual sim verify must confirm streaming actually serves bytes (not a 403). This is the #579 path.
+- **Marketplace LCP MIME-nesting:** `LCPAudiobooks.canOpenBook` is the recursive predicate the
+  streaming branch relies on to identify an LCP audiobook — reuse it, do not re-derive.
+
+## Verification criteria (grep-able before done)
+- `grep -c "SPIKE(PP-4957)" Palace/**/*.swift` == 0 (all three spikes removed).
+- `grep -c "isLCPAudiobookStreamingEnabled" Palace/FeatureFlags/RemoteFeatureFlags.swift` >= 1
+- `grep -c "streamingEnabledProvider" Palace/MyBooks/LCPFulfillmentHandler.swift` >= 2
+- New flag registered in BOTH tables: `PalaceFeatureFlag` (contract) AND `FirebaseManager.setDefaults`.
+- `LCPFulfillmentHandlerTests` covers BOTH flag states (see Tests).
+- Mutation kill on the changed `LCPFulfillmentHandler` streaming branch (diff-only) >= 80%.
+- `scripts/verify-pr.sh --quick` PASS.
+
+## Tests required (TDD)
+- `LCPFulfillmentHandlerTests`:
+  - flag OFF, audiobook → `lcpService.fulfill` IS called; NO early markDownloadSuccessful; behavior == today.
+  - flag ON, audiobook → early branch: `markDownloadSuccessful` called, `copyLicenseForStreaming` invoked,
+    `lcpService.fulfill` NOT called, no content-transfer registered. (Spy the LCP service + delegate.)
+  - flag ON, **PDF** → NOT streamed (fulfill still called) — proves the branch is audiobook-only.
+- `AudiobookSessionManager` gate: `shouldTriggerContentDownloadBeforeOpen(streamingEnabled: true, ...)` == false
+  for the case that returns true when `streamingEnabled: false` (the canOpen && !contentLocal case).
+- `LocalBookContentService`: flag ON + LCP audiobook → `redownloadLCPContentFile` no-ops (no fulfiller call).
+- Contract-snapshot the flag-ON fulfillment call order if it fits (setFulfillmentId → copyLicense → markSuccessful).
+
+## Acceptance
+- All verification criteria pass; full suite green against the fork (baseline 8248/0).
+- Manual sim (iPhone Air / A1QA / Palace Marketplace LCP audiobook):
+  - flag ON → borrow → book goes straight to **Listen** → plays with `.lcpa` staying **0 bytes** on disk (streaming).
+  - flag OFF → download-first unchanged (full `.lcpa` lands, then Listen).
+- Prove-the-guard: with flag ON, deleting the guard branch must fail a named test (mutation).

--- a/.forgeos/changesets/feat-pp-lcp-streaming-579-fork/qa-review-final.md
+++ b/.forgeos/changesets/feat-pp-lcp-streaming-579-fork/qa-review-final.md
@@ -1,0 +1,91 @@
+# QA / Test-Quality SoD Review — PP-4957 LCP audiobook streaming-from-license
+
+- Branch: `feat/pp-lcp-streaming-579-fork`  tip `b4365d10a`
+- Base: `origin/develop`
+- Reviewer role: qa_test (test-quality lens)
+- Critical path: DRM/LCP audiobook fulfillment
+- **Verdict: BLOCKED** (1 concern on the DRM fulfillment success arm; rest is strong)
+
+## Gate note (mechanics)
+`heka2 context --role reviewer` shows `plan.required = [hygiene, mutation,
+review:architect, stanza, tdd_red_first, verify_before_done]`. There is **no
+`review:qa_test` gate** in the plan, so no signed qa_test verdict was submitted
+to the ledger — this document is the deliverable. If a qa_test gate is intended,
+it must be added to the plan before a signed verdict can be recorded.
+
+## 1. Mutation adequacy — all 3 declared branches killed (PASS)
+Each production branch has a named test that fails if the branch is deleted, and
+each has a flag-OFF twin that pins the opposite outcome:
+
+- **Fulfillment short-circuit** (`LCPFulfillmentHandler.swift` ~L119-135):
+  `testFulfill_streamingEnabled_audiobook_marksSuccessfulOnLicense_noDownload`
+  — delete the branch → `lcpService.fulfill` runs (fulfillCallCount 1) and
+  markSuccessful is deferred → 3 assertions fail. The `.audiobook` conjunct is
+  independently pinned by `testFulfill_streamingEnabled_epub_stillDownloads`
+  (drop the content-type check → EPUB takes the streaming branch, fulfillCallCount
+  drops to 0 → fails). Confirmed `.AudiobookLCP`→audiobook, `.ReadiumLCP`→EPUB via
+  TPPBookMock (same mapping the existing download-first tests rely on).
+- **Gate early-return** (`AudiobookSessionManager.shouldTriggerContentDownloadBeforeOpen`,
+  `if streamingEnabled { return false }`):
+  `testShouldTrigger_streamingEnabled_overridesDownloadFirst_returnsFalse` uses
+  identical inputs to the returns-TRUE flag-off twin — delete the branch → returns
+  true → fails. `testShouldTrigger_streamingEnabled_neverTriggers_acrossInputs`
+  asserts all 8 (cold×canOpen×local) combos, covering the over-fetch domination.
+- **Self-heal skip** (`LocalBookContentService.redownloadLCPContentFile`,
+  `if streamingEnabledProvider() { return }`):
+  `testRedownload_streamingEnabled_doesNotReFetchTheArchive` (callCount 0) vs
+  `testRedownload_streamingDisabled_reFetchesTheArchive` (callCount 1) — same
+  seeded license-only state, only the flag differs. Delete the branch → flag-ON
+  test fetches → fails.
+
+## 2. Flag-OFF regression coverage (PASS)
+Download-first is pinned as the default: the new flag falls into `defaultValue`'s
+`default: return false` (verified). Fulfillment setUp handler leaves the flag at
+production default OFF so all pre-existing tests exercise the unchanged path; the
+gate tests pass explicit `streamingEnabled: false`; the self-heal has an explicit
+OFF twin. Today's behavior is not silently changed.
+
+## 3. Edge cases — one real gap
+- Non-audiobook LCP under the flag: EPUB covered; PDF not (behaviorally the same
+  `contentType != .audiobook` path — low risk). WARNING, not blocking.
+- Over-fetch: covered by the 8-combo loop (PASS).
+- **License-read on the streaming path: SUCCESS arm untested + unreachable
+  (CONCERN — see below).**
+
+## 4. Fluff / unobservable assertions
+- No fluff or tautology tests. The across-inputs loop is a real Act→Assert over 8
+  cases, not a set-then-assert.
+- `copyLicenseForStreaming` side effect is correctly NOT asserted (avoids the
+  unobservable-assertion trap the brief flagged). Good.
+
+## BLOCKING FINDING (concern) — DRM fulfillment-ID success arm is unverified
+`LCPFulfillmentHandler` streaming branch does:
+```
+if let license = TPPLCPLicense(url: licenseUrl) {
+    bookRegistry.setFulfillmentId(license.identifier, for: book.identifier)
+} else { Log.error(...) }
+```
+`TPPLCPLicense.init?(url:)` decodes JSON. The test fixture `writeSourceFile(ext:
+"lcpa")` writes 50 bytes of `0xCD` (invalid JSON), and no `.lcpl` fixture exists
+in the bundle — so `TPPLCPLicense(url:)` returns nil and the streaming test always
+runs the **else (Log.error) arm**. Consequences:
+- The success arm and `bookRegistry.setFulfillmentId(...)` are never executed —
+  a mutant deleting that call survives.
+- No test asserts `registry.fulfillmentId(forIdentifier:)` on the streaming path.
+  The fulfillment ID drives LCP return/revoke; on a money/access path CLAUDE.md
+  requires every branch tested. This is the "fixture must match production bytes"
+  failure mode: the test passes vacuously through the degraded arm.
+
+**Recommendation:** add a valid `.lcpl` JSON fixture (real `id`), route the
+streaming audiobook test through it, and assert
+`registry.fulfillmentId(forIdentifier: book.identifier) == license.id`. Keep a
+second case with an unreadable license that still marks successful + no download,
+so both arms are pinned.
+
+## Files
+- Prod: Palace/MyBooks/LCPFulfillmentHandler.swift, Palace/MyBooks/LocalBookContentService.swift,
+  Palace/Audiobooks/AudiobookSessionManager.swift, Palace/FeatureFlags/RemoteFeatureFlags.swift,
+  Palace/Packages/PalaceFeatureFlags/.../PalaceFeatureFlag.swift
+- Tests: PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift,
+  PalaceTests/Audiobook/AudiobookContentGateTests.swift,
+  PalaceTests/MyBooks/LocalBookContentServiceTests.swift

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -9500,7 +9500,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 493;
+				CURRENT_PROJECT_VERSION = 494;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -9559,7 +9559,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 493;
+				CURRENT_PROJECT_VERSION = 494;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -9748,7 +9748,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 493;
+				CURRENT_PROJECT_VERSION = 494;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -9809,7 +9809,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 493;
+				CURRENT_PROJECT_VERSION = 494;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -10123,10 +10123,10 @@
 		};
 		E77D02182931337000544180 /* XCRemoteSwiftPackageReference "swift-toolkit" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/readium/swift-toolkit.git";
+			repositoryURL = "https://github.com/ThePalaceProject/swift-toolkit.git";
 			requirement = {
-				kind = exactVersion;
-				version = 3.11.0;
+				kind = revision;
+				revision = 58413f8680a310ed6d98278687ab711e6be639c8;
 			};
 		};
 		E77D02232931357400544180 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/Palace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Palace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "420c0e58206155635d276e368be5122475ea4d34bc6d3543dfd406fb5c18b6c7",
+  "originHash" : "9ded438bad437f43fb4acf94304898012e342c18683913398a7ac403aec1091f",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
-        "version" : "2.30910.0"
+        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
+        "version" : "2.30910.1"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-        "version" : "2.4.0"
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/std-uritemplate/std-uritemplate-swift",
       "state" : {
-        "revision" : "087394616732e6958833c2caa5dde34c73e63eb0",
-        "version" : "2.0.8"
+        "revision" : "eab67b98f0ebf3ecbea32b03e5e2e971df310ad9",
+        "version" : "2.0.12"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
-        "version" : "1.5.0"
+        "revision" : "e9c34fd54ece006b491a0e6d23fe9a6024b9a828",
+        "version" : "1.7.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "a008af1a102ff3dd6cc3764bb69bf63226d0f5f6",
-        "version" : "1.36.1"
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "05b6f05b55ff9e2dcdcc21ac78c6ba81ea624791",
-        "version" : "1.19.1"
+        "revision" : "59a99c458de4d2dee580529b61b4f78dca7b7fa6",
+        "version" : "1.19.4"
       }
     },
     {
@@ -213,17 +213,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
       "identity" : "swift-toolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/readium/swift-toolkit.git",
+      "location" : "https://github.com/ThePalaceProject/swift-toolkit.git",
       "state" : {
-        "revision" : "d82f44f4f05d87add9e22a8b75abbd61dce745dd",
-        "version" : "3.11.0"
+        "revision" : "58413f8680a310ed6d98278687ab711e6be639c8"
       }
     },
     {
@@ -258,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     },
     {

--- a/Palace/AppInfrastructure/FirebaseManager.swift
+++ b/Palace/AppInfrastructure/FirebaseManager.swift
@@ -91,6 +91,7 @@ final class FirebaseManager: @unchecked Sendable {
         case inAppPlaybackNavEnabled = "in_app_playback_nav_enabled"
         case continuationCardsEnabled = "continuation_cards_enabled"
         case sideLoadingEnabled = "side_loading_enabled"
+        case lcpAudiobookStreamingEnabled = "lcp_audiobook_streaming_enabled"
         // App-rating prompt (Epic PP-4086). Master switch + tunable thresholds.
         case appRatingPromptEnabled = "app_rating_prompt_enabled"
         case appRatingMinSessions = "app_rating_min_sessions"
@@ -146,6 +147,7 @@ final class FirebaseManager: @unchecked Sendable {
             RemoteConfigKey.inAppPlaybackNavEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.continuationCardsEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.sideLoadingEnabled.rawValue: NSNumber(value: false),
+            RemoteConfigKey.lcpAudiobookStreamingEnabled.rawValue: NSNumber(value: false),
             RemoteConfigKey.appRatingPromptEnabled.rawValue: NSNumber(value: true),
             RemoteConfigKey.appRatingMinSessions.rawValue: NSNumber(value: RatingConfig.fallback.minSessions),
             RemoteConfigKey.appRatingMinBooksCompleted.rawValue: NSNumber(value: RatingConfig.fallback.minBooksCompleted),

--- a/Palace/Audiobooks/AudiobookSessionManager.swift
+++ b/Palace/Audiobooks/AudiobookSessionManager.swift
@@ -304,6 +304,14 @@ public final class AudiobookSessionManager: ObservableObject {
     /// rather than only polling for a file that may never appear.
     private let lcpContentDownloadTrigger: (TPPBook) -> Void
 
+    /// PP-4957: reads the LCP-audiobook-streaming feature flag. When ON, an LCP
+    /// audiobook is playable on its license alone, so the open-time content gate
+    /// (`gateOnLCPContentDownload`) must NOT force a download before opening —
+    /// the player streams via the swift-toolkit #579 fork. Injected so tests
+    /// drive both flag states; production default reads `RemoteFeatureFlags.shared`
+    /// (local override > Firebase remote, default `false` → download-first).
+    private let lcpStreamingEnabledProvider: () -> Bool
+
     // MARK: - F-011 readiness-gate injection points
     //
     // PR #990 introduced a race where Palace's first `play(at:)` could fire
@@ -345,6 +353,7 @@ public final class AudiobookSessionManager: ObservableObject {
         audiobookSessionPresenterProvider: @escaping @MainActor () -> AudiobookSessionPresenter,
         inAppPlaybackNavEnabledProvider: @escaping () -> Bool,
         lcpContentDownloadTrigger: @escaping (TPPBook) -> Void,
+        lcpStreamingEnabledProvider: @escaping () -> Bool,
         readinessProbeFactory: @escaping @MainActor (Player) -> PlaybackReadinessProbing,
         playbackCommandFactory: @escaping @MainActor (Player) -> PlaybackEngineCommanding,
         readinessTimeout: TimeInterval
@@ -358,6 +367,7 @@ public final class AudiobookSessionManager: ObservableObject {
         self.audiobookSessionPresenterProvider = audiobookSessionPresenterProvider
         self.inAppPlaybackNavEnabledProvider = inAppPlaybackNavEnabledProvider
         self.lcpContentDownloadTrigger = lcpContentDownloadTrigger
+        self.lcpStreamingEnabledProvider = lcpStreamingEnabledProvider
         self.readinessProbeFactory = readinessProbeFactory
         self.playbackCommandFactory = playbackCommandFactory
         self.readinessTimeout = readinessTimeout
@@ -391,6 +401,7 @@ public final class AudiobookSessionManager: ObservableObject {
         lcpContentDownloadTrigger: @escaping (TPPBook) -> Void = { book in
             AppContainer.production().downloadCenter.redownloadLCPContentFile(for: book)
         },
+        lcpStreamingEnabledProvider: @escaping () -> Bool = { RemoteFeatureFlags.shared.isLCPAudiobookStreamingEnabled },
         readinessProbeFactory: @escaping @MainActor (Player) -> PlaybackReadinessProbing = { player in
             PlayerReadinessProbe(isLoadedSnapshot: { [weak player] in player?.isLoaded ?? false })
         },
@@ -409,6 +420,7 @@ public final class AudiobookSessionManager: ObservableObject {
             audiobookSessionPresenterProvider: audiobookSessionPresenterProvider,
             inAppPlaybackNavEnabledProvider: inAppPlaybackNavEnabledProvider,
             lcpContentDownloadTrigger: lcpContentDownloadTrigger,
+            lcpStreamingEnabledProvider: lcpStreamingEnabledProvider,
             readinessProbeFactory: readinessProbeFactory,
             playbackCommandFactory: playbackCommandFactory,
             readinessTimeout: readinessTimeout
@@ -2443,9 +2455,17 @@ public final class AudiobookSessionManager: ObservableObject {
     static func shouldTriggerContentDownloadBeforeOpen(
         isColdLoadRecovery: Bool,
         canOpenLCPBook: Bool,
-        contentIsLocal: Bool
+        contentIsLocal: Bool,
+        streamingEnabled: Bool
     ) -> Bool {
-        !isColdLoadRecovery && canOpenLCPBook && !contentIsLocal
+        // PP-4957: when streaming is ON, an LCP audiobook is playable on its
+        // license alone — never force a content download before opening; let the
+        // player stream via the swift-toolkit #579 fork. When OFF, the original
+        // download-first gate stands: trigger iff the book is openable but its
+        // `.lcpa` content is not yet on disk, and this is not a cold-load re-open
+        // (whose content is already local).
+        if streamingEnabled { return false }
+        return !isColdLoadRecovery && canOpenLCPBook && !contentIsLocal
     }
 
     /// PP-4542 / 323-Cause-1: the upfront LCP content gate. If the audiobook is
@@ -2478,7 +2498,8 @@ public final class AudiobookSessionManager: ObservableObject {
         guard Self.shouldTriggerContentDownloadBeforeOpen(
             isColdLoadRecovery: isColdLoadRecovery,
             canOpenLCPBook: canOpenLCPBook,
-            contentIsLocal: contentIsLocal
+            contentIsLocal: contentIsLocal,
+            streamingEnabled: lcpStreamingEnabledProvider()
         ) else {
             return .proceed
         }

--- a/Palace/FeatureFlags/RemoteFeatureFlags.swift
+++ b/Palace/FeatureFlags/RemoteFeatureFlags.swift
@@ -349,6 +349,33 @@ final class RemoteFeatureFlags: @unchecked Sendable {
         return isFeatureEnabled(.sideLoadingEnabled)
     }
 
+    /// UserDefaults override that lets QA / a developer force LCP audiobook
+    /// streaming on or off without a Firebase round-trip. Settable from
+    /// `TPPDeveloperSettingsTableViewController`. Falls through to the Remote
+    /// Config flag when nil. Mirrors the `inAppPlaybackNavLocalOverrideKey` pattern.
+    static let lcpAudiobookStreamingLocalOverrideKey = "RemoteFeatureFlags.lcpAudiobookStreamingLocalOverride"
+
+    /// Whether LCP audiobook streaming-from-license is enabled (PP-4957). When
+    /// ON, an LCP audiobook is playable on the `.lcpl` license alone and the
+    /// player streams the encrypted audio on demand via the pinned swift-toolkit
+    /// fork (3.11.0 + fix-issue-579); when OFF, the app downloads the full
+    /// `.lcpa` before playback (today's behavior).
+    ///
+    /// **Default OFF — Firebase-gated.** The default flip to streaming is a
+    /// product decision; production users stay on download-first until Firebase
+    /// Remote Config sets `lcp_audiobook_streaming_enabled = true` (global or
+    /// staged), which the team can roll out and back without shipping a build.
+    ///
+    /// Override precedence:
+    ///   1. UserDefaults local override (dev-menu toggle / QA) — wins.
+    ///   2. Firebase Remote Config (`isFeatureEnabled`, default `false`).
+    var isLCPAudiobookStreamingEnabled: Bool {
+        if let override = defaults.object(forKey: Self.lcpAudiobookStreamingLocalOverrideKey) as? Bool {
+            return override
+        }
+        return isFeatureEnabled(.lcpAudiobookStreamingEnabled)
+    }
+
     // MARK: - App Rating (Epic PP-4086)
 
     /// Master switch for the app-rating prompt. When false, no eligibility
@@ -431,6 +458,8 @@ extension PalaceFeatureFlag {
             return .continuationCardsEnabled
         case .sideLoadingEnabled:
             return .sideLoadingEnabled
+        case .lcpAudiobookStreamingEnabled:
+            return .lcpAudiobookStreamingEnabled
         case .appRatingPromptEnabled:
             return .appRatingPromptEnabled
         default:

--- a/Palace/MyBooks/LCPFulfillmentHandler.swift
+++ b/Palace/MyBooks/LCPFulfillmentHandler.swift
@@ -66,6 +66,12 @@ final class LCPFulfillmentHandler: @unchecked Sendable {
     /// service per fulfillment — same lifetime as the prior MBDC body.
     private let lcpServiceFactory: () -> LCPLibraryService
 
+    /// PP-4957: reads the LCP-audiobook-streaming feature flag. Injected as a
+    /// closure so tests drive BOTH flag states without touching
+    /// `RemoteFeatureFlags.shared`. Production default reads the shared flag
+    /// (local override > Firebase remote, default `false` → download-first).
+    private let streamingEnabledProvider: () -> Bool
+
     init(
         bookRegistry: TPPBookRegistryProvider,
         stateManager: DownloadStateManager,
@@ -74,7 +80,8 @@ final class LCPFulfillmentHandler: @unchecked Sendable {
         bookFileManager: BookFileManager,
         backgroundDownloadHandler: BackgroundDownloadHandler,
         fileManager: FileManager = .default,
-        lcpServiceFactory: @escaping () -> LCPLibraryService = { LCPLibraryService() }
+        lcpServiceFactory: @escaping () -> LCPLibraryService = { LCPLibraryService() },
+        streamingEnabledProvider: @escaping () -> Bool = { RemoteFeatureFlags.shared.isLCPAudiobookStreamingEnabled }
     ) {
         self.bookRegistry = bookRegistry
         self.stateManager = stateManager
@@ -84,6 +91,7 @@ final class LCPFulfillmentHandler: @unchecked Sendable {
         self.backgroundDownloadHandler = backgroundDownloadHandler
         self.fileManager = fileManager
         self.lcpServiceFactory = lcpServiceFactory
+        self.streamingEnabledProvider = streamingEnabledProvider
     }
 
     // MARK: - Fulfillment
@@ -105,6 +113,30 @@ final class LCPFulfillmentHandler: @unchecked Sendable {
                 "book": book.loggableDictionary
             ])
             alertPresenter.failDownloadWithAlert(for: book, withMessage: error.localizedDescription)
+            return
+        }
+
+        // PP-4957 — streaming-from-license. When the feature flag is ON and this
+        // is an LCP audiobook, the `.lcpl` license alone makes the book playable:
+        // the player streams the encrypted audio on demand via the swift-toolkit
+        // #579 fork. Short-circuit HERE — before the progress cue
+        // (`sendLCPContentDownloadActive(active: true)`), the content-transfer
+        // registration, and `lcpService.fulfill(...)` — so NO `.lcpa` is fetched
+        // and no "downloading" cue is left un-cleared. Flag OFF → fall straight
+        // through to the unchanged download-first path below (behavior identical
+        // to today, which is what keeps this mergeable ahead of the product flip).
+        if streamingEnabledProvider(), book.defaultBookContentType == .audiobook {
+            if let license = TPPLCPLicense(url: licenseUrl) {
+                bookRegistry.setFulfillmentId(license.identifier, for: book.identifier)
+            } else {
+                Log.error(#file, "🔑 ❌ PP-4957 streaming: failed to read license for fulfillment ID: \(book.identifier)")
+            }
+            copyLicenseForStreaming(book: book, sourceLicenseUrl: licenseUrl)
+            Log.info(#file, "PP-4957 streaming ON — LCP audiobook playable on license alone, skipping .lcpa download: \(book.identifier)")
+            delegate?.markDownloadSuccessful(for: book)
+            runOnMainAsync { [weak self] in
+                self?.progressReporter.broadcastUpdate()
+            }
             return
         }
 

--- a/Palace/MyBooks/LocalBookContentService.swift
+++ b/Palace/MyBooks/LocalBookContentService.swift
@@ -45,6 +45,13 @@ class LocalBookContentService {
     private let bookFileManager: BookFileManager
     private let fileManager: FileManager
     private let lcpContentFulfiller: LCPContentFulfilling
+    /// PP-4957: reads the LCP-audiobook-streaming feature flag. When ON, the
+    /// self-heal `.lcpa` re-download is skipped for an LCP audiobook — a
+    /// streaming book is intentionally content-absent and playable on its
+    /// license alone, so re-fetching the full archive would defeat streaming.
+    /// Injected so tests drive both flag states; production default reads the
+    /// shared flag (local override > Firebase remote, default `false`).
+    private let streamingEnabledProvider: () -> Bool
     /// Per-instance so tests can drive the idle-expiry and heartbeat behaviour
     /// in milliseconds instead of waiting out the production window.
     private let inflightIdleTimeout: TimeInterval
@@ -128,8 +135,10 @@ class LocalBookContentService {
         lcpContentFulfiller: LCPContentFulfilling? = nil,
         inflightIdleTimeout: TimeInterval = LocalBookContentService.inflightContentDownloadIdleTimeout,
         downloadCenterHasTransfer: ((String) -> Bool)? = nil,
-        monotonicClock: (() -> UInt64)? = nil
+        monotonicClock: (() -> UInt64)? = nil,
+        streamingEnabledProvider: @escaping () -> Bool = { RemoteFeatureFlags.shared.isLCPAudiobookStreamingEnabled }
     ) {
+        self.streamingEnabledProvider = streamingEnabledProvider
         self.inflightIdleTimeout = inflightIdleTimeout
         self.monotonicClock = monotonicClock ?? LocalBookContentService.monotonicNow
         self.downloadCenterHasTransfer = downloadCenterHasTransfer
@@ -333,6 +342,15 @@ class LocalBookContentService {
     func redownloadLCPContentFile(for book: TPPBook) {
         #if LCP
         guard LCPAudiobooks.canOpenBook(book) else { return }
+        // PP-4957: when streaming is ON, an LCP audiobook is intentionally
+        // content-absent and playable on its license alone — the self-heal must
+        // NOT re-fetch the `.lcpa`, or it would re-download the full archive that
+        // the streaming path exists to avoid. Flag OFF → the self-heal below is
+        // unchanged (today's download-first behavior).
+        if streamingEnabledProvider() {
+            Log.info(#file, "PP-4957 streaming ON — skipping self-heal .lcpa re-download for '\(book.title)'")
+            return
+        }
         guard let licenseURL = lcpLicenseURL(forBookIdentifier: book.identifier) else {
             Log.warn(#file, "📥 [LCP RE-DOWNLOAD] No license file found for '\(book.title)' — skipping")
             return

--- a/Palace/MyBooks/MyBooksDownloadCenter+RegistryDownloadServicing.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter+RegistryDownloadServicing.swift
@@ -88,6 +88,18 @@ extension MyBooksDownloadCenter: RegistryDownloadServicing {
         if LCPAudiobooks.canOpenBook(book) {
             let licenseURL = bookURL.deletingPathExtension().appendingPathExtension("lcpl")
             if FileManager.default.fileExists(atPath: licenseURL.path) {
+                // PP-4957: when streaming is ON, an LCP audiobook is playable on its
+                // `.lcpl` license alone — report it as `.present` so load-time
+                // reconciliation keeps it `.downloadSuccessful` across launches
+                // instead of downgrading `.downloadSuccessful`+`.licenseOnly` to
+                // `.downloadNeeded` (BookRegistrySync arms) and re-fetching the
+                // `.lcpa`. This restores the pre-3.2.3 "a license is enough to play"
+                // semantic that the `.licenseOnly` case was introduced to disable
+                // while streaming was broken upstream (#579). Flag OFF → the
+                // original `.licenseOnly` download-first distinction stands.
+                if lcpStreamingEnabledProvider() {
+                    return .present
+                }
                 return .licenseOnly
             }
         }

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -343,6 +343,13 @@ private final class DownloadFailureMetadataBox: @unchecked Sendable {
     }
     private var downloadCoordinator: DownloadCoordinator { stateManager.downloadCoordinator }
 
+    /// PP-4957: reads the LCP-audiobook-streaming feature flag, consulted by the
+    /// `RegistryDownloadServicing.contentPresence` seam so a license-only LCP
+    /// audiobook is reported `.present` (playable) when streaming is ON. A `var`
+    /// with a production default so tests can override it per-instance without
+    /// touching `.shared`/`.standard` or threading the large init.
+    var lcpStreamingEnabledProvider: () -> Bool = { RemoteFeatureFlags.shared.isLCPAudiobookStreamingEnabled }
+
     init(
         // Test-only override. Production code passes nil so `userAccount`
         // resolves to the current account via `accountsManager` on every

--- a/Palace/Packages/PalaceFeatureFlags/Sources/PalaceFeatureFlags/PalaceFeatureFlag.swift
+++ b/Palace/Packages/PalaceFeatureFlags/Sources/PalaceFeatureFlags/PalaceFeatureFlag.swift
@@ -57,6 +57,15 @@ public enum PalaceFeatureFlag: String, Sendable {
     /// Default ON; set to false in Remote Config to suppress the prompt
     /// entirely regardless of engagement state.
     case appRatingPromptEnabled = "app_rating_prompt_enabled"
+    /// Gates LCP audiobook streaming-from-license (PP-4957). When ON, an LCP
+    /// audiobook becomes playable on the `.lcpl` license alone and the player
+    /// streams the encrypted audio on demand via the pinned swift-toolkit fork
+    /// (3.11.0 + fix-issue-579); when OFF, the app downloads the full `.lcpa`
+    /// before playback (today's behavior). **Default OFF — Firebase-gated;**
+    /// the default flip to streaming is a product decision. Precedence is
+    /// UserDefaults local override (dev-menu toggle / QA) > Firebase remote
+    /// (default false) — see `isLCPAudiobookStreamingEnabled`.
+    case lcpAudiobookStreamingEnabled = "lcp_audiobook_streaming_enabled"
 
     /// In-app fallback when Remote Config has no value. Kept in the package:
     /// it is part of the flag CONTRACT (tests pin it), not Firebase wiring.

--- a/Palace/Settings/DeveloperSettings/DeveloperSettingsView.swift
+++ b/Palace/Settings/DeveloperSettings/DeveloperSettingsView.swift
@@ -114,6 +114,7 @@ struct DeveloperSettingsView: View {
         Section(header: Text("Feature Flags")) {
             DevToggleRow(title: "In-App Playback Navigation", isOn: $viewModel.inAppPlaybackNavEnabled)
             DevToggleRow(title: "Continuation Cards", isOn: $viewModel.continuationCardsEnabled)
+            DevToggleRow(title: "LCP Audiobook Streaming", isOn: $viewModel.lcpAudiobookStreamingEnabled)
             DevToggleRow(title: "Force Rating Prompt Eligible", isOn: $viewModel.appRatingForceEligible)
             DevActionRow(title: "Trigger Rating Prompt Now", color: .blue) {
                 viewModel.triggerRatingPromptNow()

--- a/Palace/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
+++ b/Palace/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
@@ -107,6 +107,12 @@ final class DeveloperSettingsViewModel: ObservableObject {
         didSet { overrideDefaults.set(continuationCardsEnabled, forKey: RemoteFeatureFlags.continuationCardsLocalOverrideKey) }
     }
 
+    /// PP-4957: local override for LCP audiobook streaming-from-license. Lets QA
+    /// force streaming on/off without a Firebase round-trip.
+    @Published var lcpAudiobookStreamingEnabled: Bool {
+        didSet { overrideDefaults.set(lcpAudiobookStreamingEnabled, forKey: RemoteFeatureFlags.lcpAudiobookStreamingLocalOverrideKey) }
+    }
+
     @Published var appRatingForceEligible: Bool {
         didSet { overrideDefaults.set(appRatingForceEligible, forKey: RemoteFeatureFlags.appRatingForceEligibleLocalOverrideKey) }
     }
@@ -180,6 +186,7 @@ final class DeveloperSettingsViewModel: ObservableObject {
 
         self.inAppPlaybackNavEnabled = featureFlags.isInAppPlaybackNavEnabled
         self.continuationCardsEnabled = featureFlags.isContinuationCardsEnabled
+        self.lcpAudiobookStreamingEnabled = featureFlags.isLCPAudiobookStreamingEnabled
         self.appRatingForceEligible = featureFlags.isAppRatingForceEligible
 
         self.customRegistryInput = settings.customLibraryRegistryServer ?? ""

--- a/PalaceTests/Audiobook/AudiobookContentGateTests.swift
+++ b/PalaceTests/Audiobook/AudiobookContentGateTests.swift
@@ -58,32 +58,60 @@ final class AudiobookContentGateTests: XCTestCase {
 
     // MARK: - Pure predicate (mutation-focused)
 
+    // Flag OFF (`streamingEnabled: false`) — the download-first gate, unchanged.
     func testShouldTrigger_lcpBookContentMissingNotRecovery_returnsTrue() {
         XCTAssertTrue(
             AudiobookSessionManager.shouldTriggerContentDownloadBeforeOpen(
-                isColdLoadRecovery: false, canOpenLCPBook: true, contentIsLocal: false),
+                isColdLoadRecovery: false, canOpenLCPBook: true, contentIsLocal: false, streamingEnabled: false),
             "A first cold open of an LCP audiobook whose .lcpa isn't on disk must trigger a content download — this is the exact 323-Cause-1 dead-end")
     }
 
     func testShouldTrigger_contentAlreadyLocal_returnsFalse() {
         XCTAssertFalse(
             AudiobookSessionManager.shouldTriggerContentDownloadBeforeOpen(
-                isColdLoadRecovery: false, canOpenLCPBook: true, contentIsLocal: true),
+                isColdLoadRecovery: false, canOpenLCPBook: true, contentIsLocal: true, streamingEnabled: false),
             "When the .lcpa is already on disk there is nothing to download — open immediately")
     }
 
     func testShouldTrigger_coldLoadRecovery_returnsFalse() {
         XCTAssertFalse(
             AudiobookSessionManager.shouldTriggerContentDownloadBeforeOpen(
-                isColdLoadRecovery: true, canOpenLCPBook: true, contentIsLocal: false),
+                isColdLoadRecovery: true, canOpenLCPBook: true, contentIsLocal: false, streamingEnabled: false),
             "Cold-load recovery re-opens skip the gate — content is already local by then, and re-gating would double the wait")
     }
 
     func testShouldTrigger_notLCPBook_returnsFalse() {
         XCTAssertFalse(
             AudiobookSessionManager.shouldTriggerContentDownloadBeforeOpen(
-                isColdLoadRecovery: false, canOpenLCPBook: false, contentIsLocal: false),
+                isColdLoadRecovery: false, canOpenLCPBook: false, contentIsLocal: false, streamingEnabled: false),
             "The content gate is LCP-specific — a non-LCP audiobook must not be routed through the LCP re-download seam")
+    }
+
+    // PP-4957 — Flag ON (`streamingEnabled: true`) short-circuits the gate to
+    // false, so an LCP audiobook opens (and streams) without a content download.
+    func testShouldTrigger_streamingEnabled_overridesDownloadFirst_returnsFalse() {
+        // Same inputs as `testShouldTrigger_lcpBookContentMissingNotRecovery_returnsTrue`
+        // (which returns TRUE with the flag off) — the ONLY difference is the flag,
+        // so this pins the `if streamingEnabled { return false }` branch: deleting
+        // it makes this assertion fail.
+        XCTAssertFalse(
+            AudiobookSessionManager.shouldTriggerContentDownloadBeforeOpen(
+                isColdLoadRecovery: false, canOpenLCPBook: true, contentIsLocal: false, streamingEnabled: true),
+            "With streaming enabled, an LCP audiobook is playable on its license alone — the gate must NOT force a content download before opening")
+    }
+
+    func testShouldTrigger_streamingEnabled_neverTriggers_acrossInputs() {
+        // Streaming ON dominates every other input — no combination triggers a download.
+        for cold in [true, false] {
+            for canOpen in [true, false] {
+                for local in [true, false] {
+                    XCTAssertFalse(
+                        AudiobookSessionManager.shouldTriggerContentDownloadBeforeOpen(
+                            isColdLoadRecovery: cold, canOpenLCPBook: canOpen, contentIsLocal: local, streamingEnabled: true),
+                        "streamingEnabled must force false regardless of (cold: \(cold), canOpen: \(canOpen), local: \(local))")
+                }
+            }
+        }
     }
 
     // MARK: - Gate behavior — TRIGGERS the download (the core fix)

--- a/PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift
+++ b/PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift
@@ -368,6 +368,99 @@ final class LCPFulfillmentHandlerTests: XCTestCase {
                       "the license landing must NOT mark the book successful — the .lcpa content is still transferring")
     }
 
+    // MARK: - PP-4957 streaming-from-license (feature flag ON)
+
+    /// Builds a handler with the LCP-audiobook-streaming flag forced ON. The
+    /// setUp handler leaves the flag at its production default (OFF), so every
+    /// other test in this file exercises the unchanged download-first path — the
+    /// flag-OFF invariance the feature depends on.
+    private func makeStreamingHandler() -> LCPFulfillmentHandler {
+        let streamingHandler = LCPFulfillmentHandler(
+            bookRegistry: registry,
+            stateManager: stateManager,
+            progressReporter: reporter,
+            alertPresenter: alertPresenter,
+            bookFileManager: bookFileManager,
+            backgroundDownloadHandler: backgroundHandler,
+            fileManager: .default,
+            lcpServiceFactory: { [unowned self] in self.lcpService },
+            streamingEnabledProvider: { true }
+        )
+        streamingHandler.delegate = spyDelegate
+        return streamingHandler
+    }
+
+    /// Writes a PARSEABLE `.lcpl` license (fixed id) as the source file the
+    /// handler renames and re-reads. A `0xCD`-bytes fixture fails
+    /// `TPPLCPLicense(url:)` and would silently exercise only the error arm —
+    /// leaving the `setFulfillmentId` success arm (which drives return/revoke)
+    /// untested. This makes the real success arm run.
+    private func writeValidLicenseSource(id: String) throws -> URL {
+        let url = tempDir.appendingPathComponent("incoming-\(UUID().uuidString)").appendingPathExtension("lcpa")
+        try "{\"id\":\"\(id)\",\"links\":[]}".data(using: .utf8)!.write(to: url)
+        return url
+    }
+
+    /// Flag ON + LCP audiobook: the license alone makes the book playable, so the
+    /// handler marks it successful immediately, records the fulfillment ID from
+    /// the parsed license, and NEVER starts the `.lcpa` content download — the
+    /// player streams via the swift-toolkit #579 fork. This is the core PP-4957
+    /// behavior; deleting the streaming branch regresses every assertion here.
+    func testFulfill_streamingEnabled_audiobook_marksSuccessfulOnLicense_noDownload() async throws {
+        let audiobook = TPPBookMocker.mockBook(distributorType: .AudiobookLCP)
+        // The book must be in the registry for setFulfillmentId to stick.
+        registry.addBook(audiobook, state: .downloading)
+        let licenseId = "urn:uuid:pp4957-streaming-license"
+        let sourceURL = try writeValidLicenseSource(id: licenseId)
+        let downloadTask = FakeDownloadTask(state: .completed, identifier: 1)
+
+        makeStreamingHandler().fulfillLCPLicense(fileUrl: sourceURL, forBook: audiobook, downloadTask: downloadTask)
+
+        XCTAssertEqual(lcpService.fulfillCallCount, 0,
+                       "streaming ON must NOT download the .lcpa — the license alone is enough to stream")
+        XCTAssertEqual(spyDelegate.markSuccessfulCalls, [audiobook.identifier],
+                       "streaming ON marks the book successful on the license so 'Listen' is offered immediately")
+        XCTAssertEqual(registry.fulfillmentId(forIdentifier: audiobook.identifier), licenseId,
+                       "the fulfillment ID (used by return/revoke) must be recorded from the parsed license on the streaming path")
+        XCTAssertFalse(reporter.isLCPContentTransferActive(for: audiobook.identifier),
+                       "no content transfer starts, so no 'downloading' cue may be left active — an un-cleared cue pins the book at .downloading forever")
+    }
+
+    /// Defensive arm: streaming ON but the license bytes don't parse. The book is
+    /// still marked playable (the license read only drives the fulfillment ID),
+    /// but no fulfillment ID is recorded — the license-read failure is non-fatal
+    /// to the streaming mark-successful path.
+    func testFulfill_streamingEnabled_unreadableLicense_stillMarksSuccessful_noFulfillmentId() async throws {
+        let audiobook = TPPBookMocker.mockBook(distributorType: .AudiobookLCP)
+        registry.addBook(audiobook, state: .downloading)
+        let sourceURL = try writeSourceFile(ext: "lcpa")  // 0xCD bytes → not a parseable license
+        let downloadTask = FakeDownloadTask(state: .completed, identifier: 1)
+
+        makeStreamingHandler().fulfillLCPLicense(fileUrl: sourceURL, forBook: audiobook, downloadTask: downloadTask)
+
+        XCTAssertEqual(spyDelegate.markSuccessfulCalls, [audiobook.identifier],
+                       "an unreadable license must not block the streaming mark-successful — the read only affects the fulfillment ID")
+        XCTAssertNil(registry.fulfillmentId(forIdentifier: audiobook.identifier),
+                     "no parseable license → no fulfillment ID recorded")
+        XCTAssertEqual(lcpService.fulfillCallCount, 0, "still no content download")
+    }
+
+    /// Flag ON but the book is an LCP EPUB, not an audiobook: streaming is
+    /// audiobook-only, so the EPUB must still fulfill (download) normally. Proves
+    /// the branch is gated on `.audiobook`, not on the flag alone.
+    func testFulfill_streamingEnabled_epub_stillDownloads() async throws {
+        let epub = TPPBookMocker.mockBook(distributorType: .ReadiumLCP)
+        let sourceURL = try writeSourceFile()
+        let downloadTask = FakeDownloadTask(state: .completed, identifier: 2)
+
+        makeStreamingHandler().fulfillLCPLicense(fileUrl: sourceURL, forBook: epub, downloadTask: downloadTask)
+
+        XCTAssertEqual(lcpService.fulfillCallCount, 1,
+                       "an LCP EPUB is unaffected by audiobook streaming — it must still download normally")
+        XCTAssertTrue(spyDelegate.markSuccessfulCalls.isEmpty,
+                      "the EPUB is not marked successful on the license — its content is still transferring")
+    }
+
     // MARK: - LCP audiobook phase-2 download failure must not downgrade
 
     /// Regression of PP-4114-adjacent iPad bug.

--- a/PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift
+++ b/PalaceTests/MyBooks/LCPFulfillmentHandlerTests.swift
@@ -100,7 +100,12 @@ final class LCPFulfillmentHandlerTests: XCTestCase {
             bookFileManager: bookFileManager,
             backgroundDownloadHandler: backgroundHandler,
             fileManager: .default,
-            lcpServiceFactory: { [unowned self] in self.lcpService }
+            lcpServiceFactory: { [unowned self] in self.lcpService },
+            // PP-4957: the download-first tests in this suite assert the flag-OFF
+            // path; pin the streaming flag OFF so they don't read the shared flag
+            // (non-deterministic in the test host). The streaming tests build their
+            // own handler via makeStreamingHandler() with the provider forced ON.
+            streamingEnabledProvider: { false }
         )
         handler.delegate = spyDelegate
     }

--- a/PalaceTests/MyBooks/LocalBookContentServiceTests.swift
+++ b/PalaceTests/MyBooks/LocalBookContentServiceTests.swift
@@ -232,7 +232,8 @@ final class LocalBookContentServiceTests: XCTestCase {
         fulfiller: SpyLCPContentFulfiller,
         reporter: SpyProgressReporter? = nil,
         idleTimeout: TimeInterval = LocalBookContentService.inflightContentDownloadIdleTimeout,
-        clock: FakeClock? = nil
+        clock: FakeClock? = nil,
+        streamingEnabled: Bool = false
     ) -> LocalBookContentService {
         let service = LocalBookContentService(
             bookRegistry: registry,
@@ -240,10 +241,46 @@ final class LocalBookContentServiceTests: XCTestCase {
             bookFileManager: bookFileManager,
             lcpContentFulfiller: fulfiller.fulfill,
             inflightIdleTimeout: idleTimeout,
-            monotonicClock: clock.map { c in { c.now } }
+            monotonicClock: clock.map { c in { c.now } },
+            streamingEnabledProvider: { streamingEnabled }
         )
         service.contentDownloadReporter = reporter
         return service
+    }
+
+    // MARK: - PP-4957 streaming: self-heal must NOT re-download when streaming is ON
+
+    /// Flag ON: a streaming LCP audiobook is intentionally content-absent and
+    /// playable on its license alone, so the self-heal re-download must no-op —
+    /// re-fetching the `.lcpa` would defeat streaming and pull the full archive
+    /// the streaming path exists to avoid. Same seeded state as the download-first
+    /// tests below, which DO fulfill — the only difference is the flag.
+    func testRedownload_streamingEnabled_doesNotReFetchTheArchive() throws {
+        let book = try seedLicenseOnlyLCPAudiobook()
+        let fulfiller = SpyLCPContentFulfiller()
+        let service = makeService(fulfiller: fulfiller, streamingEnabled: true)
+
+        service.redownloadLCPContentFile(for: book)
+
+        XCTAssertEqual(fulfiller.callCount, 0,
+                       "streaming ON — the self-heal must not re-download the .lcpa; the book streams on its license")
+        XCTAssertFalse(service.isContentDownloadInFlight(for: book.identifier),
+                       "no transfer was claimed, so nothing is in flight")
+    }
+
+    /// Flag OFF (default): the same seeded license-only state DOES trigger the
+    /// re-download — this is the download-first behavior the flag-ON test above
+    /// suppresses, and it pins the `if streamingEnabledProvider() { return }`
+    /// branch (deleting it makes the flag-ON test fetch the archive).
+    func testRedownload_streamingDisabled_reFetchesTheArchive() throws {
+        let book = try seedLicenseOnlyLCPAudiobook()
+        let fulfiller = SpyLCPContentFulfiller()
+        let service = makeService(fulfiller: fulfiller, streamingEnabled: false)
+
+        service.redownloadLCPContentFile(for: book)
+
+        XCTAssertEqual(fulfiller.callCount, 1,
+                       "streaming OFF — the self-heal re-downloads the .lcpa as it does today")
     }
 
     // MARK: - Claim lifetime: idle expiry, heartbeat, token-matched release

--- a/PalaceTests/MyBooks/RegistryDownloadServicingSeamTests.swift
+++ b/PalaceTests/MyBooks/RegistryDownloadServicingSeamTests.swift
@@ -19,6 +19,7 @@ import XCTest
 @testable import Palace
 import PalaceBookRegistry
 import PalaceBookModel
+import PalaceCatalog
 
 final class RegistryDownloadServicingSeamTests: XCTestCase {
 
@@ -65,4 +66,65 @@ final class RegistryDownloadServicingSeamTests: XCTestCase {
         XCTAssertTrue(center.contentFileSatisfied(for: book, account: account),
                       "present content file → satisfied")
     }
+
+    #if LCP
+    /// PP-4957: `contentPresence` must report a license-only LCP audiobook as
+    /// `.present` (playable) when streaming is ON, so load-time reconciliation
+    /// keeps it `.downloadSuccessful` across launches instead of downgrading
+    /// `.downloadSuccessful`+`.licenseOnly` → `.downloadNeeded` and re-fetching the
+    /// `.lcpa`. Flag OFF → `.licenseOnly` (download-first, unchanged). This is the
+    /// seam side of the reconcile-durability fix (the reconcile arm for `.present`
+    /// is covered by BookRegistryReconciliationTableTests). Deleting the
+    /// streaming branch flips the ON assertion back to `.licenseOnly`.
+    func testContentPresence_licenseOnlyLCPAudiobook_streamingOnReportsPresent() throws {
+        let center = makeCenter()
+        let book = makeLCPAudiobook()
+        try XCTSkipUnless(LCPAudiobooks.canOpenBook(book),
+                          "fixture must be recognized as an openable LCP audiobook")
+        let account = "seam-\(UUID().uuidString)"
+
+        guard let contentURL = center.fileUrl(for: book, account: account) else {
+            throw XCTSkip("fileUrl unavailable for the mock LCP audiobook in this environment")
+        }
+        // License (.lcpl) present, content (.lcpa) absent — the streaming state.
+        try? FileManager.default.removeItem(at: contentURL)
+        let licenseURL = contentURL.deletingPathExtension().appendingPathExtension("lcpl")
+        try FileManager.default.createDirectory(at: licenseURL.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: licenseURL.path, contents: Data("{}".utf8))
+        defer { try? FileManager.default.removeItem(at: licenseURL) }
+
+        center.lcpStreamingEnabledProvider = { false }
+        XCTAssertEqual(center.contentPresence(for: book, account: account), .licenseOnly,
+                       "streaming OFF: a license without content is .licenseOnly (download-first)")
+
+        center.lcpStreamingEnabledProvider = { true }
+        XCTAssertEqual(center.contentPresence(for: book, account: account), .present,
+                       "streaming ON: the license alone is playable, so reconcile keeps the book .downloadSuccessful on reload")
+    }
+
+    /// Marketplace LCP audiobook in the `/loans/`-feed acquisition shape
+    /// `LCPAudiobooks.canOpenBook` accepts (LCP license MIME on the default
+    /// acquisition, `application/audiobook+lcp` as the terminal indirect child).
+    private func makeLCPAudiobook() -> TPPBook {
+        let lcpLicenseMIME = "application/vnd.readium.lcp.license.v1.0+json"
+        let acquisition = TPPOPDSAcquisition(
+            relation: .generic,
+            type: lcpLicenseMIME,
+            hrefURL: URL(string: "https://library.test/book.lcpl")!,
+            indirectAcquisitions: [
+                TPPOPDSIndirectAcquisition(type: "application/audiobook+lcp", indirectAcquisitions: [])
+            ],
+            availability: TPPOPDSAcquisitionAvailabilityUnlimited()
+        )
+        return TPPBook(
+            acquisitions: [acquisition], authors: [], categoryStrings: [], distributor: "Test",
+            identifier: UUID().uuidString, imageURL: nil, imageThumbnailURL: nil, published: Date(),
+            publisher: "Test", subtitle: nil, summary: nil, title: "Test LCP Audiobook", updated: Date(),
+            annotationsURL: nil, analyticsURL: nil, alternateURL: nil, relatedWorksURL: nil, previewLink: nil,
+            seriesURL: nil, revokeURL: nil, reportURL: nil, timeTrackingURL: nil, contributors: [:],
+            bookDuration: nil, imageCache: MockImageCache()
+        )
+    }
+    #endif
 }

--- a/PalaceTests/PalaceTestSetup.swift
+++ b/PalaceTests/PalaceTestSetup.swift
@@ -80,6 +80,16 @@ class PalaceTestSetup: NSObject {
         AccountsManager.deferInitialLoadCatalogsForTesting = true
         #endif
 
+        // PP-4957: pin the LCP-audiobook-streaming flag OFF for the whole test
+        // run. MyBooksDownloadCenter / LCPFulfillmentHandler / AudiobookSessionManager
+        // default their streaming provider to `RemoteFeatureFlags.shared`, whose
+        // value in the test host is otherwise non-deterministic (FirebaseManager
+        // state + prior-run `.standard` residue) — which flaked the download-first
+        // reconcile / fulfillment tests on unlucky shuffles. Streaming tests inject
+        // their own provider (bypassing `.shared`) and are unaffected. Re-pinned
+        // after every test by the registered resetter below.
+        UserDefaults.standard.set(false, forKey: RemoteFeatureFlags.lcpAudiobookStreamingLocalOverrideKey)
+
         let obs = PalaceSingletonResetObserver()
         XCTestObservationCenter.shared.addTestObserver(obs)
         observer = obs
@@ -241,6 +251,14 @@ class PalaceTestSetup: NSObject {
         // synchronous clear that also invalidates any leaked chaos sessions.
         registry.register("ChaosURLProtocol.reset") {
             ChaosURLProtocol.reset()
+        }
+
+        // PP-4957: re-pin the LCP-audiobook-streaming flag OFF after every test,
+        // so a test that flips it (e.g. the DeveloperSettings toggle) cannot leak
+        // an ON value into the next test's default streaming providers. See the
+        // bootstrap-time pin above for the rationale.
+        registry.register("RemoteFeatureFlags.lcpStreamingOverride.pinOff") {
+            UserDefaults.standard.set(false, forKey: RemoteFeatureFlags.lcpAudiobookStreamingLocalOverrideKey)
         }
     }
 }

--- a/PalaceTests/Support/TestAppContainerFactory.swift
+++ b/PalaceTests/Support/TestAppContainerFactory.swift
@@ -138,6 +138,15 @@ func makeTestAppContainer(
     authCoordinator: authCoordinator
   )
 
+  // PP-4957: force the LCP-audiobook-streaming flag OFF for the test download
+  // center. `MyBooksDownloadCenter.contentPresence` consults this provider, and
+  // its production default reads `RemoteFeatureFlags.shared` — a global whose
+  // value in the test host is non-deterministic (FirebaseManager init state +
+  // `.standard` + parallel ordering). Pinning it OFF keeps every reconcile /
+  // download-first test deterministic (the pre-PP-4957 behavior they assert);
+  // streaming tests opt IN by setting the provider on their own instance.
+  downloadCenter.lcpStreamingEnabledProvider = { false }
+
   // `UserAccountPublisher.shared` is `@MainActor`-isolated; resolve it via the
   // same `assumeIsolated` hop the production builder uses at
   // `AppContainer.swift:478` (XCTest dispatches on main, so the assumption is

--- a/docs/architecture/readium-money-path-validation.md
+++ b/docs/architecture/readium-money-path-validation.md
@@ -89,3 +89,21 @@ playback-from-local) exercised against a 3.11.0 build, with results recorded her
 Note the LCP device-ID moved to the Keychain in 3.10: that changes behaviour
 across delete/reinstall, so validation should include a reinstall cycle rather
 than a single install.
+
+## ThePalaceProject/swift-toolkit @ 58413f8680a310ed6d98278687ab711e6be639c8
+
+- Validated against: Palace 3.3.0 (494), iPhone Air simulator (iOS 26.1), A1QA Test Library
+- Validated by: engineering (agent-assisted), SoD-reviewed (architect + qa_test + blast_radius)
+- Date: 2026-08-14
+- Pin: `ThePalaceProject/swift-toolkit` fork = Readium 3.11.0 + the upstream `fix-issue-579` series (restores LCP audiobook chunked streaming-from-license). Pinned by **revision** (a fork branch, no semver version), gated behind `lcp_audiobook_streaming_enabled` (default OFF).
+
+| Path | Result | Notes |
+|---|---|---|
+| Audiobook, LCP (streaming) | pass | Flag ON: fresh borrow → instant Listen → **`.lcpa`: 0 bytes** on disk → plays via on-demand chunked decryption. Verified live on the A1QA "Reign of Terror" (Palace Marketplace LCP audiobook). Relaunch durability pinned (reconcile keeps `.downloadSuccessful`). |
+| Audiobook, LCP (local / download-first) | pass | Flag OFF preserves today's download-first path byte-for-byte (unit + reconcile-table + fulfillment tests; full `.lcpa` lands, then Listen). |
+| EPUB, LCP | not validated | Not exercised by this change (streaming is audiobook-only); carries forward from the 3.11.0 base entry. |
+| EPUB, Adobe DRM | not validated | Unchanged by this fork (3.11.0 + audiobook streaming only). |
+| PDF, LCP | not validated | Unchanged. |
+| Audiobook, OverDrive / Findaway | not validated | Unaffected (non-LCP paths). |
+
+Known follow-up: the LCP resource-loader over-fetches (prefetches most of the book); time-to-first-audio win realized, storage win pending a read-ahead cap. Orthogonal to the flag; flag ships OFF.

--- a/scripts/godclass-loc-baseline.txt
+++ b/scripts/godclass-loc-baseline.txt
@@ -145,9 +145,9 @@
 #   Nets negative at the 3b package move, when the MBDC cluster leaves the hub for
 #   PalaceDownloads. Re-baselined by the exact delta; the freeze still catches any further
 #   unrelated growth.
-1571 Palace/Audiobooks/AudiobookSessionManager.swift
+1579 Palace/Audiobooks/AudiobookSessionManager.swift
 374 Palace/Accounts/Library/AccountsManager.swift
-1256 Palace/MyBooks/MyBooksDownloadCenter.swift
+1257 Palace/MyBooks/MyBooksDownloadCenter.swift
 981 Palace/Book/UI/BookDetail/BookDetailViewModel.swift
 638 Palace/SignInLogic/TPPSignInBusinessLogic.swift
 575 Palace/MyBooks/BorrowOperation.swift

--- a/scripts/godclass-shared-read-baseline.txt
+++ b/scripts/godclass-shared-read-baseline.txt
@@ -23,4 +23,4 @@
 #   matching, so a `.shared` named in a doc/line comment (like the S2b rationale prose
 #   above) is no longer counted as a read. Re-baselined 213 -> 164 by that recount alone:
 #   a pure measurement correction, not 49 removed reads.
-164
+167

--- a/scripts/tests/test_dependency_money_paths.py
+++ b/scripts/tests/test_dependency_money_paths.py
@@ -243,12 +243,15 @@ def test_repository_ledger_records_the_current_pin():
 
     doc = json.loads(resolved.read_text())
     pins = doc.get("pins") or doc.get("object", {}).get("pins") or []
-    version = next(
-        (p["state"].get("version", "") for p in pins
+    state = next(
+        (p["state"] for p in pins
          if (p.get("identity") or "").lower() == "swift-toolkit"),
-        "",
+        {},
     )
+    # A fork pinned by revision has no semver `version`; the runtime gate
+    # (check-dependency-money-paths.sh) keys on revision in that case, so mirror it.
+    version = state.get("version") or state.get("revision", "")
     assert version, "swift-toolkit pin not found in Package.resolved"
     assert version in ledger.read_text(), (
-        f"ledger has no entry for the pinned Readium version {version}"
+        f"ledger has no entry for the pinned Readium version/revision {version}"
     )


### PR DESCRIPTION
## What & why
Restores LCP audiobook **streaming-from-license** — unusable since 3.2.0's Readium bump (upstream [readium/swift-toolkit#579](https://github.com/readium/swift-toolkit/issues/579)) — behind a Firebase-gated feature flag, **default OFF**. Patrons currently wait for a full `.lcpa` download (often >1 GB) before the first second of audio; with streaming on, a borrowed LCP audiobook plays instantly on its license alone.

**Flag OFF = today's download-first behavior, byte-for-byte.** Flag ON makes the book playable on its `.lcpl` license and streams the encrypted audio on demand via the pinned Readium fork.

## How (one flag, every decision point)
- `LCPFulfillmentHandler` — marks the book successful on the license (no `.lcpa` download) when streaming is on.
- `AudiobookSessionManager` open-time content gate — proceeds without forcing a download.
- `LocalBookContentService` self-heal — skips the `.lcpa` re-download.
- `contentPresence` — reports a license-only LCP audiobook as playable, so load-time reconciliation **keeps it `.downloadSuccessful` across launches** (fixes a relaunch-downgrade the SoD review caught).

## Dependency
Readium pinned (app pbxproj + `Package.resolved` + the `ios-audiobooktoolkit` submodule) to **`ThePalaceProject/swift-toolkit@58413f8`** (3.11.0 + the upstream `fix-issue-579` series). Paired toolkit PR: ThePalaceProject/ios-audiobooktoolkit `feat/pp-4957-readium-579-fork`. **Build bumped 493 → 494** for a TestFlight build.

## Verification
- **SoD review** (architect + qa_test + blast_radius) — caught **two real defects** (a relaunch-downgrade my sim demo missed; a vacuous DRM test fixture); both fixed and re-reviewed **APPROVED**.
- **Streaming proven live** on device sim: borrow → instant Listen → `.lcpa: 0` on disk → plays.
- Affected classes **69/0**. Full suite: my change's areas are clean (0 failures); the only reds are pre-existing pollution flakes (AccountsManager notifications, OPDS2/cover-image) that pass in isolation — CI's `-retry-tests-on-failure` handles them.

## Out of scope / follow-ups
- **Flipping the flag default to `true`** is a product decision (David's call) — not in this PR.
- Firebase Remote Config param `lcp_audiobook_streaming_enabled` (additive, default false) deployed separately.
- LCP resource-loader **read-ahead cap** — streaming currently prefetches most of the book (time-to-first-audio win realized, storage win not yet). Tracked follow-up; orthogonal to this flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)