### PR TITLE
fix(ledger): report distinct dependency cycles, and make the detail reachable

### DIFF
--- a/.github/workflows/ledger.yml
+++ b/.github/workflows/ledger.yml
@@ -19,6 +19,12 @@ on:
       - '**.m'
       - '**.h'
       - 'tools/ledger/**'
+      # The reporting pipeline runs on its own changes, so a PR that edits the
+      # analysis or the comment rendering demonstrates the result instead of
+      # merging unexercised. Both were silently broken for a month precisely
+      # because nothing re-ran them.
+      - '.github/workflows/ledger.yml'
+      - 'scripts/ledger_scc.py'
 
   # Allow manual trigger for testing
   workflow_dispatch:

--- a/.github/workflows/ledger.yml
+++ b/.github/workflows/ledger.yml
@@ -140,6 +140,8 @@ jobs:
           # Initialize defaults
           echo "components=0" >> $GITHUB_OUTPUT
           echo "cycles=0" >> $GITHUB_OUTPUT
+          echo "scc_count=0" >> $GITHUB_OUTPUT
+          echo "largest_scc=0" >> $GITHUB_OUTPUT
           echo "violations=0" >> $GITHUB_OUTPUT
           echo "hotspots=0" >> $GITHUB_OUTPUT
           echo "changed_files=0" >> $GITHUB_OUTPUT
@@ -269,14 +271,41 @@ jobs:
               "$OBSERVE_DIR/qa/test-matches.json" 2>/dev/null > /tmp/qa_test_matches.md || true
           fi
           
-          # Architecture: Cycle details
+          # Architecture: Cycle details.
+          #
+          # Ledger emits `.cycles` as an INTEGER and `.findings` as an empty
+          # array; ALL detail lives in `.issues[]`. The previous extraction read
+          # `.cycles[] | .components` and `.findings[] | .message`, both of which
+          # error on the real shape — the errors went to /dev/null and every PR
+          # comment silently printed "See full report for cycle details."
+          #
+          # ledger_scc.py additionally collapses the reported cycle PATHS into
+          # the distinct cycles (strongly-connected components) they represent,
+          # and discounts edges `tools/ledger/ledger-config.json` declares
+          # structurally impossible. See scripts/ledger_scc.py for why the raw
+          # path count cannot be trended.
           if [[ -f "$OBSERVE_DIR/arch/analysis.json" ]]; then
-            jq -r 'if .cycles then .cycles[] | "- " + (.components | join(" → ")) else empty end' \
-              "$OBSERVE_DIR/arch/analysis.json" 2>/dev/null > /tmp/arch_cycles.md || true
-            
-            # Findings/issues
-            jq -r '.findings[]? | "- **" + .type + "**: " + .message' \
-              "$OBSERVE_DIR/arch/analysis.json" 2>/dev/null > /tmp/arch_findings.md || true
+            python3 scripts/ledger_scc.py \
+              --analysis "$OBSERVE_DIR/arch/analysis.json" \
+              --config tools/ledger/ledger-config.json \
+              --json /tmp/arch_scc.json \
+              --markdown /tmp/arch_cycles.md || true
+
+            if [[ -f /tmp/arch_scc.json ]]; then
+              echo "scc_count=$(jq -r '.sccCount // 0' /tmp/arch_scc.json)" >> $GITHUB_OUTPUT
+              echo "largest_scc=$(jq -r '.largestSccSize // 0' /tmp/arch_scc.json)" >> $GITHUB_OUTPUT
+            fi
+
+            # Non-cycle findings (layer violations, hotspots, orphans) — also
+            # from `.issues[]`, so a violation is NAMED and not left as a bare
+            # number the reader cannot act on (pr-report-contract.md gap #8).
+            {
+              jq -r '.issues[]? | select(.type != "dependency_cycle")
+                     | "- **" + .type + "**: " + .description' \
+                "$OBSERVE_DIR/arch/analysis.json" 2>/dev/null || true
+              jq -r '.findings[]? | "- **" + .type + "**: " + .message' \
+                "$OBSERVE_DIR/arch/analysis.json" 2>/dev/null || true
+            } > /tmp/arch_findings.md || true
           fi
           
           # Parse diff summary for changed files count
@@ -321,6 +350,11 @@ jobs:
             const changedFiles = '${{ steps.parse.outputs.changed_files }}' || '0';
             const components = '${{ steps.parse.outputs.components }}' || '0';
             const cycles = '${{ steps.parse.outputs.cycles }}' || '0';
+            // Distinct cycles (strongly-connected components), not cycle paths.
+            // `cycles` above is the analyzer's raw path enumeration — see
+            // scripts/ledger_scc.py for why it cannot be trended.
+            const sccCount = '${{ steps.parse.outputs.scc_count }}' || '0';
+            const largestScc = '${{ steps.parse.outputs.largest_scc }}' || '0';
             const violations = '${{ steps.parse.outputs.violations }}' || '0';
             const hotspots = '${{ steps.parse.outputs.hotspots }}' || '0';
             const avgCouplingRaw = '${{ steps.parse.outputs.avg_coupling }}' || '0';
@@ -517,7 +551,8 @@ jobs:
             body += '| Metric | Value | ℹ️ What This Means |\n';
             body += '|--------|-------|-------------------|\n';
             body += `| Components | ${components} | Distinct modules/layers detected in your codebase |\n`;
-            body += `| Dependency Cycles | ${cycles} | Circular dependencies (A→B→C→A). Goal: **0** |\n`;
+            body += `| Dependency Cycles | ${sccCount} | Distinct circular dependencies (A→B→C→A). Goal: **0** |\n`;
+            body += `| Largest Cycle | ${largestScc === '0' ? '—' : largestScc + ' components'} | How many components are mutually tangled in the biggest cycle |\n`;
             body += `| Layer Violations | ${violations} | Dependencies that break architectural boundaries |\n`;
             body += `| Hotspots | ${hotspots} | Files with high complexity + frequent changes |\n`;
             body += `| Avg Coupling | ${avgCoupling} | How interconnected modules are (lower is better, <1.0 is good) |\n\n`;
@@ -532,7 +567,7 @@ jobs:
               body += `> ℹ️ Baseline metrics (whole-repo), not a diff delta. Watch for a value that *moves* vs. \`develop\`, not its absolute level.\n\n`;
             }
 
-            if (parseInt(archIssues) === 0 && cycles === '0' && violations === '0') {
+            if (parseInt(archIssues) === 0 && sccCount === '0' && violations === '0') {
               body += '✅ **Architecture looks healthy!**\n\n';
             } else {
               // Show issues summary
@@ -547,8 +582,8 @@ jobs:
               }
 
               // Expandable: Dependency Cycles
-              if (parseInt(cycles) > 0) {
-                body += '<details>\n<summary><strong>🔄 Dependency Cycles</strong></summary>\n\n';
+              if (parseInt(sccCount) > 0) {
+                body += `<details>\n<summary><strong>🔄 Dependency Cycles (${sccCount})</strong></summary>\n\n`;
                 try {
                   const cyclesDetail = fs.readFileSync('/tmp/arch_cycles.md', 'utf8');
                   if (cyclesDetail.trim()) {

--- a/scripts/ledger_scc.py
+++ b/scripts/ledger_scc.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+ledger_scc.py — collapse CodeAtlas Ledger's cycle-PATH enumeration into the
+distinct dependency cycles it actually represents.
+
+WHY THIS EXISTS
+---------------
+`ledger observe --domains arch` reports a "Dependency Cycles" count that
+enumerates cycle PATHS through the dependency graph, not distinct cycles. On
+develop that reads as 36 cycles:
+
+    Accounts → Book → Accounts
+    Accounts → Book → Audiobooks → Accounts
+    Accounts → Book → Audiobooks → ErrorHandling → Accounts
+    Accounts → Book → Audiobooks → ErrorHandling → Logging → Accounts
+    ...
+
+Every line is a different walk through the SAME tangle. Collapsed to
+strongly-connected components it is 2 cycles — a 17-component core and a
+2-component pair — and one of those two is an edge SwiftPM structurally
+forbids (see --config below), so the actionable answer is 1.
+
+Path count in a dense SCC is combinatorial, which makes it useless as a trend:
+across 46 PRs (2026-07-23 → 2026-08-18) it ranged 10..29 with a same-day
+spread of 10..19, while components and average coupling held constant. SCC
+count and largest-SCC size move only when a component genuinely enters or
+leaves a tangle, which is what the decomposition campaign is actually doing.
+
+The input `.issues[]` entries are the ONLY place the detail lives —
+`.cycles` is an integer and `.findings` is empty. `ledger.yml` previously read
+`jq '.cycles[] | .components'`, which errors on an integer, so every PR
+comment fell through to "See full report for cycle details."
+
+USAGE
+-----
+    ledger_scc.py --analysis artifacts/ledger/observe/latest/arch/analysis.json \
+                  [--config tools/ledger/ledger-config.json] \
+                  [--json out.json] [--markdown out.md]
+
+Writes GitHub-flavored markdown to stdout unless --markdown is given.
+Exit 0 on success (including "no cycles"), 2 on a missing/unreadable input —
+a broken input must not be reported as a clean architecture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_CYCLE_TYPE = "dependency_cycle"
+_PREFIX = "Dependency cycle detected: "
+_ARROW = "→"
+
+
+# ────────────────────────────────── parsing ──────────────────────────────────
+def parse_paths(issues: list[dict]) -> tuple[list[list[str]], int]:
+    """Extract ordered component paths from dependency_cycle issues.
+
+    Returns (paths, unparsed_count). A path is closed — its last element is
+    the same component as its first — so consecutive pairs cover every edge
+    including the one that closes the loop.
+
+    Falls back to the issue's `components` list when the description does not
+    carry an arrow-joined path (upstream format drift): the analyzer has
+    already asserted those components form a cycle, so treating them as a ring
+    preserves the SCC membership even if the exact edges are lost.
+    """
+    paths: list[list[str]] = []
+    unparsed = 0
+    for issue in issues:
+        if issue.get("type") != _CYCLE_TYPE:
+            continue
+        desc = issue.get("description", "")
+        body = desc[len(_PREFIX):] if desc.startswith(_PREFIX) else desc
+        if _ARROW in body:
+            nodes = [n.strip() for n in body.split(_ARROW) if n.strip()]
+        else:
+            nodes = [str(c).strip() for c in issue.get("components", []) if str(c).strip()]
+            if not nodes:
+                continue
+            unparsed += 1
+            nodes = nodes + [nodes[0]]  # close the ring
+        if len(nodes) == 1:
+            nodes = nodes * 2  # a self-loop is written "A → A"; tolerate "A"
+        paths.append(nodes)
+    return paths, unparsed
+
+
+def load_discounts(config_path: Path | None) -> list[tuple[str, str]]:
+    """Read `knownFalsePositiveEdges` — edges the config declares impossible.
+
+    Each entry names a `from` and a `to`, plus an optional `aka` for the
+    component name the analyzer actually emits (a SwiftPM package and its
+    target are two different names for one thing). Both spellings are honored
+    so the entry matches whichever the analyzer produced.
+    """
+    if config_path is None:
+        return []
+    try:
+        cfg = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    pairs: list[tuple[str, str]] = []
+    for e in cfg.get("knownFalsePositiveEdges", []) or []:
+        to = (e.get("to") or "").strip()
+        if not to:
+            continue
+        for src in (e.get("from"), e.get("aka")):
+            if src and (src.strip(), to) not in pairs:
+                pairs.append((src.strip(), to))
+    return pairs
+
+
+# ──────────────────────────────────── SCC ────────────────────────────────────
+def tarjan(nodes: list[str], adj: dict[str, list[str]]) -> list[list[str]]:
+    """Iterative Tarjan. Iterative because a 17-node tangle today is a deeper
+    one tomorrow, and a RecursionError in CI would read as "no cycles"."""
+    index: dict[str, int] = {}
+    low: dict[str, int] = {}
+    on_stack: dict[str, bool] = {}
+    stack: list[str] = []
+    counter = 0
+    out: list[list[str]] = []
+
+    for root in nodes:
+        if root in index:
+            continue
+        work = [(root, 0)]
+        while work:
+            v, pi = work[-1]
+            if pi == 0:
+                index[v] = low[v] = counter
+                counter += 1
+                stack.append(v)
+                on_stack[v] = True
+            recursed = False
+            neighbors = adj.get(v, [])
+            for i in range(pi, len(neighbors)):
+                w = neighbors[i]
+                if w not in index:
+                    work[-1] = (v, i + 1)
+                    work.append((w, 0))
+                    recursed = True
+                    break
+                if on_stack.get(w):
+                    low[v] = min(low[v], index[w])
+            if recursed:
+                continue
+            if low[v] == index[v]:
+                comp = []
+                while True:
+                    w = stack.pop()
+                    on_stack[w] = False
+                    comp.append(w)
+                    if w == v:
+                        break
+                out.append(sorted(comp))
+            work.pop()
+            if work:
+                u = work[-1][0]
+                low[u] = min(low[u], low[v])
+    return out
+
+
+def analyze(analysis: dict, discounts: list[tuple[str, str]]) -> dict:
+    paths, unparsed = parse_paths(analysis.get("issues", []) or [])
+
+    edges: set[tuple[str, str]] = set()
+    for nodes in paths:
+        for a, b in zip(nodes, nodes[1:]):
+            edges.add((a, b))
+
+    discount_set = set(discounts)
+    dropped = sorted(edges & discount_set)
+    edges -= discount_set
+
+    nodes = sorted({n for e in edges for n in e})
+    adj: dict[str, list[str]] = {n: [] for n in nodes}
+    for a, b in edges:
+        adj[a].append(b)
+
+    self_loops = {a for a, b in edges if a == b}
+    sccs = [
+        c for c in tarjan(nodes, adj)
+        if len(c) > 1 or (len(c) == 1 and c[0] in self_loops)
+    ]
+    sccs.sort(key=lambda c: (-len(c), c[0]))
+
+    members = {n for c in sccs for n in c}
+    detail = []
+    for c in sccs:
+        inside = sorted((a, b) for a, b in edges if a in c and b in c)
+        detail.append({
+            "size": len(c),
+            "components": c,
+            "edges": [{"from": a, "to": b} for a, b in inside],
+        })
+
+    return {
+        "cyclePathCount": len(paths),
+        "unparsedPaths": unparsed,
+        "sccCount": len(sccs),
+        "largestSccSize": max((len(c) for c in sccs), default=0),
+        "componentsInCycles": len(members),
+        "edgesInCycles": sum(len(d["edges"]) for d in detail),
+        "sccs": detail,
+        "discountedEdges": [{"from": a, "to": b} for a, b in dropped],
+    }
+
+
+# ────────────────────────────────── rendering ────────────────────────────────
+def render(summary: dict) -> str:
+    paths = summary["cyclePathCount"]
+    n = summary["sccCount"]
+
+    if n == 0:
+        if paths:
+            return (
+                "No dependency cycles remain after discounting edges the project "
+                "config declares structurally impossible.\n"
+            )
+        return "No dependency cycles.\n"
+
+    lines: list[str] = []
+    noun = "cycle" if n == 1 else "cycles"
+    lines.append(
+        f"**{n} distinct dependency {noun}** "
+        f"(largest spans **{summary['largestSccSize']}** components).\n"
+    )
+    if paths > n:
+        lines.append(
+            f"> The analyzer reports **{paths}** entries — those are cycle *paths* "
+            f"through the {noun} listed below, not {paths} separate problems. Adding "
+            f"one edge inside a tangle multiplies the path count without changing the "
+            f"architecture, so track the {noun} instead.\n"
+        )
+    lines.append("")
+
+    for i, scc in enumerate(summary["sccs"], 1):
+        if scc["size"] == 1:
+            head = f"**Cycle {i}** — `{scc['components'][0]}` depends on itself"
+        else:
+            head = (
+                f"**Cycle {i}** — {scc['size']} components, "
+                f"{len(scc['edges'])} edges between them"
+            )
+        lines.append(head)
+        lines.append("")
+        lines.append("> " + ", ".join(f"`{c}`" for c in scc["components"]))
+        lines.append("")
+        lines.append("<details><summary>edges</summary>\n")
+        lines.append("```")
+        for e in scc["edges"]:
+            lines.append(f"{e['from']} → {e['to']}")
+        lines.append("```")
+        lines.append("</details>")
+        lines.append("")
+
+    if summary["discountedEdges"]:
+        pretty = ", ".join(f"`{e['from']} → {e['to']}`" for e in summary["discountedEdges"])
+        lines.append(
+            f"_Discounted {pretty} — declared a known false positive in "
+            f"`tools/ledger/ledger-config.json`._\n"
+        )
+    return "\n".join(lines)
+
+
+# ──────────────────────────────────── main ───────────────────────────────────
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Collapse Ledger cycle paths into distinct dependency cycles (SCCs).",
+    )
+    ap.add_argument("--analysis", required=True, type=Path,
+                    help="path to arch/analysis.json from `ledger observe`")
+    ap.add_argument("--config", type=Path, default=None,
+                    help="path to ledger-config.json (reads knownFalsePositiveEdges)")
+    ap.add_argument("--json", dest="json_out", type=Path, default=None,
+                    help="write the machine-readable summary here")
+    ap.add_argument("--markdown", dest="md_out", type=Path, default=None,
+                    help="write the PR-comment markdown here (default: stdout)")
+    args = ap.parse_args(argv)
+
+    if not args.analysis.is_file():
+        print(f"error: analysis file not found: {args.analysis}", file=sys.stderr)
+        return 2
+    try:
+        doc = json.loads(args.analysis.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: could not read {args.analysis}: {exc}", file=sys.stderr)
+        return 2
+
+    summary = analyze(doc, load_discounts(args.config))
+    body = render(summary)
+
+    if args.json_out:
+        args.json_out.write_text(json.dumps(summary, indent=2) + "\n")
+    if args.md_out:
+        args.md_out.write_text(body)
+    else:
+        sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/fixtures/ledger_scc/analysis-real-develop.json
+++ b/scripts/tests/fixtures/ledger_scc/analysis-real-develop.json
@@ -1,0 +1,679 @@
+{
+  "averageCoupling" : 4.857142857142857,
+  "components" : 42,
+  "cycles" : 36,
+  "dependencies" : 204,
+  "findings" : [
+
+  ],
+  "hotspots" : 12,
+  "issues" : [
+    {
+      "components" : [
+        "Accounts",
+        "Book"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Audiobooks → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Audiobooks",
+        "Book"
+      ],
+      "description" : "Dependency cycle detected: Book → Audiobooks → Book",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "ErrorHandling"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Audiobooks → ErrorHandling → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "ErrorHandling",
+        "Logging"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Audiobooks → ErrorHandling → Logging → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Audiobooks",
+        "Book",
+        "ErrorHandling",
+        "Logging"
+      ],
+      "description" : "Dependency cycle detected: Book → Audiobooks → ErrorHandling → Logging → Book",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "ErrorHandling",
+        "Logging",
+        "Network"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Audiobooks → ErrorHandling → Logging → Network → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Logging",
+        "Network"
+      ],
+      "description" : "Dependency cycle detected: Logging → Network → Logging",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "AppRating",
+        "Audiobooks",
+        "Book",
+        "FeatureFlags",
+        "Settings"
+      ],
+      "description" : "Dependency cycle detected: FeatureFlags → AppRating → Settings → Accounts → Book → Audiobooks → FeatureFlags",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "Keychain"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Audiobooks → Keychain → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "Keychain",
+        "Settings"
+      ],
+      "description" : "Dependency cycle detected: Settings → Accounts → Book → Audiobooks → Keychain → Settings",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "MyBooks"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Audiobooks → MyBooks → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Audiobooks",
+        "MyBooks"
+      ],
+      "description" : "Dependency cycle detected: Audiobooks → MyBooks → Audiobooks",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Audiobooks",
+        "Book",
+        "MyBooks"
+      ],
+      "description" : "Dependency cycle detected: Book → Audiobooks → MyBooks → Book",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "CatalogUI",
+        "MyBooks"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Audiobooks → MyBooks → CatalogUI → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Audiobooks",
+        "CatalogUI",
+        "MyBooks"
+      ],
+      "description" : "Dependency cycle detected: Audiobooks → MyBooks → CatalogUI → Audiobooks",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Audiobooks",
+        "Book",
+        "CatalogUI",
+        "MyBooks"
+      ],
+      "description" : "Dependency cycle detected: Book → Audiobooks → MyBooks → CatalogUI → Book",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "AppRating",
+        "Audiobooks",
+        "Book",
+        "CatalogUI",
+        "FeatureFlags",
+        "MyBooks",
+        "Settings"
+      ],
+      "description" : "Dependency cycle detected: FeatureFlags → AppRating → Settings → Accounts → Book → Audiobooks → MyBooks → CatalogUI → FeatureFlags",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "CatalogUI",
+        "MyBooks"
+      ],
+      "description" : "Dependency cycle detected: MyBooks → CatalogUI → MyBooks",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Audiobooks",
+        "Book",
+        "CatalogUI",
+        "MyBooks",
+        "Platform"
+      ],
+      "description" : "Dependency cycle detected: Book → Audiobooks → MyBooks → CatalogUI → Platform → Book",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "CatalogUI",
+        "MyBooks",
+        "Platform"
+      ],
+      "description" : "Dependency cycle detected: MyBooks → CatalogUI → Platform → MyBooks",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "CatalogUI",
+        "MyBooks",
+        "Settings"
+      ],
+      "description" : "Dependency cycle detected: Settings → Accounts → Book → Audiobooks → MyBooks → CatalogUI → Settings",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "MyBooks",
+        "Notifications"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Audiobooks → MyBooks → Notifications → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Audiobooks",
+        "Book",
+        "MyBooks",
+        "Notifications"
+      ],
+      "description" : "Dependency cycle detected: Book → Audiobooks → MyBooks → Notifications → Book",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "MyBooks",
+        "OPDS2"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Audiobooks → MyBooks → OPDS2 → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Audiobooks",
+        "Book",
+        "MyBooks",
+        "OPDS2"
+      ],
+      "description" : "Dependency cycle detected: Book → Audiobooks → MyBooks → OPDS2 → Book",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Audiobooks",
+        "Book",
+        "MyBooks",
+        "PDF"
+      ],
+      "description" : "Dependency cycle detected: Book → Audiobooks → MyBooks → PDF → Book",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "MyBooks",
+        "PDF"
+      ],
+      "description" : "Dependency cycle detected: MyBooks → PDF → MyBooks",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "MyBooks",
+        "Settings"
+      ],
+      "description" : "Dependency cycle detected: Settings → Accounts → Book → Audiobooks → MyBooks → Settings",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "MyBooks",
+        "SignInLogic"
+      ],
+      "description" : "Dependency cycle detected: Accounts → Book → Audiobooks → MyBooks → SignInLogic → Accounts",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "MyBooks",
+        "Settings",
+        "SignInLogic"
+      ],
+      "description" : "Dependency cycle detected: Settings → Accounts → Book → Audiobooks → MyBooks → SignInLogic → Settings",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "Settings"
+      ],
+      "description" : "Dependency cycle detected: Settings → Accounts → Book → Audiobooks → Settings",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Book",
+        "Settings"
+      ],
+      "description" : "Dependency cycle detected: Settings → Accounts → Book → Settings",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Settings"
+      ],
+      "description" : "Dependency cycle detected: Settings → Accounts → Settings",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "AppRating",
+        "FeatureFlags",
+        "Settings"
+      ],
+      "description" : "Dependency cycle detected: FeatureFlags → AppRating → Settings → FeatureFlags",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Palace",
+        "TriageBotUI"
+      ],
+      "description" : "Dependency cycle detected: TriageBotUI → Palace → TriageBotUI",
+      "severity" : "high",
+      "type" : "dependency_cycle"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "AppInfrastructure",
+        "Audiobooks",
+        "Book",
+        "CatalogUI",
+        "ErrorHandling",
+        "FeatureFlags",
+        "Holds",
+        "Logging",
+        "MyBooks",
+        "Network",
+        "OPDS",
+        "OPDS2",
+        "PDF",
+        "Palace",
+        "Palace-noDRM",
+        "PalaceAuth",
+        "PalaceCatalog",
+        "Reader2",
+        "Settings",
+        "SignInLogic",
+        "Utilities"
+      ],
+      "description" : "PalaceCatalog is a coupling hotspot with 21 dependents",
+      "severity" : "high",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "CarPlay",
+        "CatalogUI",
+        "ErrorHandling",
+        "Holds",
+        "Keychain",
+        "Logging",
+        "MyBooks",
+        "Network",
+        "Notifications",
+        "OPDS2",
+        "Settings",
+        "SignInLogic"
+      ],
+      "description" : "Accounts is a coupling hotspot with 14 dependents",
+      "severity" : "high",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "AppInfrastructure",
+        "Audiobooks",
+        "Book",
+        "CatalogUI",
+        "MyBooks",
+        "Network",
+        "Palace",
+        "Palace-noDRM",
+        "PalaceCatalog",
+        "PalaceNetwork",
+        "ReaderStreaming",
+        "Settings",
+        "SignInLogic"
+      ],
+      "description" : "PalaceNetwork is a coupling hotspot with 13 dependents",
+      "severity" : "high",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "CarPlay",
+        "CatalogUI",
+        "Holds",
+        "Logging",
+        "Migrations",
+        "MyBooks",
+        "Notifications",
+        "OPDS2",
+        "PDF",
+        "Platform",
+        "Settings"
+      ],
+      "description" : "Book is a coupling hotspot with 13 dependents",
+      "severity" : "high",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "AppInfrastructure",
+        "Audiobooks",
+        "Book",
+        "CarPlay",
+        "CatalogUI",
+        "ErrorHandling",
+        "FeatureFlags",
+        "Holds",
+        "Keychain",
+        "Logging",
+        "Migrations",
+        "MyBooks",
+        "Network",
+        "Notifications",
+        "OPDS",
+        "OPDS2",
+        "PDF",
+        "Palace",
+        "Palace-noDRM",
+        "PalaceAuth",
+        "PalaceCatalog",
+        "PalaceKeychain",
+        "PalaceLogging",
+        "PalaceNetwork",
+        "PalaceReadingPosition",
+        "Reader2",
+        "Settings",
+        "SignInLogic",
+        "Support",
+        "Utilities"
+      ],
+      "description" : "PalaceLogging is a coupling hotspot with 30 dependents",
+      "severity" : "high",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "ErrorHandling",
+        "Keychain",
+        "Logging",
+        "MyBooks",
+        "Network",
+        "Notifications",
+        "OPDS",
+        "Settings",
+        "SignInLogic"
+      ],
+      "description" : "Logging is a coupling hotspot with 11 dependents",
+      "severity" : "high",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "AppInfrastructure",
+        "MyBooks",
+        "Network",
+        "Palace",
+        "Palace-noDRM",
+        "PalaceAuth",
+        "Settings",
+        "SignInLogic"
+      ],
+      "description" : "PalaceAuth is a coupling hotspot with 8 dependents",
+      "severity" : "medium",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "ErrorHandling",
+        "MyBooks",
+        "OPDS2",
+        "Settings",
+        "SignInLogic"
+      ],
+      "description" : "ErrorHandling is a coupling hotspot with 7 dependents",
+      "severity" : "medium",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "AppRating",
+        "Audiobooks",
+        "Book",
+        "CatalogUI",
+        "Holds",
+        "Keychain",
+        "Migrations",
+        "MyBooks",
+        "Settings",
+        "SignInLogic"
+      ],
+      "description" : "Settings is a coupling hotspot with 10 dependents",
+      "severity" : "medium",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "Logging",
+        "Migrations",
+        "MyBooks",
+        "Network",
+        "Notifications",
+        "Settings",
+        "SignInLogic"
+      ],
+      "description" : "Network is a coupling hotspot with 9 dependents",
+      "severity" : "medium",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Book",
+        "MyBooks",
+        "PDF",
+        "Palace",
+        "Palace-noDRM",
+        "PalaceUIKit",
+        "Reader2",
+        "Settings"
+      ],
+      "description" : "PalaceUIKit is a coupling hotspot with 7 dependents",
+      "severity" : "medium",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Accounts",
+        "Audiobooks",
+        "Book",
+        "CatalogUI",
+        "Holds",
+        "MyBooks",
+        "PDF",
+        "Platform",
+        "Settings"
+      ],
+      "description" : "MyBooks is a coupling hotspot with 8 dependents",
+      "severity" : "medium",
+      "type" : "hotspot"
+    },
+    {
+      "components" : [
+        "Palace",
+        "TriageBotUI"
+      ],
+      "description" : "TriageBotUI (Presentation) depends on Palace (Application) - upward dependency",
+      "severity" : "medium",
+      "type" : "layer_violation"
+    },
+    {
+      "components" : [
+        "Catalog"
+      ],
+      "description" : "Catalog has no dependencies and no dependents - possible orphan",
+      "severity" : "low",
+      "type" : "orphan_component"
+    },
+    {
+      "components" : [
+        "BuildSupport"
+      ],
+      "description" : "BuildSupport has no dependencies and no dependents - possible orphan",
+      "severity" : "low",
+      "type" : "orphan_component"
+    }
+  ],
+  "violations" : 1
+}

--- a/scripts/tests/test_ledger_scc.py
+++ b/scripts/tests/test_ledger_scc.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+test_ledger_scc.py — self-verify the ledger SCC collapser
+(scripts/ledger_scc.py).
+
+Two defects motivated the script and are pinned here as regressions:
+
+  1. `.github/workflows/ledger.yml` extracted cycle detail with
+     `jq '.cycles[] | .components'`, but CodeAtlas Ledger emits `.cycles` as an
+     INTEGER and puts the detail in `.issues[]`. The jq errored into
+     /dev/null and every PR comment silently fell through to "See full report
+     for cycle details." `analysis-real-develop.json` is a byte-for-byte
+     capture of real `ledger observe --domains arch` output so the shape that
+     broke the jq is what the tests run against.
+
+  2. The reported cycle count enumerates cycle PATHS, not distinct cycles. The
+     real capture reports 36 "cycles" that are 2 strongly-connected components
+     (one of 17 nodes, one of 2). Path count in a dense SCC is combinatorial:
+     a single added edge swings it by ~10 with no architectural change, which
+     is why the number ranged 10..29 across a month of PRs while the
+     underlying graph held steady.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "ledger_scc.py"
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "ledger_scc"
+_REAL = _FIXTURE_DIR / "analysis-real-develop.json"
+
+
+def _run(analysis: Path, config: Path | None = None, extra: list[str] | None = None):
+    cmd = [sys.executable, str(_SCRIPT), "--analysis", str(analysis)]
+    if config is not None:
+        cmd += ["--config", str(config)]
+    cmd += extra or []
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.returncode, p.stdout, p.stderr
+
+
+def _summary(tmp_path: Path, analysis: Path, config: Path | None = None) -> dict:
+    out = tmp_path / "scc.json"
+    rc, _, err = _run(analysis, config, ["--json", str(out)])
+    assert rc == 0, f"exit {rc}: {err}"
+    return json.loads(out.read_text())
+
+
+def _write(tmp_path: Path, name: str, cycles: list[str], **extra) -> Path:
+    """Build an analysis.json in the real emitted shape."""
+    issues = [
+        {
+            "components": sorted({c.strip() for c in path.split("→")}),
+            "description": f"Dependency cycle detected: {path}",
+            "severity": "high",
+            "type": "dependency_cycle",
+        }
+        for path in cycles
+    ]
+    doc = {
+        "averageCoupling": 4.86,
+        "components": 42,
+        # NOTE: an integer, exactly as ledger emits it. This is defect #1.
+        "cycles": len(cycles),
+        "dependencies": 204,
+        "findings": [],
+        "hotspots": 12,
+        "issues": issues,
+        "violations": 1,
+    }
+    doc.update(extra)
+    p = tmp_path / name
+    p.write_text(json.dumps(doc, indent=2))
+    return p
+
+
+# ───────────────────────────── defect #1: the shape ─────────────────────────
+
+def test_realCapture_cyclesField_isIntegerNotArray():
+    """The jq that broke was `.cycles[]`. Pin the shape that makes it break."""
+    doc = json.loads(_REAL.read_text())
+    assert isinstance(doc["cycles"], int)
+    assert doc["findings"] == [], "detail is NOT in .findings — that jq was broken too"
+    assert any(i["type"] == "dependency_cycle" for i in doc["issues"])
+
+
+def test_realCapture_producesNonEmptyDetail(tmp_path):
+    """The whole point: a PR comment that can actually name the cycles."""
+    md = tmp_path / "cycles.md"
+    rc, _, err = _run(_REAL, None, ["--markdown", str(md)])
+    assert rc == 0, err
+    body = md.read_text()
+    assert body.strip(), "empty detail is the bug we are fixing"
+    assert "Accounts" in body and "MyBooks" in body
+
+
+# ──────────────────── defect #2: paths collapse to components ────────────────
+
+def test_realCapture_36pathsCollapseTo2components(tmp_path):
+    s = _summary(tmp_path, _REAL)
+    assert s["cyclePathCount"] == 36
+    assert s["sccCount"] == 2
+    assert s["largestSccSize"] == 17
+
+
+def test_manyPathsThroughOneTangle_countAsOneCycle(tmp_path):
+    """Five different walks over the same 3 mutually-reachable components."""
+    a = _write(tmp_path, "one.json", [
+        "A → B → A",
+        "A → B → C → A",
+        "B → C → B",
+        "A → C → A",
+        "C → B → A → C",
+    ])
+    s = _summary(tmp_path, a)
+    assert s["cyclePathCount"] == 5
+    assert s["sccCount"] == 1
+    assert s["largestSccSize"] == 3
+    assert s["sccs"][0]["components"] == ["A", "B", "C"]
+
+
+def test_disjointTangles_countSeparately(tmp_path):
+    a = _write(tmp_path, "two.json", ["A → B → A", "Y → Z → Y"])
+    s = _summary(tmp_path, a)
+    assert s["sccCount"] == 2
+    assert s["largestSccSize"] == 2
+
+
+def test_addingOneEdge_movesPathCountButNotComponentCount(tmp_path):
+    """
+    The instability claim, made mechanical: one extra edge inside the tangle
+    multiplies the reported path count while the SCC reading holds at 1.
+    """
+    before = _write(tmp_path, "b.json", ["A → B → C → A"])
+    after = _write(tmp_path, "a.json", [
+        "A → B → C → A", "A → C → A", "A → B → A", "B → C → B",
+    ])
+    sb, sa = _summary(tmp_path, before), _summary(tmp_path, after)
+    assert sa["cyclePathCount"] > sb["cyclePathCount"]
+    assert sb["sccCount"] == sa["sccCount"] == 1
+    assert sb["largestSccSize"] == sa["largestSccSize"] == 3
+
+
+def test_noCycles_reportsZeroAndSaysSo(tmp_path):
+    a = _write(tmp_path, "clean.json", [])
+    s = _summary(tmp_path, a)
+    assert s["sccCount"] == 0
+    assert s["largestSccSize"] == 0
+    md = tmp_path / "m.md"
+    rc, _, _ = _run(a, None, ["--markdown", str(md)])
+    assert rc == 0
+    assert "No dependency cycles" in md.read_text()
+
+
+def test_selfLoop_isACycle(tmp_path):
+    a = _write(tmp_path, "self.json", ["A → A"])
+    s = _summary(tmp_path, a)
+    assert s["sccCount"] == 1
+    assert s["largestSccSize"] == 1
+
+
+# ─────────────────── knownFalsePositiveEdges are discounted ──────────────────
+
+def _config(tmp_path: Path, edges: list[dict]) -> Path:
+    p = tmp_path / "ledger-config.json"
+    p.write_text(json.dumps({"knownFalsePositiveEdges": edges}))
+    return p
+
+
+def test_knownFalsePositiveEdge_dissolvesItsCycle(tmp_path):
+    a = _write(tmp_path, "fp.json", ["A → B → A", "TriageBotUI → Palace → TriageBotUI"])
+    cfg = _config(tmp_path, [{
+        "from": "PalaceTriageBot", "aka": "TriageBotUI", "to": "Palace",
+        "confidence": "name-inferred",
+        "reason": "SwiftPM forbids a package importing the app target.",
+    }])
+    assert _summary(tmp_path, a)["sccCount"] == 2
+    s = _summary(tmp_path, a, cfg)
+    assert s["sccCount"] == 1, "the impossible edge must not inflate the count"
+    assert s["discountedEdges"] == [{"from": "TriageBotUI", "to": "Palace"}]
+
+
+def test_realCapture_withRepoConfig_dropsTheImpossibleEdge(tmp_path):
+    """`tools/ledger/ledger-config.json` already declares this edge impossible."""
+    cfg = _REPO_ROOT / "tools" / "ledger" / "ledger-config.json"
+    s = _summary(tmp_path, _REAL, cfg)
+    assert s["sccCount"] == 1
+    assert s["largestSccSize"] == 17
+    assert {"from": "TriageBotUI", "to": "Palace"} in s["discountedEdges"]
+
+
+def test_discountingIsNotUnconditional(tmp_path):
+    """An edge NOT in the config must survive — the discount is a whitelist."""
+    a = _write(tmp_path, "keep.json", ["X → Y → X"])
+    cfg = _config(tmp_path, [{"from": "TriageBotUI", "to": "Palace"}])
+    s = _summary(tmp_path, a, cfg)
+    assert s["sccCount"] == 1
+    assert s["discountedEdges"] == []
+
+
+# ───────────────────────────────── robustness ────────────────────────────────
+
+def test_missingAnalysisFile_failsLoudly(tmp_path):
+    rc, _, err = _run(tmp_path / "nope.json")
+    assert rc != 0
+    assert "not found" in err.lower()
+
+
+def test_unparseableDescription_fallsBackToComponents(tmp_path):
+    a = tmp_path / "odd.json"
+    a.write_text(json.dumps({
+        "cycles": 1, "components": 3, "dependencies": 3, "findings": [],
+        "hotspots": 0, "violations": 0,
+        "issues": [{
+            "components": ["A", "B"],
+            "description": "Dependency cycle detected (format changed upstream)",
+            "severity": "high", "type": "dependency_cycle",
+        }],
+    }))
+    s = _summary(tmp_path, a)
+    assert s["sccCount"] == 1
+    assert s["unparsedPaths"] == 1
+
+
+def test_nonCycleIssues_areIgnored(tmp_path):
+    a = _write(tmp_path, "mixed.json", ["A → B → A"])
+    doc = json.loads(a.read_text())
+    doc["issues"].append({
+        "components": ["Catalog"], "description": "Catalog has no dependencies",
+        "severity": "low", "type": "orphan_component",
+    })
+    a.write_text(json.dumps(doc))
+    s = _summary(tmp_path, a)
+    assert s["sccCount"] == 1
+    assert s["largestSccSize"] == 2
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Why

The Architecture panel on every PR comment has been reporting a number nobody could act on, and hiding the detail that would have made it actionable. This started as "is our architecture getting worse, or is the tool wrong?" — the answer is that the *count* is wrong, and the tangle it points at is real.

## Two defects, one root cause

All architecture detail lives in `.issues[]`. Neither extraction read it.

**1. The detail was never reachable.** `ledger.yml` extracted cycles with `jq '.cycles[] | .components'` and findings with `jq '.findings[] | .message'`. Ledger emits `.cycles` as an **integer** and `.findings` as an **empty array**, so both jq calls errored, both errors went to `/dev/null`, and both panels silently printed *"See full report for …"*. Confirmed against a real `ledger observe --domains arch` capture (51 issues, `.cycles` = number, `.findings` = `[]`), which is checked in as the test fixture.

**2. The count enumerates cycle PATHS, not distinct cycles.** On `develop` the 36 reported "cycles" are:

```
reported cycle PATHS: 36
actual strongly-connected components: 2
  size 17: Accounts, AppRating, Audiobooks, Book, CatalogUI, ErrorHandling,
           FeatureFlags, Keychain, Logging, MyBooks, Network, Notifications,
           OPDS2, PDF, Platform, Settings, SignInLogic
  size  2: Palace, TriageBotUI
```

Every line is a different walk through the same tangle — `Accounts → Book → Accounts`, then that plus Audiobooks, plus ErrorHandling, plus Logging. And the 2-node one is `TriageBotUI → Palace`, an edge SwiftPM structurally forbids, which `tools/ledger/ledger-config.json` has declared a `knownFalsePositiveEdge` since Wave 0 and the analyzer ignores. So the actionable count is **1**.

Path count in a dense SCC is combinatorial, which is why it can't be trended:

| | |
|---|---|
| range across 46 PRs (2026-07-23 → 08-18) | **10 – 29** |
| same-day spread (2026-08-14) | 19, 16, 11, 10, 10 |
| components / avg coupling over that window | constant (46 / 4.93) |
| newest 15 PRs vs oldest 15 | mean 12.1 vs 21.5 |

The 12 → 42 component jump on 2026-07-23 was `componentRoots` going **0 → 32** in #1329 — a measurement-aperture change, not an architectural event.

## What changes

`scripts/ledger_scc.py` collapses the paths into their SCCs, honors the config's `knownFalsePositiveEdges`, and emits both a JSON summary and the markdown the comment was always supposed to show.

This PR's own run (the workflow now triggers on its own changes) posted:

| Metric | was | now |
|---|---|---|
| Dependency Cycles | `11` | `2` |
| Largest Cycle | — | `10 components` |
| cycle detail | *"See full report for cycle details."* | every component + every edge, per cycle |
| findings detail | *"See full report for detailed findings."* | 14 hotspots, 2 layer violations, orphans — each named |
| `TriageBotUI → Palace` | counted | discounted, with the config's reason shown |

**And the collapse immediately surfaced something the path count was hiding.** A freshly-built model on current `develop` resolves to a 10-component tangle *plus a separate 3-component one* (`Audiobooks ↔ Book ↔ CatalogUI`) — not the single 17-component SCC that the stale July model shows. The big tangle has already started splitting. No reading of "11 cycles" (or "36") could have told you that; two named cycles with their members does.

## The tangle is real

Spot-checked the edges at source level before changing how they're counted:

- `Logging → Accounts` — `TPPErrorLogger.swift:810` calls `AccountsManager`
- `Logging → Book` — `Palace/Logging/TPPBook+Logging.swift`
- `Keychain → Accounts` / `Settings` — `TPPKeychainManager.swift`
- `Platform → Book` / `MyBooks` — `MyBooksDownloadCenter`, `BookReturnService`, `TPPBookState`

This PR changes how the tangle is **counted and displayed**, not the claim that it exists. SCC count and largest-SCC size move only when a component genuinely enters or leaves a tangle — which is what the decomposition campaign is actually doing, and what the raw path count was drowning out.

## Verification

- **14 new pytests**, red before the script existed, green after. Auto-collected by `tooling-checks.yml` (`pytest scripts/tests/`) — no wiring needed.
- **Mutation-tested 7/7 killed**, each by a *named* failing test: cycle-type filter removed · false-positive edges not dropped · `sccCount` = raw path count · self-loops uncounted · missing input reported as clean · no-cycle message dropped · `largestSccSize` always 0.
- **Full detector suite: 468 passed.**
- **Wiring tested end-to-end, both paths.** The `parse` step was extracted from the YAML and executed against a real `analysis.json` (emits `scc_count=1` / `largest_scc=17`, writes non-empty `arch_cycles.md` + `arch_findings.md`); the `github-script` body was rendered under `node` for the tangled tree **and** for a clean tree — the ✅ healthy verdict still fires and `Largest Cycle` reads `—`.
- Workflow YAML parses; `bash -n` clean.

## Scope

Reporting only. No production code, no gating — the workflow stays `continue-on-error: true`, and `scripts/ledger_scc.py` reads an artifact and can never fail a build.

**Not done:** the ledger binary still emits the path count upstream; this collapses it downstream rather than fixing CodeAtlas. The stale local `.ledger/` model (pinned at 2026-07-22) is untouched — anyone running `ledger observe` locally still gets July numbers unless they re-run `ledger update`.

**Deferred:** trending SCC count as a base-vs-head delta vs. `develop`, and any ratchet that would freeze it. The `.shared` read ratchet (167, monotone-down) remains the per-wave decomposition signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
