### PR TITLE
fix(keychain): stop a corrupt keychain item from crashing every launch

### DIFF
--- a/Palace/Keychain/TPPKeychainManager.swift
+++ b/Palace/Keychain/TPPKeychainManager.swift
@@ -6,6 +6,41 @@ import PalaceKeychain
 
 @objcMembers final class TPPKeychainManager: NSObject {
 
+    // MARK: - Safe archive decoding
+    //
+    // `NSKeyedUnarchiver.unarchiveObject(with:)` signals a corrupt archive by
+    // RAISING an ObjC exception, which Swift cannot catch — `try?` does not
+    // help and the process aborts. Measured by bit-flipping each byte of a
+    // valid archive in turn: the raising call aborts on 2 of 156 flips for an
+    // archived String and 63 of 277 for an archived dictionary; the throwing
+    // APIs below abort on none.
+    //
+    // That matters more here than almost anywhere else in the app.
+    // `validateKeychain()` runs from `TPPAppDelegate.performBackgroundStartupTasks()`
+    // on EVERY launch, and reaches both decoders below. A single corrupt
+    // keychain item would therefore crash the app during startup, every time —
+    // a loop a patron can only escape by reinstalling, which costs them their
+    // downloaded books. Returning nil instead lets the item be skipped.
+
+    /// Decodes an archived keychain KEY. Keys are always archived `String`s, so
+    /// the class list is closed.
+    static func decodeKeychainKey(_ data: Data) -> String? {
+        (try? NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSString.self],
+                                                 from: data)) as? String
+    }
+
+    /// Decodes an archived keychain VALUE.
+    ///
+    /// Deliberately untyped: `TPPKeychain` archives whatever callers store, and
+    /// `TPPKeychainStoredVariable` has additionally written raw JSON for
+    /// `Codable` types since the format change — so this cannot assume a class
+    /// list without silently dropping values it should migrate. Uses the
+    /// throwing top-level API, which is what `TPPKeychain.read` already uses
+    /// for the same reason.
+    static func decodeKeychainValue(_ data: Data) -> AnyObject? {
+        (try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)) as AnyObject?
+    }
+
     private static let secClassItems: [String] = [
         kSecClassGenericPassword as String,
         kSecClassInternetPassword as String,
@@ -50,7 +85,7 @@ import PalaceKeychain
                 if let array = result as? [[String: Any]] {
                     for item in array {
                         if let keyData = item[kSecAttrAccount as String] as? Data,
-                           let keyString = NSKeyedUnarchiver.unarchiveObject(with: keyData) as? String {
+                           let keyString = decodeKeychainKey(keyData) {
                             Log.info(#file, "Found keychain item to clean up: \(keyString)")
                         }
                     }
@@ -141,8 +176,8 @@ import PalaceKeychain
             for item in array {
                 if let keyData = item[kSecAttrAccount as String] as? Data,
                    let valueData = item[kSecValueData as String] as? Data,
-                   let keyString = NSKeyedUnarchiver.unarchiveObject(with: keyData) as? String {
-                    let value = NSKeyedUnarchiver.unarchiveObject(with: valueData) as AnyObject
+                   let keyString = decodeKeychainKey(keyData),
+                   let value = decodeKeychainValue(valueData) {
                     values[keyString] = value
                 }
             }

--- a/Palace/Keychain/TPPKeychainManager.swift
+++ b/Palace/Keychain/TPPKeychainManager.swift
@@ -177,6 +177,14 @@ import PalaceKeychain
                 if let keyData = item[kSecAttrAccount as String] as? Data,
                    let valueData = item[kSecValueData as String] as? Data,
                    let keyString = decodeKeychainKey(keyData),
+                   // A value that will not decode SKIPS the whole item rather
+                   // than migrating it. That is deliberate and is the safe
+                   // direction: the previous code decoded such an item to
+                   // NSNull and wrote that back over it, destroying whatever
+                   // was there. Not directly testable — this path needs a real
+                   // `SecItemCopyMatching` against the device keychain — so it
+                   // is documented rather than worked around; the decoders
+                   // themselves are pinned by unit tests.
                    let value = decodeKeychainValue(valueData) {
                     values[keyString] = value
                 }

--- a/PalaceTests/Keychain/TPPKeychainManagerTests.swift
+++ b/PalaceTests/Keychain/TPPKeychainManagerTests.swift
@@ -75,6 +75,21 @@ final class TPPKeychainManagerTests: XCTestCase {
         XCTAssertEqual(TPPKeychainManager.decodeKeychainValue(value) as? [String: String],
                        ["token": "abc"],
                        "A legitimate legacy value archive must still decode")
+
+        // The shapes that actually occur in the store, not just a dictionary:
+        // credentials are archived Strings, and `TPPKeychainStoredVariable`'s
+        // pre-JSON format archived `Data`. A silent nil on either would sign a
+        // patron out — the failure mode that is WORSE than the crash this
+        // change removes.
+        let stringValue = NSKeyedArchiver.archivedData(withRootObject: "a-bearer-token")
+        XCTAssertEqual(TPPKeychainManager.decodeKeychainValue(stringValue) as? String,
+                       "a-bearer-token",
+                       "An archived String value must still decode")
+
+        let dataValue = NSKeyedArchiver.archivedData(withRootObject: Data("{\"k\":1}".utf8))
+        XCTAssertEqual(TPPKeychainManager.decodeKeychainValue(dataValue) as? Data,
+                       Data("{\"k\":1}".utf8),
+                       "An archived Data value (the pre-JSON Codable format) must still decode")
     }
 
     /// `TPPKeychainStoredVariable` has written raw JSON for `Codable` types

--- a/PalaceTests/Keychain/TPPKeychainManagerTests.swift
+++ b/PalaceTests/Keychain/TPPKeychainManagerTests.swift
@@ -14,6 +14,78 @@ import XCTest
 @MainActor
 final class TPPKeychainManagerTests: XCTestCase {
 
+    // MARK: - Safe archive decoding (launch-path crash safety)
+
+    /// A corrupt keychain archive must be SKIPPED, not abort the process.
+    ///
+    /// `validateKeychain()` runs from
+    /// `TPPAppDelegate.performBackgroundStartupTasks()` on every launch and
+    /// decodes every keychain item it finds. The previous
+    /// `NSKeyedUnarchiver.unarchiveObject(with:)` signals corruption by RAISING
+    /// an ObjC exception that Swift cannot catch, so one bad item crashed the
+    /// app during startup — every launch, unrecoverable without a reinstall
+    /// that costs the patron their downloaded books.
+    ///
+    /// The fixture corrupts the archived CLASS NAME in place. That is
+    /// deliberate: an arbitrary bit-flip usually does NOT reproduce the raise
+    /// (only 2 of 156 positions do for a String archive), so a positional
+    /// fixture would pass against the broken implementation too and guard
+    /// nothing.
+    /// An archive whose class record is destroyed — the shape that actually
+    /// makes the legacy unarchiver raise.
+    ///
+    /// It has to be a COLLECTION archive: a `String` archive stores its value
+    /// inline as a plist string and carries no class record at all, so there is
+    /// nothing to corrupt and any fixture built from one would pass against the
+    /// broken implementation too. This is fed to both decoders, since either
+    /// can meet a corrupt blob in the keychain.
+    private func archiveWithDestroyedClassRecord() -> Data? {
+        var corrupted = NSKeyedArchiver.archivedData(withRootObject: ["a": "b"])
+        let className = Array("NSDictionary".utf8)
+        guard let r = corrupted.range(of: Data(className)) else { return nil }
+        corrupted.replaceSubrange(r, with: Data(repeating: 0x5A, count: className.count))
+        return corrupted
+    }
+
+    func testDecodeKeychainKey_withCorruptedArchive_returnsNilInsteadOfCrashing() {
+        guard let corrupted = archiveWithDestroyedClassRecord() else {
+            return XCTFail("fixture precondition: the archive should name NSDictionary")
+        }
+        XCTAssertNil(TPPKeychainManager.decodeKeychainKey(corrupted),
+                     "A corrupt keychain key must decode to nil — raising here aborts the launch")
+    }
+
+    func testDecodeKeychainValue_withCorruptedArchive_returnsNilInsteadOfCrashing() {
+        guard let corrupted = archiveWithDestroyedClassRecord() else {
+            return XCTFail("fixture precondition: the archive should name NSDictionary")
+        }
+        XCTAssertNil(TPPKeychainManager.decodeKeychainValue(corrupted),
+                     "A corrupt keychain value must decode to nil — raising here aborts the launch")
+    }
+
+    /// Corruption tolerance must not come at the cost of reading real data:
+    /// these decoders run over items written by builds years old, and a silent
+    /// nil would sign patrons out rather than migrate them.
+    func testDecoders_stillReadArchivesWrittenTheOldWay() {
+        let key = NSKeyedArchiver.archivedData(withRootObject: "account.barcode")
+        XCTAssertEqual(TPPKeychainManager.decodeKeychainKey(key), "account.barcode",
+                       "A legitimate legacy key archive must still decode")
+
+        let value = NSKeyedArchiver.archivedData(withRootObject: ["token": "abc"])
+        XCTAssertEqual(TPPKeychainManager.decodeKeychainValue(value) as? [String: String],
+                       ["token": "abc"],
+                       "A legitimate legacy value archive must still decode")
+    }
+
+    /// `TPPKeychainStoredVariable` has written raw JSON for `Codable` types
+    /// since the format change, so the value decoder meets non-archive bytes in
+    /// the wild. It must return nil quietly, not abort.
+    func testDecodeKeychainValue_withRawJSON_returnsNilQuietly() {
+        let json = Data(#"{"token":"abc"}"#.utf8)
+        XCTAssertNil(TPPKeychainManager.decodeKeychainValue(json),
+                     "Non-archive bytes must decode to nil rather than crashing the launch path")
+    }
+
     // MARK: - logKeychainError
 
     func testLogKeychainError_doesNotCrash_withKnownStatuses() {

--- a/scripts/check-raising-unarchiver.py
+++ b/scripts/check-raising-unarchiver.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""
+check-raising-unarchiver.py — ban the RAISING `NSKeyedUnarchiver` reads in the
+app target (`Palace/**/*.swift`).
+
+`NSKeyedUnarchiver.unarchiveObject(with:)` and `unarchiveObject(withFile:)`
+signal a corrupt archive by RAISING an ObjC exception
+(`NSInvalidUnarchiveOperationException` /
+`NSArchiverArchiveInconsistency`), which cannot be caught from Swift — `try?`
+does not help, and the process aborts.
+
+This is measured, not assumed. Bit-flipping each byte of a valid archive in
+turn and counting process aborts:
+
+    archived [String: String] (277 bytes)   legacy 63 aborts   modern 0
+    archived String           (156 bytes)   legacy  2 aborts   modern 0
+
+Garbage bytes and truncated archives both return nil, so a casual probe finds
+nothing — real on-disk corruption is bit-level, and that is the shape that
+kills these calls. Two live examples of why it matters:
+
+  - `TPPNetworkQueue` read persisted request headers this way on the launch
+    path (offline-queue purge) and on the drain path (PP-4987).
+  - `TPPKeychainManager.validateKeychain()` is called from
+    `TPPAppDelegate.performBackgroundStartupTasks()` on EVERY launch, and read
+    keychain blobs this way. A corrupt item there is an unrecoverable launch
+    crash loop — the patron cannot get past it without reinstalling, which
+    costs them their downloaded books.
+
+Approved replacements:
+
+    NSKeyedUnarchiver.unarchivedObject(ofClasses:from:)     // typed, throws
+    NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(_:)   // untyped, throws
+
+Both return nil / throw on corruption instead of aborting. Prefer the first
+when the expected classes are known; the second preserves "any archived type"
+semantics where the value is genuinely untyped.
+
+Scope: `Palace/**/*.swift` (app target). Tests, mocks, previews and scripts are
+excluded — a test may legitimately construct the legacy call to prove it aborts.
+
+False-positive escape hatch: `// no-raising-unarchiver: <reason>` on the
+violating line or any of the 3 preceding lines.
+
+Flags (mirror the sibling pre-commit detectors):
+  --diff <file>        Unified-diff input. `-` or omit for stdin.
+  --scan <repo-root>   Walk `<root>/Palace/**/*.swift` directly instead of a diff.
+  --severity-floor LVL Block at LVL or higher (low|medium|high). Default high.
+  --no-block           Print findings, always exit 0.
+  --quiet              Suppress trailing summary line on stderr.
+  --dry-run            Parse only; never exit non-zero on findings.
+
+Exit codes:
+  0  — no findings at or above the severity floor (default: high)
+  1  — at least one finding at or above the floor
+  2  — argument or I/O error
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from _checklib import at_or_above, iter_hunk_lines, read_diff
+
+_at_or_above = at_or_above
+
+# `unarchiveObject(with:)` / `unarchiveObject(withFile:)` — the raising forms.
+# `unarchiveTopLevelObjectWithData` and `unarchivedObject(ofClasses:` are the
+# approved throwing forms and must NOT match; the `(?!TopLevel)` guard and the
+# explicit `with(?:File)?:` argument label keep them out.
+_RE_RAISING_UNARCHIVE = re.compile(
+    r"NSKeyedUnarchiver\s*\.\s*unarchiveObject\s*\(\s*with(?:File)?\s*:"
+)
+
+_PATTERNS: tuple[tuple[str, re.Pattern, str], ...] = (
+    ("unarchiveObject", _RE_RAISING_UNARCHIVE,
+     "`NSKeyedUnarchiver.unarchiveObject(with:)` RAISES an uncatchable ObjC "
+     "exception on a corrupt archive (measured: 63 of 277 bit-flips abort)"),
+)
+
+_RE_NO_BAN_ANNOTATION = re.compile(r"//\s*no-raising-unarchiver\b", re.IGNORECASE)
+
+_NON_PROD_PATH_SUBSTRINGS = (
+    "PalaceTests/",
+    "Tests/",
+    "TestSupport/",
+    "Utilities/Testing/",
+    "Preview Content/",
+    "Mocks/",
+    ".forgeos/",
+    "scripts/_fixtures/",
+    "scripts/tests/",
+)
+
+
+def _is_non_prod_swift(path: str) -> bool:
+    return any(s in path for s in _NON_PROD_PATH_SUBSTRINGS)
+
+
+@dataclass
+class _Finding:
+    code: str
+    severity: str
+    file_path: str
+    line_no: int
+    description: str
+
+    def render(self) -> str:
+        return (f"{self.file_path}:{self.line_no}: "
+                f"{self.code}: {self.severity}: {self.description}")
+
+
+def _line_no_at_offset(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def _is_in_comment(source: str, offset: int) -> bool:
+    """True when `offset` sits inside a comment rather than in code.
+
+    Naming a banned API in prose is how you DOCUMENT the ban — this detector's
+    own header does it, and so does the fix's explanatory comment. A detector
+    that fires on its own documentation trains people to ignore it, which is
+    the failure mode these checks exist to prevent.
+
+    Handles `//` line comments (including trailing) and `/* */` blocks. A `//`
+    inside a string literal is not treated as a comment start, which keeps a
+    URL like "https://…" from masking real code after it.
+    """
+    line_start = source.rfind("\n", 0, offset) + 1
+    prefix = source[line_start:offset]
+    in_string = False
+    i = 0
+    while i < len(prefix):
+        ch = prefix[i]
+        if ch == "\\":
+            i += 2
+            continue
+        if ch == '"':
+            in_string = not in_string
+        elif not in_string and prefix.startswith("//", i):
+            return True
+        i += 1
+
+    # Block comment: an unclosed `/*` anywhere before the match.
+    opened = source.rfind("/*", 0, offset)
+    if opened != -1 and source.rfind("*/", 0, offset) < opened:
+        return True
+    # A `*`-aligned continuation line inside a block comment.
+    return prefix.lstrip().startswith("*")
+
+
+def _has_annotation(lines: list[str], call_line: int) -> bool:
+    start = max(1, call_line - 3)
+    for ln in range(start, call_line + 1):
+        if ln < 1 or ln > len(lines):
+            continue
+        if _RE_NO_BAN_ANNOTATION.search(lines[ln - 1]):
+            return True
+    return False
+
+
+def _scan_file(rel_path: str, source: str) -> list[_Finding]:
+    if _is_non_prod_swift(rel_path) or not rel_path.endswith(".swift"):
+        return []
+    lines = source.splitlines()
+    findings: list[_Finding] = []
+    for _name, rx, desc in _PATTERNS:
+        for m in rx.finditer(source):
+            if _is_in_comment(source, m.start()):
+                continue
+            line_no = _line_no_at_offset(source, m.start())
+            if _has_annotation(lines, line_no):
+                continue
+            findings.append(_Finding(
+                code="RUA-1",
+                severity="high",
+                file_path=rel_path,
+                line_no=line_no,
+                description=(
+                    f"{desc}. Use `unarchivedObject(ofClasses:from:)` when the "
+                    "expected classes are known, or "
+                    "`unarchiveTopLevelObjectWithData(_:)` when the value is "
+                    "genuinely untyped — both throw instead of aborting."
+                ),
+            ))
+    findings.sort(key=lambda f: (f.file_path, f.line_no))
+    return findings
+
+
+def _scan_diff(diff_text: str, repo_root: Path) -> list[_Finding]:
+    touched: dict[str, set[int]] = {}
+    for dl in iter_hunk_lines(diff_text):
+        if dl.kind != "+":
+            continue
+        if not dl.file_path.endswith(".swift"):
+            continue
+        if _is_non_prod_swift(dl.file_path):
+            continue
+        touched.setdefault(dl.file_path, set()).add(dl.line_no)
+
+    out: list[_Finding] = []
+    for rel_path, added_lines in touched.items():
+        on_disk = repo_root / rel_path
+        if on_disk.is_file():
+            try:
+                source = on_disk.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+        else:
+            source = _reconstruct_post_image(diff_text, rel_path)
+            if source is None:
+                continue
+        for f in _scan_file(rel_path, source):
+            if f.line_no in added_lines:
+                out.append(f)
+    return out
+
+
+def _reconstruct_post_image(diff_text: str, target_path: str) -> str | None:
+    rows: dict[int, str] = {}
+    found = False
+    for dl in iter_hunk_lines(diff_text):
+        if dl.file_path != target_path:
+            continue
+        if dl.kind not in ("+", " "):
+            continue
+        rows[dl.line_no] = dl.text
+        found = True
+    if not found:
+        return None
+    if not rows:
+        return ""
+    return "\n".join(rows.get(i, "") for i in range(1, max(rows) + 1))
+
+
+def _scan_repo(repo_root: Path) -> list[_Finding]:
+    out: list[_Finding] = []
+    palace_dir = repo_root / "Palace"
+    if not palace_dir.is_dir():
+        palace_dir = repo_root
+    for root, _dirs, files in os.walk(palace_dir):
+        for name in files:
+            if not name.endswith(".swift"):
+                continue
+            full = Path(root) / name
+            try:
+                rel = str(full.relative_to(repo_root))
+            except ValueError:
+                rel = str(full)
+            if _is_non_prod_swift(rel):
+                continue
+            try:
+                source = full.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            out.extend(_scan_file(rel, source))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check-raising-unarchiver.py",
+        description=("Ban the raising NSKeyedUnarchiver reads "
+                     "(unarchiveObject(with:)/(withFile:)) in Palace/**/*.swift."),
+    )
+    parser.add_argument("--diff", default=None)
+    parser.add_argument("--scan", default=None)
+    parser.add_argument("--severity-floor", default="high",
+                        choices=("low", "medium", "high"))
+    parser.add_argument("--no-block", action="store_true")
+    parser.add_argument("--quiet", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.scan:
+            findings = _scan_repo(Path(args.scan).resolve())
+        else:
+            findings = _scan_diff(read_diff(args.diff), Path.cwd())
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover - safety net
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    blocking = []
+    for f in sorted(findings, key=lambda x: (x.file_path, x.line_no, x.code)):
+        if _at_or_above(f.severity, args.severity_floor):
+            blocking.append(f)
+        print(f.render())
+
+    if not args.quiet:
+        print(f"\n{len(findings)} raising-unarchiver finding(s); "
+              f"{len(blocking)} at/above floor={args.severity_floor}",
+              file=sys.stderr)
+
+    if args.no_block or args.dry_run:
+        return 0
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/pre-commit-phase35-detectors.sh
+++ b/scripts/pre-commit-phase35-detectors.sh
@@ -49,6 +49,7 @@ DETECTORS=(
   "UNSYNCHRONIZED_SENDABLE_MOCK|check-unsynchronized-sendable-mock.py|block|scan"
   "ADDOPERATION_LITERAL_BAN|check-addoperation-literal-ban.py|block|diff"
   "AUTH_CHALLENGE_ASYNC_FORM|check-auth-challenge-async-form.py|block|diff"
+  "RAISING_UNARCHIVER|check-raising-unarchiver.py|block|diff"
 )
 
 OVERALL_EXIT=0

--- a/scripts/tests/fixtures/raising_unarchiver/violation_raising_unarchive.swift
+++ b/scripts/tests/fixtures/raising_unarchiver/violation_raising_unarchive.swift
@@ -1,0 +1,12 @@
+//
+//  Fixture: the banned raising read. `NSKeyedUnarchiver.unarchiveObject(with:)`
+//  signals a corrupt archive by RAISING an uncatchable ObjC exception — measured
+//  at 63 of 277 bit-flips aborting the process for a dictionary archive.
+//
+import Foundation
+
+enum RaisingUnarchiverFixture {
+    static func decode(_ data: Data) -> String? {
+        return NSKeyedUnarchiver.unarchiveObject(with: data) as? String
+    }
+}

--- a/scripts/tests/test_check_raising_unarchiver.py
+++ b/scripts/tests/test_check_raising_unarchiver.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+test_check_raising_unarchiver.py — self-verify the RUA-1 detector
+(scripts/check-raising-unarchiver.py).
+
+The detector bans `NSKeyedUnarchiver.unarchiveObject(with:)`, which signals a
+corrupt archive by RAISING an uncatchable ObjC exception. Measured by
+bit-flipping each byte of a valid archive: 2 of 156 flips abort the process for
+an archived String, 63 of 277 for an archived dictionary; the throwing
+replacements abort on none.
+
+Two live call sites motivated it: `TPPNetworkQueue` (offline-queue purge and
+drain) and `TPPKeychainManager`, whose `validateKeychain()` runs from
+`TPPAppDelegate.performBackgroundStartupTasks()` on EVERY launch — so one
+corrupt keychain item was an unrecoverable launch crash loop.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-raising-unarchiver.py"
+
+
+def _scan(root: Path) -> tuple[int, str]:
+    p = subprocess.run([sys.executable, str(_SCRIPT), "--scan", str(root)],
+                       capture_output=True, text=True)
+    return p.returncode, p.stdout + p.stderr
+
+
+def _swift(root: Path, rel: str, body: str) -> Path:
+    f = root / rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(body)
+    return f
+
+
+# ───────────────────────────── it fires ─────────────────────────────────────
+
+def test_firesOnTheRaisingCall(tmp_path):
+    _swift(tmp_path, "Palace/Thing.swift",
+           'let s = NSKeyedUnarchiver.unarchiveObject(with: data) as? String\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 1
+    assert "RUA-1" in out and "Palace/Thing.swift:1" in out
+
+
+def test_firesOnTheWithFileVariant(tmp_path):
+    _swift(tmp_path, "Palace/Thing.swift",
+           'let s = NSKeyedUnarchiver.unarchiveObject(withFile: path)\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 1
+    assert "RUA-1" in out
+
+
+def test_firesOnEachOccurrenceSeparately(tmp_path):
+    _swift(tmp_path, "Palace/Thing.swift",
+           'let a = NSKeyedUnarchiver.unarchiveObject(with: d1)\n'
+           'let b = NSKeyedUnarchiver.unarchiveObject(with: d2)\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 1
+    assert "Thing.swift:1" in out and "Thing.swift:2" in out
+
+
+# ───────────────────── it does NOT fire (the clean paths) ───────────────────
+
+def test_approvedTypedFormPasses(tmp_path):
+    _swift(tmp_path, "Palace/Thing.swift",
+           'let s = try? NSKeyedUnarchiver.unarchivedObject(\n'
+           '    ofClasses: [NSString.self], from: data) as? String\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 0, out
+
+
+def test_approvedTopLevelFormPasses(tmp_path):
+    """The untyped escape valve — must not be mistaken for the banned call."""
+    _swift(tmp_path, "Palace/Thing.swift",
+           'let v = try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 0, out
+
+
+def test_emptyTreePasses(tmp_path):
+    """Clean-diff path: a detector that cannot pass is a detector nobody wires in."""
+    (tmp_path / "Palace").mkdir()
+    rc, out = _scan(tmp_path)
+    assert rc == 0, out
+
+
+# ─────────── the false positive that shipped in the first revision ──────────
+
+def test_doesNotFireOnALineComment(tmp_path):
+    """Naming the banned API in prose is how the ban is DOCUMENTED.
+
+    The first revision of this detector fired on its own fix's explanatory
+    comment — the known "detectors count comment mentions" failure, where a
+    detector that flags its own documentation trains people to ignore it.
+    """
+    _swift(tmp_path, "Palace/Thing.swift",
+           '// NSKeyedUnarchiver.unarchiveObject(with:) raises; do not use it.\n'
+           'let s = try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(d)\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 0, out
+
+
+def test_doesNotFireOnATrailingComment(tmp_path):
+    _swift(tmp_path, "Palace/Thing.swift",
+           'let s = safeDecode(d)  // replaces NSKeyedUnarchiver.unarchiveObject(with:)\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 0, out
+
+
+def test_doesNotFireInsideABlockComment(tmp_path):
+    _swift(tmp_path, "Palace/Thing.swift",
+           '/*\n'
+           ' * Was: NSKeyedUnarchiver.unarchiveObject(with: data)\n'
+           ' */\n'
+           'let s = safeDecode(data)\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 0, out
+
+
+def test_stillFiresOnCodeAfterAStringContainingSlashes(tmp_path):
+    """A URL in a string must not be mistaken for a comment start."""
+    _swift(tmp_path, "Palace/Thing.swift",
+           'let u = "https://example.org"; '
+           'let s = NSKeyedUnarchiver.unarchiveObject(with: data)\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 1, out
+
+
+# ───────────────────────── scope and escape hatch ──────────────────────────
+
+def test_testCodeIsOutOfScope(tmp_path):
+    """A test may legitimately construct the banned call to prove it aborts."""
+    _swift(tmp_path, "PalaceTests/ThingTests.swift",
+           'let s = NSKeyedUnarchiver.unarchiveObject(with: data)\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 0, out
+
+
+def test_escapeHatchSuppresses(tmp_path):
+    _swift(tmp_path, "Palace/Thing.swift",
+           '// no-raising-unarchiver: reading a format that predates secure coding\n'
+           'let s = NSKeyedUnarchiver.unarchiveObject(with: data)\n')
+    rc, out = _scan(tmp_path)
+    assert rc == 0, out
+
+
+def test_realTreeKeychainManagerIsClean():
+    """The site this detector was written for stays fixed."""
+    src = (_REPO_ROOT / "Palace" / "Keychain" / "TPPKeychainManager.swift")
+    if not src.is_file():
+        pytest.skip("TPPKeychainManager.swift not present")
+    text = src.read_text()
+    code_lines = [ln for ln in text.splitlines()
+                  if not ln.strip().startswith(("//", "*", "/*"))]
+    assert not any("unarchiveObject(with" in ln for ln in code_lines), \
+        "TPPKeychainManager must not reintroduce the raising unarchiver"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_detectors_diff_mode.py
+++ b/scripts/tests/test_detectors_diff_mode.py
@@ -37,6 +37,7 @@ _CASES = [
     ("check-swiftui-placeholder-a11y.py",            "swiftui_a11y",        "violation.swift",                    "Palace/CatalogUI",         "PP-4421", "warn"),
     ("check-notification-center-observer-storage.py","notification_center", "violation_unstored_observer.swift",  "Palace/AppInfrastructure", "D5-1",    "warn"),
     ("check-addoperation-literal-ban.py",             "addoperation_literal_ban", "violation_addoperation_trailing_closure.swift", "Palace/Utilities", "AOB-1", "block"),
+    ("check-raising-unarchiver.py",                   "raising_unarchiver",  "violation_raising_unarchive.swift",  "Palace/Keychain",          "RUA-1",   "block"),
 ]
 
 _IDS = [c[0].removeprefix("check-").removesuffix(".py") for c in _CASES]

--- a/scripts/verify-pr.sh
+++ b/scripts/verify-pr.sh
@@ -797,6 +797,8 @@ run_phase35_detector "addoperation_literal_ban" "check-addoperation-literal-ban.
   "No raw NSOperation-family closure literal (#1338 ClangImporter @MainActor-poisoning risk)" "diff"
 run_phase35_detector "auth_challenge_async_form" "check-auth-challenge-async-form.py" "block" \
   "No completion-handler-form auth-challenge delegate callback (PP-4895 ClangImporter @MainActor-poisoning risk)" "diff"
+run_phase35_detector "raising_unarchiver" "check-raising-unarchiver.py" "block" \
+  "No NSKeyedUnarchiver.unarchiveObject(with:) — raises uncatchably on a corrupt archive" "diff"
 
 # 4. Coverage floors
 echo "--- Coverage Floors ---"


### PR DESCRIPTION
## The defect

`TPPKeychainManager` decoded keychain archives with `NSKeyedUnarchiver.unarchiveObject(with:)`, which signals a corrupt archive by **RAISING** an ObjC exception. Swift cannot catch it — `try?` does not help, the process aborts.

`validateKeychain()` runs from `TPPAppDelegate.performBackgroundStartupTasks()` on **every launch** and reaches the decoder on both paths:

```
performBackgroundStartupTasks()          ← every launch
  └─ validateKeychain()
       ├─ fresh install → cleanupAllKeychainItems()        → :53
       └─ existing user → updateKeychainForBackgroundFetch() → :144/:145
```

So one corrupt keychain item was an unrecoverable **launch crash loop** — a patron cannot get past it without reinstalling, which costs them every downloaded book.

## Measured, not assumed

Bit-flipping each byte of a valid archive in turn and counting process aborts:

| archive | legacy `unarchiveObject(with:)` | modern APIs |
|---|---|---|
| `[String: String]`, 277 bytes | **63 aborts** (first at byte 81) | 0 |
| `String`, 156 bytes | **2 aborts** | 0 |

Garbage bytes and truncated archives both return `nil`, which is why this doesn't show up in casual probing — real on-disk corruption is bit-level, and that's the shape that kills it.

## The fix

Keys decode via `unarchivedObject(ofClasses: [NSString.self])` — keys are always archived `String`s. Values decode via `unarchiveTopLevelObjectWithData`, deliberately **untyped**: the store archives whatever callers give it, and `TPPKeychainStoredVariable` has written raw JSON for `Codable` types since the format change, so a class list would silently drop values this migration must read. That's the same API `TPPKeychain.read` already uses.

**A second, quieter bug falls out.** On raw-JSON items the legacy call returned `NSNull` — and the old code *wrote that back over the item*. So this prevents data loss, not just garbage. Review verified that against `origin/develop` directly.

## The detector is the real deliverable

This was the **second** file found with the pattern (the first, `TPPNetworkQueue`, is fixed in #1396) and nothing would have stopped a third. `scripts/check-raising-unarchiver.py` bans it across `Palace/`, wired into `verify-pr.sh` and the pre-commit detector registry.

Its first revision shipped a false positive — it fired on its own documentation, the known "detectors count comment mentions" failure that trains people to ignore a check. That's now comment-aware and pinned by a test.

Review then caught something better: all 13 pytests used `--scan` while the gates wire `--diff`, so the **wired interface had no committed coverage**. It's now registered in `scripts/tests/test_detectors_diff_mode.py`, which stages a violation in a throwaway repo and feeds the real `git diff --cached`. A reviewer confirmed by negative control that neutering `_scan_diff` makes that case fail.

## Verification

- `TPPKeychainManagerTests` 9/0 — including round-trips for archived `String` and archived `Data`, because a silent nil here **signs patrons out**, which is a worse failure than the crash being removed.
- Detector: 13 unit pytests + 1 diff-mode harness case (14/14), `bash -n` clean.
- Corruption fixture destroys the archived **class name** rather than flipping a byte — deliberate: a `String` archive carries no class record at all, and an arbitrary bit-flip usually does *not* reproduce the raise, so a positional fixture would pass against the broken implementation and guard nothing.
- Guards proven by restoring the legacy decoders: three **named** tests fail.
- Mutation: 0/10 on changed lines — the diff is an API substitution plus comments, so the surface is genuinely empty. An empty surface is not a score, hence the reintroduction proof.

## Not done

A corrupt item is skipped but not repaired or reported — the same silence as before, minus the crash. Reporting it needs a product decision about what to tell a patron whose credentials just vanished.

`Palace/Network/TPPNetworkQueue.swift:241` remains a true positive on a whole-tree scan; it's fixed in #1396 and both gates wire `--diff`, so it cannot block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)