### PR TITLE
fix(registry): register scheduled re-downloads before announcing .loaded

### DIFF
--- a/Palace/Packages/PalaceBookRegistry/Sources/PalaceBookRegistry/BookRegistrySync.swift
+++ b/Palace/Packages/PalaceBookRegistry/Sources/PalaceBookRegistry/BookRegistrySync.swift
@@ -180,6 +180,20 @@ final class BookRegistrySync: @unchecked Sendable {
     return _scheduledRedownloads
   }
 
+  /// How many re-downloads this instance has registered so far.
+  ///
+  /// Exists to make the ORDERING invariant assertable rather than probabilistic:
+  /// a test can read this from inside the `setState(.loaded)` callback and prove
+  /// registration already happened, instead of running the suite repeatedly and
+  /// hoping to catch the race. The flake it replaces only reproduced under load,
+  /// which makes it useless as a regression test — this is a property of the
+  /// code and holds on an idle machine.
+  func _scheduledRedownloadCountForTesting() -> Int {
+    _scheduledRedownloadsLock.lock()
+    defer { _scheduledRedownloadsLock.unlock() }
+    return _scheduledRedownloads.count
+  }
+
   /// Test-only NARROW deterministic JOIN seam: awaits every re-download this
   /// instance scheduled, including its delay, so a test can assert on what was (or
   /// was not) scheduled without a wall-clock deadline.
@@ -356,22 +370,27 @@ final class BookRegistrySync: @unchecked Sendable {
         // until an authoritative server sync repopulates the shelf.
         self.needsRebuildFromServer = needsRebuild
 
-        callbacks.setState(.loaded)
-        self.store.registrySubject.send(snapshot)
-
-        for (identifier, state) in bookStates {
-          self.store.bookStateSubject.send((identifier, state))
-        }
-
-        NotificationCenter.default.post(name: .TPPBookRegistryDidChange, object: nil)
-        Log.info(#file, "  Registry loaded with \(bookCount) books")
-
-        // Fire the completion AFTER state is .loaded and subscribers have been
-        // notified — callers that chain sync() off load (e.g. the account-change
-        // observer, AppDelegate cold-launch) need the store populated before
-        // sync's reconciliation runs.
-        callbacks.completion?()
-
+        // Register the delayed recovery work BEFORE announcing the load.
+        //
+        // Ordering, not cosmetics: `setState(.loaded)` and `completion?()` are
+        // the signals every caller — and every test — treats as "load is done".
+        // Scheduling AFTER them meant a caller could observe `.loaded`, ask what
+        // had been scheduled, and be told "nothing", because registration was
+        // still on its way. `_awaitScheduledRedownloadsForTesting()` snapshots
+        // the task list, so a join arriving in that window returned instantly
+        // and the assertion ran too early — the flake behind
+        // `test_load_contentMissingEntirely_schedulesTheOrphanRedownload` and
+        // `test_load_licenseWithoutContent_schedulesTheContentRedownload`, which
+        // failed ALTERNATELY and reproduced in isolation (so it was never the
+        // cross-class pollution it looked like).
+        //
+        // Production behaviour is unchanged: each block is a `Task` that sleeps
+        // for its own delay before firing, so creating it microseconds earlier
+        // does not change when a download starts, and both still re-check the
+        // current account before acting. The documented reason `completion`
+        // fires last — callers chain `sync()` off it and need the store
+        // populated — is untouched; the announcements keep their relative order
+        // and simply now follow registration.
         // PP-4129: schedule recovery for orphaned downloads. Each scheduled block
         // re-checks that the account that ran the load is still current before
         // firing downloads — switching libraries during the wait would otherwise
@@ -419,6 +438,23 @@ final class BookRegistrySync: @unchecked Sendable {
             }
           }
         }
+
+        callbacks.setState(.loaded)
+        self.store.registrySubject.send(snapshot)
+
+        for (identifier, state) in bookStates {
+          self.store.bookStateSubject.send((identifier, state))
+        }
+
+        NotificationCenter.default.post(name: .TPPBookRegistryDidChange, object: nil)
+        Log.info(#file, "  Registry loaded with \(bookCount) books")
+
+        // Fire the completion AFTER state is .loaded and subscribers have been
+        // notified — callers that chain sync() off load (e.g. the account-change
+        // observer, AppDelegate cold-launch) need the store populated before
+        // sync's reconciliation runs.
+        callbacks.completion?()
+
       }
     }
   }

--- a/PalaceTests/Book/BookRegistrySyncTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncTests.swift
@@ -331,8 +331,6 @@ final class BookRegistrySyncTests: PalaceWiringTestCase {
                        "a license alone is not a playable book")
     }
 
-    /// Kills the mutant "load() drops the orphan-redownload block". Content gone
-    /// from disk with no license is a different recovery path from the one above.
     /// The ORDERING invariant behind the board flake, asserted deterministically.
     ///
     /// `_awaitScheduledRedownloadsForTesting()` snapshots the task list, so it
@@ -360,14 +358,26 @@ final class BookRegistrySyncTests: PalaceWiringTestCase {
         try writeRegistryFile(records: [record.dictionaryRepresentation], to: url)
 
         let countAtLoaded = LockIsolatedCount()
+        let countAtCompletion = LockIsolatedCount()
         let done = expectation(description: "loaded")
-        sync.load(account: account) { state in
-            if state == .loaded {
-                // Sampled AT the announcement, not after it — the whole point.
-                countAtLoaded.set(sync._scheduledRedownloadCountForTesting())
+        sync.load(
+            account: account,
+            setState: { state in
+                if state == .loaded {
+                    // Sampled AT the announcement, not after it — the whole point.
+                    countAtLoaded.set(sync._scheduledRedownloadCountForTesting())
+                }
+            },
+            completion: {
+                // Sampled at the OTHER "load is done" signal too. Guarding only
+                // `.loaded` would let someone hoist `completion?()` above
+                // registration — passing this test while breaking every caller
+                // that chains `sync()` off completion and then asks what was
+                // scheduled.
+                countAtCompletion.set(sync._scheduledRedownloadCountForTesting())
                 done.fulfill()
             }
-        }
+        )
         // Bounded wait, not a deadline poll: `done` is fulfilled by load()'s own
         // setState callback, which load invokes unconditionally on every path.
         await fulfillment(of: [done], timeout: 10.0)  // STARVE-001-OK
@@ -375,6 +385,8 @@ final class BookRegistrySyncTests: PalaceWiringTestCase {
 
         XCTAssertEqual(countAtLoaded.value, 1,
                        "the orphan re-download must be REGISTERED before .loaded is announced — otherwise a caller that observes .loaded and joins the scheduled work is told nothing was scheduled")
+        XCTAssertEqual(countAtCompletion.value, 1,
+                       "…and before completion fires, which is the signal callers chaining sync() actually wait on")
     }
 
     /// Minimal thread-safe box; the callback may arrive off the test's thread.
@@ -385,6 +397,8 @@ final class BookRegistrySyncTests: PalaceWiringTestCase {
         func set(_ v: Int) { lock.withLock { _value = v } }
     }
 
+    /// Kills the mutant "load() drops the orphan-redownload block". Content gone
+    /// from disk with no license is a different recovery path from the one above.
     func test_load_contentMissingEntirely_schedulesTheOrphanRedownload() async throws {
         let account = "brs-test-\(UUID().uuidString)"
         let (sync, spy, _) = makeSchedulingSyncManager(currentAccount: account)

--- a/PalaceTests/Book/BookRegistrySyncTests.swift
+++ b/PalaceTests/Book/BookRegistrySyncTests.swift
@@ -333,6 +333,58 @@ final class BookRegistrySyncTests: PalaceWiringTestCase {
 
     /// Kills the mutant "load() drops the orphan-redownload block". Content gone
     /// from disk with no license is a different recovery path from the one above.
+    /// The ORDERING invariant behind the board flake, asserted deterministically.
+    ///
+    /// `_awaitScheduledRedownloadsForTesting()` snapshots the task list, so it
+    /// can only join work that is already registered. Registration therefore has
+    /// to happen BEFORE `setState(.loaded)` — the signal every caller and every
+    /// test treats as "load is done". It did not: scheduling ran after both
+    /// announcements, so a join arriving in that window returned instantly and
+    /// the assertion ran before anything was scheduled.
+    ///
+    /// That produced a flake which failed ALTERNATELY between
+    /// `test_load_contentMissingEntirely_…` and `test_load_licenseWithoutContent_…`,
+    /// reproduced in isolation (so it was never the cross-class pollution it
+    /// resembled), and only under machine load — which makes the flake itself
+    /// useless as a regression test. This asserts the property instead: read the
+    /// registration count from inside the `.loaded` callback, where a
+    /// zero means the race is back.
+    func test_load_registersScheduledRedownloads_beforeAnnouncingLoaded() async throws {
+        let account = "brs-test-\(UUID().uuidString)"
+        let (sync, _, _) = makeSchedulingSyncManager(currentAccount: account)
+        let url = try XCTUnwrap(sync.registryUrl(for: account))
+        defer { cleanupAccount(url) }
+
+        let book = makeBook(identifier: "orphan-\(UUID().uuidString)")
+        let record = TPPBookRegistryRecord(book: book, state: .downloadSuccessful)
+        try writeRegistryFile(records: [record.dictionaryRepresentation], to: url)
+
+        let countAtLoaded = LockIsolatedCount()
+        let done = expectation(description: "loaded")
+        sync.load(account: account) { state in
+            if state == .loaded {
+                // Sampled AT the announcement, not after it — the whole point.
+                countAtLoaded.set(sync._scheduledRedownloadCountForTesting())
+                done.fulfill()
+            }
+        }
+        // Bounded wait, not a deadline poll: `done` is fulfilled by load()'s own
+        // setState callback, which load invokes unconditionally on every path.
+        await fulfillment(of: [done], timeout: 10.0)  // STARVE-001-OK
+        await sync._awaitScheduledRedownloadsForTesting()
+
+        XCTAssertEqual(countAtLoaded.value, 1,
+                       "the orphan re-download must be REGISTERED before .loaded is announced — otherwise a caller that observes .loaded and joins the scheduled work is told nothing was scheduled")
+    }
+
+    /// Minimal thread-safe box; the callback may arrive off the test's thread.
+    private final class LockIsolatedCount: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _value = -1
+        var value: Int { lock.withLock { _value } }
+        func set(_ v: Int) { lock.withLock { _value = v } }
+    }
+
     func test_load_contentMissingEntirely_schedulesTheOrphanRedownload() async throws {
         let account = "brs-test-\(UUID().uuidString)"
         let (sync, spy, _) = makeSchedulingSyncManager(currentAccount: account)


### PR DESCRIPTION
Develop's board is red, and `BookRegistrySyncTests` is the loudest offender. This fixes one of the five failing tests — and, more usefully, replaces a flake that only reproduces under load with a property that holds on an idle machine.

## It was never pollution

`find-test-polluter.sh` reports the victim **FAILS IN ISOLATION**, which I confirmed independently: 41 tests, one real assertion failure, class run alone. So the usual "an earlier test dirtied shared state" answer is wrong here.

## The defect

`load()` announced completion **before** registering the work it had just decided to schedule:

```
setState(.loaded)      ← "load is done"
completion?()          ← "load is done"
trackScheduledRedownload(...)   ← registration, only now
```

`_awaitScheduledRedownloadsForTesting()` **snapshots** the task list, so a caller that observed `.loaded` and asked what had been scheduled was told *nothing* — registration was still on its way. The join returned instantly and the assertion ran too early.

That's why the failing **method alternated** between `test_load_contentMissingEntirely_schedulesTheOrphanRedownload` and `test_load_licenseWithoutContent_schedulesTheContentRedownload` — whichever lost the race that run.

## The fix

Registration now precedes both announcements. Production behaviour is unchanged: each block is a `Task` that sleeps for its own delay before firing, so creating it microseconds earlier doesn't change when a download starts, and both still re-check the current account before acting. The documented reason `completion` fires last — callers chain `sync()` off it and need the store populated — is untouched; the announcements keep their relative order and simply now follow registration.

Review independently confirmed the move is safe **by isolation, not just timing**: the region runs in one `DispatchQueue.main.async` block and the Task body is `@MainActor`, so a scheduled body cannot run before the announcements even at delay 0. It also verified nothing the block reads is mutated between the old and new positions.

## On evidence — the honest part

**I could not reproduce the original flake on an idle machine.** The class passed 8/8 both *with* and *without* the fix. It only failed while reviewers and full suites were competing for the machine, which is what `parallel-clone-starvation` means — and which makes the flake itself worthless as a regression test.

So the flake is replaced by a property. `test_load_registersScheduledRedownloads_beforeAnnouncingLoaded` samples the registration count from **inside** the `.loaded` and `completion` callbacks and asserts both are 1. That fails deterministically on the old ordering, on an idle machine, in isolation — verified by restoring the original order and running that single test.

Sampling **both** signals matters: guarding only `.loaded` would let someone hoist `completion?()` above registration, passing the test while breaking exactly the callers that chain `sync()` and then ask what was scheduled.

Mutation: 0/42 on changed lines — the diff is a code move plus comments, so the surface is genuinely empty. An empty surface is not a score, hence the reintroduction proof.

## Scope

One statement reordering in `load()`, a test-only registration-count accessor, one test.

## Not done

The other board reds are untouched, and I have **not** established they share this shape:

- `ImageCacheOffMainIsolationTests` — its driver busy-spins on the cooperative pool waiting for work that needs that same pool, and it mutates `ImageCache.shared`. Already hardened once against this class and still times out (0.03s typical → 90s observed → 3m timeout).
- `AccountsManagerStateMachineWiringTests` — `testSingleFlight_twoConcurrentAwaiters_oneNetworkRequest` races a 3s deadline against `Task { for await state in account.stateStream }`.
- `TPPBookRegistryLoadReentrancyTests`, `BookRegistrySyncReentrancyTests` — not investigated.

Both diagnosed cases are the same documented `parallel-clone-starvation` class, whose registry entry prescribes replacing the wall-clock deadline with a deterministic join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)