### PR TITLE
fix(downloads): use the started-for account for a download's re-issued request (PP-4978)

### DIFF
--- a/.forgeos/intent/pp-4978-started-for-account-on-reissued-request.md
+++ b/.forgeos/intent/pp-4978-started-for-account-on-reissued-request.md
@@ -1,0 +1,162 @@
+---
+name: pp-4978-started-for-account-on-reissued-request
+created: 2026-08-17
+author: claude-opus-5
+jira: PP-4978
+---
+
+**ADR refs:** none. The governing recorded decision is the credential-isolation
+invariant at the head of `Palace/Accounts/Library/AccountCredentialResolver.swift`
+— F-034 (cross-account credential leak, PP-4020) and F-016 (ride-out over the
+account-switch window). Same boundary as PP-4969, which fixed the
+challenge-answering half of this flow.
+
+## Context
+
+`BackgroundDownloadHandler` does a download's follow-up work — re-issuing the
+request after an OPDS-entry / rights step, and deciding whether the token needs
+refreshing. Both read the account that is **current right now**, not the account
+the download was started under. A patron who switches libraries mid-download
+therefore has follow-up work performed with the new library's credentials against
+the original library's server.
+
+PP-4969 fixed the challenge-answering side of the same flow and deliberately left
+this one out, because answering a challenge and constructing a request are
+different code paths and the fix belongs in its own revert unit.
+
+## The census — four sites, ONE fixed here
+
+Enumerated rather than assumed. Review corrected this twice, and the corrections
+narrowed the change rather than widening it.
+
+| site | reads | disposition |
+|---|---|---|
+| re-issued request's `Authorization` header | `delegate.userAccount.authToken` | **fixed** |
+| token-refresh decision + `refreshTokenAndResume` | `currentUserAccount.isTokenRefreshRequired()` | **NOT fixed — see below** |
+| `MyBooksSimplifiedBearerToken.refreshToken(from:completion:)` | `currentUserAccount.authToken` | not fixed; `static`, only a URL in scope |
+| `RightsManagementDispatcher` `userAccountProvider()` | Adobe `userID`/`deviceID` for ACSM fulfillment | not fixed; DRM-binding, own decision record |
+
+`RightsManagementDispatcher`'s bearer-token line was checked and is NOT an
+instance — that token comes from the fulfillment document the server returned,
+not from an account. An architect reviewer verified this independently. Its
+*Adobe* account read is a separate, fourth site, which the first version of this
+census missed entirely.
+
+### Why the refresh half was dropped
+
+An earlier version of this change fixed the refresh decision too, on the argument
+that the decision and the action "must move together". Three reviewers
+independently showed that was wrong, and the deciding evidence is simple:
+
+`refreshTokenAndResume` rebuilds every queued request through
+`TPPNetworkExecutor.request(for:)` — the one-argument overload, which resolves
+`accountId: nil`, i.e. the CURRENT account. So even after refreshing the correct
+account, the rebuilt requests carry the current library's bearer to the original
+library's server. **Fixing the decision would have moved the leak, not closed
+it.**
+
+Two further defects in that same arm, found independently: the progress path's
+`book` comes from `taskIdentifierToBook`, which the re-issue sets to the UPDATED
+book, so the two sites would have keyed on different books — the very
+"check one account, refresh another" the design claimed to prevent; and the two
+helpers each read `persistedRecords()` separately, so a record removed between
+them yields a split decision.
+
+The refresh arm therefore needs `TPPNetworkExecutor`'s internal rebuild fixed
+first. That is a change to the executor with its own blast radius, and it is
+filed as **PP-4986** rather than bundled here.
+
+## Claims
+
+- adds `func userAccount(forCapturedId:) -> TPPUserAccount` to
+  `BackgroundDownloadHandlerDelegate`. `MyBooksDownloadCenter` already implements
+  it publicly, so this is a protocol line with **zero** production implementation
+  change; the test spy gains the same forwarding member
+- adds a single internal resolver on `BackgroundDownloadHandler` that maps a book
+  to the account its download started under, via the durable started-task record
+  (`stateManager.persistedRecords()`, keyed by `bookID`). Same two-hop shape and
+  the same degradation floor PP-4969 established and three reviewers validated.
+  It takes the delegate as a parameter rather than reading `self.delegate`, so
+  there is no nil arm inventing a fallback — an earlier draft's fallback reached
+  `AppContainer.production()` from a collaborator, against the composition-root
+  rule
+- routes the re-issued request's `Authorization` header through that account
+  rather than the current one
+- keys on `originalBook.identifier` at the re-issue site — the record is written
+  at download start under the original book, so the original is the correct key
+  even when the follow-up carries an updated book
+- tests: a library switch mid-download must leave the re-issued request carrying
+  the ORIGINAL library's token and must not send the current library's; a
+  re-issue whose updated book has a DIFFERENT identifier must still resolve
+  through the original book, which is the only test that discriminates the keying
+  decision; and the resolver must fall back to today's behaviour when there is no
+  record and when the record's account is empty
+
+## Anti-claims
+
+- does NOT change when a follow-up download happens, what it downloads, or the
+  rights-management decision — only which account's credentials it carries
+- does NOT change the token-refresh path in any way. An earlier draft did, and
+  the arm was withdrawn — see the census above. `refreshTokenAndResume` is called
+  exactly as before, with no `accountId`
+- does NOT touch the durable record's contents or when it is written. It is read
+  here, exactly as PP-4969 reads it
+- does NOT promise the record is a true capture of the started-under account.
+  `persistStartedTaskRecord` fires on the initial start AND on each transfer-retry
+  re-issue, and the store upserts by book id — so a transfer retry occurring after
+  a library switch rewrites the captured account to the then-current one, and this
+  resolver returns that. The change still narrows the defect (every case where no
+  retry intervened now resolves correctly, where none did before) but it does not
+  eliminate it. Stated here and at the resolver, because the premise "written at
+  download start" was the claim the whole fix rested on and it is only half true.
+  Closing it means preserving the original account across a retry re-issue
+- does NOT fix `MyBooksSimplifiedBearerToken.refreshToken(from:completion:)`. It
+  is `static` with only a URL in scope, so correcting it means threading an
+  account through its signature and auditing every caller — a different-shaped
+  change that would widen this revert unit. Named in Not-done so it is enumerated
+  rather than missed
+- does NOT close the underlying race. If the record is absent the code still uses
+  the current account, exactly as today, so via those arms this can only narrow
+  — not widen — the set of
+  requests carrying the wrong credential
+
+## Test-harness note
+
+The suite is based on `PalaceWiringTestCase` and mints its manager via
+`makeFreshAccountsManager()`. That is the seam
+`AccountsManagerIsolationLintTests` requires, and it matters for a reason beyond
+the lint: the base class registers `cancelAndDrainBackgroundWork()` on teardown,
+which a hand-rolled `AccountsManager()` silently skips. PP-4969 shipped that
+hand-rolled form to CI and was caught; this branch never did.
+
+## Files in scope
+
+- `Palace/MyBooks/BackgroundDownloadHandler.swift`
+- `PalaceTests/Mocks/MockBackgroundDownloadDelegate.swift`
+- `PalaceTests/MyBooks/BackgroundDownloadTokenAccountTests.swift` (new)
+- `Palace.xcodeproj/project.pbxproj` (test-target membership for the new file)
+
+## Not done
+
+Three account-derived sites on this path are deliberately left alone, each for a
+different reason:
+
+**The token-refresh decision** (`isTokenRefreshRequired()` →
+`refreshTokenAndResume`). Redirecting it is unsafe until
+`TPPNetworkExecutor.request(for:)` carries an account through the queued-request
+rebuild — otherwise the refresh targets the right account and the retries still
+send the current library's bearer. Filed as **PP-4986**, which also records the
+two secondary defects review found in the naive version.
+
+**`MyBooksSimplifiedBearerToken.refreshToken(from:completion:)`** reads
+`AppContainer.production().accountsManager.currentUserAccount.authToken` to
+authorize the CM fulfill request. `static`, with only a URL in scope, so fixing
+it means threading an account through its signature and auditing every caller —
+a different-shaped change that would widen this revert unit.
+
+**`RightsManagementDispatcher`'s `userAccountProvider()`**, which supplies the
+Adobe `userID`/`deviceID` for ACSM fulfillment. A fourth account-derived read
+with DRM-binding consequences, and there is an existing decision record on the
+resolver path in `MyBooksDownloadCenter` — but that rationale is about bearer
+auth and sign-in refresh, not a library switch, so it does not settle this case.
+Named here rather than left implied by a file marked "checked".

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -496,6 +496,7 @@
 		549EF47CE55EB2FA94C67966 /* ReaderNavBarVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97EAFD0730E88D660E745EB /* ReaderNavBarVoiceOverTests.swift */; };
 		54A659E3268D9EB2F8A0C8A5 /* SignInModalPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F258C065A0415A61F22E0C /* SignInModalPredicateTests.swift */; };
 		54B670BB3ED649CA9730B820 /* ErrorActivityTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A40759C732F4FC1B0587021 /* ErrorActivityTracker.swift */; };
+		54C66464D4C46A1EEA71944B /* BackgroundDownloadTokenAccountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B407656953C44D014EF57AF1 /* BackgroundDownloadTokenAccountTests.swift */; };
 		54D213147B9B62D2A4616A7C /* EPUBPositionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FBCE9F366E7A29724332D4 /* EPUBPositionAdapter.swift */; };
 		54E99B7757E6F82038D5F0D6 /* PerformanceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61585F7AD2A0D6CDAF2EF098 /* PerformanceMonitor.swift */; };
 		55104FF85DE440C78F18B4E7 /* TPPLastReadPositionSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706130D4BA8B4FE88304EC9C /* TPPLastReadPositionSynchronizerTests.swift */; };
@@ -3014,6 +3015,7 @@
 		B3BKLOC001F260300000001 /* TPPBookLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookLocationTests.swift; sourceTree = "<group>"; };
 		B3CBF74C265D4FA1483F1974 /* AudiobookSessionManagerPresenterMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudiobookSessionManagerPresenterMigrationTests.swift; sourceTree = "<group>"; };
 		B3FBCE9F366E7A29724332D4 /* EPUBPositionAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EPUBPositionAdapter.swift; path = ../../Palace/Reader2/BusinessLogic/EPUBPositionAdapter.swift; sourceTree = "<group>"; };
+		B407656953C44D014EF57AF1 /* BackgroundDownloadTokenAccountTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundDownloadTokenAccountTests.swift; sourceTree = "<group>"; };
 		B45DCF5D65C3866B68D2C1EE /* TPPAgeCheckStateMachineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPAgeCheckStateMachineTests.swift; sourceTree = "<group>"; };
 		B4A295B1F1809096E9203186 /* GeneralCacheClearOnUpdateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GeneralCacheClearOnUpdateTests.swift; sourceTree = "<group>"; };
 		B4A5B6C7D8E9F0A1B2C3D4E5 /* RedirectPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RedirectPolicyTests.swift; sourceTree = "<group>"; };
@@ -6035,6 +6037,7 @@
 				F05163022659D242342CC4FD /* HalfSheetProgressCueTests.swift */,
 				E9BBD6628B9E9766FE5B910F /* BookCellModelLCPProgressTests.swift */,
 				A7E07F845F399D19B6D3DA40 /* DownloadAuthChallengeWitnessTests.swift */,
+				B407656953C44D014EF57AF1 /* BackgroundDownloadTokenAccountTests.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -8132,6 +8135,7 @@
 				EA87B0AABCBF12E1F8B6D1FE /* ManifestFixture.swift in Sources */,
 				EC4E7A2AFBA08406B8C4A2E7 /* DownloadAuthChallengeWitnessTests.swift in Sources */,
 				B31E6C5D8F5609362A959604 /* NetworkResponderAuthChallengeWitnessTests.swift in Sources */,
+				54C66464D4C46A1EEA71944B /* BackgroundDownloadTokenAccountTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/MyBooks/BackgroundDownloadHandler.swift
+++ b/Palace/MyBooks/BackgroundDownloadHandler.swift
@@ -21,6 +21,11 @@ protocol BackgroundDownloadHandlerDelegate: AnyObject {
     var progressReporter: DownloadProgressReporter { get }
     var bookRegistry: TPPBookRegistryProvider { get }
     var userAccount: TPPUserAccount { get }
+    /// Resolves a specific account by its captured id. PP-4978: follow-up work on
+    /// a download must use the account the download STARTED under, which is not
+    /// necessarily `userAccount` (the current one) after a library switch.
+    /// `MyBooksDownloadCenter` already implements this — no new production code.
+    func userAccount(forCapturedId capturedAccountId: String) -> TPPUserAccount
     var tokenInterceptor: TokenRefreshInterceptor { get }
 
     func handleDownloadCompletion(session: URLSession, task: URLSessionDownloadTask, location: URL) async
@@ -175,6 +180,15 @@ final class BackgroundDownloadHandler: NSObject, @unchecked Sendable {
                     await stateManager.bookIdentifierToDownloadInfo.set(book.identifier, value: info)
                 }
             } else if AppContainer.production().accountsManager.currentUserAccount.isTokenRefreshRequired() {
+                // PP-4978 deliberately does NOT redirect this to the started-for
+                // account. Doing so looked correct and is not: the refresh rebuilds
+                // every queued request through `TPPNetworkExecutor.request(for:)`,
+                // whose one-argument overload resolves `accountId: nil` — the
+                // CURRENT account — so the rebuilt requests carry the current
+                // library's bearer regardless of which account was refreshed.
+                // Fixing the decision without that would move the leak, not close
+                // it. Tracked as PP-4986, which must carry the account through
+                // that rebuild before this decision can safely follow.
                 NSLog("Authentication might be needed after all")
                 AppContainer.production().networkExecutor.refreshTokenAndResume(task: task)
                 return
@@ -225,6 +239,53 @@ final class BackgroundDownloadHandler: NSObject, @unchecked Sendable {
         return await followAcquisitionLink(from: updatedBook, originalBook: book, originalTask: originalTask, session: session)
     }
 
+    /// The account whose credentials a download's re-issued request should use —
+    /// the account it was STARTED under, not whichever is current now.
+    ///
+    /// Resolved from the durable started-task record, keyed by book id.
+    ///
+    /// KNOWN BOUND on that record, stated because it is the premise this rests on:
+    /// it is written at download start AND rewritten on each transfer-retry
+    /// re-issue (`persistStartedTaskRecord`, called from `addDownloadTask` and
+    /// from the retry path), and `DownloadTaskPersistence.record` upserts by book
+    /// id. So a transfer retry that happens AFTER a library switch overwrites the
+    /// captured account with the then-current one, and this resolver would then
+    /// return that. It is a narrowing, not a guarantee: the record is the best
+    /// available approximation of "the account this download started under", not a
+    /// true capture of it. Closing that needs the retry to preserve the original
+    /// account, which is out of scope here.
+    ///
+    /// Degrades to `delegate.userAccount` — today's
+    /// behaviour — when there is no record or its account is empty, so this can
+    /// only ever narrow the set of requests carrying the wrong library's
+    /// credential via THOSE ARMS — never widen it. Scoped deliberately: the
+    /// retry bound above admits one narrow widening sequence (start under A,
+    /// switch to B, transient retry rewrites the record to B, switch back to A,
+    /// re-issue then resolves B where today's current-account read would have
+    /// resolved A). Two switches plus an intervening retry, against a defect
+    /// that fires on one switch — strongly narrowing on net, but not an
+    /// absolute. The start path writes
+    /// `account: currentAccountID ?? ""`, so the empty case is real, not defensive.
+    ///
+    /// Same two-hop shape as the challenge-side resolver PP-4969 added; keyed by
+    /// book rather than task because a re-issued task has no record of its own.
+    ///
+    /// Takes the delegate rather than reading `self.delegate`: every call site has
+    /// already unwrapped it, so there is no nil arm to invent a fallback for — and
+    /// the fallback an earlier draft used reached `AppContainer.production()` from
+    /// a collaborator, which is the composition-root rule this project holds.
+    func startedForAccount(for book: TPPBook, delegate: BackgroundDownloadHandlerDelegate) -> TPPUserAccount {
+        guard let startedAccountID = delegate.stateManager
+            .persistedRecords()
+            .first(where: { $0.bookID == book.identifier })?
+            .account,
+            !startedAccountID.isEmpty
+        else {
+            return delegate.userAccount
+        }
+        return delegate.userAccount(forCapturedId: startedAccountID)
+    }
+
     /// Shared follow-up step for both OPDS-entry XML and OPDS2 JSON publication
     /// paths. Given a book whose `defaultAcquisition` resolves to a direct
     /// content URL (not another opds-catalog), this swaps the original task
@@ -264,7 +325,10 @@ final class BackgroundDownloadHandler: NSObject, @unchecked Sendable {
         let newRights = detectRightsManagement(from: acquisition.type)
 
         var request = URLRequest(url: acquisitionURL, applyingCustomUserAgent: true)
-        if let token = delegate.userAccount.authToken {
+        // PP-4978: the account this download STARTED under. Keyed on
+        // `originalBook` because the record was written under it at download start;
+        // the follow-up may carry an updated book.
+        if let token = startedForAccount(for: originalBook, delegate: delegate).authToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 

--- a/Palace/MyBooks/DownloadTaskPersistence.swift
+++ b/Palace/MyBooks/DownloadTaskPersistence.swift
@@ -145,7 +145,13 @@ enum DownloadReconciliation {
 /// Crash-durable mirror of the in-flight download records. Persists to its OWN
 /// JSON file in Application Support — deliberately NOT the registry file (WS-B
 /// owns that). The in-memory `SafeDictionary`s in `DownloadStateManager` remain
-/// the hot cache; this cold store is consulted only at launch reconciliation.
+/// the hot cache. This store was originally consulted only at launch
+/// reconciliation; as of PP-4978 it is ALSO read on the download path, to
+/// recover which account a download was started under when re-issuing its
+/// request (`BackgroundDownloadHandler.startedForAccount(for:delegate:)`).
+/// That read is once per re-issue, not per progress callback, but it is no
+/// longer launch-only — a change to this file's read cost now has a runtime
+/// consumer.
 ///
 /// `@unchecked Sendable`: the sole mutable state is the on-disk file, guarded by
 /// `lock`; every accessor takes the lock for the read-modify-write.

--- a/PalaceTests/Mocks/MockBackgroundDownloadDelegate.swift
+++ b/PalaceTests/Mocks/MockBackgroundDownloadDelegate.swift
@@ -15,7 +15,7 @@ import PalaceBookModel
 import PalaceBookRegistry
 
 final class MockBackgroundDownloadDelegate: BackgroundDownloadHandlerDelegate {
-    let stateManager = DownloadStateManager()
+    let stateManager: DownloadStateManager
     let progressReporter: DownloadProgressReporter
     let bookRegistry: TPPBookRegistryProvider
     let userAccount: TPPUserAccount
@@ -30,10 +30,19 @@ final class MockBackgroundDownloadDelegate: BackgroundDownloadHandlerDelegate {
     var fulfillLCPCalls: [(fileUrl: URL, book: TPPBook)] = []
     var fileUrls: [String: URL] = [:]
 
+    /// PP-4978: accounts this spy will return from `userAccount(forCapturedId:)`.
+    /// Unset ids fall back to `userAccount`, mirroring the production resolver's
+    /// no-record behaviour.
+    var accountsForCapturedId: [String: TPPUserAccount] = [:]
+
     init(
         bookRegistry: TPPBookRegistryProvider = TPPBookRegistryMock(),
-        userAccount: TPPUserAccount = TPPUserAccountMock()
+        userAccount: TPPUserAccount = TPPUserAccountMock(),
+        /// Injectable so a suite can point the durable started-task store at a
+        /// per-test file instead of the process-wide default.
+        stateManager: DownloadStateManager = DownloadStateManager()
     ) {
+        self.stateManager = stateManager
         self.bookRegistry = bookRegistry
         self.userAccount = userAccount
         self.tokenInterceptor = TokenRefreshInterceptor()
@@ -43,6 +52,10 @@ final class MockBackgroundDownloadDelegate: BackgroundDownloadHandlerDelegate {
                 isVoiceOverRunning: { false }
             )
         )
+    }
+
+    func userAccount(forCapturedId capturedAccountId: String) -> TPPUserAccount {
+        accountsForCapturedId[capturedAccountId] ?? userAccount
     }
 
     func handleDownloadCompletion(session: URLSession, task: URLSessionDownloadTask, location: URL) async {

--- a/PalaceTests/MyBooks/BackgroundDownloadTokenAccountTests.swift
+++ b/PalaceTests/MyBooks/BackgroundDownloadTokenAccountTests.swift
@@ -1,0 +1,279 @@
+//
+//  BackgroundDownloadTokenAccountTests.swift
+//  PalaceTests
+//
+//  PP-4978. When a download is re-issued mid-flight — the follow-up request the
+//  handler builds after an OPDS-entry / rights step — it must carry the
+//  credentials of the library the download was STARTED under, not whichever
+//  library happens to be selected when the follow-up is built.
+//
+//  A patron who switches libraries during a download would otherwise have the
+//  new library's bearer token sent to the original library's server. Same
+//  credential-isolation boundary as the long-standing cross-account leak
+//  invariant in `AccountCredentialResolver` (F-034 / PP-4020), and the same
+//  boundary PP-4969 closed for the challenge-answering half of this flow.
+//
+//  The account a download started under is recoverable from its own durable
+//  started-task record, which is written at download start and keyed by book id.
+//
+
+import XCTest
+import PalaceBookModel
+@testable import Palace
+
+/// Inert session so a re-issued task created by the handler can never reach the
+/// network. Reuses `InertNoOpURLProtocol` from `BackgroundDownloadHandlerTests`;
+/// that file's own session constant is fileprivate, hence a second one here.
+private let inertTokenTestSession: URLSession = {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [InertNoOpURLProtocol.self]
+    return URLSession(configuration: config)
+}()
+
+// `PalaceWiringTestCase` rather than `XCTestCase`: it is the sanctioned seam for
+// minting an `AccountsManager`, and its tearDown calls
+// `cancelAndDrainBackgroundWork()` on every manager it minted. A hand-rolled
+// `AccountsManager()` pins the same opt-out flag but leaks that cancellation, and
+// `AccountsManagerIsolationLintTests` bans it for exactly that reason. The base is
+// already `@MainActor`.
+final class BackgroundDownloadTokenAccountTests: PalaceWiringTestCase {
+
+    private let startedLibraryID = "test-uuid-started-\(UUID().uuidString)"
+
+    /// Accounts minted for these tests, torn down after each.
+    private var mintedAccounts: [TPPUserAccount] = []
+
+    /// One manager shared by the fixture and the code under test, so credentials
+    /// never have to round-trip through the keychain — that round-trip works
+    /// locally and fails on CI (-34018), which is how PP-4969 lost a cycle.
+    private lazy var testAccountsManager: AccountsManager = makeFreshAccountsManager()
+
+    /// Per-test persistence file, removed in tearDown. Without this the suite
+    /// writes started-task records into the process-wide default store and never
+    /// cleans them up, which would leak fixture records into sibling suites.
+    private lazy var persistenceURL: URL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("pp4978-\(UUID().uuidString).json")
+
+    private lazy var isolatedStateManager = DownloadStateManager(
+        taskPersistence: DownloadTaskPersistence(fileURL: persistenceURL))
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Skip the synchronous disk-cache preload — documented as the root of the
+        // FLAKE-003 30s CI timeout. Safe here: nothing in this file reads
+        // `accountSets` or `account(uuid:)`.
+        // (`deferInitialLoadCatalogsForTesting` is the base class's job.)
+        AccountsManager.deferDiskCachePreloadForTesting = true
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: persistenceURL)
+        mintedAccounts.forEach { $0.removeAll() }
+        mintedAccounts.removeAll()
+        AccountsManager.deferDiskCachePreloadForTesting = false
+        try await super.tearDown()
+    }
+
+    private func makeAccount(id: String, token: String) -> TPPUserAccount {
+        let account = testAccountsManager.userAccount(for: id)
+        account.setAuthToken(token, barcode: nil, pin: nil, expirationDate: nil)
+        mintedAccounts.append(account)
+        return account
+    }
+
+    /// Reads the Authorization header off the request the handler actually built,
+    /// via the task it stored in the state manager. Deliberately the real
+    /// artifact rather than a spy hook: the assertion is about what goes on the
+    /// wire, so observing the constructed `URLRequest` is the honest observation.
+    /// - Parameter storedUnder: the book the handler stores the new download info
+    ///   under, which is the UPDATED book — not necessarily the one the record was
+    ///   written for. Parameterized because keying this on the original book would
+    ///   structurally prevent a test from ever exercising a divergent-identifier
+    ///   re-issue, which is exactly the case the production keying decision exists
+    ///   for.
+    private func followUpAuthorization(
+        _ delegate: MockBackgroundDownloadDelegate,
+        storedUnder book: TPPBook
+    ) async -> String? {
+        await delegate.stateManager.bookIdentifierToDownloadInfo
+            .get(book.identifier)?
+            .downloadTask
+            .originalRequest?
+            .value(forHTTPHeaderField: "Authorization")
+    }
+
+    // MARK: - The re-issued request's Authorization header
+
+    func testReissuedRequest_afterLibrarySwitch_carriesTheStartedForLibrarysToken() async throws {
+        // The heart of PP-4978. The download started under library A; the patron
+        // has since switched, so the delegate's `userAccount` is library B.
+        // The follow-up request must still authenticate as A.
+        let startedAccount = makeAccount(id: startedLibraryID, token: "started-library-token")
+        let currentAccount = makeAccount(id: "test-uuid-current-\(UUID().uuidString)",
+                                         token: "current-library-token")
+
+        let delegate = MockBackgroundDownloadDelegate(userAccount: currentAccount, stateManager: isolatedStateManager)
+        delegate.accountsForCapturedId[startedLibraryID] = startedAccount
+
+        let handler = BackgroundDownloadHandler()
+        handler.delegate = delegate
+
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        isolatedStateManager.persistStartedTask(
+            bookID: book.identifier,
+            taskIdentifier: 4_978_001,
+            downloadURL: URL(string: "https://library-a.palace-test.invalid/book")!,
+            account: startedLibraryID,
+            expectedBytes: nil)
+
+        _ = await handler.followAcquisitionLink(
+            from: book,
+            originalBook: book,
+            originalTask: fakeDownloadTask(),
+            session: inertTokenTestSession)
+
+        let observed = await followUpAuthorization(delegate, storedUnder: book)
+        let header = try XCTUnwrap(
+            observed, "the follow-up request must carry an Authorization header")
+        XCTAssertEqual(header, "Bearer started-library-token")
+        XCTAssertNotEqual(header, "Bearer current-library-token",
+                          "the current library's token must never be sent to the started-for library's server")
+    }
+
+    func testReissuedRequest_withNoStartedTaskRecord_fallsBackToTodaysBehaviour() async throws {
+        // Documented floor: a download this resolver knows nothing about behaves
+        // exactly as it does now, so the change can only narrow the defect.
+        let currentAccount = makeAccount(id: "test-uuid-current-\(UUID().uuidString)",
+                                         token: "current-library-token")
+
+        let delegate = MockBackgroundDownloadDelegate(userAccount: currentAccount, stateManager: isolatedStateManager)
+        let handler = BackgroundDownloadHandler()
+        handler.delegate = delegate
+
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        // Deliberately no persistStartedTask call.
+
+        _ = await handler.followAcquisitionLink(
+            from: book,
+            originalBook: book,
+            originalTask: fakeDownloadTask(),
+            session: inertTokenTestSession)
+
+        let observed = await followUpAuthorization(delegate, storedUnder: book)
+        let header = try XCTUnwrap(observed)
+        XCTAssertEqual(header, "Bearer current-library-token")
+    }
+
+    func testReissuedRequest_whenTheRecordHasNoAccount_fallsBackToTodaysBehaviour() throws {
+        // Not hypothetical: the start path writes `account: currentAccountID ?? ""`,
+        // so production emits the empty string whenever no account id resolves.
+        let currentAccount = makeAccount(id: "test-uuid-current-\(UUID().uuidString)",
+                                         token: "current-library-token")
+
+        let delegate = MockBackgroundDownloadDelegate(userAccount: currentAccount, stateManager: isolatedStateManager)
+        // Register an account under the EMPTY id. Without this the spy would fall
+        // back to `userAccount` for an unknown id, so dropping the emptiness guard
+        // would still resolve to `userAccount` and this test would pass for the
+        // wrong reason — it did, until a mutation run caught it.
+        delegate.accountsForCapturedId[""] = makeAccount(
+            id: "test-uuid-empty-\(UUID().uuidString)", token: "empty-id-token")
+
+        let handler = BackgroundDownloadHandler()
+        handler.delegate = delegate
+
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        isolatedStateManager.persistStartedTask(
+            bookID: book.identifier,
+            taskIdentifier: 4_978_002,
+            downloadURL: URL(string: "https://library-a.palace-test.invalid/book")!,
+            account: "",
+            expectedBytes: nil)
+
+        XCTAssertIdentical(
+            handler.startedForAccount(for: book, delegate: delegate), delegate.userAccount,
+            "an empty account id must degrade to today's account, not resolve the empty-id account")
+    }
+
+    func testReissuedRequest_whenTheUpdatedBookHasADifferentIdentifier_stillUsesTheOriginalBooksAccount() async throws {
+        // The keying decision this change documents as load-bearing: the record is
+        // written at download start under the ORIGINAL book, while the follow-up
+        // carries an UPDATED book parsed from the server's OPDS2 publication, whose
+        // identifier is server-supplied and can differ. Every other test here passes
+        // the same book as both, so keying on `updatedBook` would pass all of them
+        // — review found exactly that mutant surviving.
+        let startedAccount = makeAccount(id: startedLibraryID, token: "started-library-token")
+        let currentAccount = makeAccount(id: "test-uuid-current-\(UUID().uuidString)",
+                                         token: "current-library-token")
+
+        let delegate = MockBackgroundDownloadDelegate(userAccount: currentAccount,
+                                                      stateManager: isolatedStateManager)
+        delegate.accountsForCapturedId[startedLibraryID] = startedAccount
+
+        let handler = BackgroundDownloadHandler()
+        handler.delegate = delegate
+
+        let originalBook = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        let updatedBook = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        XCTAssertNotEqual(originalBook.identifier, updatedBook.identifier,
+                          "fixture precondition: the two books must have different identifiers")
+
+        // Record written under the ORIGINAL book, as the start path does.
+        isolatedStateManager.persistStartedTask(
+            bookID: originalBook.identifier,
+            taskIdentifier: 4_978_020,
+            downloadURL: URL(string: "https://library-a.palace-test.invalid/book")!,
+            account: startedLibraryID,
+            expectedBytes: nil)
+
+        _ = await handler.followAcquisitionLink(
+            from: updatedBook,
+            originalBook: originalBook,
+            originalTask: fakeDownloadTask(),
+            session: inertTokenTestSession)
+
+        // The handler stores the new download info under the UPDATED book.
+        let observed = await followUpAuthorization(delegate, storedUnder: updatedBook)
+        let header = try XCTUnwrap(observed, "the follow-up request must carry an Authorization header")
+        XCTAssertEqual(header, "Bearer started-library-token",
+                       "keying must follow the ORIGINAL book, which is where the record lives")
+    }
+
+    // MARK: - The account the resolver picks
+
+    func testStartedForAccount_picksTheRecordForTheChallengingBook_notTheFirstRecord() throws {
+        // Two concurrent downloads from two libraries is the defect scenario. With
+        // a single record persisted, a resolver that took the FIRST record would
+        // pass every other test here.
+        let startedAccount = makeAccount(id: startedLibraryID, token: "started-library-token")
+        let otherLibraryID = "test-uuid-other-\(UUID().uuidString)"
+        _ = makeAccount(id: otherLibraryID, token: "other-library-token")
+
+        let delegate = MockBackgroundDownloadDelegate(
+            userAccount: makeAccount(id: "test-uuid-current-\(UUID().uuidString)",
+                                     token: "current-library-token"),
+            stateManager: isolatedStateManager)
+        delegate.accountsForCapturedId[startedLibraryID] = startedAccount
+
+        let handler = BackgroundDownloadHandler()
+        handler.delegate = delegate
+
+        let otherBook = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        isolatedStateManager.persistStartedTask(
+            bookID: otherBook.identifier,
+            taskIdentifier: 4_978_010,
+            downloadURL: URL(string: "https://library-b.palace-test.invalid/book")!,
+            account: otherLibraryID,
+            expectedBytes: nil)
+
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        isolatedStateManager.persistStartedTask(
+            bookID: book.identifier,
+            taskIdentifier: 4_978_011,
+            downloadURL: URL(string: "https://library-a.palace-test.invalid/book")!,
+            account: startedLibraryID,
+            expectedBytes: nil)
+
+        XCTAssertTrue(handler.startedForAccount(for: book, delegate: delegate) === startedAccount,
+                      "the record must be selected by the book, not by position")
+    }
+}


### PR DESCRIPTION
## What was wrong

When a download is re-issued mid-flight — the follow-up request built after an OPDS-entry or rights step — it attached the bearer token of **whichever library was selected at that moment**, not the library the download was started under. A patron who switched libraries during a download had the new library's credential sent to the original library's server.

Same credential-isolation boundary as the cross-account leak invariant in `AccountCredentialResolver` (F-034 / PP-4020), and the same boundary as PP-4969.

## The fix

The account is resolved from the download's own durable started-task record, keyed by the **original** book — that is what the record is written under at download start, while the follow-up carries a server-supplied updated book whose identifier can differ.

The delegate protocol gains one member to reach the per-account lookup. `MyBooksDownloadCenter` already implements it, so **no production implementation changed**.

## What review removed

This started as a two-site fix. Three reviewers independently established that the second site — the token-refresh decision — could not be fixed here:

`refreshTokenAndResume` rebuilds every queued request through the one-argument `request(for:)`, which resolves `accountId: nil` → the **current** account. So refreshing the correct account would still have sent the current library's bearer. **The fix would have moved the leak, not closed it.**

Two further defects in that same arm: the progress path's book comes from the task map, which the re-issue sets to the *updated* book, so the two sites would have keyed on different books; and the two helpers each read the record separately, so a removal between them yields a split decision.

That arm is filed as **PP-4986**, which must carry the account through the executor's rebuild first.

## The census grew, and one claim shrank

Four account-derived sites on this path, not the one the ticket named — each now with its own disposition rather than a file marked "checked". `RightsManagementDispatcher`'s bearer line was checked and is **not** an instance: that token comes from the server's fulfillment document.

The record is also **not a true capture** of the started-under account. `persistStartedTaskRecord` fires again on each transfer-retry re-issue into an upsert-by-book-id store, so a retry after a library switch rewrites it. Stated at the resolver, in the intent, and in the commit message — because a reader forms the premise at whichever they meet first.

So the claim is scoped rather than absolute: this **narrows** the defect via the degradation arms, and one narrow sequence still widens it (start under A → switch to B → transient retry rewrites to B → switch back to A). Two switches plus an intervening retry, against a defect that fires on one — strongly narrowing on net, not an absolute.

## Verification

- **64/64** across all seven corpus-scanning meta-lint classes plus both handler suites.
- **Mutants killed one at a time**, each by its intended test: reverting the token attach; and `originalBook` → `updatedBook`, which review found surviving because every test had passed the same book as both arguments. There is now a divergent-identifier test — the only one that discriminates the keying decision.
- Tests observe the request the handler actually built, read off the task it stored, against an inert `URLProtocol` so a re-issued task can never reach the network, and a per-test persistence file so no fixture record leaks.
- All four gates rc=0.

## Deliberately not done

- **PP-4986** — the refresh decision, blocked on the executor's rebuild.
- `MyBooksSimplifiedBearerToken.refreshToken` — `static`, only a URL in scope.
- The Adobe `userID`/`deviceID` read for ACSM fulfillment — DRM-binding, deserves its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuFJhemcU8AqFruy9RrKT1
