### PR TITLE
fix(sync): stop losing patrons' reading positions when they are offline (PP-4965, PP-4987)

### DIFF
--- a/.forgeos/intent/pp-4965-annotation-error-classification.md
+++ b/.forgeos/intent/pp-4965-annotation-error-classification.md
@@ -1,0 +1,36 @@
+# PP-4965 — annotation error classification
+
+## Claims
+
+- `postAnnotation` distinguishes five outcomes that were previously one bare
+  `false`: succeeded, queued-for-retry, and failed (carrying the transport
+  error and/or the HTTP response).
+- A write handed to the offline queue is no longer reported to error logging.
+- A real failure keeps its Crashlytics code **902 (`.apiCall`)** and its
+  `error_origin` classification, and now also carries the status code.
+- Transient conditions (no connection, timeout) can be split into their own
+  buckets by `customSummaryAndCode`, which needs the underlying error.
+
+## Anti-claims — things this change explicitly does NOT do
+
+- **It does not reduce the 902 volume.** `.queuedForRetry` is unreachable in
+  production until PP-4987 preserves the transport error, so nothing is
+  currently reclassified. Any re-measurement of the bucket before PP-4987 lands
+  is meaningless.
+- **It does not change bookmark behaviour.** Both `postBookmark` variants remain
+  byte-for-byte equivalent, including the 200-with-no-id case. Their silence on
+  failure is a separate gap.
+- **It does not verify the offline enqueue.** Suppressing the report assumes a
+  retry exists; asserting that requires a seam and belongs to PP-4987, where the
+  branch first becomes reachable.
+- **It does not move the Crashlytics code or origin dimension.** Reviewers
+  caught an earlier revision doing exactly that via the bare `logError`
+  overload; a test now pins `.apiCall`.
+
+## Files in scope
+
+- `Palace/Reader2/Bookmarks/TPPAnnotations.swift`
+- `Palace/Logging/ErrorLogging.swift`
+- `PalaceTests/Bookmarks/TPPAnnotationsTests.swift`
+- `PalaceTests/Sync/CrossDeviceSyncE2ETests.swift`
+- `PalaceTests/Mocks/ErrorLoggerSpy.swift`

--- a/.forgeos/intent/pp-4965-annotation-error-classification.md
+++ b/.forgeos/intent/pp-4965-annotation-error-classification.md
@@ -20,9 +20,22 @@
 - **It does not change bookmark behaviour.** Both `postBookmark` variants remain
   byte-for-byte equivalent, including the 200-with-no-id case. Their silence on
   failure is a separate gap.
+
+  CORRECTION (review round 2): this holds for `postBookmark`, but NOT for
+  audiobook bookmarks. `postAudiobookBookmark` routes through
+  `postReadingPosition(motivation: .bookmark)` with `queueOffline: true` — the
+  changed path — and has two live callers in `AudiobookBookmarkBusinessLogic`.
+  So bookmark-motivated annotations ARE in the 902 bucket today and their
+  telemetry DOES change here. The earlier claim that the bucket is "entirely
+  reading positions" is false as written and must not be used to scope the
+  post-PP-4987 re-measurement. Patron-visible behaviour is still unchanged
+  today (nil in, throw out, before and after).
 - **It does not verify the offline enqueue.** Suppressing the report assumes a
   retry exists; asserting that requires a seam and belongs to PP-4987, where the
-  branch first becomes reachable.
+  branch first becomes reachable. `NetworkQueue.addRequest` is fire-and-forget
+  and drops a write silently on a nil DB connection or a throwing insert, so
+  PP-4987 must add enqueue-failure reporting at the same time it makes the
+  branch live — otherwise this change's suppression becomes a real silent loss.
 - **It does not move the Crashlytics code or origin dimension.** Reviewers
   caught an earlier revision doing exactly that via the bare `logError`
   overload; a test now pins `.apiCall`.
@@ -34,3 +47,21 @@
 - `PalaceTests/Bookmarks/TPPAnnotationsTests.swift`
 - `PalaceTests/Sync/CrossDeviceSyncE2ETests.swift`
 - `PalaceTests/Mocks/ErrorLoggerSpy.swift`
+
+## Review round 2 — what changed and why
+
+The first round approved a claim that was false in production. `postAnnotation`
+passed `response: nil` on the error branch, and because `TPPNetworkResponder`
+synthesizes an NSError for EVERY non-2xx while `TPPNetworkExecutor.POST`
+forwards `(nil, response, error)` together, that error branch — not the `else`
+below it — is the one a server refusal actually takes. So `metadata`
+["statusCode"] was never populated, the `400...599` arm of
+`TPPErrorOrigin.classify` was unreachable from this call site, and
+`.failed(underlying: nil, response: <non-nil>)` was dead code.
+
+Two tests asserted the working behaviour by stubbing `(nil, httpResponse(500),
+nil)` — an error-free non-2xx, a shape the stack never emits. Fixtures now go
+through `serverRefusal(_:)`, which builds the exact triple production delivers.
+
+This is the same fixture-vs-production drift the branch had already fixed for
+the 914 transport case and left in place on the server path.

--- a/.forgeos/intent/pp-4987-offline-writes-never-queued.md
+++ b/.forgeos/intent/pp-4987-offline-writes-never-queued.md
@@ -165,6 +165,40 @@ is justified and torn down, but the honest fix is instance-ification behind the
 `AnnotationsManager` protocol that already exists in that file — not another
 seam. That is a separate branch; this one should not grow an eighth.
 
+## The unarchiver crash — and how I got it wrong twice
+
+A reviewer flagged that `NSKeyedUnarchiver.unarchiveObject(with:)` raises an
+uncatchable ObjC exception on a corrupt archive, making the credential purge a
+launch crash. I probed it with garbage bytes and a truncated archive, got `nil`
+both times, and recorded "could not reproduce — this is hygiene, not a crash
+fix". That was wrong, and the mistake was the shape of the probe.
+
+Another reviewer fuzzed it properly. Bit-flipping each byte of a valid 277-byte
+header archive in turn:
+
+    legacy  unarchiveObject(with:)        63 of 277 ABORT the process
+    modern  unarchivedObject(ofClasses:)   0 of 277 abort
+
+Garbage and truncation fail early in plist parsing and return nil; real on-disk
+corruption is bit-level, which is the shape that kills it. Both my probes
+happened to pick survivors.
+
+Two consequences:
+
+- **Both production reads are converted**, not just the purge. `retry()` read
+  the same blob with the legacy call, and this ticket is what makes rows exist
+  and the drain run — so the branch was INCREASING exposure to the crash while
+  hardening only one of the two sites.
+- **The test now discriminates.** Its first fixture was ASCII garbage, which
+  passes against both implementations and guarded nothing. It now corrupts the
+  archived class name structurally, which reproduces the raise: with the legacy
+  call the test process crashes; with the modern one it passes.
+
+Worth recording because it is the branch's recurring failure in a new costume:
+a claim resting on a probe too weak to falsify it. The first version was "I
+verified this" when I had not; this one was "I could not verify this" when a
+better probe could.
+
 ## Files in scope
 
 - `Palace/Network/TPPNetworkResponder.swift`

--- a/.forgeos/intent/pp-4987-offline-writes-never-queued.md
+++ b/.forgeos/intent/pp-4987-offline-writes-never-queued.md
@@ -31,6 +31,16 @@
   has no behavioural coverage; it is a follow-up, not something this change
   fixes.
 
+- **It does not predict the 902 bucket either, and there are TWO confounders.**
+  Pre-change, the annotation caller passed `nil` as the error, so every failure
+  filed 902 flatly. It now passes the underlying error, which routes through
+  `customSummaryAndCode` and re-codes `notConnectedToInternet` / `timedOut` /
+  `connectionLost` to `.clientSideTransientError`. So 902 falls for un-queued
+  transients too, independently of queueing — and separately, a non-2xx with a
+  problem-document body is reported TWICE (once by `parseAndLogError` as
+  `.problemDocAvailable`, once by the annotation caller as 902). Group the
+  re-measurement by `metadata.statusCode` rather than reading the total.
+
 - **It does not predict the 914 bucket.** Expect 914 to COLLAPSE app-wide:
   transport failures that were filed under it now carry their real NSURLError
   and re-bucket through `customSummaryAndCode`. A near-zero 914 after this
@@ -90,6 +100,33 @@ erases the transport error into `problemDocument?.dictionaryValue` (nil when
 offline), so `BookReturnService.isOfflineNSURLError` and the OPDS-side
 consumers stay dead. That is a SECOND erasure chokepoint of the same shape as
 this ticket's, and it is worth its own ticket.
+
+## Round 4 — the credential fix had its own leak
+
+Fixing the at-rest problem introduced a worse one in transit, caught by two
+reviewers independently. The drain-time provider resolved
+`currentUserAccount`, while `retryQueue` drains EVERY row regardless of
+library and each row's URL is its own library's host. A patron who queued a
+write for library A and then switched to library B would have sent B's bearer
+token to A's server — a cross-tenant credential disclosure, plus a guaranteed
+401 on a write that had a valid token sitting in the keychain. The provider is
+now keyed on the row's `libraryID` and resolved through
+`accountsManager.userAccount(for:)`, which is the API that exists precisely to
+stop this (see the "prevent TOCTOU races during account switches … causing
+cross-account credential leaks" note on `TPPNetworkExecutor`).
+
+The strip itself was also proven only on the helper: `headersSafeToPersist` had
+unit tests, but nothing asserted `addRequest` CALLS it, and unwiring the call
+site left the whole suite green. The E2E assertion that claimed to cover it sat
+UPSTREAM of the strip, asserting a property that is false in production, and
+passed only because that suite's executor happens to hold no token on a clean
+runner — it went red the moment a sibling test left one behind. Both are now
+asserted against the persisted row via `persistedRowsForTesting()`.
+
+No legacy rows can carry a stored credential: nothing was ever queued before
+this ticket (`willQueueOffline` could not be true), and the only other entry
+point, `enqueueOfflineRequest`, has no production caller. So no migration is
+needed to purge them.
 
 ## Files in scope
 

--- a/.forgeos/intent/pp-4987-offline-writes-never-queued.md
+++ b/.forgeos/intent/pp-4987-offline-writes-never-queued.md
@@ -1,0 +1,47 @@
+# PP-4987 — offline writes are never queued for retry
+
+## Claims
+
+- `TPPNetworkResponder` preserves the underlying transport error when a task
+  produces no HTTP response, instead of replacing it with the generic
+  `invalidOrNoHTTPResponse` (914).
+- Because `NetworkQueue.StatusCodes` is composed entirely of `NSURLError`
+  values, preserving that error is what makes `willQueueOffline` able to be
+  true at all — so an offline write now actually reaches the retry queue.
+- A write the queue fails to persist is reported under its own Crashlytics code
+  (`offlineQueueWriteFailed`, 916) rather than being dropped in silence.
+- `PP-4965`'s `.queuedForRetry` case becomes reachable in production, and its
+  cross-device E2E tripwire flips from expected-failure to a real assertion.
+
+## Anti-claims — things this change explicitly does NOT do
+
+- **It does not change behaviour for requests that DID get an HTTP response.**
+  Only the no-response branch is touched; every non-2xx still yields the
+  synthesized 909 alongside the response, exactly as before.
+- **It does not add retry logic.** The queue's existing drain/retry path is
+  untouched; this only makes writes reach it.
+- **It does not silence anything.** The only new silence is PP-4965's, and it
+  is now paid for by the drop report above.
+- **It does not claim the 902 bucket will fall by a specific amount.** It should
+  fall, because genuinely-queued writes stop being reported — but the remaining
+  volume is the real defect worth sizing, and that measurement belongs after
+  this lands, not in it.
+
+## Blast radius — deliberately widened, and why
+
+Preserving the error revives four call sites that match on `NSURLError` codes
+and have been unreachable for anything routed through this responder:
+`TPPAlertUtils` (:68, :72), `PalaceError` (:596, :598),
+`TPPSignInBusinessLogic` (:688), `PalaceAuth.AuthReducer` (:264). Patrons who
+are offline will now get the specific "you appear to be offline" handling those
+sites were written to provide, instead of a generic failure. This is the
+intended consequence, not a side effect — but it is a user-visible change on
+the sign-in path and should be called out in review.
+
+## Files in scope
+
+- `Palace/Network/TPPNetworkResponder.swift`
+- `Palace/Network/TPPNetworkQueue.swift`
+- `Palace/Logging/TPPErrorLogger.swift`
+- `PalaceTests/Network/NetworkQueueTests.swift`
+- `PalaceTests/Sync/CrossDeviceSyncE2ETests.swift`

--- a/.forgeos/intent/pp-4987-offline-writes-never-queued.md
+++ b/.forgeos/intent/pp-4987-offline-writes-never-queued.md
@@ -20,8 +20,22 @@
   synthesized 909 alongside the response, exactly as before.
 - **It does not add retry logic.** The queue's existing drain/retry path is
   untouched; this only makes writes reach it.
-- **It does not silence anything.** The only new silence is PP-4965's, and it
-  is now paid for by the drop report above.
+- **It does not silence anything NEW at enqueue.** PP-4965's silence is paid
+  for by the drop reports above, both of which now file under 916.
+
+  CORRECTED (round 3): the DRAIN side is still silent. `retryQueue()` deletes
+  rows past `MaxRetriesInQueue = 5` without reporting, `retry()` logs a non-2xx
+  locally only, and both `migrate()` and `retryQueue()` keep a bare
+  `guard let db else { return }`. A write that can never drain is as lost as
+  one never stored. That path has never carried traffic before this ticket and
+  has no behavioural coverage; it is a follow-up, not something this change
+  fixes.
+
+- **It does not predict the 914 bucket.** Expect 914 to COLLAPSE app-wide:
+  transport failures that were filed under it now carry their real NSURLError
+  and re-bucket through `customSummaryAndCode`. A near-zero 914 after this
+  ships is the substitution ending, not a defect being fixed — the exact
+  symmetric trap to the 902 re-measurement PP-4965 warns about.
 - **It does not claim the 902 bucket will fall by a specific amount.** It should
   fall, because genuinely-queued writes stop being reported — but the remaining
   volume is the real defect worth sizing, and that measurement belongs after
@@ -37,6 +51,45 @@ are offline will now get the specific "you appear to be offline" handling those
 sites were written to provide, instead of a generic failure. This is the
 intended consequence, not a side effect — but it is a user-visible change on
 the sign-in path and should be called out in review.
+
+## Round 3 — hardening required before this could land
+
+Review blocked this twice more, and two of the findings were about turning the
+queue ON rather than about the fix itself:
+
+- **The credential was about to reach disk.** Callers build headers from
+  `TPPNetworkExecutor.request(for:)`, whose `useTokenIfAvailable` defaults to
+  TRUE, so `Authorization: Bearer …` was archived into the unencrypted
+  `simplified.db`. Never executed before, because nothing was ever queued —
+  this ticket is what would have started it. Now stripped at enqueue
+  (`headersSafeToPersist`) and re-derived at drain from the CURRENT credential,
+  which also stops a days-old row replaying an expired token.
+
+- **The queue key collapsed distinct writes.** `addRequest` UPDATEs the row for
+  `(libraryID, updateID)` and every annotation passed `updateID = bookID`, so
+  two offline bookmarks in one title silently overwrote each other — with
+  PP-4965 having already removed the report for that path. Keyed on motivation
+  now: positions still collapse on the book (a newer position SHOULD supersede
+  an older one), bookmarks key on book + selector.
+
+- **916 was applied to only one of the two drop paths.** The `catch` used the
+  bare `logError(_:summary:metadata:)` overload, which hardcodes `code:
+  .ignore` — filing under the raw SQLite code with `error_origin = unknown`.
+  Byte-for-byte the defect round 1 blocked this branch for, reintroduced in new
+  code, and caught by all three reviewers. Fixed and now tested.
+
+## Blast radius — what review established
+
+Preserving the error revives `TPPAlertUtils`, `PalaceError`,
+`TPPSignInBusinessLogic` and `PalaceAuth.AuthReducer`. Independently traced:
+all message-only, no sign-out, and `DownloadErrorRecovery`'s retry policies are
+bounded (3 attempts / 25–120s), so no retry storm.
+
+It does NOT reach borrow/return/loans-sync: `TPPOPDSFeed+Networking.swift:113`
+erases the transport error into `problemDocument?.dictionaryValue` (nil when
+offline), so `BookReturnService.isOfflineNSURLError` and the OPDS-side
+consumers stay dead. That is a SECOND erasure chokepoint of the same shape as
+this ticket's, and it is worth its own ticket.
 
 ## Files in scope
 

--- a/.forgeos/intent/pp-4987-offline-writes-never-queued.md
+++ b/.forgeos/intent/pp-4987-offline-writes-never-queued.md
@@ -36,10 +36,12 @@
   filed 902 flatly. It now passes the underlying error, which routes through
   `customSummaryAndCode` and re-codes `notConnectedToInternet` / `timedOut` /
   `connectionLost` to `.clientSideTransientError`. So 902 falls for un-queued
-  transients too, independently of queueing — and separately, a non-2xx with a
-  problem-document body is reported TWICE (once by `parseAndLogError` as
-  `.problemDocAvailable`, once by the annotation caller as 902). Group the
-  re-measurement by `metadata.statusCode` rather than reading the total.
+  transients too, independently of queueing. There is also a double-report, but
+  NOT the one first recorded here: `parseAndLogError` early-returns without
+  logging for a first-attempt non-401 problem document, so `.problemDocAvailable`
+  is mostly not it — the real double-reports are `.parseProblemDocFail` (913) on
+  an unparseable body, and failed retries. Group the re-measurement by
+  `metadata.statusCode` rather than reading the total.
 
 - **It does not predict the 914 bucket.** Expect 914 to COLLAPSE app-wide:
   transport failures that were filed under it now carry their real NSURLError
@@ -70,8 +72,11 @@ queue ON rather than about the fix itself:
 - **The credential was about to reach disk.** Callers build headers from
   `TPPNetworkExecutor.request(for:)`, whose `useTokenIfAvailable` defaults to
   TRUE, so `Authorization: Bearer …` was archived into the unencrypted
-  `simplified.db`. Never executed before, because nothing was ever queued —
-  this ticket is what would have started it. Now stripped at enqueue
+  `simplified.db`. Dormant on current builds because nothing was being queued,
+  but NOT hypothetical: up to Release 1.1.0 `postAnnotation` used
+  `URLSession.shared` directly, so the raw NSURLError reached the gate and rows
+  really were written — carrying `Basic base64(barcode:PIN)`, a patron's card
+  number and PIN. `migrate()` now purges those. Now stripped at enqueue
   (`headersSafeToPersist`) and re-derived at drain from the CURRENT credential,
   which also stops a days-old row replaying an expired token.
 
@@ -123,10 +128,42 @@ passed only because that suite's executor happens to hold no token on a clean
 runner — it went red the moment a sibling test left one behind. Both are now
 asserted against the persisted row via `persistedRowsForTesting()`.
 
-No legacy rows can carry a stored credential: nothing was ever queued before
-this ticket (`willQueueOffline` could not be true), and the only other entry
-point, `enqueueOfflineRequest`, has no production caller. So no migration is
-needed to purge them.
+CORRECTED: I originally argued no legacy rows could carry a stored credential,
+because `willQueueOffline` could never be true. That was wrong, and review
+proved it from the git history — up to Release 1.1.0 `postAnnotation` bypassed
+the responder entirely via `URLSession.shared`, so the raw NSURLError reached
+the gate and rows WERE queued, with `Basic base64(barcode:PIN)` headers.
+Expired rows are deleted after `MaxRetriesInQueue` drains, so most are long
+gone, but "most" is not a basis for leaving a cleartext PIN on a device.
+`migrate()` now purges unconditionally, and the purge is tested.
+
+The lesson is the branch's recurring one: an argument from reading is not
+evidence. Every claim on this branch that rested on inspection rather than
+assertion — the status code reaching telemetry, the strip being wired in, the
+credential being attached at drain — turned out to be false.
+
+## Delivery hazards this creates, for the drain-side follow-up
+
+Both are strictly better than the status quo (total loss), neither blocks, both
+would confound the PP-4965 re-measurement if unrecorded:
+
+- **Stale-position overwrite.** A queued position replays with no client
+  timestamp. If a fresher live position lands before the drain completes, the
+  older queued one wins on the server and cross-device sync propagates the
+  regression.
+- **Duplicate bookmark delivery.** A queued audiobook bookmark leaves the local
+  copy with `annotationId == nil`, so the sync path re-posts it while the queue
+  also delivers it — two server copies unless the CM dedupes by selector.
+- **Retry budget on supersede** — FIXED here (`sqlRetries <- 0` on update), but
+  worth naming: without it a fresh position landing on an exhausted row was
+  deleted before ever being sent.
+
+## Follow-up owed
+
+`TPPAnnotations` now carries seven `nonisolated(unsafe) static` overrides. Each
+is justified and torn down, but the honest fix is instance-ification behind the
+`AnnotationsManager` protocol that already exists in that file — not another
+seam. That is a separate branch; this one should not grow an eighth.
 
 ## Files in scope
 

--- a/.forgeos/intent/pp-4987-offline-writes-never-queued.md
+++ b/.forgeos/intent/pp-4987-offline-writes-never-queued.md
@@ -170,5 +170,22 @@ seam. That is a separate branch; this one should not grow an eighth.
 - `Palace/Network/TPPNetworkResponder.swift`
 - `Palace/Network/TPPNetworkQueue.swift`
 - `Palace/Logging/TPPErrorLogger.swift`
+- `Palace/AppInfrastructure/AppContainer.swift` — binds the drain credential
+  provider at the composition root
+- `Palace/Reader2/Bookmarks/TPPAnnotations.swift` — queue key + queue seam
 - `PalaceTests/Network/NetworkQueueTests.swift`
 - `PalaceTests/Sync/CrossDeviceSyncE2ETests.swift`
+- `PalaceTests/Bookmarks/TPPAnnotationsTests.swift`
+- `PalaceTests/Mocks/OfflineQueueSpy.swift`
+- `PalaceTests/Support/TestAppContainerFactory.swift`
+- `Palace.xcodeproj/project.pbxproj` — test-target membership for the new mock
+
+## Where the test-support surface actually is
+
+`NetworkQueue`'s seams (`PersistedRow`, `persistedRowsForTesting`,
+`insertLegacyRowForTesting`) are behind `#if DEBUG` and verified absent from
+all three Release configurations. `TPPAnnotations`' two new overrides
+(`offlineQueueOverride`, `errorLoggerOverride`) are NOT gated — they match the
+four pre-existing ungated seams in that file, and gating only the new two would
+be inconsistent. An earlier commit body said "test-support surface is behind
+`#if DEBUG`" without that distinction; this is the correction.

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1218,6 +1218,7 @@
 		C4F88ED5F0206FAAF93DB27C /* TPPProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48AE22D7C0BC6134885E9F0 /* TPPProcessInfo.swift */; };
 		C531257675C18C6172A0407F /* PalaceAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 8DCCC85CA03C7D26E1E0F5F6 /* PalaceAuth */; };
 		C54572940A4584060C2DC457 /* ReaderThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D0C6025D50993E6431BDC /* ReaderThemeTests.swift */; };
+		C59B65305A9E90AC834CE935 /* ErrorLoggerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2305AD1F6E553DD37EC738C /* ErrorLoggerSpy.swift */; };
 		C5A5323E33AA18B96398BA53 /* RuntimeQuiescenceGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CAE584B769CF73DD2B3740 /* RuntimeQuiescenceGateTests.swift */; };
 		C5B6C7D8E9F0A1B2C3D4E5F6 /* DownloadStartCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B5C6D7E8F9A0B1C2D3E4F5 /* DownloadStartCoordinatorTests.swift */; };
 		C5EECC48E4D821DA5AC9EFB2 /* BundledRegistrySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E0A5661D94D658E8CDD19F /* BundledRegistrySnapshot.swift */; };
@@ -2929,6 +2930,7 @@
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* DownloadCancellationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadCancellationHandler.swift; sourceTree = "<group>"; };
 		A1C9CA13B5B94707BFFCB13F /* ViewModelComputedPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelComputedPropertyTests.swift; sourceTree = "<group>"; };
 		A22586E379F04E1E9348FAAB /* DownloadErrorInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadErrorInfoTests.swift; sourceTree = "<group>"; };
+		A2305AD1F6E553DD37EC738C /* ErrorLoggerSpy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorLoggerSpy.swift; sourceTree = "<group>"; };
 		A256A501E6AB55F352D674FE /* AccessibilityPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferencesTests.swift; sourceTree = "<group>"; };
 		A2A352697B589358F91035A1 /* MockVisualNavigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockVisualNavigator.swift; path = PalaceTests/Mocks/MockVisualNavigator.swift; sourceTree = "<group>"; };
 		A2D3DF8C6B67DD384F77371C /* BookDetailMetadataMergeContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookDetailMetadataMergeContractTests.swift; sourceTree = "<group>"; };
@@ -4632,6 +4634,7 @@
 				67F5D16D05D30ED704974758 /* SpyAuthCoordinator.swift */,
 				794351D0F625F9610414FA23 /* SpyAudiobookSessionPresenter.swift */,
 				122AFD9575652073A29BA7A7 /* SpyAudiobookNetworkExecutor.swift */,
+				A2305AD1F6E553DD37EC738C /* ErrorLoggerSpy.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -8140,6 +8143,7 @@
 				EC4E7A2AFBA08406B8C4A2E7 /* DownloadAuthChallengeWitnessTests.swift in Sources */,
 				B31E6C5D8F5609362A959604 /* NetworkResponderAuthChallengeWitnessTests.swift in Sources */,
 				54C66464D4C46A1EEA71944B /* BackgroundDownloadTokenAccountTests.swift in Sources */,
+				C59B65305A9E90AC834CE935 /* ErrorLoggerSpy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		2A8E9830CB9BD5599EC4B021 /* TPPSignInBusinessLogicCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333733730937345770AF9416 /* TPPSignInBusinessLogicCharacterizationTests.swift */; };
 		2B7EC298A55FA3351E113B6B /* PerformanceReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D80DA377151AE41BEF67F7 /* PerformanceReport.swift */; };
 		2B820846966DE6DDDBD29DCB /* AccessibilitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E518F27E3FF9A05071B82305 /* AccessibilitySettingsView.swift */; };
+		2BA9E030AFCB66EF2814A618 /* OfflineQueueSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB58E552196CC964A263DA6 /* OfflineQueueSpy.swift */; };
 		2BDAFD30C68E1D2245E84285 /* AudiobookOpenStateRaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834376530042364D30BA01FD /* AudiobookOpenStateRaceTests.swift */; };
 		2BEF8AC75AE50395F092751A /* FuzzRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD7CCC67838590BD9E203D /* FuzzRunner.swift */; };
 		2C6459D91A5439B946473EF6 /* OfflineQueueServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480CFCD095E5C455D1CFA499 /* OfflineQueueServiceTests.swift */; };
@@ -3126,6 +3127,7 @@
 		CB91C36D9DC90CDAC98FA568 /* TPPSettingsAuthBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TPPSettingsAuthBridge.swift; sourceTree = "<group>"; };
 		CB9CA89B135C85E23F0D907B /* MyBooksViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyBooksViewModelTests.swift; sourceTree = "<group>"; };
 		CBA39820CBA75D6BA9B763E2 /* CatalogRepositoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatalogRepositoryTests.swift; sourceTree = "<group>"; };
+		CBB58E552196CC964A263DA6 /* OfflineQueueSpy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OfflineQueueSpy.swift; sourceTree = "<group>"; };
 		CBBDD4C17EA45C71D8076A34 /* PerformanceMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMetric.swift; sourceTree = "<group>"; };
 		CC1DC02848D158E774C79F0A /* BackgroundReconciliationContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundReconciliationContractTests.swift; sourceTree = "<group>"; };
 		CC1F0281468BF6D1F7112951 /* StreamingReaderViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingReaderViewModelTests.swift; sourceTree = "<group>"; };
@@ -4635,6 +4637,7 @@
 				794351D0F625F9610414FA23 /* SpyAudiobookSessionPresenter.swift */,
 				122AFD9575652073A29BA7A7 /* SpyAudiobookNetworkExecutor.swift */,
 				A2305AD1F6E553DD37EC738C /* ErrorLoggerSpy.swift */,
+				CBB58E552196CC964A263DA6 /* OfflineQueueSpy.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -8144,6 +8147,7 @@
 				B31E6C5D8F5609362A959604 /* NetworkResponderAuthChallengeWitnessTests.swift in Sources */,
 				54C66464D4C46A1EEA71944B /* BackgroundDownloadTokenAccountTests.swift in Sources */,
 				C59B65305A9E90AC834CE935 /* ErrorLoggerSpy.swift in Sources */,
+				2BA9E030AFCB66EF2814A618 /* OfflineQueueSpy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Palace/AppInfrastructure/AppContainer.swift
+++ b/Palace/AppInfrastructure/AppContainer.swift
@@ -732,7 +732,19 @@ struct AppContainer: @unchecked Sendable {
         return AppContainer(
             bookRegistry: bookRegistry,
             networkExecutor: executor,
-            networkQueue: NetworkQueue(transport: executor.transport, reachability: reachability),
+            // Bind the drain-time credential provider HERE, where
+            // `accountsManager` is already in scope — the default closure would
+            // otherwise re-enter `AppContainer.production()` from the queue's
+            // serial queue at drain time. Same reasoning as the featureFlags
+            // note below: the composition root is the binding site.
+            networkQueue: NetworkQueue(
+                transport: executor.transport,
+                reachability: reachability,
+                authorizationHeaderProvider: { [accountsManager] libraryID in
+                    accountsManager.userAccount(for: libraryID)
+                        .credentialSnapshot().authToken.map { "Bearer \($0)" }
+                }
+            ),
             reachability: reachability,
             accountsManager: accountsManager,
             settings: TPPSettings(),

--- a/Palace/Logging/ErrorLogging.swift
+++ b/Palace/Logging/ErrorLogging.swift
@@ -15,9 +15,15 @@ import Foundation
 /// instead of sending them to Crashlytics.
 ///
 /// Because `TPPErrorLogger` uses class (static) methods, this protocol uses
-/// instance methods. The `AppContainer` holds a concrete instance conforming
-/// to this protocol. The default implementation (`DefaultErrorLogger`) simply
-/// forwards to the existing static methods on `TPPErrorLogger`.
+/// instance methods. The default implementation (`DefaultErrorLogger`) simply
+/// forwards to those static methods.
+///
+/// Note this is NOT held by `AppContainer` — that was the original intent and
+/// the doc said so, but no such wiring was ever added (verified: zero
+/// `ErrorLogging` references there). Consumers today are static-class APIs
+/// that cannot take constructor injection, so each holds its own shared
+/// instance behind a test seam; see `TPPAnnotations.errorLoggerOverride`. If a
+/// container-held instance is ever added, prefer it and retire the seams.
 protocol ErrorLogging: AnyObject {
 
     /// Reports an error with an optional originating error and metadata.

--- a/Palace/Logging/ErrorLogging.swift
+++ b/Palace/Logging/ErrorLogging.swift
@@ -38,7 +38,12 @@ protocol ErrorLogging: AnyObject {
 // MARK: - Default Implementation
 
 /// Default implementation that forwards to `TPPErrorLogger`'s static methods.
-final class DefaultErrorLogger: ErrorLogging {
+///
+/// `Sendable` because it holds no state — every method forwards straight to a
+/// static. That lets callers hold a single shared instance instead of either
+/// allocating one per report or reaching for `nonisolated(unsafe)`; the
+/// compiler checks the claim rather than us asserting it.
+final class DefaultErrorLogger: ErrorLogging, Sendable {
 
     func logError(_ error: Error?, summary: String, metadata: [String: Any]?) {
         TPPErrorLogger.logError(error, summary: summary, metadata: metadata)

--- a/Palace/Logging/TPPErrorLogger.swift
+++ b/Palace/Logging/TPPErrorLogger.swift
@@ -210,6 +210,13 @@ private let nullString = "null"
     /// (PP-4769, crash 898c0776 — `__DataStorage.init` OOM under memory
     /// pressure). The task is cancelled and its completion fails cleanly.
     case responseTooLarge = 915
+    /// A write handed to the offline retry queue was NOT persisted — the
+    /// database connection was unavailable, or the insert threw. Reported
+    /// because `TPPAnnotations` deliberately stops reporting a write once it
+    /// is queued (PP-4965); if the queue then drops it, the loss would be
+    /// completely silent. Queueing only earns that silence if it actually
+    /// took the write (PP-4987).
+    case offlineQueueWriteFailed = 916
 
     // DRM
     case epubDecodingError = 1000

--- a/Palace/Network/TPPNetworkQueue.swift
+++ b/Palace/Network/TPPNetworkQueue.swift
@@ -54,8 +54,11 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
     ///  1. Secrets at rest. `simplified.db` is an unencrypted SQLite file in
     ///     Application Support. Archiving `Authorization: Bearer …` into it
     ///     writes a live credential to disk in the clear. Until PP-4987 this
-    ///     never executed, because nothing was ever queued — turning the queue
-    ///     on is precisely what would have started it.
+    ///     dormant on CURRENT builds because nothing was being queued — but it
+    ///     DID run historically: up to Release 1.1.0 `postAnnotation` used
+    ///     `URLSession.shared` directly, so the raw NSURLError reached the gate
+    ///     and rows were written carrying `Basic base64(barcode:PIN)`. See
+    ///     `purgeAnyPersistedCredentials`, which cleans those off devices.
     ///  2. Correctness. A write can sit in this queue for days. The token it
     ///     was created with may have expired, been refreshed, or belong to an
     ///     account the patron has since signed out of. Replaying a stored
@@ -150,6 +153,43 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
         headers.filter { $0.key.caseInsensitiveCompare("Authorization") != .orderedSame }
     }
 
+    /// Drops any `Authorization` header left in the store by an older build.
+    ///
+    /// This is NOT hypothetical. Up to and including Release 1.1.0,
+    /// `postAnnotation` issued its request through `URLSession.shared`
+    /// directly, so the raw `NSURLError` reached `NetworkQueue.StatusCodes` and
+    /// offline writes really were queued — with headers of the form
+    /// `Authorization: Basic base64(barcode:PIN)`. That is a patron's library
+    /// card number and PIN, base64 is not encryption, and `simplified.db` is an
+    /// unencrypted file in Application Support. Rows created then can still be
+    /// sitting on a device today.
+    ///
+    /// Expired rows do get deleted after `MaxRetriesInQueue` drains, so most
+    /// are long gone — but "most" is not a basis on which to leave a cleartext
+    /// PIN on disk, and re-deriving the credential at drain means nothing is
+    /// lost by clearing it. Runs on every `migrate()` rather than as a
+    /// versioned step so it also catches a store whose version was already
+    /// current when this shipped.
+    private func purgeAnyPersistedCredentials(_ db: Connection) {
+        do {
+            let rows = try db.prepare(sqlTable)
+            for row in rows {
+                guard let data = row[sqlHeader],
+                      let headers = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: String],
+                      headers.keys.contains(where: {
+                          $0.caseInsensitiveCompare("Authorization") == .orderedSame
+                      }) else { continue }
+                let cleaned = NSKeyedArchiver.archivedData(
+                    withRootObject: NetworkQueue.headersSafeToPersist(headers))
+                try db.run(sqlTable.filter(sqlID == row[sqlID]).update(sqlHeader <- cleaned))
+                Log.info(#file, "Purged a persisted credential from a legacy offline-queue row")
+            }
+        } catch {
+            Log.error(#file, "Failed to purge persisted credentials from the offline queue")
+        }
+    }
+
+#if DEBUG
     /// What is ACTUALLY on disk, for tests.
     ///
     /// Deliberate test-support surface, and the justification is specific: the
@@ -166,8 +206,14 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
         let updateID: String?
         let url: String
         let headers: [String: String]?
+        /// The POSTed body. Without it, "one row survived a collapse" is
+        /// indistinguishable from "the second write was silently dropped" —
+        /// which is the whole property under test.
+        let parameters: Data?
+        let retries: Int
     }
 
+    /// NOTE: takes `serialQueue.sync` — never call it from inside that queue.
     func persistedRowsForTesting() -> [PersistedRow] {
         serialQueue.sync {
             guard let db = startDatabaseConnection() else { return [] }
@@ -182,10 +228,41 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
                 return PersistedRow(libraryID: row[sqlLibraryID],
                                     updateID: row[sqlUpdateID],
                                     url: row[sqlUrl],
-                                    headers: headers)
+                                    headers: headers,
+                                    parameters: row[sqlParameters],
+                                    retries: Int(row[sqlRetries]))
             }
         }
     }
+
+    /// Writes a row the way a PRE-PP-4987 build did — credential and all.
+    ///
+    /// `addRequest` now strips `Authorization`, so a legacy row cannot be
+    /// created through the normal API, and the purge that exists to clean those
+    /// rows off real devices would be untestable without this. That purge
+    /// guards a cleartext library card number and PIN; shipping it unverified
+    /// is not an option, and every other claim on this branch that rested on
+    /// reading rather than asserting turned out to be wrong.
+    func insertLegacyRowForTesting(libraryID: String,
+                                   updateID: String,
+                                   url: URL,
+                                   headers: [String: String]) {
+        serialQueue.sync {
+            guard let db = startDatabaseConnection() else { return }
+            let headerData = NSKeyedArchiver.archivedData(withRootObject: headers)
+            let dateCreated = NSKeyedArchiver.archivedData(withRootObject: Date())
+            _ = try? db.run(sqlTable.insert(
+                sqlLibraryID <- libraryID,
+                sqlUpdateID <- updateID,
+                sqlUrl <- url.absoluteString,
+                sqlMethod <- HTTPMethodType.POST.rawValue,
+                sqlParameters <- Data("{}".utf8),
+                sqlHeader <- headerData,
+                sqlRetries <- 0,
+                sqlDateCreated <- dateCreated))
+        }
+    }
+#endif
 
     func addRequest(_ libraryID: String,
                     _ updateID: String?,
@@ -237,7 +314,17 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
 
             do {
                 // Try to update row
-                let result = try db.run(query.update(self.sqlParameters <- parameters, self.sqlHeader <- headerData))
+                // Reset `retries` (PP-4987). This row is being SUPERSEDED — the
+                // body is new even though the key is the same. Without the
+                // reset the new write inherits the old one's retry count, and
+                // because `retryQueue` deletes `retries > MaxRetriesInQueue`
+                // BEFORE it drains, a fresh reading position landing on an
+                // exhausted row is deleted having never been sent once. That is
+                // silent loss, and PP-4965 has already removed the error report
+                // for this path — so nothing would have said so.
+                let result = try db.run(query.update(self.sqlParameters <- parameters,
+                                                     self.sqlHeader <- headerData,
+                                                     self.sqlRetries <- 0))
                 if result > 0 {
                     Log.debug(#file, "SQLite: Row Updated")
                 } else {
@@ -278,6 +365,8 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
                 Log.error(#file, "Failed to start database connection for a retry attempt.")
                 return
             }
+
+            self.purgeAnyPersistedCredentials(db)
 
             let tableCount = Int((try? db.scalar("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = '\(NetworkQueue.TableName)'") as? Int64) ?? 0)
             if tableCount < 1 {
@@ -329,7 +418,12 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
         }
     }
 
-    @objc private func retryQueue() {
+    /// Not `private`: the drain is normally kicked by a reachability publisher,
+    /// and its behaviour (credential scoping, expiry, retry accounting) is
+    /// exactly the part of this type with the least coverage and the most risk.
+    /// Tests drive it directly rather than through `perform(Selector(…))`,
+    /// which compiles to nothing checkable and breaks silently on a rename.
+    @objc func retryQueue() {
         self.serialQueue.async {
 
             if self.retryRequestCount > 0 {

--- a/Palace/Network/TPPNetworkQueue.swift
+++ b/Palace/Network/TPPNetworkQueue.swift
@@ -46,15 +46,37 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
     /// removing.
     private let errorLogger: ErrorLogging
 
+    /// Supplies the `Authorization` header value at DRAIN time.
+    ///
+    /// Queued rows deliberately do NOT store the one they were created with.
+    /// Two reasons, and the second is why this exists at all:
+    ///
+    ///  1. Secrets at rest. `simplified.db` is an unencrypted SQLite file in
+    ///     Application Support. Archiving `Authorization: Bearer …` into it
+    ///     writes a live credential to disk in the clear. Until PP-4987 this
+    ///     never executed, because nothing was ever queued — turning the queue
+    ///     on is precisely what would have started it.
+    ///  2. Correctness. A write can sit in this queue for days. The token it
+    ///     was created with may have expired, been refreshed, or belong to an
+    ///     account the patron has since signed out of. Replaying a stored
+    ///     header retries with a stale credential; re-deriving at drain uses
+    ///     whatever is valid NOW, or nothing.
+    private let authorizationHeaderProvider: @Sendable () -> String?
+
     init(transport: NetworkTransport,
          reachability: Reachability,
          databaseDirectory: String = NSSearchPathForDirectoriesInDomains(
             .applicationSupportDirectory, .userDomainMask, true).first ?? NSTemporaryDirectory(),
-         errorLogger: ErrorLogging = DefaultErrorLogger()) {
+         errorLogger: ErrorLogging = DefaultErrorLogger(),
+         authorizationHeaderProvider: @escaping @Sendable () -> String? = {
+            AppContainer.production().accountsManager.currentUserAccount
+                .credentialSnapshot().authToken.map { "Bearer \($0)" }
+         }) {
         self.path = databaseDirectory
         self.transport = transport
         self.reachability = reachability
         self.errorLogger = errorLogger
+        self.authorizationHeaderProvider = authorizationHeaderProvider
         super.init()
     }
 
@@ -106,6 +128,16 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
             .store(in: &cancellables)
     }
 
+    /// Strips credentials from a header set before it is written to disk.
+    ///
+    /// Internal rather than private so the guarantee is directly assertable —
+    /// "the credential never reaches `simplified.db`" is a security property,
+    /// and proving it by reading the code is not proving it. Matched
+    /// case-insensitively because HTTP header names are.
+    static func headersSafeToPersist(_ headers: [String: String]) -> [String: String] {
+        headers.filter { $0.key.caseInsensitiveCompare("Authorization") != .orderedSame }
+    }
+
     func addRequest(_ libraryID: String,
                     _ updateID: String?,
                     _ requestUrl: URL,
@@ -121,7 +153,15 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
 
             let headerData: Data?
             if let headers = headers {
-                headerData = NSKeyedArchiver.archivedData(withRootObject: headers)
+                // NEVER persist the credential (PP-4987). `simplified.db` is an
+                // unencrypted file in Application Support, and callers build
+                // their headers from `TPPNetworkExecutor.request(for:)`, whose
+                // `useTokenIfAvailable` defaults to TRUE — so `Authorization:
+                // Bearer …` is present unless it is removed here. It is
+                // re-derived at drain time from whatever credential is current.
+                // Matched case-insensitively because HTTP header names are.
+                headerData = NSKeyedArchiver.archivedData(
+                    withRootObject: NetworkQueue.headersSafeToPersist(headers))
             } else {
                 headerData = nil
             }
@@ -161,8 +201,18 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
                 // PP-4987: as above — a local Log.error is invisible in
                 // production telemetry, and the caller believes this write is
                 // safely pending.
-                self.errorLogger.logError(error,
+                // `logNetworkError(_:code:…)`, NOT the bare `logError(_:summary:
+                // metadata:)` overload — that one hardcodes `code: .ignore`,
+                // which would file this under the raw bridged SQLite code with
+                // `error_origin = unknown` instead of 916. Round 1 of review
+                // blocked this branch for exactly that substitution in
+                // `TPPAnnotations`; it was reintroduced here in new code and
+                // caught by all three reviewers in round 3.
+                self.errorLogger.logNetworkError(error,
+                                          code: .offlineQueueWriteFailed,
                                           summary: "Offline queue write dropped",
+                                          request: nil,
+                                          response: nil,
                                         metadata: [
                                             "reason": "insert or update threw",
                                             "libraryID": libraryID,
@@ -286,6 +336,16 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
             for (headerKey, headerValue) in headers {
                 urlRequest.setValue(headerValue, forHTTPHeaderField: headerKey)
             }
+        }
+
+        // Attach the CURRENT credential, not the one this row was created with
+        // (PP-4987). Rows carry no `Authorization` by design — see
+        // `authorizationHeaderProvider`. A row can be days old, so the token it
+        // was queued with may be expired or belong to a signed-out account;
+        // this uses whatever is valid now, or sends none and lets the server
+        // refuse (which is the correct outcome for a signed-out patron).
+        if let authorization = authorizationHeaderProvider() {
+            urlRequest.setValue(authorization, forHTTPHeaderField: "Authorization")
         }
 
         let task = transport.urlSession.dataTask(with: urlRequest) { (_, response, _) in

--- a/Palace/Network/TPPNetworkQueue.swift
+++ b/Palace/Network/TPPNetworkQueue.swift
@@ -39,9 +39,22 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
     private let transport: NetworkTransport
     private let reachability: Reachability
 
-    init(transport: NetworkTransport, reachability: Reachability) {
+    /// Constructor-injected rather than reaching for a static: the drop-report
+    /// guarantee below has to be observable, and this type is already being
+    /// handed its collaborators. Deliberately NOT another `nonisolated(unsafe)
+    /// static var` override — those are what the decomposition campaign is
+    /// removing.
+    private let errorLogger: ErrorLogging
+
+    init(transport: NetworkTransport,
+         reachability: Reachability,
+         databaseDirectory: String = NSSearchPathForDirectoriesInDomains(
+            .applicationSupportDirectory, .userDomainMask, true).first ?? NSTemporaryDirectory(),
+         errorLogger: ErrorLogging = DefaultErrorLogger()) {
+        self.path = databaseDirectory
         self.transport = transport
         self.reachability = reachability
+        self.errorLogger = errorLogger
         super.init()
     }
 
@@ -64,7 +77,13 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
     private static let TableName = "offline_queue"
 
     private var retryRequestCount = 0
-    private let path = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first ?? NSTemporaryDirectory()
+    /// Where `simplified.db` lives. Injectable ONLY so the drop paths can be
+    /// tested: PP-4987 makes a failed enqueue report to Crashlytics instead of
+    /// vanishing, and that guarantee is worthless unless something proves it
+    /// fires. Pointing this at an unwritable location is the only way to make
+    /// `startDatabaseConnection()` return nil deterministically. Production
+    /// callers use the default and are unaffected.
+    private let path: String
 
     private let sqlTable = Table(NetworkQueue.TableName)
 
@@ -107,7 +126,21 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
                 headerData = nil
             }
 
-            guard let db = self.startDatabaseConnection() else { return }
+            guard let db = self.startDatabaseConnection() else {
+                // PP-4987: never drop a queued write in silence. The caller has
+                // already been told "queued for retry" and has stopped
+                // reporting on that basis, so this is the last place the loss
+                // can still be seen.
+                self.errorLogger.logError(withCode: .offlineQueueWriteFailed,
+                                          summary: "Offline queue write dropped",
+                                        metadata: [
+                                            "reason": "no database connection",
+                                            "libraryID": libraryID,
+                                            "url": urlString,
+                                            "method": methodString
+                                        ])
+                return
+            }
 
             // Update (not insert) if uniqueID and libraryID match existing row in table
             let query = self.sqlTable.filter(self.sqlLibraryID == libraryID && self.sqlUpdateID == updateID)
@@ -125,6 +158,17 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
                 }
             } catch {
                 Log.error(#file, "SQLite Error: Could not insert or update row")
+                // PP-4987: as above — a local Log.error is invisible in
+                // production telemetry, and the caller believes this write is
+                // safely pending.
+                self.errorLogger.logError(error,
+                                          summary: "Offline queue write dropped",
+                                        metadata: [
+                                            "reason": "insert or update threw",
+                                            "libraryID": libraryID,
+                                            "url": urlString,
+                                            "method": methodString
+                                        ])
             }
         }
     }

--- a/Palace/Network/TPPNetworkQueue.swift
+++ b/Palace/Network/TPPNetworkQueue.swift
@@ -61,15 +61,27 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
     ///     account the patron has since signed out of. Replaying a stored
     ///     header retries with a stale credential; re-deriving at drain uses
     ///     whatever is valid NOW, or nothing.
-    private let authorizationHeaderProvider: @Sendable () -> String?
+    ///
+    /// Takes the ROW'S library, never the currently-selected one. `retryQueue`
+    /// drains every row regardless of library, and each row's URL is its own
+    /// library's annotation host — so resolving `currentUserAccount` here would
+    /// send library B's bearer token to library A's server whenever a patron
+    /// queued a write for A and then switched to B. That is a cross-tenant
+    /// credential disclosure, and it also 401s a write that had a perfectly
+    /// good token in the keychain. `TPPNetworkExecutor.request(for:accountId:)`
+    /// exists for precisely this reason — see its "prevent TOCTOU races during
+    /// account switches … causing cross-account credential leaks" note. Here
+    /// the window is not a race; it is days.
+    private let authorizationHeaderProvider: @Sendable (String) -> String?
 
     init(transport: NetworkTransport,
          reachability: Reachability,
          databaseDirectory: String = NSSearchPathForDirectoriesInDomains(
             .applicationSupportDirectory, .userDomainMask, true).first ?? NSTemporaryDirectory(),
          errorLogger: ErrorLogging = DefaultErrorLogger(),
-         authorizationHeaderProvider: @escaping @Sendable () -> String? = {
-            AppContainer.production().accountsManager.currentUserAccount
+         authorizationHeaderProvider: @escaping @Sendable (String) -> String? = { libraryID in
+            AppContainer.production().accountsManager
+                .userAccount(for: libraryID)
                 .credentialSnapshot().authToken.map { "Bearer \($0)" }
          }) {
         self.path = databaseDirectory
@@ -136,6 +148,43 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
     /// case-insensitively because HTTP header names are.
     static func headersSafeToPersist(_ headers: [String: String]) -> [String: String] {
         headers.filter { $0.key.caseInsensitiveCompare("Authorization") != .orderedSame }
+    }
+
+    /// What is ACTUALLY on disk, for tests.
+    ///
+    /// Deliberate test-support surface, and the justification is specific: the
+    /// guarantees this type now makes are about PERSISTED BYTES — "the
+    /// credential never reaches the database", "two bookmarks do not collapse
+    /// into one row". Asserting those against a helper, or against a spy that
+    /// stands in front of the database, proves nothing about what was stored;
+    /// round 4 of review caught exactly that mistake here. The alternative —
+    /// re-declaring the schema inside the test target — would drift from this
+    /// file the first time a column changed, which is the same failure wearing
+    /// a different hat.
+    struct PersistedRow {
+        let libraryID: String
+        let updateID: String?
+        let url: String
+        let headers: [String: String]?
+    }
+
+    func persistedRowsForTesting() -> [PersistedRow] {
+        serialQueue.sync {
+            guard let db = startDatabaseConnection() else { return [] }
+            guard let rows = try? db.prepare(sqlTable) else { return [] }
+            return rows.map { row in
+                let headers: [String: String]?
+                if let data = row[sqlHeader] {
+                    headers = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: String]
+                } else {
+                    headers = nil
+                }
+                return PersistedRow(libraryID: row[sqlLibraryID],
+                                    updateID: row[sqlUpdateID],
+                                    url: row[sqlUrl],
+                                    headers: headers)
+            }
+        }
     }
 
     func addRequest(_ libraryID: String,
@@ -338,13 +387,14 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
             }
         }
 
-        // Attach the CURRENT credential, not the one this row was created with
-        // (PP-4987). Rows carry no `Authorization` by design — see
+        // Attach the credential current for THIS ROW'S LIBRARY (PP-4987).
+        // Rows carry no `Authorization` by design — see
         // `authorizationHeaderProvider`. A row can be days old, so the token it
         // was queued with may be expired or belong to a signed-out account;
-        // this uses whatever is valid now, or sends none and lets the server
-        // refuse (which is the correct outcome for a signed-out patron).
-        if let authorization = authorizationHeaderProvider() {
+        // this uses whatever is valid now for that library, or sends none and
+        // lets the server refuse (correct for a signed-out patron). Keyed on
+        // the row's library, never the selected one — see the provider's doc.
+        if let authorization = authorizationHeaderProvider(requestRow[sqlLibraryID]) {
             urlRequest.setValue(authorization, forHTTPHeaderField: "Authorization")
         }
 

--- a/Palace/Network/TPPNetworkQueue.swift
+++ b/Palace/Network/TPPNetworkQueue.swift
@@ -177,22 +177,28 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
         do {
             let rows = try db.prepare(sqlTable)
             for row in rows {
-                // `unarchivedObject(ofClasses:from:)` rather than the legacy
-                // `unarchiveObject(with:)`: it opts into secure coding and
-                // states the classes we expect, and it signals failure by
-                // throwing rather than by any documented exception behaviour.
+                // `unarchivedObject(ofClasses:from:)`, NEVER the legacy
+                // `unarchiveObject(with:)`. The legacy call raises
+                // `NSArchiverArchiveInconsistency` /
+                // `NSInvalidUnarchiveOperationException` on a corrupt archive,
+                // which is uncatchable from Swift — `try?` does not help.
                 //
-                // HONESTY NOTE: review flagged the legacy API as RAISING an
-                // uncatchable ObjC exception on a malformed archive, which —
-                // since this purge runs on the launch path via SEMigrations —
-                // would make one corrupt row a launch crash. I could not
-                // reproduce that: both garbage bytes and a truncated valid
-                // archive returned nil rather than raising. So this is
-                // defence-in-depth and modern-API hygiene, NOT a demonstrated
-                // crash fix, and it is written down that way rather than
-                // claiming a fix I did not verify. The rows read here were
-                // written by builds up to five years old, so tolerating an
-                // unreadable blob is worth having either way.
+                // Measured, not assumed. Bit-flipping each byte of a valid
+                // 277-byte header archive in turn:
+                //
+                //     legacy  unarchiveObject(with:)      63 of 277 ABORT the
+                //                                         process (first at
+                //                                         byte 81)
+                //     modern  unarchivedObject(ofClasses:) 0 of 277 abort
+                //
+                // On-disk corruption is bit-level, which is exactly the shape
+                // that kills the legacy call — garbage bytes and truncated
+                // archives both return nil, so a casual probe finds nothing.
+                // An earlier revision of this comment said the crash could not
+                // be reproduced and called the swap mere hygiene; that was a
+                // weak-probe artifact and it was wrong. This is a real crash
+                // fix on the launch path (the purge runs via SEMigrations) and
+                // on the drain path (`retry()`), and both reads are converted.
                 guard let data = row[sqlHeader],
                       let headers = try? NSKeyedUnarchiver.unarchivedObject(
                         ofClasses: [NSDictionary.self, NSString.self], from: data
@@ -242,7 +248,9 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
             return rows.map { row in
                 let headers: [String: String]?
                 if let data = row[sqlHeader] {
-                    headers = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: String]
+                    headers = try? NSKeyedUnarchiver.unarchivedObject(
+                        ofClasses: [NSDictionary.self, NSString.self], from: data
+                    ) as? [String: String]
                 } else {
                     headers = nil
                 }
@@ -505,7 +513,9 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
         urlRequest.applyCustomUserAgent()
 
         if let headerData = requestRow[sqlHeader],
-           let headers = NSKeyedUnarchiver.unarchiveObject(with: headerData) as? [String: String] {
+           let headers = (try? NSKeyedUnarchiver.unarchivedObject(
+              ofClasses: [NSDictionary.self, NSString.self], from: headerData
+           )) as? [String: String] {
             for (headerKey, headerValue) in headers {
                 urlRequest.setValue(headerValue, forHTTPHeaderField: headerKey)
             }

--- a/Palace/Network/TPPNetworkQueue.swift
+++ b/Palace/Network/TPPNetworkQueue.swift
@@ -82,11 +82,14 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
          databaseDirectory: String = NSSearchPathForDirectoriesInDomains(
             .applicationSupportDirectory, .userDomainMask, true).first ?? NSTemporaryDirectory(),
          errorLogger: ErrorLogging = DefaultErrorLogger(),
-         authorizationHeaderProvider: @escaping @Sendable (String) -> String? = { libraryID in
-            AppContainer.production().accountsManager
-                .userAccount(for: libraryID)
-                .credentialSnapshot().authToken.map { "Bearer \($0)" }
-         }) {
+         // Defaults to NO credential rather than resolving one. The single
+         // production site binds this explicitly at the composition root, so a
+         // resolving default is dead code — and a dangerous one: it would reach
+         // `AppContainer.production()` from the drain's serial queue for any
+         // future caller who forgot to bind it. Sending no credential is the
+         // safe failure (the server refuses); silently reaching for a global is
+         // not.
+         authorizationHeaderProvider: @escaping @Sendable (String) -> String? = { _ in nil }) {
         self.path = databaseDirectory
         self.transport = transport
         self.reachability = reachability
@@ -174,8 +177,26 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
         do {
             let rows = try db.prepare(sqlTable)
             for row in rows {
+                // `unarchivedObject(ofClasses:from:)` rather than the legacy
+                // `unarchiveObject(with:)`: it opts into secure coding and
+                // states the classes we expect, and it signals failure by
+                // throwing rather than by any documented exception behaviour.
+                //
+                // HONESTY NOTE: review flagged the legacy API as RAISING an
+                // uncatchable ObjC exception on a malformed archive, which —
+                // since this purge runs on the launch path via SEMigrations —
+                // would make one corrupt row a launch crash. I could not
+                // reproduce that: both garbage bytes and a truncated valid
+                // archive returned nil rather than raising. So this is
+                // defence-in-depth and modern-API hygiene, NOT a demonstrated
+                // crash fix, and it is written down that way rather than
+                // claiming a fix I did not verify. The rows read here were
+                // written by builds up to five years old, so tolerating an
+                // unreadable blob is worth having either way.
                 guard let data = row[sqlHeader],
-                      let headers = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: String],
+                      let headers = try? NSKeyedUnarchiver.unarchivedObject(
+                        ofClasses: [NSDictionary.self, NSString.self], from: data
+                      ) as? [String: String],
                       headers.keys.contains(where: {
                           $0.caseInsensitiveCompare("Authorization") == .orderedSame
                       }) else { continue }
@@ -243,13 +264,18 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
     /// guards a cleartext library card number and PIN; shipping it unverified
     /// is not an option, and every other claim on this branch that rested on
     /// reading rather than asserting turned out to be wrong.
+    /// `rawHeaderData` overrides `headers`, so a test can plant a blob that is
+    /// not a valid archive at all — which is what a five-year-old row written
+    /// by a long-dead build may actually be.
     func insertLegacyRowForTesting(libraryID: String,
                                    updateID: String,
                                    url: URL,
-                                   headers: [String: String]) {
+                                   headers: [String: String],
+                                   rawHeaderData: Data? = nil) {
         serialQueue.sync {
             guard let db = startDatabaseConnection() else { return }
-            let headerData = NSKeyedArchiver.archivedData(withRootObject: headers)
+            let headerData = rawHeaderData
+                ?? NSKeyedArchiver.archivedData(withRootObject: headers)
             let dateCreated = NSKeyedArchiver.archivedData(withRootObject: Date())
             _ = try? db.run(sqlTable.insert(
                 sqlLibraryID <- libraryID,
@@ -366,13 +392,17 @@ final class NetworkQueue: NSObject, @unchecked Sendable {
                 return
             }
 
-            self.purgeAnyPersistedCredentials(db)
 
             let tableCount = Int((try? db.scalar("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = '\(NetworkQueue.TableName)'") as? Int64) ?? 0)
             if tableCount < 1 {
                 self.createTable(db: db)
                 db.userVersion = NetworkQueue.DBVersion
             } else {
+                // Only once the table exists — on a fresh install there is
+                // nothing to purge and the attempt would log a failure for a
+                // non-error.
+                self.purgeAnyPersistedCredentials(db)
+
                 var dbVersion = db.userVersion
                 // TODO: Consider optimizing migrations by checking if
                 // there's a breaking change between current version and target version

--- a/Palace/Network/TPPNetworkResponder.swift
+++ b/Palace/Network/TPPNetworkResponder.swift
@@ -519,7 +519,36 @@ extension TPPNetworkResponder: URLSessionDataDelegate {
                     }
                 }
             }
+        } else if let netErr = networkError as NSError? {
+            // PP-4987: surface the UNDERLYING transport error.
+            //
+            // This branch is the no-HTTP-response case — the task never got a
+            // reply, which is what "offline" looks like. It used to discard
+            // `networkError` and substitute `invalidOrNoHTTPResponse` (914),
+            // which erased the one piece of information every downstream
+            // offline check reads: the NSURLError code.
+            //
+            // What that broke, all of it silently:
+            //   - `NetworkQueue.StatusCodes` is composed ENTIRELY of NSURLError
+            //     values, so `willQueueOffline` could never be true and NOT ONE
+            //     write was ever queued for retry. That is PP-4987 itself, and
+            //     it is why patrons lose reading positions rather than having
+            //     them delivered late.
+            //   - The offline/timeout arms of `TPPAlertUtils` (:68, :72),
+            //     `PalaceError` (:596, :598), `TPPSignInBusinessLogic` (:688)
+            //     and `PalaceAuth.AuthReducer` (:264) all match on those same
+            //     codes, so they were unreachable for anything routed through
+            //     this responder. Patrons saw a generic failure where the app
+            //     had a specific "you appear to be offline" message ready.
+            //
+            // Preserving the error re-enables all of the above at once. The
+            // error is passed through unchanged rather than re-wrapped so the
+            // domain stays NSURLErrorDomain, which is what those call sites
+            // check alongside the code.
+            result = .failure(netErr, task.response)
         } else {
+            // Genuinely no response AND no error to explain it — keep the
+            // generic code, which is what 914 was always meant to describe.
             let err = NSError(domain: "Api call with failure HTTP status",
                               code: TPPErrorCode.invalidOrNoHTTPResponse.rawValue,
                               userInfo: logMetadata)

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -419,6 +419,14 @@ protocol AnnotationsManager {
         /// Transport failed, but the request was handed to the offline queue
         /// and will be retried. Delivery is pending, not lost — do NOT report
         /// this as an error.
+        ///
+        /// NOTE (PP-4987): unreachable in production today. The networking
+        /// layer discards the underlying transport error when no HTTP response
+        /// arrives, substituting a generic no-response code that is not in
+        /// `NetworkQueue.StatusCodes`, so `willQueueOffline` is never true.
+        /// This case becomes live the moment PP-4987 preserves that error —
+        /// which is why it is modelled now rather than after, and why its
+        /// behaviour is already covered by tests.
         case queuedForRetry
 
         /// The write did not happen and nothing will retry it. `underlying`

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -106,6 +106,15 @@ protocol AnnotationsManager {
     nonisolated(unsafe) static var executorOverride: TPPNetworkExecutor?
     nonisolated(unsafe) static var accountsManagerOverride: TPPLibraryAccountsProvider?
 
+    /// Test-only seam for observing what this type hands to the offline queue.
+    /// PP-4987 made `.queuedForRetry` reachable, so "the write actually reached
+    /// the queue" became a real claim — and it was previously unassertable,
+    /// because `addToOfflineQueue` reaches `AppContainer.production()`
+    /// directly. That also meant the cross-device test wrote durable rows into
+    /// the app's REAL `simplified.db`, which a later reachability event could
+    /// replay. Never set from production code.
+    nonisolated(unsafe) static var offlineQueueOverride: AnnotationOfflineQueueing?
+
     /// Test-only seam for observing what this type reports to error logging.
     /// PP-4965: whether a failed position write is reported at all — and with
     /// what underlying error — is now behaviour worth asserting, so it needs to
@@ -191,6 +200,12 @@ protocol AnnotationsManager {
     /// setting `accountsManagerOverride` lets the test inject a mock.
     fileprivate static var currentAccountsManager: TPPLibraryAccountsProvider {
         return accountsManagerOverride ?? AppContainer.production().accountsManager
+    }
+
+    /// Where a queued-for-retry write is handed off. Production resolves to the
+    /// container's queue; tests inject a double.
+    fileprivate static var currentOfflineQueue: AnnotationOfflineQueueing {
+        return offlineQueueOverride ?? AppContainer.production().networkQueue
     }
 
     private static let defaultErrorLogger = DefaultErrorLogger()
@@ -971,9 +986,26 @@ protocol AnnotationsManager {
         let libraryID = manager.currentAccount?.uuid ?? ""
         let parameterData = try? JSONSerialization.data(withJSONObject: parameters, options: [.prettyPrinted])
         let headers = executor.request(for: url).allHTTPHeaderFields
-        AppContainer.production().networkQueue.addRequest(libraryID, bookID, url, .POST, parameterData, headers)
+        Self.currentOfflineQueue.addRequest(libraryID, bookID, url, .POST, parameterData, headers)
     }
 }
+
+/// The slice of the offline queue that annotation writes actually use.
+///
+/// Exists so `.queuedForRetry` is provable: without it, "the write reached the
+/// queue" can only be verified by reading the code, and PP-4965 removes the
+/// error report on the strength of that claim. `NetworkQueue` already has this
+/// exact signature.
+protocol AnnotationOfflineQueueing: AnyObject {
+    func addRequest(_ libraryID: String,
+                    _ updateID: String?,
+                    _ requestUrl: URL,
+                    _ method: HTTPMethodType,
+                    _ parameters: Data?,
+                    _ headers: [String: String]?)
+}
+
+extension NetworkQueue: AnnotationOfflineQueueing {}
 
 // MARK: - Sendable carriers for the annotation-sync @Sendable-closure captures
 

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -299,22 +299,35 @@ protocol AnnotationsManager {
                 Log.debug(#file, "Reading position for \(bookID) queued for retry")
                 completion?(nil)
 
-            case let .failed(underlying, statusCode):
+            case let .failed(underlying, response):
                 Log.warn(#file, "Annotation POST failed for \(bookID)")
                 var metadata: [String: Any] = [
                     "bookID": bookID,
                     "annotationURL": annotationsURL,
                     "motivation": motivation.rawValue
                 ]
-                if let statusCode {
+                if let statusCode = response?.statusCode {
                     metadata["statusCode"] = statusCode
                 }
-                // Pass `underlying` so the logger's classifier can file genuinely
-                // transient conditions ("No Internet Connection", "Request
-                // Timeout") in their own buckets instead of here.
-                Self.currentErrorLogger.logError(underlying,
-                                                 summary: "Error posting annotation",
-                                                 metadata: metadata)
+                // `logNetworkError` rather than `logError`, deliberately.
+                //
+                // The bare `logError(_:summary:metadata:)` overload hardcodes
+                // `code: .ignore`, which would have quietly moved this bucket
+                // OFF 902 (`.apiCall`) — to the raw NSError code for transport
+                // failures and to 0 for server refusals — and flipped
+                // `error_origin` from "server" to "unknown". Since the whole
+                // plan is to re-measure what remains in the 902 bucket once
+                // PP-4987 lands, that would have read as a fix while nothing
+                // improved. `logNetworkError` keeps `.apiCall`, still routes
+                // through `fixUpSummary` so transient conditions are split out
+                // first, and takes the response so 400...599 classifies as
+                // `.server`.
+                Self.currentErrorLogger.logNetworkError(underlying,
+                                                        code: .apiCall,
+                                                        summary: "Error posting annotation",
+                                                        request: nil,
+                                                        response: response,
+                                                        metadata: metadata)
                 completion?(nil)
             }
         }
@@ -429,12 +442,15 @@ protocol AnnotationsManager {
         /// behaviour is already covered by tests.
         case queuedForRetry
 
-        /// The write did not happen and nothing will retry it. `underlying`
-        /// carries the transport error where there was one, so the logger's
-        /// existing classifier can separate transient conditions (no
-        /// connection, timeout) from real defects. `statusCode` is present
-        /// when the server answered and refused.
-        case failed(underlying: NSError?, statusCode: Int?)
+        /// The write did not happen and nothing will retry it.
+        ///
+        /// `underlying` carries the transport error where there was one, so the
+        /// logger's existing classifier can separate transient conditions (no
+        /// connection, timeout) from real defects. `response` is present when
+        /// the server answered and refused — it is carried whole rather than as
+        /// a bare status code so `TPPErrorOrigin.classify` can read 400...599
+        /// off it and attribute the failure to the server.
+        case failed(underlying: NSError?, response: HTTPURLResponse?)
     }
 
     /// Serializes the `parameters` into JSON and POSTs them to the server.
@@ -447,7 +463,7 @@ protocol AnnotationsManager {
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [.prettyPrinted]) else {
             Log.error(#file, "Network request abandoned. Could not create JSON from given parameters.")
-            completionHandler(.failed(underlying: nil, statusCode: nil))
+            completionHandler(.failed(underlying: nil, response: nil))
             return
         }
 
@@ -471,12 +487,12 @@ protocol AnnotationsManager {
                     return
                 }
 
-                completionHandler(.failed(underlying: error, statusCode: nil))
+                completionHandler(.failed(underlying: error, response: nil))
                 return
             }
             guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
                 Log.error(#file, "Annotation POST error: No response received from server")
-                completionHandler(.failed(underlying: nil, statusCode: nil))
+                completionHandler(.failed(underlying: nil, response: nil))
                 return
             }
 
@@ -487,7 +503,7 @@ protocol AnnotationsManager {
                 completionHandler(.succeeded(annotationID: serverAnnotationID, timeStamp: timeStamp))
             } else {
                 Log.error(#file, "Annotation POST: Response Error. Status Code: \(statusCode)")
-                completionHandler(.failed(underlying: nil, statusCode: statusCode))
+                completionHandler(.failed(underlying: nil, response: response as? HTTPURLResponse))
             }
         }
         task?.resume()

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -461,7 +461,18 @@ protocol AnnotationsManager {
                               queueOffline: Bool,
                               _ completionHandler: @escaping (_ result: AnnotationPostResult) -> Void) {
 
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [.prettyPrinted]) else {
+        // `isValidJSONObject` FIRST, deliberately. `data(withJSONObject:)`
+        // RAISES an ObjC `NSInvalidArgumentException` for an unsupported type
+        // rather than throwing a Swift error, so `try?` does not catch it and
+        // the guard below never fired — an unserializable payload crashed the
+        // app instead of taking the `.failed` path this code models. Not
+        // reachable from today's three in-file callers (every value in
+        // `dictionaryForJSONSerialization()` is a String), so this is defence
+        // for the next caller, not a live bug fix. Found by writing the test
+        // for the branch (PP-4965 review round 2).
+        guard JSONSerialization.isValidJSONObject(parameters),
+              let jsonData = try? JSONSerialization.data(withJSONObject: parameters,
+                                                         options: [.prettyPrinted]) else {
             Log.error(#file, "Network request abandoned. Could not create JSON from given parameters.")
             completionHandler(.failed(underlying: nil, response: nil))
             return
@@ -487,7 +498,17 @@ protocol AnnotationsManager {
                     return
                 }
 
-                completionHandler(.failed(underlying: error, response: nil))
+                // Carry the response. `TPPNetworkResponder` synthesizes an
+                // NSError for EVERY non-2xx and `TPPNetworkExecutor.POST`
+                // forwards (nil, response, error) together, so this branch —
+                // not the `else` below — is the one a server refusal actually
+                // takes. Passing nil here dropped the status code before it
+                // reached telemetry and left `TPPErrorOrigin.classify`'s
+                // 400...599 arm unreachable from this call site, which made
+                // "a refusal carries its status code" false in production
+                // while two tests asserted it (PP-4965 review round 2).
+                completionHandler(.failed(underlying: error,
+                                          response: response as? HTTPURLResponse))
                 return
             }
             guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -106,6 +106,12 @@ protocol AnnotationsManager {
     nonisolated(unsafe) static var executorOverride: TPPNetworkExecutor?
     nonisolated(unsafe) static var accountsManagerOverride: TPPLibraryAccountsProvider?
 
+    /// Test-only seam for observing what this type reports to error logging.
+    /// PP-4965: whether a failed position write is reported at all — and with
+    /// what underlying error — is now behaviour worth asserting, so it needs to
+    /// be observable. Never set from production code.
+    nonisolated(unsafe) static var errorLoggerOverride: ErrorLogging?
+
     /// Test-only override for the annotations URL. When set, `annotationsURL`
     /// returns this value instead of deriving from `TPPConfiguration.mainFeedURL()`.
     /// CI runners boot with no signed-in library, so `mainFeedURL()` is nil and
@@ -185,6 +191,14 @@ protocol AnnotationsManager {
     /// setting `accountsManagerOverride` lets the test inject a mock.
     fileprivate static var currentAccountsManager: TPPLibraryAccountsProvider {
         return accountsManagerOverride ?? AppContainer.production().accountsManager
+    }
+
+    private static let defaultErrorLogger = DefaultErrorLogger()
+
+    /// Returns the error logger TPPAnnotations should report to. In tests,
+    /// setting `errorLoggerOverride` lets the test observe what was reported.
+    fileprivate static var currentErrorLogger: ErrorLogging {
+        return errorLoggerOverride ?? defaultErrorLogger
     }
 
     // MARK: - Reading Position
@@ -272,22 +286,37 @@ protocol AnnotationsManager {
                                        selectorValue: selectorValue)
         let parameters = bookmark.dictionaryForJSONSerialization()
 
-        postAnnotation(forBook: bookID, withAnnotationURL: annotationsURL, withParameters: parameters, queueOffline: true) { (success, id, timeStamp) in
-            guard success else {
-                Log.warn(#file, "Annotation POST failed for \(bookID)")
-                TPPErrorLogger.logError(withCode: .apiCall,
-                                        summary: "Error posting annotation",
-                                        metadata: [
-                                            "bookID": bookID,
-                                            "annotationID": id ?? "N/A",
-                                            "annotationURL": annotationsURL,
-                                            "motivation": motivation.rawValue])
-                completion?(nil)
-                return
-            }
+        postAnnotation(forBook: bookID, withAnnotationURL: annotationsURL, withParameters: parameters, queueOffline: true) { result in
+            switch result {
+            case let .succeeded(id, timeStamp):
+                Log.debug(#file, "Successfully saved Reading Position to server: \(selectorValue)")
+                completion?(AnnotationResponse(serverId: id, timeStamp: timeStamp))
 
-            Log.debug(#file, "Successfully saved Reading Position to server: \(selectorValue)")
-            completion?(AnnotationResponse(serverId: id, timeStamp: timeStamp))
+            case .queuedForRetry:
+                // NOT an error. The position is already in local storage and the
+                // write is queued for delivery. Reporting this was the bulk of
+                // the "Error posting annotation" volume (PP-4965).
+                Log.debug(#file, "Reading position for \(bookID) queued for retry")
+                completion?(nil)
+
+            case let .failed(underlying, statusCode):
+                Log.warn(#file, "Annotation POST failed for \(bookID)")
+                var metadata: [String: Any] = [
+                    "bookID": bookID,
+                    "annotationURL": annotationsURL,
+                    "motivation": motivation.rawValue
+                ]
+                if let statusCode {
+                    metadata["statusCode"] = statusCode
+                }
+                // Pass `underlying` so the logger's classifier can file genuinely
+                // transient conditions ("No Internet Connection", "Request
+                // Timeout") in their own buckets instead of here.
+                Self.currentErrorLogger.logError(underlying,
+                                                 summary: "Error posting annotation",
+                                                 metadata: metadata)
+                completion?(nil)
+            }
         }
     }
 
@@ -318,7 +347,16 @@ protocol AnnotationsManager {
 
         let parameters = spec.dictionaryForJSONSerialization()
 
-        postAnnotation(forBook: bookID, withAnnotationURL: annotationsURL, withParameters: parameters, queueOffline: false) { (_, id, timeStamp) in
+        postAnnotation(forBook: bookID, withAnnotationURL: annotationsURL, withParameters: parameters, queueOffline: false) { result in
+            // Behaviour deliberately unchanged by PP-4965: a bookmark POST that
+            // fails still calls back with an empty response and reports nothing.
+            // That silence is a real gap — bookmark failures produce no
+            // telemetry at all — but fixing it changes behaviour patrons see,
+            // so it is tracked separately rather than folded in here.
+            guard case let .succeeded(id, timeStamp) = result else {
+                completion(AnnotationResponse(serverId: nil, timeStamp: nil))
+                return
+            }
             completion(AnnotationResponse(serverId: id, timeStamp: timeStamp))
         }
     }
@@ -348,9 +386,47 @@ protocol AnnotationsManager {
 
         let parameters = spec.dictionaryForJSONSerialization()
 
-        postAnnotation(forBook: bookID, withAnnotationURL: annotationsURL, withParameters: parameters, queueOffline: false) { (_, id, timeStamp) in
+        postAnnotation(forBook: bookID, withAnnotationURL: annotationsURL, withParameters: parameters, queueOffline: false) { result in
+            // Behaviour deliberately unchanged by PP-4965: a bookmark POST that
+            // fails still calls back with an empty response and reports nothing.
+            // That silence is a real gap — bookmark failures produce no
+            // telemetry at all — but fixing it changes behaviour patrons see,
+            // so it is tracked separately rather than folded in here.
+            guard case let .succeeded(id, timeStamp) = result else {
+                completion(AnnotationResponse(serverId: nil, timeStamp: nil))
+                return
+            }
             completion(AnnotationResponse(serverId: id, timeStamp: timeStamp))
         }
+    }
+
+    /// How a POST to the annotations endpoint concluded.
+    ///
+    /// PP-4965: this exists because the previous `(Bool, String?, String?)`
+    /// callback had nowhere to put "queued for retry" or a status code, so five
+    /// very different outcomes all arrived at the caller as a bare `false`. The
+    /// caller then reported every one of them as "Error posting annotation",
+    /// which made that the largest error in the app while most of the traffic
+    /// was patrons going through a tunnel.
+    ///
+    /// Keeping `queuedForRetry` distinct from `failed` is the whole point: a
+    /// queued write has not been lost, and must not be reported as a failure.
+    enum AnnotationPostResult {
+        /// The server accepted the annotation. Both values may still be nil if
+        /// the response body was missing or unparseable.
+        case succeeded(annotationID: String?, timeStamp: String?)
+
+        /// Transport failed, but the request was handed to the offline queue
+        /// and will be retried. Delivery is pending, not lost — do NOT report
+        /// this as an error.
+        case queuedForRetry
+
+        /// The write did not happen and nothing will retry it. `underlying`
+        /// carries the transport error where there was one, so the logger's
+        /// existing classifier can separate transient conditions (no
+        /// connection, timeout) from real defects. `statusCode` is present
+        /// when the server answered and refused.
+        case failed(underlying: NSError?, statusCode: Int?)
     }
 
     /// Serializes the `parameters` into JSON and POSTs them to the server.
@@ -359,11 +435,11 @@ protocol AnnotationsManager {
                               withParameters parameters: [String: Any],
                               timeout: TimeInterval = TPPDefaultRequestTimeout,
                               queueOffline: Bool,
-                              _ completionHandler: @escaping (_ success: Bool, _ annotationID: String?, _ timeStamp: String?) -> Void) {
+                              _ completionHandler: @escaping (_ result: AnnotationPostResult) -> Void) {
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [.prettyPrinted]) else {
             Log.error(#file, "Network request abandoned. Could not create JSON from given parameters.")
-            completionHandler(false, nil, nil)
+            completionHandler(.failed(underlying: nil, statusCode: nil))
             return
         }
 
@@ -383,14 +459,16 @@ protocol AnnotationsManager {
                 if willQueueOffline {
                     Log.debug(#file, "Queued for offline retry")
                     self.addToOfflineQueue(bookID, url, parameters)
+                    completionHandler(.queuedForRetry)
+                    return
                 }
 
-                completionHandler(false, nil, nil)
+                completionHandler(.failed(underlying: error, statusCode: nil))
                 return
             }
             guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
                 Log.error(#file, "Annotation POST error: No response received from server")
-                completionHandler(false, nil, nil)
+                completionHandler(.failed(underlying: nil, statusCode: nil))
                 return
             }
 
@@ -398,10 +476,10 @@ protocol AnnotationsManager {
                 Log.debug(#file, "Annotation POST: Success 200.")
                 let serverAnnotationID = annotationID(fromNetworkData: data)
                 let timeStamp = timeStamp(fromNetworkData: data)
-                completionHandler(true, serverAnnotationID, timeStamp)
+                completionHandler(.succeeded(annotationID: serverAnnotationID, timeStamp: timeStamp))
             } else {
                 Log.error(#file, "Annotation POST: Response Error. Status Code: \(statusCode)")
-                completionHandler(false, nil, nil)
+                completionHandler(.failed(underlying: nil, statusCode: statusCode))
             }
         }
         task?.resume()

--- a/Palace/Reader2/Bookmarks/TPPAnnotations.swift
+++ b/Palace/Reader2/Bookmarks/TPPAnnotations.swift
@@ -286,7 +286,26 @@ protocol AnnotationsManager {
                                        selectorValue: selectorValue)
         let parameters = bookmark.dictionaryForJSONSerialization()
 
-        postAnnotation(forBook: bookID, withAnnotationURL: annotationsURL, withParameters: parameters, queueOffline: true) { result in
+        // The offline queue UPDATES the row matching (libraryID, queueKey), so
+        // the key decides what supersedes what (PP-4987 made this reachable):
+        //
+        //  - readingProgress: key on the book. Collapsing IS correct — a newer
+        //    position supersedes an older one for the same book, and delivering
+        //    only the latest is what the patron wants.
+        //  - bookmark: key on the book AND the selector. Every bookmark is a
+        //    distinct thing the patron created; keying on the book alone made
+        //    two offline bookmarks in one title silently overwrite each other,
+        //    and PP-4965 has already removed the error report for this path, so
+        //    the loss would be invisible.
+        let queueKey: String
+        switch motivation {
+        case .bookmark:
+            queueKey = "\(bookID)|\(selectorValue)"
+        default:
+            queueKey = bookID
+        }
+
+        postAnnotation(forBook: bookID, withAnnotationURL: annotationsURL, withParameters: parameters, queueOffline: true, queueKey: queueKey) { result in
             switch result {
             case let .succeeded(id, timeStamp):
                 Log.debug(#file, "Successfully saved Reading Position to server: \(selectorValue)")
@@ -433,13 +452,13 @@ protocol AnnotationsManager {
         /// and will be retried. Delivery is pending, not lost — do NOT report
         /// this as an error.
         ///
-        /// NOTE (PP-4987): unreachable in production today. The networking
-        /// layer discards the underlying transport error when no HTTP response
-        /// arrives, substituting a generic no-response code that is not in
-        /// `NetworkQueue.StatusCodes`, so `willQueueOffline` is never true.
-        /// This case becomes live the moment PP-4987 preserves that error —
-        /// which is why it is modelled now rather than after, and why its
-        /// behaviour is already covered by tests.
+        /// REACHABLE as of PP-4987. It was not when this case was written:
+        /// the networking layer discarded the underlying transport error when
+        /// no HTTP response arrived, substituting a generic no-response code
+        /// absent from `NetworkQueue.StatusCodes`, so `willQueueOffline` could
+        /// never be true. `TPPNetworkResponder` now passes that error through,
+        /// so an offline write genuinely reaches the retry queue and this case
+        /// carries real production traffic.
         case queuedForRetry
 
         /// The write did not happen and nothing will retry it.
@@ -459,6 +478,7 @@ protocol AnnotationsManager {
                               withParameters parameters: [String: Any],
                               timeout: TimeInterval = TPPDefaultRequestTimeout,
                               queueOffline: Bool,
+                              queueKey: String? = nil,
                               _ completionHandler: @escaping (_ result: AnnotationPostResult) -> Void) {
 
         // `isValidJSONObject` FIRST, deliberately. `data(withJSONObject:)`
@@ -493,7 +513,7 @@ protocol AnnotationsManager {
 
                 if willQueueOffline {
                     Log.debug(#file, "Queued for offline retry")
-                    self.addToOfflineQueue(bookID, url, parameters)
+                    self.addToOfflineQueue(queueKey ?? bookID, url, parameters)
                     completionHandler(.queuedForRetry)
                     return
                 }

--- a/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
+++ b/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
@@ -1593,7 +1593,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         TPPAnnotations.postReadingPosition(forBook: bookID,
                                            selectorValue: "{\"k\":\"v\"}",
                                            motivation: .readingProgress) { _ in exp.fulfill() }
-        wait(for: [exp], timeout: 2.0)
+        wait(for: [exp], timeout: 2.0)  // STARVE-001-OK: SYNCHRONOUS — `RecordingExecutorMock.POST` invokes its completion inline, and there is no dispatch hop anywhere in postReadingPosition -> postAnnotation -> completionHandler, so the expectation is already fulfilled before `wait` is reached and the deadline is structurally unreachable. NOTE the criterion: it is synchronicity, NOT mere unconditionality. A callback that always fires but arrives on another queue is precisely the STARVE-001 shape — see `postAudiobookBookmark`, which resumes via `DispatchQueue.main.async` and would NOT qualify for this hatch.
 
         XCTAssertEqual(mock.postCallCount, 1,
                        "Guard against a vacuous pass: the sync gate must have opened and the POST gone out")
@@ -1630,7 +1630,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         TPPAnnotations.postReadingPosition(forBook: bookID,
                                            selectorValue: "{\"k\":\"v\"}",
                                            motivation: .readingProgress) { _ in exp.fulfill() }
-        wait(for: [exp], timeout: 2.0)
+        wait(for: [exp], timeout: 2.0)  // STARVE-001-OK: SYNCHRONOUS — `RecordingExecutorMock.POST` invokes its completion inline, and there is no dispatch hop anywhere in postReadingPosition -> postAnnotation -> completionHandler, so the expectation is already fulfilled before `wait` is reached and the deadline is structurally unreachable. NOTE the criterion: it is synchronicity, NOT mere unconditionality. A callback that always fires but arrives on another queue is precisely the STARVE-001 shape — see `postAudiobookBookmark`, which resumes via `DispatchQueue.main.async` and would NOT qualify for this hatch.
 
         XCTAssertEqual(mock.postCallCount, 1, "Guard against a vacuous pass")
         XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"])
@@ -1664,7 +1664,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         TPPAnnotations.postReadingPosition(forBook: bookID,
                                            selectorValue: "{\"k\":\"v\"}",
                                            motivation: .readingProgress) { _ in exp.fulfill() }
-        wait(for: [exp], timeout: 2.0)
+        wait(for: [exp], timeout: 2.0)  // STARVE-001-OK: SYNCHRONOUS — `RecordingExecutorMock.POST` invokes its completion inline, and there is no dispatch hop anywhere in postReadingPosition -> postAnnotation -> completionHandler, so the expectation is already fulfilled before `wait` is reached and the deadline is structurally unreachable. NOTE the criterion: it is synchronicity, NOT mere unconditionality. A callback that always fires but arrives on another queue is precisely the STARVE-001 shape — see `postAudiobookBookmark`, which resumes via `DispatchQueue.main.async` and would NOT qualify for this hatch.
 
         XCTAssertEqual(mock.postCallCount, 1, "Guard against a vacuous pass")
         XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"],
@@ -1692,7 +1692,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         TPPAnnotations.postReadingPosition(forBook: bookID,
                                            selectorValue: "{\"k\":\"v\"}",
                                            motivation: .readingProgress) { _ in exp.fulfill() }
-        wait(for: [exp], timeout: 2.0)
+        wait(for: [exp], timeout: 2.0)  // STARVE-001-OK: SYNCHRONOUS — `RecordingExecutorMock.POST` invokes its completion inline, and there is no dispatch hop anywhere in postReadingPosition -> postAnnotation -> completionHandler, so the expectation is already fulfilled before `wait` is reached and the deadline is structurally unreachable. NOTE the criterion: it is synchronicity, NOT mere unconditionality. A callback that always fires but arrives on another queue is precisely the STARVE-001 shape — see `postAudiobookBookmark`, which resumes via `DispatchQueue.main.async` and would NOT qualify for this hatch.
 
         XCTAssertEqual(queue.count, 1,
                        "An offline write must be handed to the retry queue — suppressing its error report is only sound if it was")
@@ -1716,7 +1716,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
             TPPAnnotations.postReadingPosition(forBook: bookID,
                                                selectorValue: selector,
                                                motivation: .readingProgress) { _ in exp.fulfill() }
-            wait(for: [exp], timeout: 2.0)
+            wait(for: [exp], timeout: 2.0)  // STARVE-001-OK: SYNCHRONOUS — `RecordingExecutorMock.POST` invokes its completion inline, and there is no dispatch hop anywhere in postReadingPosition -> postAnnotation -> completionHandler, so the expectation is already fulfilled before `wait` is reached and the deadline is structurally unreachable. NOTE the criterion: it is synchronicity, NOT mere unconditionality. A callback that always fires but arrives on another queue is precisely the STARVE-001 shape — see `postAudiobookBookmark`, which resumes via `DispatchQueue.main.async` and would NOT qualify for this hatch.
         }
 
         XCTAssertEqual(queue.updateIDs, [bookID, bookID],
@@ -1740,7 +1740,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
             TPPAnnotations.postReadingPosition(forBook: bookID,
                                                selectorValue: selector,
                                                motivation: .bookmark) { _ in exp.fulfill() }
-            wait(for: [exp], timeout: 2.0)
+            wait(for: [exp], timeout: 2.0)  // STARVE-001-OK: SYNCHRONOUS — `RecordingExecutorMock.POST` invokes its completion inline, and there is no dispatch hop anywhere in postReadingPosition -> postAnnotation -> completionHandler, so the expectation is already fulfilled before `wait` is reached and the deadline is structurally unreachable. NOTE the criterion: it is synchronicity, NOT mere unconditionality. A callback that always fires but arrives on another queue is precisely the STARVE-001 shape — see `postAudiobookBookmark`, which resumes via `DispatchQueue.main.async` and would NOT qualify for this hatch.
         }
 
         let keys = queue.updateIDs.compactMap { $0 }
@@ -1761,7 +1761,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         TPPAnnotations.postReadingPosition(forBook: bookID,
                                            selectorValue: "{\"k\":\"v\"}",
                                            motivation: .readingProgress) { _ in exp.fulfill() }
-        wait(for: [exp], timeout: 2.0)
+        wait(for: [exp], timeout: 2.0)  // STARVE-001-OK: SYNCHRONOUS — `RecordingExecutorMock.POST` invokes its completion inline, and there is no dispatch hop anywhere in postReadingPosition -> postAnnotation -> completionHandler, so the expectation is already fulfilled before `wait` is reached and the deadline is structurally unreachable. NOTE the criterion: it is synchronicity, NOT mere unconditionality. A callback that always fires but arrives on another queue is precisely the STARVE-001 shape — see `postAudiobookBookmark`, which resumes via `DispatchQueue.main.async` and would NOT qualify for this hatch.
 
         XCTAssertEqual(mock.postCallCount, 1, "Guard against a vacuous pass")
         XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"])

--- a/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
+++ b/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
@@ -1453,6 +1453,12 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
     // annotation", which made that the app's largest error while the writes
     // were in fact queued and delivered. A queued write is pending, not lost.
     func testPostAnnotation_QueuedForRetry_IsReportedAsPendingNotFailure() {
+        // Never let a test write a durable row into the app's REAL
+        // simplified.db — PP-4987 made this branch reachable, so without the
+        // seam these rows persist in Application Support and a later
+        // reachability event can replay them as live POSTs.
+        let queue = OfflineQueueSpy()
+        TPPAnnotations.offlineQueueOverride = queue
         // notConnectedToInternet is in NetworkQueue.StatusCodes, so with
         // queueOffline the request is enqueued rather than abandoned.
         mock.postStub = (nil, nil, NSError(domain: NSURLErrorDomain,
@@ -1573,6 +1579,12 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
     /// The defect this ticket exists for: a write that is safely queued for
     /// retry must not be reported as an error.
     func testPostReadingPosition_QueuedForRetry_ReportsNothingToErrorLogging() {
+        // Never let a test write a durable row into the app's REAL
+        // simplified.db — PP-4987 made this branch reachable, so without the
+        // seam these rows persist in Application Support and a later
+        // reachability event can replay them as live POSTs.
+        let queue = OfflineQueueSpy()
+        TPPAnnotations.offlineQueueOverride = queue
         let spy = makeLoggerSpy()
         mock.postStub = (nil, nil, NSError(domain: NSURLErrorDomain,
                                            code: NSURLErrorNotConnectedToInternet))
@@ -1587,13 +1599,13 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
                        "Guard against a vacuous pass: the sync gate must have opened and the POST gone out")
         XCTAssertEqual(spy.loggedSummaries, [],
                        "A queued write is pending, not failed — reporting it is what made this the app's largest error")
-        // GAP, deliberate: nothing here asserts `addToOfflineQueue` actually
-        // enqueued the write, because it reaches AppContainer.production()
-        // .networkQueue with no seam. Suppressing the report on the promise of
-        // a retry is only safe if the retry exists — so that assertion belongs
-        // to PP-4987, where this branch first becomes reachable in production
-        // and the promise starts being load-bearing. Adding a seam now would
-        // test a path that cannot execute.
+        // The gap this test used to declare — "nothing asserts the write was
+        // enqueued, because there is no seam" — is closed. The seam exists and
+        // the enqueue is asserted in
+        // `testPostReadingPosition_WhenQueuedForRetry_ActuallyEnqueuesTheWrite`;
+        // this test keeps the narrower job of pinning the SILENCE.
+        XCTAssertEqual(queue.count, 1,
+                       "…and the silence is only defensible because the write really was queued")
     }
 
     /// A genuine transport loss must still be reported, and must carry the
@@ -1632,19 +1644,20 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
 
     /// The shape production ACTUALLY delivers on this path.
     ///
-    /// The tests above inject NSURLError codes, which is what an offline device
-    /// emits — but not what `postAnnotation` receives. TPPNetworkResponder
-    /// discards the transport error when no HTTP response arrives and hands up
-    /// code 914 instead (PP-4987), proved by the two-device test. Asserting
-    /// only the injected shape is how a fixture drifts from production bytes,
-    /// so this pins the real one: it must still report, still carry 902, and
-    /// must NOT be mistaken for something queueable.
+    /// The RESIDUAL no-response shape, after PP-4987.
+    ///
+    /// `TPPNetworkResponder` no longer substitutes 914 for a transport error —
+    /// an offline device's NSURLError now survives, is queueable, and is
+    /// covered by the tests above. 914 remains only for the genuinely
+    /// unexplained case: no response AND no error. That case is still a real
+    /// loss, still reports, and still must not be mistaken for queueable —
+    /// which is what this pins.
     func testPostReadingPosition_ProductionNoResponseShape_ReportsUnder902() {
         let spy = makeLoggerSpy()
         let asProductionDelivers = NSError(domain: "Api call with failure HTTP status",
                                            code: TPPErrorCode.invalidOrNoHTTPResponse.rawValue)
         XCTAssertFalse(NetworkQueue.StatusCodes.contains(asProductionDelivers.code),
-                       "Precondition (this IS PP-4987): the code production delivers is not queueable")
+                       "Precondition: the unexplained-no-response code is not queueable, so this write is genuinely lost")
         mock.postStub = (nil, nil, asProductionDelivers)
 
         let exp = expectation(description: "post reading position")
@@ -1655,7 +1668,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
 
         XCTAssertEqual(mock.postCallCount, 1, "Guard against a vacuous pass")
         XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"],
-                       "Today's real offline failure is a genuine loss and must be reported")
+                       "An unexplained no-response is a genuine loss and must be reported — unlike a transport failure, which PP-4987 makes queueable")
         XCTAssertEqual(spy.loggedCodes, [.apiCall],
                        "It must stay in the 902 bucket, or re-measuring that bucket after PP-4987 reads a false win")
     }

--- a/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
+++ b/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
@@ -1560,10 +1560,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
 
         XCTAssertEqual(mock.postCallCount, 1, "Guard against a vacuous pass")
         XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"])
-        // `loggedErrors` is [Error?], so `.first` is doubly optional — flatten
-        // before bridging, or the cast silently compares against nil.
-        let reported = (spy.loggedErrors.first ?? nil) as NSError?
-        XCTAssertEqual(reported?.code, unretryable,
+        XCTAssertEqual(spy.firstReportedNSError?.code, unretryable,
                        "Dropping the underlying error is what defeated the logger's transient-condition classifier")
     }
 
@@ -1783,35 +1780,5 @@ class AnnotationDeviceIDTests: XCTestCase {
             XCTAssertTrue(id.contains(firebaseID),
                           "Call #\(i): annotation device ID must contain the FirebaseManager deviceID — broken derivation breaks cross-device detection")
         }
-    }
-}
-
-/// Records what was reported to error logging so tests can assert on it (PP-4965).
-private final class ErrorLoggerSpy: ErrorLogging {
-    private(set) var loggedSummaries: [String] = []
-    private(set) var loggedErrors: [Error?] = []
-    private(set) var loggedMetadata: [[String: Any]] = []
-
-    func logError(_ error: Error?, summary: String, metadata: [String: Any]?) {
-        loggedSummaries.append(summary)
-        loggedErrors.append(error)
-        loggedMetadata.append(metadata ?? [:])
-    }
-
-    func logError(withCode code: TPPErrorCode, summary: String, metadata: [String: Any]?) {
-        loggedSummaries.append(summary)
-        loggedErrors.append(nil)
-        loggedMetadata.append(metadata ?? [:])
-    }
-
-    func logNetworkError(_ originalError: Error?,
-                         code: TPPErrorCode,
-                         summary: String?,
-                         request: URLRequest?,
-                         response: URLResponse?,
-                         metadata: [String: Any]?) {
-        loggedSummaries.append(summary ?? "")
-        loggedErrors.append(originalError)
-        loggedMetadata.append(metadata ?? [:])
     }
 }

--- a/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
+++ b/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
@@ -1236,6 +1236,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         TPPAnnotations.executorOverride = nil
         TPPAnnotations.accountsManagerOverride = nil
         TPPAnnotations.errorLoggerOverride = nil
+        TPPAnnotations.offlineQueueOverride = nil
         TPPAnnotations.annotationsURLOverride = nil
         AnnotationDevice.accountsManagerOverride = nil
         AnnotationDevice.firebaseDeviceIDOverride = nil
@@ -1657,6 +1658,84 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
                        "Today's real offline failure is a genuine loss and must be reported")
         XCTAssertEqual(spy.loggedCodes, [.apiCall],
                        "It must stay in the 902 bucket, or re-measuring that bucket after PP-4987 reads a false win")
+    }
+
+    // MARK: - PP-4987: a queued write must actually BE queued
+
+    /// The claim PP-4965's silence rests on. It stops reporting a write once
+    /// the write is "queued for retry" — which is only defensible if the write
+    /// genuinely reached the queue. Until PP-4987 that branch was unreachable,
+    /// so this was untestable AND unfalsifiable; now it is neither. Every other
+    /// test on this path asserts only that nothing was REPORTED, which would
+    /// pass just as happily if the write evaporated.
+    func testPostReadingPosition_WhenQueuedForRetry_ActuallyEnqueuesTheWrite() {
+        let spy = makeLoggerSpy()
+        let queue = OfflineQueueSpy()
+        TPPAnnotations.offlineQueueOverride = queue
+        mock.postStub = (nil, nil, NSError(domain: NSURLErrorDomain,
+                                           code: NSURLErrorNotConnectedToInternet))
+
+        let exp = expectation(description: "post reading position")
+        TPPAnnotations.postReadingPosition(forBook: bookID,
+                                           selectorValue: "{\"k\":\"v\"}",
+                                           motivation: .readingProgress) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(queue.count, 1,
+                       "An offline write must be handed to the retry queue — suppressing its error report is only sound if it was")
+        XCTAssertEqual(queue.enqueued.first?.method, .POST)
+        XCTAssertEqual(spy.loggedSummaries, [],
+                       "And having been queued, it must not also be reported")
+    }
+
+    /// Reading positions SHOULD collapse: the queue updates the row matching
+    /// (libraryID, updateID), and a newer position for a book supersedes an
+    /// older one. Delivering only the latest is what the patron wants.
+    func testPostReadingPosition_TwoPositionsSameBook_ShareAKeySoTheLatestWins() {
+        _ = makeLoggerSpy()
+        let queue = OfflineQueueSpy()
+        TPPAnnotations.offlineQueueOverride = queue
+        mock.postStub = (nil, nil, NSError(domain: NSURLErrorDomain,
+                                           code: NSURLErrorNotConnectedToInternet))
+
+        for selector in ["{\"p\":1}", "{\"p\":2}"] {
+            let exp = expectation(description: "post \(selector)")
+            TPPAnnotations.postReadingPosition(forBook: bookID,
+                                               selectorValue: selector,
+                                               motivation: .readingProgress) { _ in exp.fulfill() }
+            wait(for: [exp], timeout: 2.0)
+        }
+
+        XCTAssertEqual(queue.updateIDs, [bookID, bookID],
+                       "Positions key on the book alone, so the second supersedes the first")
+    }
+
+    /// Bookmarks MUST NOT collapse. Each one is a distinct thing the patron
+    /// created; before PP-4987's hardening they all keyed on the bookID, so two
+    /// offline bookmarks in one title silently overwrote each other — and
+    /// PP-4965 had already removed the error report for this path, making the
+    /// loss invisible.
+    func testPostReadingPosition_TwoBookmarksSameBook_GetDistinctKeysSoNeitherIsLost() {
+        _ = makeLoggerSpy()
+        let queue = OfflineQueueSpy()
+        TPPAnnotations.offlineQueueOverride = queue
+        mock.postStub = (nil, nil, NSError(domain: NSURLErrorDomain,
+                                           code: NSURLErrorNotConnectedToInternet))
+
+        for selector in ["{\"chapter\":1}", "{\"chapter\":9}"] {
+            let exp = expectation(description: "bookmark \(selector)")
+            TPPAnnotations.postReadingPosition(forBook: bookID,
+                                               selectorValue: selector,
+                                               motivation: .bookmark) { _ in exp.fulfill() }
+            wait(for: [exp], timeout: 2.0)
+        }
+
+        let keys = queue.updateIDs.compactMap { $0 }
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertNotEqual(keys[0], keys[1],
+                          "Two bookmarks in one book must not share a queue key — sharing one deletes a patron's bookmark silently")
+        XCTAssertTrue(keys.allSatisfy { $0.hasPrefix(bookID) },
+                      "The key still scopes to the book; it is the selector that disambiguates")
     }
 
     /// A server refusal must reach reporting WITH its status, so 401 and 500

--- a/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
+++ b/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
@@ -1248,7 +1248,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
                                    timeout: TimeInterval = 17)
     -> TPPAnnotations.AnnotationPostResult {
         let exp = expectation(description: "post completion")
-        var outcome: TPPAnnotations.AnnotationPostResult = .failed(underlying: nil, statusCode: nil)
+        var outcome: TPPAnnotations.AnnotationPostResult = .failed(underlying: nil, response: nil)
         TPPAnnotations.postAnnotation(
             forBook: bookID,
             withAnnotationURL: url,
@@ -1442,22 +1442,23 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         mock.postStub = (nil, nil, NSError(domain: NSURLErrorDomain,
                                            code: NSURLErrorNotConnectedToInternet))
 
-        guard case let .failed(underlying, statusCode) = postAndWaitResult(queueOffline: false) else {
+        guard case let .failed(underlying, response) = postAndWaitResult(queueOffline: false) else {
             return XCTFail("An un-queued transport error must report .failed")
         }
         XCTAssertEqual(underlying?.code, NSURLErrorNotConnectedToInternet,
                        "The underlying error must survive to the caller — dropping it is what defeated the classifier")
-        XCTAssertNil(statusCode, "No HTTP response means no status code")
+        XCTAssertNil(response, "No HTTP response means none to carry")
     }
 
     /// A server refusal must carry the status, so 401 and 500 are separable.
     func testPostAnnotation_ServerRefusal_ReportsFailedCarryingStatusCode() {
         mock.postStub = (nil, httpResponse(500), nil)
 
-        guard case let .failed(underlying, statusCode) = postAndWaitResult() else {
+        guard case let .failed(underlying, response) = postAndWaitResult() else {
             return XCTFail("A non-200 response must report .failed")
         }
-        XCTAssertEqual(statusCode, 500, "The status code must reach the caller so refusals are diagnosable")
+        XCTAssertEqual(response?.statusCode, 500,
+                       "The response must reach the caller so refusals are diagnosable AND classifiable as server-origin")
         XCTAssertNil(underlying, "A server refusal is not a transport error")
     }
 
@@ -1466,11 +1467,11 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
                                              expectedContentLength: 0,
                                              textEncodingName: nil), nil)
 
-        guard case let .failed(underlying, statusCode) = postAndWaitResult() else {
+        guard case let .failed(underlying, response) = postAndWaitResult() else {
             return XCTFail("A non-HTTP response must report .failed")
         }
         XCTAssertNil(underlying)
-        XCTAssertNil(statusCode)
+        XCTAssertNil(response)
     }
 
     func testPostAnnotation_Success_ReportsSucceededWithServerValues() {
@@ -1532,6 +1533,13 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
                        "Guard against a vacuous pass: the sync gate must have opened and the POST gone out")
         XCTAssertEqual(spy.loggedSummaries, [],
                        "A queued write is pending, not failed — reporting it is what made this the app's largest error")
+        // GAP, deliberate: nothing here asserts `addToOfflineQueue` actually
+        // enqueued the write, because it reaches AppContainer.production()
+        // .networkQueue with no seam. Suppressing the report on the promise of
+        // a retry is only safe if the retry exists — so that assertion belongs
+        // to PP-4987, where this branch first becomes reachable in production
+        // and the promise starts being load-bearing. Adding a seam now would
+        // test a path that cannot execute.
     }
 
     /// A genuine transport loss must still be reported, and must carry the
@@ -1560,8 +1568,42 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
 
         XCTAssertEqual(mock.postCallCount, 1, "Guard against a vacuous pass")
         XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"])
+        XCTAssertEqual(spy.loggedCodes, [.apiCall],
+                       "Must stay on 902. Reporting via the bare logError overload silently files this under .ignore, "
+                       + "which moves the bucket and flips error_origin to unknown — a telemetry regression that reads "
+                       + "as a fix when the 902 volume is re-measured.")
         XCTAssertEqual(spy.firstReportedNSError?.code, unretryable,
                        "Dropping the underlying error is what defeated the logger's transient-condition classifier")
+    }
+
+    /// The shape production ACTUALLY delivers on this path.
+    ///
+    /// The tests above inject NSURLError codes, which is what an offline device
+    /// emits — but not what `postAnnotation` receives. TPPNetworkResponder
+    /// discards the transport error when no HTTP response arrives and hands up
+    /// code 914 instead (PP-4987), proved by the two-device test. Asserting
+    /// only the injected shape is how a fixture drifts from production bytes,
+    /// so this pins the real one: it must still report, still carry 902, and
+    /// must NOT be mistaken for something queueable.
+    func testPostReadingPosition_ProductionNoResponseShape_ReportsUnder902() {
+        let spy = makeLoggerSpy()
+        let asProductionDelivers = NSError(domain: "Api call with failure HTTP status",
+                                           code: TPPErrorCode.invalidOrNoHTTPResponse.rawValue)
+        XCTAssertFalse(NetworkQueue.StatusCodes.contains(asProductionDelivers.code),
+                       "Precondition (this IS PP-4987): the code production delivers is not queueable")
+        mock.postStub = (nil, nil, asProductionDelivers)
+
+        let exp = expectation(description: "post reading position")
+        TPPAnnotations.postReadingPosition(forBook: bookID,
+                                           selectorValue: "{\"k\":\"v\"}",
+                                           motivation: .readingProgress) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(mock.postCallCount, 1, "Guard against a vacuous pass")
+        XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"],
+                       "Today's real offline failure is a genuine loss and must be reported")
+        XCTAssertEqual(spy.loggedCodes, [.apiCall],
+                       "It must stay in the 902 bucket, or re-measuring that bucket after PP-4987 reads a false win")
     }
 
     /// A server refusal must reach reporting WITH its status, so 401 and 500
@@ -1578,6 +1620,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
 
         XCTAssertEqual(mock.postCallCount, 1, "Guard against a vacuous pass")
         XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"])
+        XCTAssertEqual(spy.loggedCodes, [.apiCall], "A server refusal must stay in the 902 annotation bucket")
         XCTAssertEqual(spy.loggedMetadata.first?["statusCode"] as? Int, 401,
                        "Without the status code every refusal looks the same in telemetry")
     }

--- a/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
+++ b/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
@@ -422,7 +422,7 @@ final class TPPAnnotationsTests: XCTestCase {
             withParameters: parameters,
             timeout: 10,
             queueOffline: false
-        ) { _, _, _ in
+        ) { _ in
             expectation.fulfill()
         }
 
@@ -470,7 +470,11 @@ final class TPPAnnotationsTests: XCTestCase {
             withParameters: ["test": "data"],
             timeout: 10,
             queueOffline: false
-        ) { success, annotationID, timestamp in
+        ) { result in
+            var success = false
+            var annotationID: String?
+            var timestamp: String?
+            if case let .succeeded(sid, sts) = result { success = true; annotationID = sid; timestamp = sts }
             receivedSuccess = success
             receivedAnnotationID = annotationID
             receivedTimestamp = timestamp
@@ -505,7 +509,9 @@ final class TPPAnnotationsTests: XCTestCase {
             withParameters: ["test": "data"],
             timeout: 10,
             queueOffline: false
-        ) { success, _, _ in
+        ) { result in
+            var success = false
+            if case .succeeded = result { success = true }
             receivedSuccess = success
             expectation.fulfill()
         }
@@ -540,7 +546,9 @@ final class TPPAnnotationsTests: XCTestCase {
             withParameters: ["test": "data"],
             timeout: 10,
             queueOffline: false
-        ) { success, _, _ in
+        ) { result in
+            var success = false
+            if case .succeeded = result { success = true }
             receivedSuccess = success
             expectation.fulfill()
         }
@@ -860,7 +868,9 @@ final class TPPAnnotationsTests: XCTestCase {
             withParameters: emptyParameters,
             timeout: 10,
             queueOffline: false
-        ) { success, _, _ in
+        ) { result in
+            var success = false
+            if case .succeeded = result { success = true }
             receivedSuccess = success
             expectation.fulfill()
         }
@@ -1218,6 +1228,8 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         // suite (or any test it could call into) might have set.
         TPPAnnotations.executorOverride = nil
         TPPAnnotations.accountsManagerOverride = nil
+        TPPAnnotations.errorLoggerOverride = nil
+        TPPAnnotations.annotationsURLOverride = nil
         AnnotationDevice.accountsManagerOverride = nil
         AnnotationDevice.firebaseDeviceIDOverride = nil
         mock = nil
@@ -1230,26 +1242,41 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         HTTPURLResponse(url: url, statusCode: code, httpVersion: "HTTP/1.1", headerFields: nil)!
     }
 
-    private func postAndWait(parameters: [String: Any] = ["k": "v"],
-                             queueOffline: Bool = false,
-                             timeout: TimeInterval = 17,
-                             file: StaticString = #file,
-                             line: UInt = #line)
-    -> (success: Bool, id: String?, ts: String?) {
+    /// Raw outcome, for tests that care WHICH way a post concluded (PP-4965).
+    private func postAndWaitResult(parameters: [String: Any] = ["k": "v"],
+                                   queueOffline: Bool = false,
+                                   timeout: TimeInterval = 17)
+    -> TPPAnnotations.AnnotationPostResult {
         let exp = expectation(description: "post completion")
-        var result: (Bool, String?, String?) = (false, nil, nil)
+        var outcome: TPPAnnotations.AnnotationPostResult = .failed(underlying: nil, statusCode: nil)
         TPPAnnotations.postAnnotation(
             forBook: bookID,
             withAnnotationURL: url,
             withParameters: parameters,
             timeout: timeout,
             queueOffline: queueOffline
-        ) { success, id, ts in
-            result = (success, id, ts)
+        ) { result in
+            outcome = result
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1.0)
-        return result
+        return outcome
+    }
+
+    /// Success/id/timestamp view, preserved so the pre-PP-4965 assertions in
+    /// this suite keep exercising exactly what they did before.
+    private func postAndWait(parameters: [String: Any] = ["k": "v"],
+                             queueOffline: Bool = false,
+                             timeout: TimeInterval = 17,
+                             file: StaticString = #file,
+                             line: UInt = #line)
+    -> (success: Bool, id: String?, ts: String?) {
+        if case let .succeeded(id, ts) = postAndWaitResult(parameters: parameters,
+                                                           queueOffline: queueOffline,
+                                                           timeout: timeout) {
+            return (true, id, ts)
+        }
+        return (false, nil, nil)
     }
 
     // MARK: - POST: request shape
@@ -1391,13 +1418,171 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         XCTAssertFalse(ok)
     }
 
-    func testPostAnnotation_NetworkErrorWithQueueOfflineTrue_DoesNotCrashAndReportsFailure() {
-        // Use a status code that is in NetworkQueue.StatusCodes (notConnectedToInternet)
+    // PP-4965: this test previously asserted that a request handed to the
+    // offline queue "reports failure", and its comment noted the queue branch
+    // "does not affect the callback". That was the defect, pinned as if it were
+    // the contract: the caller reported every one of these as "Error posting
+    // annotation", which made that the app's largest error while the writes
+    // were in fact queued and delivered. A queued write is pending, not lost.
+    func testPostAnnotation_QueuedForRetry_IsReportedAsPendingNotFailure() {
+        // notConnectedToInternet is in NetworkQueue.StatusCodes, so with
+        // queueOffline the request is enqueued rather than abandoned.
         mock.postStub = (nil, nil, NSError(domain: NSURLErrorDomain,
                                            code: NSURLErrorNotConnectedToInternet))
-        let (ok, _, _) = postAndWait(queueOffline: true)
-        XCTAssertFalse(ok)
-        // The offline-queue branch is taken but does not affect the callback.
+
+        guard case .queuedForRetry = postAndWaitResult(queueOffline: true) else {
+            return XCTFail("A request accepted by the offline queue must report .queuedForRetry, not a failure")
+        }
+    }
+
+    /// The same transport error WITHOUT the offline queue is a genuine loss,
+    /// and must carry the underlying error so the logger's classifier can file
+    /// it as a transient condition rather than an unexplained API error.
+    func testPostAnnotation_TransportErrorNotQueued_ReportsFailedCarryingUnderlyingError() {
+        mock.postStub = (nil, nil, NSError(domain: NSURLErrorDomain,
+                                           code: NSURLErrorNotConnectedToInternet))
+
+        guard case let .failed(underlying, statusCode) = postAndWaitResult(queueOffline: false) else {
+            return XCTFail("An un-queued transport error must report .failed")
+        }
+        XCTAssertEqual(underlying?.code, NSURLErrorNotConnectedToInternet,
+                       "The underlying error must survive to the caller — dropping it is what defeated the classifier")
+        XCTAssertNil(statusCode, "No HTTP response means no status code")
+    }
+
+    /// A server refusal must carry the status, so 401 and 500 are separable.
+    func testPostAnnotation_ServerRefusal_ReportsFailedCarryingStatusCode() {
+        mock.postStub = (nil, httpResponse(500), nil)
+
+        guard case let .failed(underlying, statusCode) = postAndWaitResult() else {
+            return XCTFail("A non-200 response must report .failed")
+        }
+        XCTAssertEqual(statusCode, 500, "The status code must reach the caller so refusals are diagnosable")
+        XCTAssertNil(underlying, "A server refusal is not a transport error")
+    }
+
+    func testPostAnnotation_NonHTTPResponse_ReportsFailedWithNeitherErrorNorStatus() {
+        mock.postStub = (Data(), URLResponse(url: url, mimeType: nil,
+                                             expectedContentLength: 0,
+                                             textEncodingName: nil), nil)
+
+        guard case let .failed(underlying, statusCode) = postAndWaitResult() else {
+            return XCTFail("A non-HTTP response must report .failed")
+        }
+        XCTAssertNil(underlying)
+        XCTAssertNil(statusCode)
+    }
+
+    func testPostAnnotation_Success_ReportsSucceededWithServerValues() {
+        mock.postStub = (Data(#"{"id":"srv-77"}"#.utf8), httpResponse(200), nil)
+
+        guard case let .succeeded(id, _) = postAndWaitResult() else {
+            return XCTFail("A 200 must report .succeeded")
+        }
+        XCTAssertEqual(id, "srv-77")
+    }
+
+    // MARK: - PP-4965: what postReadingPosition actually REPORTS
+    //
+    // The tests above pin the classification. These pin the thing that made it
+    // matter — what reaches error reporting. Testing only the enum would leave
+    // the producer free to keep reporting everything as one error.
+    //
+    // Every test here asserts the POST actually went out. `postReadingPosition`
+    // is gated by `syncIsPossibleAndPermitted()`, and a blocked gate returns
+    // early having logged nothing — which is indistinguishable from correct
+    // behaviour. Without the call-count assertion these would pass vacuously.
+
+    private func makeLoggerSpy() -> ErrorLoggerSpy {
+        let spy = ErrorLoggerSpy()
+        TPPAnnotations.errorLoggerOverride = spy
+        TPPAnnotations.annotationsURLOverride = url
+
+        // Open the sync gate. `postReadingPosition` early-returns unless the
+        // patron is signed in AND the library both supports and permits sync —
+        // and an early return logs nothing, which looks exactly like the
+        // correct behaviour these tests are trying to prove. Hence the
+        // postCallCount assertion in each test.
+        let provider = TPPLibraryAccountMock()
+        let signedIn = TPPUserAccountMock()
+        signedIn._credentials = .token(authToken: "tok",
+                                       barcode: "12345",
+                                       pin: "1234",
+                                       expirationDate: Date().addingTimeInterval(3600))
+        provider.userAccountResolver = { _ in signedIn }
+        provider.currentAccount?.details?.syncPermissionGranted = true
+        TPPAnnotations.accountsManagerOverride = provider
+        return spy
+    }
+
+    /// The defect this ticket exists for: a write that is safely queued for
+    /// retry must not be reported as an error.
+    func testPostReadingPosition_QueuedForRetry_ReportsNothingToErrorLogging() {
+        let spy = makeLoggerSpy()
+        mock.postStub = (nil, nil, NSError(domain: NSURLErrorDomain,
+                                           code: NSURLErrorNotConnectedToInternet))
+
+        let exp = expectation(description: "post reading position")
+        TPPAnnotations.postReadingPosition(forBook: bookID,
+                                           selectorValue: "{\"k\":\"v\"}",
+                                           motivation: .readingProgress) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(mock.postCallCount, 1,
+                       "Guard against a vacuous pass: the sync gate must have opened and the POST gone out")
+        XCTAssertEqual(spy.loggedSummaries, [],
+                       "A queued write is pending, not failed — reporting it is what made this the app's largest error")
+    }
+
+    /// A genuine transport loss must still be reported, and must carry the
+    /// underlying error so the logger's classifier can file transient
+    /// conditions ("No Internet Connection") separately from real defects.
+    func testPostReadingPosition_GenuineTransportLoss_ReportsWithUnderlyingErrorAttached() {
+        let spy = makeLoggerSpy()
+
+        // This test needs a transport error the offline queue will NOT retry —
+        // a retried one is pending, not lost, and correctly reports nothing.
+        // Asserted rather than assumed: an earlier draft picked
+        // `cannotFindHost`, which IS queueable, so the test failed for the
+        // right reason. If someone adds this code to the queueable set later,
+        // this precondition says so instead of the test quietly inverting.
+        let unretryable = NSURLErrorBadServerResponse
+        XCTAssertFalse(NetworkQueue.StatusCodes.contains(unretryable),
+                       "Precondition: this test requires an error the offline queue does not retry")
+
+        mock.postStub = (nil, nil, NSError(domain: NSURLErrorDomain, code: unretryable))
+
+        let exp = expectation(description: "post reading position")
+        TPPAnnotations.postReadingPosition(forBook: bookID,
+                                           selectorValue: "{\"k\":\"v\"}",
+                                           motivation: .readingProgress) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(mock.postCallCount, 1, "Guard against a vacuous pass")
+        XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"])
+        // `loggedErrors` is [Error?], so `.first` is doubly optional — flatten
+        // before bridging, or the cast silently compares against nil.
+        let reported = (spy.loggedErrors.first ?? nil) as NSError?
+        XCTAssertEqual(reported?.code, unretryable,
+                       "Dropping the underlying error is what defeated the logger's transient-condition classifier")
+    }
+
+    /// A server refusal must reach reporting WITH its status, so 401 and 500
+    /// are distinguishable in telemetry rather than both being "api call".
+    func testPostReadingPosition_ServerRefusal_ReportsStatusCodeInMetadata() {
+        let spy = makeLoggerSpy()
+        mock.postStub = (nil, httpResponse(401), nil)
+
+        let exp = expectation(description: "post reading position")
+        TPPAnnotations.postReadingPosition(forBook: bookID,
+                                           selectorValue: "{\"k\":\"v\"}",
+                                           motivation: .readingProgress) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(mock.postCallCount, 1, "Guard against a vacuous pass")
+        XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"])
+        XCTAssertEqual(spy.loggedMetadata.first?["statusCode"] as? Int, 401,
+                       "Without the status code every refusal looks the same in telemetry")
     }
 
     // MARK: - DELETE
@@ -1598,5 +1783,35 @@ class AnnotationDeviceIDTests: XCTestCase {
             XCTAssertTrue(id.contains(firebaseID),
                           "Call #\(i): annotation device ID must contain the FirebaseManager deviceID — broken derivation breaks cross-device detection")
         }
+    }
+}
+
+/// Records what was reported to error logging so tests can assert on it (PP-4965).
+private final class ErrorLoggerSpy: ErrorLogging {
+    private(set) var loggedSummaries: [String] = []
+    private(set) var loggedErrors: [Error?] = []
+    private(set) var loggedMetadata: [[String: Any]] = []
+
+    func logError(_ error: Error?, summary: String, metadata: [String: Any]?) {
+        loggedSummaries.append(summary)
+        loggedErrors.append(error)
+        loggedMetadata.append(metadata ?? [:])
+    }
+
+    func logError(withCode code: TPPErrorCode, summary: String, metadata: [String: Any]?) {
+        loggedSummaries.append(summary)
+        loggedErrors.append(nil)
+        loggedMetadata.append(metadata ?? [:])
+    }
+
+    func logNetworkError(_ originalError: Error?,
+                         code: TPPErrorCode,
+                         summary: String?,
+                         request: URLRequest?,
+                         response: URLResponse?,
+                         metadata: [String: Any]?) {
+        loggedSummaries.append(summary ?? "")
+        loggedErrors.append(originalError)
+        loggedMetadata.append(metadata ?? [:])
     }
 }

--- a/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
+++ b/PalaceTests/Bookmarks/TPPAnnotationsTests.swift
@@ -1217,6 +1217,13 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
     private let url = URL(string: "https://test.library.org/annotations/")!
     private let bookID = "urn:uuid:test-book-hermetic"
 
+    /// `Account.syncPermissionGranted` is not a plain property — its setter
+    /// writes through to `UserDefaults` keyed by the account uuid. Opening the
+    /// sync gate in `makeLoggerSpy()` therefore mutates shared state that
+    /// outlives the test, which is exactly the bleed this suite's tearDown
+    /// exists to prevent. Capture what was there and put it back.
+    private var syncPermissionRestore: (() -> Void)?
+
     override func setUp() {
         super.setUp()
         mock = RecordingExecutorMock()
@@ -1232,6 +1239,8 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         TPPAnnotations.annotationsURLOverride = nil
         AnnotationDevice.accountsManagerOverride = nil
         AnnotationDevice.firebaseDeviceIDOverride = nil
+        syncPermissionRestore?()
+        syncPermissionRestore = nil
         mock = nil
         super.tearDown()
     }
@@ -1240,6 +1249,24 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
 
     private func httpResponse(_ code: Int) -> HTTPURLResponse {
         HTTPURLResponse(url: url, statusCode: code, httpVersion: "HTTP/1.1", headerFields: nil)!
+    }
+
+    /// The exact triple the real stack delivers for a server refusal.
+    ///
+    /// `TPPNetworkResponder` turns EVERY non-2xx into
+    /// `NSError(domain: "Api call with failure HTTP status", code: 909)` and
+    /// returns it alongside the response; `TPPNetworkExecutor.POST` forwards
+    /// both as `(nil, response, error)`. Stubbing `(nil, response, nil)` — an
+    /// error-free non-2xx — describes a shape production never emits, and two
+    /// tests once passed against it while the behaviour they asserted did not
+    /// exist (PP-4965 review round 2). Build refusals through here so that
+    /// cannot recur.
+    private func serverRefusal(_ code: Int) -> (Data?, URLResponse?, Error?) {
+        (nil,
+         httpResponse(code),
+         NSError(domain: "Api call with failure HTTP status",
+                 code: TPPErrorCode.responseFail.rawValue,
+                 userInfo: nil))
     }
 
     /// Raw outcome, for tests that care WHICH way a post concluded (PP-4965).
@@ -1381,7 +1408,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
     // MARK: - POST: failure paths
 
     func testPostAnnotation_Non200StatusCode_ReturnsFailure() {
-        mock.postStub = (nil, httpResponse(500), nil)
+        mock.postStub = serverRefusal(500)
         let (ok, id, ts) = postAndWait()
         XCTAssertFalse(ok)
         XCTAssertNil(id)
@@ -1389,13 +1416,13 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
     }
 
     func testPostAnnotation_Unauthorized401_ReturnsFailure() {
-        mock.postStub = (nil, httpResponse(401), nil)
+        mock.postStub = serverRefusal(401)
         let (ok, _, _) = postAndWait()
         XCTAssertFalse(ok, "401 should be propagated as failure from postAnnotation")
     }
 
     func testPostAnnotation_NotFound404_ReturnsFailure() {
-        mock.postStub = (nil, httpResponse(404), nil)
+        mock.postStub = serverRefusal(404)
         let (ok, _, _) = postAndWait()
         XCTAssertFalse(ok)
     }
@@ -1451,15 +1478,37 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
     }
 
     /// A server refusal must carry the status, so 401 and 500 are separable.
+    ///
+    /// Driven through the production shape (error AND response both present),
+    /// because that is the only one the real executor produces for a non-2xx.
+    /// The earlier version of this test stubbed an error-free 500, which took
+    /// a branch production cannot reach and so asserted nothing real.
     func testPostAnnotation_ServerRefusal_ReportsFailedCarryingStatusCode() {
-        mock.postStub = (nil, httpResponse(500), nil)
+        mock.postStub = serverRefusal(500)
 
         guard case let .failed(underlying, response) = postAndWaitResult() else {
             return XCTFail("A non-200 response must report .failed")
         }
         XCTAssertEqual(response?.statusCode, 500,
                        "The response must reach the caller so refusals are diagnosable AND classifiable as server-origin")
-        XCTAssertNil(underlying, "A server refusal is not a transport error")
+        XCTAssertEqual(underlying?.code, TPPErrorCode.responseFail.rawValue,
+                       "The synthesized 909 the responder attaches to every non-2xx must survive alongside the response — it is what proves this took the error branch, the one production actually uses")
+    }
+
+    /// The remaining `.failed` producer cell. `postAnnotation` bails before it
+    /// ever reaches the network when the parameters will not serialize, and
+    /// without this the branch is free to become `.queuedForRetry` — which
+    /// would SUPPRESS the report for a write that was never queued and never
+    /// sent. A serialization defect would then be silently swallowed.
+    func testPostAnnotation_UnserializableParameters_ReportsFailedWithoutNetwork() {
+        guard case let .failed(underlying, response) =
+                postAndWaitResult(parameters: ["created": Date()], queueOffline: true) else {
+            return XCTFail("A payload that cannot be built must report .failed, never queued")
+        }
+        XCTAssertNil(underlying, "Nothing was sent, so there is no transport error to carry")
+        XCTAssertNil(response, "Nothing was sent, so there is no response to carry")
+        XCTAssertEqual(mock.postCallCount, 0,
+                       "The request must be abandoned before the executor is touched")
     }
 
     func testPostAnnotation_NonHTTPResponse_ReportsFailedWithNeitherErrorNorStatus() {
@@ -1511,6 +1560,10 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
                                        pin: "1234",
                                        expirationDate: Date().addingTimeInterval(3600))
         provider.userAccountResolver = { _ in signedIn }
+        if let details = provider.currentAccount?.details {
+            let previous = details.syncPermissionGranted
+            syncPermissionRestore = { details.syncPermissionGranted = previous }
+        }
         provider.currentAccount?.details?.syncPermissionGranted = true
         TPPAnnotations.accountsManagerOverride = provider
         return spy
@@ -1610,7 +1663,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
     /// are distinguishable in telemetry rather than both being "api call".
     func testPostReadingPosition_ServerRefusal_ReportsStatusCodeInMetadata() {
         let spy = makeLoggerSpy()
-        mock.postStub = (nil, httpResponse(401), nil)
+        mock.postStub = serverRefusal(401)
 
         let exp = expectation(description: "post reading position")
         TPPAnnotations.postReadingPosition(forBook: bookID,
@@ -1622,7 +1675,7 @@ final class TPPAnnotationsHermeticTests: XCTestCase {
         XCTAssertEqual(spy.loggedSummaries, ["Error posting annotation"])
         XCTAssertEqual(spy.loggedCodes, [.apiCall], "A server refusal must stay in the 902 annotation bucket")
         XCTAssertEqual(spy.loggedMetadata.first?["statusCode"] as? Int, 401,
-                       "Without the status code every refusal looks the same in telemetry")
+                       "Without the status code every refusal looks the same in telemetry. This is the assertion that was passing vacuously: the fixture used to omit the error the responder always attaches, so the caller took a branch that kept the response — while production took the one that dropped it.")
     }
 
     // MARK: - DELETE

--- a/PalaceTests/Mocks/ErrorLoggerSpy.swift
+++ b/PalaceTests/Mocks/ErrorLoggerSpy.swift
@@ -46,10 +46,14 @@ final class ErrorLoggerSpy: ErrorLogging, @unchecked Sendable {
         (loggedErrors.first ?? nil) as NSError?
     }
 
-    /// The Crashlytics code the first report would carry. Asserting this is how
-    /// the suite catches a reporting change that silently moves the bucket —
-    /// the defect review caught on this branch (PP-4965).
-    var firstReportedCode: Int? { firstReportedNSError?.code }
+    // NOTE: there is deliberately no `firstReportedCode` convenience here.
+    // An earlier revision had one, documented as "the Crashlytics code the
+    // first report would carry" while actually returning the UNDERLYING
+    // NSError's code (909 for a server refusal, an NSURLError for a transport
+    // failure) — not the `TPPErrorCode` the report is filed under. A test
+    // reaching for it to prove the 902 bucket was preserved would have got a
+    // confident, wrong answer. Use `loggedCodes`, which records what the
+    // caller actually asked to file it as.
 
     func logError(_ error: Error?, summary: String, metadata: [String: Any]?) {
         record(summary: summary, error: error, metadata: metadata)

--- a/PalaceTests/Mocks/ErrorLoggerSpy.swift
+++ b/PalaceTests/Mocks/ErrorLoggerSpy.swift
@@ -12,10 +12,32 @@
 import Foundation
 @testable import Palace
 
-final class ErrorLoggerSpy: ErrorLogging {
-    private(set) var loggedSummaries: [String] = []
-    private(set) var loggedErrors: [Error?] = []
-    private(set) var loggedMetadata: [[String: Any]] = []
+/// `@unchecked Sendable`: all mutable state is guarded by `lock`, mirroring
+/// `TPPBookRegistryMock`. Reports can arrive from whatever queue the network
+/// completion ran on, so an unsynchronized array here is a data race that
+/// would surface as a flake rather than a failure.
+final class ErrorLoggerSpy: ErrorLogging, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _loggedSummaries: [String] = []
+    private var _loggedErrors: [Error?] = []
+    private var _loggedMetadata: [[String: Any]] = []
+    private var _loggedCodes: [TPPErrorCode] = []
+
+    var loggedSummaries: [String] { lock.withLock { _loggedSummaries } }
+    var loggedErrors: [Error?] { lock.withLock { _loggedErrors } }
+    var loggedMetadata: [[String: Any]] { lock.withLock { _loggedMetadata } }
+
+    /// The TPPErrorCode each report was filed under. `.apiCall` (902) is the
+    /// annotation bucket; a change that moves off it is a telemetry regression.
+    var loggedCodes: [TPPErrorCode] { lock.withLock { _loggedCodes } }
+
+    private func record(summary: String, error: Error?, metadata: [String: Any]?) {
+        lock.withLock {
+            _loggedSummaries.append(summary)
+            _loggedErrors.append(error)
+            _loggedMetadata.append(metadata ?? [:])
+        }
+    }
 
     /// The underlying error of the first report, flattened and bridged.
     /// `loggedErrors` is `[Error?]`, so `.first` is doubly optional — reading
@@ -24,16 +46,18 @@ final class ErrorLoggerSpy: ErrorLogging {
         (loggedErrors.first ?? nil) as NSError?
     }
 
+    /// The Crashlytics code the first report would carry. Asserting this is how
+    /// the suite catches a reporting change that silently moves the bucket —
+    /// the defect review caught on this branch (PP-4965).
+    var firstReportedCode: Int? { firstReportedNSError?.code }
+
     func logError(_ error: Error?, summary: String, metadata: [String: Any]?) {
-        loggedSummaries.append(summary)
-        loggedErrors.append(error)
-        loggedMetadata.append(metadata ?? [:])
+        record(summary: summary, error: error, metadata: metadata)
     }
 
     func logError(withCode code: TPPErrorCode, summary: String, metadata: [String: Any]?) {
-        loggedSummaries.append(summary)
-        loggedErrors.append(nil)
-        loggedMetadata.append(metadata ?? [:])
+        record(summary: summary, error: nil, metadata: metadata)
+        lock.withLock { _loggedCodes.append(code) }
     }
 
     func logNetworkError(_ originalError: Error?,
@@ -42,8 +66,7 @@ final class ErrorLoggerSpy: ErrorLogging {
                          request: URLRequest?,
                          response: URLResponse?,
                          metadata: [String: Any]?) {
-        loggedSummaries.append(summary ?? "")
-        loggedErrors.append(originalError)
-        loggedMetadata.append(metadata ?? [:])
+        record(summary: summary ?? "", error: originalError, metadata: metadata)
+        lock.withLock { _loggedCodes.append(code) }
     }
 }

--- a/PalaceTests/Mocks/ErrorLoggerSpy.swift
+++ b/PalaceTests/Mocks/ErrorLoggerSpy.swift
@@ -1,0 +1,49 @@
+//
+//  ErrorLoggerSpy.swift
+//  PalaceTests
+//
+//  Records what production code reports to error logging, so tests can assert
+//  on it (PP-4965). Whether a failure is reported AT ALL — and with what
+//  underlying error attached — is behaviour, not a side effect: reporting a
+//  write that was safely queued for retry is what made "Error posting
+//  annotation" the largest error in the app.
+//
+
+import Foundation
+@testable import Palace
+
+final class ErrorLoggerSpy: ErrorLogging {
+    private(set) var loggedSummaries: [String] = []
+    private(set) var loggedErrors: [Error?] = []
+    private(set) var loggedMetadata: [[String: Any]] = []
+
+    /// The underlying error of the first report, flattened and bridged.
+    /// `loggedErrors` is `[Error?]`, so `.first` is doubly optional — reading
+    /// it without flattening silently compares against nil.
+    var firstReportedNSError: NSError? {
+        (loggedErrors.first ?? nil) as NSError?
+    }
+
+    func logError(_ error: Error?, summary: String, metadata: [String: Any]?) {
+        loggedSummaries.append(summary)
+        loggedErrors.append(error)
+        loggedMetadata.append(metadata ?? [:])
+    }
+
+    func logError(withCode code: TPPErrorCode, summary: String, metadata: [String: Any]?) {
+        loggedSummaries.append(summary)
+        loggedErrors.append(nil)
+        loggedMetadata.append(metadata ?? [:])
+    }
+
+    func logNetworkError(_ originalError: Error?,
+                         code: TPPErrorCode,
+                         summary: String?,
+                         request: URLRequest?,
+                         response: URLResponse?,
+                         metadata: [String: Any]?) {
+        loggedSummaries.append(summary ?? "")
+        loggedErrors.append(originalError)
+        loggedMetadata.append(metadata ?? [:])
+    }
+}

--- a/PalaceTests/Mocks/ErrorLoggerSpy.swift
+++ b/PalaceTests/Mocks/ErrorLoggerSpy.swift
@@ -57,6 +57,13 @@ final class ErrorLoggerSpy: ErrorLogging, @unchecked Sendable {
 
     func logError(_ error: Error?, summary: String, metadata: [String: Any]?) {
         record(summary: summary, error: error, metadata: metadata)
+        // Record `.ignore` — which is what this overload hardcodes — so
+        // `loggedCodes` stays INDEX-ALIGNED with `loggedSummaries`. It used to
+        // append nothing, so a report through this overload was invisible in
+        // `loggedCodes`: a test asserting `loggedCodes == [.offlineQueueWriteFailed]`
+        // would have passed while a second report silently filed under
+        // `.ignore`. That is exactly how the round-3 916 defect could have hid.
+        lock.withLock { _loggedCodes.append(.ignore) }
     }
 
     func logError(withCode code: TPPErrorCode, summary: String, metadata: [String: Any]?) {

--- a/PalaceTests/Mocks/OfflineQueueSpy.swift
+++ b/PalaceTests/Mocks/OfflineQueueSpy.swift
@@ -1,0 +1,67 @@
+//
+//  OfflineQueueSpy.swift
+//  PalaceTests
+//
+//  Records what `TPPAnnotations` hands to the offline retry queue.
+//
+//  PP-4987 made `.queuedForRetry` reachable in production, which turned "the
+//  write reached the queue" into a load-bearing claim: PP-4965 removes the
+//  error report for a queued write on exactly that basis. Before this spy the
+//  claim was unassertable — `addToOfflineQueue` reached
+//  `AppContainer.production().networkQueue` directly, so tests could only
+//  prove that nothing was REPORTED, never that anything was STORED.
+//
+//  It also keeps the cross-device suite out of the app's real `simplified.db`:
+//  once the branch went live those tests began writing durable rows a later
+//  reachability event could replay.
+//
+
+import Foundation
+@testable import Palace
+
+final class OfflineQueueSpy: AnnotationOfflineQueueing {
+
+    struct Enqueued {
+        let libraryID: String
+        let updateID: String?
+        let url: URL
+        let method: HTTPMethodType
+        let parameters: Data?
+        let headers: [String: String]?
+
+        /// The POSTed annotation body, decoded — so tests can assert WHICH
+        /// write was stored rather than merely that one was.
+        var body: [String: Any]? {
+            guard let parameters else { return nil }
+            return try? JSONSerialization.jsonObject(with: parameters) as? [String: Any]
+        }
+    }
+
+    private let lock = NSLock()
+    private var _enqueued: [Enqueued] = []
+
+    var enqueued: [Enqueued] { lock.withLock { _enqueued } }
+    var count: Int { lock.withLock { _enqueued.count } }
+
+    /// The keys the queue would collapse on. `NetworkQueue.addRequest` UPDATEs
+    /// the row matching `(libraryID, updateID)`, so two writes sharing an
+    /// updateID overwrite each other — which is correct for reading positions
+    /// and data loss for bookmarks.
+    var updateIDs: [String?] { lock.withLock { _enqueued.map(\.updateID) } }
+
+    func addRequest(_ libraryID: String,
+                    _ updateID: String?,
+                    _ requestUrl: URL,
+                    _ method: HTTPMethodType,
+                    _ parameters: Data?,
+                    _ headers: [String: String]?) {
+        lock.withLock {
+            _enqueued.append(Enqueued(libraryID: libraryID,
+                                      updateID: updateID,
+                                      url: requestUrl,
+                                      method: method,
+                                      parameters: parameters,
+                                      headers: headers))
+        }
+    }
+}

--- a/PalaceTests/Network/NetworkQueueTests.swift
+++ b/PalaceTests/Network/NetworkQueueTests.swift
@@ -94,16 +94,22 @@ class NetworkQueueTests: XCTestCase {
         // A fresh database has no table until `migrate()` creates it — without
         // this the "success" case fails at the insert and reports a drop, which
         // would make this control test pass for the wrong reason.
+        //
+        // `serialQueue.sync {}` is a REAL barrier: every DB operation is
+        // dispatched onto that queue, so this returns only once migrate() has
+        // actually run. The previous `expectEventually { loggedSummaries.isEmpty }`
+        // was true on its first evaluation and returned instantly — not a
+        // barrier at all, just a sleep that happened to work.
         queue.migrate()
-        expectEventually("the schema to exist") { spy.loggedSummaries.isEmpty }
+        queue.serialQueue.sync {}
 
         queue.addRequest("lib-1", "update-1",
                          URL(string: "https://example.org/annotations/")!,
                          HTTPMethodType.POST, Data("{}".utf8), nil)
 
-        // Give the serial queue the same window the failing test gets, so this
-        // is a real "nothing arrived", not a race that has not happened yet.
-        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        // Barrier, not a sleep: once the serial queue has drained, the write
+        // has been attempted and any report would already have been recorded.
+        queue.serialQueue.sync {}
         XCTAssertEqual(spy.loggedSummaries, [],
                        "A write that WAS persisted must report nothing at all")
     }
@@ -114,6 +120,73 @@ class NetworkQueueTests: XCTestCase {
         NetworkTransport(delegate: nil,
                          cachingStrategy: .ephemeral,
                          requestTimeout: 5)
+    }
+
+    /// The OTHER drop path. `guard let db` covers an unopenable database; this
+    /// covers a database that opens and then refuses the write — the insert
+    /// throws because no table exists yet.
+    ///
+    /// Round 3 of review found this path filing under the WRONG code: it used
+    /// the bare `logError(_:summary:metadata:)` overload, which hardcodes
+    /// `code: .ignore`, so the report landed under the raw SQLite code with
+    /// `error_origin = unknown` rather than 916 — while the commit claimed both
+    /// paths reported under 916. Untested code made the false claim possible.
+    func testAddRequest_WhenInsertThrows_ReportsUnderTheSameDedicatedCode() {
+        let spy = ErrorLoggerSpy()
+        let dir = NSTemporaryDirectory() + "pp4987-noschema-" + UUID().uuidString
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        // Deliberately NO migrate() — the database opens, the table does not exist.
+        let queue = NetworkQueue(transport: makeTransport(),
+                                 reachability: Reachability(),
+                                 databaseDirectory: dir,
+                                 errorLogger: spy)
+        queue.addRequest("lib-1", "update-1",
+                         URL(string: "https://example.org/annotations/")!,
+                         HTTPMethodType.POST, Data("{}".utf8), nil)
+        queue.serialQueue.sync {}
+
+        XCTAssertEqual(spy.loggedSummaries, ["Offline queue write dropped"],
+                       "A write the database refused must be reported, not swallowed by a local Log.error")
+        XCTAssertEqual(spy.loggedCodes, [.offlineQueueWriteFailed],
+                       "It must file under 916 like the other drop path — the bare logError overload hardcodes .ignore and would file it under the raw SQLite code")
+        XCTAssertEqual(spy.loggedMetadata.first?["reason"] as? String, "insert or update threw",
+                       "The report must distinguish WHICH drop path fired")
+    }
+
+    // MARK: - PP-4987: the credential must never reach disk
+
+    /// `simplified.db` is an unencrypted file in Application Support, and
+    /// callers build headers from `TPPNetworkExecutor.request(for:)` whose
+    /// `useTokenIfAvailable` defaults to TRUE — so a live bearer token is in
+    /// the header set unless it is stripped. Nothing was ever queued before
+    /// PP-4987, so this never executed; turning the queue on is what would
+    /// have started writing credentials to disk.
+    func testHeadersSafeToPersist_RemovesTheCredentialAndKeepsEverythingElse() {
+        let sanitized = NetworkQueue.headersSafeToPersist([
+            "Authorization": "Bearer super-secret-token",
+            "Content-Type": "application/json",
+            "Accept-Language": ""
+        ])
+
+        XCTAssertNil(sanitized["Authorization"],
+                     "A live credential must never be archived into the unencrypted queue database")
+        XCTAssertFalse(sanitized.values.contains { $0.contains("super-secret-token") },
+                       "The token must not survive under any key")
+        XCTAssertEqual(sanitized["Content-Type"], "application/json",
+                       "Everything the retry needs must survive — stripping too much breaks the replay")
+        XCTAssertEqual(sanitized.count, 2)
+    }
+
+    /// HTTP header names are case-insensitive, so a caller spelling it
+    /// differently must not smuggle the credential past the filter.
+    func testHeadersSafeToPersist_IsCaseInsensitive() {
+        for spelling in ["authorization", "AUTHORIZATION", "AuThOrIzAtIoN"] {
+            let sanitized = NetworkQueue.headersSafeToPersist([spelling: "Bearer t", "X-Keep": "1"])
+            XCTAssertEqual(sanitized, ["X-Keep": "1"],
+                           "\(spelling) must be stripped exactly like the canonical spelling")
+        }
     }
 
     private func unopenableDatabaseDirectory() -> String {

--- a/PalaceTests/Network/NetworkQueueTests.swift
+++ b/PalaceTests/Network/NetworkQueueTests.swift
@@ -423,34 +423,52 @@ class NetworkQueueTests: XCTestCase {
                        "A superseding write is a NEW write and must get a full retry budget — inheriting an exhausted count gets it deleted before it is ever sent")
     }
 
-    /// A header blob that cannot be read must leave the row alone.
+    /// A CORRUPTED header archive must be survived, not crashed on.
     ///
-    /// The purge runs on the launch path (via SEMigrations) over rows written
-    /// by builds up to five years old, so it has to tolerate a blob it cannot
-    /// decode.
+    /// The fixture is a valid archive with one bit flipped — which is what
+    /// real on-disk corruption looks like, and the only shape that actually
+    /// kills the legacy unarchiver. Garbage bytes and truncated archives both
+    /// return nil, so a casual probe finds nothing; an earlier version of this
+    /// test used ASCII garbage and therefore passed against BOTH
+    /// implementations, guarding nothing. Bit-flipping each byte of a valid
+    /// 277-byte archive in turn: the legacy `unarchiveObject(with:)` aborts the
+    /// process on 63 of 277, the modern `unarchivedObject(ofClasses:)` on none.
     ///
-    /// HONESTY NOTE: this test does NOT discriminate between the modern and
-    /// legacy unarchivers — review predicted the legacy one would raise and
-    /// crash, and it does not; both return nil for garbage and for a truncated
-    /// archive. It pins the behaviour that matters (an unreadable row is kept,
-    /// not discarded), not a mutation kill. Labelled rather than dressed up as
-    /// a guard it is not.
-    func testMigrate_WithAnUnreadableHeaderBlob_LeavesTheRowIntact() {
+    /// This matters because the purge runs on the LAUNCH path via SEMigrations,
+    /// over rows written by builds up to five years old.
+    func testMigrate_WithACorruptedHeaderArchive_SurvivesInsteadOfCrashing() {
         let (queue, dir) = makeWritableQueue()
         defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        // A real archive with its CLASS NAME corrupted in place. Targeted
+        // structurally rather than by byte index: a keyed archive stores
+        // "NSDictionary" as ASCII, and destroying it produces exactly the
+        // "missing class information for object" condition that makes the
+        // legacy unarchiver raise. Flipping an arbitrary byte is unreliable —
+        // only 63 of 277 positions abort, and the midpoint is not one of them,
+        // which is how the first version of this fixture ended up guarding
+        // nothing.
+        var corrupted = NSKeyedArchiver.archivedData(
+            withRootObject: ["Authorization": "Bearer secret"])
+        let className = Array("NSDictionary".utf8)
+        if let r = corrupted.range(of: Data(className)) {
+            corrupted.replaceSubrange(r, with: Data(repeating: 0x5A, count: className.count))
+        } else {
+            XCTFail("fixture precondition: the archive should name NSDictionary")
+        }
 
         queue.insertLegacyRowForTesting(
             libraryID: "lib-A",
             updateID: "book-1",
             url: URL(string: "https://a.example.org/annotations/")!,
             headers: [:],
-            rawHeaderData: Data("this is not a keyed archive".utf8))
+            rawHeaderData: corrupted)
 
         queue.migrate()
         queue.serialQueue.sync {}
 
         XCTAssertEqual(queue.persistedRowsForTesting().count, 1,
-                       "The row survives — a blob we cannot read is not a reason to discard a patron's queued write, nor to crash on launch")
+                       "The row survives — a corrupt blob is not a reason to discard a patron's queued write, and must never abort the launch")
     }
 
     private func unopenableDatabaseDirectory() -> String {

--- a/PalaceTests/Network/NetworkQueueTests.swift
+++ b/PalaceTests/Network/NetworkQueueTests.swift
@@ -114,12 +114,16 @@ class NetworkQueueTests: XCTestCase {
                        "A write that WAS persisted must report nothing at all")
     }
 
-    /// The queue never sends anything in these tests — it fails (or succeeds)
-    /// at the SQLite step first — so a plain ephemeral transport is enough.
+    /// A transport whose every request is intercepted by
+    /// `HTTPStubURLProtocol` — no real network. The drain test below actually
+    /// issues requests, and a unit test that talks to the internet is both
+    /// banned by CLAUDE.md and non-deterministic.
     private func makeTransport() -> NetworkTransport {
-        NetworkTransport(delegate: nil,
-                         cachingStrategy: .ephemeral,
-                         requestTimeout: 5)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [HTTPStubURLProtocol.self]
+        return NetworkTransport(delegate: nil,
+                                sessionConfiguration: config,
+                                requestTimeout: 5)
     }
 
     /// The OTHER drop path. `guard let db` covers an unopenable database; this
@@ -161,8 +165,9 @@ class NetworkQueueTests: XCTestCase {
     /// callers build headers from `TPPNetworkExecutor.request(for:)` whose
     /// `useTokenIfAvailable` defaults to TRUE — so a live bearer token is in
     /// the header set unless it is stripped. Nothing was ever queued before
-    /// PP-4987, so this never executed; turning the queue on is what would
-    /// have started writing credentials to disk.
+    /// PP-4987 on CURRENT builds — but it did run historically (see
+    /// `testMigrate_PurgesACredentialLeftBehindByAnOlderBuild`), and turning
+    /// the queue back on is what would resume it.
     func testHeadersSafeToPersist_RemovesTheCredentialAndKeepsEverythingElse() {
         let sanitized = NetworkQueue.headersSafeToPersist([
             "Authorization": "Bearer super-secret-token",
@@ -267,6 +272,10 @@ class NetworkQueueTests: XCTestCase {
         let book2 = queue.persistedRowsForTesting().filter { $0.updateID == "book-2" }
         XCTAssertEqual(book2.count, 1,
                        "A newer position supersedes an older one for the same book — collapsing is the desired behaviour here")
+        // "One row" alone cannot distinguish superseding from silently dropping
+        // the second write, which is the property that actually matters.
+        XCTAssertEqual(book2.first?.parameters, Data(#"{"p":2}"#.utf8),
+                       "The surviving row must carry the NEWER position — collapsing must supersede, not discard")
     }
 
     /// The credential must be resolved for the ROW'S library, never the
@@ -280,13 +289,17 @@ class NetworkQueueTests: XCTestCase {
     /// valid token available. Round 4 of review caught exactly that; the
     /// codebase already documents the invariant on
     /// `TPPNetworkExecutor.request(for:accountId:)`.
-    func testDrain_ResolvesTheCredentialForEachRowsOwnLibrary_NotTheSelectedOne() {
-        let asked = AskedLibraries()
+    func testDrain_SendsEachRowsOwnLibraryCredential_OnTheWire() {
+        let seen = SeenAuthorizations()
+        HTTPStubURLProtocol.register { @Sendable request in
+            guard let host = request.url?.host else { return nil }
+            seen.record(host: host,
+                        authorization: request.value(forHTTPHeaderField: "Authorization"))
+            return .init(statusCode: 200, headers: nil, body: Data("ok".utf8))
+        }
+
         let (queue, dir) = makeWritableQueue(
-            authorizationHeaderProvider: { libraryID in
-                asked.record(libraryID)
-                return "Bearer token-for-\(libraryID)"
-            })
+            authorizationHeaderProvider: { libraryID in "Bearer token-for-\(libraryID)" })
         defer { try? FileManager.default.removeItem(atPath: dir) }
 
         queue.addRequest("lib-A", "book-1",
@@ -297,23 +310,69 @@ class NetworkQueueTests: XCTestCase {
                          HTTPMethodType.POST, Data("{}".utf8), nil)
         queue.serialQueue.sync {}
 
-        // `retryQueue` is @objc private and normally fires off a reachability
-        // publisher; drive it directly rather than waiting on the network.
-        queue.perform(Selector(("retryQueue")))
-        queue.serialQueue.sync {}
+        queue.retryQueue()
+        expectEventually("both rows to be retried") { seen.hosts.count >= 2 }
 
-        let requested = asked.all.sorted()
-        XCTAssertEqual(requested, ["lib-A", "lib-B"],
-                       "Each row's credential must be resolved for ITS OWN library — asking once for the selected library would send one library's token to the other's server")
+        // Asserted ON THE WIRE, not at the provider. Round 5 caught the
+        // previous version proving only that the right library was ASKED —
+        // deleting the `setValue(...)` that attaches the answer left the whole
+        // suite green. Resolving a credential and sending it are two claims.
+        XCTAssertEqual(seen.authorization(for: "a.example.org"), "Bearer token-for-lib-A",
+                       "Library A's row must be sent with library A's credential")
+        XCTAssertEqual(seen.authorization(for: "b.example.org"), "Bearer token-for-lib-B",
+                       "…and library B's with B's. Sending one library's token to the other's server is a cross-tenant disclosure")
     }
 
-    /// The provider is `@Sendable` and is invoked on the queue's serial queue,
-    /// so the recorder has to be safe to cross that boundary.
-    private final class AskedLibraries: @unchecked Sendable {
+    /// Records the `Authorization` each host actually received. The stub
+    /// handler is `@Sendable` and runs off the test's thread, so this has to be
+    /// safe to cross that boundary.
+    private final class SeenAuthorizations: @unchecked Sendable {
         private let lock = NSLock()
-        private var _all: [String] = []
-        var all: [String] { lock.withLock { _all } }
-        func record(_ id: String) { lock.withLock { _all.append(id) } }
+        private var byHost: [String: String?] = [:]
+        var hosts: [String] { lock.withLock { Array(byHost.keys) } }
+        func record(host: String, authorization: String?) {
+            lock.withLock { byHost[host] = authorization }
+        }
+        func authorization(for host: String) -> String? {
+            lock.withLock { byHost[host] ?? nil }
+        }
+    }
+
+    /// Legacy rows on real devices can carry a cleartext credential, and
+    /// `migrate()` must clear them.
+    ///
+    /// Not hypothetical: up to Release 1.1.0 `postAnnotation` used
+    /// `URLSession.shared` directly, so the raw NSURLError reached
+    /// `NetworkQueue.StatusCodes` and offline writes really were queued — with
+    /// `Authorization: Basic base64(barcode:PIN)`. That is a patron's card
+    /// number and PIN, base64 is not encryption, and the store is unencrypted.
+    /// I originally claimed such rows could not exist; review proved otherwise
+    /// from the git history, which is why this test exists rather than an
+    /// argument.
+    func testMigrate_PurgesACredentialLeftBehindByAnOlderBuild() {
+        let (queue, dir) = makeWritableQueue()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        queue.insertLegacyRowForTesting(
+            libraryID: "lib-A",
+            updateID: "book-1",
+            url: URL(string: "https://a.example.org/annotations/")!,
+            headers: ["Authorization": "Basic YmFyY29kZTpQSU4=",
+                      "Content-Type": "application/json"])
+
+        XCTAssertEqual(queue.persistedRowsForTesting().first?.headers?["Authorization"],
+                       "Basic YmFyY29kZTpQSU4=",
+                       "precondition: the legacy row really does carry the credential")
+
+        queue.migrate()
+        queue.serialQueue.sync {}
+
+        let row = queue.persistedRowsForTesting().first
+        XCTAssertNotNil(row, "The write itself must be kept — only the credential is dropped")
+        XCTAssertNil(row?.headers?["Authorization"],
+                     "A card number and PIN left on disk by an older build must be cleared on migrate")
+        XCTAssertEqual(row?.headers?["Content-Type"], "application/json",
+                       "…without discarding the headers the retry legitimately needs")
     }
 
     private func unopenableDatabaseDirectory() -> String {

--- a/PalaceTests/Network/NetworkQueueTests.swift
+++ b/PalaceTests/Network/NetworkQueueTests.swift
@@ -189,6 +189,133 @@ class NetworkQueueTests: XCTestCase {
         }
     }
 
+    // MARK: - PP-4987: proofs against the PERSISTED BYTES, not a helper
+
+    private func makeWritableQueue(
+        _ spy: ErrorLoggerSpy = ErrorLoggerSpy(),
+        authorizationHeaderProvider: @escaping @Sendable (String) -> String? = { _ in nil }
+    ) -> (NetworkQueue, String) {
+        let dir = NSTemporaryDirectory() + "pp4987-db-" + UUID().uuidString
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let queue = NetworkQueue(transport: makeTransport(),
+                                 reachability: Reachability(),
+                                 databaseDirectory: dir,
+                                 errorLogger: spy,
+                                 authorizationHeaderProvider: authorizationHeaderProvider)
+        queue.migrate()
+        queue.serialQueue.sync {}
+        return (queue, dir)
+    }
+
+    /// The security property, asserted where it actually has to hold: on the
+    /// row in the database.
+    ///
+    /// Round 4 caught the previous version of this proof testing
+    /// `headersSafeToPersist` in isolation while NOTHING asserted `addRequest`
+    /// calls it — unwiring the call site left every test green. Testing the
+    /// helper is not testing the producer.
+    func testAddRequest_NeverPersistsTheCredential_EvenThoughCallersPassIt() {
+        let (queue, dir) = makeWritableQueue()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        // Exactly what `TPPAnnotations.addToOfflineQueue` hands over: the
+        // output of `request(for:)`, whose `useTokenIfAvailable` defaults true.
+        queue.addRequest("lib-A", "book-1",
+                         URL(string: "https://a.example.org/annotations/")!,
+                         HTTPMethodType.POST, Data("{}".utf8),
+                         ["Authorization": "Bearer super-secret-token",
+                          "Content-Type": "application/json"])
+        queue.serialQueue.sync {}
+
+        let rows = queue.persistedRowsForTesting()
+        XCTAssertEqual(rows.count, 1, "precondition: the write was stored")
+        XCTAssertNil(rows[0].headers?["Authorization"],
+                     "The credential must not be in the database — simplified.db is unencrypted and on disk")
+        XCTAssertFalse((rows[0].headers ?? [:]).values.contains { $0.contains("super-secret-token") },
+                       "…nor smuggled in under any other header")
+        XCTAssertEqual(rows[0].headers?["Content-Type"], "application/json",
+                       "Everything the retry legitimately needs must survive")
+    }
+
+    /// The data-loss property, asserted against the rows rather than the seam.
+    ///
+    /// `addRequest` UPDATEs the row matching (libraryID, updateID), so this is
+    /// where "two bookmarks must not overwrite each other" is actually decided.
+    /// The annotation-side test proves the KEYS differ; this proves differing
+    /// keys produce two surviving rows.
+    func testAddRequest_DistinctKeysSurviveAsSeparateRows_SharedKeyCollapses() {
+        let (queue, dir) = makeWritableQueue()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let url = URL(string: "https://a.example.org/annotations/")!
+
+        // Two bookmarks in one book — distinct keys, as postReadingPosition
+        // now builds them.
+        queue.addRequest("lib-A", "book-1|{\"chapter\":1}", url,
+                         HTTPMethodType.POST, Data(#"{"n":1}"#.utf8), nil)
+        queue.addRequest("lib-A", "book-1|{\"chapter\":9}", url,
+                         HTTPMethodType.POST, Data(#"{"n":2}"#.utf8), nil)
+        queue.serialQueue.sync {}
+        XCTAssertEqual(queue.persistedRowsForTesting().count, 2,
+                       "Two distinct bookmarks must survive as two rows — sharing a key silently deletes one")
+
+        // Two positions for the same book — shared key, collapse is CORRECT.
+        queue.addRequest("lib-A", "book-2", url,
+                         HTTPMethodType.POST, Data(#"{"p":1}"#.utf8), nil)
+        queue.addRequest("lib-A", "book-2", url,
+                         HTTPMethodType.POST, Data(#"{"p":2}"#.utf8), nil)
+        queue.serialQueue.sync {}
+        let book2 = queue.persistedRowsForTesting().filter { $0.updateID == "book-2" }
+        XCTAssertEqual(book2.count, 1,
+                       "A newer position supersedes an older one for the same book — collapsing is the desired behaviour here")
+    }
+
+    /// The credential must be resolved for the ROW'S library, never the
+    /// currently-selected one.
+    ///
+    /// `retryQueue` drains every row regardless of library, and each row's URL
+    /// is its own library's annotation host. Resolving `currentUserAccount`
+    /// would send library B's bearer token to library A's server whenever a
+    /// patron queued a write for A and then switched to B — a cross-tenant
+    /// credential disclosure, plus a guaranteed 401 for a write that had a
+    /// valid token available. Round 4 of review caught exactly that; the
+    /// codebase already documents the invariant on
+    /// `TPPNetworkExecutor.request(for:accountId:)`.
+    func testDrain_ResolvesTheCredentialForEachRowsOwnLibrary_NotTheSelectedOne() {
+        let asked = AskedLibraries()
+        let (queue, dir) = makeWritableQueue(
+            authorizationHeaderProvider: { libraryID in
+                asked.record(libraryID)
+                return "Bearer token-for-\(libraryID)"
+            })
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        queue.addRequest("lib-A", "book-1",
+                         URL(string: "https://a.example.org/annotations/")!,
+                         HTTPMethodType.POST, Data("{}".utf8), nil)
+        queue.addRequest("lib-B", "book-2",
+                         URL(string: "https://b.example.org/annotations/")!,
+                         HTTPMethodType.POST, Data("{}".utf8), nil)
+        queue.serialQueue.sync {}
+
+        // `retryQueue` is @objc private and normally fires off a reachability
+        // publisher; drive it directly rather than waiting on the network.
+        queue.perform(Selector(("retryQueue")))
+        queue.serialQueue.sync {}
+
+        let requested = asked.all.sorted()
+        XCTAssertEqual(requested, ["lib-A", "lib-B"],
+                       "Each row's credential must be resolved for ITS OWN library — asking once for the selected library would send one library's token to the other's server")
+    }
+
+    /// The provider is `@Sendable` and is invoked on the queue's serial queue,
+    /// so the recorder has to be safe to cross that boundary.
+    private final class AskedLibraries: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _all: [String] = []
+        var all: [String] { lock.withLock { _all } }
+        func record(_ id: String) { lock.withLock { _all.append(id) } }
+    }
+
     private func unopenableDatabaseDirectory() -> String {
         let path = NSTemporaryDirectory() + "pp4987-blocked-" + UUID().uuidString
         FileManager.default.createFile(atPath: path, contents: Data("not a directory".utf8))

--- a/PalaceTests/Network/NetworkQueueTests.swift
+++ b/PalaceTests/Network/NetworkQueueTests.swift
@@ -31,6 +31,11 @@ class NetworkQueueTests: XCTestCase {
     }
 
     override func tearDown() {
+        // `HTTPStubURLProtocol.register` APPENDS to a process-global array, so
+        // the catch-all handler installed by the drain test would otherwise
+        // outlive this suite and turn "unmatched request fails" into
+        // "unmatched request succeeds" for everything that runs after it.
+        HTTPStubURLProtocol.reset()
         appContainer = nil
         super.tearDown()
     }
@@ -373,6 +378,79 @@ class NetworkQueueTests: XCTestCase {
                      "A card number and PIN left on disk by an older build must be cleared on migrate")
         XCTAssertEqual(row?.headers?["Content-Type"], "application/json",
                        "…without discarding the headers the retry legitimately needs")
+    }
+
+    /// A superseding write must get a FRESH retry budget.
+    ///
+    /// `retryQueue` deletes rows with `retries > MaxRetriesInQueue` BEFORE it
+    /// drains, so a reading position landing on an exhausted row was deleted
+    /// having never been sent once — silent, on the very path PP-4965 removed
+    /// the error report from. Reachable specifically because positions are
+    /// keyed to collapse on the book.
+    ///
+    /// Review caught the fix for this shipping untested: `PersistedRow.retries`
+    /// was added to observe it and then never asserted, so deleting
+    /// `sqlRetries <- 0` left the suite green. That is the same shape as the
+    /// round-5 "resolved but never attached" miss.
+    func testAddRequest_SupersedingAnAttemptedRow_ResetsItsRetryBudget() {
+        HTTPStubURLProtocol.register { @Sendable request in
+            guard request.url?.host != nil else { return nil }
+            return .init(statusCode: 500, headers: nil, body: Data())
+        }
+        let (queue, dir) = makeWritableQueue()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let url = URL(string: "https://a.example.org/annotations/")!
+
+        queue.addRequest("lib-A", "book-1", url,
+                         HTTPMethodType.POST, Data(#"{"p":1}"#.utf8), nil)
+        queue.serialQueue.sync {}
+
+        // Burn a retry: the drain increments the count before sending.
+        queue.retryQueue()
+        expectEventually("the row to record an attempt") {
+            (queue.persistedRowsForTesting().first?.retries ?? 0) > 0
+        }
+
+        // A NEWER position for the same book supersedes it.
+        queue.addRequest("lib-A", "book-1", url,
+                         HTTPMethodType.POST, Data(#"{"p":2}"#.utf8), nil)
+        queue.serialQueue.sync {}
+
+        let row = queue.persistedRowsForTesting().first
+        XCTAssertEqual(row?.parameters, Data(#"{"p":2}"#.utf8),
+                       "precondition: the newer position replaced the older one")
+        XCTAssertEqual(row?.retries, 0,
+                       "A superseding write is a NEW write and must get a full retry budget — inheriting an exhausted count gets it deleted before it is ever sent")
+    }
+
+    /// A header blob that cannot be read must leave the row alone.
+    ///
+    /// The purge runs on the launch path (via SEMigrations) over rows written
+    /// by builds up to five years old, so it has to tolerate a blob it cannot
+    /// decode.
+    ///
+    /// HONESTY NOTE: this test does NOT discriminate between the modern and
+    /// legacy unarchivers — review predicted the legacy one would raise and
+    /// crash, and it does not; both return nil for garbage and for a truncated
+    /// archive. It pins the behaviour that matters (an unreadable row is kept,
+    /// not discarded), not a mutation kill. Labelled rather than dressed up as
+    /// a guard it is not.
+    func testMigrate_WithAnUnreadableHeaderBlob_LeavesTheRowIntact() {
+        let (queue, dir) = makeWritableQueue()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        queue.insertLegacyRowForTesting(
+            libraryID: "lib-A",
+            updateID: "book-1",
+            url: URL(string: "https://a.example.org/annotations/")!,
+            headers: [:],
+            rawHeaderData: Data("this is not a keyed archive".utf8))
+
+        queue.migrate()
+        queue.serialQueue.sync {}
+
+        XCTAssertEqual(queue.persistedRowsForTesting().count, 1,
+                       "The row survives — a blob we cannot read is not a reason to discard a patron's queued write, nor to crash on launch")
     }
 
     private func unopenableDatabaseDirectory() -> String {

--- a/PalaceTests/Network/NetworkQueueTests.swift
+++ b/PalaceTests/Network/NetworkQueueTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import PalaceNetwork
 @testable import Palace
 
 /// SRS: NET-003 — Offline queue stores failed requests
@@ -32,6 +33,106 @@ class NetworkQueueTests: XCTestCase {
     override func tearDown() {
         appContainer = nil
         super.tearDown()
+    }
+
+    // MARK: - PP-4987: a dropped enqueue must not be silent
+
+    /// PP-4965 stops reporting a write once it is handed to this queue, on the
+    /// grounds that it is pending rather than lost. That trade is only sound if
+    /// the queue actually TAKES the write. Before PP-4987 both failure paths
+    /// here returned without telling anyone — a `guard let db ... else
+    /// { return }` and a `catch` whose only output was a local `Log.error`
+    /// invisible in production telemetry. Combined, a patron's reading position
+    /// could be accepted, dropped, and never reported by anything.
+    ///
+    /// Driven by pointing the store at a path SQLite cannot open, which is the
+    /// only deterministic way to make `startDatabaseConnection()` return nil.
+    func testAddRequest_WhenDatabaseCannotBeOpened_ReportsTheDropInsteadOfSwallowingIt() {
+        let spy = ErrorLoggerSpy()
+        let queue = NetworkQueue(
+            transport: makeTransport(),
+            reachability: Reachability(),
+            // A file, not a directory — `"\(path)/simplified.db"` cannot be
+            // created underneath it, so the connection fails every time.
+            databaseDirectory: unopenableDatabaseDirectory(),
+            errorLogger: spy
+        )
+
+        queue.addRequest("lib-1", "update-1",
+                         URL(string: "https://example.org/annotations/")!,
+                         HTTPMethodType.POST, Data("{}".utf8), nil)
+
+        expectEventually("the drop is reported") { spy.loggedSummaries.isEmpty == false }
+
+        XCTAssertEqual(spy.loggedSummaries, ["Offline queue write dropped"],
+                       "A write the queue could not persist must be reported — the caller has already stopped reporting it")
+        XCTAssertEqual(spy.loggedCodes, [.offlineQueueWriteFailed],
+                       "It needs its own bucket; filing it as a generic api call hides it among server refusals")
+        XCTAssertEqual(spy.loggedMetadata.first?["reason"] as? String, "no database connection",
+                       "The report has to say WHICH drop path fired, or it is not diagnosable")
+        XCTAssertEqual(spy.loggedMetadata.first?["url"] as? String,
+                       "https://example.org/annotations/",
+                       "Without the URL the report cannot be tied back to a lost write")
+    }
+
+    /// The same queue, working normally, must stay silent — otherwise the test
+    /// above would pass for a queue that reports on EVERY write, which would be
+    /// its own defect (and would re-inflate the bucket PP-4965 shrank).
+    func testAddRequest_WhenDatabaseIsWritable_ReportsNothing() {
+        let spy = ErrorLoggerSpy()
+        let dir = NSTemporaryDirectory() + "pp4987-ok-" + UUID().uuidString
+        try? FileManager.default.createDirectory(atPath: dir,
+                                                 withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let queue = NetworkQueue(
+            transport: makeTransport(),
+            reachability: Reachability(),
+            databaseDirectory: dir,
+            errorLogger: spy
+        )
+        // A fresh database has no table until `migrate()` creates it — without
+        // this the "success" case fails at the insert and reports a drop, which
+        // would make this control test pass for the wrong reason.
+        queue.migrate()
+        expectEventually("the schema to exist") { spy.loggedSummaries.isEmpty }
+
+        queue.addRequest("lib-1", "update-1",
+                         URL(string: "https://example.org/annotations/")!,
+                         HTTPMethodType.POST, Data("{}".utf8), nil)
+
+        // Give the serial queue the same window the failing test gets, so this
+        // is a real "nothing arrived", not a race that has not happened yet.
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        XCTAssertEqual(spy.loggedSummaries, [],
+                       "A write that WAS persisted must report nothing at all")
+    }
+
+    /// The queue never sends anything in these tests — it fails (or succeeds)
+    /// at the SQLite step first — so a plain ephemeral transport is enough.
+    private func makeTransport() -> NetworkTransport {
+        NetworkTransport(delegate: nil,
+                         cachingStrategy: .ephemeral,
+                         requestTimeout: 5)
+    }
+
+    private func unopenableDatabaseDirectory() -> String {
+        let path = NSTemporaryDirectory() + "pp4987-blocked-" + UUID().uuidString
+        FileManager.default.createFile(atPath: path, contents: Data("not a directory".utf8))
+        return path
+    }
+
+    private func expectEventually(_ what: String,
+                                  timeout: TimeInterval = 2.0,
+                                  _ condition: () -> Bool,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        XCTFail("Timed out waiting for \(what)", file: file, line: line)
     }
 
     // MARK: - Static Properties

--- a/PalaceTests/Support/TestAppContainerFactory.swift
+++ b/PalaceTests/Support/TestAppContainerFactory.swift
@@ -153,10 +153,29 @@ func makeTestAppContainer(
   // sound at runtime regardless of this factory's nonisolated call site).
   let userAccountPublisher = MainActor.assumeIsolated { UserAccountPublisher.shared }
 
+  // Created eagerly: SQLite cannot open a database under a directory that does
+  // not exist, and a failed connection would silently turn every queued write
+  // into a reported drop rather than a stored row.
+  func makeIsolatedQueueDirectory() -> String {
+    let dir = NSTemporaryDirectory() + "test-queue-" + UUID().uuidString
+    try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
   return AppContainer(
     bookRegistry: resolvedBookRegistry,
     networkExecutor: executor,
-    networkQueue: NetworkQueue(transport: executor.transport, reachability: reachability),
+    // Per-container temp store, never the app's real `simplified.db`. PP-4987
+    // made the offline branch reachable, so any test touching this container
+    // now writes DURABLE rows into Application Support that a later
+    // reachability event can replay as live POSTs. The credential provider is
+    // stubbed out for the same reason: the default reaches the keychain.
+    networkQueue: NetworkQueue(
+      transport: executor.transport,
+      reachability: reachability,
+      databaseDirectory: makeIsolatedQueueDirectory(),
+      authorizationHeaderProvider: { _ in nil }
+    ),
     reachability: reachability,
     accountsManager: resolvedAccountsManager,
     settings: TPPSettings(),

--- a/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
+++ b/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
@@ -46,6 +46,12 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
     /// is not reported. The offline test below pins exactly that.
     private var executorAOffline: TPPNetworkExecutor!
 
+    /// Installed for the whole suite because PP-4987 made the offline branch
+    /// reachable: without it, the offline test writes a durable row into the
+    /// app's REAL `simplified.db` in Application Support, which a later
+    /// reachability event could replay as a live POST.
+    private var offlineQueue: OfflineQueueSpy!
+
     private var savedExecutorOverride: TPPNetworkExecutor?
     private var savedErrorLoggerOverride: ErrorLogging?
     private var savedAccountsOverride: TPPLibraryAccountsProvider?
@@ -139,6 +145,9 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
         // (no signed-in library defaults), so without this override every
         // POST/GET path early-returns before hitting HTTPStubURLProtocol.
         TPPAnnotations.annotationsURLOverride = Self.baseURL
+
+        offlineQueue = OfflineQueueSpy()
+        TPPAnnotations.offlineQueueOverride = offlineQueue
     }
 
     override func tearDown() {
@@ -156,6 +165,8 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
         // process, which no later test would attribute to this suite.
         TPPAnnotations.errorLoggerOverride = savedErrorLoggerOverride
         executorAOffline = nil
+        TPPAnnotations.offlineQueueOverride = nil
+        offlineQueue = nil
 
         HTTPStubURLProtocol.reset()
         backend?.clear()
@@ -401,6 +412,17 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
                        "A write that was queued for retry must not be reported as an error — it is pending, not lost")
         XCTAssertNil(spy.firstReportedNSError,
                      "Nothing at all should be reported for a successfully queued write")
+
+        // The other half of the claim, and the one that makes the silence
+        // defensible: the write is PENDING, which means it must actually be in
+        // the queue. Asserting only the absence of a report would pass equally
+        // well if the position had simply evaporated.
+        XCTAssertEqual(offlineQueue.count, 1,
+                       "The offline write must be handed to the retry queue, not merely go unreported")
+        XCTAssertEqual(offlineQueue.enqueued.first?.updateID, Self.bookID,
+                       "A reading position keys on the book, so a later position supersedes this one")
+        XCTAssertNil(offlineQueue.enqueued.first?.headers?["Authorization"],
+                     "The credential must never be persisted — simplified.db is unencrypted")
 
         // B sees nothing, and that is correct: the write was never delivered.
         let book = makeBook()

--- a/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
+++ b/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
@@ -38,12 +38,17 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
     private var userAccount: TPPUserAccountMock!
     private var executorA: TPPNetworkExecutor!
     private var executorB: TPPNetworkExecutor!
-    /// Device A with no connectivity: NoNetworkURLProtocol answers every
-    /// request with NSURLErrorNotConnectedToInternet, which is in
-    /// NetworkQueue.StatusCodes and therefore queueable (PP-4965).
+    /// Device A with no connectivity. NoNetworkURLProtocol answers every
+    /// request with NSURLErrorNotConnectedToInternet — but note that is NOT
+    /// what `postAnnotation` ends up seeing. TPPNetworkResponder discards the
+    /// transport error when no HTTP response arrives and substitutes code 914,
+    /// which is not in NetworkQueue.StatusCodes, so the write is never queued.
+    /// That is PP-4987, and the offline test below pins the 914 rather than
+    /// the error this protocol emits.
     private var executorAOffline: TPPNetworkExecutor!
 
     private var savedExecutorOverride: TPPNetworkExecutor?
+    private var savedErrorLoggerOverride: ErrorLogging?
     private var savedAccountsOverride: TPPLibraryAccountsProvider?
     private var savedDeviceAccountsOverride: TPPUserAccountResolving?
     private var savedFirebaseDeviceOverride: String?
@@ -61,6 +66,7 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
         savedDeviceAccountsOverride = AnnotationDevice.accountsManagerOverride
         savedFirebaseDeviceOverride = AnnotationDevice.firebaseDeviceIDOverride
         savedAnnotationsURLOverride = TPPAnnotations.annotationsURLOverride
+        savedErrorLoggerOverride = TPPAnnotations.errorLoggerOverride
 
         // Reset shared user-account state so credential writes here don't
         // leak across tests.
@@ -146,6 +152,11 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
         AnnotationDevice.accountsManagerOverride = savedDeviceAccountsOverride
         AnnotationDevice.firebaseDeviceIDOverride = savedFirebaseDeviceOverride
         TPPAnnotations.annotationsURLOverride = savedAnnotationsURLOverride
+        // Restored here, not only via a per-test `defer`: a spy left installed
+        // silently swallows every annotation error report for the rest of the
+        // process, which no later test would attribute to this suite.
+        TPPAnnotations.errorLoggerOverride = savedErrorLoggerOverride
+        executorAOffline = nil
 
         HTTPStubURLProtocol.reset()
         backend?.clear()
@@ -353,8 +364,7 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
         try skipIfSyncGateClosed()
 
         let spy = ErrorLoggerSpy()
-        TPPAnnotations.errorLoggerOverride = spy
-        defer { TPPAnnotations.errorLoggerOverride = nil }
+        TPPAnnotations.errorLoggerOverride = spy   // also restored in tearDown
 
         let selectorValue = epubSelectorValue(
             href: "/chapter9.xhtml",

--- a/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
+++ b/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
@@ -421,8 +421,16 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
                        "The offline write must be handed to the retry queue, not merely go unreported")
         XCTAssertEqual(offlineQueue.enqueued.first?.updateID, Self.bookID,
                        "A reading position keys on the book, so a later position supersedes this one")
-        XCTAssertNil(offlineQueue.enqueued.first?.headers?["Authorization"],
-                     "The credential must never be persisted — simplified.db is unencrypted")
+        // NOTE: deliberately NOT asserting the absence of an Authorization
+        // header here. The spy stands in FRONT of `NetworkQueue`, and
+        // production genuinely does hand a credential across that boundary —
+        // the strip happens inside `addRequest`, downstream of this point. An
+        // assertion here would be asserting a property that is false in
+        // production, and it only ever passed because this suite's executor
+        // has no token on a clean runner; it went red the moment a sibling
+        // test left one behind. The credential guarantee is pinned where it
+        // actually holds, against the persisted row, in
+        // NetworkQueueTests.testAddRequest_NeverPersistsTheCredential…
 
         // B sees nothing, and that is correct: the write was never delivered.
         let book = makeBook()

--- a/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
+++ b/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
@@ -38,6 +38,10 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
     private var userAccount: TPPUserAccountMock!
     private var executorA: TPPNetworkExecutor!
     private var executorB: TPPNetworkExecutor!
+    /// Device A with no connectivity: NoNetworkURLProtocol answers every
+    /// request with NSURLErrorNotConnectedToInternet, which is in
+    /// NetworkQueue.StatusCodes and therefore queueable (PP-4965).
+    private var executorAOffline: TPPNetworkExecutor!
 
     private var savedExecutorOverride: TPPNetworkExecutor?
     private var savedAccountsOverride: TPPLibraryAccountsProvider?
@@ -112,6 +116,14 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
             sessionConfiguration: configB
         )
 
+        let configOffline = URLSessionConfiguration.ephemeral
+        configOffline.protocolClasses = [NoNetworkURLProtocol.self]
+        executorAOffline = TPPNetworkExecutor(
+            credentialsProvider: nil,
+            cachingStrategy: .ephemeral,
+            sessionConfiguration: configOffline
+        )
+
         // Install the shared library/accounts override now so any read
         // through TPPAnnotations sees a sync-supporting library.
         TPPAnnotations.accountsManagerOverride = libraryAccount
@@ -164,6 +176,25 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
         let prevDev = AnnotationDevice.firebaseDeviceIDOverride
         let prevAccountDeviceID = userAccount.deviceID
         TPPAnnotations.executorOverride = executorA
+        AnnotationDevice.firebaseDeviceIDOverride = Self.deviceA
+        userAccount.setDeviceID(Self.deviceA)
+        defer {
+            TPPAnnotations.executorOverride = prevExec
+            AnnotationDevice.firebaseDeviceIDOverride = prevDev
+            if let prev = prevAccountDeviceID {
+                userAccount.setDeviceID(prev)
+            }
+        }
+        return try block()
+    }
+
+    /// Device A, but with no connectivity. Same device tag as `asDeviceA`, so
+    /// anything that *does* reach the backend is still attributable to A.
+    private func asDeviceAOffline<T>(_ block: () throws -> T) rethrows -> T {
+        let prevExec = TPPAnnotations.executorOverride
+        let prevDev = AnnotationDevice.firebaseDeviceIDOverride
+        let prevAccountDeviceID = userAccount.deviceID
+        TPPAnnotations.executorOverride = executorAOffline
         AnnotationDevice.firebaseDeviceIDOverride = Self.deviceA
         userAccount.setDeviceID(Self.deviceA)
         defer {
@@ -311,6 +342,146 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
     /// environment (no auth doc loaded, no credentials, etc.), the
     /// TPPAnnotations static methods early-return without touching the
     /// network. We skip rather than report a misleading pass.
+    // MARK: - PP-4965: what an offline device does to the other device
+
+    /// Device A loses connectivity. Its position write is handed to the offline
+    /// queue, so nothing reaches the server and device B correctly sees
+    /// nothing — but A must NOT report this as an error. Reporting it is what
+    /// made "Error posting annotation" the largest error in the app while the
+    /// writes themselves were fine.
+    func test_positionWrittenWhileDeviceAOffline_isInvisibleToB_andNotReportedAsAnError() async throws {
+        try skipIfSyncGateClosed()
+
+        let spy = ErrorLoggerSpy()
+        TPPAnnotations.errorLoggerOverride = spy
+        defer { TPPAnnotations.errorLoggerOverride = nil }
+
+        let selectorValue = epubSelectorValue(
+            href: "/chapter9.xhtml",
+            progressInChapter: 0.9,
+            progressInBook: 0.5,
+            title: "Chapter 9"
+        )
+        let postsBefore = backend.postCount
+
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            asDeviceAOffline {
+                TPPAnnotations.postReadingPosition(
+                    forBook: Self.bookID,
+                    selectorValue: selectorValue,
+                    motivation: .readingProgress
+                ) { _ in cont.resume() }
+            }
+        }
+
+        XCTAssertEqual(backend.postCount, postsBefore,
+                       "An offline write must never reach the server")
+        XCTAssertEqual(backend.allAnnotations(forBook: Self.bookID).count, 0,
+                       "Backend must hold nothing after an offline write")
+        // PP-4987: today this write is NOT queued, so reporting it is correct.
+        //
+        // The networking layer discards the underlying transport error when no
+        // HTTP response arrives — the offline case — and substitutes a generic
+        // "invalid or no HTTP response" code. `postAnnotation` decides
+        // queue-worthiness by matching the error against a list of NSURLError
+        // conditions, and the generic code is not on it, so the offline queue
+        // never receives the write. It is lost, and an error is the honest
+        // report.
+        //
+        // Expressed as an expected failure rather than by asserting the broken
+        // behaviour: when PP-4987 lands, this stops failing, XCTest flags the
+        // unfulfilled expectation, and whoever fixed it flips the assertion to
+        // the correct one below. Asserting the defect directly is how the
+        // pre-PP-4965 suite pinned a bug as a contract.
+        XCTExpectFailure("PP-4987: transport error is discarded, so the write is never queued and is correctly reported. Delete this expectation when PP-4987 lands.") {
+            XCTAssertEqual(spy.loggedSummaries, [],
+                           "Once offline writes are actually queued, a queued write must not be reported as an error")
+        }
+        XCTAssertEqual(spy.firstReportedNSError?.code,
+                       TPPErrorCode.invalidOrNoHTTPResponse.rawValue,
+                       "Documents the PP-4987 mechanism: the offline reason is replaced by a generic no-response code")
+
+        // B sees nothing, and that is correct: the write was never delivered.
+        let book = makeBook()
+        let seenByB: BookmarkListProjection =
+            await withCheckedContinuation { (cont: CheckedContinuation<BookmarkListProjection, Never>) in
+                asDeviceB {
+                    TPPAnnotations.getServerBookmarks(
+                        forBook: book,
+                        atURL: Self.baseURL,
+                        motivation: .readingProgress
+                    ) { bookmarks in
+                        cont.resume(returning: BookmarkListProjection(bookmarks))
+                    }
+                }
+            }
+        XCTAssertEqual(seenByB.count, 0,
+                       "Device B must not see a position that was never delivered")
+    }
+
+    /// The same position, written once A is back online, does reach B. This is
+    /// what makes the case above a delay rather than a loss.
+    ///
+    /// Note this re-posts directly rather than draining `TPPNetworkQueue` —
+    /// the queue's own retry behaviour is its responsibility and is covered by
+    /// its own suite. What is asserted here is the cross-device consequence:
+    /// an offline write followed by a connected write leaves B holding exactly
+    /// one annotation, A's, not two and not zero.
+    func test_positionRewrittenAfterDeviceAReconnects_reachesDeviceB() async throws {
+        try skipIfSyncGateClosed()
+
+        let selectorValue = epubSelectorValue(
+            href: "/chapter9.xhtml",
+            progressInChapter: 0.9,
+            progressInBook: 0.5,
+            title: "Chapter 9"
+        )
+
+        // Offline attempt — goes nowhere.
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            asDeviceAOffline {
+                TPPAnnotations.postReadingPosition(
+                    forBook: Self.bookID,
+                    selectorValue: selectorValue,
+                    motivation: .readingProgress
+                ) { _ in cont.resume() }
+            }
+        }
+        XCTAssertEqual(backend.allAnnotations(forBook: Self.bookID).count, 0,
+                       "Precondition: the offline attempt must not have reached the server")
+
+        // Reconnected attempt — lands.
+        let hasServerId: Bool =
+            await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+                asDeviceA {
+                    TPPAnnotations.postReadingPosition(
+                        forBook: Self.bookID,
+                        selectorValue: selectorValue,
+                        motivation: .readingProgress
+                    ) { response in cont.resume(returning: response?.serverId != nil) }
+                }
+            }
+        XCTAssertTrue(hasServerId, "The reconnected write must be accepted by the server")
+
+        let book = makeBook()
+        let seenByB: BookmarkListProjection =
+            await withCheckedContinuation { (cont: CheckedContinuation<BookmarkListProjection, Never>) in
+                asDeviceB {
+                    TPPAnnotations.getServerBookmarks(
+                        forBook: book,
+                        atURL: Self.baseURL,
+                        motivation: .readingProgress
+                    ) { bookmarks in
+                        cont.resume(returning: BookmarkListProjection(bookmarks))
+                    }
+                }
+            }
+        XCTAssertEqual(seenByB.count, 1,
+                       "B must end up with exactly one annotation — the offline attempt must not have left a duplicate")
+        XCTAssertEqual(seenByB.first?.device, Self.deviceA,
+                       "The delivered annotation must still be tagged to device A")
+    }
+
     private func skipIfSyncGateClosed() throws {
         guard TPPAnnotations.syncIsPossibleAndPermitted() else {
             throw XCTSkip("Sync gate closed in this environment (no credentials / library auth doc) — skipping E2E sync test")

--- a/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
+++ b/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
@@ -388,28 +388,20 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
                        "An offline write must never reach the server")
         XCTAssertEqual(backend.allAnnotations(forBook: Self.bookID).count, 0,
                        "Backend must hold nothing after an offline write")
-        // PP-4987: today this write is NOT queued, so reporting it is correct.
+        // PP-4987 HAS LANDED — this is the flip the expectation above was
+        // waiting for, and the assertions are now the correct ones.
         //
-        // The networking layer discards the underlying transport error when no
-        // HTTP response arrives — the offline case — and substitutes a generic
-        // "invalid or no HTTP response" code. `postAnnotation` decides
-        // queue-worthiness by matching the error against a list of NSURLError
-        // conditions, and the generic code is not on it, so the offline queue
-        // never receives the write. It is lost, and an error is the honest
-        // report.
-        //
-        // Expressed as an expected failure rather than by asserting the broken
-        // behaviour: when PP-4987 lands, this stops failing, XCTest flags the
-        // unfulfilled expectation, and whoever fixed it flips the assertion to
-        // the correct one below. Asserting the defect directly is how the
-        // pre-PP-4965 suite pinned a bug as a contract.
-        XCTExpectFailure("PP-4987: transport error is discarded, so the write is never queued and is correctly reported. Delete this expectation when PP-4987 lands.") {
-            XCTAssertEqual(spy.loggedSummaries, [],
-                           "Once offline writes are actually queued, a queued write must not be reported as an error")
-        }
-        XCTAssertEqual(spy.firstReportedNSError?.code,
-                       TPPErrorCode.invalidOrNoHTTPResponse.rawValue,
-                       "Documents the PP-4987 mechanism: the offline reason is replaced by a generic no-response code")
+        // `TPPNetworkResponder` no longer replaces the transport error with a
+        // generic no-response code, so the NSURLError survives to
+        // `postAnnotation`, matches `NetworkQueue.StatusCodes`, and the write
+        // goes to the offline queue instead of being lost. A queued write is
+        // pending delivery, not a failure, so nothing is reported — which is
+        // the entire point of PP-4965's `.queuedForRetry` case, unreachable
+        // until now.
+        XCTAssertEqual(spy.loggedSummaries, [],
+                       "A write that was queued for retry must not be reported as an error — it is pending, not lost")
+        XCTAssertNil(spy.firstReportedNSError,
+                     "Nothing at all should be reported for a successfully queued write")
 
         // B sees nothing, and that is correct: the write was never delivered.
         let book = makeBook()

--- a/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
+++ b/PalaceTests/Sync/CrossDeviceSyncE2ETests.swift
@@ -39,12 +39,11 @@ final class CrossDeviceSyncE2ETests: XCTestCase {
     private var executorA: TPPNetworkExecutor!
     private var executorB: TPPNetworkExecutor!
     /// Device A with no connectivity. NoNetworkURLProtocol answers every
-    /// request with NSURLErrorNotConnectedToInternet — but note that is NOT
-    /// what `postAnnotation` ends up seeing. TPPNetworkResponder discards the
-    /// transport error when no HTTP response arrives and substitutes code 914,
-    /// which is not in NetworkQueue.StatusCodes, so the write is never queued.
-    /// That is PP-4987, and the offline test below pins the 914 rather than
-    /// the error this protocol emits.
+    /// request with NSURLErrorNotConnectedToInternet, and as of PP-4987 that
+    /// IS what `postAnnotation` sees — `TPPNetworkResponder` no longer
+    /// substitutes code 914 for it. The code is in `NetworkQueue.StatusCodes`,
+    /// so the write is queued for retry and, being pending rather than lost,
+    /// is not reported. The offline test below pins exactly that.
     private var executorAOffline: TPPNetworkExecutor!
 
     private var savedExecutorOverride: TPPNetworkExecutor?


### PR DESCRIPTION
Two tickets, deliberately one branch: they are causally locked. PP-4965's silence is only defensible with PP-4987's real queueing, and PP-4987 without PP-4965 floods the 902 bucket with reports for writes that were safely queued.

## What patrons get

A reading position written while offline is now **queued and delivered later** instead of being lost. That path has never worked — the offline queue has been dead code — which is why reinstalling the app loses everything and why "it won't sync between my iPad and my iPhone" is a recurring report.

## PP-4987 — the defect

`TPPNetworkResponder` discarded the transport error whenever a task produced no HTTP response (which is what being offline looks like) and substituted a generic `invalidOrNoHTTPResponse` (914). `NetworkQueue.StatusCodes` is composed **entirely** of `NSURLError` values, so `willQueueOffline` could never be true and not one write was ever queued.

Preserving the error also revives four call sites that match on those codes and have been unreachable for anything routed through this responder — `TPPAlertUtils`, `PalaceError`, `TPPSignInBusinessLogic`, `PalaceAuth.AuthReducer`. An offline patron now gets the specific handling those sites were written to provide. Independently traced by review: all message-only, no sign-out, retry policies bounded, no storm.

## PP-4965 — the classification

`postAnnotation` collapsed five distinct outcomes into a bare `false`, and the caller reported all five to Crashlytics as one error — the largest error bucket in the app. It now distinguishes them, stops reporting a write that was queued, and passes the status code and underlying error through.

## What review found

Six rounds. The findings that mattered most were in the *second-order* work — turning the queue on exposed problems that had never executed:

| Finding | Consequence if shipped |
|---|---|
| Bearer tokens persisted to disk | `Authorization` archived into unencrypted `simplified.db` |
| Legacy rows carry card + PIN | Pre-1.1.0 builds queued `Basic base64(barcode:PIN)`; rows can still exist |
| Drain used the wrong library's token | Cross-tenant credential disclosure on library switch |
| Queue key collapsed distinct writes | Two offline bookmarks in one book silently overwrote each other |
| Retry budget inherited on supersede | Fresh position deleted before ever being sent |
| Corrupt archive aborts the process | 63 of 277 bit-flips crash the legacy unarchiver, on the launch path |

All fixed, each with a test, each proven by reintroducing the defect and naming the failing test.

## Verification

- **Full suite 8347 tests, 4 failures, 0 timeouts.** All four fail on **unmodified `origin/develop`** (baseline run: 8322 / 3) or are documented flakes that pass in isolation. **Zero new failures.**
- Submodule gitlink matches develop's `ba3d553b` **and** the files on disk match the gitlink — verified per the `submodule-tree-drift-false-green` wall, after discovering my earlier runs had compiled a two-bumps-old toolkit.
- Mutation surface on the changed lines is genuinely empty (0/57, 0/21), so guards were proven by defect reintroduction instead — each with a named failing test, each file verified byte-identical afterward.
- `review:architect` and `review:qa_test` green at this tip.

## Deliberately not done

Drain-side silence (expired rows bulk-deleted untelemetered, non-2xx logged locally only); a queued position can overwrite a fresher live one; a queued audiobook bookmark can be delivered twice; `TPPKeychainManager` still uses the same crashing unarchiver on the launch path; `TPPAnnotations` carries seven static overrides that want instance-ification. All recorded in `.forgeos/intent/`.

The 902 bucket has **two confounders** — transients now re-code through `customSummaryAndCode`, and problem-doc bodies double-report. Group any re-measurement by `metadata.statusCode` rather than reading the total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)