### PR TITLE
fix(audiobooks): rate-aware time remaining in both players (PP-4971)

### DIFF
--- a/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
+++ b/Palace/AppInfrastructure/AudiobookMorphingPlayerView.swift
@@ -1416,8 +1416,29 @@ struct AudiobookMorphingPlayerView: View {
         // progress fraction. `durationToSelf()` is the book-elapsed time; deriving
         // `total * scrubberFraction` would leap whenever the (chapter-scoped)
         // scrubber moved. This reads the true book position independently.
-        let total = position.tracks.totalDuration
-        let remaining = max(0, total - position.durationToSelf())
+        let bookTimeRemaining = position.tracks.totalDuration - position.durationToSelf()
+        return Self.wholeBookRemainingText(bookTimeRemaining: bookTimeRemaining, rate: currentRate)
+    }
+
+    /// PP-4971: phrase the whole-book figure in wall-clock time at the speed the
+    /// patron is listening at, not in book time.
+    ///
+    /// This is the "how much longer will this take me" number, so it has to
+    /// answer that question — a 2× listener was previously told hours remained
+    /// on a book they were about to finish. The chapter timecode beside the
+    /// scrubber deliberately does NOT get this treatment: it has to keep
+    /// agreeing with the scrubber position and the chapter length.
+    ///
+    /// The rate division itself is `AudiobookPlaybackModel.remainingWallClock`,
+    /// shared with the toolkit player so the two cannot drift apart again.
+    nonisolated static func wholeBookRemainingText(
+        bookTimeRemaining: TimeInterval,
+        rate: PlaybackRate
+    ) -> String {
+        let remaining = AudiobookPlaybackModel.remainingWallClock(
+            bookTimeRemaining: bookTimeRemaining,
+            rate: rate
+        )
         let hrs = Int(remaining) / 3600
         let mins = (Int(remaining) % 3600) / 60
         if hrs > 0 { return String(format: "%d hr %02d min remaining", hrs, mins) }

--- a/PalaceTests/AppInfrastructure/AudiobookMorphingPlayerViewTests.swift
+++ b/PalaceTests/AppInfrastructure/AudiobookMorphingPlayerViewTests.swift
@@ -305,4 +305,68 @@ final class AudiobookMorphingPlayerViewTests: XCTestCase {
         XCTAssertTrue(V.downloadingAccessibilityLabel(title: "T", authors: nil, progress: 1.42).contains("100%"),
                       "Over-unity progress clamps to 100%")
     }
+
+    // MARK: - PP-4971 — whole-book remaining is wall-clock, not book time
+
+    /// The baseline: at normal speed the figure is the book time unchanged, so
+    /// the fix cannot be "always divide by something".
+    func testWholeBookRemaining_atNormalSpeed_readsBookTime() {
+        XCTAssertEqual(
+            V.wholeBookRemainingText(bookTimeRemaining: 3600, rate: .normalTime),
+            "1 hr 00 min remaining"
+        )
+    }
+
+    /// The reported defect: a 2× listener was told the full book time remained.
+    func testWholeBookRemaining_atDoubleSpeed_isHalved() {
+        XCTAssertEqual(
+            V.wholeBookRemainingText(bookTimeRemaining: 3600, rate: .doubleTime),
+            "30 min remaining"
+        )
+    }
+
+    /// Slower than normal has to move the other way — a sign error would pass a
+    /// test that only ever checked speeds above 1×.
+    func testWholeBookRemaining_belowNormalSpeed_takesLonger() {
+        XCTAssertEqual(
+            V.wholeBookRemainingText(bookTimeRemaining: 3600, rate: .threeQuartersTime),
+            "1 hr 20 min remaining"
+        )
+    }
+
+    /// Changing speed must change the answer at every step of the rail, not just
+    /// at the presets — the whole point of PP-4518 was the 0.05× steps.
+    func testWholeBookRemaining_everyRateOnTheRailProducesADistinctFigure() {
+        // 10 hours of book: enough that adjacent 0.05x steps differ by minutes.
+        let bookTime: TimeInterval = 36_000
+        var seen = Set<String>()
+        for rate in PlaybackRate.allCases {
+            seen.insert(V.wholeBookRemainingText(bookTimeRemaining: bookTime, rate: rate))
+        }
+        XCTAssertEqual(
+            seen.count, PlaybackRate.allCases.count,
+            "Two speeds produced the same remaining figure — the rate is not reaching the calculation"
+        )
+    }
+
+    /// A finished book reads zero however fast it was played.
+    func testWholeBookRemaining_finishedBookIsZeroAtEverySpeed() {
+        for rate in PlaybackRate.allCases {
+            XCTAssertEqual(
+                V.wholeBookRemainingText(bookTimeRemaining: 0, rate: rate),
+                "0 min remaining",
+                "rate \(rate.rawValue) did not report a finished book as zero"
+            )
+        }
+    }
+
+    /// The playhead can overrun the manifest duration, which used to be absorbed
+    /// by a `max(0,)` at the call site. That clamp now lives in the shared rule,
+    /// so a negative must still never surface as "-1 min remaining".
+    func testWholeBookRemaining_overrunPlayheadDoesNotGoNegative() {
+        XCTAssertEqual(
+            V.wholeBookRemainingText(bookTimeRemaining: -120, rate: .normalTime),
+            "0 min remaining"
+        )
+    }
 }


### PR DESCRIPTION
## Why

The player told a patron how much of a book was left in **book time** and never accounted for listening speed. At 2× it reported hours remaining on a book about to finish.

From the triage of the eighty-three App Store reviews left Jan–Aug 2026. One reviewer describes it precisely and draws the conclusion that matters: the counter cannot be trusted. That is the real damage — once that number is visibly wrong, every other figure the player shows looks unreliable too.

## The census changed the shape of this fix

A call-site census found the defect **twice**, and the assumption about which player mattered was backwards:

| Player | Where | Live today? |
|---|---|---|
| Toolkit `AudiobookPlayerView` | `NavigationHostView.swift:131` | **Yes** — 3.2.3 and 3.3.0 with the flag off |
| `AudiobookMorphingPlayerView` | `AppTabHostView.swift:185`, gated `if inAppPlaybackNavEnabled` | No — dark until the flag flips |

Each computed the figure itself, so each carried its own copy of the bug. Fixing only the visible one would have left a defect primed to reappear the moment `in_app_playback_nav_enabled` is turned on.

So the rule now lives in exactly one place — `AudiobookPlaybackModel.remainingWallClock(bookTimeRemaining:rate:)`, made `public` in the companion toolkit PR — and both players call it. Its `rate` parameter is non-optional, so no caller can render a remaining figure without stating a speed.

## Not done, on purpose

The **chapter timecode beside the scrubber stays in book time**. It has to keep agreeing with the scrubber position and the chapter length; rate-adjusting it would desynchronise the two. Only the whole-book figure — the one a patron reads as "how much longer will this take me" — becomes wall-clock.

## Verification

- Toolkit `AudiobookPlaybackModelTests` — 10 tests, 0 failures.
- Palace `AudiobookMorphingPlayerViewTests` — 26 tests, 0 failures.
- **The guard was proved by reintroducing the defect.** With the rate division removed, three named tests fail — `_atDoubleSpeed_isHalved`, `_belowNormalSpeed_takesLonger`, `_everyRateOnTheRailProducesADistinctFigure` — then pass again once restored. A green test on its own is not evidence a guard bites.
- Tests table across `PlaybackRate.allCases` rather than sampling presets, so every 0.05× step of the PP-4518 rail is covered, in both directions from 1.0×.

`palace_mutate.py --diff-only` reported **0 of 51 mutation points on changed lines** — it had nothing to mutate and produced no signal. Recording that rather than presenting a vacuous pass; the defect-reintroduction above is what actually establishes the tests bite.

## Reviewer note — verify-pr's green overstates what ran

`verify-pr.sh --quick` returned 31/31, but four of those did not exercise this change:

- `unit_tests` — **"6 tests, 0 failures"**, not the ~2,400-test scheme.
- `audiobook_smoke` — *"Skipped (no audiobook files changed)"*. The change is entirely audiobook.
- `accessibility` — *"No UI files changed (skipped)"*. A UI file changed and the toolkit's a11y label now announces rate-adjusted time.
- Header reads `Changed files: 1 production, 1 test` — the toolkit half is invisible because it is in the submodule.

The last three are changed-file detection missing an audiobook UI file under `AppInfrastructure/` and not seeing across the submodule boundary. Worth its own ticket; not widened here.

## Merge order

Depends on ThePalaceProject/ios-audiobooktoolkit#211. The submodule pointer here is bumped to that PR's branch tip (`1a181f35`); **re-point it to the merged `main` SHA before merging this.**

Jira: PP-4971 (epic PP-4962)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuYPobaXpQqvMvi5bcwdW5