### PR TITLE
docs(jira-skill): the create response is not what Jira stored

### DIFF
--- a/.claude/skills/jira-ticket/SKILL.md
+++ b/.claude/skills/jira-ticket/SKILL.md
@@ -102,7 +102,7 @@ auto-moves to *In Progress* once any sub-task is *In Progress*; that's expected.
 
 ---
 
-## 3. Two gotchas that will bite you
+## 3. Three gotchas that will bite you
 
 1. **`jira_create_issue` `description` stores `\n` literally.** Passed as a plain
    parameter, the two-character sequence `\n` is saved verbatim (you get literal `\n` in
@@ -113,6 +113,25 @@ auto-moves to *In Progress* once any sub-task is *In Progress*; that's expected.
    `comment` param rejects markdown ("Operation value must be an Atlassian Document").
    Just omit the comment on the transition; if you want a note, post it separately with
    `jira_add_comment` after the transition.
+3. **The create response is NOT what Jira stored — read the issue back and *diff* it.**
+   `jira_create_issue` echoes a cleaned-up `description` in its result. That echo is a
+   rendering of what you sent, not a read of what the server holds, so it looks like
+   verification and is not. One create call on PP-4997 produced **three** independent
+   corruptions, none visible in the echo:
+   - Markdown headings persisted escaped (`**Heading**` -> `\*\*Heading\*\*`) and render
+     as literal asterisks. Use Jira wiki `h3.` headings instead of `**bold**`.
+   - Every blank line was eaten, gluing headings to their paragraphs.
+   - `+` characters were silently dropped: a quoted PR title, "durable downloads +
+     registry resilience + offline-safe loans", stored double-spaced where each `+` had
+     been — a misquoted citation in a ticket whose argument rested on citing that PR.
+     (`+text+` is also Jira wiki underline, so avoid `+` in prose entirely.)
+
+   After creating, call `jira_get_issue ... fields=description` and **compare the stored
+   text against what you sent**. Do not skim it for the problem you already suspect: on
+   PP-4997 a reviewer did read the issue back and still caught only one of the three,
+   because they went looking for the escaped asterisks and read straight past the dropped
+   plus signs sitting in the same response. Reading the artifact back is necessary and
+   not sufficient — diff, don't scan. Fix what you find with `jira_update_issue`.
 
 ---
 
@@ -135,5 +154,6 @@ of the board is that it reflects reality right now.
 - [ ] Reads well to a non-engineer; no diff-dump, no `file:line` soup.
 - [ ] Story + Sub-tasks (or Epic + Stories) shape fits the size; each child self-contained.
 - [ ] Real newlines in descriptions (not literal backslash-n).
+- [ ] Issue read back with `jira_get_issue` and DIFFED against what was sent (the create echo is not the stored text).
 - [ ] Pointed with a Fibonacci value on `customfield_10033`; assigned; parent Story in the active sprint.
 - [ ] Statuses reflect reality (In Progress / Code Review / Done set as work moves).


### PR DESCRIPTION
## Why

`jira_create_issue` returns a `description` in its response that does **not** match what Jira stored. The echo renders what the client sent, not what the server holds — so it reads like verification and isn't.

Found the hard way while filing PP-4997 during the 3.3.0 regression. **One create call produced three independent corruptions, none visible in the create echo:**

- Markdown headings persisted escaped (`**Heading**` → `\*\*Heading\*\*`) and render as literal asterisks
- Every blank line was eaten, gluing headings to their paragraphs — the ticket rendered as one wall of text
- `+` characters were silently dropped: a quoted PR title, "durable downloads + registry resilience + offline-safe loans", stored double-spaced where each `+` had been — a misquoted citation in a ticket whose argument rested on citing that PR correctly

## What changes

One skill file. Section 3 becomes "Three gotchas", with the create-echo trap written up, the `h3.`-instead-of-`**bold**` fix, and the note that `+text+` is Jira wiki underline so `+` should be avoided in prose. Plus a checklist item, so it's enforced at the end of the flow rather than only buried in the gotchas.

The rule is **diff, don't scan**. Reading the issue back is necessary and not sufficient: on PP-4997 a reviewer did read it back and still caught only one of the three, because they went looking for the corruption they already suspected and read past the dropped plus signs sitting in the same response.

## Scope

Documentation only — no code, no tooling, no production behaviour. Pre-push gate correctly classified it as tooling-only, skipped the Xcode leg, and ran `scripts/tests` green.

## Not done

The `h3`-vs-`**bold**` convention is described but not enforced anywhere, and nothing validates a description before it is sent. An automatic post-create read-back + diff helper is the obvious follow-up and is deliberately deferred.