### PR TITLE
fix(auth): answer challenges with the account the request was made for (PP-4969)

### DIFF
--- a/.forgeos/intent/pp-4969-answer-challenges-with-the-request-account.md
+++ b/.forgeos/intent/pp-4969-answer-challenges-with-the-request-account.md
@@ -1,0 +1,351 @@
+---
+name: pp-4969-answer-challenges-with-the-request-account
+created: 2026-08-17
+author: claude-opus-5
+jira: PP-4969
+stacked_on: PP-4895 (fix/pp-4895-urlsession-auth-witness, tip 5e026959b)
+---
+
+**ADR refs:** none. The governing recorded decision is the credential-isolation
+invariant documented at the head of
+`Palace/Accounts/Library/AccountCredentialResolver.swift` — F-034 (cross-account
+credential leak, PP-4020) and F-016 (ride-out over the account-switch window).
+This change sits on that boundary and must not weaken either.
+
+## Context
+
+Both of the app's authentication-challenge sites can answer a challenge with a
+different library's credentials than the request was made for. Surfaced by the
+independent architect and blast-radius reviews of PP-4895; both asked that it
+ride alongside that change rather than trail it, because PP-4895 measurably
+widens one of the two windows.
+
+**Path 1 — `TPPNetworkResponder`, credential-validation requests.** The
+responder holds `credentialsProvider` **weakly** (deliberately — a strong
+reference closed a retain cycle: VM → businessLogic → networkExecutor →
+responder → provider(=VM)). At challenge time it reads
+`credentialsProvider ?? AppContainer.production().accountsManager.currentUserAccount`.
+If the only non-nil provider in the app — `AccountDetailViewModel` — is released
+while its request is in flight, the fallback substitutes the CURRENT library's
+account, so library B's server receives library A's barcode.
+
+PP-4895 did not create this: the VM could already be released before the
+challenge arrived. It widened it, because the callback is now the SDK's `async`
+requirement and the compiler-generated thunk hops to a Task before the body
+reads the weak reference. Per blast-radius, that widening is **not bounded by a
+short hop** — under the cooperative-pool saturation this project has already
+documented, it can stretch arbitrarily.
+
+**Path 2 — `MyBooksDownloadCenter`, book files behind basic auth.** The callback
+resolves credentials through `userAccount`, which is
+`injectedUserAccount ?? accountsManager.currentUserAccount` — the account current
+*when the challenge arrives*, not the account the download was started for. A
+library switch mid-download answers with the new library's card. This one is
+older than PP-4895 and is already self-flagged: that property's own doc says new
+code on the download path should use `userAccount(forCapturedId:)` instead,
+"deterministic across library-swap windows".
+
+Path 2 is only now fixable. The pre-PP-4895 callback was synchronous and
+structurally could not reach the actor-isolated `taskIdentifierToBook`; the async
+form can `await` it.
+
+## The cell table
+
+Each site is (provider/record state) × (protection space). Enumerated because the
+naive fix — return `.cancelAuthenticationChallenge` when the provider is gone —
+is WRONG in two of the six cells: cancelling a server-trust challenge breaks
+every HTTPS request, and cancelling an unsupported method changes today's
+`rejectProtectionSpace` behaviour.
+
+Path 1, `TPPNetworkResponder`:
+
+| provider | HTTP basic | server trust | other method |
+|---|---|---|---|
+| alive | its credentials | performDefaultHandling | rejectProtectionSpace |
+| supplied, since released | **cancel** (was: current account's credentials) | performDefaultHandling | rejectProtectionSpace |
+| never supplied | current account's credentials | performDefaultHandling | rejectProtectionSpace |
+
+Path 2, `MyBooksDownloadCenter`:
+
+| started-task record | HTTP basic | server trust | other method |
+|---|---|---|---|
+| present, account A (current B) | **A's credentials** (was: B's) | performDefaultHandling | rejectProtectionSpace |
+| absent / empty account | current account (unchanged) | performDefaultHandling | rejectProtectionSpace |
+
+The whole right-hand side of both tables is reached by routing the degraded case
+through a credentials provider that simply HAS no credentials, rather than
+hard-coding a disposition. `TPPBasicAuth.handleChallenge` already answers all
+three protection spaces correctly for a provider with nil username/pin: basic →
+`cancelAuthenticationChallenge`, server trust → `performDefaultHandling`, other →
+`rejectProtectionSpace`. So there stays exactly ONE decision point and the two
+sites cannot drift from it.
+
+## Claims
+
+- adds `TPPNetworkResponder.wasSuppliedCredentialsProvider`, a `let` recorded at
+  init, so a later nil weak reference can be read as "it was released" rather
+  than "none was ever supplied". Those two are indistinguishable from the weak
+  reference alone and must be answered differently — every other call site in the
+  app passes nil deliberately and relies on the fallback, so the fallback cannot
+  simply be removed
+- on the released path, answers the challenge through a no-credentials provider
+  instead of the current account, and logs a warning. Basic-auth challenges are
+  therefore declined rather than answered with the wrong library's card, while
+  server-trust and unsupported-method challenges keep today's dispositions
+  exactly
+- adds `fallbackCredentialsProvider` to `TPPNetworkResponder.init` as a
+  defaulted, lazily-invoked closure over
+  `AppContainer.production().accountsManager.currentUserAccount`. Behaviour-
+  neutral — the default resolves at challenge time exactly as the inline
+  expression did — and it is the seam that lets the "never supplied" cell be
+  tested without warming the production container, which is the pollution PP-4895
+  review spent a round removing
+- adds `MyBooksDownloadCenter.challengeAccount(for:)` in a NEW collaborator file
+  `MyBooksDownloadCenter+ChallengeAccount.swift`, resolving the challenging
+  task's account by two well-defined hops the class already trusts elsewhere:
+  `taskIdentifierToBook` (the live map used by the progress, completion and
+  retry paths) for the book, then the durable started-task record for that
+  bookID, whose `account` field is already written at download start. The hub's
+  callback body is replaced one-for-one, so the frozen hub does not grow —
+  per the freeze contract's "land your fix by EXTRACTING into a collaborator"
+- degrades to today's `userAccount` when either hop misses, so a task with no
+  live mapping or no durable record behaves exactly as it does now
+- covers both cell tables at both sites, including the two cells a naive
+  cancel-on-missing-provider fix would break, and all THREE of path 2's
+  degradation arms — no live task mapping, mapped but no record, and a record
+  whose account is the empty string. A first pass claimed the empty-account arm
+  was "covered by the record-absent test on the same branch"; that was wrong,
+  they are different branches, and the arm is not hypothetical — the start path
+  writes `account: accountScope.currentAccountID ?? ""`, so production emits `""`
+  itself. Review caught it. Also adds a selectivity test with two libraries
+  downloading concurrently, because with a single persisted record a resolver
+  that took the first record would have passed every other test here. The one
+  path-2 cell deliberately not written is record-present × unsupported-method,
+  which cannot reach a different answer
+
+## Anti-claims
+
+- does NOT remove or alter the `?? currentUserAccount` fallback for the callers
+  that intend it — every site that passes no provider keeps reaching the current
+  account
+- does NOT make `credentialsProvider` strong. That would reintroduce the retain
+  cycle the weak reference exists to break
+- does NOT change any disposition `TPPBasicAuth` returns, or add a second place
+  where a disposition is decided
+- does NOT change the download state machine, add state to it, or alter what is
+  written at download start. Path 2 only READS the record that is already
+  persisted there
+- does NOT claim declining is free. The released cell is not always a leak: when
+  the account screen's library IS the current library — the common case — the old
+  fallback happened to supply the CORRECT credential, and those requests now fail
+  instead of succeeding. Sign-out runs through the same executor, so a
+  server-side revoke that used to complete may no longer. The trade is deliberate
+  and is the standard the credential-isolation boundary sets: an operation that
+  fails and can be retried is recoverable, a credential sent to the wrong
+  library's server is not. It should still be understood as a trade rather than a
+  pure win
+- does NOT close the underlying window on path 1. A provider released before the
+  challenge arrives is still unobservable; this changes what the app DOES in that
+  case, from "send the wrong credential" to "send none"
+- does NOT touch `AccountCredentialResolver`, `currentUserAccount`'s ride-out
+  behaviour, or the F-034 lock span
+
+## Review-driven amendments (round 1)
+
+Architect and blast-radius both approved; QA requested changes. Everything below
+was taken.
+
+**A launch abort I misdiagnosed, and the correction.** A `_os_unfair_lock_recursive_abort`
+under `AppContainer._cachedValue()` killed the app at launch mid-round, and I
+attributed it to the then-new `fallbackCredentialsProvider` default — a closure
+over `AppContainer.production()` — reasoning that the container constructs the
+responder, so the default was reachable from `init`.
+
+**That attribution was wrong and is retracted.** Both reviewers independently
+built standalone reproductions showing a closure-literal default argument does not
+invoke its body at the call site; I then restored the closure default on the real
+app with a clean derived-data and it passed. The commit that had already shipped
+that exact shape, 036c2ff1c, ran 8308 tests without crashing — evidence in my own
+history I failed to check before generalizing. The abort was real; **its cause is
+unidentified.** The leading unexcluded candidate is that the run immediately
+before it failed to COMPILE, so the crashing build was incremental on top of a
+partially-built module.
+
+What IS verified, and is what the comment and memory now teach: the hazard class
+is real but belongs to VALUE-typed defaults, which are evaluated at the call site.
+`TPPNetworkExecutor`'s DI-friendly init carries exactly that form —
+`accountsManager: TPPLibraryAccountsProvider = AppContainer.production().accountsManager`
+— and is safe today only because overload ranking prefers the `@objc` init for the
+container's own call. Safe by accident, and named here so it is not load-bearing
+by accident silently.
+
+The parameter stays `nil`-defaulted regardless, for a reason that survives the
+correction: it keeps container reads off every construction path by SHAPE rather
+than by argument-evaluation rules, which is the property worth having when the
+container is what builds you.
+
+**A false census in my own comment (QA).** I had written that every site seeding
+`taskIdentifierToBook` writes the durable record first, and called that ordering
+load-bearing. Three of the five do not: the bearer-token re-issue
+(`RightsManagementDispatcher`), the follow-up/rights re-issue
+(`BackgroundDownloadHandler`), and launch-reconciliation adopt. Verified by
+reading each. The real guarantee is bookID keying with an upsert-by-bookID store,
+which is why a re-issued task inherits the right account and why task-identifier
+reuse is irrelevant. The comment now says that instead.
+
+**Path 2 had three degradation arms, not two (QA).** No live task mapping,
+mapped-but-no-record, and record-with-empty-account. Only the first was tested,
+and the test was misnamed for the second. All three now have a test, and the
+empty-account arm is not hypothetical — the start path writes
+`account: accountScope.currentAccountID ?? ""`.
+
+**A third survivor mutant, found by QA on re-review.** Re-keying hop 2 from
+bookID to `taskIdentifier` passed the entire suite, because every test until now
+challenged with the same identifier it persisted under. That refactor looks like a
+tightening and would silently break the bearer-token and rights re-issue paths,
+whose correctness rests entirely on bookID keying. A re-issue test — record
+written under one task identifier, challenge arriving on another mapped to the
+same book — now kills it.
+
+**Two named survivor mutants (QA, first round).** Dropping the emptiness guard, and taking the
+first record rather than the challenging book's. Both survived the original
+suite; a selectivity test with two libraries downloading concurrently and a
+sharpened empty-account test now kill them. The first attempt at the
+empty-account test passed for the wrong reason — it injected an account, which
+wins over the captured id and made the guard invisible — so it now asserts on the
+resolver's returned account identity, which is the only place the distinction is
+observable.
+
+**An ARC lifetime hazard in a test (architect and blast-radius, independently).**
+`ProviderBox`'s last use sat before the `await`, so an optimized build could
+release the provider before the challenge and turn a pass into a decline. Pinned
+across the await.
+
+## Review-driven amendments (round 2) — a CI-only failure the local suite hid
+
+CI failed three of the new download-path tests while the local full suite
+reported 8308 tests / 0 failures. They failed all three retry iterations, so not
+flakes. This was found only because the PR's CI was checked before merging, not
+because anything local caught it.
+
+**Mechanism, verified in source by two reviewers independently.**
+`TPPKeychainStoredVariable.write()` sets `cachedValue` and `alreadyInited = true`
+BEFORE attempting the keychain write, and `read()` short-circuits on
+`alreadyInited`. So a single instance never consults storage — a silent `-34018`
+is invisible — while a SECOND instance for the same library must hit the keychain
+and gets nothing. `TPPUserAccountTestFactory.makeIsolated(libraryUUID:)`
+deliberately constructs a fresh account bypassing the accounts-manager cache, so
+the account the test wrote and the account the resolver returned were two objects
+agreeing only through storage. Green locally, deterministically red on CI.
+
+It is also the pattern this project's test rules ban outright: never hit the real
+keychain, inject instead.
+
+**Fix.** The captured-account tests mint through the accounts manager the center
+under test is built with, so test and resolver share one instance and storage
+leaves the path.
+
+A first attempt used `AppContainer.production().accountsManager`, which CI
+rejected: `AppContainerIsolationLintTests` bans `production()` reads in test
+bodies outside a whitelist, and that test failed all three iterations.
+
+The manager is now minted via `PalaceWiringTestCase.makeFreshAccountsManager()`,
+and the suite is based on `PalaceWiringTestCase`.
+
+Two earlier attempts were both wrong, and CI caught each:
+`AppContainer.production().accountsManager` tripped
+`AppContainerIsolationLintTests`; a hand-rolled `AccountsManager()` then tripped
+`AccountsManagerIsolationLintTests`. The second is the more instructive failure —
+the hand-rolled form pinned the same opt-out flag but LEAKED
+`cancelAndDrainBackgroundWork()`, which the sanctioned seam registers on
+teardown. So the lint was not enforcing a style preference; it was enforcing a
+cleanup I had silently dropped, exactly the sort of thing a local run does not
+show. The seam does everything the hand-rolled version did, plus that.
+
+A note on process rather than code: this repo has NINE meta-lint classes and I
+had been running two. They assert over the whole test corpus, so no
+`-only-testing` selection derived from changed files can reach them — a
+structural blind spot, not forgetfulness. All seven scannable ones now run
+against this branch. That is the
+"hand-rolled `AccountsManager()`" an earlier round recorded as unacceptable, and
+that rejection was wrong: the objection was the background `loadCatalogs`
+outliving the test, and pinning the flag is exactly what suppresses it — which is
+all `makeTestAppContainer()` does for that concern. Correcting the record rather
+than leaving a rationale that rejects an option for a reason it also removes.
+
+The lint's suggested remedy, `makeTestAppContainer()`, was tried and rejected on
+its own merits: it builds an entire container to yield one member, and the
+`MyBooksDownloadCenter` inside it is constructed WITHOUT the `urlSession:` seam,
+so it creates a background `URLSession` on the single static identifier with
+itself as delegate — never invalidated, delegate retained, one stranded center
+per call. That is the exact pollution this file's seam exists to avoid, so
+routing the fixture through it would have reintroduced through the back door what
+the suite closes at the front.
+
+Either way the resolver-cache residue the review weighed is gone: nothing
+synthetic is inserted into the production graph.
+
+Honest caveat: the flag lives behind `#if DEBUG`, so in a non-DEBUG configuration
+the background load is not suppressed. That is true of the factory as well, so it
+is not a regression introduced here — but it is not a guarantee either. Accounts are torn down per test. The instance-sharing property is asserted
+directly rather than left implicit, in all three converted tests.
+
+Those assertions test INSTANCE IDENTITY, not credential visibility, and the
+distinction is the whole point. Two instances for one library agree via the
+keychain, which SUCCEEDS on a developer machine — so a `barcode ==` precondition
+passes locally and fails only on CI, reproducing the exact property this round
+exists to eliminate. Identity never round-trips through storage, so it fails
+locally. A first pass used `barcode ==` in two of the three and review measured
+the difference: reverting the helper failed 1 of 3 locally with the credential
+form, 3 of 3 with identity. All three are identity now, with a credential
+assertion kept alongside for the diagnostic message.
+
+**Two reviewer answers worth recording**, because both push back on the "cleaner"
+option:
+- Injecting a stub `AccountsManager` was rejected. A fresh `AccountsManager()`
+  starts a background `loadCatalogs` that outlives the test — a documented
+  polluter here — and a protocol seam would be a production signature change to a
+  frozen god-class on the download critical path, made to serve a test. The
+  retype belongs with the S2b MBDC wave, and even then would not simplify these
+  tests, since `userAccount(forCapturedId:)` prefers `injectedUserAccount`.
+- Evicting the synthetic accounts from the resolver cache was rejected: nothing
+  enumerates that cache, `userAccount(for:)` does not write
+  `lastKnownCurrentUserAccount` (so F-016's ride-out cannot pick one up), and
+  `TPPUserAccount.init(libraryUUID:)` is inert. Adding an eviction API purely for
+  tests would be new production surface serving only tests.
+
+**One belief corrected:** `removeAll()` is NOT scoped to an account's own keychain
+keys — it also broadcasts `TPPDidSignOut` globally and posts through
+`UserAccountPublisher`. Net-new risk here is ~zero, because
+`TPPUserAccountTestFactory`'s resetter already called it on every minted account,
+so only the timing changed. Recorded so nobody later moves that call somewhere it
+does matter.
+
+## Not done — adjacent reads left alone
+
+`BackgroundDownloadHandler.swift:267` attaches `delegate.userAccount.authToken` —
+the CURRENT account — to the follow-up download request for a book that may have
+been started under another library. Same F-034 boundary and the same
+current-versus-started-for shape this ticket fixes at the challenge site, and it
+is a second consumer of the very property path 2 redirects away from. Named
+explicitly rather than gestured at, per review; out of scope here because it is a
+request-construction path rather than a challenge answer, and deserves its own
+tests.
+
+
+
+`TPPNetworkResponder` reaches `currentUserAccount` on several other paths (the
+401 handling, token refresh, and `refreshToken`'s default argument), and the
+download start / bearer-auth path has its own `forCapturedId` note. Those are the
+same family and are deliberately untouched here: each would need its own
+reasoning about which account a retry or a refresh belongs to, and bundling them
+would put several credential-routing decisions in one revert unit.
+
+## Files in scope
+
+- `Palace/Network/TPPNetworkResponder.swift`
+- `Palace/MyBooks/MyBooksDownloadCenter.swift` (callback body, one line)
+- `Palace/MyBooks/MyBooksDownloadCenter+ChallengeAccount.swift` (new)
+- `PalaceTests/Network/NetworkResponderAuthChallengeWitnessTests.swift`
+- `PalaceTests/MyBooks/DownloadAuthChallengeWitnessTests.swift`
+- `Palace.xcodeproj/project.pbxproj` (both targets for the new production file)

--- a/.forgeos/wall-failures/2026-08-17-claim-outran-the-commit.md
+++ b/.forgeos/wall-failures/2026-08-17-claim-outran-the-commit.md
@@ -1,0 +1,107 @@
+---
+date: 2026-08-17
+source: near-miss
+walls: [contract-reconciliation, intent-recorded, blast-radius, superpartner]
+severity: medium
+wall_status: open
+---
+
+# claim-outran-the-commit
+
+## Finding
+
+PP-4969, tip `5a3f9d03c`. Two independent reviewers blocked with the same
+verdict:
+
+> "The code change you describe is not in the commit. Only the intent doc
+> changed. `DownloadAuthChallengeWitnessTests.swift` is `748f169fe…` at *both*
+> shas — byte-identical. There is no `XCTAssertIdentical` anywhere in the file."
+> — qa_test
+
+> "`XCTAssertIdentical` appears **zero** times … and zero times anywhere in
+> `git diff origin/develop...5a3f9d03c`." — blast_radius
+
+The commit message and `.forgeos/intent/pp-4969-answer-challenges-with-the-request-account.md`
+both stated, as completed fact, "All three are identity now" and "reverting the
+helper fails … 3 of 3 with identity". Against that tree the true figure was
+1 of 3. QA re-ran the measurement on the tip and got 1 of 3, matching the
+pre-change state.
+
+## What actually happened
+
+The edits were real and the 3-of-3 measurement was real — but they existed only
+in the working tree, and were destroyed before the commit.
+
+Sequence:
+
+1. Applied the identity-assertion edits to
+   `PalaceTests/MyBooks/DownloadAuthChallengeWitnessTests.swift`. Uncommitted.
+2. Ran the baseline (13/13) and then the guard-bite measurement, which mutates
+   the SAME file to reintroduce the two-instance defect. Got the genuine 3-of-3.
+3. Reverted the mutation with
+   `git checkout -- PalaceTests/MyBooks/DownloadAuthChallengeWitnessTests.swift`.
+   HEAD at that moment was `98b40ef70`, which did not contain the identity edits
+   — so the checkout discarded BOTH the defect mutation and the real work.
+4. Amended. Only `.forgeos/…` was still modified, so only the doc landed.
+
+The evidence was on screen and unread: the `git status --short` printed
+immediately before the amend listed only the intent doc. Nothing else was
+modified because the test file had already been reverted to HEAD.
+
+Net effect is worse than shipping the weaker assertions would have been. The
+weaker code carried a known, reviewer-documented gap; the artifact instead
+recorded that the gap had been measured away, so no later reader — human or gate
+— had reason to re-check.
+
+## Walls that should have caught it
+
+- **contract-reconciliation** — passed (0 findings). It matches "removes X" /
+  "adds field A to type B" shapes. A claim naming a concrete symbol
+  (`XCTAssertIdentical`) that appears nowhere in the diff is not one of its
+  shapes, so the drift was invisible to it.
+- **intent-recorded** — passed. It checks that an intent file EXISTS and
+  token-matches the commit subject. It does not compare the intent's assertions
+  against the diff.
+- **blast-radius / superpartner** — passed. Both scan the diff for risk; neither
+  reads the message or intent, so neither can see a claim about content that
+  isn't there.
+- **The reviewers caught it**, twice, independently, by hashing the blob rather
+  than reading the narrative. That worked — but it is the expensive path, and it
+  only worked because two reviewers happened to verify rather than accept.
+
+## Proposed permanent fix
+
+**Detector (designed by the blast_radius reviewer, verbatim):** in
+`scripts/check-contract-reconciliation.py`, for any claim of the form *"X is now
+Y"* / *"became Y"* where `Y` is an identifier, require `Y` to appear as an ADDED
+line in the diff. One line of output, catches this class without a human.
+
+Concretely, the trigger set should include claims naming a code identifier
+(CamelCase, `snake_case`, or `foo(bar:)` selector shape) in a sentence whose verb
+is a completion claim ("is now", "became", "now uses", "changed to", "replaced
+with"). Flag when the identifier occurs zero times in `+` lines.
+
+**Cheap author-side habit, complementary not substitute:** before re-requesting
+review, run `git show --stat HEAD` and confirm every file the message claims to
+change is listed. One command; would have caught this in isolation.
+
+**Related standing rule this instantiates:** never `git checkout -- <file>` to
+revert a mutation when that file also carries uncommitted work. Commit first,
+then mutate — the mutation revert is then safe because the tip holds the real
+change. This is the same defect class as
+`verify-means-build-not-just-review` ("'verified green' REQUIRES the CURRENT
+tip"), one level up: measured-on-a-working-tree, recorded-on-a-commit.
+
+## Application log
+
+- 2026-08-17 — Recorded. Identity edits re-applied and committed as `88973b6ba`,
+  and the measurement re-run **against the committed tip** rather than
+  re-asserted from memory: baseline 13/13, defect reintroduction fails 3 of 3
+  with no compile error, tip verified to still carry 3 `XCTAssertIdentical` after
+  the revert.
+- 2026-08-17 — Memory written:
+  `never-checkout-a-file-that-holds-uncommitted-work` (author-side habit) and the
+  existing `verify-means-build-not-just-review` cross-linked.
+- OPEN — the contract-reconciliation generalization is NOT implemented here.
+  Deliberately: this branch is a credential-path fix and tooling changes do not
+  belong in its revert unit. Filed separately so it does not evaporate.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 		34D9B1937E8049DE9B0729A3 /* AudiobookIssueFixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CF38F572AE4A88961FCA46 /* AudiobookIssueFixTests.swift */; };
 		35008DD01991700FE81D6940 /* SettingsSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551562029D888E2A48F22A52 /* SettingsSkeletonView.swift */; };
 		35250D8D6C53A1950CF6A4EB /* ReturnReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994596C5FC8FAE5BC41AEB7D /* ReturnReducer.swift */; };
+		35D6A34536A658724CCBCA64 /* MyBooksDownloadCenter+ChallengeAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC0BA48A1A27DC0C9BC3636 /* MyBooksDownloadCenter+ChallengeAccount.swift */; };
 		35E2134603214DAEB86865D9 /* CarPlayImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639A868F3BDA4A7F97660BEA /* CarPlayImageProvider.swift */; };
 		364459D0B4CBC9DACC5C6C2F /* AccessibilityServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21803F06C0E1741DD2F7973E /* AccessibilityServiceProtocol.swift */; };
 		36650A19392D0CF505DA037D /* TPPMigrationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3391CCE50BC961BC7A5726 /* TPPMigrationManagerTests.swift */; };
@@ -524,6 +525,7 @@
 		5977FE52E5B43328E7773533 /* TPPReaderFootnoteAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B4E8EC366716B84F91365E /* TPPReaderFootnoteAccessibility.swift */; };
 		59E2E27CBD048ACE94D0101C /* BookRegistryReconciliationTableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93A849278441815AA82A2FE /* BookRegistryReconciliationTableTests.swift */; };
 		5AD42A9111A49CFDF0AC22B1 /* AdobeRightsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E62D6F6D6313094B90E80E5 /* AdobeRightsParser.swift */; };
+		5AD66EC6A77192E926AC32AD /* MyBooksDownloadCenter+ChallengeAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC0BA48A1A27DC0C9BC3636 /* MyBooksDownloadCenter+ChallengeAccount.swift */; };
 		5ADD8B5E1F4D8868B3FEA17F /* PoolResponsivenessProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01209A378C5A59B2AA08C13D /* PoolResponsivenessProbeTests.swift */; };
 		5AE6D7440F7AEDED5F21C570 /* CredentialSnapshotInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1063BE37AED8A85F5812F422 /* CredentialSnapshotInvalidationTests.swift */; };
 		5AEA9E011B947419009F71DB /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503EA1993F91E009FB788 /* libc++.dylib */; };
@@ -2218,6 +2220,7 @@
 		0ABB253AB7CB4183943EBA6A /* AccountStateStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountStateStore.swift; sourceTree = "<group>"; };
 		0B60466B2029331616A708B4 /* RatingPromptPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RatingPromptPresenter.swift; sourceTree = "<group>"; };
 		0B9A4E1085F59AB6E4E0AD4C /* SupportSectionDecisionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SupportSectionDecisionTests.swift; sourceTree = "<group>"; };
+		0BC0BA48A1A27DC0C9BC3636 /* MyBooksDownloadCenter+ChallengeAccount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MyBooksDownloadCenter+ChallengeAccount.swift"; sourceTree = "<group>"; };
 		0C1F974717220248950A874F /* BorrowReducerCore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BorrowReducerCore.swift; sourceTree = "<group>"; };
 		0C33E4BDBC27454AB30FAF96 /* AlertModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertModelTests.swift; sourceTree = "<group>"; };
 		0CB69BEC26CB16962E3EE14C /* RightsManagementDispatchContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RightsManagementDispatchContractTests.swift; sourceTree = "<group>"; };
@@ -4730,6 +4733,7 @@
 				A9381BBE0CE20B654B89FFCD /* DownloadCenterBorrowReauthResetter.swift */,
 				0A731B2809097BED1D69F274 /* DownloadAccountContext.swift */,
 				A9B8F01A32F29AD53EEF2F39 /* MyBooksDownloadCenter+AccountScope.swift */,
+				0BC0BA48A1A27DC0C9BC3636 /* MyBooksDownloadCenter+ChallengeAccount.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -8704,6 +8708,7 @@
 				121523B3892A09CCEDACF8CC /* AccountCredentialResolver.swift in Sources */,
 				912940151BDB14387CDCA04A /* MarqueeText.swift in Sources */,
 				D12BD71D9E26DEABEA746DB1 /* AdobeActivationCoordinator.swift in Sources */,
+				5AD66EC6A77192E926AC32AD /* MyBooksDownloadCenter+ChallengeAccount.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9279,6 +9284,7 @@
 				16AEE219FDEB9C1FB699C6F9 /* AccountCredentialResolver.swift in Sources */,
 				1613D343B8A352AB66178488 /* MarqueeText.swift in Sources */,
 				7F48566A9000BBF77D6EC820 /* AdobeActivationCoordinator.swift in Sources */,
+				35D6A34536A658724CCBCA64 /* MyBooksDownloadCenter+ChallengeAccount.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/MyBooks/MyBooksDownloadCenter+ChallengeAccount.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter+ChallengeAccount.swift
@@ -1,0 +1,117 @@
+//
+//  MyBooksDownloadCenter+ChallengeAccount.swift
+//  Palace
+//
+//  PP-4969 — which account's credentials answer an authentication challenge on a
+//  book download.
+//
+//  The hub's challenge callback used to resolve credentials through `userAccount`,
+//  which is `injectedUserAccount ?? accountsManager.currentUserAccount` — the
+//  account current WHEN THE CHALLENGE ARRIVES, not the account the download was
+//  started for. A patron who switches libraries mid-download therefore had the
+//  challenge answered with the new library's card, so one library's server
+//  received a credential belonging to another. That is the same credential-
+//  isolation boundary as the long-standing cross-account leak invariant recorded
+//  in `AccountCredentialResolver` (F-034 / PP-4020).
+//
+//  The hub's own doc on `userAccount` has said so for a while: it calls itself the
+//  legacy resolver-fallback path, and directs new code on the download path to
+//  `userAccount(forCapturedId:)` because that one is "deterministic across
+//  library-swap windows". This is that redirection, finally applied to the
+//  challenge site.
+//
+//  Why it could not be done before PP-4969's predecessor: the callback was
+//  synchronous, and the task→book map it needs is actor-isolated. PP-4895 moved
+//  the callback to the SDK's `async` requirement (for unrelated reasons — the
+//  completion-handler form was silently failing to register), and an `await`
+//  became available inside it for the first time.
+//
+//  Lives in a collaborator rather than the hub because `MyBooksDownloadCenter` is
+//  under a god-class LOC freeze whose contract is "land your fix by EXTRACTING
+//  into a collaborator, not by growing the hub". The hub keeps a one-line call.
+//
+
+import Foundation
+
+extension MyBooksDownloadCenter {
+
+    /// The account whose credentials should answer an authentication challenge on
+    /// `task` — the account the download was STARTED for, not whichever is
+    /// current now.
+    ///
+    /// Resolved by two hops the class already relies on everywhere else:
+    ///   1. `stateManager.taskIdentifierToBook`, the live map the progress,
+    ///      completion and transient-retry paths all key off, gives the book.
+    ///      Reached through `stateManager` rather than the hub's `private`
+    ///      convenience accessor, so no production visibility widens for this.
+    ///   2. the durable started-task record for that book carries the `account`
+    ///      written at download start (`persistStartedTaskRecord`).
+    ///
+    /// WHAT THIS RESTS ON — bookID keying, not call ordering. An earlier draft of
+    /// this comment claimed every seeding site writes the record first; that is a
+    /// false census and review caught it. Of the five sites that seed
+    /// `taskIdentifierToBook`, only two do:
+    ///
+    ///   * the two download-START paths write the record via
+    ///     `persistStartedTaskRecord` (`MyBooksDownloadCenter` :1748, :2179) and
+    ///     then register (:1751, :2181, reaching
+    ///     `DownloadTaskLifecycleService` :85).
+    ///   * the bearer-token re-issue (`RightsManagementDispatcher` :193) and the
+    ///     follow-up/rights re-issue (`BackgroundDownloadHandler` :279) seed a NEW
+    ///     task for the SAME book without writing any record.
+    ///   * launch reconciliation's adopt (`MyBooksDownloadCenter` :2274) seeds
+    ///     from the persisted record itself.
+    ///
+    /// All five are correct for the same reason: hop 2 keys by bookID, and
+    /// `DownloadTaskPersistence.record` upserts by bookID, so at most one record
+    /// exists per book and it names the account that book's download started
+    /// under. A re-issued task therefore inherits the right account precisely
+    /// BECAUSE the lookup ignores task identity — which also makes task-identifier
+    /// reuse across background sessions irrelevant. Adopt is correct by
+    /// construction, being seeded from that same record.
+    ///
+    /// The one way to lose is a re-issue whose book identifier differs from the
+    /// original's; that misses the record and lands on the floor below, which is
+    /// today's behaviour.
+    ///
+    /// Degrades to `userAccount` — today's behaviour, unchanged — when either hop
+    /// misses. A task with no live mapping or no durable record is a task this
+    /// method knows nothing about, and guessing would be worse than the status
+    /// quo. That is a deliberate floor, not an oversight: it means this change can
+    /// only ever narrow the set of challenges answered with the wrong credential,
+    /// never widen it.
+    func challengeAccount(
+        for task: URLSessionTask,
+        challenge: URLAuthenticationChallenge
+    ) async -> TPPUserAccount {
+        // Only HTTP basic consumes credentials — `TPPBasicAuth.handleChallenge`
+        // answers server trust and unsupported methods without reading the
+        // provider at all. So for those, skip the lookup below rather than paying
+        // a synchronous file read and JSON decode on, among other things, every
+        // TLS handshake this delegate is asked about. Whatever is returned here
+        // cannot reach the answer for those spaces, so this is an I/O guard, not
+        // a second place that decides dispositions.
+        //
+        // COUPLED TO `TPPBasicAuth.handleChallenge`: this is a second encoding of
+        // "only basic consumes credentials", in a different module. If that switch
+        // ever grows a credential-consuming space (Digest, say), this guard would
+        // silently starve it of the started-for account while the disposition
+        // switch handled it happily. `TPPBasicAuth` carries the matching pointer
+        // back here. Change them together.
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic else {
+            return userAccount
+        }
+        guard let book = await stateManager.taskIdentifierToBook.get(task.taskIdentifier) else {
+            return userAccount
+        }
+        guard let startedAccountID = stateManager
+            .persistedRecords()
+            .first(where: { $0.bookID == book.identifier })?
+            .account,
+            !startedAccountID.isEmpty
+        else {
+            return userAccount
+        }
+        return userAccount(forCapturedId: startedAccountID)
+    }
+}

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -1680,7 +1680,9 @@ extension MyBooksDownloadCenter: URLSessionTaskDelegate {
         task: URLSessionTask,
         didReceive challenge: URLAuthenticationChallenge
     ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
-        TPPBasicAuth(credentialsProvider: userAccount).response(to: challenge)
+        // PP-4969: the account the download was STARTED for, not whichever is
+        // current now — see MyBooksDownloadCenter+ChallengeAccount.swift.
+        TPPBasicAuth(credentialsProvider: await challengeAccount(for: task, challenge: challenge)).response(to: challenge)
     }
 
     func urlSession(

--- a/Palace/Network/TPPNetworkResponder.swift
+++ b/Palace/Network/TPPNetworkResponder.swift
@@ -40,7 +40,10 @@ private struct TPPNetworkTaskInfo {
 /// crosses concurrency boundaries. All mutable state is guarded: `taskInfo` by the
 /// serial `taskInfoQueue`, `retriedURLs` and `tokenRefreshAttempts` by
 /// `retriedURLsLock`; `credentialsProvider` is a `weak var` written once in `init`
-/// and only read thereafter; the remaining stored members are immutable `let`s.
+/// and only read thereafter; the remaining stored members are immutable `let`s —
+/// including `fallbackCredentialsProvider`, a non-`Sendable` closure written once
+/// in `init` and only invoked (never reassigned), and
+/// `wasSuppliedCredentialsProvider`, a `Bool` captured at init (PP-4969).
 /// Documented invariant, not a bare waiver. (Critical-path: isolation via existing
 /// locks only — no broadening of the 401/auth decision.)
 class TPPNetworkResponder: NSObject, @unchecked Sendable {
@@ -117,13 +120,68 @@ class TPPNetworkResponder: NSObject, @unchecked Sendable {
     /// caching headers. The default is `false`.
     /// - Parameter credentialsProvider: The object providing the credentials
     /// to respond to an authentication challenge.
+    /// - Parameter fallbackCredentialsProvider: Overrides the credentials used
+    /// when NO provider was supplied at all — the deliberate configuration at
+    /// every call site but `AccountDetailViewModel`. Injectable so that path can
+    /// be exercised without warming the production container (PP-4969).
+    ///
+    /// `nil` (the default) means "resolve the current account", and that read
+    /// stays where it always was: inside the challenge callback.
+    ///
+    /// The hazard being avoided, stated precisely because an earlier version of
+    /// this comment stated it WRONGLY: `AppContainer._cachedValue()` holds an
+    /// `OSAllocatedUnfairLock` while it BUILDS the container, and the container
+    /// builds this object, so any container read that EXECUTES during `init`
+    /// re-enters that non-recursive lock and aborts the process at launch
+    /// (`_os_unfair_lock_recursive_abort`). A default argument that CALLS
+    /// `production()` — a value-typed default, no braces — does exactly that,
+    /// because value defaults are evaluated at the call site. A default that
+    /// returns a CLOSURE which calls it later does not; the generator only makes
+    /// the closure. That distinction was verified three ways: two standalone
+    /// reproductions during review, and a clean-build run of this file with the
+    /// closure default restored, which passed.
+    ///
+    /// A live example of the dangerous form is `TPPNetworkExecutor.swift`'s
+    /// DI-friendly init, whose `accountsManager` default calls
+    /// `AppContainer.production()`. It is safe today only because overload
+    /// ranking prefers the `@objc` init for the container's own call — safe by
+    /// accident, not by design.
+    ///
+    /// `nil` is used here regardless: it keeps container reads off every
+    /// construction path by shape rather than by argument-evaluation rules, which
+    /// is the property worth having when the container builds you.
     init(credentialsProvider: NYPLBasicAuthCredentialsProvider? = nil,
-         useFallbackCaching: Bool = false) {
+         useFallbackCaching: Bool = false,
+         fallbackCredentialsProvider: (() -> NYPLBasicAuthCredentialsProvider)? = nil) {
         self.taskInfo = [Int: TPPNetworkTaskInfo]()
         self.useFallbackCaching = useFallbackCaching
         self.credentialsProvider = credentialsProvider
+        // PP-4969: a nil `credentialsProvider` READ LATER cannot distinguish
+        // "released since" from "never supplied", and the two must be answered
+        // differently. Recorded here, where the difference is still knowable.
+        self.wasSuppliedCredentialsProvider = credentialsProvider != nil
+        self.fallbackCredentialsProvider = fallbackCredentialsProvider
         super.init()
     }
+
+    /// True when a credentials provider was supplied at construction. See the
+    /// challenge callback for why this cannot be inferred later.
+    private let wasSuppliedCredentialsProvider: Bool
+
+    /// See the `init` parameter doc. `nil` means "use the current account".
+    ///
+    /// Obligation on whoever injects one: it is invoked from the auth-challenge
+    /// callback, which is `nonisolated` and runs on the cooperative pool, so the
+    /// closure must be safe to call off any particular executor. Not enforced by
+    /// the type (it is not `@Sendable` — see below), so it is stated here.
+    ///
+    /// Covered by the class's `@unchecked Sendable`
+    /// conformance on the same terms as its other stored members: `let`-bound,
+    /// written once in `init`, only ever read. NOT `@Sendable`, because the value
+    /// it returns is a `NYPLBasicAuthCredentialsProvider` existential — which is
+    /// not `Sendable` — and requiring it would force every caller to launder a
+    /// credentials object through an unchecked box to inject one.
+    private let fallbackCredentialsProvider: (() -> NYPLBasicAuthCredentialsProvider)?
 
     // MARK: - Retry Tracking
 
@@ -798,8 +856,38 @@ extension TPPNetworkResponder: URLSessionTaskDelegate {
         task: URLSessionTask,
         didReceive challenge: URLAuthenticationChallenge
     ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
-        let credsProvider = credentialsProvider ?? AppContainer.production().accountsManager.currentUserAccount
-        return TPPBasicAuth(credentialsProvider: credsProvider).response(to: challenge)
+        return TPPBasicAuth(credentialsProvider: challengeCredentialsProvider()).response(to: challenge)
+    }
+
+    /// Decides WHOSE credentials answer this challenge (PP-4969).
+    ///
+    /// Three cases, and the middle one is the fix:
+    ///   * the supplied provider is still alive — use it.
+    ///   * a provider WAS supplied and has since been released — answer with no
+    ///     credentials. Falling back here would hand the challenging library the
+    ///     CURRENT library's barcode, which is the cross-account leak this
+    ///     guards (same boundary as F-034 / PP-4020).
+    ///   * none was ever supplied — use the fallback. This is the deliberate
+    ///     configuration at every call site except `AccountDetailViewModel`, so
+    ///     the fallback must stay intact for them.
+    ///
+    /// The released case returns a credential-less PROVIDER rather than a
+    /// hard-coded disposition on purpose: `TPPBasicAuth` then still answers each
+    /// protection space correctly — basic auth is declined, server trust is left
+    /// to the system (cancelling it would break every HTTPS request), and an
+    /// unsupported method is still rejected. One decision point, no drift.
+    private func challengeCredentialsProvider() -> NYPLBasicAuthCredentialsProvider {
+        if let live = credentialsProvider {
+            return live
+        }
+        if wasSuppliedCredentialsProvider {
+            Log.warn(#file, "Auth challenge: the supplied credentials provider was released before the challenge arrived; answering with no credentials rather than substituting the current account's (PP-4969). For a basic-auth challenge that means declining it; a server-trust challenge is still left to the system.")
+            return NoCredentialsProvider()
+        }
+        if let injected = fallbackCredentialsProvider {
+            return injected()
+        }
+        return AppContainer.production().accountsManager.currentUserAccount
     }
 
     func refreshToken(userAccount: TPPUserAccount = AppContainer.production().accountsManager.currentUserAccount) async throws {
@@ -818,4 +906,13 @@ extension TPPNetworkResponder: URLSessionTaskDelegate {
             throw error
         }
     }
+}
+
+/// A credentials provider that has no credentials, used to answer an
+/// authentication challenge when the provider that WOULD have answered it has
+/// been released (PP-4969). Routing that case through `TPPBasicAuth` with this
+/// keeps every protection space's disposition decided in one place.
+private final class NoCredentialsProvider: NSObject, NYPLBasicAuthCredentialsProvider {
+    var username: String? { nil }
+    var pin: String? { nil }
 }

--- a/Palace/Packages/PalaceNetwork/Sources/PalaceNetwork/TPPBasicAuth.swift
+++ b/Palace/Packages/PalaceNetwork/Sources/PalaceNetwork/TPPBasicAuth.swift
@@ -32,6 +32,11 @@ import Foundation
     /// - Parameters:
     ///   - challenge: The authentication challenge to respond to.
     ///   - completion: Always called, synchronously.
+    /// COUPLED (PP-4969): `MyBooksDownloadCenter+ChallengeAccount.swift` skips its
+    /// account lookup for any protection space this switch answers WITHOUT
+    /// reading `credentialsProvider` — today everything except HTTP basic. Adding
+    /// a credential-consuming space here means updating that guard too, or the
+    /// download path will answer the new space with the wrong account.
     @objc public func handleChallenge(_ challenge: URLAuthenticationChallenge,
                                       completion: BasicAuthCompletionHandler) {
         switch challenge.protectionSpace.authenticationMethod {

--- a/PalaceTests/MyBooks/DownloadAuthChallengeWitnessTests.swift
+++ b/PalaceTests/MyBooks/DownloadAuthChallengeWitnessTests.swift
@@ -38,8 +38,13 @@ import XCTest
 import PalaceNetwork
 @testable import Palace
 
-@MainActor
-final class DownloadAuthChallengeWitnessTests: XCTestCase {
+// `PalaceWiringTestCase` rather than `XCTestCase`: it is the sanctioned seam for
+// minting an `AccountsManager` in a test, and its tearDown calls
+// `cancelAndDrainBackgroundWork()` on every manager it minted. A hand-rolled
+// `AccountsManager()` pins the same opt-out flag but leaks that cancellation —
+// which is why `AccountsManagerIsolationLintTests` bans it, and why CI caught it.
+// The base is already `@MainActor`.
+final class DownloadAuthChallengeWitnessTests: PalaceWiringTestCase {
 
     /// The selector URLSession actually sends. Spelled as a string on purpose:
     /// `#selector` would resolve through the same Swift-level machinery this
@@ -81,9 +86,27 @@ final class DownloadAuthChallengeWitnessTests: XCTestCase {
         return center
     }
 
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Skip the synchronous on-disk cached-account load — its declaration names
+        // it the root of the FLAKE-003 30s CI timeout. Safe here because nothing in
+        // this file reads `accountSets` or `account(uuid:)`; every account read
+        // resolves through `AccountCredentialResolver`, a different structure.
+        // (`deferInitialLoadCatalogsForTesting` is the base class's job.)
+        AccountsManager.deferDiskCachePreloadForTesting = true
+    }
+
     override func tearDown() async throws {
         _signedInCenter = nil
         _signedOutCenter = nil
+        // Real keychain entries under `test-uuid-…` namespaced keys outlive the
+        // throwaway manager, so this is still load-bearing even though the manager
+        // itself dies with the test.
+        mintedLibraryAccounts.forEach { $0.removeAll() }
+        mintedLibraryAccounts.removeAll()
+        // Global flag — restore the default rather than leaking the opt-out into
+        // suites that DO read the account registry.
+        AccountsManager.deferDiskCachePreloadForTesting = false
         try await super.tearDown()
     }
 
@@ -169,6 +192,359 @@ final class DownloadAuthChallengeWitnessTests: XCTestCase {
 
         XCTAssertEqual(disposition, .rejectProtectionSpace)
         XCTAssertNil(credential)
+    }
+
+    // MARK: - Which account answers (PP-4969)
+
+    /// Builds a center whose state manager persists to a temp file, so a started-
+    /// task record can be seeded without touching the real download store.
+    ///
+    /// Deliberately does NOT pass `userAccount:` — `userAccount(forCapturedId:)`
+    /// lets an injected account win over the captured id, which would make the
+    /// captured-id resolution untestable. This center therefore resolves through
+    /// the real accounts manager, so any account it must see has to be minted via
+    /// `makeLibraryAccount` below — NOT via `TPPUserAccountTestFactory`, which
+    /// returns a separate instance that only agrees through the keychain.
+    /// - Parameter account: when supplied it becomes `userAccount`, i.e. the value
+    ///   the resolver DEGRADES to. Pass it for the fallback-arm tests so the
+    ///   fallback is observable; omit it for the captured-account test, where an
+    ///   injected account would win over the captured id and make the resolution
+    ///   untestable.
+    private func makeCenterWithPersistence(
+        _ persistenceURL: URL,
+        account: TPPUserAccount? = nil
+    ) -> (MyBooksDownloadCenter, DownloadStateManager) {
+        let stateManager = DownloadStateManager(
+            taskPersistence: DownloadTaskPersistence(fileURL: persistenceURL))
+        let center = MyBooksDownloadCenter(
+            userAccount: account,
+            bookRegistry: TPPBookRegistryMock(),
+            // Same manager `makeLibraryAccount` mints through — that shared
+            // instance is what keeps the keychain out of the resolution path.
+            accountsManager: testAccountsManager,
+            stateManager: stateManager,
+            reachability: MockReachability(initiallyConnected: true),
+            urlSession: URLSession(configuration: .ephemeral))
+        return (center, stateManager)
+    }
+
+    /// Accounts minted for the captured-account tests, cleaned up in `tearDown`.
+    private var mintedLibraryAccounts: [TPPUserAccount] = []
+
+    /// The accounts manager shared by this suite's non-injected centers and by
+    /// `makeLibraryAccount`. Fresh per test method (XCTest builds a case instance
+    /// per method), so nothing is shared across tests and nothing reaches the
+    /// production `AppContainer`.
+    ///
+    /// Constructed directly rather than via `makeTestAppContainer()` on purpose.
+    /// That factory builds an entire graph to hand back one member, and the
+    /// `MyBooksDownloadCenter` inside it is built WITHOUT the `urlSession:` seam —
+    /// so it creates a background `URLSession` on the single static
+    /// `backgroundSessionIdentifier` with itself as delegate. A `URLSession`
+    /// retains its delegate and this one is never invalidated, so every call would
+    /// strand a download center holding a background session on an identifier
+    /// Apple documents as one-live-session-per-process. That is precisely the
+    /// pollution this file's `urlSession:` seam exists to avoid for its own
+    /// centers; it would be perverse to reintroduce it through the fixture.
+    ///
+    /// The flag pin is what the factory was wanted for, and it is one line. NOTE it
+    /// lives behind `#if DEBUG` in `AccountsManager`, so in a non-DEBUG
+    /// configuration the background `loadCatalogs` is not suppressed — true of the
+    /// factory too, so this is not a regression, but it is not a guarantee either.
+    private lazy var testAccountsManager: AccountsManager = makeFreshAccountsManager()
+
+    /// Mints a library account through the SAME resolver the center under test
+    /// will use, so the test and the resolver share ONE instance.
+    ///
+    /// **Any test using a center that is NOT given an injected `userAccount:` must
+    /// mint through here**, and that center must be built with
+    /// `testAccountsManager`. Those centers resolve by library id, and only a
+    /// shared instance keeps the keychain out of the path.
+    ///
+    /// Deliberately not `TPPUserAccountTestFactory.makeIsolated`: that constructs a
+    /// fresh `TPPUserAccount` which bypasses the accounts-manager cache, so
+    /// credentials written here would only reach the resolver's instance by
+    /// round-tripping through the KEYCHAIN. That works locally and fails on CI,
+    /// where the simulator keychain returns -34018 (missing entitlement) — three
+    /// tests in this file passed locally and failed all three CI retries for
+    /// exactly that reason. Sharing the instance removes the keychain from the
+    /// path entirely, which is also what this project's test rules ask for.
+    private func makeLibraryAccount(id: String, barcode: String, pin: String) -> TPPUserAccount {
+        let account = testAccountsManager.userAccount(for: id)
+        account.setBarcode(barcode, PIN: pin)
+        mintedLibraryAccounts.append(account)
+        return account
+    }
+
+    private func tempPersistenceURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("pp4969-\(UUID().uuidString).json")
+    }
+
+    func testChallengeOnDownload_usesTheAccountTheDownloadStartedFor_notTheCurrentOne() async throws {
+        // The heart of PP-4969's download arm. The patron started this download
+        // while library A was selected and has since switched libraries. The
+        // challenge must still be answered with A's card — answering with
+        // whatever is current now hands library A's server another library's
+        // credential.
+        let persistenceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pp4969-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: persistenceURL) }
+
+        let startedLibraryID = "test-uuid-\(UUID().uuidString)"
+        let startedAccount = makeLibraryAccount(id: startedLibraryID,
+                                                barcode: "started-library-card",
+                                                pin: "started-pin")
+
+        let (center, stateManager) = makeCenterWithPersistence(persistenceURL)
+
+        // Pins the property that makes this suite independent of the keychain:
+        // the resolver hands back the SAME instance the test just wrote to, so
+        // the credentials never have to round-trip through storage. When these
+        // were two instances for one library id, they agreed only via the
+        // keychain — green locally, red on CI where it returns -34018.
+        XCTAssertIdentical(center.userAccount(forCapturedId: startedLibraryID), startedAccount,
+                           "the resolver must share the test's account instance, not depend on keychain persistence")
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        let task = fakeDownloadTask()
+
+        await stateManager.taskIdentifierToBook.set(task.taskIdentifier, value: book)
+        stateManager.persistStartedTask(
+            bookID: book.identifier,
+            taskIdentifier: task.taskIdentifier,
+            downloadURL: URL(string: "https://library-a.palace-test.invalid/book")!,
+            account: startedLibraryID,
+            expectedBytes: nil)
+
+        let (disposition, credential) = await center.urlSession(
+            URLSession(configuration: .ephemeral),
+            task: task,
+            didReceive: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, "started-library-card",
+                       "the challenge must be answered with the account the download started for")
+        XCTAssertEqual(credential?.password, "started-pin")
+    }
+
+    func testChallengeOnDownload_forATaskWithNoLiveMapping_fallsBackToTodaysBehaviour() async {
+        // Degradation arm 1 of 3: the task is not in `taskIdentifierToBook`, so
+        // resolution stops at hop 1 and never reaches the record lookup. (This
+        // test was originally misnamed "withNoStartedTaskRecord", which described
+        // arm 2 — a different branch it never reached. Review caught it.)
+        let signedIn = TPPUserAccountTestFactory.makeIsolated()
+        signedIn.setBarcode("fallback-card", PIN: "fallback-pin")
+        let center = makeCenter(account: signedIn)
+
+        let (disposition, credential) = await center.urlSession(
+            URLSession(configuration: .ephemeral),
+            task: fakeDownloadTask(),
+            didReceive: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, "fallback-card")
+    }
+
+    func testChallengeOnDownload_withAStartedTaskRecord_stillDefersOnServerTrust() async {
+        // The captured-account lookup must not change what a TLS trust challenge
+        // does. Cancelling one would break every https download. Note the
+        // resolver short-circuits before hop 1 for non-basic spaces (it skips a
+        // file read that cannot affect the answer), so what this pins is the
+        // OUTCOME contract: whichever account resolution happens or is skipped,
+        // a trust challenge is still handed back to the system.
+        let persistenceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pp4969-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: persistenceURL) }
+
+        let startedLibraryID = "test-uuid-\(UUID().uuidString)"
+        _ = makeLibraryAccount(id: startedLibraryID, barcode: "irrelevant", pin: "irrelevant")
+
+        let (center, stateManager) = makeCenterWithPersistence(persistenceURL)
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        let task = fakeDownloadTask()
+        await stateManager.taskIdentifierToBook.set(task.taskIdentifier, value: book)
+        stateManager.persistStartedTask(
+            bookID: book.identifier,
+            taskIdentifier: task.taskIdentifier,
+            downloadURL: URL(string: "https://library-a.palace-test.invalid/book")!,
+            account: startedLibraryID,
+            expectedBytes: nil)
+
+        let (disposition, credential) = await center.urlSession(
+            URLSession(configuration: .ephemeral),
+            task: task,
+            didReceive: challenge(method: NSURLAuthenticationMethodServerTrust))
+
+        XCTAssertEqual(disposition, .performDefaultHandling)
+        XCTAssertNil(credential)
+    }
+
+    func testChallengeOnDownload_whenTheTaskIsMappedButHasNoRecord_fallsBackToTodaysBehaviour() async {
+        // Degradation arm 2 of 3: the book IS known, but no durable record names
+        // an account for it. Distinct branch from arm 1 above.
+        let persistenceURL = tempPersistenceURL()
+        defer { try? FileManager.default.removeItem(at: persistenceURL) }
+
+        let fallbackAccount = TPPUserAccountTestFactory.makeIsolated()
+        fallbackAccount.setBarcode("fallback-card", PIN: "fallback-pin")
+        let (center, stateManager) = makeCenterWithPersistence(persistenceURL, account: fallbackAccount)
+
+        let task = fakeDownloadTask()
+        await stateManager.taskIdentifierToBook.set(
+            task.taskIdentifier, value: TPPBookMocker.mockBook(distributorType: .EpubZip))
+        // Deliberately no persistStartedTask call.
+
+        let (disposition, credential) = await center.urlSession(
+            URLSession(configuration: .ephemeral), task: task, didReceive: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, "fallback-card")
+    }
+
+    func testChallengeOnDownload_whenTheRecordHasNoAccount_fallsBackToTodaysBehaviour() async {
+        // Degradation arm 3 of 3, and NOT hypothetical: the start path writes
+        // `account: accountScope.currentAccountID ?? ""`, so production emits the
+        // empty string itself whenever no account id is resolvable. Without the
+        // emptiness guard this would resolve the "" account rather than degrade.
+        let persistenceURL = tempPersistenceURL()
+        defer { try? FileManager.default.removeItem(at: persistenceURL) }
+
+        // Asserted on the RESOLVER rather than through the delegate, deliberately.
+        // Observed through the challenge answer these two outcomes are identical:
+        // an injected account wins over the captured id (so the guard would be
+        // invisible), and without one, both the degraded account and the
+        // empty-id account are credential-less in a test environment, so both
+        // answers are `.cancelAuthenticationChallenge`. The distinction is real
+        // but only visible as WHICH account is resolved, so that is what this
+        // pins. Removing the emptiness guard makes it resolve the ""-keyed
+        // account instead and this fails.
+        let (center, stateManager) = makeCenterWithPersistence(persistenceURL)
+
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        let task = fakeDownloadTask()
+        await stateManager.taskIdentifierToBook.set(task.taskIdentifier, value: book)
+        stateManager.persistStartedTask(
+            bookID: book.identifier,
+            taskIdentifier: task.taskIdentifier,
+            downloadURL: URL(string: "https://library-a.palace-test.invalid/book")!,
+            account: "",
+            expectedBytes: nil)
+
+        let resolved = await center.challengeAccount(for: task, challenge: basicAuthChallenge())
+
+        XCTAssertTrue(resolved === center.userAccount,
+                      "an empty account id must degrade to today's account, not resolve the empty-id account")
+        XCTAssertFalse(resolved === center.userAccount(forCapturedId: ""),
+                       "the empty-id account must never answer a challenge")
+    }
+
+    func testChallengeOnDownload_withTwoLibrariesDownloading_picksTheChallengingBooksAccount() async {
+        // Selectivity. Two concurrent downloads from two libraries IS the defect
+        // scenario, and with only one record persisted a resolver that just took
+        // the FIRST record would pass every other test in this file.
+        let persistenceURL = tempPersistenceURL()
+        defer { try? FileManager.default.removeItem(at: persistenceURL) }
+
+        let otherLibraryID = "test-uuid-\(UUID().uuidString)"
+        _ = makeLibraryAccount(id: otherLibraryID,
+                               barcode: "other-library-card",
+                               pin: "other-pin")
+
+        let challengingLibraryID = "test-uuid-\(UUID().uuidString)"
+        let challengingAccount = makeLibraryAccount(id: challengingLibraryID,
+                                                    barcode: "challenging-library-card",
+                                                    pin: "challenging-pin")
+
+        let (center, stateManager) = makeCenterWithPersistence(persistenceURL)
+        // IDENTITY, not credential visibility. Identity is the storage-independent
+        // property: two instances for one library agree via the keychain, which
+        // SUCCEEDS locally, so a `.barcode` precondition passes here and fails only
+        // on CI — reproducing the very defect this suite exists to eliminate.
+        // Measured: reverting the helper fails all three converted tests locally
+        // with identity, and only one with the credential form.
+        XCTAssertIdentical(center.userAccount(forCapturedId: challengingLibraryID), challengingAccount,
+                           "the resolver must share this test's account instance, not depend on keychain persistence")
+        XCTAssertEqual(challengingAccount.barcode, "challenging-library-card",
+                       "fixture precondition: the credentials this test wrote must be visible")
+
+        // The OTHER library's download is recorded first, so `.first` alone would
+        // return it.
+        let otherBook = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        stateManager.persistStartedTask(
+            bookID: otherBook.identifier,
+            taskIdentifier: 900_001,
+            downloadURL: URL(string: "https://library-b.palace-test.invalid/book")!,
+            account: otherLibraryID,
+            expectedBytes: nil)
+
+        let challengingBook = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        let task = fakeDownloadTask()
+        await stateManager.taskIdentifierToBook.set(task.taskIdentifier, value: challengingBook)
+        stateManager.persistStartedTask(
+            bookID: challengingBook.identifier,
+            taskIdentifier: task.taskIdentifier,
+            downloadURL: URL(string: "https://library-a.palace-test.invalid/book")!,
+            account: challengingLibraryID,
+            expectedBytes: nil)
+
+        let (disposition, credential) = await center.urlSession(
+            URLSession(configuration: .ephemeral), task: task, didReceive: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, "challenging-library-card",
+                       "the record must be selected by the challenging task's book, not by position")
+    }
+
+    func testChallengeOnDownload_afterTheTaskIsReissued_stillUsesTheOriginalAccount() async {
+        // The bearer-token and rights re-issue paths (RightsManagementDispatcher,
+        // BackgroundDownloadHandler) create a NEW task for the SAME book and seed
+        // the map for it WITHOUT writing a new record. Resolution therefore has to
+        // key on the book, not the task — which is the entire correctness argument
+        // for those two sites.
+        //
+        // Without this test, re-keying hop 2 to `$0.taskIdentifier ==
+        // task.taskIdentifier` passes the whole suite, because every other test
+        // here challenges with the same identifier it persisted under. That
+        // refactor would look like a tightening and would silently break re-issue.
+        let persistenceURL = tempPersistenceURL()
+        defer { try? FileManager.default.removeItem(at: persistenceURL) }
+
+        let startedLibraryID = "test-uuid-\(UUID().uuidString)"
+        let startedAccount = makeLibraryAccount(id: startedLibraryID,
+                                                barcode: "original-library-card",
+                                                pin: "original-pin")
+
+        let (center, stateManager) = makeCenterWithPersistence(persistenceURL)
+        // Identity, for the reason given in the selectivity test above.
+        XCTAssertIdentical(center.userAccount(forCapturedId: startedLibraryID), startedAccount,
+                           "the resolver must share this test's account instance, not depend on keychain persistence")
+        XCTAssertEqual(startedAccount.barcode, "original-library-card",
+                       "fixture precondition: the credentials this test wrote must be visible")
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+
+        // The record is written under the ORIGINAL task identifier...
+        stateManager.persistStartedTask(
+            bookID: book.identifier,
+            taskIdentifier: 900_777,
+            downloadURL: URL(string: "https://library-a.palace-test.invalid/book")!,
+            account: startedLibraryID,
+            expectedBytes: nil)
+
+        // ...and the challenge arrives on the RE-ISSUED task, mapped to the same
+        // book, with no record of its own.
+        let reissuedTask = fakeDownloadTask()
+        XCTAssertNotEqual(reissuedTask.taskIdentifier, 900_777,
+                          "fixture precondition: the re-issued task must have a different identifier")
+        await stateManager.taskIdentifierToBook.set(reissuedTask.taskIdentifier, value: book)
+
+        let (disposition, credential) = await center.urlSession(
+            URLSession(configuration: .ephemeral),
+            task: reissuedTask,
+            didReceive: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, "original-library-card",
+                       "a re-issued task must inherit the account its book's download started under")
     }
 
     // MARK: - Helpers

--- a/PalaceTests/Network/NetworkResponderAuthChallengeWitnessTests.swift
+++ b/PalaceTests/Network/NetworkResponderAuthChallengeWitnessTests.swift
@@ -118,6 +118,142 @@ final class NetworkResponderAuthChallengeWitnessTests: XCTestCase {
         XCTAssertNil(credential)
     }
 
+    // MARK: - Which account answers (PP-4969)
+
+    /// Holds the ONLY strong reference to the account-screen provider, so a test
+    /// can decide exactly when it dies. The responder itself holds it weakly, and
+    /// the whole point of PP-4969 is what happens after it is gone — so lifetime
+    /// has to be explicit here rather than incidental. (A first version of this
+    /// helper returned a `() -> Void` release closure; discarding that closure in
+    /// the "still alive" test silently dropped the last reference and the provider
+    /// died before the assertion. Hence a named box.)
+    private final class ProviderBox {
+        var provider: MockCredentialsProvider?
+    }
+
+    /// Returns a responder over a releasable account-screen provider plus a
+    /// distinct fallback standing in for "whatever library is current now".
+    private func makeReleasableResponder() -> (TPPNetworkResponder, ProviderBox) {
+        let box = ProviderBox()
+        let screen = MockCredentialsProvider()
+        screen.username = "screen-barcode"
+        screen.pin = "screen-pin"
+        box.provider = screen
+
+        let fallback = MockCredentialsProvider()
+        fallback.username = "current-library-barcode"
+        fallback.pin = "current-library-pin"
+
+        let responder = TPPNetworkResponder(
+            credentialsProvider: screen,
+            useFallbackCaching: false,
+            fallbackCredentialsProvider: { fallback })
+        return (responder, box)
+    }
+
+    func testProviderReleasedMidRequest_declinesRatherThanSendingTheCurrentLibrarysBarcode() async {
+        // The heart of PP-4969. The account screen supplied the credentials and
+        // has since closed. Falling back to the current library would send THAT
+        // library's card to this library's server.
+        let (responder, box) = makeReleasableResponder()
+        box.provider = nil
+
+        let (disposition, credential) = await respond(responder, to: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .cancelAuthenticationChallenge,
+                       "a released provider must decline, not substitute")
+        XCTAssertNil(credential)
+        XCTAssertNotEqual(credential?.user, "current-library-barcode",
+                          "the current library's barcode must never answer another library's challenge")
+    }
+
+    func testProviderReleasedMidRequest_stillDefersOnServerTrust() async {
+        // The cell a naive "cancel when the provider is gone" fix breaks.
+        // Cancelling a TLS trust challenge would break every https request.
+        let (responder, box) = makeReleasableResponder()
+        box.provider = nil
+
+        let (disposition, credential) = await respond(
+            responder, to: challenge(method: NSURLAuthenticationMethodServerTrust))
+
+        XCTAssertEqual(disposition, .performDefaultHandling)
+        XCTAssertNil(credential)
+    }
+
+    func testProviderReleasedMidRequest_stillRejectsAnUnsupportedMethod() async {
+        // The second cell a naive cancel-on-missing-provider fix would change.
+        let (responder, box) = makeReleasableResponder()
+        box.provider = nil
+
+        let (disposition, _) = await respond(
+            responder, to: challenge(method: NSURLAuthenticationMethodNTLM))
+
+        XCTAssertEqual(disposition, .rejectProtectionSpace)
+    }
+
+    func testProviderStillAlive_usesItsCredentialsNotTheFallback() async {
+        // Guards the other direction: the new "was it ever supplied" bookkeeping
+        // must not divert a live provider to the fallback.
+        let (responder, box) = makeReleasableResponder()
+
+        let (disposition, credential) = await respond(responder, to: basicAuthChallenge())
+
+        // Keep `box` alive ACROSS the await above. ARC guarantees a reference
+        // only to its last use, so if the only mention of `box` sat before the
+        // await, an optimized build could release it — and the provider with it —
+        // before the challenge is answered, and this test would fail as a decline.
+        // That would make it pass or fail on optimization level rather than on
+        // behaviour. Both a use after the await and the explicit call below pin it.
+        withExtendedLifetime(box) {}
+        XCTAssertNotNil(box.provider)
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, "screen-barcode")
+        XCTAssertEqual(credential?.password, "screen-pin")
+    }
+
+    func testNoProviderEverSupplied_stillReachesTheCurrentAccount() async {
+        // Every other call site in the app passes nil deliberately and relies on
+        // this fallback. Declining here would break all of them, so "released"
+        // and "never supplied" must stay distinguishable.
+        let fallback = MockCredentialsProvider()
+        fallback.username = "current-library-barcode"
+        fallback.pin = "current-library-pin"
+        let responder = TPPNetworkResponder(
+            credentialsProvider: nil,
+            useFallbackCaching: false,
+            fallbackCredentialsProvider: { fallback })
+
+        let (disposition, credential) = await respond(responder, to: basicAuthChallenge())
+
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, "current-library-barcode")
+    }
+
+    func testNoProviderEverSupplied_stillDefersOnServerTrust() async {
+        let (disposition, credential) = await respond(
+            makeFallbackOnlyResponder(), to: challenge(method: NSURLAuthenticationMethodServerTrust))
+
+        XCTAssertEqual(disposition, .performDefaultHandling)
+        XCTAssertNil(credential)
+    }
+
+    func testNoProviderEverSupplied_stillRejectsAnUnsupportedMethod() async {
+        let (disposition, _) = await respond(
+            makeFallbackOnlyResponder(), to: challenge(method: NSURLAuthenticationMethodNTLM))
+
+        XCTAssertEqual(disposition, .rejectProtectionSpace)
+    }
+
+    private func makeFallbackOnlyResponder() -> TPPNetworkResponder {
+        let fallback = MockCredentialsProvider()
+        fallback.username = "current-library-barcode"
+        fallback.pin = "current-library-pin"
+        return TPPNetworkResponder(
+            credentialsProvider: nil,
+            useFallbackCaching: false,
+            fallbackCredentialsProvider: { fallback })
+    }
+
     // MARK: - Helpers
 
     /// Invokes the delegate callback and returns its answer.
@@ -127,6 +263,13 @@ final class NetworkResponderAuthChallengeWitnessTests: XCTestCase {
     /// SILGen on Xcode 26.2. Registration is asserted separately above, via the
     /// same `respondsToSelector:` URLSession consults.
     private func respond(
+        to challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        await respond(responder, to: challenge)
+    }
+
+    private func respond(
+        _ responder: TPPNetworkResponder,
         to challenge: URLAuthenticationChallenge
     ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
         await responder.urlSession(


### PR DESCRIPTION
> **Stacked on #1385 (PP-4895).** Base is that branch, not `develop`. It depends on the async callback #1385 introduces — the pre-PP-4895 callback was synchronous and structurally could not reach the actor-isolated task map this needs. Merge #1385 first.

## What was wrong

Both of the app's authentication-challenge sites could answer with a **different library's credentials** than the request was made for, so one library's server received a card belonging to another.

**Path 1 — network layer.** `TPPNetworkResponder` holds its credentials provider weakly, on purpose (a strong reference closed a retain cycle through `AccountDetailViewModel`). At challenge time it read `provider ?? currentUserAccount`. If the account screen closed while its card-validation request was in flight, the fallback substituted the **current** library's account. PP-4895 did not create that window — the screen could already be gone before the challenge arrived — but it widened it, and per review the widening is not bounded by a short hop: under cooperative-pool saturation it can stretch arbitrarily.

**Path 2 — download center.** The older half of the same defect, found by review. It resolved through `userAccount`, the account current *when the challenge arrives* rather than the one the download started for, so a library switch mid-download answered with the new library's card. That property's own doc has long said new code on the download path should use the captured-account lookup instead.

## Why neither hard-codes a refusal

The obvious fix — return `.cancelAuthenticationChallenge` when the provider is gone — is **wrong in two cells**: it would also cancel TLS server-trust challenges (breaking every HTTPS request) and change what an unsupported method returns. Writing the cell tables out first is what surfaced that.

Instead the degraded case is routed through a provider that simply *has no credentials*, so `TPPBasicAuth` still decides all three protection spaces and there remains exactly one decision point.

## How each path resolves

**Path 1** records at construction whether a provider was supplied at all. A later nil weak reference cannot otherwise be told apart from "none was ever supplied" — which is the deliberate configuration at every other call site and must keep reaching the current account.

**Path 2** resolves the challenging task's account by two hops the class already trusts: the live task→book map, then the durable started-task record whose `account` field is written at download start. It degrades to today's behaviour when either hop misses, so this can only ever **narrow** the set of challenges answered with the wrong credential.

## Verification

- Full suite: **8308 tests, 0 failures**, 19 skipped, no timeouts or restarts.
- **Four mutants, applied one at a time against a green baseline**, each killing exactly its intended test with no compile error:
  1. delete the released-provider branch → decline test fails
  2. make the download resolver ignore the started-task record → library-switch test fails
  3. drop the empty-account guard → empty-account test fails
  4. re-key the record lookup from bookID to taskIdentifier → re-issue test fails
- Reviewed by architect, qa_test and blast_radius, bound to this tip.

Mutants 3 and 4 both **survived the original suite** and were found by review. Mutant 4 is the instructive one: it would have read as a tightening in code review while silently breaking the bearer-token and rights re-issue paths, whose entire correctness argument is bookID keying.

## A correction recorded in the history

A launch abort appeared mid-development and I attributed it to a defaulted closure over `AppContainer.production()`. **That attribution was wrong and is retracted.** Two reviewers built standalone reproductions disproving it; restoring the closure default on a clean build of the real app passed; and the commit that had already shipped that exact shape ran 8308 tests without crashing.

The verified rule, now in the code comment and the memory: a **value-typed** default that calls `production()` is evaluated at the call site and would re-enter the container's build lock; a default returning a **closure** that calls it later does not. `TPPNetworkExecutor`'s DI init carries exactly the dangerous form and is safe today only because overload ranking prefers the `@objc` init — safe by accident.

The abort itself is recorded as **unidentified**, with the leading unexcluded candidate named. Carrying an unexplained crash is better than carrying a plausible wrong rule that would teach the next author to reject a legitimate seam.

## A known trade, stated deliberately

Declining is **not** a pure win. When the account screen's library *is* the current library — the common case — the old fallback happened to supply the correct credential, and those requests now fail instead. Sign-out runs through the same executor, so a server-side revoke that used to complete may not. The trade is deliberate and is the standard a credential-isolation boundary sets: a failed operation is recoverable, a credential sent to the wrong library's server is not.

## Deliberately not done

- The underlying window on path 1 is not closed. A provider released before the challenge arrives is still unobservable; what changes is what the app does about it. Closing it properly means keeping the request's own account alive alongside the request — a larger change to executor ownership.
- `BackgroundDownloadHandler.swift:267` attaches the **current** account's token to a follow-up download for a book possibly started under another library. Same F-034 boundary, named explicitly in the intent; out of scope because it is request construction rather than a challenge answer, and it deserves its own tests.
- `TPPNetworkExecutor.swift:186`'s value-typed container default is left alone for the same reason — it is a separate hazard and should not share a revert unit with credential routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuFJhemcU8AqFruy9RrKT1
