### PR TITLE
fix(lint): flag assertions that cannot fail (FLUFF-005, FLUFF-006)

### DIFF
--- a/scripts/lint-test-quality.py
+++ b/scripts/lint-test-quality.py
@@ -51,6 +51,27 @@ FLUFF_PATTERNS = [
     # Pattern: enum raw value assertion
     (r'XCTAssertEqual\(\w+\.\w+\.rawValue,\s*["\d]',
      "FLUFF-004: Enum raw value assertion. Tests the enum definition, not behavior."),
+
+    # Pattern: an assertion on a literal. `XCTAssertTrue(true)` /
+    # `XCTAssertFalse(false)` / `XCTAssertEqual(1, 1)` cannot fail, so the test
+    # reports green having proven nothing — and still counts toward coverage.
+    #
+    # This is the shape that hides behind a `#else` arm or a `guard let ... else`
+    # escape: the file looks like coverage in the tree and in the numbers, and is
+    # vacuous in that configuration. Found 2026-08-18 in
+    # PalaceTests/LCP/LCPAudiobooksTests.swift (34 instances on a DRM path) by a
+    # reviewer, while this linter reported the file clean — 76 across 14 files
+    # corpus-wide. CLAUDE.md bans assertions "mathematically guaranteed to pass";
+    # nothing enforced it until now.
+    #
+    # A deliberate no-op needs `XCTSkip` (which reports as skipped) or
+    # `// lint-ignore: FLUFF-005` with a reason — not a green assertion.
+    (r'XCTAssert(?:True\(\s*true\s*[,)]|False\(\s*false\s*[,)])',
+     "FLUFF-005: Assertion on a literal. Cannot fail; reports green having proven "
+     "nothing. Use XCTSkip for a deliberate no-op, or assert the real behavior."),
+
+    (r'XCTAssertEqual\(\s*(\w+)\s*,\s*\1\s*[,)]',
+     "FLUFF-006: Self-comparison (XCTAssertEqual(x, x)). Always passes."),
 ]
 
 # Methods/calls that act as assertions (raise XCTFail on failure). The linter

--- a/scripts/tests/test_lint_test_quality.py
+++ b/scripts/tests/test_lint_test_quality.py
@@ -323,3 +323,91 @@ def test_changed_mode_end_to_end_clean_passes(tmp_path):
         capture_output=True, text=True, cwd=repo,
     )
     assert r.returncode == 0, r.stdout + r.stderr
+
+
+# --- FLUFF-005 / FLUFF-006: assertions that cannot fail ---------------------
+#
+# Added 2026-08-18. A reviewer found 34 `XCTAssertTrue(true, ...)` in
+# PalaceTests/LCP/LCPAudiobooksTests.swift — a DRM path — while this linter
+# reported the file clean. 76 across 14 files corpus-wide. CLAUDE.md bans
+# assertions "mathematically guaranteed to pass"; nothing enforced it.
+
+def _lint_source(tmp_path, body: str) -> list:
+    """Run the file-level linter over a synthetic test file."""
+    f = tmp_path / "SomeTests.swift"
+    f.write_text(body)
+    return _LTQ.lint_file(str(f))
+
+
+def _codes(violations) -> str:
+    return " ".join(str(getattr(v, "message", v)) for v in violations)
+
+
+def test_fluff005_flags_assert_true_on_literal(tmp_path):
+    v = _lint_source(tmp_path, """
+import XCTest
+final class SomeTests: XCTestCase {
+    func testThing() {
+        XCTAssertTrue(true, "LCP not enabled - test skipped")
+    }
+}
+""")
+    assert "FLUFF-005" in _codes(v), "an assertion on a literal must be flagged"
+
+
+def test_fluff005_flags_assert_false_on_literal(tmp_path):
+    v = _lint_source(tmp_path, """
+import XCTest
+final class SomeTests: XCTestCase {
+    func testThing() {
+        XCTAssertFalse(false)
+    }
+}
+""")
+    assert "FLUFF-005" in _codes(v)
+
+
+def test_fluff006_flags_self_comparison(tmp_path):
+    v = _lint_source(tmp_path, """
+import XCTest
+final class SomeTests: XCTestCase {
+    func testThing() {
+        let total = compute()
+        XCTAssertEqual(total, total)
+    }
+}
+""")
+    assert "FLUFF-006" in _codes(v)
+
+
+def test_fluff005_does_not_flag_a_real_assertion(tmp_path):
+    """The clean path must pass — a detector that flags real assertions is worse
+    than none. Guards the obvious false positives: a variable named `true`-ish,
+    and an assertion whose ARGUMENT is a call returning Bool."""
+    v = _lint_source(tmp_path, """
+import XCTest
+final class SomeTests: XCTestCase {
+    func testThing() {
+        XCTAssertTrue(cart.isEmpty)
+        XCTAssertFalse(player.isPlaying)
+        XCTAssertEqual(cart.total, 15.99)
+        XCTAssertTrue(audiobook.supportsStreaming())
+    }
+}
+""")
+    assert "FLUFF-005" not in _codes(v), "must not flag assertions on real expressions"
+    assert "FLUFF-006" not in _codes(v), "must not flag comparisons of distinct operands"
+
+
+def test_fluff005_skip_is_the_sanctioned_no_op(tmp_path):
+    """`XCTSkip` reports as skipped rather than green, so it is the correct way
+    to express 'not applicable here' and must not be flagged."""
+    v = _lint_source(tmp_path, """
+import XCTest
+final class SomeTests: XCTestCase {
+    func testThing() throws {
+        throw XCTSkip("LCP not enabled in this configuration")
+    }
+}
+""")
+    assert "FLUFF-005" not in _codes(v)


### PR DESCRIPTION
CLAUDE.md bans assertions "mathematically guaranteed to pass" and names `XCTAssertTrue(x == true || x == false)` and `XCTAssertEqual(x, x)` explicitly. **Nothing enforced it.** `lint-test-quality.py` had no rule matching `XCTAssertTrue(true, ...)`, so a file full of them reported clean.

## Why it matters more than the count

Found by a reviewer, not by the linter: `PalaceTests/LCP/LCPAudiobooksTests.swift` carries **34** of them on a DRM path. Corpus-wide, **76 across 14 files**.

The shape is the problem. These sit behind a `#else` arm or a `guard let … else` escape, so in the configuration where the object cannot be constructed the file passes green having asserted nothing — while still appearing as LCP coverage in the file tree and in the coverage numbers. That is worse than an honest gap, because its presence is exactly why nobody noticed the path was untested.

## The rules

- **FLUFF-005** — assertion on a literal (`XCTAssertTrue(true)`, `XCTAssertFalse(false)`).
- **FLUFF-006** — self-comparison (`XCTAssertEqual(x, x)`).

A deliberate no-op has a correct spelling — `XCTSkip`, which reports as *skipped* rather than green — and is left unflagged on purpose, as is `// lint-ignore: FLUFF-005` with a reason.

## Evidence

Five pytests including the **clean path**, because a detector that flags real assertions is worse than none: `XCTAssertTrue(cart.isEmpty)`, `XCTAssertTrue(audiobook.supportsStreaming())` and `XCTAssertEqual(cart.total, 15.99)` are asserted *not* to trip it.

Guard proved by reintroducing the defect — removing the FLUFF-005 rule fails exactly the two detection tests by name while the clean-path tests still pass. Full file: **21/21**.

## Scope

Two detector rules and their tests. No existing rule changed, so nothing that passed before starts failing except on the new patterns.

**Not done:** the 76 existing occurrences are not fixed here — this only makes them visible. Cleanup is PP-4982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kfpr1JNEEz1VUSavgDJb4t