### PR TITLE
docs+tooling: make "whose failure is this?" a mechanical question

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,42 @@ false positives. Wiring bugs (a scan-only detector called with `--diff`) are
 invisible to a fixture that only ever stages a violation — always assert the
 clean path passes too.
 
-**5. Retire the admin-merge reflex.** Once the board is trustworthy (1–4), red
+**5. A red test is a question about HISTORY, not a prompt to theorise.** Before
+explaining WHY a test fails, establish WHOSE it is — mechanically, from other
+runs and other suites. Two axes, two tools, both cheap:
+
+```bash
+# Axis 1 — across CI runs: is it new here, pre-existing, or retry-masked?
+python3 scripts/ci-test-history.py <TestClass>[.method] [--limit N]
+
+# Axis 2 — across suites: does it pass alone? then who dirties it?
+scripts/find-test-polluter.sh --victim <TestClass>
+```
+
+Read the **per-iteration** results, not the run verdict. `-retry-tests-on-failure
+-test-iterations 3` means a test that passes 2 of 3 reports the job GREEN while a
+real regression sits underneath — so "passed · FAILED · passed" is a finding, not
+noise. A test that flips with unrelated load is measuring the machine and cannot
+gate CI; make it assert a property of the code (see
+`AccountRegistryStorePoolStarvationTests` for the shape: assert operations
+COMPLETE, keep the load-sensitive variant behind an env flag).
+
+Incident (PR #1380, 2026-08-14): a toolkit-bump PR went red and the first
+diagnosis offered was runner oversubscription — plausible, self-consistent, and
+wrong. One command against the previous green run settled it:
+
+    #1377 (green)  passed 0.183s · passed 0.004s · passed 0.004s
+    #1380 (red)    passed 0.215s · FAILED 69.186s · passed 0.003s
+
+Same test, same runner shape, different code — the branch DID introduce it. No
+amount of reasoning about runners produces that table; only the history does.
+Reviewer pushback ("others aren't having this issue") was correct and the theory
+was not. **Get the table first.** Corollaries worth knowing: a test that never
+appears in a run may have been renamed or never registered, which is
+indistinguishable from passing; and NEW-here + passes-in-isolation means your
+branch newly EXPOSED pollution rather than broke logic — a different fix.
+
+**6. Retire the admin-merge reflex.** Once the board is trustworthy (1–5), red
 means **stop**. `--admin` over a red check is allowed ONLY when the failure is a
 specific, named, already-tracked flake that passes in isolation — and that flake
 must have a de-flake item per #2. Never `--admin` over a red board whose failure

--- a/scripts/ci-test-history.py
+++ b/scripts/ci-test-history.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Answer "is this test failure OURS?" from CI history, before theorising.
+
+THE INCIDENT THIS EXISTS FOR (2026-08-14, PR #1380). A toolkit-bump PR went red
+on `AccountRegistryStorePoolStarvationTests`. The first diagnosis offered was
+"CI runs 4 simulator clones per runner, so the machine is oversubscribed and the
+probe legitimately cannot be scheduled" — plausible, self-consistent, and WRONG.
+Pulling the same test out of the previous GREEN run settled it in one command:
+
+    #1377 (green)  passed 0.183s · passed 0.004s · passed 0.004s
+    #1380 (red)    passed 0.215s · FAILED 69.186s · passed 0.003s
+
+Same test, same runner shape, different code. It WAS ours. The reviewer was
+right and the theory was wrong, and no amount of reasoning about runners would
+have produced that table — only the history did.
+
+WHAT IT ANSWERS, mechanically:
+
+  NEW          the test passed on earlier runs and fails now -> this branch
+               introduced it. Fix it; do not blame the runner.
+  PRE-EXISTING it fails on other branches too -> not yours. Say so with
+               evidence instead of absorbing someone else's red.
+  FLAKY        it passes AND fails within a single run's iterations -> retry is
+               masking it. This is the dangerous one: `-retry-tests-on-failure
+               -test-iterations 3` reports the run green while a real regression
+               sits underneath. In the incident above the test passed 2 of 3
+               iterations; retry would have swallowed a genuine regression
+               exactly as readily as it surfaced a false one.
+
+WHAT IT DOES NOT ANSWER. Whether the failure is test POLLUTION (order-dependent
+state from an earlier test). That axis is `scripts/find-test-polluter.sh`, and
+the two together are the protocol: history says whose it is, the polluter script
+says why. A test that is NEW here but passes in isolation locally is pollution
+your branch newly exposed, not necessarily logic your branch broke.
+
+    python3 scripts/ci-test-history.py <TestName>[.method] [options]
+
+      --limit N       CI runs to scan (default 10)
+      --branch B      restrict to one branch
+      --workflow W    workflow name (default "Unit Tests")
+      --repo R        owner/name (default: inferred from origin)
+      --no-cache      re-download logs instead of reusing them
+
+Exit 0 whatever the verdict — this is a diagnostic, not a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+
+# Parallel-clone form:  Test case 'Class.method()' passed on 'Clone 1 of …' (0.004 seconds)
+PARALLEL = re.compile(
+    r"Test case '([\w]+)\.([\w]+)\(\)' (passed|failed) on '([^']*)' \(([\d.]+) seconds\)"
+)
+# Serial xcodebuild form:  Test Case '-[Bundle.Class method]' passed (0.038 seconds).
+SERIAL = re.compile(
+    r"Test Case '-\[[\w.]*?([\w]+) ([\w]+)\]' (passed|failed) \(([\d.]+) seconds\)"
+)
+
+
+def sh(cmd: list[str]) -> str:
+    return subprocess.run(cmd, capture_output=True, text=True).stdout
+
+
+def infer_repo() -> str:
+    url = sh(["git", "remote", "get-url", "origin"]).strip()
+    m = re.search(r"[:/]([\w-]+/[\w-]+?)(?:\.git)?$", url)
+    if not m:
+        print("error: could not infer repo from origin; pass --repo owner/name", file=sys.stderr)
+        raise SystemExit(2)
+    return m.group(1)
+
+
+def runs(repo: str, workflow: str, limit: int, branch: str | None) -> list[dict]:
+    cmd = ["gh", "run", "list", "--repo", repo, "--workflow", workflow,
+           "--limit", str(limit), "--json", "databaseId,headBranch,headSha,conclusion,createdAt"]
+    if branch:
+        cmd += ["--branch", branch]
+    import json
+    out = sh(cmd)
+    try:
+        return json.loads(out) if out.strip() else []
+    except json.JSONDecodeError:
+        print(f"error: could not list runs (is `gh` authenticated?)\n{out[:200]}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def log_for(repo: str, run_id: int, use_cache: bool) -> str:
+    cache = os.path.join(tempfile.gettempdir(), f"ci-log-{repo.replace('/', '_')}-{run_id}.txt")
+    if use_cache and os.path.exists(cache) and os.path.getsize(cache) > 0:
+        return open(cache, encoding="utf-8", errors="replace").read()
+    text = sh(["gh", "run", "view", str(run_id), "--repo", repo, "--log"])
+    if text.strip():
+        with open(cache, "w", encoding="utf-8") as fh:
+            fh.write(text)
+    return text
+
+
+def results_for(log: str, cls: str, method: str | None) -> list[tuple[str, str, str]]:
+    """-> [(method, passed|failed, seconds)] for every iteration found."""
+    found = []
+    for rx, groups in ((PARALLEL, (1, 2, 3, 5)), (SERIAL, (1, 2, 3, 4))):
+        for m in rx.finditer(log):
+            c, meth, verdict, secs = (m.group(g) for g in groups)
+            if c != cls:
+                continue
+            if method and meth != method:
+                continue
+            found.append((meth, verdict, secs))
+    return found
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(add_help=True)
+    ap.add_argument("test", help="TestClass or TestClass.method")
+    ap.add_argument("--limit", type=int, default=10)
+    ap.add_argument("--branch")
+    ap.add_argument("--workflow", default="Unit Tests")
+    ap.add_argument("--repo")
+    ap.add_argument("--no-cache", action="store_true")
+    args = ap.parse_args(argv[1:])
+
+    cls, _, method = args.test.partition(".")
+    method = method or None
+    repo = args.repo or infer_repo()
+
+    found = runs(repo, args.workflow, args.limit, args.branch)
+    if not found:
+        print(f"no runs of workflow {args.workflow!r} on {repo}")
+        return 0
+
+    print(f"{args.test} — {len(found)} run(s) of {args.workflow!r} on {repo}\n")
+    per_branch: dict[str, list[str]] = defaultdict(list)
+    flaky_runs: list[str] = []
+    any_seen = False
+
+    for r in found:
+        log = log_for(repo, r["databaseId"], not args.no_cache)
+        res = results_for(log, cls, method)
+        stamp = f"{r['createdAt'][5:16]}  {r['headSha'][:8]}  {(r['headBranch'] or '?')[:34]:34s}"
+        if not res:
+            print(f"  {stamp}  run={r['conclusion'] or '-':8s}  (test not in this run)")
+            continue
+        any_seen = True
+        verdicts = [v for _, v, _ in res]
+        detail = " · ".join(f"{v} {s}s" for _, v, s in res)
+        mixed = "passed" in verdicts and "failed" in verdicts
+        flag = "  <- MIXED, retry is masking this" if mixed else ""
+        if mixed:
+            flaky_runs.append(r["headSha"][:8])
+        print(f"  {stamp}  run={r['conclusion'] or '-':8s}  {detail}{flag}")
+        per_branch[r["headBranch"] or "?"].append("failed" if "failed" in verdicts else "passed")
+
+    print()
+    if not any_seen:
+        print(f"VERDICT: {args.test} never ran in the scanned window.")
+        print("  Widen with --limit, or check the name — a renamed/never-registered test")
+        print("  silently runs nowhere, which looks identical to passing.")
+        return 0
+
+    failing = {b for b, v in per_branch.items() if "failed" in v}
+    passing = {b for b, v in per_branch.items() if "passed" in v}
+
+    if flaky_runs:
+        print(f"VERDICT: FLAKY — passes and fails within a single run ({', '.join(flaky_runs)}).")
+        print("  Retry reports the run green while the defect stays. Do NOT re-run to")
+        print("  clear it; a test that flips on load is measuring the machine, not the code.")
+    elif failing and not (failing & passing) and len(passing) > 0:
+        print(f"VERDICT: NEW — fails only on {', '.join(sorted(failing))}, passes elsewhere.")
+        print("  This branch introduced it. Fix the change, not the environment.")
+    elif failing and passing:
+        print(f"VERDICT: MIXED across branches — fails on {', '.join(sorted(failing))}, "
+              f"passes on {', '.join(sorted(passing))}.")
+        print("  Compare the per-iteration timings above before concluding; a large")
+        print("  duration change is a load/scheduling signal, a hard failure is logic.")
+    elif failing:
+        print(f"VERDICT: PRE-EXISTING — fails on every branch scanned ({', '.join(sorted(failing))}).")
+        print("  Not introduced by your branch. Say so with this evidence rather than")
+        print("  absorbing it — but it still needs an owner.")
+    else:
+        print("VERDICT: green everywhere in the scanned window.")
+
+    print("\nNext, for the pollution axis (order-dependent state, which CI history")
+    print("cannot see):  scripts/find-test-polluter.sh --victim " + cls)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
When a test goes red the reflex is to explain **why**. The cheaper and more reliable first move is to establish **whose it is** — from history, before any theory.

## The incident this generalises

PR #1380 went red on `AccountRegistryStorePoolStarvationTests`. The first diagnosis offered was runner oversubscription: CI runs 4 simulator clones per runner, so the probe "legitimately" couldn't be scheduled. Plausible, self-consistent, and **wrong**.

One comparison against the previous green run settled it:

```
#1377 (green)  passed 0.183s · passed 0.004s · passed 0.004s
#1380 (red)    passed 0.215s · FAILED 69.186s · passed 0.003s
```

Same test, same runner shape, different code — the branch **had** introduced it. (The bump adds `Task { await MainActor.run { … } }` hops, so a test racing the global scheduler became load-sensitive.) Reviewer pushback — *"others aren't having this issue"* — was right and the theory was not.

No amount of reasoning about runners produces that table. Only the history does.

## `scripts/ci-test-history.py`

```bash
python3 scripts/ci-test-history.py <TestClass>[.method] [--limit N] [--branch B]
```

Produces the table in one command and classifies the result:

| verdict | meaning |
|---|---|
| **NEW** | passes on earlier runs / other branches, fails here → yours |
| **PRE-EXISTING** | fails everywhere scanned → not yours; say so with evidence |
| **FLAKY** | passes **and** fails within one run's iterations → retry is masking it |

That last verdict is the one nobody looks for. With `-retry-tests-on-failure -test-iterations 3`, a test passing 2 of 3 reports the job **green**. In this incident it passed 2 of 3 — retry would have swallowed a genuine regression exactly as readily as it surfaced a false one.

## Verified against the real incident, not a fixture

Run on the failing test, it reproduces the table above and flags `87cf85fa` as MIXED. Run on the rewritten test, it reports green (`0.004s · 0.002s`).

It also surfaced a fact I did not have by hand: the same test passed **3/3 on an unrelated branch** at 16:00 the same day — independent corroboration that the failure was ours.

## The rule

CLAUDE.md gets this as green-board **rule 5** (admin-merge becomes 6), pairing the two axes:

- `ci-test-history.py` — whose it is, across **runs**
- `find-test-polluter.sh` — why, across **suites**

Two corollaries are recorded with it: a test absent from a run may have been renamed or never registered, which is **indistinguishable from passing**; and NEW-here + passes-in-isolation means the branch **exposed** pollution rather than broke logic — a different fix.

## Not done

No pytest in `scripts/tests/`. Green-board rule 4 sets that bar for **gates**; this is a diagnostic that gates nothing and exits 0 on every verdict. If it's ever wired into a hook or `verify-pr.sh`, it needs the pytest and the wiring test first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)