### PR TITLE
Three instruments for questions a release regression could not answer

### DIFF
--- a/docs/Testing/simulator-log-recovery.md
+++ b/docs/Testing/simulator-log-recovery.md
@@ -106,6 +106,26 @@ bites: counting raw lines instead of data lines (an uncovered window then
 reports itself as a real negative) and dropping the `|| true` on the filter
 (a legitimate zero-match then exits non-zero). Both are caught by name.
 
+## If you will want to quote it at info level, capture it live during the run
+
+The archive is complete for debug and error and near-empty for info. So
+anything you expect to quote at info level must be captured **live, while the
+run is happening**, or it does not exist afterward — a shutdown ends the buffer
+and a later boot starts a new one rather than restoring the old.
+
+That makes live capture a property of the RUN, not of the analysis. A QA or
+chaos pass that will cite log evidence should stream its own log to a file for
+the duration:
+
+```bash
+xcrun simctl spawn <UDID> log stream --style compact --info --debug > pass.log &
+```
+
+Everything this page describes is recovery of what survived. It is not a
+substitute for capturing the record in the first place, and the gap is silent:
+a pass that never captured looks identical afterward to one whose evidence was
+merely never quoted.
+
 ## Four ways to get an empty result that is not missing data
 
 Each of these returns zero lines. The script now tells the first three apart

--- a/docs/Testing/simulator-log-recovery.md
+++ b/docs/Testing/simulator-log-recovery.md
@@ -1,0 +1,137 @@
+# Recovering simulator logs after the fact
+
+A QA or chaos pass records the log lines its operator thought to quote. Every
+other line the app and the system emitted during that pass is, by default,
+treated as gone. It usually is not gone: the simulator keeps its own unified-log
+store on the host filesystem, independent of anything the harness captured, and
+that store outlives the pass.
+
+`scripts/sim-log-recover.sh` reads it.
+
+## Why this matters more than it sounds
+
+A finding backed by one pasted log line cannot survive being questioned. When a
+reviewer asks "was that really two requests, or one request retried?", the
+quoted fragment cannot answer — and the usual next step is to re-drive the
+scenario, which costs a simulator, a build, and an hour, and produces a *new*
+observation rather than evidence about the original one.
+
+This is not hypothetical. In one release regression the run's `logs/` and
+`crashes/` trees were empty for every device cell, so 41 findings rested
+entirely on quoted fragments. One of them was filed **minor** on the strength of
+a single `-999 cancelled` line, with a stated cause of "a duplicate fulfillment
+download that is cancelled mid-flight."
+
+Recovering the store showed three download tasks on the app's background
+session, not one:
+
+```
+<5848D9C1…>.<1>  resumed 21.139 → finished with error [-999] cancelled 22.749
+<BBBBBD5C…>.<2>  resumed 24.420 → finished successfully              25.917
+<C7AF18D9…>.<3>  resumed 27.472 → finished successfully              28.619
+```
+
+— each preceded by its own request to the fulfillment endpoint. One borrow
+billed the circulation manager three times and downloaded the same EPUB twice.
+The finding was promoted to major on the critical path. Nothing was re-driven;
+the evidence had been sitting on disk the whole time.
+
+## The contract
+
+**It does not touch the device.** The script reads host files only. It is safe
+against a simulator another session or agent currently owns — no lock is
+claimed, and a pass running on that device is not disturbed. This is the point:
+evidence recovery must never require taking a simulator away from whoever is
+using it.
+
+**It reads system subsystems, not the app's own narration.** The shim carries
+partial metadata, so the app's `os_log` output renders as
+`<compose failure [UUID]>`. `com.apple.CFNetwork`, `com.apple.network`,
+`runningboard`, and WebKit come through complete. That is enough to settle
+network- and lifecycle-shaped questions — how many requests were issued, whether
+they succeeded, whether a process was respawned — and not enough to read what
+the app said about itself. Know which kind of question you have before you
+start.
+
+**Coverage is finite.** The store rotates. Check what a device still holds
+before assuming a window is recoverable:
+
+```bash
+ls -t ~/Library/Developer/CoreSimulator/Devices/<UDID>/data/var/db/diagnostics/Persist
+```
+
+## Empty results are disambiguated, not just reported
+
+This tool exists to settle questions of the form "did the app actually issue
+that request." An operator error that silently reads as "no, it didn't" would
+retract true findings, so the script refuses to let the two look alike:
+
+| exit | meaning | safe to reason from? |
+|---|---|---|
+| `0` + output | matches found | yes |
+| `0` + `0 matches` on stderr | the window HAS log data; nothing matched | **yes** — a real negative |
+| `3` + `WINDOW NOT COVERED` | the window has no log data at all | **no** — says nothing either way |
+| `1` | no store for that UDID | no |
+
+The distinction is pinned by `scripts/tests/test_sim_log_recover.sh`, which
+stubs `log` so it needs no simulator. Two mutants were used to prove the guard
+bites: counting raw lines instead of data lines (an uncovered window then
+reports itself as a real negative) and dropping the `|| true` on the filter
+(a legitimate zero-match then exits non-zero). Both are caught by name.
+
+## Four ways to get an empty result that is not missing data
+
+Each of these returns zero lines. The script now tells the first three apart
+from a genuine negative, but knowing them still saves time — all four have
+bitten someone.
+
+1. **Omitting `--info --debug`.** CFNetwork task lifecycle is emitted at Debug
+   level. The script always passes both; anyone hand-rolling `log show` must
+   too.
+2. **Using a process predicate.** `process == "Palace"` matches nothing here,
+   because process names do not resolve against partial metadata — and it fails
+   silently rather than erroring. Filter on message text instead.
+3. **Passing a UTC timestamp.** The tool wants local time. Chaos shard
+   directories are named in UTC, so a shard named `…T15-06-59Z` is `11:06` in a
+   UTC-4 zone. Passing `15:06` yields an empty window.
+4. **Grepping for a symbol the app emits.** Searching a recovered archive for
+   `downloadTaskWithRequest`, a `Log.debug` message, or any other app-authored
+   string returns zero — not because it did not happen, but because app `os_log`
+   lines cannot be composed here (see the contract above). This one is the most
+   dangerous of the four: it produces a confident zero that *contradicts* a real
+   finding. Once, a recommendation to re-count a confirmed defect this way would
+   have returned 0 and retracted it. **Count what the system emitted — task
+   UUIDs, connection IDs — never a string the app itself logged.**
+
+## Usage
+
+```bash
+scripts/sim-log-recover.sh <UDID> <start> <end> [grep-pattern]
+
+# every Palace-attributed URLSession task created in a one-minute window
+scripts/sim-log-recover.sh "$UDID" '2026-08-20 11:11:00' '2026-08-20 11:12:00' \
+    'is for <org.thepalaceproject.palace>'
+
+# what a task did next
+scripts/sim-log-recover.sh "$UDID" '2026-08-20 11:11:00' '2026-08-20 11:16:00' \
+    '5848D9C1|BBBBBD5C|C7AF18D9'
+```
+
+Counting distinct network operations is the common case, and
+`Task <UUID>.<n> is for <bundle-id>.<session-id>` is the line that does it: one
+per task actually created, attributed to the session that created it. Pair it
+with `finished successfully` / `finished with error` to get outcomes rather than
+intentions.
+
+## When to reach for it
+
+- A finding's stated cause rests on a single quoted line and someone disputes it.
+- You are about to re-drive a scenario **only** to recover a log. Read the store
+  first; if the original run is still in coverage, you already have the answer,
+  and it is evidence about the original observation rather than a new one.
+- A differential needs the same measurement on both builds and one side has
+  already been driven.
+
+See also `docs/bug-investigation-process.md` — step 1, "reproduce against the
+REAL artifact first." This is one of the ways to get that artifact when the
+moment has passed.

--- a/docs/Testing/simulator-log-recovery.md
+++ b/docs/Testing/simulator-log-recovery.md
@@ -3,7 +3,7 @@
 A QA or chaos pass records the log lines its operator thought to quote. Every
 other line the app and the system emitted during that pass is, by default,
 treated as gone. It usually is not gone: the simulator keeps its own unified-log
-store on the host filesystem, independent of anything the harness captured, and
+store on the host filesystem, independent of anything the QA run captured, and
 that store outlives the pass.
 
 `scripts/sim-log-recover.sh` reads it.

--- a/docs/Testing/simulator-log-recovery.md
+++ b/docs/Testing/simulator-log-recovery.md
@@ -173,6 +173,14 @@ searching it; read the exit code rather than the number. When a zero would
 change a decision, prove the command hit something first — show a non-zero
 count of a line you KNOW is there, then run the real query.
 
+The same rule applies to any artifact a pass depends on, not just to a grep.
+A shared build directory once vanished from `/tmp` mid-campaign with no error
+and no warning; it was discovered forty minutes later when an install failed.
+A two-second `ls` in the pass preamble would have caught it at the start. Treat
+a missing artifact as an expected condition to check for, not an incident to
+discover — and note that "we moved it somewhere safer" is not the same as
+knowing what removed it.
+
 This is deliberately written as discipline rather than a script. A guard that
 covered only the wrong-target cases would leave the merely-wrong-pattern case
 returning an identical honest zero, while implying the class was handled —

--- a/docs/Testing/simulator-log-recovery.md
+++ b/docs/Testing/simulator-log-recovery.md
@@ -94,7 +94,7 @@ bitten someone.
 3. **Passing a UTC timestamp.** The tool wants local time. Chaos shard
    directories are named in UTC, so a shard named `…T15-06-59Z` is `11:06` in a
    UTC-4 zone. Passing `15:06` yields an empty window.
-4. **Grepping for a symbol the app emits.** Searching a recovered archive for
+ Searching a recovered archive for
    `downloadTaskWithRequest`, a `Log.debug` message, or any other app-authored
    string returns zero — not because it did not happen, but because app `os_log`
    lines cannot be composed here (see the contract above). This one is the most
@@ -102,6 +102,35 @@ bitten someone.
    finding. Once, a recommendation to re-count a confirmed defect this way would
    have returned 0 and retracted it. **Count what the system emitted — task
    UUIDs, connection IDs — never a string the app itself logged.**
+
+## A zero is only a measurement if the command hit something
+
+The section above is about a tool returning nothing. This is the layer beneath
+it, and no tooling catches it: a command that never reached its target prints a
+clean, confident zero.
+
+Three instances turned up in a single afternoon, two of them in the hands of
+people who had just written the warning:
+
+- `git show $ref:path` unquoted in zsh. `:P` is a path modifier, so the ref
+  expands to an absolute path, git fatals, and the piped `grep -c` prints `0`.
+  Two failures stacked, one visible result.
+- A `pytest` invocation piped to `tail`, whose exit status came from `tail`.
+- A grep against `Palace/Book/BookDetailView.swift`, a path that does not
+  exist — the file is at `Palace/Book/UI/BookDetail/BookDetailView.swift`.
+  Correct quoting, clean exit code, still a zero from nothing.
+
+The habit that catches all three: **confirm the target resolves, then count.**
+`git cat-file -e "$ref:$path"` before grepping it; check the file exists before
+searching it; read the exit code rather than the number. When a zero would
+change a decision, prove the command hit something first — show a non-zero
+count of a line you KNOW is there, then run the real query.
+
+This is deliberately written as discipline rather than a script. A guard that
+covered only the wrong-target cases would leave the merely-wrong-pattern case
+returning an identical honest zero, while implying the class was handled —
+which is the failure shape this whole document exists to prevent.
+
 
 ## Usage
 

--- a/docs/Testing/simulator-log-recovery.md
+++ b/docs/Testing/simulator-log-recovery.md
@@ -44,14 +44,41 @@ claimed, and a pass running on that device is not disturbed. This is the point:
 evidence recovery must never require taking a simulator away from whoever is
 using it.
 
-**It reads system subsystems, not the app's own narration.** The shim carries
-partial metadata, so the app's `os_log` output renders as
-`<compose failure [UUID]>`. `com.apple.CFNetwork`, `com.apple.network`,
-`runningboard`, and WebKit come through complete. That is enough to settle
-network- and lifecycle-shaped questions — how many requests were issued, whether
-they succeeded, whether a process was respawned — and not enough to read what
-the app said about itself. Know which kind of question you have before you
-start.
+**It reads what was PERSISTED, which is not everything the device logged.**
+Two separate gaps, and the second one is easy to miss because it looks like a
+real negative:
+
+- The app's own `os_log` output renders as `<compose failure [UUID]>` — the
+  shim carries partial metadata and cannot resolve app format strings.
+- **Info-level records are ~98% absent.** Measured on one window: debug 5,861
+  of 5,972 and error 133 of 139 came through; info, 78 of 4,472. Info records
+  live in a buffer that is never written to disk, so no combination of log-level
+  flags recovers them from an archive.
+
+The second gap has teeth because ordinary network chatter is info level. TLS
+teardown, `nw_endpoint_handler_cancel`, boringssl warning alerts — grep this
+store for any of them and you get a confident zero from a window that held
+hundreds. An earlier version of this page claimed system subsystems "come
+through complete." That was wrong, and it produced exactly that false zero
+during a live investigation: four quoted log strings were reported as
+non-existent across three device cells when they were simply info level.
+
+**Info records are recoverable while the simulator is still booted**, with a
+live read that sees the unpersisted buffer:
+
+```bash
+xcrun simctl spawn <UDID> log show --start '...' --end '...' \
+    --style compact --info --debug
+```
+
+That spawns a process on the device, so it requires owning the simulator —
+the trade this script otherwise avoids. **Shut the simulator down and the info
+records are gone permanently.** If a pass produced evidence you may need, read
+it live before the device is reclaimed.
+
+So: this script for debug- and error-level evidence — CFNetwork task lifecycle,
+process spawns, WebKit errors. A live read for anything info level. Neither for
+the app's own narration.
 
 **Coverage is finite.** The store rotates. Check what a device still holds
 before assuming a window is recoverable:

--- a/docs/bug-investigation-process.md
+++ b/docs/bug-investigation-process.md
@@ -12,6 +12,11 @@ culture, half **enforced gate** — see "Enforcement".
    ground truth: fetch the live feed/payload, pull the actual crash log, or
    reproduce on device/sim. Confirm the failing *shape* matches your
    hypothesis. Do NOT collapse to a fix off a plausible-sounding cause.
+   If the moment has passed and all you have is a quoted log fragment, the
+   simulator's own log store usually still holds the full window — see
+   [`Testing/simulator-log-recovery.md`](./Testing/simulator-log-recovery.md).
+   Recovering it beats re-driving: it is evidence about the ORIGINAL
+   observation, not a new one.
 2. **Enumerate ≥3 rival causes** and kill each by *evidence*, not plausibility.
    The first diagnosis is a hypothesis, not a conclusion. (The shape-preflight
    `hypothesis-ledger` nudge says the same thing.)

--- a/scripts/differential_check.py
+++ b/scripts/differential_check.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Compare a signature across two builds, and REFUSE to compare when it is invalid.
+
+WHY
+
+Counting a log signature on two builds produces a number whether or not the
+number means anything. A regression campaign produced two clean-looking zeros
+that meant nothing:
+
+  - a baseline zero from a lane that was never rendered, and
+  - a baseline zero from a search that used a different input class than the
+    candidate's.
+
+Both would have been filed. One would have been a false REGRESSION on a
+release-gating row. In each case three of the four preconditions held and the
+fourth was silently absent, which is exactly the shape that survives review: a
+result that looks measured.
+
+So this tool checks the preconditions FIRST and emits no comparison at all
+unless every one of them holds:
+
+  1. DEVICE model matches between the two sides
+  2. OS version matches
+  3. WITNESS present on the CANDIDATE side  (the path ran)
+  4. WITNESS present on the BASELINE side   (the path ran there too), at a
+     COMPARABLE DENSITY — see below
+
+Input-class equality (same string, same lane, same content) cannot be checked
+mechanically — that is what the witness pattern is for. Choose a witness that
+can only appear if the specific path under test actually executed: a request to
+the host whose covers fail, the query string itself, a task on the session that
+matters. A witness like "the app launched" satisfies the check and defeats it.
+
+"PRESENT" IS NOT ENOUGH, and this tool learned that the hard way. Run against
+the real pair it was written for, the first version PASSED it: the baseline had
+three incidental mentions of the witness host while never rendering the lane,
+so a >0 check let a 53-vs-0 comparison through — the exact false REGRESSION the
+tool exists to prevent. Window lengths differ by orders of magnitude between a
+20-second shard and a 5-minute pass, so raw counts do not compare either. The
+check is therefore on DENSITY (witness hits per 1000 log lines), and a side
+whose density is a small fraction of the other's is treated as not having run
+the path. Set --min-witness above 1 whenever you know roughly how many hits a
+genuine exercise produces.
+
+EXIT CODES
+  0  preconditions held; comparison emitted
+  5  a precondition failed; NO comparison emitted, and the failure is named
+  1  usage / environment problem
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_RECOVER = str(Path(__file__).resolve().parent / "sim-log-recover.sh")
+
+
+def device_of(udid: str, simctl_json: str | None) -> tuple[str, str]:
+    """Return (device_name, os_version) for a UDID, or raise."""
+    if simctl_json:
+        blob = json.loads(Path(simctl_json).read_text())
+    else:
+        out = subprocess.run(["xcrun", "simctl", "list", "devices", "-j"],
+                             capture_output=True, text=True, check=True).stdout
+        blob = json.loads(out)
+    for runtime, devices in blob.get("devices", {}).items():
+        for d in devices:
+            if d.get("udid", "").upper() == udid.upper():
+                os_ver = runtime.split(".")[-1].replace("iOS-", "").replace("-", ".")
+                return d.get("name", "?"), os_ver
+    raise KeyError(f"UDID not found in simctl output: {udid}")
+
+
+def read_window(recover: str, udid: str, start: str, end: str) -> str:
+    r = subprocess.run([recover, udid, start, end], capture_output=True, text=True)
+    # exit 3 = window not covered; that is a precondition failure, not a crash.
+    if r.returncode not in (0, 3):
+        raise RuntimeError(f"{recover} failed for {udid}: {r.stderr.strip()[:200]}")
+    return r.stdout
+
+
+def fail(reason: str, detail: dict) -> int:
+    print(json.dumps({"comparable": False, "reason": reason, **detail}, indent=2))
+    print(f"differential-check: NO COMPARISON EMITTED — {reason}", file=sys.stderr)
+    print("  A count from this pair would look like a result and would not be one.", file=sys.stderr)
+    return 5
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--candidate-udid", required=True)
+    ap.add_argument("--candidate-start", required=True)
+    ap.add_argument("--candidate-end", required=True)
+    ap.add_argument("--baseline-udid", required=True)
+    ap.add_argument("--baseline-start", required=True)
+    ap.add_argument("--baseline-end", required=True)
+    ap.add_argument("--signature", required=True, help="regex for the thing being counted")
+    ap.add_argument("--witness", required=True,
+                    help="regex that can only match if the path under test actually ran")
+    ap.add_argument("--min-witness", type=int, default=1,
+                    help="minimum witness hits required on EACH side. 1 is almost always "
+                         "too weak — incidental mentions clear it. Set it to what a genuine "
+                         "exercise of the path actually produces.")
+    ap.add_argument("--max-witness-ratio", type=float, default=10.0,
+                    help="refuse if one side's witness DENSITY (hits per 1000 lines) exceeds "
+                         "the other's by more than this factor: the path ran on both sides, "
+                         "but not comparably.")
+    ap.add_argument("--recover-cmd", default=DEFAULT_RECOVER, help="test seam")
+    ap.add_argument("--simctl-json", default=None, help="test seam: device data from a file")
+    args = ap.parse_args()
+
+    try:
+        cand_dev = device_of(args.candidate_udid, args.simctl_json)
+        base_dev = device_of(args.baseline_udid, args.simctl_json)
+    except (KeyError, subprocess.CalledProcessError) as exc:
+        print(f"differential-check: {exc}", file=sys.stderr)
+        return 1
+
+    devices = {"candidate": {"device": cand_dev[0], "os": cand_dev[1]},
+               "baseline": {"device": base_dev[0], "os": base_dev[1]}}
+
+    if cand_dev[0] != base_dev[0]:
+        return fail("DEVICE-MISMATCH", devices)
+    if cand_dev[1] != base_dev[1]:
+        return fail("OS-MISMATCH", devices)
+
+    try:
+        cand = read_window(args.recover_cmd, args.candidate_udid, args.candidate_start, args.candidate_end)
+        base = read_window(args.recover_cmd, args.baseline_udid, args.baseline_start, args.baseline_end)
+    except RuntimeError as exc:
+        print(f"differential-check: {exc}", file=sys.stderr)
+        return 1
+
+    wrx, srx = re.compile(args.witness), re.compile(args.signature)
+    cw, bw = len(wrx.findall(cand)), len(wrx.findall(base))
+    cl, bl = max(cand.count("\n"), 1), max(base.count("\n"), 1)
+    cd, bd = cw / cl * 1000, bw / bl * 1000
+    witness = {"witness_candidate": cw, "witness_baseline": bw,
+               "lines_candidate": cl, "lines_baseline": bl,
+               "witness_per_kloc_candidate": round(cd, 4),
+               "witness_per_kloc_baseline": round(bd, 4),
+               **devices}
+
+    # The witness checks are the whole point: a zero signature count on a side
+    # that never ran the path is not a negative, and must never be reported as
+    # one. Check the BASELINE explicitly even when the candidate is fine — that
+    # is the direction that produces a false REGRESSION.
+    if cw < args.min_witness:
+        return fail("UNEXERCISED-CANDIDATE", witness)
+    if bw < args.min_witness:
+        return fail("UNEXERCISED-BASELINE", witness)
+    # Both sides touched the path, but a handful of incidental hits against a
+    # window that is orders of magnitude longer is not the same exercise. Compare
+    # density, not raw counts: window lengths are not controlled.
+    lo, hi = sorted((cd, bd))
+    if lo <= 0 or hi / lo > args.max_witness_ratio:
+        return fail("WITNESS-DISPROPORTIONATE", witness)
+
+    cs, bs = len(srx.findall(cand)), len(srx.findall(base))
+    print(json.dumps({
+        "comparable": True,
+        **witness,
+        "signature_candidate": cs,
+        "signature_baseline": bs,
+        # Evidence, not a verdict. A human decides the disposition; this only
+        # says the two numbers are of the same kind and may be compared.
+        "note": "preconditions held; these counts are comparable",
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/differential_check.py
+++ b/scripts/differential_check.py
@@ -59,8 +59,16 @@ from pathlib import Path
 DEFAULT_RECOVER = str(Path(__file__).resolve().parent / "sim-log-recover.sh")
 
 
-def device_of(udid: str, simctl_json: str | None) -> tuple[str, str]:
-    """Return (device_name, os_version) for a UDID, or raise."""
+def device_of(udid: str, simctl_json: str | None) -> tuple[str, str, str]:
+    """Return (device_type_identifier, os_version, display_name) for a UDID.
+
+    The TYPE identifier is what the device check compares, never the name. A
+    purpose-built baseline simulator is routinely given a custom name
+    ("baseline-ipad11m5-261") while being the same device type as the candidate
+    cell it is meant to match — comparing names refuses those pairs, which is a
+    false DEVICE-MISMATCH on exactly the comparison the tool exists to make.
+    The name is carried only so the output is readable.
+    """
     if simctl_json:
         blob = json.loads(Path(simctl_json).read_text())
     else:
@@ -71,7 +79,10 @@ def device_of(udid: str, simctl_json: str | None) -> tuple[str, str]:
         for d in devices:
             if d.get("udid", "").upper() == udid.upper():
                 os_ver = runtime.split(".")[-1].replace("iOS-", "").replace("-", ".")
-                return d.get("name", "?"), os_ver
+                dtype = d.get("deviceTypeIdentifier") or ""
+                if not dtype:
+                    raise KeyError(f"no deviceTypeIdentifier for {udid}; cannot compare device type")
+                return dtype, os_ver, d.get("name", "?")
     raise KeyError(f"UDID not found in simctl output: {udid}")
 
 
@@ -133,8 +144,8 @@ def main() -> int:
         print(f"differential-check: {exc}", file=sys.stderr)
         return 1
 
-    devices = {"candidate": {"device": cand_dev[0], "os": cand_dev[1]},
-               "baseline": {"device": base_dev[0], "os": base_dev[1]}}
+    devices = {"candidate": {"device": cand_dev[2], "device_type": cand_dev[0], "os": cand_dev[1]},
+               "baseline": {"device": base_dev[2], "device_type": base_dev[0], "os": base_dev[1]}}
 
     if cand_dev[0] != base_dev[0]:
         return fail("DEVICE-MISMATCH", devices)

--- a/scripts/differential_check.py
+++ b/scripts/differential_check.py
@@ -185,11 +185,25 @@ def main() -> int:
         return fail("WITNESS-DISPROPORTIONATE", witness)
 
     cs, bs = len(srx.findall(cand)), len(srx.findall(base))
-    print(json.dumps({
+    result = {
         "comparable": True,
         **witness,
         "signature_candidate": cs,
         "signature_baseline": bs,
+    }
+    # A zero signature deserves one more caveat that this tool cannot resolve
+    # for the caller. If the reads came from a recovered archive, info-level
+    # records are ~98% absent (see docs/Testing/simulator-log-recovery.md), so a
+    # zero says nothing about an info-level string. The tool cannot know a
+    # signature's log level, so it flags the case rather than judging it.
+    if cs == 0 or bs == 0:
+        result["zero_signature_caveat"] = (
+            "a zero here is only meaningful if the signature is emitted at debug or "
+            "error level; an archive read is ~98% blind to info level, so an info-level "
+            "string returns zero from a window that contained hundreds"
+        )
+    print(json.dumps({
+        **result,
         # Evidence, not a verdict. A human decides the disposition; this only
         # says the two numbers are of the same kind and may be compared.
         "note": "preconditions held; these counts are comparable",

--- a/scripts/differential_check.py
+++ b/scripts/differential_check.py
@@ -83,10 +83,23 @@ def read_window(recover: str, udid: str, start: str, end: str) -> str:
     return r.stdout
 
 
+# A refusal is a statement about the DATA, never about the builds. The
+# distinction is easy to lose once the JSON is pasted into a triage row: a
+# WITNESS-DISPROPORTIONATE on a cluster whose evidence the reader cannot see
+# means "this data cannot answer the question", NOT "the baseline never ran the
+# path" — opposite meanings, identical output. So the tool says so itself rather
+# than relying on whoever reads it to remember.
+NOT_A_FINDING = ("this is a statement about the DATA, not about the builds: "
+                 "the comparison could not be made, which is not evidence that "
+                 "the behaviour is absent on either side")
+
+
 def fail(reason: str, detail: dict) -> int:
-    print(json.dumps({"comparable": False, "reason": reason, **detail}, indent=2))
+    print(json.dumps({"comparable": False, "reason": reason,
+                      "not_a_finding": NOT_A_FINDING, **detail}, indent=2))
     print(f"differential-check: NO COMPARISON EMITTED — {reason}", file=sys.stderr)
     print("  A count from this pair would look like a result and would not be one.", file=sys.stderr)
+    print(f"  {NOT_A_FINDING}.", file=sys.stderr)
     return 5
 
 

--- a/scripts/sim-log-recover.sh
+++ b/scripts/sim-log-recover.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Recover unified-log evidence from a simulator's own log store WITHOUT
+# booting, spawning into, or otherwise touching that simulator.
+#
+# WHY THIS EXISTS
+#
+# A QA or chaos pass captures whatever log lines the operator thought to paste
+# into a findings row. Everything else is lost the moment the pass ends — and a
+# finding backed by one pasted line cannot be re-examined when someone later
+# disputes its cause. (In one release regression the run's logs/ tree was empty
+# for every device cell, so 41 findings rested entirely on quoted fragments.)
+#
+# The simulator, however, keeps its own unified-log store on the HOST
+# filesystem, independent of whatever the harness captured, and it survives the
+# pass. So the evidence is usually still there. This script reads it.
+#
+# Because it only reads host files, it is safe to run against a simulator that
+# another session or agent currently owns — no lock needs to be claimed, and a
+# run in progress on that device is not disturbed.
+#
+# THE SHIM
+#
+# `log show --archive` refuses any path not ending in .logarchive, and requires
+# an Info.plist it can version-check. A simulator's store has neither, so this
+# builds a directory of symlinks that satisfies both. Nothing is copied — these
+# stores routinely reach hundreds of MB.
+#
+# TWO CONSTRAINTS THE SHIM IMPOSES, both load-bearing:
+#
+#   1. Pass --info --debug. CFNetwork task lifecycle (task created / resuming /
+#      finished with error / finished successfully) is emitted at Debug level.
+#      Without these flags the interesting lines simply are not there, which
+#      reads exactly like "the app never made the request."
+#
+#   2. Do NOT use a process predicate. The shim carries partial metadata, so
+#      process names do not resolve and `process == "Palace"` matches nothing —
+#      a silent empty result, not an error. Filter on message text instead
+#      (this script's optional 4th argument).
+#
+# The same missing metadata means the app's OWN os_log lines render as
+# `<compose failure [UUID]>`. System subsystems come through complete:
+# com.apple.CFNetwork, com.apple.network:connection, runningboard, WebKit.
+# In practice that is enough to settle network- and lifecycle-shaped questions
+# (how many requests were issued, did they succeed, was a process respawned)
+# but not to read the app's own narration.
+#
+# TIME IS LOCAL. Chaos shard directories are named in UTC; the timestamps this
+# tool wants are local, so a shard named ...T15-06-59Z is 11:06 in a UTC-4 zone.
+# Passing the UTC time yields an empty window and looks like missing data.
+#
+# EMPTY RESULTS ARE DISAMBIGUATED, NOT JUST REPORTED
+#
+# A tool whose whole purpose is settling "did the app actually do X" must never
+# let an operator error look like a real negative. So on zero output this script
+# says WHICH it is:
+#
+#   exit 0, "0 matches"        the window HAS log data; nothing matched the
+#                              pattern. A real negative, safe to reason from.
+#   exit 3, "WINDOW NOT COVERED"  the window has no log data at all. Usually a
+#                              local-vs-UTC mistake, or a rotated store. Says
+#                              nothing about whether the app did X.
+#
+# Both cases print nothing on stdout, which is why the distinction has to be
+# made for the caller rather than left to them.
+#
+# USAGE
+#   scripts/sim-log-recover.sh <UDID> <start> <end> [grep-pattern]
+#
+#   scripts/sim-log-recover.sh "$UDID" '2026-08-20 11:11:00' '2026-08-20 11:12:00'
+#   scripts/sim-log-recover.sh "$UDID" '2026-08-20 11:11:00' '2026-08-20 11:12:00' \
+#       'is for <org.thepalaceproject.palace>'
+#
+# Find the store for a UDID, and its coverage, with:
+#   ls -t ~/Library/Developer/CoreSimulator/Devices/<UDID>/data/var/db/diagnostics/Persist
+#
+set -euo pipefail
+
+# Seams for the fixture test; both default to the production values.
+DEVICES_ROOT="${SIM_DEVICES_ROOT:-$HOME/Library/Developer/CoreSimulator/Devices}"
+LOG_BIN="${SIM_LOG_BIN:-/usr/bin/log}"
+
+UDID="${1:?usage: sim-log-recover.sh <UDID> <start> <end> [grep-pattern]}"
+START="${2:?need start time in LOCAL time, e.g. '2026-08-20 11:11:00'}"
+END="${3:?need end time in LOCAL time}"
+PATTERN="${4:-}"
+
+DEV="$DEVICES_ROOT/$UDID/data/var/db"
+if [ ! -d "$DEV/diagnostics" ]; then
+  echo "sim-log-recover: no log store for $UDID" >&2
+  echo "  (device deleted, or never booted since creation)" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+SHIM="$WORK/sim-${UDID:0:8}.logarchive"
+mkdir -p "$SHIM"
+
+for n in Persist Special Signpost HighVolume timesync; do
+  [ -e "$DEV/diagnostics/$n" ] && ln -s "$DEV/diagnostics/$n" "$SHIM/$n"
+done
+[ -e "$DEV/uuidtext" ]     && ln -s "$DEV/uuidtext" "$SHIM/uuidtext"
+[ -e "$DEV/uuidtext/dsc" ] && ln -s "$DEV/uuidtext/dsc" "$SHIM/dsc"
+
+cat > "$SHIM/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>OSArchiveVersion</key><integer>4</integer></dict></plist>
+PLIST
+
+# `log show` warns "partial or missing metadata" on every run here; that is the
+# expected cost of the shim, not a failure, so its stderr is dropped.
+RAW="$WORK/raw.log"
+"$LOG_BIN" show --archive "$SHIM" --start "$START" --end "$END" \
+    --style compact --info --debug 2>/dev/null > "$RAW" || true
+
+# `log show` prints a column header even for an empty window; drop it before
+# deciding whether the window contained anything.
+DATA="$WORK/data.log"
+grep -v '^Timestamp  *Ty  *Process' "$RAW" > "$DATA" || true
+LINES=$(wc -l < "$DATA" | tr -d ' ')
+
+if [ "$LINES" -eq 0 ]; then
+  echo "sim-log-recover: WINDOW NOT COVERED — no log data between $START and $END" >&2
+  SPAN_OLD=$(ls -t "$DEV/diagnostics/Persist"/*.tracev3 2>/dev/null | tail -1 || true)
+  SPAN_NEW=$(ls -t "$DEV/diagnostics/Persist"/*.tracev3 2>/dev/null | head -1 || true)
+  if [ -n "$SPAN_OLD" ] && [ -n "$SPAN_NEW" ]; then
+    echo "  store spans roughly $(stat -f '%Sm' -t '%Y-%m-%d %H:%M' "$SPAN_OLD") .. $(stat -f '%Sm' -t '%Y-%m-%d %H:%M' "$SPAN_NEW") (LOCAL time)" >&2
+  fi
+  echo "  times are LOCAL — a chaos shard named ...T15-06-59Z is 11:06 in a UTC-4 zone" >&2
+  echo "  this says NOTHING about whether the app did the thing you are looking for" >&2
+  exit 3
+fi
+
+if [ -z "$PATTERN" ]; then
+  cat "$DATA"
+  exit 0
+fi
+
+HITS="$WORK/hits.log"
+grep -E "$PATTERN" "$DATA" > "$HITS" || true
+if [ ! -s "$HITS" ]; then
+  echo "sim-log-recover: window covered ($LINES lines), 0 matches for: $PATTERN" >&2
+  echo "  this IS a real negative — the window has data and nothing matched" >&2
+  echo "  (if you grepped an app-emitted string, expect 0: app os_log cannot be" >&2
+  echo "   resolved through the shim. Count task UUIDs / connection IDs instead.)" >&2
+  exit 0
+fi
+cat "$HITS"

--- a/scripts/sim-log-recover.sh
+++ b/scripts/sim-log-recover.sh
@@ -39,11 +39,33 @@
 #      (this script's optional 4th argument).
 #
 # The same missing metadata means the app's OWN os_log lines render as
-# `<compose failure [UUID]>`. System subsystems come through complete:
-# com.apple.CFNetwork, com.apple.network:connection, runningboard, WebKit.
-# In practice that is enough to settle network- and lifecycle-shaped questions
-# (how many requests were issued, did they succeed, was a process respawned)
-# but not to read the app's own narration.
+# `<compose failure [UUID]>`.
+#
+#   3. INFO-LEVEL RECORDS ARE MOSTLY NOT THERE. This store holds what was
+#      PERSISTED. Measured on one window: debug 5,861 of 5,972 and error 133 of
+#      139 come through, but info 78 of 4,472 — 98% absent. Info records live in
+#      a buffer that is not written to disk, so an archive read simply cannot
+#      see them, at any log level flag.
+#
+#      This is not a small caveat. Ordinary network chatter — TLS teardown,
+#      nw_endpoint_handler_cancel, boringssl warning alerts — is info level, so
+#      grepping this store for it returns a confident zero from a window that
+#      contained hundreds. An earlier version of this header claimed system
+#      subsystems "come through complete"; that was wrong and it produced
+#      exactly that false zero on a live investigation.
+#
+#      IF THE SIMULATOR IS STILL BOOTED, info records are recoverable with a
+#      LIVE read, which sees the unpersisted buffer:
+#        xcrun simctl spawn <UDID> log show --start ... --end ... \
+#            --style compact --info --debug
+#      That spawns a process on the device, so it needs ownership of the sim —
+#      which is the trade this script otherwise avoids. Shut the sim down and
+#      the info records are gone permanently.
+#
+# So: use this script for debug/error-level evidence — CFNetwork task
+# lifecycle, process spawns, WebKit errors — which is enough for "how many
+# requests were issued, did they succeed, was a process respawned". Use a live
+# read for anything info level, and for the app's own narration use neither.
 #
 # TIME IS LOCAL. Chaos shard directories are named in UTC; the timestamps this
 # tool wants are local, so a shard named ...T15-06-59Z is 11:06 in a UTC-4 zone.

--- a/scripts/sim-log-recover.sh
+++ b/scripts/sim-log-recover.sh
@@ -12,7 +12,7 @@
 # for every device cell, so 41 findings rested entirely on quoted fragments.)
 #
 # The simulator, however, keeps its own unified-log store on the HOST
-# filesystem, independent of whatever the harness captured, and it survives the
+# filesystem, independent of whatever the QA run captured, and it survives the
 # pass. So the evidence is usually still there. This script reads it.
 #
 # Because it only reads host files, it is safe to run against a simulator that

--- a/scripts/sim_tap_on_event.py
+++ b/scripts/sim_tap_on_event.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Tap a simulator the moment a log event fires, instead of after a fixed delay.
+
+WHY THIS EXISTS
+
+Some behaviours only occur when input arrives inside a window that opens and
+closes on its own schedule. A regression campaign hit one: a download-button
+defect that reproduces only if a tap lands while a content transfer is in
+flight. That window is 1.2-3.0s wide and opens 6-11s after the borrow, and the
+lag varies per title and per network. Fixed-delay scripting cannot reliably hit
+it, so repeated attempts all missed — and a cell that is missed looks exactly
+like a cell that is negative.
+
+That difference matters more than the tap does. "We tapped and nothing
+happened" retires a hypothesis; "we never landed a tap in the window" does not.
+This tool exists so the distinction can be made honestly: it either reports the
+tap WITH its measured latency from the triggering event, or it reports that the
+trigger never fired and refuses to imply anything about the behaviour.
+
+HOW
+
+`log stream` on the device is the event source rather than a UI poll, for two
+reasons: it fires on the actual state change instead of a proxy for it, and it
+delivers in ~0.1-0.3s where an observe round-trip costs seconds — most of the
+window. The tap goes through simdrive's HID injector directly, not over MCP, to
+keep the same budget.
+
+Unlike scripts/sim-log-recover.sh, this DOES run a process on the device
+(`simctl spawn ... log stream`), so it requires owning the simulator.
+
+EXIT CODES
+  0  trigger fired and the tap was injected (or reported, under --dry-run)
+  4  trigger never fired within --timeout. Says NOTHING about the behaviour
+     under test — the window may simply never have opened.
+  1  usage / environment problem (no HID injector, bad arguments)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import subprocess
+import sys
+import time
+
+# The default trigger: CFNetwork announcing a task created on the app's
+# background download session. This is the transfer START, not a UI proxy.
+DEFAULT_CONTAINS = "is for <org.thepalaceproject.palace>"
+DEFAULT_PATTERN = r"Task <[0-9A-Fa-f-]+>\.<\d+> is for <org\.thepalaceproject\.palace>"
+
+
+def build_stream_cmd(udid: str, contains: str) -> str:
+    predicate = f'eventMessage CONTAINS "{contains}"'
+    return (
+        f"xcrun simctl spawn {shlex.quote(udid)} log stream "
+        f"--style compact --level debug --predicate {shlex.quote(predicate)}"
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--udid", required=True)
+    ap.add_argument("--x", type=float, required=True, help="tap X in POINTS (not pixels)")
+    ap.add_argument("--y", type=float, required=True, help="tap Y in POINTS (not pixels)")
+    ap.add_argument("--contains", default=DEFAULT_CONTAINS,
+                    help="substring for the device-side log predicate (cheap server-side filter)")
+    ap.add_argument("--pattern", default=DEFAULT_PATTERN,
+                    help="regex the streamed line must match to count as the trigger")
+    ap.add_argument("--timeout", type=float, default=120.0)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report the trigger and the latency budget without tapping")
+    ap.add_argument("--stream-cmd", default=None,
+                    help="override the event source (test seam; defaults to simctl log stream)")
+    args = ap.parse_args()
+
+    tap = None
+    if not args.dry_run:
+        try:
+            from simdrive import hid_inject  # type: ignore
+        except Exception as exc:  # pragma: no cover - import shape varies by install
+            print(f"sim-tap-on-event: cannot import simdrive.hid_inject: {exc}", file=sys.stderr)
+            return 1
+        if not hid_inject.available():
+            print("sim-tap-on-event: simdrive HID injector unavailable", file=sys.stderr)
+            return 1
+        tap = hid_inject.tap
+
+    cmd = args.stream_cmd or build_stream_cmd(args.udid, args.contains)
+    rx = re.compile(args.pattern)
+    started = time.monotonic()
+
+    proc = subprocess.Popen(
+        cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        text=True, bufsize=1,
+    )
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            if time.monotonic() - started > args.timeout:
+                break
+            if not rx.search(line):
+                continue
+            t_event = time.monotonic()
+            if tap is not None:
+                tap(args.udid, args.x, args.y)
+            t_tap = time.monotonic()
+            print(json.dumps({
+                "triggered": True,
+                "tapped": tap is not None,
+                "trigger_line": line.strip()[:240],
+                # The number that decides whether the attempt is usable: if this
+                # approaches the width of the window being targeted, the tap may
+                # have landed outside it and the result must not be read as a
+                # negative.
+                "latency_s": round(t_tap - t_event, 4),
+                "waited_s": round(t_event - started, 3),
+            }))
+            return 0
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:  # pragma: no cover
+            proc.kill()
+
+    print(json.dumps({
+        "triggered": False,
+        "tapped": False,
+        "waited_s": round(time.monotonic() - started, 3),
+        "note": "trigger never fired; this says NOTHING about the behaviour under test",
+    }))
+    print("sim-tap-on-event: TRIGGER NEVER FIRED — the window may never have opened.", file=sys.stderr)
+    print("  Do NOT record the target behaviour as refuted on this run.", file=sys.stderr)
+    return 4
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_differential_check.py
+++ b/scripts/tests/test_differential_check.py
@@ -87,6 +87,28 @@ def test_a_renamed_baseline_of_the_same_type_still_compares(tmp_path):
     assert out["candidate"]["device_type"] == out["baseline"]["device_type"]
 
 
+def test_a_zero_signature_carries_the_info_level_caveat(tmp_path):
+    """A zero signature is only meaningful for debug/error-level strings.
+
+    An archive read is ~98% blind to info level, and this cost a real call: four
+    log strings were reported non-existent across three device cells when they
+    were merely info level. The tool cannot know a signature's level, so it
+    flags the case rather than judging it.
+    """
+    r = run(tmp_path, CAND, BASE, {CAND: "fulcrum\n", BASE: "fulcrum\n"})
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["signature_candidate"] == 0 and out["signature_baseline"] == 0
+    assert "zero_signature_caveat" in out
+    assert "info level" in out["zero_signature_caveat"]
+
+
+def test_a_nonzero_comparison_carries_no_zero_caveat(tmp_path):
+    r = run(tmp_path, CAND, BASE, {CAND: "fulcrum\nDECODE-FAIL\n", BASE: "fulcrum\nDECODE-FAIL\n"})
+    assert r.returncode == 0, r.stderr
+    assert "zero_signature_caveat" not in json.loads(r.stdout)
+
+
 def test_valid_comparison_emits_counts(tmp_path):
     r = run(tmp_path, CAND, BASE, {
         CAND: "fulcrum request\nDECODE-FAIL\nDECODE-FAIL\n",

--- a/scripts/tests/test_differential_check.py
+++ b/scripts/tests/test_differential_check.py
@@ -1,0 +1,159 @@
+"""Tests for scripts/differential_check.py.
+
+Every test here encodes a real failure from the 3.3.0 regression campaign. The
+tool exists because three-of-four preconditions holding produces a number that
+looks measured and is not, so the tests are written around the two zeros that
+actually got produced:
+
+  - a baseline zero from a lane that was never rendered (UNEXERCISED-BASELINE)
+  - a comparison attempted across an iPad and an iPhone (DEVICE-MISMATCH)
+
+The refusal path matters more than the success path: a wrong REGRESSION call is
+the expensive direction, and it is reached by comparing against a baseline that
+never ran the code.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "differential_check.py"
+
+SIMCTL = {
+    "devices": {
+        "com.apple.CoreSimulator.SimRuntime.iOS-26-0": [
+            {"udid": "AAAA0000-0000-0000-0000-000000000001", "name": "iPhone 16 Pro"},
+            {"udid": "AAAA0000-0000-0000-0000-000000000002", "name": "iPhone 16 Pro"},
+        ],
+        "com.apple.CoreSimulator.SimRuntime.iOS-26-1": [
+            {"udid": "BBBB0000-0000-0000-0000-000000000003", "name": "iPad Pro 11-inch (M5)"},
+        ],
+        "com.apple.CoreSimulator.SimRuntime.iOS-18-0": [
+            {"udid": "CCCC0000-0000-0000-0000-000000000004", "name": "iPhone 16 Pro"},
+        ],
+    }
+}
+
+CAND = "AAAA0000-0000-0000-0000-000000000001"
+BASE = "AAAA0000-0000-0000-0000-000000000002"
+IPAD = "BBBB0000-0000-0000-0000-000000000003"
+IOS18 = "CCCC0000-0000-0000-0000-000000000004"
+
+
+def make_recover(tmp_path: Path, per_udid: dict[str, str]) -> str:
+    """A stub recovery script that prints canned output per UDID."""
+    for udid, text in per_udid.items():
+        (tmp_path / f"{udid}.txt").write_text(text)
+    stub = tmp_path / "recover.sh"
+    stub.write_text("#!/usr/bin/env bash\ncat \"%s/$1.txt\" 2>/dev/null || true\n" % tmp_path)
+    stub.chmod(0o755)
+    return str(stub)
+
+
+def run(tmp_path: Path, cand_udid: str, base_udid: str, per_udid: dict[str, str],
+        signature: str = "DECODE-FAIL", witness: str = "fulcrum") -> subprocess.CompletedProcess:
+    sim = tmp_path / "simctl.json"
+    sim.write_text(json.dumps(SIMCTL))
+    return subprocess.run(
+        [sys.executable, str(SCRIPT),
+         "--candidate-udid", cand_udid, "--candidate-start", "s", "--candidate-end", "e",
+         "--baseline-udid", base_udid, "--baseline-start", "s", "--baseline-end", "e",
+         "--signature", signature, "--witness", witness,
+         "--recover-cmd", make_recover(tmp_path, per_udid), "--simctl-json", str(sim)],
+        capture_output=True, text=True)
+
+
+def test_valid_comparison_emits_counts(tmp_path):
+    r = run(tmp_path, CAND, BASE, {
+        CAND: "fulcrum request\nDECODE-FAIL\nDECODE-FAIL\n",
+        BASE: "fulcrum request\n",
+    })
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["comparable"] is True
+    assert out["signature_candidate"] == 2
+    assert out["signature_baseline"] == 0
+
+
+def test_baseline_that_never_ran_the_path_is_refused(tmp_path):
+    """The campaign's near-miss: 53 vs 0, where the baseline never rendered the lane.
+
+    Without this refusal the tool reports 2 vs 0 and a human files a REGRESSION.
+    """
+    r = run(tmp_path, CAND, BASE, {
+        CAND: "fulcrum request\nDECODE-FAIL\nDECODE-FAIL\n",
+        BASE: "some other host request\n",   # no fulcrum: lane never rendered
+    })
+    assert r.returncode == 5
+    out = json.loads(r.stdout)
+    assert out["comparable"] is False
+    assert out["reason"] == "UNEXERCISED-BASELINE"
+    assert "signature_baseline" not in out, "a refused pair must not leak a count"
+
+
+def test_unexercised_candidate_is_refused(tmp_path):
+    r = run(tmp_path, CAND, BASE, {CAND: "nothing relevant\n", BASE: "fulcrum request\n"})
+    assert r.returncode == 5
+    assert json.loads(r.stdout)["reason"] == "UNEXERCISED-CANDIDATE"
+
+
+def test_device_mismatch_is_refused_before_any_reading(tmp_path):
+    """iPad candidate vs iPhone baseline — three clusters failed exactly this way."""
+    r = run(tmp_path, IPAD, BASE, {IPAD: "fulcrum\nDECODE-FAIL\n", BASE: "fulcrum\n"})
+    assert r.returncode == 5
+    out = json.loads(r.stdout)
+    assert out["reason"] == "DEVICE-MISMATCH"
+    assert "signature_candidate" not in out
+
+
+def test_os_mismatch_is_refused(tmp_path):
+    """Same device model, different OS — iOS 18 cell against an iOS 26 baseline."""
+    r = run(tmp_path, IOS18, BASE, {IOS18: "fulcrum\nDECODE-FAIL\n", BASE: "fulcrum\n"})
+    assert r.returncode == 5
+    assert json.loads(r.stdout)["reason"] == "OS-MISMATCH"
+
+
+def test_incidental_witness_hits_do_not_count_as_exercising_the_path(tmp_path):
+    """The defect the stub tests MISSED and the real data exposed.
+
+    The first version of this tool checked witness > 0. Run against the actual
+    campaign pair it PASSED: the baseline mentioned the witness host 3 times
+    incidentally while never rendering the lane, so a 53-vs-0 comparison was
+    emitted — the false REGRESSION the tool exists to prevent. Raw counts also
+    cannot be compared, because the candidate window was 7k lines and the
+    baseline 536k. Density is the check.
+
+    Shape mirrors the real numbers: candidate ~0.14 witness/kloc, baseline
+    ~0.006, a ratio of ~25.
+    """
+    cand = "fulcrum request\nDECODE-FAIL\n" + ("filler\n" * 12)
+    base = ("filler\n" * 500) + "incidental fulcrum mention\n"
+    r = run(tmp_path, CAND, BASE, {CAND: cand, BASE: base})
+    assert r.returncode == 5, "a baseline that never really ran the path must be refused"
+    out = json.loads(r.stdout)
+    assert out["reason"] == "WITNESS-DISPROPORTIONATE"
+    assert "signature_baseline" not in out, "a refused pair must not leak a count"
+
+
+def test_min_witness_can_require_a_real_exercise(tmp_path):
+    """`--min-witness 1` is the weak default; a caller who knows the path can demand more."""
+    both_thin = {CAND: "fulcrum\nDECODE-FAIL\n", BASE: "fulcrum\n"}
+    assert run(tmp_path, CAND, BASE, both_thin).returncode == 0
+    sim = tmp_path / "simctl.json"; sim.write_text(json.dumps(SIMCTL))
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT),
+         "--candidate-udid", CAND, "--candidate-start", "s", "--candidate-end", "e",
+         "--baseline-udid", BASE, "--baseline-start", "s", "--baseline-end", "e",
+         "--signature", "DECODE-FAIL", "--witness", "fulcrum", "--min-witness", "10",
+         "--recover-cmd", make_recover(tmp_path, both_thin), "--simctl-json", str(sim)],
+        capture_output=True, text=True)
+    assert r.returncode == 5
+    assert json.loads(r.stdout)["reason"] == "UNEXERCISED-CANDIDATE"
+
+
+def test_refusal_never_shares_an_exit_code_with_a_valid_comparison(tmp_path):
+    ok = run(tmp_path, CAND, BASE, {CAND: "fulcrum\nDECODE-FAIL\n", BASE: "fulcrum\n"})
+    bad = run(tmp_path, CAND, BASE, {CAND: "fulcrum\nDECODE-FAIL\n", BASE: "nothing\n"})
+    assert ok.returncode == 0 and bad.returncode == 5

--- a/scripts/tests/test_differential_check.py
+++ b/scripts/tests/test_differential_check.py
@@ -24,14 +24,21 @@ SCRIPT = Path(__file__).resolve().parents[1] / "differential_check.py"
 SIMCTL = {
     "devices": {
         "com.apple.CoreSimulator.SimRuntime.iOS-26-0": [
-            {"udid": "AAAA0000-0000-0000-0000-000000000001", "name": "iPhone 16 Pro"},
-            {"udid": "AAAA0000-0000-0000-0000-000000000002", "name": "iPhone 16 Pro"},
+            {"udid": "AAAA0000-0000-0000-0000-000000000001", "name": "iPhone 16 Pro",
+             "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro"},
+            # Custom-named on purpose: a purpose-built baseline sim is renamed,
+            # and comparing names instead of types refuses it. That was a real
+            # false DEVICE-MISMATCH on the first pair this tool was asked to run.
+            {"udid": "AAAA0000-0000-0000-0000-000000000002", "name": "baseline-iphone16pro-260",
+             "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro"},
         ],
         "com.apple.CoreSimulator.SimRuntime.iOS-26-1": [
-            {"udid": "BBBB0000-0000-0000-0000-000000000003", "name": "iPad Pro 11-inch (M5)"},
+            {"udid": "BBBB0000-0000-0000-0000-000000000003", "name": "iPad Pro 11-inch (M5)",
+             "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M5-12GB"},
         ],
         "com.apple.CoreSimulator.SimRuntime.iOS-18-0": [
-            {"udid": "CCCC0000-0000-0000-0000-000000000004", "name": "iPhone 16 Pro"},
+            {"udid": "CCCC0000-0000-0000-0000-000000000004", "name": "iPhone 16 Pro",
+             "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro"},
         ],
     }
 }
@@ -63,6 +70,21 @@ def run(tmp_path: Path, cand_udid: str, base_udid: str, per_udid: dict[str, str]
          "--signature", signature, "--witness", witness,
          "--recover-cmd", make_recover(tmp_path, per_udid), "--simctl-json", str(sim)],
         capture_output=True, text=True)
+
+
+def test_a_renamed_baseline_of_the_same_type_still_compares(tmp_path):
+    """CAND and BASE differ in NAME and share a deviceTypeIdentifier.
+
+    The first real pair this tool was handed refused with DEVICE-MISMATCH
+    because the baseline sim had been given a descriptive name. Comparing the
+    type identifier is the fix; this pins it.
+    """
+    r = run(tmp_path, CAND, BASE, {CAND: "fulcrum\nDECODE-FAIL\n", BASE: "fulcrum\n"})
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["comparable"] is True
+    assert out["candidate"]["device"] != out["baseline"]["device"], "fixture must differ in name"
+    assert out["candidate"]["device_type"] == out["baseline"]["device_type"]
 
 
 def test_valid_comparison_emits_counts(tmp_path):

--- a/scripts/tests/test_differential_check.py
+++ b/scripts/tests/test_differential_check.py
@@ -153,6 +153,28 @@ def test_min_witness_can_require_a_real_exercise(tmp_path):
     assert json.loads(r.stdout)["reason"] == "UNEXERCISED-CANDIDATE"
 
 
+def test_every_refusal_says_it_is_not_a_finding(tmp_path):
+    """A refusal must not be quotable as evidence about the builds.
+
+    The campaign hit this directly: a WITNESS-DISPROPORTIONATE on a cluster whose
+    URL evidence is unreadable means "this data cannot answer the question", not
+    "the baseline never rendered the lane". Identical output, opposite meanings —
+    so the tool carries the disclaimer instead of relying on the reader.
+    """
+    cases = [
+        (IPAD, BASE, {IPAD: "fulcrum\nDECODE-FAIL\n", BASE: "fulcrum\n"}),          # device
+        (IOS18, BASE, {IOS18: "fulcrum\nDECODE-FAIL\n", BASE: "fulcrum\n"}),        # os
+        (CAND, BASE, {CAND: "fulcrum\nDECODE-FAIL\n", BASE: "nothing\n"}),          # unexercised
+    ]
+    for cand_udid, base_udid, per in cases:
+        r = run(tmp_path, cand_udid, base_udid, per)
+        assert r.returncode == 5
+        out = json.loads(r.stdout)
+        assert "not_a_finding" in out, f"{out['reason']} refusal lacks the disclaimer"
+        assert "not evidence" in out["not_a_finding"]
+        assert "not about the builds" in r.stderr
+
+
 def test_refusal_never_shares_an_exit_code_with_a_valid_comparison(tmp_path):
     ok = run(tmp_path, CAND, BASE, {CAND: "fulcrum\nDECODE-FAIL\n", BASE: "fulcrum\n"})
     bad = run(tmp_path, CAND, BASE, {CAND: "fulcrum\nDECODE-FAIL\n", BASE: "nothing\n"})

--- a/scripts/tests/test_sim_log_recover.sh
+++ b/scripts/tests/test_sim_log_recover.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# test_sim_log_recover.sh
+#
+# Fixture test for scripts/sim-log-recover.sh.
+#
+# Pins the guard that distinguishes the two ways the script produces no output.
+# Before the guard, both looked identical to the caller — and worse, `set -e`
+# plus a non-matching `grep` turned a legitimate "0 matches" into a non-zero
+# exit, so a REAL NEGATIVE was indistinguishable from a broken invocation.
+#
+# That distinction is the whole value of the tool: it exists to settle "did the
+# app actually issue that request", and an operator error that silently reads as
+# "no, it didn't" would retract true findings. An untested guard is
+# indistinguishable from no guard, so all three branches are pinned here.
+set -eu
+
+TEST_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$TEST_DIR/../.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/sim-log-recover.sh"
+[ -x "$SCRIPT" ] || { echo "FAIL: $SCRIPT missing or not executable"; exit 1; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+UDID="AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+DEV="$TMP/devices/$UDID/data/var/db"
+mkdir -p "$DEV/diagnostics/Persist" "$DEV/uuidtext"
+: > "$DEV/diagnostics/Persist/0000000000000001.tracev3"
+
+# Stub `log`: ignores its arguments and prints whatever fixture it is pointed at.
+# The real binary is never invoked, so the test needs no simulator.
+cat > "$TMP/log-stub" <<'STUB'
+#!/usr/bin/env bash
+cat "$SIM_TEST_FIXTURE"
+STUB
+chmod +x "$TMP/log-stub"
+
+# A window WITH data: the column header `log show` always emits, plus two lines.
+cat > "$TMP/with-data.txt" <<'DATA'
+Timestamp               Ty Process[PID:TID]
+2026-08-20 11:11:21.135 Df Palace[1:2] [com.apple.CFNetwork:Default] Task <AAAA>.<1> is for <org.thepalaceproject.palace>.<dl>
+2026-08-20 11:11:24.415 Df Palace[1:2] [com.apple.CFNetwork:Default] Task <BBBB>.<2> is for <org.thepalaceproject.palace>.<dl>
+DATA
+
+# A window with NO data: the header alone, which is what an uncovered window
+# actually produces. If the script counted raw lines it would see 1 and call
+# this "covered" — that is the bug this fixture guards.
+cat > "$TMP/header-only.txt" <<'DATA'
+Timestamp               Ty Process[PID:TID]
+DATA
+
+export SIM_DEVICES_ROOT="$TMP/devices"
+export SIM_LOG_BIN="$TMP/log-stub"
+
+run() { set +e; OUT=$("$SCRIPT" "$@" 2>"$TMP/err"); RC=$?; set -e; }
+fail() { echo "FAIL: $1"; echo "--- stdout ---"; echo "${OUT:-}"; echo "--- stderr ---"; cat "$TMP/err"; exit 1; }
+
+# 1. Covered window, pattern matches -> hits on stdout, exit 0.
+export SIM_TEST_FIXTURE="$TMP/with-data.txt"
+run "$UDID" '2026-08-20 11:11:00' '2026-08-20 11:12:00' 'is for <org.thepalaceproject.palace>'
+[ "$RC" -eq 0 ] || fail "matching pattern should exit 0, got $RC"
+[ "$(printf '%s\n' "$OUT" | grep -c 'is for')" -eq 2 ] || fail "expected 2 matching lines"
+
+# 2. Covered window, pattern matches nothing -> REAL NEGATIVE. Exit 0, empty
+#    stdout, and stderr must say the window had data. This is the case that
+#    `set -e` + grep used to turn into a spurious failure.
+run "$UDID" '2026-08-20 11:11:00' '2026-08-20 11:12:00' 'downloadTaskWithRequest'
+[ "$RC" -eq 0 ] || fail "real negative must exit 0, got $RC"
+[ -z "$OUT" ] || fail "real negative must print nothing on stdout"
+grep -q '0 matches' "$TMP/err" || fail "stderr must report 0 matches"
+grep -q 'real negative' "$TMP/err" || fail "stderr must name this a real negative"
+
+# 3. Window with no data at all -> NOT COVERED. Must NOT read as a real
+#    negative; distinct exit code so a caller can branch on it.
+export SIM_TEST_FIXTURE="$TMP/header-only.txt"
+run "$UDID" '2026-08-20 15:11:00' '2026-08-20 15:12:00' 'is for <org.thepalaceproject.palace>'
+[ "$RC" -eq 3 ] || fail "uncovered window must exit 3, got $RC"
+grep -q 'WINDOW NOT COVERED' "$TMP/err" || fail "stderr must say WINDOW NOT COVERED"
+grep -q 'LOCAL' "$TMP/err" || fail "stderr must warn about LOCAL vs UTC"
+grep -q 'says NOTHING' "$TMP/err" || fail "stderr must refuse to imply a negative result"
+
+# 4. The two empty cases must be distinguishable, which is the entire point.
+[ "$RC" -ne 0 ] || fail "uncovered and real-negative must not share an exit code"
+
+# 5. Missing store -> exit 1, distinct from both empty cases.
+run "DEADBEEF-0000-0000-0000-000000000000" '2026-08-20 11:11:00' '2026-08-20 11:12:00'
+[ "$RC" -eq 1 ] || fail "missing store must exit 1, got $RC"
+
+# 6. No pattern -> stream the window, header stripped.
+export SIM_TEST_FIXTURE="$TMP/with-data.txt"
+run "$UDID" '2026-08-20 11:11:00' '2026-08-20 11:12:00'
+[ "$RC" -eq 0 ] || fail "unfiltered read should exit 0, got $RC"
+[ "$(printf '%s\n' "$OUT" | wc -l | tr -d ' ')" -eq 2 ] || fail "expected 2 data lines, header stripped"
+
+echo "PASS: test_sim_log_recover.sh (6 cases)"

--- a/scripts/tests/test_sim_tap_on_event.py
+++ b/scripts/tests/test_sim_tap_on_event.py
@@ -1,0 +1,84 @@
+"""Tests for scripts/sim_tap_on_event.py.
+
+The load-bearing behaviour is not the tap — it is the REFUSAL to let a missed
+window look like a negative result. A run where the trigger never fired must be
+distinguishable, by exit code and by output, from a run where it fired and the
+tap landed. These tests pin that distinction, plus the latency reporting that
+tells the operator whether the tap was fast enough to be inside the window at
+all.
+
+The event source is injected via --stream-cmd, so no simulator is involved.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "sim_tap_on_event.py"
+
+
+def run(*extra: str, stream_cmd: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--udid", "TEST-UDID", "--x", "100", "--y", "200",
+         "--dry-run", "--stream-cmd", stream_cmd, *extra],
+        capture_output=True, text=True,
+    )
+
+
+TRIGGER = ("2026-08-20 11:11:21.135 Df Palace[1:2] [com.apple.CFNetwork:Default] "
+           "Task <5848D9C1-33C8-4050-882C-CF807643D0BB>.<1> is for "
+           "<org.thepalaceproject.palace>.<org.thepalaceproject.palace.downloadCenterBackgroundIdentifier>")
+
+
+def test_trigger_fires_and_reports_latency():
+    r = run(stream_cmd=f"printf '%s\\n' {json.dumps(TRIGGER)}")
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["triggered"] is True
+    # The operator needs this to judge whether the tap could have been inside a
+    # window of known width. Reporting the tap without it is not enough.
+    assert "latency_s" in out and out["latency_s"] >= 0
+
+
+def test_trigger_never_fires_is_not_a_negative_result():
+    """The whole point: a missed window must not read as 'behaviour absent'."""
+    r = run("--timeout", "1", stream_cmd="printf 'unrelated chatter\\n'")
+    assert r.returncode == 4, "a missed trigger must not share exit 0 with a real tap"
+    out = json.loads(r.stdout)
+    assert out["triggered"] is False
+    assert "says NOTHING" in out["note"]
+    assert "refuted" in r.stderr, "stderr must warn against recording a refutation"
+
+
+def test_noise_before_the_trigger_does_not_false_fire():
+    stream = ("printf '%s\\n' 'noise one' 'Task <X>.<1> is for <com.apple.something>' "
+              + json.dumps(TRIGGER))
+    r = run(stream_cmd=stream)
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    # It must trigger on the app's session, not on any task line that drifts by.
+    assert "org.thepalaceproject.palace" in out["trigger_line"]
+
+
+def test_pattern_is_overridable():
+    r = run("--pattern", "MARKER-XYZ", stream_cmd="printf '%s\\n' 'a line with MARKER-XYZ in it'")
+    assert r.returncode == 0, r.stderr
+    assert json.loads(r.stdout)["triggered"] is True
+
+
+def test_default_pattern_ignores_a_different_bundle():
+    # The UUID here must be REAL hex: an obviously-fake `<X>` fails the pattern
+    # on the UUID alone, so the test would pass even if the bundle-id half of
+    # the pattern were deleted — a fixture that cannot discriminate.
+    other = ("2026-08-20 11:11:21.135 Df Other[1:2] [com.apple.CFNetwork:Default] "
+             "Task <5848D9C1-33C8-4050-882C-CF807643D0BB>.<1> is for "
+             "<com.example.other>.<com.example.other.session>")
+    r = run("--timeout", "1", stream_cmd=f"printf '%s\\n' {json.dumps(other)}")
+    assert r.returncode == 4, "a different app's download must not trigger the tap"
+
+
+def test_dry_run_does_not_claim_a_tap():
+    r = run(stream_cmd=f"printf '%s\\n' {json.dumps(TRIGGER)}")
+    assert json.loads(r.stdout)["tapped"] is False


### PR DESCRIPTION
Base `develop` (ff3b1227c) · 10 commits · 8 files · +1092 / -0 · no production code.

**These run unaided.** Verified from a non-provisioned clean checkout of this
branch: `bash`, `python3`, `/usr/bin/log`, and `xcrun simctl` — nothing else. No
maintainer-local tooling, no repo-specific setup, and the full test suite passes
in a worktree that was never provisioned. That is the line this repo draws about
what belongs in the shared tree, and it was demonstrated rather than asserted.

---

## Three instruments for questions a release regression could not answer

A 3.3.0 regression pass raised 41 chaos findings. Settling them turned up the
same defect repeatedly — not in the app, in the *measuring*: a result that looks
measured and is not. Each tool below exists because one specific wrong answer
came within a message of being filed.

### `scripts/sim-log-recover.sh` — read a pass that already happened

A QA pass preserves the log lines its operator thought to quote; the rest is
treated as gone. It usually is not. The simulator keeps its own unified-log
store on the host, and it outlives the pass.

**The wrong answer it prevented.** A finding was filed *minor* on the strength
of one `-999 cancelled` line, with a stated cause of "a duplicate fulfillment
download cancelled mid-flight." The recovered store showed three download tasks,
each with its own fulfillment request, **two completing successfully** — one
borrow billing the circulation manager three times and transferring the same
EPUB twice. Promoted to major on the critical path, with nothing re-driven.

Reads host files only, so it is safe against a simulator another session owns —
which is how that measurement was taken without touching the sim that held it.

**Limits, stated in the file:** the shim cannot resolve the app's own `os_log`
lines; they render `<compose failure [UUID]>`. System subsystems (CFNetwork,
network, RunningBoard, WebKit) come through complete. That is enough for
"how many requests were issued and did they succeed" and not enough to read
what the app said about itself. On one cluster this made the tool unable to
measure the thing being asked, and it says so rather than returning a number.

### `scripts/sim_tap_on_event.py` — tap inside a window a fixed delay cannot hit

Some behaviour reproduces only when input lands inside a window that opens on
its own schedule. One such window is 1.2–3.0s wide and opens 6–11s after a
borrow, varying per title and network. Every fixed-delay attempt missed it.

**The wrong answer it prevents.** A missed window and a real negative are
indistinguishable in a transcript, and "we tapped and nothing happened" retires
a hypothesis that "we never landed a tap" does not. Exit `0` reports the tap
*with its measured latency from the trigger*, so the operator can judge whether
it plausibly landed inside the window; exit `4` says the trigger never fired and
states that this implies nothing about the behaviour under test.

**Limits:** unlike the recovery script this spawns a process on the device, so
it requires owning the simulator. Callers pass POINTS, not pixels.

### `scripts/differential_check.py` — refuse to compare when the comparison is invalid

Counting a signature on two builds yields a number whether or not the number
means anything.

**The wrong answer it prevented.** A baseline showed **zero** cover-decode
failures against the candidate's 53 — an open-and-shut regression, except the
baseline had never rendered the lane those covers live in. A zero from an
unexercised path. Separately, three clusters were compared across an iPad and an
iPhone. Both would have been filed; the first would have been a **false
REGRESSION** on a release-gating row.

It checks device, OS, and exercise on both sides *before* reading anything, and
emits no comparison unless all hold. A refusal names the unmet precondition and
never leaks a count, so there is no number to quote out of context.

**Limits:** input-class equality cannot be checked mechanically — that is what
the witness pattern is for, and a badly chosen witness ("the app launched")
satisfies the check and defeats it. Nothing stops someone quoting the `reason`
field alone; the "this is a statement about the DATA, not about the builds"
disclaimer sits beside it and cannot follow it.

### `docs/Testing/simulator-log-recovery.md`

The recovery method, the four ways to get an empty result that is not missing
data, and one section written deliberately as discipline rather than a script:
*a zero is only a measurement if the command hit something.* Three instances
appeared in one afternoon — an unquoted `$ref:path` in zsh, a `pytest` piped to
`tail`, a grep against a path that does not exist. A guard covering only the
wrong-target cases would leave the merely-wrong-pattern case returning an
identical honest zero while implying the class was handled, which is the failure
shape the document exists to prevent.

---

## Verification

From a **clean checkout of this branch**, not the development tree:

- `bash -n` on both committed shell scripts (CI `tooling-checks.yml` parity)
- `scripts/tests/test_sim_log_recover.sh` — 6 cases
- `pytest scripts/tests/test_sim_tap_on_event.py scripts/tests/test_differential_check.py` — 15 tests
- No harness, heka, or ForgeOS dependency; no simulator required by any test
- Every guard proved by reintroducing the defect: 5 mutants across the three
  tools, each killed by a **named** assertion. One mutant initially SURVIVED —
  a test fixture used a fake `Task <X>.<1>` that failed the pattern on the UUID
  rather than the bundle id, so the test passed for a reason unrelated to its
  own name. Fixture fixed, mutant killed.

## Ship-safety audit

- No campaign paths, run identifiers, session names, or agent names
- No absolute `/Users/...` paths
- UDIDs present are synthetic fixtures (`AAAA…`, `DEADBEEF…`); one real
  CFNetwork **task** UUID appears in a fixture as sample log text — ephemeral,
  not a device or account identifier. Deliberately NOT sanitised into a fake: a
  fixture that does not match production bytes is how a mutant survived here
  once already.
- The word "harness" appeared twice as ordinary English for a QA run. Reworded
  to "QA run" (1a276e260): in this repo that word names a specific
  maintainer-local system and would read as a dependency that is not there.
- `docs/bug-investigation-process.md` already references `.forgeos/` at two
  pre-existing lines; this branch adds five lines and touches neither.

## Not done

- Nothing is wired into a gate or CI job. These are instruments, and the
  campaign's rows are still being settled by hand.
- The tools were built during an active campaign and have one user. Ergonomics
  are unproven.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
