### PR TITLE
fix(downloads): answer download auth challenges via the async delegate form (PP-4895)

### DIFF
--- a/.forgeos/intent/pp-4895-async-delegate-auth-challenge.md
+++ b/.forgeos/intent/pp-4895-async-delegate-auth-challenge.md
@@ -1,0 +1,231 @@
+---
+name: pp-4895-async-delegate-auth-challenge
+created: 2026-08-17
+author: claude-opus-5
+jira: PP-4895
+---
+
+**ADR refs:** none. The closest recorded decision is the wall-failure
+`.forgeos/wall-failures/2026-07-07-pr1205-wknavigationdelegate-mainactor-witness.md`
+(same defect class, WebKit sign-in) and the CLAUDE.md rule that a
+`nearly matches optional requirement` on a delegate is never benign.
+
+## Context — measured, not theorised
+
+`Palace-noDRM` build of `origin/develop` (a0968e652) emits, verbatim:
+
+```
+Palace/MyBooks/MyBooksDownloadCenter.swift:1636:10: warning: instance method
+  'urlSession(_:task:didReceive:completionHandler:)' nearly matches optional
+  requirement 'urlSession(_:task:didReceive:completionHandler:)' of protocol
+  'URLSessionTaskDelegate'
+  note: candidate has non-matching type '(URLSession, URLSessionTask,
+    URLAuthenticationChallenge, @escaping (URLSession.AuthChallengeDisposition,
+    URLCredential?) -> Void) -> ()'
+  note: requirement declared here
+    optional func urlSession(..., completionHandler: @escaping @MainActor
+      @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+```
+
+The same warning fires on `Palace/Network/TPPNetworkResponder.swift:765` — the
+app's two and only authentication-challenge implementations.
+
+`@MainActor` is not in the SDK header. `NSURLSession.h` annotates that block
+`NS_SWIFT_SENDABLE` only. The `@MainActor` is the Xcode 26.2 ClangImporter
+canonical-block-type poisoning already documented for `NSOperationQueue`
+(memory `webkit-clangimporter-mainactor-poisoning`, cracked on #1338), now
+confirmed on a second block shape:
+`void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)`, shared
+between Foundation's `URLSessionTaskDelegate` requirement and WebKit's
+`WKNavigationDelegate.webView(_:didReceive:completionHandler:)`, which WebKit
+blanket-annotates `WK_SWIFT_UI_ACTOR`.
+
+Reproduced standalone, two files, iOS 26.2 and macOS SDKs, `-swift-version 6
+-strict-concurrency=complete`, first-use-wins per frontend process:
+
+| import order | warns on | `responds(to:)` for the ObjC selector |
+|---|---|---|
+| WebKit decl first | our URLSession method | **false** |
+| Foundation decl first | WebKit's method | true |
+
+The runtime consequence is proven, not inferred: in the poisoned batch
+`responds(to: NSSelectorFromString("URLSession:task:didReceiveChallenge:completionHandler:"))`
+returns **false**. URLSession dispatches optional delegate methods by
+`respondsToSelector:`, so the callback is not merely un-witnessed — it is
+absent from the ObjC runtime and can never be invoked. Patron-visible effect:
+a download served behind HTTP basic auth gets no credential from the app.
+
+Two consequences that shape the fix:
+
+1. Which side loses is decided by frontend batch membership, so an unrelated
+   file move can flip it. This is a lottery, not a stable state — which is why
+   the DRM target can be green on the same source.
+2. Annotating our handler `@escaping @MainActor @Sendable` fixes only the
+   poisoned arm and breaks the clean arm. That is the
+   `invariant-retirement-needs-a-census` trap; both arms must pass.
+
+Forcing the selector was measured and is not available: an explicit
+`@objc(URLSession:task:didReceiveChallenge:completionHandler:)` is a hard
+compile error ("provided by method ... conflicts with optional requirement").
+
+## Claims
+
+- replaces the completion-handler spelling of the authentication-challenge
+  delegate method with the SDK's **async** spelling —
+  `urlSession(_:task:didReceive:) async -> (disposition, credential)` — at both
+  sites (`MyBooksDownloadCenter`, `TPPNetworkResponder`). The async requirement
+  carries no block parameter, so there is nothing for the importer's
+  canonical-block-type cache to poison. Measured: registers in BOTH import
+  orders, warns in neither
+- preserves the credential decision exactly. `TPPBasicAuth` remains the single
+  decision point and is still constructed with the same credentials provider at
+  each site; only the shape of the delegate hop changes
+- adds `PalaceTests/MyBooks/DownloadAuthChallengeWitnessTests`, which asserts
+  the contract the compiler stopped guaranteeing: the ObjC selector is present in
+  the class's method list, and the challenge yields the stored barcode and PIN,
+  cancels on a repeat failure, defers on server trust, and rejects a protection
+  space we do not handle. The behaviour tests call the callback DIRECTLY —
+  optional-requirement dispatch through the `URLSessionTaskDelegate` existential
+  was tried and crashes swift-frontend in SILGen on Xcode 26.2, so registration
+  is asserted separately rather than through that path
+- adds the equivalent registration + behaviour coverage for
+  `TPPNetworkResponder`
+- adds `TPPBasicAuth.response(to:)`, the single place that adapts the existing
+  completion-handler decision into the value the async callbacks return. Both
+  challenge sites route through it, so the two cannot drift, and the "always
+  calls its completion synchronously" assumption is stated once rather than
+  twice inline. Covered directly in `TPPBasicAuthTests` by an equivalence test
+  across all four protection-space branches
+- ratchets the `MyBooksDownloadCenter` god-class baseline DOWN 1257 -> 1256.
+  The first draft of this fix grew the hub by 4 lines and the freeze gate
+  correctly blocked it; extracting the shared adapter reversed that
+- adds `scripts/check-auth-challenge-async-form.py` (ACF-1), a source-level
+  detector banning the completion-handler form of an auth-challenge delegate
+  callback in `Palace/**`, wired into `verify-pr.sh` and the Phase-3.5
+  pre-commit hook, with `scripts/tests/test_check_auth_challenge_async_form.py`
+  (12 cases incl. a comment-only-mention pass) and a new assertion in the hook
+  fixture test covering both the block AND the clean-diff pass. A source-level
+  gate is required because the existing build-log gate can only see the batch
+  lottery draw a given build happened to make
+- makes `non-drm-build.yml` tee its build and run the existing witness-drift
+  gate on that log. CI has never scanned a noDRM build, which is why a detector
+  that was already correct never fired on this
+
+## Anti-claims
+
+- does NOT change what disposition is returned for any protection space, or
+  what credential is built. `TPPBasicAuth.handleChallenge` is untouched
+- does NOT add `@MainActor` anywhere, and does not annotate any handler to
+  match the poisoned import shape
+- does NOT change the session's delegate queue or the download state machine,
+  and does not weaken the `@unchecked Sendable` contract. It DOES narrow that
+  contract's stated justification: the new callback is `nonisolated async`, so
+  its body runs off the `.main` delegate queue. See the review-driven amendment
+  below — the class header now carries an explicit exception instead of a
+  universal that is no longer true
+- does NOT attempt a general fix for the importer bug or audit every other
+  block shape in the app. The build log is the oracle for what is currently
+  mis-registered and it names exactly these two sites; a broader sweep of
+  WebKit-shared block shapes is called out as follow-up, not done here
+- does NOT silence the warning by the compiler's suggested `private` or
+  "move to another extension" — both hide the signal the CI detector depends on
+
+## Review-driven amendments (round 1)
+
+Architect (blocking, discipline): the class-header `@unchecked Sendable`
+justification on `MyBooksDownloadCenter` asserted that the `.main` delegate queue
+means "every delegate callback lands on the main thread". The new callback is
+`nonisolated async`, so its body runs on the cooperative pool — the effect is
+still safe (traced: `injectedUserAccount` is a `let`; `AccountCredentialResolver`
+is deliberately lock-backed rather than an actor precisely so it is reachable
+synchronously from any thread; `TPPUserAccount` serializes keychain on
+`accountInfoQueue`; the callback writes no MBDC state) but the stated universal
+was false. That comment now carries an explicit, reasoned exception rather than
+leaving a reader to infer one.
+
+Architect (warning, accepted as follow-up): `void (^)(void)` also carries
+`WK_SWIFT_UI_ACTOR` in eight WebKit declarations, and `NotificationService` +
+`TPPAppDelegate` implement non-`@MainActor` optional requirements with that
+shape. Neither warns in the current DRM or noDRM logs, so both are latent
+lottery exposure rather than live defects. Named here so the follow-up is
+specific instead of "audit the block shapes some day".
+
+QA (blocking, redundancy): the second registration test could not fail while the
+first passed — same method list reached through a compile-time upcast. Replaced
+both with a single `instancesRespond(to:)` assertion, which asks the CLASS and so
+needs no instance, no production container, and no background session.
+
+QA (blocking, pollution): the suite constructed a download center per test. A
+`URLSession` retains its delegate, so a center that delegates for a live session
+cannot deinit and its `.shared` observers outlive the suite — real pollution
+aimed at exactly the registry suites that read `AppContainer.production()`. Both
+suites now build through the documented `urlSession:` seam, which skips
+background-session construction entirely; the injected ephemeral session has no
+delegate, so nothing retains the center and it deinits normally. THAT is what
+closes the vector.
+
+A first pass at this also claimed to cut construction count "from 7 to 2", which
+was wrong and both the QA and architect reviewers caught it: `setUp()` runs per
+test method, so building both fixtures there made it 12, not 2. The fixtures are
+now lazy, so each test constructs only the one it uses and the registration test
+constructs none — 5 rather than 12. Stated plainly because the earlier
+"two centers for the whole class" wording invited a later reader to turn these
+into genuine class-level shared state, which WOULD be pollution.
+
+QA (gap): added the missing `rejectProtectionSpace` cell to the responder suite,
+so both challenge sites now cover the same four protection-space branches.
+
+QA (gap, accepted): the `credentialsProvider ?? AppContainer.production()`
+fallback arm in `TPPNetworkResponder` is untested. It is an unchanged line, and
+exercising it requires warming the production container — the pollution this
+round is reducing. Left uncovered deliberately rather than traded against test
+isolation.
+
+Both reviewers flagged a dangling citation of the pre-rename intent filename;
+fixed. The guard-bite proof was re-run against the new class-level assertion:
+same result, no compile error, registration fails while all five behaviour tests
+pass.
+
+## Files in scope
+
+- `Palace/MyBooks/MyBooksDownloadCenter.swift`
+- `Palace/Network/TPPNetworkResponder.swift`
+- `Palace/Packages/PalaceNetwork/Sources/PalaceNetwork/TPPBasicAuth.swift`
+- `PalaceTests/MyBooks/DownloadAuthChallengeWitnessTests.swift` (new)
+- `PalaceTests/Network/NetworkResponderAuthChallengeWitnessTests.swift` (new)
+- `PalaceTests/SignInLogic/TPPBasicAuthTests.swift`
+- `Palace.xcodeproj/project.pbxproj` (test-target membership for the new files)
+- `scripts/check-auth-challenge-async-form.py` (new)
+- `scripts/tests/test_check_auth_challenge_async_form.py` (new)
+- `scripts/tests/fixtures/auth_challenge_async_form/` (new)
+- `scripts/tests/test_pre_commit_phase35_detectors.sh`
+- `scripts/pre-commit-phase35-detectors.sh`
+- `scripts/verify-pr.sh`
+- `scripts/godclass-loc-baseline.txt`
+- `.github/workflows/non-drm-build.yml`
+
+## Verification
+
+- `responds(to:)` proof of the defect and of the fix, both import orders, in a
+  standalone two-file reproducer (iOS 26.2 + macOS SDKs)
+- `Palace-noDRM` build before: warns on both sites. After: no witness warning
+- DRM `Palace` build before: no warning — the same source, the other draw. This
+  is the evidence that a build-log gate alone cannot hold the invariant
+- 12 new delegate tests + 2 `TPPBasicAuth` tests pass on the DRM target
+- Guard-bite proof: with `@nonobjc` on the download-center callback (the
+  runtime shape of the defect — method present in Swift, absent from ObjC) both
+  registration test fails by name while ALL FIVE behaviour tests still pass. The
+  mutant was applied to the download-center callback only, so it exercises that
+  suite's guard; the responder's registration assertion is the same construct
+  against the same runtime question. Re-run after the assertion was collapsed to
+  a single class-level check, rather than assumed to carry over — and the first
+  attempt at the mutant was malformed and failed to COMPILE, which per this
+  project's rule is not a kill; the reported result is from the corrected one.
+  Hand-authored and mechanism-targeted; it is a demonstration that the guard
+  bites, not a mutation score
+- `palace_mutate.py --diff-only` reports 0 mutation points on the changed lines
+  in both files, honestly: the diff introduces no operator, conditional, or
+  return to perturb. Reported as an empty surface rather than dressed up as a
+  pass
+- 12/12 detector pytests; full `scripts/tests/` suite; hook fixture test (7
+  assertions)

--- a/.github/workflows/non-drm-build.yml
+++ b/.github/workflows/non-drm-build.yml
@@ -21,5 +21,21 @@ jobs:
         run: ./scripts/build-3rd-party-dependencies.sh --no-private
         env:
           BUILD_CONTEXT: ci
+      # tee to a log so the @objc-witness-drift gate below can scan the build
+      # warnings. `set -o pipefail` is set EXPLICITLY: GitHub's default bash does
+      # NOT enable it, so `cmd | tee` would return tee's exit 0 and mask a
+      # failing build as a green step.
       - name: Build Palace without DRM support
-        run: ./scripts/xcode-build-nodrm.sh
+        shell: bash
+        run: |
+          set -o pipefail
+          ./scripts/xcode-build-nodrm.sh 2>&1 | tee nodrm-build-output.log
+
+      # PP-4895: the noDRM target is where the URLSession auth-challenge witness
+      # drift was visible. Which target sees it is decided by ClangImporter
+      # frontend-batch membership, so the DRM log this gate already scans in
+      # unit-testing.yml is only one draw of that lottery — the same source was
+      # clean there and drifted here. Scanning both logs is what closes it.
+      - name: Guard against @objc witness drift (silent delegate skip)
+        if: always()
+        run: scripts/check-objc-witness-nearly-matches.sh nodrm-build-output.log

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1104,6 +1104,7 @@
 		B2B83791BFBF163B523E1711 /* MarqueeTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C35CC60B407DEE9F38BE6E /* MarqueeTextTests.swift */; };
 		B2C3D4E5F607183940516273 /* TPPSAMLFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6071839405162 /* TPPSAMLFlowTests.swift */; };
 		B2EFD1B3DC448596EF07CE6C /* PalaceAuth in Frameworks */ = {isa = PBXBuildFile; productRef = A90B9B9E556C02F12E456D66 /* PalaceAuth */; };
+		B31E6C5D8F5609362A959604 /* NetworkResponderAuthChallengeWitnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FB829FF7EEDCC53E6D0C0A /* NetworkResponderAuthChallengeWitnessTests.swift */; };
 		B32C1861F3CF56D89B38AC80 /* PalaceTestSetupObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C821947A4DF5BDE2F8089DF /* PalaceTestSetupObservationTests.swift */; };
 		B391CA8F88F1509C8186952B /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0E8572081C2297DABD606F /* DictionaryExtensionsTests.swift */; };
 		B3A4B5C6D7E8F9A0B1C2D3E4 /* RedirectPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A2B3C4D5E6F7A8B9C0D1E2 /* RedirectPolicy.swift */; };
@@ -1858,6 +1859,7 @@
 		EAF119E22F1A6B735238C6D4 /* TPPSignInBusinessLogicStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5F04553ABBB927952EB31B /* TPPSignInBusinessLogicStateMachineTests.swift */; };
 		EB326405080495E05AB3DEB6 /* AccountAuthSurfaceHostsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810C0A1999902FEEE96BD07D /* AccountAuthSurfaceHostsTests.swift */; };
 		EBC03E3A5BDEC0BD519B325B /* TriageBotSupportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C540202A7A2D7469AEF27B82 /* TriageBotSupportView.swift */; };
+		EC4E7A2AFBA08406B8C4A2E7 /* DownloadAuthChallengeWitnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E07F845F399D19B6D3DA40 /* DownloadAuthChallengeWitnessTests.swift */; };
 		EC75FDA52C9B331548ED96A1 /* URLResponseNYPLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4NETW003FR000000000001 /* URLResponseNYPLTests.swift */; };
 		ECE62F70E5B6E18FE97D46A3 /* AudiobookLoaderPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAAA013BC37CAFD5930A97A /* AudiobookLoaderPredicateTests.swift */; };
 		ED02D7C5C1A2D9C7020CE052 /* TPPBookDRMProtectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25174690C33556366CFFE575 /* TPPBookDRMProtectedTests.swift */; };
@@ -2838,6 +2840,7 @@
 		8673802153960A8CA7EAE753 /* AccountsManager+TPPCurrentLibraryAccountProviding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AccountsManager+TPPCurrentLibraryAccountProviding.swift"; sourceTree = "<group>"; };
 		867797B6E90539304E2A80B5 /* AudiobookColdLoadRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookColdLoadRecoveryTests.swift; sourceTree = "<group>"; };
 		867AE0470C91DD0D498E68F4 /* AppContainerAudiobookFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContainerAudiobookFactoryTests.swift; sourceTree = "<group>"; };
+		86FB829FF7EEDCC53E6D0C0A /* NetworkResponderAuthChallengeWitnessTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkResponderAuthChallengeWitnessTests.swift; sourceTree = "<group>"; };
 		8A2EAE5D772D960178EBD800 /* AccessibilityServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityServiceTests.swift; sourceTree = "<group>"; };
 		8A963381EB27A2A8D0EFF8AB /* URLSessionStubbingResetTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLSessionStubbingResetTests.swift; sourceTree = "<group>"; };
 		8A97CD1F92B404EA664C6968 /* OPDSFeedCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OPDSFeedCacheTests.swift; path = OPDS2/OPDSFeedCacheTests.swift; sourceTree = "<group>"; };
@@ -2938,6 +2941,7 @@
 		A6D99F654723B202B64BEDFD /* SideloadedLaneTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideloadedLaneTests.swift; sourceTree = "<group>"; };
 		A7531D0BC80AF1F317534E80 /* Account+State.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Account+State.swift"; sourceTree = "<group>"; };
 		A77E63314ED6F70CC68C0DA0 /* AudiobookAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookAccessibilityTests.swift; sourceTree = "<group>"; };
+		A7E07F845F399D19B6D3DA40 /* DownloadAuthChallengeWitnessTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadAuthChallengeWitnessTests.swift; sourceTree = "<group>"; };
 		A7E31E236C9F4875AEF5B087 /* AccountsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsManagerTests.swift; sourceTree = "<group>"; };
 		A81CEAD2E6B1E066814D228A /* AppContainerWithSignInModalSheetPresenterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContainerWithSignInModalSheetPresenterTests.swift; sourceTree = "<group>"; };
 		A823D80D192BABA400B55DE2 /* Palace.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Palace.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3852,6 +3856,7 @@
 				3248EFDDABC9F2BE1324CA2A /* TPPNetworkExecutorConcurrencyTests.swift */,
 				BE12F746B54CDA3922AE8C5F /* TPPNetworkResponderSizeLimitTests.swift */,
 				311C22277A57709E36DC54F7 /* TPPNetworkExecutorCancellationTests.swift */,
+				86FB829FF7EEDCC53E6D0C0A /* NetworkResponderAuthChallengeWitnessTests.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -6029,6 +6034,7 @@
 				646F0794DF56A2A89E10A5BF /* MyBooksDownloadCenterAccountScopeSeamTests.swift */,
 				F05163022659D242342CC4FD /* HalfSheetProgressCueTests.swift */,
 				E9BBD6628B9E9766FE5B910F /* BookCellModelLCPProgressTests.swift */,
+				A7E07F845F399D19B6D3DA40 /* DownloadAuthChallengeWitnessTests.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -8124,6 +8130,8 @@
 				6091BEEB1CF681BB93C34786 /* AdobeActivationCoordinatorTests.swift in Sources */,
 				E3033DED04E67DB65B42AB99 /* AdobeActivationDedupTests.swift in Sources */,
 				EA87B0AABCBF12E1F8B6D1FE /* ManifestFixture.swift in Sources */,
+				EC4E7A2AFBA08406B8C4A2E7 /* DownloadAuthChallengeWitnessTests.swift in Sources */,
+				B31E6C5D8F5609362A959604 /* NetworkResponderAuthChallengeWitnessTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -56,7 +56,18 @@ private final class DownloadFailureMetadataBox: @unchecked Sendable {
 ///     • `session` (`URLSession!`) — created during `setupSession()` at init and
 ///       only re-created via main-thread flows (`recreateSessionForMockBackend`,
 ///       DEBUG-only, and the reset path); the session's own `delegateQueue` is
-///       `.main`, so every delegate callback lands on the main thread.
+///       `.main`, so every delegate callback lands on the main thread — with ONE
+///       explicit exception, below.
+///   EXCEPTION (PP-4895) — `urlSession(_:task:didReceive:)`, the authentication
+///   challenge, is the SDK's `async` requirement rather than a completion-handler
+///   one (see the callback for why it has to be). It is `nonisolated`, so its body
+///   runs on the cooperative pool, NOT on the `.main` delegate queue. It stays
+///   sound without relying on the main-queue serialization above: it reads only
+///   `injectedUserAccount` (a `let`) and `accountsManager`, resolves credentials
+///   through `AccountCredentialResolver` (deliberately lock-backed rather than an
+///   actor, precisely so it is reachable synchronously from any thread), and
+///   `TPPUserAccount` serializes its own keychain access on `accountInfoQueue`. It
+///   writes no MBDC state. Do not read the main-queue guarantee as universal.
 ///     • `bookIdentifierOfBookToRemove` — scratch state for the remove-from-device
 ///       confirmation alert, written and read only on the main-thread UI flow.
 ///     • `reachabilityCancellable` — installed once by `bindReachability()` during
@@ -1633,13 +1644,43 @@ extension MyBooksDownloadCenter: URLSessionDownloadDelegate {
 }
 
 extension MyBooksDownloadCenter: URLSessionTaskDelegate {
+    /// Answers an authentication challenge on a download — the path that hands a
+    /// library's server the patron's barcode and PIN when the book file itself is
+    /// behind HTTP basic auth.
+    ///
+    /// PP-4895 — this is deliberately the SDK's **async** spelling rather than the
+    /// completion-handler one, and it must stay that way. The completion-handler
+    /// requirement's block type,
+    /// `void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)`, is
+    /// shared with `WKNavigationDelegate.webView(_:didReceive:completionHandler:)`,
+    /// which WebKit blanket-annotates `WK_SWIFT_UI_ACTOR` (@MainActor). Under
+    /// Xcode 26.2 the ClangImporter caches one imported Swift type per canonical
+    /// block type per frontend process, first use wins — so when a WebKit
+    /// declaration is imported ahead of Foundation's, the requirement surfaces as
+    /// `@escaping @MainActor @Sendable` and a plain `@escaping` handler silently
+    /// stops matching it. A method that fails to match an `@objc` optional
+    /// requirement is not exported to the ObjC runtime at all, and URLSession
+    /// invokes optional delegate methods only when the delegate
+    /// `respondsToSelector:` — so the callback simply never fires and every
+    /// basic-auth download proceeds with no credential.
+    ///
+    /// Annotating the handler to match is not a fix: it repairs the poisoned
+    /// import order and breaks the clean one, since which side loses is decided by
+    /// frontend batch membership. Forcing the selector with an explicit
+    /// `@objc(URLSession:task:didReceiveChallenge:completionHandler:)` is a hard
+    /// compile error. The async requirement carries no block parameter, so there
+    /// is nothing to poison — it registers under both import orders. Same defect
+    /// class as the `WKNavigationDelegate` sign-in break in #1205 and the
+    /// `NSOperationQueue` off-main trap in #1338.
+    ///
+    /// Guarded by `DownloadAuthChallengeWitnessTests`, which asserts the selector
+    /// is present in the ObjC runtime rather than trusting the compiler.
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
-        didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let handler = TPPBasicAuth(credentialsProvider: userAccount)
-        handler.handleChallenge(challenge, completion: completionHandler)
+        didReceive challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        TPPBasicAuth(credentialsProvider: userAccount).response(to: challenge)
     }
 
     func urlSession(

--- a/Palace/Network/TPPNetworkResponder.swift
+++ b/Palace/Network/TPPNetworkResponder.swift
@@ -54,15 +54,28 @@ class TPPNetworkResponder: NSObject, @unchecked Sendable {
     private var taskInfo: [TaskID: TPPNetworkTaskInfo]
     private let useFallbackCaching: Bool
     /// WEAK on purpose: the responder reads the provider ONCE per auth challenge
-    /// (synchronously, with a `?? currentUserAccount` fallback — see
-    /// `urlSession(_:didReceive:...)`), and never retains it beyond a method-local
-    /// `TPPBasicAuth`. A strong reference here closed a retain cycle for any
-    /// provider that also (transitively) owns the executor — the
-    /// `AccountDetailViewModel` case: VM → businessLogic → networkExecutor →
-    /// responder → credentialsProvider(=VM). The only non-nil provider in the app
-    /// is that VM, and it is the ROOT owner of its executor chain, so it is alive
-    /// whenever a challenge fires; every other site passes nil and already relies
-    /// on the fallback. Holding it weakly breaks the leak with no behavior change.
+    /// (with a `?? currentUserAccount` fallback — see `urlSession(_:task:didReceive:)`),
+    /// and never retains it beyond a method-local `TPPBasicAuth`. A strong
+    /// reference here closed a retain cycle for any provider that also
+    /// (transitively) owns the executor — the `AccountDetailViewModel` case:
+    /// VM → businessLogic → networkExecutor → responder → credentialsProvider(=VM).
+    /// The only non-nil provider in the app is that VM, and it is the ROOT owner of
+    /// its executor chain, so it is normally alive whenever a challenge fires;
+    /// every other site passes nil and already relies on the fallback.
+    ///
+    /// KNOWN RACE, and PP-4895 widened the window rather than introducing it. The
+    /// read is no longer synchronous on the session's delegate queue: the callback
+    /// is now the SDK's `async` requirement, so the compiler-generated thunk hops
+    /// to a Task before the body runs. If the VM is released inside that hop — or,
+    /// as was already possible, before the challenge arrived at all — the weak
+    /// reference is nil and the fallback substitutes the CURRENT library's account.
+    /// On a credential-validation request aimed at a different library, that means
+    /// sending the wrong library's barcode. A nil provider is indistinguishable
+    /// from "no provider was ever supplied", which is the deliberate configuration
+    /// at every other call site, so the fallback cannot simply be removed. Tracked
+    /// separately (PP-4969) rather than fixed here: closing it means distinguishing
+    /// "died" from "never had one" and deciding to cancel instead of substitute,
+    /// which is a behavior change on a credential path and needs its own ticket.
     private weak var credentialsProvider: NYPLBasicAuthCredentialsProvider?
 
     /// Tracks URLs that have been retried after a 401 to prevent infinite retry loops.
@@ -762,13 +775,31 @@ extension URLSessionTask {
 // ----------------------------------------------------------------------------
 // MARK: - URLSessionTaskDelegate
 extension TPPNetworkResponder: URLSessionTaskDelegate {
-    func urlSession(_ session: URLSession,
-                    task: URLSessionTask,
-                    didReceive challenge: URLAuthenticationChallenge,
-                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    /// Answers an authentication challenge on any request routed through the
+    /// network layer.
+    ///
+    /// PP-4895 — deliberately the SDK's **async** spelling, and it must stay that
+    /// way. The completion-handler requirement shares its block type with
+    /// `WKNavigationDelegate.webView(_:didReceive:completionHandler:)`, which
+    /// WebKit annotates `WK_SWIFT_UI_ACTOR`; under Xcode 26.2 the ClangImporter
+    /// caches one imported type per canonical block type per frontend process, so
+    /// whichever framework is imported first decides whether the requirement
+    /// carries `@MainActor`. When WebKit wins, a plain `@escaping` handler stops
+    /// matching, the method is never exported to the ObjC runtime, and URLSession
+    /// — which invokes optional delegate methods only when the delegate
+    /// `respondsToSelector:` — never calls it. The async requirement has no block
+    /// parameter and so registers under both import orders. Full reasoning and the
+    /// two-order reproduction are on the download center's copy of this callback
+    /// (`MyBooksDownloadCenter`), the app's only other challenge site.
+    ///
+    /// Guarded by `NetworkResponderAuthChallengeWitnessTests`.
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
         let credsProvider = credentialsProvider ?? AppContainer.production().accountsManager.currentUserAccount
-        let authChallenger = TPPBasicAuth(credentialsProvider: credsProvider)
-        authChallenger.handleChallenge(challenge, completion: completionHandler)
+        return TPPBasicAuth(credentialsProvider: credsProvider).response(to: challenge)
     }
 
     func refreshToken(userAccount: TPPUserAccount = AppContainer.production().accountsManager.currentUserAccount) async throws {

--- a/Palace/Packages/PalaceNetwork/Sources/PalaceNetwork/TPPBasicAuth.swift
+++ b/Palace/Packages/PalaceNetwork/Sources/PalaceNetwork/TPPBasicAuth.swift
@@ -56,4 +56,33 @@ import Foundation
             completion(.rejectProtectionSpace, nil)
         }
     }
+
+    /// Returns the answer to `challenge` directly, for the `async` URLSession
+    /// delegate callbacks.
+    ///
+    /// Those callbacks return their disposition rather than passing it to a
+    /// completion handler — deliberately, because the completion-handler form of
+    /// the delegate requirement can silently fail to register at all under the
+    /// Xcode 26.2 ClangImporter (PP-4895; see the callbacks in
+    /// `MyBooksDownloadCenter` / `TPPNetworkResponder` for the full reasoning).
+    /// This is the one place that adapts between the two shapes, so both sites
+    /// stay identical and the assumption they rest on is stated once.
+    ///
+    /// Safe because `handleChallenge` always calls its completion synchronously.
+    /// If that ever stopped being true, this returns `.performDefaultHandling`
+    /// — a challenge left to the system — rather than hanging the request.
+    /// Not `@objc` — the tuple return has no Objective-C representation, and no
+    /// Objective-C caller needs it.
+    // PUBLIC_INTENT: PalaceNetwork is an SPM package and both consumers of this
+    // are in the app target (MyBooksDownloadCenter, TPPNetworkResponder), so
+    // `internal` would not reach them. Same visibility as `handleChallenge`,
+    // which it wraps; it adds no new capability, only the returning shape the
+    // async URLSession delegate callbacks need.
+    public func response(
+        to challenge: URLAuthenticationChallenge
+    ) -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        var response: (URLSession.AuthChallengeDisposition, URLCredential?) = (.performDefaultHandling, nil)
+        handleChallenge(challenge) { response = ($0, $1) }
+        return response
+    }
 }

--- a/PalaceTests/MyBooks/DownloadAuthChallengeWitnessTests.swift
+++ b/PalaceTests/MyBooks/DownloadAuthChallengeWitnessTests.swift
@@ -1,0 +1,219 @@
+//
+//  DownloadAuthChallengeWitnessTests.swift
+//  PalaceTests
+//
+//  PP-4895. When a library serves a book file behind HTTP basic auth, the only
+//  thing standing between the patron and a failed download is the download
+//  center's authentication-challenge delegate callback. URLSession decides
+//  whether to invoke an optional delegate method by asking the delegate
+//  `respondsToSelector:` — so a method that the Swift compiler declined to
+//  register as the protocol witness is not "slightly wrong", it is absent from
+//  the ObjC runtime and is never called. No error, no crash, no log.
+//
+//  That is exactly what an Xcode 26.2 ClangImporter defect can do to this one
+//  method: WebKit annotates `WKNavigationDelegate`'s auth-challenge block
+//  `WK_SWIFT_UI_ACTOR` (@MainActor), Foundation annotates the structurally
+//  identical `URLSessionTaskDelegate` block `NS_SWIFT_SENDABLE`, and whichever
+//  the compiler imports FIRST in a given frontend process wins for both. When
+//  WebKit wins, the requirement surfaces as `@MainActor @Sendable` and the
+//  app's plain `@escaping` handler stops matching. Which side loses is decided
+//  by frontend batch membership, so an unrelated file move can flip it.
+//
+//  The compiler therefore cannot be relied on to guarantee this callback is
+//  reachable. These tests assert the guarantee directly, at the same layer
+//  URLSession uses:
+//    1. the ObjC selector is present in the class's method list — the same
+//       `respondsToSelector:` question URLSession asks of the delegate, and
+//    2. the callback answers a challenge with the patron's stored credential,
+//       cancels rather than replaying a rejected one, defers on TLS trust, and
+//       rejects a protection space it does not handle.
+//
+//  See `.forgeos/intent/pp-4895-async-delegate-auth-challenge.md` for the
+//  measured two-import-order reproduction, and the memory
+//  `webkit-clangimporter-mainactor-poisoning` for the first sighting of this
+//  compiler defect (on a different block shape, #1338).
+//
+
+import XCTest
+import PalaceNetwork
+@testable import Palace
+
+@MainActor
+final class DownloadAuthChallengeWitnessTests: XCTestCase {
+
+    /// The selector URLSession actually sends. Spelled as a string on purpose:
+    /// `#selector` would resolve through the same Swift-level machinery this
+    /// test exists to distrust.
+    private static let authChallengeSelector = NSSelectorFromString(
+        "URLSession:task:didReceiveChallenge:completionHandler:")
+
+    private let barcode = "12345678901234"
+    private let pin = "9999"
+
+    /// Built LAZILY, per test, and only when a test actually needs one — the
+    /// registration test below needs none at all, because it asks the class
+    /// rather than an instance.
+    ///
+    /// Constructing a download center is worth avoiding: `URLSession` retains
+    /// its delegate, so a center that delegates for a live background session can
+    /// never deinit and its `.shared` observers outlive the whole suite, which is
+    /// pollution aimed straight at the registry suites that read
+    /// `AppContainer.production()`. The `urlSession:` seam below is what actually
+    /// closes that — the injected ephemeral session has no delegate, so nothing
+    /// retains the center and it deinits normally. Laziness is the smaller,
+    /// additive win: fewer constructions, not safer ones.
+    private var _signedInCenter: MyBooksDownloadCenter?
+    private var _signedOutCenter: MyBooksDownloadCenter?
+
+    private var signedInCenter: MyBooksDownloadCenter {
+        if let existing = _signedInCenter { return existing }
+        let account = TPPUserAccountTestFactory.makeIsolated()
+        account.setBarcode(barcode, PIN: pin)
+        let center = makeCenter(account: account)
+        _signedInCenter = center
+        return center
+    }
+
+    private var signedOutCenter: MyBooksDownloadCenter {
+        if let existing = _signedOutCenter { return existing }
+        let center = makeCenter(account: TPPUserAccountTestFactory.makeIsolated())
+        _signedOutCenter = center
+        return center
+    }
+
+    override func tearDown() async throws {
+        _signedInCenter = nil
+        _signedOutCenter = nil
+        try await super.tearDown()
+    }
+
+    private func makeCenter(account: TPPUserAccount) -> MyBooksDownloadCenter {
+        MyBooksDownloadCenter(
+            userAccount: account,
+            bookRegistry: TPPBookRegistryMock(),
+            stateManager: DownloadStateManager(),
+            reachability: MockReachability(initiallyConnected: true),
+            // Test seam — see the property doc above. Delegate-less on purpose:
+            // that is what lets this center deinit. Never resumed; this suite
+            // invokes the delegate callback directly.
+            urlSession: URLSession(configuration: .ephemeral)
+        )
+    }
+
+    // MARK: - Runtime registration
+
+    func testAuthChallengeCallback_isPresentInTheObjCRuntime() {
+        // Asked of the CLASS, not an instance: `instancesRespond(to:)` reads the
+        // very method list `respondsToSelector:` consults, so it answers the same
+        // question URLSession will ask — without constructing a download center,
+        // and so without touching the production container at all.
+        XCTAssertTrue(
+            MyBooksDownloadCenter.instancesRespond(to: Self.authChallengeSelector),
+            """
+            MyBooksDownloadCenter does not respond to \
+            URLSession:task:didReceiveChallenge:completionHandler:. URLSession \
+            only invokes optional delegate methods the delegate responds to, so \
+            every basic-auth-protected download will proceed with no credential \
+            and fail. Check the build log for a 'nearly matches optional \
+            requirement' warning on this method before theorising about timing.
+            """)
+    }
+
+    // MARK: - Credential behaviour, observed through the delegate
+
+    func testBasicAuthChallenge_suppliesTheStoredBarcodeAndPIN() async {
+        let (disposition, credential) = await respond(
+            signedInCenter, to: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, barcode)
+        XCTAssertEqual(credential?.password, pin)
+    }
+
+    func testBasicAuthChallenge_whenSignedOut_cancelsRatherThanRetrying() async {
+        // No barcode/PIN stored. Offering no credential must cancel, not fall
+        // through to default handling — default handling would surface the
+        // system's own auth prompt over the app.
+        let (disposition, credential) = await respond(
+            signedOutCenter, to: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+        XCTAssertNil(credential)
+    }
+
+    func testBasicAuthChallenge_afterAPreviousFailure_cancelsInsteadOfReplaying() async {
+        // Re-sending credentials the server has already rejected is how a
+        // patron's library card gets locked out. One attempt only.
+        let (disposition, credential) = await respond(
+            signedInCenter, to: basicAuthChallenge(previousFailureCount: 1))
+
+        XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+        XCTAssertNil(credential)
+    }
+
+    func testServerTrustChallenge_defersToTheSystem() async {
+        // A TLS server-trust challenge must NOT be answered with a barcode, and
+        // must not be cancelled — cancelling would break every https download.
+        let (disposition, credential) = await respond(
+            signedInCenter, to: challenge(method: NSURLAuthenticationMethodServerTrust))
+
+        XCTAssertEqual(disposition, .performDefaultHandling)
+        XCTAssertNil(credential)
+    }
+
+    func testUnsupportedAuthenticationMethod_rejectsTheProtectionSpace() async {
+        // Rejecting lets URLSession move on to another method rather than
+        // handing the server a credential it did not ask for.
+        let (disposition, credential) = await respond(
+            signedInCenter, to: challenge(method: NSURLAuthenticationMethodNTLM))
+
+        XCTAssertEqual(disposition, .rejectProtectionSpace)
+        XCTAssertNil(credential)
+    }
+
+    // MARK: - Helpers
+
+    /// Invokes the delegate callback and returns its answer.
+    ///
+    /// Deliberately a direct call rather than optional-requirement dispatch
+    /// (`(center as URLSessionTaskDelegate).urlSession?(...)`): optional-chaining
+    /// an `async` `@objc` requirement that returns a tuple crashes
+    /// swift-frontend in SILGen on Xcode 26.2
+    /// (`Lowering::ResultPlanBuilder::buildForScalar`). Registration — the half a
+    /// direct call cannot see — is asserted separately above, against the same
+    /// method list `respondsToSelector:` consults.
+    private func respond(
+        _ center: MyBooksDownloadCenter,
+        to challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        await center.urlSession(
+            URLSession(configuration: .ephemeral),
+            task: fakeDownloadTask(),
+            didReceive: challenge)
+    }
+
+    private func basicAuthChallenge(previousFailureCount: Int = 0) -> URLAuthenticationChallenge {
+        challenge(method: NSURLAuthenticationMethodHTTPBasic,
+                  previousFailureCount: previousFailureCount)
+    }
+
+    private func challenge(
+        method: String,
+        previousFailureCount: Int = 0
+    ) -> URLAuthenticationChallenge {
+        let protectionSpace = URLProtectionSpace(
+            host: "circulation.palace-test.invalid",
+            port: 443,
+            protocol: "https",
+            realm: "Palace",
+            authenticationMethod: method)
+
+        return URLAuthenticationChallenge(
+            protectionSpace: protectionSpace,
+            proposedCredential: nil,
+            previousFailureCount: previousFailureCount,
+            failureResponse: nil,
+            error: nil,
+            sender: MockChallengeSender())
+    }
+}

--- a/PalaceTests/Network/NetworkResponderAuthChallengeWitnessTests.swift
+++ b/PalaceTests/Network/NetworkResponderAuthChallengeWitnessTests.swift
@@ -1,0 +1,162 @@
+//
+//  NetworkResponderAuthChallengeWitnessTests.swift
+//  PalaceTests
+//
+//  PP-4895. The network layer's authentication-challenge callback is the second
+//  of the app's two challenge sites (the other is the download center, see
+//  `DownloadAuthChallengeWitnessTests` for the full write-up of the compiler
+//  defect these tests exist to out-guard).
+//
+//  In short: URLSession invokes an optional delegate method only when the
+//  delegate answers `respondsToSelector:`, and under Xcode 26.2 a ClangImporter
+//  block-type cache collision with WebKit can leave this method unmatched — and
+//  therefore absent from the ObjC runtime — with no error and no crash. So the
+//  registration is asserted directly instead of being assumed from the fact that
+//  the code compiles.
+//
+
+import XCTest
+import PalaceNetwork
+@testable import Palace
+
+@MainActor
+final class NetworkResponderAuthChallengeWitnessTests: XCTestCase {
+
+    /// Spelled as a string on purpose — `#selector` would resolve through the
+    /// same Swift machinery this test is here to distrust.
+    private static let authChallengeSelector = NSSelectorFromString(
+        "URLSession:task:didReceiveChallenge:completionHandler:")
+
+    private let barcode = "23456789012345"
+    private let pin = "1234"
+
+    /// `TPPNetworkResponder.credentialsProvider` is a `weak var`, so the provider
+    /// has to be owned by the test. If it were a local, it would deallocate and
+    /// the responder would silently fall back to the current user account —
+    /// passing for the wrong reason.
+    private var credentialsProvider: MockCredentialsProvider!
+    private var responder: TPPNetworkResponder!
+
+    override func setUp() {
+        super.setUp()
+        credentialsProvider = MockCredentialsProvider()
+        credentialsProvider.username = barcode
+        credentialsProvider.pin = pin
+        responder = TPPNetworkResponder(credentialsProvider: credentialsProvider,
+                                       useFallbackCaching: false)
+    }
+
+    override func tearDown() {
+        responder = nil
+        credentialsProvider = nil
+        super.tearDown()
+    }
+
+    // MARK: - Runtime registration
+
+    func testAuthChallengeCallback_isPresentInTheObjCRuntime() {
+        // Asked of the CLASS: `instancesRespond(to:)` reads the same method list
+        // `respondsToSelector:` consults, so it answers the question URLSession
+        // will ask of any instance.
+        XCTAssertTrue(
+            TPPNetworkResponder.instancesRespond(to: Self.authChallengeSelector),
+            """
+            TPPNetworkResponder does not respond to \
+            URLSession:task:didReceiveChallenge:completionHandler:. URLSession \
+            only invokes optional delegate methods the delegate responds to, so \
+            no request routed through the network layer would ever be able to \
+            answer a basic-auth challenge. Check the build log for a 'nearly \
+            matches optional requirement' warning on this method.
+            """)
+    }
+
+    // MARK: - Credential behaviour, observed through the delegate
+
+    func testBasicAuthChallenge_suppliesTheProviderCredential() async {
+        let (disposition, credential) = await respond(to: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, barcode)
+        XCTAssertEqual(credential?.password, pin)
+    }
+
+    func testBasicAuthChallenge_withNoStoredPIN_cancels() async {
+        credentialsProvider.pin = nil
+
+        let (disposition, credential) = await respond(to: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+        XCTAssertNil(credential)
+    }
+
+    func testBasicAuthChallenge_afterAPreviousFailure_cancelsInsteadOfReplaying() async {
+        // Replaying credentials the server already rejected is how a patron's
+        // card gets locked out.
+        let (disposition, credential) = await respond(
+            to: basicAuthChallenge(previousFailureCount: 1))
+
+        XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+        XCTAssertNil(credential)
+    }
+
+    func testServerTrustChallenge_defersToTheSystem() async {
+        let (disposition, credential) = await respond(
+            to: challenge(method: NSURLAuthenticationMethodServerTrust))
+
+        XCTAssertEqual(disposition, .performDefaultHandling)
+        XCTAssertNil(credential)
+    }
+
+    func testUnsupportedAuthenticationMethod_rejectsTheProtectionSpace() async {
+        // Rejecting lets URLSession move on to another method rather than
+        // handing the server a credential it did not ask for. Present at both
+        // challenge sites so the two cannot answer this cell differently.
+        let (disposition, credential) = await respond(
+            to: challenge(method: NSURLAuthenticationMethodNTLM))
+
+        XCTAssertEqual(disposition, .rejectProtectionSpace)
+        XCTAssertNil(credential)
+    }
+
+    // MARK: - Helpers
+
+    /// Invokes the delegate callback and returns its answer.
+    ///
+    /// A direct call, not optional-requirement dispatch: optional-chaining an
+    /// `async` `@objc` requirement that returns a tuple crashes swift-frontend in
+    /// SILGen on Xcode 26.2. Registration is asserted separately above, via the
+    /// same `respondsToSelector:` URLSession consults.
+    private func respond(
+        to challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        await responder.urlSession(
+            URLSession(configuration: .ephemeral),
+            task: fakeDownloadTask(),
+            didReceive: challenge)
+    }
+
+    private func basicAuthChallenge(previousFailureCount: Int = 0) -> URLAuthenticationChallenge {
+        challenge(method: NSURLAuthenticationMethodHTTPBasic,
+                  previousFailureCount: previousFailureCount)
+    }
+
+    private func challenge(
+        method: String,
+        previousFailureCount: Int = 0
+    ) -> URLAuthenticationChallenge {
+        let protectionSpace = URLProtectionSpace(
+            host: "circulation.palace-test.invalid",
+            port: 443,
+            protocol: "https",
+            realm: "Palace",
+            authenticationMethod: method)
+
+        return URLAuthenticationChallenge(
+            protectionSpace: protectionSpace,
+            proposedCredential: nil,
+            previousFailureCount: previousFailureCount,
+            failureResponse: nil,
+            error: nil,
+            sender: MockChallengeSender())
+    }
+}

--- a/PalaceTests/SignInLogic/TPPBasicAuthTests.swift
+++ b/PalaceTests/SignInLogic/TPPBasicAuthTests.swift
@@ -210,6 +210,51 @@ final class TPPBasicAuthTests: XCTestCase {
         }
     }
 
+    // MARK: - Returning form used by the async delegate callbacks (PP-4895)
+
+    func testResponseTo_returnsTheSameAnswerAsTheCompletionForm() {
+        // The async URLSession delegate callbacks return a disposition instead of
+        // invoking a handler, and route through `response(to:)` to get it. The
+        // two shapes must not be allowed to drift apart, so this pins them to the
+        // same answer across every protection space the switch handles.
+        credentialsProvider.username = "testuser"
+        credentialsProvider.pin = "testpin"
+
+        let cases: [(String, URLAuthenticationChallenge)] = [
+            ("basic", createBasicAuthChallenge()),
+            ("basic after a failure", createBasicAuthChallenge(previousFailureCount: 1)),
+            ("server trust", createServerTrustChallenge()),
+            ("unsupported method", createChallenge(method: NSURLAuthenticationMethodNTLM)),
+        ]
+
+        for (name, challenge) in cases {
+            var expectedDisposition: URLSession.AuthChallengeDisposition?
+            var expectedCredential: URLCredential?
+            basicAuth.handleChallenge(challenge) { disposition, credential in
+                expectedDisposition = disposition
+                expectedCredential = credential
+            }
+
+            let (disposition, credential) = basicAuth.response(to: challenge)
+
+            XCTAssertEqual(disposition, expectedDisposition, "disposition drifted for \(name)")
+            XCTAssertEqual(credential?.user, expectedCredential?.user, "credential drifted for \(name)")
+            XCTAssertEqual(credential?.password, expectedCredential?.password,
+                           "credential drifted for \(name)")
+        }
+    }
+
+    func testResponseTo_returnsTheStoredCredentialForABasicAuthChallenge() {
+        credentialsProvider.username = "testuser"
+        credentialsProvider.pin = "testpin"
+
+        let (disposition, credential) = basicAuth.response(to: createBasicAuthChallenge())
+
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, "testuser")
+        XCTAssertEqual(credential?.password, "testpin")
+    }
+
     // MARK: - Helper Methods
 
     private func createBasicAuthChallenge(previousFailureCount: Int = 0) -> URLAuthenticationChallenge {

--- a/scripts/check-auth-challenge-async-form.py
+++ b/scripts/check-auth-challenge-async-form.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""
+check-auth-challenge-async-form.py — require the ASYNC spelling for
+authentication-challenge delegate callbacks in the app target
+(`Palace/**/*.swift`).
+
+Catches the PP-4895 regression class, a second sighting of the #1338 Xcode 26.2
+ClangImporter defect on a different block shape.
+
+The canonical clang block type
+`void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)` is shared by
+two SDK requirements that annotate it differently:
+
+  * `URLSessionTaskDelegate` / `URLSessionDelegate` auth challenge —
+    `NS_SWIFT_SENDABLE`
+  * `WKNavigationDelegate.webView(_:didReceive:completionHandler:)` —
+    `WK_SWIFT_UI_ACTOR`, i.e. `@MainActor`
+
+The ClangImporter caches ONE imported Swift type per canonical block type per
+`swift-frontend` process, first use wins. So whichever framework is imported
+first in a given compile batch decides whether BOTH requirements carry
+`@MainActor`, and the loser's implementation stops matching its requirement. A
+method that fails to match an `@objc` optional requirement is not exported to
+the ObjC runtime at all — and URLSession/WebKit invoke optional delegate methods
+only when the delegate answers `respondsToSelector:` — so the callback silently
+never fires. Measured on iOS 26.2 and macOS SDKs, both orders:
+
+    WebKit decl first     -> our URLSession method warns; responds(to:) == false
+    Foundation decl first -> WebKit's method warns instead
+
+Annotating the handler to match is NOT a fix: it repairs one import order and
+breaks the other, because which side loses depends only on frontend batch
+membership. Forcing the selector with an explicit
+`@objc(URLSession:task:didReceiveChallenge:completionHandler:)` is a hard
+compile error ("provided by method ... conflicts with optional requirement").
+
+The fix is to implement the SDK's ASYNC spelling instead. It carries no block
+parameter, so there is nothing for the importer to poison, and it registers
+under both orders:
+
+    func urlSession(_ session: URLSession, task: URLSessionTask,
+                    didReceive challenge: URLAuthenticationChallenge)
+    async -> (URLSession.AuthChallengeDisposition, URLCredential?)   // APPROVED
+
+    func urlSession(_ session: URLSession, task: URLSessionTask,
+                    didReceive challenge: URLAuthenticationChallenge,
+                    completionHandler: @escaping (...) -> Void)      // BANNED
+
+Note the build-log detector (`check-objc-witness-nearly-matches.sh`) cannot
+replace this one: it only sees the batch lottery draw that a given build
+happened to make. The DRM `Palace` target and the `Palace-noDRM` target compiled
+from the SAME source disagreed about whether this warning fires, which is how
+the defect reached a release in the first place — CI only ever scanned the DRM
+log.
+
+Detection: any `func` whose parameter list mentions `URLAuthenticationChallenge`
+AND has a `completionHandler:` parameter. Parameter lists are extracted by
+balanced-paren scan (they span lines and contain nested parens from closure
+types), over a comment-stripped copy of the source so a prose mention in a doc
+comment cannot trip the gate.
+
+Scope: `Palace/**/*.swift` (app target). Test/mock/preview/scripts dirs are
+excluded — mirrors `check-addoperation-literal-ban.py`.
+
+False-positive escape hatch: `// no-auth-challenge-async-form: <reason>` on the
+violating line or any of the 3 preceding lines.
+
+Flags (mirror the sibling pre-commit detectors):
+  --diff <file>        Unified-diff input. `-` or omit for stdin.
+  --scan <repo-root>   Walk `<root>/Palace/**/*.swift` directly instead of a
+                       diff (whole-tree dry run / bootstrap).
+  --severity-floor LVL Block at LVL or higher (low|medium|high). Default high.
+  --no-block           Print findings, always exit 0.
+  --quiet              Suppress trailing summary line on stderr.
+  --dry-run            Parse only; never exit non-zero on findings.
+
+Exit codes:
+  0  — no findings at or above the severity floor (default: high)
+  1  — at least one finding at or above the floor
+  2  — argument or I/O error
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from _checklib import at_or_above, iter_hunk_lines, read_diff
+
+_at_or_above = at_or_above
+
+_RE_FUNC = re.compile(r"\bfunc\s+[A-Za-z_]\w*\s*(?:<[^>]*>\s*)?\(")
+_RE_CHALLENGE_PARAM = re.compile(r"\bURLAuthenticationChallenge\b")
+_RE_COMPLETION_PARAM = re.compile(r"\bcompletionHandler\s*:")
+
+_RE_NO_BAN_ANNOTATION = re.compile(
+    r"//\s*no-auth-challenge-async-form\b", re.IGNORECASE
+)
+
+# Non-prod path substrings — mirrors check-addoperation-literal-ban.py.
+_NON_PROD_PATH_SUBSTRINGS = (
+    "PalaceTests/",
+    "Tests/",
+    "TestSupport/",
+    "Utilities/Testing/",
+    "Preview Content/",
+    "Mocks/",
+    ".forgeos/",
+    "scripts/_fixtures/",
+    "scripts/tests/",
+)
+
+
+def _is_non_prod_swift(path: str) -> bool:
+    return any(s in path for s in _NON_PROD_PATH_SUBSTRINGS)
+
+
+@dataclass
+class _Finding:
+    code: str
+    severity: str
+    file_path: str
+    line_no: int
+    description: str
+
+    def render(self) -> str:
+        return (f"{self.file_path}:{self.line_no}: "
+                f"{self.code}: {self.severity}: {self.description}")
+
+
+def _blank_comments(source: str) -> str:
+    """Return `source` with comment bodies replaced by spaces, preserving every
+    byte offset and newline so line numbers still map exactly.
+
+    Prose in a doc comment must never trip this gate — the sibling ratchet
+    detectors have been tripped by comments before, and the fixed callbacks this
+    gate protects carry long explanatory comments that name both the banned
+    parameter and the challenge type.
+    """
+    out = list(source)
+    i, n = 0, len(source)
+    state = None  # None | 'line' | 'block' | 'string'
+    depth = 0
+    while i < n:
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < n else ""
+        if state is None:
+            if ch == '"':
+                state = 'string'
+            elif ch == "/" and nxt == "/":
+                state = 'line'
+                out[i] = out[i + 1] = " "
+                i += 2
+                continue
+            elif ch == "/" and nxt == "*":
+                state = 'block'
+                depth = 1
+                out[i] = out[i + 1] = " "
+                i += 2
+                continue
+        elif state == 'string':
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                state = None
+        elif state == 'line':
+            if ch == "\n":
+                state = None
+            else:
+                out[i] = " "
+        elif state == 'block':
+            if ch == "/" and nxt == "*":
+                depth += 1
+                out[i] = out[i + 1] = " "
+                i += 2
+                continue
+            if ch == "*" and nxt == "/":
+                depth -= 1
+                out[i] = out[i + 1] = " "
+                i += 2
+                if depth == 0:
+                    state = None
+                continue
+            if ch != "\n":
+                out[i] = " "
+        i += 1
+    return "".join(out)
+
+
+def _param_list(source: str, open_paren: int) -> tuple[str, int] | None:
+    """Return (parameter-list text, offset just past the closing paren) for the
+    `(` at `open_paren`, or None when unbalanced."""
+    depth = 0
+    i = open_paren
+    n = len(source)
+    while i < n:
+        if source[i] == "(":
+            depth += 1
+        elif source[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return source[open_paren + 1:i], i + 1
+        i += 1
+    return None
+
+
+def _line_no_at_offset(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def _has_annotation(lines: list[str], call_line: int) -> bool:
+    start = max(1, call_line - 3)
+    for ln in range(start, call_line + 1):
+        if ln < 1 or ln > len(lines):
+            continue
+        if _RE_NO_BAN_ANNOTATION.search(lines[ln - 1]):
+            return True
+    return False
+
+
+def _scan_file(rel_path: str, source: str) -> list[_Finding]:
+    """Find completion-handler-form auth-challenge callbacks. Line-no sorted."""
+    if _is_non_prod_swift(rel_path):
+        return []
+    if not rel_path.endswith(".swift"):
+        return []
+
+    code = _blank_comments(source)
+    lines = source.splitlines()
+    findings: list[_Finding] = []
+
+    for m in _RE_FUNC.finditer(code):
+        extracted = _param_list(code, m.end() - 1)
+        if extracted is None:
+            continue
+        params, _ = extracted
+        if not _RE_CHALLENGE_PARAM.search(params):
+            continue
+        if not _RE_COMPLETION_PARAM.search(params):
+            continue
+        line_no = _line_no_at_offset(code, m.start())
+        if _has_annotation(lines, line_no):
+            continue
+        findings.append(_Finding(
+            code="ACF-1",
+            severity="high",
+            file_path=rel_path,
+            line_no=line_no,
+            description=(
+                "authentication-challenge delegate callback declared in the "
+                "completion-handler form — Xcode 26.2 ClangImporter "
+                "@MainActor-poisoning risk (PP-4895): a WebKit auth-challenge "
+                "declaration anywhere in the same compile batch flips the "
+                "requirement to @MainActor, this method stops matching it, and "
+                "it is then absent from the ObjC runtime, so URLSession never "
+                "calls it and the challenge goes unanswered. Implement the SDK's "
+                "async spelling instead: `... didReceive challenge: "
+                "URLAuthenticationChallenge) async -> "
+                "(URLSession.AuthChallengeDisposition, URLCredential?)`."
+            ),
+        ))
+
+    findings.sort(key=lambda f: (f.file_path, f.line_no))
+    return findings
+
+
+# --- Diff mode ---------------------------------------------------------------
+
+def _scan_diff(diff_text: str, repo_root: Path) -> list[_Finding]:
+    """Scan a unified diff: per touched file, reconstruct or read the post-image
+    and emit findings whose line numbers fall on ADDED lines."""
+    touched: dict[str, set[int]] = {}
+    for dl in iter_hunk_lines(diff_text):
+        if dl.kind != "+":
+            continue
+        if not dl.file_path.endswith(".swift"):
+            continue
+        if _is_non_prod_swift(dl.file_path):
+            continue
+        touched.setdefault(dl.file_path, set()).add(dl.line_no)
+
+    out: list[_Finding] = []
+    for rel_path, added_lines in touched.items():
+        on_disk = repo_root / rel_path
+        if on_disk.is_file():
+            try:
+                source = on_disk.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+        else:
+            source = _reconstruct_post_image(diff_text, rel_path)
+            if source is None:
+                continue
+        for f in _scan_file(rel_path, source):
+            # A multi-line signature counts as touched when ANY of its lines is
+            # added — a diff that adds only the `completionHandler:` line to an
+            # existing `func` header is exactly the regression to catch.
+            if _signature_touches(source, f.line_no, added_lines):
+                out.append(f)
+    return out
+
+
+def _signature_touches(source: str, decl_line: int, added: set[int]) -> bool:
+    """True when any line of the declaration starting at `decl_line` was added.
+
+    The signature's extent is taken as the declaration line through the line
+    holding its closing paren.
+    """
+    code = _blank_comments(source)
+    lines = code.splitlines()
+    if decl_line < 1 or decl_line > len(lines):
+        return decl_line in added
+    offset = sum(len(l) + 1 for l in lines[:decl_line - 1])
+    open_paren = code.find("(", offset)
+    if open_paren == -1:
+        return decl_line in added
+    extracted = _param_list(code, open_paren)
+    if extracted is None:
+        return decl_line in added
+    _, end = extracted
+    last_line = _line_no_at_offset(code, end - 1)
+    return any(ln in added for ln in range(decl_line, last_line + 1))
+
+
+def _reconstruct_post_image(diff_text: str, target_path: str) -> str | None:
+    """Reconstruct a synthetic post-image when the file isn't on disk."""
+    rows: dict[int, str] = {}
+    found = False
+    for dl in iter_hunk_lines(diff_text):
+        if dl.file_path != target_path:
+            continue
+        if dl.kind not in ("+", " "):
+            continue
+        rows[dl.line_no] = dl.text
+        found = True
+    if not found:
+        return None
+    if not rows:
+        return ""
+    max_line = max(rows)
+    return "\n".join(rows.get(i, "") for i in range(1, max_line + 1))
+
+
+# --- Scan mode ---------------------------------------------------------------
+
+def _scan_repo(repo_root: Path) -> list[_Finding]:
+    out: list[_Finding] = []
+    palace_dir = repo_root / "Palace"
+    if not palace_dir.is_dir():
+        palace_dir = repo_root
+    for root, _dirs, files in os.walk(palace_dir):
+        for name in files:
+            if not name.endswith(".swift"):
+                continue
+            full = Path(root) / name
+            try:
+                rel = str(full.relative_to(repo_root))
+            except ValueError:
+                rel = str(full)
+            if _is_non_prod_swift(rel):
+                continue
+            try:
+                source = full.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            out.extend(_scan_file(rel, source))
+    return out
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check-auth-challenge-async-form.py",
+        description=(
+            "Require the async spelling for authentication-challenge delegate "
+            "callbacks in Palace/**/*.swift — Xcode 26.2 ClangImporter "
+            "@MainActor-poisoning risk (PP-4895)."
+        ),
+    )
+    parser.add_argument("--diff", default=None,
+                        help="Unified-diff input file. `-` or omit for stdin.")
+    parser.add_argument("--scan", default=None,
+                        help="Repo root to walk directly instead of a diff.")
+    parser.add_argument("--severity-floor", default="high",
+                        choices=("low", "medium", "high"),
+                        help="Block at LVL or above (default: high).")
+    parser.add_argument("--no-block", action="store_true",
+                        help="Print findings, always exit 0.")
+    parser.add_argument("--quiet", action="store_true",
+                        help="Suppress summary line on stderr.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print findings; do not exit non-zero.")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.scan:
+            findings = _scan_repo(Path(args.scan).resolve())
+        else:
+            diff_text = read_diff(args.diff)
+            findings = _scan_diff(diff_text, Path.cwd())
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover - safety net
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    blocking: list[_Finding] = []
+    for f in sorted(findings, key=lambda x: (x.file_path, x.line_no, x.code)):
+        if _at_or_above(f.severity, args.severity_floor):
+            blocking.append(f)
+        print(f.render())
+
+    if not args.quiet:
+        print(f"\n{len(findings)} auth-challenge-async-form finding(s); "
+              f"{len(blocking)} at/above floor={args.severity_floor}",
+              file=sys.stderr)
+
+    if args.no_block or args.dry_run:
+        return 0
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/godclass-loc-baseline.txt
+++ b/scripts/godclass-loc-baseline.txt
@@ -145,9 +145,12 @@
 #   Nets negative at the 3b package move, when the MBDC cluster leaves the hub for
 #   PalaceDownloads. Re-baselined by the exact delta; the freeze still catches any further
 #   unrelated growth.
+# PP-4895 (-1 on MyBooksDownloadCenter, 1257 -> 1256): the URLSession auth-challenge
+#   callback moved to the SDK's async spelling, and the shape adaptation both challenge
+#   sites needed now lives once on TPPBasicAuth.response(to:) instead of twice inline.
 1579 Palace/Audiobooks/AudiobookSessionManager.swift
 374 Palace/Accounts/Library/AccountsManager.swift
-1257 Palace/MyBooks/MyBooksDownloadCenter.swift
+1256 Palace/MyBooks/MyBooksDownloadCenter.swift
 981 Palace/Book/UI/BookDetail/BookDetailViewModel.swift
 638 Palace/SignInLogic/TPPSignInBusinessLogic.swift
 575 Palace/MyBooks/BorrowOperation.swift

--- a/scripts/pre-commit-phase35-detectors.sh
+++ b/scripts/pre-commit-phase35-detectors.sh
@@ -48,6 +48,7 @@ DETECTORS=(
   "NOTIFICATION_CENTER_OBSERVER_STORAGE|check-notification-center-observer-storage.py|warn|diff"
   "UNSYNCHRONIZED_SENDABLE_MOCK|check-unsynchronized-sendable-mock.py|block|scan"
   "ADDOPERATION_LITERAL_BAN|check-addoperation-literal-ban.py|block|diff"
+  "AUTH_CHALLENGE_ASYNC_FORM|check-auth-challenge-async-form.py|block|diff"
 )
 
 OVERALL_EXIT=0

--- a/scripts/tests/fixtures/auth_challenge_async_form/clean_annotation_escape.swift
+++ b/scripts/tests/fixtures/auth_challenge_async_form/clean_annotation_escape.swift
@@ -1,0 +1,15 @@
+// Fixture: the documented escape hatch. MUST PASS.
+import Foundation
+
+final class LegacyDelegate: NSObject, URLSessionTaskDelegate {
+    // no-auth-challenge-async-form: pinned to the completion-handler form by an
+    // upstream SDK constraint; tracked separately.
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        completionHandler(.performDefaultHandling, nil)
+    }
+}

--- a/scripts/tests/fixtures/auth_challenge_async_form/clean_async_form.swift
+++ b/scripts/tests/fixtures/auth_challenge_async_form/clean_async_form.swift
@@ -1,0 +1,13 @@
+// Fixture: the approved async spelling. Carries no block parameter, so nothing
+// for the ClangImporter to poison. MUST PASS.
+import Foundation
+
+final class DownloadDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        (.performDefaultHandling, nil)
+    }
+}

--- a/scripts/tests/fixtures/auth_challenge_async_form/clean_comment_mentions_only.swift
+++ b/scripts/tests/fixtures/auth_challenge_async_form/clean_comment_mentions_only.swift
@@ -1,0 +1,21 @@
+// Fixture: the fixed production files carry long doc comments that name BOTH
+// `completionHandler:` and `URLAuthenticationChallenge` while describing the
+// defect. A substring-grep detector trips on those comments; this one must not.
+// MUST PASS.
+import Foundation
+
+/// PP-4895 — deliberately the async spelling. The banned form would read
+/// `didReceive challenge: URLAuthenticationChallenge, completionHandler:
+/// @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void`,
+/// which the importer can leave unmatched.
+final class DownloadDelegate: NSObject, URLSessionTaskDelegate {
+    /* A block comment naming completionHandler: and URLAuthenticationChallenge
+       together, for good measure. */
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        (.performDefaultHandling, nil)
+    }
+}

--- a/scripts/tests/fixtures/auth_challenge_async_form/clean_unrelated_completion_handler.swift
+++ b/scripts/tests/fixtures/auth_challenge_async_form/clean_unrelated_completion_handler.swift
@@ -1,0 +1,18 @@
+// Fixture: a completion-handler delegate method with NO auth challenge in it,
+// and an auth-challenge helper with NO completion handler. Neither is the
+// poisoned shape. MUST PASS.
+import Foundation
+
+final class Redirects: NSObject, URLSessionTaskDelegate {
+    func urlSession(_ session: URLSession,
+                    task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest,
+                    completionHandler: @escaping (URLRequest?) -> Void) {
+        completionHandler(request)
+    }
+
+    func describe(_ challenge: URLAuthenticationChallenge) -> String {
+        challenge.protectionSpace.authenticationMethod
+    }
+}

--- a/scripts/tests/fixtures/auth_challenge_async_form/violation_urlsession_session_level.swift
+++ b/scripts/tests/fixtures/auth_challenge_async_form/violation_urlsession_session_level.swift
@@ -1,0 +1,11 @@
+// Fixture: the SESSION-level challenge (URLSessionDelegate) shares the same
+// poisoned block type. MUST be flagged (ACF-1).
+import Foundation
+
+final class SessionDelegate: NSObject, URLSessionDelegate {
+    func urlSession(_ session: URLSession,
+                    didReceive challenge: URLAuthenticationChallenge,
+                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        completionHandler(.performDefaultHandling, nil)
+    }
+}

--- a/scripts/tests/fixtures/auth_challenge_async_form/violation_urlsession_task_completion_handler.swift
+++ b/scripts/tests/fixtures/auth_challenge_async_form/violation_urlsession_task_completion_handler.swift
@@ -1,0 +1,14 @@
+// Fixture: the PP-4895 shape — URLSessionTaskDelegate auth challenge written in
+// the completion-handler form. MUST be flagged (ACF-1).
+import Foundation
+
+final class DownloadDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        completionHandler(.performDefaultHandling, nil)
+    }
+}

--- a/scripts/tests/fixtures/auth_challenge_async_form/violation_webkit_navigation_delegate.swift
+++ b/scripts/tests/fixtures/auth_challenge_async_form/violation_webkit_navigation_delegate.swift
@@ -1,0 +1,11 @@
+// Fixture: WebKit is the OTHER arm of the same collision — when Foundation is
+// imported first, this side is the one that stops matching. MUST be flagged.
+import WebKit
+
+final class WebSheetCoordinator: NSObject, WKNavigationDelegate {
+    func webView(_ webView: WKWebView,
+                 didReceive challenge: URLAuthenticationChallenge,
+                 completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        completionHandler(.performDefaultHandling, nil)
+    }
+}

--- a/scripts/tests/test_check_auth_challenge_async_form.py
+++ b/scripts/tests/test_check_auth_challenge_async_form.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+test_check_auth_challenge_async_form.py — self-verify the ACF-1 detector
+(scripts/check-auth-challenge-async-form.py).
+
+Guards the PP-4895 regression class: an authentication-challenge delegate
+callback written in the completion-handler form can be left unmatched by the
+Xcode 26.2 ClangImporter (WebKit annotates the shared canonical block type
+`@MainActor`, Foundation does not, first import in the batch wins), which strips
+the method from the ObjC runtime entirely — so URLSession, which invokes
+optional delegate methods only via `respondsToSelector:`, never calls it and the
+challenge goes unanswered with no error and no crash.
+
+Asserts the predicate fires on all three arms of the collision (task-level
+challenge, session-level challenge, and WebKit's side — whichever side loses the
+import lottery is the broken one), and that it PASSES the approved async
+spelling, the escape hatch, an unrelated completion-handler delegate method, and
+— the failure mode sibling ratchet detectors have actually hit — source whose
+COMMENTS name both banned tokens while the code is clean.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-auth-challenge-async-form.py"
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "auth_challenge_async_form"
+
+
+def _run_scan(scan_root: Path) -> tuple[int, str, str]:
+    """Invoke the detector in --scan mode; return (rc, stdout, stderr)."""
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--scan", str(scan_root), "--quiet"],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+        timeout=30,
+    )
+    return (result.returncode, result.stdout, result.stderr)
+
+
+def _run_diff(diff_text: str, cwd: Path) -> tuple[int, str, str]:
+    """Invoke the detector in --diff mode over stdin."""
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--diff", "-", "--quiet"],
+        input=diff_text,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        timeout=30,
+    )
+    return (result.returncode, result.stdout, result.stderr)
+
+
+def _isolate(tmp_path: Path, fixture_name: str) -> Path:
+    """Copy ONE fixture into a tmp Palace/ tree so --scan sees only it."""
+    src = _FIXTURE_DIR / fixture_name
+    assert src.is_file(), f"missing fixture: {src}"
+    palace = tmp_path / "Palace"
+    palace.mkdir(exist_ok=True)
+    (palace / fixture_name).write_text(src.read_text(encoding="utf-8"),
+                                      encoding="utf-8")
+    return tmp_path
+
+
+# --- Violations: every arm of the shared-block-type collision ----------------
+
+def test_violation_task_level_challenge_is_flagged(tmp_path):
+    """The PP-4895 shape itself — URLSessionTaskDelegate. MUST flag ACF-1."""
+    rc, out, _ = _run_scan(_isolate(
+        tmp_path, "violation_urlsession_task_completion_handler.swift"))
+    assert rc != 0, f"expected non-zero exit, got 0. stdout={out!r}"
+    assert "ACF-1" in out, f"expected ACF-1 finding. stdout={out!r}"
+    assert "high" in out
+    assert "violation_urlsession_task_completion_handler.swift" in out
+
+
+def test_violation_session_level_challenge_is_flagged(tmp_path):
+    """URLSessionDelegate's session-level challenge shares the block type."""
+    rc, out, _ = _run_scan(_isolate(
+        tmp_path, "violation_urlsession_session_level.swift"))
+    assert rc != 0, f"expected non-zero exit, got 0. stdout={out!r}"
+    assert "ACF-1" in out
+
+
+def test_violation_webkit_side_is_flagged(tmp_path):
+    """WebKit's own auth challenge is the arm that breaks when Foundation wins
+    the import lottery — banning only the Foundation side would leave the
+    invariant half-encoded."""
+    rc, out, _ = _run_scan(_isolate(
+        tmp_path, "violation_webkit_navigation_delegate.swift"))
+    assert rc != 0, f"expected non-zero exit, got 0. stdout={out!r}"
+    assert "ACF-1" in out
+
+
+def test_violation_reports_the_declaration_line(tmp_path):
+    """The finding must point at the `func` line, not at the file."""
+    rc, out, _ = _run_scan(_isolate(
+        tmp_path, "violation_urlsession_task_completion_handler.swift"))
+    assert rc != 0
+    line = next(l for l in out.splitlines() if "ACF-1" in l)
+    reported = int(line.split(":")[1])
+    assert reported == 6, f"expected the func line (6), got {reported}: {line!r}"
+
+
+# --- Clean fixtures: the detector must not block correct code ----------------
+
+def test_clean_async_form_passes(tmp_path):
+    """The approved spelling. MUST PASS."""
+    rc, out, _ = _run_scan(_isolate(tmp_path, "clean_async_form.swift"))
+    assert rc == 0, f"expected clean pass, got rc={rc}. stdout={out!r}"
+    assert out.strip() == ""
+
+
+def test_clean_comment_mentions_only_passes(tmp_path):
+    """Prose naming both banned tokens must not trip the gate. This is the
+    concrete failure mode of the substring-grep ratchet detectors, and the
+    production files fixed by PP-4895 carry exactly such comments."""
+    rc, out, _ = _run_scan(_isolate(tmp_path, "clean_comment_mentions_only.swift"))
+    assert rc == 0, f"comment-only mention must not block. stdout={out!r}"
+
+
+def test_clean_annotation_escape_passes(tmp_path):
+    """The documented `// no-auth-challenge-async-form:` hatch. MUST PASS."""
+    rc, out, _ = _run_scan(_isolate(tmp_path, "clean_annotation_escape.swift"))
+    assert rc == 0, f"escape hatch must pass. stdout={out!r}"
+
+
+def test_clean_unrelated_completion_handler_passes(tmp_path):
+    """A completion-handler delegate method with no challenge, and a challenge
+    helper with no completion handler — neither is the poisoned shape."""
+    rc, out, _ = _run_scan(_isolate(
+        tmp_path, "clean_unrelated_completion_handler.swift"))
+    assert rc == 0, f"unrelated shapes must pass. stdout={out!r}"
+
+
+def test_test_target_sources_are_out_of_scope(tmp_path):
+    """A violation under PalaceTests/ is out of scope — tests legitimately build
+    challenge fixtures and stand up throwaway delegates."""
+    src = _FIXTURE_DIR / "violation_urlsession_task_completion_handler.swift"
+    tests_dir = tmp_path / "PalaceTests"
+    tests_dir.mkdir()
+    (tests_dir / "SomeDelegateTests.swift").write_text(
+        src.read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "Palace").mkdir()
+    rc, out, _ = _run_scan(tmp_path)
+    assert rc == 0, f"PalaceTests/ must be out of scope. stdout={out!r}"
+
+
+# --- Diff mode ---------------------------------------------------------------
+
+def test_diff_mode_flags_an_added_violation(tmp_path):
+    """Diff mode is how the pre-commit path invokes this. An added violating
+    signature must block."""
+    (tmp_path / "Palace").mkdir()
+    diff = (
+        "diff --git a/Palace/New.swift b/Palace/New.swift\n"
+        "--- /dev/null\n"
+        "+++ b/Palace/New.swift\n"
+        "@@ -0,0 +1,8 @@\n"
+        "+import Foundation\n"
+        "+final class D: NSObject, URLSessionTaskDelegate {\n"
+        "+    func urlSession(_ s: URLSession,\n"
+        "+                    task: URLSessionTask,\n"
+        "+                    didReceive c: URLAuthenticationChallenge,\n"
+        "+                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {\n"
+        "+    }\n"
+        "+}\n"
+    )
+    rc, out, _ = _run_diff(diff, tmp_path)
+    assert rc != 0, f"expected non-zero exit, got 0. stdout={out!r}"
+    assert "ACF-1" in out
+
+
+def test_diff_mode_passes_a_clean_diff(tmp_path):
+    """The clean-diff path MUST pass. A detector invoked with an interface it
+    rejects (or one that mis-parses a normal diff) would block every commit;
+    asserting only the violation path leaves that hole open."""
+    (tmp_path / "Palace").mkdir()
+    diff = (
+        "diff --git a/Palace/New.swift b/Palace/New.swift\n"
+        "--- /dev/null\n"
+        "+++ b/Palace/New.swift\n"
+        "@@ -0,0 +1,7 @@\n"
+        "+import Foundation\n"
+        "+final class D: NSObject, URLSessionTaskDelegate {\n"
+        "+    func urlSession(_ s: URLSession,\n"
+        "+                    task: URLSessionTask,\n"
+        "+                    didReceive c: URLAuthenticationChallenge)\n"
+        "+    async -> (URLSession.AuthChallengeDisposition, URLCredential?) {\n"
+        "+        (.performDefaultHandling, nil) }\n"
+        "+}\n"
+    )
+    rc, out, _ = _run_diff(diff, tmp_path)
+    assert rc == 0, f"clean diff must pass. rc={rc} stdout={out!r}"
+
+
+def test_diff_mode_ignores_an_untouched_preexisting_violation(tmp_path):
+    """Diff mode is ADDED-lines scoped, so an unrelated one-line edit to a file
+    that already holds a violation must not block that commit."""
+    palace = tmp_path / "Palace"
+    palace.mkdir()
+    src = (_FIXTURE_DIR / "violation_urlsession_task_completion_handler.swift"
+           ).read_text(encoding="utf-8")
+    (palace / "Legacy.swift").write_text(src + "\n// trailing note\n",
+                                        encoding="utf-8")
+    diff = (
+        "diff --git a/Palace/Legacy.swift b/Palace/Legacy.swift\n"
+        "--- a/Palace/Legacy.swift\n"
+        "+++ b/Palace/Legacy.swift\n"
+        f"@@ -14,0 +{len(src.splitlines()) + 1},1 @@\n"
+        "+// trailing note\n"
+    )
+    rc, out, _ = _run_diff(diff, tmp_path)
+    assert rc == 0, f"untouched pre-existing violation must not block. stdout={out!r}"

--- a/scripts/tests/test_pre_commit_phase35_detectors.sh
+++ b/scripts/tests/test_pre_commit_phase35_detectors.sh
@@ -194,7 +194,60 @@ if [ "$MOCK_CLEAN_EXIT" -ne 0 ]; then
   exit 1
 fi
 
-echo "PASS: 6 assertions — hook blocks violations, identifies detector, honors both"
+# --- Assert 7: AUTH_CHALLENGE_ASYNC_FORM detector fires on its fixture ---
+# (PP-4895) An authentication-challenge delegate callback written in the
+# completion-handler form must block: the Xcode 26.2 ClangImporter can leave it
+# unmatched, which strips it from the ObjC runtime, and URLSession then never
+# calls it — the challenge goes unanswered with no error. Rewriting it in the
+# SDK's async spelling must pass again.
+git rm -q -r --cached PalaceTests
+rm -rf PalaceTests
+cat > Palace/ChallengeDelegate.swift <<'EOF'
+import Foundation
+final class ChallengeDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(_ session: URLSession,
+                    task: URLSessionTask,
+                    didReceive challenge: URLAuthenticationChallenge,
+                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        completionHandler(.performDefaultHandling, nil)
+    }
+}
+EOF
+git add Palace/ChallengeDelegate.swift
+set +e
+ACF_OUT=$(echo "$JSON_INPUT" | bash "$HOOK" 2>&1)
+ACF_EXIT=$?
+set -e
+if [ "$ACF_EXIT" -eq 0 ] || ! echo "$ACF_OUT" | grep -q "AUTH_CHALLENGE_ASYNC_FORM\|auth-challenge-async-form"; then
+  echo "FAIL: completion-handler-form auth-challenge callback did not block (exit $ACF_EXIT)"
+  echo "$ACF_OUT" | sed 's/^/    /'
+  exit 1
+fi
+# Clean path: the same callback in the async spelling → must pass.
+cat > Palace/ChallengeDelegate.swift <<'EOF'
+import Foundation
+final class ChallengeDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(_ session: URLSession,
+                    task: URLSessionTask,
+                    didReceive challenge: URLAuthenticationChallenge)
+    async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        (.performDefaultHandling, nil)
+    }
+}
+EOF
+git add Palace/ChallengeDelegate.swift
+set +e
+ACF_CLEAN_OUT=$(echo "$JSON_INPUT" | bash "$HOOK" 2>&1)
+ACF_CLEAN_EXIT=$?
+set -e
+if [ "$ACF_CLEAN_EXIT" -ne 0 ]; then
+  echo "FAIL: async-form auth-challenge callback spuriously blocked (exit $ACF_CLEAN_EXIT)"
+  echo "$ACF_CLEAN_OUT" | sed 's/^/    /'
+  exit 1
+fi
+
+echo "PASS: 7 assertions — hook blocks violations, identifies detector, honors both"
 echo "      bypass envvars, passes a clean diff (no detector spuriously blocks),"
-echo "      and the unsynchronized-sendable-mock detector fires + clean-passes."
+echo "      and the unsynchronized-sendable-mock + auth-challenge-async-form"
+echo "      detectors each fire on a violation and clean-pass on the fix."
 exit 0

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -762,6 +762,8 @@ run_phase35_detector "unsynchronized_sendable_mock" "check-unsynchronized-sendab
   "No unsynchronized @unchecked Sendable mock driven by concurrent tests" "scan"
 run_phase35_detector "addoperation_literal_ban" "check-addoperation-literal-ban.py" "block" \
   "No raw NSOperation-family closure literal (#1338 ClangImporter @MainActor-poisoning risk)" "diff"
+run_phase35_detector "auth_challenge_async_form" "check-auth-challenge-async-form.py" "block" \
+  "No completion-handler-form auth-challenge delegate callback (PP-4895 ClangImporter @MainActor-poisoning risk)" "diff"
 
 # 4. Coverage floors
 echo "--- Coverage Floors ---"


### PR DESCRIPTION
## What was wrong

When a library serves a book file behind HTTP basic auth, the download center's authentication-challenge callback is what hands the server the patron's barcode and PIN. On `Palace-noDRM` that callback was not reaching the app at all, and the same was true of the equivalent callback in `TPPNetworkResponder`.

URLSession invokes an optional delegate method only when the delegate answers `respondsToSelector:`. Under Xcode 26.2 the ClangImporter caches one imported Swift type per canonical block type per compiler process, first use wins — and WebKit's auth-challenge block (annotated `@MainActor`) and Foundation's (annotated `Sendable`) are the same canonical block type. When WebKit is imported first, the requirement surfaces as `@MainActor @Sendable`, our plain handler stops matching it, and **a method that fails to match an `@objc` optional requirement is not exported to the Objective-C runtime at all**. The callback then silently never fires: no error, no crash, no log.

## Measured, not reasoned about

Two-file reproducer on both the iOS 26.2 and macOS SDKs, swapping nothing but file order:

| import order | warns on | `responds(to:)` for the selector |
|---|---|---|
| WebKit first | our URLSession method | **false** |
| Foundation first | WebKit's method | true |

`false` is the whole bug. Which side loses is decided only by compiler batch membership — which is why the DRM `Palace` target was clean on **identical source** while `Palace-noDRM` warned.

Two consequences that shaped the fix:

- Annotating our handler to match would repair the poisoned arm and break the clean one. Both arms had to pass.
- Forcing the selector with an explicit `@objc(...)` is a hard compile error, so it is not an option worth revisiting.

## The fix

The SDK's **async** spelling of the same callback. It carries no block parameter, so there is nothing for the importer to poison, and it registers under both import orders. The credential decision is unchanged: `TPPBasicAuth` still makes it, and the one place that adapts its answer for the async form now lives on `TPPBasicAuth.response(to:)` so the two challenge sites cannot drift apart.

## Why CI never caught it

PR CI builds only the DRM scheme. `non-drm-build.yml` is `workflow_dispatch` — manual. The witness-drift detector was already in place and already correct; it was pointed at the only build CI produces.

This adds a **source-level** detector that bans the completion-handler form outright, on both arms of the collision. A build-log gate cannot replace it: a log only reports the one compile ordering that build happened to produce.

## Coverage

Because the compiler can no longer be trusted to guarantee the callback is reachable, the tests assert it directly — that the selector is present in the class's method list, and that a challenge is answered with the stored credential, cancelled rather than replayed after a rejection, deferred on TLS trust, and rejected for an unsupported method.

**The guard was proven, not assumed.** With the callback deliberately stripped from the runtime (`@nonobjc`), the registration test fails while *all five behaviour tests still pass*. That is exactly the shape of the shipped defect, and the reason the registration assertion had to exist.

## Verification

- `Palace-noDRM` before: warns on both sites. After: clean build, no witness warning (only the pre-existing benign CarPlay different-name match).
- `Palace` (DRM) before: no warning — same source, the other draw.
- Full suite: **8308 tests, 0 failures**, 19 skipped, no timeouts or restarts.
- Detector self-tests 12/12; pre-commit hook fixture 7/7 including the clean-diff pass.
- Reviewed by three independent reviewers (architect, qa_test, blast_radius) bound to this tip.

## Deliberately not done

- No general remedy for the compiler defect. A second block shape with the same exposure is latent in `NotificationService` and `TPPAppDelegate` — neither warns today — filed as **PP-4972**.
- A follow-up credential defect surfaced during review and is filed as **PP-4969**, implemented and stacked on this branch.
- Making `Palace-noDRM` a per-PR CI job is what would catch this class automatically, but it costs a full extra build per PR. Owner call; the source-level detector covers the class meanwhile.

## Follow-ups noted in review (non-blocking, not in this PR)

- Move the "class-level shared state would be pollution" warning from the intent doc into the test file, where a future editor will actually see it.
- Typo in the intent doc: "both registration test fails by name".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuFJhemcU8AqFruy9RrKT1
