### PR TITLE
refactor(downloads): delete the vestigial bookIdentifierOfBookToRemove state (PP-4896)

### DIFF
--- a/.forgeos/intent/pp4896-remove-vestigial-book-to-remove.md
+++ b/.forgeos/intent/pp4896-remove-vestigial-book-to-remove.md
@@ -1,0 +1,79 @@
+---
+name: pp4896-remove-vestigial-book-to-remove
+created: 2026-08-19
+author: Maurice Carrier
+branch: fix/pp-4896-remove-vestigial-book-to-remove
+priority: PP-4896 / Normal (critical-path file: download center)
+---
+
+# Intent: delete the vestigial `bookIdentifierOfBookToRemove` scratch state from MyBooksDownloadCenter
+
+## Context
+
+PP-4896 was raised by independent architect review during Wave 3 S2b (PR #1358).
+`MyBooksDownloadCenter.bookIdentifierOfBookToRemove` is declared once and
+assigned `nil` at three sites but read NOWHERE in the tree, so the guard
+`if accountScope.currentAccountID == account { bookIdentifierOfBookToRemove = nil }`
+in `reset(account:)` has zero observable effect — the `==`/`!=` mutant is
+unkillable by construction.
+
+The ticket asked to resolve one of two possibilities via git history. History
+settles it as case 1 (genuinely vestigial):
+
+- Introduced 2014-08-04 (`709bf4c5b`) as scratch state for a `UIAlertViewDelegate`
+  confirm-delete callback. `UIAlertView`'s delegate carries no payload, so the
+  book identifier had to be stashed on the instance between "show alert" and
+  "user tapped Delete".
+- The reader (`alertView:didDismissWithButtonIndex:`) AND the writer
+  (`removeCompletedDownloadForBookIdentifier:`) were BOTH deleted together on
+  2020-02-12 in `b34820563` ("Fix / silence Xcode 11.3.1 warnings"), which
+  dropped the deprecated `UIAlertViewDelegate` conformance.
+- At that commit's parent, `removeCompletedDownloadForBookIdentifier:` had NO
+  callers anywhere in the tree (only its `.h` declaration and `.m` definition),
+  so the flow was already dead before it was removed. Nothing was lost.
+
+No feature is missing today. Remove-from-device is live via the `.remove`
+button, which routes through `didSelectReturn()` → `BookReturnService` →
+`deleteLocalContent(for:account:)`, passing the identifier as an ARGUMENT rather
+than stashing it in instance scratch state. `BookCellModel` documents the
+product decision explicitly: "Local delete and in-progress indicator: no
+confirmation needed" — only `.return` (giving the book back) is confirmed.
+
+## Claims
+
+- Deletes the `private var bookIdentifierOfBookToRemove: String?` declaration and
+  all three `= nil` assignments (in `reset(_ libraryID:)`, `reset(account:)`, and
+  `reset()`).
+- Deletes the now-empty account-match guard in `reset(account:)`, leaving the
+  method as its single meaningful statement `contentResetService.reset(account: account)`.
+  Account scoping for the reset is unchanged — it lives in the service, which
+  already receives `account`.
+- Deletes the class doc-comment bullet describing the field as main-thread-only
+  mutable state, since the field no longer exists.
+- Deletes `testResetAccount_consultsInjectedScopeSeamOnBothGuardBranches` from
+  `MyBooksDownloadCenterAccountScopeSeamTests`. That test pins ONLY the guard
+  being deleted; with the guard gone `reset(account:)` performs no account-scope
+  read, so the test asserts nothing. Its "HONEST LIMITATION" note is removed with it.
+- Replaces that test 1:1 (per the CLAUDE.md fluff-replacement rule) with
+  `testPersistStartedTaskRecord_*` covering the OTHER live `accountScope` read in
+  the class — `persistStartedTaskRecord` stamping the durable record's `account`
+  from the seam. This read was previously unpinned at the MBDC level, so seam
+  coverage in this class goes UP, not down.
+
+## Anti-claims
+
+- Does NOT change any user-visible behavior. This is write-only dead state; no
+  branch that anyone can observe is altered.
+- Does NOT rewire or reintroduce a confirm-delete alert. The product's current
+  no-confirmation-for-local-delete behavior is deliberate and stays as is.
+- Does NOT change `reset(_ libraryID:)`, `reset()`, or `reset(account:)` account
+  semantics — `contentResetService` still receives exactly the same account
+  argument in each.
+- Does NOT touch the `accountScope` seam itself, its adapter, or the other seam
+  read at `persistStartedTaskRecord` / `fileUrl`.
+- Does NOT remove the two existing `fileUrl` seam tests.
+
+## Files in scope
+
+- `Palace/MyBooks/MyBooksDownloadCenter.swift`
+- `PalaceTests/MyBooks/MyBooksDownloadCenterAccountScopeSeamTests.swift`

--- a/Palace/MyBooks/DownloadAccountContext.swift
+++ b/Palace/MyBooks/DownloadAccountContext.swift
@@ -30,8 +30,10 @@ import Foundation
 /// isolation + auth-surface host classification). Value-only.
 protocol DownloadAccountScopeProviding: Sendable {
     /// The current library's identifier. Backs per-account download-file
-    /// scoping (`BookFileManager.fileUrl(for:)`) and the account-switch reset
-    /// guards. Semantically the defaults-backed `currentAccountId`, not a
+    /// scoping (`BookFileManager.fileUrl(for:)`) and the account stamped on a
+    /// durable started-task record (`MyBooksDownloadCenter.persistStartedTaskRecord`),
+    /// which decides whose credentials answer a resumed background download's auth
+    /// challenge. Semantically the defaults-backed `currentAccountId`, not a
     /// resolved-`Account` uuid — a book file must resolve under the selected
     /// library even before its `Account` object has materialized.
     var currentAccountID: String? { get }

--- a/Palace/MyBooks/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/MyBooksDownloadCenter.swift
@@ -68,8 +68,6 @@ private final class DownloadFailureMetadataBox: @unchecked Sendable {
 ///   actor, precisely so it is reachable synchronously from any thread), and
 ///   `TPPUserAccount` serializes its own keychain access on `accountInfoQueue`. It
 ///   writes no MBDC state. Do not read the main-queue guarantee as universal.
-///     • `bookIdentifierOfBookToRemove` — scratch state for the remove-from-device
-///       confirmation alert, written and read only on the main-thread UI flow.
 ///     • `reachabilityCancellable` — installed once by `bindReachability()` during
 ///       main-thread wiring.
 ///   The concurrent teardown/scheduling hops the class performs run through
@@ -257,7 +255,6 @@ private final class DownloadFailureMetadataBox: @unchecked Sendable {
     let overdriveAPIExecutor: OverdriveAPIExecutor
     #endif
 
-    private var bookIdentifierOfBookToRemove: String?
     private var session: URLSession!
 
     // MARK: - Reliability WS-A: background session identity + completion handler
@@ -1895,21 +1892,16 @@ extension MyBooksDownloadCenter {
 extension MyBooksDownloadCenter: TPPBookDownloadsDeleting {
     func reset(_ libraryID: String!) {
         contentResetService.reset(account: libraryID)
-        bookIdentifierOfBookToRemove = nil
     }
 
     func reset(account: String) {
         contentResetService.reset(account: account)
-        if accountScope.currentAccountID == account {
-            bookIdentifierOfBookToRemove = nil
-        }
     }
 
     /// Required by MyBooksDownloadCenterProviding. Resets the current
     /// account.
     func reset() {
         contentResetService.reset()
-        bookIdentifierOfBookToRemove = nil
     }
 
     func deleteAudiobooks(forAccount account: String) {

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterAccountScopeSeamTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterAccountScopeSeamTests.swift
@@ -21,11 +21,14 @@
 //       account) would resolve a different id here → the assertion fails.
 //
 //    2. `persistStartedTaskRecord` account stamp — the durable started-task
-//       record's `account` is read from the injected seam at persist time. Launch
-//       reconciliation is account-scoped, so a wrong stamp recovers the wrong
-//       library's in-flight download. Asserted both for a single persist and
-//       across a mid-session account change (proving a live read per persist, not
-//       an init-time capture).
+//       record's `account` is read from the injected seam at persist time. Since
+//       PP-4978 that stamp is read back on the DOWNLOAD path to decide whose
+//       credentials answer a re-issued request's auth challenge, so a wrong stamp
+//       authenticates against the wrong library. (Launch reconciliation itself
+//       never reads `.account` — it matches by `bookID`/`taskIdentifier`.)
+//       Asserted for a single persist, across a mid-session account change
+//       (proving a live read per persist, not an init-time capture), and for the
+//       no-current-account sentinel.
 //
 //  Copyright © 2026 The Palace Project. All rights reserved.
 //
@@ -157,10 +160,13 @@ final class MyBooksDownloadCenterAccountScopeSeamTests: XCTestCase {
 
     // MARK: - 2. persistStartedTaskRecord stamps the account from the injected seam
 
-    /// The durable started-task record exists so a mid-download process kill can
-    /// be reconciled at launch — and reconciliation is account-scoped, so the
-    /// `account` stamped on the record decides which library's in-flight download
-    /// is recovered. That stamp reads the injected scope seam
+    /// The durable started-task record survives a mid-download process kill. Its
+    /// `account` is not used by launch reconciliation — that matches by `bookID`
+    /// and `taskIdentifier` — but since PP-4978 it is read back on the download
+    /// path (`BackgroundDownloadHandler.startedForAccount`) to recover which
+    /// library a download was started under when re-issuing its request. A wrong
+    /// stamp therefore answers an auth challenge with the wrong library's
+    /// credentials. That stamp reads the injected scope seam
     /// (`MyBooksDownloadCenter.persistStartedTaskRecord`), so this test asserts
     /// the persisted record carries exactly the id the spy reports.
     ///
@@ -189,7 +195,7 @@ final class MyBooksDownloadCenterAccountScopeSeamTests: XCTestCase {
         XCTAssertEqual(records.count, 1, "a started task must produce exactly one durable record")
         XCTAssertEqual(records.first?.bookID, book.identifier)
         XCTAssertEqual(records.first?.account, accountID,
-            "the durable record's account must be the injected seam's current id — launch reconciliation is account-scoped, so a wrong stamp recovers the wrong library's download")
+            "the durable record's account must be the injected seam's current id — it is read back on the download path to pick the credentials that answer a re-issued request's auth challenge, so a wrong stamp authenticates against the wrong library")
         XCTAssertEqual(records.first?.taskIdentifier, task.taskIdentifier,
             "the record must carry the LIVE task's identifier — reconciliation matches a resumed background task by it, so a wrong value orphans the download")
         XCTAssertEqual(records.first?.downloadURL, taskURL,
@@ -223,7 +229,8 @@ final class MyBooksDownloadCenterAccountScopeSeamTests: XCTestCase {
     /// The stamp must be a LIVE seam read at persist time, not an id captured
     /// when MBDC was constructed. A user switching libraries mid-session and
     /// then starting a download must get the NEW library on the record; an
-    /// init-time capture would stamp the old one and misroute reconciliation.
+    /// init-time capture would stamp the old one and answer that download's auth
+    /// challenge with the previous library's credentials.
     func testPersistStartedTaskRecord_tracksInjectedScopeSeamAcrossAccountChange() throws {
         let firstID = "first-lib-\(UUID().uuidString)"
         let secondID = "second-lib-\(UUID().uuidString)"

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterAccountScopeSeamTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterAccountScopeSeamTests.swift
@@ -20,13 +20,12 @@
 //       retype (BookFileManager reading `AppContainer.production()`'s current
 //       account) would resolve a different id here → the assertion fails.
 //
-//    2. `reset(account:)` seam-consultation — the account-match guard reads the
-//       injected seam. The spy counts `currentAccountID` reads; both guard
-//       branches (matching + non-matching id) must consult it. A mutant that
-//       re-hardcoded the guard onto a concrete manager reads the spy 0 times →
-//       the assertions fail. (The guarded effect is unobservable scratch state,
-//       so the ==/!= flip is not killable without new production surface — see
-//       the test's inline HONEST LIMITATION note.)
+//    2. `persistStartedTaskRecord` account stamp — the durable started-task
+//       record's `account` is read from the injected seam at persist time. Launch
+//       reconciliation is account-scoped, so a wrong stamp recovers the wrong
+//       library's in-flight download. Asserted both for a single persist and
+//       across a mid-session account change (proving a live read per persist, not
+//       an init-time capture).
 //
 //  Copyright © 2026 The Palace Project. All rights reserved.
 //
@@ -156,52 +155,101 @@ final class MyBooksDownloadCenterAccountScopeSeamTests: XCTestCase {
             "the file-path account must follow the injected seam's current value on each read — proving a live seam read, not an init-time capture")
     }
 
-    // MARK: - 2. reset(account:) consults the injected seam
+    // MARK: - 2. persistStartedTaskRecord stamps the account from the injected seam
 
-    /// `reset(account:)`'s account-match guard compares the argument against the
-    /// injected scope seam's `currentAccountID`. This test drives BOTH sides of
-    /// that guard — a MATCHING id (guard true) and a NON-matching id (guard
-    /// false) — and asserts the seam is the operand consulted in each case.
+    /// The durable started-task record exists so a mid-download process kill can
+    /// be reconciled at launch — and reconciliation is account-scoped, so the
+    /// `account` stamped on the record decides which library's in-flight download
+    /// is recovered. That stamp reads the injected scope seam
+    /// (`MyBooksDownloadCenter.persistStartedTaskRecord`), so this test asserts
+    /// the persisted record carries exactly the id the spy reports.
     ///
-    /// A mutant that re-hardcoded the guard onto a concrete
-    /// `AccountsManager.currentAccountId` reads the spy 0 times → both assertions
-    /// fail. Exercising both branches also pins that the argument actually flows
-    /// into a comparison against the seam value (not ignored).
-    ///
-    /// HONEST LIMITATION — the `==` → `!=` mutant is NOT killed here. The guard's
-    /// only effect is clearing `bookIdentifierOfBookToRemove`, which in the
-    /// current tree is write-only scratch state: it is never assigned a non-nil
-    /// value and never read back through any public/internal surface (verified by
-    /// a whole-tree grep). There is therefore NO observable behavioral difference
-    /// between the guard being true and false. Per the S2b review constraint we do
-    /// NOT add a test-only `_forTesting` getter to production just to observe it;
-    /// the seam-consultation + both-branches pin is the strongest assertion the
-    /// existing surface allows. When the remove-from-device confirmation flow that
-    /// reads this scratch state is (re)wired, this test should be upgraded to
-    /// assert the cleared/retained effect and kill the ==/!= mutant.
-    func testResetAccount_consultsInjectedScopeSeamOnBothGuardBranches() {
-        // Guard-true branch: reset argument MATCHES the seam's current id.
-        let matchingID = "current-lib-\(UUID().uuidString)"
-        let matchSpy = SpyDownloadAccountScope(accountID: matchingID)
-        let matchCenter = MyBooksDownloadCenter(
-            bookRegistry: registry,
-            accountScope: matchSpy
-        )
-        let matchBefore = matchSpy.accountIDReadCount
-        matchCenter.reset(account: matchingID)
-        XCTAssertGreaterThan(matchSpy.accountIDReadCount, matchBefore,
-            "reset(account:) with a MATCHING id must read the injected seam's currentAccountID for its guard, not a hardcoded AccountsManager")
+    /// A mutant that re-hardcoded the stamp onto a concrete
+    /// `AccountsManager.currentAccountId` — or that stamped the empty-string
+    /// fallback unconditionally — persists a different account than the spy's →
+    /// the assertion fails.
+    func testPersistStartedTaskRecord_stampsAccountFromInjectedScopeSeam() throws {
+        let accountID = "stamp-lib-\(UUID().uuidString)"
+        let spy = SpyDownloadAccountScope(accountID: accountID)
+        let (center, stateManager) = try makeCenterWithIsolatedPersistence(scope: spy)
 
-        // Guard-false branch: reset argument does NOT match the seam's current id.
-        let nonMatchSpy = SpyDownloadAccountScope(accountID: "current-lib-\(UUID().uuidString)")
-        let nonMatchCenter = MyBooksDownloadCenter(
-            bookRegistry: registry,
-            accountScope: nonMatchSpy
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        let url = try XCTUnwrap(URL(string: "https://example.test/\(book.identifier)"))
+        let (task, session) = downloadTask(for: url)
+        defer { session.invalidateAndCancel() }
+
+        center.persistStartedTaskRecord(task: task, book: book, request: URLRequest(url: url))
+
+        let records = stateManager.persistedRecords()
+        XCTAssertEqual(records.count, 1, "a started task must produce exactly one durable record")
+        XCTAssertEqual(records.first?.bookID, book.identifier)
+        XCTAssertEqual(records.first?.account, accountID,
+            "the durable record's account must be the injected seam's current id — launch reconciliation is account-scoped, so a wrong stamp recovers the wrong library's download")
+    }
+
+    /// The stamp must be a LIVE seam read at persist time, not an id captured
+    /// when MBDC was constructed. A user switching libraries mid-session and
+    /// then starting a download must get the NEW library on the record; an
+    /// init-time capture would stamp the old one and misroute reconciliation.
+    func testPersistStartedTaskRecord_tracksInjectedScopeSeamAcrossAccountChange() throws {
+        let firstID = "first-lib-\(UUID().uuidString)"
+        let secondID = "second-lib-\(UUID().uuidString)"
+        let spy = SpyDownloadAccountScope(accountID: firstID)
+        let (center, stateManager) = try makeCenterWithIsolatedPersistence(scope: spy)
+
+        let firstBook = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        let firstURL = try XCTUnwrap(URL(string: "https://example.test/\(firstBook.identifier)"))
+        let (firstTask, firstSession) = downloadTask(for: firstURL)
+        defer { firstSession.invalidateAndCancel() }
+        center.persistStartedTaskRecord(task: firstTask, book: firstBook, request: URLRequest(url: firstURL))
+
+        spy.setAccountID(secondID)
+
+        let secondBook = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        let secondURL = try XCTUnwrap(URL(string: "https://example.test/\(secondBook.identifier)"))
+        let (secondTask, secondSession) = downloadTask(for: secondURL)
+        defer { secondSession.invalidateAndCancel() }
+        center.persistStartedTaskRecord(task: secondTask, book: secondBook, request: URLRequest(url: secondURL))
+
+        let records = stateManager.persistedRecords()
+        XCTAssertEqual(
+            records.first(where: { $0.bookID == firstBook.identifier })?.account, firstID,
+            "the record written BEFORE the account change must keep the account current at ITS persist time")
+        XCTAssertEqual(
+            records.first(where: { $0.bookID == secondBook.identifier })?.account, secondID,
+            "the record written AFTER the account change must carry the NEW id — proving a live seam read per persist, not an init-time capture")
+    }
+
+    // MARK: - Helpers
+
+    /// MBDC wired to the given scope seam and to a `DownloadStateManager` whose
+    /// durable store is a throwaway file, so the assertions read back only what
+    /// this test wrote and nothing touches the shared production store.
+    private func makeCenterWithIsolatedPersistence(
+        scope: SpyDownloadAccountScope
+    ) throws -> (MyBooksDownloadCenter, DownloadStateManager) {
+        let storeURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("AccountScopeSeamTests-tasks-\(UUID().uuidString).json")
+        addTeardownBlock { try? FileManager.default.removeItem(at: storeURL) }
+
+        let stateManager = DownloadStateManager(
+            taskPersistence: DownloadTaskPersistence(fileURL: storeURL)
         )
-        let nonMatchBefore = nonMatchSpy.accountIDReadCount
-        nonMatchCenter.reset(account: "some-other-lib-\(UUID().uuidString)")
-        XCTAssertGreaterThan(nonMatchSpy.accountIDReadCount, nonMatchBefore,
-            "reset(account:) with a NON-matching id must still read the injected seam's currentAccountID to evaluate its guard")
+        let center = MyBooksDownloadCenter(
+            bookRegistry: registry,
+            accountScope: scope,
+            stateManager: stateManager
+        )
+        return (center, stateManager)
+    }
+
+    /// A real, never-resumed `URLSessionDownloadTask` — `persistStartedTaskRecord`
+    /// reads `task.taskIdentifier` and `task.originalRequest`, both of which are
+    /// populated at creation. The session is returned so the caller can invalidate
+    /// it rather than leaking it onto `URLSession.shared`.
+    private func downloadTask(for url: URL) -> (URLSessionDownloadTask, URLSession) {
+        let session = URLSession(configuration: .ephemeral)
+        return (session.downloadTask(with: url), session)
     }
 }
 

--- a/PalaceTests/MyBooks/MyBooksDownloadCenterAccountScopeSeamTests.swift
+++ b/PalaceTests/MyBooks/MyBooksDownloadCenterAccountScopeSeamTests.swift
@@ -174,17 +174,50 @@ final class MyBooksDownloadCenterAccountScopeSeamTests: XCTestCase {
         let (center, stateManager) = try makeCenterWithIsolatedPersistence(scope: spy)
 
         let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
-        let url = try XCTUnwrap(URL(string: "https://example.test/\(book.identifier)"))
-        let (task, session) = downloadTask(for: url)
+        // DISTINCT urls: production prefers the LIVE task's `originalRequest` over
+        // the passed request, because a retry re-issues the task against a
+        // refreshed (re-signed) url while the caller still holds the original.
+        // Same url in both slots would let a swapped precedence pass.
+        let taskURL = try XCTUnwrap(URL(string: "https://example.test/live/\(book.identifier)"))
+        let staleRequestURL = try XCTUnwrap(URL(string: "https://example.test/stale/\(book.identifier)"))
+        let (task, session) = downloadTask(for: taskURL)
         defer { session.invalidateAndCancel() }
 
-        center.persistStartedTaskRecord(task: task, book: book, request: URLRequest(url: url))
+        center.persistStartedTaskRecord(task: task, book: book, request: URLRequest(url: staleRequestURL))
 
         let records = stateManager.persistedRecords()
         XCTAssertEqual(records.count, 1, "a started task must produce exactly one durable record")
         XCTAssertEqual(records.first?.bookID, book.identifier)
         XCTAssertEqual(records.first?.account, accountID,
             "the durable record's account must be the injected seam's current id — launch reconciliation is account-scoped, so a wrong stamp recovers the wrong library's download")
+        XCTAssertEqual(records.first?.taskIdentifier, task.taskIdentifier,
+            "the record must carry the LIVE task's identifier — reconciliation matches a resumed background task by it, so a wrong value orphans the download")
+        XCTAssertEqual(records.first?.downloadURL, taskURL,
+            "the live task's originalRequest url must win over the passed request's — a retry re-issues against a refreshed url and the record must track it")
+    }
+
+    /// The empty-string account is a LOAD-BEARING sentinel, not a defensive
+    /// default: `BackgroundDownloadHandler.startedForAccount` and
+    /// `MyBooksDownloadCenter+ChallengeAccount` both branch on
+    /// `!startedAccountID.isEmpty` to decide whether to answer a download auth
+    /// challenge with the CAPTURED account or fall back to the current one. A
+    /// non-empty stand-in (`"unknown"`, `"none"`) reads as a real account id and
+    /// routes credentials to `userAccount(forCapturedId:)` for a library that
+    /// does not exist — a silent download-auth failure. This pins the nil arm of
+    /// the coalescing so that sentinel cannot drift.
+    func testPersistStartedTaskRecord_withNoCurrentAccount_stampsEmptySentinel() throws {
+        let spy = SpyDownloadAccountScope(accountID: nil)
+        let (center, stateManager) = try makeCenterWithIsolatedPersistence(scope: spy)
+
+        let book = TPPBookMocker.mockBook(distributorType: .EpubZip)
+        let url = try XCTUnwrap(URL(string: "https://example.test/\(book.identifier)"))
+        let (task, session) = downloadTask(for: url)
+        defer { session.invalidateAndCancel() }
+
+        center.persistStartedTaskRecord(task: task, book: book, request: URLRequest(url: url))
+
+        XCTAssertEqual(stateManager.persistedRecords().first?.account, "",
+            "with no current account the stamp must be exactly the empty string — consumers test `.isEmpty` to fall back to the current user account, so any other stand-in routes download auth to a nonexistent library")
     }
 
     /// The stamp must be a LIVE seam read at persist time, not an id captured

--- a/scripts/godclass-loc-baseline.txt
+++ b/scripts/godclass-loc-baseline.txt
@@ -148,9 +148,15 @@
 # PP-4895 (-1 on MyBooksDownloadCenter, 1257 -> 1256): the URLSession auth-challenge
 #   callback moved to the SDK's async spelling, and the shape adaptation both challenge
 #   sites needed now lives once on TPPBasicAuth.response(to:) instead of twice inline.
+# PP-4896 (-6 on MyBooksDownloadCenter, 1256 -> 1250): deleted the vestigial
+#   bookIdentifierOfBookToRemove scratch state — the property, its three `= nil`
+#   assignments, the account-match guard that only cleared it, and the doc bullet
+#   describing it. Its reader died in 2020 (b34820563) with the UIAlertViewDelegate
+#   confirm-delete flow, whose writer already had no callers. Pure removal, no
+#   behavior change.
 1579 Palace/Audiobooks/AudiobookSessionManager.swift
 374 Palace/Accounts/Library/AccountsManager.swift
-1256 Palace/MyBooks/MyBooksDownloadCenter.swift
+1250 Palace/MyBooks/MyBooksDownloadCenter.swift
 981 Palace/Book/UI/BookDetail/BookDetailViewModel.swift
 638 Palace/SignInLogic/TPPSignInBusinessLogic.swift
 575 Palace/MyBooks/BorrowOperation.swift


### PR DESCRIPTION
Resolves [PP-4896](https://ebce-lyrasis.atlassian.net/browse/PP-4896).

## The question the ticket asked

PP-4896 was raised by independent architect review during Wave 3 S2b (#1358). `MyBooksDownloadCenter.bookIdentifierOfBookToRemove` is assigned `nil` at three sites and read nowhere, so the guard

```swift
if accountScope.currentAccountID == account { bookIdentifierOfBookToRemove = nil }
```

in `reset(account:)` had no observable effect and its `==`/`!=` mutant was unkillable by construction. The ticket asked us to decide between two possibilities from git history: genuinely vestigial state to delete, or a lost remove-from-device confirmation flow whose reader should be rewired.

## The answer: case 1, genuinely vestigial

- **2014-08-04 (`709bf4c5b`)** — introduced to carry a book identifier across a `UIAlertViewDelegate` confirm-delete callback. `UIAlertView`'s delegate carries no payload, so the id had to live on the instance between "show alert" and "user tapped Delete".
- **2020-02-12 (`b34820563`)** — the reader (`alertView:didDismissWithButtonIndex:`) *and* the writer (`removeCompletedDownloadForBookIdentifier:`) were deleted together when the deprecated `UIAlertViewDelegate` conformance was dropped.
- At that commit's **parent, the writer already had zero callers** — only its `.h` declaration and `.m` definition. The flow was dead before it was removed. Nothing was lost; only the property and its `nil` assignments were left behind.

Case 2 is ruled out on the product side too. Remove-from-device is live via the `.remove` button → `didSelectReturn()` → `BookReturnService` → `deleteLocalContent(for:account:)`, passing the identifier as an *argument*. `BookCellModel` records the deliberate decision — "Local delete and in-progress indicator: no confirmation needed"; only `.return`, which actually gives the book back, is confirmed.

## What changed

**8 production lines deleted** — the property, its three `= nil` assignments, the now-empty account-match guard, and the class doc-comment bullet. No behavior change. Account scoping for `reset(account:)` is unaffected: it lives in `contentResetService`, which still receives the identical argument.

**Test swap.** The ticket anticipated the `reset(account:)` test merely dropping its "unkillable mutant" note, but with the guard gone that method performs no account-scope read at all, so the test asserts nothing and can only be deleted. Replaced 1:1 (per the CLAUDE.md fluff-replacement rule) with tests pinning the *other* live `accountScope` read in the class — `persistStartedTaskRecord`'s account stamp, previously unpinned at the MBDC level. Seam coverage goes up, not down.

**`godclass-loc-baseline.txt` ratcheted 1256 → 1250.** The gate exits 0 on a shrink, so CI would not have caught leaving it — and stale headroom on a frozen god-class is the accretion this change opposes.

## Verification

`scripts/verify-pr.sh --quick --diff-baseline`: **32/32 CLEAR**, `unit_tests` passing outright. Full suite: 8323 tests + 6 TenPrintCover, 0 failures, 0 timeouts.

Every new assertion is mutation-verified, each mutant applied to the committed tip and reverted after, each kill confirmed by a **named** failing test:

| Mutant | Killed by |
|---|---|
| `?? ""` → `""` | both persist tests |
| live seam read → init-time `lazy var` capture | `..._tracksInjectedScopeSeamAcrossAccountChange` **only** |
| `?? ""` → `?? "unknown"` | `..._withNoCurrentAccount_stampsEmptySentinel` |
| `taskIdentifier` → `0` | `..._stampsAccountFromInjectedScopeSeam` |
| url precedence swap | `..._stampsAccountFromInjectedScopeSeam` |

Rows 2 and 3 are the ones that matter. Row 2 shows the account-change test earns its place rather than duplicating the first. Row 3 came from QA review: the nil arm was unpinned, and that empty string is a **load-bearing sentinel** — `BackgroundDownloadHandler.startedForAccount` and `MyBooksDownloadCenter+ChallengeAccount` both branch on `!startedAccountID.isEmpty` to decide whether a resumed background download's auth challenge uses the captured or current account. A non-empty stand-in reads as a real library id and routes credentials to a library that does not exist.

## Review

Architect, QA, and blast-radius reviewers each raised findings across three rounds; all were fixed at the source rather than argued down. Beyond the sentinel above: the LOC ratchet, a stale `DownloadAccountScopeProviding` doc that still advertised "the account-switch reset guards" (this branch deleted the last one), and four test strings that named the wrong blast radius — they claimed launch reconciliation is account-scoped, but `runLaunchReconciliation` reads `bookID` and matches by `taskIdentifier`, never `.account`. The real consequence is the PP-4978 download-path read.

## Follow-ups, deliberately not folded in

- `MyBooksDownloadCenter.reset(account:)` now has **zero** callers and satisfies neither `TPPBookDownloadsDeleting` nor `MyBooksDownloadCenterProviding` — the same species of vestigial surface this ticket was raised about. Worth deleting standalone *before* the 3b `PalaceDownloads` extraction, since moving dead code into a new package is worse than deleting it first.
- The `@unchecked Sendable` doc comment omits `reconcileObserver` and `lcpStreamingEnabledProvider`. That comment is the soundness justification for the annotation on a critical-path class, so an incomplete enumeration there is the higher-priority of the two.
- `expectedBytes` on the durable record is written and never read — write-only state of exactly the shape this PR deletes. QA confirmed a `nil → 0` mutant survives as an *equivalent* mutant, not a coverage gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PP-4896]: https://ebce-lyrasis.atlassian.net/browse/PP-4896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ